### PR TITLE
Scope Matrix callback failures to their sync batch instead of the process

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -191,12 +191,15 @@ def _create_task_wrapper(
                 # Task was cancelled, this is expected during shutdown
                 pass
             except Exception:
-                if sync_cache_trust is not None:
+                if sync_cache_trust is not None and dispatch is not None:
                     sync_cache_trust.mark_callback_failed(dispatch)
                 elif owner is not None:
                     owner.mark_callback_failed()
                 # Log the exception with full traceback
                 logger.exception("Error in event callback")
+            finally:
+                if sync_cache_trust is not None and dispatch is not None:
+                    sync_cache_trust.mark_callback_finished(dispatch)
 
         # Keep a strong reference via background task registry.
         create_background_task(error_handler(), owner=owner)
@@ -1126,6 +1129,8 @@ class AgentBot:
                 except Exception:
                     self._sync_cache_trust.mark_callback_failed(dispatch)
                     logger.exception("Error in event callback")
+                finally:
+                    self._sync_cache_trust.mark_callback_finished(dispatch)
 
             create_background_task(error_handler(), owner=self._runtime_view)
 
@@ -1188,68 +1193,72 @@ class AgentBot:
         room_member_join_hooks_were_armed = self._room_member_join_hooks_armed
         room_member_join_hook_plan = _RoomMemberJoinSyncHookPlan()
         # Taken before this response can certify, so a side effect that fails
-        # replays the batch it belongs to rather than the one it produced.
+        # replays the batch it belongs to rather than the one it produced. Until
+        # it is released, no replay may be certified as repaired.
         dispatch = self._sync_cache_trust.dispatch_callback()
-        self.last_sync_time = mark_matrix_sync_success(self.agent_name)
-        self._last_sync_monotonic = time.monotonic()
+        try:
+            self.last_sync_time = mark_matrix_sync_success(self.agent_name)
+            self._last_sync_monotonic = time.monotonic()
 
-        if self._sync_shutting_down:
-            return
+            if self._sync_shutting_down:
+                return
 
-        if isinstance(_response, nio.SyncResponse):
-            await self._apply_own_room_membership_from_sync(_response)
-            restored_token_first_sync_response = (
-                first_sync_response and self._sync_cache_trust.state is SyncTrustState.PENDING
-            )
-            try:
-                cache_result = await self._conversation_cache.cache_sync_timeline_for_certification(_response)
-            except asyncio.CancelledError as exc:
-                cache_result = SyncCacheWriteResult(complete=False, errors=(exc,))
-                self._certify_sync_response(
+            if isinstance(_response, nio.SyncResponse):
+                await self._apply_own_room_membership_from_sync(_response)
+                restored_token_first_sync_response = (
+                    first_sync_response and self._sync_cache_trust.state is SyncTrustState.PENDING
+                )
+                try:
+                    cache_result = await self._conversation_cache.cache_sync_timeline_for_certification(_response)
+                except asyncio.CancelledError as exc:
+                    cache_result = SyncCacheWriteResult(complete=False, errors=(exc,))
+                    self._certify_sync_response(
+                        next_batch=_response.next_batch,
+                        cache_result=cache_result,
+                        first_sync=first_sync_response,
+                    )
+                    raise
+                decision = self._certify_sync_response(
                     next_batch=_response.next_batch,
                     cache_result=cache_result,
                     first_sync=first_sync_response,
                 )
-                raise
-            decision = self._certify_sync_response(
-                next_batch=_response.next_batch,
-                cache_result=cache_result,
-                first_sync=first_sync_response,
-            )
-            room_member_join_hook_plan = self._room_member_join_sync_hook_plan(
-                first_sync_response=first_sync_response,
-                restored_token_first_sync_response=restored_token_first_sync_response,
-                hooks_were_armed=room_member_join_hooks_were_armed,
-                decision=decision,
-            )
-        elif isinstance(_response, nio.SlidingSyncResponse):
-            # Sliding sync never certifies the classic checkpoint, but the
-            # account's own kicks and bans still must fence and purge rooms.
-            await self._apply_own_room_membership_from_sliding_sync(_response)
-        self._first_sync_done = True
-        self._room_member_join_hooks_armed = room_member_join_hook_plan.arm_after_response
-
-        try:
-            await self._run_sync_response_side_effects(
-                _response,
-                first_sync_response=first_sync_response,
-                room_member_join_hook_plan=room_member_join_hook_plan,
-            )
-        except asyncio.CancelledError:
-            self._sync_cache_trust.mark_callback_failed(dispatch)
-            raise
-        except Exception:
-            self._sync_cache_trust.mark_callback_failed(dispatch)
-            raise
-        if self._calls_reconcile_pending:
-            self._calls_reconcile_pending = False
-            call_manager = self._call_manager
-            if call_manager is not None:
-                create_background_task(
-                    call_manager.reconcile_joined_rooms(),
-                    name=f"matrix_rtc_reconcile_{self.agent_name}",
-                    owner=self._runtime_view,
+                room_member_join_hook_plan = self._room_member_join_sync_hook_plan(
+                    first_sync_response=first_sync_response,
+                    restored_token_first_sync_response=restored_token_first_sync_response,
+                    hooks_were_armed=room_member_join_hooks_were_armed,
+                    decision=decision,
                 )
+            elif isinstance(_response, nio.SlidingSyncResponse):
+                # Sliding sync never certifies the classic checkpoint, but the
+                # account's own kicks and bans still must fence and purge rooms.
+                await self._apply_own_room_membership_from_sliding_sync(_response)
+            self._first_sync_done = True
+            self._room_member_join_hooks_armed = room_member_join_hook_plan.arm_after_response
+
+            try:
+                await self._run_sync_response_side_effects(
+                    _response,
+                    first_sync_response=first_sync_response,
+                    room_member_join_hook_plan=room_member_join_hook_plan,
+                )
+            except asyncio.CancelledError:
+                self._sync_cache_trust.mark_callback_failed(dispatch)
+                raise
+            except Exception:
+                self._sync_cache_trust.mark_callback_failed(dispatch)
+                raise
+            if self._calls_reconcile_pending:
+                self._calls_reconcile_pending = False
+                call_manager = self._call_manager
+                if call_manager is not None:
+                    create_background_task(
+                        call_manager.reconcile_joined_rooms(),
+                        name=f"matrix_rtc_reconcile_{self.agent_name}",
+                        owner=self._runtime_view,
+                    )
+        finally:
+            self._sync_cache_trust.mark_callback_finished(dispatch)
 
     async def _on_sync_error(self, _response: nio.SyncError) -> None:
         """Update the watchdog clock on sync errors without marking cache state fresh."""

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -168,7 +168,7 @@ def _create_task_wrapper(
     callback: Callable[..., Awaitable[None]],
     *,
     owner: BotRuntimeState | None = None,
-    on_error: Callable[[], None] | None = None,
+    sync_cache_trust: SyncCacheTrust | None = None,
 ) -> Callable[..., Awaitable[None]]:
     """Create a wrapper that runs the callback as a background task.
 
@@ -178,6 +178,11 @@ def _create_task_wrapper(
     """
 
     async def wrapper(*args: object, **kwargs: object) -> None:
+        # Take the dispatch ticket here, while the sync response that carries
+        # this event is still being handed out: the task below may outlive many
+        # later batches, and only this position can replay the one it belongs to.
+        dispatch = sync_cache_trust.dispatch_callback() if sync_cache_trust is not None else None
+
         # Create the task but don't await it - let it run in background
         async def error_handler() -> None:
             try:
@@ -186,8 +191,8 @@ def _create_task_wrapper(
                 # Task was cancelled, this is expected during shutdown
                 pass
             except Exception:
-                if on_error is not None:
-                    on_error()
+                if sync_cache_trust is not None:
+                    sync_cache_trust.mark_callback_failed(dispatch)
                 elif owner is not None:
                     owner.mark_callback_failed()
                 # Log the exception with full traceback
@@ -1076,8 +1081,12 @@ class AgentBot:
             cache_result=cache_result,
             first_sync=first_sync,
         )
-        if decision.reset_client_token and self.client is not None:
+        if self.client is None:
+            return decision
+        if decision.reset_client_token:
             cast("Any", self.client).next_batch = None
+        elif decision.replay_from_token is not None:
+            cast("Any", self.client).next_batch = decision.replay_from_token
         return decision
 
     def seconds_since_last_sync_activity(self) -> float | None:
@@ -1103,6 +1112,7 @@ class AgentBot:
             if not isinstance(event, nio.RoomMemberEvent):
                 return
             hooks_armed_at_delivery = self._first_sync_done and self._room_member_join_hooks_armed
+            dispatch = self._sync_cache_trust.dispatch_callback()
 
             async def error_handler() -> None:
                 try:
@@ -1114,7 +1124,7 @@ class AgentBot:
                 except asyncio.CancelledError:
                     pass
                 except Exception:
-                    self._sync_cache_trust.mark_callback_failed()
+                    self._sync_cache_trust.mark_callback_failed(dispatch)
                     logger.exception("Error in event callback")
 
             create_background_task(error_handler(), owner=self._runtime_view)
@@ -1177,6 +1187,9 @@ class AgentBot:
         first_sync_response = not self._first_sync_done
         room_member_join_hooks_were_armed = self._room_member_join_hooks_armed
         room_member_join_hook_plan = _RoomMemberJoinSyncHookPlan()
+        # Taken before this response can certify, so a side effect that fails
+        # replays the batch it belongs to rather than the one it produced.
+        dispatch = self._sync_cache_trust.dispatch_callback()
         self.last_sync_time = mark_matrix_sync_success(self.agent_name)
         self._last_sync_monotonic = time.monotonic()
 
@@ -1223,10 +1236,10 @@ class AgentBot:
                 room_member_join_hook_plan=room_member_join_hook_plan,
             )
         except asyncio.CancelledError:
-            self._sync_cache_trust.mark_callback_failed()
+            self._sync_cache_trust.mark_callback_failed(dispatch)
             raise
         except Exception:
-            self._sync_cache_trust.mark_callback_failed()
+            self._sync_cache_trust.mark_callback_failed(dispatch)
             raise
         if self._calls_reconcile_pending:
             self._calls_reconcile_pending = False
@@ -1306,7 +1319,6 @@ class AgentBot:
 
     def _register_call_manager_callbacks(self, client: nio.AsyncClient) -> None:
         """Build the optional call manager and wire its Matrix callbacks."""
-        callback_failed = self._sync_cache_trust.mark_callback_failed
         self._call_manager = maybe_build_call_manager(
             agent_name=self.agent_name,
             config=self.config,
@@ -1320,7 +1332,7 @@ class AgentBot:
             _create_task_wrapper(
                 self._on_room_membership_event,
                 owner=self._runtime_view,
-                on_error=callback_failed,
+                sync_cache_trust=self._sync_cache_trust,
             ),
             nio.RoomMemberEvent,
         )
@@ -1330,7 +1342,7 @@ class AgentBot:
             _create_task_wrapper(
                 self._call_manager.on_room_event,
                 owner=self._runtime_view,
-                on_error=callback_failed,
+                sync_cache_trust=self._sync_cache_trust,
             ),
             nio.UnknownEvent,
         )
@@ -1338,7 +1350,7 @@ class AgentBot:
             _create_task_wrapper(  # ty: ignore[invalid-argument-type]  # matrix-nio callback types are too strict here
                 self._call_manager.on_to_device_event,
                 owner=self._runtime_view,
-                on_error=callback_failed,
+                sync_cache_trust=self._sync_cache_trust,
             ),
             AuthenticatedToDeviceEvent,
         )
@@ -1444,16 +1456,23 @@ class AgentBot:
             await asyncio.to_thread(interactive.init_persistence, self.runtime_paths.storage_root)
             client = self.client
             assert client is not None
-            callback_failed = self._sync_cache_trust.mark_callback_failed
 
             # Register event callbacks - wrap them to run as background tasks
             # This ensures the sync loop is never blocked, allowing stop reactions to work
             client.add_event_callback(
-                _create_task_wrapper(self._on_invite, owner=self._runtime_view, on_error=callback_failed),
+                _create_task_wrapper(
+                    self._on_invite,
+                    owner=self._runtime_view,
+                    sync_cache_trust=self._sync_cache_trust,
+                ),
                 nio.InviteEvent,  # ty: ignore[invalid-argument-type]  # InviteEvent doesn't inherit Event
             )
             client.add_event_callback(
-                _create_task_wrapper(self._on_message, owner=self._runtime_view, on_error=callback_failed),
+                _create_task_wrapper(
+                    self._on_message,
+                    owner=self._runtime_view,
+                    sync_cache_trust=self._sync_cache_trust,
+                ),
                 nio.RoomMessageText,
             )
             client.add_event_callback(
@@ -1461,7 +1480,11 @@ class AgentBot:
                 nio.RedactionEvent,
             )
             client.add_event_callback(
-                _create_task_wrapper(self._on_reaction, owner=self._runtime_view, on_error=callback_failed),
+                _create_task_wrapper(
+                    self._on_reaction,
+                    owner=self._runtime_view,
+                    sync_cache_trust=self._sync_cache_trust,
+                ),
                 nio.ReactionEvent,
             )
 
@@ -1469,7 +1492,7 @@ class AgentBot:
             media_callback = _create_task_wrapper(
                 self._on_media_message,
                 owner=self._runtime_view,
-                on_error=callback_failed,
+                sync_cache_trust=self._sync_cache_trust,
             )
             for event_type in MATRIX_MEDIA_EVENT_TYPES:
                 client.add_event_callback(media_callback, event_type)
@@ -1477,7 +1500,7 @@ class AgentBot:
                 _create_task_wrapper(
                     self._on_unknown_event,
                     owner=self._runtime_view,
-                    on_error=callback_failed,
+                    sync_cache_trust=self._sync_cache_trust,
                 ),
                 nio.UnknownEvent,
             )
@@ -1485,7 +1508,7 @@ class AgentBot:
                 _create_task_wrapper(
                     self._on_decryption_failure,
                     owner=self._runtime_view,
-                    on_error=callback_failed,
+                    sync_cache_trust=self._sync_cache_trust,
                 ),
                 nio.MegolmEvent,
             )
@@ -1498,7 +1521,7 @@ class AgentBot:
                 callback_wrapper=lambda callback: _create_task_wrapper(
                     callback,
                     owner=self._runtime_view,
-                    on_error=callback_failed,
+                    sync_cache_trust=self._sync_cache_trust,
                 ),
             )
             await self._set_presence_with_model_info()
@@ -1720,7 +1743,7 @@ class AgentBot:
             owner=self._runtime_view,
             shutdown_intent=shutdown_intent,
         )
-        callback_failure_count = self._runtime_view.callback_failure_count
+        callback_failure_count = self._sync_cache_trust.outstanding_callback_failures
         if (
             background_tasks_completed
             and drain_result.completed

--- a/src/mindroom/matrix/sync_cache_trust.py
+++ b/src/mindroom/matrix/sync_cache_trust.py
@@ -24,6 +24,14 @@ if TYPE_CHECKING:
     from mindroom.bot_runtime_view import BotRuntimeView
 
 
+@dataclass(frozen=True)
+class SyncCallbackDispatch:
+    """One dispatched Matrix callback, bound to the batch that can replay it."""
+
+    sequence: int
+    replay_token: str | None
+
+
 @dataclass
 class SyncCacheTrust:
     """Own one bot's cache-certified sync continuity."""
@@ -35,6 +43,20 @@ class SyncCacheTrust:
     state: SyncTrustState = SyncTrustState.COLD
     checkpoint: SyncCheckpoint | None = None
     _awaiting_initial_window: bool = field(default=False, init=False, repr=False)
+    # The last token whose sync delta reached durable cache. A callback failure
+    # replays from here, because the batch it belongs to came after it.
+    _certified_token: str | None = field(default=None, init=False, repr=False)
+    _dispatch_sequence: int = field(default=0, init=False, repr=False)
+    # Dispatch sequence -> the token its batch must be replayed from.
+    _failed_dispatches: dict[int, str | None] = field(default_factory=dict, init=False, repr=False)
+    # Lifetime failures this trust bound to a batch, to tell them apart from the
+    # ones only the runtime counted.
+    _attributed_failures: int = field(default=0, init=False, repr=False)
+    # Inclusive dispatch-sequence range covered by the replay currently in flight.
+    _replay_window: tuple[int, int] | None = field(default=None, init=False, repr=False)
+    # Positions already rewound to. A position is never retried, so a callback
+    # that fails on every delivery cannot hold the sync loop on one token.
+    _replayed_positions: set[str | None] = field(default_factory=set, init=False, repr=False)
 
     async def prepare_startup(self) -> str | None:
         """Initialize cache trust, then restore a valid checkpoint or start cold."""
@@ -44,7 +66,15 @@ class SyncCacheTrust:
         except Exception as exc:
             self.logger.warning("matrix_principal_event_cache_init_failed", error=str(exc))
 
+        # Startup either proves a checkpoint against the live cache generation or
+        # purges the untrusted rows, so no earlier batch is left unaccounted for.
+        self._failed_dispatches.clear()
+        self._replayed_positions.clear()
+        self._replay_window = None
+        self._attributed_failures = self.runtime.callback_failure_count
+
         loaded = self._load_valid_checkpoint()
+        self._certified_token = loaded.token if loaded is not None else None
         if loaded is None and self.invalidate_for_cache_scope_cleanup():
             try:
                 await cache.purge_principal()
@@ -104,15 +134,42 @@ class SyncCacheTrust:
         self.checkpoint = None
         if self._clear_saved():
             return True
-        self.runtime.mark_callback_failed()
+        self._record_callback_failure(self.dispatch_callback())
         self.runtime.event_cache.disable("sync_checkpoint_clear_failed")
         self.logger.warning("matrix_cache_scope_cleanup_deferred_until_checkpoint_replay")
         return False
 
-    def mark_callback_failed(self) -> None:
-        """Poison sync continuity after a Matrix callback failure."""
-        self.runtime.mark_callback_failed()
+    def dispatch_callback(self) -> SyncCallbackDispatch:
+        """Bind a callback about to run to the checkpoint that replays its batch."""
+        self._dispatch_sequence += 1
+        return SyncCallbackDispatch(sequence=self._dispatch_sequence, replay_token=self._certified_token)
+
+    @property
+    def outstanding_callback_failures(self) -> int:
+        """Return failed callbacks whose sync batch has not been replayed yet.
+
+        Failures reported straight to the runtime carry no sync position, so no
+        replay can ever vouch for them and they keep continuity uncertain for
+        the rest of the process.
+        """
+        unattributed = self.runtime.callback_failure_count - self._attributed_failures
+        return len(self._failed_dispatches) + max(unattributed, 0)
+
+    def mark_callback_failed(self, dispatch: SyncCallbackDispatch | None = None) -> None:
+        """Poison sync continuity until the failed callback's batch is replayed.
+
+        ``dispatch`` must be the ticket taken when the callback was handed the
+        event.  Without it the failure is attributed to the current position,
+        which is only correct for callbacks that cannot outlive their batch.
+        """
+        self._record_callback_failure(dispatch if dispatch is not None else self.dispatch_callback())
         self.invalidate_for_cache_scope_cleanup()
+
+    def _record_callback_failure(self, dispatch: SyncCallbackDispatch) -> None:
+        """Track one failed callback against the batch that has to be re-delivered."""
+        self.runtime.mark_callback_failed()
+        self._attributed_failures += 1
+        self._failed_dispatches[dispatch.sequence] = dispatch.replay_token
 
     def certify_response(
         self,
@@ -132,6 +189,7 @@ class SyncCacheTrust:
         if limited_timeline and not self._awaiting_initial_window:
             decision = replace(decision, reset_client_token=True)
         self._apply_decision(decision, cache_result=cache_result)
+        decision = self._request_callback_replay(decision)
         # Re-arm from applied trust, not from the decision: _apply_decision rejects
         # certification while a callback failure is outstanding, and a rejected
         # certification must not license another since-less replay.
@@ -140,6 +198,44 @@ class SyncCacheTrust:
         elif self.state is SyncTrustState.CERTIFIED:
             self._awaiting_initial_window = False
         return decision
+
+    def _request_callback_replay(self, decision: SyncCertificationDecision) -> SyncCertificationDecision:
+        """Ask the sync loop to re-deliver the batches a failed callback left unfinished."""
+        if not self._failed_dispatches or decision.reset_client_token:
+            return decision
+        sequence = min(self._failed_dispatches)
+        token = self._failed_dispatches[sequence]
+        # Only a token replay proves the batch was re-delivered: the homeserver
+        # either resends the whole delta from it or flags the timeline limited.
+        # A since-less window carries a fresh timeline slice instead, so it says
+        # nothing about a batch that has already scrolled out of it.
+        if token is None or token in self._replayed_positions:
+            # Replaying the same position again would only re-run the callback
+            # that keeps failing, and the sync loop would never move forward.
+            return decision
+        self._replayed_positions.add(token)
+        self._replay_window = (sequence, self._dispatch_sequence)
+        self.logger.warning(
+            "matrix_sync_callback_replay_requested",
+            outstanding_callback_failures=len(self._failed_dispatches),
+        )
+        return replace(decision, replay_from_token=token)
+
+    def _repair_replayed_callback_failures(self, decision: SyncCertificationDecision) -> None:
+        """Forget the failures whose batches this certified replay re-delivered."""
+        window = self._replay_window
+        self._replay_window = None
+        if window is None or decision.state is not SyncTrustState.CERTIFIED:
+            return
+        replayed_from, requested_at = window
+        repaired = [sequence for sequence in self._failed_dispatches if replayed_from <= sequence <= requested_at]
+        for sequence in repaired:
+            del self._failed_dispatches[sequence]
+        self.logger.info(
+            "matrix_sync_callback_replay_certified",
+            repaired_callback_failures=len(repaired),
+            outstanding_callback_failures=len(self._failed_dispatches),
+        )
 
     def reject_unknown_pos(self) -> SyncCertificationDecision:
         """Invalidate a checkpoint rejected by the homeserver."""
@@ -155,7 +251,8 @@ class SyncCacheTrust:
         cache_result: SyncCacheWriteResult | None = None,
     ) -> None:
         """Apply one certifier decision to trust state and durable storage."""
-        callback_failure_count = self.runtime.callback_failure_count
+        self._repair_replayed_callback_failures(decision)
+        callback_failure_count = self.outstanding_callback_failures
         if callback_failure_count:
             self.state = SyncTrustState.UNCERTAIN
             self.checkpoint = None
@@ -172,6 +269,7 @@ class SyncCacheTrust:
         if decision.clear_saved_token:
             self._clear_saved()
         if decision.checkpoint_to_save is not None:
+            self._certified_token = decision.checkpoint_to_save.token
             self.save(decision.checkpoint_to_save)
         if decision.reason is not None:
             diagnostics = sync_cache_write_diagnostics(cache_result) if cache_result is not None else {}

--- a/src/mindroom/matrix/sync_cache_trust.py
+++ b/src/mindroom/matrix/sync_cache_trust.py
@@ -52,8 +52,15 @@ class SyncCacheTrust:
     # Lifetime failures this trust bound to a batch, to tell them apart from the
     # ones only the runtime counted.
     _attributed_failures: int = field(default=0, init=False, repr=False)
+    # Callback tickets handed out and not yet resolved either way.
+    _inflight_dispatches: set[int] = field(default_factory=set, init=False, repr=False)
     # Inclusive dispatch-sequence range covered by the replay currently in flight.
     _replay_window: tuple[int, int] | None = field(default=None, init=False, repr=False)
+    # A replay whose delta is durable, still waiting on the callbacks it dispatched:
+    # (replayed_from, requested_at, replayed_through).
+    _pending_repair: tuple[int, int, int] | None = field(default=None, init=False, repr=False)
+    # Set while cached rows have been dropped, so no old position may be resumed.
+    _scope_invalidated: bool = field(default=False, init=False, repr=False)
     # Positions already rewound to. A position is never retried, so a callback
     # that fails on every delivery cannot hold the sync loop on one token.
     _replayed_positions: set[str | None] = field(default_factory=set, init=False, repr=False)
@@ -70,7 +77,10 @@ class SyncCacheTrust:
         # purges the untrusted rows, so no earlier batch is left unaccounted for.
         self._failed_dispatches.clear()
         self._replayed_positions.clear()
+        self._inflight_dispatches.clear()
         self._replay_window = None
+        self._pending_repair = None
+        self._scope_invalidated = False
         self._attributed_failures = self.runtime.callback_failure_count
 
         loaded = self._load_valid_checkpoint()
@@ -132,6 +142,9 @@ class SyncCacheTrust:
         """Invalidate continuity before principal- or room-owned rows are removed."""
         self.state = SyncTrustState.UNCERTAIN
         self.checkpoint = None
+        # Rows are about to disappear, so no earlier position stays resumable and
+        # a callback failure must not put one back until something recertifies.
+        self._scope_invalidated = True
         if self._clear_saved():
             return True
         self._record_callback_failure(self.dispatch_callback())
@@ -139,10 +152,21 @@ class SyncCacheTrust:
         self.logger.warning("matrix_cache_scope_cleanup_deferred_until_checkpoint_replay")
         return False
 
+    def _replay_floor(self) -> str | None:
+        """Return the newest position the cache is provably complete through."""
+        if self.checkpoint is not None:
+            return self.checkpoint.token
+        return self._certified_token
+
     def dispatch_callback(self) -> SyncCallbackDispatch:
         """Bind a callback about to run to the checkpoint that replays its batch."""
         self._dispatch_sequence += 1
-        return SyncCallbackDispatch(sequence=self._dispatch_sequence, replay_token=self._certified_token)
+        self._inflight_dispatches.add(self._dispatch_sequence)
+        return SyncCallbackDispatch(sequence=self._dispatch_sequence, replay_token=self._replay_floor())
+
+    def mark_callback_finished(self, dispatch: SyncCallbackDispatch) -> None:
+        """Release a callback ticket that ran to completion without poisoning trust."""
+        self._inflight_dispatches.discard(dispatch.sequence)
 
     @property
     def outstanding_callback_failures(self) -> int:
@@ -163,13 +187,36 @@ class SyncCacheTrust:
         which is only correct for callbacks that cannot outlive their batch.
         """
         self._record_callback_failure(dispatch if dispatch is not None else self.dispatch_callback())
-        self.invalidate_for_cache_scope_cleanup()
+        self.state = SyncTrustState.UNCERTAIN
+        self.checkpoint = None
+        self._preserve_replay_floor()
 
     def _record_callback_failure(self, dispatch: SyncCallbackDispatch) -> None:
         """Track one failed callback against the batch that has to be re-delivered."""
         self.runtime.mark_callback_failed()
         self._attributed_failures += 1
+        self._inflight_dispatches.discard(dispatch.sequence)
         self._failed_dispatches[dispatch.sequence] = dispatch.replay_token
+
+    def _preserve_replay_floor(self) -> None:
+        """Hold durable continuity at the position the failed batches replay from.
+
+        Keeping it lets a restart resume there and re-deliver the batch, which
+        is the same repair the in-process replay performs.  A later checkpoint
+        would not cover the failed batch, so it is rewound rather than kept.
+        """
+        unattributed = self.runtime.callback_failure_count - self._attributed_failures
+        floor = None if unattributed > 0 or self._scope_invalidated else self._earliest_failed_floor()
+        if floor is None:
+            self._clear_saved()
+            return
+        self.save(SyncCheckpoint(floor))
+
+    def _earliest_failed_floor(self) -> str | None:
+        """Return the replay position of the oldest failure still outstanding."""
+        if not self._failed_dispatches:
+            return None
+        return self._failed_dispatches[min(self._failed_dispatches)]
 
     def certify_response(
         self,
@@ -201,7 +248,7 @@ class SyncCacheTrust:
 
     def _request_callback_replay(self, decision: SyncCertificationDecision) -> SyncCertificationDecision:
         """Ask the sync loop to re-deliver the batches a failed callback left unfinished."""
-        if not self._failed_dispatches or decision.reset_client_token:
+        if not self._failed_dispatches or decision.reset_client_token or self._pending_repair is not None:
             return decision
         sequence = min(self._failed_dispatches)
         token = self._failed_dispatches[sequence]
@@ -222,12 +269,32 @@ class SyncCacheTrust:
         return replace(decision, replay_from_token=token)
 
     def _repair_replayed_callback_failures(self, decision: SyncCertificationDecision) -> None:
-        """Forget the failures whose batches this certified replay re-delivered."""
+        """Forget the failures whose batches a certified replay re-delivered."""
+        self._resolve_pending_repair()
         window = self._replay_window
         self._replay_window = None
         if window is None or decision.state is not SyncTrustState.CERTIFIED:
             return
-        replayed_from, requested_at = window
+        # The replay's delta is durable, but the callbacks it just handed out
+        # are still running. Their batch is the one being vouched for, so the
+        # repair waits for them instead of trusting the write alone.
+        self._pending_repair = (*window, self._dispatch_sequence)
+        self._resolve_pending_repair()
+
+    def _resolve_pending_repair(self) -> None:
+        """Complete a held repair once the replay's own callbacks have all landed."""
+        if self._pending_repair is None:
+            return
+        replayed_from, requested_at, replayed_through = self._pending_repair
+        replay_batch = range(requested_at + 1, replayed_through + 1)
+        if any(sequence in self._inflight_dispatches for sequence in replay_batch):
+            return
+        self._pending_repair = None
+        if any(sequence in self._failed_dispatches for sequence in replay_batch):
+            # The replay re-delivered the batch and a callback failed again, so
+            # it proves nothing. The newer failure carries its own replay.
+            self.logger.warning("matrix_sync_callback_replay_failed_again")
+            return
         repaired = [sequence for sequence in self._failed_dispatches if replayed_from <= sequence <= requested_at]
         for sequence in repaired:
             del self._failed_dispatches[sequence]
@@ -256,7 +323,7 @@ class SyncCacheTrust:
         if callback_failure_count:
             self.state = SyncTrustState.UNCERTAIN
             self.checkpoint = None
-            self._clear_saved()
+            self._preserve_replay_floor()
             self.logger.warning(
                 "matrix_sync_certification_uncertain",
                 reason="callback_failed",
@@ -270,6 +337,7 @@ class SyncCacheTrust:
             self._clear_saved()
         if decision.checkpoint_to_save is not None:
             self._certified_token = decision.checkpoint_to_save.token
+            self._scope_invalidated = False
             self.save(decision.checkpoint_to_save)
         if decision.reason is not None:
             diagnostics = sync_cache_write_diagnostics(cache_result) if cache_result is not None else {}

--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -52,6 +52,9 @@ class SyncCertificationDecision:
     clear_saved_token: bool = False
     reset_client_token: bool = False
     reason: str | None = None
+    # Rewind the client here to re-deliver the batches a failed callback left
+    # unfinished. ``reset_client_token`` is the since-less form of the same ask.
+    replay_from_token: str | None = None
 
 
 def _uncertain_decision(

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -1110,7 +1110,7 @@ async def test_callback_failure_clears_saved_checkpoint_immediately(tmp_path: Pa
     callback = _create_task_wrapper(
         failing_callback,
         owner=bot._runtime_view,
-        on_error=bot._sync_cache_trust.mark_callback_failed,
+        sync_cache_trust=bot._sync_cache_trust,
     )
     await callback()
     await wait_for_background_tasks(timeout=0.5, owner=bot._runtime_view)

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -1096,8 +1096,8 @@ async def test_callback_failure_prevents_certified_shutdown_checkpoint(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_callback_failure_clears_saved_checkpoint_immediately(tmp_path: Path) -> None:
-    """A failed Matrix callback must clear already-persisted sync continuity."""
+async def test_callback_failure_holds_saved_checkpoint_at_the_replay_floor(tmp_path: Path) -> None:
+    """A failed Matrix callback must hold durable continuity where its batch replays from."""
     bot = _agent_bot(tmp_path)
     save_sync_token(tmp_path, bot.agent_name, "s_before_failure", cache_generation=_CACHE_GENERATION)
     bot._sync_cache_trust.state = SyncTrustState.CERTIFIED
@@ -1118,7 +1118,9 @@ async def test_callback_failure_clears_saved_checkpoint_immediately(tmp_path: Pa
     assert bot._runtime_view.callback_failure_count == 1
     assert bot._sync_cache_trust.state is SyncTrustState.UNCERTAIN
     assert bot._sync_cache_trust.checkpoint is None
-    assert _load_sync_token_value(tmp_path, bot.agent_name) is None
+    # Kept, not cleared: restarting here resumes before the failed batch and
+    # re-delivers it, which is the same repair the in-process replay performs.
+    assert _load_sync_token_value(tmp_path, bot.agent_name) == "s_before_failure"
 
 
 @pytest.mark.asyncio
@@ -1143,7 +1145,7 @@ async def test_room_member_callback_failure_prevents_certified_checkpoint(tmp_pa
     assert bot._runtime_view.callback_failure_count == 1
     assert bot._sync_cache_trust.state is SyncTrustState.UNCERTAIN
     assert bot._sync_cache_trust.checkpoint is None
-    assert _load_sync_token_value(tmp_path, bot.agent_name) is None
+    assert _load_sync_token_value(tmp_path, bot.agent_name) == "s_before_member_failure"
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_cache_trust.py
+++ b/tests/test_sync_cache_trust.py
@@ -110,6 +110,158 @@ def test_callback_failure_blocks_later_certification(tmp_path: Path) -> None:
     assert load_sync_checkpoint(tmp_path, "code") is None
 
 
+def test_callback_failure_clears_once_its_batch_is_replayed(tmp_path: Path) -> None:
+    """Replaying the batch behind a callback failure must restore certification."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_certified",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    trust.mark_callback_failed()
+
+    trust.certify_response(
+        next_batch="s_after_failure",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    replayed = trust.certify_response(
+        next_batch="s_replayed",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    assert replayed.state is SyncTrustState.CERTIFIED
+    assert trust.state is SyncTrustState.CERTIFIED
+    assert load_sync_checkpoint(tmp_path, "code") == SyncCheckpoint(
+        token="s_replayed",  # noqa: S106
+        cache_generation=_GENERATION,
+    )
+
+
+def test_callback_failure_replays_from_the_last_certified_token(tmp_path: Path) -> None:
+    """The rewind must resume from the checkpoint that precedes the failed batch."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_certified",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    trust.mark_callback_failed()
+
+    replay = trust.certify_response(
+        next_batch="s_after_failure",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    assert replay.replay_from_token == "s_certified"  # noqa: S105
+    assert replay.reset_client_token is False
+    assert trust.state is SyncTrustState.UNCERTAIN
+
+
+def test_callback_failure_without_a_certified_token_stays_uncertain(tmp_path: Path) -> None:
+    """With no checkpoint to replay from, the batch cannot be proven re-delivered."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.mark_callback_failed()
+
+    replay = trust.certify_response(
+        next_batch="s_after_failure",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    later = trust.certify_response(
+        next_batch="s_later",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    assert replay.replay_from_token is None
+    assert replay.reset_client_token is False
+    assert later.replay_from_token is None
+    assert trust.state is SyncTrustState.UNCERTAIN
+    assert load_sync_checkpoint(tmp_path, "code") is None
+
+
+def test_runtime_only_callback_failure_still_blocks_certification(tmp_path: Path) -> None:
+    """A failure never bound to a batch has no replay, so trust must stay closed."""
+    trust, _cache, runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_certified",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    runtime.mark_callback_failed()
+
+    decision = trust.certify_response(
+        next_batch="s_after_failure",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    assert decision.replay_from_token is None
+    assert trust.outstanding_callback_failures == 1
+    assert trust.state is SyncTrustState.UNCERTAIN
+
+
+def test_callback_failure_after_the_rewind_is_not_repaired_by_it(tmp_path: Path) -> None:
+    """A replay only covers the batches dispatched before it was requested."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_certified",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    trust.mark_callback_failed()
+    trust.certify_response(
+        next_batch="s_after_failure",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    # Dispatched by the replayed batch itself, so the replay cannot vouch for it.
+    trust.mark_callback_failed(trust.dispatch_callback())
+
+    replayed = trust.certify_response(
+        next_batch="s_replayed",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    assert replayed.state is SyncTrustState.CERTIFIED
+    assert trust.state is SyncTrustState.UNCERTAIN
+    assert trust.outstanding_callback_failures == 1
+    assert load_sync_checkpoint(tmp_path, "code") is None
+
+
+def test_repeated_failure_at_the_same_position_stops_replaying(tmp_path: Path) -> None:
+    """A callback that keeps failing must not livelock the sync loop on one token."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_certified",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    trust.mark_callback_failed(trust.dispatch_callback())
+
+    first = trust.certify_response(
+        next_batch="s_after_failure",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    # The replay re-delivers the event, and the same callback fails again.
+    trust.mark_callback_failed(trust.dispatch_callback())
+    second = trust.certify_response(
+        next_batch="s_after_replay",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    assert first.replay_from_token == "s_certified"  # noqa: S105
+    assert second.replay_from_token is None
+    assert second.reset_client_token is False
+    assert trust.state is SyncTrustState.UNCERTAIN
+
+
 def test_positioned_limited_response_resets_sync_continuity(tmp_path: Path) -> None:
     """A limited response after a position must force one since-less replay."""
     trust, _cache, _runtime = _trust(tmp_path)

--- a/tests/test_sync_cache_trust.py
+++ b/tests/test_sync_cache_trust.py
@@ -110,6 +110,120 @@ def test_callback_failure_blocks_later_certification(tmp_path: Path) -> None:
     assert load_sync_checkpoint(tmp_path, "code") is None
 
 
+def test_callback_failure_keeps_durable_continuity_at_the_replay_floor(tmp_path: Path) -> None:
+    """The checkpoint the failed batch replays from must survive the failure."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_certified",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    trust.mark_callback_failed()
+
+    assert trust.state is SyncTrustState.UNCERTAIN
+    assert trust.checkpoint is None
+    assert load_sync_checkpoint(tmp_path, "code") == SyncCheckpoint(
+        token="s_certified",  # noqa: S106
+        cache_generation=_GENERATION,
+    )
+
+
+def test_callback_failure_rewinds_durable_continuity_behind_its_batch(tmp_path: Path) -> None:
+    """A later checkpoint cannot stand: it does not cover the batch that failed."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_before_batch",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    dispatch = trust.dispatch_callback()
+    trust.certify_response(
+        next_batch="s_after_batch",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    trust.mark_callback_failed(dispatch)
+
+    assert load_sync_checkpoint(tmp_path, "code") == SyncCheckpoint(
+        token="s_before_batch",  # noqa: S106
+        cache_generation=_GENERATION,
+    )
+
+
+def test_scope_cleanup_is_not_undone_by_a_later_callback_failure(tmp_path: Path) -> None:
+    """Rows removed for a departed room make the old position unresumable for good."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_certified",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    trust.invalidate_for_cache_scope_cleanup()
+
+    trust.mark_callback_failed()
+
+    assert load_sync_checkpoint(tmp_path, "code") is None
+
+
+def test_unattributed_failure_clears_durable_continuity(tmp_path: Path) -> None:
+    """A failure with no known batch could sit anywhere, so nothing may be resumed."""
+    trust, _cache, runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_certified",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    runtime.mark_callback_failed()
+
+    trust.certify_response(
+        next_batch="s_after_failure",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    assert load_sync_checkpoint(tmp_path, "code") is None
+
+
+def test_replay_is_not_repaired_until_its_own_callbacks_finish(tmp_path: Path) -> None:
+    """A certified replay proves the write, not the callbacks it dispatched."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    trust.certify_response(
+        next_batch="s_certified",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    trust.mark_callback_failed()
+    trust.certify_response(
+        next_batch="s_after_failure",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    replay_callback = trust.dispatch_callback()
+
+    still_running = trust.certify_response(
+        next_batch="s_replayed",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+    held_state = trust.state
+    held_failures = trust.outstanding_callback_failures
+    trust.mark_callback_finished(replay_callback)
+    finished = trust.certify_response(
+        next_batch="s_after_replay",
+        cache_result=SyncCacheWriteResult(complete=True),
+        first_sync=False,
+    )
+
+    assert still_running.state is SyncTrustState.CERTIFIED
+    assert held_state is SyncTrustState.UNCERTAIN
+    assert held_failures == 1
+    assert finished.state is SyncTrustState.CERTIFIED
+    assert trust.state is SyncTrustState.CERTIFIED
+    assert trust.outstanding_callback_failures == 0
+
+
 def test_callback_failure_clears_once_its_batch_is_replayed(tmp_path: Path) -> None:
     """Replaying the batch behind a callback failure must restore certification."""
     trust, _cache, _runtime = _trust(tmp_path)
@@ -204,8 +318,8 @@ def test_runtime_only_callback_failure_still_blocks_certification(tmp_path: Path
     assert trust.state is SyncTrustState.UNCERTAIN
 
 
-def test_callback_failure_after_the_rewind_is_not_repaired_by_it(tmp_path: Path) -> None:
-    """A replay only covers the batches dispatched before it was requested."""
+def test_callback_failure_during_the_replay_repairs_nothing(tmp_path: Path) -> None:
+    """A replay whose own callback fails proves nothing, not even for the older batch."""
     trust, _cache, _runtime = _trust(tmp_path)
     trust.certify_response(
         next_batch="s_certified",
@@ -229,8 +343,11 @@ def test_callback_failure_after_the_rewind_is_not_repaired_by_it(tmp_path: Path)
 
     assert replayed.state is SyncTrustState.CERTIFIED
     assert trust.state is SyncTrustState.UNCERTAIN
-    assert trust.outstanding_callback_failures == 1
-    assert load_sync_checkpoint(tmp_path, "code") is None
+    assert trust.outstanding_callback_failures == 2
+    assert load_sync_checkpoint(tmp_path, "code") == SyncCheckpoint(
+        token="s_certified",  # noqa: S106
+        cache_generation=_GENERATION,
+    )
 
 
 def test_repeated_failure_at_the_same_position_stops_replaying(tmp_path: Path) -> None:

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1125,6 +1125,7 @@ async def test_full_state_only_after_successful_first_sync() -> None:
     bot.rooms = []
     bot.client = FakeClient()
     bot.orchestrator = None
+    bot._sync_cache_trust = MagicMock()
     bot._runtime_view = BotRuntimeState(
         client=bot.client,
         config=MagicMock(spec=Config),
@@ -1263,6 +1264,7 @@ async def test_sliding_sync_response_marks_sync_success() -> None:
     bot._calls_reconcile_pending = False
     bot._room_member_join_hooks_armed = False
     bot.orchestrator = None
+    bot._sync_cache_trust = MagicMock()
 
     await AgentBot._on_sync_response(bot, nio.SlidingSyncResponse("pos"))
 


### PR DESCRIPTION
## The bug

`BotRuntimeState.callback_failure_count` is incremented by `mark_callback_failed()` and **never reset anywhere**. `SyncCacheTrust._apply_decision` short-circuits on it:

```python
callback_failure_count = self.runtime.callback_failure_count
if callback_failure_count:
    self.state = SyncTrustState.UNCERTAIN
    self.checkpoint = None
    self._clear_saved()
    self.logger.warning("matrix_sync_certification_uncertain", reason="callback_failed", ...)
    return
```

A single Matrix callback exception therefore makes **every later sync response uncertain for the rest of the process**. The durable checkpoint is cleared on every sync, the event cache is never trusted again, and each restart pays for a cold sync. Only a restart clears it, and `_on_sync_response` counts `asyncio.CancelledError` as a callback failure, so a watchdog cancellation is enough to trip it.

## Why the counter cannot simply be reset

The counter guards something real. If a callback failed for sync N, the effects of N may never have reached the durable cache, and a later sync N+1's token does **not** cover those events. Resetting on the next successful sync would silently certify a cache with a hole in it.

## The design

A callback failure belongs to one sync batch, and the only thing that clears it is a proven replay of that batch.

**1. Bind the failure to a batch.** `SyncCacheTrust.dispatch_callback()` hands out a `SyncCallbackDispatch` ticket carrying the position the cache is provably complete through. The ticket is taken **synchronously, at dispatch**, because a callback runs as a background task and can outlive many later batches. nio runs event callbacks before the response callback for the same response, so the ticket holds the position *preceding* the batch being delivered. `mark_callback_failed(dispatch)` records the failure against that position.

**2. Keep the checkpoint that batch replays from.** A failure no longer deletes durable continuity. The last certified checkpoint is exactly what the replay rewinds to, so resuming there after a restart re-delivers the failed batch — the same repair. If a newer checkpoint was already saved, it is rewound to the failed batch's floor, since a later token does not cover that batch. This is what turns "every restart is cold" back into a warm resume.

**3. Replay once.** Certification asks the client to rewind to that token (`SyncCertificationDecision.replay_from_token`, applied in `_certify_sync_response`). A position is never replayed twice, so a callback that fails on every delivery cannot hold the sync loop on one token.

**4. Clear only when the replay's write *and* its callbacks both succeed.** Certifying the replay response proves the delta was persisted, but the callbacks that response just handed out are still running — and their batch is the one being vouched for. Tickets are tracked until they resolve, and the repair is held until every ticket the replay dispatched has landed. If one of them fails, the replay proves nothing and repairs neither batch.

Continuity is still cleared outright, and stays uncertain for the process, whenever nothing is provable:

| Case | Why no replay proves it |
| --- | --- |
| Reported straight to the runtime (`owner.mark_callback_failed()`) | carries no sync position |
| No certified checkpoint to rewind to | a since-less window carries a fresh timeline slice, not the missing batch |
| Cached rows dropped for a departed room | no earlier position stays resumable |
| Position already replayed once | otherwise a permanently failing callback livelocks the sync loop |

`callback_failure_count` stays on the runtime as a lifetime diagnostic but no longer gates anything. The shutdown checkpoint flush consults `SyncCacheTrust.outstanding_callback_failures`, which counts unrepaired failures and still includes runtime-only ones.

Re-delivery is safe: `turn_store.is_handled(event_id)` already dedupes replayed events, and the codebase already replays via `reset_client_token` for limited timelines and `M_UNKNOWN_POS`.

## Deliberate behavior changes

Two existing tests asserted that a callback failure **clears** the saved checkpoint. Under point 2 it is now held at the replay floor instead, so they were updated (`test_callback_failure_holds_saved_checkpoint_at_the_replay_floor`, `test_room_member_callback_failure_prevents_certified_checkpoint`). This is the intended change: clearing was what made every restart cold.

## Tests

Written test-first; each failed before its change.

- `test_callback_failure_clears_once_its_batch_is_replayed` — the latch itself. Before: `AssertionError: assert <SyncTrustState.UNCERTAIN: 'uncertain'> is <SyncTrustState.CERTIFIED: 'certified'>`
- `test_callback_failure_keeps_durable_continuity_at_the_replay_floor` — before: `assert None == SyncCheckpoint(token='s_certified', ...)`
- `test_callback_failure_rewinds_durable_continuity_behind_its_batch` — before: `assert None == SyncCheckpoint(token='s_before_batch', ...)`
- `test_replay_is_not_repaired_until_its_own_callbacks_finish`
- `test_scope_cleanup_is_not_undone_by_a_later_callback_failure` — before: `assert SyncCheckpoint(token='s_certified', ...) is None`
- `test_callback_failure_during_the_replay_repairs_nothing`
- `test_callback_failure_replays_from_the_last_certified_token`
- `test_callback_failure_without_a_certified_token_stays_uncertain`
- `test_unattributed_failure_clears_durable_continuity`
- `test_repeated_failure_at_the_same_position_stops_replaying`

Full suite green. `+227/-26` production lines (ignoring the `_on_sync_response` reindentation for its `try/finally`), `+278` test lines.

## For a reviewer

The general "certify while callbacks are still in flight" race is **not** fixed here, only closed for the replay. Every ordinary batch still certifies at response time while its background callbacks run; if one fails afterwards, the next response rewinds continuity. Closing that generally needs an atomic durable fence (append raw events, mark projections dirty, commit, then certify), which is a separate change.