### PR TITLE
Batch-prefetch overlapping knowledge chunks within a proven bound

### DIFF
--- a/src/mindroom/chunking.py
+++ b/src/mindroom/chunking.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from agno.knowledge.chunking.fixed import FixedSizeChunking
 from agno.knowledge.document.base import Document
 
+#: Largest number of UTF-8 bytes a single character can occupy.
+_MAX_UTF8_BYTES_PER_CHARACTER = 4
+
 
 class SafeFixedSizeChunking(FixedSizeChunking):
     """Avoid pathological micro-chunks when whitespace is far from the boundary."""
@@ -22,13 +25,55 @@ class SafeFixedSizeChunking(FixedSizeChunking):
             raise ValueError(msg)
         self.min_chunk_fill_ratio = min_chunk_fill_ratio
 
+    def _min_chunk_size(self) -> int:
+        """Return the shortest chunk a whitespace-aligned split may produce."""
+        return max(1, int(self.chunk_size * self.min_chunk_fill_ratio))
+
+    def _min_chunk_step(self) -> int:
+        """Return the smallest distance between two consecutive chunk starts.
+
+        A chunk that keeps its whitespace boundary is at least
+        ``_min_chunk_size`` characters long, and the next chunk starts
+        ``overlap`` characters before its end, so a start advances by at least
+        ``min_chunk_size - overlap``. Once the overlap reaches that length the
+        advance can shrink to one character, which is what makes near-total
+        overlap so expensive.
+        """
+        return max(1, self._min_chunk_size() - self.overlap)
+
+    def max_chunk_text_bytes(self, source_bytes: int) -> int:
+        """Return an upper bound on the UTF-8 bytes :meth:`chunk` emits for one file.
+
+        ``source_bytes`` is a file's size on disk. Readers decode files as
+        UTF-8, so the decoded content holds at most that many characters and at
+        most that many UTF-8 bytes, and ``clean_text`` only collapses
+        whitespace runs, so neither count grows before chunking. Two
+        independent bounds hold on top of that, and the tighter one wins:
+
+        * no character is covered by more than ``chunk_size / min_step`` chunks,
+          because chunks are at most ``chunk_size`` long and their starts are at
+          least ``min_step`` apart;
+        * every chunk but the first repeats at most ``overlap`` characters of
+          its predecessor, and a character costs at most four UTF-8 bytes.
+        """
+        if source_bytes <= 0:
+            return 0
+        if self.overlap <= 0:
+            # Chunks partition content that cleaning only ever shrank.
+            return source_bytes
+        step = self._min_chunk_step()
+        max_chunks = (source_bytes - 1) // step + 1
+        by_repeats = source_bytes + max_chunks * self.overlap * _MAX_UTF8_BYTES_PER_CHARACTER
+        by_coverage = ((self.chunk_size - 1) // step + 1) * source_bytes
+        return min(by_repeats, by_coverage)
+
     def chunk(self, document: Document) -> list[Document]:
         """Split one document while avoiding tiny boundary fragments."""
         content = self.clean_text(document.content)
         content_length = len(content)
         chunked_documents: list[Document] = []
         chunk_number = 1
-        min_chunk_size = max(1, int(self.chunk_size * self.min_chunk_fill_ratio))
+        min_chunk_size = self._min_chunk_size()
         start = 0
 
         while start < content_length:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -991,22 +991,27 @@ class KnowledgeManager:
                 return True
         return False
 
+    def _chunking_strategy(self) -> SafeFixedSizeChunking:
+        """Build the chunking strategy every text-like read of this base uses."""
+        base_config = self.config.get_knowledge_base_config(self.base_id)
+        return SafeFixedSizeChunking(
+            chunk_size=base_config.chunk_size,
+            overlap=base_config.chunk_overlap,
+        )
+
     def _build_reader(self, file_path: Path) -> Reader:
         """Build a per-file reader with conservative chunking for text-like content."""
-        base_config = self.config.get_knowledge_base_config(self.base_id)
         reader = ReaderFactory.get_reader_for_extension(file_path.suffix.lower())
 
         # Large markdown/plain-text files are the common source of oversized embed requests.
         if not isinstance(reader, (TextReader, MarkdownReader)):
             return reader
 
+        chunking_strategy = self._chunking_strategy()
         configured_reader = deepcopy(reader)
         configured_reader.chunk = True
-        configured_reader.chunk_size = base_config.chunk_size
-        configured_reader.chunking_strategy = SafeFixedSizeChunking(
-            chunk_size=base_config.chunk_size,
-            overlap=base_config.chunk_overlap,
-        )
+        configured_reader.chunk_size = chunking_strategy.chunk_size
+        configured_reader.chunking_strategy = chunking_strategy
         return configured_reader
 
     def _default_collection_name(self) -> str:
@@ -1370,27 +1375,23 @@ class KnowledgeManager:
     def _chunk_texts_for_batch(self, files: Sequence[Path]) -> list[str]:
         """Return chunk texts to prefetch, stopping at the memory budget.
 
-        Overlapping chunks duplicate source text, so their fully materialized
-        size cannot be bounded from the source-file size alone. Those bases use
-        the normal per-file embedding path instead.
-
         The size check has to precede the read: chunking materializes a file's
         entire content, so a budget consulted afterwards cannot stop a single
         oversized file from blowing the bound. A file that cannot fit the
         remaining budget is skipped rather than ending the pass, so smaller
         files behind it still benefit.
 
+        Overlapping chunks re-emit the same characters many times over, so a
+        file's size on disk stops bounding the text its chunks occupy: 4 KB at
+        chunk_size=128/overlap=127 materializes ~484 KB. The admission test is
+        therefore the chunker's own worst-case expansion of that size, never
+        the size itself.
+
         Skipped files are simply not prefetched; their chunks are embedded by
         the normal per-file path, so the only cost of the bound is speed,
         never correctness.
         """
-        if self.config.get_knowledge_base_config(self.base_id).chunk_overlap:
-            # Overlapping chunks re-emit the same bytes many times over, so a
-            # file's size on disk stops bounding the text its chunks occupy:
-            # 4 KB at chunk_size=128/overlap=127 materializes ~484 KB. There is
-            # no cheap pre-read bound for that, so prefetch is skipped entirely
-            # and the per-file path indexes normally.
-            return []
+        chunking_strategy = self._chunking_strategy()
         chunk_texts: list[str] = []
         remaining = _MAX_PREFETCH_TEXT_BYTES
         skipped = 0
@@ -1401,7 +1402,7 @@ class KnowledgeManager:
                 source_size = resolved_path.stat().st_size
             except OSError:
                 continue
-            if source_size > remaining:
+            if chunking_strategy.max_chunk_text_bytes(source_size) > remaining:
                 skipped += 1
                 continue
             for text in self._chunk_texts_for_prefetch(resolved_path):

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -22,6 +22,10 @@ from mindroom.chunking import SafeFixedSizeChunking
 #: exercises the gap between character counts and UTF-8 byte counts.
 _MULTIBYTE = "é中\U0001f600"
 
+#: Fill ratios covering an overlap below, at and above the shortest accepted
+#: chunk, which is where the smallest chunk-to-chunk advance changes shape.
+_FILL_RATIOS = (0.1, 0.5, 0.9, 1.0)
+
 
 def _emitted_and_bound(
     content: str,
@@ -96,13 +100,16 @@ def test_bound_covers_named_scenarios(content: str, chunk_size: int, overlap: in
     assert emitted <= bound, f"chunking emitted {emitted} bytes past a bound of {bound}"
 
 
-def test_bound_covers_every_small_whitespace_layout() -> None:
+@pytest.mark.parametrize("fill_ratio", _FILL_RATIOS)
+def test_bound_covers_every_small_whitespace_layout(fill_ratio: float) -> None:
     """Exhaust the whitespace layouts that drive the chunker's boundary search.
 
     Whether a chunk keeps its whitespace boundary or falls back to a hard split
     is what decides how far the next chunk start advances, so the smallest
     inputs where every layout is enumerable are the strongest evidence that no
-    layout beats the bound.
+    layout beats the bound. The fill ratio is swept too: it sets the shortest
+    accepted chunk, so it decides where the smallest advance sits relative to
+    the overlap, and fixing it at one value leaves that arithmetic untested.
     """
     for chunk_size in range(2, 9):
         for overlap in range(chunk_size):
@@ -111,10 +118,15 @@ def test_bound_covers_every_small_whitespace_layout() -> None:
             for length in range(13 if chunk_size <= 4 else 9):
                 for layout in itertools.product("a ", repeat=length):
                     content = "".join(layout)
-                    emitted, bound = _emitted_and_bound(content, chunk_size=chunk_size, overlap=overlap)
+                    emitted, bound = _emitted_and_bound(
+                        content,
+                        chunk_size=chunk_size,
+                        overlap=overlap,
+                        fill_ratio=fill_ratio,
+                    )
                     assert emitted <= bound, (
-                        f"chunk_size={chunk_size} overlap={overlap} content={content!r} "
-                        f"emitted {emitted} bytes past a bound of {bound}"
+                        f"chunk_size={chunk_size} overlap={overlap} fill_ratio={fill_ratio} "
+                        f"content={content!r} emitted {emitted} bytes past a bound of {bound}"
                     )
 
 
@@ -122,7 +134,7 @@ def test_bound_covers_every_small_whitespace_layout() -> None:
 def _chunking_cases(draw: st.DrawFn) -> tuple[str, int, int, float]:
     chunk_size = draw(st.integers(min_value=2, max_value=64))
     overlap = draw(st.integers(min_value=0, max_value=chunk_size - 1))
-    fill_ratio = draw(st.sampled_from([0.1, 0.5, 0.9, 1.0]))
+    fill_ratio = draw(st.sampled_from(_FILL_RATIOS))
     content = draw(st.text(alphabet="ab \n\t" + _MULTIBYTE, max_size=200))
     return content, chunk_size, overlap, fill_ratio
 

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,0 +1,143 @@
+"""Worst-case chunk-expansion bounds for :class:`SafeFixedSizeChunking`.
+
+The embedding prefetch in ``mindroom.knowledge.manager`` decides whether to
+read a file at all from ``max_chunk_text_bytes``, so a bound that ever
+underestimates what ``chunk`` materializes would silently unbound prefetch
+memory. Every test here therefore compares the bound against the real chunker
+rather than against a restatement of its formula.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from agno.knowledge.document.base import Document
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from mindroom.chunking import SafeFixedSizeChunking
+
+#: One 2-byte, one 3-byte and one 4-byte character, so generated content
+#: exercises the gap between character counts and UTF-8 byte counts.
+_MULTIBYTE = "é中\U0001f600"
+
+
+def _emitted_and_bound(
+    content: str,
+    *,
+    chunk_size: int,
+    overlap: int,
+    fill_ratio: float = 0.5,
+) -> tuple[int, int]:
+    """Return the UTF-8 bytes chunking really emits and the bound claimed for them."""
+    strategy = SafeFixedSizeChunking(
+        chunk_size=chunk_size,
+        overlap=overlap,
+        min_chunk_fill_ratio=fill_ratio,
+    )
+    documents = strategy.chunk(Document(content=content))
+    emitted = sum(len(document.content.encode("utf-8")) for document in documents)
+    return emitted, strategy.max_chunk_text_bytes(len(content.encode("utf-8")))
+
+
+@pytest.mark.parametrize("chunk_size", [128, 1_000, 5_000])
+def test_zero_overlap_keeps_the_source_size_as_its_bound(chunk_size: int) -> None:
+    """Without overlap the chunks partition the content, so the bound is the file size."""
+    strategy = SafeFixedSizeChunking(chunk_size=chunk_size, overlap=0)
+
+    assert strategy.max_chunk_text_bytes(0) == 0
+    assert strategy.max_chunk_text_bytes(1) == 1
+    assert strategy.max_chunk_text_bytes(8_000_000) == 8_000_000
+
+
+def test_moderate_overlap_admits_realistically_sized_files() -> None:
+    """A 10% overlap must stay cheap enough for ordinary files to be prefetched."""
+    strategy = SafeFixedSizeChunking(chunk_size=1_000, overlap=100)
+
+    # Two megabytes of source still fit an eight-megabyte prefetch budget.
+    assert strategy.max_chunk_text_bytes(2_000_000) <= 8_000_000
+
+
+def test_near_total_overlap_bound_reflects_the_real_amplification() -> None:
+    """Overlap one below the chunk size really does multiply a small file."""
+    content = "x" * 4_000
+
+    emitted, bound = _emitted_and_bound(content, chunk_size=128, overlap=127)
+
+    assert emitted > 100 * len(content), "the pathological case stopped amplifying"
+    assert emitted <= bound
+    assert bound <= 128 * len(content)
+
+
+_SCENARIOS = {
+    "empty": ("", 128, 64),
+    "single character": ("a", 128, 64),
+    "shorter than one chunk": ("word " * 10, 128, 64),
+    "no overlap": ("word " * 500, 128, 0),
+    "moderate overlap": ("word " * 500, 1_000, 100),
+    "overlap one below chunk size": ("word " * 500, 128, 127),
+    "no whitespace at all": ("x" * 2_000, 128, 64),
+    "whitespace just inside the boundary": (("x" * 126 + " x"), 128, 64),
+    "whitespace just past the minimum fill": (("x" * 65 + " "), 128, 64),
+    "whitespace far from every boundary": (("x" * 200 + " ") * 5, 128, 32),
+    "multibyte without overlap": (_MULTIBYTE * 500, 128, 0),
+    "multibyte with moderate overlap": (_MULTIBYTE * 500, 128, 32),
+    "multibyte with near-total overlap": (_MULTIBYTE * 200, 128, 127),
+    "multibyte around whitespace": ((_MULTIBYTE * 20 + " ") * 20, 128, 64),
+}
+
+
+@pytest.mark.parametrize(("content", "chunk_size", "overlap"), _SCENARIOS.values(), ids=list(_SCENARIOS))
+def test_bound_covers_named_scenarios(content: str, chunk_size: int, overlap: int) -> None:
+    """Every hand-picked shape stays inside the bound computed from its byte size."""
+    emitted, bound = _emitted_and_bound(content, chunk_size=chunk_size, overlap=overlap)
+
+    assert emitted <= bound, f"chunking emitted {emitted} bytes past a bound of {bound}"
+
+
+def test_bound_covers_every_small_whitespace_layout() -> None:
+    """Exhaust the whitespace layouts that drive the chunker's boundary search.
+
+    Whether a chunk keeps its whitespace boundary or falls back to a hard split
+    is what decides how far the next chunk start advances, so the smallest
+    inputs where every layout is enumerable are the strongest evidence that no
+    layout beats the bound.
+    """
+    for chunk_size in range(2, 9):
+        for overlap in range(chunk_size):
+            # Small chunk sizes get longer inputs so several chunks, and so
+            # several overlap-driven advances, fit inside one enumerated layout.
+            for length in range(13 if chunk_size <= 4 else 9):
+                for layout in itertools.product("a ", repeat=length):
+                    content = "".join(layout)
+                    emitted, bound = _emitted_and_bound(content, chunk_size=chunk_size, overlap=overlap)
+                    assert emitted <= bound, (
+                        f"chunk_size={chunk_size} overlap={overlap} content={content!r} "
+                        f"emitted {emitted} bytes past a bound of {bound}"
+                    )
+
+
+@st.composite
+def _chunking_cases(draw: st.DrawFn) -> tuple[str, int, int, float]:
+    chunk_size = draw(st.integers(min_value=2, max_value=64))
+    overlap = draw(st.integers(min_value=0, max_value=chunk_size - 1))
+    fill_ratio = draw(st.sampled_from([0.1, 0.5, 0.9, 1.0]))
+    content = draw(st.text(alphabet="ab \n\t" + _MULTIBYTE, max_size=200))
+    return content, chunk_size, overlap, fill_ratio
+
+
+@settings(max_examples=300, deadline=None)
+@given(_chunking_cases())
+def test_bound_never_underestimates_emitted_chunk_bytes(case: tuple[str, int, int, float]) -> None:
+    """Generated content must never chunk into more bytes than the bound allows."""
+    content, chunk_size, overlap, fill_ratio = case
+
+    emitted, bound = _emitted_and_bound(
+        content,
+        chunk_size=chunk_size,
+        overlap=overlap,
+        fill_ratio=fill_ratio,
+    )
+
+    assert emitted <= bound

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -51,23 +51,23 @@ def test_zero_overlap_keeps_the_source_size_as_its_bound(chunk_size: int) -> Non
     assert strategy.max_chunk_text_bytes(8_000_000) == 8_000_000
 
 
-def test_moderate_overlap_admits_realistically_sized_files() -> None:
-    """A 10% overlap must stay cheap enough for ordinary files to be prefetched."""
+def test_moderate_overlap_expands_by_a_small_factor() -> None:
+    """A 10% overlap must stay cheap enough for ordinary files to be admitted."""
     strategy = SafeFixedSizeChunking(chunk_size=1_000, overlap=100)
 
-    # Two megabytes of source still fit an eight-megabyte prefetch budget.
-    assert strategy.max_chunk_text_bytes(2_000_000) <= 8_000_000
+    assert strategy.max_chunk_text_bytes(2_000_000) <= 2 * 2_000_000
 
 
 def test_near_total_overlap_bound_reflects_the_real_amplification() -> None:
     """Overlap one below the chunk size really does multiply a small file."""
     content = "x" * 4_000
+    source_bytes = len(content.encode("utf-8"))
 
     emitted, bound = _emitted_and_bound(content, chunk_size=128, overlap=127)
 
-    assert emitted > 100 * len(content), "the pathological case stopped amplifying"
+    assert emitted > 100 * source_bytes, "the pathological case stopped amplifying"
     assert emitted <= bound
-    assert bound <= 128 * len(content)
+    assert bound <= 128 * source_bytes
 
 
 _SCENARIOS = {

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -2814,19 +2814,105 @@ async def test_oversized_file_still_indexes_and_publishes(
     assert "huge.md" in stored
 
 
-@pytest.mark.asyncio
-async def test_overlapping_chunks_still_index_and_publish(tmp_path: Path, embedder: _RecordingEmbedder) -> None:
-    """Skipping prefetch for overlapping chunks must not skip indexing."""
+def _overlapping_body(tokens: int) -> str:
+    """Return text whose chunks differ, so batched requests cannot dedupe away."""
+    return " ".join(f"token{index:04d}" for index in range(tokens))
+
+
+def test_moderate_overlap_is_still_batch_prefetched(tmp_path: Path) -> None:
+    """Ordinary overlap expands predictably, so it must not disable prefetch."""
     docs_path = tmp_path / "docs"
     docs_path.mkdir()
-    (docs_path / "overlapped.md").write_text("y" * 600, encoding="utf-8")
-    config = _config(tmp_path, docs_path, chunk_size=128, chunk_overlap=64)
+    source = docs_path / "overlapped.md"
+    source.write_text(_overlapping_body(500), encoding="utf-8")
+    config = _config(tmp_path, docs_path, chunk_size=1_000, chunk_overlap=100)
+
+    texts = _manager(config)._chunk_texts_for_batch([source])
+
+    assert len(texts) > 1, "overlapping chunks were not prefetched at all"
+
+
+def test_prefetch_skips_overlap_expansion_that_outgrows_the_budget(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Admission is decided by worst-case expansion, not by the size on disk.
+
+    The oversized file here is smaller than the whole budget; only its overlap
+    expansion is not, so a check against the raw file size would read it.
+    """
+    monkeypatch.setattr(knowledge_manager_module, "_MAX_PREFETCH_TEXT_BYTES", 4_000)
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    expanding = docs_path / "expanding.md"
+    expanding.write_text("x" * 2_500, encoding="utf-8")
+    small = docs_path / "small.md"
+    small.write_text(_overlapping_body(50), encoding="utf-8")
+    config = _config(tmp_path, docs_path, chunk_size=1_000, chunk_overlap=100)
+    read_files: list[str] = []
+    original_chunk = KnowledgeManager._chunk_texts_for_prefetch
+
+    def _record_read(self: KnowledgeManager, resolved_path: Path) -> tuple[str, ...]:
+        read_files.append(resolved_path.name)
+        return original_chunk(self, resolved_path)
+
+    monkeypatch.setattr(KnowledgeManager, "_chunk_texts_for_prefetch", _record_read)
+
+    texts = _manager(config)._chunk_texts_for_batch([expanding, small])
+
+    assert expanding.stat().st_size < 4_000, "the oversized file no longer fits the budget by raw size"
+    assert read_files == ["small.md"], "the expanding file was materialized before prefetch declined it"
+    assert texts, "the smaller file behind the skipped one was never prefetched"
+    assert sum(len(text.encode("utf-8")) for text in texts) <= 4_000
+
+
+@pytest.mark.asyncio
+async def test_overlapping_chunks_are_batch_prefetched_and_published(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """Overlapping chunks embed in real multi-input requests and stay searchable."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "overlapped.md").write_text(_overlapping_body(500), encoding="utf-8")
+    config = _config(tmp_path, docs_path, chunk_size=1_000, chunk_overlap=100)
     runtime_paths = runtime_paths_for(config)
 
     assert await _manager(config).reindex_all() == 1
 
-    assert [batch for batch in embedder.batch_requests if len(batch) > 1] == [], "prefetch ran despite overlap"
+    assert [batch for batch in embedder.batch_requests if len(batch) > 1], "no multi-input request was issued"
+    assert embedder.single_requests == [], "every overlapping chunk was served from the batch prefetch"
     state = _published_state(config, runtime_paths)
     assert state is not None
     assert state.status == "complete"
     assert state.indexed_count == 1
+    lookup = get_published_index("docs", config=config, runtime_paths=runtime_paths)
+    assert lookup.index is not None
+    hits = lookup.index.knowledge.search("token0000", max_results=5)
+    assert hits, "the published overlapping index returned nothing"
+    assert all("token" in document.content for document in hits)
+
+
+@pytest.mark.asyncio
+async def test_file_skipped_by_overlap_expansion_still_indexes_and_publishes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file prefetch declines must still be indexed by the per-file path."""
+    monkeypatch.setattr(knowledge_manager_module, "_MAX_PREFETCH_TEXT_BYTES", 4_000)
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "expanding.md").write_text("x" * 2_500, encoding="utf-8")
+    for index in range(3):
+        (docs_path / f"small{index}.md").write_text(f"small body {index}", encoding="utf-8")
+    config = _config(tmp_path, docs_path, chunk_size=1_000, chunk_overlap=100)
+    runtime_paths = runtime_paths_for(config)
+
+    assert await _manager(config).reindex_all() == 4
+
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.status == "complete"
+    assert state.indexed_count == 4
+    stored = sorted(record.metadata["source_path"] for record in _FakeVectorDb.store[state.collection])
+    assert "expanding.md" in stored

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -380,6 +380,11 @@ def _write_corpus(docs_path: Path, count: int, *, body: str = "content") -> list
     return names
 
 
+def _overlapping_body(tokens: int) -> str:
+    """Return text whose chunks all differ, so batched requests cannot dedupe them away."""
+    return " ".join(f"token{index:04d}" for index in range(tokens))
+
+
 def _candidate_collections() -> list[str]:
     return sorted(name for name in _FakeVectorDb.store if "_candidate_" in name)
 
@@ -2812,11 +2817,6 @@ async def test_oversized_file_still_indexes_and_publishes(
     assert state.indexed_count == 4
     stored = sorted(record.metadata["source_path"] for record in _FakeVectorDb.store[state.collection])
     assert "huge.md" in stored
-
-
-def _overlapping_body(tokens: int) -> str:
-    """Return text whose chunks differ, so batched requests cannot dedupe away."""
-    return " ".join(f"token{index:04d}" for index in range(tokens))
 
 
 def test_moderate_overlap_is_still_batch_prefetched(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

`KnowledgeManager._chunk_texts_for_batch()` returned immediately whenever a knowledge base had a nonzero `chunk_overlap`, so embedding prefetch (and therefore multi-input embedding requests) was disabled for those bases.

The guard was added for a real reason: overlapping chunks re-emit the same characters, so source-file size stops bounding the text the chunks materialize. At `chunk_size=128` / `chunk_overlap=127`, 4,000 source characters expand into ~3,873 chunks and ~495 KB of chunk text. But the guard is blunt: it also disables batching for ordinary configurations such as a 10% overlap, where the expansion is small and predictable.

## Change

Replace the blanket guard with the chunker's own worst-case expansion, computed before the file is read.

`SafeFixedSizeChunking.max_chunk_text_bytes(source_bytes)` returns an upper bound on the UTF-8 bytes `chunk()` can emit for a source of that size. Prefetch admits a file only when that bound fits the remaining budget, so `_MAX_PREFETCH_TEXT_BYTES` remains a hard bound on the chunk text one prefetch pass holds, and a file whose expansion cannot fit is never read or chunked.

### Safety invariant

For any file of `source_bytes` on disk, the total UTF-8 bytes of the chunk texts prefetch retains never exceeds `_MAX_PREFETCH_TEXT_BYTES`, because each file is admitted only while `max_chunk_text_bytes(source_bytes) <= remaining`.

### Why the bound cannot underestimate

Readers decode files as UTF-8, so the decoded content holds at most `source_bytes` characters and at most `source_bytes` UTF-8 bytes; `clean_text` only collapses whitespace runs, so neither count grows before chunking. On top of that, chunk starts advance by at least `min_step = max(1, min_chunk_size - overlap)` characters, where `min_chunk_size` is the same value `chunk()` uses to reject tiny boundary fragments. Two independent bounds follow, and the tighter one wins:

- **coverage** — chunks are at most `chunk_size` long and their starts are `min_step` apart, so no character is repeated into more than `(chunk_size - 1) // min_step + 1` chunks;
- **repeats** — every chunk but the first repeats at most `overlap` characters of its predecessor, and a character costs at most 4 UTF-8 bytes, so the total is at most `source_bytes + max_chunks * overlap * 4`.

With `overlap == 0` the chunks partition the cleaned content, so the bound is exactly the file size and admission is unchanged.

## Behavior

- Moderate overlap now batches: `chunk_size=1000` / `overlap=100` bounds a source at ~1.8x, so ordinary files fit an 8 MB budget.
- Pathological overlap stays out: `chunk_size=128` / `overlap=127` bounds a 4 KB source at 512 KB, which fails admission against a small budget, and the file is never read by the prefetch path.
- Declined files are still indexed by the ordinary per-file path, and smaller files behind a declined one stay eligible.
- Batch item/payload limits, provider capability detection, cardinality fallback, retry behavior, auth/global-failure handling and the short-lived embedding cache are untouched.

## Tests

`tests/test_chunking.py` (new) checks the bound against the real chunker rather than against a restatement of its formula:

- zero overlap keeps the source size as its bound;
- named scenarios: no overlap, moderate overlap, `chunk_size - 1` overlap, whitespace near and far from boundaries, no whitespace at all, ASCII and multibyte (2/3/4-byte characters), empty and short content;
- exhaustive enumeration of every whitespace layout for small chunk sizes and overlaps, swept across fill ratios, since the boundary search and the shortest accepted chunk are what decide how far a start advances;
- a Hypothesis property test over generated ASCII + multibyte content, bounded to keep the suite fast.

Test strength was checked by mutation: advancing `_min_chunk_step` one character too far, and scaling the returned bound to 90%, each fail the deterministic tests on their own, without relying on the randomized search.

`tests/test_knowledge_resumable_refresh.py`:

- moderate overlap is prefetched instead of declined;
- an end-to-end refresh with moderate overlap issues real multi-input embedding requests, serves every chunk from the prefetch cache, and publishes a searchable index;
- a file whose overlap expansion exceeds the remaining budget is not read, even though its raw size fits the budget, and a smaller file behind it is still prefetched;
- that skipped file is still indexed and published;
- the existing pathological-overlap and zero-overlap bound tests are unchanged and still pass.

The three new behavior tests fail against the pre-change implementation for the intended reasons (`overlapping chunks were not prefetched at all`, `the expanding file was materialized before prefetch declined it`, `no multi-input request was issued`), and the expansion test also fails if admission is reverted to a raw-size check.

## Validation

- `uv run pytest tests/test_chunking.py tests/test_knowledge_resumable_refresh.py` — pass
- `uv run pytest -q -x --lf --cache-clear` — pass
- `uv run ruff check` / `ruff format --check`, `uv run ty check`, `uv run tach check --dependencies --interfaces`, `uv run pre-commit run --all-files`, `git diff --check` — all clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chunk sizing for UTF-8 so generated chunk volume is properly bounded.
  * Made chunking configuration consistent across readers and applied a worst-case byte-budget check for overlapping prefetch.

* **Tests**
  * Added unit and property-based coverage ensuring the computed UTF-8 byte bound never underestimates emitted chunk bytes.
  * Expanded overlap and prefetch/batching tests to verify budget admission behavior and preserved indexing/searchability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
