### PR TITLE
Keep Claude stream setup off the event loop

### DIFF
--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -50,6 +50,7 @@ can still replay poisoned history.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any, cast
 
 from mindroom.hooks.enrichment import is_transient_context
@@ -58,6 +59,8 @@ from mindroom.model_defaults import TOOL_SEARCH_UNSUPPORTED_MODEL_ID_PREFIXES
 from mindroom.model_instance_checks import isinstance_of_loaded
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from agno.models.anthropic import Claude as AnthropicClaude
 
 _PROMPT_CACHE_HOOK_ATTR = "_mindroom_claude_prompt_cache_hook_installed"
@@ -478,12 +481,35 @@ def _request_kwargs_with_prompt_cache_ladder(
     return prepared_kwargs
 
 
+class _OffloadedAsyncStreamManager:
+    """Construct one synchronous SDK stream manager away from the event loop."""
+
+    def __init__(self, stream_factory: Callable[[], Any]) -> None:
+        self._stream_factory = stream_factory
+        self._stream_manager: Any = None
+
+    async def __aenter__(self) -> object:
+        self._stream_manager = await asyncio.to_thread(self._stream_factory)
+        return await self._stream_manager.__aenter__()
+
+    async def __aexit__(self, exc_type: object, exc_value: object, traceback: object) -> bool | None:
+        result: bool | None = await self._stream_manager.__aexit__(exc_type, exc_value, traceback)
+        return result
+
+
 class _PromptCacheMessagesProxy:
     """Messages namespace proxy that adds the cache ladder on create/stream."""
 
-    def __init__(self, messages_namespace: object, model: AnthropicClaude) -> None:
+    def __init__(
+        self,
+        messages_namespace: object,
+        model: AnthropicClaude,
+        *,
+        offload_stream_setup: bool,
+    ) -> None:
         self._messages_namespace: Any = messages_namespace
         self._model = model
+        self._offload_stream_setup = offload_stream_setup
 
     def _prepared(self, request_kwargs: dict[str, Any]) -> dict[str, Any]:
         return prepare_claude_request_kwargs(self._model, request_kwargs)
@@ -492,6 +518,10 @@ class _PromptCacheMessagesProxy:
         return self._messages_namespace.create(**self._prepared(request_kwargs))
 
     def stream(self, **request_kwargs: object) -> object:
+        if self._offload_stream_setup:
+            return _OffloadedAsyncStreamManager(
+                lambda: self._messages_namespace.stream(**self._prepared(request_kwargs)),
+            )
         return self._messages_namespace.stream(**self._prepared(request_kwargs))
 
     def __getattr__(self, name: str) -> object:
@@ -518,13 +548,24 @@ def prepare_claude_request_kwargs(
 class _PromptCacheBetaProxy:
     """Beta namespace proxy that routes beta.messages through the ladder."""
 
-    def __init__(self, beta_namespace: object, model: AnthropicClaude) -> None:
+    def __init__(
+        self,
+        beta_namespace: object,
+        model: AnthropicClaude,
+        *,
+        offload_stream_setup: bool,
+    ) -> None:
         self._beta_namespace: Any = beta_namespace
         self._model = model
+        self._offload_stream_setup = offload_stream_setup
 
     @property
     def messages(self) -> _PromptCacheMessagesProxy:
-        return _PromptCacheMessagesProxy(self._beta_namespace.messages, self._model)
+        return _PromptCacheMessagesProxy(
+            self._beta_namespace.messages,
+            self._model,
+            offload_stream_setup=self._offload_stream_setup,
+        )
 
     def __getattr__(self, name: str) -> object:
         return getattr(self._beta_namespace, name)
@@ -533,17 +574,32 @@ class _PromptCacheBetaProxy:
 class _PromptCacheClientProxy:
     """Anthropic SDK client proxy that applies the ladder to message requests."""
 
-    def __init__(self, client: object, model: AnthropicClaude) -> None:
+    def __init__(
+        self,
+        client: object,
+        model: AnthropicClaude,
+        *,
+        offload_stream_setup: bool = False,
+    ) -> None:
         self._client: Any = client
         self._model = model
+        self._offload_stream_setup = offload_stream_setup
 
     @property
     def messages(self) -> _PromptCacheMessagesProxy:
-        return _PromptCacheMessagesProxy(self._client.messages, self._model)
+        return _PromptCacheMessagesProxy(
+            self._client.messages,
+            self._model,
+            offload_stream_setup=self._offload_stream_setup,
+        )
 
     @property
     def beta(self) -> _PromptCacheBetaProxy:
-        return _PromptCacheBetaProxy(self._client.beta, self._model)
+        return _PromptCacheBetaProxy(
+            self._client.beta,
+            self._model,
+            offload_stream_setup=self._offload_stream_setup,
+        )
 
     # Python looks dunder methods up on the type, bypassing __getattr__, so
     # context-manager use of the proxied client must be delegated explicitly.
@@ -595,7 +651,7 @@ def install_claude_prompt_cache_hook(model: object) -> None:
 
     def _get_async_client_with_prompt_cache() -> object:
         client = original_get_async_client()
-        return _PromptCacheClientProxy(client, claude_model)
+        return _PromptCacheClientProxy(client, claude_model, offload_stream_setup=True)
 
     model_dict["get_client"] = _get_client_with_prompt_cache
     model_dict["get_async_client"] = _get_async_client_with_prompt_cache

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -489,7 +489,36 @@ class _OffloadedAsyncStreamManager:
         self._stream_manager: Any = None
 
     async def __aenter__(self) -> object:
-        self._stream_manager = await asyncio.to_thread(self._stream_factory)
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        baseline_cancel_count = current_task.cancelling()
+        deferred_cancel_count = 0
+        deferred_cancel: asyncio.CancelledError | None = None
+        setup_task = asyncio.create_task(asyncio.to_thread(self._stream_factory))
+
+        while not setup_task.done():
+            try:
+                await asyncio.shield(setup_task)
+            except asyncio.CancelledError as exc:
+                new_cancel_count = current_task.cancelling() - baseline_cancel_count
+                if new_cancel_count <= 0:
+                    raise
+                for _ in range(new_cancel_count):
+                    current_task.uncancel()
+                deferred_cancel_count += new_cancel_count
+                deferred_cancel = deferred_cancel or exc
+
+        try:
+            self._stream_manager = setup_task.result()
+        except BaseException as setup_error:
+            if deferred_cancel is None:
+                raise
+            for _ in range(deferred_cancel_count):
+                current_task.cancel()
+            raise deferred_cancel from setup_error
+
+        for _ in range(deferred_cancel_count):
+            current_task.cancel()
         return await self._stream_manager.__aenter__()
 
     async def __aexit__(self, exc_type: object, exc_value: object, traceback: object) -> bool | None:

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -491,7 +491,6 @@ class _OffloadedAsyncStreamManager:
     async def __aenter__(self) -> object:
         current_task = asyncio.current_task()
         assert current_task is not None
-        baseline_cancel_count = current_task.cancelling()
         deferred_cancel_count = 0
         deferred_cancel: asyncio.CancelledError | None = None
         setup_task = asyncio.create_task(asyncio.to_thread(self._stream_factory))
@@ -500,12 +499,14 @@ class _OffloadedAsyncStreamManager:
             try:
                 await asyncio.shield(setup_task)
             except asyncio.CancelledError as exc:
-                new_cancel_count = current_task.cancelling() - baseline_cancel_count
-                if new_cancel_count <= 0:
+                if setup_task.cancelled():
                     raise
-                for _ in range(new_cancel_count):
+                caller_cancel_count = current_task.cancelling()
+                if caller_cancel_count <= 0:
+                    raise
+                for _ in range(caller_cancel_count):
                     current_task.uncancel()
-                deferred_cancel_count += new_cancel_count
+                deferred_cancel_count += caller_cancel_count
                 deferred_cancel = deferred_cancel or exc
 
         try:

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -1,12 +1,15 @@
 """Test extra_kwargs functionality in model configuration."""
 
 import asyncio
+import gc
 import importlib
 import os
 import tempfile
 import threading
+import warnings
 from pathlib import Path
 
+import httpx
 import pytest
 import yaml
 from agno.models.anthropic import Claude
@@ -19,6 +22,7 @@ from agno.models.openai.like import OpenAILike
 from agno.models.response import ModelResponse
 from agno.models.vertexai.claude import Claude as VertexAIClaude
 from agno.utils.models.claude import format_messages
+from anthropic import AsyncAnthropic
 from anthropic.types import Message as AnthropicMessage
 
 from mindroom.claude_prompt_cache import (
@@ -1536,6 +1540,91 @@ async def test_prompt_cache_hook_constructs_async_stream_off_event_loop(*, use_b
     assert heartbeat_before_release == [True]
     assert stream_thread_ids
     assert stream_thread_ids[0] != event_loop_thread_id
+
+
+@pytest.mark.parametrize("cancel_count", [1, 2])
+@pytest.mark.parametrize("use_beta", [False, True])
+@pytest.mark.asyncio
+async def test_cancelled_async_stream_setup_does_not_orphan_sdk_request_coroutine(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    cancel_count: int,
+    use_beta: bool,
+) -> None:
+    """Cancellation during worker setup must dispose the SDK request coroutine."""
+    transport_calls = 0
+
+    class _RecordingTransport(httpx.AsyncBaseTransport):
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            nonlocal transport_calls
+            transport_calls += 1
+            return httpx.Response(200, request=request)
+
+    client = AsyncAnthropic(
+        api_key="test-key",
+        http_client=httpx.AsyncClient(transport=_RecordingTransport()),
+    )
+    model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=False)
+    setup_started = threading.Event()
+    allow_setup = threading.Event()
+    setup_finished = threading.Event()
+    manager_created = threading.Event()
+
+    def blocking_prepare(_model: object, request_kwargs: dict[str, object]) -> dict[str, object]:
+        setup_started.set()
+        assert allow_setup.wait(2.0)
+        setup_finished.set()
+        return request_kwargs
+
+    messages_namespace = client.beta.messages if use_beta else client.messages
+    namespace_type = type(messages_namespace)
+    original_stream = namespace_type.stream
+
+    def observed_stream(self: object, **kwargs: object) -> object:
+        stream_manager = original_stream(self, **kwargs)
+        manager_created.set()
+        return stream_manager
+
+    monkeypatch.setattr("mindroom.claude_prompt_cache.prepare_claude_request_kwargs", blocking_prepare)
+    monkeypatch.setattr(namespace_type, "stream", observed_stream)
+    vars(model)["get_async_client"] = lambda: client
+    vars(model)["_prepare_request_kwargs"] = lambda *_args, **_kwargs: {"max_tokens": 1}
+    vars(model)["_has_beta_features"] = lambda **_kwargs: use_beta
+    install_claude_prompt_cache_hook(model)
+
+    async def consume_stream() -> list[ModelResponse]:
+        return [
+            response
+            async for response in model.ainvoke_stream(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+            )
+        ]
+
+    setup_task = asyncio.create_task(consume_stream())
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            assert await asyncio.to_thread(setup_started.wait, 2.0)
+            for _ in range(cancel_count):
+                setup_task.cancel()
+            allow_setup.set()
+            with pytest.raises(asyncio.CancelledError):
+                await setup_task
+        finally:
+            allow_setup.set()
+
+        assert await asyncio.to_thread(setup_finished.wait, 2.0)
+        assert await asyncio.to_thread(manager_created.wait, 2.0)
+        assert setup_task.cancelling() == cancel_count
+        del setup_task
+        for _ in range(3):
+            gc.collect()
+            await asyncio.sleep(0)
+
+    await client.close()
+    assert transport_calls == 0
+    assert not any("was never awaited" in str(warning.message) for warning in caught)
 
 
 def _dirty_replay_messages() -> list[Message]:

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -1,8 +1,10 @@
 """Test extra_kwargs functionality in model configuration."""
 
+import asyncio
 import importlib
 import os
 import tempfile
+import threading
 from pathlib import Path
 
 import pytest
@@ -1457,6 +1459,83 @@ async def test_prompt_cache_hook_drops_orphaned_search_use_from_streaming_replay
     )
     assert any(getattr(block, "type", None) == "tool_use" for block in assistant_wire["content"])
     assert wire_messages[-1]["content"][0]["type"] == "tool_result"
+
+
+@pytest.mark.parametrize("use_beta", [False, True])
+@pytest.mark.asyncio
+async def test_prompt_cache_hook_constructs_async_stream_off_event_loop(*, use_beta: bool) -> None:
+    """Slow synchronous SDK stream setup must not block unrelated async work."""
+    model = Claude(id="claude-opus-4-8", api_key="test-key", cache_system_prompt=False)
+    stream_started = threading.Event()
+    heartbeat_seen = threading.Event()
+    allow_stream_return = threading.Event()
+    heartbeat_before_release: list[bool] = []
+    stream_thread_ids: list[int] = []
+    event_loop_thread_id = threading.get_ident()
+
+    class _EmptyAsyncStream:
+        async def __aenter__(self) -> object:
+            return self
+
+        async def __aexit__(self, *_args: object) -> None:
+            return None
+
+        def __aiter__(self) -> object:
+            return self
+
+        async def __anext__(self) -> object:
+            raise StopAsyncIteration
+
+    class _BlockingAsyncMessagesAPI:
+        def stream(self, **_kwargs: object) -> object:
+            stream_thread_ids.append(threading.get_ident())
+            stream_started.set()
+            assert allow_stream_return.wait(2.0)
+            return _EmptyAsyncStream()
+
+    class _FakeBetaAPI:
+        def __init__(self) -> None:
+            self.messages = _BlockingAsyncMessagesAPI()
+
+    class _FakeAsyncClient:
+        def __init__(self) -> None:
+            self.messages = _BlockingAsyncMessagesAPI()
+            self.beta = _FakeBetaAPI()
+
+    def release_after_heartbeat() -> None:
+        assert stream_started.wait(2.0)
+        heartbeat_before_release.append(heartbeat_seen.wait(0.5))
+        allow_stream_return.set()
+
+    vars(model)["get_async_client"] = lambda: _FakeAsyncClient()
+    vars(model)["_prepare_request_kwargs"] = lambda *_args, **_kwargs: {}
+    vars(model)["_has_beta_features"] = lambda **_kwargs: use_beta
+    install_claude_prompt_cache_hook(model)
+    release_thread = threading.Thread(target=release_after_heartbeat)
+    release_thread.start()
+
+    async def consume_stream() -> list[ModelResponse]:
+        return [
+            response
+            async for response in model.ainvoke_stream(
+                messages=[Message(role="user", content="Current turn")],
+                assistant_message=Message(role="assistant"),
+            )
+        ]
+
+    stream_task = asyncio.create_task(consume_stream())
+    try:
+        assert await asyncio.to_thread(stream_started.wait, 2.0)
+        await asyncio.sleep(0)
+        heartbeat_seen.set()
+        assert await asyncio.wait_for(stream_task, timeout=2.0) == []
+    finally:
+        allow_stream_return.set()
+        await asyncio.to_thread(release_thread.join, 2.0)
+
+    assert heartbeat_before_release == [True]
+    assert stream_thread_ids
+    assert stream_thread_ids[0] != event_loop_thread_id
 
 
 def _dirty_replay_messages() -> list[Message]:

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -1543,11 +1543,13 @@ async def test_prompt_cache_hook_constructs_async_stream_off_event_loop(*, use_b
 
 
 @pytest.mark.parametrize("cancel_count", [1, 2])
+@pytest.mark.parametrize("cancel_before_setup", [False, True])
 @pytest.mark.parametrize("use_beta", [False, True])
 @pytest.mark.asyncio
-async def test_cancelled_async_stream_setup_does_not_orphan_sdk_request_coroutine(
+async def test_cancelled_async_stream_setup_does_not_orphan_sdk_request_coroutine(  # noqa: PLR0915
     monkeypatch: pytest.MonkeyPatch,
     *,
+    cancel_before_setup: bool,
     cancel_count: int,
     use_beta: bool,
 ) -> None:
@@ -1593,6 +1595,11 @@ async def test_cancelled_async_stream_setup_does_not_orphan_sdk_request_coroutin
     install_claude_prompt_cache_hook(model)
 
     async def consume_stream() -> list[ModelResponse]:
+        if cancel_before_setup:
+            current_task = asyncio.current_task()
+            assert current_task is not None
+            for _ in range(cancel_count):
+                current_task.cancel()
         return [
             response
             async for response in model.ainvoke_stream(
@@ -1606,8 +1613,9 @@ async def test_cancelled_async_stream_setup_does_not_orphan_sdk_request_coroutin
         warnings.simplefilter("always")
         try:
             assert await asyncio.to_thread(setup_started.wait, 2.0)
-            for _ in range(cancel_count):
-                setup_task.cancel()
+            if not cancel_before_setup:
+                for _ in range(cancel_count):
+                    setup_task.cancel()
             allow_setup.set()
             with pytest.raises(asyncio.CancelledError):
                 await setup_task


### PR DESCRIPTION
## Summary

- construct async Anthropic stream managers in a worker thread
- keep stream entry, iteration, and cleanup on the event loop
- preserve synchronous client behavior
- preserve cancellation before or during setup without orphaning SDK request coroutines
- cover regular and beta paths with heartbeat and real-SDK cancellation tests

## Why

The Anthropic async streaming helper performs synchronous request transformation before returning its async context manager. Large requests can therefore block unrelated async work. This moves only that synchronous construction phase off-loop.

Cancellation is deferred only until setup owns the SDK manager, then restored before public `__aenter__()` so the SDK consumes and cancels its request coroutine without issuing an HTTP request.

## Validation

- `uv run --all-extras pytest tests/test_extra_kwargs.py --cache-clear -x --lf` — 73 passed
- real SDK cancellation matrix covers regular/beta, cancellation before/during setup, and one/two cancellation requests; zero HTTP calls and no unawaited-coroutine warnings
- `uv run --all-extras pre-commit run --files src/mindroom/claude_prompt_cache.py tests/test_extra_kwargs.py` — passed
- `uv run tach check --dependencies --interfaces` — passed
- full non-live suite reached 8,441 passed / 31 skipped before an unrelated xdist console-wrapping assertion stopped the run; that test passed alone
