### PR TITLE
Prevent mixed-requester replay drops

### DIFF
--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -327,7 +327,7 @@ async def _blocked_before_plan(
             thread_id=prepared.replay_guard.thread_id,
             may_be_superseded_by_newer_requester_turn=may_be_superseded,
         )
-        if not skips_turn:
+        if may_be_superseded and not skips_turn:
             controller.deps.logger.warning(
                 "Thread replay guard degraded; proceeding without negative newer-message proof",
                 event_id=prepared.event.event_id,

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -315,9 +315,9 @@ async def _blocked_before_plan(
     ):
         return True
 
-    may_be_superseded = (
-        prepared.dispatch.envelope.origin.may_be_superseded_by_newer_requester_turn
-        and _all_sources_belong_to_requester(prepared.handled_turn, requester_user_id)
+    may_be_superseded = prepared.dispatch.envelope.origin.may_be_superseded_by_newer_requester_turn and all(
+        metadata.sender == requester_user_id
+        for metadata in (prepared.handled_turn.source_event_metadata or {}).values()
     )
     if prepared.replay_guard.degraded:
         skips_turn = await controller._has_newer_unresponded_cached_thread_event(
@@ -345,17 +345,6 @@ async def _blocked_before_plan(
     if skips_turn:
         controller._mark_source_events_responded(prepared.handled_turn)
     return skips_turn
-
-
-def _all_sources_belong_to_requester(handled_turn: TurnRecord, requester_user_id: str) -> bool:
-    """Return whether one newer requester turn may safely supersede the full batch."""
-    if len(handled_turn.source_event_ids) < 2:
-        return True
-    source_metadata = handled_turn.source_event_metadata
-    return source_metadata is not None and all(
-        (metadata := source_metadata.get(event_id)) is not None and metadata.sender == requester_user_id
-        for event_id in handled_turn.source_event_ids
-    )
 
 
 def _attachment_parts(

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -315,7 +315,10 @@ async def _blocked_before_plan(
     ):
         return True
 
-    may_be_superseded = prepared.dispatch.envelope.origin.may_be_superseded_by_newer_requester_turn
+    may_be_superseded = (
+        prepared.dispatch.envelope.origin.may_be_superseded_by_newer_requester_turn
+        and _all_sources_belong_to_requester(prepared.handled_turn, requester_user_id)
+    )
     if prepared.replay_guard.degraded:
         skips_turn = await controller._has_newer_unresponded_cached_thread_event(
             room_id=room.room_id,
@@ -342,6 +345,17 @@ async def _blocked_before_plan(
     if skips_turn:
         controller._mark_source_events_responded(prepared.handled_turn)
     return skips_turn
+
+
+def _all_sources_belong_to_requester(handled_turn: TurnRecord, requester_user_id: str) -> bool:
+    """Return whether one newer requester turn may safely supersede the full batch."""
+    if len(handled_turn.source_event_ids) < 2:
+        return True
+    source_metadata = handled_turn.source_event_metadata
+    return source_metadata is not None and all(
+        (metadata := source_metadata.get(event_id)) is not None and metadata.sender == requester_user_id
+        for event_id in handled_turn.source_event_ids
+    )
 
 
 def _attachment_parts(

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -11,6 +11,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 from pydantic import ValidationError
+from structlog.testing import capture_logs
 
 from mindroom.attachments import _attachment_id_for_event, load_attachment, register_local_attachment
 from mindroom.bot import AgentBot
@@ -4244,15 +4245,28 @@ async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Pat
         },
     )
 
-    action_mock = AsyncMock(return_value=_DispatchPlan(kind="ignore"))
+    plan_calls: list[PreparedDispatch] = []
+
+    async def prepare_dispatch(*_args: object, **_kwargs: object) -> object:
+        return prepared_dispatch_result(dispatch)
+
+    async def plan_turn(
+        _room: object,
+        _event: object,
+        prepared_dispatch: PreparedDispatch,
+        **_kwargs: object,
+    ) -> _DispatchPlan:
+        plan_calls.append(prepared_dispatch)
+        return _DispatchPlan(kind="ignore")
+
     with (
+        capture_logs() as captured_logs,
         patch.object(
             bot._turn_controller,
             "_prepare_dispatch",
-            new=AsyncMock(return_value=prepared_dispatch_result(dispatch)),
+            new=prepare_dispatch,
         ),
-        patch.object(bot._turn_policy, "plan_turn", new=action_mock),
-        patch.object(bot._turn_controller.deps.logger, "warning") as warning_mock,
+        patch.object(bot._turn_policy, "plan_turn", new=plan_turn),
     ):
         await bot._turn_controller._dispatch_text_message(
             room,
@@ -4261,8 +4275,11 @@ async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Pat
             handled_turn=handled_turn,
         )
 
-    action_mock.assert_awaited_once()
-    warning_mock.assert_not_called()
+    assert plan_calls == [dispatch]
+    assert not any(
+        log.get("event") == "Thread replay guard degraded; proceeding without negative newer-message proof"
+        for log in captured_logs
+    )
     bot.event_cache.get_recent_room_events.assert_not_awaited()
     assert not bot._turn_store.is_handled("$alice")
     assert not bot._turn_store.is_handled("$bob")

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -4201,7 +4201,8 @@ async def test_backlog_replay_skips_older_message_when_newer_exists(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Path) -> None:
+@pytest.mark.parametrize("degraded", [False, True])
+async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Path, *, degraded: bool) -> None:
     """A newer primary-requester message must not settle another requester's source."""
     bot = _make_bot(tmp_path)
     room = _make_room()
@@ -4222,7 +4223,19 @@ async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Pat
         thread_id=None,
         latest_event_id="$newer-bob",
     )
-    _set_context_histories(dispatch, [newer_bob_message])
+    if degraded:
+        degraded_history = ThreadHistoryResult(
+            [newer_bob_message],
+            is_full_history=False,
+            diagnostics={
+                THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_DEGRADED,
+                THREAD_HISTORY_DEGRADED_DIAGNOSTIC: True,
+            },
+        )
+        dispatch.context.thread_history = degraded_history
+        dispatch.context.replay_guard_history = degraded_history
+    else:
+        _set_context_histories(dispatch, [newer_bob_message])
     handled_turn = TurnRecord.create(
         ["$alice", "$bob"],
         source_event_metadata={
@@ -4239,6 +4252,7 @@ async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Pat
             new=AsyncMock(return_value=prepared_dispatch_result(dispatch)),
         ),
         patch.object(bot._turn_policy, "plan_turn", new=action_mock),
+        patch.object(bot._turn_controller.deps.logger, "warning") as warning_mock,
     ):
         await bot._turn_controller._dispatch_text_message(
             room,
@@ -4248,6 +4262,8 @@ async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Pat
         )
 
     action_mock.assert_awaited_once()
+    warning_mock.assert_not_called()
+    bot.event_cache.get_recent_room_events.assert_not_awaited()
     assert not bot._turn_store.is_handled("$alice")
     assert not bot._turn_store.is_handled("$bob")
 

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -4203,8 +4203,14 @@ async def test_backlog_replay_skips_older_message_when_newer_exists(tmp_path: Pa
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("degraded", [False, True])
-async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Path, *, degraded: bool) -> None:
-    """A newer primary-requester message must not settle another requester's source."""
+@pytest.mark.parametrize("mixed_requesters", [False, True])
+async def test_backlog_replay_respects_coalesced_source_ownership(
+    tmp_path: Path,
+    *,
+    degraded: bool,
+    mixed_requesters: bool,
+) -> None:
+    """A newer requester turn supersedes a coalesced batch only when every source is theirs."""
     bot = _make_bot(tmp_path)
     room = _make_room()
     primary_event = PreparedTextEvent(
@@ -4214,14 +4220,19 @@ async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Pat
         source={"content": {"msgtype": "m.text", "body": "bob"}},
         server_timestamp=2000,
     )
-    dispatch = _prepared_dispatch(event_id="$bob", requester_user_id="@bob:localhost", body="bob")
+    dispatch = _prepared_dispatch(
+        event_id="$bob",
+        requester_user_id="@bob:localhost",
+        body="bob",
+        thread_id="$thread",
+    )
     newer_bob_message = ResolvedVisibleMessage(
         sender="@bob:localhost",
         body="newer bob",
         timestamp=3000,
         event_id="$newer-bob",
         content={"body": "newer bob"},
-        thread_id=None,
+        thread_id="$thread",
         latest_event_id="$newer-bob",
     )
     if degraded:
@@ -4235,12 +4246,24 @@ async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Pat
         )
         dispatch.context.thread_history = degraded_history
         dispatch.context.replay_guard_history = degraded_history
+        bot.event_cache.get_recent_room_events.return_value = [
+            _text_event(
+                event_id="$newer-bob",
+                body="newer bob",
+                sender="@bob:localhost",
+                server_timestamp=3000,
+                thread_id="$thread",
+            ).source,
+        ]
     else:
         _set_context_histories(dispatch, [newer_bob_message])
     handled_turn = TurnRecord.create(
         ["$alice", "$bob"],
         source_event_metadata={
-            "$alice": SourceEventMetadata(sender="@alice:localhost", timestamp_ms=1000),
+            "$alice": SourceEventMetadata(
+                sender="@alice:localhost" if mixed_requesters else "@bob:localhost",
+                timestamp_ms=1000,
+            ),
             "$bob": SourceEventMetadata(sender="@bob:localhost", timestamp_ms=2000),
         },
     )
@@ -4275,14 +4298,21 @@ async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Pat
             handled_turn=handled_turn,
         )
 
-    assert plan_calls == [dispatch]
+    assert plan_calls == ([dispatch] if mixed_requesters else [])
     assert not any(
         log.get("event") == "Thread replay guard degraded; proceeding without negative newer-message proof"
         for log in captured_logs
     )
-    bot.event_cache.get_recent_room_events.assert_not_awaited()
-    assert not bot._turn_store.is_handled("$alice")
-    assert not bot._turn_store.is_handled("$bob")
+    if degraded and not mixed_requesters:
+        bot.event_cache.get_recent_room_events.assert_awaited_once_with(
+            room.room_id,
+            event_type="m.room.message",
+            since_ts_ms=2000,
+        )
+    else:
+        bot.event_cache.get_recent_room_events.assert_not_awaited()
+    assert bot._turn_store.is_handled("$alice") is not mixed_requesters
+    assert bot._turn_store.is_handled("$bob") is not mixed_requesters
 
 
 @pytest.mark.asyncio
@@ -4882,6 +4912,7 @@ async def test_backlog_replay_degraded_thread_history_fails_open_without_positiv
     action_mock = AsyncMock(return_value=_DispatchPlan(kind="ignore"))
     history_guard = MagicMock(wraps=bot._turn_controller._has_newer_unresponded_in_thread)
     with (
+        capture_logs() as captured_logs,
         patch.object(
             bot._turn_controller,
             "_prepare_dispatch",
@@ -4900,6 +4931,10 @@ async def test_backlog_replay_degraded_thread_history_fails_open_without_positiv
     )
     action_mock.assert_awaited_once()
     assert not bot._turn_store.is_handled("$m1")
+    assert any(
+        log.get("event") == "Thread replay guard degraded; proceeding without negative newer-message proof"
+        for log in captured_logs
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -53,7 +53,7 @@ from mindroom.dispatch_source import (
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     VOICE_SOURCE_KIND,
 )
-from mindroom.handled_turns import TurnRecord
+from mindroom.handled_turns import SourceEventMetadata, TurnRecord
 from mindroom.hooks import MessageEnvelope
 from mindroom.inbound_turn_normalizer import (
     BatchMediaAttachmentRequest,
@@ -4198,6 +4198,58 @@ async def test_backlog_replay_skips_older_message_when_newer_exists(tmp_path: Pa
     # Older message should be skipped — resolve_dispatch_action never called
     action_mock.assert_not_awaited()
     assert bot._turn_store.is_handled("$m1")
+
+
+@pytest.mark.asyncio
+async def test_backlog_replay_keeps_mixed_requester_coalesced_turn(tmp_path: Path) -> None:
+    """A newer primary-requester message must not settle another requester's source."""
+    bot = _make_bot(tmp_path)
+    room = _make_room()
+    primary_event = PreparedTextEvent(
+        sender="@bob:localhost",
+        event_id="$bob",
+        body="bob",
+        source={"content": {"msgtype": "m.text", "body": "bob"}},
+        server_timestamp=2000,
+    )
+    dispatch = _prepared_dispatch(event_id="$bob", requester_user_id="@bob:localhost", body="bob")
+    newer_bob_message = ResolvedVisibleMessage(
+        sender="@bob:localhost",
+        body="newer bob",
+        timestamp=3000,
+        event_id="$newer-bob",
+        content={"body": "newer bob"},
+        thread_id=None,
+        latest_event_id="$newer-bob",
+    )
+    _set_context_histories(dispatch, [newer_bob_message])
+    handled_turn = TurnRecord.create(
+        ["$alice", "$bob"],
+        source_event_metadata={
+            "$alice": SourceEventMetadata(sender="@alice:localhost", timestamp_ms=1000),
+            "$bob": SourceEventMetadata(sender="@bob:localhost", timestamp_ms=2000),
+        },
+    )
+
+    action_mock = AsyncMock(return_value=_DispatchPlan(kind="ignore"))
+    with (
+        patch.object(
+            bot._turn_controller,
+            "_prepare_dispatch",
+            new=AsyncMock(return_value=prepared_dispatch_result(dispatch)),
+        ),
+        patch.object(bot._turn_policy, "plan_turn", new=action_mock),
+    ):
+        await bot._turn_controller._dispatch_text_message(
+            room,
+            primary_event,
+            "@bob:localhost",
+            handled_turn=handled_turn,
+        )
+
+    action_mock.assert_awaited_once()
+    assert not bot._turn_store.is_handled("$alice")
+    assert not bot._turn_store.is_handled("$bob")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- prevent the replay guard from settling a coalesced turn when its physical sources belong to different requesters
- preserve newer-message suppression for single-requester coalesced turns in complete and degraded history
- suppress degraded replay-proof warnings when whole-turn suppression is intentionally ineligible
- add complete and degraded regressions for the exact mixed-requester loss found by the real-Tuwunel campaign

## Failure mechanism

Active-response follow-ups are intentionally coalesced by conversation, so one batch may contain messages from multiple requesters.
The replay guard previously checked only the primary event and requester.
When that requester had a newer unhandled message, it settled the entire batch, including another requester's unsuperseded source, without a response.

## Validation

Current head:

- `152` tests in `tests/test_live_message_coalescing.py`
- `13` focused backlog-replay tests
- Ruff, format, ty, Vulture, Tach, module privacy, and diff checks
- source diff: `+5/-2`, net `+3`

Prior head `27b25bb84`:

- full suite: `11727` tests, `54` skipped, zero failures/errors
- real-Tuwunel frozen trace: `200` operations, `45` roots, `135` canonical replies, zero coordinator timeouts, dispatch timeouts, or event-loop stalls

Fresh full-suite and real-Tuwunel gates remain pending on the current exact head.
The deterministic predecessor live failure bundle remains in the campaign evidence and is not committed to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved message replay handling when a conversation contains events from multiple requesters.
  - Prevented messages from being incorrectly skipped or treated as superseded during backlog processing.
  - Added safer behavior when thread history is incomplete or degraded, with clearer diagnostic logging.
  - Strengthened handling of coalesced messages to ensure each source event is processed and marked consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->