### PR TITLE
Add built-in synthetic model

### DIFF
--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -21,6 +21,7 @@ Models define the AI providers and model IDs used by agents.
 - `cerebras` - Cerebras-hosted models
 - `deepseek` - DeepSeek models
 - `zai` - Z.ai GLM models
+- `synthetic` - Built-in Lorem Ipsum model for local conversations and load generation
 
 ## Model Config Fields
 
@@ -125,6 +126,38 @@ models:
     extra_kwargs:
       base_url: http://localhost:8080/v1
 ```
+
+## Built-In Synthetic Model
+
+Use `provider: synthetic` to exercise normal MindRoom conversations without an API key or model server.
+The model streams a seeded random amount of Lorem Ipsum at a fixed character rate.
+When the agent has the `shell` tool, the model occasionally calls `run_shell_command` with `echo hi` and then continues its response.
+
+```yaml
+models:
+  synthetic:
+    provider: synthetic
+    id: lorem-ipsum
+    extra_kwargs:
+      seed: 1
+      min_response_chars: 320
+      max_response_chars: 960
+      chunk_chars: 40
+      chars_per_second: 80
+      tool_call_probability: 0.2
+
+agents:
+  load_test:
+    display_name: Load Test
+    role: Generate synthetic traffic.
+    model: synthetic
+    tools: [shell]
+    rooms: [lobby]
+```
+
+Tag `@load_test` in Lobby to receive a streamed synthetic reply through the same Matrix path as any other agent.
+Set `tool_call_probability: 1` to force the shell call on every turn, or `0` to disable tool calls.
+Changing `seed` changes the repeatable response length, split point, and tool-call choice for each conversation history.
 
 ## OpenAI API Models
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2346,6 +2346,7 @@ Models define the AI providers and model IDs used by agents.
 - `cerebras` - Cerebras-hosted models
 - `deepseek` - DeepSeek models
 - `zai` - Z.ai GLM models
+- `synthetic` - Built-in Lorem Ipsum model for local conversations and load generation
 
 ## Model Config Fields
 
@@ -2450,6 +2451,38 @@ models:
     extra_kwargs:
       base_url: http://localhost:8080/v1
 ```
+
+## Built-In Synthetic Model
+
+Use `provider: synthetic` to exercise normal MindRoom conversations without an API key or model server.
+The model streams a seeded random amount of Lorem Ipsum at a fixed character rate.
+When the agent has the `shell` tool, the model occasionally calls `run_shell_command` with `echo hi` and then continues its response.
+
+```yaml
+models:
+  synthetic:
+    provider: synthetic
+    id: lorem-ipsum
+    extra_kwargs:
+      seed: 1
+      min_response_chars: 320
+      max_response_chars: 960
+      chunk_chars: 40
+      chars_per_second: 80
+      tool_call_probability: 0.2
+
+agents:
+  load_test:
+    display_name: Load Test
+    role: Generate synthetic traffic.
+    model: synthetic
+    tools: [shell]
+    rooms: [lobby]
+```
+
+Tag `@load_test` in Lobby to receive a streamed synthetic reply through the same Matrix path as any other agent.
+Set `tool_call_probability: 1` to force the shell call on every turn, or `0` to disable tool calls.
+Changing `seed` changes the repeatable response length, split point, and tool-call choice for each conversation history.
 
 ## OpenAI API Models
 

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -17,6 +17,7 @@ Models define the AI providers and model IDs used by agents.
 - `cerebras` - Cerebras-hosted models
 - `deepseek` - DeepSeek models
 - `zai` - Z.ai GLM models
+- `synthetic` - Built-in Lorem Ipsum model for local conversations and load generation
 
 ## Model Config Fields
 
@@ -121,6 +122,38 @@ models:
     extra_kwargs:
       base_url: http://localhost:8080/v1
 ```
+
+## Built-In Synthetic Model
+
+Use `provider: synthetic` to exercise normal MindRoom conversations without an API key or model server.
+The model streams a seeded random amount of Lorem Ipsum at a fixed character rate.
+When the agent has the `shell` tool, the model occasionally calls `run_shell_command` with `echo hi` and then continues its response.
+
+```yaml
+models:
+  synthetic:
+    provider: synthetic
+    id: lorem-ipsum
+    extra_kwargs:
+      seed: 1
+      min_response_chars: 320
+      max_response_chars: 960
+      chunk_chars: 40
+      chars_per_second: 80
+      tool_call_probability: 0.2
+
+agents:
+  load_test:
+    display_name: Load Test
+    role: Generate synthetic traffic.
+    model: synthetic
+    tools: [shell]
+    rooms: [lobby]
+```
+
+Tag `@load_test` in Lobby to receive a streamed synthetic reply through the same Matrix path as any other agent.
+Set `tool_call_probability: 1` to force the shell call on every turn, or `0` to disable tool calls.
+Changing `seed` changes the repeatable response length, split point, and tool-call choice for each conversation history.
 
 ## OpenAI API Models
 

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -155,7 +155,15 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
     if (
         canonical_provider_key
-        not in {"ollama", "llama_cpp", "vertexai_claude", "codex", "openai_codex", _BEDROCK_CLAUDE_PROVIDER}
+        not in {
+            "ollama",
+            "llama_cpp",
+            "vertexai_claude",
+            "codex",
+            "openai_codex",
+            "synthetic",
+            _BEDROCK_CLAUDE_PROVIDER,
+        }
         and "api_key" not in extra_kwargs
     ):
         api_key = get_api_key_for_provider(canonical_provider_key, runtime_paths=runtime_paths)
@@ -197,6 +205,12 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         host = model_config.host or get_ollama_host(runtime_paths=runtime_paths) or OLLAMA_HOST_DEFAULT
         logger.debug("using_ollama_host", host=host)
         return Ollama(id=model_id, host=host, **extra_kwargs)
+
+    if canonical_provider_key == "synthetic":
+        from mindroom.synthetic_model import SyntheticModel  # noqa: PLC0415
+
+        extra_kwargs.pop("api_key", None)
+        return SyntheticModel(id=model_id, **extra_kwargs)
 
     if canonical_provider_key == "openrouter":
         from mindroom.openai_models import MindRoomOpenRouter  # noqa: PLC0415

--- a/src/mindroom/synthetic_model.py
+++ b/src/mindroom/synthetic_model.py
@@ -1,0 +1,225 @@
+"""Built-in synthetic model for local conversations and load generation."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import random
+import time
+from collections.abc import AsyncIterator, Iterator, Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from agno.models.base import Model
+from agno.models.response import ModelResponse
+
+if TYPE_CHECKING:
+    from agno.models.message import Message
+
+_LOREM = (
+    "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et "
+    "dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex "
+    "ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat "
+    "nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim "
+    "id est laborum. "
+)
+_SHELL_TOOL = "run_shell_command"
+
+
+@dataclass(frozen=True, slots=True)
+class _ResponsePlan:
+    body: str
+    split_at: int | None
+    tool_call_id: str | None
+
+    @property
+    def prefix(self) -> str:
+        return self.body if self.split_at is None else self.body[: self.split_at]
+
+    @property
+    def suffix(self) -> str:
+        return "" if self.split_at is None else self.body[self.split_at :]
+
+
+@dataclass
+class SyntheticModel(Model):
+    """Stream seeded Lorem Ipsum and occasionally call the configured shell tool."""
+
+    name: str | None = "Synthetic"
+    provider: str | None = "Synthetic"
+    seed: int = 1
+    min_response_chars: int = 320
+    max_response_chars: int = 960
+    chunk_chars: int = 40
+    chars_per_second: float = 80.0
+    tool_call_probability: float = 0.2
+
+    def __post_init__(self) -> None:
+        """Validate configured response generation settings."""
+        super().__post_init__()
+        if self.min_response_chars < 2:
+            msg = "min_response_chars must be at least 2"
+            raise ValueError(msg)
+        if self.max_response_chars < self.min_response_chars:
+            msg = "max_response_chars must be greater than or equal to min_response_chars"
+            raise ValueError(msg)
+        if self.chunk_chars < 1:
+            msg = "chunk_chars must be positive"
+            raise ValueError(msg)
+        if self.chars_per_second < 0:
+            msg = "chars_per_second must be non-negative"
+            raise ValueError(msg)
+        if not 0 <= self.tool_call_probability <= 1:
+            msg = "tool_call_probability must be between 0 and 1"
+            raise ValueError(msg)
+
+    def invoke(
+        self,
+        messages: list[Message],
+        *,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        tool_choice: str | Mapping[str, Any] | None = None,
+        **_kwargs: object,
+    ) -> ModelResponse:
+        """Return one rate-limited synthetic response phase."""
+        plan, continuation = self._execution(messages, tools, tool_choice)
+        content = plan.suffix if continuation else plan.prefix
+        self._sleep_sync(len(content))
+        return ModelResponse(
+            content=content,
+            tool_calls=self._tool_calls(plan, continuation),
+        )
+
+    async def ainvoke(
+        self,
+        messages: list[Message],
+        *,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        tool_choice: str | Mapping[str, Any] | None = None,
+        **_kwargs: object,
+    ) -> ModelResponse:
+        """Return one asynchronously rate-limited synthetic response phase."""
+        plan, continuation = self._execution(messages, tools, tool_choice)
+        content = plan.suffix if continuation else plan.prefix
+        await self._sleep_async(len(content))
+        return ModelResponse(
+            content=content,
+            tool_calls=self._tool_calls(plan, continuation),
+        )
+
+    def invoke_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        tool_choice: str | Mapping[str, Any] | None = None,
+        **_kwargs: object,
+    ) -> Iterator[ModelResponse]:
+        """Stream one synthetic response phase at the configured rate."""
+        plan, continuation = self._execution(messages, tools, tool_choice)
+        content = plan.suffix if continuation else plan.prefix
+        for chunk in self._chunks(content):
+            self._sleep_sync(len(chunk))
+            yield ModelResponse(content=chunk)
+        if tool_calls := self._tool_calls(plan, continuation):
+            yield ModelResponse(tool_calls=tool_calls)
+
+    async def ainvoke_stream(
+        self,
+        messages: list[Message],
+        *,
+        tools: Sequence[Mapping[str, Any]] | None = None,
+        tool_choice: str | Mapping[str, Any] | None = None,
+        **_kwargs: object,
+    ) -> AsyncIterator[ModelResponse]:
+        """Asynchronously stream one synthetic response phase at the configured rate."""
+        plan, continuation = self._execution(messages, tools, tool_choice)
+        content = plan.suffix if continuation else plan.prefix
+        for chunk in self._chunks(content):
+            await self._sleep_async(len(chunk))
+            yield ModelResponse(content=chunk)
+        if tool_calls := self._tool_calls(plan, continuation):
+            yield ModelResponse(tool_calls=tool_calls)
+
+    def _parse_provider_response(self, response: object, **_kwargs: object) -> ModelResponse:
+        if not isinstance(response, ModelResponse):
+            msg = "SyntheticModel only parses ModelResponse values"
+            raise TypeError(msg)
+        return response
+
+    def _parse_provider_response_delta(self, response: object) -> ModelResponse:
+        if not isinstance(response, ModelResponse):
+            msg = "SyntheticModel only parses ModelResponse values"
+            raise TypeError(msg)
+        return response
+
+    def _execution(
+        self,
+        messages: Sequence[Message],
+        tools: Sequence[Mapping[str, Any]] | None,
+        tool_choice: str | Mapping[str, Any] | None,
+    ) -> tuple[_ResponsePlan, bool]:
+        plan = self._plan(messages, shell_available=tool_choice != "none" and self._tool_available(tools))
+        last_message = messages[-1] if messages else None
+        continuation = (
+            plan.tool_call_id is not None
+            and last_message is not None
+            and last_message.role == self.tool_message_role
+            and last_message.tool_call_id == plan.tool_call_id
+        )
+        return plan, continuation
+
+    def _plan(self, messages: Sequence[Message], *, shell_available: bool) -> _ResponsePlan:
+        user_history = "\0".join(message.get_content_string() for message in messages if message.role == "user")
+        digest = hashlib.sha256(f"{self.seed}\0{user_history}".encode()).digest()
+        randomizer = random.Random(int.from_bytes(digest))  # noqa: S311 - replayable synthetic behavior
+        response_chars = randomizer.randint(self.min_response_chars, self.max_response_chars)
+        body = (_LOREM * ((response_chars // len(_LOREM)) + 1))[:response_chars]
+        if not shell_available or randomizer.random() >= self.tool_call_probability:
+            return _ResponsePlan(body=body, split_at=None, tool_call_id=None)
+        return _ResponsePlan(
+            body=body,
+            split_at=randomizer.randint(1, response_chars - 1),
+            tool_call_id=f"synthetic-{digest.hex()[:16]}",
+        )
+
+    @staticmethod
+    def _tool_available(tools: Sequence[Mapping[str, Any]] | None) -> bool:
+        for tool in tools or ():
+            function = tool.get("function")
+            if isinstance(function, Mapping) and function.get("name") == _SHELL_TOOL:
+                return True
+            if tool.get("name") == _SHELL_TOOL:
+                return True
+        return False
+
+    @staticmethod
+    def _tool_calls(plan: _ResponsePlan, continuation: bool) -> list[dict[str, Any]]:
+        if continuation or plan.tool_call_id is None:
+            return []
+        return [
+            {
+                "id": plan.tool_call_id,
+                "type": "function",
+                "function": {
+                    "name": _SHELL_TOOL,
+                    "arguments": json.dumps({"args": ["echo", "hi"]}, separators=(",", ":")),
+                },
+            },
+        ]
+
+    def _chunks(self, content: str) -> Iterator[str]:
+        for start in range(0, len(content), self.chunk_chars):
+            yield content[start : start + self.chunk_chars]
+
+    def _sleep_sync(self, character_count: int) -> None:
+        if self.chars_per_second:
+            time.sleep(character_count / self.chars_per_second)
+
+    async def _sleep_async(self, character_count: int) -> None:
+        if self.chars_per_second:
+            await asyncio.sleep(character_count / self.chars_per_second)
+
+
+__all__ = ["SyntheticModel"]

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -17,6 +17,7 @@ from mindroom.openai_models import (
     MindRoomOpenAIResponses,
     MindRoomOpenRouter,
 )
+from mindroom.synthetic_model import SyntheticModel
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -71,6 +72,32 @@ def test_openai_wire_providers_use_replay_compatible_models(tmp_path: Path) -> N
     for provider, model_cls in expected.items():
         model = get_model_instance(config, runtime_paths_for(config), provider)
         assert isinstance(model, model_cls), provider
+
+
+def test_synthetic_provider_loads_without_credentials(tmp_path: Path) -> None:
+    """Synthetic models load locally with their configured generation settings."""
+    config = bind_runtime_paths(
+        Config(
+            models={
+                "load": ModelConfig(
+                    provider="synthetic",
+                    id="lorem-ipsum",
+                    extra_kwargs={
+                        "min_response_chars": 128,
+                        "max_response_chars": 128,
+                        "chars_per_second": 0,
+                    },
+                ),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+
+    model = get_model_instance(config, runtime_paths_for(config), "load")
+
+    assert isinstance(model, SyntheticModel)
+    assert model.min_response_chars == 128
+    assert model.max_response_chars == 128
 
 
 def test_vertexai_claude_gets_explicit_timeout_so_large_outputs_can_run_non_streaming(tmp_path: Path) -> None:

--- a/tests/test_synthetic_model.py
+++ b/tests/test_synthetic_model.py
@@ -1,0 +1,123 @@
+"""Tests for the built-in synthetic model."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from agno.models.message import Message
+from agno.models.response import ModelResponse, ModelResponseEvent
+
+from mindroom.synthetic_model import SyntheticModel
+from mindroom.tool_system.metadata import get_tool_by_name
+from tests.conftest import test_runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _model(**changes: object) -> SyntheticModel:
+    defaults: dict[str, object] = {
+        "id": "lorem-ipsum",
+        "seed": 17,
+        "min_response_chars": 128,
+        "max_response_chars": 128,
+        "chunk_chars": 17,
+        "chars_per_second": 0,
+    }
+    return SyntheticModel(**(defaults | changes))
+
+
+def test_streams_exact_lorem_length_in_configured_chunks() -> None:
+    """Configured response length and chunk size control streamed Lorem Ipsum."""
+    model = _model()
+
+    chunks = [response.content or "" for response in model.invoke_stream([Message(role="user", content="hello")])]
+    body = "".join(chunks)
+
+    assert body.startswith("Lorem ipsum")
+    assert len(body) == 128
+    assert all(len(chunk) == 17 for chunk in chunks[:-1])
+    assert len(chunks[-1]) <= 17
+
+
+def test_fixed_rate_applies_to_each_streamed_chunk() -> None:
+    """Each chunk waits for its character count at the configured fixed rate."""
+    model = _model(min_response_chars=10, max_response_chars=10, chunk_chars=4, chars_per_second=2)
+
+    with patch("mindroom.synthetic_model.time.sleep") as sleep:
+        list(model.invoke_stream([Message(role="user", content="hello")]))
+
+    assert [call.args[0] for call in sleep.call_args_list] == [2.0, 2.0, 1.0]
+
+
+def test_missing_shell_tool_returns_complete_text_without_tool_call() -> None:
+    """Tool selection stays disabled when the agent does not expose shell."""
+    model = _model(tool_call_probability=1)
+
+    responses = list(
+        model.invoke_stream(
+            [Message(role="user", content="hello")],
+            tools=[],
+        ),
+    )
+
+    assert len("".join(response.content or "" for response in responses)) == 128
+    assert not any(response.tool_calls for response in responses)
+
+
+@pytest.mark.asyncio
+async def test_shell_tool_runs_echo_hi_then_lorem_stream_continues(tmp_path: Path) -> None:
+    """A forced tool turn executes real shell echo and then resumes the same response."""
+    model = _model(tool_call_probability=1)
+    shell = get_tool_by_name(
+        "shell",
+        test_runtime_paths(tmp_path),
+        disable_sandbox_proxy=True,
+        worker_target=None,
+    )
+    messages = [Message(role="user", content="exercise shell")]
+    responses = [
+        response
+        async for response in model.aresponse_stream(
+            messages,
+            tools=[shell.async_functions["run_shell_command"]],
+        )
+        if isinstance(response, ModelResponse)
+    ]
+
+    assistant_content = "".join(
+        response.content
+        for response in responses
+        if response.event == ModelResponseEvent.assistant_response.value and isinstance(response.content, str)
+    )
+    completed_tools = [
+        execution
+        for response in responses
+        if response.event == ModelResponseEvent.tool_call_completed.value
+        for execution in response.tool_executions or ()
+    ]
+
+    assert len(assistant_content) == 128
+    assert assistant_content.startswith("Lorem ipsum")
+    assert [execution.tool_name for execution in completed_tools] == ["run_shell_command"]
+    assert [execution.tool_args for execution in completed_tools] == [{"args": ["echo", "hi"]}]
+    assert [execution.result for execution in completed_tools] == ["hi"]
+    assert [message.role for message in messages] == ["user", "assistant", "tool", "assistant"]
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"min_response_chars": 1}, "at least 2"),
+        ({"min_response_chars": 10, "max_response_chars": 9}, "greater than or equal"),
+        ({"chunk_chars": 0}, "chunk_chars must be positive"),
+        ({"chars_per_second": -1}, "chars_per_second must be non-negative"),
+        ({"tool_call_probability": 1.1}, "between 0 and 1"),
+    ],
+)
+def test_invalid_settings_fail_at_construction(changes: dict[str, object], message: str) -> None:
+    """Invalid generation settings fail before serving any requests."""
+    with pytest.raises(ValueError, match=message):
+        _model(**changes)


### PR DESCRIPTION
## Summary

- add a built-in `synthetic` provider that streams seeded Lorem Ipsum at a fixed character rate
- occasionally call the existing `run_shell_command` tool with `echo hi` when an agent exposes `shell`, then continue the same response
- document direct agent configuration and cover model loading, streaming, rate limiting, tool execution, and continuation

This extracts only the fake-model feature from #1668. It intentionally excludes the live Matrix stress framework, workflows, baselines, telemetry, and fuzz-harness changes.

## Example

```yaml
models:
  synthetic:
    provider: synthetic
    id: lorem-ipsum

agents:
  load_test:
    display_name: Load Test
    role: Generate synthetic traffic.
    model: synthetic
    tools: [shell]
    rooms: [lobby]
```

Tag `@load_test` in Lobby to receive the streamed reply.

## Validation

- `pre-commit run --all-files`
- `pytest -n auto -x --lf` (11,681 passed, 54 skipped)
- focused test executes real `run_shell_command` with `echo hi` and verifies Lorem streaming resumes afterward