### PR TITLE
Reset sync continuity only for gaps Matrix recovery left open

### DIFF
--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -1373,6 +1373,16 @@ class ThreadSyncWritePolicy:
         return tuple(limited_room_ids), ()
 
     @staticmethod
+    def _recovered_sync_timeline_room_ids(response: nio.SyncResponse) -> tuple[str, ...]:
+        """Return limited rooms the Matrix client reports it backfilled."""
+        # Matrix clients without limited-timeline recovery report nothing, and a
+        # gap that cannot be proven closed must be read as still open.
+        reported = getattr(response, "recovered_room_ids", ())
+        if not isinstance(reported, (frozenset, set, tuple, list)):
+            return ()
+        return tuple(room_id for room_id in reported if isinstance(room_id, str))
+
+    @staticmethod
     def _cache_task_errors(results: list[object | BaseException]) -> tuple[BaseException, ...]:
         """Return task outcomes that prevent cache certification."""
         errors: list[BaseException] = []
@@ -1402,10 +1412,12 @@ class ThreadSyncWritePolicy:
                 runtime_available=self._cache_ops.cache_runtime_available(),
                 runtime_diagnostics=self._cache_ops.cache_runtime_diagnostics(),
             )
+        recovered_room_ids = self._recovered_sync_timeline_room_ids(response)
         if not self._cache_ops.cache_runtime_available():
             return SyncCacheWriteResult(
                 complete=False,
                 limited_room_ids=limited_room_ids,
+                recovered_room_ids=recovered_room_ids,
                 runtime_available=False,
                 task_count=0,
                 runtime_diagnostics=self._cache_ops.cache_runtime_diagnostics(),
@@ -1422,6 +1434,7 @@ class ThreadSyncWritePolicy:
             return SyncCacheWriteResult(
                 complete=False,
                 limited_room_ids=limited_room_ids,
+                recovered_room_ids=recovered_room_ids,
                 errors=(exc,),
                 runtime_available=self._cache_ops.cache_runtime_available(),
                 runtime_diagnostics=self._cache_ops.cache_runtime_diagnostics(),
@@ -1437,6 +1450,7 @@ class ThreadSyncWritePolicy:
         return SyncCacheWriteResult(
             complete=complete,
             limited_room_ids=limited_room_ids,
+            recovered_room_ids=recovered_room_ids,
             errors=errors,
             runtime_available=runtime_available,
             task_count=len(tasks),

--- a/src/mindroom/matrix/sync_cache_trust.py
+++ b/src/mindroom/matrix/sync_cache_trust.py
@@ -128,8 +128,11 @@ class SyncCacheTrust:
             cache_result=cache_result,
             first_sync=first_sync,
         )
-        limited_timeline = bool(cache_result.limited_room_ids)
-        if limited_timeline and not self._awaiting_initial_window:
+        # Only a gap the Matrix client could not close costs a replay. A gap it
+        # backfilled has already delivered its events through the timeline
+        # callbacks, so dropping the position would re-read every joined room
+        # to recover nothing.
+        if cache_result.unrecovered_room_ids and not self._awaiting_initial_window:
             decision = replace(decision, reset_client_token=True)
         self._apply_decision(decision, cache_result=cache_result)
         # Re-arm from applied trust, not from the decision: _apply_decision rejects

--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -36,10 +36,24 @@ class SyncCacheWriteResult:
     runtime_available: bool | None = None
     task_count: int | None = None
     runtime_diagnostics: dict[str, object] | None = None
+    # Limited rooms the Matrix client proved it backfilled. Empty by default, so
+    # a client that reports nothing leaves every gap counted as still open.
+    recovered_room_ids: tuple[str, ...] = ()
+
+    @property
+    def unrecovered_room_ids(self) -> tuple[str, ...]:
+        """Return limited rooms whose timeline gap was never proven closed."""
+        recovered = set(self.recovered_room_ids)
+        return tuple(room_id for room_id in self.limited_room_ids if room_id not in recovered)
 
     @property
     def certified(self) -> bool:
-        """Return whether this result proves the sync delta reached durable cache."""
+        """Return whether this result proves the sync delta reached durable cache.
+
+        A backfilled gap still fails certification: the events it recovered
+        reach the cache through timeline callbacks, not through this response,
+        so this write alone does not prove the delta is durable.
+        """
         return self.complete and not self.limited_room_ids and not self.errors
 
 
@@ -121,6 +135,7 @@ def sync_cache_write_diagnostics(cache_result: SyncCacheWriteResult) -> dict[str
         "cache_write_complete": cache_result.complete,
         "cache_write_certified": cache_result.certified,
         "cache_limited_room_count": len(cache_result.limited_room_ids),
+        "cache_unrecovered_room_count": len(cache_result.unrecovered_room_ids),
         "cache_error_count": len(cache_result.errors),
     }
     if cache_result.runtime_available is not None:

--- a/tests/test_bot_sync_event_cache.py
+++ b/tests/test_bot_sync_event_cache.py
@@ -406,6 +406,48 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         )
 
     @pytest.mark.asyncio
+    async def test_recovered_limited_sync_keeps_the_client_position(self, bot: AgentBot) -> None:
+        """A gap the Matrix client backfilled must not drop the position it already holds."""
+        room_id = "!test:localhost"
+        _save_certified_sync_token(bot, "s_before_gap")
+        bot._runtime_view.mark_runtime_started()
+        bot._sync_cache_trust.state = SyncTrustState.CERTIFIED
+        bot.client.next_batch = "s_after_gap"
+        sync_response = self._sync_response(
+            {room_id: MagicMock(timeline=MagicMock(events=[], limited=True))},
+        )
+        sync_response.recovered_room_ids = frozenset({room_id})
+
+        await self._run_sync_response_without_startup_side_effects(bot, sync_response)
+
+        assert bot.client.next_batch == "s_after_gap"
+        # The delta still came through a gap, so it certifies nothing on its own.
+        assert bot._sync_cache_trust.state is SyncTrustState.UNCERTAIN
+        assert _load_sync_token_value(bot.storage_path, bot.agent_name) is None
+        bot.event_cache.mark_room_threads_stale.assert_awaited_once_with(
+            room_id,
+            reason="limited_sync_timeline",
+        )
+
+    @pytest.mark.asyncio
+    async def test_unrecovered_limited_sync_still_drops_the_client_position(self, bot: AgentBot) -> None:
+        """A gap left open must keep costing the since-less replay that guards the cache."""
+        room_id = "!test:localhost"
+        _save_certified_sync_token(bot, "s_before_gap")
+        bot._runtime_view.mark_runtime_started()
+        bot._sync_cache_trust.state = SyncTrustState.CERTIFIED
+        bot.client.next_batch = "s_after_gap"
+        sync_response = self._sync_response(
+            {room_id: MagicMock(timeline=MagicMock(events=[], limited=True))},
+        )
+        sync_response.recovered_room_ids = frozenset()
+
+        await self._run_sync_response_without_startup_side_effects(bot, sync_response)
+
+        assert bot.client.next_batch is None
+        assert bot._sync_cache_trust.state is SyncTrustState.UNCERTAIN
+
+    @pytest.mark.asyncio
     async def test_limited_sync_marks_room_stale_before_admitting_partial_events(self, bot: AgentBot) -> None:
         """The durable room stale marker must land before any partial timeline event is admitted."""
         room_id = "!room:localhost"
@@ -436,6 +478,37 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         )
         call_names = [name for name, _args, _kwargs in event_cache.mock_calls]
         assert call_names.index("mark_room_threads_stale") < call_names.index("store_events_batch")
+
+    @pytest.mark.asyncio
+    async def test_recovered_limited_room_reaches_certification_as_recovered(self, bot: AgentBot) -> None:
+        """A gap the Matrix client closed must be reported as recovered, not merely limited."""
+        room_id = "!room:localhost"
+        event_cache = _runtime_event_cache()
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+        response = self._sync_response({room_id: MagicMock(timeline=MagicMock(events=[], limited=True))})
+        response.recovered_room_ids = frozenset({room_id})
+
+        result = await bot._conversation_cache.cache_sync_timeline_for_certification(response)
+
+        assert result.limited_room_ids == (room_id,)
+        assert result.recovered_room_ids == (room_id,)
+        assert result.unrecovered_room_ids == ()
+
+    @pytest.mark.asyncio
+    async def test_client_that_reports_no_recovery_leaves_the_room_unrecovered(self, bot: AgentBot) -> None:
+        """A client that cannot prove a gap closed must be read as not having closed it."""
+        room_id = "!room:localhost"
+        event_cache = _runtime_event_cache()
+        bot.event_cache = event_cache
+        _install_runtime_write_coordinator(bot)
+
+        result = await bot._conversation_cache.cache_sync_timeline_for_certification(
+            self._sync_response({room_id: MagicMock(timeline=MagicMock(events=[], limited=True))}),
+        )
+
+        assert result.recovered_room_ids == ()
+        assert result.unrecovered_room_ids == (room_id,)
 
     @pytest.mark.asyncio
     async def test_limited_sync_stale_marker_failure_fails_certification_closed(self, bot: AgentBot) -> None:

--- a/tests/test_sync_cache_trust.py
+++ b/tests/test_sync_cache_trust.py
@@ -364,3 +364,63 @@ def test_saved_retry_token_requires_current_generation(
     save_sync_token(tmp_path, "code", "s_saved", cache_generation=saved_generation)
 
     assert trust.retry_token() == expected
+
+
+def test_recovered_limited_response_keeps_the_client_position(tmp_path: Path) -> None:
+    """A gap Matrix recovery closed must not cost a since-less replay."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.state = SyncTrustState.CERTIFIED
+
+    decision = trust.certify_response(
+        next_batch="s_recovered",
+        cache_result=SyncCacheWriteResult(
+            complete=False,
+            limited_room_ids=("!room:localhost",),
+            recovered_room_ids=("!room:localhost",),
+        ),
+        first_sync=False,
+    )
+
+    assert decision.reset_client_token is False
+    # The delta still went through a gap, so it certifies nothing.
+    assert trust.state is SyncTrustState.UNCERTAIN
+    assert load_sync_checkpoint(tmp_path, "code") is None
+
+
+def test_partially_recovered_response_still_resets_sync_continuity(tmp_path: Path) -> None:
+    """One room left unrecovered is enough to distrust the position."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.state = SyncTrustState.CERTIFIED
+
+    decision = trust.certify_response(
+        next_batch="s_partial",
+        cache_result=SyncCacheWriteResult(
+            complete=False,
+            limited_room_ids=("!recovered:localhost", "!open:localhost"),
+            recovered_room_ids=("!recovered:localhost",),
+        ),
+        first_sync=False,
+    )
+
+    assert decision.reset_client_token is True
+
+
+def test_sustained_recovered_gaps_never_replay(tmp_path: Path) -> None:
+    """A run of recovered gaps must cost no replay at all."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.state = SyncTrustState.CERTIFIED
+
+    decisions = [
+        trust.certify_response(
+            next_batch=f"s_recovered_{index}",
+            cache_result=SyncCacheWriteResult(
+                complete=False,
+                limited_room_ids=("!room:localhost",),
+                recovered_room_ids=("!room:localhost",),
+            ),
+            first_sync=False,
+        )
+        for index in range(4)
+    ]
+
+    assert [decision.reset_client_token for decision in decisions] == [False] * 4

--- a/tests/test_sync_certification.py
+++ b/tests/test_sync_certification.py
@@ -103,6 +103,7 @@ def test_sync_cache_write_diagnostics_explains_uncertainty() -> None:
         "cache_write_complete": False,
         "cache_write_certified": False,
         "cache_limited_room_count": 1,
+        "cache_unrecovered_room_count": 1,
         "cache_error_count": 1,
         "cache_runtime_available": False,
         "cache_task_count": 3,
@@ -151,3 +152,16 @@ def test_unknown_pos_clears_saved_and_client_token() -> None:
     assert decision.clear_saved_token is True
     assert decision.reset_client_token is True
     assert decision.reason == "unknown_pos"
+
+
+def test_unrecovered_room_ids_counts_only_proven_recoveries() -> None:
+    """Only a limited room the client proved it backfilled stops counting as open."""
+    result = SyncCacheWriteResult(
+        complete=False,
+        limited_room_ids=("!open:localhost", "!closed:localhost"),
+        recovered_room_ids=("!closed:localhost", "!never-limited:localhost"),
+    )
+
+    assert result.unrecovered_room_ids == ("!open:localhost",)
+    # A backfilled gap is still a gap for certification purposes.
+    assert result.certified is False


### PR DESCRIPTION
## The problem

`SyncCacheTrust.certify_response` asked for a since-less replay on *any* limited timeline:

```python
limited_timeline = bool(cache_result.limited_room_ids)
if limited_timeline and not self._awaiting_initial_window:
    decision = replace(decision, reset_client_token=True)
```

`reset_client_token` sets the Matrix client's `next_batch = None`. The next sync is a cold one, in which every joined room reports a limited timeline, which marks every cached thread in every one of those rooms stale and forces a full history re-scan.

That was a sound guard when a limited timeline meant lost events. It is not sound now that the Matrix client recovers limited timelines: it walks the gap and delivers the missed events through the timeline callbacks. The reset throws that work away and then pays a far larger price than the gap it was guarding against, so recovery as integrated was a net loss.

## The change

Make the reset conditional on the recovery outcome instead of on the raw wire flag. The reset is **not** removed: a gap that was never closed still costs the replay, because that is the guard against trusting a cache with a hole in it.

- `SyncCacheWriteResult` gains `recovered_room_ids`, read off the sync response, and derives `unrecovered_room_ids` as the limited rooms those do not cover.
- `certify_response` resets only when `unrecovered_room_ids` is non-empty.
- `sync_cache_write_diagnostics` reports `cache_unrecovered_room_count` alongside the existing limited-room count.

## Fail-closed at every step

- A Matrix client that reports nothing (an older release, or one with recovery disabled) leaves `recovered_room_ids` empty, so every limited room stays unrecovered and behaviour is byte-for-byte what it is today.
- `_recovered_sync_timeline_room_ids` reads the attribute defensively and rejects anything that is not a set/tuple/list of strings, so a mock or a malformed response degrades to "nothing recovered" rather than to "everything recovered".
- A room is only removed from the unrecovered set by an explicit, positive report naming it. Partial recovery still resets: one open room out of five is enough.
- A gap that is still open on this response counts as unrecovered, not as "probably fine next time".

**This is safe to merge before the client release that populates the field.** Until the dependency is bumped the derived set equals `limited_room_ids` and nothing changes at runtime.

## Deliberately unchanged

- **Certification.** A recovered gap still fails to certify. The events it recovered reach the cache through timeline callbacks, not through this response, so this write does not prove the delta is durable. A recovered gap therefore stays `UNCERTAIN` and saves no checkpoint; it simply no longer restarts the sync stream cold. The next complete delta certifies as before.
- **Thread staleness.** Room threads are still marked stale for every limited room, recovered or not, for the same reason. That invalidation is per-room and bounded to the rooms that were actually limited; the pathology this PR fixes was the *cold sync* turning one limited room into every joined room being limited.

## Tests

- `tests/test_sync_cache_trust.py`: a recovered gap keeps the position and still does not certify; a partially recovered response still resets; a run of recovered gaps never replays.
- `tests/test_bot_sync_event_cache.py`: end to end through `_on_sync_response`, a recovered limited room leaves `client.next_batch` intact while an unrecovered one still clears it; and the write policy reports recovery through to the certification result, including the case where the client reports nothing.
- `tests/test_sync_certification.py`: `unrecovered_room_ids` counts only proven recoveries, and a recovered gap is still uncertified.

Pre-fix, the end-to-end test failed on exactly the symptom this PR is about:

```
>       assert bot.client.next_batch == "s_after_gap"
E       AssertionError: assert None == 's_after_gap'
```

## Sequencing

The field is populated by the Matrix client change in mindroom-ai/mindroom-nio#25. Order: release the client with that change, then bump `mindroom-nio` here. This PR can land in either order without a behaviour change of its own; it only starts doing anything once the pin moves.
