### PR TITLE
Reset sync continuity once per gap, not every other response

### DIFF
--- a/src/mindroom/matrix/sync_cache_trust.py
+++ b/src/mindroom/matrix/sync_cache_trust.py
@@ -133,7 +133,7 @@ class SyncCacheTrust:
             decision = replace(decision, reset_client_token=True)
         if decision.reset_client_token:
             self._awaiting_initial_window = True
-        elif limited_timeline or decision.state is SyncTrustState.CERTIFIED:
+        elif decision.state is SyncTrustState.CERTIFIED:
             self._awaiting_initial_window = False
         self._apply_decision(decision, cache_result=cache_result)
         return decision

--- a/src/mindroom/matrix/sync_cache_trust.py
+++ b/src/mindroom/matrix/sync_cache_trust.py
@@ -131,11 +131,14 @@ class SyncCacheTrust:
         limited_timeline = bool(cache_result.limited_room_ids)
         if limited_timeline and not self._awaiting_initial_window:
             decision = replace(decision, reset_client_token=True)
+        self._apply_decision(decision, cache_result=cache_result)
+        # Re-arm from applied trust, not from the decision: _apply_decision rejects
+        # certification while a callback failure is outstanding, and a rejected
+        # certification must not license another since-less replay.
         if decision.reset_client_token:
             self._awaiting_initial_window = True
-        elif decision.state is SyncTrustState.CERTIFIED:
+        elif self.state is SyncTrustState.CERTIFIED:
             self._awaiting_initial_window = False
-        self._apply_decision(decision, cache_result=cache_result)
         return decision
 
     def reject_unknown_pos(self) -> SyncCertificationDecision:

--- a/tests/test_sync_cache_trust.py
+++ b/tests/test_sync_cache_trust.py
@@ -189,6 +189,39 @@ def test_sustained_limited_responses_reset_once_until_a_delta_certifies(tmp_path
     assert [decision.reset_client_token for decision in decisions] == [True, False, False, False]
 
 
+def test_callback_rejected_certification_does_not_rearm_the_replay_guard(tmp_path: Path) -> None:
+    """A decision certified but rejected for callback failure must not re-arm the replay."""
+    trust, _cache, runtime = _trust(tmp_path)
+    trust.state = SyncTrustState.CERTIFIED
+
+    first = trust.certify_response(
+        next_batch="s_partial",
+        cache_result=SyncCacheWriteResult(
+            complete=False,
+            limited_room_ids=("!room:localhost",),
+        ),
+        first_sync=False,
+    )
+    runtime.mark_callback_failed()
+    trust.certify_response(
+        next_batch="s_complete",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    final = trust.certify_response(
+        next_batch="s_partial_again",
+        cache_result=SyncCacheWriteResult(
+            complete=False,
+            limited_room_ids=("!room:localhost",),
+        ),
+        first_sync=False,
+    )
+
+    assert first.reset_client_token is True
+    assert trust.state is SyncTrustState.UNCERTAIN
+    assert final.reset_client_token is False
+
+
 @pytest.mark.asyncio
 async def test_cold_limited_initial_window_does_not_reset_again(tmp_path: Path) -> None:
     """A since-less startup window may be limited without replaying itself forever."""

--- a/tests/test_sync_cache_trust.py
+++ b/tests/test_sync_cache_trust.py
@@ -169,6 +169,26 @@ def test_limited_recovery_window_is_consumed_once_then_complete_delta_certifies(
     )
 
 
+def test_sustained_limited_responses_reset_once_until_a_delta_certifies(tmp_path: Path) -> None:
+    """Back-to-back gaps must cost one replay, not one every other response."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.state = SyncTrustState.CERTIFIED
+
+    decisions = [
+        trust.certify_response(
+            next_batch=f"s_partial_{index}",
+            cache_result=SyncCacheWriteResult(
+                complete=False,
+                limited_room_ids=("!room:localhost",),
+            ),
+            first_sync=False,
+        )
+        for index in range(4)
+    ]
+
+    assert [decision.reset_client_token for decision in decisions] == [True, False, False, False]
+
+
 @pytest.mark.asyncio
 async def test_cold_limited_initial_window_does_not_reset_again(tmp_path: Path) -> None:
     """A since-less startup window may be limited without replaying itself forever."""


### PR DESCRIPTION
## Problem

`SyncCacheTrust.certify_response` guards the since-less replay with
`_awaiting_initial_window`, but it cleared that flag on *any* limited timeline
that did not itself request a reset:

```python
if decision.reset_client_token:
    self._awaiting_initial_window = True
elif limited_timeline or decision.state is SyncTrustState.CERTIFIED:
    self._awaiting_initial_window = False
```

Under sustained gaps the guard therefore alternates rather than latching:

| response | limited | reset_client_token | `_awaiting_initial_window` after |
|---|---|---|---|
| 1 | yes | **True** | True |
| 2 | yes | False | **False** ← cleared by `limited_timeline` |
| 3 | yes | **True** | True |
| 4 | yes | False | False |

So a client seeing back-to-back limited timelines replays a since-less sync
roughly every other response.

That is expensive out of proportion to the gap. `reset_client_token` drops the
client position (`next_batch = None`), so the following response is an initial
window in which *every* joined room reports `timeline.limited`. Each of those
rooms then has its cached thread snapshots marked stale by the normal
limited-timeline path. One gap in one room turns into repeated full-room cold
syncs and repeated cache invalidation across every room, and each cold sync is
itself likely to be limited — which feeds the next alternation.

## Fix

Clear the flag only when a delta actually certifies:

```python
elif decision.state is SyncTrustState.CERTIFIED:
```

A gap still forces exactly one since-less replay. No further replay is
requested until a complete delta restores trust, so a run of limited responses
costs one replay instead of one every other response.

This deliberately does not change *when* a token is certified or saved, does
not touch per-room cache invalidation, and does not remove the reset — a real
unrecovered gap still gets its replay.

## Test

`test_sustained_limited_responses_reset_once_until_a_delta_certifies` drives
four consecutive limited responses and asserts the reset pattern.

Before the fix:

```
assert [True, False, True, False] == [True, False, False, False]
E         At index 2 diff: True != False
```

After: passes.

Existing coverage that pins the surrounding behaviour still passes unchanged —
`test_positioned_limited_response_resets_sync_continuity` (first gap still
resets), `test_limited_recovery_window_is_consumed_once_then_complete_delta_certifies`
(no reset loop, certifies on a complete delta), and
`test_cold_limited_initial_window_does_not_reset_again` (cold startup window).

## Verification

`tests/test_sync_cache_trust.py` and `tests/test_sync_certification.py`: 35 passed.

Also ran `test_sync_restart_retry.py`, `test_sync_task_cancellation.py`,
`test_bot_sync_event_cache.py`, `test_event_cache_write_coordination.py`,
`test_thread_repair.py` — all passed.

Not run: the full suite, and `tests/test_matrix_sync_tokens.py`, which fails to
import locally with `ModuleNotFoundError: No module named 'psycopg'` on `main`
as well (missing optional extra in my environment, not related to this change).
Local `pre-commit` `ty` was skipped for the same reason — it reports 24
unresolved imports for optional dependency groups (`livekit`, `playwright`,
`psycopg`, `googleapiclient`, …) on an unmodified tree, none referencing the
files touched here. CI should run both properly.

## Summary by Sourcery

Adjust sync continuity handling so that sustained limited responses trigger only a single since-less replay until a complete delta re-certifies trust.

Bug Fixes:
- Prevent sync continuity from repeatedly resetting on back-to-back limited timelines, avoiding unnecessary repeated since-less replays.

Tests:
- Add a regression test covering sustained limited responses to ensure the reset pattern only occurs once until a certifying delta is received.