### PR TITLE
Bump mindroom-nio to 0.30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   # Arbitrary Olm to-device encryption uses the fork's tested internal API; update only with its round-trip tests.
-  "mindroom-nio[e2e]==0.28",
+  "mindroom-nio[e2e]==0.30",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/uv.lock
+++ b/uv.lock
@@ -4515,7 +4515,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = "==0.28" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = "==0.30" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4625,7 +4625,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "0.28.0"
+version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4637,9 +4637,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d2/83/eaf92704ed816fc62ea73000bf0068134b204b23d24e05226f0e0f9c9bf4/mindroom_nio-0.28.0.tar.gz", hash = "sha256:72915dd2caa397ea10cbb0da7aeae76932c8e375ff0ce552c9901f6318c9c404", size = 181209, upload-time = "2026-07-23T05:18:34.809Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/68/98e56bddd4d4b38d3b386c7b3c239b37e614101c4aac6b3d1367742f2d00/mindroom_nio-0.30.0.tar.gz", hash = "sha256:b6f5defaa159b68c12d02dbdca6816b673bf06a97cece31ebc04ca1dd72f735f", size = 184078, upload-time = "2026-07-25T15:22:37.737Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/0e/3e20ceb83b16f58f0fde190112b29bf1160f18d4d413fadf6f86800b7b5c/mindroom_nio-0.28.0-py3-none-any.whl", hash = "sha256:2319021b20cddf4fec3836e8a16d7ee5a10d228e9a6c84fb84f0da8ffca902d3", size = 209267, upload-time = "2026-07-23T05:18:33.22Z" },
+    { url = "https://files.pythonhosted.org/packages/00/3c/9f195d1dd80f586363b3eab880f59be4c3725bc09315ccbdf14cd8723e37/mindroom_nio-0.30.0-py3-none-any.whl", hash = "sha256:0cf1ea1b207a9307db08da1597ac34b7888a69f6497eb91783fe93a6c64d1b64", size = 212431, upload-time = "2026-07-25T15:22:36.305Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Bumps `mindroom-nio[e2e]` from `==0.28` to `==0.30` (0.30.0 on PyPI). Only `pyproject.toml` pins the version; `uv lock` touched nothing else (`mindroom-nio v0.28.0 -> v0.30.0`).

## What's in the two releases

[0.29.0](https://github.com/mindroom-ai/mindroom-nio/releases/tag/0.29.0)
- Rebased the fork onto upstream matrix-nio 0.26.0, including the vodozemac migration, Python 3.10 minimum, password-change API, unencrypted-media parsing for encrypted containers, and flattened event helpers.
- Retained fork-specific full-state sliding sync.

[0.30.0](https://github.com/mindroom-ai/mindroom-nio/releases/tag/0.30.0)
- Durable per-room limited-timeline recovery: monotonic transport tokens, held live rows, restart resumption when encrypted sync-token storage is active, cross-transport event-ID de-duplication, and one later decrypted replay.
- Encrypted client store migrated from schema v2 to v3; `SyncRecoveryGaps` and `PendingTimelineEvents` exported from `nio.store`.
- Room sends now fail closed while a room has an unresolved recovery lane; concurrent classic and Sliding Sync recovery pumps are serialized.

## Upgrade note

Encryption stores migrate v2 -> v3 on first use, and downgrading to 0.29.0 after the migration is not supported. Deployed instances (`mindroom-lab`, `mindroom-chat`, hosted instances) will migrate their `mindroom_data/encryption_keys/` stores on the next start.

## Testing

- Full `uv run pytest tests/` run locally. The 15 failures are all pre-existing CLI-output assertions that break on ANSI escape codes in this terminal (`assert '2 warnings' in '...\x1b[1;36m2\x1b[0m warnings'`); they reproduce identically on `main` with nio 0.28 and none touch Matrix or nio.
- Everything matched by `-k "matrix or nio or sync or encrypt"` passes, including the matrix_rtc real-olm E2EE tests that the pin comment in `pyproject.toml` calls out.
- `uv run pre-commit` hooks pass on the commit.