### PR TITLE
Fix orderly shutdown after duplicate SIGINT

### DIFF
--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2151,7 +2151,36 @@ async def _cancel_task_if_pending(task: asyncio.Task | None) -> None:
         await task
 
 
-async def main(  # noqa: C901, PLR0912, PLR0915
+async def _finish_runtime_shutdown(
+    *,
+    shutdown_wait_task: asyncio.Task[bool] | None,
+    api_task: asyncio.Task[None] | None,
+    orchestrator_task: asyncio.Task[None] | None,
+    auxiliary_tasks: list[asyncio.Task],
+    orchestrator: _MultiAgentOrchestrator | None,
+    stall_detector: EventLoopStallDetector | None,
+) -> None:
+    """Finish one runtime cleanup sequence without duplicating partial teardown."""
+    await _cancel_task_if_pending(shutdown_wait_task)
+    await _cancel_task_if_pending(api_task)
+    await _cancel_task_if_pending(orchestrator_task)
+    for task in auxiliary_tasks:
+        task.cancel()
+    for task in auxiliary_tasks:
+        with suppress(asyncio.CancelledError):
+            await task
+    try:
+        if orchestrator is not None:
+            await orchestrator.stop()
+    finally:
+        if stall_detector is not None:
+            stall_detector.stop()
+        reset_matrix_sync_health()
+        reset_runtime_state()
+        shutdown_primary_worker_manager()
+
+
+async def main(  # noqa: PLR0915
     log_level: str,
     runtime_paths: RuntimePaths,
     *,
@@ -2249,22 +2278,26 @@ async def main(  # noqa: C901, PLR0912, PLR0915
         logger.exception("Error in MindRoom runtime")
         raise
     finally:
+        shutdown_was_requested = shutdown_requested.is_set()
         shutdown_requested.set()
-        await _cancel_task_if_pending(shutdown_wait_task)
-        await _cancel_task_if_pending(api_task)
-        await _cancel_task_if_pending(orchestrator_task)
-        # Cancel auxiliary supervisors before shutting down the orchestrator itself.
-        for task in auxiliary_tasks:
-            task.cancel()
-        for task in auxiliary_tasks:
-            with suppress(asyncio.CancelledError):
-                await task
+        cleanup_task = asyncio.create_task(
+            _finish_runtime_shutdown(
+                shutdown_wait_task=shutdown_wait_task,
+                api_task=api_task,
+                orchestrator_task=orchestrator_task,
+                auxiliary_tasks=auxiliary_tasks,
+                orchestrator=orchestrator,
+                stall_detector=stall_detector,
+            ),
+            name="runtime_shutdown",
+        )
         try:
-            if orchestrator is not None:
-                await orchestrator.stop()
-        finally:
-            if stall_detector is not None:
-                stall_detector.stop()
-            reset_matrix_sync_health()
-            reset_runtime_state()
-            shutdown_primary_worker_manager()
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            if not shutdown_was_requested:
+                cleanup_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await cleanup_task
+                raise
+            logger.info("Ignoring duplicate signal cancellation during runtime cleanup")
+            await cleanup_task

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2180,7 +2180,32 @@ async def _finish_runtime_shutdown(
         shutdown_primary_worker_manager()
 
 
-async def main(  # noqa: PLR0915
+async def _wait_for_runtime_shutdown_cleanup(
+    cleanup_task: asyncio.Task[None],
+    *,
+    shutdown_was_requested: bool,
+) -> None:
+    """Wait for cleanup while preserving caller cancellation semantics."""
+    while True:
+        try:
+            await asyncio.shield(cleanup_task)
+        except asyncio.CancelledError:
+            if cleanup_task.done():
+                await cleanup_task
+                return
+            if not shutdown_was_requested:
+                cleanup_task.cancel()
+                with suppress(asyncio.CancelledError):
+                    await cleanup_task
+                raise
+            # Once orderly shutdown starts, later cancellation is duplicate
+            # shutdown pressure; cleanup must finish before main returns.
+            logger.info("Ignoring repeated signal cancellation during runtime cleanup")
+        else:
+            return
+
+
+async def main(
     log_level: str,
     runtime_paths: RuntimePaths,
     *,
@@ -2265,6 +2290,8 @@ async def main(  # noqa: PLR0915
     except asyncio.CancelledError:
         if not shutdown_requested.is_set():
             raise
+        # After an explicit shutdown request, cancellation is shutdown pressure
+        # rather than caller cancellation and must not bypass orderly cleanup.
         logger.info("Ignoring duplicate signal cancellation during requested shutdown")
     except KeyboardInterrupt:
         shutdown_requested.set()
@@ -2291,13 +2318,7 @@ async def main(  # noqa: PLR0915
             ),
             name="runtime_shutdown",
         )
-        try:
-            await asyncio.shield(cleanup_task)
-        except asyncio.CancelledError:
-            if not shutdown_was_requested:
-                cleanup_task.cancel()
-                with suppress(asyncio.CancelledError):
-                    await cleanup_task
-                raise
-            logger.info("Ignoring duplicate signal cancellation during runtime cleanup")
-            await cleanup_task
+        await _wait_for_runtime_shutdown_cleanup(
+            cleanup_task,
+            shutdown_was_requested=shutdown_was_requested,
+        )

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2151,7 +2151,7 @@ async def _cancel_task_if_pending(task: asyncio.Task | None) -> None:
         await task
 
 
-async def main(  # noqa: PLR0915
+async def main(  # noqa: C901, PLR0912, PLR0915
     log_level: str,
     runtime_paths: RuntimePaths,
     *,
@@ -2233,6 +2233,10 @@ async def main(  # noqa: PLR0915
             api_server=api_server,
         )
 
+    except asyncio.CancelledError:
+        if not shutdown_requested.is_set():
+            raise
+        logger.info("Ignoring duplicate signal cancellation during requested shutdown")
     except KeyboardInterrupt:
         shutdown_requested.set()
         logger.info("Multi-agent bot system stopped by user")

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2195,8 +2195,12 @@ async def _wait_for_runtime_shutdown_cleanup(
                 return
             if not shutdown_was_requested:
                 cleanup_task.cancel()
-                with suppress(asyncio.CancelledError):
+                try:
                     await cleanup_task
+                except asyncio.CancelledError:
+                    pass
+                except Exception:
+                    logger.exception("Runtime cleanup failed while propagating caller cancellation")
                 raise
             # Once orderly shutdown starts, later cancellation is duplicate
             # shutdown pressure; cleanup must finish before main returns.

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -571,6 +571,80 @@ class TestAgentBot(AgentBotTestBase):
         mock_orchestrator.start.assert_awaited_once()
 
     @pytest.mark.asyncio
+    async def test_orchestrator_main_finishes_requested_shutdown_after_duplicate_signal_cancel(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A second SIGINT cancellation must not abort cleanup started by the first signal."""
+        reset_runtime_state()
+        start_released = asyncio.Event()
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.knowledge_refresh_scheduler = None
+
+        async def _start() -> None:
+            await start_released.wait()
+
+        async def _stop() -> None:
+            start_released.set()
+
+        async def _cancel_after_requested_shutdown(**kwargs: object) -> None:
+            shutdown_requested = kwargs["shutdown_requested"]
+            assert isinstance(shutdown_requested, asyncio.Event)
+            shutdown_requested.set()
+            raise asyncio.CancelledError
+
+        async def _blocked_auxiliary_task(*_args: object, **_kwargs: object) -> None:
+            await asyncio.Event().wait()
+
+        mock_orchestrator.start = AsyncMock(side_effect=_start)
+        mock_orchestrator.stop = AsyncMock(side_effect=_stop)
+
+        with (
+            patch("mindroom.orchestrator.setup_logging"),
+            patch("mindroom.orchestrator.sync_env_to_credentials"),
+            patch("mindroom.orchestrator._MultiAgentOrchestrator", return_value=mock_orchestrator),
+            patch("mindroom.orchestrator._run_auxiliary_task_forever", new=_blocked_auxiliary_task),
+            patch(
+                "mindroom.orchestrator._wait_for_runtime_completion",
+                side_effect=_cancel_after_requested_shutdown,
+            ),
+        ):
+            await main(log_level="INFO", runtime_paths=self._runtime_paths(tmp_path), api=False)
+
+        mock_orchestrator.stop.assert_awaited_once()
+        mock_orchestrator.start.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_main_propagates_unrequested_task_cancellation(self, tmp_path: Path) -> None:
+        """Embedding callers must retain cancellation when no shutdown signal was requested."""
+        reset_runtime_state()
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.knowledge_refresh_scheduler = None
+        mock_orchestrator.start = AsyncMock()
+        mock_orchestrator.stop = AsyncMock()
+
+        async def _cancel_without_shutdown(**_kwargs: object) -> None:
+            raise asyncio.CancelledError
+
+        async def _blocked_auxiliary_task(*_args: object, **_kwargs: object) -> None:
+            await asyncio.Event().wait()
+
+        with (
+            patch("mindroom.orchestrator.setup_logging"),
+            patch("mindroom.orchestrator.sync_env_to_credentials"),
+            patch("mindroom.orchestrator._MultiAgentOrchestrator", return_value=mock_orchestrator),
+            patch("mindroom.orchestrator._run_auxiliary_task_forever", new=_blocked_auxiliary_task),
+            patch(
+                "mindroom.orchestrator._wait_for_runtime_completion",
+                side_effect=_cancel_without_shutdown,
+            ),
+            pytest.raises(asyncio.CancelledError),
+        ):
+            await main(log_level="INFO", runtime_paths=self._runtime_paths(tmp_path), api=False)
+
+        mock_orchestrator.stop.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_orchestrator_main_fails_when_api_server_exits_unexpectedly(self, tmp_path: Path) -> None:
         """An unexpected API-server task failure should stop the top-level run non-silently."""
         reset_runtime_state()

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -577,21 +577,22 @@ class TestAgentBot(AgentBotTestBase):
     ) -> None:
         """A second SIGINT cancellation must not abort cleanup started by the first signal."""
         reset_runtime_state()
-        start_released = asyncio.Event()
+        stop_started = asyncio.Event()
+        stop_released = asyncio.Event()
         mock_orchestrator = MagicMock()
         mock_orchestrator.knowledge_refresh_scheduler = None
 
         async def _start() -> None:
-            await start_released.wait()
+            await asyncio.Event().wait()
 
         async def _stop() -> None:
-            start_released.set()
+            stop_started.set()
+            await stop_released.wait()
 
-        async def _cancel_after_requested_shutdown(**kwargs: object) -> None:
+        async def _request_shutdown(**kwargs: object) -> None:
             shutdown_requested = kwargs["shutdown_requested"]
             assert isinstance(shutdown_requested, asyncio.Event)
             shutdown_requested.set()
-            raise asyncio.CancelledError
 
         async def _blocked_auxiliary_task(*_args: object, **_kwargs: object) -> None:
             await asyncio.Event().wait()
@@ -606,10 +607,16 @@ class TestAgentBot(AgentBotTestBase):
             patch("mindroom.orchestrator._run_auxiliary_task_forever", new=_blocked_auxiliary_task),
             patch(
                 "mindroom.orchestrator._wait_for_runtime_completion",
-                side_effect=_cancel_after_requested_shutdown,
+                side_effect=_request_shutdown,
             ),
         ):
-            await main(log_level="INFO", runtime_paths=self._runtime_paths(tmp_path), api=False)
+            main_task = asyncio.create_task(
+                main(log_level="INFO", runtime_paths=self._runtime_paths(tmp_path), api=False),
+            )
+            await asyncio.wait_for(stop_started.wait(), timeout=1)
+            main_task.cancel()
+            stop_released.set()
+            await asyncio.wait_for(main_task, timeout=1)
 
         mock_orchestrator.stop.assert_awaited_once()
         mock_orchestrator.start.assert_awaited_once()

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -51,6 +51,7 @@ from mindroom.orchestrator import (
     _run_auxiliary_task_forever,
     _SignalAwareUvicornServer,
     _wait_for_runtime_completion,
+    _wait_for_runtime_shutdown_cleanup,
     main,
 )
 from mindroom.runtime_shutdown import ORDERLY_SHUTDOWN
@@ -571,87 +572,64 @@ class TestAgentBot(AgentBotTestBase):
         mock_orchestrator.start.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_orchestrator_main_finishes_requested_shutdown_after_repeated_signal_cancels(
+    async def test_runtime_cleanup_finishes_requested_shutdown_after_repeated_signal_cancels(
         self,
-        tmp_path: Path,
     ) -> None:
         """Repeated SIGINT cancellation must not abort cleanup started by the first signal."""
-        reset_runtime_state()
-        stop_started = asyncio.Event()
-        stop_released = asyncio.Event()
-        mock_orchestrator = MagicMock()
-        mock_orchestrator.knowledge_refresh_scheduler = None
+        cleanup_started = asyncio.Event()
+        cleanup_released = asyncio.Event()
 
-        async def _start() -> None:
-            await asyncio.Event().wait()
+        async def _cleanup() -> None:
+            cleanup_started.set()
+            await cleanup_released.wait()
 
-        async def _stop() -> None:
-            stop_started.set()
-            await stop_released.wait()
-
-        async def _request_shutdown(**kwargs: object) -> None:
-            shutdown_requested = kwargs["shutdown_requested"]
-            assert isinstance(shutdown_requested, asyncio.Event)
-            shutdown_requested.set()
-
-        async def _blocked_auxiliary_task(*_args: object, **_kwargs: object) -> None:
-            await asyncio.Event().wait()
-
-        mock_orchestrator.start = AsyncMock(side_effect=_start)
-        mock_orchestrator.stop = AsyncMock(side_effect=_stop)
-
-        with (
-            patch("mindroom.orchestrator.setup_logging"),
-            patch("mindroom.orchestrator.sync_env_to_credentials"),
-            patch("mindroom.orchestrator._MultiAgentOrchestrator", return_value=mock_orchestrator),
-            patch("mindroom.orchestrator._run_auxiliary_task_forever", new=_blocked_auxiliary_task),
-            patch(
-                "mindroom.orchestrator._wait_for_runtime_completion",
-                side_effect=_request_shutdown,
+        cleanup_task = asyncio.create_task(_cleanup())
+        wait_task = asyncio.create_task(
+            _wait_for_runtime_shutdown_cleanup(
+                cleanup_task,
+                shutdown_was_requested=True,
             ),
-        ):
-            main_task = asyncio.create_task(
-                main(log_level="INFO", runtime_paths=self._runtime_paths(tmp_path), api=False),
-            )
-            await asyncio.wait_for(stop_started.wait(), timeout=1)
-            main_task.cancel()
-            await asyncio.sleep(0)
-            main_task.cancel()
-            stop_released.set()
-            await asyncio.wait_for(main_task, timeout=1)
+        )
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+        await asyncio.sleep(0)
+        wait_task.cancel()
+        await asyncio.sleep(0)
+        wait_task.cancel()
+        cleanup_released.set()
+        await asyncio.wait_for(wait_task, timeout=1)
 
-        mock_orchestrator.stop.assert_awaited_once()
-        mock_orchestrator.start.assert_awaited_once()
+        assert cleanup_task.done()
 
     @pytest.mark.asyncio
-    async def test_orchestrator_main_propagates_unrequested_task_cancellation(self, tmp_path: Path) -> None:
-        """Embedding callers must retain cancellation when no shutdown signal was requested."""
-        reset_runtime_state()
-        mock_orchestrator = MagicMock()
-        mock_orchestrator.knowledge_refresh_scheduler = None
-        mock_orchestrator.start = AsyncMock()
-        mock_orchestrator.stop = AsyncMock()
+    async def test_runtime_cleanup_preserves_unrequested_cancellation_after_cleanup_failure(
+        self,
+    ) -> None:
+        """Cleanup failure must not replace cancellation from an embedding caller."""
+        cleanup_started = asyncio.Event()
 
-        async def _cancel_without_shutdown(**_kwargs: object) -> None:
-            raise asyncio.CancelledError
+        async def _failing_cleanup() -> None:
+            cleanup_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError as exc:
+                msg = "cleanup failed"
+                raise RuntimeError(msg) from exc
 
-        async def _blocked_auxiliary_task(*_args: object, **_kwargs: object) -> None:
-            await asyncio.Event().wait()
-
-        with (
-            patch("mindroom.orchestrator.setup_logging"),
-            patch("mindroom.orchestrator.sync_env_to_credentials"),
-            patch("mindroom.orchestrator._MultiAgentOrchestrator", return_value=mock_orchestrator),
-            patch("mindroom.orchestrator._run_auxiliary_task_forever", new=_blocked_auxiliary_task),
-            patch(
-                "mindroom.orchestrator._wait_for_runtime_completion",
-                side_effect=_cancel_without_shutdown,
+        cleanup_task = asyncio.create_task(_failing_cleanup())
+        wait_task = asyncio.create_task(
+            _wait_for_runtime_shutdown_cleanup(
+                cleanup_task,
+                shutdown_was_requested=False,
             ),
-            pytest.raises(asyncio.CancelledError),
-        ):
-            await main(log_level="INFO", runtime_paths=self._runtime_paths(tmp_path), api=False)
+        )
+        await asyncio.wait_for(cleanup_started.wait(), timeout=1)
+        await asyncio.sleep(0)
+        wait_task.cancel()
 
-        mock_orchestrator.stop.assert_awaited_once()
+        with pytest.raises(asyncio.CancelledError):
+            await wait_task
+        with pytest.raises(RuntimeError, match="cleanup failed"):
+            cleanup_task.result()
 
     @pytest.mark.asyncio
     async def test_orchestrator_main_fails_when_api_server_exits_unexpectedly(self, tmp_path: Path) -> None:

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -571,11 +571,11 @@ class TestAgentBot(AgentBotTestBase):
         mock_orchestrator.start.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_orchestrator_main_finishes_requested_shutdown_after_duplicate_signal_cancel(
+    async def test_orchestrator_main_finishes_requested_shutdown_after_repeated_signal_cancels(
         self,
         tmp_path: Path,
     ) -> None:
-        """A second SIGINT cancellation must not abort cleanup started by the first signal."""
+        """Repeated SIGINT cancellation must not abort cleanup started by the first signal."""
         reset_runtime_state()
         stop_started = asyncio.Event()
         stop_released = asyncio.Event()
@@ -614,6 +614,8 @@ class TestAgentBot(AgentBotTestBase):
                 main(log_level="INFO", runtime_paths=self._runtime_paths(tmp_path), api=False),
             )
             await asyncio.wait_for(stop_started.wait(), timeout=1)
+            main_task.cancel()
+            await asyncio.sleep(0)
             main_task.cancel()
             stop_released.set()
             await asyncio.wait_for(main_task, timeout=1)


### PR DESCRIPTION
## Why

An embedded Uvicorn signal can request orderly MindRoom shutdown while a duplicate process-group SIGINT also cancels the top-level asyncio task.

That second cancellation previously interrupted `orchestrator.stop()` inside `finally`, left SQLite work and response bookkeeping half-finished, and made the process require SIGKILL.
After restart, a visible placeholder could be emitted again for the same source event.

## What changed

- Finish runtime teardown in one named cleanup task.
- Keep requested-shutdown cleanup shielded through every repeated cancellation until teardown finishes.
- Preserve ordinary caller cancellation when no shutdown request exists, even if teardown itself fails.
- Log teardown failure without replacing the caller's original cancellation.
- Keep orchestrator stop, task drains, runtime-state reset, stall-detector stop, and worker-manager shutdown in one exact cleanup sequence.

## Validation

- The repeated-cancellation regression fails deterministically on the original PR head and passes after the shielding loop.
- `tests/test_orchestrator_runtime.py`: 76 passed, 4 skipped.
- Ruff, formatting, `ty`, Vulture, Tach, module privacy, and every all-file hook pass.
- Tests target the cleanup-policy helper directly with zero patches.
- Exact clean real-Tuwunel replay passed on predecessor `b2d515c87`.
- That replay covered 200 operations, 28 batches, one MindRoom restart, one outage, and 135 canonical replies with zero duplicates.
- Current exact head `b2b1cc007` needs the same live replay after CI.
- Production diff: `src/mindroom/orchestrator.py` `+81/-19`, net `+62`.
