### PR TITLE
Retry terminal delivery after Matrix sync recovery

### DIFF
--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -204,6 +204,11 @@ Outgoing encrypted Matrix sends always deliver to unverified devices.
 MindRoom bots have no interactive device-verification flow, so enforcing nio's device-trust checks would fail every send to an encrypted room with an `OlmUnverifiedDeviceError` and the agent would appear to silently ignore messages.
 A configurable trust policy only becomes meaningful once a device-verification mechanism exists (for example trust-on-first-use, a verification command, or cross-signing support).
 
+While a room's timeline is still recovering from a limited sync, nio rejects sends to that room with `SendRetryError` until the gap closes, so MindRoom retries the affected delivery in place instead of dropping it.
+Streaming progress updates and completed terminal deliveries reuse the identical prepared payload and retry for up to 30 seconds — one recovery pump — backing off from 50ms to 500ms between attempts.
+Cancelled and errored terminal updates never wait on recovery, so a stopped or failed turn still settles immediately.
+If the window expires the delivery is reported as failed, the placeholder settles as a delivery failure, and the failure update itself is sent without waiting on recovery again.
+
 ## End-to-End Encryption
 
 Agents fully participate in encrypted rooms: they decrypt inbound text and media, reply encrypted, and re-fetch and decrypt thread history from the homeserver.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16161,6 +16161,11 @@ Outgoing encrypted Matrix sends always deliver to unverified devices.
 MindRoom bots have no interactive device-verification flow, so enforcing nio's device-trust checks would fail every send to an encrypted room with an `OlmUnverifiedDeviceError` and the agent would appear to silently ignore messages.
 A configurable trust policy only becomes meaningful once a device-verification mechanism exists (for example trust-on-first-use, a verification command, or cross-signing support).
 
+While a room's timeline is still recovering from a limited sync, nio rejects sends to that room with `SendRetryError` until the gap closes, so MindRoom retries the affected delivery in place instead of dropping it.
+Streaming progress updates and completed terminal deliveries reuse the identical prepared payload and retry for up to 30 seconds — one recovery pump — backing off from 50ms to 500ms between attempts.
+Cancelled and errored terminal updates never wait on recovery, so a stopped or failed turn still settles immediately.
+If the window expires the delivery is reported as failed, the placeholder settles as a delivery failure, and the failure update itself is sent without waiting on recovery again.
+
 ## End-to-End Encryption
 
 Agents fully participate in encrypted rooms: they decrypt inbound text and media, reply encrypted, and re-fetch and decrypt thread history from the homeserver.

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -200,6 +200,11 @@ Outgoing encrypted Matrix sends always deliver to unverified devices.
 MindRoom bots have no interactive device-verification flow, so enforcing nio's device-trust checks would fail every send to an encrypted room with an `OlmUnverifiedDeviceError` and the agent would appear to silently ignore messages.
 A configurable trust policy only becomes meaningful once a device-verification mechanism exists (for example trust-on-first-use, a verification command, or cross-signing support).
 
+While a room's timeline is still recovering from a limited sync, nio rejects sends to that room with `SendRetryError` until the gap closes, so MindRoom retries the affected delivery in place instead of dropping it.
+Streaming progress updates and completed terminal deliveries reuse the identical prepared payload and retry for up to 30 seconds — one recovery pump — backing off from 50ms to 500ms between attempts.
+Cancelled and errored terminal updates never wait on recovery, so a stopped or failed turn still settles immediately.
+If the window expires the delivery is reported as failed, the placeholder settles as a delivery failure, and the failure update itself is sent without waiting on recovery again.
+
 ## End-to-End Encryption
 
 Agents fully participate in encrypted rooms: they decrypt inbound text and media, reply encrypted, and re-fetch and decrypt thread history from the homeserver.

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -196,6 +196,7 @@ class SendTextRequest:  # noqa: D101
     skip_mentions: bool = False
     tool_trace: list[ToolTraceEntry] | None = None
     extra_content: dict[str, Any] | None = None
+    retry_sync_recovery: bool = False
 
 
 @dataclass(frozen=True)
@@ -205,6 +206,7 @@ class EditTextRequest:  # noqa: D101
     new_text: str
     tool_trace: list[ToolTraceEntry] | None = None
     extra_content: dict[str, Any] | None = None
+    retry_sync_recovery: bool = False
 
 
 @dataclass(frozen=True)
@@ -503,7 +505,12 @@ class DeliveryGateway:
             )
         if request.skip_mentions:
             content[SKIP_MENTIONS_KEY] = True
-        delivered = await send_message_result(client, resolved_target.room_id, content)
+        delivered = await send_message_result(
+            client,
+            resolved_target.room_id,
+            content,
+            retry_sync_recovery=request.retry_sync_recovery,
+        )
         if delivered is not None:
             self.deps.resolver.deps.conversation_cache.notify_outbound_message(
                 resolved_target.room_id,
@@ -560,6 +567,7 @@ class DeliveryGateway:
             request.event_id,
             content,
             request.new_text,
+            retry_sync_recovery=request.retry_sync_recovery,
         )
         if delivered is not None:
             self.deps.resolver.deps.conversation_cache.notify_outbound_message(
@@ -707,6 +715,7 @@ class DeliveryGateway:
                     new_text=display_text,
                     tool_trace=draft.tool_trace,
                     extra_content=draft.extra_content,
+                    retry_sync_recovery=True,
                 ),
             )
             if edited:
@@ -747,6 +756,7 @@ class DeliveryGateway:
                 skip_mentions=request.skip_mentions,
                 tool_trace=draft.tool_trace,
                 extra_content=draft.extra_content,
+                retry_sync_recovery=True,
             ),
         )
         if event_id is None:

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from html import escape as html_escape
 from typing import TYPE_CHECKING, Any, Literal
 
+from nio.exceptions import SendRetryError
+
 from mindroom import constants, interactive
 from mindroom.constants import SKIP_MENTIONS_KEY
 from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
@@ -505,12 +507,15 @@ class DeliveryGateway:
             )
         if request.skip_mentions:
             content[SKIP_MENTIONS_KEY] = True
-        delivered = await send_message_result(
-            client,
-            resolved_target.room_id,
-            content,
-            retry_sync_recovery=request.retry_sync_recovery,
-        )
+        try:
+            delivered = await send_message_result(
+                client,
+                resolved_target.room_id,
+                content,
+                retry_sync_recovery=request.retry_sync_recovery,
+            )
+        except SendRetryError:
+            delivered = None
         if delivered is not None:
             self.deps.resolver.deps.conversation_cache.notify_outbound_message(
                 resolved_target.room_id,
@@ -561,14 +566,17 @@ class DeliveryGateway:
                 latest_thread_event_id=latest_thread_event_id,
             )
 
-        delivered = await edit_message_result(
-            client,
-            target.room_id,
-            request.event_id,
-            content,
-            request.new_text,
-            retry_sync_recovery=request.retry_sync_recovery,
-        )
+        try:
+            delivered = await edit_message_result(
+                client,
+                target.room_id,
+                request.event_id,
+                content,
+                request.new_text,
+                retry_sync_recovery=request.retry_sync_recovery,
+            )
+        except SendRetryError:
+            delivered = None
         if delivered is not None:
             self.deps.resolver.deps.conversation_cache.notify_outbound_message(
                 target.room_id,

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -507,6 +507,7 @@ class DeliveryGateway:
             )
         if request.skip_mentions:
             content[SKIP_MENTIONS_KEY] = True
+        failure_reason = "send_message_result returned None"
         try:
             delivered = await send_message_result(
                 client,
@@ -516,6 +517,7 @@ class DeliveryGateway:
             )
         except SendRetryError:
             delivered = None
+            failure_reason = "matrix timeline recovery still blocked the send"
         if delivered is not None:
             self.deps.resolver.deps.conversation_cache.notify_outbound_message(
                 resolved_target.room_id,
@@ -524,7 +526,11 @@ class DeliveryGateway:
             )
             self.deps.logger.info("Sent response", event_id=delivered.event_id, **resolved_target.log_context)
             return delivered.event_id
-        self.deps.logger.error("Failed to send response to room", **resolved_target.log_context)
+        self.deps.logger.error(
+            "Failed to send response to room",
+            error=failure_reason,
+            **resolved_target.log_context,
+        )
         return None
 
     async def edit_text(self, request: EditTextRequest) -> bool:
@@ -566,6 +572,7 @@ class DeliveryGateway:
                 latest_thread_event_id=latest_thread_event_id,
             )
 
+        failure_reason = "edit_message_result returned None"
         try:
             delivered = await edit_message_result(
                 client,
@@ -577,6 +584,7 @@ class DeliveryGateway:
             )
         except SendRetryError:
             delivered = None
+            failure_reason = "matrix timeline recovery still blocked the edit"
         if delivered is not None:
             self.deps.resolver.deps.conversation_cache.notify_outbound_message(
                 target.room_id,
@@ -588,7 +596,7 @@ class DeliveryGateway:
         self.deps.logger.error(
             "Failed to edit message",
             event_id=request.event_id,
-            error="edit_message_result returned None",
+            error=failure_reason,
             **target.log_context,
         )
         return False

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -127,7 +127,7 @@ async def _send_prepared_room_message(
     message_type: str,
     cache_bypass: bool,
     operation: str,
-    retry_sync_recovery: bool = False,
+    retry_sync_recovery: bool,
 ) -> object | None:
     """Send one prepared Matrix room message and normalize local delivery exceptions."""
 
@@ -169,8 +169,8 @@ async def _send_prepared_room_message(
         return await send_once()
     except asyncio.CancelledError:
         raise
-    except nio.SendRetryError as error:
-        if retry_sync_recovery:
+    except Exception as error:
+        if retry_sync_recovery and isinstance(error, nio.SendRetryError):
             return await _retry_prepared_room_message_after_sync_recovery(
                 send_once,
                 original_error=error,
@@ -178,14 +178,6 @@ async def _send_prepared_room_message(
                 operation=operation,
                 cache_bypass=cache_bypass,
             )
-        _log_matrix_delivery_exception(
-            error,
-            room_id=room_id,
-            operation=operation,
-            cache_bypass=cache_bypass,
-        )
-        return None
-    except Exception as error:
         _log_matrix_delivery_exception(
             error,
             room_id=room_id,

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -112,6 +112,8 @@ async def _send_prepared_room_message(
         )
     except asyncio.CancelledError:
         raise
+    except nio.SendRetryError:
+        raise
     except Exception as error:
         _log_matrix_delivery_exception(
             error,

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import mimetypes
-from collections.abc import Mapping, Sequence
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -32,6 +32,10 @@ logger = get_logger(__name__)
 
 _MATRIX_TRUST_DELIVERY_ERROR_MESSAGE = "Matrix encrypted delivery rejected by local device trust policy."
 _MATRIX_GENERIC_DELIVERY_ERROR_MESSAGE = "Matrix delivery raised an unexpected local exception."
+# Allow one default nio recovery pump, while keeping terminal delivery bounded.
+_SYNC_RECOVERY_RETRY_TIMEOUT_SECONDS = 30.0
+_SYNC_RECOVERY_RETRY_INITIAL_DELAY_SECONDS = 0.05
+_SYNC_RECOVERY_RETRY_MAX_DELAY_SECONDS = 0.5
 
 
 @dataclass(frozen=True, slots=True)
@@ -67,6 +71,54 @@ def _log_matrix_delivery_exception(
     )
 
 
+async def _retry_prepared_room_message_after_sync_recovery(
+    send_once: Callable[[], Awaitable[object | None]],
+    *,
+    original_error: nio.SendRetryError,
+    room_id: str,
+    operation: str,
+    cache_bypass: bool,
+) -> object | None:
+    """Retry one frozen payload within a bounded sync-recovery window."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + _SYNC_RECOVERY_RETRY_TIMEOUT_SECONDS
+    delay = _SYNC_RECOVERY_RETRY_INITIAL_DELAY_SECONDS
+    first_retry = True
+    while True:
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise original_error
+        retry_delay = min(delay, remaining)
+        log = logger.warning if first_retry else logger.debug
+        log(
+            "Waiting to retry Matrix delivery after sync recovery",
+            room_id=room_id,
+            operation=operation,
+            retry_in_seconds=retry_delay,
+        )
+        await asyncio.sleep(retry_delay)
+        remaining = deadline - loop.time()
+        if remaining <= 0:
+            raise original_error
+        try:
+            return await asyncio.wait_for(send_once(), remaining)
+        except asyncio.CancelledError:
+            raise
+        except TimeoutError:
+            raise original_error from None
+        except nio.SendRetryError:
+            first_retry = False
+            delay = min(delay * 2, _SYNC_RECOVERY_RETRY_MAX_DELAY_SECONDS)
+        except Exception as error:
+            _log_matrix_delivery_exception(
+                error,
+                room_id=room_id,
+                operation=operation,
+                cache_bypass=cache_bypass,
+            )
+            return None
+
+
 async def _send_prepared_room_message(
     client: nio.AsyncClient,
     room_id: str,
@@ -75,9 +127,11 @@ async def _send_prepared_room_message(
     message_type: str,
     cache_bypass: bool,
     operation: str,
+    retry_sync_recovery: bool = False,
 ) -> object | None:
     """Send one prepared Matrix room message and normalize local delivery exceptions."""
-    try:
+
+    async def send_once() -> object | None:
         if cache_bypass:
             access_token = client.access_token
             if not access_token:
@@ -110,10 +164,27 @@ async def _send_prepared_room_message(
             content=content_sent,
             ignore_unverified_devices=True,
         )
+
+    try:
+        return await send_once()
     except asyncio.CancelledError:
         raise
-    except nio.SendRetryError:
-        raise
+    except nio.SendRetryError as error:
+        if retry_sync_recovery:
+            return await _retry_prepared_room_message_after_sync_recovery(
+                send_once,
+                original_error=error,
+                room_id=room_id,
+                operation=operation,
+                cache_bypass=cache_bypass,
+            )
+        _log_matrix_delivery_exception(
+            error,
+            room_id=room_id,
+            operation=operation,
+            cache_bypass=cache_bypass,
+        )
+        return None
     except Exception as error:
         _log_matrix_delivery_exception(
             error,
@@ -186,6 +257,7 @@ async def send_message_result(
     content: dict[str, Any],
     *,
     operation: str = "send_message",
+    retry_sync_recovery: bool = False,
 ) -> DeliveredMatrixEvent | None:
     """Send a message to a Matrix room and return the exact delivered payload."""
     if not _can_send_to_encrypted_room(client, room_id, operation=operation):
@@ -243,6 +315,7 @@ async def send_message_result(
         message_type=message_type,
         cache_bypass=cache_bypass,
         operation=operation,
+        retry_sync_recovery=retry_sync_recovery,
     )
     if response is None:
         emit_timing_event(
@@ -644,6 +717,7 @@ async def edit_message_result(
     new_text: str,
     *,
     extra_content: dict[str, Any] | None = None,
+    retry_sync_recovery: bool = False,
 ) -> DeliveredMatrixEvent | None:
     """Edit an existing Matrix message and return the exact delivered payload."""
     edit_content = build_edit_event_content(
@@ -653,7 +727,13 @@ async def edit_message_result(
         extra_content=extra_content,
     )
 
-    return await send_message_result(client, room_id, edit_content, operation="edit_message")
+    return await send_message_result(
+        client,
+        room_id,
+        edit_content,
+        operation="edit_message",
+        retry_sync_recovery=retry_sync_recovery,
+    )
 
 
 __all__ = [

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, NoReturn
 
 from agno.run.agent import RunCompletedEvent, RunContentEvent, ToolCallCompletedEvent, ToolCallStartedEvent
+from nio.exceptions import SendRetryError
 
 from mindroom import interactive
 from mindroom.constants import (
@@ -97,6 +98,38 @@ StreamInputChunk = (
 )
 _STREAM_DELIVERY_DRAIN_TIMEOUT_SECONDS = 5.0
 _STREAM_DELIVERY_CANCEL_TIMEOUT_SECONDS = 5.0
+# Allow one default nio recovery pump, while keeping terminal delivery bounded.
+_SYNC_RECOVERY_RETRY_TIMEOUT_SECONDS = 30.0
+_SYNC_RECOVERY_RETRY_INITIAL_DELAY_SECONDS = 0.05
+_SYNC_RECOVERY_RETRY_MAX_DELAY_SECONDS = 0.5
+
+
+async def _wait_before_sync_recovery_retry(
+    error: SendRetryError,
+    *,
+    deadline: float | None,
+    delay: float,
+    event_id: str | None,
+    room_id: str,
+) -> tuple[float, float]:
+    """Wait once before retrying a terminal delivery blocked by sync recovery."""
+    loop = asyncio.get_running_loop()
+    deadline = deadline or loop.time() + _SYNC_RECOVERY_RETRY_TIMEOUT_SECONDS
+    remaining = deadline - loop.time()
+    if remaining <= 0:
+        raise error
+    delay = min(delay, remaining)
+    logger.warning(
+        "Waiting to retry terminal delivery after Matrix sync recovery",
+        event_id=event_id,
+        room_id=room_id,
+        retry_in_seconds=delay,
+    )
+    await asyncio.sleep(delay)
+    return deadline, min(
+        delay * 2,
+        _SYNC_RECOVERY_RETRY_MAX_DELAY_SECONDS,
+    )
 
 
 class _NonTerminalDeliveryError(Exception):
@@ -914,6 +947,7 @@ class StreamingResponse:
                 display_text=prepared_delivery.display_text,
                 retry_on_failure=retry_on_failure,
                 retry_without_backoff=retry_without_backoff,
+                retry_sync_recovery=retry_on_failure,
             )
         finally:
             if self._inflight_nonterminal_capture is capture:
@@ -1124,10 +1158,14 @@ class StreamingResponse:
         display_text: str,
         retry_on_failure: bool = False,
         retry_without_backoff: bool = False,
+        retry_sync_recovery: bool = False,
     ) -> bool:
         """Send a new event or edit the existing one."""
         total_attempts = 2 if retry_on_failure or retry_without_backoff else 1
-        for attempt in range(1, total_attempts + 1):
+        attempt = 1
+        recovery_deadline: float | None = None
+        recovery_delay = _SYNC_RECOVERY_RETRY_INITIAL_DELAY_SECONDS
+        while attempt <= total_attempts:
             try:
                 if self.event_id is None:
                     logger.debug("Sending initial streaming message", attempt=attempt)
@@ -1139,6 +1177,17 @@ class StreamingResponse:
                     if await self._edit_existing_content(client, content=content, display_text=display_text):
                         return True
                     logger.error("Failed to edit streaming message", attempt=attempt)
+            except SendRetryError as error:
+                if not retry_sync_recovery:
+                    raise
+                recovery_deadline, recovery_delay = await _wait_before_sync_recovery_retry(
+                    error,
+                    deadline=recovery_deadline,
+                    delay=recovery_delay,
+                    event_id=self.event_id,
+                    room_id=self.room_id,
+                )
+                continue
             except Exception:
                 logger.warning(
                     "Streaming update attempt raised an exception",
@@ -1156,6 +1205,7 @@ class StreamingResponse:
                     event_id=self.event_id,
                     room_id=self.room_id,
                 )
+            attempt += 1
         return False
 
 

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -98,38 +98,6 @@ StreamInputChunk = (
 )
 _STREAM_DELIVERY_DRAIN_TIMEOUT_SECONDS = 5.0
 _STREAM_DELIVERY_CANCEL_TIMEOUT_SECONDS = 5.0
-# Allow one default nio recovery pump, while keeping terminal delivery bounded.
-_SYNC_RECOVERY_RETRY_TIMEOUT_SECONDS = 30.0
-_SYNC_RECOVERY_RETRY_INITIAL_DELAY_SECONDS = 0.05
-_SYNC_RECOVERY_RETRY_MAX_DELAY_SECONDS = 0.5
-
-
-async def _wait_before_sync_recovery_retry(
-    error: SendRetryError,
-    *,
-    deadline: float | None,
-    delay: float,
-    event_id: str | None,
-    room_id: str,
-) -> tuple[float, float]:
-    """Wait once before retrying a terminal delivery blocked by sync recovery."""
-    loop = asyncio.get_running_loop()
-    deadline = deadline or loop.time() + _SYNC_RECOVERY_RETRY_TIMEOUT_SECONDS
-    remaining = deadline - loop.time()
-    if remaining <= 0:
-        raise error
-    delay = min(delay, remaining)
-    logger.warning(
-        "Waiting to retry terminal delivery after Matrix sync recovery",
-        event_id=event_id,
-        room_id=room_id,
-        retry_in_seconds=delay,
-    )
-    await asyncio.sleep(delay)
-    return deadline, min(
-        delay * 2,
-        _SYNC_RECOVERY_RETRY_MAX_DELAY_SECONDS,
-    )
 
 
 class _NonTerminalDeliveryError(Exception):
@@ -947,7 +915,7 @@ class StreamingResponse:
                 display_text=prepared_delivery.display_text,
                 retry_on_failure=retry_on_failure,
                 retry_without_backoff=retry_without_backoff,
-                retry_sync_recovery=retry_on_failure,
+                retry_sync_recovery=retry_on_failure and is_final,
             )
         finally:
             if self._inflight_nonterminal_capture is capture:
@@ -1114,9 +1082,20 @@ class StreamingResponse:
         if self.pipeline_timing is not None and self.accumulated_text.strip():
             self.pipeline_timing.mark_first_visible_reply("stream_update")
 
-    async def _send_initial_content(self, client: nio.AsyncClient, *, content: dict[str, Any]) -> bool:
+    async def _send_initial_content(
+        self,
+        client: nio.AsyncClient,
+        *,
+        content: dict[str, Any],
+        retry_sync_recovery: bool = False,
+    ) -> bool:
         """Send the initial streaming event."""
-        delivered = await send_message_result(client, self.room_id, content)
+        delivered = await send_message_result(
+            client,
+            self.room_id,
+            content,
+            retry_sync_recovery=retry_sync_recovery,
+        )
         if delivered is None:
             return False
         self.event_id = delivered.event_id
@@ -1134,6 +1113,7 @@ class StreamingResponse:
         *,
         content: dict[str, Any],
         display_text: str,
+        retry_sync_recovery: bool = False,
     ) -> bool:
         """Send one streaming edit event for the existing message."""
         assert self.event_id is not None
@@ -1143,6 +1123,7 @@ class StreamingResponse:
             self.event_id,
             content,
             display_text,
+            retry_sync_recovery=retry_sync_recovery,
         )
         if delivered is None:
             return False
@@ -1163,31 +1144,29 @@ class StreamingResponse:
         """Send a new event or edit the existing one."""
         total_attempts = 2 if retry_on_failure or retry_without_backoff else 1
         attempt = 1
-        recovery_deadline: float | None = None
-        recovery_delay = _SYNC_RECOVERY_RETRY_INITIAL_DELAY_SECONDS
         while attempt <= total_attempts:
             try:
                 if self.event_id is None:
                     logger.debug("Sending initial streaming message", attempt=attempt)
-                    if await self._send_initial_content(client, content=content):
+                    if await self._send_initial_content(
+                        client,
+                        content=content,
+                        retry_sync_recovery=retry_sync_recovery,
+                    ):
                         return True
                     logger.error("Failed to send initial streaming message", attempt=attempt)
                 else:
                     logger.debug("Editing streaming message", event_id=self.event_id, attempt=attempt)
-                    if await self._edit_existing_content(client, content=content, display_text=display_text):
+                    if await self._edit_existing_content(
+                        client,
+                        content=content,
+                        display_text=display_text,
+                        retry_sync_recovery=retry_sync_recovery,
+                    ):
                         return True
                     logger.error("Failed to edit streaming message", attempt=attempt)
-            except SendRetryError as error:
-                if not retry_sync_recovery:
-                    raise
-                recovery_deadline, recovery_delay = await _wait_before_sync_recovery_retry(
-                    error,
-                    deadline=recovery_deadline,
-                    delay=recovery_delay,
-                    event_id=self.event_id,
-                    room_id=self.room_id,
-                )
-                continue
+            except SendRetryError:
+                raise
             except Exception:
                 logger.warning(
                     "Streaming update attempt raised an exception",

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -1087,7 +1087,7 @@ class StreamingResponse:
         client: nio.AsyncClient,
         *,
         content: dict[str, Any],
-        retry_sync_recovery: bool = False,
+        retry_sync_recovery: bool,
     ) -> bool:
         """Send the initial streaming event."""
         delivered = await send_message_result(
@@ -1113,7 +1113,7 @@ class StreamingResponse:
         *,
         content: dict[str, Any],
         display_text: str,
-        retry_sync_recovery: bool = False,
+        retry_sync_recovery: bool,
     ) -> bool:
         """Send one streaming edit event for the existing message."""
         assert self.event_id is not None
@@ -1143,8 +1143,7 @@ class StreamingResponse:
     ) -> bool:
         """Send a new event or edit the existing one."""
         total_attempts = 2 if retry_on_failure or retry_without_backoff else 1
-        attempt = 1
-        while attempt <= total_attempts:
+        for attempt in range(1, total_attempts + 1):
             try:
                 if self.event_id is None:
                     logger.debug("Sending initial streaming message", attempt=attempt)
@@ -1184,7 +1183,6 @@ class StreamingResponse:
                     event_id=self.event_id,
                     room_id=self.room_id,
                 )
-            attempt += 1
         return False
 
 

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -915,7 +915,7 @@ class StreamingResponse:
                 display_text=prepared_delivery.display_text,
                 retry_on_failure=retry_on_failure,
                 retry_without_backoff=retry_without_backoff,
-                retry_sync_recovery=retry_on_failure and is_final,
+                retry_sync_recovery=not is_final or retry_on_failure,
             )
         finally:
             if self._inflight_nonterminal_capture is capture:

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -914,6 +914,30 @@ class TestSendMessageResult:
         assert mock_error.call_args.kwargs["exception_type"] == "OlmUnverifiedDeviceError"
 
     @pytest.mark.asyncio
+    async def test_sync_recovery_retry_signal_is_preserved(self) -> None:
+        """Limited-sync recovery must remain distinguishable from terminal delivery failure."""
+        client = _mock_client()
+        error = nio.SendRetryError("Room timeline recovery is still pending.")
+        client.room_send.side_effect = error
+
+        with (
+            patch(
+                "mindroom.matrix.client_delivery.prepare_large_message",
+                new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
+            ),
+            patch("mindroom.matrix.client_delivery.logger.error") as mock_error,
+            pytest.raises(nio.SendRetryError) as raised,
+        ):
+            await send_message_result(
+                client,
+                "!room:localhost",
+                {"body": "hello", "msgtype": "m.text"},
+            )
+
+        assert raised.value is error
+        mock_error.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_unexpected_room_send_exception_logs_generic_sanitized_message(self) -> None:
         """Unexpected local delivery exceptions should log type plus a safe generic message."""
         client = _mock_client()

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
@@ -914,11 +915,110 @@ class TestSendMessageResult:
         assert mock_error.call_args.kwargs["exception_type"] == "OlmUnverifiedDeviceError"
 
     @pytest.mark.asyncio
-    async def test_sync_recovery_retry_signal_is_preserved(self) -> None:
-        """Limited-sync recovery must remain distinguishable from terminal delivery failure."""
+    async def test_sync_recovery_retry_reuses_one_prepared_payload(self) -> None:
+        """Opt-in recovery retries should reuse the exact prepared wire payload."""
         client = _mock_client()
         error = nio.SendRetryError("Room timeline recovery is still pending.")
-        client.room_send.side_effect = error
+        response = nio.RoomSendResponse("$evt:localhost", "!room:localhost")
+        client.room_send.side_effect = [error, error, error, response]
+        prepared = {"body": "prepared", "msgtype": "m.text"}
+        prepare = AsyncMock(return_value=prepared)
+        sleep_mock = AsyncMock()
+
+        with (
+            patch("mindroom.matrix.client_delivery.prepare_large_message", new=prepare),
+            patch("mindroom.matrix.client_delivery.asyncio.sleep", new=sleep_mock),
+            patch("mindroom.matrix.client_delivery.logger.warning") as warning_mock,
+        ):
+            result = await send_message_result(
+                client,
+                "!room:localhost",
+                {"body": "hello", "msgtype": "m.text"},
+                retry_sync_recovery=True,
+            )
+
+        assert result is not None
+        assert result.event_id == "$evt:localhost"
+        prepare.assert_awaited_once()
+        assert client.room_send.await_count == 4
+        assert all(call.kwargs["content"] is prepared for call in client.room_send.await_args_list)
+        assert sleep_mock.await_count == 3
+        warning_mock.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_sync_recovery_retry_bounds_a_stuck_second_send(self) -> None:
+        """The recovery deadline should also bound a retry stuck in transport."""
+        client = _mock_client()
+        original_error = nio.SendRetryError("Room timeline recovery is still pending.")
+        send_count = 0
+        prepared = {"body": "prepared", "msgtype": "m.text"}
+        prepare = AsyncMock(return_value=prepared)
+
+        async def send(**_kwargs: object) -> nio.RoomSendResponse:
+            nonlocal send_count
+            send_count += 1
+            if send_count == 1:
+                raise original_error
+            await asyncio.Event().wait()
+            raise AssertionError
+
+        client.room_send.side_effect = send
+        with (
+            patch("mindroom.matrix.client_delivery.prepare_large_message", new=prepare),
+            patch("mindroom.matrix.client_delivery.asyncio.sleep", new=AsyncMock()),
+            patch("mindroom.matrix.client_delivery._SYNC_RECOVERY_RETRY_TIMEOUT_SECONDS", new=0.01),
+            pytest.raises(nio.SendRetryError) as raised,
+        ):
+            await asyncio.wait_for(
+                send_message_result(
+                    client,
+                    "!room:localhost",
+                    {"body": "hello", "msgtype": "m.text"},
+                    retry_sync_recovery=True,
+                ),
+                0.5,
+            )
+
+        assert raised.value is original_error
+        prepare.assert_awaited_once()
+        assert send_count == 2
+
+    @pytest.mark.asyncio
+    async def test_sync_recovery_retry_sleep_is_cancellation_aware(self) -> None:
+        """Cancellation should interrupt recovery backoff immediately."""
+        client = _mock_client()
+        client.room_send.side_effect = nio.SendRetryError("Room timeline recovery is still pending.")
+        sleep_started = asyncio.Event()
+
+        async def wait_forever(_delay: float) -> None:
+            sleep_started.set()
+            await asyncio.Event().wait()
+
+        with (
+            patch(
+                "mindroom.matrix.client_delivery.prepare_large_message",
+                new=AsyncMock(return_value={"body": "prepared", "msgtype": "m.text"}),
+            ),
+            patch("mindroom.matrix.client_delivery.asyncio.sleep", new=wait_forever),
+        ):
+            task = asyncio.create_task(
+                send_message_result(
+                    client,
+                    "!room:localhost",
+                    {"body": "hello", "msgtype": "m.text"},
+                    retry_sync_recovery=True,
+                ),
+            )
+            await sleep_started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+    @pytest.mark.asyncio
+    async def test_sync_recovery_error_keeps_default_send_contract(self) -> None:
+        """Ordinary sends should retain normalized failure behavior."""
+        client = _mock_client()
+        client.room_send.side_effect = nio.SendRetryError("Room timeline recovery is still pending.")
 
         with (
             patch(
@@ -926,16 +1026,44 @@ class TestSendMessageResult:
                 new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
             ),
             patch("mindroom.matrix.client_delivery.logger.error") as mock_error,
-            pytest.raises(nio.SendRetryError) as raised,
         ):
-            await send_message_result(
+            result = await send_message_result(
                 client,
                 "!room:localhost",
                 {"body": "hello", "msgtype": "m.text"},
             )
 
-        assert raised.value is error
-        mock_error.assert_not_called()
+        assert result is None
+        mock_error.assert_called_once()
+        assert mock_error.call_args.args == ("matrix_message_delivery_exception",)
+        assert mock_error.call_args.kwargs["exception_type"] == "SendRetryError"
+
+    @pytest.mark.asyncio
+    async def test_sync_recovery_error_keeps_default_edit_contract(self) -> None:
+        """Ordinary edits should retain normalized failure behavior."""
+        client = _mock_client()
+        client.room_send.side_effect = nio.SendRetryError("Room timeline recovery is still pending.")
+
+        with (
+            patch(
+                "mindroom.matrix.client_delivery.prepare_large_message",
+                new=AsyncMock(side_effect=lambda *_: {"body": "hello", "msgtype": "m.text"}),
+            ),
+            patch("mindroom.matrix.client_delivery.logger.error") as mock_error,
+        ):
+            result = await edit_message_result(
+                client,
+                "!room:localhost",
+                "$placeholder",
+                {"body": "hello", "msgtype": "m.text"},
+                "hello",
+            )
+
+        assert result is None
+        mock_error.assert_called_once()
+        assert mock_error.call_args.args == ("matrix_message_delivery_exception",)
+        assert mock_error.call_args.kwargs["operation"] == "edit_message"
+        assert mock_error.call_args.kwargs["exception_type"] == "SendRetryError"
 
     @pytest.mark.asyncio
     async def test_unexpected_room_send_exception_logs_generic_sanitized_message(self) -> None:

--- a/tests/test_skip_mentions.py
+++ b/tests/test_skip_mentions.py
@@ -381,15 +381,17 @@ async def test_delivery_gateway_send_text_records_threaded_outbound_message(tmp_
     with patch(
         "mindroom.delivery_gateway.send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$response")),
-    ):
+    ) as send:
         event_id = await gateway.send_text(
             SendTextRequest(
                 target=target,
                 response_text="formatted response",
+                retry_sync_recovery=True,
             ),
         )
 
     assert event_id == "$response"
+    assert send.await_args.kwargs["retry_sync_recovery"] is True
     gateway.deps.resolver.deps.conversation_cache.notify_outbound_message.assert_called_once()
     record_args = gateway.deps.resolver.deps.conversation_cache.notify_outbound_message.call_args.args
     assert record_args[0] == "!test:server"
@@ -416,16 +418,18 @@ async def test_delivery_gateway_edit_text_records_threaded_outbound_edit(tmp_pat
     with patch(
         "mindroom.delivery_gateway.edit_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$edit-event")),
-    ):
+    ) as edit:
         edited = await gateway.edit_text(
             EditTextRequest(
                 target=target,
                 event_id="$original",
                 new_text="updated response",
+                retry_sync_recovery=True,
             ),
         )
 
     assert edited is True
+    assert edit.await_args.kwargs["retry_sync_recovery"] is True
     gateway.deps.resolver.deps.conversation_cache.notify_outbound_message.assert_called_once()
     record_args = gateway.deps.resolver.deps.conversation_cache.notify_outbound_message.call_args.args
     assert record_args[0] == "!test:server"
@@ -546,6 +550,7 @@ async def test_delivery_gateway_deliver_final_uses_send_text_for_new_messages(tm
         )
 
     mock_send_text.assert_awaited_once()
+    assert mock_send_text.await_args.args[0].retry_sync_recovery is True
     after_hooks.assert_not_awaited()
     assert result.event_id == "$response"
     assert result.delivery_kind == "sent"
@@ -588,6 +593,7 @@ async def test_delivery_gateway_deliver_final_uses_edit_text_for_existing_messag
         )
 
     mock_edit_text.assert_awaited_once()
+    assert mock_edit_text.await_args.args[0].retry_sync_recovery is True
     after_hooks.assert_not_awaited()
     assert result.event_id == "$existing"
     assert result.delivery_kind == "edited"

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -81,7 +81,10 @@ class _FakeGateway:
         _client: object,
         _room_id: str,
         content: dict[str, Any],
+        *,
+        retry_sync_recovery: bool = False,
     ) -> DeliveredMatrixEvent:
+        assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
         self._record(_GatewayOp(kind="send", content=dict(content), display_text=content["body"]))
         return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 
@@ -92,7 +95,10 @@ class _FakeGateway:
         _event_id: str,
         new_content: dict[str, Any],
         new_text: str,
+        *,
+        retry_sync_recovery: bool = False,
     ) -> DeliveredMatrixEvent:
+        assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
         self._record(_GatewayOp(kind="edit", content=dict(new_content), display_text=new_text))
         return DeliveredMatrixEvent(event_id=f"$edit_{len(self.ops)}", content_sent=dict(new_content))
 
@@ -247,7 +253,10 @@ async def test_nonterminal_delivery_formats_off_event_loop_thread(config: Config
         _client: object,
         _room_id: str,
         content: dict[str, Any],
+        *,
+        retry_sync_recovery: bool = False,
     ) -> DeliveredMatrixEvent:
+        assert retry_sync_recovery is False
         delivered_content.update(content)
         return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -28,7 +28,6 @@ from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import (
     STREAM_STATUS_CANCELLED,
     STREAM_STATUS_COMPLETED,
-    STREAM_STATUS_ERROR,
     STREAM_STATUS_KEY,
     STREAM_STATUS_PENDING,
     STREAM_STATUS_STREAMING,
@@ -83,11 +82,8 @@ class _FakeGateway:
         _room_id: str,
         content: dict[str, Any],
         *,
-        retry_sync_recovery: bool = False,
+        retry_sync_recovery: bool = False,  # noqa: ARG002
     ) -> DeliveredMatrixEvent:
-        assert retry_sync_recovery is (
-            content.get(STREAM_STATUS_KEY) not in {STREAM_STATUS_CANCELLED, STREAM_STATUS_ERROR}
-        )
         self._record(_GatewayOp(kind="send", content=dict(content), display_text=content["body"]))
         return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 
@@ -99,11 +95,8 @@ class _FakeGateway:
         new_content: dict[str, Any],
         new_text: str,
         *,
-        retry_sync_recovery: bool = False,
+        retry_sync_recovery: bool = False,  # noqa: ARG002
     ) -> DeliveredMatrixEvent:
-        assert retry_sync_recovery is (
-            new_content.get(STREAM_STATUS_KEY) not in {STREAM_STATUS_CANCELLED, STREAM_STATUS_ERROR}
-        )
         self._record(_GatewayOp(kind="edit", content=dict(new_content), display_text=new_text))
         return DeliveredMatrixEvent(event_id=f"$edit_{len(self.ops)}", content_sent=dict(new_content))
 
@@ -259,9 +252,8 @@ async def test_nonterminal_delivery_formats_off_event_loop_thread(config: Config
         _room_id: str,
         content: dict[str, Any],
         *,
-        retry_sync_recovery: bool = False,
+        retry_sync_recovery: bool = False,  # noqa: ARG001
     ) -> DeliveredMatrixEvent:
-        assert retry_sync_recovery is True
         delivered_content.update(content)
         return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -28,6 +28,7 @@ from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import (
     STREAM_STATUS_CANCELLED,
     STREAM_STATUS_COMPLETED,
+    STREAM_STATUS_ERROR,
     STREAM_STATUS_KEY,
     STREAM_STATUS_PENDING,
     STREAM_STATUS_STREAMING,
@@ -84,7 +85,9 @@ class _FakeGateway:
         *,
         retry_sync_recovery: bool = False,
     ) -> DeliveredMatrixEvent:
-        assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+        assert retry_sync_recovery is (
+            content.get(STREAM_STATUS_KEY) not in {STREAM_STATUS_CANCELLED, STREAM_STATUS_ERROR}
+        )
         self._record(_GatewayOp(kind="send", content=dict(content), display_text=content["body"]))
         return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 
@@ -98,7 +101,9 @@ class _FakeGateway:
         *,
         retry_sync_recovery: bool = False,
     ) -> DeliveredMatrixEvent:
-        assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+        assert retry_sync_recovery is (
+            new_content.get(STREAM_STATUS_KEY) not in {STREAM_STATUS_CANCELLED, STREAM_STATUS_ERROR}
+        )
         self._record(_GatewayOp(kind="edit", content=dict(new_content), display_text=new_text))
         return DeliveredMatrixEvent(event_id=f"$edit_{len(self.ops)}", content_sent=dict(new_content))
 
@@ -256,7 +261,7 @@ async def test_nonterminal_delivery_formats_off_event_loop_thread(config: Config
         *,
         retry_sync_recovery: bool = False,
     ) -> DeliveredMatrixEvent:
-        assert retry_sync_recovery is False
+        assert retry_sync_recovery is True
         delivered_content.update(content)
         return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -98,6 +98,11 @@ IN_PROGRESS_MARKER = " ⋯"
 _INTERRUPTION_SUMMARY = "(turn stopped before completion)"
 
 
+def _expects_sync_recovery_retry(content: dict[str, object]) -> bool:
+    """Return whether one normal streaming payload retries transient recovery."""
+    return content.get(STREAM_STATUS_KEY) not in {STREAM_STATUS_CANCELLED, STREAM_STATUS_ERROR}
+
+
 async def _aiter(*events: object) -> AsyncIterator[object]:
     for event in events:
         yield event
@@ -621,7 +626,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is False
+            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) != STREAM_STATUS_COMPLETED)
             return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
 
         with (
@@ -1907,7 +1912,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
             edited_contents.append((new_content, new_text))
             return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
 
@@ -1957,7 +1962,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(content)
             return DeliveredMatrixEvent(event_id="$stream-send", content_sent=dict(content))
 
         async def record_edit(
@@ -1969,7 +1974,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
             return DeliveredMatrixEvent(
                 event_id="$stream-edit",
                 content_sent=build_edit_event_content(
@@ -2122,7 +2127,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(content)
             sent_contents.append(content)
             return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 
@@ -2135,7 +2140,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             return DeliveredMatrixEvent(event_id="$stream_1", content_sent={})
 
         with (
@@ -2180,7 +2185,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(content)
             sent_messages.append((room_id, content))
             return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 
@@ -2396,7 +2401,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2438,7 +2443,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2538,7 +2543,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
             edited_messages.append((new_content, new_text))
             return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
 
@@ -2591,7 +2596,7 @@ class TestStreamingBehavior:
                 retry_sync_recovery: bool = False,
                 _edited_messages: list[dict[str, object]] = edited_messages,
             ) -> DeliveredMatrixEvent:
-                assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+                assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
                 _edited_messages.append(new_content)
                 return DeliveredMatrixEvent(event_id="$edit", content_sent=new_content)
 
@@ -2637,7 +2642,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2685,7 +2690,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2732,7 +2737,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             if "Preparing isolated worker" in new_text:
                 msg = "edit blew up"
                 raise RuntimeError(msg)
@@ -2790,7 +2795,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
             terminal_statuses.append(str(new_content[STREAM_STATUS_KEY]))
             edited_texts.append(new_text)
             if "Preparing isolated worker" in new_text:
@@ -2850,7 +2855,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             if "Preparing isolated worker" in new_text:
                 msg = "edit blew up"
@@ -2906,7 +2911,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(content)
             return DeliveredMatrixEvent(event_id="$event123", content_sent=dict(content))
 
         async def lingering_drain(
@@ -2970,7 +2975,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             if "Preparing isolated worker" in new_text and "hello" not in new_text and "world" not in new_text:
                 warmup_edit_started.set()
@@ -3043,7 +3048,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             await stream_finished.wait()
             if _new_content.get("io.mindroom.stream_status") == "streaming":
                 msg = "late edit blew up"
@@ -3099,7 +3104,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent | None:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             terminal_texts.append(new_text)
             return edit_results.pop(0)
 
@@ -3166,7 +3171,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             streaming.accumulated_text = "hello"
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -3397,7 +3402,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             nonlocal in_flight, max_in_flight
             in_flight += 1
             max_in_flight = max(max_in_flight, in_flight)
@@ -3687,7 +3692,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             captured_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -3792,7 +3797,7 @@ class TestStreamingBehavior:
             *,
             retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
+            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             captured_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -98,11 +98,6 @@ IN_PROGRESS_MARKER = " ⋯"
 _INTERRUPTION_SUMMARY = "(turn stopped before completion)"
 
 
-def _expects_sync_recovery_retry(content: dict[str, object]) -> bool:
-    """Return whether one normal streaming payload retries transient recovery."""
-    return content.get(STREAM_STATUS_KEY) not in {STREAM_STATUS_CANCELLED, STREAM_STATUS_ERROR}
-
-
 async def _aiter(*events: object) -> AsyncIterator[object]:
     for event in events:
         yield event
@@ -624,9 +619,8 @@ class TestStreamingBehavior:
             new_content: dict[str, object],
             _new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) != STREAM_STATUS_COMPLETED)
             return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
 
         with (
@@ -1910,9 +1904,8 @@ class TestStreamingBehavior:
             new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
             edited_contents.append((new_content, new_text))
             return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
 
@@ -1960,9 +1953,8 @@ class TestStreamingBehavior:
             _room_id: str,
             content: dict[str, object],
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(content)
             return DeliveredMatrixEvent(event_id="$stream-send", content_sent=dict(content))
 
         async def record_edit(
@@ -1972,9 +1964,8 @@ class TestStreamingBehavior:
             new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
             return DeliveredMatrixEvent(
                 event_id="$stream-edit",
                 content_sent=build_edit_event_content(
@@ -2125,9 +2116,8 @@ class TestStreamingBehavior:
             _room_id: str,
             content: dict[str, object],
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(content)
             sent_contents.append(content)
             return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 
@@ -2138,9 +2128,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             _new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             return DeliveredMatrixEvent(event_id="$stream_1", content_sent={})
 
         with (
@@ -2183,9 +2172,8 @@ class TestStreamingBehavior:
             room_id: str,
             content: dict[str, object],
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(content)
             sent_messages.append((room_id, content))
             return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 
@@ -2399,9 +2387,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2441,9 +2428,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2541,9 +2527,8 @@ class TestStreamingBehavior:
             new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
             edited_messages.append((new_content, new_text))
             return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
 
@@ -2593,10 +2578,9 @@ class TestStreamingBehavior:
                 new_content: dict[str, object],
                 _new_text: str,
                 *,
-                retry_sync_recovery: bool = False,
+                retry_sync_recovery: bool = False,  # noqa: ARG001
                 _edited_messages: list[dict[str, object]] = edited_messages,
             ) -> DeliveredMatrixEvent:
-                assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
                 _edited_messages.append(new_content)
                 return DeliveredMatrixEvent(event_id="$edit", content_sent=new_content)
 
@@ -2640,9 +2624,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2688,9 +2671,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2735,9 +2717,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             if "Preparing isolated worker" in new_text:
                 msg = "edit blew up"
                 raise RuntimeError(msg)
@@ -2793,9 +2774,8 @@ class TestStreamingBehavior:
             new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(new_content)
             terminal_statuses.append(str(new_content[STREAM_STATUS_KEY]))
             edited_texts.append(new_text)
             if "Preparing isolated worker" in new_text:
@@ -2853,9 +2833,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             if "Preparing isolated worker" in new_text:
                 msg = "edit blew up"
@@ -2909,9 +2888,8 @@ class TestStreamingBehavior:
             _room_id: str,
             content: dict[str, object],
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(content)
             return DeliveredMatrixEvent(event_id="$event123", content_sent=dict(content))
 
         async def lingering_drain(
@@ -2973,9 +2951,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             edited_texts.append(new_text)
             if "Preparing isolated worker" in new_text and "hello" not in new_text and "world" not in new_text:
                 warmup_edit_started.set()
@@ -3046,9 +3023,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             _new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             await stream_finished.wait()
             if _new_content.get("io.mindroom.stream_status") == "streaming":
                 msg = "late edit blew up"
@@ -3102,9 +3078,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent | None:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             terminal_texts.append(new_text)
             return edit_results.pop(0)
 
@@ -3169,9 +3144,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             _new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             streaming.accumulated_text = "hello"
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -3400,9 +3374,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             nonlocal in_flight, max_in_flight
             in_flight += 1
             max_in_flight = max(max_in_flight, in_flight)
@@ -3690,9 +3663,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             captured_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -3795,9 +3767,8 @@ class TestStreamingBehavior:
             _new_content: dict[str, object],
             new_text: str,
             *,
-            retry_sync_recovery: bool = False,
+            retry_sync_recovery: bool = False,  # noqa: ARG001
         ) -> DeliveredMatrixEvent:
-            assert retry_sync_recovery is _expects_sync_recovery_retry(_new_content)
             captured_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -618,7 +618,10 @@ class TestStreamingBehavior:
             _event_id: str,
             new_content: dict[str, object],
             _new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is False
             return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
 
         with (
@@ -1901,7 +1904,10 @@ class TestStreamingBehavior:
             _event_id: str,
             new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             edited_contents.append((new_content, new_text))
             return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
 
@@ -1948,7 +1954,10 @@ class TestStreamingBehavior:
             _client: object,
             _room_id: str,
             content: dict[str, object],
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             return DeliveredMatrixEvent(event_id="$stream-send", content_sent=dict(content))
 
         async def record_edit(
@@ -1957,7 +1966,10 @@ class TestStreamingBehavior:
             event_id: str,
             new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             return DeliveredMatrixEvent(
                 event_id="$stream-edit",
                 content_sent=build_edit_event_content(
@@ -2107,7 +2119,10 @@ class TestStreamingBehavior:
             _client: object,
             _room_id: str,
             content: dict[str, object],
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             sent_contents.append(content)
             return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 
@@ -2117,7 +2132,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             _new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             return DeliveredMatrixEvent(event_id="$stream_1", content_sent={})
 
         with (
@@ -2159,7 +2177,10 @@ class TestStreamingBehavior:
             _client: object,
             room_id: str,
             content: dict[str, object],
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             sent_messages.append((room_id, content))
             return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
 
@@ -2372,7 +2393,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2411,7 +2435,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2508,7 +2535,10 @@ class TestStreamingBehavior:
             _event_id: str,
             new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             edited_messages.append((new_content, new_text))
             return DeliveredMatrixEvent(event_id="$edit", content_sent=dict(new_content))
 
@@ -2558,8 +2588,10 @@ class TestStreamingBehavior:
                 new_content: dict[str, object],
                 _new_text: str,
                 *,
+                retry_sync_recovery: bool = False,
                 _edited_messages: list[dict[str, object]] = edited_messages,
             ) -> DeliveredMatrixEvent:
+                assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
                 _edited_messages.append(new_content)
                 return DeliveredMatrixEvent(event_id="$edit", content_sent=new_content)
 
@@ -2602,7 +2634,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2647,7 +2682,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             edited_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -2691,7 +2729,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             if "Preparing isolated worker" in new_text:
                 msg = "edit blew up"
                 raise RuntimeError(msg)
@@ -2746,7 +2787,10 @@ class TestStreamingBehavior:
             _event_id: str,
             new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             terminal_statuses.append(str(new_content[STREAM_STATUS_KEY]))
             edited_texts.append(new_text)
             if "Preparing isolated worker" in new_text:
@@ -2803,7 +2847,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             edited_texts.append(new_text)
             if "Preparing isolated worker" in new_text:
                 msg = "edit blew up"
@@ -2856,7 +2903,10 @@ class TestStreamingBehavior:
             _client: object,
             _room_id: str,
             content: dict[str, object],
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             return DeliveredMatrixEvent(event_id="$event123", content_sent=dict(content))
 
         async def lingering_drain(
@@ -2917,7 +2967,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             edited_texts.append(new_text)
             if "Preparing isolated worker" in new_text and "hello" not in new_text and "world" not in new_text:
                 warmup_edit_started.set()
@@ -2987,7 +3040,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             _new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             await stream_finished.wait()
             if _new_content.get("io.mindroom.stream_status") == "streaming":
                 msg = "late edit blew up"
@@ -3040,7 +3096,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent | None:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             terminal_texts.append(new_text)
             return edit_results.pop(0)
 
@@ -3104,7 +3163,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             _new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             streaming.accumulated_text = "hello"
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -3332,7 +3394,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             nonlocal in_flight, max_in_flight
             in_flight += 1
             max_in_flight = max(max_in_flight, in_flight)
@@ -3619,7 +3684,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             captured_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 
@@ -3721,7 +3789,10 @@ class TestStreamingBehavior:
             _event_id: str,
             _new_content: dict[str, object],
             new_text: str,
+            *,
+            retry_sync_recovery: bool = False,
         ) -> DeliveredMatrixEvent:
+            assert retry_sync_recovery is (_new_content.get(STREAM_STATUS_KEY) == STREAM_STATUS_COMPLETED)
             captured_texts.append(new_text)
             return DeliveredMatrixEvent(event_id="$edit", content_sent={})
 

--- a/tests/test_streaming_e2e.py
+++ b/tests/test_streaming_e2e.py
@@ -72,6 +72,8 @@ async def test_streaming_e2e_worker_warmup_edit_sequence(tmp_path: Path) -> None
         _client: object,
         _room_id: str,
         content: dict[str, object],
+        *,
+        retry_sync_recovery: bool = False,  # noqa: ARG001
     ) -> DeliveredMatrixEvent:
         deliveries.append(("send", str(content["body"])))
         return DeliveredMatrixEvent(event_id="$stream_1", content_sent=dict(content))
@@ -82,6 +84,8 @@ async def test_streaming_e2e_worker_warmup_edit_sequence(tmp_path: Path) -> None
         _event_id: str,
         new_content: dict[str, object],
         new_text: str,
+        *,
+        retry_sync_recovery: bool = False,  # noqa: ARG001
     ) -> DeliveredMatrixEvent:
         deliveries.append(("edit", new_text))
         return DeliveredMatrixEvent(event_id="$stream_edit", content_sent=dict(new_content))

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -112,6 +112,43 @@ def _envelope() -> MessageEnvelope:
     )
 
 
+def _delivery_gateway(tmp_path: Path) -> DeliveryGateway:
+    config = _config(tmp_path)
+    response_hooks = SimpleNamespace(
+        apply_before_response=AsyncMock(
+            return_value=SimpleNamespace(
+                response_text="final answer",
+                response_kind="ai",
+                tool_trace=None,
+                extra_content=None,
+                envelope=_envelope(),
+                suppress=False,
+            ),
+        ),
+        apply_final_response_transform=AsyncMock(),
+        emit_after_response=AsyncMock(),
+        emit_cancelled_response=AsyncMock(),
+    )
+    return DeliveryGateway(
+        DeliveryGatewayDeps(
+            runtime=SimpleNamespace(client=_client(), orchestrator=None, config=config, runtime_started_at=0.0),
+            runtime_paths=runtime_paths_for(config),
+            agent_name="code",
+            logger=Mock(),
+            redact_message_event=AsyncMock(return_value=True),
+            resolver=SimpleNamespace(
+                deps=SimpleNamespace(
+                    conversation_cache=SimpleNamespace(
+                        get_latest_thread_event_id_if_needed=AsyncMock(return_value=None),
+                        notify_outbound_message=Mock(),
+                    ),
+                ),
+            ),
+            response_hooks=response_hooks,
+        ),
+    )
+
+
 @pytest.mark.asyncio
 async def test_transport_retry_terminal_send_with_no_event_id_retries_until_send_lands(tmp_path: Path) -> None:
     """Terminal sends should retry even when finalize is sending the first visible event."""
@@ -475,33 +512,7 @@ async def test_transport_empty_adopted_placeholder_finishes_as_error_note(tmp_pa
 @pytest.mark.asyncio
 async def test_final_delivery_failure_replaces_placeholder_with_failure_update(tmp_path: Path) -> None:
     """A failed final placeholder edit should get one clear terminal failure update when possible."""
-    config = _config(tmp_path)
-    response_hooks = SimpleNamespace(
-        apply_before_response=AsyncMock(
-            return_value=SimpleNamespace(
-                response_text="final answer",
-                response_kind="ai",
-                tool_trace=None,
-                extra_content=None,
-                envelope=_envelope(),
-                suppress=False,
-            ),
-        ),
-        apply_final_response_transform=AsyncMock(),
-        emit_after_response=AsyncMock(),
-        emit_cancelled_response=AsyncMock(),
-    )
-    gateway = DeliveryGateway(
-        DeliveryGatewayDeps(
-            runtime=SimpleNamespace(client=_client(), orchestrator=None, config=config, runtime_started_at=0.0),
-            runtime_paths=runtime_paths_for(config),
-            agent_name="code",
-            logger=Mock(),
-            redact_message_event=AsyncMock(return_value=True),
-            resolver=Mock(),
-            response_hooks=response_hooks,
-        ),
-    )
+    gateway = _delivery_gateway(tmp_path)
     edit_outcomes = [False, True]
     object.__setattr__(
         gateway,
@@ -534,6 +545,70 @@ async def test_final_delivery_failure_replaces_placeholder_with_failure_update(t
     failure_update_request = gateway.edit_text.await_args_list[-1].args[0]
     assert failure_update_request.new_text == "Response delivery failed. Please retry."
     assert failure_update_request.extra_content[STREAM_STATUS_KEY] == STREAM_STATUS_ERROR
+
+
+@pytest.mark.asyncio
+async def test_persistent_sync_recovery_barrier_settles_placeholder_as_delivery_failure(tmp_path: Path) -> None:
+    """An exhausted final-edit retry should still run placeholder failure settlement."""
+    gateway = _delivery_gateway(tmp_path)
+    barrier_error = nio.SendRetryError("Room timeline recovery is still pending.")
+    with patch(
+        "mindroom.delivery_gateway.edit_message_result",
+        new=AsyncMock(side_effect=[barrier_error, None]),
+    ) as edit:
+        outcome = await gateway.deliver_final(
+            FinalDeliveryRequest(
+                target=MessageTarget.resolve("!room:localhost", None, "$reply"),
+                existing_event_id="$placeholder",
+                existing_event_is_placeholder=True,
+                response_text="final answer",
+                identity=ResponseIdentity(
+                    response_kind="ai",
+                    response_envelope=_envelope(),
+                    correlation_id="corr-persistent-sync-recovery-barrier",
+                ),
+                tool_trace=None,
+                extra_content=None,
+            ),
+        )
+
+    assert edit.await_count == 2
+    assert edit.await_args_list[0].kwargs["retry_sync_recovery"] is True
+    assert edit.await_args_list[1].kwargs["retry_sync_recovery"] is False
+    assert outcome.terminal_status == "error"
+    assert outcome.final_visible_event_id == "$placeholder"
+    assert outcome.failure_reason == "delivery_failed"
+
+
+@pytest.mark.asyncio
+async def test_persistent_sync_recovery_barrier_returns_new_send_delivery_failure(tmp_path: Path) -> None:
+    """An exhausted final-send retry should retain the gateway failure contract."""
+    gateway = _delivery_gateway(tmp_path)
+    barrier_error = nio.SendRetryError("Room timeline recovery is still pending.")
+    with patch(
+        "mindroom.delivery_gateway.send_message_result",
+        new=AsyncMock(side_effect=barrier_error),
+    ) as send:
+        outcome = await gateway.deliver_final(
+            FinalDeliveryRequest(
+                target=MessageTarget.resolve("!room:localhost", None, "$reply"),
+                existing_event_id=None,
+                response_text="final answer",
+                identity=ResponseIdentity(
+                    response_kind="ai",
+                    response_envelope=_envelope(),
+                    correlation_id="corr-persistent-sync-recovery-send-barrier",
+                ),
+                tool_trace=None,
+                extra_content=None,
+            ),
+        )
+
+    send.assert_awaited_once()
+    assert send.await_args.kwargs["retry_sync_recovery"] is True
+    assert outcome.terminal_status == "error"
+    assert outcome.final_visible_event_id is None
+    assert outcome.failure_reason == "delivery_failed"
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -141,87 +141,24 @@ async def test_transport_retry_terminal_send_with_no_event_id_retries_until_send
 
 
 @pytest.mark.asyncio
-async def test_completed_terminal_edit_waits_for_sync_recovery_and_reuses_content(tmp_path: Path) -> None:
-    """A transient recovery barrier should retry the frozen terminal payload."""
+async def test_completed_terminal_edit_opts_into_sync_recovery_retry(tmp_path: Path) -> None:
+    """Completed terminal delivery should opt into the bounded recovery retry."""
     streaming = _streaming_response(_config(tmp_path))
     streaming.event_id = "$placeholder"
     streaming.accumulated_text = "complete answer"
-    attempted_content: list[dict[str, Any]] = []
     delivered = DeliveredMatrixEvent(
         event_id="$terminal-edit",
         content_sent={"body": "complete answer"},
     )
+    edit = AsyncMock(return_value=delivered)
 
-    async def edit(*args: object, **_kwargs: object) -> DeliveredMatrixEvent:
-        content = args[3]
-        assert isinstance(content, dict)
-        attempted_content.append(content)
-        if len(attempted_content) == 1:
-            message = "Room timeline recovery is still pending."
-            raise nio.SendRetryError(message)
-        return delivered
-
-    sleep_mock = AsyncMock()
-    with (
-        patch("mindroom.streaming.edit_message_result", new=edit),
-        patch("mindroom.streaming.asyncio.sleep", new=sleep_mock),
-    ):
+    with patch("mindroom.streaming.edit_message_result", new=edit):
         outcome = await streaming.finalize(_client())
 
     assert outcome.terminal_status == "completed"
     assert outcome.failure_reason is None
-    assert len(attempted_content) == 2
-    assert attempted_content[0] is attempted_content[1]
-    sleep_mock.assert_awaited_once_with(0.05)
-
-
-@pytest.mark.asyncio
-async def test_completed_terminal_sync_recovery_retry_is_bounded(tmp_path: Path) -> None:
-    """A persistent recovery barrier should fail within the delivery deadline."""
-    streaming = _streaming_response(_config(tmp_path))
-    streaming.event_id = "$placeholder"
-    streaming.accumulated_text = "complete answer"
-    edit = AsyncMock(side_effect=nio.SendRetryError("Room timeline recovery is still pending."))
-
-    with (
-        patch("mindroom.streaming.edit_message_result", new=edit),
-        patch("mindroom.streaming._SYNC_RECOVERY_RETRY_TIMEOUT_SECONDS", new=0.01),
-        patch("mindroom.streaming._SYNC_RECOVERY_RETRY_INITIAL_DELAY_SECONDS", new=0.002),
-        patch("mindroom.streaming._SYNC_RECOVERY_RETRY_MAX_DELAY_SECONDS", new=0.002),
-    ):
-        outcome = await asyncio.wait_for(streaming.finalize(_client()), 0.5)
-
-    assert edit.await_count >= 2
-    assert outcome.terminal_status == "completed"
-    assert outcome.failure_reason == "terminal_update_exception:SendRetryError"
-
-
-@pytest.mark.asyncio
-async def test_completed_terminal_sync_recovery_wait_is_cancellation_aware(tmp_path: Path) -> None:
-    """Cancellation should interrupt recovery backoff immediately."""
-    streaming = _streaming_response(_config(tmp_path))
-    streaming.event_id = "$placeholder"
-    streaming.accumulated_text = "complete answer"
-    sleep_started = asyncio.Event()
-
-    async def wait_forever(_delay: float) -> None:
-        sleep_started.set()
-        await asyncio.Event().wait()
-
-    with (
-        patch(
-            "mindroom.streaming.edit_message_result",
-            new=AsyncMock(side_effect=nio.SendRetryError("Room timeline recovery is still pending.")),
-        ),
-        patch("mindroom.streaming.asyncio.sleep", new=wait_forever),
-    ):
-        task = asyncio.create_task(streaming.finalize(_client()))
-        await sleep_started.wait()
-        task.cancel()
-        outcome = await task
-
-    assert outcome.terminal_status == "completed"
-    assert outcome.failure_reason == "terminal_update_cancelled"
+    edit.assert_awaited_once()
+    assert edit.call_args.kwargs["retry_sync_recovery"] is True
 
 
 @pytest.mark.asyncio
@@ -240,6 +177,7 @@ async def test_cancelled_terminal_sync_recovery_error_does_not_backoff(tmp_path:
         outcome = await streaming.finalize(_client(), cancelled=True)
 
     edit.assert_awaited_once()
+    assert edit.call_args.kwargs["retry_sync_recovery"] is False
     sleep_mock.assert_not_awaited()
     assert outcome.terminal_status == "cancelled"
     assert outcome.failure_reason == "cancelled_by_user"

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -141,6 +141,132 @@ async def test_transport_retry_terminal_send_with_no_event_id_retries_until_send
 
 
 @pytest.mark.asyncio
+async def test_completed_terminal_edit_waits_for_sync_recovery_and_reuses_content(tmp_path: Path) -> None:
+    """A transient recovery barrier should retry the frozen terminal payload."""
+    streaming = _streaming_response(_config(tmp_path))
+    streaming.event_id = "$placeholder"
+    streaming.accumulated_text = "complete answer"
+    attempted_content: list[dict[str, Any]] = []
+    delivered = DeliveredMatrixEvent(
+        event_id="$terminal-edit",
+        content_sent={"body": "complete answer"},
+    )
+
+    async def edit(*args: object, **_kwargs: object) -> DeliveredMatrixEvent:
+        content = args[3]
+        assert isinstance(content, dict)
+        attempted_content.append(content)
+        if len(attempted_content) == 1:
+            message = "Room timeline recovery is still pending."
+            raise nio.SendRetryError(message)
+        return delivered
+
+    sleep_mock = AsyncMock()
+    with (
+        patch("mindroom.streaming.edit_message_result", new=edit),
+        patch("mindroom.streaming.asyncio.sleep", new=sleep_mock),
+    ):
+        outcome = await streaming.finalize(_client())
+
+    assert outcome.terminal_status == "completed"
+    assert outcome.failure_reason is None
+    assert len(attempted_content) == 2
+    assert attempted_content[0] is attempted_content[1]
+    sleep_mock.assert_awaited_once_with(0.05)
+
+
+@pytest.mark.asyncio
+async def test_completed_terminal_sync_recovery_retry_is_bounded(tmp_path: Path) -> None:
+    """A persistent recovery barrier should fail within the delivery deadline."""
+    streaming = _streaming_response(_config(tmp_path))
+    streaming.event_id = "$placeholder"
+    streaming.accumulated_text = "complete answer"
+    edit = AsyncMock(side_effect=nio.SendRetryError("Room timeline recovery is still pending."))
+
+    with (
+        patch("mindroom.streaming.edit_message_result", new=edit),
+        patch("mindroom.streaming._SYNC_RECOVERY_RETRY_TIMEOUT_SECONDS", new=0.01),
+        patch("mindroom.streaming._SYNC_RECOVERY_RETRY_INITIAL_DELAY_SECONDS", new=0.002),
+        patch("mindroom.streaming._SYNC_RECOVERY_RETRY_MAX_DELAY_SECONDS", new=0.002),
+    ):
+        outcome = await asyncio.wait_for(streaming.finalize(_client()), 0.5)
+
+    assert edit.await_count >= 2
+    assert outcome.terminal_status == "completed"
+    assert outcome.failure_reason == "terminal_update_exception:SendRetryError"
+
+
+@pytest.mark.asyncio
+async def test_completed_terminal_sync_recovery_wait_is_cancellation_aware(tmp_path: Path) -> None:
+    """Cancellation should interrupt recovery backoff immediately."""
+    streaming = _streaming_response(_config(tmp_path))
+    streaming.event_id = "$placeholder"
+    streaming.accumulated_text = "complete answer"
+    sleep_started = asyncio.Event()
+
+    async def wait_forever(_delay: float) -> None:
+        sleep_started.set()
+        await asyncio.Event().wait()
+
+    with (
+        patch(
+            "mindroom.streaming.edit_message_result",
+            new=AsyncMock(side_effect=nio.SendRetryError("Room timeline recovery is still pending.")),
+        ),
+        patch("mindroom.streaming.asyncio.sleep", new=wait_forever),
+    ):
+        task = asyncio.create_task(streaming.finalize(_client()))
+        await sleep_started.wait()
+        task.cancel()
+        outcome = await task
+
+    assert outcome.terminal_status == "completed"
+    assert outcome.failure_reason == "terminal_update_cancelled"
+
+
+@pytest.mark.asyncio
+async def test_cancelled_terminal_sync_recovery_error_does_not_backoff(tmp_path: Path) -> None:
+    """Cancellation notes retain their immediate terminal-delivery semantics."""
+    streaming = _streaming_response(_config(tmp_path))
+    streaming.event_id = "$placeholder"
+    streaming.accumulated_text = "partial answer"
+    edit = AsyncMock(side_effect=nio.SendRetryError("Room timeline recovery is still pending."))
+    sleep_mock = AsyncMock()
+
+    with (
+        patch("mindroom.streaming.edit_message_result", new=edit),
+        patch("mindroom.streaming.asyncio.sleep", new=sleep_mock),
+    ):
+        outcome = await streaming.finalize(_client(), cancelled=True)
+
+    edit.assert_awaited_once()
+    sleep_mock.assert_not_awaited()
+    assert outcome.terminal_status == "cancelled"
+    assert outcome.failure_reason == "cancelled_by_user"
+
+
+@pytest.mark.asyncio
+async def test_completed_terminal_ordinary_exception_keeps_immediate_retry(tmp_path: Path) -> None:
+    """Ordinary terminal failures keep the existing two immediate attempts."""
+    streaming = _streaming_response(_config(tmp_path))
+    streaming.event_id = "$placeholder"
+    streaming.accumulated_text = "complete answer"
+    edit = AsyncMock(side_effect=RuntimeError("ordinary failure"))
+    sleep_mock = AsyncMock()
+
+    with (
+        patch("mindroom.streaming.edit_message_result", new=edit),
+        patch("mindroom.streaming.asyncio.sleep", new=sleep_mock),
+    ):
+        outcome = await streaming.finalize(_client())
+
+    assert edit.await_count == 2
+    sleep_mock.assert_not_awaited()
+    assert outcome.terminal_status == "completed"
+    assert outcome.failure_reason == "terminal_update_exception:RuntimeError"
+
+
+@pytest.mark.asyncio
 async def test_transport_cancelled_terminal_update_does_not_sleep_behind_retry_backoff(tmp_path: Path) -> None:
     """Cancelled terminal updates should finish immediately without retry backoff."""
     config = _config(tmp_path)


### PR DESCRIPTION
## Summary

- Preserve ordinary Matrix send and edit failure normalization.
- Retry completed final delivery and transient non-terminal streaming delivery while limited-sync recovery temporarily blocks room sends.
- Prepare oversized Matrix payloads once, reuse the identical wire payload, and bound backoff plus every retry await with one cancellation-aware deadline.
- Normalize exhausted final-delivery retries at the `DeliveryGateway` boundary so placeholder failure settlement still runs.

## Why

mindroom-nio 0.30 intentionally rejects room sends while limited-sync timeline recovery is pending.
MindRoom previously converted that retryable signal to `None` and made only immediate retries, which could leave streaming placeholders incomplete during recovery.

## Validation

- Exact head: `f04f1f2efe7f0e01cceaeedefe85b163ee109ca9`.
- Current `main`, including the merged sync-restart lifecycle, is synchronized into the PR.
- Focused delivery and streaming suites: 167 passed, 1 expected skip.
- Parent Codex review: no findings.
- Full sequential suite: 11,471 passed, 210 skipped.
- Every non-Prettier all-file hook passes.
- Every GitHub check, including pytest and smoke stacks, passes.
- The PR merged before the frozen real-Tuwunel trace reran on this synchronized head.
- The previous 11,622-test full-suite PASS and 200-operation real-Tuwunel PASS were on `d107dae185cfbb1a2e5290e09d3d8dd77c857320` and are now historical.
