### PR TITLE
Clear calls config from projected Docker worker snapshots

### DIFF
--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -221,6 +221,7 @@ The Docker backend starts one worker container per worker key and reuses it unti
 This is the simplest way to get one persistent container per agent without running Kubernetes.
 MindRoom builds a projected read-only config snapshot for each worker from `MINDROOM_DOCKER_WORKER_HOST_CONFIG_PATH`, rewrites config-relative paths into that snapshot, copies only the referenced config-relative assets needed for that worker into the snapshot, and mounts only the snapshot root into the container.
 MindRoom also sanitizes the projected worker `config.yaml`, removing sensitive config keys and authorization headers from the worker-visible snapshot before it is written.
+Control-plane-only sections that a worker never reads are cleared from that snapshot as well, including `teams`, `cultures`, `calls`, `room_models`, `bot_accounts`, `authorization`, and the Matrix room and space settings.
 Agent-scoped workers such as unscoped, `worker_scope: shared`, and `worker_scope: user_agent` snapshot only that agent's projected context files and assigned knowledge bases.
 `worker_scope: user` intentionally shares one worker across multiple agents, so it keeps the broader shared projection for that worker.
 Writable file-memory paths are rewritten into the worker's own state root instead of being mounted from the host config tree.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17699,6 +17699,7 @@ The Docker backend starts one worker container per worker key and reuses it unti
 This is the simplest way to get one persistent container per agent without running Kubernetes.
 MindRoom builds a projected read-only config snapshot for each worker from `MINDROOM_DOCKER_WORKER_HOST_CONFIG_PATH`, rewrites config-relative paths into that snapshot, copies only the referenced config-relative assets needed for that worker into the snapshot, and mounts only the snapshot root into the container.
 MindRoom also sanitizes the projected worker `config.yaml`, removing sensitive config keys and authorization headers from the worker-visible snapshot before it is written.
+Control-plane-only sections that a worker never reads are cleared from that snapshot as well, including `teams`, `cultures`, `calls`, `room_models`, `bot_accounts`, `authorization`, and the Matrix room and space settings.
 Agent-scoped workers such as unscoped, `worker_scope: shared`, and `worker_scope: user_agent` snapshot only that agent's projected context files and assigned knowledge bases.
 `worker_scope: user` intentionally shares one worker across multiple agents, so it keeps the broader shared projection for that worker.
 Writable file-memory paths are rewritten into the worker's own state root instead of being mounted from the host config tree.

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -217,6 +217,7 @@ The Docker backend starts one worker container per worker key and reuses it unti
 This is the simplest way to get one persistent container per agent without running Kubernetes.
 MindRoom builds a projected read-only config snapshot for each worker from `MINDROOM_DOCKER_WORKER_HOST_CONFIG_PATH`, rewrites config-relative paths into that snapshot, copies only the referenced config-relative assets needed for that worker into the snapshot, and mounts only the snapshot root into the container.
 MindRoom also sanitizes the projected worker `config.yaml`, removing sensitive config keys and authorization headers from the worker-visible snapshot before it is written.
+Control-plane-only sections that a worker never reads are cleared from that snapshot as well, including `teams`, `cultures`, `calls`, `room_models`, `bot_accounts`, `authorization`, and the Matrix room and space settings.
 Agent-scoped workers such as unscoped, `worker_scope: shared`, and `worker_scope: user_agent` snapshot only that agent's projected context files and assigned knowledge bases.
 `worker_scope: user` intentionally shares one worker across multiple agents, so it keeps the broader shared projection for that worker.
 Writable file-memory paths are rewritten into the worker's own state root instead of being mounted from the host config tree.

--- a/src/mindroom/workers/backends/docker_projection.py
+++ b/src/mindroom/workers/backends/docker_projection.py
@@ -541,16 +541,6 @@ class DockerProjectionManager:
                     ]
             config_data["agents"] = filtered_agents
 
-            raw_calls = config_data.get("calls")
-            if isinstance(raw_calls, dict):
-                calls = cast("dict[str, object]", raw_calls)
-                raw_call_agents = calls.get("agents")
-                if isinstance(raw_call_agents, dict):
-                    call_agents = cast("dict[str, object]", raw_call_agents)
-                    calls["agents"] = {
-                        name: profile for name, profile in call_agents.items() if name in filtered_agents
-                    }
-
         raw_knowledge_bases = config_data.get("knowledge_bases")
         if isinstance(raw_knowledge_bases, dict) and projected_knowledge_base_ids is not None:
             knowledge_bases = cast("dict[str, object]", raw_knowledge_bases)
@@ -562,6 +552,7 @@ class DockerProjectionManager:
 
         config_data["teams"] = {}
         config_data["cultures"] = {}
+        config_data["calls"] = {}
         config_data["room_models"] = {}
         config_data["bot_accounts"] = []
         config_data["authorization"] = {}

--- a/src/mindroom/workers/backends/docker_projection.py
+++ b/src/mindroom/workers/backends/docker_projection.py
@@ -541,6 +541,16 @@ class DockerProjectionManager:
                     ]
             config_data["agents"] = filtered_agents
 
+            raw_calls = config_data.get("calls")
+            if isinstance(raw_calls, dict):
+                calls = cast("dict[str, object]", raw_calls)
+                raw_call_agents = calls.get("agents")
+                if isinstance(raw_call_agents, dict):
+                    call_agents = cast("dict[str, object]", raw_call_agents)
+                    calls["agents"] = {
+                        name: profile for name, profile in call_agents.items() if name in filtered_agents
+                    }
+
         raw_knowledge_bases = config_data.get("knowledge_bases")
         if isinstance(raw_knowledge_bases, dict) and projected_knowledge_base_ids is not None:
             knowledge_bases = cast("dict[str, object]", raw_knowledge_bases)

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -2206,6 +2206,92 @@ router:
     assert list(projected_config["agents"]) == ["My Agent"]
 
 
+def test_docker_projection_filters_call_agents_to_projected_agents(
+    tmp_path: Path,
+) -> None:
+    """calls.agents entries for stripped agents must not survive projection.
+
+    Leftover references fail Config validation inside the worker
+    ("calls.agents references unknown agent(s): ..."), crash-looping every
+    dedicated worker start.
+    """
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+agents:
+  alpha:
+    display_name: Alpha
+    role: Test
+    model: default
+    worker_scope: shared
+  beta:
+    display_name: Beta
+    role: Test
+    model: default
+calls:
+  enabled: true
+  profiles:
+    realtime-profile:
+      backend: realtime
+      model: test-realtime-model
+      credentials_service: openai
+      voice: test-voice
+  agents:
+    alpha: realtime-profile
+    beta: realtime-profile
+models:
+  default:
+    provider: openai
+    id: test-model
+router:
+  model: default
+""".lstrip(),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(config_path=config_path, storage_path=tmp_path)
+    config = _DockerWorkerBackendConfig(
+        image="ghcr.io/mindroom-ai/mindroom:latest",
+        worker_port=8766,
+        storage_mount_path="/app/worker",
+        config_path="/app/config-host/config.yaml",
+        host_config_path=config_path,
+        idle_timeout_seconds=60.0,
+        ready_timeout_seconds=5.0,
+        name_prefix="mindroom-worker",
+        publish_host="127.0.0.1",
+        endpoint_host="127.0.0.1",
+        user="1000:1000",
+        extra_env={},
+        extra_labels={},
+    )
+    manager = DockerProjectionManager(
+        config=config,
+        projected_configs_root=tmp_path / _PROJECTED_CONFIGS_DIRNAME,
+        runtime_paths=runtime_paths,
+    )
+    worker_paths = local_worker_state_paths_for_root(tmp_path / "workers" / "call-agents")
+    worker_key = resolve_worker_key(
+        "shared",
+        ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="alpha",
+            requester_id=None,
+            room_id="!room:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+            tenant_id="default",
+        ),
+        agent_name="alpha",
+    )
+
+    projection = manager.projected_config(worker_paths, worker_key=worker_key, materialize=False)
+    projected_config = yaml.safe_load(projection.projected_yaml)
+
+    assert list(projected_config["agents"]) == ["alpha"]
+    assert projected_config["calls"]["agents"] == {"alpha": "realtime-profile"}
+
+
 def test_docker_backend_recreates_container_when_launch_config_changes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -2206,28 +2206,32 @@ router:
     assert list(projected_config["agents"]) == ["My Agent"]
 
 
-def test_docker_projection_filters_call_agents_to_projected_agents(
+def test_docker_projection_keeps_no_references_to_stripped_agents(
+    monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """calls.agents entries for stripped agents must not survive projection.
+    """Projected worker configs must stay loadable after projection strips other agents.
 
-    Leftover references fail Config validation inside the worker
+    References to stripped agents fail Config validation inside the worker
     ("calls.agents references unknown agent(s): ..."), crash-looping every
     dedicated worker start.
     """
-    config_path = tmp_path / "config.yaml"
-    config_path.write_text(
-        """
+    backend, fake_client, _sync_calls = _backend(
+        monkeypatch,
+        tmp_path,
+        config_text="""
 agents:
   alpha:
     display_name: Alpha
     role: Test
     model: default
     worker_scope: shared
+    delegate_to: [beta]
   beta:
     display_name: Beta
     role: Test
     model: default
+    worker_scope: shared
 calls:
   enabled: true
   profiles:
@@ -2243,53 +2247,26 @@ models:
   default:
     provider: openai
     id: test-model
-router:
-  model: default
 """.lstrip(),
-        encoding="utf-8",
-    )
-    runtime_paths = resolve_runtime_paths(config_path=config_path, storage_path=tmp_path)
-    config = _DockerWorkerBackendConfig(
-        image="ghcr.io/mindroom-ai/mindroom:latest",
-        worker_port=8766,
-        storage_mount_path="/app/worker",
-        config_path="/app/config-host/config.yaml",
-        host_config_path=config_path,
-        idle_timeout_seconds=60.0,
-        ready_timeout_seconds=5.0,
-        name_prefix="mindroom-worker",
-        publish_host="127.0.0.1",
-        endpoint_host="127.0.0.1",
-        user="1000:1000",
-        extra_env={},
-        extra_labels={},
-    )
-    manager = DockerProjectionManager(
-        config=config,
-        projected_configs_root=tmp_path / _PROJECTED_CONFIGS_DIRNAME,
-        runtime_paths=runtime_paths,
-    )
-    worker_paths = local_worker_state_paths_for_root(tmp_path / "workers" / "call-agents")
-    worker_key = resolve_worker_key(
-        "shared",
-        ToolExecutionIdentity(
-            channel="matrix",
-            agent_name="alpha",
-            requester_id=None,
-            room_id="!room:example.org",
-            thread_id=None,
-            resolved_thread_id=None,
-            session_id=None,
-            tenant_id="default",
-        ),
-        agent_name="alpha",
     )
 
-    projection = manager.projected_config(worker_paths, worker_key=worker_key, materialize=False)
-    projected_config = yaml.safe_load(projection.projected_yaml)
+    backend.ensure_worker(WorkerSpec("v1:default:shared:alpha"), now=10.0)
+
+    volumes = fake_client.containers.run_calls[0]["volumes"]
+    assert isinstance(volumes, dict)
+    projection_root = _projection_root(volumes)
+    projected_config = yaml.safe_load((projection_root / "config.yaml").read_text(encoding="utf-8"))
 
     assert list(projected_config["agents"]) == ["alpha"]
-    assert projected_config["calls"]["agents"] == {"alpha": "realtime-profile"}
+    assert projected_config["agents"]["alpha"]["delegate_to"] == []
+    assert projected_config["calls"] == {}
+
+    projected_runtime_paths = resolve_runtime_paths(
+        config_path=projection_root / "config.yaml",
+        storage_path=tmp_path / "projected-storage",
+    )
+
+    assert set(load_config(projected_runtime_paths).agents) == {"alpha"}
 
 
 def test_docker_backend_recreates_container_when_launch_config_changes(


### PR DESCRIPTION
## Problem

Every Docker sandbox worker with a restricted agent slice crash-loops on startup:

```
pydantic ValidationError: calls.agents references unknown agent(s): mindroom_dev, openclaw
```

`_sanitize_projected_config_data` filters `agents:` down to the projected agent set (and already prunes `delegate_to` references), but left top-level `calls.agents` untouched. `Config.validate_call_agents` then rejects the projected config inside the worker (`sandbox_runner.py` -> `load_config`), the container exits(3), and each `run_shell_command` call hangs minutes before failing.

Observed during a stress test on the mindroom.chat instance: 121 consecutive `run_shell_command` failures, p50 197s / max 845s per call, 100% failure rate for any config where `calls.agents` names an agent outside the worker's slice.

## Fix

Clear the whole `calls` block from the projected worker config, alongside the sections the sanitizer already wipes (`teams`, `cultures`, `room_models`, `bot_accounts`, `authorization`, `matrix_room_access`, `matrix_space`, `mindroom_user`).

No worker reads `config.calls`. Every reader is control plane: `bot.py`, `entity_resolution.py`, `matrix_rtc/call_manager.py`, `orchestration/config_updates.py`. Nothing in the worker path (`api/sandbox_runner*.py`, `workers/runtime.py`) imports `matrix_rtc`.

Clearing beats filtering `calls.agents` down to the projected agents:

- One line instead of ten, with no dependency on `filtered_agents`, so it also applies when projection does not filter agents at all.
- Stays correct if a future field under `calls` gains agent or room references, instead of silently reintroducing the same crash-loop.
- Drops call profiles (`credentials_service` names, model IDs, voice) from the worker-visible snapshot, matching the projection's existing minimize-what-the-worker-sees behavior.

## Testing

- New regression test loads the materialized projection through the real `load_config`, which is the call that actually failed inside the worker, instead of asserting a YAML shape. It also covers `delegate_to` pruning, which had no test anywhere in the repo.
- `pytest tests/test_docker_worker_backend.py` - 96 passed.
- Verified against production config: projecting for a single agent now yields `calls: {}` and the snapshot validates.

## Notes

- Kubernetes backend does not share this sanitize path and does no config projection (`grep sanitize|projected_agent_names` across `workers/` hits only `docker_projection.py`); not affected.
- Separate follow-up worth filing: worker crash-loops should fail fast instead of letting the tool call wait for the full ready timeout.