### PR TITLE
Preserve active responses across Matrix sync restarts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,7 +94,7 @@ Matrix sync callback
 | `turn_store.py` | Unified durable turn access (wraps the handled-turn ledger) |
 | `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
 | `redacted_turn_cleanup.py` | Source-redaction tombstoning and serialized persisted replay cleanup |
-| `sync_restart_retry.py` | One-shot re-dispatch of responses cancelled by sync-restart recovery |
+| `sync_restart_retry.py` | Rooms whose turns a bot replacement interrupted, handed to the replacement's recovery |
 | `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation, detached inbox responses, shutdown drains) |
 | `response_turn.py` | Shared blocking/streaming response-turn drivers behind the agent and team envelopes (attempt loop, dynamic-tool continuation, empty-run retry, interrupt recording) |
 | `response_terminal.py` | Pending-visible classification and terminal stream outcomes for failed or cancelled turns |

--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -77,7 +77,7 @@ Per-source Matrix revision tuples keep durable edit facts newest-wins across ret
 `EditRegenerator` groups edits by room, response anchor, and requester in a bounded per-response mailbox.
 One draining owner folds each source's newest Matrix revision into a complete response request and loops when newer edits arrive.
 Physical source IDs are exclusive turn claims, while discovery aliases are advisory settlement keys observed by `wait_for_turn_settled`.
-A sync-restart cancellation leaves its mailbox snapshot for `SyncRestartRetryQueue` to drain before later edits supersede it.
+A sync-restart cancellation leaves its revision uncommitted and records the room in `InterruptedTurnRooms`, so the replacement runtime's recovery re-drives the turn instead of losing it.
 The two physical stores remain intentionally redundant so run metadata can repair a ledger write lost during a crash.
 `TurnStore` applies deterministic field precedence: a present ledger record owns canonical source identity and anchor, while a newer delivered run can repair mutable response and regeneration facts after a crash.
 Recovery never replaces a ledger record that changed while run metadata was loading.

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -93,7 +93,6 @@ Config changes are detected via polling (`watch_paths()` checks watched source-f
 4. A runtime being replaced wakes its pre-admission waiters with `ResponseAdmissionRefusedError`.
    This is deliberately not an `asyncio.CancelledError`, because the Matrix callback must fail and invalidate the old sync checkpoint so the replacement runtime replays the source event.
    The refusal path performs no Matrix I/O, so replacement shutdown cannot stall on an untimed send.
-   A queued sync-restart retry is put back on the queue rather than consuming its one attempt.
    Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped
 5. If responses never drain, the reload stops deferring after ten minutes and closes the gate over the still-running responses, so a config change cannot be starved forever on a busy install
 6. `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`
@@ -162,6 +161,9 @@ Non-MindRoom bots listed in `bot_accounts` are excluded from this detection.
 - Each bot runs its own sync loop via `sync_forever_with_restart()`
 - Sync loop failures trigger automatic restart with linear backoff (5s, 10s, 15s, ... up to 60s max)
 - Watchdog-driven restarts of stalled sync loops add 0–10s of random jitter on top of the backoff so a loop-wide stall does not restart every sync loop as one thundering herd
+- An automatic receive-loop restart replaces only the sync task and its watchdog, so in-flight responses keep their original owner and finish across the restart
+- The response runtime is drained and cancelled only when the bot itself stops: a config reload replacing the entity, entity removal, or process shutdown
+- Each of those lifecycle events logs `restart_reason_category` and `resulting_action`, so `matrix_sync_transport_restart` is distinguishable from `matrix_agent_response_runtime_shutdown` in logs
 - Event callbacks run as background tasks (never block the sync loop)
 - `ResponseTracker` prevents duplicate replies
 - `StopManager` handles cancellation of in-progress responses

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16289,7 +16289,6 @@ Config changes are detected via polling (`watch_paths()` checks watched source-f
 4. A runtime being replaced wakes its pre-admission waiters with `ResponseAdmissionRefusedError`.
    This is deliberately not an `asyncio.CancelledError`, because the Matrix callback must fail and invalidate the old sync checkpoint so the replacement runtime replays the source event.
    The refusal path performs no Matrix I/O, so replacement shutdown cannot stall on an untimed send.
-   A queued sync-restart retry is put back on the queue rather than consuming its one attempt.
    Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped
 5. If responses never drain, the reload stops deferring after ten minutes and closes the gate over the still-running responses, so a config change cannot be starved forever on a busy install
 6. `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`
@@ -16358,6 +16357,9 @@ Non-MindRoom bots listed in `bot_accounts` are excluded from this detection.
 - Each bot runs its own sync loop via `sync_forever_with_restart()`
 - Sync loop failures trigger automatic restart with linear backoff (5s, 10s, 15s, ... up to 60s max)
 - Watchdog-driven restarts of stalled sync loops add 0–10s of random jitter on top of the backoff so a loop-wide stall does not restart every sync loop as one thundering herd
+- An automatic receive-loop restart replaces only the sync task and its watchdog, so in-flight responses keep their original owner and finish across the restart
+- The response runtime is drained and cancelled only when the bot itself stops: a config reload replacing the entity, entity removal, or process shutdown
+- Each of those lifecycle events logs `restart_reason_category` and `resulting_action`, so `matrix_sync_transport_restart` is distinguishable from `matrix_agent_response_runtime_shutdown` in logs
 - Event callbacks run as background tasks (never block the sync loop)
 - `ResponseTracker` prevents duplicate replies
 - `StopManager` handles cancellation of in-progress responses

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -89,7 +89,6 @@ Config changes are detected via polling (`watch_paths()` checks watched source-f
 4. A runtime being replaced wakes its pre-admission waiters with `ResponseAdmissionRefusedError`.
    This is deliberately not an `asyncio.CancelledError`, because the Matrix callback must fail and invalidate the old sync checkpoint so the replacement runtime replays the source event.
    The refusal path performs no Matrix I/O, so replacement shutdown cannot stall on an untimed send.
-   A queued sync-restart retry is put back on the queue rather than consuming its one attempt.
    Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped
 5. If responses never drain, the reload stops deferring after ten minutes and closes the gate over the still-running responses, so a config change cannot be starved forever on a busy install
 6. `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`
@@ -158,6 +157,9 @@ Non-MindRoom bots listed in `bot_accounts` are excluded from this detection.
 - Each bot runs its own sync loop via `sync_forever_with_restart()`
 - Sync loop failures trigger automatic restart with linear backoff (5s, 10s, 15s, ... up to 60s max)
 - Watchdog-driven restarts of stalled sync loops add 0–10s of random jitter on top of the backoff so a loop-wide stall does not restart every sync loop as one thundering herd
+- An automatic receive-loop restart replaces only the sync task and its watchdog, so in-flight responses keep their original owner and finish across the restart
+- The response runtime is drained and cancelled only when the bot itself stops: a config reload replacing the entity, entity removal, or process shutdown
+- Each of those lifecycle events logs `restart_reason_category` and `resulting_action`, so `matrix_sync_transport_restart` is distinguishable from `matrix_agent_response_runtime_shutdown` in logs
 - Event callbacks run as background tasks (never block the sync loop)
 - `ResponseTracker` prevents duplicate replies
 - `StopManager` handles cancellation of in-progress responses

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -57,7 +57,12 @@ from mindroom.matrix_rtc.call_manager import CallManager, maybe_build_call_manag
 from mindroom.memory import store_conversation_memory
 from mindroom.message_target import MessageTarget  # noqa: TC001
 from mindroom.post_response_effects import PostResponseEffectsSupport
-from mindroom.runtime_shutdown import ENTITY_REMOVED_SHUTDOWN, GENERIC_SHUTDOWN, RuntimeShutdownIntent
+from mindroom.runtime_shutdown import (
+    ENTITY_REMOVED_SHUTDOWN,
+    GENERIC_SHUTDOWN,
+    RuntimeShutdownIntent,
+    restart_reason_category_for,
+)
 from mindroom.stop import StopManager
 from mindroom.teams import TeamMode, TeamOutcome, resolve_configured_team
 from mindroom.timestamp_formatting import format_timestamp_ms
@@ -109,7 +114,7 @@ from .scheduling import (
     restore_scheduled_tasks,
 )
 from .startup_errors import PermanentStartupError
-from .sync_restart_retry import SyncRestartRetryQueue
+from .sync_restart_retry import InterruptedTurnRooms
 from .turn_controller import TurnController, TurnControllerDeps
 from .turn_policy import IngressHookRunner, TurnPolicy, TurnPolicyDeps
 from .turn_store import TurnStore, TurnStoreDeps
@@ -330,7 +335,7 @@ class AgentBot:
         self.config_path = config_path
         self.logger = logger.bind(agent=self.agent_name)
         self.stop_manager = StopManager()
-        self._restart_retry_queue = SyncRestartRetryQueue()
+        self._interrupted_turn_rooms = InterruptedTurnRooms()
         self.running = False
         self.last_sync_time = None
         self._last_sync_monotonic = None
@@ -529,7 +534,7 @@ class AgentBot:
                 ingress_hook_runner=self._ingress_hook_runner,
                 generate_response=lambda request: self._run_regenerated_response(request),
                 wait_for_turn_settled=self._turn_store.wait_for_turn_settled,
-                restart_retry=self._restart_retry_queue,
+                interrupted_turn_rooms=self._interrupted_turn_rooms,
                 timestamp_formatter=lambda timestamp_ms: format_timestamp_ms(
                     timestamp_ms,
                     timezone=self.config.timezone,
@@ -579,7 +584,7 @@ class AgentBot:
                 coalescing_gate=self._coalescing_gate,
                 edit_regenerator=self._edit_regenerator,
                 ingress=self._ingress_validator,
-                restart_retry=self._restart_retry_queue,
+                interrupted_turn_rooms=self._interrupted_turn_rooms,
             ),
         )
 
@@ -742,8 +747,8 @@ class AgentBot:
 
     @property
     def pending_sync_restart_retry_room_ids(self) -> frozenset[str]:
-        """Return rooms with interrupted turns awaiting same-bot retry."""
-        return self._restart_retry_queue.pending_room_ids
+        """Return rooms with interrupted turns awaiting replacement recovery."""
+        return self._interrupted_turn_rooms.pending_room_ids
 
     @property
     def agent_name(self) -> str:
@@ -1177,15 +1182,6 @@ class AgentBot:
 
         if self._sync_shutting_down:
             return
-
-        if self._restart_retry_queue.has_pending:
-            # The sync loop is healthy again: re-dispatch turns whose responses
-            # were cancelled by stall recovery, once each.
-            create_background_task(
-                self._restart_retry_queue.flush(),
-                name=f"sync_restart_retry_{self.agent_name}",
-                owner=self._runtime_view,
-            )
 
         if isinstance(_response, nio.SyncResponse):
             await self._apply_own_room_membership_from_sync(_response)
@@ -1695,16 +1691,10 @@ class AgentBot:
     ) -> None:
         """Cancel work that must not outlive the Matrix sync loop."""
         if not self._sync_shutting_down:
-            reason_category = {
-                "restart": "config_reload",
-                "entity_removed": "agent_shutdown",
-                "shutdown": "process_shutdown",
-                None: "agent_shutdown",
-            }[shutdown_intent.stop_reason]
-            logger.info(
+            self.logger.info(
                 "matrix_agent_response_runtime_shutdown",
                 active_response_count=self.in_flight_response_count,
-                restart_reason_category=reason_category,
+                restart_reason_category=restart_reason_category_for(shutdown_intent),
                 resulting_action="drain_then_cancel_response_runtime",
             )
         self._sync_shutting_down = True

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1694,6 +1694,19 @@ class AgentBot:
         shutdown_intent: RuntimeShutdownIntent = GENERIC_SHUTDOWN,
     ) -> None:
         """Cancel work that must not outlive the Matrix sync loop."""
+        if not self._sync_shutting_down:
+            reason_category = {
+                "restart": "config_reload",
+                "entity_removed": "agent_shutdown",
+                "shutdown": "process_shutdown",
+                None: "agent_shutdown",
+            }[shutdown_intent.stop_reason]
+            logger.info(
+                "matrix_agent_response_runtime_shutdown",
+                active_response_count=self.in_flight_response_count,
+                restart_reason_category=reason_category,
+                resulting_action="drain_then_cancel_response_runtime",
+            )
         self._sync_shutting_down = True
         self._response_runner.refuse_pending_admissions()
         await self._cancel_startup_thread_prewarm()

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from mindroom.hooks import MessageEnvelope
     from mindroom.matrix.event_info import EventInfo
     from mindroom.message_target import MessageTarget
-    from mindroom.sync_restart_retry import SyncRestartRetryQueue
+    from mindroom.sync_restart_retry import InterruptedTurnRooms
     from mindroom.turn_policy import IngressHookRunner
     from mindroom.turn_store import TurnStore
 
@@ -44,7 +44,7 @@ class EditRegeneratorDeps:
     ingress_hook_runner: IngressHookRunner
     generate_response: Callable[[ResponseRequest], Awaitable[str | None]]
     wait_for_turn_settled: Callable[[tuple[str, ...]], Awaitable[None]]
-    restart_retry: SyncRestartRetryQueue
+    interrupted_turn_rooms: InterruptedTurnRooms
     timestamp_formatter: Callable[[float | None], str | None]
 
 
@@ -318,11 +318,10 @@ class EditRegenerator:
             ),
         )
 
-        async def retry_mailbox() -> None:
-            await self._drain(room, record, mailbox)
-
-        def retry_after_sync_restart() -> None:
-            if self.deps.restart_retry.register(driving_edit.revision[1], retry_mailbox, room_id=room.room_id):
+        def record_interrupted_turn() -> None:
+            # The interrupted revision must stay uncommitted so the replacement
+            # runtime's recovery re-drives it instead of treating it as applied.
+            if self.deps.interrupted_turn_rooms.register(driving_edit.revision[1], room_id=room.room_id):
                 applied.clear()
 
         return (
@@ -346,7 +345,7 @@ class EditRegenerator:
                         dict.fromkeys((*record.replay_source_event_ids, driving_edit.original_event_id)),
                     ),
                 ),
-                on_sync_restart_cancelled=retry_after_sync_restart,
+                on_sync_restart_cancelled=record_interrupted_turn,
                 sync_restart_retry_source_event_id=retry_source_event_id,
                 on_deferred_outcome_handled=lambda response_event_id: (
                     self.deps.turn_store.record_turn(replace(record, response_event_id=response_event_id))

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -345,8 +345,11 @@ class _SyncIteration:
                 await task
             except (asyncio.CancelledError, _MatrixSyncStalledError):
                 pass
-            except Exception:
-                logger.warning("Suppressed error during sync iteration cleanup", exc_info=True)
+            except Exception as exc:
+                logger.warning(
+                    "sync_iteration_cleanup_failed",
+                    exception_type=type(exc).__name__,
+                )
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -257,26 +257,30 @@ class _SyncIteration:
                 if elapsed <= startup_timeout_seconds:
                     continue
                 logger.error(
-                    "Matrix sync watchdog: first sync never completed",
-                    agent_name=bot.agent_name,
+                    "matrix_sync_watchdog_stalled",
+                    active_response_count=bot.in_flight_response_count,
                     elapsed_seconds=elapsed,
+                    restart_reason_category="first_sync_timeout",
+                    resulting_action="cancel_receive_loop",
                     startup_timeout_seconds=startup_timeout_seconds,
                 )
             elif sync_age_seconds <= MATRIX_SYNC_WATCHDOG_TIMEOUT_SECONDS:
                 continue
             else:
                 logger.error(
-                    "Matrix sync watchdog detected a stalled sync loop",
-                    agent_name=bot.agent_name,
-                    stale_for_seconds=sync_age_seconds,
+                    "matrix_sync_watchdog_stalled",
+                    active_response_count=bot.in_flight_response_count,
                     last_sync_time=bot.last_sync_time.isoformat() if bot.last_sync_time is not None else None,
+                    restart_reason_category="sync_activity_timeout",
+                    resulting_action="cancel_receive_loop",
+                    stale_for_seconds=sync_age_seconds,
                 )
 
             watchdog_cancelled_sync.set()
             request_task_cancel(sync_task, cancel_source="sync_restart")
             with suppress(asyncio.CancelledError):
                 await sync_task
-            msg = f"Matrix sync loop stalled for {bot.agent_name}"
+            msg = "Matrix sync loop stalled"
             raise _MatrixSyncStalledError(msg)
 
     @classmethod
@@ -343,6 +347,58 @@ class _SyncIteration:
                 pass
             except Exception:
                 logger.warning("Suppressed error during sync iteration cleanup", exc_info=True)
+
+
+@dataclass(frozen=True, slots=True)
+class _SyncIterationOutcome:
+    """Result of one receive-loop iteration after child-task cleanup."""
+
+    restart_reason_category: str | None = None
+    stalled_restart: bool = False
+    supervisor_cancelled: bool = False
+
+
+async def _run_sync_iteration(
+    bot: AgentBot | TeamBot,
+    *,
+    retry_count: int,
+) -> _SyncIterationOutcome:
+    """Run and clean up one receive-loop iteration without touching live responses."""
+    iteration: _SyncIteration | None = None
+    shutdown_intent = GENERIC_SHUTDOWN
+    try:
+        logger.info("starting_sync_loop")
+        iteration = _SyncIteration.start(bot)
+        await iteration.wait()
+        if not bot.running:
+            return _SyncIterationOutcome()
+        logger.warning(
+            "sync_loop_returned_while_bot_running",
+            retry_count=retry_count + 1,
+        )
+        return _SyncIterationOutcome(restart_reason_category="unexpected_sync_return")
+    except asyncio.CancelledError as exc:
+        if is_sync_restart_cancel(exc):
+            shutdown_intent = SYNC_RESTART_SHUTDOWN
+        logger.info("sync_task_cancelled")
+        return _SyncIterationOutcome(supervisor_cancelled=True)
+    except _MatrixSyncStalledError:
+        return _SyncIterationOutcome(
+            restart_reason_category="watchdog_stall",
+            stalled_restart=True,
+        )
+    except Exception as exc:
+        logger.error(  # noqa: TRY400 - exception text may contain identifiers.
+            "sync_loop_failed",
+            exception_type=type(exc).__name__,
+            retry_count=retry_count + 1,
+        )
+        return _SyncIterationOutcome(restart_reason_category="sync_failure")
+    finally:
+        if iteration is not None:
+            await iteration.cancel(shutdown_intent=shutdown_intent)
+            if not bot.running:
+                await bot.prepare_for_sync_shutdown(shutdown_intent=shutdown_intent)
 
 
 def _log_detached_task_result(task: asyncio.Task, *, message: str) -> None:
@@ -553,53 +609,29 @@ async def sync_forever_with_restart(bot: AgentBot | TeamBot, max_retries: int = 
     """Run sync_forever with automatic restart on failure."""
     retry_count = 0
     while bot.running and (max_retries < 0 or retry_count < max_retries):
-        iteration: _SyncIteration | None = None
-        stalled_restart = False
-        retry_after_cleanup = False
-        sync_restart_cancelled = False
-        try:
-            logger.info("starting_sync_loop", agent=bot.agent_name)
-            iteration = _SyncIteration.start(bot)
-            await iteration.wait()
-            if not bot.running:
-                # sync_forever returned normally after an intentional stop.
-                break
-            retry_count += 1
-            retry_after_cleanup = True
-            logger.warning(
-                "sync_loop_returned_while_bot_running",
-                agent=bot.agent_name,
-                retry_count=retry_count,
-            )
-        except asyncio.CancelledError as exc:
-            # Task cancellation is part of normal shutdown.
-            sync_restart_cancelled = is_sync_restart_cancel(exc)
-            logger.info("sync_task_cancelled", agent=bot.agent_name)
+        outcome = await _run_sync_iteration(bot, retry_count=retry_count)
+        if outcome.supervisor_cancelled or not bot.running:
             break
-        except _MatrixSyncStalledError:
-            retry_count += 1
-            stalled_restart = True
-            retry_after_cleanup = True
-            logger.warning("restarting_stalled_sync_loop", agent=bot.agent_name, retry_count=retry_count)
-        except Exception:
-            retry_count += 1
-            retry_after_cleanup = True
-            logger.exception("sync_loop_failed", agent=bot.agent_name, retry_count=retry_count)
-        finally:
-            if iteration is not None:
-                will_retry = retry_after_cleanup and bot.running and (max_retries < 0 or retry_count < max_retries)
-                shutdown_intent = SYNC_RESTART_SHUTDOWN if will_retry or sync_restart_cancelled else GENERIC_SHUTDOWN
-                await iteration.cancel(shutdown_intent=shutdown_intent)
-                await bot.prepare_for_sync_shutdown(shutdown_intent=shutdown_intent)
-
-        if not bot.running:
-            break
+        restart_reason_category = outcome.restart_reason_category
+        assert restart_reason_category is not None
+        retry_count += 1
+        will_retry = max_retries < 0 or retry_count < max_retries
+        logger.warning(
+            "matrix_sync_transport_restart",
+            active_response_count=bot.in_flight_response_count,
+            restart_reason_category=restart_reason_category,
+            resulting_action="restart_receive_loop" if will_retry else "preserve_response_runtime",
+            retry_count=retry_count,
+            will_retry=will_retry,
+        )
         if max_retries >= 0 and retry_count >= max_retries:
             logger.error(
                 "sync_loop_retries_exhausted",
-                agent=bot.agent_name,
+                active_response_count=bot.in_flight_response_count,
                 retry_count=retry_count,
                 max_retries=max_retries,
+                restart_reason_category=restart_reason_category,
+                resulting_action="preserve_response_runtime",
             )
             break
 
@@ -608,7 +640,7 @@ async def sync_forever_with_restart(bot: AgentBot | TeamBot, max_retries: int = 
             initial_delay_seconds=5.0,
             max_delay_seconds=60.0,
         )
-        if stalled_restart:
+        if outcome.stalled_restart:
             wait_time += _stalled_restart_jitter_seconds()
-        logger.info("restarting_sync_loop", agent=bot.agent_name, retry_count=retry_count, wait_seconds=wait_time)
+        logger.info("restarting_sync_loop", retry_count=retry_count, wait_seconds=wait_time)
         await asyncio.sleep(wait_time)

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -33,6 +33,8 @@ from mindroom.matrix.health import (
 from mindroom.runtime_shutdown import (
     GENERIC_SHUTDOWN,
     SYNC_RESTART_SHUTDOWN,
+    RestartReasonCategory,
+    RuntimeLifecycleAction,
     RuntimeShutdownIntent,
     shutdown_intent_for_entity,
 )
@@ -258,6 +260,7 @@ class _SyncIteration:
                     continue
                 logger.error(
                     "matrix_sync_watchdog_stalled",
+                    agent=bot.agent_name,
                     active_response_count=bot.in_flight_response_count,
                     elapsed_seconds=elapsed,
                     restart_reason_category="first_sync_timeout",
@@ -269,6 +272,7 @@ class _SyncIteration:
             else:
                 logger.error(
                     "matrix_sync_watchdog_stalled",
+                    agent=bot.agent_name,
                     active_response_count=bot.in_flight_response_count,
                     last_sync_time=bot.last_sync_time.isoformat() if bot.last_sync_time is not None else None,
                     restart_reason_category="sync_activity_timeout",
@@ -280,7 +284,7 @@ class _SyncIteration:
             request_task_cancel(sync_task, cancel_source="sync_restart")
             with suppress(asyncio.CancelledError):
                 await sync_task
-            msg = "Matrix sync loop stalled"
+            msg = f"Matrix sync loop stalled for {bot.agent_name}"
             raise _MatrixSyncStalledError(msg)
 
     @classmethod
@@ -345,63 +349,54 @@ class _SyncIteration:
                 await task
             except (asyncio.CancelledError, _MatrixSyncStalledError):
                 pass
-            except Exception as exc:
-                logger.warning(
-                    "sync_iteration_cleanup_failed",
-                    exception_type=type(exc).__name__,
-                )
+            except Exception:
+                logger.warning("sync_iteration_cleanup_failed", agent=self.bot.agent_name, exc_info=True)
 
 
 @dataclass(frozen=True, slots=True)
 class _SyncIterationOutcome:
-    """Result of one receive-loop iteration after child-task cleanup."""
+    """Why one receive-loop iteration ended, and how its runtime must be settled."""
 
-    restart_reason_category: str | None = None
+    # None means the supervisor is done with this bot: it either stopped or was
+    # cancelled, so no replacement receive loop should start.
+    restart_reason_category: RestartReasonCategory | None = None
     stalled_restart: bool = False
-    supervisor_cancelled: bool = False
+    shutdown_intent: RuntimeShutdownIntent = GENERIC_SHUTDOWN
 
 
-async def _run_sync_iteration(
-    bot: AgentBot | TeamBot,
-    *,
-    retry_count: int,
-) -> _SyncIterationOutcome:
-    """Run and clean up one receive-loop iteration without touching live responses."""
+async def _run_sync_iteration(bot: AgentBot | TeamBot, *, attempt: int) -> _SyncIterationOutcome:
+    """Run one receive-loop iteration and settle only the tasks that iteration owns.
+
+    Live responses outlive a transport restart: the response runtime is torn down
+    only once the bot itself has stopped, which is a config, agent, or process
+    shutdown driven by the caller rather than a restart of the receive loop.
+    """
     iteration: _SyncIteration | None = None
-    shutdown_intent = GENERIC_SHUTDOWN
+    outcome = _SyncIterationOutcome()
     try:
-        logger.info("starting_sync_loop")
+        logger.info("starting_sync_loop", agent=bot.agent_name)
         iteration = _SyncIteration.start(bot)
         await iteration.wait()
-        if not bot.running:
-            return _SyncIterationOutcome()
-        logger.warning(
-            "sync_loop_returned_while_bot_running",
-            retry_count=retry_count + 1,
-        )
-        return _SyncIterationOutcome(restart_reason_category="unexpected_sync_return")
+        if bot.running:
+            logger.warning("sync_loop_returned_while_bot_running", agent=bot.agent_name, retry_count=attempt)
+            outcome = _SyncIterationOutcome(restart_reason_category="unexpected_sync_return")
     except asyncio.CancelledError as exc:
+        logger.info("sync_task_cancelled", agent=bot.agent_name)
         if is_sync_restart_cancel(exc):
-            shutdown_intent = SYNC_RESTART_SHUTDOWN
-        logger.info("sync_task_cancelled")
-        return _SyncIterationOutcome(supervisor_cancelled=True)
+            # A replacement runtime is taking over, so its predecessor's responses
+            # must carry sync-restart provenance into the drain below.
+            outcome = _SyncIterationOutcome(shutdown_intent=SYNC_RESTART_SHUTDOWN)
     except _MatrixSyncStalledError:
-        return _SyncIterationOutcome(
-            restart_reason_category="watchdog_stall",
-            stalled_restart=True,
-        )
-    except Exception as exc:
-        logger.error(  # noqa: TRY400 - exception text may contain identifiers.
-            "sync_loop_failed",
-            exception_type=type(exc).__name__,
-            retry_count=retry_count + 1,
-        )
-        return _SyncIterationOutcome(restart_reason_category="sync_failure")
+        outcome = _SyncIterationOutcome(restart_reason_category="watchdog_stall", stalled_restart=True)
+    except Exception:
+        logger.exception("sync_loop_failed", agent=bot.agent_name, retry_count=attempt)
+        outcome = _SyncIterationOutcome(restart_reason_category="sync_failure")
     finally:
         if iteration is not None:
-            await iteration.cancel(shutdown_intent=shutdown_intent)
+            await iteration.cancel(shutdown_intent=outcome.shutdown_intent)
             if not bot.running:
-                await bot.prepare_for_sync_shutdown(shutdown_intent=shutdown_intent)
+                await bot.prepare_for_sync_shutdown(shutdown_intent=outcome.shutdown_intent)
+    return outcome
 
 
 def _log_detached_task_result(task: asyncio.Task, *, message: str) -> None:
@@ -612,29 +607,30 @@ async def sync_forever_with_restart(bot: AgentBot | TeamBot, max_retries: int = 
     """Run sync_forever with automatic restart on failure."""
     retry_count = 0
     while bot.running and (max_retries < 0 or retry_count < max_retries):
-        outcome = await _run_sync_iteration(bot, retry_count=retry_count)
-        if outcome.supervisor_cancelled or not bot.running:
+        outcome = await _run_sync_iteration(bot, attempt=retry_count + 1)
+        if outcome.restart_reason_category is None or not bot.running:
             break
-        restart_reason_category = outcome.restart_reason_category
-        assert restart_reason_category is not None
         retry_count += 1
         will_retry = max_retries < 0 or retry_count < max_retries
+        resulting_action: RuntimeLifecycleAction = "restart_receive_loop" if will_retry else "preserve_response_runtime"
         logger.warning(
             "matrix_sync_transport_restart",
+            agent=bot.agent_name,
             active_response_count=bot.in_flight_response_count,
-            restart_reason_category=restart_reason_category,
-            resulting_action="restart_receive_loop" if will_retry else "preserve_response_runtime",
+            restart_reason_category=outcome.restart_reason_category,
+            resulting_action=resulting_action,
             retry_count=retry_count,
             will_retry=will_retry,
         )
-        if max_retries >= 0 and retry_count >= max_retries:
+        if not will_retry:
+            # The entity keeps its live responses but has no receive loop left, so
+            # its stale sync clock surfaces it through the Matrix sync health snapshot.
             logger.error(
                 "sync_loop_retries_exhausted",
-                active_response_count=bot.in_flight_response_count,
+                agent=bot.agent_name,
                 retry_count=retry_count,
                 max_retries=max_retries,
-                restart_reason_category=restart_reason_category,
-                resulting_action="preserve_response_runtime",
+                restart_reason_category=outcome.restart_reason_category,
             )
             break
 
@@ -645,5 +641,5 @@ async def sync_forever_with_restart(bot: AgentBot | TeamBot, max_retries: int = 
         )
         if outcome.stalled_restart:
             wait_time += _stalled_restart_jitter_seconds()
-        logger.info("restarting_sync_loop", retry_count=retry_count, wait_seconds=wait_time)
+        logger.info("restarting_sync_loop", agent=bot.agent_name, retry_count=retry_count, wait_seconds=wait_time)
         await asyncio.sleep(wait_time)

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1147,13 +1147,13 @@ class ResponseRunner:
         request: ResponseRequest,
         final_outcome: FinalDeliveryOutcome,
     ) -> None:
-        """Tell the dispatcher when stall recovery interrupted a marked-handled turn.
+        """Tell the dispatcher when a bot replacement interrupted a marked-handled turn.
 
         Only turns that end as a visible interrupted note are reported: they get
-        recorded in the handled-turn ledger, so the post-restart sync replay
-        dedups them away and an explicit retry is their only recovery. Unmarked
-        turns are recovered by that replay instead; retrying them too would
-        answer twice.
+        recorded in the handled-turn ledger, so the replacement runtime's sync
+        replay dedups them away and room-scoped recovery is their only route back.
+        Unmarked turns are recovered by that replay instead; recovering them too
+        would answer twice.
         """
         if request.on_sync_restart_cancelled is None or final_outcome.terminal_status != "cancelled":
             return

--- a/src/mindroom/runtime_shutdown.py
+++ b/src/mindroom/runtime_shutdown.py
@@ -13,12 +13,42 @@ __all__ = [
     "GENERIC_SHUTDOWN",
     "ORDERLY_SHUTDOWN",
     "SYNC_RESTART_SHUTDOWN",
+    "RestartReasonCategory",
+    "RuntimeLifecycleAction",
     "RuntimeShutdownIntent",
     "StopReason",
+    "restart_reason_category_for",
     "shutdown_intent_for_entity",
 ]
 
 StopReason = Literal["restart", "entity_removed", "shutdown"]
+
+# One taxonomy for the `restart_reason_category` and `resulting_action` fields that
+# the sync supervisor and the bot response runtime both log, so the two emitters
+# cannot drift into describing the same lifecycle event differently.
+RestartReasonCategory = Literal[
+    "first_sync_timeout",
+    "sync_activity_timeout",
+    "watchdog_stall",
+    "sync_failure",
+    "unexpected_sync_return",
+    "config_reload",
+    "agent_shutdown",
+    "process_shutdown",
+]
+RuntimeLifecycleAction = Literal[
+    "cancel_receive_loop",
+    "restart_receive_loop",
+    "preserve_response_runtime",
+    "drain_then_cancel_response_runtime",
+]
+
+_STOP_REASON_CATEGORIES: dict[StopReason | None, RestartReasonCategory] = {
+    "restart": "config_reload",
+    "entity_removed": "agent_shutdown",
+    "shutdown": "process_shutdown",
+    None: "agent_shutdown",
+}
 
 
 @dataclass(frozen=True)
@@ -33,6 +63,11 @@ GENERIC_SHUTDOWN = RuntimeShutdownIntent(stop_reason=None, cancel_source=None)
 ORDERLY_SHUTDOWN = RuntimeShutdownIntent(stop_reason="shutdown", cancel_source=None)
 ENTITY_REMOVED_SHUTDOWN = RuntimeShutdownIntent(stop_reason="entity_removed", cancel_source=None)
 SYNC_RESTART_SHUTDOWN = RuntimeShutdownIntent(stop_reason="restart", cancel_source="sync_restart")
+
+
+def restart_reason_category_for(shutdown_intent: RuntimeShutdownIntent) -> RestartReasonCategory:
+    """Return the log category describing why one response runtime is shutting down."""
+    return _STOP_REASON_CATEGORIES[shutdown_intent.stop_reason]
 
 
 def shutdown_intent_for_entity(

--- a/src/mindroom/sync_restart_retry.py
+++ b/src/mindroom/sync_restart_retry.py
@@ -1,14 +1,14 @@
 """One-shot re-dispatch of responses cancelled by sync-restart recovery.
 
-When the Matrix sync watchdog restarts a stalled sync loop, in-flight
-responses are cancelled and their placeholder becomes a terminal
+When the orchestrator replaces a bot during a sync-restart shutdown,
+in-flight responses are cancelled and their placeholder becomes a terminal
 "[Response interrupted by service restart]" note. The turn controller
-registers a retry here, and the bot flushes the queue once its sync loop
-reports a healthy sync response again. Each source event is retried at
-most once; a retry that is itself interrupted is not requeued. A retry
-refused by a config apply is the exception: nothing ran, so it stays
-pending for the next flush. Pending room ids also let the orchestrator
-hand retries to a replacement bot.
+registers a retry here, and the replacement bot flushes the queue once its
+sync loop reports a healthy response. Each source event is retried at most
+once; a retry that is itself interrupted is not requeued. A retry refused by
+a config apply is the exception: nothing ran, so it stays pending for the next
+flush. Pending room ids also let the orchestrator hand retries to a replacement
+bot.
 """
 
 from __future__ import annotations

--- a/src/mindroom/sync_restart_retry.py
+++ b/src/mindroom/sync_restart_retry.py
@@ -1,19 +1,16 @@
-"""One-shot re-dispatch of responses cancelled by sync-restart recovery.
+"""Rooms whose turns were interrupted by a sync-restart shutdown.
 
-When the orchestrator replaces a bot during a sync-restart shutdown,
-in-flight responses are cancelled and their placeholder becomes a terminal
-"[Response interrupted by service restart]" note. The turn controller
-registers a retry here, and the replacement bot flushes the queue once its
-sync loop reports a healthy response. Each source event is retried at most
-once; a retry that is itself interrupted is not requeued. A retry refused by
-a config apply is the exception: nothing ran, so it stays pending for the next
-flush. Pending room ids also let the orchestrator hand retries to a replacement
-bot.
+Only a bot being replaced cancels responses with sync-restart provenance: an
+automatic receive-loop restart leaves live responses with their original owner.
+The interrupted response's placeholder becomes a terminal "[Response interrupted
+by service restart]" note, so the turn controller records its room here and the
+orchestrator hands those rooms to the replacement bot, whose stale-stream
+recovery re-drives the interrupted turns. Each source event is recorded once, so
+one interrupted turn cannot claim two recovery attempts.
 """
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -23,26 +20,16 @@ from agno.run.team import TeamRunOutput
 from mindroom.constants import MATRIX_EVENT_ID_METADATA_KEY, MATRIX_SOURCE_EVENT_IDS_METADATA_KEY
 from mindroom.history.storage import is_model_history_visible_run
 from mindroom.logging_config import get_logger
-from mindroom.response_admission import ResponseAdmissionRefusedError
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    from collections.abc import Sequence
 
     from mindroom.history.types import HistoryScope
 
 logger = get_logger(__name__)
 
-_MAX_ATTEMPTED_KEYS = 512
 _INTERRUPTED_REPLAY_STATE_KEY = "mindroom_replay_state"
 _INTERRUPTED_REPLAY_STATE = "interrupted"
-
-
-@dataclass(frozen=True)
-class _PendingRetry:
-    """One retry callback plus the Matrix room containing its terminal marker."""
-
-    room_id: str
-    callback: Callable[[], Awaitable[None]]
 
 
 def _run_matches_scope(run: RunOutput | TeamRunOutput, scope: HistoryScope) -> bool:
@@ -97,68 +84,20 @@ def interrupted_source_needs_retry(
 
 
 @dataclass
-class SyncRestartRetryQueue:
-    """Hold one-shot retry callbacks keyed by source event id."""
+class InterruptedTurnRooms:
+    """Hold the rooms of turns interrupted by a sync-restart shutdown."""
 
-    _pending: dict[str, _PendingRetry] = field(default_factory=dict)
-    _attempted: dict[str, None] = field(default_factory=dict)
-    _flush_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-
-    @property
-    def has_pending(self) -> bool:
-        """Return whether any retry is waiting for sync recovery."""
-        return bool(self._pending)
+    _pending: dict[str, str] = field(default_factory=dict)
 
     @property
     def pending_room_ids(self) -> frozenset[str]:
-        """Return rooms whose interrupted turns still await a retry."""
-        return frozenset(pending.room_id for pending in self._pending.values())
+        """Return rooms whose interrupted turns still await replacement recovery."""
+        return frozenset(self._pending.values())
 
-    def register(self, key: str, retry: Callable[[], Awaitable[None]], *, room_id: str) -> bool:
-        """Queue one retry for a source event; refuse anything already seen."""
-        if key in self._attempted or key in self._pending:
+    def register(self, key: str, *, room_id: str) -> bool:
+        """Record one interrupted source event; refuse anything already seen."""
+        if key in self._pending:
             return False
-        self._pending[key] = _PendingRetry(room_id=room_id, callback=retry)
-        logger.info("sync_restart_retry_queued", source_event_id=key, pending_count=len(self._pending))
+        self._pending[key] = room_id
+        logger.info("sync_restart_interrupted_turn_recorded", source_event_id=key, pending_count=len(self._pending))
         return True
-
-    def _mark_attempted(self, key: str) -> None:
-        """Record one attempted key, bounding the dedup memory."""
-        self._attempted[key] = None
-        while len(self._attempted) > _MAX_ATTEMPTED_KEYS:
-            self._attempted.pop(next(iter(self._attempted)))
-
-    async def flush(self) -> None:
-        """Run every queued retry exactly once in FIFO order, isolating individual failures."""
-        async with self._flush_lock:
-            while self._pending:
-                key = next(iter(self._pending))
-                pending = self._pending[key]
-                retry = pending.callback
-                logger.info("sync_restart_retry_started", source_event_id=key)
-                # Burn the key unless admission refused it. Promoting only after the
-                # retry actually ran means there is no rollback to get wrong:
-                # _mark_attempted evicts the oldest key once it hits its bound, and
-                # that eviction cannot be undone.
-                attempted = True
-                try:
-                    await retry()
-                except ResponseAdmissionRefusedError:
-                    # A config apply refused the response before any lifecycle work,
-                    # so nothing ran. Stop the pass rather than re-raising: the gate
-                    # stays closed for the whole apply, so every pending retry must
-                    # stay queued for the next flush.
-                    attempted = False
-                    logger.info("sync_restart_retry_deferred_by_config_apply", source_event_id=key)
-                    return
-                except asyncio.CancelledError:
-                    # The flush task is being torn down mid-retry; the retry did run,
-                    # so log the dead end before propagating.
-                    logger.warning("sync_restart_retry_cancelled", source_event_id=key)
-                    raise
-                except Exception:
-                    logger.exception("sync_restart_retry_failed", source_event_id=key)
-                finally:
-                    if attempted:
-                        self._pending.pop(key)
-                        self._mark_attempted(key)

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -65,7 +65,7 @@ from mindroom.dispatch_source import (
 )
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.error_handling import get_user_friendly_error_message
-from mindroom.handled_turns import TurnRecord, same_turn_identity
+from mindroom.handled_turns import TurnRecord
 from mindroom.hooks import MessageEnvelope, build_hook_matrix_admin, hook_ingress_policy
 from mindroom.inbound_turn_normalizer import (
     DispatchPayloadWithAttachmentsRequest,
@@ -137,7 +137,7 @@ if TYPE_CHECKING:
     from mindroom.message_target import MessageTarget
     from mindroom.response_lifecycle import QueuedHumanNoticeReservation
     from mindroom.response_runner import ResponseRunner
-    from mindroom.sync_restart_retry import SyncRestartRetryQueue
+    from mindroom.sync_restart_retry import InterruptedTurnRooms
     from mindroom.tool_system.runtime_context import ToolRuntimeSupport
     from mindroom.turn_store import TurnStore
 
@@ -327,7 +327,7 @@ class TurnControllerDeps:
     coalescing_gate: CoalescingGate
     edit_regenerator: _EditRegenerator
     ingress: IngressValidator
-    restart_retry: SyncRestartRetryQueue
+    interrupted_turn_rooms: InterruptedTurnRooms
 
 
 @dataclass
@@ -1672,54 +1672,18 @@ class TurnController:
         self,
         room: nio.MatrixRoom,
         event: DispatchEvent,
-        dispatch: PreparedDispatch,
-        action: ResponseAction,
-        payload_inputs: DispatchPayloadInputs,
         *,
         handled_turn: TurnRecord,
-        matrix_run_metadata: dict[str, Any] | None,
-        retry_team_mode: TeamMode | None,
     ) -> tuple[Callable[[], None], Callable[[str], None]]:
-        """Build callbacks for sync-restart retry and deferred handled recording."""
+        """Build callbacks for interrupted-turn recording and deferred handled recording."""
 
-        def register_sync_restart_retry() -> None:
-            async def retry() -> None:
-                retry_turn = self.deps.turn_store.get_turn_record(event.event_id)
-                while retry_turn is not None and not self.deps.turn_store.try_claim_turn(retry_turn):
-                    await self.deps.turn_store.wait_for_turn_settled(retry_turn.indexed_event_ids)
-                    retry_turn = self.deps.turn_store.get_turn_record(event.event_id)
-                if retry_turn is None:
-                    return
-                try:
-                    current_record = self.deps.turn_store.get_turn_record(event.event_id)
-                    if (
-                        current_record is None
-                        or not same_turn_identity(current_record, handled_turn)
-                        or current_record.source_event_revisions != handled_turn.source_event_revisions
-                    ):
-                        return
-                    await self._execute_response_action(
-                        room,
-                        event,
-                        dispatch,
-                        action,
-                        payload_inputs,
-                        processing_log="Retrying response interrupted by sync restart",
-                        dispatch_started_at=time.monotonic(),
-                        handled_turn=retry_turn,
-                        matrix_run_metadata=matrix_run_metadata,
-                        retry_team_mode=retry_team_mode,
-                        sync_restart_retry_source_event_id=event.event_id,
-                    )
-                finally:
-                    self.deps.turn_store.release_pending_turn_claim(retry_turn)
-
-            self.deps.restart_retry.register(event.event_id, retry, room_id=room.room_id)
+        def record_interrupted_turn() -> None:
+            self.deps.interrupted_turn_rooms.register(event.event_id, room_id=room.room_id)
 
         def record_deferred_outcome(response_event_id: str) -> None:
             self._mark_source_events_responded(replace(handled_turn, response_event_id=response_event_id))
 
-        return register_sync_restart_retry, record_deferred_outcome
+        return record_interrupted_turn, record_deferred_outcome
 
     async def _execute_response_action(  # noqa: C901, PLR0912, PLR0915
         self,
@@ -1735,8 +1699,6 @@ class TurnController:
         matrix_run_metadata: dict[str, Any] | None = None,
         queued_notice_reservation: QueuedHumanNoticeReservation | None = None,
         on_lifecycle_lock_acquired: Callable[[], None] | None = None,
-        retry_team_mode: TeamMode | None = None,
-        sync_restart_retry_source_event_id: str | None = None,
     ) -> None:
         """Execute one final response path for a prepared dispatch action."""
         if room.room_id != dispatch.target.room_id:
@@ -1805,8 +1767,8 @@ class TurnController:
             if action.kind == "team":
                 assert action.form_team is not None
                 assert action.form_team.mode is not None
-                team_mode = retry_team_mode or action.form_team.mode
-                if retry_team_mode is None and action.form_team.intent is not TeamIntent.CONFIGURED_TEAM and event.body:
+                team_mode = action.form_team.mode
+                if action.form_team.intent is not TeamIntent.CONFIGURED_TEAM and event.body:
                     team_mode = await select_ad_hoc_team_mode(
                         event.body,
                         action.form_team.eligible_members,
@@ -1814,15 +1776,10 @@ class TurnController:
                         self.deps.runtime_paths,
                     )
 
-            register_sync_restart_retry, record_deferred_outcome = self._build_response_settlement_callbacks(
+            record_interrupted_turn, record_deferred_outcome = self._build_response_settlement_callbacks(
                 room,
                 event,
-                dispatch,
-                action,
-                payload_inputs,
                 handled_turn=handled_turn,
-                matrix_run_metadata=matrix_run_metadata,
-                retry_team_mode=team_mode,
             )
             try:
                 if action.kind == "team":
@@ -1848,8 +1805,7 @@ class TurnController:
                                 target=dispatch.target,
                                 source_event_ids=handled_turn.indexed_event_ids,
                             ),
-                            on_sync_restart_cancelled=register_sync_restart_retry,
-                            sync_restart_retry_source_event_id=sync_restart_retry_source_event_id,
+                            on_sync_restart_cancelled=record_interrupted_turn,
                             on_deferred_outcome_handled=record_deferred_outcome,
                         ),
                         team_agents=action.form_team.eligible_members,
@@ -1876,8 +1832,7 @@ class TurnController:
                                 target=dispatch.target,
                                 source_event_ids=handled_turn.indexed_event_ids,
                             ),
-                            on_sync_restart_cancelled=register_sync_restart_retry,
-                            sync_restart_retry_source_event_id=sync_restart_retry_source_event_id,
+                            on_sync_restart_cancelled=record_interrupted_turn,
                             on_deferred_outcome_handled=record_deferred_outcome,
                         ),
                     )

--- a/tests/test_edit_regenerator.py
+++ b/tests/test_edit_regenerator.py
@@ -23,7 +23,7 @@ from mindroom.hooks.ingress import HookIngressPolicy
 from mindroom.matrix.event_info import EventInfo
 from mindroom.message_target import MessageTarget
 from mindroom.response_runner import ResponseRequest
-from mindroom.sync_restart_retry import SyncRestartRetryQueue
+from mindroom.sync_restart_retry import InterruptedTurnRooms
 from mindroom.timestamp_formatting import format_timestamp_ms
 from mindroom.turn_policy import IngressHookRunner
 from mindroom.turn_store import TurnStore, TurnStoreDeps
@@ -65,7 +65,7 @@ class _Harness:
     ingress_hook_runner: MagicMock
     generate_response: AsyncMock
     wait_for_turn_settled: AsyncMock
-    restart_retry: SyncRestartRetryQueue
+    interrupted_turn_rooms: InterruptedTurnRooms
     config: Config
     runtime_paths: RuntimePaths
     room: nio.MatrixRoom
@@ -204,7 +204,7 @@ def _harness(tmp_path: Path, *, turn_record: TurnRecord | None) -> _Harness:
             return await generate_response(request)
 
     wait_for_turn_settled = AsyncMock()
-    restart_retry = SyncRestartRetryQueue()
+    interrupted_turn_rooms = InterruptedTurnRooms()
     regenerator = EditRegenerator(
         EditRegeneratorDeps(
             runtime=_RuntimeStub(client=AsyncMock(spec=nio.AsyncClient), config=config),
@@ -215,7 +215,7 @@ def _harness(tmp_path: Path, *, turn_record: TurnRecord | None) -> _Harness:
             ingress_hook_runner=ingress_hook_runner,
             generate_response=run_locked_response,
             wait_for_turn_settled=wait_for_turn_settled,
-            restart_retry=restart_retry,
+            interrupted_turn_rooms=interrupted_turn_rooms,
             timestamp_formatter=lambda timestamp_ms: format_timestamp_ms(timestamp_ms, timezone=config.timezone),
         ),
     )
@@ -226,7 +226,7 @@ def _harness(tmp_path: Path, *, turn_record: TurnRecord | None) -> _Harness:
         ingress_hook_runner=ingress_hook_runner,
         generate_response=generate_response,
         wait_for_turn_settled=wait_for_turn_settled,
-        restart_retry=restart_retry,
+        interrupted_turn_rooms=interrupted_turn_rooms,
         config=config,
         runtime_paths=runtime_paths,
         room=nio.MatrixRoom(room_id=ROOM_ID, own_user_id=f"@{AGENT_NAME}:example.org"),
@@ -1456,47 +1456,33 @@ async def test_generate_response_failure_propagates_without_recording(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_sync_restart_cancellation_retries_without_committing_interrupted_edit(tmp_path: Path) -> None:
-    """A sync-restart interruption retains its run until retry lock acquisition."""
+async def test_sync_restart_cancellation_leaves_interrupted_edit_uncommitted(tmp_path: Path) -> None:
+    """A replacement interruption must leave its revision for room-scoped recovery."""
     record = _turn_record()
     harness = _harness(tmp_path, turn_record=record)
     attempts = 0
 
-    async def interrupt_then_succeed(request: ResponseRequest) -> str:
+    async def interrupt(request: ResponseRequest) -> str:
         nonlocal attempts
         attempts += 1
         assert request.on_lifecycle_lock_acquired is not None
         request.on_lifecycle_lock_acquired()
-        if attempts == 1:
-            assert request.on_sync_restart_cancelled is not None
-            assert request.on_deferred_outcome_handled is not None
-            request.on_sync_restart_cancelled()
-            request.on_deferred_outcome_handled("$interrupted:example.org")
-            raise asyncio.CancelledError
-        return NEW_RESPONSE_EVENT_ID
+        assert request.on_sync_restart_cancelled is not None
+        assert request.on_deferred_outcome_handled is not None
+        request.on_sync_restart_cancelled()
+        request.on_deferred_outcome_handled("$interrupted:example.org")
+        raise asyncio.CancelledError
 
-    harness.generate_response.side_effect = interrupt_then_succeed
+    harness.generate_response.side_effect = interrupt
     event, event_info = _edit_event(new_body="latest after restart")
 
     with pytest.raises(asyncio.CancelledError):
         await _handle_edit(harness, event, event_info)
 
-    assert harness.restart_retry.has_pending is True
+    assert attempts == 1
+    assert harness.interrupted_turn_rooms.pending_room_ids == {ROOM_ID}
     harness.turn_store.record_turn.assert_not_called()
-    assert harness.turn_store.remove_stale_runs_for_edit.call_count == 1
     assert harness.regenerator._mailboxes == {}
-
-    await harness.restart_retry.flush()
-
-    assert harness.restart_retry.has_pending is False
-    assert attempts == 2
-    assert harness.generate_response.await_args.args[0].prompt == "latest after restart"
-    recorded = harness.turn_store.record_turn.call_args.args[0]
-    assert recorded.response_event_id == NEW_RESPONSE_EVENT_ID
-    assert recorded.source_event_revisions == {
-        ORIGINAL_EVENT_ID: (event.server_timestamp, event.event_id),
-    }
-    assert harness.turn_store.remove_stale_runs_for_edit.call_count == 2
     expected_record = replace(
         record,
         source_event_prompts={ORIGINAL_EVENT_ID: "latest after restart"},
@@ -1504,9 +1490,9 @@ async def test_sync_restart_cancellation_retries_without_committing_interrupted_
             ORIGINAL_EVENT_ID: (event.server_timestamp, event.event_id),
         },
     )
-    assert all(
-        removal.kwargs == {"turn_record": expected_record, "requester_user_id": USER_ID}
-        for removal in harness.turn_store.remove_stale_runs_for_edit.call_args_list
+    harness.turn_store.remove_stale_runs_for_edit.assert_called_once_with(
+        turn_record=expected_record,
+        requester_user_id=USER_ID,
     )
 
 
@@ -1534,76 +1520,32 @@ async def test_restart_replays_durably_committed_interrupted_edit(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_swallowed_sync_restart_keeps_mailbox_snapshot_for_retry(tmp_path: Path) -> None:
+async def test_swallowed_sync_restart_leaves_edit_uncommitted(tmp_path: Path) -> None:
     """A runner-returned interruption marker must not consume the queued edit."""
     harness = _harness(tmp_path, turn_record=_turn_record())
     attempts = 0
 
-    async def interrupt_then_succeed(request: ResponseRequest) -> str:
+    async def interrupt(request: ResponseRequest) -> str:
         nonlocal attempts
         attempts += 1
-        if attempts == 1:
-            assert request.on_sync_restart_cancelled is not None
-            request.on_sync_restart_cancelled()
-            return "$interrupted:example.org"
-        return NEW_RESPONSE_EVENT_ID
+        assert request.on_sync_restart_cancelled is not None
+        request.on_sync_restart_cancelled()
+        return "$interrupted:example.org"
 
-    harness.generate_response.side_effect = interrupt_then_succeed
+    harness.generate_response.side_effect = interrupt
     event, event_info = _edit_event(new_body="latest after restart")
 
     await _handle_edit(harness, event, event_info)
 
     assert attempts == 1
-    assert harness.restart_retry.has_pending is True
+    assert harness.interrupted_turn_rooms.pending_room_ids == {ROOM_ID}
     harness.turn_store.record_turn.assert_not_called()
-    assert harness.regenerator._mailboxes == {}
-
-    await harness.restart_retry.flush()
-
-    assert attempts == 2
-    recorded = harness.turn_store.record_turn.call_args.args[0]
-    assert recorded.response_event_id == NEW_RESPONSE_EVENT_ID
-    assert recorded.source_event_revisions == {
-        ORIGINAL_EVENT_ID: (event.server_timestamp, event.event_id),
-    }
-
-
-@pytest.mark.asyncio
-async def test_second_sync_restart_durably_settles_one_shot_retry(tmp_path: Path) -> None:
-    """A retry interrupted again must commit its terminal snapshot instead of losing the edit."""
-    harness = _harness(tmp_path, turn_record=_turn_record())
-    attempts = 0
-
-    async def interrupt_twice(request: ResponseRequest) -> str:
-        nonlocal attempts
-        attempts += 1
-        assert request.on_sync_restart_cancelled is not None
-        request.on_sync_restart_cancelled()
-        return f"$interrupted-{attempts}:example.org"
-
-    harness.generate_response.side_effect = interrupt_twice
-    event, event_info = _edit_event(new_body="survive second restart")
-
-    await _handle_edit(harness, event, event_info)
-    assert harness.restart_retry.has_pending is True
-    harness.turn_store.record_turn.assert_not_called()
-
-    await harness.restart_retry.flush()
-
-    assert attempts == 2
-    assert harness.restart_retry.has_pending is False
-    recorded = harness.turn_store.record_turn.call_args.args[0]
-    assert recorded.response_event_id == "$interrupted-2:example.org"
-    assert recorded.source_event_prompts == {ORIGINAL_EVENT_ID: "survive second restart"}
-    assert recorded.source_event_revisions == {
-        ORIGINAL_EVENT_ID: (event.server_timestamp, event.event_id),
-    }
     assert harness.regenerator._mailboxes == {}
 
 
 @pytest.mark.asyncio
-async def test_sync_restart_retries_waiting_coalesced_sibling(tmp_path: Path) -> None:
-    """Restart cancellation must requeue every source waiting in the mailbox."""
+async def test_sync_restart_leaves_every_waiting_coalesced_source_uncommitted(tmp_path: Path) -> None:
+    """Restart cancellation must leave every source in the mailbox for recovery."""
     first_event_id = "$m1:example.org"
     second_event_id = "$m2:example.org"
     harness = _harness(
@@ -1631,21 +1573,19 @@ async def test_sync_restart_retries_waiting_coalesced_sibling(tmp_path: Path) ->
             sibling_hook_finished.set()
         return False
 
-    async def interrupt_then_succeed(request: ResponseRequest) -> str:
+    async def interrupt(request: ResponseRequest) -> str:
         nonlocal attempts
         attempts += 1
-        if attempts == 1:
-            generation_started.set()
-            await cancel_generation.wait()
-            assert request.on_sync_restart_cancelled is not None
-            assert request.on_deferred_outcome_handled is not None
-            request.on_sync_restart_cancelled()
-            request.on_deferred_outcome_handled("$interrupted:example.org")
-            raise asyncio.CancelledError
-        return NEW_RESPONSE_EVENT_ID
+        generation_started.set()
+        await cancel_generation.wait()
+        assert request.on_sync_restart_cancelled is not None
+        assert request.on_deferred_outcome_handled is not None
+        request.on_sync_restart_cancelled()
+        request.on_deferred_outcome_handled("$interrupted:example.org")
+        raise asyncio.CancelledError
 
     harness.ingress_hook_runner.emit_message_received_hooks.side_effect = hook
-    harness.generate_response.side_effect = interrupt_then_succeed
+    harness.generate_response.side_effect = interrupt
     first, first_info = _edit_event(
         original_event_id=first_event_id,
         new_body="first edited",
@@ -1670,22 +1610,12 @@ async def test_sync_restart_retries_waiting_coalesced_sibling(tmp_path: Path) ->
     with pytest.raises(asyncio.CancelledError):
         await first_task
 
-    assert harness.restart_retry.has_pending is True
-    assert harness.regenerator._mailboxes == {}
-    await asyncio.wait_for(harness.restart_retry.flush(), timeout=2)
-
-    assert attempts == 2
+    assert attempts == 1
     assert hook_calls == 2
-    recorded = harness.turn_store.record_turn.call_args.args[0]
-    assert recorded.source_event_prompts == {
-        first_event_id: "first edited",
-        second_event_id: "second edited",
-    }
-    assert recorded.source_event_revisions == {
-        first_event_id: (1_000_010, "$edit-first:example.org"),
-        second_event_id: (1_000_020, "$edit-second:example.org"),
-    }
-    assert harness.restart_retry.has_pending is False
+    assert harness.interrupted_turn_rooms.pending_room_ids == {ROOM_ID}
+    # Neither the driving edit nor its waiting sibling may commit, so replacement
+    # recovery re-drives the whole coalesced turn.
+    harness.turn_store.record_turn.assert_not_called()
     assert harness.regenerator._mailboxes == {}
 
 

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiosqlite
 import nio
 import pytest
+from structlog.testing import capture_logs
 
 from mindroom.background_tasks import wait_for_background_tasks
 from mindroom.bot import AgentBot, _create_task_wrapper
@@ -29,7 +30,7 @@ from mindroom.matrix.sync_certification import SyncCheckpoint, SyncTrustState
 from mindroom.matrix.sync_tokens import clear_sync_token, load_sync_checkpoint, save_sync_token
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.response_admission import ResponseAdmissionGate
-from mindroom.runtime_shutdown import GENERIC_SHUTDOWN, SYNC_RESTART_SHUTDOWN
+from mindroom.runtime_shutdown import GENERIC_SHUTDOWN, ORDERLY_SHUTDOWN, SYNC_RESTART_SHUTDOWN, RuntimeShutdownIntent
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -984,6 +985,35 @@ async def test_prepare_for_sync_shutdown_flushes_latest_sync_token(tmp_path: Pat
     checkpoint = load_sync_checkpoint(tmp_path, bot.agent_name)
     assert checkpoint is not None
     assert checkpoint.token == "s_shutdown"  # noqa: S105
+
+
+@pytest.mark.parametrize(
+    ("shutdown_intent", "reason_category"),
+    [
+        (GENERIC_SHUTDOWN, "agent_shutdown"),
+        (SYNC_RESTART_SHUTDOWN, "config_reload"),
+        (ORDERLY_SHUTDOWN, "process_shutdown"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_response_runtime_shutdown_log_is_structured_and_identifier_free(
+    tmp_path: Path,
+    shutdown_intent: RuntimeShutdownIntent,
+    reason_category: str,
+) -> None:
+    """Full shutdown logs action and response count without Matrix identifiers."""
+    bot = _agent_bot(tmp_path)
+    bot._coalescing_gate.drain_all = AsyncMock(return_value=CoalescingDrainResult(completed=True))
+
+    with capture_logs() as logs:
+        await bot.prepare_for_sync_shutdown(shutdown_intent=shutdown_intent)
+
+    shutdown_logs = [entry for entry in logs if entry["event"] == "matrix_agent_response_runtime_shutdown"]
+    assert len(shutdown_logs) == 1
+    assert shutdown_logs[0]["active_response_count"] == 0
+    assert shutdown_logs[0]["restart_reason_category"] == reason_category
+    assert shutdown_logs[0]["resulting_action"] == "drain_then_cancel_response_runtime"
+    assert not {"agent", "agent_name", "room_id", "event_id", "user_id"} & shutdown_logs[0].keys()
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -30,7 +30,13 @@ from mindroom.matrix.sync_certification import SyncCheckpoint, SyncTrustState
 from mindroom.matrix.sync_tokens import clear_sync_token, load_sync_checkpoint, save_sync_token
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.response_admission import ResponseAdmissionGate
-from mindroom.runtime_shutdown import GENERIC_SHUTDOWN, ORDERLY_SHUTDOWN, SYNC_RESTART_SHUTDOWN, RuntimeShutdownIntent
+from mindroom.runtime_shutdown import (
+    ENTITY_REMOVED_SHUTDOWN,
+    GENERIC_SHUTDOWN,
+    ORDERLY_SHUTDOWN,
+    SYNC_RESTART_SHUTDOWN,
+    RuntimeShutdownIntent,
+)
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
@@ -991,6 +997,7 @@ async def test_prepare_for_sync_shutdown_flushes_latest_sync_token(tmp_path: Pat
     ("shutdown_intent", "reason_category"),
     [
         (GENERIC_SHUTDOWN, "agent_shutdown"),
+        (ENTITY_REMOVED_SHUTDOWN, "agent_shutdown"),
         (SYNC_RESTART_SHUTDOWN, "config_reload"),
         (ORDERLY_SHUTDOWN, "process_shutdown"),
     ],
@@ -1003,7 +1010,6 @@ async def test_response_runtime_shutdown_log_is_structured_and_identifier_free(
 ) -> None:
     """Full shutdown logs action and response count without Matrix identifiers."""
     bot = _agent_bot(tmp_path)
-    bot._coalescing_gate.drain_all = AsyncMock(return_value=CoalescingDrainResult(completed=True))
 
     with capture_logs() as logs:
         await bot.prepare_for_sync_shutdown(shutdown_intent=shutdown_intent)

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -1003,12 +1003,12 @@ async def test_prepare_for_sync_shutdown_flushes_latest_sync_token(tmp_path: Pat
     ],
 )
 @pytest.mark.asyncio
-async def test_response_runtime_shutdown_log_is_structured_and_identifier_free(
+async def test_response_runtime_shutdown_log_names_its_agent_and_reason(
     tmp_path: Path,
     shutdown_intent: RuntimeShutdownIntent,
     reason_category: str,
 ) -> None:
-    """Full shutdown logs action and response count without Matrix identifiers."""
+    """Full shutdown logs its agent, action, and response count, but no conversation."""
     bot = _agent_bot(tmp_path)
 
     with capture_logs() as logs:
@@ -1016,10 +1016,11 @@ async def test_response_runtime_shutdown_log_is_structured_and_identifier_free(
 
     shutdown_logs = [entry for entry in logs if entry["event"] == "matrix_agent_response_runtime_shutdown"]
     assert len(shutdown_logs) == 1
+    assert shutdown_logs[0]["agent"] == bot.agent_name
     assert shutdown_logs[0]["active_response_count"] == 0
     assert shutdown_logs[0]["restart_reason_category"] == reason_category
     assert shutdown_logs[0]["resulting_action"] == "drain_then_cancel_response_runtime"
-    assert not {"agent", "agent_name", "room_id", "event_id", "user_id"} & shutdown_logs[0].keys()
+    assert not {"room_id", "event_id", "user_id"} & shutdown_logs[0].keys()
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_restart_retry.py
+++ b/tests/test_sync_restart_retry.py
@@ -13,23 +13,17 @@ from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
-from structlog.testing import capture_logs
 
 from mindroom.constants import MATRIX_EVENT_ID_METADATA_KEY
 from mindroom.final_delivery import FinalDeliveryOutcome
 from mindroom.history.types import HistoryScope
-from mindroom.response_admission import ResponseAdmissionRefusedError
 from mindroom.response_runner import PostLockRequestPreparationError, ResponseRequest, ResponseRunner
-from mindroom.sync_restart_retry import (
-    _MAX_ATTEMPTED_KEYS,
-    SyncRestartRetryQueue,
-    interrupted_source_needs_retry,
-)
+from mindroom.sync_restart_retry import InterruptedTurnRooms, interrupted_source_needs_retry
 from tests.conftest import delivered_matrix_event, request_envelope, unwrap_extracted_collaborator
 from tests.response_runner_helpers import _bot, _plain_request, _target
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -305,258 +299,56 @@ def test_notify_uses_only_the_canonical_final_delivery_outcome() -> None:
     assert calls == []
 
 
-@pytest.mark.asyncio
-async def test_queue_runs_each_retry_exactly_once() -> None:
-    """Flushing must run queued retries once and refuse re-registration."""
-    queue = SyncRestartRetryQueue()
-    runs: list[str] = []
+def test_interrupted_turn_rooms_record_each_source_once() -> None:
+    """One interrupted source must claim exactly one room-scoped recovery slot."""
+    rooms = InterruptedTurnRooms()
 
-    async def retry() -> None:
-        runs.append("ran")
-
-    assert queue.register("$event", retry, room_id="!room:localhost") is True
-    assert queue.register("$event", retry, room_id="!room:localhost") is False
-    assert queue.has_pending
-    assert queue.pending_room_ids == {"!room:localhost"}
-
-    await queue.flush()
-    assert runs == ["ran"]
-    assert not queue.has_pending
-    assert not queue.pending_room_ids
-
-    # Already-attempted keys never requeue, so a second stall cannot loop.
-    assert queue.register("$event", retry, room_id="!room:localhost") is False
-    await queue.flush()
-    assert runs == ["ran"]
+    assert rooms.register("$event", room_id="!room:localhost") is True
+    assert rooms.register("$event", room_id="!other:localhost") is False
+    assert rooms.pending_room_ids == {"!room:localhost"}
 
 
-@pytest.mark.asyncio
-async def test_concurrent_flushes_share_one_serial_retry_pass() -> None:
-    """Overlapping healthy sync callbacks must not run the same retry twice."""
-    queue = SyncRestartRetryQueue()
-    started = asyncio.Event()
-    release = asyncio.Event()
-    runs = 0
+def test_interrupted_turn_rooms_collect_every_interrupted_room() -> None:
+    """The orchestrator hands the replacement bot every room holding a terminal note."""
+    rooms = InterruptedTurnRooms()
 
-    async def retry() -> None:
-        nonlocal runs
-        runs += 1
-        started.set()
-        await release.wait()
+    rooms.register("$first", room_id="!one:localhost")
+    rooms.register("$second", room_id="!two:localhost")
+    rooms.register("$third", room_id="!one:localhost")
 
-    assert queue.register("$event", retry, room_id="!room:localhost") is True
-    first = asyncio.create_task(queue.flush())
-    await started.wait()
-    second = asyncio.create_task(queue.flush())
-    await asyncio.sleep(0)
-    assert not second.done()
-
-    release.set()
-    await asyncio.gather(first, second)
-
-    assert runs == 1
-    assert not queue.has_pending
+    assert rooms.pending_room_ids == {"!one:localhost", "!two:localhost"}
 
 
-@pytest.mark.asyncio
-async def test_queue_isolates_individual_retry_failures() -> None:
-    """One failing retry must not block the others."""
-    queue = SyncRestartRetryQueue()
-    runs: list[str] = []
-
-    async def failing() -> None:
-        msg = "deliberate test error"
-        raise RuntimeError(msg)
-
-    async def succeeding() -> None:
-        runs.append("ok")
-
-    queue.register("$a", failing, room_id="!a:localhost")
-    queue.register("$b", succeeding, room_id="!b:localhost")
-    await queue.flush()
-    assert runs == ["ok"]
-
-
-@pytest.mark.asyncio
-async def test_queue_flushes_in_registration_order() -> None:
-    """Retries must run FIFO so older interrupted turns answer first."""
-    queue = SyncRestartRetryQueue()
-    runs: list[str] = []
-
-    def make_retry(key: str) -> Callable[[], Awaitable[None]]:
-        async def retry() -> None:
-            runs.append(key)
-
-        return retry
-
-    for key in ("$first", "$second", "$third"):
-        queue.register(key, make_retry(key), room_id="!room:localhost")
-
-    await queue.flush()
-    assert runs == ["$first", "$second", "$third"]
-
-
-@pytest.mark.asyncio
-async def test_cancelled_flush_logs_in_flight_key_and_keeps_rest_pending() -> None:
-    """Cancelling a flush mid-retry must log the lost key, propagate, and keep later retries queued."""
-    queue = SyncRestartRetryQueue()
-    started = asyncio.Event()
-
-    async def hanging() -> None:
-        started.set()
-        await asyncio.Event().wait()
-
-    async def later() -> None:
-        pass
-
-    queue.register("$in_flight", hanging, room_id="!in-flight:localhost")
-    queue.register("$later", later, room_id="!later:localhost")
-    flush_task = asyncio.create_task(queue.flush())
-    await started.wait()
-
-    flush_task.cancel()
-    with capture_logs() as logs, pytest.raises(asyncio.CancelledError):
-        await flush_task
-
-    assert [entry["source_event_id"] for entry in logs if entry["event"] == "sync_restart_retry_cancelled"] == [
-        "$in_flight",
-    ]
-    # The interrupted key was already promoted to attempted and never requeues.
-    assert queue.register("$in_flight", hanging, room_id="!in-flight:localhost") is False
-    # The untouched retry survives for the next healthy sync response.
-    assert queue.has_pending
-
-
-@pytest.mark.asyncio
-async def test_config_apply_refusal_requeues_retry_and_keeps_rest_pending() -> None:
-    """A refused retry ran nothing, so it must stay queued instead of burning its one attempt."""
-    queue = SyncRestartRetryQueue()
-    runs: list[str] = []
-
-    gate_closed = True
-
-    async def refused() -> None:
-        runs.append("$refused")
-        if gate_closed:
-            raise ResponseAdmissionRefusedError
-
-    async def later() -> None:
-        runs.append("$later")
-
-    queue.register("$refused", refused, room_id="!room:localhost")
-    queue.register("$later", later, room_id="!later:localhost")
-
-    with capture_logs() as logs:
-        await queue.flush()
-
-    # The pass stops: the gate stays closed for the whole apply, so continuing
-    # would only burn every remaining retry against the same closed gate.
-    assert runs == ["$refused"]
-    assert [
-        entry["source_event_id"] for entry in logs if entry["event"] == "sync_restart_retry_deferred_by_config_apply"
-    ] == [
-        "$refused",
-    ]
-    # Nothing was attempted, so both keys survive for the next flush.
-    assert queue.has_pending
-    assert queue.pending_room_ids == frozenset({"!room:localhost", "!later:localhost"})
-    # Re-registering is still refused because the key is queued, not because it
-    # was burned; the queued callback is the one that runs.
-    assert queue.register("$refused", refused, room_id="!room:localhost") is False
-
-    # Once the apply finishes the gate reopens, so the next flush drains both in
-    # the original FIFO order.
-    gate_closed = False
-    runs.clear()
-    await queue.flush()
-    assert runs == ["$refused", "$later"]
-    assert not queue.has_pending
-
-
-@pytest.mark.asyncio
-async def test_config_apply_refusal_at_attempted_bound_keeps_every_key_burned() -> None:
-    """A refusal must not evict an older attempted key and let it run a second time.
-
-    _mark_attempted evicts the oldest key once it reaches its bound, and that
-    eviction cannot be undone. Promoting a key only after its retry actually ran
-    is what keeps the "retried at most once" contract at the bound.
-    """
-    queue = SyncRestartRetryQueue()
-
-    async def noop() -> None:
-        return
-
-    # Fill the attempted ledger exactly to its bound by running real retries.
-    for index in range(_MAX_ATTEMPTED_KEYS):
-        key = f"$attempted-{index}"
-        assert queue.register(key, noop, room_id="!room:localhost") is True
-    await queue.flush()
-
-    oldest_key = "$attempted-0"
-    assert queue.register(oldest_key, noop, room_id="!room:localhost") is False
-
-    async def refused() -> None:
-        raise ResponseAdmissionRefusedError
-
-    queue.register("$refused", refused, room_id="!room:localhost")
-    await queue.flush()
-
-    # The refusal promoted nothing, so no older key was evicted to make room and
-    # the oldest attempted key is still burned.
-    assert queue.register(oldest_key, noop, room_id="!room:localhost") is False
-    assert queue.has_pending
-
-
-@pytest.mark.asyncio
-async def test_watchdog_cancelled_response_is_redispatched_once_and_answers() -> None:
-    """The dispatch/retry seam answers on the retry and never retries twice."""
-    queue = SyncRestartRetryQueue()
-    runner = ResponseRunner(deps=MagicMock())
-    answers: list[str] = []
-    attempts = 0
-
-    async def execute_action() -> None:
-        nonlocal attempts
-        attempts += 1
-
-        def register_retry() -> None:
-            queue.register("$source", execute_action, room_id="!room:localhost")
-
-        if attempts == 1:
-            # First attempt: cancelled mid-generation by stall recovery.
-            _notify(
-                runner,
-                _request(on_sync_restart_cancelled=register_retry),
-                _cancelled_outcome(failure_reason="sync_restart_cancelled"),
-            )
-        else:
-            answers.append("pong")
-
-    await execute_action()
-    assert queue.has_pending
-    assert answers == []
-
-    await queue.flush()  # The sync loop reported a healthy response again.
-    assert answers == ["pong"]
-    assert attempts == 2
-
-    await queue.flush()
-    assert attempts == 2
-
-
-@pytest.mark.asyncio
-async def test_user_stopped_response_is_not_retried() -> None:
-    """A user stop must leave the retry queue empty."""
-    queue = SyncRestartRetryQueue()
+def test_bot_replacement_cancellation_records_the_interrupted_room() -> None:
+    """The dispatch seam hands a replacement-cancelled turn to room-scoped recovery."""
+    rooms = InterruptedTurnRooms()
     runner = ResponseRunner(deps=MagicMock())
 
-    def register_retry() -> None:
-        queue.register("$source", MagicMock(), room_id="!room:localhost")
+    def record_interrupted_turn() -> None:
+        rooms.register("$source", room_id="!room:localhost")
 
     _notify(
         runner,
-        _request(on_sync_restart_cancelled=register_retry),
+        _request(on_sync_restart_cancelled=record_interrupted_turn),
+        _cancelled_outcome(failure_reason="sync_restart_cancelled"),
+    )
+
+    assert rooms.pending_room_ids == {"!room:localhost"}
+
+
+@pytest.mark.asyncio
+async def test_user_stopped_response_is_not_recovered() -> None:
+    """A user stop must leave no room queued for replacement recovery."""
+    rooms = InterruptedTurnRooms()
+    runner = ResponseRunner(deps=MagicMock())
+
+    def record_interrupted_turn() -> None:
+        rooms.register("$source", room_id="!room:localhost")
+
+    _notify(
+        runner,
+        _request(on_sync_restart_cancelled=record_interrupted_turn),
         _cancelled_outcome(failure_reason="cancelled_by_user"),
     )
 
-    assert not queue.has_pending
+    assert not rooms.pending_room_ids

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -2454,5 +2454,11 @@ async def test_single_failure_no_duplicate_cleanup_logs(
     with capture_logs() as logs:
         await sync_forever_with_restart(bot, max_retries=1)
 
-    cleanup_warnings = [entry for entry in logs if entry["event"] == "Suppressed error during sync iteration cleanup"]
-    assert len(cleanup_warnings) == 1, f"Expected exactly 1 cleanup warning, got {len(cleanup_warnings)}"
+    cleanup_warnings = [entry for entry in logs if entry["event"] == "sync_iteration_cleanup_failed"]
+    assert cleanup_warnings == [
+        {
+            "event": "sync_iteration_cleanup_failed",
+            "exception_type": "RuntimeError",
+            "log_level": "warning",
+        },
+    ]

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -50,7 +50,6 @@ from mindroom.runtime_shutdown import (
     RuntimeShutdownIntent,
     shutdown_intent_for_entity,
 )
-from mindroom.sync_restart_retry import SyncRestartRetryQueue
 from tests.conftest import (
     TEST_PASSWORD,
     make_event_cache_mock,
@@ -138,9 +137,6 @@ class _ResponseOwningBot(_FakeBot):
         self.response_tasks: list[asyncio.Task[None]] = []
         self.response_cancel_sources: list[str] = []
         self.response_completions = 0
-        self.final_messages = 0
-        self.interruption_messages = 0
-        self.retries_queued = 0
 
     @property
     def in_flight_response_count(self) -> int:
@@ -157,14 +153,9 @@ class _ResponseOwningBot(_FakeBot):
         try:
             await self.response_finish.wait()
         except asyncio.CancelledError as exc:
-            cancel_source = classify_cancel_source(exc)
-            self.response_cancel_sources.append(cancel_source)
-            if cancel_source == "sync_restart":
-                self.interruption_messages += 1
-                self.retries_queued += 1
+            self.response_cancel_sources.append(classify_cancel_source(exc))
             raise
         self.response_completions += 1
-        self.final_messages += 1
 
     async def sync_forever(self) -> None:
         self.sync_calls += 1
@@ -349,21 +340,20 @@ async def test_watchdog_restart_preserves_one_active_response(monkeypatch: pytes
         assert bot.live_sync_count == 1
         assert bot.in_flight_response_count == 1
         assert not bot.response_tasks[0].done()
-        assert bot.interruption_messages == 0
-        assert bot.retries_queued == 0
+        assert bot.response_cancel_sources == []
 
         await _finish_responses_and_stop_transport(bot, final_sync_iteration=2, supervisor=supervisor)
 
     assert bot.response_completions == 1
-    assert bot.final_messages == 1
-    assert bot.interruption_messages == 0
-    assert bot.retries_queued == 0
+    assert bot.response_cancel_sources == []
     restart_logs = [entry for entry in logs if entry["event"] == "matrix_sync_transport_restart"]
     assert len(restart_logs) == 1
     assert restart_logs[0]["active_response_count"] == 1
     assert restart_logs[0]["restart_reason_category"] == "watchdog_stall"
     assert restart_logs[0]["resulting_action"] == "restart_receive_loop"
-    assert not {"agent", "agent_name", "room_id", "event_id", "user_id"} & restart_logs[0].keys()
+    # Attribute the flapping entity without naming any Matrix conversation.
+    assert restart_logs[0]["agent"] == "test_agent"
+    assert not {"room_id", "event_id", "user_id"} & restart_logs[0].keys()
 
 
 @pytest.mark.asyncio
@@ -379,15 +369,12 @@ async def test_watchdog_restart_preserves_several_active_responses(monkeypatch: 
 
     assert bot.in_flight_response_count == 3
     assert all(not task.done() for task in bot.response_tasks)
-    assert bot.interruption_messages == 0
-    assert bot.retries_queued == 0
+    assert bot.response_cancel_sources == []
 
     await _finish_responses_and_stop_transport(bot, final_sync_iteration=2, supervisor=supervisor)
 
     assert bot.response_completions == 3
-    assert bot.final_messages == 3
-    assert bot.interruption_messages == 0
-    assert bot.retries_queued == 0
+    assert bot.response_cancel_sources == []
 
 
 @pytest.mark.asyncio
@@ -406,16 +393,13 @@ async def test_repeated_watchdog_restarts_keep_one_sync_loop_and_response_owner(
     assert bot.live_sync_count == 1
     assert bot.max_live_sync_count == 1
     assert bot.in_flight_response_count == 2
-    assert bot.interruption_messages == 0
-    assert bot.retries_queued == 0
+    assert bot.response_cancel_sources == []
 
     await _finish_responses_and_stop_transport(bot, final_sync_iteration=4, supervisor=supervisor)
 
     assert bot.live_sync_count == 0
     assert bot.response_completions == 2
-    assert bot.final_messages == 2
-    assert bot.interruption_messages == 0
-    assert bot.retries_queued == 0
+    assert bot.response_cancel_sources == []
 
 
 @pytest.mark.asyncio
@@ -435,8 +419,6 @@ async def test_config_reload_cancellation_keeps_interruption_and_retry_semantics
 
     assert bot.in_flight_response_count == 0
     assert bot.response_completions == 0
-    assert bot.interruption_messages == 1
-    assert bot.retries_queued == 1
     assert bot.response_cancel_sources == ["sync_restart"]
     assert bot.prepare_for_sync_shutdown_cancel_messages == ["sync_restart"]
 
@@ -458,8 +440,6 @@ async def test_process_shutdown_cancellation_stays_prompt_without_sync_retry() -
 
     assert bot.in_flight_response_count == 0
     assert bot.response_completions == 0
-    assert bot.interruption_messages == 0
-    assert bot.retries_queued == 0
     assert bot.response_cancel_sources == ["interrupted"]
     assert bot.prepare_for_sync_shutdown_cancel_messages == [None]
 
@@ -534,26 +514,23 @@ async def test_replacement_start_failure_is_visible_bounded_and_preserves_respon
     assert bot.prepare_for_sync_shutdown_calls == 0
     assert bot.in_flight_response_count == 1
     assert not bot.response_tasks[0].done()
-    assert bot.interruption_messages == 0
-    assert bot.retries_queued == 0
-    logger.error.assert_any_call(
+    assert bot.response_cancel_sources == []
+    logger.exception.assert_any_call(
         "sync_loop_failed",
-        exception_type="RuntimeError",
+        agent="test_agent",
         retry_count=2,
     )
     logger.error.assert_any_call(
         "sync_loop_retries_exhausted",
-        active_response_count=1,
+        agent="test_agent",
         retry_count=2,
         max_retries=2,
         restart_reason_category="sync_failure",
-        resulting_action="preserve_response_runtime",
     )
 
     bot.response_finish.set()
     await asyncio.gather(*bot.response_tasks)
     assert bot.response_completions == 1
-    assert bot.final_messages == 1
 
 
 @pytest.mark.asyncio
@@ -1146,7 +1123,6 @@ async def test_full_state_only_after_successful_first_sync() -> None:
     bot._room_member_join_hooks_armed = False
     bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
     bot.rooms = []
-    bot._restart_retry_queue = SyncRestartRetryQueue()
     bot.client = FakeClient()
     bot.orchestrator = None
     bot._runtime_view = BotRuntimeState(
@@ -1286,7 +1262,6 @@ async def test_sliding_sync_response_marks_sync_success() -> None:
     bot._sync_shutting_down = False
     bot._calls_reconcile_pending = False
     bot._room_member_join_hooks_armed = False
-    bot._restart_retry_queue = SyncRestartRetryQueue()
     bot.orchestrator = None
 
     await AgentBot._on_sync_response(bot, nio.SlidingSyncResponse("pos"))
@@ -1356,7 +1331,6 @@ async def test_sliding_sync_remote_departure_fences_and_purges() -> None:
     bot._sync_shutting_down = False
     bot._calls_reconcile_pending = False
     bot._room_member_join_hooks_armed = True
-    bot._restart_retry_queue = SyncRestartRetryQueue()
     bot.orchestrator = None
     bot._local_departures_awaiting_sync = set()
     bot._sync_cache_trust = MagicMock()
@@ -2374,11 +2348,10 @@ async def test_running_bot_logs_when_sync_retries_exhausted(monkeypatch: pytest.
     assert bot.prepare_for_sync_shutdown_calls == 0
     logger.error.assert_called_once_with(
         "sync_loop_retries_exhausted",
-        active_response_count=0,
+        agent="test_agent",
         retry_count=2,
         max_retries=2,
         restart_reason_category="unexpected_sync_return",
-        resulting_action="preserve_response_runtime",
     )
 
 
@@ -2455,10 +2428,6 @@ async def test_single_failure_no_duplicate_cleanup_logs(
         await sync_forever_with_restart(bot, max_retries=1)
 
     cleanup_warnings = [entry for entry in logs if entry["event"] == "sync_iteration_cleanup_failed"]
-    assert cleanup_warnings == [
-        {
-            "event": "sync_iteration_cleanup_failed",
-            "exception_type": "RuntimeError",
-            "log_level": "warning",
-        },
-    ]
+    assert len(cleanup_warnings) == 1
+    assert cleanup_warnings[0]["agent"] == "test_agent"
+    assert cleanup_warnings[0]["exc_info"] is True

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -100,6 +100,11 @@ class _FakeBot:
             return None
         return time.monotonic() - self._last_sync_monotonic
 
+    @property
+    def in_flight_response_count(self) -> int:
+        """Return the fake bot's active response count."""
+        return 0
+
     async def sync_forever(self) -> None:
         self.sync_calls += 1
         try:
@@ -118,6 +123,118 @@ class _FakeBot:
         self._sync_shutting_down = True
         self.prepare_for_sync_shutdown_calls += 1
         self.prepare_for_sync_shutdown_cancel_messages.append(shutdown_intent.cancel_source)
+
+
+class _ResponseOwningBot(_FakeBot):
+    """Fake sync transport plus independently owned response tasks."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.live_sync_count = 0
+        self.max_live_sync_count = 0
+        self.sync_starts: asyncio.Queue[int] = asyncio.Queue()
+        self.sync_releases: dict[int, asyncio.Event] = {}
+        self.response_finish = asyncio.Event()
+        self.response_tasks: list[asyncio.Task[None]] = []
+        self.response_cancel_sources: list[str] = []
+        self.response_completions = 0
+        self.final_messages = 0
+        self.interruption_messages = 0
+        self.retries_queued = 0
+
+    @property
+    def in_flight_response_count(self) -> int:
+        """Return response tasks whose single owner has not settled them."""
+        return sum(not task.done() for task in self.response_tasks)
+
+    def start_responses(self, count: int) -> None:
+        """Start deterministic responses blocked on one shared completion event."""
+        self.response_tasks.extend(
+            asyncio.create_task(self._run_response(), name=f"owned_response_{index}") for index in range(count)
+        )
+
+    async def _run_response(self) -> None:
+        try:
+            await self.response_finish.wait()
+        except asyncio.CancelledError as exc:
+            cancel_source = classify_cancel_source(exc)
+            self.response_cancel_sources.append(cancel_source)
+            if cancel_source == "sync_restart":
+                self.interruption_messages += 1
+                self.retries_queued += 1
+            raise
+        self.response_completions += 1
+        self.final_messages += 1
+
+    async def sync_forever(self) -> None:
+        self.sync_calls += 1
+        iteration = self.sync_calls
+        release = self.sync_releases.setdefault(iteration, asyncio.Event())
+        self.live_sync_count += 1
+        self.max_live_sync_count = max(self.max_live_sync_count, self.live_sync_count)
+        await self.sync_starts.put(iteration)
+        try:
+            await release.wait()
+        finally:
+            self.live_sync_count -= 1
+
+    async def prepare_for_sync_shutdown(
+        self,
+        *,
+        shutdown_intent: RuntimeShutdownIntent = GENERIC_SHUTDOWN,
+    ) -> None:
+        await super().prepare_for_sync_shutdown(shutdown_intent=shutdown_intent)
+        cancel_message = cancel_message_for_source(shutdown_intent.cancel_source)
+        active_responses = [task for task in self.response_tasks if not task.done()]
+        for task in active_responses:
+            if cancel_message is None:
+                task.cancel()
+            else:
+                task.cancel(msg=cancel_message)
+        await asyncio.gather(*active_responses, return_exceptions=True)
+
+
+def _install_deterministic_stalls(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    stall_count: int,
+) -> None:
+    """Replace watchdog timing with a fixed number of immediate stalls."""
+    remaining_stalls = stall_count
+
+    async def watch(
+        _bot: _FakeBot,
+        sync_task: asyncio.Task[object],
+        watchdog_cancelled_sync: asyncio.Event,
+    ) -> None:
+        nonlocal remaining_stalls
+        if remaining_stalls == 0:
+            await sync_task
+            return
+        remaining_stalls -= 1
+        watchdog_cancelled_sync.set()
+        sync_task.cancel(msg=SYNC_RESTART_CANCEL_MSG)
+        await asyncio.gather(sync_task, return_exceptions=True)
+        msg = "Matrix sync loop stalled"
+        raise _MatrixSyncStalledError(msg)
+
+    monkeypatch.setattr(_SyncIteration, "_watch", staticmethod(watch))
+    monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(runtime_helpers, "_stalled_restart_jitter_seconds", lambda: 0.0)
+
+
+async def _finish_responses_and_stop_transport(
+    bot: _ResponseOwningBot,
+    *,
+    final_sync_iteration: int,
+    supervisor: asyncio.Task[None],
+) -> None:
+    """Complete responses once, then stop the final receive loop cleanly."""
+    bot.response_finish.set()
+    await asyncio.gather(*bot.response_tasks)
+    bot.running = False
+    bot.sync_releases[final_sync_iteration].set()
+    await supervisor
 
 
 @pytest.mark.asyncio
@@ -213,8 +330,230 @@ async def test_sync_forever_with_restart_restarts_stalled_sync(monkeypatch: pyte
     assert bot.first_call_cancelled is True
     assert bot.first_call_cancel_args == (SYNC_RESTART_CANCEL_MSG,)
     assert bot.sync_calls == 1  # sync_forever called once, then sync_then_stop stopped
-    assert bot.prepare_for_sync_shutdown_calls == 2
-    assert bot.prepare_for_sync_shutdown_cancel_messages == [SYNC_RESTART_CANCEL_MSG, None]
+    assert bot.prepare_for_sync_shutdown_calls == 1
+    assert bot.prepare_for_sync_shutdown_cancel_messages == [None]
+
+
+@pytest.mark.asyncio
+async def test_watchdog_restart_preserves_one_active_response(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One stalled receive loop must not cancel, retry, or duplicate an active response."""
+    bot = _ResponseOwningBot()
+    bot.start_responses(1)
+    _install_deterministic_stalls(monkeypatch, stall_count=1)
+
+    with capture_logs() as logs:
+        supervisor = asyncio.create_task(sync_forever_with_restart(bot, max_retries=3))
+        assert await bot.sync_starts.get() == 1
+        assert await bot.sync_starts.get() == 2
+
+        assert bot.live_sync_count == 1
+        assert bot.in_flight_response_count == 1
+        assert not bot.response_tasks[0].done()
+        assert bot.interruption_messages == 0
+        assert bot.retries_queued == 0
+
+        await _finish_responses_and_stop_transport(bot, final_sync_iteration=2, supervisor=supervisor)
+
+    assert bot.response_completions == 1
+    assert bot.final_messages == 1
+    assert bot.interruption_messages == 0
+    assert bot.retries_queued == 0
+    restart_logs = [entry for entry in logs if entry["event"] == "matrix_sync_transport_restart"]
+    assert len(restart_logs) == 1
+    assert restart_logs[0]["active_response_count"] == 1
+    assert restart_logs[0]["restart_reason_category"] == "watchdog_stall"
+    assert restart_logs[0]["resulting_action"] == "restart_receive_loop"
+    assert not {"agent", "agent_name", "room_id", "event_id", "user_id"} & restart_logs[0].keys()
+
+
+@pytest.mark.asyncio
+async def test_watchdog_restart_preserves_several_active_responses(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One receive-loop restart must leave every active response with its original owner."""
+    bot = _ResponseOwningBot()
+    bot.start_responses(3)
+    _install_deterministic_stalls(monkeypatch, stall_count=1)
+
+    supervisor = asyncio.create_task(sync_forever_with_restart(bot, max_retries=3))
+    assert await bot.sync_starts.get() == 1
+    assert await bot.sync_starts.get() == 2
+
+    assert bot.in_flight_response_count == 3
+    assert all(not task.done() for task in bot.response_tasks)
+    assert bot.interruption_messages == 0
+    assert bot.retries_queued == 0
+
+    await _finish_responses_and_stop_transport(bot, final_sync_iteration=2, supervisor=supervisor)
+
+    assert bot.response_completions == 3
+    assert bot.final_messages == 3
+    assert bot.interruption_messages == 0
+    assert bot.retries_queued == 0
+
+
+@pytest.mark.asyncio
+async def test_repeated_watchdog_restarts_keep_one_sync_loop_and_response_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated stalls must replace receive loops serially without touching responses."""
+    bot = _ResponseOwningBot()
+    bot.start_responses(2)
+    _install_deterministic_stalls(monkeypatch, stall_count=3)
+
+    supervisor = asyncio.create_task(sync_forever_with_restart(bot, max_retries=5))
+    assert [await bot.sync_starts.get() for _ in range(4)] == [1, 2, 3, 4]
+
+    assert bot.sync_calls == 4
+    assert bot.live_sync_count == 1
+    assert bot.max_live_sync_count == 1
+    assert bot.in_flight_response_count == 2
+    assert bot.interruption_messages == 0
+    assert bot.retries_queued == 0
+
+    await _finish_responses_and_stop_transport(bot, final_sync_iteration=4, supervisor=supervisor)
+
+    assert bot.live_sync_count == 0
+    assert bot.response_completions == 2
+    assert bot.final_messages == 2
+    assert bot.interruption_messages == 0
+    assert bot.retries_queued == 0
+
+
+@pytest.mark.asyncio
+async def test_config_reload_cancellation_keeps_interruption_and_retry_semantics() -> None:
+    """Full bot replacement must still cancel and queue recovery for active responses."""
+    bot = _ResponseOwningBot()
+    bot.start_responses(1)
+
+    supervisor = asyncio.create_task(sync_forever_with_restart(bot))
+    assert await bot.sync_starts.get() == 1
+    supervisor.cancel(msg=SYNC_RESTART_CANCEL_MSG)
+    await supervisor
+    assert bot.live_sync_count == 0
+    assert bot.in_flight_response_count == 1
+
+    await bot.prepare_for_sync_shutdown(shutdown_intent=SYNC_RESTART_SHUTDOWN)
+
+    assert bot.in_flight_response_count == 0
+    assert bot.response_completions == 0
+    assert bot.interruption_messages == 1
+    assert bot.retries_queued == 1
+    assert bot.response_cancel_sources == ["sync_restart"]
+    assert bot.prepare_for_sync_shutdown_cancel_messages == ["sync_restart"]
+
+
+@pytest.mark.asyncio
+async def test_process_shutdown_cancellation_stays_prompt_without_sync_retry() -> None:
+    """Process shutdown must still cancel active work without mislabeling it as transport recovery."""
+    bot = _ResponseOwningBot()
+    bot.start_responses(1)
+
+    supervisor = asyncio.create_task(sync_forever_with_restart(bot))
+    assert await bot.sync_starts.get() == 1
+    supervisor.cancel()
+    await supervisor
+    assert bot.live_sync_count == 0
+    assert bot.in_flight_response_count == 1
+
+    await bot.prepare_for_sync_shutdown(shutdown_intent=ORDERLY_SHUTDOWN)
+
+    assert bot.in_flight_response_count == 0
+    assert bot.response_completions == 0
+    assert bot.interruption_messages == 0
+    assert bot.retries_queued == 0
+    assert bot.response_cancel_sources == ["interrupted"]
+    assert bot.prepare_for_sync_shutdown_cancel_messages == [None]
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_replacement_leaves_no_sync_or_response_tasks(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation after one replacement starts must settle every owned task."""
+    bot = _ResponseOwningBot()
+    bot.start_responses(2)
+    _install_deterministic_stalls(monkeypatch, stall_count=1)
+
+    supervisor = asyncio.create_task(sync_forever_with_restart(bot, max_retries=3))
+    assert await bot.sync_starts.get() == 1
+    assert await bot.sync_starts.get() == 2
+    supervisor.cancel()
+    await supervisor
+
+    assert bot.live_sync_count == 0
+    assert bot.in_flight_response_count == 2
+    await bot.prepare_for_sync_shutdown()
+
+    assert bot.in_flight_response_count == 0
+    assert all(task.done() for task in bot.response_tasks)
+    assert bot.response_cancel_sources == ["interrupted", "interrupted"]
+    assert not [
+        task
+        for task in asyncio.all_tasks()
+        if not task.done() and task.get_name() in {"matrix_sync_test_agent", "matrix_sync_watchdog_test_agent"}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_replacement_start_failure_is_visible_bounded_and_preserves_response_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed replacement start must exhaust visibly without duplicating response ownership."""
+    bot = _ResponseOwningBot()
+    bot.start_responses(1)
+    start_calls = 0
+    cleanup_calls = 0
+
+    class StalledIteration:
+        async def wait(self) -> None:
+            msg = "Matrix sync loop stalled"
+            raise _MatrixSyncStalledError(msg)
+
+        async def cancel(self, *, shutdown_intent: RuntimeShutdownIntent = GENERIC_SHUTDOWN) -> None:
+            nonlocal cleanup_calls
+            assert shutdown_intent == GENERIC_SHUTDOWN
+            cleanup_calls += 1
+
+    def start_iteration(_bot: _ResponseOwningBot) -> StalledIteration:
+        nonlocal start_calls
+        start_calls += 1
+        if start_calls == 1:
+            return StalledIteration()
+        msg = "replacement sync start failed"
+        raise RuntimeError(msg)
+
+    logger = MagicMock()
+    monkeypatch.setattr(_SyncIteration, "start", start_iteration)
+    monkeypatch.setattr(runtime_helpers, "logger", logger)
+    monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(runtime_helpers, "_stalled_restart_jitter_seconds", lambda: 0.0)
+
+    await sync_forever_with_restart(bot, max_retries=2)
+
+    assert start_calls == 2
+    assert cleanup_calls == 1
+    assert bot.prepare_for_sync_shutdown_calls == 0
+    assert bot.in_flight_response_count == 1
+    assert not bot.response_tasks[0].done()
+    assert bot.interruption_messages == 0
+    assert bot.retries_queued == 0
+    logger.error.assert_any_call(
+        "sync_loop_failed",
+        exception_type="RuntimeError",
+        retry_count=2,
+    )
+    logger.error.assert_any_call(
+        "sync_loop_retries_exhausted",
+        active_response_count=1,
+        retry_count=2,
+        max_retries=2,
+        restart_reason_category="sync_failure",
+        resulting_action="preserve_response_runtime",
+    )
+
+    bot.response_finish.set()
+    await asyncio.gather(*bot.response_tasks)
+    assert bot.response_completions == 1
+    assert bot.final_messages == 1
 
 
 @pytest.mark.asyncio
@@ -285,7 +624,7 @@ async def test_failed_restart_does_not_add_jitter(monkeypatch: pytest.MonkeyPatc
     await sync_forever_with_restart(bot, max_retries=2)
 
     assert jitter_calls == []
-    assert bot.prepare_for_sync_shutdown_cancel_messages == [SYNC_RESTART_CANCEL_MSG, None]
+    assert bot.prepare_for_sync_shutdown_cancel_messages == [None]
 
 
 def test_stalled_restart_jitter_spreads_restarts() -> None:
@@ -339,7 +678,7 @@ async def test_sync_forever_with_restart_retries_on_sync_restart_cancel(
     assert bot.first_call_cancelled is True
     assert bot.first_call_cancel_args == (SYNC_RESTART_CANCEL_MSG,)
     assert bot.sync_calls == 1
-    assert bot.prepare_for_sync_shutdown_calls == 2
+    assert bot.prepare_for_sync_shutdown_calls == 1
 
 
 @pytest.mark.asyncio
@@ -540,10 +879,10 @@ def test_log_cancelled_response_source_logs_interrupted_with_traceback() -> None
 
 
 @pytest.mark.asyncio
-async def test_sync_forever_with_restart_cancels_deferred_work_before_retry_backoff(
+async def test_sync_forever_with_restart_preserves_runtime_before_retry_backoff(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Restart backoff should only happen after deferred overdue drain cleanup."""
+    """Receive-loop restart must not tear down response runtime before backoff."""
     bot = _FakeBot()
     call_order: list[str] = []
     call_count = 0
@@ -575,7 +914,7 @@ async def test_sync_forever_with_restart_cancels_deferred_work_before_retry_back
 
     await sync_forever_with_restart(bot, max_retries=2)
 
-    assert call_order[:2] == ["prepare", "retry_delay"]
+    assert call_order == ["retry_delay", "prepare"]
 
 
 @pytest.mark.asyncio
@@ -1252,11 +1591,8 @@ async def test_stop_entities_completes_with_real_supervisor_task(monkeypatch: py
 
     assert elapsed <= 2.0
     assert supervisor_task.done()
-    assert bot.prepare_for_sync_shutdown_calls >= 2
-    assert bot.prepare_for_sync_shutdown_cancel_messages[:2] == [
-        "sync_restart",
-        "sync_restart",
-    ]
+    assert bot.prepare_for_sync_shutdown_calls == 1
+    assert bot.prepare_for_sync_shutdown_cancel_messages == ["sync_restart"]
     bot.stop.assert_awaited_once_with(shutdown_intent=SYNC_RESTART_SHUTDOWN)
 
 
@@ -2012,8 +2348,8 @@ async def test_clean_sync_return_while_running_restarts(monkeypatch: pytest.Monk
     await sync_forever_with_restart(bot, max_retries=3)
 
     assert bot.sync_calls == 2
-    assert bot.prepare_for_sync_shutdown_calls == 2
-    assert bot.prepare_for_sync_shutdown_cancel_messages == [SYNC_RESTART_CANCEL_MSG, None]
+    assert bot.prepare_for_sync_shutdown_calls == 1
+    assert bot.prepare_for_sync_shutdown_cancel_messages == [None]
     assert retry_attempts == [1]
 
 
@@ -2035,12 +2371,14 @@ async def test_running_bot_logs_when_sync_retries_exhausted(monkeypatch: pytest.
 
     assert bot.running is True
     assert bot.sync_calls == 2
-    assert bot.prepare_for_sync_shutdown_calls == 2
+    assert bot.prepare_for_sync_shutdown_calls == 0
     logger.error.assert_called_once_with(
         "sync_loop_retries_exhausted",
-        agent="test_agent",
+        active_response_count=0,
         retry_count=2,
         max_retries=2,
+        restart_reason_category="unexpected_sync_return",
+        resulting_action="preserve_response_runtime",
     )
 
 

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import asyncio
 import threading
 from contextlib import asynccontextmanager
-from dataclasses import dataclass, field, fields, replace
+from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import MagicMock
 
@@ -55,7 +55,7 @@ from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.response_admission import ResponseAdmissionRefusedError
 from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparation
 from mindroom.response_runner import ResponseRequest
-from mindroom.sync_restart_retry import SyncRestartRetryQueue
+from mindroom.sync_restart_retry import InterruptedTurnRooms
 from mindroom.tool_system.runtime_context import ToolRuntimeSupport
 from mindroom.turn_controller import TurnController, TurnControllerDeps
 from mindroom.turn_origin import TurnIntent
@@ -245,7 +245,7 @@ class _Harness:
     runner: _RecordingResponseRunner
     gateway: _RecordingDeliveryGateway
     turn_store: TurnStore
-    restart_retry: SyncRestartRetryQueue
+    interrupted_turn_rooms: InterruptedTurnRooms
     gate: CoalescingGate
     gate_batches: list[CoalescedBatch]
     conversation_cache: AsyncMock
@@ -357,7 +357,7 @@ def _build_harness(
     )
     runner = _RecordingResponseRunner()
     gateway = _RecordingDeliveryGateway()
-    restart_retry = SyncRestartRetryQueue()
+    interrupted_turn_rooms = InterruptedTurnRooms()
     controller_ref: list[TurnController] = []
     gate_batches: list[CoalescedBatch] = []
 
@@ -398,7 +398,7 @@ def _build_harness(
             coalescing_gate=gate,
             edit_regenerator=_UnusedEditRegenerator(),
             ingress=ingress_validator,
-            restart_retry=restart_retry,
+            interrupted_turn_rooms=interrupted_turn_rooms,
         ),
     )
     controller_ref.append(controller)
@@ -408,7 +408,7 @@ def _build_harness(
         runner=runner,
         gateway=gateway,
         turn_store=turn_store,
-        restart_retry=restart_retry,
+        interrupted_turn_rooms=interrupted_turn_rooms,
         gate=gate,
         gate_batches=gate_batches,
         conversation_cache=conversation_cache,
@@ -1319,9 +1319,8 @@ async def test_user_message_cannot_spoof_scheduled_thread_promotion(tmp_path: Pa
 async def test_deferred_sync_restart_records_handled_outcome_before_rethrow(
     config: Config,
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A queued retry must not race normal replay of the same visibly settled source turn."""
+    """A turn interrupted by bot replacement must settle durably before rethrowing."""
     harness = _build_harness(config, tmp_path)
     harness.runner.deferred_sync_restart_error = asyncio.CancelledError("sync_restart")
     room = _room_with_members(config, "general")
@@ -1330,56 +1329,21 @@ async def test_deferred_sync_restart_records_handled_outcome_before_rethrow(
     with pytest.raises(asyncio.CancelledError, match="sync_restart"):
         await harness.deliver(room, event)
 
-    assert harness.restart_retry.has_pending
+    assert harness.interrupted_turn_rooms.pending_room_ids == {room.room_id}
     assert harness.runner.requests[0].sync_restart_retry_source_event_id is None
     assert harness.turn_store.is_handled(event.event_id) is True
     record = harness.turn_store.get_turn_record(event.event_id)
     assert record is not None
     assert record.response_event_id == "$response:localhost"
 
-    harness.runner.deferred_sync_restart_error = None
-    retry_started = asyncio.Event()
-    release_retry = asyncio.Event()
-    generate_response = harness.runner.generate_response
-
-    async def generate_retry_with_barrier(request: ResponseRequest) -> str | None:
-        if request.sync_restart_retry_source_event_id is not None:
-            harness.runner.response_event_id = "$retried-response:localhost"
-            retry_started.set()
-            await release_retry.wait()
-        return await generate_response(request)
-
-    monkeypatch.setattr(harness.runner, "generate_response", generate_retry_with_barrier)
-    retry = asyncio.create_task(harness.restart_retry.flush())
-    await retry_started.wait()
-    settlement_started = asyncio.Event()
-
-    async def wait_for_settlement() -> None:
-        settlement_started.set()
-        await harness.turn_store.wait_for_turn_settled((event.event_id,))
-
-    waiter = asyncio.create_task(wait_for_settlement())
-    await settlement_started.wait()
-    try:
-        assert not waiter.done()
-    finally:
-        release_retry.set()
-        await retry
-        await waiter
-
-    assert harness.runner.requests[1].sync_restart_retry_source_event_id == event.event_id
-    retried_record = harness.turn_store.get_turn_record(event.event_id)
-    assert retried_record is not None
-    assert retried_record.response_event_id == "$retried-response:localhost"
-
 
 @pytest.mark.asyncio
-async def test_sync_restart_retry_reloads_relay_after_alias_owner_completes(
+async def test_interrupted_router_relay_detaches_its_advisory_human_alias(
     config: Config,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Retry the physical relay after its advisory human alias settles independently."""
+    """An interrupted relay must drop an alias whose owner settled independently."""
     harness = _build_harness(config, tmp_path)
     harness.runner.deferred_sync_restart_error = asyncio.CancelledError("sync_restart")
     room = _room_with_members(config, "general", ROUTER_AGENT_NAME)
@@ -1413,66 +1377,7 @@ async def test_sync_restart_retry_reloads_relay_after_alias_owner_completes(
     relay_record = harness.turn_store.get_turn_record(relay.event_id)
     assert relay_record is not None
     assert relay_record.discovery_event_ids == ()
-    harness.runner.deferred_sync_restart_error = None
-
-    async def unexpected_wait(_event_ids: tuple[str, ...]) -> None:
-        msg = "canonical relay retry must not wait on its detached alias"
-        raise AssertionError(msg)
-
-    monkeypatch.setattr(harness.turn_store, "wait_for_turn_settled", unexpected_wait)
-    await harness.restart_retry.flush()
-
-    assert len(harness.runner.requests) == 2
-    assert harness.runner.requests[1].sync_restart_retry_source_event_id == relay.event_id
-    retried_record = harness.turn_store.get_turn_record(relay.event_id)
-    assert retried_record is not None
-    assert retried_record.response_event_id == "$response:localhost"
-
-
-@pytest.mark.asyncio
-async def test_sync_restart_retry_skips_prompt_after_waiting_edit_commits(
-    config: Config,
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """A queued normal retry must not replay its stale prompt after an edit wins."""
-    harness = _build_harness(config, tmp_path)
-    harness.runner.deferred_sync_restart_error = asyncio.CancelledError("sync_restart")
-    room = _room_with_members(config, "general")
-    event = _text_event("stale original prompt")
-
-    with pytest.raises(asyncio.CancelledError, match="sync_restart"):
-        await harness.deliver(room, event)
-
-    record = harness.turn_store.get_turn_record(event.event_id)
-    assert record is not None
-    assert harness.turn_store.try_claim_turn(record)
-    wait_started = asyncio.Event()
-    wait_for_turn_settled = harness.turn_store.wait_for_turn_settled
-
-    async def wait_with_barrier(event_ids: tuple[str, ...]) -> None:
-        wait_started.set()
-        await wait_for_turn_settled(event_ids)
-
-    monkeypatch.setattr(harness.turn_store, "wait_for_turn_settled", wait_with_barrier)
-    harness.runner.deferred_sync_restart_error = None
-    retry = asyncio.create_task(harness.restart_retry.flush())
-    await wait_started.wait()
-    assert not retry.done()
-
-    edited_record = replace(
-        record,
-        response_event_id="$edited-response:localhost",
-        source_event_revisions={event.event_id: (event.server_timestamp + 1, "$edit:localhost")},
-    )
-    harness.turn_store.record_turn(edited_record)
-    harness.turn_store.release_pending_turn_claim(record)
-    await retry
-
-    assert len(harness.runner.requests) == 1
-    settled_record = harness.turn_store.get_turn_record(event.event_id)
-    assert settled_record is not None
-    assert settled_record.response_event_id == "$edited-response:localhost"
+    assert harness.interrupted_turn_rooms.pending_room_ids == {room.room_id}
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -1986,7 +1986,7 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
         bot.client = AsyncMock()
-        tracker = _set_turn_store_tracker(bot, MagicMock())
+        _set_turn_store_tracker(bot, MagicMock())
         bot.logger = MagicMock()
         _replace_turn_policy_deps(bot, logger=bot.logger)
 
@@ -2031,9 +2031,6 @@ class TestAgentBot(AgentBotTestBase):
 
         async def generate_team_response(request: ResponseRequest, **_kwargs: object) -> str:
             team_requests.append(request)
-            if len(team_requests) == 1:
-                assert request.on_sync_restart_cancelled is not None
-                request.on_sync_restart_cancelled()
             return "$team-response"
 
         mock_generate_team_response = AsyncMock(side_effect=generate_team_response)
@@ -2060,11 +2057,6 @@ class TestAgentBot(AgentBotTestBase):
                 dispatch_started_at=0.0,
                 handled_turn=TurnRecord.create([event.event_id]),
             )
-            tracker.get_turn_record.return_value = TurnRecord.create(
-                [event.event_id],
-                response_event_id="$team-response",
-            )
-            await bot._restart_retry_queue.flush()
 
         assert action.form_team is not None
         mock_select_team_mode.assert_awaited_once_with(
@@ -2073,8 +2065,7 @@ class TestAgentBot(AgentBotTestBase):
             bot._turn_controller.deps.runtime.config,
             bot._turn_controller.deps.runtime_paths,
         )
-        assert [request.sync_restart_retry_source_event_id for request in team_requests] == [None, event.event_id]
-        assert mock_generate_team_response.await_count == 2
+        assert mock_generate_team_response.await_count == 1
         assert mock_generate_team_response.await_args.kwargs["team_mode"] == "coordinate"
         assert mock_generate_team_response.await_args.kwargs["team_agents"] == action.form_team.eligible_members
 


### PR DESCRIPTION
## Summary

- Separate automatic Matrix receive-loop restart cleanup from full agent response-runtime shutdown.
- Keep active responses single-owned across watchdog stalls and sync transport failures.
- Add identifier-free lifecycle logs for transport restart versus config, process, and agent shutdown.

## Before / after

Before, automatic sync-loop cleanup invoked full response shutdown, cancelling in-flight responses and activating restart recovery.
After, automatic transport retries clean up only sync and watchdog tasks; explicit config, agent, and process shutdown still use the existing response drain and recovery behavior.

## Validation

- `pytest -n auto -x --lf -q`
- Focused sync, shutdown, config-reload, ingress, and dispatch suites
- `ty check src tests`
- `tach check --dependencies --interfaces`
- Intended-file `pre-commit` hooks
- `git diff --check`

`pre-commit run --all-files` passes every hook except Prettier, which rewrites seven unrelated frontend files already present on `main`; those unrelated edits are excluded from this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Matrix sync stalls with more precise restart categorization and clearer “restart vs drain/cancel” behavior.
  * Preserved response runtime ownership across watchdog-driven receive-loop restarts, avoiding premature teardown.
  * Enhanced structured shutdown logging to report active in-flight responses and the resulting shutdown action.
* **Tests**
  * Expanded structured-log assertions for orderly shutdown.
  * Strengthened cancellation and restart tests to verify response ownership and retry/backoff timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->