### PR TITLE
Use model context for compaction summaries

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -193,7 +193,7 @@ Crossing that soft trigger while still within the hard budget leaves the stored 
 
 You can tune compaction behavior with these settings:
 
-- Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
 - Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
@@ -201,7 +201,7 @@ You can tune compaction behavior with these settings:
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.

--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -196,7 +196,7 @@ You can tune compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
-- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
+- Use `fallback_model` to name a different model config retried once when the summary model refuses for safeguards; the same input is reused when it fits, otherwise it is rebuilt under the fallback model's own context budget, and after success that model serves the remaining chunks.
 - Set `enabled: false` to disable automatic pre-reply compaction for this agent.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -389,7 +389,7 @@ defaults:
   compaction:
     enabled: true
     threshold_percent: 0.8
-    # The effective replay window also caps compaction summary input chunks.
+    # Summary input chunks use the selected compaction model's context window.
     # Destructive compaction requires a resolved summary input budget greater than 2,000 tokens.
     replay_window_tokens: null     # Optional operational cap; does not change the model's real context window
     reserve_tokens: 16384

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -258,13 +258,13 @@ It runs only when history exceeds the hard replay budget for the next reply.
 You can tune compaction behavior with these settings:
 
 - Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
-- Use `replay_window_tokens` to keep persisted replay, required-compaction planning, and summary input chunks within a smaller operational window without presenting that smaller value as the provider's request limit.
+- Use `replay_window_tokens` to keep persisted replay and required-compaction planning within a smaller operational window without presenting that smaller value as the provider's request limit.
 - Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
 - Use `model` to choose the summary model, and `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 
@@ -292,7 +292,7 @@ models:
 
 defaults:
   compaction:
-    replay_window_tokens: 200000  # Cap persisted replay and compaction summary chunks
+    replay_window_tokens: 200000  # Compact persisted replay around a smaller operational window
 ```
 
 This is useful for models with smaller context windows or long-running conversations that accumulate persisted history.

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -33,7 +33,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` or `compaction.fallback_model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
+| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it for compaction summary input and as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` or `compaction.fallback_model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
 
 ## Configuration Examples
 
@@ -260,7 +260,7 @@ You can tune compaction behavior with these settings:
 - Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
 - Use `replay_window_tokens` to keep persisted replay and required-compaction planning within a smaller operational window without presenting that smaller value as the provider's request limit.
 - Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
-- Use `model` to choose the summary model, and `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
+- Use `model` to choose the summary model, and `fallback_model` to name a different model config retried once when the summary model refuses for safeguards; the same input is reused when it fits, otherwise it is rebuilt under the fallback model's own context budget, and after success that model serves the remaining chunks.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.

--- a/docs/configuration/teams.md
+++ b/docs/configuration/teams.md
@@ -110,7 +110,7 @@ Crossing that soft trigger while still within the hard budget leaves the stored 
 
 You can tune team-scoped compaction behavior with these settings:
 
-- Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
 - Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
@@ -118,7 +118,7 @@ You can tune team-scoped compaction behavior with these settings:
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.

--- a/docs/configuration/teams.md
+++ b/docs/configuration/teams.md
@@ -113,7 +113,7 @@ You can tune team-scoped compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
-- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
+- Use `fallback_model` to name a different model config retried once when the summary model refuses for safeguards; the same input is reused when it fits, otherwise it is rebuilt under the fallback model's own context budget, and after success that model serves the remaining chunks.
 - Set `enabled: false` to disable automatic pre-reply compaction for a team.
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -64,7 +64,7 @@ Each model entry supports these fields:
 - **host** - Optional host URL (e.g., for Ollama or OpenAI-compatible servers)
 - **api_key** - Optional API key (usually set via env vars instead)
 - **extra_kwargs** - Additional provider-specific parameters (e.g., `base_url`)
-- **context_window** - Actual provider context window size in tokens; when set, MindRoom uses it as the default replay-planning and compaction-summary window unless compaction config sets a smaller `replay_window_tokens`, and applies a final replay-fit step that may reduce or disable persisted replay for that run; on `vertexai_claude` models it additionally enables request-time fitting that trims replayed history when a request would exceed the window
+- **context_window** - Actual provider context window size in tokens; when set, MindRoom uses it for compaction summary input and as the default replay-planning window unless compaction config sets a smaller `replay_window_tokens`, and applies a final replay-fit step that may reduce or disable persisted replay for that run; on `vertexai_claude` models it additionally enables request-time fitting that trims replayed history when a request would exceed the window
 
 ### Supported Providers
 
@@ -187,9 +187,9 @@ agents:
 - **compaction**: Optional per-agent required-compaction overrides (`enabled`, `threshold_tokens`, `threshold_percent`, `replay_window_tokens`, `reserve_tokens`, `model`); when the active runtime model has a known `context_window`, MindRoom always computes a replay plan for the current run and reduces or disables persisted replay when needed.
 Automatic destructive compaction is enabled by default through `defaults.compaction`, but it runs only when raw history exceeds the hard replay budget for the next reply.
 `threshold_tokens` and `threshold_percent` set a soft trigger budget for planning metadata and compaction notices; crossing that soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting.
-`replay_window_tokens` can cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
+`replay_window_tokens` can cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 If the active model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 Set `enabled: false` in defaults or the agent override to disable automatic pre-reply compaction.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1246,7 +1246,7 @@ defaults:
   compaction:
     enabled: true
     threshold_percent: 0.8
-    # The effective replay window also caps compaction summary input chunks.
+    # Summary input chunks use the selected compaction model's context window.
     # Destructive compaction requires a resolved summary input budget greater than 2,000 tokens.
     replay_window_tokens: null     # Optional operational cap; does not change the model's real context window
     reserve_tokens: 16384
@@ -1846,7 +1846,7 @@ Crossing that soft trigger while still within the hard budget leaves the stored 
 
 You can tune compaction behavior with these settings:
 
-- Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
 - Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
@@ -1854,7 +1854,7 @@ You can tune compaction behavior with these settings:
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.
@@ -2583,13 +2583,13 @@ It runs only when history exceeds the hard replay budget for the next reply.
 You can tune compaction behavior with these settings:
 
 - Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
-- Use `replay_window_tokens` to keep persisted replay, required-compaction planning, and summary input chunks within a smaller operational window without presenting that smaller value as the provider's request limit.
+- Use `replay_window_tokens` to keep persisted replay and required-compaction planning within a smaller operational window without presenting that smaller value as the provider's request limit.
 - Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
 - Use `model` to choose the summary model, and `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 
@@ -2617,7 +2617,7 @@ models:
 
 defaults:
   compaction:
-    replay_window_tokens: 200000  # Cap persisted replay and compaction summary chunks
+    replay_window_tokens: 200000  # Compact persisted replay around a smaller operational window
 ```
 
 This is useful for models with smaller context windows or long-running conversations that accumulate persisted history.
@@ -2799,7 +2799,7 @@ Crossing that soft trigger while still within the hard budget leaves the stored 
 
 You can tune team-scoped compaction behavior with these settings:
 
-- Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
 - Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
@@ -2807,7 +2807,7 @@ You can tune team-scoped compaction behavior with these settings:
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1849,7 +1849,7 @@ You can tune compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
-- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
+- Use `fallback_model` to name a different model config retried once when the summary model refuses for safeguards; the same input is reused when it fits, otherwise it is rebuilt under the fallback model's own context budget, and after success that model serves the remaining chunks.
 - Set `enabled: false` to disable automatic pre-reply compaction for this agent.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
@@ -2358,7 +2358,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` or `compaction.fallback_model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
+| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it for compaction summary input and as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` or `compaction.fallback_model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
 
 ## Configuration Examples
 
@@ -2585,7 +2585,7 @@ You can tune compaction behavior with these settings:
 - Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
 - Use `replay_window_tokens` to keep persisted replay and required-compaction planning within a smaller operational window without presenting that smaller value as the provider's request limit.
 - Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
-- Use `model` to choose the summary model, and `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
+- Use `model` to choose the summary model, and `fallback_model` to name a different model config retried once when the summary model refuses for safeguards; the same input is reused when it fits, otherwise it is rebuilt under the fallback model's own context budget, and after success that model serves the remaining chunks.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
@@ -2802,7 +2802,7 @@ You can tune team-scoped compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
-- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
+- Use `fallback_model` to name a different model config retried once when the summary model refuses for safeguards; the same input is reused when it fits, otherwise it is rebuilt under the fallback model's own context budget, and after success that model serves the remaining chunks.
 - Set `enabled: false` to disable automatic pre-reply compaction for a team.
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -189,7 +189,7 @@ Crossing that soft trigger while still within the hard budget leaves the stored 
 
 You can tune compaction behavior with these settings:
 
-- Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
 - Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
@@ -197,7 +197,7 @@ You can tune compaction behavior with these settings:
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -192,7 +192,7 @@ You can tune compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
-- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
+- Use `fallback_model` to name a different model config retried once when the summary model refuses for safeguards; the same input is reused when it fits, otherwise it is rebuilt under the fallback model's own context budget, and after success that model serves the remaining chunks.
 - Set `enabled: false` to disable automatic pre-reply compaction for this agent.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -385,7 +385,7 @@ defaults:
   compaction:
     enabled: true
     threshold_percent: 0.8
-    # The effective replay window also caps compaction summary input chunks.
+    # Summary input chunks use the selected compaction model's context window.
     # Destructive compaction requires a resolved summary input budget greater than 2,000 tokens.
     replay_window_tokens: null     # Optional operational cap; does not change the model's real context window
     reserve_tokens: 16384

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -29,7 +29,7 @@ Each model configuration supports the following fields:
 | `host` | No | `null` | Host URL for self-hosted models (e.g., Ollama) |
 | `api_key` | No | `null` | API key (usually read from environment variables) |
 | `extra_kwargs` | No | `null` | Additional provider-specific parameters |
-| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` or `compaction.fallback_model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
+| `context_window` | No | `null` | Actual provider context window size in tokens; MindRoom uses it for compaction summary input and as the default replay-planning window unless compaction sets a smaller `replay_window_tokens`; an explicit `compaction.model` or `compaction.fallback_model` needs its own `context_window` for summary generation; on `vertexai_claude` it also enables request-time fitting |
 
 ## Configuration Examples
 
@@ -256,7 +256,7 @@ You can tune compaction behavior with these settings:
 - Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
 - Use `replay_window_tokens` to keep persisted replay and required-compaction planning within a smaller operational window without presenting that smaller value as the provider's request limit.
 - Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
-- Use `model` to choose the summary model, and `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
+- Use `model` to choose the summary model, and `fallback_model` to name a different model config retried once when the summary model refuses for safeguards; the same input is reused when it fits, otherwise it is rebuilt under the fallback model's own context budget, and after success that model serves the remaining chunks.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -254,13 +254,13 @@ It runs only when history exceeds the hard replay budget for the next reply.
 You can tune compaction behavior with these settings:
 
 - Use `threshold_tokens` or `threshold_percent` to set the soft trigger budget. Crossing this soft trigger while still within the hard budget leaves the stored session unchanged and relies on replay fitting for that reply.
-- Use `replay_window_tokens` to keep persisted replay, required-compaction planning, and summary input chunks within a smaller operational window without presenting that smaller value as the provider's request limit.
+- Use `replay_window_tokens` to keep persisted replay and required-compaction planning within a smaller operational window without presenting that smaller value as the provider's request limit.
 - Use `reserve_tokens` to leave hard-budget headroom for the current prompt and output.
 - Use `model` to choose the summary model, and `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
 
 When the active runtime model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 
@@ -288,7 +288,7 @@ models:
 
 defaults:
   compaction:
-    replay_window_tokens: 200000  # Cap persisted replay and compaction summary chunks
+    replay_window_tokens: 200000  # Compact persisted replay around a smaller operational window
 ```
 
 This is useful for models with smaller context windows or long-running conversations that accumulate persisted history.

--- a/skills/mindroom-docs/references/page__configuration__teams__index.md
+++ b/skills/mindroom-docs/references/page__configuration__teams__index.md
@@ -106,7 +106,7 @@ Crossing that soft trigger while still within the hard budget leaves the stored 
 
 You can tune team-scoped compaction behavior with these settings:
 
-- Use `replay_window_tokens` to cap persisted replay, required-compaction planning, and summary input chunks below the model's real context window without lowering the provider request limit.
+- Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
 - Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
@@ -114,7 +114,7 @@ You can tune team-scoped compaction behavior with these settings:
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.
 When that model window is unknown, an explicit `replay_window_tokens` still supplies the replay-planning window.
-The effective replay window also caps each compaction summary input chunk.
+Each compaction summary input chunk is sized independently from the selected compaction model's real `context_window`, after reserve, prompt overhead, and a safety margin.
 Destructive compaction requires the resolved summary input budget to exceed 2,000 tokens.
 With the default `reserve_tokens`, this makes destructive compaction unavailable when the compaction model's context window is roughly 10,000 tokens or smaller; lowering `reserve_tokens` restores availability for such small windows.
 If you set `compaction.model`, that summary model must also define its own `context_window`, but only for the durable summary-generation pass.

--- a/skills/mindroom-docs/references/page__configuration__teams__index.md
+++ b/skills/mindroom-docs/references/page__configuration__teams__index.md
@@ -109,7 +109,7 @@ You can tune team-scoped compaction behavior with these settings:
 - Use `replay_window_tokens` to cap persisted replay and required-compaction planning below the model's real context window without lowering the provider request limit.
 - Use `reserve_tokens` to leave hard-budget headroom.
 - Use `model` to choose the summary model.
-- Use `fallback_model` to name a different model config that resends the unchanged summary prompt and input once (only the target model differs) when the summary model refuses for safeguards; after a successful fallback, that model serves the remaining compaction chunks and is reported as the summary model.
+- Use `fallback_model` to name a different model config retried once when the summary model refuses for safeguards; the same input is reused when it fits, otherwise it is rebuilt under the fallback model's own context budget, and after success that model serves the remaining chunks.
 - Set `enabled: false` to disable automatic pre-reply compaction for a team.
 
 When the active team model window is known, replay safety uses the smaller of it and `replay_window_tokens`.

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -245,8 +245,8 @@ class CompactionOverrideConfig(BaseModel):
         default=None,
         ge=1,
         description=(
-            "Optional operational cap for persisted replay, required-compaction planning, and summary input chunks; "
-            "destructive compaction requires the resolved summary input budget to exceed 2,000 tokens"
+            "Optional operational cap for persisted replay and required-compaction planning; compaction summary "
+            "input is instead budgeted from the selected compaction model's context window"
         ),
     )
     reserve_tokens: int | None = Field(
@@ -298,8 +298,8 @@ class CompactionConfig(BaseModel):
         default=None,
         ge=1,
         description=(
-            "Optional operational cap for persisted replay, required-compaction planning, and summary input chunks; "
-            "destructive compaction requires the resolved summary input budget to exceed 2,000 tokens"
+            "Optional operational cap for persisted replay and required-compaction planning; compaction summary "
+            "input is instead budgeted from the selected compaction model's context window"
         ),
     )
     reserve_tokens: int = Field(
@@ -566,9 +566,10 @@ class ModelConfig(BaseModel):
         default=None,
         ge=1,
         description=(
-            "Actual provider context window size in tokens. MindRoom uses it as the default replay-planning "
-            "window unless compaction.replay_window_tokens sets a smaller cap. An explicit compaction.model "
-            "or compaction.fallback_model also needs its own context_window for summary generation. "
+            "Actual provider context window size in tokens. MindRoom uses it for compaction summary input and as "
+            "the default replay-planning window unless compaction.replay_window_tokens sets a smaller replay cap. "
+            "An explicit compaction.model or compaction.fallback_model also needs its own context_window for "
+            "summary generation. "
             "On vertexai_claude models it additionally "
             "enables request-time fitting that trims replayed history when a request would exceed the window"
         ),

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -260,7 +260,10 @@ class CompactionOverrideConfig(BaseModel):
     )
     fallback_model: str | None = Field(
         default=None,
-        description="Optional model config name retried once when the summary model refuses for safeguards",
+        description=(
+            "Optional model config name retried once when the summary model refuses for safeguards; summary input "
+            "is rebuilt under the fallback model's context budget when needed"
+        ),
     )
 
     @model_validator(mode="after")
@@ -313,7 +316,10 @@ class CompactionConfig(BaseModel):
     )
     fallback_model: str | None = Field(
         default=None,
-        description="Optional model config name retried once when the summary model refuses for safeguards",
+        description=(
+            "Optional model config name retried once when the summary model refuses for safeguards; summary input "
+            "is rebuilt under the fallback model's context budget when needed"
+        ),
     )
 
     @model_validator(mode="after")

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -113,6 +113,7 @@ class _GeneratedSummaryChunk:
     # The model that actually served this chunk (fallback after a refusal switch).
     model: Model
     model_name: str
+    model_input_budget_tokens: int
 
 
 def _persist_cleared_force_state_if_needed(
@@ -201,6 +202,7 @@ async def compact_scope_history(
     summary_prompt: str,
     fallback_summary_model: Model | None = None,
     fallback_summary_model_name: str | None = None,
+    fallback_summary_input_budget: int | None = None,
     lifecycle_notice_event_id: str | None = None,
     progress_callback: Callable[[CompactionLifecycleProgress], Awaitable[None]] | None = None,
 ) -> CompactionOutcome | None:
@@ -264,6 +266,7 @@ async def compact_scope_history(
         summary_model_name=summary_model_name,
         fallback_summary_model=fallback_summary_model,
         fallback_summary_model_name=fallback_summary_model_name,
+        fallback_summary_input_budget=fallback_summary_input_budget,
         session_id=session.session_id,
         scope=scope,
         state=state,
@@ -373,6 +376,7 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901
     summary_prompt: str,
     fallback_summary_model: Model | None = None,
     fallback_summary_model_name: str | None = None,
+    fallback_summary_input_budget: int | None = None,
     before_persist_callback: Callable[[Sequence[RunOutput | TeamRunOutput]], Awaitable[None]] | None = None,
 ) -> _CompactionRewriteResult | None:
     final_summary_text = _current_summary_text(working_session) or ""
@@ -428,6 +432,7 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901
             estimate_kind=estimate_kind,
             fallback_model=fallback_summary_model,
             fallback_model_name=fallback_summary_model_name,
+            fallback_input_budget=fallback_summary_input_budget,
         )
         if new_summary.model is not summary_model:
             # A safeguard-refusal fallback served this chunk; it becomes the
@@ -435,8 +440,10 @@ async def _rewrite_working_session_for_compaction(  # noqa: C901
             summary_model = new_summary.model
             summary_model_name = new_summary.model_name
             token_estimator, estimate_kind = _compaction_sizing(summary_model)
+            summary_input_budget = new_summary.model_input_budget_tokens
             fallback_summary_model = None
             fallback_summary_model_name = None
+            fallback_summary_input_budget = None
         included_runs = new_summary.included_runs
         generated_summary = new_summary.summary
         if before_persist_callback is not None:
@@ -561,7 +568,7 @@ def _sizing_log_fields(*, kind: CompactionEstimateKind, estimate: int, budget_to
     }
 
 
-async def _generate_compaction_summary_with_retry(
+async def _generate_compaction_summary_with_retry(  # noqa: PLR0915
     *,
     model: Model,
     model_name: str,
@@ -578,14 +585,15 @@ async def _generate_compaction_summary_with_retry(
     estimate_kind: CompactionEstimateKind,
     fallback_model: Model | None = None,
     fallback_model_name: str | None = None,
+    fallback_input_budget: int | None = None,
 ) -> _GeneratedSummaryChunk:
     """Generate one summary chunk, retrying the same or smaller input when safe.
 
     A safeguard refusal from the primary model switches once to
-    ``fallback_model``, keeping the ``summary_prompt`` and ``summary_input``
-    bytes, included runs, and budget unchanged (only the target model
-    differs); a refusal or failure from the fallback propagates. The switch
-    shares the retry policy's attempt bound, so a
+    ``fallback_model``. The input remains unchanged when it fits the fallback
+    model, otherwise it is rebuilt under that model's own budget. A refusal or
+    failure from the fallback propagates. The switch shares the retry policy's
+    attempt bound, so a
     refusal after an earlier shrink or transient retry propagates without a
     fallback call. All other failures keep the existing shrink and transient
     same-input retry behavior.
@@ -639,6 +647,21 @@ async def _generate_compaction_summary_with_retry(
             # earlier shrink or transient retry propagates instead of issuing a
             # third provider call.
             if fallback_model is not None and attempt < retry_policy.max_attempts and is_model_safeguard_refusal(exc):
+                assert fallback_model_name is not None
+                assert fallback_input_budget is not None
+                fallback_token_estimator, fallback_estimate_kind = _compaction_sizing(fallback_model)
+                if fallback_token_estimator(summary_input) <= fallback_input_budget:
+                    rebuilt_input, rebuilt_runs = summary_input, included_runs
+                else:
+                    rebuilt_input, rebuilt_runs = _build_summary_input(
+                        previous_summary=previous_summary,
+                        compacted_runs=compactable_runs,
+                        history_settings=history_settings,
+                        max_input_tokens=fallback_input_budget,
+                        token_estimator=fallback_token_estimator,
+                    )
+                if not rebuilt_runs:
+                    raise
                 logger.info(
                     "Compaction summary refused; switching to fallback model",
                     session_id=session_id,
@@ -646,14 +669,18 @@ async def _generate_compaction_summary_with_retry(
                     attempt=attempt,
                     refused_model=model_name,
                     fallback_model=fallback_model_name,
+                    fallback_summary_input_budget_tokens=fallback_input_budget,
                 )
-                assert fallback_model_name is not None
                 model = fallback_model
                 model_name = fallback_model_name
-                # The fallback resends the unchanged prompt and input bytes
-                # exactly once; only the target model differs.
+                summary_input = rebuilt_input
+                included_runs = rebuilt_runs
+                budget = fallback_input_budget
+                token_estimator = fallback_token_estimator
+                estimate_kind = fallback_estimate_kind
                 fallback_model = None
                 fallback_model_name = None
+                fallback_input_budget = None
                 attempt += 1
                 continue
             retry_decision: SummaryRetryDecision | None = retry_policy.retry_budget(
@@ -703,6 +730,7 @@ async def _generate_compaction_summary_with_retry(
             included_runs=included_runs,
             model=model,
             model_name=model_name,
+            model_input_budget_tokens=budget,
         )
 
 

--- a/src/mindroom/history/policy.py
+++ b/src/mindroom/history/policy.py
@@ -43,6 +43,10 @@ def resolve_history_execution_plan(
         compaction_context_window=compaction_context_window,
         reserve_tokens=compaction_config.reserve_tokens,
     )
+    fallback_summary_input_budget_tokens = _resolve_fallback_summary_input_budget(
+        config=config,
+        compaction_config=compaction_config,
+    )
 
     threshold_tokens = None
     replay_budget_tokens = None
@@ -80,6 +84,7 @@ def resolve_history_execution_plan(
         unavailable_reason=unavailable_reason,
         hard_replay_budget_tokens=hard_replay_budget_tokens,
         compaction_fallback_model_name=compaction_config.fallback_model,
+        compaction_fallback_summary_input_budget_tokens=fallback_summary_input_budget_tokens,
     )
 
 
@@ -219,6 +224,22 @@ def _resolve_summary_input_budget(
     if summary_input_budget_tokens <= 2 * COMPACTION_SUMMARY_RETRY_FLOOR_TOKENS:
         return summary_input_budget_tokens, "summary_input_budget_without_retry_headroom"
     return summary_input_budget_tokens, None
+
+
+def _resolve_fallback_summary_input_budget(
+    *,
+    config: Config,
+    compaction_config: CompactionConfig,
+) -> int | None:
+    """Return a usable summary budget for the optional fallback model."""
+    fallback_model_name = compaction_config.fallback_model
+    if fallback_model_name is None:
+        return None
+    fallback_budget, unavailable_reason = _resolve_summary_input_budget(
+        compaction_context_window=config.get_model_context_window(fallback_model_name),
+        reserve_tokens=compaction_config.reserve_tokens,
+    )
+    return fallback_budget if unavailable_reason is None else None
 
 
 def context_budget_after_reserve(context_window_tokens: int, reserve_tokens: int, spent_tokens: int = 0) -> int:

--- a/src/mindroom/history/policy.py
+++ b/src/mindroom/history/policy.py
@@ -41,7 +41,6 @@ def resolve_history_execution_plan(
     )
     summary_input_budget_tokens, unavailable_reason = _resolve_summary_input_budget(
         compaction_context_window=compaction_context_window,
-        replay_window_tokens=replay_window_tokens,
         reserve_tokens=compaction_config.reserve_tokens,
     )
 
@@ -195,11 +194,12 @@ def describe_compaction_unavailability(plan: ResolvedHistoryExecutionPlan) -> st
 def _resolve_summary_input_budget(
     *,
     compaction_context_window: int | None,
-    replay_window_tokens: int | None,
     reserve_tokens: int,
 ) -> tuple[int | None, CompactionAvailabilityReason | None]:
     """Resolve a summary budget large enough for the request envelope and one degradation retry.
 
+    Summary input uses the selected compaction model's real context window.
+    The smaller replay window controls persisted replay and trigger planning only.
     Plans require more than twice the shared retry floor so halving leaves a
     genuinely smaller target with room for the request envelope and run content.
     """
@@ -214,8 +214,6 @@ def _resolve_summary_input_budget(
         compaction_context_window,
         reserve_tokens=normalized_reserve_tokens,
     )
-    if replay_window_tokens is not None:
-        summary_input_budget_tokens = min(summary_input_budget_tokens, replay_window_tokens)
     if summary_input_budget_tokens <= 0:
         return summary_input_budget_tokens, "non_positive_summary_input_budget"
     if summary_input_budget_tokens <= 2 * COMPACTION_SUMMARY_RETRY_FLOOR_TOKENS:

--- a/src/mindroom/history/runtime.py
+++ b/src/mindroom/history/runtime.py
@@ -568,11 +568,16 @@ async def _run_scope_compaction(
         execution_plan.compaction_model_name,
     )
     fallback_model_name = execution_plan.compaction_fallback_model_name
+    fallback_summary_input_budget = execution_plan.compaction_fallback_summary_input_budget_tokens
     fallback_model: Model | None = None
-    if fallback_model_name is not None and _compaction_fallback_is_distinct(
-        config,
-        primary_model_name=execution_plan.compaction_model_name,
-        fallback_model_name=fallback_model_name,
+    if (
+        fallback_model_name is not None
+        and fallback_summary_input_budget is not None
+        and _compaction_fallback_is_distinct(
+            config,
+            primary_model_name=execution_plan.compaction_model_name,
+            fallback_model_name=fallback_model_name,
+        )
     ):
         # The fallback is an optional resilience knob: when its construction
         # fails (missing SDK, credentials, client setup), compaction still
@@ -603,6 +608,7 @@ async def _run_scope_compaction(
         summary_prompt=config.get_prompt("COMPACTION_SUMMARY_PROMPT"),
         fallback_summary_model=fallback_model,
         fallback_summary_model_name=fallback_model_name if fallback_model is not None else None,
+        fallback_summary_input_budget=fallback_summary_input_budget if fallback_model is not None else None,
         lifecycle_notice_event_id=lifecycle_notice_event_id,
         progress_callback=progress_callback,
     )

--- a/src/mindroom/history/types.py
+++ b/src/mindroom/history/types.py
@@ -131,6 +131,7 @@ class ResolvedHistoryExecutionPlan:
     unavailable_reason: CompactionAvailabilityReason | None = None
     hard_replay_budget_tokens: int | None = None
     compaction_fallback_model_name: str | None = None
+    compaction_fallback_summary_input_budget_tokens: int | None = None
 
 
 @dataclass(frozen=True)

--- a/tests/test_compact_context.py
+++ b/tests/test_compact_context.py
@@ -373,8 +373,7 @@ async def test_compact_context_requires_summary_input_budget_with_retry_headroom
     """Manual compaction should not set the force flag when the summary budget cannot shrink."""
     config, runtime_paths = _make_config_with_context_window(
         tmp_path,
-        context_window=48_000,
-        compaction=CompactionConfig(replay_window_tokens=800),
+        context_window=10_000,
     )
     identity = _execution_identity()
     storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=identity)

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -167,6 +167,7 @@ def _make_config(
     tmp_path: Path,
     *,
     compaction: CompactionConfig | None = None,
+    context_window: int = 64_000,
 ) -> tuple[Config, RuntimePaths]:
     runtime_paths = resolve_runtime_paths(
         config_path=tmp_path / "config.yaml",
@@ -186,7 +187,7 @@ def _make_config(
             },
             defaults=DefaultsConfig(tools=[], compaction=compaction or CompactionConfig()),
             models={
-                "default": ModelConfig(provider="openai", id="test-model", context_window=64_000),
+                "default": ModelConfig(provider="openai", id="test-model", context_window=context_window),
             },
         ),
         runtime_paths,
@@ -1814,7 +1815,7 @@ async def test_near_cap_durable_summary_with_tiny_budget_is_unavailable_without_
     summary_input_budget = COMPACTION_SUMMARY_RETRY_FLOOR_TOKENS + 1
     config, runtime_paths = _make_config(
         tmp_path,
-        compaction=CompactionConfig(replay_window_tokens=summary_input_budget),
+        context_window=10_000,
     )
     storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
     previous_summary = ("word " * 975) + "TAIL-FACT-MUST-SURVIVE"

--- a/tests/test_compaction_invariants.py
+++ b/tests/test_compaction_invariants.py
@@ -1520,6 +1520,7 @@ async def test_retry_helper_switches_to_fallback_once_with_unchanged_prompt_and_
             estimate_kind="o200k_base_tokens",
             fallback_model=fallback,
             fallback_model_name="fallback-model",
+            fallback_input_budget=4_000,
         )
 
     assert generated.summary is recovered_summary
@@ -1592,6 +1593,7 @@ async def test_retry_helper_propagates_fallback_refusal_or_failure(fallback_erro
             estimate_kind="o200k_base_tokens",
             fallback_model=fallback,
             fallback_model_name="fallback-model",
+            fallback_input_budget=4_000,
         )
 
     assert raised.value is fallback_error
@@ -1635,6 +1637,7 @@ async def test_retry_helper_refusal_after_transient_retry_propagates_within_atte
             estimate_kind="o200k_base_tokens",
             fallback_model=fallback,
             fallback_model_name="fallback-model",
+            fallback_input_budget=4_000,
         )
 
     assert raised.value is refusal
@@ -1678,7 +1681,7 @@ async def test_compaction_fallback_serves_later_chunks_state_and_outcome(tmp_pat
             state=read_scope_state(session, _SCOPE),
             history_settings=_HISTORY_SETTINGS,
             available_history_budget=None,
-            summary_input_budget=10_000,
+            summary_input_budget=100_000,
             summary_model=primary,
             summary_model_name="summary-model",
             replay_window_tokens=64_000,
@@ -1686,13 +1689,17 @@ async def test_compaction_fallback_serves_later_chunks_state_and_outcome(tmp_pat
             summary_prompt=COMPACTION_SUMMARY_PROMPT,
             fallback_summary_model=fallback,
             fallback_summary_model_name="fallback-model",
+            fallback_summary_input_budget=10_000,
         )
 
     assert outcome is not None
-    # Chunk 1 refuses on the primary and resends the unchanged prompt and
-    # input to the fallback; chunk 2 goes straight to the fallback.
+    # The primary sees both runs. Its smaller-context fallback rebuilds the
+    # refused chunk with run 1, then keeps its own budget for run 2.
     assert [model_id for model_id, _ in attempts] == ["summary-model", "fallback-model-id", "fallback-model-id"]
-    assert attempts[1][1] == attempts[0][1]
+    assert "RUN1-MARKER" in attempts[0][1]
+    assert "RUN2-MARKER" in attempts[0][1]
+    assert "RUN1-MARKER" in attempts[1][1]
+    assert "RUN2-MARKER" not in attempts[1][1]
     assert "RUN2-MARKER" in attempts[2][1]
     assert outcome.summary_model == "fallback-model"
     persisted = get_agent_session(storage, "session-1")

--- a/tests/test_history_compaction_rewrite.py
+++ b/tests/test_history_compaction_rewrite.py
@@ -94,6 +94,7 @@ async def _rewrite_single_run(
     summary_model: FakeModel | None = None,
     fallback_summary_model: FakeModel | None = None,
     fallback_summary_model_name: str | None = None,
+    fallback_summary_input_budget: int | None = None,
     progress_callback: Callable[[CompactionLifecycleProgress], Awaitable[None]] | None = None,
 ) -> _CompactionRewriteResult | None:
     return await _rewrite_working_session_for_compaction(
@@ -104,6 +105,13 @@ async def _rewrite_single_run(
         summary_model_name="summary-model",
         fallback_summary_model=fallback_summary_model,
         fallback_summary_model_name=fallback_summary_model_name,
+        fallback_summary_input_budget=(
+            fallback_summary_input_budget
+            if fallback_summary_input_budget is not None
+            else summary_input_budget
+            if fallback_summary_model is not None
+            else None
+        ),
         session_id=working_session.session_id,
         scope=HistoryScope(kind="agent", scope_id="test_agent"),
         state=HistoryScopeState(force_compact_before_next_run=True),

--- a/tests/test_history_prepare_lifecycle.py
+++ b/tests/test_history_prepare_lifecycle.py
@@ -1124,6 +1124,7 @@ async def test_prepare_history_for_run_failure_notice_reports_serving_fallback_m
         hard_replay_budget_tokens=1,
         summary_input_budget_tokens=summary_input_budget,
         compaction_fallback_model_name="fallback-model",
+        compaction_fallback_summary_input_budget_tokens=summary_input_budget,
     )
     # Chunk 1: primary refuses, the fallback serves the retry; chunk 2 then
     # fails hard on the fallback.
@@ -1203,6 +1204,7 @@ async def test_prepare_history_for_run_compacts_on_primary_when_fallback_constru
         hard_replay_budget_tokens=1,
         summary_input_budget_tokens=16_000,
         compaction_fallback_model_name="fallback-model",
+        compaction_fallback_summary_input_budget_tokens=16_000,
     )
 
     def _load_model(_config: object, _paths: object, name: str = "default", **_kwargs: object) -> FakeModel:

--- a/tests/test_history_replay_planning.py
+++ b/tests/test_history_replay_planning.py
@@ -21,7 +21,6 @@ from mindroom.history.compaction import (
 from mindroom.history.policy import (
     classify_compaction_decision,
     context_budget_after_reserve,
-    describe_compaction_unavailability,
     resolve_history_execution_plan,
 )
 from mindroom.history.runtime import (
@@ -114,22 +113,12 @@ async def test_prepare_history_for_run_authored_compaction_still_plans_safe_repl
     assert prepared.replay_plan.num_history_messages is None
 
 
-@pytest.mark.asyncio
-async def test_small_replay_window_cannot_select_required_compaction_without_progress(tmp_path: Path) -> None:
-    config, runtime_paths = _make_config(
+def test_small_replay_window_does_not_cap_compaction_model_input(tmp_path: Path) -> None:
+    config, _runtime_paths_value = _make_config(
         tmp_path,
         compaction=CompactionOverrideConfig(enabled=True, replay_window_tokens=1),
         context_window=1_000_000,
     )
-    storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
-    session = _session(
-        "session-1",
-        runs=[
-            _completed_run("run-1"),
-            _completed_run("run-2"),
-        ],
-    )
-    storage.upsert_session(session)
 
     execution_plan = resolve_history_execution_plan(
         config=config,
@@ -140,40 +129,10 @@ async def test_small_replay_window_cannot_select_required_compaction_without_pro
         static_prompt_tokens=10,
     )
 
-    assert execution_plan.summary_input_budget_tokens == 1
-    assert execution_plan.destructive_compaction_available is False
-    assert execution_plan.unavailable_reason == "summary_input_budget_without_retry_headroom"
-    assert describe_compaction_unavailability(execution_plan) == (
-        "the summary input budget must exceed 2,000 tokens to provide meaningful headroom for a smaller retry"
-    )
-
-    with patch("mindroom.history.runtime._run_scope_compaction_with_lifecycle", new=AsyncMock()) as compact_mock:
-        prepared_attempts = [
-            await prepare_history_for_run_for_test(
-                agent=_agent(db=storage),
-                agent_name="test_agent",
-                full_prompt="Current prompt",
-                session_id="session-1",
-                runtime_paths=runtime_paths,
-                config=config,
-                execution_identity=None,
-                storage=storage,
-                session=session,
-            )
-            for _attempt in range(2)
-        ]
-
-    assert [
-        (prepared.compaction_decision.mode, prepared.compaction_decision.reason) for prepared in prepared_attempts
-    ] == [
-        ("none", "compaction_unavailable"),
-        ("none", "compaction_unavailable"),
-    ]
-    compact_mock.assert_not_awaited()
-    persisted = get_agent_session(storage, "session-1")
-    assert persisted is not None
-    assert persisted.summary is None
-    assert [run.run_id for run in persisted.runs] == ["run-1", "run-2"]
+    assert execution_plan.replay_window_tokens == 1
+    assert execution_plan.summary_input_budget_tokens == 881_616
+    assert execution_plan.destructive_compaction_available is True
+    assert execution_plan.unavailable_reason is None
 
 
 @pytest.mark.asyncio
@@ -931,21 +890,22 @@ def test_resolve_history_execution_plan_marks_non_positive_summary_budget_unavai
 
 
 @pytest.mark.parametrize(
-    ("replay_window_tokens", "expected_available"),
+    ("context_window_tokens", "expected_summary_input_budget", "expected_available"),
     [
-        (2 * COMPACTION_SUMMARY_RETRY_FLOOR_TOKENS, False),
-        (2 * COMPACTION_SUMMARY_RETRY_FLOOR_TOKENS + 1, True),
+        (10_000, 2 * COMPACTION_SUMMARY_RETRY_FLOOR_TOKENS, False),
+        (10_001, 2 * COMPACTION_SUMMARY_RETRY_FLOOR_TOKENS + 1, True),
     ],
 )
 def test_resolve_history_execution_plan_enforces_minimum_summary_input_budget(
     tmp_path: Path,
-    replay_window_tokens: int,
+    context_window_tokens: int,
+    expected_summary_input_budget: int,
     expected_available: bool,
 ) -> None:
     config, _runtime_paths_value = _make_config(
         tmp_path,
-        compaction=CompactionOverrideConfig(enabled=True, replay_window_tokens=replay_window_tokens),
-        context_window=1_000_000,
+        compaction=CompactionOverrideConfig(enabled=True),
+        context_window=context_window_tokens,
     )
 
     execution_plan = resolve_history_execution_plan(
@@ -953,11 +913,11 @@ def test_resolve_history_execution_plan_enforces_minimum_summary_input_budget(
         compaction_config=config.resolve_entity("test_agent").compaction_config,
         has_authored_compaction_config=config.resolve_entity("test_agent").has_authored_compaction_config,
         active_model_name="default",
-        active_context_window=1_000_000,
+        active_context_window=context_window_tokens,
         static_prompt_tokens=10,
     )
 
-    assert execution_plan.summary_input_budget_tokens == replay_window_tokens
+    assert execution_plan.summary_input_budget_tokens == expected_summary_input_budget
     assert execution_plan.destructive_compaction_available is expected_available
     assert (execution_plan.unavailable_reason is None) is expected_available
 
@@ -1009,11 +969,11 @@ def test_resolve_history_execution_plan_keeps_replay_headroom_when_compaction_di
 @pytest.mark.parametrize(
     ("active_context_window", "expected_replay_window", "expected_summary_input_budget"),
     [
-        (1_000_000, 200_000, 200_000),
+        (1_000_000, 200_000, 881_616),
         (100_000, 100_000, 71_616),
     ],
 )
-def test_resolve_history_execution_plan_caps_replay_without_changing_model_window(
+def test_resolve_history_execution_plan_caps_replay_without_capping_summary_input(
     tmp_path: Path,
     active_context_window: int,
     expected_replay_window: int,

--- a/tests/test_history_replay_planning.py
+++ b/tests/test_history_replay_planning.py
@@ -669,6 +669,45 @@ def test_resolve_history_execution_plan_carries_fallback_model_name(tmp_path: Pa
 
     assert execution_plan.compaction_model_name == "summary-model"
     assert execution_plan.compaction_fallback_model_name == "fallback-model"
+    assert execution_plan.compaction_fallback_summary_input_budget_tokens == 10_800
+
+
+def test_resolve_history_execution_plan_uses_each_compaction_model_window_for_summary_budget(
+    tmp_path: Path,
+) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"test_agent": AgentConfig(display_name="Test Agent")},
+            defaults=DefaultsConfig(
+                tools=[],
+                compaction=CompactionConfig(
+                    model="summary-model",
+                    fallback_model="fallback-model",
+                    replay_window_tokens=200_000,
+                ),
+            ),
+            models={
+                "default": ModelConfig(provider="openai", id="default-model", context_window=1_000_000),
+                "summary-model": ModelConfig(provider="openai", id="summary-model-id", context_window=1_000_000),
+                "fallback-model": ModelConfig(provider="openai", id="fallback-model-id", context_window=200_000),
+            },
+        ),
+        runtime_paths,
+    )
+
+    execution_plan = resolve_history_execution_plan(
+        config=config,
+        compaction_config=config.resolve_entity("test_agent").compaction_config,
+        has_authored_compaction_config=True,
+        active_model_name="default",
+        active_context_window=1_000_000,
+        static_prompt_tokens=10_000,
+    )
+
+    assert execution_plan.replay_window_tokens == 200_000
+    assert execution_plan.summary_input_budget_tokens == 881_616
+    assert execution_plan.compaction_fallback_summary_input_budget_tokens == 161_616
 
 
 def test_compaction_fallback_is_distinct_guards_same_alias_and_same_target(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- keep `replay_window_tokens` scoped to persisted replay and compaction-trigger planning
- size summary input from the selected compaction model context, preserving reserve, prompt overhead, safety margin, and shrink retry
- update configuration docs and regression coverage

A 200k replay cap no longer forces a 1M-context summary model to split otherwise fitting history across several summary requests. With the default reserve, a 1M model gets an 881,616-token summary-input budget while replay remains capped at 200k.

## Tests

- `.venv/bin/pytest tests/test_history_replay_planning.py tests/test_compact_context.py tests/test_compaction_invariants.py -x --lf -n auto --no-cov -q`
- `.venv/bin/pytest -x --lf -n auto --no-cov -q`
- `.venv/bin/pre-commit run --files <changed files>`