### PR TITLE
Add built-in synthetic model for live Matrix stress

### DIFF
--- a/.github/workflows/live-matrix-stress.yml
+++ b/.github/workflows/live-matrix-stress.yml
@@ -75,7 +75,9 @@ jobs:
           -k "synthetic or stress or barrier or baseline"
 
   smoke:
-    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.tier == 'smoke')
+    if: >-
+      (github.event_name == 'pull_request' && github.base_ref == 'main') ||
+      (github.event_name == 'workflow_dispatch' && inputs.tier == 'smoke')
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
@@ -83,15 +85,7 @@ jobs:
       - name: Checkout MindRoom
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
-          fetch-depth: 0
           lfs: true
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-
-      - name: Integrate pull request with current main
-        if: github.event_name == 'pull_request'
-        run: |
-          git fetch --no-tags origin main
-          git -c user.name=mindroom-ci -c user.email=ci@mindroom.local merge --no-edit --no-ff FETCH_HEAD
 
       - name: Checkout mindroom-nio
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5

--- a/.github/workflows/live-matrix-stress.yml
+++ b/.github/workflows/live-matrix-stress.yml
@@ -133,6 +133,13 @@ jobs:
           repository: mindroom-ai/mindroom-nio
           path: mindroom-nio
 
+      - name: Checkout exact current main baseline
+        uses: actions/checkout@v5
+        with:
+          path: baseline-mindroom
+          ref: main
+          lfs: true
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
@@ -145,12 +152,36 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras
 
-      - name: Run full synchronized stress gate
+      - name: Run exact main baseline sample 1
+        run: >-
+          uv run python scripts/testing/fuzz_live_matrix.py
+          --nio-overlay mindroom-nio
+          --mindroom-runtime baseline-mindroom
+          --profile stress
+          --write-baseline artifacts/live-matrix-stress/main-baseline.json
+
+      - name: Run exact main baseline sample 2
+        run: >-
+          uv run python scripts/testing/fuzz_live_matrix.py
+          --nio-overlay mindroom-nio
+          --mindroom-runtime baseline-mindroom
+          --profile stress
+          --write-baseline artifacts/live-matrix-stress/main-baseline.json
+
+      - name: Run exact main baseline sample 3
+        run: >-
+          uv run python scripts/testing/fuzz_live_matrix.py
+          --nio-overlay mindroom-nio
+          --mindroom-runtime baseline-mindroom
+          --profile stress
+          --write-baseline artifacts/live-matrix-stress/main-baseline.json
+
+      - name: Run candidate synchronized stress gate
         run: >-
           uv run python scripts/testing/fuzz_live_matrix.py
           --nio-overlay mindroom-nio
           --profile stress
-          --baseline scripts/testing/baselines/live-matrix-stress-50x45x2.json
+          --baseline artifacts/live-matrix-stress/main-baseline.json
           --enforce-performance
 
       - name: Upload stress evidence

--- a/.github/workflows/live-matrix-stress.yml
+++ b/.github/workflows/live-matrix-stress.yml
@@ -10,10 +10,14 @@ on:
       - "local/instances/deploy/**"
       - "scripts/testing/fuzz_live_matrix.py"
       - "scripts/testing/live_matrix_stress.py"
+      - "src/mindroom/model_loading.py"
       - "src/mindroom/matrix/**"
       - "src/mindroom/streaming.py"
+      - "src/mindroom/synthetic_model.py"
       - "tests/test_live_matrix_fuzz.py"
       - "tests/test_live_matrix_stress.py"
+      - "tests/test_model_loading.py"
+      - "tests/test_synthetic_model.py"
       - "uv.lock"
   push:
     tags:
@@ -62,7 +66,13 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run deterministic stress tests
-        run: uv run pytest -n auto -x --lf tests/test_live_matrix_stress.py tests/test_live_matrix_fuzz.py -k "stress or barrier or baseline"
+        run: >-
+          uv run pytest -n auto -x --lf
+          tests/test_synthetic_model.py
+          tests/test_model_loading.py
+          tests/test_live_matrix_stress.py
+          tests/test_live_matrix_fuzz.py
+          -k "synthetic or stress or barrier or baseline"
 
   smoke:
     if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.tier == 'smoke')

--- a/.github/workflows/live-matrix-stress.yml
+++ b/.github/workflows/live-matrix-stress.yml
@@ -83,7 +83,15 @@ jobs:
       - name: Checkout MindRoom
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
+          fetch-depth: 0
           lfs: true
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Integrate pull request with current main
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --no-tags origin main
+          git -c user.name=mindroom-ci -c user.email=ci@mindroom.local merge --no-edit --no-ff FETCH_HEAD
 
       - name: Checkout mindroom-nio
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5

--- a/.github/workflows/live-matrix-stress.yml
+++ b/.github/workflows/live-matrix-stress.yml
@@ -52,12 +52,12 @@ jobs:
 
     steps:
       - name: Checkout MindRoom
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Set up Python
         run: uv python install 3.13
@@ -81,24 +81,25 @@ jobs:
 
     steps:
       - name: Checkout MindRoom
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           lfs: true
 
       - name: Checkout mindroom-nio
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           repository: mindroom-ai/mindroom-nio
           path: mindroom-nio
+          ref: 837dbc77d9a60183c08570835139d24c280c22d7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Set up Python
         run: uv python install 3.13
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -116,7 +117,7 @@ jobs:
 
       - name: Upload stress evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: live-matrix-stress-smoke-${{ github.run_id }}
           path: artifacts/live-matrix-stress/
@@ -133,31 +134,32 @@ jobs:
 
     steps:
       - name: Checkout MindRoom
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           lfs: true
 
       - name: Checkout mindroom-nio
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           repository: mindroom-ai/mindroom-nio
           path: mindroom-nio
+          ref: 837dbc77d9a60183c08570835139d24c280c22d7
 
       - name: Checkout exact current main baseline
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           path: baseline-mindroom
           ref: main
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Set up Python
         run: uv python install 3.13
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -196,7 +198,7 @@ jobs:
 
       - name: Upload stress evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: live-matrix-stress-full-${{ github.run_id }}
           path: artifacts/live-matrix-stress/
@@ -210,24 +212,25 @@ jobs:
 
     steps:
       - name: Checkout MindRoom
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           lfs: true
 
       - name: Checkout mindroom-nio
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           repository: mindroom-ai/mindroom-nio
           path: mindroom-nio
+          ref: 837dbc77d9a60183c08570835139d24c280c22d7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
 
       - name: Set up Python
         run: uv python install 3.13
 
       - name: Install just
-        uses: extractions/setup-just@v3
+        uses: extractions/setup-just@f8a3cce218d9f83db3a2ecd90e41ac3de6cdfd9b # v3
 
       - name: Install dependencies
         run: uv sync --all-extras
@@ -245,7 +248,7 @@ jobs:
 
       - name: Upload soak evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: live-matrix-stress-soak-${{ github.run_id }}
           path: artifacts/live-matrix-stress/

--- a/.github/workflows/live-matrix-stress.yml
+++ b/.github/workflows/live-matrix-stress.yml
@@ -1,0 +1,212 @@
+name: Live Matrix Stress
+
+on:
+  pull_request:
+    branches:
+      - main
+      - test/fuzz-live-chaos-expansion
+    paths:
+      - ".github/workflows/live-matrix-stress.yml"
+      - "local/instances/deploy/**"
+      - "scripts/testing/fuzz_live_matrix.py"
+      - "scripts/testing/live_matrix_stress.py"
+      - "src/mindroom/matrix/**"
+      - "src/mindroom/streaming.py"
+      - "tests/test_live_matrix_fuzz.py"
+      - "tests/test_live_matrix_stress.py"
+      - "uv.lock"
+  push:
+    tags:
+      - "v*"
+  schedule:
+    - cron: "17 7 * * *"
+  workflow_dispatch:
+    inputs:
+      tier:
+        description: Stress tier to execute
+        required: true
+        type: choice
+        default: full
+        options:
+          - smoke
+          - full
+          - soak
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: live-matrix-stress-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  unit:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout MindRoom
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run deterministic stress tests
+        run: uv run pytest -n auto -x --lf tests/test_live_matrix_stress.py tests/test_live_matrix_fuzz.py -k "stress or barrier or baseline"
+
+  smoke:
+    if: github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && inputs.tier == 'smoke')
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout MindRoom
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Checkout mindroom-nio
+        uses: actions/checkout@v5
+        with:
+          repository: mindroom-ai/mindroom-nio
+          path: mindroom-nio
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run real Tuwunel and PostgreSQL smoke stress
+        run: >-
+          uv run python scripts/testing/fuzz_live_matrix.py
+          --nio-overlay mindroom-nio
+          --profile stress
+          --threads 10
+          --stream-seconds 10
+          --edit-interval 0.5
+          --waves 1
+          --history-turns 5
+
+      - name: Upload stress evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-matrix-stress-smoke-${{ github.run_id }}
+          path: artifacts/live-matrix-stress/
+          if-no-files-found: error
+          retention-days: 14
+
+  full:
+    if: >-
+      github.event_name == 'schedule' ||
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.tier == 'full')
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout MindRoom
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Checkout mindroom-nio
+        uses: actions/checkout@v5
+        with:
+          repository: mindroom-ai/mindroom-nio
+          path: mindroom-nio
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run full synchronized stress gate
+        run: >-
+          uv run python scripts/testing/fuzz_live_matrix.py
+          --nio-overlay mindroom-nio
+          --profile stress
+          --baseline scripts/testing/baselines/live-matrix-stress-50x45x2.json
+          --enforce-performance
+
+      - name: Upload stress evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-matrix-stress-full-${{ github.run_id }}
+          path: artifacts/live-matrix-stress/
+          if-no-files-found: error
+          retention-days: 30
+
+  soak:
+    if: github.event_name == 'workflow_dispatch' && inputs.tier == 'soak'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout MindRoom
+        uses: actions/checkout@v5
+        with:
+          lfs: true
+
+      - name: Checkout mindroom-nio
+        uses: actions/checkout@v5
+        with:
+          repository: mindroom-ai/mindroom-nio
+          path: mindroom-nio
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run optional overlapping follow-up soak
+        run: >-
+          uv run python scripts/testing/fuzz_live_matrix.py
+          --nio-overlay mindroom-nio
+          --profile stress
+          --threads 75
+          --stream-seconds 600
+          --edit-interval 0.5
+          --waves 1
+          --overlapping-followups
+
+      - name: Upload soak evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: live-matrix-stress-soak-${{ github.run_id }}
+          path: artifacts/live-matrix-stress/
+          if-no-files-found: error
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -242,6 +242,8 @@ terraform.tfstate
 
 # Local artifacts
 backups/
+artifacts/live-matrix-stress/
+artifacts/live-matrix-stress-tests/
 saas-platform/.env.backup
 wgcf-account.toml
 wgcf-profile.conf

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -325,10 +325,10 @@ agents:
 # Model configurations (at least a "default" model is recommended)
 models:
   default:
-    provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
+    provider: anthropic            # Required: openai, azure, anthropic, ollama, synthetic, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
     id: claude-sonnet-5            # Required: Model ID for the provider
   sonnet:
-    provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
+    provider: anthropic            # Required: openai, azure, anthropic, ollama, synthetic, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
     id: claude-sonnet-5            # Required: Model ID for the provider
     host: null                     # Optional: Host URL (e.g., for Ollama)
     api_key: null                  # Optional: API key (usually from env vars)

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -21,6 +21,7 @@ Models define the AI providers and model IDs used by agents.
 - `cerebras` - Cerebras-hosted models
 - `deepseek` - DeepSeek models
 - `zai` - Z.ai GLM models
+- `synthetic` - Built-in deterministic streaming model for local load and tool-call testing
 
 ## Model Config Fields
 
@@ -125,6 +126,43 @@ models:
     extra_kwargs:
       base_url: http://localhost:8080/v1
 ```
+
+## Built-In Synthetic Model
+
+Use `provider: synthetic` to run realistic local concurrency tests without an API key or external model server.
+The model streams deterministic Lorem Ipsum at a fixed character rate, chooses a seeded response length, and can issue the built-in `sleep` tool before continuing the same response.
+The default tool-call probability is zero, so enabling tool calls is always explicit.
+
+```yaml
+models:
+  load_test:
+    provider: synthetic
+    id: local-load-test
+    extra_kwargs:
+      seed: 17
+      min_response_chars: 800
+      max_response_chars: 1600
+      chunk_chars: 40
+      chars_per_second: 80
+      tool_call_probability: 0.5
+      min_sleep_seconds: 1
+      max_sleep_seconds: 3
+
+agents:
+  load_test:
+    display_name: Load Test
+    role: Exercise the full MindRoom response path.
+    model: load_test
+    tools: [sleep]
+    rooms: [lobby]
+```
+
+The same seed and matched request identity always produce the same body length, tool decision, split point, and sleep duration.
+Set `identity_pattern` to extract a stable request marker when prompts contain changing surrounding context.
+Set `activation_pattern` to make unmatched setup or lifecycle prompts return the short `inactive_response` without a tool call or barrier wait.
+The advanced `barrier_size` and `barrier_group_pattern` settings synchronize request groups for deterministic concurrency tests.
+Set `coordination_key` when separately materialized model instances must share that barrier and optional stream-serialization state.
+Set `telemetry_path` only for local tests that need append-only request timing evidence.
 
 ## OpenAI API Models
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -67,6 +67,7 @@ Every failure persists the exact logical workload as `scenario.json` in the fail
 Replay preserves operation batches and inputs, but external scheduling and runtime output can differ.
 
 The stress profile uses one room, one agent, 50 independent threads, a synchronized fake-model barrier, 45-second streams, 0.5-second pulses, two waves, and a disposable PostgreSQL event cache by default.
+It disables automatic thread summaries so background summary reads cannot cross cache-wave boundaries or consume model barrier slots.
 It clears only namespace data after deterministic history preparation so the first wave proves cold scans and the second wave proves warm reuse without replacing cache-certification metadata.
 Every stress run retains sanitized success or failure evidence under `artifacts/live-matrix-stress/`.
 Use `--write-baseline scripts/testing/baselines/live-matrix-stress-50x45x2.json` for three identical clean main runs before enabling `--baseline` and `--enforce-performance`.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,6 +72,8 @@ Use `--write-baseline scripts/testing/baselines/live-matrix-stress-50x45x2.json`
 The first two baseline runs retain a sample collection, and the third run writes the versioned median-of-three baseline only when dispersion is within the configured 25 percent allowance.
 Use `--mindroom-runtime` to drive a separate clean exact MindRoom checkout with the current harness, which lets three exact-main runs establish a same-machine baseline before the candidate run.
 Use `--fault-mode serialize-streams` without baseline flags to prove the synchronized concurrency gate rejects deliberately serialized model streams.
+The external API-health probe has an absolute five-second ceiling matching MindRoom's native event-loop stall detector.
+The sync-age probe has an absolute 120-second ceiling matching the production sync-watchdog restart threshold.
 
 ### Generate and sync managed avatars
 Run MindRoom at least once before syncing so the router account exists in Matrix state.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -69,12 +69,12 @@ The chaos profile runs sustained multi-sender multi-room load that only settles 
 Every failure persists the exact logical workload as `scenario.json` in the failure bundle and prints its path for replay with `--trace`.
 Replay preserves operation batches and inputs, but external scheduling and runtime output can differ.
 
-The stress profile uses one room, one agent, 50 independent threads, a synchronized fake-model barrier, 45-second streams, 0.5-second pulses, two waves, and a disposable PostgreSQL event cache by default.
-It disables automatic thread summaries so background summary reads cannot cross cache-wave boundaries or consume model barrier slots.
+The stress profile uses ten rooms, one agent, 100 independent threads, the built-in seeded `synthetic` model, 45-second maximum streams, 0.5-second chunks, real seeded `sleep` tool calls, two waves, and a disposable PostgreSQL event cache by default.
+It disables automatic thread summaries so background summary reads cannot cross cache-wave boundaries.
 It clears only namespace data after deterministic history preparation so the first wave proves cold scans and the second wave proves warm reuse without replacing cache-certification metadata.
 Between waves, it sends a harmless reaction and waits for that exact event in the agent's principal-scoped PostgreSQL cache so the warm wave cannot overtake pending sync of the cold wave's real Matrix edits.
 Every stress run retains sanitized success or failure evidence under `artifacts/live-matrix-stress/`.
-Use `--write-baseline scripts/testing/baselines/live-matrix-stress-50x45x2.json` for three identical clean main runs before enabling `--baseline` and `--enforce-performance`.
+Use `--write-baseline scripts/testing/baselines/live-matrix-stress.json` for three identical clean main runs before enabling `--baseline` and `--enforce-performance`.
 The first two baseline runs retain a sample collection, and the third run writes the versioned median-of-three baseline only when dispersion is within the configured 25 percent allowance.
 Use `--mindroom-runtime` to drive a separate clean exact MindRoom checkout with the current harness, which lets three exact-main runs establish a same-machine baseline before the candidate run.
 Use `--fault-mode serialize-streams` without baseline flags to prove the synchronized concurrency gate rejects deliberately serialized model streams.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -72,6 +72,7 @@ Use `--write-baseline scripts/testing/baselines/live-matrix-stress-50x45x2.json`
 The first two baseline runs retain a sample collection, and the third run writes the versioned median-of-three baseline only when dispersion is within the configured 25 percent allowance.
 Use `--mindroom-runtime` to drive a separate clean exact MindRoom checkout with the current harness, which lets three exact-main runs establish a same-machine baseline before the candidate run.
 Use `--fault-mode serialize-streams` without baseline flags to prove the synchronized concurrency gate rejects deliberately serialized model streams.
+Warm-wave invalidation scans remain reported metrics rather than an accepted threshold until cache self-healing lands, while multiple repair scans for one thread in one wave always fail.
 The external API-health probe has an absolute five-second ceiling matching MindRoom's native event-loop stall detector.
 The sync-age probe has an absolute 120-second ceiling matching the production sync-watchdog restart threshold.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,6 +52,7 @@ uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio 
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile chaos --seed 42 --steps 200 --clients 4 --rooms 2
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --api-port 18765
+uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --api-port 18765 --state-root ~/.mindroom/live-fuzz-stress
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --threads 10 --stream-seconds 10 --waves 1
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --mindroom-runtime ../mindroom-main --profile stress --write-baseline artifacts/live-matrix-stress/main-baseline.json
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --fault-mode serialize-streams
@@ -59,6 +60,8 @@ uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio 
 
 The live harness requires `--nio-overlay` to name a clean exact Git checkout of mindroom-nio.
 It rejects missing or dirty overlays, revision mismatches, and a child process that imports nio from another checkout.
+The default durable state root serializes live stacks across worktrees.
+Use a separate `--state-root` only when every port and disposable resource is isolated from another active campaign.
 
 The saturation profile uses a 180-second per-reply deadline because its slow 12-way stream workload intentionally queues much more work than normal fuzz runs.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,6 +50,8 @@ uv run python scripts/testing/fuzz_matrix_event_cache.py --seed 42 --steps 500
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --seed 42 --steps 200 --threads 45
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile saturation
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile chaos --seed 42 --steps 200 --clients 4 --rooms 2
+uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress
+uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --threads 10 --stream-seconds 10 --waves 1
 ```
 
 The live harness requires `--nio-overlay` to name a clean exact Git checkout of mindroom-nio.
@@ -60,6 +62,12 @@ The saturation profile uses a 180-second per-reply deadline because its slow 12-
 The chaos profile runs sustained multi-sender multi-room load that only settles at generated checkpoints, mixing hot-thread floods, in-flight edits and redactions, MindRoom warm/kill/cold restarts, Tuwunel restarts, and full outage windows with recovery gaps.
 Every failure persists the exact logical workload as `scenario.json` in the failure bundle and prints its path for replay with `--trace`.
 Replay preserves operation batches and inputs, but external scheduling and runtime output can differ.
+
+The stress profile uses one room, one agent, 50 independent threads, a synchronized fake-model barrier, 45-second streams, 0.5-second pulses, two waves, and a disposable PostgreSQL event cache by default.
+It clears only namespace data after deterministic history preparation so the first wave proves cold scans and the second wave proves warm reuse without replacing cache-certification metadata.
+Every stress run retains sanitized success or failure evidence under `artifacts/live-matrix-stress/`.
+Use `--write-baseline scripts/testing/baselines/live-matrix-stress-50x45x2.json` for three identical clean main runs before enabling `--baseline` and `--enforce-performance`.
+The first two baseline runs retain a sample collection, and the third run writes the versioned median-of-three baseline only when dispersion is within the configured 25 percent allowance.
 
 ### Generate and sync managed avatars
 Run MindRoom at least once before syncing so the router account exists in Matrix state.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -69,6 +69,7 @@ Replay preserves operation batches and inputs, but external scheduling and runti
 The stress profile uses one room, one agent, 50 independent threads, a synchronized fake-model barrier, 45-second streams, 0.5-second pulses, two waves, and a disposable PostgreSQL event cache by default.
 It disables automatic thread summaries so background summary reads cannot cross cache-wave boundaries or consume model barrier slots.
 It clears only namespace data after deterministic history preparation so the first wave proves cold scans and the second wave proves warm reuse without replacing cache-certification metadata.
+Between waves, it sends a harmless reaction and waits for that exact event in the agent's principal-scoped PostgreSQL cache so the warm wave cannot overtake pending sync of the cold wave's real Matrix edits.
 Every stress run retains sanitized success or failure evidence under `artifacts/live-matrix-stress/`.
 Use `--write-baseline scripts/testing/baselines/live-matrix-stress-50x45x2.json` for three identical clean main runs before enabling `--baseline` and `--enforce-performance`.
 The first two baseline runs retain a sample collection, and the third run writes the versioned median-of-three baseline only when dispersion is within the configured 25 percent allowance.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,6 +51,7 @@ uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio 
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile saturation
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile chaos --seed 42 --steps 200 --clients 4 --rooms 2
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress
+uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --api-port 18765
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --threads 10 --stream-seconds 10 --waves 1
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --mindroom-runtime ../mindroom-main --profile stress --write-baseline artifacts/live-matrix-stress/main-baseline.json
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --fault-mode serialize-streams

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -52,6 +52,8 @@ uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio 
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile chaos --seed 42 --steps 200 --clients 4 --rooms 2
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress
 uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --threads 10 --stream-seconds 10 --waves 1
+uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --mindroom-runtime ../mindroom-main --profile stress --write-baseline artifacts/live-matrix-stress/main-baseline.json
+uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay ../mindroom-nio --profile stress --fault-mode serialize-streams
 ```
 
 The live harness requires `--nio-overlay` to name a clean exact Git checkout of mindroom-nio.
@@ -68,6 +70,8 @@ It clears only namespace data after deterministic history preparation so the fir
 Every stress run retains sanitized success or failure evidence under `artifacts/live-matrix-stress/`.
 Use `--write-baseline scripts/testing/baselines/live-matrix-stress-50x45x2.json` for three identical clean main runs before enabling `--baseline` and `--enforce-performance`.
 The first two baseline runs retain a sample collection, and the third run writes the versioned median-of-three baseline only when dispersion is within the configured 25 percent allowance.
+Use `--mindroom-runtime` to drive a separate clean exact MindRoom checkout with the current harness, which lets three exact-main runs establish a same-machine baseline before the candidate run.
+Use `--fault-mode serialize-streams` without baseline flags to prove the synchronized concurrency gate rejects deliberately serialized model streams.
 
 ### Generate and sync managed avatars
 Run MindRoom at least once before syncing so the router account exists in Matrix state.

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -1490,6 +1490,14 @@ class NioOverlay:
     revision: str
 
 
+@dataclass(frozen=True, slots=True)
+class MindroomRuntime:
+    """Clean exact MindRoom checkout loaded by the managed child."""
+
+    path: Path
+    revision: str
+
+
 class ManagedTuwunelStack:
     """Disposable Tuwunel plus the current worktree's MindRoom runtime."""
 
@@ -1502,7 +1510,9 @@ class ManagedTuwunelStack:
         artifact_directory: Path | None = None,
         state_root: Path = DEFAULT_LIVE_FUZZ_STATE_ROOT,
         nio_overlay: NioOverlay | None = None,
+        mindroom_root: Path | None = None,
         mindroom_revision: str | None = None,
+        runner_revision: str | None = None,
         stress_config: StressConfig | None = None,
     ) -> None:
         token = secrets.token_hex(4)
@@ -1536,11 +1546,20 @@ class ManagedTuwunelStack:
         self._env: dict[str, str] = {}
         self._provenance_sink = provenance_sink
         self.nio_overlay = nio_overlay
+        self._mindroom_root = mindroom_root.resolve() if mindroom_root is not None else None
         self._mindroom_revision = mindroom_revision
+        self._runner_revision = runner_revision
         self._host_lease: TextIOWrapper | None = None
         self._mindroom_start_log_offset = 0
         self.stress_config = stress_config
-        self.stress_controller = StressModelController(stress_config) if stress_config is not None else None
+        self.stress_controller = (
+            StressModelController(
+                stress_config,
+                serialize_streams=stress_config.fault_mode == "serialize-streams",
+            )
+            if stress_config is not None
+            else None
+        )
         self.stress_postgres = (
             ManagedStressPostgres(f"{self.instance_name}-postgres") if stress_config is not None else None
         )
@@ -1548,8 +1567,12 @@ class ManagedTuwunelStack:
     def _frozen_mindroom_revision(self) -> str:
         """Freeze and return the one MindRoom revision allowed for this run."""
         if self._mindroom_revision is None:
-            self._mindroom_revision = _required_mindroom_revision()
+            self._mindroom_revision = _required_mindroom_revision(self._selected_mindroom_root())
         return self._mindroom_revision
+
+    def _selected_mindroom_root(self) -> Path:
+        """Return the explicit runtime root or the current patched runner root."""
+        return self._mindroom_root or PROJECT_ROOT.resolve()
 
     def _required_nio_overlay(self) -> NioOverlay:
         """Return the preflighted overlay or reject live stack creation."""
@@ -2071,12 +2094,15 @@ class ManagedTuwunelStack:
     def _start_mindroom(self) -> None:
         assert self._log_handle is not None
         overlay = self._required_nio_overlay()
+        mindroom_root = self._selected_mindroom_root()
         self.attestation_path.unlink(missing_ok=True)
         self._mindroom_start_log_offset = self.log_path.stat().st_size if self.log_path.exists() else 0
         self._mindroom_process = subprocess.Popen(
             [
                 "uv",
                 "run",
+                "--project",
+                str(mindroom_root),
                 "--with-editable",
                 str(overlay.path),
                 "python",
@@ -2089,7 +2115,7 @@ class ManagedTuwunelStack:
                 "--log-level",
                 "DEBUG" if self.stress_config is not None else "INFO",
             ],
-            cwd=PROJECT_ROOT,
+            cwd=mindroom_root,
             env=self._env,
             stdout=self._log_handle,
             stderr=subprocess.STDOUT,
@@ -2141,6 +2167,8 @@ class ManagedTuwunelStack:
                         self.attestation_path,
                         overlay=overlay,
                         expected_mindroom_revision=expected_mindroom_revision,
+                        expected_mindroom_root=self._selected_mindroom_root(),
+                        expected_runner_revision=self._runner_revision,
                     ),
                     **self._tuwunel_provenance(),
                     "runtime_generation": len(self._runtime_generations) + 1,
@@ -2171,6 +2199,8 @@ class ManagedTuwunelStack:
             provenance,
             overlay=self._required_nio_overlay(),
             expected_mindroom_revision=self._frozen_mindroom_revision(),
+            expected_mindroom_root=self._selected_mindroom_root(),
+            expected_runner_revision=self._runner_revision,
         )
         final_source_validation = {
             key: validated[key]
@@ -2181,7 +2211,11 @@ class ManagedTuwunelStack:
                 "nio_dirty",
                 "nio_expected_revision",
                 "nio_revision",
+                "runner_dirty",
+                "runner_expected_revision",
+                "runner_revision",
             )
+            if key in validated
         }
         self.runtime_provenance = {
             **provenance,
@@ -5614,6 +5648,11 @@ def _parse_args() -> argparse.Namespace:
         required=True,
         help="clean exact mindroom-nio Git checkout loaded by the live MindRoom child",
     )
+    parser.add_argument(
+        "--mindroom-runtime",
+        type=Path,
+        help="clean exact MindRoom checkout loaded by the child; defaults to this harness checkout",
+    )
     parser.add_argument("--profile", choices=("fuzz", "saturation", "chaos", "stress"), default="fuzz")
     parser.add_argument("--seed", type=int, default=1)
     parser.add_argument("--steps", type=_positive_int, default=200)
@@ -5626,6 +5665,12 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--baseline", type=Path)
     parser.add_argument("--write-baseline", type=Path)
     parser.add_argument("--enforce-performance", action="store_true")
+    parser.add_argument(
+        "--fault-mode",
+        choices=("none", "serialize-streams"),
+        default="none",
+        help="deliberately inject a named workload fault; never used for performance baselines",
+    )
     parser.add_argument("--overlapping-followups", action="store_true")
     parser.add_argument("--max-batch-size", type=_positive_int, default=16)
     parser.add_argument("--restart-interval", type=_non_negative_int, default=100)
@@ -5835,11 +5880,69 @@ def _git_revision(path: Path) -> str | None:
     return result.stdout.strip() if result.returncode == 0 else None
 
 
-def _required_mindroom_revision() -> str:
-    """Return the exact runner revision or fail before live setup."""
-    revision = _git_revision(PROJECT_ROOT)
+def _required_mindroom_revision(root: Path = PROJECT_ROOT) -> str:
+    """Return one exact MindRoom revision or fail before live setup."""
+    revision = _git_revision(root)
     if revision is None:
-        msg = "could not freeze the live runner MindRoom revision"
+        msg = f"could not freeze the live MindRoom revision for {root}"
+        raise RuntimeError(msg)
+    return revision
+
+
+def _prepare_mindroom_runtime(path: Path | None) -> MindroomRuntime:
+    """Fail closed unless the selected child runtime is an exact clean checkout."""
+    root = (path or PROJECT_ROOT).expanduser().resolve()
+    module_path = root / "src" / "mindroom" / "__init__.py"
+    if not module_path.is_file():
+        msg = f"MindRoom runtime does not contain src/mindroom/__init__.py: {root}"
+        raise RuntimeError(msg)
+    _require_git_root(module_path, root, "MindRoom")
+    revision, dirty = _git_state_for_file(
+        module_path,
+        scopes=(
+            root / "src" / "mindroom",
+            root / "pyproject.toml",
+            root / "uv.lock",
+        ),
+    )
+    if revision is None:
+        msg = f"could not verify exact MindRoom runtime revision: {root}"
+        raise RuntimeError(msg)
+    if dirty:
+        msg = f"live fuzz requires a clean exact MindRoom runtime: {root}"
+        raise RuntimeError(msg)
+    return MindroomRuntime(path=root, revision=revision)
+
+
+def _selected_mindroom_runtime(path: Path | None) -> MindroomRuntime:
+    """Return the runner checkout by default or preflight an explicit runtime."""
+    if path is None:
+        return MindroomRuntime(
+            path=PROJECT_ROOT.resolve(),
+            revision=_required_mindroom_revision(),
+        )
+    return _prepare_mindroom_runtime(path)
+
+
+def _required_runner_revision() -> str:
+    """Return the clean exact harness revision or fail before disposable setup."""
+    script_path = Path(__file__).resolve()
+    revision, dirty = _git_state_for_file(
+        script_path,
+        scopes=(
+            script_path,
+            script_path.with_name("live_matrix_stress.py"),
+            PROJECT_ROOT / "justfile",
+            PROJECT_ROOT / "local" / "instances" / "deploy",
+            PROJECT_ROOT / "pyproject.toml",
+            PROJECT_ROOT / "uv.lock",
+        ),
+    )
+    if revision is None:
+        msg = "could not freeze the live harness revision"
+        raise RuntimeError(msg)
+    if dirty:
+        msg = "live fuzz requires a clean exact harness checkout"
         raise RuntimeError(msg)
     return revision
 
@@ -5899,6 +6002,8 @@ def _validated_child_provenance(
     *,
     overlay: NioOverlay,
     expected_mindroom_revision: str,
+    expected_mindroom_root: Path | None = None,
+    expected_runner_revision: str | None = None,
 ) -> dict[str, object]:
     """Validate actual child imports against the runner and requested overlay."""
     raw = json.loads(attestation_path.read_text(encoding="utf-8"))
@@ -5909,7 +6014,38 @@ def _validated_child_provenance(
         raw,
         overlay=overlay,
         expected_mindroom_revision=expected_mindroom_revision,
+        expected_mindroom_root=expected_mindroom_root,
+        expected_runner_revision=expected_runner_revision,
     )
+
+
+def _validated_runner_provenance(expected_revision: str | None) -> dict[str, object]:
+    """Validate the clean harness checkout separately from the selected runtime."""
+    if expected_revision is None:
+        return {}
+    script_path = Path(__file__).resolve()
+    revision, dirty = _git_state_for_file(
+        script_path,
+        scopes=(
+            script_path,
+            script_path.with_name("live_matrix_stress.py"),
+            PROJECT_ROOT / "justfile",
+            PROJECT_ROOT / "local" / "instances" / "deploy",
+            PROJECT_ROOT / "pyproject.toml",
+            PROJECT_ROOT / "uv.lock",
+        ),
+    )
+    if revision != expected_revision:
+        msg = f"live harness revision changed after preflight: expected {expected_revision}, loaded {revision}"
+        raise RuntimeError(msg)
+    if dirty:
+        msg = "live fuzz requires a clean exact harness checkout"
+        raise RuntimeError(msg)
+    return {
+        "runner_revision": revision,
+        "runner_expected_revision": expected_revision,
+        "runner_dirty": dirty,
+    }
 
 
 def _validated_import_provenance(
@@ -5917,6 +6053,8 @@ def _validated_import_provenance(
     *,
     overlay: NioOverlay,
     expected_mindroom_revision: str,
+    expected_mindroom_root: Path | None = None,
+    expected_runner_revision: str | None = None,
 ) -> dict[str, object]:
     """Validate imported module paths against frozen exact clean checkouts."""
     mindroom_value = raw.get("mindroom_module_path")
@@ -5926,22 +6064,33 @@ def _validated_import_provenance(
         raise TypeError(msg)
     mindroom_path = Path(mindroom_value).resolve()
     nio_path = Path(nio_value).resolve()
+    uses_runner_runtime = expected_mindroom_root is None
+    mindroom_root = (expected_mindroom_root or PROJECT_ROOT).resolve()
     _require_path_within(
         mindroom_path,
-        PROJECT_ROOT,
-        "loaded MindRoom path is outside the live runner checkout",
+        mindroom_root,
+        (
+            "loaded MindRoom path is outside the live runner checkout"
+            if uses_runner_runtime
+            else "loaded MindRoom path is outside the selected runtime checkout"
+        ),
     )
-    _require_git_root(mindroom_path, PROJECT_ROOT, "MindRoom")
-    mindroom_revision, mindroom_dirty = _git_state_for_file(
-        mindroom_path,
-        scopes=(
-            PROJECT_ROOT / "src" / "mindroom",
+    _require_git_root(mindroom_path, mindroom_root, "MindRoom")
+    mindroom_scopes: tuple[Path, ...] = (
+        mindroom_root / "src" / "mindroom",
+        mindroom_root / "pyproject.toml",
+        mindroom_root / "uv.lock",
+    )
+    if mindroom_root == PROJECT_ROOT.resolve():
+        mindroom_scopes = (
+            *mindroom_scopes,
             Path(__file__),
             PROJECT_ROOT / "justfile",
             PROJECT_ROOT / "local" / "instances" / "deploy",
-            PROJECT_ROOT / "pyproject.toml",
-            PROJECT_ROOT / "uv.lock",
-        ),
+        )
+    mindroom_revision, mindroom_dirty = _git_state_for_file(
+        mindroom_path,
+        scopes=mindroom_scopes,
     )
     if mindroom_revision is None:
         msg = "could not verify the loaded MindRoom revision"
@@ -5951,7 +6100,7 @@ def _validated_import_provenance(
         raise RuntimeError(msg)
     if mindroom_revision != expected_mindroom_revision:
         msg = (
-            "loaded MindRoom revision does not match the live runner: "
+            "loaded MindRoom revision does not match the selected runtime: "
             f"expected {expected_mindroom_revision}, loaded {mindroom_revision}"
         )
         raise RuntimeError(msg)
@@ -5977,8 +6126,10 @@ def _validated_import_provenance(
     if nio_dirty:
         msg = "live fuzz requires a clean loaded mindroom-nio overlay"
         raise RuntimeError(msg)
+    runner_provenance = _validated_runner_provenance(expected_runner_revision)
     return {
         **raw,
+        **runner_provenance,
         "mindroom_revision": mindroom_revision,
         "mindroom_expected_revision": expected_mindroom_revision,
         "mindroom_dirty": mindroom_dirty,
@@ -5988,7 +6139,12 @@ def _validated_import_provenance(
     }
 
 
-def _run_provenance(mindroom_revision: str | None = None) -> dict[str, object]:
+def _run_provenance(
+    mindroom_revision: str | None = None,
+    *,
+    mindroom_root: Path = PROJECT_ROOT,
+    runner_revision: str | None = None,
+) -> dict[str, object]:
     """Capture parent identity until child-attested provenance replaces it.
 
     Only inert build/version identity is recorded; no credentials, tokens, or
@@ -6000,7 +6156,9 @@ def _run_provenance(mindroom_revision: str | None = None) -> dict[str, object]:
         "mindroom_module_path": str(Path(mindroom.__file__ or "").resolve()),
         "nio_module_path": str(Path(nio.__file__ or "").resolve()),
     }
-    provenance["mindroom_head"] = mindroom_revision or _required_mindroom_revision()
+    provenance["mindroom_head"] = mindroom_revision or _required_mindroom_revision(mindroom_root)
+    if runner_revision is not None:
+        provenance["runner_head"] = runner_revision
     try:
         provenance["nio_version"] = version("mindroom-nio")
     except PackageNotFoundError:
@@ -6317,6 +6475,32 @@ def _require_exact_nio_provenance(
         raise RuntimeError(msg)
 
 
+def _require_exact_runtime_generation(
+    generation: object,
+    *,
+    index: int,
+    frozen_revision: str,
+) -> None:
+    """Reject one mixed, dirty, or stale runtime generation."""
+    if not isinstance(generation, dict):
+        msg = f"passing live run has invalid runtime generation {index}"
+        raise TypeError(msg)
+    generation = cast("dict[str, object]", generation)
+    if (
+        generation.get("mindroom_revision") != frozen_revision
+        or generation.get("mindroom_expected_revision") != frozen_revision
+        or generation.get("mindroom_dirty") is not False
+    ):
+        msg = f"passing live run generation {index} did not use exact clean MindRoom {frozen_revision}"
+        raise RuntimeError(msg)
+    runner_expected = generation.get("runner_expected_revision")
+    if runner_expected is not None and (
+        generation.get("runner_revision") != runner_expected or generation.get("runner_dirty") is not False
+    ):
+        msg = f"passing live run generation {index} did not use its exact clean harness"
+        raise RuntimeError(msg)
+
+
 def _require_exact_mindroom_provenance(
     provenance: Mapping[str, object],
     *,
@@ -6335,17 +6519,11 @@ def _require_exact_mindroom_provenance(
         msg = "passing live run omitted per-generation runtime attestations"
         raise RuntimeError(msg)
     for index, generation in enumerate(generations, start=1):
-        if not isinstance(generation, dict):
-            msg = f"passing live run has invalid runtime generation {index}"
-            raise TypeError(msg)
-        generation = cast("dict[str, object]", generation)
-        if (
-            generation.get("mindroom_revision") != frozen_revision
-            or generation.get("mindroom_expected_revision") != frozen_revision
-            or generation.get("mindroom_dirty") is not False
-        ):
-            msg = f"passing live run generation {index} did not use exact clean MindRoom {frozen_revision}"
-            raise RuntimeError(msg)
+        _require_exact_runtime_generation(
+            generation,
+            index=index,
+            frozen_revision=frozen_revision,
+        )
     if not require_final:
         return
     final_validation = provenance.get("final_source_validation")
@@ -6360,6 +6538,9 @@ def _require_exact_mindroom_provenance(
         "nio_dirty",
         "nio_expected_revision",
         "nio_revision",
+        "runner_dirty",
+        "runner_expected_revision",
+        "runner_revision",
     )
     if (
         final_validation.get("mindroom_revision") != frozen_revision
@@ -6402,6 +6583,7 @@ def _stress_config_from_args(args: argparse.Namespace) -> StressConfig:
         cache_backend=args.cache_backend,
         seed=args.seed,
         overlapping_followups=args.overlapping_followups,
+        fault_mode=args.fault_mode,
     )
     config.validate()
     return config
@@ -6440,6 +6622,7 @@ def _compare_stress_baseline(
     *,
     config: StressConfig,
     result: Mapping[str, object],
+    enforce: bool,
 ) -> Mapping[str, object]:
     _require_persistent_stress_path(path)
     baseline = StressBaseline.from_json(path.read_text(encoding="utf-8"))
@@ -6450,7 +6633,10 @@ def _compare_stress_baseline(
             f"stress baseline workload mismatch: profile={baseline.profile!r}, config_sha256={baseline.config_sha256!r}"
         )
         raise ValueError(msg)
-    return baseline.compare(_baseline_sample_from_result(result))
+    return baseline.compare(
+        _baseline_sample_from_result(result),
+        enforce=enforce,
+    )
 
 
 def _append_stress_baseline_sample(
@@ -6576,18 +6762,47 @@ def _capture_stress_bundle(
         )
 
 
-def _run_stress_main(args: argparse.Namespace) -> None:
-    """Run one complete stress campaign unit and retain success evidence."""
-    config = _stress_config_from_args(args)
+def _validate_stress_cli(args: argparse.Namespace, config: StressConfig) -> None:
+    """Reject contradictory stress flags before starting disposable services."""
     if args.enforce_performance and args.baseline is None:
         msg = "--enforce-performance requires --baseline"
         raise ValueError(msg)
+    if config.fault_mode != "none" and (args.baseline is not None or args.write_baseline is not None):
+        msg = "fault-injected stress runs cannot read or write performance baselines"
+        raise ValueError(msg)
+
+
+def _close_failed_stress_run(
+    stack: ManagedTuwunelStack,
+    bundle: StressArtifactBundle,
+    failure: BaseException,
+) -> None:
+    """Attempt cleanup and record whether disposable resources were removed."""
+    resources_removed = True
+    try:
+        stack.close()
+    except BaseException as cleanup_error:
+        resources_removed = False
+        failure.add_note(f"stress cleanup failure: {cleanup_error}")
+    with suppress(BaseException):
+        bundle.write_json(
+            "cleanup-manifest.json",
+            {"status": "FAILED", "resources_removed": resources_removed},
+        )
+
+
+def _run_stress_main(args: argparse.Namespace) -> None:
+    """Run one complete stress campaign unit and retain success evidence."""
+    config = _stress_config_from_args(args)
+    _validate_stress_cli(args, config)
     artifact_root = args.artifact_root or DEFAULT_STRESS_ARTIFACT_ROOT
     _require_persistent_stress_path(artifact_root)
     if args.save_trace is not None:
         _require_persistent_stress_path(args.save_trace)
         _atomic_text_write(args.save_trace, config.to_json() + "\n")
-    mindroom_revision = _required_mindroom_revision()
+    mindroom_runtime = _selected_mindroom_runtime(args.mindroom_runtime)
+    mindroom_revision = mindroom_runtime.revision
+    runner_revision = _required_runner_revision() if args.mindroom_runtime is not None else None
     run_id = f"{time.strftime('%Y%m%dT%H%M%S')}-{secrets.token_hex(4)}"
     bundle = StressArtifactBundle.create(artifact_root, run_id)
     journal: list[Mapping[str, object]] = []
@@ -6600,7 +6815,9 @@ def _run_stress_main(args: argparse.Namespace) -> None:
         ),
         artifact_directory=bundle.directory,
         nio_overlay=args.nio_overlay,
+        mindroom_root=mindroom_runtime.path,
         mindroom_revision=mindroom_revision,
+        runner_revision=runner_revision,
         stress_config=config,
     )
     result: dict[str, object] | None = None
@@ -6622,6 +6839,7 @@ def _run_stress_main(args: argparse.Namespace) -> None:
                 args.baseline,
                 config=config,
                 result=result,
+                enforce=args.enforce_performance,
             )
         if args.write_baseline is not None:
             result["baseline_write"] = _append_stress_baseline_sample(
@@ -6642,15 +6860,7 @@ def _run_stress_main(args: argparse.Namespace) -> None:
                 failure=exc,
                 baseline_comparison=baseline_comparison,
             )
-        try:
-            stack.close()
-        except BaseException as cleanup_error:
-            exc.add_note(f"stress cleanup failure: {cleanup_error}")
-        with suppress(BaseException):
-            bundle.write_json(
-                "cleanup-manifest.json",
-                {"status": "FAILED", "resources_removed": True},
-            )
+        _close_failed_stress_run(stack, bundle, exc)
         print(f"Live Matrix stress failure bundle: {bundle.directory}", file=sys.stderr)
         raise
 
@@ -6667,7 +6877,15 @@ def _run_stress_main(args: argparse.Namespace) -> None:
             baseline_comparison=baseline_comparison,
         )
 
-    stack.close(before_destructive_cleanup=snapshot_evidence)
+    try:
+        stack.close(before_destructive_cleanup=snapshot_evidence)
+    except BaseException:
+        with suppress(BaseException):
+            bundle.write_json(
+                "cleanup-manifest.json",
+                {"status": "FAILED", "resources_removed": False},
+            )
+        raise
     bundle.write_json(
         "cleanup-manifest.json",
         {"status": "PASS", "resources_removed": True},
@@ -6676,15 +6894,8 @@ def _run_stress_main(args: argparse.Namespace) -> None:
     print(json.dumps(result, sort_keys=True))
 
 
-def main() -> None:
-    """Run one trace against a fresh disposable real-server stack."""
-    if len(sys.argv) >= 4 and sys.argv[1] == "__mindroom_runtime_child__":
-        _run_mindroom_runtime_child(Path(sys.argv[2]), sys.argv[3:])
-        return
-    args = _parse_args()
-    if args.profile == "stress":
-        _run_stress_main(args)
-        return
+def _run_nonstress_main(args: argparse.Namespace) -> None:
+    """Run one fuzz, saturation, or chaos trace."""
     args.artifact_root = args.artifact_root or DEFAULT_ARTIFACT_ROOT
     nio_overlay: NioOverlay = args.nio_overlay
     scenario = _scenario_from_args(args)
@@ -6694,13 +6905,19 @@ def main() -> None:
     if reply_timeout is None:
         reply_timeout = _PROFILE_REPLY_TIMEOUTS[scenario.profile]
 
-    mindroom_revision = _required_mindroom_revision()
+    mindroom_runtime = _selected_mindroom_runtime(args.mindroom_runtime)
+    mindroom_revision = mindroom_runtime.revision
+    runner_revision = _required_runner_revision() if args.mindroom_runtime is not None else None
     run_id = f"{time.strftime('%Y%m%dT%H%M%S')}-{secrets.token_hex(4)}"
     bundle = FailureBundle.create(
         args.artifact_root,
         run_id,
         scenario=scenario,
-        provenance=_run_provenance(mindroom_revision),
+        provenance=_run_provenance(
+            mindroom_revision,
+            mindroom_root=mindroom_runtime.path,
+            runner_revision=runner_revision,
+        ),
     )
     stack = ManagedTuwunelStack(
         stream_profile=_PROFILE_STREAMS[scenario.profile],
@@ -6708,7 +6925,9 @@ def main() -> None:
         provenance_sink=bundle.update_provenance,
         artifact_directory=bundle.directory,
         nio_overlay=nio_overlay,
+        mindroom_root=mindroom_runtime.path,
         mindroom_revision=mindroom_revision,
+        runner_revision=runner_revision,
     )
     runner_holder: dict[str, LiveFuzzRunner] = {}
     try:
@@ -6758,6 +6977,18 @@ def main() -> None:
     # A passing run has no failure to preserve. Delete its bundle only after
     # teardown also succeeds, so a cleanup failure retains recovery evidence.
     bundle.discard()
+
+
+def main() -> None:
+    """Run one trace against a fresh disposable real-server stack."""
+    if len(sys.argv) >= 4 and sys.argv[1] == "__mindroom_runtime_child__":
+        _run_mindroom_runtime_child(Path(sys.argv[2]), sys.argv[3:])
+        return
+    args = _parse_args()
+    if args.profile == "stress":
+        _run_stress_main(args)
+        return
+    _run_nonstress_main(args)
 
 
 def _persist_failure_bundle(

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -5111,6 +5111,7 @@ class LiveMatrixStressRunner:
         self._journal_sequence = 0
         self._sent_content: dict[str, Mapping[str, Any]] = {}
         self._wave_log_ranges: list[tuple[int, int]] = []
+        self._sync_fences: list[dict[str, object]] = []
 
     def _terminal_body_complete(self, body: str) -> bool:
         if body in self._expected_stress_bodies:
@@ -5136,10 +5137,12 @@ class LiveMatrixStressRunner:
         for wave in range(self.config.waves):
             start_offset = self.stack.log_path.stat().st_size
             turns = await self._run_wave(wave, roots, reply_targets)
+            reply_targets = {turn.thread: self._one_response_event(turn.event_id) for turn in turns}
+            if wave + 1 < self.config.waves:
+                await self._wait_for_agent_sync_fence(wave, reply_targets[0])
             end_offset = self.stack.log_path.stat().st_size
             self._wave_log_ranges.append((start_offset, end_offset))
             turns_by_wave.append(turns)
-            reply_targets = {turn.thread: self._one_response_event(turn.event_id) for turn in turns}
 
         self.controller.assert_complete()
         self.stack.assert_stress_dependencies_healthy()
@@ -5181,8 +5184,49 @@ class LiveMatrixStressRunner:
             "cache_by_wave": [metrics.summary() for metrics in wave_cache_metrics],
             "runtime_log_metrics": complete_log_metrics.summary(),
             "performance_sample": asdict(performance_sample),
+            "sync_fences": self._sync_fences,
             "oracle": _sanitized_oracle_snapshot(self.oracle),
         }
+
+    async def _wait_for_agent_sync_fence(self, wave: int, target_event_id: str) -> None:
+        """Keep the next wave behind the agent's sync of all prior Matrix edits."""
+        postgres = self.stack.stress_postgres
+        if postgres is None:
+            msg = "stress sync fence requires PostgreSQL"
+            raise RuntimeError(msg)
+        started_at = time.monotonic()
+        event_id = await self.client.send_event(
+            "m.reaction",
+            f"live-stress-sync-fence-{wave}",
+            {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": target_event_id,
+                    "key": f"live-stress-sync-fence-{wave}",
+                },
+            },
+        )
+        self._record_journal(
+            {
+                "kind": "stress_sync_fence",
+                "after_wave": wave,
+                "event_id": event_id,
+            },
+        )
+        await asyncio.to_thread(
+            postgres.wait_for_cached_event,
+            base_namespace=self.stack.namespace,
+            principal_id=self.stack.agent_id,
+            room_id=self.stack.room_id,
+            event_id=event_id,
+            timeout_seconds=self.config.settlement_timeout_seconds,
+        )
+        self._sync_fences.append(
+            {
+                "after_wave": wave,
+                "cache_wait_ms": round((time.monotonic() - started_at) * 1000, 1),
+            },
+        )
 
     async def _prepare_history(self) -> tuple[dict[int, str], dict[int, str]]:
         """Create 50 roots plus one fast long history before the cold boundary."""

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -5544,12 +5544,7 @@ async def _sample_stress_resources(
     samples: list[ResourceSample],
 ) -> None:
     """Sample process, sync, Tuwunel, and PostgreSQL health at bounded cadence."""
-    pid = stack.mindroom_pid
-    if pid is None:
-        msg = "MindRoom process missing before stress resource sampling"
-        raise RuntimeError(msg)
-    process = psutil.Process(pid)
-    process.cpu_percent(None)
+    process: psutil.Process | None = None
     started_at = time.monotonic()
     async with httpx.AsyncClient(timeout=10) as client:
         while not stop.is_set():
@@ -5572,12 +5567,7 @@ async def _sample_stress_resources(
                 asyncio.to_thread(postgres.is_healthy) if postgres is not None else asyncio.sleep(0, result=False),
                 asyncio.to_thread(stack.tuwunel_is_healthy),
             )
-            try:
-                cpu_percent = process.cpu_percent(None)
-                rss_bytes = process.memory_info().rss
-            except psutil.Error:
-                cpu_percent = 0.0
-                rss_bytes = 0
+            process, cpu_percent, rss_bytes = _sample_mindroom_process(stack, process)
             samples.append(
                 ResourceSample(
                     offset_seconds=round(time.monotonic() - started_at, 3),
@@ -5596,6 +5586,25 @@ async def _sample_stress_resources(
                 )
             except TimeoutError:
                 continue
+
+
+def _sample_mindroom_process(
+    stack: ManagedTuwunelStack,
+    process: psutil.Process | None,
+) -> tuple[psutil.Process, float, int]:
+    """Sample the current runtime process, rebinding after managed restarts."""
+    pid = stack.mindroom_pid
+    if pid is None:
+        msg = "MindRoom process missing during stress resource sampling"
+        raise RuntimeError(msg)
+    if process is None or process.pid != pid:
+        process = psutil.Process(pid)
+        process.cpu_percent(None)
+    try:
+        return process, process.cpu_percent(None), process.memory_info().rss
+    except psutil.Error as exc:
+        msg = f"MindRoom process {pid} disappeared during stress resource sampling"
+        raise RuntimeError(msg) from exc
 
 
 async def _run_stress_live(
@@ -6903,7 +6912,7 @@ def _run_stress_main(args: argparse.Namespace) -> None:
         {"status": "PASS", "resources_removed": True},
     )
     result["artifact_directory"] = str(bundle.directory)
-    print(json.dumps(result, sort_keys=True))
+    print(json.dumps(bundle.sanitizer.value(result), sort_keys=True))
 
 
 def _run_nonstress_main(args: argparse.Namespace) -> None:

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -5942,6 +5942,7 @@ def _git_state_for_file(
     path: Path,
     *,
     scopes: Collection[Path] = (),
+    ignored_untracked_scopes: Collection[Path] = (),
 ) -> tuple[str | None, bool]:
     """Return the containing Git revision and whether its checkout is dirty."""
     root = _git_root_for_path(path)
@@ -5963,12 +5964,27 @@ def _git_state_for_file(
         str(scope.resolve().relative_to(root)) for scope in scopes or (path,) if scope.resolve().is_relative_to(root)
     ]
     status = subprocess.run(
-        ("git", "-C", str(root), "status", "--short", "--untracked-files=all", "--", *relative_scopes),
+        ("git", "-C", str(root), "status", "--porcelain=v1", "-z", "--untracked-files=all", "--", *relative_scopes),
         check=False,
         capture_output=True,
         text=True,
         timeout=10,
     )
+    ignored_untracked = tuple(
+        scope.resolve().relative_to(root) for scope in ignored_untracked_scopes if scope.resolve().is_relative_to(root)
+    )
+    dirty_entries = [
+        entry
+        for entry in status.stdout.split("\0")
+        if entry
+        and (
+            not entry.startswith("?? ")
+            or not any(
+                (candidate := Path(entry[3:])) == ignored or candidate.is_relative_to(ignored)
+                for ignored in ignored_untracked
+            )
+        )
+    ]
     revision = subprocess.run(
         ("git", "-C", str(root), "rev-parse", "HEAD"),
         check=False,
@@ -5978,7 +5994,15 @@ def _git_state_for_file(
     )
     return (
         revision.stdout.strip() if revision.returncode == 0 else None,
-        status.returncode != 0 or bool(status.stdout.strip()),
+        status.returncode != 0 or bool(dirty_entries),
+    )
+
+
+def _nio_build_metadata_paths(root: Path) -> tuple[Path, ...]:
+    """Return inert setuptools metadata locations created by editable builds."""
+    return (
+        root / "mindroom_nio.egg-info",
+        root / "src" / "mindroom_nio.egg-info",
     )
 
 
@@ -6079,6 +6103,7 @@ def _prepare_nio_overlay(path: Path | None) -> NioOverlay:
             root / "pyproject.toml",
             root / "uv.lock",
         ),
+        ignored_untracked_scopes=_nio_build_metadata_paths(root),
     )
     if revision is None:
         msg = f"could not verify exact mindroom-nio overlay revision: {root}"
@@ -6235,6 +6260,7 @@ def _validated_import_provenance(
             overlay_path / "pyproject.toml",
             overlay_path / "uv.lock",
         ),
+        ignored_untracked_scopes=_nio_build_metadata_paths(overlay_path),
     )
     if nio_revision != overlay.revision:
         msg = (

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -45,7 +45,6 @@ from urllib.parse import quote
 
 import httpx
 import nio
-import psutil
 import yaml
 
 import mindroom
@@ -104,6 +103,8 @@ else:
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
     from io import TextIOWrapper
+
+    import psutil
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 INSTANCE_REGISTRY = PROJECT_ROOT / "local" / "instances" / "deploy" / "instances.json"
@@ -5607,16 +5608,18 @@ def _sample_mindroom_process(
     process: psutil.Process | None,
 ) -> tuple[psutil.Process, float, int]:
     """Sample the current runtime process, rebinding after managed restarts."""
+    import psutil as psutil_module  # noqa: PLC0415
+
     pid = stack.mindroom_pid
     if pid is None:
         msg = "MindRoom process missing during stress resource sampling"
         raise RuntimeError(msg)
     if process is None or process.pid != pid:
-        process = psutil.Process(pid)
+        process = psutil_module.Process(pid)
         process.cpu_percent(None)
     try:
         return process, process.cpu_percent(None), process.memory_info().rss
-    except psutil.Error as exc:
+    except psutil_module.Error as exc:
         msg = f"MindRoom process {pid} disappeared during stress resource sampling"
         raise RuntimeError(msg) from exc
 

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -2103,7 +2103,12 @@ class ManagedTuwunelStack:
                     "startup_thread_prewarm": self.stress_config is None,
                 },
             },
-            "defaults": {"tools": [], "enable_streaming": True, "markdown": False},
+            "defaults": {
+                "tools": [],
+                "enable_streaming": True,
+                "markdown": False,
+                "thread_summary_first_threshold": 1_000_000 if self.stress_config is not None else 1,
+            },
             "memory": {"backend": "file"},
             "router": {
                 "model": "default",

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -5028,6 +5028,8 @@ class _StressWaveAudit:
     source_to_placeholder_ms: tuple[float, ...]
     source_to_first_content_ms: tuple[float, ...]
     source_to_final_ms: tuple[float, ...]
+    source_event_timestamps_ms: tuple[int, ...]
+    final_event_timestamps_ms: tuple[int, ...]
     matrix_edit_count: int
     streaming_status_counts: Mapping[str, int]
 
@@ -5119,8 +5121,14 @@ class LiveMatrixStressRunner:
         complete_log_metrics.assert_healthy(check_duplicate_repairs=False)
         self._assert_reservation_telemetry(complete_log_metrics)
         source_to_final = [latency for audit in audits for latency in audit.source_to_final_ms]
-        first_sent = min(turn.sent_at for turns in turns_by_wave for turn in turns)
-        wall_seconds = max(0.001, time.monotonic() - first_sent)
+        wall_seconds = max(
+            0.001,
+            (
+                max(timestamp for audit in audits for timestamp in audit.final_event_timestamps_ms)
+                - min(timestamp for audit in audits for timestamp in audit.source_event_timestamps_ms)
+            )
+            / 1000,
+        )
         performance_sample = BaselineSample(
             source_to_final_p95_ms=percentile(source_to_final, 95),
             source_to_final_p99_ms=percentile(source_to_final, 99),
@@ -5355,15 +5363,19 @@ class LiveMatrixStressRunner:
         placeholder_latencies: list[float] = []
         content_latencies: list[float] = []
         final_latencies: list[float] = []
+        source_timestamps: list[int] = []
+        final_timestamps: list[int] = []
         status_counts: Counter[str] = Counter()
         matrix_edit_count = 0
         for turn in turns:
-            metric, edit_timestamps, statuses = self._audit_turn(events, turn)
+            metric, edit_timestamps, statuses, source_ts, final_ts = self._audit_turn(events, turn)
             thread_metrics.append(metric)
             edits_by_stream[f"wave-{wave:02d}/thread-{turn.thread:03d}"] = edit_timestamps
             placeholder_latencies.append(cast("float", metric["source_to_placeholder_ms"]))
             content_latencies.append(cast("float", metric["source_to_first_content_ms"]))
             final_latencies.append(cast("float", metric["source_to_final_ms"]))
+            source_timestamps.append(source_ts)
+            final_timestamps.append(final_ts)
             matrix_edit_count += len(edit_timestamps)
             status_counts.update(statuses)
         return _StressWaveAudit(
@@ -5373,6 +5385,8 @@ class LiveMatrixStressRunner:
             source_to_placeholder_ms=tuple(placeholder_latencies),
             source_to_first_content_ms=tuple(content_latencies),
             source_to_final_ms=tuple(final_latencies),
+            source_event_timestamps_ms=tuple(source_timestamps),
+            final_event_timestamps_ms=tuple(final_timestamps),
             matrix_edit_count=matrix_edit_count,
             streaming_status_counts=dict(status_counts),
         )
@@ -5381,7 +5395,7 @@ class LiveMatrixStressRunner:
         self,
         events: Mapping[str, Mapping[str, Any]],
         turn: _StressTurn,
-    ) -> tuple[dict[str, object], tuple[float, ...], Counter[str]]:
+    ) -> tuple[dict[str, object], tuple[float, ...], Counter[str], int, int]:
         response_event_id = self._one_response_event(turn.event_id)
         response = events.get(response_event_id)
         source = events.get(turn.event_id)
@@ -5455,7 +5469,7 @@ class LiveMatrixStressRunner:
                 f"COMPLETE[wave={turn.wave};thread={turn.thread:03d};pulses={self.config.pulses_per_stream}]"
             ),
         }
-        return metric, edit_timestamps, statuses
+        return metric, edit_timestamps, statuses, source_ts, final_ts
 
     def _wave_log_texts(self) -> tuple[str, ...]:
         payload = self.stack.log_path.read_bytes()

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -1545,6 +1545,7 @@ class ManagedTuwunelStack:
         self._model_server: ThreadingHTTPServer | None = None
         self._model_thread: threading.Thread | None = None
         self._mindroom_process: subprocess.Popen[str] | None = None
+        self._mindroom_runtime_pid: int | None = None
         self._log_handle: TextIOWrapper | None = None
         self._env: dict[str, str] = {}
         self._provenance_sink = provenance_sink
@@ -1958,9 +1959,16 @@ class ManagedTuwunelStack:
 
     @property
     def mindroom_pid(self) -> int | None:
-        """Return the active MindRoom process ID for bounded resource sampling."""
+        """Return the managed process-group leader used for cleanup."""
         process = self._mindroom_process
         return process.pid if process is not None and process.poll() is None else None
+
+    @property
+    def mindroom_runtime_pid(self) -> int | None:
+        """Return the attested Python runtime process ID for resource sampling."""
+        if self.mindroom_pid is None:
+            return None
+        return self._mindroom_runtime_pid
 
     def assert_stress_dependencies_healthy(self) -> None:
         """Fail unless stress uses live Tuwunel, PostgreSQL, and the configured backend."""
@@ -2123,6 +2131,7 @@ class ManagedTuwunelStack:
         assert self._log_handle is not None
         overlay = self._required_nio_overlay()
         mindroom_root = self._selected_mindroom_root()
+        self._mindroom_runtime_pid = None
         self.attestation_path.unlink(missing_ok=True)
         self._mindroom_start_log_offset = self.log_path.stat().st_size if self.log_path.exists() else 0
         self._mindroom_process = subprocess.Popen(
@@ -2201,6 +2210,7 @@ class ManagedTuwunelStack:
                     **self._tuwunel_provenance(),
                     "runtime_generation": len(self._runtime_generations) + 1,
                 }
+                self._mindroom_runtime_pid = cast("int", generation["runtime_pid"])
                 self._runtime_generations.append(generation)
                 self.runtime_provenance = {
                     **generation,
@@ -2287,12 +2297,14 @@ class ManagedTuwunelStack:
     def _stop_mindroom(self, *, kill: bool = False) -> None:
         process = self._mindroom_process
         if process is None:
+            self._mindroom_runtime_pid = None
             return
         return_code = process.poll()
         if return_code is not None:
             with suppress(ProcessLookupError):
                 os.killpg(process.pid, signal.SIGKILL)
             self._mindroom_process = None
+            self._mindroom_runtime_pid = None
             msg = f"MindRoom exited before managed shutdown with status {return_code}"
             raise RuntimeError(msg)
         if kill:
@@ -2300,6 +2312,7 @@ class ManagedTuwunelStack:
                 os.killpg(process.pid, signal.SIGKILL)
             process.wait(timeout=10)
             self._mindroom_process = None
+            self._mindroom_runtime_pid = None
             return
         try:
             os.killpg(process.pid, signal.SIGINT)
@@ -2308,6 +2321,7 @@ class ManagedTuwunelStack:
                 return_code = process.wait(timeout=10)
             finally:
                 self._mindroom_process = None
+                self._mindroom_runtime_pid = None
             msg = f"MindRoom exited before managed SIGINT delivery with status {return_code}"
             raise RuntimeError(msg) from exc
         try:
@@ -2319,9 +2333,11 @@ class ManagedTuwunelStack:
                 process.wait(timeout=10)
             finally:
                 self._mindroom_process = None
+                self._mindroom_runtime_pid = None
             msg = "MindRoom ignored SIGINT and required SIGKILL"
             raise TimeoutError(msg) from exc
         self._mindroom_process = None
+        self._mindroom_runtime_pid = None
         expected_return_codes = {0, -int(signal.SIGINT), 128 + int(signal.SIGINT)}
         if return_code not in expected_return_codes:
             msg = f"MindRoom graceful shutdown exited with status {return_code}"
@@ -5617,7 +5633,7 @@ def _sample_mindroom_process(
     """Sample the current runtime process, rebinding after managed restarts."""
     import psutil as psutil_module  # noqa: PLC0415
 
-    pid = stack.mindroom_pid
+    pid = stack.mindroom_runtime_pid
     if pid is None:
         msg = "MindRoom process missing during stress resource sampling"
         raise RuntimeError(msg)
@@ -6057,13 +6073,18 @@ def _validated_child_provenance(
     if not isinstance(raw, dict):
         msg = "MindRoom runtime attestation must be a JSON object"
         raise TypeError(msg)
-    return _validated_import_provenance(
+    provenance = _validated_import_provenance(
         raw,
         overlay=overlay,
         expected_mindroom_revision=expected_mindroom_revision,
         expected_mindroom_root=expected_mindroom_root,
         expected_runner_revision=expected_runner_revision,
     )
+    runtime_pid = raw.get("runtime_pid")
+    if isinstance(runtime_pid, bool) or not isinstance(runtime_pid, int) or runtime_pid <= 0:
+        msg = "MindRoom runtime attestation omitted a valid runtime PID"
+        raise TypeError(msg)
+    return provenance
 
 
 def _validated_runner_provenance(expected_revision: str | None) -> dict[str, object]:
@@ -6225,6 +6246,7 @@ def _run_mindroom_runtime_child(attestation_path: Path, arguments: list[str]) ->
     payload = {
         "python": sys.version.split()[0],
         "platform": sys.platform,
+        "runtime_pid": os.getpid(),
         "mindroom_module_path": str(Path(mindroom_file).resolve()),
         "nio_module_path": str(Path(nio_file).resolve()),
         "nio_version": version("mindroom-nio"),

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -5,6 +5,8 @@ transport and the complete MindRoom sync/dispatch/cache path. It starts an
 isolated Tuwunel, a deterministic OpenAI-compatible stub, and the current
 worktree's MindRoom process. Every run uses disposable Matrix accounts and
 removes the isolated stack afterward.
+The stress profile routes its agent through MindRoom's built-in synthetic
+model while retaining the stub for lifecycle calls.
 
 Run with ``uv run python scripts/testing/fuzz_live_matrix.py --nio-overlay
 /path/to/clean/mindroom-nio --seed 42``.
@@ -63,14 +65,13 @@ if __package__:
         StressBaseline,
         StressConfig,
         StressLogMetrics,
-        StressModelController,
         StressRequest,
+        SyntheticStressAudit,
         aggregate_log_metrics,
         assert_matrix_edit_shape,
         assert_resource_health,
         current_machine_class,
         latency_summary,
-        parse_stress_request,
         parse_structured_log,
         percentile,
         resource_summary,
@@ -86,14 +87,13 @@ else:
         StressBaseline,
         StressConfig,
         StressLogMetrics,
-        StressModelController,
         StressRequest,
+        SyntheticStressAudit,
         aggregate_log_metrics,
         assert_matrix_edit_shape,
         assert_resource_health,
         current_machine_class,
         latency_summary,
-        parse_stress_request,
         parse_structured_log,
         percentile,
         resource_summary,
@@ -1093,8 +1093,6 @@ class _ModelHandler(BaseHTTPRequestHandler):
     slow_stream_segments = 120
     slow_stream_delay = 0.02
     first_token_delay = 0.0
-    stress_controller: ClassVar[StressModelController | None] = None
-
     # Class-level observation map guarded by a lock because the stub runs under a
     # ThreadingHTTPServer: concurrent MindRoom requests each land in their own
     # handler thread. Each entry records the source-revision markers seen on the
@@ -1197,32 +1195,6 @@ class _ModelHandler(BaseHTTPRequestHandler):
             return frozenset()
         return frozenset()
 
-    @staticmethod
-    def _final_user_text(payload: Mapping[str, object]) -> str:
-        """Return text from the final user message for stress-marker routing."""
-        messages = payload.get("messages")
-        if not isinstance(messages, list):
-            return ""
-        for raw_message in reversed(messages):
-            if not isinstance(raw_message, dict):
-                continue
-            message = cast("dict[str, object]", raw_message)
-            if message.get("role") != "user":
-                continue
-            content = message.get("content")
-            if isinstance(content, str):
-                return content
-            if isinstance(content, list):
-                return " ".join(
-                    text
-                    for part in content
-                    if isinstance(part, dict)
-                    for text in (cast("dict[str, object]", part).get("text"),)
-                    if isinstance(text, str)
-                )
-            return ""
-        return ""
-
     def do_POST(self) -> None:
         if self.path.rstrip("/") != "/v1/chat/completions":
             self.send_error(HTTPStatus.NOT_FOUND)
@@ -1231,16 +1203,6 @@ class _ModelHandler(BaseHTTPRequestHandler):
         payload = json.loads(self.rfile.read(content_length))
         call_id = next(self.call_ids)
         self._record_observation(call_id, self._final_user_markers(payload))
-        stress_request = parse_stress_request(self._final_user_text(payload)) if payload.get("stream") is True else None
-        if stress_request is not None:
-            if self.stress_controller is None:
-                self.send_error(HTTPStatus.BAD_REQUEST, "stress requests require the armed streaming controller")
-                return
-            try:
-                self._send_stress_stream(call_id, stress_request)
-            except OSError:
-                self.close_connection = True
-            return
         content = self._response_text(call_id)
         if self._is_slow_call(call_id) and self.first_token_delay > 0:
             time.sleep(self.first_token_delay)
@@ -1317,50 +1279,6 @@ class _ModelHandler(BaseHTTPRequestHandler):
                 },
             )
             time.sleep(chunk_delay)
-        self._write_sse(
-            {
-                **base,
-                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-            },
-        )
-        self.wfile.write(b"data: [DONE]\n\n")
-        self.wfile.flush()
-        self.close_connection = True
-
-    def _send_stress_stream(self, call_id: int, request: StressRequest) -> None:
-        """Emit exact controller-owned stress pulses through OpenAI SSE."""
-        controller = self.stress_controller
-        assert controller is not None
-        self.send_response(HTTPStatus.OK)
-        self.send_header("Content-Type", "text/event-stream")
-        self.send_header("Cache-Control", "no-cache")
-        self.send_header("Connection", "close")
-        self.end_headers()
-        base = {
-            "id": f"live-stress-response-{call_id}",
-            "object": "chat.completion.chunk",
-            "created": int(time.time()),
-            "model": MODEL_ID,
-        }
-        self._write_sse(
-            {
-                **base,
-                "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
-            },
-        )
-        for chunk in controller.stream(request):
-            self._write_sse(
-                {
-                    **base,
-                    "choices": [
-                        {
-                            "index": 0,
-                            "delta": {"content": chunk},
-                            "finish_reason": None,
-                        },
-                    ],
-                },
-            )
         self._write_sse(
             {
                 **base,
@@ -1531,6 +1449,7 @@ class ManagedTuwunelStack:
         self.storage_path = self.root / "mindroom_data"
         self.config_path = self.root / "config.yaml"
         self.log_path = self.root / "mindroom.log"
+        self.synthetic_telemetry_path = self.root / "synthetic-model.jsonl"
         self.attestation_path = self.root / "runtime-attestation.json"
         self.runtime_provenance: dict[str, object] | None = None
         self._runtime_generations: list[dict[str, object]] = []
@@ -1558,13 +1477,8 @@ class ManagedTuwunelStack:
         self._host_lease: TextIOWrapper | None = None
         self._mindroom_start_log_offset = 0
         self.stress_config = stress_config
-        self.stress_controller = (
-            StressModelController(
-                stress_config,
-                serialize_streams=stress_config.fault_mode == "serialize-streams",
-            )
-            if stress_config is not None
-            else None
+        self.stress_audit = (
+            SyntheticStressAudit(stress_config, self.synthetic_telemetry_path) if stress_config is not None else None
         )
         self.stress_postgres = (
             ManagedStressPostgres(f"{self.instance_name}-postgres") if stress_config is not None else None
@@ -1893,7 +1807,6 @@ class ManagedTuwunelStack:
             _attempt_cleanup(errors, "stop model server", server.shutdown)
             _attempt_cleanup(errors, "close model server", server.server_close)
             self._model_server = None
-            _ModelHandler.stress_controller = None
         if self._model_thread is not None:
             thread = self._model_thread
             if _attempt_cleanup(
@@ -2062,7 +1975,6 @@ class ManagedTuwunelStack:
         _ModelHandler.slow_stream_segments = profile.slow_stream_segments
         _ModelHandler.slow_stream_delay = profile.slow_stream_delay
         _ModelHandler.first_token_delay = profile.first_token_delay
-        _ModelHandler.stress_controller = self.stress_controller
         self._model_server = ThreadingHTTPServer(("127.0.0.1", 0), _ModelHandler)
         port = self._model_server.server_address[1]
         self._model_thread = threading.Thread(
@@ -2077,27 +1989,49 @@ class ManagedTuwunelStack:
         model_extra_kwargs: dict[str, object] = {
             "base_url": f"http://127.0.0.1:{model_port}/v1",
         }
-        if self.stress_config is not None:
-            model_extra_kwargs.update(
-                {
-                    "timeout": (self.stress_config.barrier_timeout_seconds + self.stress_config.stream_seconds + 30),
-                    "max_retries": 0,
-                },
-            )
-        config = {
-            "models": {
-                "default": {
-                    "provider": "openai",
-                    "id": MODEL_ID,
-                    "extra_kwargs": model_extra_kwargs,
-                },
+        models: dict[str, object] = {
+            "default": {
+                "provider": "openai",
+                "id": MODEL_ID,
+                "extra_kwargs": model_extra_kwargs,
             },
+        }
+        agent_model = "default"
+        agent_tools: list[str] = []
+        if self.stress_config is not None:
+            stress = self.stress_config
+            models["stress"] = {
+                "provider": "synthetic",
+                "id": "live-matrix-stress",
+                "extra_kwargs": {
+                    "seed": stress.seed,
+                    "min_response_chars": stress.min_response_chars,
+                    "max_response_chars": stress.max_response_chars,
+                    "chunk_chars": stress.chunk_chars,
+                    "chars_per_second": stress.chars_per_second,
+                    "tool_call_probability": stress.tool_call_probability,
+                    "min_sleep_seconds": stress.min_sleep_seconds,
+                    "max_sleep_seconds": stress.max_sleep_seconds,
+                    "identity_pattern": r"LMS\[wave=\d+;thread=\d+;seed=-?\d+\]",
+                    "activation_pattern": r"LMS\[wave=\d+;thread=\d+;seed=-?\d+\]",
+                    "barrier_size": stress.threads,
+                    "barrier_group_pattern": r"LMS\[wave=(\d+);",
+                    "barrier_timeout_seconds": stress.barrier_timeout_seconds,
+                    "serialize_streams": stress.fault_mode == "serialize-streams",
+                    "telemetry_path": str(self.synthetic_telemetry_path),
+                    "coordination_key": self.namespace,
+                },
+            }
+            agent_model = "stress"
+            agent_tools = ["sleep"]
+        config = {
+            "models": models,
             "agents": {
                 AGENT_NAME: {
                     "display_name": "Live Fuzz Agent",
                     "role": "Return a deterministic acknowledgement.",
-                    "model": "default",
-                    "tools": [],
+                    "model": agent_model,
+                    "tools": agent_tools,
                     "rooms": list(self.room_keys),
                     "learning": False,
                     "startup_thread_prewarm": self.stress_config is None,
@@ -5048,6 +4982,7 @@ class _StressTurn:
     label: str
     wave: int
     thread: int
+    room_id: str
     event_id: str
     thread_root: str
     sent_at: float
@@ -5091,14 +5026,14 @@ class LiveMatrixStressRunner:
         *,
         journal: Callable[[Mapping[str, object]], None] | None = None,
     ) -> None:
-        controller = stack.stress_controller
-        if controller is None:
-            msg = "live stress runner requires an armed stress model controller"
+        audit = stack.stress_audit
+        if audit is None:
+            msg = "live stress runner requires an armed synthetic model audit"
             raise RuntimeError(msg)
         self.stack = stack
         self.client = client
         self.config = config
-        self.controller = controller
+        self.model_audit = audit
         self.journal = journal
         self._expected_stress_bodies: set[str] = set()
         self.oracle = ExactReplyOracle(
@@ -5114,7 +5049,7 @@ class LiveMatrixStressRunner:
         self._sync_fences: list[dict[str, object]] = []
 
     def _terminal_body_complete(self, body: str) -> bool:
-        if body in self._expected_stress_bodies:
+        if body == "SYNTHETIC READY" or body in self._expected_stress_bodies:
             return True
         call_id = _body_call_id(body)
         return call_id is not None and body == _ModelHandler.response_text_for(call_id)
@@ -5139,12 +5074,12 @@ class LiveMatrixStressRunner:
             turns = await self._run_wave(wave, roots, reply_targets)
             reply_targets = {turn.thread: self._one_response_event(turn.event_id) for turn in turns}
             if wave + 1 < self.config.waves:
-                await self._wait_for_agent_sync_fence(wave, reply_targets[0])
+                await self._wait_for_agent_sync_fence(wave, reply_targets)
             end_offset = self.stack.log_path.stat().st_size
             self._wave_log_ranges.append((start_offset, end_offset))
             turns_by_wave.append(turns)
 
-        self.controller.assert_complete()
+        self.model_audit.assert_complete()
         self.stack.assert_stress_dependencies_healthy()
         events = await self._paginate_canonical_events()
         audits = tuple(self._audit_wave(events, wave, turns) for wave, turns in enumerate(turns_by_wave))
@@ -5178,7 +5113,7 @@ class LiveMatrixStressRunner:
             "hot_history_turns": self.config.history_turns,
             "waves": [audit.summary() for audit in audits],
             "per_thread": [metric for audit in audits for metric in audit.thread_metrics],
-            "model": self.controller.snapshot(),
+            "model": self.model_audit.snapshot(),
             "matrix_edit_count": sum(audit.matrix_edit_count for audit in audits),
             "matrix_edit_activity": matrix_edit_activity,
             "cache_by_wave": [metrics.summary() for metrics in wave_cache_metrics],
@@ -5188,48 +5123,67 @@ class LiveMatrixStressRunner:
             "oracle": _sanitized_oracle_snapshot(self.oracle),
         }
 
-    async def _wait_for_agent_sync_fence(self, wave: int, target_event_id: str) -> None:
+    async def _wait_for_agent_sync_fence(
+        self,
+        wave: int,
+        reply_targets: Mapping[int, str],
+    ) -> None:
         """Keep the next wave behind the agent's sync of all prior Matrix edits."""
         postgres = self.stack.stress_postgres
         if postgres is None:
             msg = "stress sync fence requires PostgreSQL"
             raise RuntimeError(msg)
         started_at = time.monotonic()
-        event_id = await self.client.send_event(
-            "m.reaction",
-            f"live-stress-sync-fence-{wave}",
-            {
-                "m.relates_to": {
-                    "rel_type": "m.annotation",
-                    "event_id": target_event_id,
-                    "key": f"live-stress-sync-fence-{wave}",
+        first_thread_by_room = {
+            self._room_id_for_thread(thread): thread for thread in reversed(range(self.config.threads))
+        }
+        fences: list[tuple[str, str]] = []
+        for room_index, room_id in enumerate(self.client.room_ids):
+            thread = first_thread_by_room[room_id]
+            event_id = await self.client.send_event(
+                "m.reaction",
+                f"live-stress-sync-fence-{wave}-{room_index}",
+                {
+                    "m.relates_to": {
+                        "rel_type": "m.annotation",
+                        "event_id": reply_targets[thread],
+                        "key": f"live-stress-sync-fence-{wave}",
+                    },
                 },
-            },
-        )
-        self._record_journal(
-            {
-                "kind": "stress_sync_fence",
-                "after_wave": wave,
-                "event_id": event_id,
-            },
-        )
-        await asyncio.to_thread(
-            postgres.wait_for_cached_event,
-            base_namespace=self.stack.namespace,
-            principal_id=self.stack.agent_id,
-            room_id=self.stack.room_id,
-            event_id=event_id,
-            timeout_seconds=self.config.settlement_timeout_seconds,
+                room_id=room_id,
+            )
+            fences.append((room_id, event_id))
+            self._record_journal(
+                {
+                    "kind": "stress_sync_fence",
+                    "after_wave": wave,
+                    "room": room_index,
+                    "event_id": event_id,
+                },
+            )
+        await asyncio.gather(
+            *(
+                asyncio.to_thread(
+                    postgres.wait_for_cached_event,
+                    base_namespace=self.stack.namespace,
+                    principal_id=self.stack.agent_id,
+                    room_id=room_id,
+                    event_id=event_id,
+                    timeout_seconds=self.config.settlement_timeout_seconds,
+                )
+                for room_id, event_id in fences
+            ),
         )
         self._sync_fences.append(
             {
                 "after_wave": wave,
+                "rooms": len(fences),
                 "cache_wait_ms": round((time.monotonic() - started_at) * 1000, 1),
             },
         )
 
     async def _prepare_history(self) -> tuple[dict[int, str], dict[int, str]]:
-        """Create 50 roots plus one fast long history before the cold boundary."""
+        """Create configured roots plus one fast long history before the cold boundary."""
         root_results = await self._send_many(
             (
                 (
@@ -5279,7 +5233,7 @@ class LiveMatrixStressRunner:
         requests = tuple(
             StressRequest(wave=wave, thread=thread, seed=self.config.seed) for thread in range(self.config.threads)
         )
-        self._expected_stress_bodies.update(self.controller.expected_body(request) for request in requests)
+        self._expected_stress_bodies.update(self.model_audit.expected_body(request) for request in requests)
         sent_results = await self._send_many(
             (
                 (
@@ -5297,6 +5251,7 @@ class LiveMatrixStressRunner:
                 label=label,
                 wave=wave,
                 thread=thread,
+                room_id=self._room_id_for_thread(thread),
                 event_id=event_id,
                 thread_root=roots[thread],
                 sent_at=self.oracle.sent_at[event_id],
@@ -5320,13 +5275,13 @@ class LiveMatrixStressRunner:
     ) -> None:
         """Send deterministic queued follow-ups after every wave stream starts."""
         deadline = time.monotonic() + self.config.barrier_timeout_seconds
-        while self.controller.reached_count(wave) < self.config.threads:
+        while self.model_audit.reached_count(wave) < self.config.threads:
             if time.monotonic() >= deadline:
-                reached = self.controller.reached_count(wave)
+                reached = self.model_audit.reached_count(wave)
                 msg = f"overlap phase barrier reached {reached}/{self.config.threads}"
                 raise TimeoutError(msg)
             await asyncio.sleep(0.05)
-        await asyncio.sleep(min(self.config.stream_seconds / 2, self.config.edit_interval * 2))
+        await asyncio.sleep(self.config.edit_interval * 2)
         await self._send_many(
             (
                 (
@@ -5373,11 +5328,13 @@ class LiveMatrixStressRunner:
             if relation is not None:
                 content["m.relates_to"] = relation
             sent_at = time.monotonic()
+            room_id = self._room_id_for_thread(thread)
             try:
                 event_id = await self.client.send_event(
                     "m.room.message",
                     f"live-stress-{label.replace(':', '-')}",
                     content,
+                    room_id=room_id,
                 )
                 self.oracle.expect(
                     label,
@@ -5393,6 +5350,7 @@ class LiveMatrixStressRunner:
                         "label": label,
                         "wave": _wave_from_label(label),
                         "thread": thread,
+                        "room": self.client.room_ids.index(room_id),
                         "event_id": event_id,
                     },
                 )
@@ -5425,10 +5383,11 @@ class LiveMatrixStressRunner:
 
     async def _paginate_canonical_events(self) -> dict[str, dict[str, Any]]:
         events: dict[str, dict[str, Any]] = {}
-        for event in await self.client.paginate_room(self.stack.room_id):
-            event_id = event.get("event_id")
-            if isinstance(event_id, str) and event_id not in events:
-                events[event_id] = event
+        for room_id in self.client.room_ids:
+            for event in await self.client.paginate_room(room_id):
+                event_id = event.get("event_id")
+                if isinstance(event_id, str) and event_id not in events:
+                    events[event_id] = {**event, "_stress_room_id": room_id}
         return events
 
     def _audit_wave(
@@ -5498,14 +5457,23 @@ class LiveMatrixStressRunner:
             )
             for index, event in enumerate(ordered_events)
         ]
+        for event in (source, response, *ordered_replacements):
+            if event.get("_stress_room_id") != turn.room_id:
+                msg = f"cross-room stress event for {turn.label}"
+                raise AssertionError(msg)
         request = StressRequest(wave=turn.wave, thread=turn.thread, seed=self.config.seed)
-        expected_body = self.controller.expected_body(request)
+        plan = self.model_audit.plan(request)
+        expected_body = plan.body
         if not bodies or bodies[-1] != expected_body:
             msg = f"stress final content mismatch for {turn.label}"
             raise AssertionError(msg)
-        pulse_numbers = [_last_stress_pulse(body) for body in bodies if body is not None and "SYNTHETIC wave=" in body]
-        if pulse_numbers != sorted(pulse_numbers):
-            msg = f"same-thread edit ordering violation for {turn.label}: {pulse_numbers}"
+        progress_lengths = [
+            _matching_prefix_length(body, expected_body)
+            for body in bodies
+            if body is not None and body.startswith("SYNTHETIC[")
+        ]
+        if progress_lengths != sorted(progress_lengths):
+            msg = f"same-thread edit ordering violation for {turn.label}: {progress_lengths}"
             raise AssertionError(msg)
         statuses = Counter(
             status
@@ -5521,7 +5489,7 @@ class LiveMatrixStressRunner:
         content_events = [
             event
             for event, body in zip(ordered_events, bodies, strict=True)
-            if body is not None and "SYNTHETIC wave=" in body
+            if body is not None and body.startswith("SYNTHETIC[")
         ]
         if not content_events:
             msg = f"stress response {turn.label} never exposed streamed content"
@@ -5544,11 +5512,12 @@ class LiveMatrixStressRunner:
                     )
                 ],
             ),
-            "final_completion_marker": (
-                f"COMPLETE[wave={turn.wave};thread={turn.thread:03d};pulses={self.config.pulses_per_stream}]"
-            ),
+            "final_completion_marker": (f"COMPLETE[{plan.request_id}]"),
         }
         return metric, edit_timestamps, statuses, source_ts, final_ts
+
+    def _room_id_for_thread(self, thread: int) -> str:
+        return self.client.room_ids[thread % len(self.client.room_ids)]
 
     def _wave_log_texts(self) -> tuple[str, ...]:
         payload = self.stack.log_path.read_bytes()
@@ -5611,12 +5580,12 @@ def _stream_status(event: Mapping[str, Any], *, is_edit: bool) -> str | None:
     return status if isinstance(status, str) else None
 
 
-def _last_stress_pulse(body: str) -> int:
-    matches = re.findall(r"\bpulse=(\d{3})/\d{3}", body)
-    if not matches:
-        msg = "stress body omitted pulse marker"
-        raise AssertionError(msg)
-    return int(matches[-1])
+def _matching_prefix_length(body: str, expected: str) -> int:
+    """Return how much exact synthetic content one visible edit exposes."""
+    return next(
+        (index for index, (actual, planned) in enumerate(zip(body, expected, strict=False)) if actual != planned),
+        min(len(body), len(expected)),
+    )
 
 
 def _required_event_timestamp(event: Mapping[str, Any], label: str) -> int:
@@ -5706,7 +5675,8 @@ async def _run_stress_live(
     journal: Callable[[Mapping[str, object]], None] | None = None,
 ) -> dict[str, object]:
     """Own the Matrix client and sampler around one complete stress run."""
-    client = LiveMatrixClient(stack.homeserver, stack.room_id)
+    room_ids = tuple(stack.room_ids[room_key] for room_key in stack.room_keys)
+    client = LiveMatrixClient(stack.homeserver, stack.room_id, room_ids=room_ids)
     runner = LiveMatrixStressRunner(stack, client, config, journal=journal)
     stop_sampler = asyncio.Event()
     resource_samples: list[ResourceSample] = []
@@ -5755,6 +5725,14 @@ def _positive_float(value: str) -> float:
     return parsed
 
 
+def _probability(value: str) -> float:
+    parsed = float(value)
+    if not 0 <= parsed <= 1:
+        msg = "must be between 0 and 1"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
 def _parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -5785,6 +5763,10 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--threads", type=_positive_int)
     parser.add_argument("--stream-seconds", type=_positive_float, default=45.0)
     parser.add_argument("--edit-interval", type=_positive_float, default=0.5)
+    parser.add_argument("--chars-per-second", type=_positive_float, default=80.0)
+    parser.add_argument("--tool-call-probability", type=_probability, default=1.0)
+    parser.add_argument("--min-sleep-seconds", type=_non_negative_int, default=1)
+    parser.add_argument("--max-sleep-seconds", type=_non_negative_int, default=3)
     parser.add_argument("--waves", type=_positive_int, default=2)
     parser.add_argument("--history-turns", type=_non_negative_int, default=20)
     parser.add_argument("--cache-backend", choices=("postgres",), default="postgres")
@@ -5801,7 +5783,11 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--max-batch-size", type=_positive_int, default=16)
     parser.add_argument("--restart-interval", type=_non_negative_int, default=100)
     parser.add_argument("--clients", type=_positive_int, default=4, help="chaos senders racing concurrently")
-    parser.add_argument("--rooms", type=_positive_int, default=2, help="chaos rooms hosting threads")
+    parser.add_argument(
+        "--rooms",
+        type=_positive_int,
+        help="rooms hosting chaos or stress threads (default: 2 chaos, 10 stress)",
+    )
     parser.add_argument("--hot-thread-weight", type=_positive_int, default=6)
     parser.add_argument("--checkpoint-interval", type=_non_negative_int, default=40)
     parser.add_argument("--lifecycle-interval", type=_non_negative_int, default=70)
@@ -5897,7 +5883,7 @@ def _scenario_from_args(args: argparse.Namespace) -> LiveFuzzScenario:
             tuning=ChaosTuning(
                 thread_count=args.threads or 45,
                 client_count=args.clients,
-                room_count=args.rooms,
+                room_count=args.rooms or 2,
                 max_batch_size=args.max_batch_size,
                 hot_thread_weight=args.hot_thread_weight,
                 checkpoint_interval=args.checkpoint_interval,
@@ -6707,9 +6693,14 @@ def _stress_config_from_args(args: argparse.Namespace) -> StressConfig:
         _require_persistent_stress_path(args.trace)
         return StressConfig.from_json(args.trace.read_text(encoding="utf-8"))
     config = StressConfig(
-        threads=args.threads or 50,
+        threads=args.threads or 100,
+        rooms=args.rooms or 10,
         stream_seconds=args.stream_seconds,
         edit_interval=args.edit_interval,
+        chars_per_second=args.chars_per_second,
+        tool_call_probability=args.tool_call_probability,
+        min_sleep_seconds=args.min_sleep_seconds,
+        max_sleep_seconds=args.max_sleep_seconds,
         waves=args.waves,
         history_turns=args.history_turns,
         cache_backend=args.cache_backend,
@@ -6730,7 +6721,9 @@ def _require_persistent_stress_path(path: Path) -> None:
 
 
 def _stress_profile_name(config: StressConfig) -> str:
-    return f"stress-{config.threads}x{config.stream_seconds:g}s-{config.edit_interval:g}s-{config.waves}w"
+    return (
+        f"stress-{config.threads}t-{config.rooms}r-{config.stream_seconds:g}s-{config.edit_interval:g}s-{config.waves}w"
+    )
 
 
 def _stress_config_sha256(config: StressConfig) -> str:
@@ -6938,7 +6931,7 @@ def _run_stress_main(args: argparse.Namespace) -> None:
     journal: list[Mapping[str, object]] = []
     bundle.write_json("scenario.json", json.loads(config.to_json()))
     stack = ManagedTuwunelStack(
-        room_keys=(ROOM_KEY,),
+        room_keys=(ROOM_KEY, *(f"stress{index}" for index in range(1, config.rooms))),
         provenance_sink=lambda provenance: bundle.write_json(
             "git-runtime-provenance.json",
             provenance,

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -1228,9 +1228,9 @@ class _ModelHandler(BaseHTTPRequestHandler):
         payload = json.loads(self.rfile.read(content_length))
         call_id = next(self.call_ids)
         self._record_observation(call_id, self._final_user_markers(payload))
-        stress_request = parse_stress_request(self._final_user_text(payload))
+        stress_request = parse_stress_request(self._final_user_text(payload)) if payload.get("stream") is True else None
         if stress_request is not None:
-            if payload.get("stream") is not True or self.stress_controller is None:
+            if self.stress_controller is None:
                 self.send_error(HTTPStatus.BAD_REQUEST, "stress requests require the armed streaming controller")
                 return
             try:

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -2063,12 +2063,22 @@ class ManagedTuwunelStack:
         return port
 
     def _write_config(self, model_port: int) -> None:
+        model_extra_kwargs: dict[str, object] = {
+            "base_url": f"http://127.0.0.1:{model_port}/v1",
+        }
+        if self.stress_config is not None:
+            model_extra_kwargs.update(
+                {
+                    "timeout": (self.stress_config.barrier_timeout_seconds + self.stress_config.stream_seconds + 30),
+                    "max_retries": 0,
+                },
+            )
         config = {
             "models": {
                 "default": {
                     "provider": "openai",
                     "id": MODEL_ID,
-                    "extra_kwargs": {"base_url": f"http://127.0.0.1:{model_port}/v1"},
+                    "extra_kwargs": model_extra_kwargs,
                 },
             },
             "agents": {

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -1980,11 +1980,12 @@ class ManagedTuwunelStack:
             raise RuntimeError(msg)
 
     def clear_stress_cache(self) -> None:
-        """Create a real cold-cache boundary without replacing certification metadata."""
+        """Create a cold cache boundary while preserving sync and certification state."""
         if self.stress_postgres is None:
             msg = "cannot clear stress cache on a non-stress stack"
             raise RuntimeError(msg)
         self.stress_postgres.clear_cache_namespace(self.namespace)
+        self.restart_mindroom()
 
     def stress_postgres_diagnostics(self) -> Mapping[str, object]:
         """Return exact synthetic PostgreSQL diagnostics for artifact capture."""

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -1517,6 +1517,7 @@ class ManagedTuwunelStack:
         mindroom_revision: str | None = None,
         runner_revision: str | None = None,
         stress_config: StressConfig | None = None,
+        api_port: int | None = None,
     ) -> None:
         token = secrets.token_hex(4)
         self._stream_profile = stream_profile or StreamProfile()
@@ -1553,6 +1554,7 @@ class ManagedTuwunelStack:
         self._mindroom_root = mindroom_root.resolve() if mindroom_root is not None else None
         self._mindroom_revision = mindroom_revision
         self._runner_revision = runner_revision
+        self._requested_api_port = api_port
         self._host_lease: TextIOWrapper | None = None
         self._mindroom_start_log_offset = 0
         self.stress_config = stress_config
@@ -1756,7 +1758,8 @@ class ManagedTuwunelStack:
         registry = json.loads(INSTANCE_REGISTRY.read_text(encoding="utf-8"))
         instance = registry["instances"][self.instance_name]
         matrix_port = int(instance["matrix_port"])
-        self.api_port = int(instance["mindroom_port"])
+        allocated_api_port = int(instance["mindroom_port"])
+        self.api_port = self._requested_api_port if self._requested_api_port is not None else allocated_api_port
         domain = str(instance["domain"])
         self.homeserver = f"http://127.0.0.1:{matrix_port}"
         self.server_name = f"m-{domain}"
@@ -5716,6 +5719,11 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         help="clean exact MindRoom checkout loaded by the child; defaults to this harness checkout",
     )
+    parser.add_argument(
+        "--api-port",
+        type=_positive_int,
+        help="explicit isolated MindRoom API port; defaults to local instance allocation",
+    )
     parser.add_argument("--profile", choices=("fuzz", "saturation", "chaos", "stress"), default="fuzz")
     parser.add_argument("--seed", type=int, default=1)
     parser.add_argument("--steps", type=_positive_int, default=200)
@@ -6886,6 +6894,7 @@ def _run_stress_main(args: argparse.Namespace) -> None:
         mindroom_revision=mindroom_revision,
         runner_revision=runner_revision,
         stress_config=config,
+        api_port=args.api_port,
     )
     result: dict[str, object] | None = None
     baseline_comparison: Mapping[str, object] | None = None
@@ -6995,6 +7004,7 @@ def _run_nonstress_main(args: argparse.Namespace) -> None:
         mindroom_root=mindroom_runtime.path,
         mindroom_revision=mindroom_revision,
         runner_revision=runner_revision,
+        api_port=args.api_port,
     )
     runner_holder: dict[str, LiveFuzzRunner] = {}
     try:

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -1703,7 +1703,9 @@ class ManagedTuwunelStack:
                 {
                     "MINDROOM_EVENT_CACHE_DATABASE_URL": self.stress_postgres.database_url,
                     "MINDROOM_LOG_FORMAT": "json",
-                    "MINDROOM_LOG_LEVEL": "DEBUG",
+                    "MINDROOM_LOGGER_LEVELS": (
+                        "mindroom.timing:DEBUG,mindroom.matrix.cache.outbound_thread_reservations:DEBUG"
+                    ),
                     "MINDROOM_TIMING": "1",
                 },
             )
@@ -2092,7 +2094,7 @@ class ManagedTuwunelStack:
                 "--api-port",
                 str(self.api_port),
                 "--log-level",
-                "DEBUG" if self.stress_config is not None else "INFO",
+                "INFO",
             ],
             cwd=mindroom_root,
             env=self._env,

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -2493,14 +2493,14 @@ class LiveMatrixClient:
         for room_id in self.room_ids:
             room = joined.get(room_id, {}) if isinstance(joined, dict) else {}
             timeline = room.get("timeline", {}) if isinstance(room, dict) else {}
-            if timeline.get("limited") is True and not allow_limited:
-                msg = "incremental Matrix fuzz sync unexpectedly returned a limited timeline"
-                raise AssertionError(msg)
             events = timeline.get("events", [])
             if not isinstance(events, list):
                 msg = "Matrix sync room timeline events must be a list"
                 raise TypeError(msg)
-            for raw_event in events:
+            recovered_events: list[Mapping[str, Any]] = []
+            if timeline.get("limited") is True and not allow_limited:
+                recovered_events = await self.paginate_room(room_id)
+            for raw_event in [*recovered_events, *events]:
                 if not isinstance(raw_event, dict):
                     continue
                 event = cast("dict[str, Any]", raw_event)
@@ -2952,13 +2952,13 @@ class ExactReplyOracle:
             for room_id in self.client.room_ids:
                 room = joined.get(room_id, {}) if isinstance(joined, dict) else {}
                 timeline = room.get("timeline", {}) if isinstance(room, dict) else {}
-                if timeline.get("limited") is True and not allow_limited:
-                    msg = "live fuzz oracle received a limited timeline; reduce batch size"
-                    raise AssertionError(msg)
                 events = timeline.get("events", [])
                 if not isinstance(events, list):
                     continue
-                for raw_event in events:
+                recovered_events: list[Mapping[str, Any]] = []
+                if timeline.get("limited") is True and not allow_limited:
+                    recovered_events = await self.client.paginate_room(room_id)
+                for raw_event in [*recovered_events, *events]:
                     if isinstance(raw_event, dict):
                         self._ingest_event(raw_event)
 

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -5500,9 +5500,6 @@ class LiveMatrixStressRunner:
             msg = f"cold wave produced {cold.full_scans}/{self.config.threads} full scans"
             raise AssertionError(msg)
         for wave, warm in enumerate(metrics[1:], start=1):
-            if warm.full_scans:
-                msg = f"warm wave {wave} performed {warm.full_scans} redundant full scans"
-                raise AssertionError(msg)
             if warm.cache_hits < self.config.threads:
                 msg = f"warm wave {wave} produced {warm.cache_hits}/{self.config.threads} cache hits"
                 raise AssertionError(msg)

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -5773,6 +5773,12 @@ def _parse_args() -> argparse.Namespace:
         type=_positive_int,
         help="explicit isolated MindRoom API port; defaults to local instance allocation",
     )
+    parser.add_argument(
+        "--state-root",
+        type=Path,
+        default=DEFAULT_LIVE_FUZZ_STATE_ROOT,
+        help="persistent lease and crash-manifest root; use a separate root only with isolated resources",
+    )
     parser.add_argument("--profile", choices=("fuzz", "saturation", "chaos", "stress"), default="fuzz")
     parser.add_argument("--seed", type=int, default=1)
     parser.add_argument("--steps", type=_positive_int, default=200)
@@ -6944,6 +6950,7 @@ def _run_stress_main(args: argparse.Namespace) -> None:
         runner_revision=runner_revision,
         stress_config=config,
         api_port=args.api_port,
+        state_root=args.state_root,
     )
     result: dict[str, object] | None = None
     baseline_comparison: Mapping[str, object] | None = None
@@ -7054,6 +7061,7 @@ def _run_nonstress_main(args: argparse.Namespace) -> None:
         mindroom_revision=mindroom_revision,
         runner_revision=runner_revision,
         api_port=args.api_port,
+        state_root=args.state_root,
     )
     runner_holder: dict[str, LiveFuzzRunner] = {}
     try:

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -68,6 +68,7 @@ if __package__:
         StressRequest,
         aggregate_log_metrics,
         assert_matrix_edit_shape,
+        assert_resource_health,
         current_machine_class,
         latency_summary,
         parse_stress_request,
@@ -90,6 +91,7 @@ else:
         StressRequest,
         aggregate_log_metrics,
         assert_matrix_edit_shape,
+        assert_resource_health,
         current_machine_class,
         latency_summary,
         parse_stress_request,
@@ -5093,7 +5095,7 @@ class LiveMatrixStressRunner:
         events = await self._paginate_canonical_events()
         audits = tuple(self._audit_wave(events, wave, turns) for wave, turns in enumerate(turns_by_wave))
         all_edits = {label: edits for audit in audits for label, edits in audit.edits_by_stream.items()}
-        assert_matrix_edit_shape(self.config, all_edits)
+        matrix_edit_activity = assert_matrix_edit_shape(self.config, all_edits)
         wave_logs = self._wave_log_texts()
         wave_cache_metrics = tuple(aggregate_log_metrics(text) for text in wave_logs)
         self._assert_cache_wave_shape(wave_cache_metrics)
@@ -5118,6 +5120,7 @@ class LiveMatrixStressRunner:
             "per_thread": [metric for audit in audits for metric in audit.thread_metrics],
             "model": self.controller.snapshot(),
             "matrix_edit_count": sum(audit.matrix_edit_count for audit in audits),
+            "matrix_edit_activity": matrix_edit_activity,
             "cache_by_wave": [metrics.summary() for metrics in wave_cache_metrics],
             "runtime_log_metrics": complete_log_metrics.summary(),
             "performance_sample": asdict(performance_sample),
@@ -5615,13 +5618,7 @@ async def _run_stress_live(
                 msg = "live Matrix stress cleanup failed"
                 raise ExceptionGroup(msg, cleanup_errors)
     resources = resource_summary(resource_samples)
-    if resources["tuwunel_unhealthy_samples"] or resources["postgres_unhealthy_samples"]:
-        msg = f"stress dependency health sampling failed: {resources}"
-        raise AssertionError(msg)
-    health_latency = cast("Mapping[str, object]", resources["health_latency_ms"])
-    if health_latency.get("max", 0) > 5000:
-        msg = f"stress API health latency exceeded five-second watchdog boundary: {health_latency}"
-        raise AssertionError(msg)
+    assert_resource_health(resources)
     result["resources"] = resources
     result["resource_samples"] = [asdict(sample) for sample in resource_samples]
     return result

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -5100,7 +5100,7 @@ class LiveMatrixStressRunner:
         complete_log_metrics = aggregate_log_metrics(
             self.stack.log_path.read_text(encoding="utf-8", errors="replace"),
         )
-        complete_log_metrics.assert_healthy()
+        complete_log_metrics.assert_healthy(check_duplicate_repairs=False)
         self._assert_reservation_telemetry(complete_log_metrics)
         source_to_final = [latency for audit in audits for latency in audit.source_to_final_ms]
         first_sent = min(turn.sent_at for turns in turns_by_wave for turn in turns)
@@ -5451,6 +5451,8 @@ class LiveMatrixStressRunner:
         if len(metrics) != self.config.waves:
             msg = f"stress cache metrics cover {len(metrics)}/{self.config.waves} waves"
             raise AssertionError(msg)
+        for wave_metrics in metrics:
+            wave_metrics.assert_healthy()
         cold = metrics[0]
         if cold.full_scans < self.config.threads:
             msg = f"cold wave produced {cold.full_scans}/{self.config.threads} full scans"

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -5233,7 +5233,7 @@ class LiveMatrixStressRunner:
         requests = tuple(
             StressRequest(wave=wave, thread=thread, seed=self.config.seed) for thread in range(self.config.threads)
         )
-        self._expected_stress_bodies.update(self.model_audit.expected_body(request) for request in requests)
+        self._expected_stress_bodies.update(self.model_audit.expected_matrix_body(request) for request in requests)
         sent_results = await self._send_many(
             (
                 (
@@ -5463,7 +5463,7 @@ class LiveMatrixStressRunner:
                 raise AssertionError(msg)
         request = StressRequest(wave=turn.wave, thread=turn.thread, seed=self.config.seed)
         plan = self.model_audit.plan(request)
-        expected_body = plan.body
+        expected_body = self.model_audit.expected_matrix_body(request)
         if not bodies or bodies[-1] != expected_body:
             msg = f"stress final content mismatch for {turn.label}"
             raise AssertionError(msg)

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -31,9 +31,10 @@ import sys
 import tempfile
 import threading
 import time
-from collections import defaultdict
+from collections import Counter, defaultdict
 from contextlib import suppress
 from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
 from enum import StrEnum
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -44,16 +45,62 @@ from urllib.parse import quote
 
 import httpx
 import nio
+import psutil
 import yaml
 
 import mindroom
-from mindroom.constants import SOURCE_KIND_KEY
+from mindroom.constants import SOURCE_KIND_KEY, STREAM_STATUS_COMPLETED, STREAM_STATUS_KEY
 from mindroom.dispatch_source import AUTO_RESUME_MESSAGE, TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.handled_turns import TurnRecord, TurnRecordCodec
 from mindroom.streaming import INTERRUPTED_RESPONSE_NOTE, RESTART_INTERRUPTED_RESPONSE_NOTE
 
+if __package__:
+    from scripts.testing.live_matrix_stress import (
+        DEFAULT_STRESS_ARTIFACT_ROOT,
+        BaselineSample,
+        ManagedStressPostgres,
+        ResourceSample,
+        StressArtifactBundle,
+        StressBaseline,
+        StressConfig,
+        StressLogMetrics,
+        StressModelController,
+        StressRequest,
+        aggregate_log_metrics,
+        assert_matrix_edit_shape,
+        current_machine_class,
+        latency_summary,
+        parse_stress_request,
+        parse_structured_log,
+        percentile,
+        resource_summary,
+        write_replay_command,
+    )
+else:
+    from live_matrix_stress import (
+        DEFAULT_STRESS_ARTIFACT_ROOT,
+        BaselineSample,
+        ManagedStressPostgres,
+        ResourceSample,
+        StressArtifactBundle,
+        StressBaseline,
+        StressConfig,
+        StressLogMetrics,
+        StressModelController,
+        StressRequest,
+        aggregate_log_metrics,
+        assert_matrix_edit_shape,
+        current_machine_class,
+        latency_summary,
+        parse_stress_request,
+        parse_structured_log,
+        percentile,
+        resource_summary,
+        write_replay_command,
+    )
+
 if TYPE_CHECKING:
-    from collections.abc import Callable, Collection, Mapping
+    from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
     from io import TextIOWrapper
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
@@ -1043,6 +1090,7 @@ class _ModelHandler(BaseHTTPRequestHandler):
     slow_stream_segments = 120
     slow_stream_delay = 0.02
     first_token_delay = 0.0
+    stress_controller: ClassVar[StressModelController | None] = None
 
     # Class-level observation map guarded by a lock because the stub runs under a
     # ThreadingHTTPServer: concurrent MindRoom requests each land in their own
@@ -1146,6 +1194,32 @@ class _ModelHandler(BaseHTTPRequestHandler):
             return frozenset()
         return frozenset()
 
+    @staticmethod
+    def _final_user_text(payload: Mapping[str, object]) -> str:
+        """Return text from the final user message for stress-marker routing."""
+        messages = payload.get("messages")
+        if not isinstance(messages, list):
+            return ""
+        for raw_message in reversed(messages):
+            if not isinstance(raw_message, dict):
+                continue
+            message = cast("dict[str, object]", raw_message)
+            if message.get("role") != "user":
+                continue
+            content = message.get("content")
+            if isinstance(content, str):
+                return content
+            if isinstance(content, list):
+                return " ".join(
+                    text
+                    for part in content
+                    if isinstance(part, dict)
+                    for text in (cast("dict[str, object]", part).get("text"),)
+                    if isinstance(text, str)
+                )
+            return ""
+        return ""
+
     def do_POST(self) -> None:
         if self.path.rstrip("/") != "/v1/chat/completions":
             self.send_error(HTTPStatus.NOT_FOUND)
@@ -1154,6 +1228,16 @@ class _ModelHandler(BaseHTTPRequestHandler):
         payload = json.loads(self.rfile.read(content_length))
         call_id = next(self.call_ids)
         self._record_observation(call_id, self._final_user_markers(payload))
+        stress_request = parse_stress_request(self._final_user_text(payload))
+        if stress_request is not None:
+            if payload.get("stream") is not True or self.stress_controller is None:
+                self.send_error(HTTPStatus.BAD_REQUEST, "stress requests require the armed streaming controller")
+                return
+            try:
+                self._send_stress_stream(call_id, stress_request)
+            except OSError:
+                self.close_connection = True
+            return
         content = self._response_text(call_id)
         if self._is_slow_call(call_id) and self.first_token_delay > 0:
             time.sleep(self.first_token_delay)
@@ -1230,6 +1314,50 @@ class _ModelHandler(BaseHTTPRequestHandler):
                 },
             )
             time.sleep(chunk_delay)
+        self._write_sse(
+            {
+                **base,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            },
+        )
+        self.wfile.write(b"data: [DONE]\n\n")
+        self.wfile.flush()
+        self.close_connection = True
+
+    def _send_stress_stream(self, call_id: int, request: StressRequest) -> None:
+        """Emit exact controller-owned stress pulses through OpenAI SSE."""
+        controller = self.stress_controller
+        assert controller is not None
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "text/event-stream")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        base = {
+            "id": f"live-stress-response-{call_id}",
+            "object": "chat.completion.chunk",
+            "created": int(time.time()),
+            "model": MODEL_ID,
+        }
+        self._write_sse(
+            {
+                **base,
+                "choices": [{"index": 0, "delta": {"role": "assistant"}, "finish_reason": None}],
+            },
+        )
+        for chunk in controller.stream(request):
+            self._write_sse(
+                {
+                    **base,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {"content": chunk},
+                            "finish_reason": None,
+                        },
+                    ],
+                },
+            )
         self._write_sse(
             {
                 **base,
@@ -1375,6 +1503,7 @@ class ManagedTuwunelStack:
         state_root: Path = DEFAULT_LIVE_FUZZ_STATE_ROOT,
         nio_overlay: NioOverlay | None = None,
         mindroom_revision: str | None = None,
+        stress_config: StressConfig | None = None,
     ) -> None:
         token = secrets.token_hex(4)
         self._stream_profile = stream_profile or StreamProfile()
@@ -1410,6 +1539,11 @@ class ManagedTuwunelStack:
         self._mindroom_revision = mindroom_revision
         self._host_lease: TextIOWrapper | None = None
         self._mindroom_start_log_offset = 0
+        self.stress_config = stress_config
+        self.stress_controller = StressModelController(stress_config) if stress_config is not None else None
+        self.stress_postgres = (
+            ManagedStressPostgres(f"{self.instance_name}-postgres") if stress_config is not None else None
+        )
 
     def _frozen_mindroom_revision(self) -> str:
         """Freeze and return the one MindRoom revision allowed for this run."""
@@ -1604,6 +1738,8 @@ class ManagedTuwunelStack:
 
         _run_command("just", "local-instances-start-matrix", self.instance_name)
         self._wait_for_url(f"{self.homeserver}/_matrix/client/versions", timeout=30)
+        if self.stress_postgres is not None:
+            self.stress_postgres.start()
         model_port = self._start_model_server()
         self._write_config(model_port)
         self._env = {
@@ -1618,8 +1754,19 @@ class ManagedTuwunelStack:
             "OPENAI_API_KEY": "sk-live-fuzz",
             "UV_PYTHON": "3.13",
         }
+        if self.stress_postgres is not None:
+            self._env.update(
+                {
+                    "MINDROOM_EVENT_CACHE_DATABASE_URL": self.stress_postgres.database_url,
+                    "MINDROOM_LOG_FORMAT": "json",
+                    "MINDROOM_LOG_LEVEL": "DEBUG",
+                    "MINDROOM_TIMING": "1",
+                },
+            )
         self._log_handle = self.log_path.open("a", encoding="utf-8")
         self._start_mindroom()
+        if self.stress_config is not None:
+            self.assert_stress_dependencies_healthy()
         self._write_manifest(
             state="ready",
             matrix_port=matrix_port,
@@ -1716,6 +1863,7 @@ class ManagedTuwunelStack:
             _attempt_cleanup(errors, "stop model server", server.shutdown)
             _attempt_cleanup(errors, "close model server", server.server_close)
             self._model_server = None
+            _ModelHandler.stress_controller = None
         if self._model_thread is not None:
             thread = self._model_thread
             if _attempt_cleanup(
@@ -1726,6 +1874,8 @@ class ManagedTuwunelStack:
                 self._model_thread = None
         if before_destructive_cleanup is not None:
             _attempt_cleanup(errors, "snapshot runtime evidence", before_destructive_cleanup)
+        if self.stress_postgres is not None:
+            _attempt_cleanup(errors, "remove stress PostgreSQL", self.stress_postgres.close)
         if self._created and _attempt_cleanup(
             errors,
             "remove Tuwunel instance",
@@ -1766,6 +1916,70 @@ class ManagedTuwunelStack:
             "sync_restart_retries": log.count("sync_restart_retry_started"),
         }
 
+    @property
+    def mindroom_pid(self) -> int | None:
+        """Return the active MindRoom process ID for bounded resource sampling."""
+        process = self._mindroom_process
+        return process.pid if process is not None and process.poll() is None else None
+
+    def assert_stress_dependencies_healthy(self) -> None:
+        """Fail unless stress uses live Tuwunel, PostgreSQL, and the configured backend."""
+        if self.stress_config is None or self.stress_postgres is None:
+            msg = "stress dependency preflight requires a stress-configured stack"
+            raise RuntimeError(msg)
+        self.assert_mindroom_running()
+        if not self.stress_postgres.is_healthy():
+            msg = "stress PostgreSQL failed readiness after MindRoom startup"
+            raise RuntimeError(msg)
+        result = subprocess.run(
+            ("docker", "inspect", "--format", "{{.State.Running}}", f"{self.instance_name}-tuwunel"),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.stdout.strip() != "true":
+            msg = "stress Tuwunel container is not running"
+            raise RuntimeError(msg)
+        events, _ = parse_structured_log(self.log_path.read_text(encoding="utf-8", errors="replace"))
+        initialized = any(
+            event.get("event") == "Matrix event cache startup maintenance complete"
+            and event.get("backend") == "postgres"
+            and event.get("namespace") == self.namespace
+            for event in events
+        )
+        if not initialized:
+            msg = "stress runtime did not attest PostgreSQL event-cache initialization"
+            raise RuntimeError(msg)
+        log_text = self.log_path.read_text(encoding="utf-8", errors="replace").lower()
+        if "continuing without advisory cache" in log_text or "disabling advisory matrix event cache" in log_text:
+            msg = "stress runtime reported cache disablement instead of PostgreSQL"
+            raise RuntimeError(msg)
+
+    def clear_stress_cache(self) -> None:
+        """Create a real cold-cache boundary without replacing certification metadata."""
+        if self.stress_postgres is None:
+            msg = "cannot clear stress cache on a non-stress stack"
+            raise RuntimeError(msg)
+        self.stress_postgres.clear_cache_namespace(self.namespace)
+
+    def stress_postgres_diagnostics(self) -> Mapping[str, object]:
+        """Return exact synthetic PostgreSQL diagnostics for artifact capture."""
+        if self.stress_postgres is None:
+            return {"started": False}
+        return self.stress_postgres.diagnostics()
+
+    def tuwunel_is_healthy(self) -> bool:
+        """Return whether the exact managed Tuwunel container is running."""
+        result = subprocess.run(
+            ("docker", "inspect", "--format", "{{.State.Running}}", f"{self.instance_name}-tuwunel"),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0 and result.stdout.strip() == "true"
+
     def tuwunel_log(self, *, tail: int = 4000) -> str:
         """Return the homeserver container log for durable failure evidence.
 
@@ -1796,6 +2010,7 @@ class ManagedTuwunelStack:
         _ModelHandler.slow_stream_segments = profile.slow_stream_segments
         _ModelHandler.slow_stream_delay = profile.slow_stream_delay
         _ModelHandler.first_token_delay = profile.first_token_delay
+        _ModelHandler.stress_controller = self.stress_controller
         self._model_server = ThreadingHTTPServer(("127.0.0.1", 0), _ModelHandler)
         port = self._model_server.server_address[1]
         self._model_thread = threading.Thread(
@@ -1823,11 +2038,15 @@ class ManagedTuwunelStack:
                     "tools": [],
                     "rooms": list(self.room_keys),
                     "learning": False,
+                    "startup_thread_prewarm": self.stress_config is None,
                 },
             },
             "defaults": {"tools": [], "enable_streaming": True, "markdown": False},
             "memory": {"backend": "file"},
-            "router": {"model": "default"},
+            "router": {
+                "model": "default",
+                "startup_thread_prewarm": self.stress_config is None,
+            },
             "mindroom_user": {"username": "livefuzzowner", "display_name": "Live Fuzz Owner"},
             "matrix_room_access": {
                 "mode": "multi_user",
@@ -1842,6 +2061,11 @@ class ManagedTuwunelStack:
                 "agent_reply_permissions": {},
             },
         }
+        if self.stress_config is not None:
+            config["cache"] = {
+                "backend": self.stress_config.cache_backend,
+                "namespace": self.namespace,
+            }
         self.config_path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
 
     def _start_mindroom(self) -> None:
@@ -1863,7 +2087,7 @@ class ManagedTuwunelStack:
                 "--api-port",
                 str(self.api_port),
                 "--log-level",
-                "INFO",
+                "DEBUG" if self.stress_config is not None else "INFO",
             ],
             cwd=PROJECT_ROOT,
             env=self._env,
@@ -2423,6 +2647,7 @@ class ExactReplyOracle:
         coalescing_threads: bool = False,
         ledger_path: Path | None = None,
         expected_body_for: Callable[[int], str] = _ModelHandler.response_text_for,
+        terminal_body_predicate: Callable[[str], bool] | None = None,
     ) -> None:
         self.client = client
         self.agent_id = agent_id
@@ -2430,6 +2655,7 @@ class ExactReplyOracle:
         self.coalescing_threads = coalescing_threads
         self.ledger_path = ledger_path
         self.expected_body_for = expected_body_for
+        self.terminal_body_predicate = terminal_body_predicate
         self._ledger_records: dict[str, TurnRecord] = {}
         self._ledger_read_at = 0.0
         self.internal_source_ids: set[str] = set()
@@ -2793,6 +3019,8 @@ class ExactReplyOracle:
         not terminal, so they must keep settlement open.
         """
         if body.endswith((INTERRUPTED_RESPONSE_NOTE, RESTART_INTERRUPTED_RESPONSE_NOTE)):
+            return True
+        if self.terminal_body_predicate is not None and self.terminal_body_predicate(body):
             return True
         call_id = _body_call_id(body)
         return call_id is not None and body == self.expected_body_for(call_id)
@@ -4727,10 +4955,653 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
+@dataclass(frozen=True, slots=True)
+class _StressTurn:
+    """One logical stress source and its real transport timing."""
+
+    label: str
+    wave: int
+    thread: int
+    event_id: str
+    thread_root: str
+    sent_at: float
+
+
+@dataclass(frozen=True, slots=True)
+class _StressWaveAudit:
+    """Canonical Matrix evidence and timing metrics for one wave."""
+
+    wave: int
+    thread_metrics: tuple[dict[str, object], ...]
+    edits_by_stream: Mapping[str, tuple[float, ...]]
+    source_to_placeholder_ms: tuple[float, ...]
+    source_to_first_content_ms: tuple[float, ...]
+    source_to_final_ms: tuple[float, ...]
+    matrix_edit_count: int
+    streaming_status_counts: Mapping[str, int]
+
+    def summary(self) -> dict[str, object]:
+        """Return JSON-safe per-wave transport metrics."""
+        return {
+            "wave": self.wave,
+            "source_to_placeholder_ms": latency_summary(self.source_to_placeholder_ms),
+            "source_to_first_content_ms": latency_summary(self.source_to_first_content_ms),
+            "source_to_final_ms": latency_summary(self.source_to_final_ms),
+            "matrix_edit_count": self.matrix_edit_count,
+            "streaming_status_counts": dict(self.streaming_status_counts),
+        }
+
+
+class LiveMatrixStressRunner:
+    """Run synchronized cold and warm waves through the existing live harness."""
+
+    def __init__(
+        self,
+        stack: ManagedTuwunelStack,
+        client: LiveMatrixClient,
+        config: StressConfig,
+        *,
+        journal: Callable[[Mapping[str, object]], None] | None = None,
+    ) -> None:
+        controller = stack.stress_controller
+        if controller is None:
+            msg = "live stress runner requires an armed stress model controller"
+            raise RuntimeError(msg)
+        self.stack = stack
+        self.client = client
+        self.config = config
+        self.controller = controller
+        self.journal = journal
+        self._expected_stress_bodies: set[str] = set()
+        self.oracle = ExactReplyOracle(
+            client,
+            stack.agent_id,
+            coalescing_threads=config.overlapping_followups,
+            ledger_path=stack.storage_path / "tracking" / f"{AGENT_NAME}_responded.json",
+            terminal_body_predicate=self._terminal_body_complete,
+        )
+        self._journal_sequence = 0
+        self._sent_content: dict[str, Mapping[str, Any]] = {}
+        self._wave_log_ranges: list[tuple[int, int]] = []
+
+    def _terminal_body_complete(self, body: str) -> bool:
+        if body in self._expected_stress_bodies:
+            return True
+        call_id = _body_call_id(body)
+        return call_id is not None and body == _ModelHandler.response_text_for(call_id)
+
+    async def run(self) -> dict[str, object]:
+        """Prepare history, execute both waves, and enforce exact final state."""
+        await self.client.register()
+        await self.client.join_room()
+        await self.client.sync_incremental(timeout_ms=0, allow_limited=True)
+        await self.oracle.initialize()
+        roots, reply_targets = await self._prepare_history()
+        await self.client.wait_until_quiet(
+            deadline_seconds=self.config.settlement_timeout_seconds,
+            quiet_seconds=0.75,
+        )
+        await asyncio.sleep(1)
+        self.stack.clear_stress_cache()
+
+        turns_by_wave: list[tuple[_StressTurn, ...]] = []
+        for wave in range(self.config.waves):
+            start_offset = self.stack.log_path.stat().st_size
+            turns = await self._run_wave(wave, roots, reply_targets)
+            end_offset = self.stack.log_path.stat().st_size
+            self._wave_log_ranges.append((start_offset, end_offset))
+            turns_by_wave.append(turns)
+            reply_targets = {turn.thread: self._one_response_event(turn.event_id) for turn in turns}
+
+        self.controller.assert_complete()
+        self.stack.assert_stress_dependencies_healthy()
+        events = await self._paginate_canonical_events()
+        audits = tuple(self._audit_wave(events, wave, turns) for wave, turns in enumerate(turns_by_wave))
+        all_edits = {label: edits for audit in audits for label, edits in audit.edits_by_stream.items()}
+        assert_matrix_edit_shape(self.config, all_edits)
+        wave_logs = self._wave_log_texts()
+        wave_cache_metrics = tuple(aggregate_log_metrics(text) for text in wave_logs)
+        self._assert_cache_wave_shape(wave_cache_metrics)
+        complete_log_metrics = aggregate_log_metrics(
+            self.stack.log_path.read_text(encoding="utf-8", errors="replace"),
+        )
+        complete_log_metrics.assert_healthy()
+        self._assert_reservation_telemetry(complete_log_metrics)
+        source_to_final = [latency for audit in audits for latency in audit.source_to_final_ms]
+        first_sent = min(turn.sent_at for turns in turns_by_wave for turn in turns)
+        wall_seconds = max(0.001, time.monotonic() - first_sent)
+        performance_sample = BaselineSample(
+            source_to_final_p95_ms=percentile(source_to_final, 95),
+            source_to_final_p99_ms=percentile(source_to_final, 99),
+            throughput_responses_per_second=len(source_to_final) / wall_seconds,
+        )
+        return {
+            "status": "PASS",
+            "roots": len(roots),
+            "hot_history_turns": self.config.history_turns,
+            "waves": [audit.summary() for audit in audits],
+            "per_thread": [metric for audit in audits for metric in audit.thread_metrics],
+            "model": self.controller.snapshot(),
+            "matrix_edit_count": sum(audit.matrix_edit_count for audit in audits),
+            "cache_by_wave": [metrics.summary() for metrics in wave_cache_metrics],
+            "runtime_log_metrics": complete_log_metrics.summary(),
+            "performance_sample": asdict(performance_sample),
+            "oracle": _sanitized_oracle_snapshot(self.oracle),
+        }
+
+    async def _prepare_history(self) -> tuple[dict[int, str], dict[int, str]]:
+        """Create 50 roots plus one fast long history before the cold boundary."""
+        root_results = await self._send_many(
+            (
+                (
+                    f"root:{thread}",
+                    thread,
+                    None,
+                    None,
+                    f"Synthetic stress root {thread:03d}",
+                )
+                for thread in range(self.config.threads)
+            ),
+        )
+        await self.oracle.wait_until_exact(
+            deadline_seconds=self.config.settlement_timeout_seconds,
+            settle_seconds=0.75,
+        )
+        roots = {thread: event_id for _, thread, event_id in root_results}
+        reply_targets = {thread: self._one_response_event(event_id) for _, thread, event_id in root_results}
+        for history_turn in range(self.config.history_turns):
+            label = f"hot-history:{history_turn:03d}"
+            results = await self._send_many(
+                (
+                    (
+                        label,
+                        0,
+                        roots[0],
+                        reply_targets[0],
+                        f"Synthetic hot history turn {history_turn:03d}",
+                    ),
+                ),
+            )
+            source_event_id = results[0][2]
+            await self.oracle.wait_until_exact(
+                deadline_seconds=self.config.settlement_timeout_seconds,
+                settle_seconds=0.1,
+            )
+            reply_targets[0] = self._one_response_event(source_event_id)
+        return roots, reply_targets
+
+    async def _run_wave(
+        self,
+        wave: int,
+        roots: Mapping[int, str],
+        reply_targets: Mapping[int, str],
+    ) -> tuple[_StressTurn, ...]:
+        """Send one synchronized source per thread and wait for terminal edits."""
+        requests = tuple(
+            StressRequest(wave=wave, thread=thread, seed=self.config.seed) for thread in range(self.config.threads)
+        )
+        self._expected_stress_bodies.update(self.controller.expected_body(request) for request in requests)
+        sent_results = await self._send_many(
+            (
+                (
+                    f"wave:{wave}:thread:{thread}",
+                    thread,
+                    roots[thread],
+                    reply_targets[thread],
+                    f"Synthetic stress wave {wave} thread {thread:03d} {self.config.marker(wave, thread)}",
+                )
+                for thread in range(self.config.threads)
+            ),
+        )
+        turns = tuple(
+            _StressTurn(
+                label=label,
+                wave=wave,
+                thread=thread,
+                event_id=event_id,
+                thread_root=roots[thread],
+                sent_at=self.oracle.sent_at[event_id],
+            )
+            for label, thread, event_id in sent_results
+        )
+        if self.config.overlapping_followups:
+            await self._send_overlapping_followups(wave, roots, turns)
+        await self.oracle.wait_until_exact(
+            deadline_seconds=self.config.settlement_timeout_seconds,
+            settle_seconds=0.75,
+        )
+        self.stack.assert_stress_dependencies_healthy()
+        return turns
+
+    async def _send_overlapping_followups(
+        self,
+        wave: int,
+        roots: Mapping[int, str],
+        turns: Sequence[_StressTurn],
+    ) -> None:
+        """Send deterministic queued follow-ups after every wave stream starts."""
+        deadline = time.monotonic() + self.config.barrier_timeout_seconds
+        while self.controller.reached_count(wave) < self.config.threads:
+            if time.monotonic() >= deadline:
+                reached = self.controller.reached_count(wave)
+                msg = f"overlap phase barrier reached {reached}/{self.config.threads}"
+                raise TimeoutError(msg)
+            await asyncio.sleep(0.05)
+        await asyncio.sleep(min(self.config.stream_seconds / 2, self.config.edit_interval * 2))
+        await self._send_many(
+            (
+                (
+                    f"overlap:{wave}:thread:{turn.thread}",
+                    turn.thread,
+                    roots[turn.thread],
+                    turn.event_id,
+                    f"Synthetic overlapping follow-up wave {wave} thread {turn.thread:03d}",
+                )
+                for turn in turns
+            ),
+        )
+
+    async def _send_many(
+        self,
+        specifications: Iterable[tuple[str, int, str | None, str | None, str]],
+    ) -> list[tuple[str, int, str]]:
+        """Send and register a concurrent deterministic source group."""
+        specs = tuple(specifications)
+        for _ in specs:
+            self.oracle.begin_expectation_registration()
+
+        async def send_one(
+            label: str,
+            thread: int,
+            thread_root: str | None,
+            reply_to: str | None,
+            body: str,
+        ) -> tuple[str, int, str]:
+            registered = False
+            relation = None
+            if thread_root is not None and reply_to is not None:
+                relation = {
+                    "rel_type": "m.thread",
+                    "event_id": thread_root,
+                    "is_falling_back": True,
+                    "m.in_reply_to": {"event_id": reply_to},
+                }
+            content = {
+                "msgtype": "m.text",
+                "body": f"{body} {self.stack.agent_id}",
+                "m.mentions": {"user_ids": [self.stack.agent_id]},
+            }
+            if relation is not None:
+                content["m.relates_to"] = relation
+            sent_at = time.monotonic()
+            try:
+                event_id = await self.client.send_event(
+                    "m.room.message",
+                    f"live-stress-{label.replace(':', '-')}",
+                    content,
+                )
+                self.oracle.expect(
+                    label,
+                    event_id,
+                    thread=thread,
+                    client=0,
+                    sent_at=sent_at,
+                )
+                self._sent_content[event_id] = content
+                self._record_journal(
+                    {
+                        "kind": "stress_source",
+                        "label": label,
+                        "wave": _wave_from_label(label),
+                        "thread": thread,
+                        "event_id": event_id,
+                    },
+                )
+                registered = True
+                return label, thread, event_id
+            finally:
+                self.oracle.finish_expectation_registration(validate=registered)
+
+        return list(
+            await asyncio.gather(
+                *(send_one(*specification) for specification in specs),
+            ),
+        )
+
+    def _record_journal(self, payload: Mapping[str, object]) -> None:
+        if self.journal is None:
+            return
+        self._journal_sequence += 1
+        self.journal({"sequence": self._journal_sequence, **payload})
+
+    def _one_response_event(self, source_event_id: str) -> str:
+        response_ids = self.oracle.response_ids.get(source_event_id, set())
+        if len(response_ids) != 1:
+            msg = (
+                f"stress source {self.oracle.expected_sources.get(source_event_id, source_event_id)} "
+                f"has {len(response_ids)} canonical responses"
+            )
+            raise AssertionError(msg)
+        return next(iter(response_ids))
+
+    async def _paginate_canonical_events(self) -> dict[str, dict[str, Any]]:
+        events: dict[str, dict[str, Any]] = {}
+        for event in await self.client.paginate_room(self.stack.room_id):
+            event_id = event.get("event_id")
+            if isinstance(event_id, str) and event_id not in events:
+                events[event_id] = event
+        return events
+
+    def _audit_wave(
+        self,
+        events: Mapping[str, Mapping[str, Any]],
+        wave: int,
+        turns: Sequence[_StressTurn],
+    ) -> _StressWaveAudit:
+        thread_metrics: list[dict[str, object]] = []
+        edits_by_stream: dict[str, tuple[float, ...]] = {}
+        placeholder_latencies: list[float] = []
+        content_latencies: list[float] = []
+        final_latencies: list[float] = []
+        status_counts: Counter[str] = Counter()
+        matrix_edit_count = 0
+        for turn in turns:
+            metric, edit_timestamps, statuses = self._audit_turn(events, turn)
+            thread_metrics.append(metric)
+            edits_by_stream[f"wave-{wave:02d}/thread-{turn.thread:03d}"] = edit_timestamps
+            placeholder_latencies.append(cast("float", metric["source_to_placeholder_ms"]))
+            content_latencies.append(cast("float", metric["source_to_first_content_ms"]))
+            final_latencies.append(cast("float", metric["source_to_final_ms"]))
+            matrix_edit_count += len(edit_timestamps)
+            status_counts.update(statuses)
+        return _StressWaveAudit(
+            wave=wave,
+            thread_metrics=tuple(thread_metrics),
+            edits_by_stream=edits_by_stream,
+            source_to_placeholder_ms=tuple(placeholder_latencies),
+            source_to_first_content_ms=tuple(content_latencies),
+            source_to_final_ms=tuple(final_latencies),
+            matrix_edit_count=matrix_edit_count,
+            streaming_status_counts=dict(status_counts),
+        )
+
+    def _audit_turn(
+        self,
+        events: Mapping[str, Mapping[str, Any]],
+        turn: _StressTurn,
+    ) -> tuple[dict[str, object], tuple[float, ...], Counter[str]]:
+        response_event_id = self._one_response_event(turn.event_id)
+        response = events.get(response_event_id)
+        source = events.get(turn.event_id)
+        if response is None or source is None:
+            msg = f"stress final audit missing source or response for {turn.label}"
+            raise AssertionError(msg)
+        replacements = [event for event in events.values() if _replacement_target(event) == response_event_id]
+        ordered_replacements = sorted(
+            replacements,
+            key=lambda event: _replacement_order(
+                cast("str", event.get("event_id", "")),
+                event.get("origin_server_ts"),
+                is_edit=True,
+            ),
+        )
+        ordered_events = [response, *ordered_replacements]
+        bodies = [
+            _canonical_message_body(
+                cast("Mapping[str, Any]", event.get("content", {})),
+                is_edit=index > 0,
+            )
+            for index, event in enumerate(ordered_events)
+        ]
+        request = StressRequest(wave=turn.wave, thread=turn.thread, seed=self.config.seed)
+        expected_body = self.controller.expected_body(request)
+        if not bodies or bodies[-1] != expected_body:
+            msg = f"stress final content mismatch for {turn.label}"
+            raise AssertionError(msg)
+        pulse_numbers = [_last_stress_pulse(body) for body in bodies if body is not None and "SYNTHETIC wave=" in body]
+        if pulse_numbers != sorted(pulse_numbers):
+            msg = f"same-thread edit ordering violation for {turn.label}: {pulse_numbers}"
+            raise AssertionError(msg)
+        statuses = Counter(
+            status
+            for index, event in enumerate(ordered_events)
+            for status in (_stream_status(event, is_edit=index > 0),)
+            if status is not None
+        )
+        if statuses[STREAM_STATUS_COMPLETED] != 1:
+            msg = f"stress response {turn.label} has terminal status count {statuses[STREAM_STATUS_COMPLETED]}"
+            raise AssertionError(msg)
+        source_ts = _required_event_timestamp(source, turn.label)
+        response_ts = _required_event_timestamp(response, turn.label)
+        content_events = [
+            event
+            for event, body in zip(ordered_events, bodies, strict=True)
+            if body is not None and "SYNTHETIC wave=" in body
+        ]
+        if not content_events:
+            msg = f"stress response {turn.label} never exposed streamed content"
+            raise AssertionError(msg)
+        first_content_ts = _required_event_timestamp(content_events[0], turn.label)
+        final_ts = _required_event_timestamp(ordered_events[-1], turn.label)
+        edit_timestamps = tuple(_required_event_timestamp(event, turn.label) / 1000 for event in ordered_replacements)
+        metric = {
+            "label": f"wave-{turn.wave:02d}/thread-{turn.thread:03d}",
+            "source_to_placeholder_ms": float(response_ts - source_ts),
+            "source_to_first_content_ms": float(first_content_ts - source_ts),
+            "source_to_final_ms": float(final_ts - source_ts),
+            "matrix_stream_duration_ms": float(final_ts - first_content_ts),
+            "matrix_edit_count": len(ordered_replacements),
+            "matrix_edit_gap_ms": latency_summary(
+                [
+                    float(right - left)
+                    for left, right in itertools.pairwise(
+                        [_required_event_timestamp(event, turn.label) for event in ordered_events],
+                    )
+                ],
+            ),
+            "final_completion_marker": (
+                f"COMPLETE[wave={turn.wave};thread={turn.thread:03d};pulses={self.config.pulses_per_stream}]"
+            ),
+        }
+        return metric, edit_timestamps, statuses
+
+    def _wave_log_texts(self) -> tuple[str, ...]:
+        payload = self.stack.log_path.read_bytes()
+        return tuple(payload[start:end].decode("utf-8", errors="replace") for start, end in self._wave_log_ranges)
+
+    def _assert_cache_wave_shape(
+        self,
+        metrics: Sequence[StressLogMetrics],
+    ) -> None:
+        if len(metrics) != self.config.waves:
+            msg = f"stress cache metrics cover {len(metrics)}/{self.config.waves} waves"
+            raise AssertionError(msg)
+        cold = metrics[0]
+        if cold.full_scans < self.config.threads:
+            msg = f"cold wave produced {cold.full_scans}/{self.config.threads} full scans"
+            raise AssertionError(msg)
+        for wave, warm in enumerate(metrics[1:], start=1):
+            if warm.full_scans:
+                msg = f"warm wave {wave} performed {warm.full_scans} redundant full scans"
+                raise AssertionError(msg)
+            if warm.cache_hits < self.config.threads:
+                msg = f"warm wave {wave} produced {warm.cache_hits}/{self.config.threads} cache hits"
+                raise AssertionError(msg)
+
+    @staticmethod
+    def _assert_reservation_telemetry(metrics: StressLogMetrics) -> None:
+        if metrics.reservation_active_final is None:
+            msg = "stress run omitted outbound reservation lifecycle telemetry"
+            raise AssertionError(msg)
+        if metrics.reservation_active_final:
+            msg = f"stress run leaked {metrics.reservation_active_final} outbound thread reservations"
+            raise AssertionError(msg)
+
+
+def _wave_from_label(label: str) -> int | None:
+    fields = label.split(":")
+    return int(fields[1]) if fields[0] in {"wave", "overlap"} and len(fields) > 1 else None
+
+
+def _replacement_target(event: Mapping[str, Any]) -> str | None:
+    if event.get("type") != "m.room.message":
+        return None
+    content = event.get("content")
+    if not isinstance(content, dict):
+        return None
+    relation = content.get("m.relates_to")
+    if not isinstance(relation, dict) or relation.get("rel_type") != "m.replace":
+        return None
+    target = relation.get("event_id")
+    return target if isinstance(target, str) else None
+
+
+def _stream_status(event: Mapping[str, Any], *, is_edit: bool) -> str | None:
+    content = event.get("content")
+    if not isinstance(content, dict):
+        return None
+    status_source = content.get("m.new_content") if is_edit else content
+    if not isinstance(status_source, dict):
+        return None
+    status = status_source.get(STREAM_STATUS_KEY)
+    return status if isinstance(status, str) else None
+
+
+def _last_stress_pulse(body: str) -> int:
+    matches = re.findall(r"\bpulse=(\d{3})/\d{3}", body)
+    if not matches:
+        msg = "stress body omitted pulse marker"
+        raise AssertionError(msg)
+    return int(matches[-1])
+
+
+def _required_event_timestamp(event: Mapping[str, Any], label: str) -> int:
+    timestamp = event.get("origin_server_ts")
+    if not isinstance(timestamp, int):
+        msg = f"stress event for {label} omitted origin_server_ts"
+        raise TypeError(msg)
+    return timestamp
+
+
+async def _sample_stress_resources(
+    stack: ManagedTuwunelStack,
+    config: StressConfig,
+    stop: asyncio.Event,
+    samples: list[ResourceSample],
+) -> None:
+    """Sample process, sync, Tuwunel, and PostgreSQL health at bounded cadence."""
+    pid = stack.mindroom_pid
+    if pid is None:
+        msg = "MindRoom process missing before stress resource sampling"
+        raise RuntimeError(msg)
+    process = psutil.Process(pid)
+    process.cpu_percent(None)
+    started_at = time.monotonic()
+    async with httpx.AsyncClient(timeout=10) as client:
+        while not stop.is_set():
+            sample_started = time.monotonic()
+            health_latency_ms: float | None = None
+            sync_age_seconds: float | None = None
+            try:
+                response = await client.get(f"http://127.0.0.1:{stack.api_port}/api/health")
+                health_latency_ms = (time.monotonic() - sample_started) * 1000
+                response.raise_for_status()
+                health = response.json()
+                raw_sync_time = health.get("last_sync_time") if isinstance(health, dict) else None
+                if isinstance(raw_sync_time, str):
+                    sync_time = datetime.fromisoformat(raw_sync_time)
+                    sync_age_seconds = max(0.0, (datetime.now(UTC) - sync_time).total_seconds())
+            except (httpx.HTTPError, ValueError):
+                health_latency_ms = None
+            postgres = stack.stress_postgres
+            postgres_healthy, tuwunel_healthy = await asyncio.gather(
+                asyncio.to_thread(postgres.is_healthy) if postgres is not None else asyncio.sleep(0, result=False),
+                asyncio.to_thread(stack.tuwunel_is_healthy),
+            )
+            try:
+                cpu_percent = process.cpu_percent(None)
+                rss_bytes = process.memory_info().rss
+            except psutil.Error:
+                cpu_percent = 0.0
+                rss_bytes = 0
+            samples.append(
+                ResourceSample(
+                    offset_seconds=round(time.monotonic() - started_at, 3),
+                    cpu_percent=cpu_percent,
+                    rss_bytes=rss_bytes,
+                    sync_age_seconds=sync_age_seconds,
+                    health_latency_ms=health_latency_ms,
+                    tuwunel_healthy=tuwunel_healthy,
+                    postgres_healthy=postgres_healthy,
+                ),
+            )
+            try:
+                await asyncio.wait_for(
+                    stop.wait(),
+                    timeout=config.resource_sample_interval_seconds,
+                )
+            except TimeoutError:
+                continue
+
+
+async def _run_stress_live(
+    stack: ManagedTuwunelStack,
+    config: StressConfig,
+    *,
+    journal: Callable[[Mapping[str, object]], None] | None = None,
+) -> dict[str, object]:
+    """Own the Matrix client and sampler around one complete stress run."""
+    client = LiveMatrixClient(stack.homeserver, stack.room_id)
+    runner = LiveMatrixStressRunner(stack, client, config, journal=journal)
+    stop_sampler = asyncio.Event()
+    resource_samples: list[ResourceSample] = []
+    sampler = asyncio.create_task(
+        _sample_stress_resources(stack, config, stop_sampler, resource_samples),
+        name="live_matrix_stress_resource_sampler",
+    )
+    primary_error: BaseException | None = None
+    try:
+        result = await runner.run()
+    except BaseException as exc:
+        primary_error = exc
+        raise
+    finally:
+        stop_sampler.set()
+        sampler_result = await asyncio.gather(sampler, return_exceptions=True)
+        close_error = await _close_live_matrix_client(client)
+        cleanup_errors = [error for error in (*sampler_result, close_error) if isinstance(error, BaseException)]
+        if cleanup_errors:
+            if primary_error is not None:
+                for error in cleanup_errors:
+                    primary_error.add_note(f"stress cleanup failure: {error}")
+            else:
+                msg = "live Matrix stress cleanup failed"
+                raise ExceptionGroup(msg, cleanup_errors)
+    resources = resource_summary(resource_samples)
+    if resources["tuwunel_unhealthy_samples"] or resources["postgres_unhealthy_samples"]:
+        msg = f"stress dependency health sampling failed: {resources}"
+        raise AssertionError(msg)
+    health_latency = cast("Mapping[str, object]", resources["health_latency_ms"])
+    if health_latency.get("max", 0) > 5000:
+        msg = f"stress API health latency exceeded five-second watchdog boundary: {health_latency}"
+        raise AssertionError(msg)
+    result["resources"] = resources
+    result["resource_samples"] = [asdict(sample) for sample in resource_samples]
+    return result
+
+
 def _non_negative_int(value: str) -> int:
     parsed = int(value)
     if parsed < 0:
         msg = "must be non-negative"
+        raise argparse.ArgumentTypeError(msg)
+    return parsed
+
+
+def _positive_float(value: str) -> float:
+    parsed = float(value)
+    if parsed <= 0:
+        msg = "must be positive"
         raise argparse.ArgumentTypeError(msg)
     return parsed
 
@@ -4743,10 +5614,19 @@ def _parse_args() -> argparse.Namespace:
         required=True,
         help="clean exact mindroom-nio Git checkout loaded by the live MindRoom child",
     )
-    parser.add_argument("--profile", choices=("fuzz", "saturation", "chaos"), default="fuzz")
+    parser.add_argument("--profile", choices=("fuzz", "saturation", "chaos", "stress"), default="fuzz")
     parser.add_argument("--seed", type=int, default=1)
     parser.add_argument("--steps", type=_positive_int, default=200)
-    parser.add_argument("--threads", type=_positive_int, default=45)
+    parser.add_argument("--threads", type=_positive_int)
+    parser.add_argument("--stream-seconds", type=_positive_float, default=45.0)
+    parser.add_argument("--edit-interval", type=_positive_float, default=0.5)
+    parser.add_argument("--waves", type=_positive_int, default=2)
+    parser.add_argument("--history-turns", type=_non_negative_int, default=20)
+    parser.add_argument("--cache-backend", choices=("postgres",), default="postgres")
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--write-baseline", type=Path)
+    parser.add_argument("--enforce-performance", action="store_true")
+    parser.add_argument("--overlapping-followups", action="store_true")
     parser.add_argument("--max-batch-size", type=_positive_int, default=16)
     parser.add_argument("--restart-interval", type=_non_negative_int, default=100)
     parser.add_argument("--clients", type=_positive_int, default=4, help="chaos senders racing concurrently")
@@ -4768,8 +5648,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--artifact-root",
         type=Path,
-        default=DEFAULT_ARTIFACT_ROOT,
-        help="stable ignored directory holding one durable failure bundle per run",
+        help="stable ignored directory holding durable run evidence",
     )
     return parser.parse_args()
 
@@ -4833,6 +5712,9 @@ async def _run_live(
 
 def _scenario_from_args(args: argparse.Namespace) -> LiveFuzzScenario:
     """Build or load the requested trace."""
+    if args.profile == "stress":
+        msg = "stress profile uses StressConfig rather than LiveFuzzScenario"
+        raise ValueError(msg)
     if args.trace is not None:
         return LiveFuzzScenario.from_json(args.trace.read_text(encoding="utf-8"))
     if args.profile == "saturation":
@@ -4842,7 +5724,7 @@ def _scenario_from_args(args: argparse.Namespace) -> LiveFuzzScenario:
             args.seed,
             steps=args.steps,
             tuning=ChaosTuning(
-                thread_count=args.threads,
+                thread_count=args.threads or 45,
                 client_count=args.clients,
                 room_count=args.rooms,
                 max_batch_size=args.max_batch_size,
@@ -4855,7 +5737,7 @@ def _scenario_from_args(args: argparse.Namespace) -> LiveFuzzScenario:
     return live_scenario_from_seed(
         args.seed,
         steps=args.steps,
-        thread_count=args.threads,
+        thread_count=args.threads or 45,
         max_batch_size=args.max_batch_size,
         restart_interval=args.restart_interval,
     )
@@ -5506,12 +6388,304 @@ def _require_runtime_provenance(
     return provenance
 
 
+def _stress_config_from_args(args: argparse.Namespace) -> StressConfig:
+    """Build or replay one exact stress configuration."""
+    if args.trace is not None:
+        _require_persistent_stress_path(args.trace)
+        return StressConfig.from_json(args.trace.read_text(encoding="utf-8"))
+    config = StressConfig(
+        threads=args.threads or 50,
+        stream_seconds=args.stream_seconds,
+        edit_interval=args.edit_interval,
+        waves=args.waves,
+        history_turns=args.history_turns,
+        cache_backend=args.cache_backend,
+        seed=args.seed,
+        overlapping_followups=args.overlapping_followups,
+    )
+    config.validate()
+    return config
+
+
+def _require_persistent_stress_path(path: Path) -> None:
+    """Reject trace, baseline, and artifact paths rooted in temporary storage."""
+    resolved = path.expanduser().resolve()
+    if "tmp" in {part.lower() for part in resolved.parts}:
+        msg = f"live Matrix stress evidence must not use temporary storage: {path}"
+        raise ValueError(msg)
+
+
+def _stress_profile_name(config: StressConfig) -> str:
+    return f"stress-{config.threads}x{config.stream_seconds:g}s-{config.edit_interval:g}s-{config.waves}w"
+
+
+def _stress_config_sha256(config: StressConfig) -> str:
+    return hashlib.sha256(config.to_json().encode()).hexdigest()
+
+
+def _baseline_sample_from_result(result: Mapping[str, object]) -> BaselineSample:
+    raw_sample = result.get("performance_sample")
+    if not isinstance(raw_sample, dict):
+        msg = "stress result omitted performance sample"
+        raise TypeError(msg)
+    return BaselineSample(
+        source_to_final_p95_ms=float(raw_sample["source_to_final_p95_ms"]),
+        source_to_final_p99_ms=float(raw_sample["source_to_final_p99_ms"]),
+        throughput_responses_per_second=float(raw_sample["throughput_responses_per_second"]),
+    )
+
+
+def _compare_stress_baseline(
+    path: Path,
+    *,
+    config: StressConfig,
+    result: Mapping[str, object],
+) -> Mapping[str, object]:
+    _require_persistent_stress_path(path)
+    baseline = StressBaseline.from_json(path.read_text(encoding="utf-8"))
+    expected_profile = _stress_profile_name(config)
+    expected_hash = _stress_config_sha256(config)
+    if baseline.profile != expected_profile or baseline.config_sha256 != expected_hash:
+        msg = (
+            f"stress baseline workload mismatch: profile={baseline.profile!r}, config_sha256={baseline.config_sha256!r}"
+        )
+        raise ValueError(msg)
+    return baseline.compare(_baseline_sample_from_result(result))
+
+
+def _append_stress_baseline_sample(
+    path: Path,
+    *,
+    config: StressConfig,
+    source_revision: str,
+    result: Mapping[str, object],
+) -> Mapping[str, object]:
+    """Append one clean sample and materialize a baseline after three stable runs."""
+    _require_persistent_stress_path(path)
+    collection_path = path.with_suffix(path.suffix + ".samples")
+    profile = _stress_profile_name(config)
+    config_sha256 = _stress_config_sha256(config)
+    samples: list[dict[str, float]] = []
+    if collection_path.exists():
+        payload = json.loads(collection_path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict):
+            msg = "stress baseline sample collection must be an object"
+            raise TypeError(msg)
+        identity = (
+            payload.get("profile"),
+            payload.get("source_revision"),
+            payload.get("config_sha256"),
+            payload.get("machine_class"),
+        )
+        if identity != (profile, source_revision, config_sha256, current_machine_class()):
+            msg = f"stress baseline sample identity changed: {identity}"
+            raise ValueError(msg)
+        raw_samples = payload.get("samples")
+        if not isinstance(raw_samples, list):
+            msg = "stress baseline sample collection is missing samples"
+            raise TypeError(msg)
+        samples = [cast("dict[str, float]", sample) for sample in raw_samples if isinstance(sample, dict)]
+        if len(samples) != len(raw_samples):
+            msg = "stress baseline sample collection contains malformed samples"
+            raise TypeError(msg)
+    samples.append(asdict(_baseline_sample_from_result(result)))
+    collection = {
+        "version": 1,
+        "profile": profile,
+        "source_revision": source_revision,
+        "config_sha256": config_sha256,
+        "machine_class": current_machine_class(),
+        "samples": samples,
+    }
+    _atomic_json_write(collection_path, collection)
+    outcome: dict[str, object] = {
+        "sample_count": len(samples),
+        "sample_collection": str(collection_path),
+        "baseline": None,
+    }
+    if len(samples) < 3:
+        return outcome
+    baseline = StressBaseline(
+        profile=profile,
+        source_revision=source_revision,
+        config_sha256=config_sha256,
+        machine_class=current_machine_class(),
+        samples=tuple(BaselineSample(**sample) for sample in samples[-3:]),
+    )
+    _atomic_text_write(path, baseline.to_json() + "\n")
+    outcome["baseline"] = str(path)
+    outcome["medians"] = baseline.medians()
+    return outcome
+
+
+def _atomic_json_write(path: Path, payload: object) -> None:
+    _atomic_text_write(path, json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _atomic_text_write(path: Path, payload: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_suffix(path.suffix + ".pending")
+    temporary.write_text(payload, encoding="utf-8")
+    temporary.replace(path)
+
+
+def _capture_stress_bundle(
+    bundle: StressArtifactBundle,
+    stack: ManagedTuwunelStack,
+    config: StressConfig,
+    journal: Sequence[Mapping[str, object]],
+    *,
+    result: Mapping[str, object] | None,
+    failure: BaseException | None,
+    baseline_comparison: Mapping[str, object] | None,
+) -> None:
+    """Persist complete sanitized evidence before disposable services stop."""
+    provenance = stack.runtime_provenance or _run_provenance()
+    bundle.write_json("scenario.json", json.loads(config.to_json()))
+    bundle.write_json("git-runtime-provenance.json", provenance)
+    bundle.write_text(
+        "realized-operation-journal.jsonl",
+        "".join(json.dumps(entry, sort_keys=True) + "\n" for entry in journal),
+    )
+    bundle.write_text(
+        "mindroom-sanitized.log",
+        stack.log_path.read_text(encoding="utf-8", errors="replace")
+        if stack.log_path.exists()
+        else "<missing MindRoom log>\n",
+    )
+    bundle.write_text("tuwunel-sanitized.log", stack.tuwunel_log())
+    bundle.write_json("postgres-diagnostics.json", stack.stress_postgres_diagnostics())
+    bundle.write_text("replay.txt", write_replay_command())
+    if result is not None:
+        compact_summary = {
+            key: value
+            for key, value in result.items()
+            if key not in {"per_thread", "resource_samples", "oracle", "model"}
+        }
+        bundle.write_json("summary.json", compact_summary)
+        bundle.write_json("per-thread-samples.json", result.get("per_thread", []))
+        bundle.write_json("resource-samples.json", result.get("resource_samples", []))
+        bundle.write_json("model-timing.json", result.get("model", {}))
+        bundle.write_json("oracle-snapshot.json", result.get("oracle", {}))
+    if baseline_comparison is not None:
+        bundle.write_json("baseline-comparison.json", baseline_comparison)
+    if failure is not None:
+        bundle.write_text(
+            "failure.txt",
+            f"{type(failure).__name__}: {failure}\n",
+        )
+
+
+def _run_stress_main(args: argparse.Namespace) -> None:
+    """Run one complete stress campaign unit and retain success evidence."""
+    config = _stress_config_from_args(args)
+    if args.enforce_performance and args.baseline is None:
+        msg = "--enforce-performance requires --baseline"
+        raise ValueError(msg)
+    artifact_root = args.artifact_root or DEFAULT_STRESS_ARTIFACT_ROOT
+    _require_persistent_stress_path(artifact_root)
+    if args.save_trace is not None:
+        _require_persistent_stress_path(args.save_trace)
+        _atomic_text_write(args.save_trace, config.to_json() + "\n")
+    mindroom_revision = _required_mindroom_revision()
+    run_id = f"{time.strftime('%Y%m%dT%H%M%S')}-{secrets.token_hex(4)}"
+    bundle = StressArtifactBundle.create(artifact_root, run_id)
+    journal: list[Mapping[str, object]] = []
+    bundle.write_json("scenario.json", json.loads(config.to_json()))
+    stack = ManagedTuwunelStack(
+        room_keys=(ROOM_KEY,),
+        provenance_sink=lambda provenance: bundle.write_json(
+            "git-runtime-provenance.json",
+            provenance,
+        ),
+        artifact_directory=bundle.directory,
+        nio_overlay=args.nio_overlay,
+        mindroom_revision=mindroom_revision,
+        stress_config=config,
+    )
+    result: dict[str, object] | None = None
+    baseline_comparison: Mapping[str, object] | None = None
+    try:
+        stack.start()
+        started_at = time.monotonic()
+        result = asyncio.run(
+            _run_stress_live(
+                stack,
+                config,
+                journal=journal.append,
+            ),
+        )
+        result["wall_seconds"] = round(time.monotonic() - started_at, 3)
+        result["seed"] = config.seed
+        if args.baseline is not None:
+            baseline_comparison = _compare_stress_baseline(
+                args.baseline,
+                config=config,
+                result=result,
+            )
+        if args.write_baseline is not None:
+            result["baseline_write"] = _append_stress_baseline_sample(
+                args.write_baseline,
+                config=config,
+                source_revision=mindroom_revision,
+                result=result,
+            )
+        _require_runtime_provenance(stack, args.nio_overlay)
+    except BaseException as exc:
+        with suppress(BaseException):
+            _capture_stress_bundle(
+                bundle,
+                stack,
+                config,
+                journal,
+                result=result,
+                failure=exc,
+                baseline_comparison=baseline_comparison,
+            )
+        try:
+            stack.close()
+        except BaseException as cleanup_error:
+            exc.add_note(f"stress cleanup failure: {cleanup_error}")
+        with suppress(BaseException):
+            bundle.write_json(
+                "cleanup-manifest.json",
+                {"status": "FAILED", "resources_removed": True},
+            )
+        print(f"Live Matrix stress failure bundle: {bundle.directory}", file=sys.stderr)
+        raise
+
+    assert result is not None
+
+    def snapshot_evidence() -> None:
+        _capture_stress_bundle(
+            bundle,
+            stack,
+            config,
+            journal,
+            result=result,
+            failure=None,
+            baseline_comparison=baseline_comparison,
+        )
+
+    stack.close(before_destructive_cleanup=snapshot_evidence)
+    bundle.write_json(
+        "cleanup-manifest.json",
+        {"status": "PASS", "resources_removed": True},
+    )
+    result["artifact_directory"] = str(bundle.directory)
+    print(json.dumps(result, sort_keys=True))
+
+
 def main() -> None:
     """Run one trace against a fresh disposable real-server stack."""
     if len(sys.argv) >= 4 and sys.argv[1] == "__mindroom_runtime_child__":
         _run_mindroom_runtime_child(Path(sys.argv[2]), sys.argv[3:])
         return
     args = _parse_args()
+    if args.profile == "stress":
+        _run_stress_main(args)
+        return
+    args.artifact_root = args.artifact_root or DEFAULT_ARTIFACT_ROOT
     nio_overlay: NioOverlay = args.nio_overlay
     scenario = _scenario_from_args(args)
     if args.save_trace is not None:

--- a/scripts/testing/fuzz_live_matrix.py
+++ b/scripts/testing/fuzz_live_matrix.py
@@ -1920,6 +1920,20 @@ class ManagedTuwunelStack:
         _attempt_cleanup(errors, "release host lease", self._release_host_lease)
         _raise_cleanup_failures(errors, message="live Matrix fuzz cleanup failed")
 
+    def owned_resources_removed(self) -> bool:
+        """Return whether every disposable resource and host lease is gone."""
+        postgres_removed = self.stress_postgres is None or not self.stress_postgres.started
+        return (
+            self._mindroom_process is None
+            and self._log_handle is None
+            and self._model_server is None
+            and self._model_thread is None
+            and postgres_removed
+            and not self._created
+            and not Path(self.temp_dir.name).exists()
+            and self._host_lease is None
+        )
+
     def log_tail(self, lines: int = 80) -> str:
         """Return recent MindRoom output when a live invariant fails."""
         if not self.log_path.exists():
@@ -6778,16 +6792,14 @@ def _close_failed_stress_run(
     failure: BaseException,
 ) -> None:
     """Attempt cleanup and record whether disposable resources were removed."""
-    resources_removed = True
     try:
         stack.close()
     except BaseException as cleanup_error:
-        resources_removed = False
         failure.add_note(f"stress cleanup failure: {cleanup_error}")
     with suppress(BaseException):
         bundle.write_json(
             "cleanup-manifest.json",
-            {"status": "FAILED", "resources_removed": resources_removed},
+            {"status": "FAILED", "resources_removed": stack.owned_resources_removed()},
         )
 
 
@@ -6883,7 +6895,7 @@ def _run_stress_main(args: argparse.Namespace) -> None:
         with suppress(BaseException):
             bundle.write_json(
                 "cleanup-manifest.json",
-                {"status": "FAILED", "resources_removed": False},
+                {"status": "FAILED", "resources_removed": stack.owned_resources_removed()},
             )
         raise
     bundle.write_json(

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -891,7 +891,10 @@ class ArtifactSanitizer:
         if isinstance(value, str):
             return self.text(value)
         if isinstance(value, Mapping):
-            return {str(item_key): self.value(item_value, key=str(item_key)) for item_key, item_value in value.items()}
+            return {
+                self.text(str(item_key)): self.value(item_value, key=str(item_key))
+                for item_key, item_value in value.items()
+            }
         if isinstance(value, list | tuple):
             return [self.value(item) for item in value]
         return value
@@ -1035,6 +1038,11 @@ class ManagedStressPostgres:
     image: str = "postgres:15-alpine"
     host_port: int | None = None
     _started: bool = False
+
+    @property
+    def started(self) -> bool:
+        """Return whether the owned PostgreSQL container should still exist."""
+        return self._started
 
     @property
     def database_url(self) -> str:

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -1232,11 +1232,11 @@ class ManagedStressPostgres:
                     f"room_id={room_id}",
                     "-v",
                     f"event_id={event_id}",
-                    "-Atc",
-                    query,
+                    "-At",
                 ),
                 check=False,
                 capture_output=True,
+                input=query,
                 text=True,
                 timeout=30,
             )

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -418,6 +418,7 @@ class StressLogMetrics:
     live_append_successes: int = 0
     live_append_failures: int = 0
     repair_fetches_by_thread: Counter[str] = field(default_factory=Counter)
+    repair_fetches_by_thread_and_caller: Counter[tuple[str, str]] = field(default_factory=Counter)
     reservation_created: int = 0
     reservation_alias_transitions: int = 0
     reservation_released: int = 0
@@ -491,6 +492,8 @@ class StressLogMetrics:
                 self.full_scans += 1
                 thread_label = str(event.get("thread_id", "<unknown-thread>"))
                 self.repair_fetches_by_thread[thread_label] += 1
+                caller_label = str(event.get("caller_label", "<unknown-caller>"))
+                self.repair_fetches_by_thread_and_caller[(thread_label, caller_label)] += 1
             reject_reason = event.get("cache_reject_reason")
             if isinstance(reject_reason, str) and reject_reason:
                 self.cache_invalidated_reasons[reject_reason] += 1
@@ -616,7 +619,11 @@ class StressLogMetrics:
         )
         failures.extend(f"{count} {label}" for count, label in health_counts if count)
         if check_duplicate_repairs:
-            duplicate_repairs = {thread: count for thread, count in self.repair_fetches_by_thread.items() if count > 1}
+            duplicate_repairs = {
+                f"{thread} ({caller})": count
+                for (thread, caller), count in self.repair_fetches_by_thread_and_caller.items()
+                if count > 1
+            }
             if duplicate_repairs:
                 failures.append(f"duplicate repair scans: {duplicate_repairs}")
         if failures:

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -634,7 +634,7 @@ class StressLogMetrics:
             },
         }
 
-    def assert_healthy(self) -> None:
+    def assert_healthy(self, *, check_duplicate_repairs: bool = True) -> None:
         """Fail on correctness signals that invalidate a normal stress run."""
         failures: list[str] = []
         if self.known_thread_room_barrier_count:
@@ -653,9 +653,10 @@ class StressLogMetrics:
             (self.cache_store_failures, "cache/store failures"),
         )
         failures.extend(f"{count} {label}" for count, label in health_counts if count)
-        duplicate_repairs = {thread: count for thread, count in self.repair_fetches_by_thread.items() if count > 1}
-        if duplicate_repairs:
-            failures.append(f"duplicate repair scans: {duplicate_repairs}")
+        if check_duplicate_repairs:
+            duplicate_repairs = {thread: count for thread, count in self.repair_fetches_by_thread.items() if count > 1}
+            if duplicate_repairs:
+                failures.append(f"duplicate repair scans: {duplicate_repairs}")
         if failures:
             raise AssertionError("; ".join(failures))
 

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -1114,7 +1114,10 @@ class ManagedStressPostgres:
             "mindroom_event_cache_room_state",
         )
         statements = " ".join(
-            f"DELETE FROM {table} WHERE namespace = '{namespace}';"  # noqa: S608 - table allowlist and validated namespace
+            (
+                f"DELETE FROM {table} WHERE namespace = '{namespace}' "  # noqa: S608 - table allowlist and validated namespace
+                f"OR namespace LIKE '{namespace}:%';"
+            )
             for table in tables
         )
         result = subprocess.run(

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -542,7 +542,7 @@ class StressLogMetrics:
             if isinstance(reject_reason, str) and reject_reason:
                 self.cache_invalidated_reasons[reject_reason] += 1
         if message == "Thread history cache store completed":
-            outcome = str(event.get("outcome", "unknown"))
+            outcome = str(event.get("cache_store_outcome", event.get("outcome", "unknown")))
             self.snapshot_store_outcomes[outcome] += 1
             if outcome in {"writes_unavailable", "error", "failed"}:
                 self.cache_store_failures += 1

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 from mindroom.synthetic_model import SyntheticPlan, synthetic_plan
+from mindroom.tool_system.events import format_tool_combined
 
 STRESS_TRACE_VERSION = 1
 STRESS_BASELINE_VERSION = 1
@@ -209,8 +210,21 @@ class SyntheticStressAudit:
         )
 
     def expected_body(self, request: StressRequest) -> str:
-        """Return the exact final body for one configured request."""
+        """Return the exact model-generated body for one configured request."""
         return self.plan(request).body
+
+    def expected_matrix_body(self, request: StressRequest) -> str:
+        """Return the exact body after MindRoom inserts its visible tool marker."""
+        plan = self.plan(request)
+        if plan.split_at is None or plan.sleep_seconds is None:
+            return plan.body
+        tool_marker, _ = format_tool_combined(
+            "sleep",
+            {"seconds": plan.sleep_seconds},
+            None,
+            tool_index=1,
+        )
+        return plan.prefix + tool_marker + plan.suffix
 
     def reached_count(self, wave: int) -> int:
         """Return distinct initial requests recorded at one wave barrier."""

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -50,6 +50,8 @@ _UNCAUGHT_SIGNALS = (
     "task exception was never retrieved",
     "traceback (most recent call last)",
 )
+_EVENT_LOOP_PROBE_CEILING_MS = 5000.0
+_SYNC_STARVATION_CEILING_SECONDS = 120.0
 
 
 def _positive(value: float, field_name: str) -> None:
@@ -354,8 +356,15 @@ class StressModelController:
                 {"offset_seconds": round(moment - origin, 3), "active_streams": active}
                 for moment, active in self._active_timeline
             ]
+        barrier_waits = [
+            float(wait)
+            for observation in observations
+            for wait in (observation["barrier_wait_ms"],)
+            if isinstance(wait, int | float)
+        ]
         return {
             "reached_by_wave": {str(wave): self.reached_count(wave) for wave in range(self.config.waves)},
+            "barrier_wait_ms": latency_summary(barrier_waits),
             "max_active_streams": self.max_active_streams,
             "total_pulses": self.total_pulses,
             "active_stream_timeline": timeline,
@@ -984,9 +993,37 @@ def resource_summary(samples: Sequence[ResourceSample]) -> dict[str, object]:
         "rss_bytes": latency_summary(rss),
         "sync_age_seconds": latency_summary(sync_age),
         "health_latency_ms": latency_summary(health_latency),
+        "event_loop_probe_latency_ms": latency_summary(health_latency),
+        "mindroom_health_probe_failures": sum(sample.health_latency_ms is None for sample in samples),
         "tuwunel_unhealthy_samples": sum(not sample.tuwunel_healthy for sample in samples),
         "postgres_unhealthy_samples": sum(not sample.postgres_healthy for sample in samples),
     }
+
+
+def assert_resource_health(summary: Mapping[str, object]) -> None:
+    """Fail on dependency loss, event-loop starvation, or stale Matrix sync."""
+    dependency_failures = (
+        (_integer(summary.get("mindroom_health_probe_failures")), "MindRoom health probe failures"),
+        (_integer(summary.get("tuwunel_unhealthy_samples")), "Tuwunel unhealthy samples"),
+        (_integer(summary.get("postgres_unhealthy_samples")), "PostgreSQL unhealthy samples"),
+    )
+    failures = [f"{count} {label}" for count, label in dependency_failures if count]
+    event_loop_probe = summary.get("event_loop_probe_latency_ms")
+    if isinstance(event_loop_probe, Mapping):
+        maximum = event_loop_probe.get("max")
+        if isinstance(maximum, int | float) and maximum > _EVENT_LOOP_PROBE_CEILING_MS:
+            failures.append(
+                f"event-loop progress probe exceeded {_EVENT_LOOP_PROBE_CEILING_MS:g} ms: {maximum:g} ms",
+            )
+    sync_age = summary.get("sync_age_seconds")
+    if isinstance(sync_age, Mapping):
+        maximum = sync_age.get("max")
+        if isinstance(maximum, int | float) and maximum > _SYNC_STARVATION_CEILING_SECONDS:
+            failures.append(
+                f"Matrix sync age exceeded {_SYNC_STARVATION_CEILING_SECONDS:g} s watchdog boundary: {maximum:g} s",
+            )
+    if failures:
+        raise AssertionError("; ".join(failures))
 
 
 @dataclass(slots=True)
@@ -1169,10 +1206,30 @@ def expected_minimum_matrix_edits(config: StressConfig) -> int:
     return max(2, math.floor(config.stream_seconds / 5.0))
 
 
+def matrix_edit_activity(
+    edits_by_stream: Mapping[str, Sequence[float]],
+) -> dict[str, object]:
+    """Return a relative timeline of simultaneously active Matrix edit streams."""
+    intervals = [(min(edits), max(edits)) for edits in edits_by_stream.values() if edits]
+    edit_times = sorted({time_value for edits in edits_by_stream.values() for time_value in edits})
+    origin = edit_times[0] if edit_times else 0.0
+    timeline = [
+        {
+            "offset_seconds": round(timestamp - origin, 3),
+            "active_streams": sum(start <= timestamp <= end for start, end in intervals),
+        }
+        for timestamp in edit_times
+    ]
+    return {
+        "max_active_streams": max((int(point["active_streams"]) for point in timeline), default=0),
+        "timeline": timeline,
+    }
+
+
 def assert_matrix_edit_shape(
     config: StressConfig,
     edits_by_stream: Mapping[str, Sequence[float]],
-) -> None:
+) -> dict[str, object]:
     """Fail unless every stream produced repeated overlapping Matrix edits."""
     expected_streams = config.threads * config.waves
     if len(edits_by_stream) != expected_streams:
@@ -1183,17 +1240,12 @@ def assert_matrix_edit_shape(
     if sparse:
         msg = f"insufficient Matrix edit activity; minimum={minimum}, streams={sparse}"
         raise AssertionError(msg)
-    intervals = [(min(edits), max(edits)) for edits in edits_by_stream.values() if edits]
-    simultaneous = max(
-        (
-            sum(start <= timestamp <= end for start, end in intervals)
-            for timestamp in sorted({time_value for edits in edits_by_stream.values() for time_value in edits})
-        ),
-        default=0,
-    )
+    activity = matrix_edit_activity(edits_by_stream)
+    simultaneous = int(activity["max_active_streams"])
     if simultaneous < config.threads:
         msg = f"Matrix edit overlap reached {simultaneous}/{config.threads} streams"
         raise AssertionError(msg)
+    return activity
 
 
 def write_replay_command(
@@ -1223,9 +1275,11 @@ __all__ = [
     "StressRequest",
     "aggregate_log_metrics",
     "assert_matrix_edit_shape",
+    "assert_resource_health",
     "current_machine_class",
     "expected_minimum_matrix_edits",
     "latency_summary",
+    "matrix_edit_activity",
     "parse_stress_request",
     "parse_structured_log",
     "percentile",

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -1,0 +1,1225 @@
+"""Deterministic configuration, telemetry, and evidence for live Matrix stress runs."""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import platform
+import re
+import statistics
+import subprocess
+import threading
+import time
+from collections import Counter, defaultdict
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+
+STRESS_TRACE_VERSION = 1
+STRESS_BASELINE_VERSION = 1
+DEFAULT_STRESS_ARTIFACT_ROOT = Path("artifacts/live-matrix-stress")
+DEFAULT_PERFORMANCE_ALLOWANCE = 0.25
+STRESS_MARKER_PATTERN = re.compile(r"LMS\[wave=(\d+);thread=(\d+);seed=(-?\d+)\]")
+_SENSITIVE_KEY_PATTERN = re.compile(
+    r"(?:access[_-]?token|authorization|cookie|database[_-]?url|password|secret|sync[_-]?token)",
+    re.IGNORECASE,
+)
+_BEARER_PATTERN = re.compile(r"(?i)\bBearer\s+[A-Za-z0-9._~+/=-]+")
+_ACCESS_TOKEN_PATTERN = re.compile(r"\b(?:syt|MDA|sk)-[A-Za-z0-9._~-]{6,}\b")
+_POSTGRES_URL_PATTERN = re.compile(r"(?i)\bpostgres(?:ql)?://[^\s\"']+")
+_URL_PATTERN = re.compile(r"\bhttps?://[^\s\"']+")
+_ROOM_ID_PATTERN = re.compile(r"![A-Za-z0-9._~=/+-]+:[A-Za-z0-9._:-]+")
+_EVENT_ID_PATTERN = re.compile(r"\$[A-Za-z0-9._~=/+-]+")
+_USER_ID_PATTERN = re.compile(r"@[A-Za-z0-9._=/-]+:[A-Za-z0-9._:-]+")
+_SYNC_TOKEN_PATTERN = re.compile(r"\bs\d+_[A-Za-z0-9._~=/+-]{8,}\b")
+_PRIVATE_PATH_PATTERN = re.compile(r"(?<![A-Za-z0-9.])/(?:Users|home|private|tmp)/[^\s\"']+")
+_POSTGRES_CONCURRENCY_ERRORS = (
+    "another command is already in progress",
+    "another operation is in progress",
+)
+_INTERRUPTION_SIGNALS = (
+    "response interrupted",
+    "response was interrupted",
+    "restart interrupted",
+)
+_UNCAUGHT_SIGNALS = (
+    "uncaught exception",
+    "unhandled exception",
+    "task exception was never retrieved",
+    "traceback (most recent call last)",
+)
+
+
+def _positive(value: float, field_name: str) -> None:
+    if value <= 0:
+        msg = f"{field_name} must be positive"
+        raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True)
+class StressConfig:
+    """Replayable synthetic workload shape for one stress run."""
+
+    threads: int = 50
+    stream_seconds: float = 45.0
+    edit_interval: float = 0.5
+    waves: int = 2
+    history_turns: int = 20
+    cache_backend: Literal["postgres"] = "postgres"
+    seed: int = 1
+    overlapping_followups: bool = False
+    barrier_timeout_seconds: float = 90.0
+    settlement_timeout_seconds: float = 180.0
+    resource_sample_interval_seconds: float = 0.5
+
+    def validate(self) -> None:
+        """Reject shapes that cannot provide exact deterministic evidence."""
+        _positive(self.threads, "threads")
+        _positive(self.stream_seconds, "stream_seconds")
+        _positive(self.edit_interval, "edit_interval")
+        _positive(self.waves, "waves")
+        if self.history_turns < 0:
+            msg = "history_turns must be non-negative"
+            raise ValueError(msg)
+        if self.cache_backend != "postgres":
+            msg = "stress profile requires PostgreSQL and never falls back to SQLite"
+            raise ValueError(msg)
+        _positive(self.barrier_timeout_seconds, "barrier_timeout_seconds")
+        _positive(self.settlement_timeout_seconds, "settlement_timeout_seconds")
+        _positive(self.resource_sample_interval_seconds, "resource_sample_interval_seconds")
+        exact_pulses = self.stream_seconds / self.edit_interval
+        if not math.isclose(exact_pulses, round(exact_pulses), abs_tol=1e-9):
+            msg = "stream_seconds must be exactly divisible by edit_interval"
+            raise ValueError(msg)
+
+    @property
+    def pulses_per_stream(self) -> int:
+        """Return exact model update pulses emitted by every stream."""
+        self.validate()
+        return round(self.stream_seconds / self.edit_interval)
+
+    @property
+    def expected_model_pulses(self) -> int:
+        """Return total model pulses for the configured waves."""
+        return self.threads * self.waves * self.pulses_per_stream
+
+    def marker(self, wave: int, thread: int) -> str:
+        """Build one deterministic synthetic request marker."""
+        if wave not in range(self.waves) or thread not in range(self.threads):
+            msg = f"stress marker outside configured shape: wave={wave}, thread={thread}"
+            raise ValueError(msg)
+        return f"LMS[wave={wave};thread={thread:03d};seed={self.seed}]"
+
+    def to_json(self) -> str:
+        """Serialize one replayable stress scenario."""
+        self.validate()
+        return json.dumps(
+            {"version": STRESS_TRACE_VERSION, "profile": "stress", "config": asdict(self)},
+            indent=2,
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_json(cls, value: str) -> StressConfig:
+        """Load and validate one stress scenario."""
+        payload = json.loads(value)
+        if (
+            not isinstance(payload, dict)
+            or payload.get("version") != STRESS_TRACE_VERSION
+            or payload.get("profile") != "stress"
+        ):
+            msg = "unsupported live Matrix stress trace"
+            raise ValueError(msg)
+        raw_config = payload.get("config")
+        if not isinstance(raw_config, dict):
+            msg = "live Matrix stress trace is missing config"
+            raise TypeError(msg)
+        config = cls(**cast("dict[str, Any]", raw_config))
+        config.validate()
+        return config
+
+
+@dataclass(frozen=True, slots=True)
+class StressRequest:
+    """Logical identity parsed from one synthetic model request."""
+
+    wave: int
+    thread: int
+    seed: int
+
+    @property
+    def label(self) -> str:
+        """Return a stable artifact-safe logical label."""
+        return f"wave-{self.wave:02d}/thread-{self.thread:03d}"
+
+
+def parse_stress_request(text: str) -> StressRequest | None:
+    """Parse the one stress marker embedded in a model request."""
+    matches = STRESS_MARKER_PATTERN.findall(text)
+    if not matches:
+        return None
+    if len(matches) != 1:
+        msg = f"stress model request contains {len(matches)} markers"
+        raise ValueError(msg)
+    wave, thread, seed = matches[0]
+    return StressRequest(wave=int(wave), thread=int(thread), seed=int(seed))
+
+
+@dataclass(slots=True)
+class StreamObservation:
+    """Thread-safe timing observations for one fake-model stream."""
+
+    request: StressRequest
+    reached_at: float
+    released_at: float | None = None
+    started_at: float | None = None
+    finished_at: float | None = None
+    pulses: list[float] = field(default_factory=list)
+    cancelled: bool = False
+
+    def artifact_dict(self) -> dict[str, object]:
+        """Return relative timings without host-clock data."""
+        released_at = self.released_at
+        started_at = self.started_at
+        finished_at = self.finished_at
+        return {
+            "label": self.request.label,
+            "barrier_wait_ms": None if released_at is None else round((released_at - self.reached_at) * 1000, 3),
+            "stream_duration_seconds": (
+                None if started_at is None or finished_at is None else round(finished_at - started_at, 3)
+            ),
+            "pulse_count": len(self.pulses),
+            "pulse_offsets_seconds": (
+                [] if started_at is None else [round(pulse - started_at, 3) for pulse in self.pulses]
+            ),
+            "cancelled": self.cancelled,
+        }
+
+
+class StressModelController:
+    """Reusable per-wave barrier and exact-cadence fake-model stream controller."""
+
+    def __init__(
+        self,
+        config: StressConfig,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+        serialize_streams: bool = False,
+    ) -> None:
+        config.validate()
+        self.config = config
+        self._clock = clock
+        self._sleeper = sleeper
+        self._condition = threading.Condition()
+        self._observations: dict[tuple[int, int], StreamObservation] = {}
+        self._active_streams = 0
+        self._max_active_streams = 0
+        self._active_timeline: list[tuple[float, int]] = []
+        self._serialization_lock = threading.Lock() if serialize_streams else None
+
+    def _validate_request(self, request: StressRequest) -> None:
+        if request.seed != self.config.seed:
+            msg = f"stress request seed {request.seed} does not match configured seed {self.config.seed}"
+            raise ValueError(msg)
+        if request.wave not in range(self.config.waves) or request.thread not in range(self.config.threads):
+            msg = f"stress request outside configured shape: {request.label}"
+            raise ValueError(msg)
+
+    def reach_barrier(self, request: StressRequest) -> StreamObservation:
+        """Register one request and wait until its complete wave reaches the barrier."""
+        self._validate_request(request)
+        key = (request.wave, request.thread)
+        deadline = self._clock() + self.config.barrier_timeout_seconds
+        with self._condition:
+            if key in self._observations:
+                msg = f"duplicate stress model request at {request.label}"
+                raise RuntimeError(msg)
+            observation = StreamObservation(request=request, reached_at=self._clock())
+            self._observations[key] = observation
+            self._condition.notify_all()
+            while self.reached_count(request.wave) < self.config.threads:
+                remaining = deadline - self._clock()
+                if remaining <= 0:
+                    missing = sorted(set(range(self.config.threads)) - self.reached_threads(request.wave))
+                    msg = (
+                        f"stress model barrier wave {request.wave} reached "
+                        f"{self.reached_count(request.wave)}/{self.config.threads}; missing={missing}"
+                    )
+                    raise TimeoutError(msg)
+                self._condition.wait(timeout=remaining)
+            released_at = self._clock()
+            for wave_key, wave_observation in self._observations.items():
+                if wave_key[0] == request.wave and wave_observation.released_at is None:
+                    wave_observation.released_at = released_at
+            self._condition.notify_all()
+            return observation
+
+    def stream(self, request: StressRequest) -> Iterator[str]:
+        """Yield exact deterministic pulses after the wave barrier releases."""
+        observation = self.reach_barrier(request)
+        serialization_lock = self._serialization_lock
+        if serialization_lock is None:
+            yield from self._stream_observation(observation)
+            return
+        with serialization_lock:
+            yield from self._stream_observation(observation)
+
+    def expected_body(self, request: StressRequest) -> str:
+        """Return the exact cumulative body produced by one complete stream."""
+        self._validate_request(request)
+        chunks = []
+        for pulse in range(self.config.pulses_per_stream):
+            completion = (
+                f" COMPLETE[wave={request.wave};thread={request.thread:03d};pulses={self.config.pulses_per_stream}]"
+                if pulse + 1 == self.config.pulses_per_stream
+                else ""
+            )
+            chunks.append(
+                f"SYNTHETIC wave={request.wave} thread={request.thread:03d} "
+                f"pulse={pulse + 1:03d}/{self.config.pulses_per_stream:03d}{completion} ",
+            )
+        return "".join(chunks)
+
+    def _stream_observation(self, observation: StreamObservation) -> Iterator[str]:
+        with self._condition:
+            observation.started_at = self._clock()
+            self._active_streams += 1
+            self._max_active_streams = max(self._max_active_streams, self._active_streams)
+            self._active_timeline.append((observation.started_at, self._active_streams))
+        try:
+            for pulse in range(self.config.pulses_per_stream):
+                scheduled_at = cast("float", observation.started_at) + (pulse + 1) * self.config.edit_interval
+                delay = scheduled_at - self._clock()
+                if delay > 0:
+                    self._sleeper(delay)
+                emitted_at = self._clock()
+                with self._condition:
+                    observation.pulses.append(emitted_at)
+                completion = (
+                    f" COMPLETE[wave={observation.request.wave};thread={observation.request.thread:03d};"
+                    f"pulses={self.config.pulses_per_stream}]"
+                    if pulse + 1 == self.config.pulses_per_stream
+                    else ""
+                )
+                yield (
+                    f"SYNTHETIC wave={observation.request.wave} thread={observation.request.thread:03d} "
+                    f"pulse={pulse + 1:03d}/{self.config.pulses_per_stream:03d}{completion} "
+                )
+        except GeneratorExit:
+            observation.cancelled = True
+            raise
+        finally:
+            with self._condition:
+                observation.finished_at = self._clock()
+                self._active_streams -= 1
+                self._active_timeline.append((observation.finished_at, self._active_streams))
+                self._condition.notify_all()
+
+    def reached_threads(self, wave: int) -> set[int]:
+        """Return logical threads registered at one wave barrier."""
+        return {thread for (observed_wave, thread) in self._observations if observed_wave == wave}
+
+    def reached_count(self, wave: int) -> int:
+        """Return request count registered at one wave barrier."""
+        return len(self.reached_threads(wave))
+
+    @property
+    def max_active_streams(self) -> int:
+        """Return maximum simultaneous fake-model streams."""
+        with self._condition:
+            return self._max_active_streams
+
+    @property
+    def total_pulses(self) -> int:
+        """Return emitted model pulse count."""
+        with self._condition:
+            return sum(len(observation.pulses) for observation in self._observations.values())
+
+    def snapshot(self) -> dict[str, object]:
+        """Return synthetic logical model timing evidence."""
+        with self._condition:
+            observations = [observation.artifact_dict() for _, observation in sorted(self._observations.items())]
+            origin = min(
+                (observation.reached_at for observation in self._observations.values()),
+                default=self._clock(),
+            )
+            timeline = [
+                {"offset_seconds": round(moment - origin, 3), "active_streams": active}
+                for moment, active in self._active_timeline
+            ]
+        return {
+            "reached_by_wave": {str(wave): self.reached_count(wave) for wave in range(self.config.waves)},
+            "max_active_streams": self.max_active_streams,
+            "total_pulses": self.total_pulses,
+            "active_stream_timeline": timeline,
+            "streams": observations,
+        }
+
+    def assert_complete(self, *, duration_tolerance_seconds: float | None = None) -> None:
+        """Fail unless every configured stream reached full cadence and concurrency."""
+        tolerance = duration_tolerance_seconds
+        if tolerance is None:
+            tolerance = max(0.25, self.config.edit_interval * 2)
+        failures = self._completion_failures(tolerance)
+        if failures:
+            raise AssertionError("; ".join(failures))
+
+    def _completion_failures(self, tolerance: float) -> list[str]:
+        """Return every model-shape failure without stopping at the first."""
+        failures: list[str] = []
+        for wave in range(self.config.waves):
+            reached = self.reached_count(wave)
+            if reached != self.config.threads:
+                failures.append(f"wave {wave} barrier reached {reached}/{self.config.threads}")
+        if self.max_active_streams != self.config.threads:
+            failures.append(
+                f"maximum active model streams {self.max_active_streams}/{self.config.threads}",
+            )
+        for key, observation in sorted(self._observations.items()):
+            if len(observation.pulses) != self.config.pulses_per_stream:
+                failures.append(
+                    f"wave {key[0]} thread {key[1]} emitted "
+                    f"{len(observation.pulses)}/{self.config.pulses_per_stream} pulses",
+                )
+            if observation.started_at is None or observation.finished_at is None:
+                failures.append(f"wave {key[0]} thread {key[1]} did not finish")
+                continue
+            duration = observation.finished_at - observation.started_at
+            if abs(duration - self.config.stream_seconds) > tolerance:
+                failures.append(
+                    f"wave {key[0]} thread {key[1]} duration "
+                    f"{duration:.3f}s outside {self.config.stream_seconds:.3f}s +/- {tolerance:.3f}s",
+                )
+            if observation.cancelled:
+                failures.append(f"wave {key[0]} thread {key[1]} was cancelled")
+        return failures
+
+
+def percentile(values: Sequence[float], percentile_value: float) -> float:
+    """Return a linearly interpolated percentile using sorted observations."""
+    if not values:
+        msg = "cannot calculate a percentile without observations"
+        raise ValueError(msg)
+    if not 0 <= percentile_value <= 100:
+        msg = "percentile must be between 0 and 100"
+        raise ValueError(msg)
+    ordered = sorted(float(value) for value in values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * percentile_value / 100
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] + (ordered[upper] - ordered[lower]) * fraction
+
+
+def latency_summary(values: Sequence[float]) -> dict[str, float | int]:
+    """Summarize one timing family with all stress-gate percentiles."""
+    if not values:
+        return {"count": 0}
+    return {
+        "count": len(values),
+        "p50": round(percentile(values, 50), 3),
+        "p90": round(percentile(values, 90), 3),
+        "p95": round(percentile(values, 95), 3),
+        "p99": round(percentile(values, 99), 3),
+        "max": round(max(values), 3),
+    }
+
+
+@dataclass(slots=True)
+class StressLogMetrics:
+    """Aggregate production structured logs into explicit stress signals."""
+
+    room_barrier_count: int = 0
+    thread_barrier_count: int = 0
+    known_thread_room_barrier_count: int = 0
+    predecessor_wait_ms: list[float] = field(default_factory=list)
+    update_run_ms: list[float] = field(default_factory=list)
+    update_total_ms: list[float] = field(default_factory=list)
+    coalesced_intermediate_writes: int = 0
+    cache_hits: int = 0
+    cache_misses: int = 0
+    full_scans: int = 0
+    snapshot_store_outcomes: Counter[str] = field(default_factory=Counter)
+    cache_invalidated_reasons: Counter[str] = field(default_factory=Counter)
+    missing_raw_cache_skips: int = 0
+    live_append_successes: int = 0
+    live_append_failures: int = 0
+    repair_fetches_by_thread: Counter[str] = field(default_factory=Counter)
+    reservation_created: int = 0
+    reservation_alias_transitions: int = 0
+    reservation_released: int = 0
+    reservation_expired: int = 0
+    reservation_active_final: int | None = None
+    watchdog_stalls: int = 0
+    sync_restarts: int = 0
+    sync_restart_retries: int = 0
+    interruptions: int = 0
+    uncaught_exceptions: int = 0
+    postgres_concurrency_errors: int = 0
+    cache_store_failures: int = 0
+
+    def ingest(self, event: Mapping[str, object]) -> None:
+        """Fold one structured log event into metric counters."""
+        message = str(event.get("event", event.get("message", "")))
+        lowered = message.lower()
+        self._ingest_outbound_schedule(message, event)
+        self._ingest_update_timing(message, event)
+        self._ingest_cache_history(message, lowered, event)
+        self._ingest_reservation(message, event)
+        self._ingest_health(lowered)
+        if "cache" in lowered and ("failure" in lowered or "failed" in lowered) and event.get("outcome") == "success":
+            self.cache_store_failures += 1
+
+    def _ingest_outbound_schedule(
+        self,
+        message: str,
+        event: Mapping[str, object],
+    ) -> None:
+        """Count outbound cache barrier routing decisions."""
+        if message != "Event cache outbound schedule timing":
+            return
+        barrier_kind = event.get("barrier_kind")
+        if message == "Event cache outbound schedule timing":
+            if barrier_kind == "room":
+                self.room_barrier_count += 1
+                if event.get("is_edit") is True:
+                    self.known_thread_room_barrier_count += 1
+            elif barrier_kind == "thread":
+                self.thread_barrier_count += 1
+
+    def _ingest_update_timing(
+        self,
+        message: str,
+        event: Mapping[str, object],
+    ) -> None:
+        """Collect cache write queue and execution timings."""
+        if message != "Event cache update timing":
+            return
+        self._append_numeric(event, "predecessor_wait_ms", self.predecessor_wait_ms)
+        self._append_numeric(event, "update_run_ms", self.update_run_ms)
+        self._append_numeric(event, "total_ms", self.update_total_ms)
+        self.coalesced_intermediate_writes += _integer(event.get("coalesced_update_count"))
+        if event.get("outcome") == "error":
+            self.cache_store_failures += 1
+
+    def _ingest_cache_history(
+        self,
+        message: str,
+        lowered: str,
+        event: Mapping[str, object],
+    ) -> None:
+        """Collect cache read, repair, store, and append outcomes."""
+        if message == "matrix_cache_thread_history_refreshed":
+            mode = event.get("mode")
+            if mode == "cache_hit":
+                self.cache_hits += 1
+            elif mode == "full_scan":
+                self.cache_misses += 1
+                self.full_scans += 1
+                thread_label = str(event.get("thread_id", "<unknown-thread>"))
+                self.repair_fetches_by_thread[thread_label] += 1
+            reject_reason = event.get("cache_reject_reason")
+            if isinstance(reject_reason, str) and reject_reason:
+                self.cache_invalidated_reasons[reject_reason] += 1
+        if message == "Thread history cache store completed":
+            outcome = str(event.get("outcome", "unknown"))
+            self.snapshot_store_outcomes[outcome] += 1
+            if outcome in {"writes_unavailable", "error", "failed"}:
+                self.cache_store_failures += 1
+        if "missing raw cache" in lowered or event.get("reason") == "missing_raw_cache":
+            self.missing_raw_cache_skips += 1
+        if "append thread event to cache" in lowered:
+            if "failed" in lowered or event.get("outcome") == "error":
+                self.live_append_failures += 1
+                self.cache_store_failures += 1
+            else:
+                self.live_append_successes += 1
+
+    def _ingest_reservation(
+        self,
+        message: str,
+        event: Mapping[str, object],
+    ) -> None:
+        """Collect reservation lifecycle and terminal leak telemetry."""
+        if message == "outbound_thread_reservation":
+            action = event.get("action")
+            if action == "created":
+                self.reservation_created += 1
+            elif action == "alias_transition":
+                self.reservation_alias_transitions += 1
+            elif action == "released":
+                self.reservation_released += 1
+            elif action == "expired":
+                self.reservation_expired += 1
+            active_count = event.get("active_count")
+            if isinstance(active_count, int):
+                self.reservation_active_final = active_count
+
+    def _ingest_health(self, lowered: str) -> None:
+        """Count runtime health, restart, and database failure signals."""
+        if "event_loop_stall_detected" in lowered:
+            self.watchdog_stalls += 1
+        if "sync restart" in lowered or "sync_watchdog_restart" in lowered:
+            self.sync_restarts += 1
+        if "sync_restart_retry_started" in lowered:
+            self.sync_restart_retries += 1
+        if any(signal in lowered for signal in _INTERRUPTION_SIGNALS):
+            self.interruptions += 1
+        if any(signal in lowered for signal in _UNCAUGHT_SIGNALS):
+            self.uncaught_exceptions += 1
+        if any(signal in lowered for signal in _POSTGRES_CONCURRENCY_ERRORS):
+            self.postgres_concurrency_errors += 1
+
+    @staticmethod
+    def _append_numeric(
+        event: Mapping[str, object],
+        key: str,
+        destination: list[float],
+    ) -> None:
+        value = event.get(key)
+        if isinstance(value, int | float) and not isinstance(value, bool):
+            destination.append(float(value))
+
+    def summary(self) -> dict[str, object]:
+        """Return JSON-safe aggregate telemetry."""
+        return {
+            "barriers": {
+                "room": self.room_barrier_count,
+                "thread": self.thread_barrier_count,
+                "known_thread_room_violations": self.known_thread_room_barrier_count,
+            },
+            "write_coordination": {
+                "predecessor_wait_ms": latency_summary(self.predecessor_wait_ms),
+                "update_run_ms": latency_summary(self.update_run_ms),
+                "total_ms": latency_summary(self.update_total_ms),
+                "coalesced_intermediate_writes": self.coalesced_intermediate_writes,
+            },
+            "cache": {
+                "hits": self.cache_hits,
+                "misses": self.cache_misses,
+                "full_scans": self.full_scans,
+                "snapshot_store_outcomes": dict(self.snapshot_store_outcomes),
+                "invalidated_reasons": dict(self.cache_invalidated_reasons),
+                "missing_raw_cache_skips": self.missing_raw_cache_skips,
+                "live_append_successes": self.live_append_successes,
+                "live_append_failures": self.live_append_failures,
+                "repair_fetches_by_thread": dict(self.repair_fetches_by_thread),
+            },
+            "reservations": {
+                "created": self.reservation_created,
+                "alias_transitions": self.reservation_alias_transitions,
+                "released": self.reservation_released,
+                "expired": self.reservation_expired,
+                "active_final": self.reservation_active_final,
+            },
+            "health": {
+                "watchdog_stalls": self.watchdog_stalls,
+                "sync_restarts": self.sync_restarts,
+                "sync_restart_retries": self.sync_restart_retries,
+                "interruptions": self.interruptions,
+                "uncaught_exceptions": self.uncaught_exceptions,
+                "postgres_concurrency_errors": self.postgres_concurrency_errors,
+                "cache_store_failures": self.cache_store_failures,
+            },
+        }
+
+    def assert_healthy(self) -> None:
+        """Fail on correctness signals that invalidate a normal stress run."""
+        failures: list[str] = []
+        if self.known_thread_room_barrier_count:
+            failures.append(
+                f"{self.known_thread_room_barrier_count} known-thread edits used room barriers",
+            )
+        if self.reservation_active_final not in {None, 0}:
+            failures.append(f"{self.reservation_active_final} thread reservations leaked")
+        health_counts = (
+            (self.watchdog_stalls, "event-loop watchdog stalls"),
+            (self.sync_restarts, "internal sync restarts"),
+            (self.sync_restart_retries, "sync-restart retries"),
+            (self.interruptions, "interruption signals"),
+            (self.uncaught_exceptions, "uncaught exceptions"),
+            (self.postgres_concurrency_errors, "PostgreSQL connection-concurrency errors"),
+            (self.cache_store_failures, "cache/store failures"),
+        )
+        failures.extend(f"{count} {label}" for count, label in health_counts if count)
+        duplicate_repairs = {thread: count for thread, count in self.repair_fetches_by_thread.items() if count > 1}
+        if duplicate_repairs:
+            failures.append(f"duplicate repair scans: {duplicate_repairs}")
+        if failures:
+            raise AssertionError("; ".join(failures))
+
+
+def _integer(value: object) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def parse_structured_log(text: str) -> tuple[list[dict[str, object]], list[str]]:
+    """Parse JSON log lines while retaining non-JSON lines for signal scans."""
+    events: list[dict[str, object]] = []
+    raw_lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            payload = json.loads(stripped)
+        except json.JSONDecodeError:
+            raw_lines.append(stripped)
+            continue
+        if isinstance(payload, dict):
+            events.append(cast("dict[str, object]", payload))
+        else:
+            raw_lines.append(stripped)
+    return events, raw_lines
+
+
+def aggregate_log_metrics(text: str) -> StressLogMetrics:
+    """Aggregate JSON and fallback text logs without dropping fatal signals."""
+    events, raw_lines = parse_structured_log(text)
+    metrics = StressLogMetrics()
+    for event in events:
+        metrics.ingest(event)
+    for line in raw_lines:
+        metrics.ingest({"event": line})
+    return metrics
+
+
+@dataclass(frozen=True, slots=True)
+class BaselineSample:
+    """One exact-run performance observation."""
+
+    source_to_final_p95_ms: float
+    source_to_final_p99_ms: float
+    throughput_responses_per_second: float
+
+
+@dataclass(frozen=True, slots=True)
+class StressBaseline:
+    """Versioned median-of-three-or-more baseline for one named profile."""
+
+    profile: str
+    source_revision: str
+    config_sha256: str
+    machine_class: str
+    samples: tuple[BaselineSample, ...]
+    allowance: float = DEFAULT_PERFORMANCE_ALLOWANCE
+
+    def validate(self) -> None:
+        """Reject incomplete, high-variance, or arbitrary baselines."""
+        if not self.profile or not self.source_revision or not self.config_sha256 or not self.machine_class:
+            msg = "baseline identity fields must be non-empty"
+            raise ValueError(msg)
+        if len(self.samples) < 3:
+            msg = "performance baselines require at least three clean executions"
+            raise ValueError(msg)
+        if not 0 < self.allowance <= 0.5:
+            msg = "baseline allowance must be positive and at most 50%"
+            raise ValueError(msg)
+        for sample in self.samples:
+            _positive(sample.source_to_final_p95_ms, "source_to_final_p95_ms")
+            _positive(sample.source_to_final_p99_ms, "source_to_final_p99_ms")
+            _positive(sample.throughput_responses_per_second, "throughput_responses_per_second")
+        for metric in (
+            "source_to_final_p95_ms",
+            "source_to_final_p99_ms",
+            "throughput_responses_per_second",
+        ):
+            values = [float(getattr(sample, metric)) for sample in self.samples]
+            median = statistics.median(values)
+            dispersion = (max(values) - min(values)) / median
+            if dispersion > self.allowance:
+                msg = (
+                    f"baseline {metric} dispersion {dispersion:.3f} exceeds "
+                    f"allowance {self.allowance:.3f}; fix determinism before gating"
+                )
+                raise ValueError(msg)
+
+    def medians(self) -> dict[str, float]:
+        """Return metric medians used by regression gates."""
+        self.validate()
+        return {
+            field_name: statistics.median(float(getattr(sample, field_name)) for sample in self.samples)
+            for field_name in (
+                "source_to_final_p95_ms",
+                "source_to_final_p99_ms",
+                "throughput_responses_per_second",
+            )
+        }
+
+    def compare(
+        self,
+        candidate: BaselineSample,
+        *,
+        machine_class: str | None = None,
+    ) -> dict[str, object]:
+        """Return comparison details and fail when candidate exceeds allowance."""
+        candidate_machine_class = machine_class or current_machine_class()
+        if candidate_machine_class != self.machine_class:
+            msg = (
+                "stress baseline machine class mismatch: "
+                f"baseline={self.machine_class!r}, candidate={candidate_machine_class!r}"
+            )
+            raise ValueError(msg)
+        medians = self.medians()
+        limits = {
+            "source_to_final_p95_ms": medians["source_to_final_p95_ms"] * (1 + self.allowance),
+            "source_to_final_p99_ms": medians["source_to_final_p99_ms"] * (1 + self.allowance),
+            "throughput_responses_per_second": medians["throughput_responses_per_second"] * (1 - self.allowance),
+        }
+        failures: list[str] = []
+        if candidate.source_to_final_p95_ms > limits["source_to_final_p95_ms"]:
+            failures.append("source_to_final_p95_ms")
+        if candidate.source_to_final_p99_ms > limits["source_to_final_p99_ms"]:
+            failures.append("source_to_final_p99_ms")
+        if candidate.throughput_responses_per_second < limits["throughput_responses_per_second"]:
+            failures.append("throughput_responses_per_second")
+        result = {
+            "baseline_medians": {key: round(value, 3) for key, value in medians.items()},
+            "limits": {key: round(value, 3) for key, value in limits.items()},
+            "candidate": asdict(candidate),
+            "allowance": self.allowance,
+            "machine_class": self.machine_class,
+            "passed": not failures,
+            "regressed_metrics": failures,
+        }
+        if failures:
+            msg = f"stress performance regression: {', '.join(failures)}"
+            raise AssertionError(msg)
+        return result
+
+    def to_json(self) -> str:
+        """Serialize one sanitized versioned baseline."""
+        self.validate()
+        return json.dumps(
+            {
+                "version": STRESS_BASELINE_VERSION,
+                "profile": self.profile,
+                "source_revision": self.source_revision,
+                "config_sha256": self.config_sha256,
+                "machine_class": self.machine_class,
+                "allowance": self.allowance,
+                "samples": [asdict(sample) for sample in self.samples],
+                "medians": self.medians(),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+
+    @classmethod
+    def from_json(cls, value: str) -> StressBaseline:
+        """Parse a complete versioned baseline."""
+        payload = json.loads(value)
+        if not isinstance(payload, dict) or payload.get("version") != STRESS_BASELINE_VERSION:
+            msg = "unsupported or missing live Matrix stress baseline version"
+            raise ValueError(msg)
+        raw_samples = payload.get("samples")
+        if not isinstance(raw_samples, list):
+            msg = "live Matrix stress baseline is missing samples"
+            raise TypeError(msg)
+        baseline = cls(
+            profile=str(payload.get("profile", "")),
+            source_revision=str(payload.get("source_revision", "")),
+            config_sha256=str(payload.get("config_sha256", "")),
+            machine_class=str(payload.get("machine_class", "")),
+            allowance=float(payload.get("allowance", DEFAULT_PERFORMANCE_ALLOWANCE)),
+            samples=tuple(
+                BaselineSample(**cast("dict[str, float]", sample)) for sample in raw_samples if isinstance(sample, dict)
+            ),
+        )
+        if len(baseline.samples) != len(raw_samples):
+            msg = "live Matrix stress baseline contains a malformed sample"
+            raise TypeError(msg)
+        baseline.validate()
+        return baseline
+
+
+def current_machine_class() -> str:
+    """Return a sanitized stable machine-class key for baseline comparability."""
+    return f"{platform.system().lower()}-{platform.machine().lower()}-{os.cpu_count() or 0}cpu"
+
+
+class ArtifactSanitizer:
+    """Stable logical-ID and secret sanitizer for persistent stress evidence."""
+
+    def __init__(self) -> None:
+        self._labels: dict[str, dict[str, str]] = defaultdict(dict)
+
+    def _label(self, family: str, value: str) -> str:
+        labels = self._labels[family]
+        if value not in labels:
+            labels[value] = f"<{family}-{len(labels) + 1:03d}>"
+        return labels[value]
+
+    def text(self, value: str) -> str:
+        """Redact credentials, URLs, paths, and raw Matrix identifiers."""
+        sanitized = _BEARER_PATTERN.sub("<authorization>", value)
+        sanitized = _ACCESS_TOKEN_PATTERN.sub("<secret>", sanitized)
+        sanitized = _POSTGRES_URL_PATTERN.sub("<database-url>", sanitized)
+        sanitized = _URL_PATTERN.sub("<url>", sanitized)
+        sanitized = _SYNC_TOKEN_PATTERN.sub("<sync-token>", sanitized)
+        sanitized = _PRIVATE_PATH_PATTERN.sub("<path>", sanitized)
+        sanitized = _ROOM_ID_PATTERN.sub(lambda match: self._label("room", match.group()), sanitized)
+        sanitized = _EVENT_ID_PATTERN.sub(lambda match: self._label("event", match.group()), sanitized)
+        return _USER_ID_PATTERN.sub(lambda match: self._label("user", match.group()), sanitized)
+
+    def value(self, value: object, *, key: str | None = None) -> object:
+        """Recursively sanitize one JSON-safe value."""
+        if key is not None and _SENSITIVE_KEY_PATTERN.search(key):
+            return "<redacted>"
+        if isinstance(value, str):
+            return self.text(value)
+        if isinstance(value, Mapping):
+            return {str(item_key): self.value(item_value, key=str(item_key)) for item_key, item_value in value.items()}
+        if isinstance(value, list | tuple):
+            return [self.value(item) for item in value]
+        return value
+
+    def assert_clean(self, value: str) -> None:
+        """Reject sanitizer output that still contains a forbidden secret class."""
+        forbidden = {
+            "authorization": _BEARER_PATTERN,
+            "access token": _ACCESS_TOKEN_PATTERN,
+            "database URL": _POSTGRES_URL_PATTERN,
+            "private path": _PRIVATE_PATH_PATTERN,
+            "room ID": _ROOM_ID_PATTERN,
+            "event ID": _EVENT_ID_PATTERN,
+            "user ID": _USER_ID_PATTERN,
+            "sync token": _SYNC_TOKEN_PATTERN,
+        }
+        leaked = [name for name, pattern in forbidden.items() if pattern.search(value)]
+        if leaked:
+            msg = f"stress artifact sanitizer leaked: {', '.join(leaked)}"
+            raise AssertionError(msg)
+
+
+def _is_forbidden_artifact_root(path: Path) -> bool:
+    resolved = path.expanduser().resolve()
+    forbidden_roots = (Path("/tmp"), Path("/private/tmp"), Path("/var/tmp"))  # noqa: S108
+    if any(resolved == root or resolved.is_relative_to(root) for root in forbidden_roots):
+        return True
+    return "tmp" in {part.lower() for part in resolved.parts}
+
+
+class StressArtifactBundle:
+    """Persistent atomic and sanitized evidence for successful or failed stress runs."""
+
+    def __init__(self, directory: Path, *, sanitizer: ArtifactSanitizer | None = None) -> None:
+        self.directory = directory
+        self.sanitizer = sanitizer or ArtifactSanitizer()
+
+    @classmethod
+    def create(cls, root: Path, run_id: str) -> StressArtifactBundle:
+        """Create one persistent non-temporary run directory."""
+        if _is_forbidden_artifact_root(root):
+            msg = f"stress artifact root must be persistent and not temporary: {root}"
+            raise ValueError(msg)
+        if not run_id or "/" in run_id:
+            msg = "stress run ID must be one path component"
+            raise ValueError(msg)
+        directory = root.expanduser().resolve() / run_id
+        directory.mkdir(parents=True, exist_ok=False)
+        return cls(directory)
+
+    def write_json(self, name: str, payload: object) -> Path:
+        """Atomically write one recursively sanitized JSON artifact."""
+        sanitized = self.sanitizer.value(payload)
+        serialized = json.dumps(sanitized, indent=2, sort_keys=True) + "\n"
+        self.sanitizer.assert_clean(serialized)
+        return self._atomic_write(name, serialized)
+
+    def write_text(self, name: str, payload: str) -> Path:
+        """Atomically write one sanitized text artifact."""
+        sanitized = self.sanitizer.text(payload)
+        self.sanitizer.assert_clean(sanitized)
+        return self._atomic_write(name, sanitized)
+
+    def _atomic_write(self, name: str, payload: str) -> Path:
+        if Path(name).name != name:
+            msg = f"stress artifact name must be one path component: {name}"
+            raise ValueError(msg)
+        destination = self.directory / name
+        temporary = destination.with_suffix(destination.suffix + ".pending")
+        temporary.write_text(payload, encoding="utf-8")
+        temporary.replace(destination)
+        return destination
+
+
+@dataclass(frozen=True, slots=True)
+class ResourceSample:
+    """Bounded process and dependency health sample."""
+
+    offset_seconds: float
+    cpu_percent: float
+    rss_bytes: int
+    sync_age_seconds: float | None
+    health_latency_ms: float | None
+    tuwunel_healthy: bool
+    postgres_healthy: bool
+
+
+def resource_summary(samples: Sequence[ResourceSample]) -> dict[str, object]:
+    """Summarize bounded runtime resource and health samples."""
+    if not samples:
+        return {"count": 0}
+    cpu = [sample.cpu_percent for sample in samples]
+    rss = [float(sample.rss_bytes) for sample in samples]
+    sync_age = [sample.sync_age_seconds for sample in samples if sample.sync_age_seconds is not None]
+    health_latency = [sample.health_latency_ms for sample in samples if sample.health_latency_ms is not None]
+    return {
+        "count": len(samples),
+        "cpu_percent": latency_summary(cpu),
+        "rss_bytes": latency_summary(rss),
+        "sync_age_seconds": latency_summary(sync_age),
+        "health_latency_ms": latency_summary(health_latency),
+        "tuwunel_unhealthy_samples": sum(not sample.tuwunel_healthy for sample in samples),
+        "postgres_unhealthy_samples": sum(not sample.postgres_healthy for sample in samples),
+    }
+
+
+@dataclass(slots=True)
+class ManagedStressPostgres:
+    """Exact disposable PostgreSQL container owned by one stress stack."""
+
+    name: str
+    password: str = "synthetic-stress-password"  # noqa: S105 - disposable synthetic database
+    image: str = "postgres:15-alpine"
+    host_port: int | None = None
+    _started: bool = False
+
+    @property
+    def database_url(self) -> str:
+        """Return the local synthetic DSN used only by the live child."""
+        if self.host_port is None:
+            msg = "stress PostgreSQL has not started"
+            raise RuntimeError(msg)
+        return f"postgresql://cache:{self.password}@127.0.0.1:{self.host_port}/mindroom"
+
+    def start(self) -> None:
+        """Start and verify a disposable PostgreSQL container."""
+        subprocess.run(
+            (
+                "docker",
+                "run",
+                "--detach",
+                "--name",
+                self.name,
+                "--publish",
+                "127.0.0.1::5432",
+                "--env",
+                "POSTGRES_USER=cache",
+                "--env",
+                f"POSTGRES_PASSWORD={self.password}",
+                "--env",
+                "POSTGRES_DB=mindroom",
+                self.image,
+            ),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self._started = True
+        port_result = subprocess.run(
+            ("docker", "port", self.name, "5432/tcp"),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        endpoint = port_result.stdout.strip().rsplit(":", maxsplit=1)
+        if len(endpoint) != 2 or not endpoint[1].isdigit():
+            msg = f"could not resolve stress PostgreSQL host port: {port_result.stdout!r}"
+            raise RuntimeError(msg)
+        self.host_port = int(endpoint[1])
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            probe = subprocess.run(
+                ("docker", "exec", self.name, "pg_isready", "-U", "cache", "-d", "mindroom"),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if probe.returncode == 0:
+                return
+            time.sleep(0.2)
+        msg = "stress PostgreSQL did not become ready within 60 seconds"
+        raise TimeoutError(msg)
+
+    def is_healthy(self) -> bool:
+        """Return whether the exact container is running and PostgreSQL responds."""
+        if not self._started:
+            return False
+        result = subprocess.run(
+            ("docker", "exec", self.name, "pg_isready", "-U", "cache", "-d", "mindroom"),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+
+    def diagnostics(self) -> dict[str, object]:
+        """Capture sanitized connection and table activity diagnostics."""
+        if not self._started:
+            return {"started": False}
+        query = (
+            "SELECT datname, state, count(*) "
+            "FROM pg_stat_activity WHERE datname = 'mindroom' GROUP BY datname, state ORDER BY state;"
+        )
+        result = subprocess.run(
+            ("docker", "exec", self.name, "psql", "-U", "cache", "-d", "mindroom", "-Atc", query),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        return {
+            "started": True,
+            "healthy": self.is_healthy(),
+            "image": self.image,
+            "activity": result.stdout.splitlines(),
+            "diagnostic_exit_code": result.returncode,
+        }
+
+    def clear_cache_namespace(self, namespace: str) -> None:
+        """Delete cache data rows while retaining the runtime certification generation."""
+        if not self._started:
+            msg = "cannot clear a stress PostgreSQL namespace before startup"
+            raise RuntimeError(msg)
+        if not re.fullmatch(r"[A-Za-z0-9_-]+", namespace):
+            msg = f"invalid synthetic cache namespace: {namespace!r}"
+            raise ValueError(msg)
+        tables = (
+            "mindroom_event_cache_thread_events",
+            "mindroom_event_cache_events",
+            "mindroom_event_cache_event_edits",
+            "mindroom_event_cache_event_threads",
+            "mindroom_event_cache_redacted_events",
+            "mindroom_event_cache_mxc_text",
+            "mindroom_event_cache_event_mxc_references",
+            "mindroom_event_cache_thread_state",
+            "mindroom_event_cache_room_state",
+        )
+        statements = " ".join(
+            f"DELETE FROM {table} WHERE namespace = '{namespace}';"  # noqa: S608 - table allowlist and validated namespace
+            for table in tables
+        )
+        result = subprocess.run(
+            (
+                "docker",
+                "exec",
+                self.name,
+                "psql",
+                "-U",
+                "cache",
+                "-d",
+                "mindroom",
+                "-v",
+                "ON_ERROR_STOP=1",
+                "-c",
+                statements,
+            ),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode:
+            msg = f"failed to clear synthetic stress cache namespace: {result.stderr}"
+            raise RuntimeError(msg)
+
+    def close(self) -> None:
+        """Remove only the exact owned PostgreSQL container."""
+        if not self._started:
+            return
+        subprocess.run(
+            ("docker", "rm", "--force", "--volumes", self.name),
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        self._started = False
+
+
+def expected_minimum_matrix_edits(config: StressConfig) -> int:
+    """Derive a conservative edit floor from production throttle cadence.
+
+    Streaming begins near 0.5 seconds and ramps to a five-second steady state.
+    Requiring one edit per five seconds proves repeated real replacements while
+    allowing intentional character and cache-write coalescing.
+    """
+    return max(2, math.floor(config.stream_seconds / 5.0))
+
+
+def assert_matrix_edit_shape(
+    config: StressConfig,
+    edits_by_stream: Mapping[str, Sequence[float]],
+) -> None:
+    """Fail unless every stream produced repeated overlapping Matrix edits."""
+    expected_streams = config.threads * config.waves
+    if len(edits_by_stream) != expected_streams:
+        msg = f"Matrix edit evidence covers {len(edits_by_stream)}/{expected_streams} streams"
+        raise AssertionError(msg)
+    minimum = expected_minimum_matrix_edits(config)
+    sparse = {label: len(edits) for label, edits in edits_by_stream.items() if len(edits) < minimum}
+    if sparse:
+        msg = f"insufficient Matrix edit activity; minimum={minimum}, streams={sparse}"
+        raise AssertionError(msg)
+    intervals = [(min(edits), max(edits)) for edits in edits_by_stream.values() if edits]
+    simultaneous = max(
+        (
+            sum(start <= timestamp <= end for start, end in intervals)
+            for timestamp in sorted({time_value for edits in edits_by_stream.values() for time_value in edits})
+        ),
+        default=0,
+    )
+    if simultaneous < config.threads:
+        msg = f"Matrix edit overlap reached {simultaneous}/{config.threads} streams"
+        raise AssertionError(msg)
+
+
+def write_replay_command(
+    *,
+    scenario_path: str = "scenario.json",
+    artifact_root: str = "artifacts/live-matrix-stress",
+) -> str:
+    """Return a repository-relative replay command without host-specific paths."""
+    return (
+        "uv run python scripts/testing/fuzz_live_matrix.py "
+        f"--profile stress --trace {scenario_path} --artifact-root {artifact_root} "
+        "--nio-overlay <clean-mindroom-nio-checkout>\n"
+    )
+
+
+__all__ = [
+    "DEFAULT_STRESS_ARTIFACT_ROOT",
+    "ArtifactSanitizer",
+    "BaselineSample",
+    "ManagedStressPostgres",
+    "ResourceSample",
+    "StressArtifactBundle",
+    "StressBaseline",
+    "StressConfig",
+    "StressLogMetrics",
+    "StressModelController",
+    "StressRequest",
+    "aggregate_log_metrics",
+    "assert_matrix_edit_shape",
+    "current_machine_class",
+    "expected_minimum_matrix_edits",
+    "latency_summary",
+    "parse_stress_request",
+    "parse_structured_log",
+    "percentile",
+    "resource_summary",
+    "write_replay_command",
+]

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -10,19 +10,19 @@ import platform
 import re
 import statistics
 import subprocess
-import threading
 import time
 from collections import Counter, defaultdict
-from collections.abc import Callable, Iterator, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
+
+from mindroom.synthetic_model import SyntheticPlan, synthetic_plan
 
 STRESS_TRACE_VERSION = 1
 STRESS_BASELINE_VERSION = 1
 DEFAULT_STRESS_ARTIFACT_ROOT = Path("artifacts/live-matrix-stress")
 DEFAULT_PERFORMANCE_ALLOWANCE = 0.25
-STRESS_MARKER_PATTERN = re.compile(r"LMS\[wave=(\d+);thread=(\d+);seed=(-?\d+)\]")
 _SENSITIVE_KEY_PATTERN = re.compile(
     r"(?:access[_-]?token|authorization|cookie|database[_-]?url|password|secret|sync[_-]?token)",
     re.IGNORECASE,
@@ -65,9 +65,14 @@ def _positive(value: float, field_name: str) -> None:
 class StressConfig:
     """Replayable synthetic workload shape for one stress run."""
 
-    threads: int = 50
+    threads: int = 100
+    rooms: int = 10
     stream_seconds: float = 45.0
     edit_interval: float = 0.5
+    chars_per_second: float = 80.0
+    tool_call_probability: float = 1.0
+    min_sleep_seconds: int = 1
+    max_sleep_seconds: int = 3
     waves: int = 2
     history_turns: int = 20
     cache_backend: Literal["postgres"] = "postgres"
@@ -81,8 +86,22 @@ class StressConfig:
     def validate(self) -> None:
         """Reject shapes that cannot provide exact deterministic evidence."""
         _positive(self.threads, "threads")
+        _positive(self.rooms, "rooms")
+        if self.rooms > self.threads:
+            msg = "rooms cannot exceed threads"
+            raise ValueError(msg)
         _positive(self.stream_seconds, "stream_seconds")
         _positive(self.edit_interval, "edit_interval")
+        _positive(self.chars_per_second, "chars_per_second")
+        if not 0 <= self.tool_call_probability <= 1:
+            msg = "tool_call_probability must be between 0 and 1"
+            raise ValueError(msg)
+        if self.min_sleep_seconds < 0:
+            msg = "min_sleep_seconds must be non-negative"
+            raise ValueError(msg)
+        if self.max_sleep_seconds < self.min_sleep_seconds:
+            msg = "max_sleep_seconds must be greater than or equal to min_sleep_seconds"
+            raise ValueError(msg)
         _positive(self.waves, "waves")
         if self.history_turns < 0:
             msg = "history_turns must be non-negative"
@@ -102,15 +121,19 @@ class StressConfig:
             raise ValueError(msg)
 
     @property
-    def pulses_per_stream(self) -> int:
-        """Return exact model update pulses emitted by every stream."""
-        self.validate()
-        return round(self.stream_seconds / self.edit_interval)
+    def min_response_chars(self) -> int:
+        """Return the shortest seeded response at half the configured duration."""
+        return max(64, round(self.stream_seconds * self.chars_per_second / 2))
 
     @property
-    def expected_model_pulses(self) -> int:
-        """Return total model pulses for the configured waves."""
-        return self.threads * self.waves * self.pulses_per_stream
+    def max_response_chars(self) -> int:
+        """Return the longest seeded response at the configured duration."""
+        return max(self.min_response_chars, round(self.stream_seconds * self.chars_per_second))
+
+    @property
+    def chunk_chars(self) -> int:
+        """Return the chunk size matching the configured update cadence."""
+        return max(1, round(self.edit_interval * self.chars_per_second))
 
     def marker(self, wave: int, thread: int) -> str:
         """Build one deterministic synthetic request marker."""
@@ -162,70 +185,108 @@ class StressRequest:
         return f"wave-{self.wave:02d}/thread-{self.thread:03d}"
 
 
-def parse_stress_request(text: str) -> StressRequest | None:
-    """Parse the one stress marker embedded in a model request."""
-    matches = STRESS_MARKER_PATTERN.findall(text)
-    if not matches:
-        return None
-    if len(matches) != 1:
-        msg = f"stress model request contains {len(matches)} markers"
-        raise ValueError(msg)
-    wave, thread, seed = matches[0]
-    return StressRequest(wave=int(wave), thread=int(thread), seed=int(seed))
+class SyntheticStressAudit:
+    """Audit exact built-in synthetic-model behavior from append-only telemetry."""
 
-
-@dataclass(slots=True)
-class StreamObservation:
-    """Thread-safe timing observations for one fake-model stream."""
-
-    request: StressRequest
-    reached_at: float
-    released_at: float | None = None
-    started_at: float | None = None
-    finished_at: float | None = None
-    pulses: list[float] = field(default_factory=list)
-    cancelled: bool = False
-
-    def artifact_dict(self) -> dict[str, object]:
-        """Return relative timings without host-clock data."""
-        released_at = self.released_at
-        started_at = self.started_at
-        finished_at = self.finished_at
-        return {
-            "label": self.request.label,
-            "barrier_wait_ms": None if released_at is None else round((released_at - self.reached_at) * 1000, 3),
-            "stream_duration_seconds": (
-                None if started_at is None or finished_at is None else round(finished_at - started_at, 3)
-            ),
-            "pulse_count": len(self.pulses),
-            "pulse_offsets_seconds": (
-                [] if started_at is None else [round(pulse - started_at, 3) for pulse in self.pulses]
-            ),
-            "cancelled": self.cancelled,
-        }
-
-
-class StressModelController:
-    """Reusable per-wave barrier and exact-cadence fake-model stream controller."""
-
-    def __init__(
-        self,
-        config: StressConfig,
-        *,
-        clock: Callable[[], float] = time.monotonic,
-        sleeper: Callable[[float], None] = time.sleep,
-        serialize_streams: bool = False,
-    ) -> None:
+    def __init__(self, config: StressConfig, telemetry_path: Path) -> None:
         config.validate()
         self.config = config
-        self._clock = clock
-        self._sleeper = sleeper
-        self._condition = threading.Condition()
-        self._observations: dict[tuple[int, int], StreamObservation] = {}
-        self._active_streams = 0
-        self._max_active_streams = 0
-        self._active_timeline: list[tuple[float, int]] = []
-        self._serialization_lock = threading.Lock() if serialize_streams else None
+        self.telemetry_path = telemetry_path
+
+    def plan(self, request: StressRequest) -> SyntheticPlan:
+        """Return the exact seeded model plan for one stress request."""
+        self._validate_request(request)
+        identity = self.config.marker(request.wave, request.thread)
+        return synthetic_plan(
+            identity,
+            seed=self.config.seed,
+            min_response_chars=self.config.min_response_chars,
+            max_response_chars=self.config.max_response_chars,
+            tool_call_probability=self.config.tool_call_probability,
+            min_sleep_seconds=self.config.min_sleep_seconds,
+            max_sleep_seconds=self.config.max_sleep_seconds,
+            tool_available=True,
+        )
+
+    def expected_body(self, request: StressRequest) -> str:
+        """Return the exact final body for one configured request."""
+        return self.plan(request).body
+
+    def reached_count(self, wave: int) -> int:
+        """Return distinct initial requests recorded at one wave barrier."""
+        return len(
+            {
+                str(event["request_id"])
+                for event in self._events()
+                if event.get("kind") == "barrier_reached"
+                and event.get("phase") == "initial"
+                and event.get("group") == str(wave)
+            },
+        )
+
+    def snapshot(self) -> dict[str, object]:
+        """Return deterministic request counts, concurrency, and response shape."""
+        events = self._stress_events()
+        counts = Counter((str(event.get("kind")), str(event.get("phase"))) for event in events)
+        plans = [
+            self.plan(StressRequest(wave=wave, thread=thread, seed=self.config.seed))
+            for wave in range(self.config.waves)
+            for thread in range(self.config.threads)
+        ]
+        timeline, max_active_streams = self._active_timeline(events)
+        return {
+            "reached_by_wave": {str(wave): self.reached_count(wave) for wave in range(self.config.waves)},
+            "event_counts": {f"{kind}:{phase}": count for (kind, phase), count in sorted(counts.items())},
+            "max_active_streams": max_active_streams,
+            "active_stream_timeline": timeline,
+            "response_chars": latency_summary([float(len(plan.body)) for plan in plans]),
+            "tool_calls": sum(plan.tool_call_id is not None for plan in plans),
+            "sleep_seconds": latency_summary(
+                [float(plan.sleep_seconds) for plan in plans if plan.sleep_seconds is not None],
+            ),
+        }
+
+    def assert_complete(self) -> None:
+        """Fail unless every seeded request completed every expected phase once."""
+        events = self._stress_events()
+        failures: list[str] = []
+        for wave in range(self.config.waves):
+            reached = self.reached_count(wave)
+            if reached != self.config.threads:
+                failures.append(f"wave {wave} barrier reached {reached}/{self.config.threads}")
+        by_request = Counter(
+            (
+                str(event.get("request_id")),
+                str(event.get("kind")),
+                str(event.get("phase")),
+            )
+            for event in events
+        )
+        for wave in range(self.config.waves):
+            for thread in range(self.config.threads):
+                request = StressRequest(wave=wave, thread=thread, seed=self.config.seed)
+                plan = self.plan(request)
+                expected = {
+                    ("barrier_reached", "initial"): 1,
+                    ("request_started", "initial"): 1,
+                    ("request_finished", "initial"): 1,
+                    ("tool_call_emitted", "initial"): int(plan.tool_call_id is not None),
+                    ("request_started", "continuation"): int(plan.tool_call_id is not None),
+                    ("request_finished", "continuation"): int(plan.tool_call_id is not None),
+                }
+                for (kind, phase), count in expected.items():
+                    actual = by_request[(plan.request_id, kind, phase)]
+                    if actual != count:
+                        failures.append(
+                            f"{request.label} {kind}:{phase} count {actual}/{count}",
+                        )
+        max_active_streams = self._active_timeline(events)[1]
+        if max_active_streams != self.config.threads:
+            failures.append(
+                f"maximum active model streams {max_active_streams}/{self.config.threads}",
+            )
+        if failures:
+            raise AssertionError("; ".join(failures))
 
     def _validate_request(self, request: StressRequest) -> None:
         if request.seed != self.config.seed:
@@ -235,181 +296,58 @@ class StressModelController:
             msg = f"stress request outside configured shape: {request.label}"
             raise ValueError(msg)
 
-    def reach_barrier(self, request: StressRequest) -> StreamObservation:
-        """Register one request and wait until its complete wave reaches the barrier."""
-        self._validate_request(request)
-        key = (request.wave, request.thread)
-        deadline = self._clock() + self.config.barrier_timeout_seconds
-        with self._condition:
-            if key in self._observations:
-                msg = f"duplicate stress model request at {request.label}"
-                raise RuntimeError(msg)
-            observation = StreamObservation(request=request, reached_at=self._clock())
-            self._observations[key] = observation
-            self._condition.notify_all()
-            while self.reached_count(request.wave) < self.config.threads:
-                remaining = deadline - self._clock()
-                if remaining <= 0:
-                    missing = sorted(set(range(self.config.threads)) - self.reached_threads(request.wave))
-                    msg = (
-                        f"stress model barrier wave {request.wave} reached "
-                        f"{self.reached_count(request.wave)}/{self.config.threads}; missing={missing}"
-                    )
-                    raise TimeoutError(msg)
-                self._condition.wait(timeout=remaining)
-            released_at = self._clock()
-            for wave_key, wave_observation in self._observations.items():
-                if wave_key[0] == request.wave and wave_observation.released_at is None:
-                    wave_observation.released_at = released_at
-            self._condition.notify_all()
-            return observation
+    def _events(self) -> list[dict[str, object]]:
+        if not self.telemetry_path.exists():
+            return []
+        events: list[dict[str, object]] = []
+        for line in self.telemetry_path.read_text(encoding="utf-8").splitlines():
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                msg = "synthetic model telemetry entry must be an object"
+                raise TypeError(msg)
+            events.append(cast("dict[str, object]", payload))
+        return events
 
-    def stream(self, request: StressRequest) -> Iterator[str]:
-        """Yield exact deterministic pulses after the wave barrier releases."""
-        observation = self.reach_barrier(request)
-        serialization_lock = self._serialization_lock
-        if serialization_lock is None:
-            yield from self._stream_observation(observation)
-            return
-        with serialization_lock:
-            yield from self._stream_observation(observation)
-
-    def expected_body(self, request: StressRequest) -> str:
-        """Return the exact cumulative body produced by one complete stream."""
-        self._validate_request(request)
-        chunks = []
-        for pulse in range(self.config.pulses_per_stream):
-            completion = (
-                f" COMPLETE[wave={request.wave};thread={request.thread:03d};pulses={self.config.pulses_per_stream}]"
-                if pulse + 1 == self.config.pulses_per_stream
-                else ""
-            )
-            chunks.append(
-                f"SYNTHETIC wave={request.wave} thread={request.thread:03d} "
-                f"pulse={pulse + 1:03d}/{self.config.pulses_per_stream:03d}{completion} ",
-            )
-        return "".join(chunks)
-
-    def _stream_observation(self, observation: StreamObservation) -> Iterator[str]:
-        with self._condition:
-            observation.started_at = self._clock()
-            self._active_streams += 1
-            self._max_active_streams = max(self._max_active_streams, self._active_streams)
-            self._active_timeline.append((observation.started_at, self._active_streams))
-        try:
-            for pulse in range(self.config.pulses_per_stream):
-                scheduled_at = cast("float", observation.started_at) + (pulse + 1) * self.config.edit_interval
-                delay = scheduled_at - self._clock()
-                if delay > 0:
-                    self._sleeper(delay)
-                emitted_at = self._clock()
-                with self._condition:
-                    observation.pulses.append(emitted_at)
-                completion = (
-                    f" COMPLETE[wave={observation.request.wave};thread={observation.request.thread:03d};"
-                    f"pulses={self.config.pulses_per_stream}]"
-                    if pulse + 1 == self.config.pulses_per_stream
-                    else ""
-                )
-                yield (
-                    f"SYNTHETIC wave={observation.request.wave} thread={observation.request.thread:03d} "
-                    f"pulse={pulse + 1:03d}/{self.config.pulses_per_stream:03d}{completion} "
-                )
-        except GeneratorExit:
-            observation.cancelled = True
-            raise
-        finally:
-            with self._condition:
-                observation.finished_at = self._clock()
-                self._active_streams -= 1
-                self._active_timeline.append((observation.finished_at, self._active_streams))
-                self._condition.notify_all()
-
-    def reached_threads(self, wave: int) -> set[int]:
-        """Return logical threads registered at one wave barrier."""
-        return {thread for (observed_wave, thread) in self._observations if observed_wave == wave}
-
-    def reached_count(self, wave: int) -> int:
-        """Return request count registered at one wave barrier."""
-        return len(self.reached_threads(wave))
-
-    @property
-    def max_active_streams(self) -> int:
-        """Return maximum simultaneous fake-model streams."""
-        with self._condition:
-            return self._max_active_streams
-
-    @property
-    def total_pulses(self) -> int:
-        """Return emitted model pulse count."""
-        with self._condition:
-            return sum(len(observation.pulses) for observation in self._observations.values())
-
-    def snapshot(self) -> dict[str, object]:
-        """Return synthetic logical model timing evidence."""
-        with self._condition:
-            observations = [observation.artifact_dict() for _, observation in sorted(self._observations.items())]
-            origin = min(
-                (observation.reached_at for observation in self._observations.values()),
-                default=self._clock(),
-            )
-            timeline = [
-                {"offset_seconds": round(moment - origin, 3), "active_streams": active}
-                for moment, active in self._active_timeline
-            ]
-        barrier_waits = [
-            float(wait)
-            for observation in observations
-            for wait in (observation["barrier_wait_ms"],)
-            if isinstance(wait, int | float)
-        ]
-        return {
-            "reached_by_wave": {str(wave): self.reached_count(wave) for wave in range(self.config.waves)},
-            "barrier_wait_ms": latency_summary(barrier_waits),
-            "max_active_streams": self.max_active_streams,
-            "total_pulses": self.total_pulses,
-            "active_stream_timeline": timeline,
-            "streams": observations,
+    def _stress_events(self) -> list[dict[str, object]]:
+        request_ids = {
+            self.plan(
+                StressRequest(
+                    wave=wave,
+                    thread=thread,
+                    seed=self.config.seed,
+                ),
+            ).request_id
+            for wave in range(self.config.waves)
+            for thread in range(self.config.threads)
         }
+        return [event for event in self._events() if event.get("request_id") in request_ids]
 
-    def assert_complete(self, *, duration_tolerance_seconds: float | None = None) -> None:
-        """Fail unless every configured stream reached full cadence and concurrency."""
-        tolerance = duration_tolerance_seconds
-        if tolerance is None:
-            tolerance = max(0.25, self.config.edit_interval * 2)
-        failures = self._completion_failures(tolerance)
-        if failures:
-            raise AssertionError("; ".join(failures))
-
-    def _completion_failures(self, tolerance: float) -> list[str]:
-        """Return every model-shape failure without stopping at the first."""
-        failures: list[str] = []
-        for wave in range(self.config.waves):
-            reached = self.reached_count(wave)
-            if reached != self.config.threads:
-                failures.append(f"wave {wave} barrier reached {reached}/{self.config.threads}")
-        if self.max_active_streams != self.config.threads:
-            failures.append(
-                f"maximum active model streams {self.max_active_streams}/{self.config.threads}",
+    @staticmethod
+    def _active_timeline(events: Sequence[Mapping[str, object]]) -> tuple[list[dict[str, object]], int]:
+        ordered = sorted(
+            (
+                (float(event["time"]), 1 if event.get("kind") == "request_started" else -1)
+                for event in events
+                if event.get("kind") in {"request_started", "request_finished"}
+            ),
+            key=lambda item: (item[0], -item[1]),
+        )
+        if not ordered:
+            return [], 0
+        origin = ordered[0][0]
+        active = 0
+        maximum = 0
+        timeline: list[dict[str, object]] = []
+        for timestamp, delta in ordered:
+            active += delta
+            maximum = max(maximum, active)
+            timeline.append(
+                {
+                    "offset_seconds": round(timestamp - origin, 3),
+                    "active_streams": active,
+                },
             )
-        for key, observation in sorted(self._observations.items()):
-            if len(observation.pulses) != self.config.pulses_per_stream:
-                failures.append(
-                    f"wave {key[0]} thread {key[1]} emitted "
-                    f"{len(observation.pulses)}/{self.config.pulses_per_stream} pulses",
-                )
-            if observation.started_at is None or observation.finished_at is None:
-                failures.append(f"wave {key[0]} thread {key[1]} did not finish")
-                continue
-            duration = observation.finished_at - observation.started_at
-            if abs(duration - self.config.stream_seconds) > tolerance:
-                failures.append(
-                    f"wave {key[0]} thread {key[1]} duration "
-                    f"{duration:.3f}s outside {self.config.stream_seconds:.3f}s +/- {tolerance:.3f}s",
-                )
-            if observation.cancelled:
-                failures.append(f"wave {key[0]} thread {key[1]} was cancelled")
-        return failures
+        return timeline, maximum
 
 
 def percentile(values: Sequence[float], percentile_value: float) -> float:
@@ -1340,8 +1278,8 @@ __all__ = [
     "StressBaseline",
     "StressConfig",
     "StressLogMetrics",
-    "StressModelController",
     "StressRequest",
+    "SyntheticStressAudit",
     "aggregate_log_metrics",
     "assert_matrix_edit_shape",
     "assert_resource_health",
@@ -1349,7 +1287,6 @@ __all__ = [
     "expected_minimum_matrix_edits",
     "latency_summary",
     "matrix_edit_activity",
-    "parse_stress_request",
     "parse_structured_log",
     "percentile",
     "resource_summary",

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -70,6 +70,7 @@ class StressConfig:
     cache_backend: Literal["postgres"] = "postgres"
     seed: int = 1
     overlapping_followups: bool = False
+    fault_mode: Literal["none", "serialize-streams"] = "none"
     barrier_timeout_seconds: float = 90.0
     settlement_timeout_seconds: float = 180.0
     resource_sample_interval_seconds: float = 0.5
@@ -85,6 +86,9 @@ class StressConfig:
             raise ValueError(msg)
         if self.cache_backend != "postgres":
             msg = "stress profile requires PostgreSQL and never falls back to SQLite"
+            raise ValueError(msg)
+        if self.fault_mode not in {"none", "serialize-streams"}:
+            msg = f"unsupported stress fault mode: {self.fault_mode}"
             raise ValueError(msg)
         _positive(self.barrier_timeout_seconds, "barrier_timeout_seconds")
         _positive(self.settlement_timeout_seconds, "settlement_timeout_seconds")
@@ -758,8 +762,9 @@ class StressBaseline:
         candidate: BaselineSample,
         *,
         machine_class: str | None = None,
+        enforce: bool = True,
     ) -> dict[str, object]:
-        """Return comparison details and fail when candidate exceeds allowance."""
+        """Return comparison details and optionally enforce the allowance."""
         candidate_machine_class = machine_class or current_machine_class()
         if candidate_machine_class != self.machine_class:
             msg = (
@@ -789,7 +794,7 @@ class StressBaseline:
             "passed": not failures,
             "regressed_metrics": failures,
         }
-        if failures:
+        if failures and enforce:
             msg = f"stress performance regression: {', '.join(failures)}"
             raise AssertionError(msg)
         return result

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -1218,6 +1218,7 @@ class ManagedStressPostgres:
                 (
                     "docker",
                     "exec",
+                    "--interactive",
                     self.name,
                     "psql",
                     "-U",

--- a/scripts/testing/live_matrix_stress.py
+++ b/scripts/testing/live_matrix_stress.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import os
@@ -1189,6 +1190,65 @@ class ManagedStressPostgres:
         if result.returncode:
             msg = f"failed to clear synthetic stress cache namespace: {result.stderr}"
             raise RuntimeError(msg)
+
+    def wait_for_cached_event(
+        self,
+        *,
+        base_namespace: str,
+        principal_id: str,
+        room_id: str,
+        event_id: str,
+        timeout_seconds: float,
+    ) -> None:
+        """Wait until one exact sync event reaches a principal-scoped cache."""
+        if not self._started:
+            msg = "cannot inspect a stress PostgreSQL namespace before startup"
+            raise RuntimeError(msg)
+        principal_digest = hashlib.sha256(principal_id.encode()).hexdigest()
+        namespace = f"{base_namespace}:principal:{principal_digest}"
+        query = (
+            "SELECT EXISTS("
+            "SELECT 1 FROM mindroom_event_cache_events "
+            "WHERE namespace = :'namespace' AND room_id = :'room_id' AND event_id = :'event_id'"
+            ");"
+        )
+        deadline = time.monotonic() + timeout_seconds
+        while True:
+            result = subprocess.run(
+                (
+                    "docker",
+                    "exec",
+                    self.name,
+                    "psql",
+                    "-U",
+                    "cache",
+                    "-d",
+                    "mindroom",
+                    "-v",
+                    "ON_ERROR_STOP=1",
+                    "-v",
+                    f"namespace={namespace}",
+                    "-v",
+                    f"room_id={room_id}",
+                    "-v",
+                    f"event_id={event_id}",
+                    "-Atc",
+                    query,
+                ),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if result.returncode:
+                msg = f"failed to inspect synthetic stress cache namespace: {result.stderr}"
+                raise RuntimeError(msg)
+            if result.stdout.strip() == "t":
+                return
+            if time.monotonic() >= deadline:
+                msg = "stress sync fence did not reach the agent cache before timeout"
+                raise TimeoutError(msg)
+            time.sleep(0.1)
 
     def close(self) -> None:
         """Remove only the exact owned PostgreSQL container."""

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1182,10 +1182,10 @@ agents:
 # Model configurations (at least a "default" model is recommended)
 models:
   default:
-    provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
+    provider: anthropic            # Required: openai, azure, anthropic, ollama, synthetic, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
     id: claude-sonnet-5            # Required: Model ID for the provider
   sonnet:
-    provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
+    provider: anthropic            # Required: openai, azure, anthropic, ollama, synthetic, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
     id: claude-sonnet-5            # Required: Model ID for the provider
     host: null                     # Optional: Host URL (e.g., for Ollama)
     api_key: null                  # Optional: API key (usually from env vars)
@@ -2346,6 +2346,7 @@ Models define the AI providers and model IDs used by agents.
 - `cerebras` - Cerebras-hosted models
 - `deepseek` - DeepSeek models
 - `zai` - Z.ai GLM models
+- `synthetic` - Built-in deterministic streaming model for local load and tool-call testing
 
 ## Model Config Fields
 
@@ -2450,6 +2451,43 @@ models:
     extra_kwargs:
       base_url: http://localhost:8080/v1
 ```
+
+## Built-In Synthetic Model
+
+Use `provider: synthetic` to run realistic local concurrency tests without an API key or external model server.
+The model streams deterministic Lorem Ipsum at a fixed character rate, chooses a seeded response length, and can issue the built-in `sleep` tool before continuing the same response.
+The default tool-call probability is zero, so enabling tool calls is always explicit.
+
+```yaml
+models:
+  load_test:
+    provider: synthetic
+    id: local-load-test
+    extra_kwargs:
+      seed: 17
+      min_response_chars: 800
+      max_response_chars: 1600
+      chunk_chars: 40
+      chars_per_second: 80
+      tool_call_probability: 0.5
+      min_sleep_seconds: 1
+      max_sleep_seconds: 3
+
+agents:
+  load_test:
+    display_name: Load Test
+    role: Exercise the full MindRoom response path.
+    model: load_test
+    tools: [sleep]
+    rooms: [lobby]
+```
+
+The same seed and matched request identity always produce the same body length, tool decision, split point, and sleep duration.
+Set `identity_pattern` to extract a stable request marker when prompts contain changing surrounding context.
+Set `activation_pattern` to make unmatched setup or lifecycle prompts return the short `inactive_response` without a tool call or barrier wait.
+The advanced `barrier_size` and `barrier_group_pattern` settings synchronize request groups for deterministic concurrency tests.
+Set `coordination_key` when separately materialized model instances must share that barrier and optional stream-serialization state.
+Set `telemetry_path` only for local tests that need append-only request timing evidence.
 
 ## OpenAI API Models
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -321,10 +321,10 @@ agents:
 # Model configurations (at least a "default" model is recommended)
 models:
   default:
-    provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
+    provider: anthropic            # Required: openai, azure, anthropic, ollama, synthetic, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
     id: claude-sonnet-5            # Required: Model ID for the provider
   sonnet:
-    provider: anthropic            # Required: openai, azure, anthropic, ollama, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
+    provider: anthropic            # Required: openai, azure, anthropic, ollama, synthetic, google, gemini, vertexai_claude, groq, cerebras, openrouter, deepseek
     id: claude-sonnet-5            # Required: Model ID for the provider
     host: null                     # Optional: Host URL (e.g., for Ollama)
     api_key: null                  # Optional: API key (usually from env vars)

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -17,6 +17,7 @@ Models define the AI providers and model IDs used by agents.
 - `cerebras` - Cerebras-hosted models
 - `deepseek` - DeepSeek models
 - `zai` - Z.ai GLM models
+- `synthetic` - Built-in deterministic streaming model for local load and tool-call testing
 
 ## Model Config Fields
 
@@ -121,6 +122,43 @@ models:
     extra_kwargs:
       base_url: http://localhost:8080/v1
 ```
+
+## Built-In Synthetic Model
+
+Use `provider: synthetic` to run realistic local concurrency tests without an API key or external model server.
+The model streams deterministic Lorem Ipsum at a fixed character rate, chooses a seeded response length, and can issue the built-in `sleep` tool before continuing the same response.
+The default tool-call probability is zero, so enabling tool calls is always explicit.
+
+```yaml
+models:
+  load_test:
+    provider: synthetic
+    id: local-load-test
+    extra_kwargs:
+      seed: 17
+      min_response_chars: 800
+      max_response_chars: 1600
+      chunk_chars: 40
+      chars_per_second: 80
+      tool_call_probability: 0.5
+      min_sleep_seconds: 1
+      max_sleep_seconds: 3
+
+agents:
+  load_test:
+    display_name: Load Test
+    role: Exercise the full MindRoom response path.
+    model: load_test
+    tools: [sleep]
+    rooms: [lobby]
+```
+
+The same seed and matched request identity always produce the same body length, tool decision, split point, and sleep duration.
+Set `identity_pattern` to extract a stable request marker when prompts contain changing surrounding context.
+Set `activation_pattern` to make unmatched setup or lifecycle prompts return the short `inactive_response` without a tool call or barrier wait.
+The advanced `barrier_size` and `barrier_group_pattern` settings synchronize request groups for deterministic concurrency tests.
+Set `coordination_key` when separately materialized model instances must share that barrier and optional stream-serialization state.
+Set `telemetry_path` only for local tests that need append-only request timing evidence.
 
 ## OpenAI API Models
 

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -553,7 +553,7 @@ class ModelConfig(BaseModel):
     """Configuration for an AI model."""
 
     provider: str = Field(
-        description="Model provider (openai, anthropic, vertexai_claude, ollama, etc)",
+        description="Model provider (openai, anthropic, vertexai_claude, ollama, synthetic, etc)",
     )
     id: str = Field(description="Model ID specific to the provider")
     host: str | None = Field(default=None, description="Optional host URL (e.g., for Ollama)")

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -155,7 +155,15 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
     if (
         canonical_provider_key
-        not in {"ollama", "llama_cpp", "vertexai_claude", "codex", "openai_codex", _BEDROCK_CLAUDE_PROVIDER}
+        not in {
+            "ollama",
+            "llama_cpp",
+            "vertexai_claude",
+            "codex",
+            "openai_codex",
+            "synthetic",
+            _BEDROCK_CLAUDE_PROVIDER,
+        }
         and "api_key" not in extra_kwargs
     ):
         api_key = get_api_key_for_provider(canonical_provider_key, runtime_paths=runtime_paths)
@@ -197,6 +205,11 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         host = model_config.host or get_ollama_host(runtime_paths=runtime_paths) or OLLAMA_HOST_DEFAULT
         logger.debug("using_ollama_host", host=host)
         return Ollama(id=model_id, host=host, **extra_kwargs)
+
+    if canonical_provider_key == "synthetic":
+        from mindroom.synthetic_model import SyntheticModel  # noqa: PLC0415
+
+        return SyntheticModel(id=model_id, **extra_kwargs)
 
     if canonical_provider_key == "openrouter":
         from mindroom.openai_models import MindRoomOpenRouter  # noqa: PLC0415
@@ -341,7 +354,7 @@ def get_model_instance(
     model_creds = creds_manager.load_credentials(f"model:{model_name}")
     model_api_key = model_creds.get("api_key") if model_creds else None
 
-    if model_api_key:
+    if model_api_key and canonical_provider(provider) != "synthetic":
         extra_kwargs["api_key"] = model_api_key
 
     if canonical_provider(provider) in {"codex", "openai_codex"}:

--- a/src/mindroom/synthetic_model.py
+++ b/src/mindroom/synthetic_model.py
@@ -1,0 +1,506 @@
+"""Deterministic built-in model for realistic local load and tool-call testing."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import random
+import re
+import threading
+import time
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+
+if TYPE_CHECKING:
+    from agno.models.message import Message
+
+_LOREM = (
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et "
+    "dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex "
+    "ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat "
+    "nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim "
+    "id est laborum. "
+)
+_MINIMUM_RESPONSE_CHARS = 64
+
+
+@dataclass
+class _CoordinationState:
+    sync_condition: threading.Condition = field(default_factory=threading.Condition)
+    sync_barrier_members: dict[str, set[str]] = field(default_factory=dict)
+    sync_released_groups: set[str] = field(default_factory=set)
+    sync_stream_lock: threading.Lock = field(default_factory=threading.Lock)
+    async_condition: asyncio.Condition | None = None
+    async_barrier_members: dict[str, set[str]] = field(default_factory=dict)
+    async_released_groups: set[str] = field(default_factory=set)
+    async_stream_lock: asyncio.Lock | None = None
+    telemetry_lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_COORDINATION_STATES: dict[str, _CoordinationState] = {}
+_COORDINATION_STATES_LOCK = threading.Lock()
+
+
+def _coordination_state(key: str | None) -> _CoordinationState:
+    if key is None:
+        return _CoordinationState()
+    with _COORDINATION_STATES_LOCK:
+        return _COORDINATION_STATES.setdefault(key, _CoordinationState())
+
+
+@dataclass(frozen=True, slots=True)
+class SyntheticPlan:
+    """One replayable response and optional tool continuation."""
+
+    request_id: str
+    body: str
+    split_at: int | None
+    tool_call_id: str | None
+    sleep_seconds: int | None
+
+    @property
+    def prefix(self) -> str:
+        """Return content emitted before the tool call."""
+        return self.body if self.split_at is None else self.body[: self.split_at]
+
+    @property
+    def suffix(self) -> str:
+        """Return content emitted after the tool result."""
+        return "" if self.split_at is None else self.body[self.split_at :]
+
+
+def _request_digest(seed: int, identity: str) -> bytes:
+    return hashlib.sha256(f"{seed}\0{identity}".encode()).digest()
+
+
+def synthetic_request_id(seed: int, identity: str) -> str:
+    """Return a stable opaque identifier for one synthetic request."""
+    return _request_digest(seed, identity).hex()[:16]
+
+
+def _fixed_length_body(request_id: str, length: int) -> str:
+    prefix = f"SYNTHETIC[{request_id}] "
+    suffix = f" COMPLETE[{request_id}]"
+    filler_length = length - len(prefix) - len(suffix)
+    filler = (_LOREM * ((filler_length // len(_LOREM)) + 1))[:filler_length]
+    return prefix + filler + suffix
+
+
+def synthetic_plan(
+    identity: str,
+    *,
+    seed: int,
+    min_response_chars: int,
+    max_response_chars: int,
+    tool_call_probability: float,
+    min_sleep_seconds: int,
+    max_sleep_seconds: int,
+    tool_available: bool,
+) -> SyntheticPlan:
+    """Build one deterministic response plan without retaining mutable request state."""
+    digest = _request_digest(seed, identity)
+    randomizer = random.Random(int.from_bytes(digest))  # noqa: S311 - replayable test behavior
+    request_id = digest.hex()[:16]
+    response_chars = randomizer.randint(min_response_chars, max_response_chars)
+    body = _fixed_length_body(request_id, response_chars)
+    use_tool = tool_available and randomizer.random() < tool_call_probability
+    if not use_tool:
+        return SyntheticPlan(
+            request_id=request_id,
+            body=body,
+            split_at=None,
+            tool_call_id=None,
+            sleep_seconds=None,
+        )
+    lower_split = max(len(f"SYNTHETIC[{request_id}] "), response_chars // 4)
+    upper_split = min(response_chars - len(f" COMPLETE[{request_id}]"), response_chars * 3 // 4)
+    split_at = randomizer.randint(lower_split, upper_split)
+    return SyntheticPlan(
+        request_id=request_id,
+        body=body,
+        split_at=split_at,
+        tool_call_id=f"synthetic-{request_id}",
+        sleep_seconds=randomizer.randint(min_sleep_seconds, max_sleep_seconds),
+    )
+
+
+@dataclass
+class SyntheticModel(Model):
+    """Generate deterministic streamed text and optional real tool-call continuations."""
+
+    name: str | None = "Synthetic"
+    provider: str | None = "Synthetic"
+    seed: int = 1
+    min_response_chars: int = 320
+    max_response_chars: int = 960
+    chunk_chars: int = 40
+    chars_per_second: float = 80.0
+    tool_call_probability: float = 0.0
+    min_sleep_seconds: int = 1
+    max_sleep_seconds: int = 3
+    identity_pattern: str | None = None
+    activation_pattern: str | None = None
+    inactive_response: str = "SYNTHETIC READY"
+    barrier_size: int = 0
+    barrier_group_pattern: str | None = None
+    barrier_timeout_seconds: float = 90.0
+    serialize_streams: bool = False
+    telemetry_path: str | None = None
+    coordination_key: str | None = None
+    _identity_regex: re.Pattern[str] | None = field(init=False, default=None, repr=False)
+    _activation_regex: re.Pattern[str] | None = field(init=False, default=None, repr=False)
+    _barrier_group_regex: re.Pattern[str] | None = field(init=False, default=None, repr=False)
+    _state: _CoordinationState = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        """Validate deterministic generation and optional concurrency controls."""
+        super().__post_init__()
+        self._validate_generation_settings()
+        self._validate_barrier_settings()
+        self._identity_regex = re.compile(self.identity_pattern) if self.identity_pattern else None
+        self._activation_regex = re.compile(self.activation_pattern) if self.activation_pattern else None
+        self._barrier_group_regex = re.compile(self.barrier_group_pattern) if self.barrier_group_pattern else None
+        self._state = _coordination_state(self.coordination_key)
+
+    def _validate_generation_settings(self) -> None:
+        if not self.inactive_response:
+            msg = "inactive_response must not be empty"
+            raise ValueError(msg)
+        if self.min_response_chars < _MINIMUM_RESPONSE_CHARS:
+            msg = f"min_response_chars must be at least {_MINIMUM_RESPONSE_CHARS}"
+            raise ValueError(msg)
+        if self.max_response_chars < self.min_response_chars:
+            msg = "max_response_chars must be greater than or equal to min_response_chars"
+            raise ValueError(msg)
+        if self.chunk_chars < 1:
+            msg = "chunk_chars must be positive"
+            raise ValueError(msg)
+        if self.chars_per_second < 0:
+            msg = "chars_per_second must be non-negative"
+            raise ValueError(msg)
+        if not 0 <= self.tool_call_probability <= 1:
+            msg = "tool_call_probability must be between 0 and 1"
+            raise ValueError(msg)
+        if self.min_sleep_seconds < 0:
+            msg = "min_sleep_seconds must be non-negative"
+            raise ValueError(msg)
+        if self.max_sleep_seconds < self.min_sleep_seconds:
+            msg = "max_sleep_seconds must be greater than or equal to min_sleep_seconds"
+            raise ValueError(msg)
+
+    def _validate_barrier_settings(self) -> None:
+        if self.barrier_size < 0:
+            msg = "barrier_size must be non-negative"
+            raise ValueError(msg)
+        if self.barrier_size and self.barrier_group_pattern is None:
+            msg = "barrier_group_pattern is required when barrier_size is enabled"
+            raise ValueError(msg)
+        if self.barrier_timeout_seconds <= 0:
+            msg = "barrier_timeout_seconds must be positive"
+            raise ValueError(msg)
+
+    def plan_for_prompt(self, prompt: str, *, tool_available: bool = True) -> SyntheticPlan:
+        """Return the exact plan used for one prompt."""
+        identity = self._identity(prompt)
+        if not self._is_active(prompt):
+            return SyntheticPlan(
+                request_id=synthetic_request_id(self.seed, identity),
+                body=self.inactive_response,
+                split_at=None,
+                tool_call_id=None,
+                sleep_seconds=None,
+            )
+        return synthetic_plan(
+            identity,
+            seed=self.seed,
+            min_response_chars=self.min_response_chars,
+            max_response_chars=self.max_response_chars,
+            tool_call_probability=self.tool_call_probability,
+            min_sleep_seconds=self.min_sleep_seconds,
+            max_sleep_seconds=self.max_sleep_seconds,
+            tool_available=tool_available,
+        )
+
+    def invoke(
+        self,
+        messages: list[Message],
+        *,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        tool_choice: str | Mapping[str, Any] | None = None,
+        **_kwargs: object,
+    ) -> ModelResponse:
+        """Return one deterministic non-streaming model response."""
+        plan, phase, group = self._execution(messages, tools, tool_choice)
+        self._reach_sync_barrier(plan, phase, group)
+        lock = self._state.sync_stream_lock if self.serialize_streams else _NullLock()
+        with lock:
+            self._record("request_started", plan, phase, group)
+            try:
+                content = self._content_for_phase(plan, phase)
+                self._sleep_sync(len(content))
+                return ModelResponse(
+                    content=content,
+                    tool_calls=self._tool_calls_for_phase(plan, phase),
+                )
+            finally:
+                self._record("request_finished", plan, phase, group)
+
+    async def ainvoke(
+        self,
+        messages: list[Message],
+        *,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        tool_choice: str | Mapping[str, Any] | None = None,
+        **_kwargs: object,
+    ) -> ModelResponse:
+        """Return one deterministic asynchronous non-streaming model response."""
+        plan, phase, group = self._execution(messages, tools, tool_choice)
+        await self._reach_async_barrier(plan, phase, group)
+        lock = self._get_async_stream_lock() if self.serialize_streams else _AsyncNullLock()
+        async with lock:
+            self._record("request_started", plan, phase, group)
+            try:
+                content = self._content_for_phase(plan, phase)
+                await self._sleep_async(len(content))
+                return ModelResponse(
+                    content=content,
+                    tool_calls=self._tool_calls_for_phase(plan, phase),
+                )
+            finally:
+                self._record("request_finished", plan, phase, group)
+
+    def invoke_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        tool_choice: str | Mapping[str, Any] | None = None,
+        **_kwargs: object,
+    ) -> Iterator[ModelResponse]:
+        """Stream deterministic fixed-rate chunks and an optional tool call."""
+        plan, phase, group = self._execution(messages, tools, tool_choice)
+        self._reach_sync_barrier(plan, phase, group)
+        lock = self._state.sync_stream_lock if self.serialize_streams else _NullLock()
+        with lock:
+            self._record("request_started", plan, phase, group)
+            try:
+                for chunk in self._chunks(self._content_for_phase(plan, phase)):
+                    self._sleep_sync(len(chunk))
+                    yield ModelResponse(content=chunk)
+                tool_calls = self._tool_calls_for_phase(plan, phase)
+                if tool_calls:
+                    self._record("tool_call_emitted", plan, phase, group)
+                    yield ModelResponse(tool_calls=tool_calls)
+            finally:
+                self._record("request_finished", plan, phase, group)
+
+    async def ainvoke_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        tool_choice: str | Mapping[str, Any] | None = None,
+        **_kwargs: object,
+    ) -> AsyncIterator[ModelResponse]:
+        """Asynchronously stream deterministic chunks and an optional tool call."""
+        plan, phase, group = self._execution(messages, tools, tool_choice)
+        await self._reach_async_barrier(plan, phase, group)
+        lock = self._get_async_stream_lock() if self.serialize_streams else _AsyncNullLock()
+        async with lock:
+            self._record("request_started", plan, phase, group)
+            try:
+                for chunk in self._chunks(self._content_for_phase(plan, phase)):
+                    await self._sleep_async(len(chunk))
+                    yield ModelResponse(content=chunk)
+                tool_calls = self._tool_calls_for_phase(plan, phase)
+                if tool_calls:
+                    self._record("tool_call_emitted", plan, phase, group)
+                    yield ModelResponse(tool_calls=tool_calls)
+            finally:
+                self._record("request_finished", plan, phase, group)
+
+    def _parse_provider_response(self, response: object, **_kwargs: object) -> ModelResponse:
+        if not isinstance(response, ModelResponse):
+            msg = "SyntheticModel only parses ModelResponse values"
+            raise TypeError(msg)
+        return response
+
+    def _parse_provider_response_delta(self, response: object) -> ModelResponse:
+        if not isinstance(response, ModelResponse):
+            msg = "SyntheticModel only parses ModelResponse values"
+            raise TypeError(msg)
+        return response
+
+    def _execution(
+        self,
+        messages: Sequence[Message],
+        tools: Sequence[Mapping[str, Any]] | None,
+        tool_choice: str | Mapping[str, Any] | None,
+    ) -> tuple[SyntheticPlan, str, str | None]:
+        prompt = self._latest_user_text(messages)
+        tool_available = tool_choice != "none" and self._tool_available(tools, "sleep")
+        plan = self.plan_for_prompt(prompt, tool_available=tool_available)
+        last_message = messages[-1] if messages else None
+        continuation = (
+            plan.tool_call_id is not None
+            and last_message is not None
+            and last_message.role == self.tool_message_role
+            and last_message.tool_call_id == plan.tool_call_id
+        )
+        phase = "continuation" if continuation else "initial"
+        group = self._barrier_group(prompt) if self._is_active(prompt) else None
+        return plan, phase, group
+
+    def _is_active(self, prompt: str) -> bool:
+        return self._activation_regex is None or self._activation_regex.search(prompt) is not None
+
+    def _identity(self, prompt: str) -> str:
+        if self._identity_regex is None:
+            return prompt
+        match = self._identity_regex.search(prompt)
+        return match.group(0) if match is not None else prompt
+
+    def _barrier_group(self, prompt: str) -> str | None:
+        if self._barrier_group_regex is None:
+            return None
+        match = self._barrier_group_regex.search(prompt)
+        if match is None:
+            return None
+        return match.group(1) if match.lastindex else match.group(0)
+
+    @staticmethod
+    def _latest_user_text(messages: Sequence[Message]) -> str:
+        for message in reversed(messages):
+            if message.role == "user":
+                return message.get_content_string()
+        return ""
+
+    @staticmethod
+    def _tool_available(tools: Sequence[Mapping[str, Any]] | None, tool_name: str) -> bool:
+        for tool in tools or ():
+            function = tool.get("function")
+            if isinstance(function, Mapping) and function.get("name") == tool_name:
+                return True
+            if tool.get("name") == tool_name:
+                return True
+        return False
+
+    @staticmethod
+    def _content_for_phase(plan: SyntheticPlan, phase: str) -> str:
+        return plan.suffix if phase == "continuation" else plan.prefix
+
+    @staticmethod
+    def _tool_calls_for_phase(plan: SyntheticPlan, phase: str) -> list[dict[str, Any]]:
+        if phase != "initial" or plan.tool_call_id is None or plan.sleep_seconds is None:
+            return []
+        return [
+            {
+                "id": plan.tool_call_id,
+                "type": "function",
+                "function": {
+                    "name": "sleep",
+                    "arguments": json.dumps({"seconds": plan.sleep_seconds}, separators=(",", ":")),
+                },
+            },
+        ]
+
+    def _chunks(self, content: str) -> Iterator[str]:
+        for start in range(0, len(content), self.chunk_chars):
+            yield content[start : start + self.chunk_chars]
+
+    def _sleep_sync(self, character_count: int) -> None:
+        if self.chars_per_second:
+            time.sleep(character_count / self.chars_per_second)
+
+    async def _sleep_async(self, character_count: int) -> None:
+        if self.chars_per_second:
+            await asyncio.sleep(character_count / self.chars_per_second)
+
+    def _reach_sync_barrier(self, plan: SyntheticPlan, phase: str, group: str | None) -> None:
+        if phase != "initial" or group is None or self.barrier_size == 0:
+            return
+        deadline = time.monotonic() + self.barrier_timeout_seconds
+        state = self._state
+        with state.sync_condition:
+            members = state.sync_barrier_members.setdefault(group, set())
+            members.add(plan.request_id)
+            self._record("barrier_reached", plan, phase, group)
+            if len(members) >= self.barrier_size:
+                state.sync_released_groups.add(group)
+                state.sync_condition.notify_all()
+            while group not in state.sync_released_groups:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    msg = f"synthetic model barrier {group!r} reached {len(members)}/{self.barrier_size}"
+                    raise TimeoutError(msg)
+                state.sync_condition.wait(timeout=remaining)
+
+    async def _reach_async_barrier(self, plan: SyntheticPlan, phase: str, group: str | None) -> None:
+        if phase != "initial" or group is None or self.barrier_size == 0:
+            return
+        condition = self._get_async_condition()
+        async with asyncio.timeout(self.barrier_timeout_seconds):
+            async with condition:
+                members = self._state.async_barrier_members.setdefault(group, set())
+                members.add(plan.request_id)
+                self._record("barrier_reached", plan, phase, group)
+                if len(members) >= self.barrier_size:
+                    self._state.async_released_groups.add(group)
+                    condition.notify_all()
+                await condition.wait_for(lambda: group in self._state.async_released_groups)
+
+    def _get_async_condition(self) -> asyncio.Condition:
+        if self._state.async_condition is None:
+            self._state.async_condition = asyncio.Condition()
+        return self._state.async_condition
+
+    def _get_async_stream_lock(self) -> asyncio.Lock:
+        if self._state.async_stream_lock is None:
+            self._state.async_stream_lock = asyncio.Lock()
+        return self._state.async_stream_lock
+
+    def _record(self, kind: str, plan: SyntheticPlan, phase: str, group: str | None) -> None:
+        if self.telemetry_path is None:
+            return
+        payload = {
+            "kind": kind,
+            "request_id": plan.request_id,
+            "phase": phase,
+            "group": group,
+            "time": time.monotonic(),
+        }
+        path = Path(self.telemetry_path)
+        with self._state.telemetry_lock:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+class _NullLock:
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(self, *_args: object) -> None:
+        return None
+
+
+class _AsyncNullLock:
+    async def __aenter__(self) -> None:
+        return None
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+__all__ = [
+    "SyntheticModel",
+    "SyntheticPlan",
+    "synthetic_plan",
+    "synthetic_request_id",
+]

--- a/src/mindroom/synthetic_model.py
+++ b/src/mindroom/synthetic_model.py
@@ -31,15 +31,21 @@ _MINIMUM_RESPONSE_CHARS = 64
 
 
 @dataclass
+class _AsyncCoordinationState:
+    condition: asyncio.Condition = field(default_factory=asyncio.Condition)
+    async_barrier_members: dict[str, set[str]] = field(default_factory=dict)
+    async_released_groups: set[str] = field(default_factory=set)
+    stream_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+
+@dataclass
 class _CoordinationState:
     sync_condition: threading.Condition = field(default_factory=threading.Condition)
     sync_barrier_members: dict[str, set[str]] = field(default_factory=dict)
     sync_released_groups: set[str] = field(default_factory=set)
     sync_stream_lock: threading.Lock = field(default_factory=threading.Lock)
-    async_condition: asyncio.Condition | None = None
-    async_barrier_members: dict[str, set[str]] = field(default_factory=dict)
-    async_released_groups: set[str] = field(default_factory=set)
-    async_stream_lock: asyncio.Lock | None = None
+    async_states: dict[asyncio.AbstractEventLoop, _AsyncCoordinationState] = field(default_factory=dict)
+    async_states_lock: threading.Lock = field(default_factory=threading.Lock)
     telemetry_lock: threading.Lock = field(default_factory=threading.Lock)
 
 
@@ -444,26 +450,31 @@ class SyntheticModel(Model):
     async def _reach_async_barrier(self, plan: SyntheticPlan, phase: str, group: str | None) -> None:
         if phase != "initial" or group is None or self.barrier_size == 0:
             return
-        condition = self._get_async_condition()
+        state = self._get_async_state()
         async with asyncio.timeout(self.barrier_timeout_seconds):
-            async with condition:
-                members = self._state.async_barrier_members.setdefault(group, set())
+            async with state.condition:
+                members = state.async_barrier_members.setdefault(group, set())
                 members.add(plan.request_id)
                 self._record("barrier_reached", plan, phase, group)
                 if len(members) >= self.barrier_size:
-                    self._state.async_released_groups.add(group)
-                    condition.notify_all()
-                await condition.wait_for(lambda: group in self._state.async_released_groups)
+                    state.async_released_groups.add(group)
+                    state.condition.notify_all()
+                await state.condition.wait_for(lambda: group in state.async_released_groups)
 
-    def _get_async_condition(self) -> asyncio.Condition:
-        if self._state.async_condition is None:
-            self._state.async_condition = asyncio.Condition()
-        return self._state.async_condition
+    def _get_async_state(self) -> _AsyncCoordinationState:
+        loop = asyncio.get_running_loop()
+        with self._state.async_states_lock:
+            closed_loops = [known_loop for known_loop in self._state.async_states if known_loop.is_closed()]
+            for closed_loop in closed_loops:
+                del self._state.async_states[closed_loop]
+            state = self._state.async_states.get(loop)
+            if state is None:
+                state = _AsyncCoordinationState()
+                self._state.async_states[loop] = state
+            return state
 
     def _get_async_stream_lock(self) -> asyncio.Lock:
-        if self._state.async_stream_lock is None:
-            self._state.async_stream_lock = asyncio.Lock()
-        return self._state.async_stream_lock
+        return self._get_async_state().stream_lock
 
     def _record(self, kind: str, plan: SyntheticPlan, phase: str, group: str | None) -> None:
         if self.telemetry_path is None:

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -3862,6 +3862,7 @@ def test_start_mindroom_uses_editable_overlay_and_persists_each_pid(
             "--with-editable",
             "/persistent/mindroom-nio",
         ]
+        assert commands[0][-2:] == ["--log-level", "INFO"]
         assert manifests == [
             {"state": "starting_mindroom", "mindroom_pid": 4242},
             {"state": "ready", "mindroom_pid": 4242},

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -4495,11 +4495,16 @@ def test_cache_wave_gate_records_unresolved_warm_scans_without_accepting_duplica
         full_scans=2,
         cache_hits=2,
         repair_fetches_by_thread={"thread-0": 1, "thread-1": 1},
+        repair_fetches_by_thread_and_caller={
+            ("thread-0", "dispatch_context"): 1,
+            ("thread-1", "dispatch_context"): 1,
+        },
     )
 
     runner._assert_cache_wave_shape((cold, warm))
 
     warm.repair_fetches_by_thread["thread-0"] = 2
+    warm.repair_fetches_by_thread_and_caller[("thread-0", "dispatch_context")] = 2
     with pytest.raises(AssertionError, match="duplicate repair scans"):
         runner._assert_cache_wave_shape((cold, warm))
 

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 
 import psutil
 import pytest
+import yaml
 
 import scripts.testing.fuzz_live_matrix as live_fuzz
 from scripts.testing.fuzz_live_matrix import (
@@ -4397,6 +4398,34 @@ def test_live_stack_wires_serialization_fault_into_model_controller(tmp_path: Pa
     try:
         assert stack.stress_controller is not None
         assert stack.stress_controller._serialization_lock is not None
+    finally:
+        stack.temp_dir.cleanup()
+
+
+def test_stress_stack_bounds_model_timeout_beyond_barrier_and_disables_retries(
+    tmp_path: Path,
+) -> None:
+    """Long barrier waits must not trigger duplicate OpenAI requests."""
+    config = live_fuzz.StressConfig(
+        threads=2,
+        stream_seconds=45,
+        edit_interval=0.5,
+        waves=1,
+        history_turns=0,
+        barrier_timeout_seconds=90,
+    )
+    stack = ManagedTuwunelStack(
+        state_root=tmp_path / "state",
+        stress_config=config,
+    )
+    try:
+        stack._write_config(12345)
+        payload = yaml.safe_load(stack.config_path.read_text(encoding="utf-8"))
+        assert payload["models"]["default"]["extra_kwargs"] == {
+            "base_url": "http://127.0.0.1:12345/v1",
+            "max_retries": 0,
+            "timeout": 165,
+        }
     finally:
         stack.temp_dir.cleanup()
 

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -4322,6 +4322,29 @@ def test_live_stack_wires_serialization_fault_into_model_controller(tmp_path: Pa
         stack.temp_dir.cleanup()
 
 
+def test_resource_sampler_rebinds_after_managed_runtime_restart(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CPU and RSS evidence must follow the new child PID after a cold boundary."""
+    stack = SimpleNamespace(mindroom_pid=22)
+    stale_process = SimpleNamespace(pid=11)
+    current_process = MagicMock(pid=22)
+    current_process.cpu_percent.side_effect = [None, 37.5]
+    current_process.memory_info.return_value = SimpleNamespace(rss=123456)
+    process_factory = MagicMock(return_value=current_process)
+    monkeypatch.setattr(live_fuzz.psutil, "Process", process_factory)
+
+    process, cpu_percent, rss_bytes = live_fuzz._sample_mindroom_process(
+        stack,  # type: ignore[arg-type]
+        stale_process,  # type: ignore[arg-type]
+    )
+
+    assert process is current_process
+    assert cpu_percent == 37.5
+    assert rss_bytes == 123456
+    process_factory.assert_called_once_with(22)
+
+
 def test_clear_stress_cache_restarts_runtime_without_clearing_sync_checkpoint() -> None:
     """An empty SQL cache must not leave a stale warm in-memory cache behind."""
     stack = object.__new__(ManagedTuwunelStack)

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -4264,6 +4264,27 @@ def test_stack_close_groups_ordinary_cleanup_failures() -> None:
     assert "release host lease: lease failed" in str(raised.value.exceptions[1])
 
 
+def test_owned_resources_removed_requires_every_resource_and_lease_gone(tmp_path: Path) -> None:
+    """Cleanup evidence should report resource state independently of snapshot errors."""
+    stack = object.__new__(ManagedTuwunelStack)
+    disposable = tmp_path / "disposable"
+    disposable.mkdir()
+    stack.temp_dir = SimpleNamespace(name=str(disposable))
+    stack._mindroom_process = None
+    stack._log_handle = None
+    stack._model_server = None
+    stack._model_thread = None
+    stack.stress_postgres = SimpleNamespace(started=False)
+    stack._created = False
+    stack._host_lease = None
+
+    assert stack.owned_resources_removed() is False
+    disposable.rmdir()
+    assert stack.owned_resources_removed() is True
+    stack._created = True
+    assert stack.owned_resources_removed() is False
+
+
 def test_host_lease_excludes_second_live_stack(tmp_path: Path) -> None:
     """Separate worktrees cannot allocate colliding Matrix ports concurrently."""
     first = ManagedTuwunelStack(state_root=tmp_path / "state")

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -3479,6 +3479,7 @@ def test_child_provenance_uses_loaded_overlay(
                 "nio_module_path": str(tmp_path / "overlay" / "nio" / "__init__.py"),
                 "nio_version": "1.2.3",
                 "python": "3.13",
+                "runtime_pid": 1234,
             },
         ),
         encoding="utf-8",
@@ -3506,6 +3507,24 @@ def test_child_provenance_uses_loaded_overlay(
     assert provenance["nio_module_path"] == str((tmp_path / "overlay" / "nio" / "__init__.py").resolve())
     assert provenance["nio_revision"] == "nio-head"
     assert provenance["nio_expected_revision"] == "nio-head"
+    assert provenance["runtime_pid"] == 1234
+
+
+def test_child_provenance_requires_runtime_pid(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Resource evidence must bind to the attested Python child, not its launcher."""
+    attestation = tmp_path / "runtime-attestation.json"
+    attestation.write_text("{}", encoding="utf-8")
+    monkeypatch.setattr(live_fuzz, "_validated_import_provenance", lambda *_args, **_kwargs: {})
+
+    with pytest.raises(TypeError, match="valid runtime PID"):
+        _validated_child_provenance(
+            attestation,
+            overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
+            expected_mindroom_revision="mindroom-head",
+        )
 
 
 def test_child_provenance_rejects_revision_changed_after_preflight(
@@ -3562,6 +3581,7 @@ def test_child_provenance_allows_distinct_exact_runtime_and_runner(
             {
                 "mindroom_module_path": str(runtime_module),
                 "nio_module_path": str(nio_module),
+                "runtime_pid": 1234,
             },
         ),
         encoding="utf-8",
@@ -3615,6 +3635,7 @@ def test_restart_rejects_mindroom_head_move_and_keeps_first_generation(
             {
                 "mindroom_module_path": str(mindroom_path),
                 "nio_module_path": str(nio_path),
+                "runtime_pid": 1234,
             },
         ),
         encoding="utf-8",
@@ -4131,6 +4152,7 @@ def test_runtime_provenance_identifies_tuwunel_server(
                 "nio_dirty": False,
                 "nio_expected_revision": "nio-head",
                 "nio_revision": "nio-head",
+                "runtime_pid": 1234,
             },
         )
         monkeypatch.setattr(
@@ -4155,6 +4177,7 @@ def test_runtime_provenance_identifies_tuwunel_server(
         assert all(generation["mindroom_revision"] == "abc" for generation in generations)
         assert stack.runtime_provenance["mindroom_frozen_revision"] == "abc"
         assert stack.runtime_provenance["runtime_generation"] == 2
+        assert stack._mindroom_runtime_pid == 1234
         assert len(sink) == 2
         assert len(sink[0]["runtime_generations"]) == 1
         assert sink[1] == stack.runtime_provenance
@@ -4191,6 +4214,7 @@ def test_final_source_recheck_rejects_post_attestation_mutation(
             {
                 "mindroom_module_path": str(mindroom_path),
                 "nio_module_path": str(nio_path),
+                "runtime_pid": 1234,
             },
         ),
         encoding="utf-8",
@@ -4458,7 +4482,7 @@ def test_resource_sampler_rebinds_after_managed_runtime_restart(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """CPU and RSS evidence must follow the new child PID after a cold boundary."""
-    stack = SimpleNamespace(mindroom_pid=22)
+    stack = SimpleNamespace(mindroom_runtime_pid=22)
     stale_process = SimpleNamespace(pid=11)
     current_process = MagicMock(pid=22)
     current_process.cpu_percent.side_effect = [None, 37.5]

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -3437,6 +3437,55 @@ def test_child_provenance_rejects_revision_changed_after_preflight(
         )
 
 
+def test_child_provenance_allows_distinct_exact_runtime_and_runner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One clean harness may load another clean exact MindRoom revision for baselines."""
+    runner_root = tmp_path / "runner"
+    runtime_root = tmp_path / "runtime"
+    overlay = tmp_path / "nio"
+    runtime_module = runtime_root / "src" / "mindroom" / "__init__.py"
+    nio_module = overlay / "src" / "nio" / "__init__.py"
+    attestation = tmp_path / "runtime-attestation.json"
+    attestation.write_text(
+        json.dumps(
+            {
+                "mindroom_module_path": str(runtime_module),
+                "nio_module_path": str(nio_module),
+            },
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(live_fuzz, "PROJECT_ROOT", runner_root)
+    monkeypatch.setattr(
+        live_fuzz,
+        "_git_root_for_path",
+        lambda path: runtime_root if path == runtime_module else overlay,
+    )
+
+    def git_state(path: Path, **_kwargs: object) -> tuple[str, bool]:
+        if path == runtime_module:
+            return "runtime-head", False
+        if path == nio_module:
+            return "nio-head", False
+        return "runner-head", False
+
+    monkeypatch.setattr(live_fuzz, "_git_state_for_file", git_state)
+
+    provenance = _validated_child_provenance(
+        attestation,
+        overlay=NioOverlay(path=overlay, revision="nio-head"),
+        expected_mindroom_revision="runtime-head",
+        expected_mindroom_root=runtime_root,
+        expected_runner_revision="runner-head",
+    )
+
+    assert provenance["mindroom_revision"] == "runtime-head"
+    assert provenance["runner_revision"] == "runner-head"
+    assert provenance["nio_revision"] == "nio-head"
+
+
 def test_restart_rejects_mindroom_head_move_and_keeps_first_generation(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -3644,6 +3693,7 @@ def test_start_mindroom_uses_editable_overlay_and_persists_each_pid(
     stack = ManagedTuwunelStack(
         state_root=tmp_path / "state",
         nio_overlay=NioOverlay(path=Path("/persistent/mindroom-nio"), revision="nio-head"),
+        mindroom_root=Path("/persistent/mindroom"),
     )
     commands: list[list[str]] = []
     manifests: list[dict[str, object]] = []
@@ -3675,7 +3725,12 @@ def test_start_mindroom_uses_editable_overlay_and_persists_each_pid(
         stack._start_mindroom()
 
         assert commands
-        assert commands[0][2:4] == ["--with-editable", "/persistent/mindroom-nio"]
+        assert commands[0][2:6] == [
+            "--project",
+            "/persistent/mindroom",
+            "--with-editable",
+            "/persistent/mindroom-nio",
+        ]
         assert manifests == [
             {"state": "starting_mindroom", "mindroom_pid": 4242},
             {"state": "ready", "mindroom_pid": 4242},
@@ -4195,6 +4250,26 @@ def test_host_lease_excludes_second_live_stack(tmp_path: Path) -> None:
         second._release_host_lease()
         first.temp_dir.cleanup()
         second.temp_dir.cleanup()
+
+
+def test_live_stack_wires_serialization_fault_into_model_controller(tmp_path: Path) -> None:
+    """The CLI-level fault reaches the model controller used by the live stack."""
+    config = live_fuzz.StressConfig(
+        threads=2,
+        waves=1,
+        stream_seconds=0.02,
+        edit_interval=0.01,
+        fault_mode="serialize-streams",
+    )
+    stack = ManagedTuwunelStack(
+        state_root=tmp_path / "state",
+        stress_config=config,
+    )
+    try:
+        assert stack.stress_controller is not None
+        assert stack.stress_controller._serialization_lock is not None
+    finally:
+        stack.temp_dir.cleanup()
 
 
 def test_live_stack_manifest_is_atomic_and_recoverable(tmp_path: Path) -> None:
@@ -5774,6 +5849,7 @@ def test_main_preserves_base_exception_evidence_and_closes_stack(
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
+        mindroom_runtime=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
         reply_timeout=1.0,
@@ -5802,7 +5878,7 @@ def test_main_preserves_base_exception_evidence_and_closes_stack(
 
     monkeypatch.setattr(live_fuzz, "_parse_args", lambda: args)
     monkeypatch.setattr(live_fuzz, "_scenario_from_args", lambda _args: _bundle_scenario())
-    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision: {})
+    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision, **_kwargs: {})
     monkeypatch.setattr(live_fuzz, "ManagedTuwunelStack", InterruptedStack)
     monkeypatch.setattr(live_fuzz, "_run_live", interrupt_run)
     monkeypatch.setattr(
@@ -5832,6 +5908,7 @@ def test_main_bad_failure_log_preserves_primary_and_closes_stack(
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=failure_log,
+        mindroom_runtime=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
         reply_timeout=1.0,
@@ -5859,7 +5936,7 @@ def test_main_bad_failure_log_preserves_primary_and_closes_stack(
 
     monkeypatch.setattr(live_fuzz, "_parse_args", lambda: args)
     monkeypatch.setattr(live_fuzz, "_scenario_from_args", lambda _args: _bundle_scenario())
-    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision: {})
+    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision, **_kwargs: {})
     monkeypatch.setattr(live_fuzz, "ManagedTuwunelStack", InterruptedStack)
     monkeypatch.setattr(live_fuzz, "_run_live", interrupt_run)
     monkeypatch.setattr(live_fuzz, "_persist_failure_bundle", lambda *_args, **_kwargs: None)
@@ -5879,6 +5956,7 @@ def test_main_bundle_capture_failure_preserves_primary_and_closes_stack(
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
+        mindroom_runtime=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
         reply_timeout=1.0,
@@ -5911,7 +5989,7 @@ def test_main_bundle_capture_failure_preserves_primary_and_closes_stack(
 
     monkeypatch.setattr(live_fuzz, "_parse_args", lambda: args)
     monkeypatch.setattr(live_fuzz, "_scenario_from_args", lambda _args: _bundle_scenario())
-    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision: {})
+    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision, **_kwargs: {})
     monkeypatch.setattr(live_fuzz, "ManagedTuwunelStack", InterruptedStack)
     monkeypatch.setattr(live_fuzz, "_run_live", fail_run)
     monkeypatch.setattr(live_fuzz, "_persist_failure_bundle", fail_capture)
@@ -5931,6 +6009,7 @@ def test_main_stop_interrupt_preserves_primary_and_closes_stack(
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
+        mindroom_runtime=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
         reply_timeout=1.0,
@@ -5977,7 +6056,7 @@ def test_main_stop_interrupt_preserves_primary_and_closes_stack(
 
     monkeypatch.setattr(live_fuzz, "_parse_args", lambda: args)
     monkeypatch.setattr(live_fuzz, "_scenario_from_args", lambda _args: _bundle_scenario())
-    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision: {})
+    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision, **_kwargs: {})
     monkeypatch.setattr(live_fuzz, "ManagedTuwunelStack", InterruptedStack)
     monkeypatch.setattr(live_fuzz, "_run_live", fail_run)
 
@@ -5999,6 +6078,7 @@ def test_main_rechecks_sources_at_teardown_and_receipt_boundaries(
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
+        mindroom_runtime=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
         reply_timeout=1.0,
@@ -6054,7 +6134,7 @@ def test_main_rechecks_sources_at_teardown_and_receipt_boundaries(
 
     monkeypatch.setattr(live_fuzz, "_parse_args", lambda: args)
     monkeypatch.setattr(live_fuzz, "_scenario_from_args", lambda _args: _bundle_scenario())
-    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision: {})
+    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision, **_kwargs: {})
     monkeypatch.setattr(live_fuzz, "_required_mindroom_revision", lambda: "mindroom-head")
     monkeypatch.setattr(live_fuzz, "ManagedTuwunelStack", PassingStack)
     monkeypatch.setattr(live_fuzz, "_run_live", pass_run)
@@ -6089,6 +6169,7 @@ def test_main_cleanup_failure_retains_pre_teardown_evidence(
         artifact_root=artifact_root,
         profile="fuzz",
         failure_log=None,
+        mindroom_runtime=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
         reply_timeout=1.0,
@@ -6171,7 +6252,7 @@ def test_main_cleanup_failure_retains_pre_teardown_evidence(
 
     monkeypatch.setattr(live_fuzz, "_parse_args", lambda: args)
     monkeypatch.setattr(live_fuzz, "_scenario_from_args", lambda _args: _bundle_scenario())
-    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision: {})
+    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision, **_kwargs: {})
     monkeypatch.setattr(live_fuzz, "ManagedTuwunelStack", CleanupFailingStack)
     monkeypatch.setattr(live_fuzz, "_run_live", pass_run)
 
@@ -6221,6 +6302,7 @@ def test_main_missing_runtime_provenance_captures_bundle_before_teardown(
         artifact_root=artifact_root,
         profile="fuzz",
         failure_log=None,
+        mindroom_runtime=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
         reply_timeout=1.0,
@@ -6264,7 +6346,7 @@ def test_main_missing_runtime_provenance_captures_bundle_before_teardown(
 
     monkeypatch.setattr(live_fuzz, "_parse_args", lambda: args)
     monkeypatch.setattr(live_fuzz, "_scenario_from_args", lambda _args: _bundle_scenario())
-    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision: {})
+    monkeypatch.setattr(live_fuzz, "_run_provenance", lambda _revision, **_kwargs: {})
     monkeypatch.setattr(live_fuzz, "ManagedTuwunelStack", MissingProvenanceStack)
     monkeypatch.setattr(live_fuzz, "_run_live", pass_run)
 

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -75,6 +75,34 @@ def test_model_stream_disconnect_does_not_escape_request_handler() -> None:
     assert handler.close_connection is True
 
 
+def test_nonstreaming_summary_prompt_does_not_enter_stress_barrier() -> None:
+    """Background summaries may quote a marker without becoming stress requests."""
+    handler = object.__new__(_ModelHandler)
+    marker = live_fuzz.StressConfig(
+        threads=1,
+        waves=1,
+        stream_seconds=1,
+        edit_interval=1,
+    ).marker(0, 0)
+    payload = json.dumps(
+        {
+            "messages": [{"role": "user", "content": f"<thread_messages>{marker}</thread_messages>"}],
+            "stream": False,
+        },
+    ).encode()
+    handler.path = "/v1/chat/completions"
+    handler.headers = {"Content-Length": str(len(payload))}
+    handler.rfile = io.BytesIO(payload)
+    handler.call_ids = iter((1,))
+    handler.close_connection = False
+    sent: list[dict[str, object]] = []
+    handler._send_json = sent.append  # type: ignore[method-assign]
+
+    handler.do_POST()
+
+    assert sent[0]["choices"][0]["message"]["content"].startswith("LIVE-FUZZ call=1")  # type: ignore[index]
+
+
 def test_lifecycle_command_timeout_kills_bounded_process_group() -> None:
     """A hung lifecycle command must time out instead of hanging the campaign."""
     with pytest.raises(TimeoutError, match="command timed out"):

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -77,11 +77,12 @@ def test_model_stream_disconnect_does_not_escape_request_handler() -> None:
     assert handler.close_connection is True
 
 
-def test_nonstreaming_summary_prompt_does_not_enter_stress_barrier() -> None:
-    """Background summaries may quote a marker without becoming stress requests."""
+def test_nonstreaming_summary_marker_uses_regular_stub_response() -> None:
+    """Background summaries may quote stress input while using the lifecycle stub."""
     handler = object.__new__(_ModelHandler)
     marker = live_fuzz.StressConfig(
         threads=1,
+        rooms=1,
         waves=1,
         stream_seconds=1,
         edit_interval=1,
@@ -4418,10 +4419,11 @@ def test_host_lease_excludes_second_live_stack(tmp_path: Path) -> None:
         second.temp_dir.cleanup()
 
 
-def test_live_stack_wires_serialization_fault_into_model_controller(tmp_path: Path) -> None:
-    """The CLI-level fault reaches the model controller used by the live stack."""
+def test_live_stack_wires_serialization_fault_into_builtin_model(tmp_path: Path) -> None:
+    """The CLI-level fault reaches the built-in model used by the live stack."""
     config = live_fuzz.StressConfig(
         threads=2,
+        rooms=1,
         waves=1,
         stream_seconds=0.02,
         edit_interval=0.01,
@@ -4432,18 +4434,24 @@ def test_live_stack_wires_serialization_fault_into_model_controller(tmp_path: Pa
         stress_config=config,
     )
     try:
-        assert stack.stress_controller is not None
-        assert stack.stress_controller._serialization_lock is not None
+        stack._write_config(12345)
+        payload = yaml.safe_load(stack.config_path.read_text(encoding="utf-8"))
+        assert payload["models"]["stress"]["provider"] == "synthetic"
+        assert payload["models"]["stress"]["extra_kwargs"]["serialize_streams"] is True
+        assert payload["agents"]["general"]["model"] == "stress"
+        assert payload["agents"]["general"]["tools"] == ["sleep"]
+        assert stack.stress_audit is not None
     finally:
         stack.temp_dir.cleanup()
 
 
-def test_stress_stack_bounds_model_timeout_beyond_barrier_and_disables_retries(
+def test_stress_stack_configures_seeded_builtin_model_without_credentials(
     tmp_path: Path,
 ) -> None:
-    """Long barrier waits must not trigger duplicate OpenAI requests."""
+    """Stress uses the built-in model while lifecycle calls keep the tiny stub."""
     config = live_fuzz.StressConfig(
         threads=2,
+        rooms=1,
         stream_seconds=45,
         edit_interval=0.5,
         waves=1,
@@ -4459,9 +4467,12 @@ def test_stress_stack_bounds_model_timeout_beyond_barrier_and_disables_retries(
         payload = yaml.safe_load(stack.config_path.read_text(encoding="utf-8"))
         assert payload["models"]["default"]["extra_kwargs"] == {
             "base_url": "http://127.0.0.1:12345/v1",
-            "max_retries": 0,
-            "timeout": 165,
         }
+        synthetic = payload["models"]["stress"]
+        assert synthetic["provider"] == "synthetic"
+        assert synthetic["extra_kwargs"]["barrier_size"] == 2
+        assert synthetic["extra_kwargs"]["tool_call_probability"] == 1
+        assert synthetic["extra_kwargs"]["activation_pattern"].startswith("LMS")
         assert payload["defaults"]["thread_summary_first_threshold"] == 1_000_000
     finally:
         stack.temp_dir.cleanup()
@@ -4472,6 +4483,7 @@ def test_cache_wave_gate_records_unresolved_warm_scans_without_accepting_duplica
     runner = object.__new__(live_fuzz.LiveMatrixStressRunner)
     runner.config = live_fuzz.StressConfig(
         threads=2,
+        rooms=1,
         stream_seconds=1,
         edit_interval=0.5,
         waves=2,

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -6104,6 +6104,7 @@ def test_main_preserves_base_exception_evidence_and_closes_stack(
     """An interrupted campaign preserves evidence and tears down its stack."""
     args = SimpleNamespace(
         api_port=None,
+        state_root=tmp_path / "state",
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
@@ -6164,6 +6165,7 @@ def test_main_bad_failure_log_preserves_primary_and_closes_stack(
     mindroom_log.write_text("mindroom output\n", encoding="utf-8")
     args = SimpleNamespace(
         api_port=None,
+        state_root=tmp_path / "state",
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=failure_log,
@@ -6213,6 +6215,7 @@ def test_main_bundle_capture_failure_preserves_primary_and_closes_stack(
     """Any evidence-capture failure still preserves the run error and teardown."""
     args = SimpleNamespace(
         api_port=None,
+        state_root=tmp_path / "state",
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
@@ -6267,6 +6270,7 @@ def test_main_stop_interrupt_preserves_primary_and_closes_stack(
     """An interrupted evidence stage cannot mask the run error or skip close."""
     args = SimpleNamespace(
         api_port=None,
+        state_root=tmp_path / "state",
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
@@ -6337,6 +6341,7 @@ def test_main_rechecks_sources_at_teardown_and_receipt_boundaries(
     """PASS revalidates after runtime work and again after teardown."""
     args = SimpleNamespace(
         api_port=None,
+        state_root=tmp_path / "state",
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
@@ -6429,6 +6434,7 @@ def test_main_cleanup_failure_retains_pre_teardown_evidence(
     artifact_root = tmp_path / "artifacts"
     args = SimpleNamespace(
         api_port=None,
+        state_root=tmp_path / "state",
         artifact_root=artifact_root,
         profile="fuzz",
         failure_log=None,
@@ -6563,6 +6569,7 @@ def test_main_missing_runtime_provenance_captures_bundle_before_teardown(
     log_path.write_text("runtime without attestation\n", encoding="utf-8")
     args = SimpleNamespace(
         api_port=None,
+        state_root=tmp_path / "state",
         artifact_root=artifact_root,
         profile="fuzz",
         failure_log=None,

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -3869,6 +3869,18 @@ def test_start_mindroom_uses_editable_overlay_and_persists_each_pid(
         stack.temp_dir.cleanup()
 
 
+def test_live_stack_accepts_explicit_isolated_api_port(tmp_path: Path) -> None:
+    """Live campaigns may avoid another campaign's conventional API port."""
+    stack = ManagedTuwunelStack(
+        state_root=tmp_path / "state",
+        api_port=18765,
+    )
+    try:
+        assert stack._requested_api_port == 18765
+    finally:
+        stack.temp_dir.cleanup()
+
+
 @pytest.mark.asyncio
 async def test_run_live_closes_every_client_without_masking_primary_failure(
     monkeypatch: pytest.MonkeyPatch,
@@ -6090,6 +6102,7 @@ def test_main_preserves_base_exception_evidence_and_closes_stack(
 ) -> None:
     """An interrupted campaign preserves evidence and tears down its stack."""
     args = SimpleNamespace(
+        api_port=None,
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
@@ -6149,6 +6162,7 @@ def test_main_bad_failure_log_preserves_primary_and_closes_stack(
     mindroom_log = tmp_path / "mindroom.log"
     mindroom_log.write_text("mindroom output\n", encoding="utf-8")
     args = SimpleNamespace(
+        api_port=None,
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=failure_log,
@@ -6197,6 +6211,7 @@ def test_main_bundle_capture_failure_preserves_primary_and_closes_stack(
 ) -> None:
     """Any evidence-capture failure still preserves the run error and teardown."""
     args = SimpleNamespace(
+        api_port=None,
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
@@ -6250,6 +6265,7 @@ def test_main_stop_interrupt_preserves_primary_and_closes_stack(
 ) -> None:
     """An interrupted evidence stage cannot mask the run error or skip close."""
     args = SimpleNamespace(
+        api_port=None,
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
@@ -6319,6 +6335,7 @@ def test_main_rechecks_sources_at_teardown_and_receipt_boundaries(
 ) -> None:
     """PASS revalidates after runtime work and again after teardown."""
     args = SimpleNamespace(
+        api_port=None,
         artifact_root=tmp_path / "artifacts",
         profile="fuzz",
         failure_log=None,
@@ -6410,6 +6427,7 @@ def test_main_cleanup_failure_retains_pre_teardown_evidence(
     """A passing workload snapshots disposable evidence before failed cleanup."""
     artifact_root = tmp_path / "artifacts"
     args = SimpleNamespace(
+        api_port=None,
         artifact_root=artifact_root,
         profile="fuzz",
         failure_log=None,
@@ -6543,6 +6561,7 @@ def test_main_missing_runtime_provenance_captures_bundle_before_teardown(
     _write_ledger(ledger_path, {})
     log_path.write_text("runtime without attestation\n", encoding="utf-8")
     args = SimpleNamespace(
+        api_port=None,
         artifact_root=artifact_root,
         profile="fuzz",
         failure_log=None,

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -7,6 +7,7 @@ import io
 import json
 import shutil
 import signal
+import subprocess
 import sys
 from collections import defaultdict
 from dataclasses import replace
@@ -42,6 +43,7 @@ from scripts.testing.fuzz_live_matrix import (
     ManagedTuwunelStack,
     NioOverlay,
     _body_call_id,
+    _git_state_for_file,
     _ModelHandler,
     _parse_markers,
     _persist_failure_bundle,
@@ -3417,6 +3419,51 @@ def test_nio_overlay_preflight_rejects_missing_checkout() -> None:
     """A gate-quality run cannot reach stack creation without an explicit overlay."""
     with pytest.raises(RuntimeError, match="requires --nio-overlay"):
         _prepare_nio_overlay(None)
+
+
+def test_git_state_ignores_only_declared_untracked_build_metadata(tmp_path: Path) -> None:
+    """Editable-build metadata is inert while any other source dirt stays fatal."""
+    root = tmp_path / "nio"
+    module = root / "src" / "nio" / "__init__.py"
+    module.parent.mkdir(parents=True)
+    module.write_text("", encoding="utf-8")
+    subprocess.run(("git", "init", str(root)), check=True, capture_output=True)
+    subprocess.run(("git", "-C", str(root), "add", str(module.relative_to(root))), check=True)
+    subprocess.run(
+        (
+            "git",
+            "-C",
+            str(root),
+            "-c",
+            "user.name=MindRoom Tests",
+            "-c",
+            "user.email=tests@mindroom.local",
+            "commit",
+            "-m",
+            "fixture",
+        ),
+        check=True,
+        capture_output=True,
+    )
+    metadata = root / "src" / "mindroom_nio.egg-info"
+    metadata.mkdir()
+    (metadata / "PKG-INFO").write_text("generated", encoding="utf-8")
+
+    revision, dirty = _git_state_for_file(
+        module,
+        scopes=(root / "src",),
+        ignored_untracked_scopes=(metadata,),
+    )
+
+    assert revision is not None
+    assert dirty is False
+
+    (root / "src" / "unexpected.py").write_text("", encoding="utf-8")
+    assert _git_state_for_file(
+        module,
+        scopes=(root / "src",),
+        ignored_untracked_scopes=(metadata,),
+    )[1]
 
 
 def test_stack_rejects_missing_nio_overlay_before_live_setup(

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -2577,8 +2577,8 @@ async def test_duplicate_canonical_reply_inside_edit_window_is_detected() -> Non
 
 
 @pytest.mark.asyncio
-async def test_matrix_quiet_window_rejects_limited_sync_without_advancing_cursor() -> None:
-    """A truncated saturation window fails instead of silently skipping events."""
+async def test_matrix_quiet_window_recovers_limited_sync_before_advancing_cursor() -> None:
+    """A truncated sync is hydrated through canonical pagination before advancing."""
     client = LiveMatrixClient("http://matrix.invalid", "!room:example")
 
     async def limited_sync(_since: str | None, *, timeout_ms: int) -> dict[str, Any]:
@@ -2598,10 +2598,88 @@ async def test_matrix_quiet_window_rejects_limited_sync_without_advancing_cursor
         }
 
     client.sync = limited_sync  # type: ignore[method-assign]
+
+    async def paginate_room(room_id: str) -> list[dict[str, Any]]:
+        assert room_id == "!room:example"
+        return [{"event_id": "$recovered"}]
+
+    client.paginate_room = paginate_room  # type: ignore[method-assign]
     try:
-        with pytest.raises(AssertionError, match="limited timeline"):
-            await client.wait_until_quiet(deadline_seconds=1.0, quiet_seconds=0.0)
+        await client.wait_until_quiet(deadline_seconds=1.0, quiet_seconds=0.0)
+        assert client.next_batch == "truncated"
+        assert client.seen_events == {"$recovered": {"event_id": "$recovered"}}
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_matrix_limited_sync_keeps_cursor_when_pagination_fails() -> None:
+    """A failed canonical backfill must leave the prior sync cursor reusable."""
+    client = LiveMatrixClient("http://matrix.invalid", "!room:example")
+
+    async def limited_sync(_since: str | None, *, timeout_ms: int) -> dict[str, Any]:
+        assert timeout_ms > 0
+        return {
+            "next_batch": "truncated",
+            "rooms": {
+                "join": {
+                    "!room:example": {
+                        "timeline": {
+                            "limited": True,
+                            "events": [],
+                        },
+                    },
+                },
+            },
+        }
+
+    async def failed_pagination(_room_id: str) -> list[dict[str, Any]]:
+        msg = "pagination failed"
+        raise RuntimeError(msg)
+
+    client.sync = limited_sync  # type: ignore[method-assign]
+    client.paginate_room = failed_pagination  # type: ignore[method-assign]
+    try:
+        with pytest.raises(RuntimeError, match="pagination failed"):
+            await client.sync_incremental(timeout_ms=1)
         assert client.next_batch is None
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_exact_reply_oracle_recovers_limited_sync_through_pagination() -> None:
+    """The exact oracle must hydrate a limited gap instead of losing a source."""
+    client = LiveMatrixClient("http://matrix.invalid", "!room:example")
+    oracle = ExactReplyOracle(client, "@agent:example")
+    oracle.expect("root:0", "$source")
+
+    async def limited_sync(_since: str | None, *, timeout_ms: int) -> dict[str, Any]:
+        assert timeout_ms > 0
+        return {
+            "next_batch": "truncated",
+            "rooms": {
+                "join": {
+                    "!room:example": {
+                        "timeline": {
+                            "limited": True,
+                            "events": [],
+                        },
+                    },
+                },
+            },
+        }
+
+    async def paginate_room(room_id: str) -> list[dict[str, Any]]:
+        assert room_id == "!room:example"
+        return [{"event_id": "$source", "sender": "@user:example", "type": "m.room.message", "content": {}}]
+
+    client.sync = limited_sync  # type: ignore[method-assign]
+    client.paginate_room = paginate_room  # type: ignore[method-assign]
+    try:
+        await oracle.pump(timeout_ms=1)
+        assert oracle.observed_sources == {"$source"}
+        assert oracle.next_batch == "truncated"
     finally:
         await client.close()
 

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -4462,6 +4462,7 @@ def test_stress_stack_bounds_model_timeout_beyond_barrier_and_disables_retries(
             "max_retries": 0,
             "timeout": 165,
         }
+        assert payload["defaults"]["thread_summary_first_threshold"] == 1_000_000
     finally:
         stack.temp_dir.cleanup()
 

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -23,6 +23,7 @@ from mindroom.streaming import RESTART_INTERRUPTED_RESPONSE_NOTE
 if TYPE_CHECKING:
     from collections.abc import Callable, Collection
 
+import psutil
 import pytest
 
 import scripts.testing.fuzz_live_matrix as live_fuzz
@@ -4410,7 +4411,7 @@ def test_resource_sampler_rebinds_after_managed_runtime_restart(
     current_process.cpu_percent.side_effect = [None, 37.5]
     current_process.memory_info.return_value = SimpleNamespace(rss=123456)
     process_factory = MagicMock(return_value=current_process)
-    monkeypatch.setattr(live_fuzz.psutil, "Process", process_factory)
+    monkeypatch.setattr(psutil, "Process", process_factory)
 
     process, cpu_percent, rss_bytes = live_fuzz._sample_mindroom_process(
         stack,  # type: ignore[arg-type]

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -4430,6 +4430,30 @@ def test_stress_stack_bounds_model_timeout_beyond_barrier_and_disables_retries(
         stack.temp_dir.cleanup()
 
 
+def test_cache_wave_gate_records_unresolved_warm_scans_without_accepting_duplicates() -> None:
+    """Warm invalidation scans remain metrics until cache self-healing lands."""
+    runner = object.__new__(live_fuzz.LiveMatrixStressRunner)
+    runner.config = live_fuzz.StressConfig(
+        threads=2,
+        stream_seconds=1,
+        edit_interval=0.5,
+        waves=2,
+        history_turns=0,
+    )
+    cold = live_fuzz.StressLogMetrics(full_scans=2)
+    warm = live_fuzz.StressLogMetrics(
+        full_scans=2,
+        cache_hits=2,
+        repair_fetches_by_thread={"thread-0": 1, "thread-1": 1},
+    )
+
+    runner._assert_cache_wave_shape((cold, warm))
+
+    warm.repair_fetches_by_thread["thread-0"] = 2
+    with pytest.raises(AssertionError, match="duplicate repair scans"):
+        runner._assert_cache_wave_shape((cold, warm))
+
+
 def test_resource_sampler_rebinds_after_managed_runtime_restart(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -4106,6 +4106,7 @@ def test_stack_close_attempts_every_stage_before_rethrowing_first_interrupt(
     stack._log_handle = FakeLog()
     stack._model_server = FakeServer()
     stack._model_thread = FakeThread()
+    stack.stress_postgres = None
     stack._created = True
     stack.instance_name = "fuzz-test"
     stack.temp_dir = FakeTempDir()
@@ -4164,6 +4165,7 @@ def test_stack_close_groups_ordinary_cleanup_failures() -> None:
     stack._log_handle = None
     stack._model_server = None
     stack._model_thread = None
+    stack.stress_postgres = None
     stack._created = False
     stack.temp_dir = FakeTempDir()
     stack._write_manifest = lambda **_kwargs: events.append("manifest")  # type: ignore[method-assign]
@@ -5770,6 +5772,7 @@ def test_main_preserves_base_exception_evidence_and_closes_stack(
     """An interrupted campaign preserves evidence and tears down its stack."""
     args = SimpleNamespace(
         artifact_root=tmp_path / "artifacts",
+        profile="fuzz",
         failure_log=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
@@ -5827,6 +5830,7 @@ def test_main_bad_failure_log_preserves_primary_and_closes_stack(
     mindroom_log.write_text("mindroom output\n", encoding="utf-8")
     args = SimpleNamespace(
         artifact_root=tmp_path / "artifacts",
+        profile="fuzz",
         failure_log=failure_log,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
@@ -5873,6 +5877,7 @@ def test_main_bundle_capture_failure_preserves_primary_and_closes_stack(
     """Any evidence-capture failure still preserves the run error and teardown."""
     args = SimpleNamespace(
         artifact_root=tmp_path / "artifacts",
+        profile="fuzz",
         failure_log=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
@@ -5924,6 +5929,7 @@ def test_main_stop_interrupt_preserves_primary_and_closes_stack(
     """An interrupted evidence stage cannot mask the run error or skip close."""
     args = SimpleNamespace(
         artifact_root=tmp_path / "artifacts",
+        profile="fuzz",
         failure_log=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
@@ -5991,6 +5997,7 @@ def test_main_rechecks_sources_at_teardown_and_receipt_boundaries(
     """PASS revalidates after runtime work and again after teardown."""
     args = SimpleNamespace(
         artifact_root=tmp_path / "artifacts",
+        profile="fuzz",
         failure_log=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
@@ -6080,6 +6087,7 @@ def test_main_cleanup_failure_retains_pre_teardown_evidence(
     artifact_root = tmp_path / "artifacts"
     args = SimpleNamespace(
         artifact_root=artifact_root,
+        profile="fuzz",
         failure_log=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,
@@ -6211,6 +6219,7 @@ def test_main_missing_runtime_provenance_captures_bundle_before_teardown(
     log_path.write_text("runtime without attestation\n", encoding="utf-8")
     args = SimpleNamespace(
         artifact_root=artifact_root,
+        profile="fuzz",
         failure_log=None,
         nio_overlay=NioOverlay(path=tmp_path / "nio", revision="nio-head"),
         pending_grace=0.0,

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -13,6 +13,7 @@ from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
 
 from mindroom.constants import SOURCE_KIND_KEY
 from mindroom.dispatch_source import AUTO_RESUME_MESSAGE, TRUSTED_INTERNAL_RELAY_SOURCE_KIND
@@ -4270,6 +4271,21 @@ def test_live_stack_wires_serialization_fault_into_model_controller(tmp_path: Pa
         assert stack.stress_controller._serialization_lock is not None
     finally:
         stack.temp_dir.cleanup()
+
+
+def test_clear_stress_cache_restarts_runtime_without_clearing_sync_checkpoint() -> None:
+    """An empty SQL cache must not leave a stale warm in-memory cache behind."""
+    stack = object.__new__(ManagedTuwunelStack)
+    postgres = MagicMock()
+    stack.stress_postgres = postgres
+    stack.namespace = "synthetic"
+    restart = MagicMock()
+    stack.restart_mindroom = restart  # type: ignore[method-assign]
+
+    stack.clear_stress_cache()
+
+    postgres.clear_cache_namespace.assert_called_once_with("synthetic")
+    restart.assert_called_once_with()
 
 
 def test_live_stack_manifest_is_atomic_and_recoverable(tmp_path: Path) -> None:

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -136,6 +136,7 @@ def test_synthetic_stress_audit_requires_real_tool_continuation(tmp_path: Path) 
 
     audit.assert_complete()
     assert audit.expected_body(request) == plan.body
+    assert audit.expected_matrix_body(request) == plan.prefix + "\n\n🔧 `sleep` [1]\n\n" + plan.suffix
     assert audit.snapshot()["tool_calls"] == 1
 
     telemetry_path.write_text(

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -349,7 +349,7 @@ def test_log_metrics_aggregate_cache_write_and_health_signals() -> None:
             json.dumps(
                 {
                     "event": "Thread history cache store completed",
-                    "outcome": "not_replaced",
+                    "cache_store_outcome": "not_replaced",
                 },
             ),
             json.dumps(

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -1,0 +1,538 @@
+"""Deterministic unit and fault-injection tests for the live Matrix stress framework."""
+
+# Test names state their behavior more precisely than repeated function docstrings.
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+import json
+import shutil
+import threading
+from dataclasses import replace
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.testing.live_matrix_stress import (
+    ArtifactSanitizer,
+    BaselineSample,
+    ManagedStressPostgres,
+    ResourceSample,
+    StressArtifactBundle,
+    StressBaseline,
+    StressConfig,
+    StressLogMetrics,
+    StressModelController,
+    StressRequest,
+    aggregate_log_metrics,
+    assert_matrix_edit_shape,
+    current_machine_class,
+    expected_minimum_matrix_edits,
+    latency_summary,
+    parse_stress_request,
+    percentile,
+    resource_summary,
+    write_replay_command,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from pytest_mock import MockerFixture
+
+
+class _FakeClock:
+    """Advance deterministic monotonic time whenever the model sleeps."""
+
+    def __init__(self) -> None:
+        self.value = 100.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def sleep(self, seconds: float) -> None:
+        self.value += seconds
+
+
+def _sample(multiplier: float = 1.0) -> BaselineSample:
+    return BaselineSample(
+        source_to_final_p95_ms=1000 * multiplier,
+        source_to_final_p99_ms=1200 * multiplier,
+        throughput_responses_per_second=10 / multiplier,
+    )
+
+
+def _stable_baseline() -> StressBaseline:
+    return StressBaseline(
+        profile="stress-50x45x2",
+        source_revision="a" * 40,
+        config_sha256="b" * 64,
+        machine_class=current_machine_class(),
+        samples=(_sample(0.98), _sample(1.0), _sample(1.02)),
+    )
+
+
+def test_stress_profile_defaults_and_trace_round_trip() -> None:
+    config = StressConfig()
+
+    assert config.threads == 50
+    assert config.stream_seconds == 45
+    assert config.edit_interval == 0.5
+    assert config.pulses_per_stream == 90
+    assert config.waves == 2
+    assert config.cache_backend == "postgres"
+    assert config.expected_model_pulses == 9000
+    assert StressConfig.from_json(config.to_json()) == config
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"threads": 0}, "threads must be positive"),
+        ({"cache_backend": "sqlite"}, "requires PostgreSQL"),
+        ({"stream_seconds": 1.1, "edit_interval": 0.5}, "exactly divisible"),
+        ({"history_turns": -1}, "history_turns must be non-negative"),
+    ],
+)
+def test_stress_config_rejects_invalid_shapes(changes: dict[str, object], message: str) -> None:
+    config = replace(StressConfig(), **changes)
+
+    with pytest.raises(ValueError, match=message):
+        config.validate()
+
+
+def test_stress_marker_parse_and_validation() -> None:
+    config = StressConfig(threads=2, waves=1, stream_seconds=1, edit_interval=0.5, seed=17)
+
+    marker = config.marker(0, 1)
+
+    assert marker == "LMS[wave=0;thread=001;seed=17]"
+    assert parse_stress_request(f"synthetic {marker}") == StressRequest(wave=0, thread=1, seed=17)
+    assert parse_stress_request("ordinary setup call") is None
+    with pytest.raises(ValueError, match="contains 2 markers"):
+        parse_stress_request(f"{marker} {marker}")
+
+
+def test_fifty_request_barrier_releases_together() -> None:
+    config = StressConfig(
+        threads=50,
+        waves=1,
+        stream_seconds=0.01,
+        edit_interval=0.01,
+        barrier_timeout_seconds=5,
+    )
+    controller = StressModelController(config)
+    release = threading.Barrier(config.threads + 1)
+    failures: list[BaseException] = []
+
+    def reach(thread_index: int) -> None:
+        release.wait()
+        try:
+            list(
+                controller.stream(
+                    StressRequest(wave=0, thread=thread_index, seed=config.seed),
+                ),
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    workers = [threading.Thread(target=reach, args=(thread_index,)) for thread_index in range(config.threads)]
+    for worker in workers:
+        worker.start()
+    release.wait()
+    for worker in workers:
+        worker.join(timeout=10)
+
+    assert not failures
+    assert not any(worker.is_alive() for worker in workers)
+    assert controller.reached_count(0) == 50
+    assert controller.max_active_streams == 50
+    assert controller.total_pulses == 50
+    controller.assert_complete(duration_tolerance_seconds=0.1)
+
+
+def test_barrier_timeout_reports_exact_missing_threads() -> None:
+    config = StressConfig(
+        threads=3,
+        waves=1,
+        stream_seconds=0.01,
+        edit_interval=0.01,
+        barrier_timeout_seconds=0.05,
+    )
+    controller = StressModelController(config)
+
+    with pytest.raises(
+        TimeoutError,
+        match=r"reached 1/3; missing=\[1, 2\]",
+    ):
+        controller.reach_barrier(StressRequest(wave=0, thread=0, seed=config.seed))
+
+
+def test_exact_pulse_count_duration_and_completion_marker() -> None:
+    clock = _FakeClock()
+    config = StressConfig(threads=1, waves=1, stream_seconds=2, edit_interval=0.5)
+    controller = StressModelController(config, clock=clock, sleeper=clock.sleep)
+
+    chunks = list(controller.stream(StressRequest(wave=0, thread=0, seed=config.seed)))
+
+    assert len(chunks) == 4
+    assert "pulse=001/004" in chunks[0]
+    assert chunks[-1].endswith("COMPLETE[wave=0;thread=000;pulses=4] ")
+    snapshot = controller.snapshot()
+    assert snapshot["total_pulses"] == 4
+    stream = snapshot["streams"][0]
+    assert stream["stream_duration_seconds"] == 2.0
+    assert stream["pulse_offsets_seconds"] == [0.5, 1.0, 1.5, 2.0]
+    controller.assert_complete()
+
+
+def test_serialized_stream_fault_fails_concurrency_gate() -> None:
+    config = StressConfig(
+        threads=2,
+        waves=1,
+        stream_seconds=0.02,
+        edit_interval=0.01,
+        barrier_timeout_seconds=2,
+    )
+    controller = StressModelController(config, serialize_streams=True)
+    workers = [
+        threading.Thread(
+            target=lambda thread_index=thread_index: list(
+                controller.stream(
+                    StressRequest(wave=0, thread=thread_index, seed=config.seed),
+                ),
+            ),
+        )
+        for thread_index in range(config.threads)
+    ]
+    for worker in workers:
+        worker.start()
+    for worker in workers:
+        worker.join(timeout=5)
+
+    assert controller.max_active_streams == 1
+    with pytest.raises(AssertionError, match="maximum active model streams 1/2"):
+        controller.assert_complete()
+
+
+def test_cancelled_stream_is_recorded_and_fails_gate() -> None:
+    clock = _FakeClock()
+    config = StressConfig(threads=1, waves=1, stream_seconds=2, edit_interval=0.5)
+    controller = StressModelController(config, clock=clock, sleeper=clock.sleep)
+    stream: Iterator[str] = controller.stream(StressRequest(wave=0, thread=0, seed=config.seed))
+
+    next(stream)
+    stream.close()
+
+    with pytest.raises(AssertionError, match="was cancelled"):
+        controller.assert_complete()
+
+
+def test_latency_percentiles_are_interpolated() -> None:
+    values = [1, 2, 3, 4, 5]
+
+    assert percentile(values, 50) == 3
+    assert percentile(values, 90) == pytest.approx(4.6)
+    assert latency_summary(values) == {
+        "count": 5,
+        "p50": 3.0,
+        "p90": 4.6,
+        "p95": 4.8,
+        "p99": 4.96,
+        "max": 5,
+    }
+    assert latency_summary([]) == {"count": 0}
+
+
+def test_baseline_round_trip_and_candidate_comparison() -> None:
+    baseline = _stable_baseline()
+
+    loaded = StressBaseline.from_json(baseline.to_json())
+    comparison = loaded.compare(_sample(1.1))
+
+    assert comparison["passed"] is True
+    assert comparison["allowance"] == 0.25
+    assert comparison["baseline_medians"]["source_to_final_p95_ms"] == 1000
+
+
+def test_baseline_regression_gate_cannot_be_disabled() -> None:
+    baseline = _stable_baseline()
+
+    with pytest.raises(AssertionError, match="stress performance regression"):
+        baseline.compare(_sample(1.4))
+
+
+def test_baseline_rejects_different_machine_class() -> None:
+    baseline = _stable_baseline()
+
+    with pytest.raises(ValueError, match="machine class mismatch"):
+        baseline.compare(_sample(), machine_class="different-machine")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "{}",
+        '{"version": 1, "profile": "stress"}',
+        (
+            '{"version": 1, "profile": "stress", "source_revision": "a", '
+            '"config_sha256": "b", "samples": [{"source_to_final_p95_ms": 1}]}'
+        ),
+    ],
+)
+def test_malformed_or_missing_baseline_fails(payload: str) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        StressBaseline.from_json(payload)
+
+
+def test_high_variance_baseline_is_rejected() -> None:
+    baseline = StressBaseline(
+        profile="stress",
+        source_revision="a",
+        config_sha256="b",
+        machine_class=current_machine_class(),
+        samples=(_sample(0.5), _sample(1), _sample(1.5)),
+    )
+
+    with pytest.raises(ValueError, match="fix determinism before gating"):
+        baseline.validate()
+
+
+def test_log_metrics_aggregate_cache_write_and_health_signals() -> None:
+    text = "\n".join(
+        [
+            json.dumps(
+                {
+                    "event": "Event cache outbound schedule timing",
+                    "barrier_kind": "thread",
+                    "is_edit": True,
+                },
+            ),
+            json.dumps(
+                {
+                    "event": "Event cache update timing",
+                    "predecessor_wait_ms": 3,
+                    "update_run_ms": 5,
+                    "total_ms": 8,
+                    "coalesced_update_count": 4,
+                    "outcome": "ok",
+                },
+            ),
+            json.dumps(
+                {
+                    "event": "matrix_cache_thread_history_refreshed",
+                    "mode": "cache_hit",
+                },
+            ),
+            json.dumps(
+                {
+                    "event": "Thread history cache store completed",
+                    "outcome": "not_replaced",
+                },
+            ),
+            json.dumps(
+                {
+                    "event": "outbound_thread_reservation",
+                    "action": "released",
+                    "active_count": 0,
+                },
+            ),
+        ],
+    )
+
+    metrics = aggregate_log_metrics(text)
+    summary = metrics.summary()
+
+    assert summary["barriers"] == {
+        "room": 0,
+        "thread": 1,
+        "known_thread_room_violations": 0,
+    }
+    assert summary["write_coordination"]["coalesced_intermediate_writes"] == 4
+    assert summary["cache"]["hits"] == 1
+    assert summary["cache"]["snapshot_store_outcomes"] == {"not_replaced": 1}
+    assert summary["reservations"]["released"] == 1
+    metrics.assert_healthy()
+
+
+@pytest.mark.parametrize(
+    ("event", "message"),
+    [
+        (
+            {
+                "event": "Event cache outbound schedule timing",
+                "barrier_kind": "room",
+                "is_edit": True,
+            },
+            "known-thread edits used room barriers",
+        ),
+        (
+            {
+                "event": "outbound_thread_reservation",
+                "action": "created",
+                "active_count": 1,
+            },
+            "thread reservations leaked",
+        ),
+        ({"event": "event_loop_stall_detected"}, "watchdog stalls"),
+        ({"event": "sync_restart_retry_started"}, "sync-restart retries"),
+        ({"event": "Response was interrupted"}, "interruption signals"),
+        ({"event": "Task exception was never retrieved"}, "uncaught exceptions"),
+        ({"event": "another command is already in progress"}, "PostgreSQL connection-concurrency"),
+    ],
+)
+def test_fault_signals_fail_health_gate(event: dict[str, object], message: str) -> None:
+    metrics = StressLogMetrics()
+    metrics.ingest(event)
+
+    with pytest.raises(AssertionError, match=message):
+        metrics.assert_healthy()
+
+
+def test_duplicate_cache_repair_scan_fails_gate() -> None:
+    metrics = StressLogMetrics()
+    event = {
+        "event": "matrix_cache_thread_history_refreshed",
+        "mode": "full_scan",
+        "thread_id": "thread-001",
+    }
+
+    metrics.ingest(event)
+    metrics.ingest(event)
+
+    with pytest.raises(AssertionError, match="duplicate repair scans"):
+        metrics.assert_healthy()
+
+
+def test_artifact_sanitizer_redacts_secrets_urls_paths_and_matrix_ids() -> None:
+    sanitizer = ArtifactSanitizer()
+    raw = {
+        "access_token": "syt-secret-token-value",
+        "message": (
+            "Authorization: Bearer raw-secret "
+            "postgresql://cache:password@db.internal/mindroom "
+            "https://private.example/path "
+            "/Users/person/private/log "
+            "!room:private.example $eventabcdef @person:private.example s123_longrawsynctoken"
+        ),
+    }
+
+    sanitized = sanitizer.value(raw)
+    serialized = json.dumps(sanitized)
+
+    sanitizer.assert_clean(serialized)
+    assert sanitized["access_token"] == "<redacted>"  # noqa: S105 - sanitizer sentinel
+    assert "raw-secret" not in serialized
+    assert "private.example" not in serialized
+    assert "/Users/person" not in serialized
+    assert "<room-001>" in serialized
+    assert "<event-001>" in serialized
+    assert "<user-001>" in serialized
+
+
+def test_sanitizer_fault_injection_detects_unredacted_token() -> None:
+    sanitizer = ArtifactSanitizer()
+
+    with pytest.raises(AssertionError, match="sanitizer leaked"):
+        sanitizer.assert_clean("Authorization: Bearer leaked-token")
+
+
+def test_artifact_bundle_retains_success_and_failure_evidence() -> None:
+    persistent_root = Path.cwd() / "artifacts" / "live-matrix-stress-tests"
+    run_root = persistent_root / "run-001"
+    if run_root.exists():
+        shutil.rmtree(run_root)
+    try:
+        bundle = StressArtifactBundle.create(persistent_root, "run-001")
+
+        summary_path = bundle.write_json(
+            "summary.json",
+            {"room_id": "!room:synthetic.invalid", "result": "PASS"},
+        )
+        failure_path = bundle.write_text(
+            "failure.txt",
+            "synthetic failure for $event:synthetic.invalid",
+        )
+
+        assert summary_path.exists()
+        assert failure_path.exists()
+        assert "!room:" not in summary_path.read_text(encoding="utf-8")
+        assert "$event" not in failure_path.read_text(encoding="utf-8")
+    finally:
+        shutil.rmtree(run_root, ignore_errors=True)
+
+
+@pytest.mark.parametrize(
+    "root",
+    [
+        Path("/tmp/live-matrix-stress"),  # noqa: S108 - path must be rejected
+        Path("/private/tmp/live-matrix-stress"),
+        Path("/var/tmp/live-matrix-stress"),  # noqa: S108 - path must be rejected
+    ],
+)
+def test_artifact_bundle_rejects_temporary_roots(root: Path) -> None:
+    with pytest.raises(ValueError, match="must be persistent"):
+        StressArtifactBundle.create(root, "run")
+
+
+def test_matrix_edit_shape_counts_and_overlap() -> None:
+    config = StressConfig(threads=2, waves=1, stream_seconds=10, edit_interval=0.5)
+    edits = {
+        "wave-00/thread-000": [1.0, 5.0],
+        "wave-00/thread-001": [2.0, 6.0],
+    }
+
+    assert expected_minimum_matrix_edits(config) == 2
+    assert_matrix_edit_shape(config, edits)
+
+
+def test_matrix_edit_shape_faults_on_missing_final_edit() -> None:
+    config = StressConfig(threads=2, waves=1, stream_seconds=10, edit_interval=0.5)
+
+    with pytest.raises(AssertionError, match="insufficient Matrix edit activity"):
+        assert_matrix_edit_shape(
+            config,
+            {
+                "wave-00/thread-000": [1.0, 5.0],
+                "wave-00/thread-001": [2.0],
+            },
+        )
+
+
+def test_resource_summary_reports_cpu_rss_sync_and_health() -> None:
+    samples = [
+        ResourceSample(0, 10, 100, 0.2, 3, True, True),
+        ResourceSample(1, 20, 200, 0.4, 5, False, True),
+    ]
+
+    summary = resource_summary(samples)
+
+    assert summary["count"] == 2
+    assert summary["cpu_percent"]["p50"] == 15
+    assert summary["rss_bytes"]["max"] == 200
+    assert summary["tuwunel_unhealthy_samples"] == 1
+    assert summary["postgres_unhealthy_samples"] == 0
+
+
+def test_managed_postgres_preflight_never_falls_back(mocker: MockerFixture) -> None:
+    completed = mocker.Mock(returncode=0, stdout="127.0.0.1:54321\n", stderr="")
+    run = mocker.patch("scripts.testing.live_matrix_stress.subprocess.run", return_value=completed)
+    postgres = ManagedStressPostgres("synthetic-postgres")
+
+    postgres.start()
+
+    assert postgres.host_port == 54321
+    assert postgres.database_url == "postgresql://cache:synthetic-stress-password@127.0.0.1:54321/mindroom"
+    assert any(call.args[0][:3] == ("docker", "run", "--detach") for call in run.call_args_list)
+    assert postgres.is_healthy()
+    postgres.close()
+    assert any(call.args[0][:3] == ("docker", "rm", "--force") for call in run.call_args_list)
+
+
+def test_replay_command_uses_only_repository_relative_paths() -> None:
+    command = write_replay_command()
+
+    assert "scripts/testing/fuzz_live_matrix.py" in command
+    assert "artifacts/live-matrix-stress" in command
+    assert "/Users/" not in command

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -617,6 +617,7 @@ def test_stress_sync_fence_waits_for_exact_principal_event(mocker: MockerFixture
     )
 
     command = run.call_args.args[0]
+    assert command[:4] == ("docker", "exec", "--interactive", "synthetic-postgres")
     assert any(field.startswith("namespace=synthetic:principal:") for field in command)
     assert "room_id=!room:localhost" in command
     assert "event_id=$event" in command

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -329,6 +329,7 @@ def test_duplicate_cache_repair_scan_fails_gate() -> None:
         "event": "matrix_cache_thread_history_refreshed",
         "mode": "full_scan",
         "thread_id": "thread-001",
+        "caller_label": "dispatch_context",
     }
 
     metrics.ingest(event)
@@ -336,6 +337,21 @@ def test_duplicate_cache_repair_scan_fails_gate() -> None:
 
     with pytest.raises(AssertionError, match="duplicate repair scans"):
         metrics.assert_healthy()
+
+
+def test_different_full_scan_callers_are_not_duplicate_repairs() -> None:
+    metrics = StressLogMetrics()
+    event = {
+        "event": "matrix_cache_thread_history_refreshed",
+        "mode": "full_scan",
+        "thread_id": "thread-001",
+    }
+
+    metrics.ingest({**event, "caller_label": "dispatch_context"})
+    metrics.ingest({**event, "caller_label": "thread_summary_background"})
+
+    assert metrics.repair_fetches_by_thread == {"thread-001": 2}
+    metrics.assert_healthy()
 
 
 def test_whole_run_health_can_exclude_intentional_cross_phase_repairs() -> None:

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -620,7 +620,10 @@ def test_stress_sync_fence_waits_for_exact_principal_event(mocker: MockerFixture
     assert any(field.startswith("namespace=synthetic:principal:") for field in command)
     assert "room_id=!room:localhost" in command
     assert "event_id=$event" in command
-    assert "WHERE namespace = :'namespace' AND room_id = :'room_id' AND event_id = :'event_id'" in command[-1]
+    assert (
+        "WHERE namespace = :'namespace' AND room_id = :'room_id' AND event_id = :'event_id'"
+        in run.call_args.kwargs["input"]
+    )
 
 
 def test_replay_command_uses_only_repository_relative_paths() -> None:

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -82,6 +82,7 @@ def test_stress_profile_defaults_and_trace_round_trip() -> None:
     assert config.pulses_per_stream == 90
     assert config.waves == 2
     assert config.cache_backend == "postgres"
+    assert config.fault_mode == "none"
     assert config.expected_model_pulses == 9000
     assert StressConfig.from_json(config.to_json()) == config
 
@@ -93,6 +94,7 @@ def test_stress_profile_defaults_and_trace_round_trip() -> None:
         ({"cache_backend": "sqlite"}, "requires PostgreSQL"),
         ({"stream_seconds": 1.1, "edit_interval": 0.5}, "exactly divisible"),
         ({"history_turns": -1}, "history_turns must be non-negative"),
+        ({"fault_mode": "unknown"}, "unsupported stress fault mode"),
     ],
 )
 def test_stress_config_rejects_invalid_shapes(changes: dict[str, object], message: str) -> None:
@@ -216,6 +218,12 @@ def test_serialized_stream_fault_fails_concurrency_gate() -> None:
         controller.assert_complete()
 
 
+def test_serialized_stream_fault_round_trips_in_replay_config() -> None:
+    config = StressConfig(fault_mode="serialize-streams")
+
+    assert StressConfig.from_json(config.to_json()).fault_mode == "serialize-streams"
+
+
 def test_cancelled_stream_is_recorded_and_fails_gate() -> None:
     clock = _FakeClock()
     config = StressConfig(threads=1, waves=1, stream_seconds=2, edit_interval=0.5)
@@ -256,11 +264,22 @@ def test_baseline_round_trip_and_candidate_comparison() -> None:
     assert comparison["baseline_medians"]["source_to_final_p95_ms"] == 1000
 
 
-def test_baseline_regression_gate_cannot_be_disabled() -> None:
+def test_baseline_regression_gate_fails_when_enforced() -> None:
     baseline = _stable_baseline()
 
     with pytest.raises(AssertionError, match="stress performance regression"):
         baseline.compare(_sample(1.4))
+
+
+def test_baseline_regression_can_be_observed_without_enforcement() -> None:
+    comparison = _stable_baseline().compare(_sample(1.4), enforce=False)
+
+    assert comparison["passed"] is False
+    assert comparison["regressed_metrics"] == [
+        "source_to_final_p95_ms",
+        "source_to_final_p99_ms",
+        "throughput_responses_per_second",
+    ]
 
 
 def test_baseline_rejects_different_machine_class() -> None:

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -482,7 +482,11 @@ def test_artifact_bundle_retains_success_and_failure_evidence() -> None:
 
         summary_path = bundle.write_json(
             "summary.json",
-            {"room_id": "!room:synthetic.invalid", "result": "PASS"},
+            {
+                "room_id": "!room:synthetic.invalid",
+                "result": "PASS",
+                "repair_fetches_by_thread": {"$event:synthetic.invalid": 1},
+            },
         )
         failure_path = bundle.write_text(
             "failure.txt",
@@ -493,6 +497,7 @@ def test_artifact_bundle_retains_success_and_failure_evidence() -> None:
         assert failure_path.exists()
         assert "!room:" not in summary_path.read_text(encoding="utf-8")
         assert "$event" not in failure_path.read_text(encoding="utf-8")
+        assert "$event" not in summary_path.read_text(encoding="utf-8")
     finally:
         shutil.rmtree(run_root, ignore_errors=True)
 

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -424,6 +424,19 @@ def test_duplicate_cache_repair_scan_fails_gate() -> None:
         metrics.assert_healthy()
 
 
+def test_whole_run_health_can_exclude_intentional_cross_phase_repairs() -> None:
+    metrics = StressLogMetrics()
+    event = {
+        "event": "matrix_cache_thread_history_refreshed",
+        "mode": "full_scan",
+        "thread_id": "thread-001",
+    }
+    metrics.ingest(event)
+    metrics.ingest(event)
+
+    metrics.assert_healthy(check_duplicate_repairs=False)
+
+
 def test_artifact_sanitizer_redacts_secrets_urls_paths_and_matrix_ids() -> None:
     sanitizer = ArtifactSanitizer()
     raw = {

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -27,6 +27,7 @@ from scripts.testing.live_matrix_stress import (
     StressRequest,
     aggregate_log_metrics,
     assert_matrix_edit_shape,
+    assert_resource_health,
     current_machine_class,
     expected_minimum_matrix_edits,
     latency_summary,
@@ -186,6 +187,7 @@ def test_exact_pulse_count_duration_and_completion_marker() -> None:
     stream = snapshot["streams"][0]
     assert stream["stream_duration_seconds"] == 2.0
     assert stream["pulse_offsets_seconds"] == [0.5, 1.0, 1.5, 2.0]
+    assert snapshot["barrier_wait_ms"]["count"] == 1
     controller.assert_complete()
 
 
@@ -516,7 +518,10 @@ def test_matrix_edit_shape_counts_and_overlap() -> None:
     }
 
     assert expected_minimum_matrix_edits(config) == 2
-    assert_matrix_edit_shape(config, edits)
+    activity = assert_matrix_edit_shape(config, edits)
+
+    assert activity["max_active_streams"] == 2
+    assert activity["timeline"][0] == {"offset_seconds": 0.0, "active_streams": 1}
 
 
 def test_matrix_edit_shape_faults_on_missing_final_edit() -> None:
@@ -543,8 +548,25 @@ def test_resource_summary_reports_cpu_rss_sync_and_health() -> None:
     assert summary["count"] == 2
     assert summary["cpu_percent"]["p50"] == 15
     assert summary["rss_bytes"]["max"] == 200
+    assert summary["event_loop_probe_latency_ms"]["max"] == 5
+    assert summary["mindroom_health_probe_failures"] == 0
     assert summary["tuwunel_unhealthy_samples"] == 1
     assert summary["postgres_unhealthy_samples"] == 0
+
+
+@pytest.mark.parametrize(
+    ("summary", "message"),
+    [
+        ({"mindroom_health_probe_failures": 1}, "MindRoom health probe failures"),
+        ({"tuwunel_unhealthy_samples": 1}, "Tuwunel unhealthy samples"),
+        ({"postgres_unhealthy_samples": 1}, "PostgreSQL unhealthy samples"),
+        ({"event_loop_probe_latency_ms": {"max": 5001}}, "event-loop progress probe"),
+        ({"sync_age_seconds": {"max": 121}}, "Matrix sync age"),
+    ],
+)
+def test_resource_health_safety_ceilings_fail(summary: dict[str, object], message: str) -> None:
+    with pytest.raises(AssertionError, match=message):
+        assert_resource_health(summary)
 
 
 def test_managed_postgres_preflight_never_falls_back(mocker: MockerFixture) -> None:

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -549,6 +549,19 @@ def test_managed_postgres_preflight_never_falls_back(mocker: MockerFixture) -> N
     assert any(call.args[0][:3] == ("docker", "rm", "--force") for call in run.call_args_list)
 
 
+def test_stress_cache_clear_covers_principal_scoped_namespaces(mocker: MockerFixture) -> None:
+    completed = mocker.Mock(returncode=0, stdout="", stderr="")
+    run = mocker.patch("scripts.testing.live_matrix_stress.subprocess.run", return_value=completed)
+    postgres = ManagedStressPostgres("synthetic-postgres")
+    postgres._started = True
+
+    postgres.clear_cache_namespace("synthetic")
+
+    sql = run.call_args.args[0][-1]
+    assert "namespace = 'synthetic' OR namespace LIKE 'synthetic:%'" in sql
+    assert sql.count("DELETE FROM") == 9
+
+
 def test_replay_command_uses_only_repository_relative_paths() -> None:
     command = write_replay_command()
 

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 import shutil
-import threading
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -23,37 +22,21 @@ from scripts.testing.live_matrix_stress import (
     StressBaseline,
     StressConfig,
     StressLogMetrics,
-    StressModelController,
     StressRequest,
+    SyntheticStressAudit,
     aggregate_log_metrics,
     assert_matrix_edit_shape,
     assert_resource_health,
     current_machine_class,
     expected_minimum_matrix_edits,
     latency_summary,
-    parse_stress_request,
     percentile,
     resource_summary,
     write_replay_command,
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-
     from pytest_mock import MockerFixture
-
-
-class _FakeClock:
-    """Advance deterministic monotonic time whenever the model sleeps."""
-
-    def __init__(self) -> None:
-        self.value = 100.0
-
-    def __call__(self) -> float:
-        return self.value
-
-    def sleep(self, seconds: float) -> None:
-        self.value += seconds
 
 
 def _sample(multiplier: float = 1.0) -> BaselineSample:
@@ -77,14 +60,18 @@ def _stable_baseline() -> StressBaseline:
 def test_stress_profile_defaults_and_trace_round_trip() -> None:
     config = StressConfig()
 
-    assert config.threads == 50
+    assert config.threads == 100
+    assert config.rooms == 10
     assert config.stream_seconds == 45
     assert config.edit_interval == 0.5
-    assert config.pulses_per_stream == 90
+    assert config.chars_per_second == 80
+    assert config.min_response_chars == 1800
+    assert config.max_response_chars == 3600
+    assert config.chunk_chars == 40
+    assert config.tool_call_probability == 1
     assert config.waves == 2
     assert config.cache_backend == "postgres"
     assert config.fault_mode == "none"
-    assert config.expected_model_pulses == 9000
     assert StressConfig.from_json(config.to_json()) == config
 
 
@@ -92,6 +79,7 @@ def test_stress_profile_defaults_and_trace_round_trip() -> None:
     ("changes", "message"),
     [
         ({"threads": 0}, "threads must be positive"),
+        ({"threads": 2, "rooms": 3}, "rooms cannot exceed threads"),
         ({"cache_backend": "sqlite"}, "requires PostgreSQL"),
         ({"stream_seconds": 1.1, "edit_interval": 0.5}, "exactly divisible"),
         ({"history_turns": -1}, "history_turns must be non-negative"),
@@ -105,119 +93,13 @@ def test_stress_config_rejects_invalid_shapes(changes: dict[str, object], messag
         config.validate()
 
 
-def test_stress_marker_parse_and_validation() -> None:
-    config = StressConfig(threads=2, waves=1, stream_seconds=1, edit_interval=0.5, seed=17)
+def test_stress_marker_and_request_label() -> None:
+    config = StressConfig(threads=2, rooms=1, waves=1, stream_seconds=1, edit_interval=0.5, seed=17)
 
     marker = config.marker(0, 1)
 
     assert marker == "LMS[wave=0;thread=001;seed=17]"
-    assert parse_stress_request(f"synthetic {marker}") == StressRequest(wave=0, thread=1, seed=17)
-    assert parse_stress_request("ordinary setup call") is None
-    with pytest.raises(ValueError, match="contains 2 markers"):
-        parse_stress_request(f"{marker} {marker}")
-
-
-def test_fifty_request_barrier_releases_together() -> None:
-    config = StressConfig(
-        threads=50,
-        waves=1,
-        stream_seconds=0.01,
-        edit_interval=0.01,
-        barrier_timeout_seconds=5,
-    )
-    controller = StressModelController(config)
-    release = threading.Barrier(config.threads + 1)
-    failures: list[BaseException] = []
-
-    def reach(thread_index: int) -> None:
-        release.wait()
-        try:
-            list(
-                controller.stream(
-                    StressRequest(wave=0, thread=thread_index, seed=config.seed),
-                ),
-            )
-        except BaseException as exc:  # pragma: no cover - asserted below
-            failures.append(exc)
-
-    workers = [threading.Thread(target=reach, args=(thread_index,)) for thread_index in range(config.threads)]
-    for worker in workers:
-        worker.start()
-    release.wait()
-    for worker in workers:
-        worker.join(timeout=10)
-
-    assert not failures
-    assert not any(worker.is_alive() for worker in workers)
-    assert controller.reached_count(0) == 50
-    assert controller.max_active_streams == 50
-    assert controller.total_pulses == 50
-    controller.assert_complete(duration_tolerance_seconds=0.1)
-
-
-def test_barrier_timeout_reports_exact_missing_threads() -> None:
-    config = StressConfig(
-        threads=3,
-        waves=1,
-        stream_seconds=0.01,
-        edit_interval=0.01,
-        barrier_timeout_seconds=0.05,
-    )
-    controller = StressModelController(config)
-
-    with pytest.raises(
-        TimeoutError,
-        match=r"reached 1/3; missing=\[1, 2\]",
-    ):
-        controller.reach_barrier(StressRequest(wave=0, thread=0, seed=config.seed))
-
-
-def test_exact_pulse_count_duration_and_completion_marker() -> None:
-    clock = _FakeClock()
-    config = StressConfig(threads=1, waves=1, stream_seconds=2, edit_interval=0.5)
-    controller = StressModelController(config, clock=clock, sleeper=clock.sleep)
-
-    chunks = list(controller.stream(StressRequest(wave=0, thread=0, seed=config.seed)))
-
-    assert len(chunks) == 4
-    assert "pulse=001/004" in chunks[0]
-    assert chunks[-1].endswith("COMPLETE[wave=0;thread=000;pulses=4] ")
-    snapshot = controller.snapshot()
-    assert snapshot["total_pulses"] == 4
-    stream = snapshot["streams"][0]
-    assert stream["stream_duration_seconds"] == 2.0
-    assert stream["pulse_offsets_seconds"] == [0.5, 1.0, 1.5, 2.0]
-    assert snapshot["barrier_wait_ms"]["count"] == 1
-    controller.assert_complete()
-
-
-def test_serialized_stream_fault_fails_concurrency_gate() -> None:
-    config = StressConfig(
-        threads=2,
-        waves=1,
-        stream_seconds=0.02,
-        edit_interval=0.01,
-        barrier_timeout_seconds=2,
-    )
-    controller = StressModelController(config, serialize_streams=True)
-    workers = [
-        threading.Thread(
-            target=lambda thread_index=thread_index: list(
-                controller.stream(
-                    StressRequest(wave=0, thread=thread_index, seed=config.seed),
-                ),
-            ),
-        )
-        for thread_index in range(config.threads)
-    ]
-    for worker in workers:
-        worker.start()
-    for worker in workers:
-        worker.join(timeout=5)
-
-    assert controller.max_active_streams == 1
-    with pytest.raises(AssertionError, match="maximum active model streams 1/2"):
-        controller.assert_complete()
+    assert StressRequest(wave=0, thread=1, seed=17).label == "wave-00/thread-001"
 
 
 def test_serialized_stream_fault_round_trips_in_replay_config() -> None:
@@ -226,17 +108,46 @@ def test_serialized_stream_fault_round_trips_in_replay_config() -> None:
     assert StressConfig.from_json(config.to_json()).fault_mode == "serialize-streams"
 
 
-def test_cancelled_stream_is_recorded_and_fails_gate() -> None:
-    clock = _FakeClock()
-    config = StressConfig(threads=1, waves=1, stream_seconds=2, edit_interval=0.5)
-    controller = StressModelController(config, clock=clock, sleeper=clock.sleep)
-    stream: Iterator[str] = controller.stream(StressRequest(wave=0, thread=0, seed=config.seed))
+def test_synthetic_stress_audit_requires_real_tool_continuation(tmp_path: Path) -> None:
+    config = StressConfig(
+        threads=1,
+        rooms=1,
+        waves=1,
+        stream_seconds=2,
+        edit_interval=0.5,
+        tool_call_probability=1,
+    )
+    telemetry_path = tmp_path / "synthetic.jsonl"
+    audit = SyntheticStressAudit(config, telemetry_path)
+    request = StressRequest(wave=0, thread=0, seed=config.seed)
+    plan = audit.plan(request)
+    events = [
+        {"kind": "barrier_reached", "phase": "initial", "group": "0", "time": 1.0},
+        {"kind": "request_started", "phase": "initial", "group": "0", "time": 2.0},
+        {"kind": "tool_call_emitted", "phase": "initial", "group": "0", "time": 3.0},
+        {"kind": "request_finished", "phase": "initial", "group": "0", "time": 4.0},
+        {"kind": "request_started", "phase": "continuation", "group": "0", "time": 5.0},
+        {"kind": "request_finished", "phase": "continuation", "group": "0", "time": 6.0},
+    ]
+    telemetry_path.write_text(
+        "".join(json.dumps({"request_id": plan.request_id, **event}) + "\n" for event in events),
+        encoding="utf-8",
+    )
 
-    next(stream)
-    stream.close()
+    audit.assert_complete()
+    assert audit.expected_body(request) == plan.body
+    assert audit.snapshot()["tool_calls"] == 1
 
-    with pytest.raises(AssertionError, match="was cancelled"):
-        controller.assert_complete()
+    telemetry_path.write_text(
+        "".join(
+            json.dumps({"request_id": plan.request_id, **event}) + "\n"
+            for event in events
+            if event["phase"] != "continuation"
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(AssertionError, match="request_started:continuation count 0/1"):
+        audit.assert_complete()
 
 
 def test_latency_percentiles_are_interpolated() -> None:
@@ -516,7 +427,7 @@ def test_artifact_bundle_rejects_temporary_roots(root: Path) -> None:
 
 
 def test_matrix_edit_shape_counts_and_overlap() -> None:
-    config = StressConfig(threads=2, waves=1, stream_seconds=10, edit_interval=0.5)
+    config = StressConfig(threads=2, rooms=1, waves=1, stream_seconds=10, edit_interval=0.5)
     edits = {
         "wave-00/thread-000": [1.0, 5.0],
         "wave-00/thread-001": [2.0, 6.0],
@@ -530,7 +441,7 @@ def test_matrix_edit_shape_counts_and_overlap() -> None:
 
 
 def test_matrix_edit_shape_faults_on_missing_final_edit() -> None:
-    config = StressConfig(threads=2, waves=1, stream_seconds=10, edit_interval=0.5)
+    config = StressConfig(threads=2, rooms=1, waves=1, stream_seconds=10, edit_interval=0.5)
 
     with pytest.raises(AssertionError, match="insufficient Matrix edit activity"):
         assert_matrix_edit_shape(

--- a/tests/test_live_matrix_stress.py
+++ b/tests/test_live_matrix_stress.py
@@ -602,6 +602,27 @@ def test_stress_cache_clear_covers_principal_scoped_namespaces(mocker: MockerFix
     assert sql.count("DELETE FROM") == 9
 
 
+def test_stress_sync_fence_waits_for_exact_principal_event(mocker: MockerFixture) -> None:
+    completed = mocker.Mock(returncode=0, stdout="t\n", stderr="")
+    run = mocker.patch("scripts.testing.live_matrix_stress.subprocess.run", return_value=completed)
+    postgres = ManagedStressPostgres("synthetic-postgres")
+    postgres._started = True
+
+    postgres.wait_for_cached_event(
+        base_namespace="synthetic",
+        principal_id="@mindroom_general_synthetic:localhost",
+        room_id="!room:localhost",
+        event_id="$event",
+        timeout_seconds=1,
+    )
+
+    command = run.call_args.args[0]
+    assert any(field.startswith("namespace=synthetic:principal:") for field in command)
+    assert "room_id=!room:localhost" in command
+    assert "event_id=$event" in command
+    assert "WHERE namespace = :'namespace' AND room_id = :'room_id' AND event_id = :'event_id'" in command[-1]
+
+
 def test_replay_command_uses_only_repository_relative_paths() -> None:
     command = write_replay_command()
 

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -17,6 +17,7 @@ from mindroom.openai_models import (
     MindRoomOpenAIResponses,
     MindRoomOpenRouter,
 )
+from mindroom.synthetic_model import SyntheticModel
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -71,6 +72,33 @@ def test_openai_wire_providers_use_replay_compatible_models(tmp_path: Path) -> N
     for provider, model_cls in expected.items():
         model = get_model_instance(config, runtime_paths_for(config), provider)
         assert isinstance(model, model_cls), provider
+
+
+def test_synthetic_provider_needs_no_api_key_or_network(tmp_path: Path) -> None:
+    """Synthetic models load directly from explicit deterministic settings."""
+    config = bind_runtime_paths(
+        Config(
+            models={
+                "load": ModelConfig(
+                    provider="synthetic",
+                    id="synthetic",
+                    extra_kwargs={
+                        "seed": 42,
+                        "min_response_chars": 128,
+                        "max_response_chars": 128,
+                        "chars_per_second": 0,
+                    },
+                ),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+
+    model = get_model_instance(config, runtime_paths_for(config), "load")
+
+    assert isinstance(model, SyntheticModel)
+    assert model.seed == 42
+    assert len(model.plan_for_prompt("hello").body) == 128
 
 
 def test_vertexai_claude_gets_explicit_timeout_so_large_outputs_can_run_non_streaming(tmp_path: Path) -> None:

--- a/tests/test_synthetic_model.py
+++ b/tests/test_synthetic_model.py
@@ -182,6 +182,28 @@ async def test_async_barrier_releases_one_group_together(tmp_path: Path) -> None
     assert all("request-" not in line for line in telemetry_path.read_text(encoding="utf-8").splitlines())
 
 
+def test_shared_async_coordination_isolated_between_event_loop_lifetimes(tmp_path: Path) -> None:
+    settings: dict[str, object] = {
+        "coordination_key": str(tmp_path),
+        "barrier_size": 2,
+        "barrier_group_pattern": r"wave=(\d+)",
+        "barrier_timeout_seconds": 1,
+        "serialize_streams": True,
+    }
+    models = (_model(**settings), _model(**settings))
+
+    async def run(wave: int) -> None:
+        async def consume(model: SyntheticModel, request: int) -> None:
+            messages = [Message(role="user", content=f"request-{request} wave={wave}")]
+            async for _response in model.ainvoke_stream(messages, tools=[]):
+                pass
+
+        await asyncio.gather(*(consume(model, request) for request, model in enumerate(models)))
+
+    asyncio.run(run(0))
+    asyncio.run(run(1))
+
+
 @pytest.mark.parametrize(
     ("changes", "message"),
     [

--- a/tests/test_synthetic_model.py
+++ b/tests/test_synthetic_model.py
@@ -1,0 +1,200 @@
+"""Tests for the deterministic built-in synthetic model."""
+
+# Test names state behavior more precisely than repeated one-line docstrings.
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from dataclasses import replace
+from typing import TYPE_CHECKING
+
+import pytest
+from agno.models.message import Message
+from agno.models.response import ModelResponse, ModelResponseEvent
+from agno.tools.sleep import SleepTools
+
+from mindroom.synthetic_model import SyntheticModel
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _model(**changes: object) -> SyntheticModel:
+    defaults: dict[str, object] = {
+        "id": "synthetic",
+        "seed": 17,
+        "min_response_chars": 128,
+        "max_response_chars": 256,
+        "chunk_chars": 17,
+        "chars_per_second": 0,
+        "identity_pattern": r"request-\d+",
+    }
+    return SyntheticModel(**(defaults | changes))
+
+
+def _sleep_function() -> object:
+    return SleepTools().functions["sleep"]
+
+
+def test_plan_is_exact_seeded_and_fixed_length() -> None:
+    model = _model(min_response_chars=200, max_response_chars=200)
+
+    first = model.plan_for_prompt("noise request-42 more noise")
+    second = model.plan_for_prompt("request-42")
+    different = model.plan_for_prompt("request-43")
+
+    assert first == second
+    assert first != different
+    assert len(first.body) == 200
+    assert first.body.startswith(f"SYNTHETIC[{first.request_id}] ")
+    assert first.body.endswith(f" COMPLETE[{first.request_id}]")
+
+
+def test_activation_pattern_keeps_setup_requests_fast_and_tool_free() -> None:
+    model = _model(
+        activation_pattern=r"request-\d+",
+        barrier_size=2,
+        barrier_group_pattern=r"(setup)",
+        barrier_timeout_seconds=0.01,
+        tool_call_probability=1,
+    )
+
+    plan = model.plan_for_prompt("setup request", tool_available=True)
+    responses = list(
+        model.invoke_stream(
+            [Message(role="user", content="setup request")],
+            tools=[{"name": "sleep"}],
+        ),
+    )
+
+    assert plan.body == "SYNTHETIC READY"
+    assert plan.tool_call_id is None
+    assert [response.content for response in responses] == ["SYNTHETIC READY"]
+
+
+def test_coordination_key_shares_barrier_across_fresh_models(tmp_path: Path) -> None:
+    settings: dict[str, object] = {
+        "coordination_key": str(tmp_path),
+        "barrier_size": 2,
+        "barrier_group_pattern": r"wave=(\d+)",
+        "barrier_timeout_seconds": 2,
+    }
+    models = (_model(**settings), _model(**settings))
+    failures: list[BaseException] = []
+
+    def run(model: SyntheticModel, request: int) -> None:
+        try:
+            list(
+                model.invoke_stream(
+                    [Message(role="user", content=f"wave=0 request-{request}")],
+                ),
+            )
+        except BaseException as exc:  # pragma: no cover - asserted below
+            failures.append(exc)
+
+    threads = [threading.Thread(target=run, args=(model, request)) for request, model in enumerate(models)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert not failures
+    assert not any(thread.is_alive() for thread in threads)
+
+
+def test_stream_runs_real_sleep_tool_then_continues_exact_body() -> None:
+    model = _model(
+        tool_call_probability=1,
+        min_sleep_seconds=0,
+        max_sleep_seconds=0,
+    )
+    messages = [Message(role="user", content="request-7")]
+    expected = model.plan_for_prompt("request-7").body
+    responses = list(
+        model.response_stream(
+            messages,
+            tools=[_sleep_function()],
+        ),
+    )
+
+    assistant_content = "".join(
+        response.content
+        for response in responses
+        if isinstance(response, ModelResponse)
+        and response.event == ModelResponseEvent.assistant_response.value
+        and isinstance(response.content, str)
+    )
+    completed_tools = [
+        execution
+        for response in responses
+        if isinstance(response, ModelResponse) and response.event == ModelResponseEvent.tool_call_completed.value
+        for execution in response.tool_executions or ()
+    ]
+
+    assert assistant_content == expected
+    assert [execution.tool_name for execution in completed_tools] == ["sleep"]
+    assert [execution.tool_args for execution in completed_tools] == [{"seconds": 0}]
+    assert [message.role for message in messages] == ["user", "assistant", "tool", "assistant"]
+
+
+def test_missing_tool_returns_complete_text_without_fake_call() -> None:
+    model = _model(tool_call_probability=1)
+    messages = [Message(role="user", content="request-8")]
+
+    responses = list(model.invoke_stream(messages, tools=[]))
+
+    assert (
+        "".join(response.content or "" for response in responses)
+        == model.plan_for_prompt(
+            "request-8",
+            tool_available=False,
+        ).body
+    )
+    assert not any(response.tool_calls for response in responses)
+
+
+@pytest.mark.asyncio
+async def test_async_barrier_releases_one_group_together(tmp_path: Path) -> None:
+    telemetry_path = tmp_path / "synthetic.jsonl"
+    model = _model(
+        min_response_chars=64,
+        max_response_chars=64,
+        barrier_size=4,
+        barrier_group_pattern=r"wave=(\d+)",
+        barrier_timeout_seconds=1,
+        telemetry_path=str(telemetry_path),
+    )
+
+    async def run(thread: int) -> str:
+        messages = [Message(role="user", content=f"request-{thread} wave=3")]
+        chunks = [response.content or "" async for response in model.ainvoke_stream(messages, tools=[])]
+        return "".join(chunks)
+
+    results = await asyncio.gather(*(run(thread) for thread in range(4)))
+    telemetry = [json.loads(line) for line in telemetry_path.read_text(encoding="utf-8").splitlines()]
+
+    assert all(result for result in results)
+    assert [event["kind"] for event in telemetry].count("barrier_reached") == 4
+    assert {event["group"] for event in telemetry} == {"3"}
+    assert all("request-" not in line for line in telemetry_path.read_text(encoding="utf-8").splitlines())
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"min_response_chars": 63}, "at least 64"),
+        ({"min_response_chars": 100, "max_response_chars": 99}, "greater than or equal"),
+        ({"chunk_chars": 0}, "chunk_chars must be positive"),
+        ({"chars_per_second": -1}, "chars_per_second must be non-negative"),
+        ({"tool_call_probability": 1.1}, "between 0 and 1"),
+        ({"min_sleep_seconds": -1}, "must be non-negative"),
+        ({"min_sleep_seconds": 2, "max_sleep_seconds": 1}, "greater than or equal"),
+        ({"barrier_size": 2}, "barrier_group_pattern is required"),
+    ],
+)
+def test_invalid_settings_fail_at_construction(changes: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        replace(_model(), **changes)


### PR DESCRIPTION
## Summary

- add a built-in `synthetic` model provider with deterministic fixed-rate Lorem streaming and real `sleep` tool continuations
- extend live Matrix stress to 100 concurrent threads across 10 rooms with exact model and Matrix concurrency audits
- keep PostgreSQL, Tuwunel, replay, scoped telemetry, resource sampling, and cleanup evidence in smoke and full CI tiers

This PR is stacked on #1639.

## Validation

- `pytest -n auto -x --lf`: 11,861 passed, 54 skipped
- changed-file pre-commit hooks: passed
- `tach check --dependencies --interfaces`: passed
- `privata .`: passed
- 50-thread, one-room, two-wave, 45-second live run: passed with 1,661 Matrix edits and zero runtime health violations
- 100-thread, ten-room live run: passed with 784 Matrix edits, 100 observed concurrent streams, and zero stalls, sync restarts, PostgreSQL errors, or resource leaks
- latest-head 10-thread current-main integration smoke: passed with 77 Matrix edits, 10 observed concurrent streams, and zero runtime health violations

Live runs used an integration of this branch with current `main` so the Matrix history prerequisite already merged there was present.
The CI smoke job runs when the PR targets `main`; stacked PRs run deterministic unit CI until they are retargeted because #1639 conflicts with current `main` in unrelated runtime files.
