### PR TITLE
Make the test suite colour-deterministic in any shell

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,20 +4,19 @@ This file exists at the repository root so pytest imports it before
 ``tests/conftest.py`` and before any test module imports the MindRoom CLI.
 """
 
-from __future__ import annotations
-
 import os
 
-# Rich resolves colour support once, when a `Console` is constructed, and the CLI builds
-# its consoles at import time (`mindroom.cli.config`, `.desktop`, `.service`). Typer does
-# the same for its own error consoles. A shell that forces colour (Claude Code, Codex and
-# several terminals export `FORCE_COLOR`) therefore bakes ANSI escapes into output that
-# `typer.testing.CliRunner` captures from a non-tty buffer, breaking substring assertions
-# and YAML parsing of `mindroom config init --print`.
+# Rich resolves color support once, when a `Console` is constructed, and the CLI builds
+# its consoles at import time (`mindroom.cli.config`, `.desktop`, `.service`), so no
+# fixture can influence them. A shell that exports `FORCE_COLOR` (Claude Code, Codex and
+# several terminals do) makes Rich force a color terminal even though
+# `typer.testing.CliRunner` captures to a non-tty buffer, baking ANSI escapes into output
+# that tests assert on and parse as YAML.
 #
-# Neutralise the forcing variables and pin a dumb terminal here, before anything imports
-# Rich or Typer, so `pytest` behaves identically in every shell. `NO_COLOR` alone is not
-# enough: it strips colour but leaves bold and other SGR codes.
-for _colour_forcing_var in ("CLICOLOR_FORCE", "COLORTERM", "FORCE_COLOR", "PY_COLORS"):
-    os.environ.pop(_colour_forcing_var, None)
+# Pinning a dumb terminal is the one switch that settles it, because Rich gates all three
+# sources of noise on `Console.is_dumb_terminal`: color (`_detect_color_system` returns
+# `None`), control codes (`Console.control` writes nothing) and width (`Console.size`
+# returns a fixed 80x25 instead of the invoking terminal's size). It wins over
+# `FORCE_COLOR` and over Typer's own `force_terminal` consoles. Setting `NO_COLOR`
+# instead would not do: it strips color but leaves bold and other SGR codes.
 os.environ["TERM"] = "dumb"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,23 @@
+"""Root pytest configuration.
+
+This file exists at the repository root so pytest imports it before
+``tests/conftest.py`` and before any test module imports the MindRoom CLI.
+"""
+
+from __future__ import annotations
+
+import os
+
+# Rich resolves colour support once, when a `Console` is constructed, and the CLI builds
+# its consoles at import time (`mindroom.cli.config`, `.desktop`, `.service`). Typer does
+# the same for its own error consoles. A shell that forces colour (Claude Code, Codex and
+# several terminals export `FORCE_COLOR`) therefore bakes ANSI escapes into output that
+# `typer.testing.CliRunner` captures from a non-tty buffer, breaking substring assertions
+# and YAML parsing of `mindroom config init --print`.
+#
+# Neutralise the forcing variables and pin a dumb terminal here, before anything imports
+# Rich or Typer, so `pytest` behaves identically in every shell. `NO_COLOR` alone is not
+# enough: it strips colour but leaves bold and other SGR codes.
+for _colour_forcing_var in ("CLICOLOR_FORCE", "COLORTERM", "FORCE_COLOR", "PY_COLORS"):
+    os.environ.pop(_colour_forcing_var, None)
+os.environ["TERM"] = "dumb"

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -55,6 +55,15 @@ if TYPE_CHECKING:
 runner = CliRunner()
 
 
+def test_cli_console_renders_without_ansi_escapes(capsys: pytest.CaptureFixture[str]) -> None:
+    """The root conftest must keep the import-time CLI console colourless in any shell."""
+    config_cli.console.print("[bold red]MindRoom Doctor[/bold red]")
+
+    captured = capsys.readouterr().out
+    assert "\x1b" not in captured
+    assert "MindRoom Doctor" in captured
+
+
 @pytest.fixture(autouse=True)
 def _clear_runtime_path_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MINDROOM_CONFIG_PATH", raising=False)

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -55,15 +55,6 @@ if TYPE_CHECKING:
 runner = CliRunner()
 
 
-def test_cli_console_renders_without_ansi_escapes(capsys: pytest.CaptureFixture[str]) -> None:
-    """The root conftest must keep the import-time CLI console colourless in any shell."""
-    config_cli.console.print("[bold red]MindRoom Doctor[/bold red]")
-
-    captured = capsys.readouterr().out
-    assert "\x1b" not in captured
-    assert "MindRoom Doctor" in captured
-
-
 @pytest.fixture(autouse=True)
 def _clear_runtime_path_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("MINDROOM_CONFIG_PATH", raising=False)
@@ -100,6 +91,15 @@ def _write_minimal_runtime_config(path: Path) -> None:
         "authorization:\n  global_users: []\n",
         encoding="utf-8",
     )
+
+
+def test_cli_console_renders_without_ansi_escapes(capsys: pytest.CaptureFixture[str]) -> None:
+    """The root conftest must keep the import-time CLI console plain in any shell."""
+    config_cli.console.print("[bold red]MindRoom Doctor[/bold red]")
+
+    captured = capsys.readouterr().out
+    assert "\x1b" not in captured
+    assert "MindRoom Doctor" in captured
 
 
 def test_cli_import_keeps_help_path_runtime_modules_lazy() -> None:

--- a/tests/test_cli_trigger.py
+++ b/tests/test_cli_trigger.py
@@ -10,7 +10,6 @@ from typing import cast
 
 import httpx
 import pytest
-from click.utils import strip_ansi
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
 from typer.testing import CliRunner
@@ -478,8 +477,7 @@ def test_trigger_send_rejects_data_json_that_is_not_object(tmp_path: Path) -> No
             "--data-json",
             "[]",
         ],
-        env={"FORCE_COLOR": "1"},
     )
 
     assert result.exit_code == 2
-    assert "--data-json must decode to a JSON object" in strip_ansi(result.output)
+    assert "--data-json must decode to a JSON object" in result.output

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -34,7 +34,7 @@ from mindroom.services.systemd import _restart_service as _restart_systemd_servi
 from mindroom.services.systemd import _start_service as _start_systemd_service
 from mindroom.services.systemd import _stop_service as _stop_systemd_service
 
-runner = CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})
+runner = CliRunner()
 
 
 def test_build_service_command_runs_mindroom_with_uv_tool(tmp_path: Path) -> None:


### PR DESCRIPTION
Fixes #1660.

## Problem

Rich resolves color support **once, at `Console` construction**, and the CLI builds its consoles at import time (`mindroom.cli.config:54`, `mindroom.cli.desktop:25-26`, `mindroom.cli.service:17-18`). Typer does the same for its own error consoles. A shell that exports `FORCE_COLOR` — Claude Code, Codex and several terminal setups do — makes Rich force a color terminal even though `typer.testing.CliRunner` captures to a non-tty buffer, so ANSI escapes land in `result.output`: substring assertions miss, and `mindroom config init --print` output no longer parses as YAML.

CI is green because GitHub Actions does not set `FORCE_COLOR`, so this is pure local noise — but persistent noise: every contributor with a color-forcing shell sees red tests on an untouched `main`.

On `main`, with `FORCE_COLOR=3 COLORTERM=truecolor TERM=xterm-256color`:

```
27 failed, 211 passed
```

(the issue reported 23; the four extra are `TestRunApiFlags`/`TestRunErrorHandling` cases that fail as `assert 1 == 0` from the same cause)

## Fix

An autouse fixture cannot fix this — the consoles already exist before any fixture runs. Instead a root `conftest.py` pins `TERM=dumb`. pytest imports the rootdir conftest before `tests/conftest.py` and before any test module imports the CLI, so it lands ahead of every `Console()` and ahead of Typer's import-time `FORCE_TERMINAL` detection.

That single variable is enough because Rich gates all three sources of captured-output noise on `Console.is_dumb_terminal`:

| Noise | Gate |
|---|---|
| Color | `_detect_color_system` returns `None` before it ever reads `COLORTERM`, so `Style.render` emits raw text |
| Control codes (cursor moves from `console.status`, used by `mindroom doctor`) | `Console.control` writes nothing |
| Width-dependent wrapping | `Console.size` returns a fixed 80x25 instead of the invoking terminal's size |

It wins over `FORCE_COLOR` and over Typer's `force_terminal=True` consoles, so no environment variables need to be deleted — verified green with `FORCE_COLOR=3 COLORTERM=truecolor CLICOLOR_FORCE=1 PY_COLORS=1` all still exported. `NO_COLOR` would not have worked: it strips color but leaves bold and other SGR codes.

Also in this PR:

- Dropped the two per-file workarounds this bug had forced: the `CliRunner(env={"NO_COLOR": "1", "TERM": "dumb"})` in `tests/test_services.py` and the `env={"FORCE_COLOR": "1"}` + `strip_ansi` dance in `tests/test_cli_trigger.py`. The latter is now inert anyway — the console's color system is fixed at import, so `CliRunner`'s per-invocation env cannot re-enable it.
- Added `test_cli_console_renders_without_ansi_escapes`, which renders markup through the import-time CLI console and asserts no escapes survive. Verified it fails (`assert '\x1b' not in '\x1b[1;31mM...tor\x1b[0m\n'`) with the root conftest removed.

## Verification

| Check | Result |
|---|---|
| Full suite under `FORCE_COLOR=3 COLORTERM=truecolor CLICOLOR_FORCE=1 PY_COLORS=1 TERM=xterm-256color` | ✅ 11669 passed, 41 skipped |
| Regression test with the fix reverted | ❌ fails as intended |
| `pre-commit run --files <changed>` | ✅ passed (ruff, ty, tach, module privacy) |

No `sys.path` side effect from the new root file: `tests/__init__.py` already makes the repo root pytest's insert basedir.