### PR TITLE
Route streaming cache edits through thread barriers

### DIFF
--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -14,6 +14,7 @@ Developer note:
 - `sqlite_agent_message_snapshot.py` owns SQLite reads for latest cached agent message snapshots.
 - `postgres_event_cache_events.py`, `postgres_event_cache_threads.py`, and `postgres_agent_message_snapshot.py` own the equivalent PostgreSQL row helpers.
 - `sqlite_cache_maintenance.py` and `postgres_cache_maintenance.py` own transactional migration, invariant repair, and startup diagnostics.
+- `outbound_thread_reservations.py` owns bounded principal-, room-, and event-scoped thread claims for local response edits.
 - `thread_writes.py` owns live, outbound, and sync mutation flows; `thread_bookkeeping.py` resolves thread impact and `thread_write_cache_ops.py` applies queued cache mutations.
 
 Package boundary:

--- a/src/mindroom/matrix/cache/outbound_thread_reservations.py
+++ b/src/mindroom/matrix/cache/outbound_thread_reservations.py
@@ -1,0 +1,151 @@
+"""Bounded thread claims for locally delivered Matrix response events."""
+
+from __future__ import annotations
+
+import time
+import typing
+from dataclasses import dataclass, field
+
+_DEFAULT_TTL_SECONDS = 6 * 60 * 60
+_DEFAULT_MAX_RESERVATIONS = 4096
+_DEFAULT_MAX_ALIASES_PER_RESERVATION = 32
+
+
+@dataclass(frozen=True, slots=True)
+class OutboundThreadReservationKey:
+    """Isolate one response identity by cache principal and Matrix room."""
+
+    principal_id: str
+    room_id: str
+    event_id: str
+
+
+@dataclass(slots=True)
+class _OutboundThreadReservation:
+    stable_key: OutboundThreadReservationKey
+    thread_id: str
+    expires_at: float
+    aliases: dict[OutboundThreadReservationKey, None] = field(default_factory=dict)
+
+
+@dataclass
+class OutboundThreadReservations:
+    """Retain certified outbound thread identities until terminal delivery."""
+
+    ttl_seconds: float = _DEFAULT_TTL_SECONDS
+    max_reservations: int = _DEFAULT_MAX_RESERVATIONS
+    max_aliases_per_reservation: int = _DEFAULT_MAX_ALIASES_PER_RESERVATION
+    clock: typing.Callable[[], float] = time.monotonic
+    _reservations: dict[OutboundThreadReservationKey, _OutboundThreadReservation] = field(
+        default_factory=dict,
+        init=False,
+    )
+    _by_event: dict[OutboundThreadReservationKey, _OutboundThreadReservation] = field(
+        default_factory=dict,
+        init=False,
+    )
+
+    def _key(self, principal_id: str, room_id: str, event_id: str) -> OutboundThreadReservationKey:
+        return OutboundThreadReservationKey(principal_id, room_id, event_id)
+
+    def _drop(self, reservation: _OutboundThreadReservation) -> None:
+        self._reservations.pop(reservation.stable_key, None)
+        for alias in reservation.aliases:
+            if self._by_event.get(alias) is reservation:
+                self._by_event.pop(alias, None)
+
+    def _prune_expired(self, now: float) -> None:
+        for reservation in tuple(self._reservations.values()):
+            if reservation.expires_at <= now:
+                self._drop(reservation)
+
+    def _refresh(self, reservation: _OutboundThreadReservation, now: float) -> None:
+        reservation.expires_at = now + self.ttl_seconds
+
+    def _bind_alias(
+        self,
+        reservation: _OutboundThreadReservation,
+        alias: OutboundThreadReservationKey,
+    ) -> None:
+        existing = self._by_event.get(alias)
+        if existing is reservation:
+            return
+        if existing is not None:
+            return
+        if len(reservation.aliases) >= self.max_aliases_per_reservation:
+            removable_alias = next(
+                (key for key in reservation.aliases if key != reservation.stable_key),
+                None,
+            )
+            if removable_alias is None:
+                return
+            reservation.aliases.pop(removable_alias)
+            self._by_event.pop(removable_alias, None)
+        reservation.aliases[alias] = None
+        self._by_event[alias] = reservation
+
+    def reserve(
+        self,
+        principal_id: str,
+        room_id: str,
+        event_id: str,
+        thread_id: str,
+    ) -> None:
+        """Reserve one stable response identity with certified thread scope."""
+        now = self.clock()
+        self._prune_expired(now)
+        stable_key = self._key(principal_id, room_id, event_id)
+        existing = self._by_event.get(stable_key)
+        if existing is not None and existing.thread_id == thread_id:
+            self._refresh(existing, now)
+            return
+        if existing is not None:
+            self._drop(existing)
+        if len(self._reservations) >= self.max_reservations:
+            self._drop(min(self._reservations.values(), key=lambda item: item.expires_at))
+        reservation = _OutboundThreadReservation(
+            stable_key=stable_key,
+            thread_id=thread_id,
+            expires_at=now + self.ttl_seconds,
+        )
+        self._reservations[stable_key] = reservation
+        self._bind_alias(reservation, stable_key)
+
+    def resolve(
+        self,
+        principal_id: str,
+        room_id: str,
+        event_id: str,
+        *,
+        transitioned_event_id: str | None = None,
+    ) -> str | None:
+        """Resolve one event alias and retain a returned event-ID transition."""
+        now = self.clock()
+        self._prune_expired(now)
+        reservation = self._by_event.get(self._key(principal_id, room_id, event_id))
+        if reservation is None:
+            return None
+        self._refresh(reservation, now)
+        if transitioned_event_id is not None:
+            self._bind_alias(
+                reservation,
+                self._key(principal_id, room_id, transitioned_event_id),
+            )
+        return reservation.thread_id
+
+    def release(self, principal_id: str, room_id: str, event_id: str) -> None:
+        """Release one reservation and every event-ID alias retained with it."""
+        now = self.clock()
+        self._prune_expired(now)
+        reservation = self._by_event.get(self._key(principal_id, room_id, event_id))
+        if reservation is not None:
+            self._drop(reservation)
+
+    @property
+    def active_count(self) -> int:
+        """Return live reservation count after lazy TTL cleanup."""
+        self._prune_expired(self.clock())
+        return len(self._reservations)
+
+
+__all__ = ["OutboundThreadReservationKey", "OutboundThreadReservations"]

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -65,6 +65,11 @@ class ThreadMutationCacheOps:
             return {"cache_backend": "none"}
         return self.runtime.event_cache.runtime_diagnostics()
 
+    def cache_principal_id(self) -> str:
+        """Return principal namespace owning outbound write reservations."""
+        assert self.runtime.event_cache is not None
+        return self.runtime.event_cache.principal_id
+
     def pending_durable_write_room_ids(self) -> tuple[str, ...]:
         """Return rooms with runtime-only writes that must persist before sync certification."""
         if self.runtime.event_cache is None:

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -9,10 +9,11 @@ These three policies are the only writers of durable thread-cache state:
    policy can additionally run in fail-closed mode (``raise_on_cache_write_failure``) so sync-token
    certification only certifies responses whose writes durably landed.
 
-3. Barrier routing: mutations whose thread is known pre-queue run on the per-thread barrier; mutations
-   that need cache lookups to resolve their thread (plain edits and replies, outbound redactions) stay
-   on the room barrier, because earlier queued writes can create the lookup rows they depend on
-   (ISSUE-189 tracks finer routing).
+3. Barrier routing: mutations whose thread is known pre-queue run on the per-thread barrier.
+   Locally streamed responses reserve their certified thread identity before relation-free edits begin,
+   so those edits avoid cache lookups and retain the per-thread barrier.
+   Mutations whose identity remains unknown stay on the room barrier because earlier queued writes can
+   create the lookup rows they depend on.
 
 4. UNKNOWN-impact mutations invalidate the whole room's cached threads eagerly, outside the per-thread
    queue: concurrent per-thread writers cannot uphold the ``room_invalidated_at >= validated_at``
@@ -41,7 +42,14 @@ from typing import TYPE_CHECKING, Any
 
 import nio
 
-from mindroom.constants import STREAM_STATUS_KEY, STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING
+from mindroom.constants import (
+    STREAM_STATUS_CANCELLED,
+    STREAM_STATUS_COMPLETED,
+    STREAM_STATUS_ERROR,
+    STREAM_STATUS_KEY,
+    STREAM_STATUS_PENDING,
+    STREAM_STATUS_STREAMING,
+)
 from mindroom.matrix.event_info import EventInfo, is_thread_affecting_relation
 from mindroom.matrix.sync_certification import SyncCacheWriteResult
 from mindroom.matrix.thread_bookkeeping import (
@@ -58,6 +66,7 @@ from .event_normalization import (
     normalize_event_source_for_cache,
     normalize_nio_event_for_cache,
 )
+from .outbound_thread_reservations import OutboundThreadReservations
 
 if TYPE_CHECKING:
     from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
@@ -70,6 +79,13 @@ __all__ = [
 
 
 _NONTERMINAL_STREAM_STATUSES = frozenset({STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING})
+_TERMINAL_STREAM_STATUSES = frozenset(
+    {
+        STREAM_STATUS_CANCELLED,
+        STREAM_STATUS_COMPLETED,
+        STREAM_STATUS_ERROR,
+    },
+)
 _LIMITED_SYNC_TIMELINE_REASON = "limited_sync_timeline"
 _SYNC_TIMELINE_WRITE_FAILED_REASON = "sync_timeline_write_failed"
 
@@ -122,7 +138,6 @@ def _collect_sync_event_cache_update(
 def _outbound_streaming_edit_coalesce_context(
     *,
     event_info: EventInfo,
-    event_id: str,
     event_source: dict[str, object],
 ) -> tuple[tuple[str, str], dict[str, object]] | None:
     if not event_info.is_edit or not isinstance(event_info.original_event_id, str):
@@ -138,10 +153,25 @@ def _outbound_streaming_edit_coalesce_context(
     return (
         ("outbound_streaming_edit", event_info.original_event_id),
         {
-            "original_event_id": event_info.original_event_id,
-            "latest_event_id": event_id,
+            "stream_status": typing.cast("dict[str, object]", new_content).get(STREAM_STATUS_KEY),
         },
     )
+
+
+def _outbound_stream_status(
+    event_source: dict[str, object],
+    *,
+    event_info: EventInfo,
+) -> object:
+    content = event_source.get("content")
+    if not isinstance(content, dict):
+        return None
+    status_content = typing.cast("dict[str, object]", content)
+    if event_info.is_edit:
+        new_content = status_content.get("m.new_content")
+        if isinstance(new_content, dict):
+            status_content = typing.cast("dict[str, object]", new_content)
+    return status_content.get(STREAM_STATUS_KEY)
 
 
 def _mutation_reason(
@@ -285,18 +315,17 @@ class ThreadOutboundWritePolicy:
         resolver: ThreadMutationResolver,
         cache_ops: ThreadMutationCacheOps,
         require_client: typing.Callable[[], nio.AsyncClient],
+        reservations: OutboundThreadReservations | None = None,
     ) -> None:
         self._resolver = resolver
         self._cache_ops = cache_ops
         self._require_client = require_client
+        self._reservations = reservations or OutboundThreadReservations()
 
     def _emit_outbound_schedule_timing(
         self,
         *,
         barrier_kind: str,
-        room_id: str,
-        thread_id: str | None,
-        event_id: str,
         event_type: str | None,
         event_info: EventInfo,
         has_coalesce_key: bool,
@@ -305,9 +334,6 @@ class ThreadOutboundWritePolicy:
             "Event cache outbound schedule timing",
             operation="matrix_cache_notify_outbound_event",
             barrier_kind=barrier_kind,
-            room_id=room_id,
-            thread_id=thread_id,
-            event_id=event_id,
             event_type=event_type,
             is_edit=event_info.is_edit,
             is_reaction=event_info.is_reaction,
@@ -320,12 +346,18 @@ class ThreadOutboundWritePolicy:
         event_id: str,
         event_source: dict[str, Any],
         event_info: EventInfo,
+        *,
+        known_thread_id: str | None = None,
     ) -> None:
-        impact = await self._resolver.resolve_thread_impact_for_mutation(
-            room_id,
-            event_info=event_info,
-            event_id=event_id,
-            context="outbound",
+        impact = (
+            MutationThreadImpact.threaded(known_thread_id)
+            if known_thread_id is not None
+            else await self._resolver.resolve_thread_impact_for_mutation(
+                room_id,
+                event_info=event_info,
+                event_id=event_id,
+                context="outbound",
+            )
         )
         if impact.state is not MutationThreadImpactState.THREADED:
             await self._cache_ops.store_events_batch(
@@ -343,6 +375,68 @@ class ThreadOutboundWritePolicy:
             context="outbound",
             room_level_skip_message="Skipping outbound thread cache bookkeeping for non-threaded event mutation",
             invalidate_on_append_failure=False,
+        )
+
+    def _resolve_prequeue_thread_route(
+        self,
+        *,
+        room_id: str,
+        event_id: str,
+        event_info: EventInfo,
+        stream_status: object,
+    ) -> tuple[str | None, str | None, str | None]:
+        """Resolve explicit or reserved thread scope before entering a write queue."""
+        explicit_thread_id = event_info.thread_id or event_info.thread_id_from_edit
+        raw_reservation_event_id = event_info.original_event_id if event_info.is_edit else event_id
+        reservation_event_id = raw_reservation_event_id if isinstance(raw_reservation_event_id, str) else None
+        needs_reservation_scope = reservation_event_id is not None and (
+            stream_status in _NONTERMINAL_STREAM_STATUSES
+            or stream_status in _TERMINAL_STREAM_STATUSES
+            or (explicit_thread_id is None and event_info.is_edit)
+        )
+        principal_id = self._cache_ops.cache_principal_id() if needs_reservation_scope else None
+        if (
+            explicit_thread_id is not None
+            and reservation_event_id is not None
+            and stream_status in _NONTERMINAL_STREAM_STATUSES
+        ):
+            assert principal_id is not None
+            self._reservations.reserve(
+                principal_id,
+                room_id,
+                reservation_event_id,
+                explicit_thread_id,
+            )
+        reserved_thread_id = None
+        if (
+            explicit_thread_id is None
+            and event_info.is_edit
+            and isinstance(event_info.original_event_id, str)
+            and principal_id is not None
+        ):
+            reserved_thread_id = self._reservations.resolve(
+                principal_id,
+                room_id,
+                event_info.original_event_id,
+                transitioned_event_id=event_id,
+            )
+        return explicit_thread_id or reserved_thread_id, principal_id, reservation_event_id
+
+    def _release_terminal_thread_reservation(
+        self,
+        *,
+        principal_id: str | None,
+        room_id: str,
+        reservation_event_id: str | None,
+        stream_status: object,
+    ) -> None:
+        """Release a terminal claim after its queued update captured thread scope."""
+        if principal_id is None or reservation_event_id is None or stream_status not in _TERMINAL_STREAM_STATUSES:
+            return
+        self._reservations.release(
+            principal_id,
+            room_id,
+            reservation_event_id,
         )
 
     def notify_outbound_event(
@@ -363,9 +457,12 @@ class ThreadOutboundWritePolicy:
             event_id = typing.cast("str", event_id_value)
 
             event_info = EventInfo.from_event(normalized_event_source)
+            stream_status = _outbound_stream_status(
+                normalized_event_source,
+                event_info=event_info,
+            )
             coalesce_context = _outbound_streaming_edit_coalesce_context(
                 event_info=event_info,
-                event_id=event_id,
                 event_source=normalized_event_source,
             )
             coalesce_key, coalesce_log_context = coalesce_context if coalesce_context is not None else (None, None)
@@ -375,9 +472,6 @@ class ThreadOutboundWritePolicy:
             if event_info.is_reaction:
                 self._emit_outbound_schedule_timing(
                     barrier_kind="room",
-                    room_id=room_id,
-                    thread_id=None,
-                    event_id=event_id,
                     event_type=event_type,
                     event_info=event_info,
                     has_coalesce_key=coalesce_key is not None,
@@ -418,41 +512,50 @@ class ThreadOutboundWritePolicy:
                     emit_timing=emit_timing,
                 )
                 return
-            thread_id = event_info.thread_id or event_info.thread_id_from_edit
+            thread_id, principal_id, reservation_event_id = self._resolve_prequeue_thread_route(
+                room_id=room_id,
+                event_id=event_id,
+                event_info=event_info,
+                stream_status=stream_status,
+            )
             if thread_id is not None:
                 self._emit_outbound_schedule_timing(
                     barrier_kind="thread",
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    event_id=event_id,
                     event_type=event_type,
                     event_info=event_info,
                     has_coalesce_key=coalesce_key is not None,
                 )
-                self._schedule_fail_open_thread_update(
-                    room_id,
-                    thread_id,
-                    lambda: self._apply_outbound_event_notification(
+                try:
+                    self._schedule_fail_open_thread_update(
                         room_id,
-                        event_id,
-                        normalized_event_source,
-                        event_info,
-                    ),
-                    name="matrix_cache_notify_outbound_event",
-                    cancelled_message="Ignoring cancelled outbound cache bookkeeping after successful send",
-                    failure_message="Ignoring outbound cache bookkeeping failure after successful send",
-                    log_context={"event_id": event_id},
-                    emit_timing=emit_timing,
-                    coalesce_key=coalesce_key,
-                    coalesce_log_context=coalesce_log_context,
-                )
+                        thread_id,
+                        lambda: self._apply_outbound_event_notification(
+                            room_id,
+                            event_id,
+                            normalized_event_source,
+                            event_info,
+                            known_thread_id=thread_id,
+                        ),
+                        name="matrix_cache_notify_outbound_event",
+                        cancelled_message="Ignoring cancelled outbound cache bookkeeping after successful send",
+                        failure_message="Ignoring outbound cache bookkeeping failure after successful send",
+                        log_context={"event_id": event_id},
+                        emit_timing=emit_timing,
+                        coalesce_key=coalesce_key,
+                        coalesce_log_context=coalesce_log_context,
+                    )
+                finally:
+                    self._release_terminal_thread_reservation(
+                        principal_id=principal_id,
+                        room_id=room_id,
+                        reservation_event_id=reservation_event_id,
+                        stream_status=stream_status,
+                    )
                 return
-            # Lookup-dependent outbound mutations stay on the room barrier because earlier outbound writes can create the lookup rows needed to resolve thread impact. Safe parallelization would require reservation-based routing (see ISSUE-189).
+            # Truly lookup-dependent outbound mutations stay on the room barrier because earlier
+            # outbound writes can create the rows needed to resolve thread impact.
             self._emit_outbound_schedule_timing(
                 barrier_kind="room",
-                room_id=room_id,
-                thread_id=None,
-                event_id=event_id,
                 event_type=event_type,
                 event_info=event_info,
                 has_coalesce_key=coalesce_key is not None,
@@ -510,6 +613,27 @@ class ThreadOutboundWritePolicy:
                 "event_id": event_id,
                 "content": dict(content),
             },
+        )
+
+    def reserve_thread_response(self, room_id: str, event_id: str, thread_id: str) -> None:
+        """Retain one known response thread before later edits drop relation metadata."""
+        if not self._cache_ops.cache_runtime_available():
+            return
+        self._reservations.reserve(
+            self._cache_ops.cache_principal_id(),
+            room_id,
+            event_id,
+            thread_id,
+        )
+
+    def release_thread_response(self, room_id: str, event_id: str) -> None:
+        """Release one terminal response reservation and all retained event aliases."""
+        if self._cache_ops.runtime.event_cache is None:
+            return
+        self._reservations.release(
+            self._cache_ops.cache_principal_id(),
+            room_id,
+            event_id,
         )
 
     def _normalize_outbound_event_source(

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -325,8 +325,6 @@ class EventCacheWriteCoordinator:
     def _log_coalesced_update_if_needed(
         self,
         *,
-        room_id: str,
-        thread_id: str | None,
         kind: typing.Literal["room", "thread"],
         name: str,
         update_state: _QueuedUpdateState,
@@ -335,15 +333,12 @@ class EventCacheWriteCoordinator:
         if dropped_update_count <= 0:
             return
         log_context = {
-            "room_id": room_id,
             "barrier_kind": kind,
             "operation": name,
             "coalesced_update_count": dropped_update_count,
             "dropped_update_count": dropped_update_count,
             **update_state.coalesce_log_context,
         }
-        if thread_id is not None:
-            log_context["thread_id"] = thread_id
         self.logger.info("Coalesced outbound streaming edit cache updates", **log_context)
 
     def _release_active_entry(
@@ -442,8 +437,6 @@ class EventCacheWriteCoordinator:
             assert current_task is not None
             with bound_log_context(task_name=current_task.get_name()):
                 self._log_coalesced_update_if_needed(
-                    room_id=room_id,
-                    thread_id=thread_id,
                     kind=kind,
                     name=name,
                     update_state=update_state,
@@ -491,8 +484,6 @@ class EventCacheWriteCoordinator:
                     emit_timing_event(
                         "Event cache update timing",
                         barrier_kind=kind,
-                        room_id=room_id,
-                        thread_id=thread_id,
                         operation=name,
                         predecessor_count=predecessor_count,
                         queued_behind_predecessor=predecessor_count > 0,

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -229,6 +229,12 @@ class ConversationCacheProtocol(Protocol):
         This is advisory post-redaction bookkeeping and must fail open.
         """
 
+    def reserve_outbound_thread(self, room_id: str, event_id: str, thread_id: str) -> None:
+        """Reserve one known outbound response thread for later relation-free edits."""
+
+    def release_outbound_thread(self, room_id: str, event_id: str) -> None:
+        """Release one outbound response thread reservation after terminal delivery."""
+
     async def append_live_event(
         self,
         room_id: str,
@@ -997,6 +1003,14 @@ class MatrixConversationCache(ConversationCacheProtocol):
         self._evict_turn_thread_reads_for_room(room_id)
         self._evict_turn_event_lookups_for_room(room_id)
         self._outbound.notify_outbound_redaction(room_id, redacted_event_id)
+
+    def reserve_outbound_thread(self, room_id: str, event_id: str, thread_id: str) -> None:
+        """Reserve one known outbound response thread for later relation-free edits."""
+        self._outbound.reserve_thread_response(room_id, event_id, thread_id)
+
+    def release_outbound_thread(self, room_id: str, event_id: str) -> None:
+        """Release one outbound response thread reservation after terminal delivery."""
+        self._outbound.release_thread_response(room_id, event_id)
 
     def _evict_turn_thread_reads_for_room(self, room_id: str) -> None:
         """Discard thread reads changed by a successful outbound mutation."""

--- a/src/mindroom/matrix/thread_bookkeeping.py
+++ b/src/mindroom/matrix/thread_bookkeeping.py
@@ -15,7 +15,8 @@ Who may mutate thread state, and how:
    (``ThreadOutboundWritePolicy``, ``ThreadLiveWritePolicy``, ``ThreadSyncWritePolicy``),
    which all resolve impact through this module's ``ThreadMutationResolver``,
    apply it through ``mindroom.matrix.cache.thread_write_cache_ops.ThreadMutationCacheOps``,
-   and order every write through the per-room ``EventCacheWriteCoordinator`` barrier.
+   and order every write through the room or certified per-thread
+   ``EventCacheWriteCoordinator`` barrier.
    The only other thread-cache writer is the read-refill in
    ``mindroom.matrix.client_thread_history``: after an authoritative homeserver fetch it stores the
    snapshot through the guarded ``replace_thread_if_not_newer``, and it invalidates entries it proves

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -642,7 +642,28 @@ class StreamingResponse:
             return stream_status
         return STREAM_STATUS_COMPLETED
 
-    async def finalize(  # noqa: C901, PLR0911, PLR0912
+    async def finalize(
+        self,
+        client: nio.AsyncClient,
+        *,
+        cancelled: bool = False,
+        restart_interrupted: bool = False,
+        cancel_source: Literal["user_stop", "sync_restart", "interrupted"] | None = None,
+        error: Exception | None = None,
+    ) -> StreamTransportOutcome:
+        """Send one terminal update and always release its thread reservation."""
+        try:
+            return await self._finalize(
+                client,
+                cancelled=cancelled,
+                restart_interrupted=restart_interrupted,
+                cancel_source=cancel_source,
+                error=error,
+            )
+        finally:
+            self._release_thread_write_reservation()
+
+    async def _finalize(  # noqa: C901, PLR0911, PLR0912
         self,
         client: nio.AsyncClient,
         *,
@@ -1038,6 +1059,22 @@ class StreamingResponse:
             return
         self.conversation_cache.notify_outbound_message(self.room_id, edit_event_id, content_sent)
 
+    def _reserve_thread_write_reservation(self) -> None:
+        """Retain known thread identity for later edits whose envelope only carries m.replace."""
+        if self.conversation_cache is None or self.event_id is None or self.thread_id is None:
+            return
+        self.conversation_cache.reserve_outbound_thread(
+            self.room_id,
+            self.event_id,
+            self.thread_id,
+        )
+
+    def _release_thread_write_reservation(self) -> None:
+        """Release thread identity after terminal success, failure, or cancellation."""
+        if self.conversation_cache is None or self.event_id is None:
+            return
+        self.conversation_cache.release_outbound_thread(self.room_id, self.event_id)
+
     def _mark_first_visible_reply_if_needed(self) -> None:
         """Mark first visible reply timing once visible text exists."""
         if self.pipeline_timing is not None and self.accumulated_text.strip():
@@ -1049,6 +1086,7 @@ class StreamingResponse:
         if delivered is None:
             return False
         self.event_id = delivered.event_id
+        self._reserve_thread_write_reservation()
         if self.visible_event_id_callback is not None:
             self.visible_event_id_callback(delivered.event_id)
         await self._record_streaming_send(delivered.event_id, delivered.content_sent)
@@ -1763,6 +1801,7 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
 
     if existing_event_id:
         streaming.event_id = existing_event_id
+        streaming._reserve_thread_write_reservation()
         if visible_event_id_callback is not None:
             visible_event_id_callback(existing_event_id)
         streaming.accumulated_text = ""
@@ -1903,6 +1942,7 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                 )
             if tool_trace_collector is not None:
                 tool_trace_collector[:] = streaming.tool_trace
+            streaming._release_thread_write_reservation()
 
     assert transport_outcome is not None
     return transport_outcome

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -1808,7 +1808,13 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
         streaming.placeholder_progress_sent = adopt_existing_placeholder
 
     if header:
-        await streaming.update_content(header, client)
+        header_delivered = False
+        try:
+            await streaming.update_content(header, client)
+            header_delivered = True
+        finally:
+            if not header_delivered:
+                streaming._release_thread_write_reservation()
 
     worker_progress_queue: asyncio.Queue[WorkerProgressEvent] = asyncio.Queue()
     delivery_queue: asyncio.Queue[_DeliveryRequest | None] = asyncio.Queue()
@@ -1816,6 +1822,7 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
     delivery_task: asyncio.Task[None] | None = None
     loop = asyncio.get_running_loop()
     transport_outcome: StreamTransportOutcome | None = None
+    finalization_started = False
     with worker_progress_pump_scope(loop, worker_progress_queue) as pump:
         delivery_task = asyncio.create_task(_drive_stream_delivery(client, streaming, delivery_queue))
         progress_task = asyncio.create_task(
@@ -1874,6 +1881,7 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                 user_stop_message="Streaming response cancelled by user",
                 interrupted_message="Streaming response interrupted — traceback for diagnosis",
             )
+            finalization_started = True
             transport_outcome = await streaming.finalize(client, cancel_source=cancel_source)
             raise StreamingDeliveryError(
                 exc,
@@ -1917,6 +1925,7 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                 ) from shutdown_timeout
             if isinstance(exc, _NonTerminalDeliveryError):
                 streaming.restore_last_delivered_state()
+            finalization_started = True
             transport_outcome = await streaming.finalize(client, error=delivery_error)
             raise StreamingDeliveryError(
                 delivery_error,
@@ -1926,6 +1935,7 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                 transport_outcome=transport_outcome,
             ) from delivery_error
         else:
+            finalization_started = True
             transport_outcome = await streaming.finalize(client)
         finally:
             cleanup_error = await _shutdown_worker_progress_drain(pump, progress_task)
@@ -1942,7 +1952,8 @@ async def send_streaming_response(  # noqa: C901, PLR0912, PLR0915
                 )
             if tool_trace_collector is not None:
                 tool_trace_collector[:] = streaming.tool_trace
-            streaming._release_thread_write_reservation()
+            if not finalization_started:
+                streaming._release_thread_write_reservation()
 
     assert transport_outcome is not None
     return transport_outcome

--- a/tach.toml
+++ b/tach.toml
@@ -1919,10 +1919,16 @@ path = "mindroom.matrix.cache.write_coordinator"
 depends_on = []
 
 [[modules]]
+path = "mindroom.matrix.cache.outbound_thread_reservations"
+depends_on = []
+visibility = ["mindroom.matrix.cache.thread_writes"]
+
+[[modules]]
 path = "mindroom.matrix.cache.thread_writes"
 depends_on = [
     "mindroom.constants",
     "mindroom.matrix.cache.event_normalization",
+    "mindroom.matrix.cache.outbound_thread_reservations",
     "mindroom.matrix.event_info",
     "mindroom.matrix.sync_certification",
     "mindroom.matrix.thread_bookkeeping",

--- a/tests/test_dispatch_timing_instrumentation.py
+++ b/tests/test_dispatch_timing_instrumentation.py
@@ -282,9 +282,6 @@ def test_notify_outbound_message_marks_cache_schedule() -> None:
             {
                 "operation": "matrix_cache_notify_outbound_event",
                 "barrier_kind": "thread",
-                "room_id": "!room:localhost",
-                "thread_id": "$thread",
-                "event_id": "$tool_use",
                 "event_type": "m.room.message",
                 "is_edit": False,
                 "is_reaction": False,

--- a/tests/test_event_cache_write_coordination.py
+++ b/tests/test_event_cache_write_coordination.py
@@ -550,6 +550,25 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
 
         now = 16.0
         assert reservations.active_count == 0
+        assert reservations.resolve("principal-a", "!room-a", "$event") is None
+
+    def test_thread_reservations_evict_soonest_expiring_claim_at_capacity(self) -> None:
+        """Capacity cleanup should evict the claim nearest expiration."""
+        now = 10.0
+        reservations = OutboundThreadReservations(
+            ttl_seconds=5.0,
+            max_reservations=2,
+            clock=lambda: now,
+        )
+        reservations.reserve("principal-a", "!room", "$oldest", "$thread-oldest")
+        now = 11.0
+        reservations.reserve("principal-a", "!room", "$newer", "$thread-newer")
+        reservations.reserve("principal-a", "!room", "$newest", "$thread-newest")
+
+        assert reservations.active_count == 2
+        assert reservations.resolve("principal-a", "!room", "$oldest") is None
+        assert reservations.resolve("principal-a", "!room", "$newer") == "$thread-newer"
+        assert reservations.resolve("principal-a", "!room", "$newest") == "$thread-newest"
 
     @pytest.mark.asyncio
     async def test_outbound_nonterminal_streaming_edits_coalesce_pending_cache_updates(

--- a/tests/test_event_cache_write_coordination.py
+++ b/tests/test_event_cache_write_coordination.py
@@ -11,8 +11,16 @@ import pytest
 
 import mindroom.timing as timing_module
 from mindroom.background_tasks import wait_for_background_tasks
-from mindroom.constants import STREAM_STATUS_COMPLETED, STREAM_STATUS_KEY
+from mindroom.constants import (
+    STREAM_STATUS_CANCELLED,
+    STREAM_STATUS_COMPLETED,
+    STREAM_STATUS_ERROR,
+    STREAM_STATUS_KEY,
+    STREAM_STATUS_PENDING,
+    STREAM_STATUS_STREAMING,
+)
 from mindroom.matrix.cache import ThreadHistoryResult, thread_writes
+from mindroom.matrix.cache.outbound_thread_reservations import OutboundThreadReservations
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.conversation_cache import MatrixConversationCache
 from mindroom.matrix.event_info import EventInfo
@@ -227,6 +235,323 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         assert observed_options == [(False, None, None, event_cache.principal_id)]
 
     @pytest.mark.asyncio
+    async def test_ten_reserved_thread_streams_overlap_and_preserve_each_thread_order(self) -> None:
+        """Reserved edits should overlap across threads while retaining exact per-thread order."""
+        room_id = "!test:localhost"
+        thread_count = 10
+        event_cache = _runtime_event_cache()
+        coordinator = EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=_make_client_mock(),
+                event_cache=event_cache,
+                coordinator=coordinator,
+            ),
+        )
+        thread_ids = [f"$thread-{index}:localhost" for index in range(thread_count)]
+        original_event_ids = [f"$stream-{index}:localhost" for index in range(thread_count)]
+
+        for thread_id, original_event_id in zip(thread_ids, original_event_ids, strict=True):
+            access.notify_outbound_message(
+                room_id,
+                original_event_id,
+                {
+                    "body": "Working",
+                    "msgtype": "m.notice",
+                    STREAM_STATUS_KEY: STREAM_STATUS_PENDING,
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": thread_id,
+                        "is_falling_back": True,
+                        "m.in_reply_to": {"event_id": thread_id},
+                    },
+                },
+            )
+        await asyncio.gather(
+            *(
+                coordinator.wait_for_thread_idle(
+                    room_id,
+                    thread_id,
+                    coordination_scope=event_cache.principal_id,
+                )
+                for thread_id in thread_ids
+            ),
+        )
+        assert access._outbound._reservations.active_count == thread_count
+
+        event_cache.append_event.reset_mock()
+        event_cache.mark_thread_stale.reset_mock()
+        entered_by_thread = {thread_id: asyncio.Event() for thread_id in thread_ids}
+        release_first_edits = asyncio.Event()
+        active_threads: set[str] = set()
+        max_active_thread_count = 0
+        appended_event_ids_by_thread: dict[str, list[str]] = {thread_id: [] for thread_id in thread_ids}
+
+        async def blocking_mark_thread_stale(_room_id: str, thread_id: str, *, reason: str) -> None:
+            nonlocal max_active_thread_count
+            assert reason == "outbound_thread_mutation"
+            active_threads.add(thread_id)
+            max_active_thread_count = max(max_active_thread_count, len(active_threads))
+            entered_by_thread[thread_id].set()
+            await release_first_edits.wait()
+            active_threads.remove(thread_id)
+
+        async def record_append(
+            _room_id: str,
+            thread_id: str,
+            event_source: dict[str, object],
+        ) -> bool:
+            appended_event_ids_by_thread[thread_id].append(str(event_source["event_id"]))
+            return True
+
+        event_cache.mark_thread_stale = AsyncMock(side_effect=blocking_mark_thread_stale)
+        event_cache.append_event = AsyncMock(side_effect=record_append)
+
+        with (
+            patch.object(coordinator, "queue_room_update", wraps=coordinator.queue_room_update) as room_updates,
+            patch.object(coordinator, "queue_thread_update", wraps=coordinator.queue_thread_update) as thread_updates,
+        ):
+            try:
+                for stream_index, (_thread_id, original_event_id) in enumerate(
+                    zip(thread_ids, original_event_ids, strict=True),
+                ):
+                    for edit_index in range(3):
+                        body = f"stream {stream_index} update {edit_index}"
+                        access.notify_outbound_message(
+                            room_id,
+                            f"$edit-{stream_index}-{edit_index}:localhost",
+                            {
+                                "body": f"* {body}",
+                                "msgtype": "m.notice",
+                                "m.new_content": {
+                                    "body": body,
+                                    "msgtype": "m.notice",
+                                    STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+                                },
+                                "m.relates_to": {
+                                    "rel_type": "m.replace",
+                                    "event_id": original_event_id,
+                                },
+                            },
+                        )
+                    final_body = f"stream {stream_index} final"
+                    access.notify_outbound_message(
+                        room_id,
+                        f"$edit-{stream_index}-final:localhost",
+                        {
+                            "body": f"* {final_body}",
+                            "msgtype": "m.text",
+                            "m.new_content": {
+                                "body": final_body,
+                                "msgtype": "m.text",
+                                STREAM_STATUS_KEY: STREAM_STATUS_COMPLETED,
+                            },
+                            "m.relates_to": {
+                                "rel_type": "m.replace",
+                                "event_id": original_event_id,
+                            },
+                        },
+                    )
+
+                await asyncio.wait_for(
+                    asyncio.gather(*(entered.wait() for entered in entered_by_thread.values())),
+                    timeout=1.0,
+                )
+                assert max_active_thread_count == thread_count
+                assert room_updates.call_count == 0
+                assert thread_updates.call_count == thread_count * 4
+            finally:
+                release_first_edits.set()
+                await coordinator.close()
+
+        for stream_index, thread_id in enumerate(thread_ids):
+            assert appended_event_ids_by_thread[thread_id] == [
+                f"$edit-{stream_index}-0:localhost",
+                f"$edit-{stream_index}-2:localhost",
+                f"$edit-{stream_index}-final:localhost",
+            ]
+        assert access._outbound._reservations.active_count == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("terminal_status", [STREAM_STATUS_CANCELLED, STREAM_STATUS_ERROR])
+    async def test_terminal_failure_releases_reservation_after_queued_edits(
+        self,
+        terminal_status: str,
+    ) -> None:
+        """Failure and cancellation should release claims after capturing terminal thread scope."""
+        room_id = "!test:localhost"
+        thread_id = "$thread:localhost"
+        original_event_id = "$stream:localhost"
+        event_cache = _runtime_event_cache()
+        coordinator = EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=_make_client_mock(),
+                event_cache=event_cache,
+                coordinator=coordinator,
+            ),
+        )
+        access.notify_outbound_message(
+            room_id,
+            original_event_id,
+            {
+                "body": "Working",
+                "msgtype": "m.notice",
+                STREAM_STATUS_KEY: STREAM_STATUS_PENDING,
+                "m.relates_to": {"rel_type": "m.thread", "event_id": thread_id},
+            },
+        )
+        await coordinator.wait_for_thread_idle(
+            room_id,
+            thread_id,
+            coordination_scope=event_cache.principal_id,
+        )
+        assert access._outbound._reservations.active_count == 1
+        event_cache.append_event.reset_mock()
+
+        for event_id, body, stream_status in (
+            ("$edit-progress:localhost", "partial", STREAM_STATUS_STREAMING),
+            ("$edit-terminal:localhost", "terminal", terminal_status),
+        ):
+            access.notify_outbound_message(
+                room_id,
+                event_id,
+                {
+                    "body": f"* {body}",
+                    "msgtype": "m.text",
+                    "m.new_content": {
+                        "body": body,
+                        "msgtype": "m.text",
+                        STREAM_STATUS_KEY: stream_status,
+                    },
+                    "m.relates_to": {
+                        "rel_type": "m.replace",
+                        "event_id": original_event_id,
+                    },
+                },
+            )
+
+        assert access._outbound._reservations.active_count == 0
+        await coordinator.wait_for_thread_idle(
+            room_id,
+            thread_id,
+            coordination_scope=event_cache.principal_id,
+        )
+        appended_event_ids = [call.args[2]["event_id"] for call in event_cache.append_event.await_args_list]
+        assert appended_event_ids == ["$edit-progress:localhost", "$edit-terminal:localhost"]
+        assert not coordinator._room_states
+
+    @pytest.mark.asyncio
+    async def test_edit_event_id_transition_retains_thread_without_duplicate_terminal_write(self) -> None:
+        """A retained edit alias should route a transitioned terminal target to the same thread."""
+        room_id = "!test:localhost"
+        thread_id = "$thread:localhost"
+        original_event_id = "$stream:localhost"
+        first_edit_event_id = "$edit-first:localhost"
+        event_cache = _runtime_event_cache()
+        coordinator = EventCacheWriteCoordinator(
+            logger=MagicMock(),
+            background_task_owner=object(),
+        )
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=_make_client_mock(),
+                event_cache=event_cache,
+                coordinator=coordinator,
+            ),
+        )
+        access.notify_outbound_message(
+            room_id,
+            original_event_id,
+            {
+                "body": "Working",
+                "msgtype": "m.notice",
+                STREAM_STATUS_KEY: STREAM_STATUS_PENDING,
+                "m.relates_to": {"rel_type": "m.thread", "event_id": thread_id},
+            },
+        )
+        await coordinator.wait_for_thread_idle(
+            room_id,
+            thread_id,
+            coordination_scope=event_cache.principal_id,
+        )
+        event_cache.append_event.reset_mock()
+        access.notify_outbound_message(
+            room_id,
+            first_edit_event_id,
+            {
+                "body": "* partial",
+                "msgtype": "m.notice",
+                "m.new_content": {
+                    "body": "partial",
+                    "msgtype": "m.notice",
+                    STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+                },
+                "m.relates_to": {
+                    "rel_type": "m.replace",
+                    "event_id": original_event_id,
+                },
+            },
+        )
+        access.notify_outbound_message(
+            room_id,
+            "$edit-terminal:localhost",
+            {
+                "body": "* final",
+                "msgtype": "m.text",
+                "m.new_content": {
+                    "body": "final",
+                    "msgtype": "m.text",
+                    STREAM_STATUS_KEY: STREAM_STATUS_COMPLETED,
+                },
+                "m.relates_to": {
+                    "rel_type": "m.replace",
+                    "event_id": first_edit_event_id,
+                },
+            },
+        )
+
+        await coordinator.wait_for_thread_idle(
+            room_id,
+            thread_id,
+            coordination_scope=event_cache.principal_id,
+        )
+        assert [call.args[2]["event_id"] for call in event_cache.append_event.await_args_list] == [
+            first_edit_event_id,
+            "$edit-terminal:localhost",
+        ]
+        assert all(call.args[1] == thread_id for call in event_cache.append_event.await_args_list)
+        assert access._outbound._reservations.active_count == 0
+
+    def test_thread_reservations_isolate_principals_rooms_and_expire(self) -> None:
+        """Reservation keys should not collide and lazy TTL cleanup should bound stale claims."""
+        now = 10.0
+        reservations = OutboundThreadReservations(
+            ttl_seconds=5.0,
+            max_reservations=3,
+            clock=lambda: now,
+        )
+        reservations.reserve("principal-a", "!room-a", "$event", "$thread-a")
+        reservations.reserve("principal-b", "!room-a", "$event", "$thread-b")
+        reservations.reserve("principal-a", "!room-b", "$event", "$thread-c")
+
+        assert reservations.resolve("principal-a", "!room-a", "$event") == "$thread-a"
+        assert reservations.resolve("principal-b", "!room-a", "$event") == "$thread-b"
+        assert reservations.resolve("principal-a", "!room-b", "$event") == "$thread-c"
+
+        now = 16.0
+        assert reservations.active_count == 0
+
+    @pytest.mark.asyncio
     async def test_outbound_nonterminal_streaming_edits_coalesce_pending_cache_updates(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -293,7 +618,9 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         assert appended_event["content"]["m.new_content"]["body"] == "stream update 2"
         assert any(
             call.kwargs.get("coalesced_update_count") == 2
-            and call.kwargs.get("original_event_id") == "$stream-original:localhost"
+            and call.kwargs.get("stream_status") == STREAM_STATUS_STREAMING
+            and "original_event_id" not in call.kwargs
+            and "latest_event_id" not in call.kwargs
             for call in coordinator_logger.info.call_args_list
         )
         assert any(
@@ -303,6 +630,8 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             and call.kwargs["coalesced_update_count"] == 2
             and call.kwargs["predecessor_wait_ms"] >= 0.0
             and call.kwargs["update_run_ms"] >= 0.0
+            and "room_id" not in call.kwargs
+            and "thread_id" not in call.kwargs
             for call in timing_logger.debug.call_args_list
         )
 

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -1938,6 +1938,8 @@ class TestStreamingBehavior:
         mock_client = _make_matrix_client_mock()
         conversation_cache = AsyncMock()
         conversation_cache.notify_outbound_message = Mock()
+        conversation_cache.reserve_outbound_thread = Mock()
+        conversation_cache.release_outbound_thread = Mock()
 
         async def one_chunk_stream() -> AsyncIterator[str]:
             yield "Hello from stream"

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -1994,6 +1994,53 @@ class TestStreamingBehavior:
         assert second_call[:2] == ("!test:localhost", "$stream-edit")
         assert second_call[2]["m.relates_to"]["rel_type"] == "m.replace"
         assert second_call[2]["m.relates_to"]["event_id"] == "$stream-send"
+        conversation_cache.reserve_outbound_thread.assert_called_once_with(
+            "!test:localhost",
+            "$stream-send",
+            "$thread_root",
+        )
+        conversation_cache.release_outbound_thread.assert_called_once_with(
+            "!test:localhost",
+            "$stream-send",
+        )
+
+    @pytest.mark.asyncio
+    async def test_adopted_event_header_failure_releases_thread_reservation(self) -> None:
+        """A header edit failure must not retain an adopted response reservation."""
+        mock_client = _make_matrix_client_mock()
+        conversation_cache = MagicMock()
+
+        async def empty_stream() -> AsyncIterator[str]:
+            if False:
+                yield ""
+
+        with (
+            patch(
+                "mindroom.streaming.edit_message_result",
+                new=AsyncMock(side_effect=RuntimeError("header edit failed")),
+            ),
+            pytest.raises(RuntimeError, match="header edit failed"),
+        ):
+            await send_streaming_response(
+                client=mock_client,
+                target=MessageTarget.resolve("!test:localhost", "$thread_root", "$original_123"),
+                config=self.config,
+                runtime_paths=runtime_paths_for(self.config),
+                response_stream=empty_stream(),
+                header="Header",
+                existing_event_id="$thinking_123",
+                conversation_cache=conversation_cache,
+            )
+
+        conversation_cache.reserve_outbound_thread.assert_called_once_with(
+            "!test:localhost",
+            "$thinking_123",
+            "$thread_root",
+        )
+        conversation_cache.release_outbound_thread.assert_called_once_with(
+            "!test:localhost",
+            "$thinking_123",
+        )
 
     @pytest.mark.asyncio
     async def test_streaming_first_send_uses_resolved_thread_root(

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -164,6 +164,39 @@ async def test_transport_cancelled_terminal_update_does_not_sleep_behind_retry_b
 
 
 @pytest.mark.asyncio
+async def test_failed_terminal_update_releases_existing_thread_reservation(tmp_path: Path) -> None:
+    """Terminal failure should release an adopted response claim even when no edit lands."""
+    config = _config(tmp_path)
+    conversation_cache = MagicMock()
+    streaming = StreamingResponse(
+        target=MessageTarget.resolve("!room:localhost", "$thread", "$reply"),
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        conversation_cache=conversation_cache,
+    )
+    streaming.event_id = "$placeholder"
+    streaming.accumulated_text = "partial answer"
+    streaming._reserve_thread_write_reservation()
+
+    with patch(
+        "mindroom.streaming.edit_message_result",
+        new=AsyncMock(return_value=None),
+    ):
+        outcome = await streaming.finalize(_client(), error=RuntimeError("delivery failed"))
+
+    assert outcome.terminal_status == "error"
+    conversation_cache.reserve_outbound_thread.assert_called_once_with(
+        "!room:localhost",
+        "$placeholder",
+        "$thread",
+    )
+    conversation_cache.release_outbound_thread.assert_called_once_with(
+        "!room:localhost",
+        "$placeholder",
+    )
+
+
+@pytest.mark.asyncio
 async def test_transport_restart_interrupted_terminal_update_does_not_sleep_behind_retry_backoff(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- retain outbound stream thread identity in a bounded principal-, room-, and event-scoped reservation
- route relation-free streaming edits through certified per-thread cache barriers while preserving the room fallback for unknown mutations
- release reservations after terminal success, failure, or cancellation and retain aliases across legitimate event-ID transitions
- keep pending intermediate-edit coalescing per thread while preserving initial, executing, and terminal writes
- remove room, thread, and event identifiers from cache timing and coalescing telemetry

## Design and guarantees

`src/mindroom/matrix/cache/outbound_thread_reservations.py` owns the bounded in-memory reservation index.
`src/mindroom/matrix/cache/thread_writes.py` resolves reservation-backed thread scope before queue selection, so no room history lookup is needed for known local streams.
`src/mindroom/streaming.py` reserves after the initial event identity is known and releases on every terminal path.
Unknown edits and redactions retain the conservative room barrier.
Same-thread writes remain ordered by the existing coordinator; different certified threads may execute concurrently.

## Tests

- deterministic ten-thread event-gated concurrency test: all ten thread lanes entered before release, no room-barrier enqueue occurred, and every lane persisted its first intermediate edit, latest coalesced intermediate edit, and terminal edit in order
- reservation isolation, TTL cleanup, terminal failure/cancellation, and event-ID transition coverage
- focused streaming, delivery, cache mutation, thread resolution, stale cleanup, and sync-cache suites
- repository test suite, with the plugin CLI files run serially to avoid terminal wrapping caused by long parallel-worker temporary paths
- formatting, lint, type checks, Tach dependency/interface checks, pre-commit, and `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved streaming response edits to preserve the correct thread across ongoing updates and event transitions.
  - Enhanced ordering for simultaneous edits, reducing conflicts and ensuring updates are applied consistently.
  - Added safeguards to clean up temporary thread state after completion, cancellation, or errors.
  - Improved handling of expired or high-volume pending response updates for more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->