### PR TITLE
Bump mindroom-nio to 0.31

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   # Arbitrary Olm to-device encryption uses the fork's tested internal API; update only with its round-trip tests.
-  "mindroom-nio[e2e]==0.30",
+  "mindroom-nio[e2e]==0.31",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/uv.lock
+++ b/uv.lock
@@ -1364,7 +1364,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
@@ -4515,7 +4515,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = "==0.30" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = "==0.31" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4625,7 +4625,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "0.30.0"
+version = "0.31.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4637,9 +4637,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/68/98e56bddd4d4b38d3b386c7b3c239b37e614101c4aac6b3d1367742f2d00/mindroom_nio-0.30.0.tar.gz", hash = "sha256:b6f5defaa159b68c12d02dbdca6816b673bf06a97cece31ebc04ca1dd72f735f", size = 184078, upload-time = "2026-07-25T15:22:37.737Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/88/ff684847de83744240387dd2fa345feabc103cbde140c81ef770b6040fd7/mindroom_nio-0.31.0.tar.gz", hash = "sha256:972f43a6e3b6390ba7123f250162898ad8c35f525efb970e5f1d10c6bc18095c", size = 185977, upload-time = "2026-07-25T18:38:23.624Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/3c/9f195d1dd80f586363b3eab880f59be4c3725bc09315ccbdf14cd8723e37/mindroom_nio-0.30.0-py3-none-any.whl", hash = "sha256:0cf1ea1b207a9307db08da1597ac34b7888a69f6497eb91783fe93a6c64d1b64", size = 212431, upload-time = "2026-07-25T15:22:36.305Z" },
+    { url = "https://files.pythonhosted.org/packages/83/66/c62a1cb25f217f118e67f5437420bdd3005964a21e3a5182b5ee4d51943f/mindroom_nio-0.31.0-py3-none-any.whl", hash = "sha256:9f7a160db13dc4f90f37e0c0cf88d3c008ac47ac2e61b88672e1cf7130fed939", size = 214365, upload-time = "2026-07-25T18:38:22.069Z" },
 ]
 
 [package.optional-dependencies]
@@ -5121,7 +5121,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -5132,7 +5132,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -5159,9 +5159,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -5172,7 +5172,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -7208,10 +7208,10 @@ name = "pyobjc-framework-applicationservices"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-coretext", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/4d/0ebdd8144aba94b8fe9828ccee5616a4bf53d1f8bc51cff55f3cce86d695/pyobjc_framework_applicationservices-12.2.1.tar.gz", hash = "sha256:048ea663c9ac75c44a15dc7d5b8d78cbb4c97bf1c76e83835e8d5498e184001f", size = 109342, upload-time = "2026-06-19T16:19:46.149Z" }
 wheels = [
@@ -7229,7 +7229,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -7247,9 +7247,9 @@ name = "pyobjc-framework-coretext"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/9c/4c7f452059dc1d3845b8e627b9113c247a997b9b07518e848c2ab7ff3149/pyobjc_framework_coretext-12.2.1.tar.gz", hash = "sha256:af740e784d7c592c34025ec7165f4f6c1a69b5a2d9075f06e41e4f77c212aed2", size = 97349, upload-time = "2026-06-19T16:20:22.508Z" }
 wheels = [
@@ -7267,8 +7267,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [


### PR DESCRIPTION
Bumps `mindroom-nio[e2e]` from `0.30` to `0.31`.

## Scope correction

The task this came from described a `0.28 -> 0.31.0` jump across four fork releases. That is true of the working checkout, but **not of `main`**: `main` already carries `0.30` via #1655 ("Bump mindroom-nio to 0.30"), which absorbed the two risky releases:

- **0.29.0** — rebase onto upstream matrix-nio 0.26.0 (vodozemac migration, Python 3.10 minimum, password-change API, flattened event helpers, corrected room-redaction transaction IDs).
- **0.30.0** — durable per-room limited-timeline recovery, encrypted client store schema **v2 -> v3**.

So the diff this PR actually introduces is **two releases**, both narrow:

- **0.30.1** — keep the recovered history of a limited-timeline walk that runs out of events. A forward `/messages` walk bounded by the window's token ends on a page with no `end` token; that exhausted page was treated as unprovable and the whole collected gap was discarded. Upstream measured 173/200 events lost on Synapse and 148/200 on Tuwunel under concurrent writes; zero after the fix.
- **0.31.0** — limited-timeline recovery for the Simplified Sliding Sync transport, plus a new `AsyncClientConfig.backfill_sliding_seed_rooms` (default 1000, 0 disables) that widens the first sliding request's list ranges so every room yields a `prev_batch` token to walk back from.

## Operational note: store schema v2 -> v3 is one-way

Worth restating for deployments even though it landed in #1655 rather than here: existing **encryption stores are migrated in place from schema v2 to v3 on first use and cannot be downgraded afterwards**. Anyone rolling back past `0.30` after starting on it will need to discard the encryption store. This PR does not add a new migration on top of that.

## Context, not a change: sliding recovery is currently dormant

- `src/mindroom/matrix/client_session.py` sets `backfill_limited_timelines=True` in `matrix_client_config()`.
- `src/mindroom/config/matrix.py` still defaults `matrix_sync.mode` to `classic`.

The recovery path added in 0.31.0 only engages on the `sliding` transport, so on default config this PR changes no runtime behaviour beyond the 0.30.1 classic-transport fix. `backfill_sliding_seed_rooms` is left at its upstream default; MindRoom does not set it.

## What I ran

All commands from a clean worktree of `origin/main` (`1d81200a2`), macOS/arm64, CPython 3.13.10, uv 0.11.31.

| Command | Result |
| --- | --- |
| `uv lock` | `Updated mindroom-nio v0.30.0 -> v0.31.0` |
| `uv sync --all-extras` | ok |
| `uv run python -c "import mindroom"` | ok, resolves `mindroom-nio 0.31.0` |
| `uv run pytest -m "not requires_matrix"` (the CI invocation) | **11658 passed, 41 skipped**, exit 0 |
| `uv run pytest -m "not requires_matrix" -k "matrix or sync or olm or desktop or client or crypto or encrypt"` | 6060 passed, 13 skipped |
| `uv lock --check` after `uv sync --all-extras` | clean, no lock drift (CI's `git diff --exit-code` step will pass) |
| `pre-commit run --files pyproject.toml uv.lock` | all applicable hooks pass |

The full suite needed `NO_COLOR=1 TERM=dumb`. Without it, 23 CLI tests fail on ANSI escapes leaking into captured output. **These are pre-existing and unrelated**: I verified by stashing this change, re-syncing to `mindroom-nio 0.30.0`, and re-running the same five files — identical 23 failures on the baseline. Follow-up issue filed separately.

`pre-commit`'s `pyproject-fmt` hook normalises the pin to `==0.31` (same convention as the previous `==0.30`); the lock records the matching `specifier = "==0.31"`.

## API-compatibility review

Checked every nio surface `src/mindroom` touches against the installed 0.31.0:

- **Internal Olm API** used by `src/mindroom/matrix_rtc/key_transport.py` — `Olm._olm_encrypt(self, session, recipient_device, message_type, content)`, `Olm.get_missing_sessions`, `olm.session_store`, `olm.device_store`, `OlmDevice.curve25519` — all still present with the same shape. This is the surface the `pyproject.toml` comment warns about.
- **Store** — `nio.store.SqliteStore` (used by `src/mindroom/desktop/identity.py`), plus the `SyncRecoveryGaps` / `PendingTimelineEvents` exports added in 0.30.0, all importable.
- **Redaction transaction IDs** — `AsyncClient.room_redact` gained a `tx_id` parameter upstream, but no MindRoom call site passes one (`src/mindroom/stop.py`, `src/mindroom/bot.py`, `src/mindroom/custom_tools/matrix_api.py`, `src/mindroom/matrix/stale_stream_cleanup.py` all call it positionally with `room_id, event_id` plus `reason=`). No impact.
- **Config** — `AsyncClientConfig` still exposes `backfill_limited_timelines`, `backfill_timeout`, `custom_headers`, `replace_rotated_device_keys`; the new `backfill_sliding_seed_rooms` defaults to 1000.
- Other imports verified: `nio.api.Api` / `RelationshipType`, `nio.exceptions.LocalProtocolError` / `OlmTrustError`, `nio.responses.RoomGetEventError` / `RoomThreadsResponse`, `nio.crypto.cross_signing.cross_signing_sidecar_path`, `nio.crypto.OlmDevice`, `nio.MegolmEvent`.

Nothing in `src/mindroom` relies on removed behaviour. No vodozemac-specific code exists in MindRoom (that migration is internal to nio and already shipped in `main`).

## Not verified

- **The `requires_matrix` tests were not run** — they need a live homeserver, and CI deselects them too. The sliding and classic recovery paths are exercised by nio's own live checks, not here.
- **No live run against a real homeserver.** In particular the 0.30.1 classic-transport recovery fix, which is the only behaviour change reaching MindRoom's default config, is covered only by nio's upstream measurements, not by anything in this repo.
- **`uv.lock` carries unrelated marker churn.** Re-resolving with uv 0.11.31 drops a redundant `marker = "sys_platform != 'emscripten' and sys_platform != 'win32'"` from transitive deps of `cuda-bindings`, four `nvidia-*` and four `pyobjc-*` packages. I confirmed this is a uv-version artifact, not a consequence of the bump: `uv lock` on unmodified `main` is a no-op, and the churn appears on any forced re-resolve. Left in rather than hand-edited.

## Summary by Sourcery

Build:
- Update pyproject dependency pin for mindroom-nio[e2e] from 0.30 to 0.31 and regenerate uv.lock to match.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the core messaging dependency to version 0.31.
  * Includes the latest dependency improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->