### PR TITLE
Fix startup auto-resume cache race

### DIFF
--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -113,12 +113,14 @@ class ThreadReadPolicy:
         fetch_thread_history_from_client: _ThreadHistoryFetcher,
         fetch_dispatch_thread_history_from_client: _ThreadHistoryFetcher,
         fetch_dispatch_thread_snapshot_from_client: _ThreadHistoryFetcher,
+        refresh_thread_history_from_source: _ThreadHistoryFetcher,
     ) -> None:
         self._logger_getter = logger_getter
         self.runtime = runtime
         self.fetch_thread_history_from_client = fetch_thread_history_from_client
         self.fetch_dispatch_thread_history_from_client = fetch_dispatch_thread_history_from_client
         self.fetch_dispatch_thread_snapshot_from_client = fetch_dispatch_thread_snapshot_from_client
+        self.refresh_thread_history_from_source = refresh_thread_history_from_source
 
     @property
     def logger(self) -> structlog.stdlib.BoundLogger:
@@ -372,6 +374,26 @@ class ThreadReadPolicy:
             fetcher=fetcher,
             name=self._operation_name_for_mode(mode),
             full_history=mode.full_history,
+            caller_label=caller_label,
+            queue_wait_started=queue_wait_started,
+        )
+
+    async def refresh_thread_from_source(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        caller_label: str,
+    ) -> ThreadHistoryResult:
+        """Refresh one full thread directly from Matrix through the same-thread write barrier."""
+        queue_wait_started = time.perf_counter()
+        await self._wait_for_pending_thread_cache_updates(room_id, thread_id)
+        return await self._run_thread_read(
+            room_id,
+            thread_id,
+            fetcher=self.refresh_thread_history_from_source,
+            name="matrix_cache_refresh_strict_thread_from_source",
+            full_history=True,
             caller_label=caller_label,
             queue_wait_started=queue_wait_started,
         )

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -13,9 +13,9 @@ Read-side invariants:
    (``THREAD_HISTORY_SOURCE_DEGRADED``) instead of blocking dispatch; consumers must treat that result
    as unusable for caching, memoization, and root proofs.
 
-3. ``ADVISORY_FULL`` and ``STRICT_FULL`` have no dispatch timeout and run through the same-thread
-   barrier; ``STRICT_FULL`` is intentionally not dispatch-safe because it may block for authoritative
-   post-lock model context.
+3. ``ADVISORY_FULL``, ``STRICT_FULL``, and ``STRICT_SOURCE_REFRESH`` have no dispatch timeout and run
+   through the same-thread barrier; strict modes are intentionally not dispatch-safe because they may
+   block for authoritative post-lock model context or a direct source refresh.
 
 4. A stale-cache thread tail is never used for MSC3440 latest-event fallback:
    ``get_latest_thread_event_id_if_needed`` falls back to the thread root instead.
@@ -68,6 +68,7 @@ class ThreadReadMode(Enum):
     DISPATCH_SNAPSHOT = auto()
     DISPATCH_FULL = auto()
     STRICT_FULL = auto()
+    STRICT_SOURCE_REFRESH = auto()
 
     @property
     def full_history(self) -> bool:
@@ -76,6 +77,7 @@ class ThreadReadMode(Enum):
             ThreadReadMode.ADVISORY_FULL,
             ThreadReadMode.DISPATCH_FULL,
             ThreadReadMode.STRICT_FULL,
+            ThreadReadMode.STRICT_SOURCE_REFRESH,
         }
 
     @property
@@ -140,6 +142,7 @@ class ThreadReadPolicy:
             ThreadReadMode.DISPATCH_SNAPSHOT: self.fetch_dispatch_thread_snapshot_from_client,
             ThreadReadMode.DISPATCH_FULL: self.fetch_dispatch_thread_history_from_client,
             ThreadReadMode.STRICT_FULL: self.fetch_dispatch_thread_history_from_client,
+            ThreadReadMode.STRICT_SOURCE_REFRESH: self.refresh_thread_history_from_source,
         }[mode]
 
     def _operation_name_for_mode(self, mode: ThreadReadMode) -> str:
@@ -147,6 +150,7 @@ class ThreadReadPolicy:
         return {
             ThreadReadMode.ADVISORY_FULL: "matrix_cache_refresh_thread_history",
             ThreadReadMode.STRICT_FULL: "matrix_cache_refresh_strict_thread_history",
+            ThreadReadMode.STRICT_SOURCE_REFRESH: "matrix_cache_refresh_strict_thread_from_source",
         }[mode]
 
     async def _wait_for_pending_thread_cache_updates(self, room_id: str, thread_id: str) -> None:
@@ -374,26 +378,6 @@ class ThreadReadPolicy:
             fetcher=fetcher,
             name=self._operation_name_for_mode(mode),
             full_history=mode.full_history,
-            caller_label=caller_label,
-            queue_wait_started=queue_wait_started,
-        )
-
-    async def refresh_thread_from_source(
-        self,
-        room_id: str,
-        thread_id: str,
-        *,
-        caller_label: str,
-    ) -> ThreadHistoryResult:
-        """Refresh one full thread directly from Matrix through the same-thread write barrier."""
-        queue_wait_started = time.perf_counter()
-        await self._wait_for_pending_thread_cache_updates(room_id, thread_id)
-        return await self._run_thread_read(
-            room_id,
-            thread_id,
-            fetcher=self.refresh_thread_history_from_source,
-            name="matrix_cache_refresh_strict_thread_from_source",
-            full_history=True,
             caller_label=caller_label,
             queue_wait_started=queue_wait_started,
         )

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -41,6 +41,7 @@ from mindroom.matrix.client_thread_history import (
     fetch_dispatch_thread_snapshot,
     fetch_thread_history,
     get_room_threads_page,
+    refresh_thread_history_from_source,
     untrusted_cached_thread_ids,
 )
 from mindroom.matrix.event_info import EventInfo
@@ -190,6 +191,15 @@ class ConversationCacheProtocol(Protocol):
         caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Resolve strict full history without reusing the current turn's memoized read."""
+
+    async def refresh_strict_thread_history_from_source(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        caller_label: str = "unknown",
+    ) -> ThreadReadResult:
+        """Refresh strict full history directly from Matrix."""
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Resolve the cached thread root for one event when known."""
@@ -414,6 +424,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             fetch_thread_history_from_client=self._fetch_thread_history_from_client,
             fetch_dispatch_thread_history_from_client=self._fetch_dispatch_thread_history_from_client,
             fetch_dispatch_thread_snapshot_from_client=self._fetch_dispatch_thread_snapshot_from_client,
+            refresh_thread_history_from_source=self._refresh_thread_history_from_client,
         )
         resolver = ThreadMutationResolver(
             logger_getter=lambda: self.logger,
@@ -677,6 +688,27 @@ class MatrixConversationCache(ConversationCacheProtocol):
             coordinator_queue_wait_ms=coordinator_queue_wait_ms,
         )
 
+    async def _refresh_thread_history_from_client(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        caller_label: str,
+        coordinator_queue_wait_ms: float,
+    ) -> ThreadHistoryResult:
+        """Refresh one thread from Matrix without accepting a cache hit or stale fallback."""
+        return await refresh_thread_history_from_source(
+            self._require_client(),
+            room_id,
+            thread_id,
+            self.runtime.event_cache,
+            allow_stale_fallback=False,
+            cache_write_guard_started_at=time.time(),
+            trusted_sender_ids=self._trusted_sender_ids(),
+            caller_label=caller_label,
+            coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+        )
+
     async def _fetch_thread_from_client(
         self,
         fetcher: Callable[..., Awaitable[ThreadHistoryResult]],
@@ -934,6 +966,20 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id,
             thread_id,
             mode=ThreadReadMode.STRICT_FULL,
+            caller_label=caller_label,
+        )
+
+    async def refresh_strict_thread_history_from_source(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        caller_label: str = "unknown",
+    ) -> ThreadReadResult:
+        """Refresh strict full history directly from Matrix."""
+        return await self._reads.refresh_thread_from_source(
+            room_id,
+            thread_id,
             caller_label=caller_label,
         )
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -984,8 +984,9 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 caller_label=caller_label,
             )
         finally:
-            # The source path can mark cache rows stale before raising or being cancelled.
-            self._evict_turn_thread_reads_for_thread(room_id, thread_id)
+            # Opaque source history can mark every thread in the room stale before
+            # raising or being cancelled.
+            self._evict_turn_thread_reads_for_room(room_id)
             self._evict_turn_event_lookups_for_room(room_id)
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
@@ -1070,15 +1071,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
             return
         for cache_key in tuple(turn_cache):
             if cache_key[0] == room_id:
-                turn_cache.pop(cache_key)
-
-    def _evict_turn_thread_reads_for_thread(self, room_id: str, thread_id: str) -> None:
-        """Discard thread reads touched by one explicit source refresh."""
-        turn_cache = self._turn_thread_read_cache.get()
-        if turn_cache is None:
-            return
-        for cache_key in tuple(turn_cache):
-            if cache_key[:2] == (room_id, thread_id):
                 turn_cache.pop(cache_key)
 
     def _evict_turn_event_lookup(self, room_id: str, event_id: str) -> None:

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -977,13 +977,16 @@ class MatrixConversationCache(ConversationCacheProtocol):
         caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Refresh strict full history directly from Matrix."""
-        result = await self._reads.refresh_thread_from_source(
-            room_id,
-            thread_id,
-            caller_label=caller_label,
-        )
-        self._evict_turn_thread_reads_for_thread(room_id, thread_id)
-        return result
+        try:
+            return await self._reads.refresh_thread_from_source(
+                room_id,
+                thread_id,
+                caller_label=caller_label,
+            )
+        finally:
+            # The source path can mark cache rows stale before raising or being cancelled.
+            self._evict_turn_thread_reads_for_thread(room_id, thread_id)
+            self._evict_turn_event_lookups_for_room(room_id)
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Resolve the cached thread root for one event when known."""
@@ -1070,7 +1073,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 turn_cache.pop(cache_key)
 
     def _evict_turn_thread_reads_for_thread(self, room_id: str, thread_id: str) -> None:
-        """Discard thread reads replaced by one explicit source refresh."""
+        """Discard thread reads touched by one explicit source refresh."""
         turn_cache = self._turn_thread_read_cache.get()
         if turn_cache is None:
             return

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -977,17 +977,12 @@ class MatrixConversationCache(ConversationCacheProtocol):
         caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Refresh strict full history directly from Matrix."""
-        try:
-            return await self._reads.refresh_thread_from_source(
-                room_id,
-                thread_id,
-                caller_label=caller_label,
-            )
-        finally:
-            # Opaque source history can mark every thread in the room stale before
-            # raising or being cancelled.
-            self._evict_turn_thread_reads_for_room(room_id)
-            self._evict_turn_event_lookups_for_room(room_id)
+        return await self._reads.read_thread(
+            room_id,
+            thread_id,
+            mode=ThreadReadMode.STRICT_SOURCE_REFRESH,
+            caller_label=caller_label,
+        )
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Resolve the cached thread root for one event when known."""

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -977,11 +977,13 @@ class MatrixConversationCache(ConversationCacheProtocol):
         caller_label: str = "unknown",
     ) -> ThreadReadResult:
         """Refresh strict full history directly from Matrix."""
-        return await self._reads.refresh_thread_from_source(
+        result = await self._reads.refresh_thread_from_source(
             room_id,
             thread_id,
             caller_label=caller_label,
         )
+        self._evict_turn_thread_reads_for_thread(room_id, thread_id)
+        return result
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Resolve the cached thread root for one event when known."""
@@ -1065,6 +1067,15 @@ class MatrixConversationCache(ConversationCacheProtocol):
             return
         for cache_key in tuple(turn_cache):
             if cache_key[0] == room_id:
+                turn_cache.pop(cache_key)
+
+    def _evict_turn_thread_reads_for_thread(self, room_id: str, thread_id: str) -> None:
+        """Discard thread reads replaced by one explicit source refresh."""
+        turn_cache = self._turn_thread_read_cache.get()
+        if turn_cache is None:
+            return
+        for cache_key in tuple(turn_cache):
+            if cache_key[:2] == (room_id, thread_id):
                 turn_cache.pop(cache_key)
 
     def _evict_turn_event_lookup(self, room_id: str, event_id: str) -> None:

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -44,7 +44,6 @@ from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_message_content, markdown_to_html
 from mindroom.matrix.message_content import extract_and_resolve_message, extract_edit_body
 from mindroom.matrix.thread_diagnostics import (
-    THREAD_HISTORY_SOURCE_CACHE,
     THREAD_HISTORY_SOURCE_DIAGNOSTIC,
     THREAD_HISTORY_SOURCE_HOMESERVER,
     is_thread_history_degraded,
@@ -334,6 +333,9 @@ async def _auto_resume_interrupted_threads(
                 target_event_id=interrupted_thread.target_event_id,
             )
             continue
+        if delay_due:
+            await asyncio.sleep(delay)
+            delay_due = False
         if not await _interrupted_target_remains_latest_human_work(
             interrupted_thread,
             config=config,
@@ -347,16 +349,6 @@ async def _auto_resume_interrupted_threads(
                 config=config,
                 runtime_paths=runtime_paths,
             )
-            if delay_due:
-                await asyncio.sleep(delay)
-                delay_due = False
-                if not await _interrupted_target_remains_latest_human_work(
-                    interrupted_thread,
-                    config=config,
-                    runtime_paths=runtime_paths,
-                    conversation_cache=conversation_cache,
-                ):
-                    continue
             delay_due = True
             delivered = await send_message_result(client, interrupted_thread.room_id, content)
             if delivered is not None:
@@ -445,7 +437,7 @@ def _authoritative_history_after_target(
     if not history.is_full_history or is_thread_history_degraded(history):
         msg = "Thread history is incomplete or degraded"
         raise ValueError(msg)
-    if history_source not in {THREAD_HISTORY_SOURCE_CACHE, THREAD_HISTORY_SOURCE_HOMESERVER}:
+    if history_source != THREAD_HISTORY_SOURCE_HOMESERVER:
         msg = f"Non-authoritative thread history source: {history_source!r}"
         raise ValueError(msg)
     target_index = next(

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -106,6 +106,10 @@ class _InterruptedThread:
     timestamp_ms: int = field(default=0, compare=False)
 
 
+class _InterruptedTargetAbsentError(ValueError):
+    """Raised when strict thread history does not contain the interrupted response."""
+
+
 @dataclass(frozen=True)
 class StaleStreamCleanupActor:
     """One bot account that may repair its own stale messages."""
@@ -410,10 +414,21 @@ async def _interrupted_target_remains_latest_human_work(
             interrupted_thread.thread_id,
             caller_label="startup_auto_resume_freshness",
         )
-        later_messages = _authoritative_history_after_target(
-            history,
-            target_event_id=interrupted_thread.target_event_id,
-        )
+        try:
+            later_messages = _authoritative_history_after_target(
+                history,
+                target_event_id=interrupted_thread.target_event_id,
+            )
+        except _InterruptedTargetAbsentError:
+            history = await conversation_cache.refresh_strict_thread_history_from_source(
+                interrupted_thread.room_id,
+                interrupted_thread.thread_id,
+                caller_label="startup_auto_resume_target_refresh",
+            )
+            later_messages = _authoritative_history_after_target(
+                history,
+                target_event_id=interrupted_thread.target_event_id,
+            )
         remains_latest = _later_thread_activity_is_internal(
             later_messages,
             config=config,
@@ -454,7 +469,7 @@ def _authoritative_history_after_target(
     )
     if target_index is None:
         msg = f"Interrupted target absent from thread history: {target_event_id}"
-        raise ValueError(msg)
+        raise _InterruptedTargetAbsentError(msg)
     return history[target_index + 1 :]
 
 

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -106,10 +106,6 @@ class _InterruptedThread:
     timestamp_ms: int = field(default=0, compare=False)
 
 
-class _InterruptedTargetAbsentError(ValueError):
-    """Raised when strict thread history does not contain the interrupted response."""
-
-
 @dataclass(frozen=True)
 class StaleStreamCleanupActor:
     """One bot account that may repair its own stale messages."""
@@ -409,26 +405,15 @@ async def _interrupted_target_remains_latest_human_work(
         return False
 
     try:
-        history = await conversation_cache.get_strict_thread_history(
+        history = await conversation_cache.refresh_strict_thread_history_from_source(
             interrupted_thread.room_id,
             interrupted_thread.thread_id,
             caller_label="startup_auto_resume_freshness",
         )
-        try:
-            later_messages = _authoritative_history_after_target(
-                history,
-                target_event_id=interrupted_thread.target_event_id,
-            )
-        except _InterruptedTargetAbsentError:
-            history = await conversation_cache.refresh_strict_thread_history_from_source(
-                interrupted_thread.room_id,
-                interrupted_thread.thread_id,
-                caller_label="startup_auto_resume_target_refresh",
-            )
-            later_messages = _authoritative_history_after_target(
-                history,
-                target_event_id=interrupted_thread.target_event_id,
-            )
+        later_messages = _authoritative_history_after_target(
+            history,
+            target_event_id=interrupted_thread.target_event_id,
+        )
         remains_latest = _later_thread_activity_is_internal(
             later_messages,
             config=config,
@@ -469,7 +454,7 @@ def _authoritative_history_after_target(
     )
     if target_index is None:
         msg = f"Interrupted target absent from thread history: {target_event_id}"
-        raise _InterruptedTargetAbsentError(msg)
+        raise ValueError(msg)
     return history[target_index + 1 :]
 
 

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -821,50 +821,53 @@ async def test_strict_source_refresh_bypasses_usable_cache(
     """Explicit source refresh should serialize one Matrix fetch without accepting a cache hit."""
     event_cache = SqliteEventCache(tmp_path / "event_cache.db")
     await event_cache.initialize()
-    client = MagicMock()
+    client = object()
     conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=client)
-
-    async def run_thread_update(
-        _room_id: str,
-        _thread_id: str,
-        update_coro_factory: Callable[[], Awaitable[ThreadHistoryResult]],
-        **_kwargs: object,
-    ) -> ThreadHistoryResult:
-        return await update_coro_factory()
-
-    coordinator = MagicMock()
-    coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
-    coordinator.run_thread_update = AsyncMock(side_effect=run_thread_update)
+    coordinator = EventCacheWriteCoordinator(logger=conversation_cache.logger)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    release_write = asyncio.Event()
+    write_started = asyncio.Event()
+
+    async def pending_cache_write() -> None:
+        write_started.set()
+        await release_write.wait()
+
+    pending_write_task = coordinator.queue_thread_update(
+        "!room:localhost",
+        "$thread:localhost",
+        pending_cache_write,
+        name="matrix_cache_pending_source_refresh_test_write",
+        coordination_scope=event_cache.principal_id,
+    )
     fetched_history = thread_history_result(
         [ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Target", event_id="$target")],
         is_full_history=True,
     )
 
     try:
-        with (
-            patch(
-                "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
-                AsyncMock(return_value=fetched_history),
-            ) as refresh_thread_history,
-            patch(
-                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_history",
-                AsyncMock(side_effect=AssertionError("source refresh must bypass usable cache")),
-            ),
-        ):
-            result = await conversation_cache.refresh_strict_thread_history_from_source(
-                "!room:localhost",
-                "$thread:localhost",
-                caller_label="startup_auto_resume_target_refresh",
+        await asyncio.wait_for(write_started.wait(), timeout=0.2)
+        with patch(
+            "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+            AsyncMock(return_value=fetched_history),
+        ) as refresh_thread_history:
+            read_task = asyncio.create_task(
+                conversation_cache.refresh_strict_thread_history_from_source(
+                    "!room:localhost",
+                    "$thread:localhost",
+                    caller_label="startup_auto_resume_target_refresh",
+                ),
             )
+            await asyncio.sleep(0)
+            refresh_thread_history.assert_not_awaited()
+            release_write.set()
+            result = await asyncio.wait_for(read_task, timeout=0.2)
     finally:
+        release_write.set()
+        await pending_write_task
         await event_cache.close()
 
     assert [message.event_id for message in result] == ["$target"]
     assert result.is_full_history is True
-    coordinator.wait_for_thread_idle.assert_awaited_once()
-    coordinator.run_thread_update.assert_awaited_once()
-    assert coordinator.run_thread_update.await_args.kwargs["name"] == ("matrix_cache_refresh_strict_thread_from_source")
     refresh_thread_history.assert_awaited_once()
     assert refresh_thread_history.await_args.args[:4] == (
         client,

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -815,6 +815,67 @@ async def test_fresh_strict_history_bypasses_inherited_turn_memoization(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_strict_source_refresh_bypasses_usable_cache(
+    tmp_path: Path,
+) -> None:
+    """Explicit source refresh should serialize one Matrix fetch without accepting a cache hit."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    client = MagicMock()
+    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=client)
+
+    async def run_thread_update(
+        _room_id: str,
+        _thread_id: str,
+        update_coro_factory: Callable[[], Awaitable[ThreadHistoryResult]],
+        **_kwargs: object,
+    ) -> ThreadHistoryResult:
+        return await update_coro_factory()
+
+    coordinator = MagicMock()
+    coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
+    coordinator.run_thread_update = AsyncMock(side_effect=run_thread_update)
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    fetched_history = thread_history_result(
+        [ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Target", event_id="$target")],
+        is_full_history=True,
+    )
+
+    try:
+        with (
+            patch(
+                "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+                AsyncMock(return_value=fetched_history),
+            ) as refresh_thread_history,
+            patch(
+                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_history",
+                AsyncMock(side_effect=AssertionError("source refresh must bypass usable cache")),
+            ),
+        ):
+            result = await conversation_cache.refresh_strict_thread_history_from_source(
+                "!room:localhost",
+                "$thread:localhost",
+                caller_label="startup_auto_resume_target_refresh",
+            )
+    finally:
+        await event_cache.close()
+
+    assert [message.event_id for message in result] == ["$target"]
+    assert result.is_full_history is True
+    coordinator.wait_for_thread_idle.assert_awaited_once()
+    coordinator.run_thread_update.assert_awaited_once()
+    assert coordinator.run_thread_update.await_args.kwargs["name"] == ("matrix_cache_refresh_strict_thread_from_source")
+    refresh_thread_history.assert_awaited_once()
+    assert refresh_thread_history.await_args.args[:4] == (
+        client,
+        "!room:localhost",
+        "$thread:localhost",
+        event_cache,
+    )
+    assert refresh_thread_history.await_args.kwargs["allow_stale_fallback"] is False
+
+
+@pytest.mark.asyncio
 async def test_strict_thread_history_propagates_cache_coordinator_timeout(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -825,6 +825,9 @@ async def test_strict_source_refresh_bypasses_usable_cache(
     conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=client)
     coordinator = EventCacheWriteCoordinator(logger=conversation_cache.logger)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    conversation_cache._reads.read_thread = AsyncMock(
+        side_effect=AssertionError("explicit source refresh must bypass normal cache selection"),
+    )
     release_write = asyncio.Event()
     write_started = asyncio.Event()
 
@@ -876,6 +879,7 @@ async def test_strict_source_refresh_bypasses_usable_cache(
         event_cache,
     )
     assert refresh_thread_history.await_args.kwargs["allow_stale_fallback"] is False
+    conversation_cache._reads.read_thread.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -983,6 +987,68 @@ async def test_failed_strict_source_refresh_evicts_turn_memoization(tmp_path: Pa
 
     assert [message.event_id for message in before_refresh] == ["$question"]
     assert [message.event_id for message in after_refresh] == ["$question", "$answer"]
+    assert fetch_thread_history.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_room_stale_source_refresh_evicts_sibling_thread_memoization(tmp_path: Path) -> None:
+    """A room-scoped opaque-history failure should evict sibling thread reads."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=object())
+    conversation_cache.runtime.event_cache_write_coordinator = EventCacheWriteCoordinator(
+        logger=conversation_cache.logger,
+    )
+    stale_sibling = thread_history_result(
+        [ResolvedVisibleMessage.synthetic(sender="@user:localhost", body="Old", event_id="$old")],
+        is_full_history=True,
+    )
+    fresh_sibling = thread_history_result(
+        [
+            *stale_sibling,
+            ResolvedVisibleMessage.synthetic(sender="@user:localhost", body="New", event_id="$new"),
+        ],
+        is_full_history=True,
+    )
+    source_error = RuntimeError("opaque room history")
+
+    async def fail_after_room_invalidation(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
+        await event_cache.mark_room_threads_stale(
+            "!room:localhost",
+            reason="opaque_encrypted_thread_history",
+        )
+        raise source_error
+
+    try:
+        with (
+            patch(
+                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_history",
+                AsyncMock(side_effect=[stale_sibling, fresh_sibling]),
+            ) as fetch_thread_history,
+            patch(
+                "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+                fail_after_room_invalidation,
+            ),
+        ):
+            async with conversation_cache.turn_scope():
+                before_refresh = await conversation_cache.get_strict_thread_history(
+                    "!room:localhost",
+                    "$sibling:localhost",
+                )
+                with pytest.raises(RuntimeError, match="opaque room history"):
+                    await conversation_cache.refresh_strict_thread_history_from_source(
+                        "!room:localhost",
+                        "$target:localhost",
+                    )
+                after_refresh = await conversation_cache.get_strict_thread_history(
+                    "!room:localhost",
+                    "$sibling:localhost",
+                )
+    finally:
+        await event_cache.close()
+
+    assert [message.event_id for message in before_refresh] == ["$old"]
+    assert [message.event_id for message in after_refresh] == ["$old", "$new"]
     assert fetch_thread_history.await_count == 2
 
 

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -879,6 +879,60 @@ async def test_strict_source_refresh_bypasses_usable_cache(
 
 
 @pytest.mark.asyncio
+async def test_strict_source_refresh_evicts_turn_memoization(tmp_path: Path) -> None:
+    """A successful source refresh should prevent later same-turn reads from returning stale history."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=object())
+    conversation_cache.runtime.event_cache_write_coordinator = EventCacheWriteCoordinator(
+        logger=conversation_cache.logger,
+    )
+    cached_history = thread_history_result(
+        [ResolvedVisibleMessage.synthetic(sender="@user:localhost", body="Question", event_id="$question")],
+        is_full_history=True,
+    )
+    refreshed_history = thread_history_result(
+        [
+            *cached_history,
+            ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Answer", event_id="$answer"),
+        ],
+        is_full_history=True,
+    )
+
+    try:
+        with (
+            patch(
+                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_history",
+                AsyncMock(side_effect=[cached_history, refreshed_history]),
+            ) as fetch_thread_history,
+            patch(
+                "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+                AsyncMock(return_value=refreshed_history),
+            ),
+        ):
+            async with conversation_cache.turn_scope():
+                before_refresh = await conversation_cache.get_strict_thread_history(
+                    "!room:localhost",
+                    "$thread:localhost",
+                )
+                refreshed = await conversation_cache.refresh_strict_thread_history_from_source(
+                    "!room:localhost",
+                    "$thread:localhost",
+                )
+                after_refresh = await conversation_cache.get_strict_thread_history(
+                    "!room:localhost",
+                    "$thread:localhost",
+                )
+    finally:
+        await event_cache.close()
+
+    assert [message.event_id for message in before_refresh] == ["$question"]
+    assert [message.event_id for message in refreshed] == ["$question", "$answer"]
+    assert [message.event_id for message in after_refresh] == ["$question", "$answer"]
+    assert fetch_thread_history.await_count == 2
+
+
+@pytest.mark.asyncio
 async def test_strict_thread_history_propagates_cache_coordinator_timeout(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -933,6 +933,129 @@ async def test_strict_source_refresh_evicts_turn_memoization(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_failed_strict_source_refresh_evicts_turn_memoization(tmp_path: Path) -> None:
+    """A failed source refresh should not leave an earlier same-turn strict read reusable."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=object())
+    conversation_cache.runtime.event_cache_write_coordinator = EventCacheWriteCoordinator(
+        logger=conversation_cache.logger,
+    )
+    cached_history = thread_history_result(
+        [ResolvedVisibleMessage.synthetic(sender="@user:localhost", body="Question", event_id="$question")],
+        is_full_history=True,
+    )
+    later_history = thread_history_result(
+        [
+            *cached_history,
+            ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Answer", event_id="$answer"),
+        ],
+        is_full_history=True,
+    )
+
+    try:
+        with (
+            patch(
+                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_history",
+                AsyncMock(side_effect=[cached_history, later_history]),
+            ) as fetch_thread_history,
+            patch(
+                "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+                AsyncMock(side_effect=RuntimeError("source refresh failed")),
+            ),
+        ):
+            async with conversation_cache.turn_scope():
+                before_refresh = await conversation_cache.get_strict_thread_history(
+                    "!room:localhost",
+                    "$thread:localhost",
+                )
+                with pytest.raises(RuntimeError, match="source refresh failed"):
+                    await conversation_cache.refresh_strict_thread_history_from_source(
+                        "!room:localhost",
+                        "$thread:localhost",
+                    )
+                after_refresh = await conversation_cache.get_strict_thread_history(
+                    "!room:localhost",
+                    "$thread:localhost",
+                )
+    finally:
+        await event_cache.close()
+
+    assert [message.event_id for message in before_refresh] == ["$question"]
+    assert [message.event_id for message in after_refresh] == ["$question", "$answer"]
+    assert fetch_thread_history.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_strict_source_refresh_evicts_point_event_memoization(tmp_path: Path) -> None:
+    """A source refresh should prevent same-turn point reads from returning pre-refresh content."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=object())
+    conversation_cache.runtime.event_cache_write_coordinator = EventCacheWriteCoordinator(
+        logger=conversation_cache.logger,
+    )
+    original_event = _make_text_event(
+        event_id="$reply",
+        sender="@bot:localhost",
+        body="Draft answer",
+        server_timestamp=2000,
+        source_content={
+            "body": "Draft answer",
+            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread:localhost"},
+        },
+    )
+    edit_event = _make_text_event(
+        event_id="$reply-edit",
+        sender="@bot:localhost",
+        body="* Final answer",
+        server_timestamp=3000,
+        source_content={
+            "body": "* Final answer",
+            "m.new_content": {"body": "Final answer", "msgtype": "m.text"},
+            "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
+        },
+    )
+    refreshed_history = thread_history_result(
+        [ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Final answer", event_id="$reply")],
+        is_full_history=True,
+    )
+
+    async def refresh_source(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
+        await event_cache.store_event(
+            "$reply-edit",
+            "!room:localhost",
+            _cache_source(edit_event),
+        )
+        return refreshed_history
+
+    try:
+        await event_cache.store_event(
+            "$reply",
+            "!room:localhost",
+            _cache_source(original_event),
+        )
+        with patch(
+            "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+            refresh_source,
+        ):
+            async with conversation_cache.turn_scope():
+                before_refresh = await conversation_cache.get_event("!room:localhost", "$reply")
+                await conversation_cache.refresh_strict_thread_history_from_source(
+                    "!room:localhost",
+                    "$thread:localhost",
+                )
+                after_refresh = await conversation_cache.get_event("!room:localhost", "$reply")
+    finally:
+        await event_cache.close()
+
+    assert isinstance(before_refresh, nio.RoomGetEventResponse)
+    assert before_refresh.event.body == "Draft answer"
+    assert isinstance(after_refresh, nio.RoomGetEventResponse)
+    assert after_refresh.event.body == "Final answer"
+
+
+@pytest.mark.asyncio
 async def test_strict_thread_history_propagates_cache_coordinator_timeout(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -825,15 +825,29 @@ async def test_strict_source_refresh_bypasses_usable_cache(
     conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=client)
     coordinator = EventCacheWriteCoordinator(logger=conversation_cache.logger)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
-    conversation_cache._reads.read_thread = AsyncMock(
-        side_effect=AssertionError("explicit source refresh must bypass normal cache selection"),
-    )
+    barrier_entered = asyncio.Event()
     release_write = asyncio.Event()
     write_started = asyncio.Event()
+    wait_for_thread_idle = coordinator.wait_for_thread_idle
 
     async def pending_cache_write() -> None:
         write_started.set()
         await release_write.wait()
+
+    async def observed_wait_for_thread_idle(
+        room_id: str,
+        thread_id: str,
+        *,
+        ignore_cancelled_room_fences: bool = False,
+        coordination_scope: str,
+    ) -> None:
+        barrier_entered.set()
+        await wait_for_thread_idle(
+            room_id,
+            thread_id,
+            ignore_cancelled_room_fences=ignore_cancelled_room_fences,
+            coordination_scope=coordination_scope,
+        )
 
     pending_write_task = coordinator.queue_thread_update(
         "!room:localhost",
@@ -848,22 +862,33 @@ async def test_strict_source_refresh_bypasses_usable_cache(
     )
 
     try:
-        await asyncio.wait_for(write_started.wait(), timeout=0.2)
-        with patch(
-            "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
-            AsyncMock(return_value=fetched_history),
-        ) as refresh_thread_history:
+        await asyncio.wait_for(write_started.wait(), timeout=5.0)
+        with (
+            patch.object(
+                coordinator,
+                "wait_for_thread_idle",
+                side_effect=observed_wait_for_thread_idle,
+            ),
+            patch(
+                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_history",
+                AsyncMock(side_effect=AssertionError("source refresh must bypass cache selection")),
+            ) as cache_thread_history,
+            patch(
+                "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+                AsyncMock(return_value=fetched_history),
+            ) as refresh_thread_history,
+        ):
             read_task = asyncio.create_task(
                 conversation_cache.refresh_strict_thread_history_from_source(
                     "!room:localhost",
                     "$thread:localhost",
-                    caller_label="startup_auto_resume_target_refresh",
+                    caller_label="startup_auto_resume_freshness",
                 ),
             )
-            await asyncio.sleep(0)
+            await asyncio.wait_for(barrier_entered.wait(), timeout=5.0)
             refresh_thread_history.assert_not_awaited()
             release_write.set()
-            result = await asyncio.wait_for(read_task, timeout=0.2)
+            result = await asyncio.wait_for(read_task, timeout=5.0)
     finally:
         release_write.set()
         await pending_write_task
@@ -879,246 +904,7 @@ async def test_strict_source_refresh_bypasses_usable_cache(
         event_cache,
     )
     assert refresh_thread_history.await_args.kwargs["allow_stale_fallback"] is False
-    conversation_cache._reads.read_thread.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_strict_source_refresh_evicts_turn_memoization(tmp_path: Path) -> None:
-    """A successful source refresh should prevent later same-turn reads from returning stale history."""
-    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await event_cache.initialize()
-    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=object())
-    conversation_cache.runtime.event_cache_write_coordinator = EventCacheWriteCoordinator(
-        logger=conversation_cache.logger,
-    )
-    cached_history = thread_history_result(
-        [ResolvedVisibleMessage.synthetic(sender="@user:localhost", body="Question", event_id="$question")],
-        is_full_history=True,
-    )
-    refreshed_history = thread_history_result(
-        [
-            *cached_history,
-            ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Answer", event_id="$answer"),
-        ],
-        is_full_history=True,
-    )
-
-    try:
-        with (
-            patch(
-                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_history",
-                AsyncMock(side_effect=[cached_history, refreshed_history]),
-            ) as fetch_thread_history,
-            patch(
-                "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
-                AsyncMock(return_value=refreshed_history),
-            ),
-        ):
-            async with conversation_cache.turn_scope():
-                before_refresh = await conversation_cache.get_strict_thread_history(
-                    "!room:localhost",
-                    "$thread:localhost",
-                )
-                refreshed = await conversation_cache.refresh_strict_thread_history_from_source(
-                    "!room:localhost",
-                    "$thread:localhost",
-                )
-                after_refresh = await conversation_cache.get_strict_thread_history(
-                    "!room:localhost",
-                    "$thread:localhost",
-                )
-    finally:
-        await event_cache.close()
-
-    assert [message.event_id for message in before_refresh] == ["$question"]
-    assert [message.event_id for message in refreshed] == ["$question", "$answer"]
-    assert [message.event_id for message in after_refresh] == ["$question", "$answer"]
-    assert fetch_thread_history.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_failed_strict_source_refresh_evicts_turn_memoization(tmp_path: Path) -> None:
-    """A failed source refresh should not leave an earlier same-turn strict read reusable."""
-    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await event_cache.initialize()
-    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=object())
-    conversation_cache.runtime.event_cache_write_coordinator = EventCacheWriteCoordinator(
-        logger=conversation_cache.logger,
-    )
-    cached_history = thread_history_result(
-        [ResolvedVisibleMessage.synthetic(sender="@user:localhost", body="Question", event_id="$question")],
-        is_full_history=True,
-    )
-    later_history = thread_history_result(
-        [
-            *cached_history,
-            ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Answer", event_id="$answer"),
-        ],
-        is_full_history=True,
-    )
-
-    try:
-        with (
-            patch(
-                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_history",
-                AsyncMock(side_effect=[cached_history, later_history]),
-            ) as fetch_thread_history,
-            patch(
-                "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
-                AsyncMock(side_effect=RuntimeError("source refresh failed")),
-            ),
-        ):
-            async with conversation_cache.turn_scope():
-                before_refresh = await conversation_cache.get_strict_thread_history(
-                    "!room:localhost",
-                    "$thread:localhost",
-                )
-                with pytest.raises(RuntimeError, match="source refresh failed"):
-                    await conversation_cache.refresh_strict_thread_history_from_source(
-                        "!room:localhost",
-                        "$thread:localhost",
-                    )
-                after_refresh = await conversation_cache.get_strict_thread_history(
-                    "!room:localhost",
-                    "$thread:localhost",
-                )
-    finally:
-        await event_cache.close()
-
-    assert [message.event_id for message in before_refresh] == ["$question"]
-    assert [message.event_id for message in after_refresh] == ["$question", "$answer"]
-    assert fetch_thread_history.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_room_stale_source_refresh_evicts_sibling_thread_memoization(tmp_path: Path) -> None:
-    """A room-scoped opaque-history failure should evict sibling thread reads."""
-    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await event_cache.initialize()
-    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=object())
-    conversation_cache.runtime.event_cache_write_coordinator = EventCacheWriteCoordinator(
-        logger=conversation_cache.logger,
-    )
-    stale_sibling = thread_history_result(
-        [ResolvedVisibleMessage.synthetic(sender="@user:localhost", body="Old", event_id="$old")],
-        is_full_history=True,
-    )
-    fresh_sibling = thread_history_result(
-        [
-            *stale_sibling,
-            ResolvedVisibleMessage.synthetic(sender="@user:localhost", body="New", event_id="$new"),
-        ],
-        is_full_history=True,
-    )
-    source_error = RuntimeError("opaque room history")
-
-    async def fail_after_room_invalidation(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
-        await event_cache.mark_room_threads_stale(
-            "!room:localhost",
-            reason="opaque_encrypted_thread_history",
-        )
-        raise source_error
-
-    try:
-        with (
-            patch(
-                "mindroom.matrix.conversation_cache.fetch_dispatch_thread_history",
-                AsyncMock(side_effect=[stale_sibling, fresh_sibling]),
-            ) as fetch_thread_history,
-            patch(
-                "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
-                fail_after_room_invalidation,
-            ),
-        ):
-            async with conversation_cache.turn_scope():
-                before_refresh = await conversation_cache.get_strict_thread_history(
-                    "!room:localhost",
-                    "$sibling:localhost",
-                )
-                with pytest.raises(RuntimeError, match="opaque room history"):
-                    await conversation_cache.refresh_strict_thread_history_from_source(
-                        "!room:localhost",
-                        "$target:localhost",
-                    )
-                after_refresh = await conversation_cache.get_strict_thread_history(
-                    "!room:localhost",
-                    "$sibling:localhost",
-                )
-    finally:
-        await event_cache.close()
-
-    assert [message.event_id for message in before_refresh] == ["$old"]
-    assert [message.event_id for message in after_refresh] == ["$old", "$new"]
-    assert fetch_thread_history.await_count == 2
-
-
-@pytest.mark.asyncio
-async def test_strict_source_refresh_evicts_point_event_memoization(tmp_path: Path) -> None:
-    """A source refresh should prevent same-turn point reads from returning pre-refresh content."""
-    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await event_cache.initialize()
-    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=object())
-    conversation_cache.runtime.event_cache_write_coordinator = EventCacheWriteCoordinator(
-        logger=conversation_cache.logger,
-    )
-    original_event = _make_text_event(
-        event_id="$reply",
-        sender="@bot:localhost",
-        body="Draft answer",
-        server_timestamp=2000,
-        source_content={
-            "body": "Draft answer",
-            "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread:localhost"},
-        },
-    )
-    edit_event = _make_text_event(
-        event_id="$reply-edit",
-        sender="@bot:localhost",
-        body="* Final answer",
-        server_timestamp=3000,
-        source_content={
-            "body": "* Final answer",
-            "m.new_content": {"body": "Final answer", "msgtype": "m.text"},
-            "m.relates_to": {"rel_type": "m.replace", "event_id": "$reply"},
-        },
-    )
-    refreshed_history = thread_history_result(
-        [ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Final answer", event_id="$reply")],
-        is_full_history=True,
-    )
-
-    async def refresh_source(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
-        await event_cache.store_event(
-            "$reply-edit",
-            "!room:localhost",
-            _cache_source(edit_event),
-        )
-        return refreshed_history
-
-    try:
-        await event_cache.store_event(
-            "$reply",
-            "!room:localhost",
-            _cache_source(original_event),
-        )
-        with patch(
-            "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
-            refresh_source,
-        ):
-            async with conversation_cache.turn_scope():
-                before_refresh = await conversation_cache.get_event("!room:localhost", "$reply")
-                await conversation_cache.refresh_strict_thread_history_from_source(
-                    "!room:localhost",
-                    "$thread:localhost",
-                )
-                after_refresh = await conversation_cache.get_event("!room:localhost", "$reply")
-    finally:
-        await event_cache.close()
-
-    assert isinstance(before_refresh, nio.RoomGetEventResponse)
-    assert before_refresh.event.body == "Draft answer"
-    assert isinstance(after_refresh, nio.RoomGetEventResponse)
-    assert after_refresh.event.body == "Final answer"
+    cache_thread_history.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -295,14 +295,19 @@ def _authoritative_history(*messages: ResolvedVisibleMessage) -> ThreadHistoryRe
 
 def _auto_resume_conversation_cache(interrupted: list[InterruptedThread]) -> AsyncMock:
     conversation_cache = AsyncMock()
-    conversation_cache.get_strict_thread_history = AsyncMock(
-        side_effect=lambda room_id, thread_id, **_: _authoritative_history(
+
+    def history_for_thread(room_id: str, thread_id: str, **_: object) -> ThreadHistoryResult:
+        return _authoritative_history(
             *[
                 _history_message(item.target_event_id, timestamp=item.timestamp_ms)
                 for item in interrupted
                 if (item.room_id, item.thread_id) == (room_id, thread_id)
             ],
-        ),
+        )
+
+    conversation_cache.get_strict_thread_history = AsyncMock(side_effect=history_for_thread)
+    conversation_cache.refresh_strict_thread_history_from_source = AsyncMock(
+        side_effect=history_for_thread,
     )
     conversation_cache.notify_outbound_message = Mock()
     return conversation_cache
@@ -939,6 +944,10 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
         conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
             _history_message("$other"),
         )
+        conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
+        conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+            _history_message("$other"),
+        )
     elif conversation_cache is not None and history_case == "untrusted_sender":
         state = MatrixState.load(runtime_paths_for(config))
         state.accounts.pop(managed_account_key("other"))
@@ -960,6 +969,57 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
 
     assert resumed_count == 0
     mock_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_refreshes_matrix_when_startup_cache_omits_target(tmp_path: Path) -> None:
+    """Startup recovery should refresh Matrix once when sync has not appended the target to cache yet."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [
+        InterruptedThread(
+            ROOM_ID,
+            "$thread",
+            "$target",
+            "partial",
+            "test_agent",
+            original_sender_id=USER_ID,
+        ),
+    ]
+    conversation_cache = _auto_resume_conversation_cache(interrupted)
+    conversation_cache.get_strict_thread_history.side_effect = None
+    conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
+        _history_message("$older"),
+    )
+    conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
+    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+        _history_message("$target"),
+    )
+
+    with patch(
+        "mindroom.matrix.stale_stream_cleanup.send_message_result",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
+    ) as mock_send:
+        resumed_count = await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=conversation_cache,
+        )
+
+    assert resumed_count == 1
+    conversation_cache.get_strict_thread_history.assert_awaited_once_with(
+        ROOM_ID,
+        "$thread",
+        caller_label="startup_auto_resume_freshness",
+    )
+    conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once_with(
+        ROOM_ID,
+        "$thread",
+        caller_label="startup_auto_resume_target_refresh",
+    )
+    mock_send.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -26,6 +26,7 @@ from mindroom.entity_resolution import MissingManagedEntityAccountError, entity_
 from mindroom.matrix import stale_stream_cleanup as stale_stream_cleanup_module
 from mindroom.matrix.cache import ThreadHistoryResult, thread_history_result
 from mindroom.matrix.client import ResolvedVisibleMessage
+from mindroom.matrix.client_thread_history import OpaqueEncryptedThreadHistoryError
 from mindroom.matrix.identity import managed_account_key
 from mindroom.matrix.stale_stream_cleanup import (
     StaleStreamCleanupActor,
@@ -919,7 +920,10 @@ async def test_prior_auto_resume_relay_does_not_suppress_sibling_resume(tmp_path
     mock_send.assert_awaited_once()
 
 
-@pytest.mark.parametrize("history_case", ["missing", "failed", "degraded", "missing_target", "untrusted_sender"])
+@pytest.mark.parametrize(
+    "history_case",
+    ["missing", "failed", "incomplete", "degraded", "opaque", "missing_target", "untrusted_sender"],
+)
 @pytest.mark.asyncio
 async def test_auto_resume_fails_closed_without_authoritative_target_history(
     tmp_path: Path,
@@ -928,16 +932,36 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
     """Unusable history or untrusted sender classification should suppress auto-resume."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
-    interrupted = [InterruptedThread(ROOM_ID, "$thread", "$target", "partial", "test_agent")]
+    interrupted = [
+        InterruptedThread(
+            ROOM_ID,
+            "$thread",
+            "$target",
+            "partial",
+            "test_agent",
+            original_sender_id=USER_ID,
+        ),
+    ]
     conversation_cache = None if history_case == "missing" else _auto_resume_conversation_cache(interrupted)
     if conversation_cache is not None and history_case == "failed":
         conversation_cache.refresh_strict_thread_history_from_source.side_effect = RuntimeError("history failed")
-    elif conversation_cache is not None and history_case == "degraded":
+    elif conversation_cache is not None and history_case == "incomplete":
         conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
         conversation_cache.refresh_strict_thread_history_from_source.return_value = thread_history_result(
             [_history_message("$target")],
             is_full_history=False,
-            diagnostics={"thread_read_source": "degraded", "thread_read_degraded": True},
+            diagnostics={"thread_read_source": "homeserver"},
+        )
+    elif conversation_cache is not None and history_case == "degraded":
+        conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
+        conversation_cache.refresh_strict_thread_history_from_source.return_value = thread_history_result(
+            [_history_message("$target")],
+            is_full_history=True,
+            diagnostics={"thread_read_source": "homeserver", "thread_read_degraded": True},
+        )
+    elif conversation_cache is not None and history_case == "opaque":
+        conversation_cache.refresh_strict_thread_history_from_source.side_effect = OpaqueEncryptedThreadHistoryError(
+            "opaque history",
         )
     elif conversation_cache is not None and history_case == "missing_target":
         conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
@@ -965,6 +989,46 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
 
     assert resumed_count == 0
     mock_send.assert_not_awaited()
+    if conversation_cache is not None:
+        conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once_with(
+            ROOM_ID,
+            "$thread",
+            caller_label="startup_auto_resume_freshness",
+        )
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_propagates_cancelled_source_refresh(tmp_path: Path) -> None:
+    """Cancellation should abort recovery without sending an unchecked resume."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [
+        InterruptedThread(
+            ROOM_ID,
+            "$thread",
+            "$target",
+            "partial",
+            "test_agent",
+            original_sender_id=USER_ID,
+        ),
+    ]
+    conversation_cache = _auto_resume_conversation_cache(interrupted)
+    conversation_cache.refresh_strict_thread_history_from_source.side_effect = asyncio.CancelledError
+
+    with (
+        patch("mindroom.matrix.stale_stream_cleanup.send_message_result", new=AsyncMock()) as mock_send,
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=conversation_cache,
+        )
+
+    mock_send.assert_not_awaited()
+    conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -851,8 +851,8 @@ async def test_auto_resume_classifies_later_activity_by_effective_sender_and_his
         ),
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
-    conversation_cache.get_strict_thread_history.side_effect = None
-    conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
+    conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
+    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
         _history_message("$target", timestamp=100),
         _history_message("$newer", sender=newer_sender, timestamp=100, content=newer_content),
     )
@@ -889,8 +889,8 @@ async def test_prior_auto_resume_relay_does_not_suppress_sibling_resume(tmp_path
         ),
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
-    conversation_cache.get_strict_thread_history.side_effect = None
-    conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
+    conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
+    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
         _history_message("$target"),
         _history_message(
             "$prior-resume",
@@ -931,19 +931,15 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
     interrupted = [InterruptedThread(ROOM_ID, "$thread", "$target", "partial", "test_agent")]
     conversation_cache = None if history_case == "missing" else _auto_resume_conversation_cache(interrupted)
     if conversation_cache is not None and history_case == "failed":
-        conversation_cache.get_strict_thread_history.side_effect = RuntimeError("history failed")
+        conversation_cache.refresh_strict_thread_history_from_source.side_effect = RuntimeError("history failed")
     elif conversation_cache is not None and history_case == "degraded":
-        conversation_cache.get_strict_thread_history.side_effect = None
-        conversation_cache.get_strict_thread_history.return_value = thread_history_result(
+        conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
+        conversation_cache.refresh_strict_thread_history_from_source.return_value = thread_history_result(
             [_history_message("$target")],
             is_full_history=False,
             diagnostics={"thread_read_source": "degraded", "thread_read_degraded": True},
         )
     elif conversation_cache is not None and history_case == "missing_target":
-        conversation_cache.get_strict_thread_history.side_effect = None
-        conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
-            _history_message("$other"),
-        )
         conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
         conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
             _history_message("$other"),
@@ -952,8 +948,8 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
         state = MatrixState.load(runtime_paths_for(config))
         state.accounts.pop(managed_account_key("other"))
         state.save(runtime_paths_for(config))
-        conversation_cache.get_strict_thread_history.side_effect = None
-        conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
+        conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
+        conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
             _history_message("$target"),
             _history_message("$later", sender=OTHER_BOT_USER_ID),
         )
@@ -1009,17 +1005,58 @@ async def test_auto_resume_refreshes_matrix_when_startup_cache_omits_target(tmp_
         )
 
     assert resumed_count == 1
-    conversation_cache.get_strict_thread_history.assert_awaited_once_with(
+    conversation_cache.get_strict_thread_history.assert_not_awaited()
+    conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once_with(
         ROOM_ID,
         "$thread",
         caller_label="startup_auto_resume_freshness",
     )
+    mock_send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_cache(tmp_path: Path) -> None:
+    """Startup recovery should not resume when Matrix has newer human work absent from cache."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [
+        InterruptedThread(
+            ROOM_ID,
+            "$thread",
+            "$target",
+            "partial",
+            "test_agent",
+            original_sender_id=USER_ID,
+        ),
+    ]
+    conversation_cache = _auto_resume_conversation_cache(interrupted)
+    conversation_cache.get_strict_thread_history.side_effect = None
+    conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
+        _history_message("$target"),
+    )
+    conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
+    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+        _history_message("$target"),
+        _history_message("$newer-human", sender=USER_ID),
+    )
+
+    with patch("mindroom.matrix.stale_stream_cleanup.send_message_result", new=AsyncMock()) as mock_send:
+        resumed_count = await auto_resume_interrupted_threads(
+            client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=conversation_cache,
+        )
+
+    assert resumed_count == 0
+    conversation_cache.get_strict_thread_history.assert_not_awaited()
     conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once_with(
         ROOM_ID,
         "$thread",
-        caller_label="startup_auto_resume_target_refresh",
+        caller_label="startup_auto_resume_freshness",
     )
-    mock_send.assert_awaited_once()
+    mock_send.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -1050,7 +1087,7 @@ async def test_auto_resume_rechecks_after_delay_before_each_delivery(tmp_path: P
             messages.append(_history_message("$human-later", sender=USER_ID))
         return _authoritative_history(*messages)
 
-    conversation_cache.get_strict_thread_history.side_effect = history_for_call
+    conversation_cache.refresh_strict_thread_history_from_source.side_effect = history_for_call
 
     with (
         patch(
@@ -2091,7 +2128,9 @@ async def test_recent_mid_tool_shutdown_marker_resumes_only_without_newer_human_
             ),
         )
     conversation_cache = AsyncMock()
-    conversation_cache.get_strict_thread_history.return_value = _authoritative_history(*history_messages)
+    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+        *history_messages,
+    )
     conversation_cache.notify_outbound_message = Mock()
 
     with patch(

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -290,7 +290,7 @@ def _authoritative_history(*messages: ResolvedVisibleMessage) -> ThreadHistoryRe
     return thread_history_result(
         list(messages),
         is_full_history=True,
-        diagnostics={"thread_read_source": "cache"},
+        diagnostics={"thread_read_source": "homeserver"},
     )
 
 
@@ -306,7 +306,6 @@ def _auto_resume_conversation_cache(interrupted: list[InterruptedThread]) -> Asy
             ],
         )
 
-    conversation_cache.get_strict_thread_history = AsyncMock(side_effect=history_for_thread)
     conversation_cache.refresh_strict_thread_history_from_source = AsyncMock(
         side_effect=history_for_thread,
     )
@@ -1032,53 +1031,6 @@ async def test_auto_resume_propagates_cancelled_source_refresh(tmp_path: Path) -
 
 
 @pytest.mark.asyncio
-async def test_auto_resume_refreshes_matrix_when_startup_cache_omits_target(tmp_path: Path) -> None:
-    """Startup recovery should refresh Matrix once when sync has not appended the target to cache yet."""
-    config = _make_config(tmp_path)
-    client = AsyncMock(spec=nio.AsyncClient)
-    interrupted = [
-        InterruptedThread(
-            ROOM_ID,
-            "$thread",
-            "$target",
-            "partial",
-            "test_agent",
-            original_sender_id=USER_ID,
-        ),
-    ]
-    conversation_cache = _auto_resume_conversation_cache(interrupted)
-    conversation_cache.get_strict_thread_history.side_effect = None
-    conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
-        _history_message("$older"),
-    )
-    conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
-    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
-        _history_message("$target"),
-    )
-
-    with patch(
-        "mindroom.matrix.stale_stream_cleanup.send_message_result",
-        new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
-    ) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
-            client,
-            interrupted,
-            config=config,
-            runtime_paths=runtime_paths_for(config),
-            conversation_cache=conversation_cache,
-        )
-
-    assert resumed_count == 1
-    conversation_cache.get_strict_thread_history.assert_not_awaited()
-    conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once_with(
-        ROOM_ID,
-        "$thread",
-        caller_label="startup_auto_resume_freshness",
-    )
-    mock_send.assert_awaited_once()
-
-
-@pytest.mark.asyncio
 async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_cache(tmp_path: Path) -> None:
     """Startup recovery should not resume when Matrix has newer human work absent from cache."""
     config = _make_config(tmp_path)
@@ -1094,10 +1046,6 @@ async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_
         ),
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
-    conversation_cache.get_strict_thread_history.side_effect = None
-    conversation_cache.get_strict_thread_history.return_value = _authoritative_history(
-        _history_message("$target"),
-    )
     conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
     conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
         _history_message("$target"),
@@ -1114,7 +1062,6 @@ async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_
         )
 
     assert resumed_count == 0
-    conversation_cache.get_strict_thread_history.assert_not_awaited()
     conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once_with(
         ROOM_ID,
         "$thread",
@@ -1124,8 +1071,8 @@ async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_
 
 
 @pytest.mark.asyncio
-async def test_auto_resume_rechecks_after_delay_before_each_delivery(tmp_path: Path) -> None:
-    """Resume should recheck freshness after each rate-limit delay."""
+async def test_auto_resume_checks_freshness_after_delay_before_each_delivery(tmp_path: Path) -> None:
+    """Activity becoming visible during a rate-limit delay should suppress resume."""
     config = _make_config(tmp_path)
     client = AsyncMock(spec=nio.AsyncClient)
     interrupted = [
@@ -1142,12 +1089,20 @@ async def test_auto_resume_rechecks_after_delay_before_each_delivery(tmp_path: P
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
     history_calls: dict[str, int] = {}
+    activity_arrived_during_delay = asyncio.Event()
+    delay_count = 0
+
+    async def sleep_with_activity(_: float) -> None:
+        nonlocal delay_count
+        delay_count += 1
+        if delay_count == 2:
+            activity_arrived_during_delay.set()
 
     def history_for_call(_: str, thread_id: str, **__: object) -> ThreadHistoryResult:
         history_calls[thread_id] = history_calls.get(thread_id, 0) + 1
         index = thread_id.removeprefix("$thread-")
         messages = [_history_message(f"$target-{index}")]
-        if index == "4" or (index == "2" and history_calls[thread_id] == 2):
+        if index == "4" or (index == "2" and activity_arrived_during_delay.is_set()):
             messages.append(_history_message("$human-later", sender=USER_ID))
         return _authoritative_history(*messages)
 
@@ -1158,7 +1113,10 @@ async def test_auto_resume_rechecks_after_delay_before_each_delivery(tmp_path: P
             "mindroom.matrix.stale_stream_cleanup.send_message_result",
             new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
         ) as mock_send,
-        patch("mindroom.matrix.stale_stream_cleanup.asyncio.sleep", new=AsyncMock()) as mock_sleep,
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.asyncio.sleep",
+            new=AsyncMock(side_effect=sleep_with_activity),
+        ) as mock_sleep,
     ):
         resumed_count = await auto_resume_interrupted_threads(
             client,
@@ -1176,12 +1134,12 @@ async def test_auto_resume_rechecks_after_delay_before_each_delivery(tmp_path: P
     ]
     assert history_calls == {
         "$thread-0": 1,
-        "$thread-1": 2,
-        "$thread-2": 2,
+        "$thread-1": 1,
+        "$thread-2": 1,
         "$thread-3": 1,
         "$thread-4": 1,
     }
-    assert mock_sleep.await_args_list == [call(2.0), call(2.0)]
+    assert mock_sleep.await_args_list == [call(2.0), call(2.0), call(2.0)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Startup stale-stream recovery can find an interrupted response on Matrix before the initial sync callback appends that event to the durable thread cache. The freshness gate then accepts an older valid cache snapshot, cannot find the known target, and permanently skips auto-resume.

## Fix

- Add a named strict source-refresh mode that bypasses usable cache hits while retaining the same-thread write barrier.
- Apply any rate-limit delay first, then perform exactly one unconditional source refresh immediately before each resume attempt.
- Keep incomplete, degraded, untrusted, missing-target, and failed histories fail-closed.

## Validation

- Both owning event-cache and stale-stream-cleanup test files pass, including PostgreSQL-parametrized contracts.
- Ruff, format, ty, Vulture, Tach, module privacy, diff checks, and all pre-commit hooks pass.
- Earlier full-suite and real-Tuwunel evidence is stale after the review follow-up; fresh exact-head gates are pending.

Found during the real-Tuwunel gate for #1641; the bug reproduces on `main` and is intentionally isolated here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added strict source-refresh support for retrieving authoritative thread history directly from the homeserver.
  - Added controls to bypass cached or stale thread-history data during freshness checks.

- **Bug Fixes**
  - Improved interrupted-thread auto-resume validation by consistently checking for newer human activity.
  - Prevented automatic resumes when authoritative history is missing, opaque, incomplete, or indicates newer work.
  - Strengthened source validation to ensure freshness decisions use homeserver-provided history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->