### PR TITLE
Make threaded cache mutations atomic and bound speculative repair fan-out

### DIFF
--- a/scripts/testing/benchmark_thread_history_reuse.py
+++ b/scripts/testing/benchmark_thread_history_reuse.py
@@ -24,7 +24,7 @@ from typing import Any
 from unittest.mock import AsyncMock
 
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
-from mindroom.matrix.cache.thread_cache_state import ThreadCacheReplaceOutcome
+from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome, ThreadCacheReplaceOutcome
 from mindroom.matrix.client_thread_history import _load_cached_thread_history_if_usable
 from mindroom.matrix.thread_resolution_reuse import ThreadResolutionReuseCache
 
@@ -185,8 +185,13 @@ async def run_benchmark(*, visible_messages: int, edits_per_agent_message: int, 
                 appended = _appended_user_message(last_timestamp, turn)
                 last_timestamp = int(appended["origin_server_ts"])
                 await event_cache.mark_thread_stale(ROOM, THREAD, reason="live_thread_mutation")
-                assert await event_cache.append_event(ROOM, THREAD, appended)
-                assert await event_cache.revalidate_thread_after_incremental_update(ROOM, THREAD)
+                append_outcome = await event_cache.apply_thread_mutation_append(
+                    ROOM,
+                    THREAD,
+                    appended,
+                    append_failed_reason="live_append_failed",
+                )
+                assert append_outcome is ThreadAppendOutcome.APPENDED
                 elapsed_ms, visible, kind = await _timed_resolve(event_cache, reuse=reuse)
                 incremental_timings.append(elapsed_ms)
             _report(

--- a/scripts/testing/fuzz_matrix_event_cache.py
+++ b/scripts/testing/fuzz_matrix_event_cache.py
@@ -662,9 +662,14 @@ class CacheFuzzRunner:
             reason=reason,
         )
         if operation.variant % 2:
-            await self.cache.revalidate_thread_after_incremental_update(
+            # Trust is now only ever restored as part of an append, in the same transaction.
+            source = threaded_message_source(operation)
+            self._remember_source(source)
+            await self.cache.apply_thread_mutation_append(
                 current_room_id,
                 current_thread_id,
+                source,
+                append_failed_reason="sync_append_failed",
             )
 
     async def _apply_room_stale_marker(self, operation: FuzzOperation) -> None:

--- a/src/mindroom/matrix/cache/__init__.py
+++ b/src/mindroom/matrix/cache/__init__.py
@@ -34,7 +34,7 @@ from .agent_message_snapshot import AgentMessageSnapshot
 from .event_cache import ConversationEventCache, SharedConversationEventCache, ThreadCacheState, ThreadRevision
 from .event_normalization import is_opaque_encrypted_event_source, normalize_nio_event_for_cache
 from .thread_cache_helpers import thread_cache_rejection_reason
-from .thread_cache_state import ThreadCacheReplaceOutcome
+from .thread_cache_state import ThreadAppendOutcome, ThreadCacheReplaceOutcome
 from .thread_history_result import ThreadHistoryResult, thread_history_result
 from .write_coordinator import EventCacheWriteCoordinator
 
@@ -43,6 +43,7 @@ __all__ = [
     "ConversationEventCache",
     "EventCacheWriteCoordinator",
     "SharedConversationEventCache",
+    "ThreadAppendOutcome",
     "ThreadCacheReplaceOutcome",
     "ThreadCacheState",
     "ThreadHistoryResult",

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -207,9 +207,6 @@ class ConversationEventCache(Protocol):
     async def mark_room_threads_stale(self, room_id: str, *, reason: str) -> None:
         """Persist a durable invalidate-and-refetch marker for every cached thread in one room."""
 
-    async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
-        """Append one event when the thread already has cached data."""
-
     async def apply_thread_mutation_append(
         self,
         room_id: str,
@@ -219,13 +216,6 @@ class ConversationEventCache(Protocol):
         append_failed_reason: str,
     ) -> ThreadAppendOutcome:
         """Append one threaded mutation and settle this thread's trust in one transaction."""
-
-    async def revalidate_thread_after_incremental_update(
-        self,
-        room_id: str,
-        thread_id: str,
-    ) -> bool:
-        """Refresh thread validation after a safe incremental update."""
 
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Return the cached thread ID for one event."""

--- a/src/mindroom/matrix/cache/event_cache.py
+++ b/src/mindroom/matrix/cache/event_cache.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from collections.abc import Collection
 
     from .agent_message_snapshot import AgentMessageSnapshot
-    from .thread_cache_state import ThreadCacheReplaceOutcome
+    from .thread_cache_state import ThreadAppendOutcome, ThreadCacheReplaceOutcome
 
 
 @dataclass(frozen=True, slots=True)
@@ -209,6 +209,16 @@ class ConversationEventCache(Protocol):
 
     async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
         """Append one event when the thread already has cached data."""
+
+    async def apply_thread_mutation_append(
+        self,
+        room_id: str,
+        thread_id: str,
+        event: dict[str, Any],
+        *,
+        append_failed_reason: str,
+    ) -> ThreadAppendOutcome:
+        """Append one threaded mutation and settle this thread's trust in one transaction."""
 
     async def revalidate_thread_after_incremental_update(
         self,

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -24,6 +24,7 @@ from .postgres_redaction import redact_postgres_connection_info
 from .thread_cache_state import (
     THREAD_HISTORY_TRUST_METADATA_KEY,
     THREAD_HISTORY_TRUST_VERSION,
+    ThreadAppendOutcome,
     ThreadCacheReplaceOutcome,
     incoming_thread_invalidation_takes_precedence,
     replacement_validated_at,
@@ -1646,6 +1647,31 @@ class PostgresEventCache:
                 ),
             ),
         )
+
+    async def apply_thread_mutation_append(
+        self,
+        room_id: str,
+        thread_id: str,
+        event: dict[str, Any],
+        *,
+        append_failed_reason: str,
+    ) -> ThreadAppendOutcome:
+        """Append one threaded mutation and settle this thread's trust atomically."""
+        normalized_event = normalize_event_source_for_cache(event)
+        result = await self._operation(
+            room_id,
+            operation="apply_thread_mutation_append",
+            disabled_result=ThreadAppendOutcome.WRITES_UNAVAILABLE,
+            callback=lambda db: postgres_event_cache_threads.apply_thread_mutation_append_locked(
+                db,
+                namespace=self._runtime.namespace,
+                room_id=room_id,
+                thread_id=thread_id,
+                normalized_event=normalized_event,
+                append_failed_reason=append_failed_reason,
+            ),
+        )
+        return ThreadAppendOutcome(result)
 
     async def revalidate_thread_after_incremental_update(
         self,

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -1630,24 +1630,6 @@ class PostgresEventCache:
             )
             raise
 
-    async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
-        """Append one event when the thread already has cached data."""
-        normalized_event = normalize_event_source_for_cache(event)
-        return bool(
-            await self._operation(
-                room_id,
-                operation="append_event",
-                disabled_result=False,
-                callback=lambda db: postgres_event_cache_threads.append_existing_thread_event(
-                    db,
-                    namespace=self._runtime.namespace,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    normalized_event=normalized_event,
-                ),
-            ),
-        )
-
     async def apply_thread_mutation_append(
         self,
         room_id: str,
@@ -1658,7 +1640,7 @@ class PostgresEventCache:
     ) -> ThreadAppendOutcome:
         """Append one threaded mutation and settle this thread's trust atomically."""
         normalized_event = normalize_event_source_for_cache(event)
-        result = await self._operation(
+        return await self._operation(
             room_id,
             operation="apply_thread_mutation_append",
             disabled_result=ThreadAppendOutcome.WRITES_UNAVAILABLE,
@@ -1669,27 +1651,6 @@ class PostgresEventCache:
                 thread_id=thread_id,
                 normalized_event=normalized_event,
                 append_failed_reason=append_failed_reason,
-            ),
-        )
-        return ThreadAppendOutcome(result)
-
-    async def revalidate_thread_after_incremental_update(
-        self,
-        room_id: str,
-        thread_id: str,
-    ) -> bool:
-        """Refresh one thread's validated timestamp after a safe incremental update."""
-        return bool(
-            await self._operation(
-                room_id,
-                operation="revalidate_thread_after_incremental_update",
-                disabled_result=False,
-                callback=lambda db: postgres_event_cache_threads.revalidate_thread_after_incremental_update_locked(
-                    db,
-                    namespace=self._runtime.namespace,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                ),
             ),
         )
 

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -22,8 +22,10 @@ from .postgres_event_cache_events import (
     write_lookup_index_rows,
 )
 from .thread_cache_state import (
+    ThreadAppendOutcome,
     ThreadCacheReplaceOutcome,
     ThreadCacheStateRow,
+    append_keeps_thread_valid,
     can_revalidate_after_incremental_update,
     guarded_thread_replacement_conflict,
     incremental_thread_revalidation_reasons,
@@ -615,6 +617,115 @@ async def revalidate_thread_after_incremental_update_locked(
         (time.time(), namespace, room_id, thread_id),
     )
     return True
+
+
+async def _thread_has_appendable_snapshot_rows(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+) -> bool:
+    """Return whether this thread has snapshot rows an incremental append can extend.
+
+    Mirrors the join ``append_existing_thread_event`` performs, so it predicts that call exactly.
+    """
+    row = await fetchone(
+        db,
+        """
+        SELECT 1
+        FROM mindroom_event_cache_thread_events AS membership
+        JOIN mindroom_event_cache_events AS events
+            ON events.namespace = membership.namespace
+            AND events.event_id = membership.event_id
+            AND events.room_id = membership.room_id
+        WHERE membership.namespace = %s
+            AND membership.room_id = %s
+            AND membership.thread_id = %s
+        LIMIT 1
+        """,
+        (namespace, room_id, thread_id),
+    )
+    return row is not None
+
+
+async def apply_thread_mutation_append_locked(
+    db: AsyncConnection,
+    *,
+    namespace: str,
+    room_id: str,
+    thread_id: str,
+    normalized_event: dict[str, Any],
+    append_failed_reason: str,
+) -> ThreadAppendOutcome:
+    """Append one threaded mutation and settle this thread's trust in the same transaction.
+
+    The caller used to mark the thread stale, append, and revalidate as three separate operations,
+    each taking the write lock on its own. A reader between the first and last saw a thread that was
+    about to be perfectly appendable reported as invalid, and rejected it. Holding all three steps in
+    one transaction means a reader observes either the state before the mutation or the state after
+    it, and a crash rolls the whole thing back rather than leaving a half-applied snapshot trusted.
+    """
+    state_row = await _load_thread_cache_state_row(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    if not await _thread_has_appendable_snapshot_rows(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+    ):
+        # There is no snapshot to extend, so only a full history scan can make this thread readable.
+        # The lookup-index rows are still worth recording for later thread resolution.
+        await write_lookup_index_rows(
+            db,
+            namespace=namespace,
+            room_id=room_id,
+            serialized_events=[serialize_cached_event(event_id_for_cache(normalized_event), normalized_event)],
+            cached_at=time.time(),
+            thread_id=thread_id,
+        )
+        await mark_thread_stale_locked(
+            db,
+            namespace=namespace,
+            room_id=room_id,
+            thread_id=thread_id,
+            reason=append_failed_reason,
+        )
+        return ThreadAppendOutcome.SNAPSHOT_MISSING
+
+    appended = await append_existing_thread_event(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+        normalized_event=normalized_event,
+    )
+    if not appended:
+        await mark_thread_stale_locked(
+            db,
+            namespace=namespace,
+            room_id=room_id,
+            thread_id=thread_id,
+            reason=append_failed_reason,
+        )
+        return ThreadAppendOutcome.APPEND_REFUSED
+
+    if not append_keeps_thread_valid(state_row):
+        return ThreadAppendOutcome.APPENDED_STALE
+
+    await db.execute(
+        """
+        UPDATE mindroom_event_cache_thread_state
+        SET validated_at = %s, invalidated_at = NULL, invalidation_reason = NULL
+        WHERE namespace = %s AND room_id = %s AND thread_id = %s
+        """,
+        (time.time(), namespace, room_id, thread_id),
+    )
+    return ThreadAppendOutcome.APPENDED
 
 
 async def mark_room_stale_locked(

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -602,11 +602,7 @@ async def apply_thread_mutation_append_locked(
 ) -> ThreadAppendOutcome:
     """Append one threaded mutation and settle this thread's trust in the same transaction.
 
-    The caller used to mark the thread stale, append, and revalidate as three separate operations,
-    each taking the write lock on its own. A reader between the first and last saw a thread that was
-    about to be perfectly appendable reported as invalid, and rejected it. Holding all three steps in
-    one transaction means a reader observes either the state before the mutation or the state after
-    it, and a crash rolls the whole thing back rather than leaving a half-applied snapshot trusted.
+    See invariant 5 in the module docstring of ``sqlite_event_cache_threads`` for why it is one.
     """
     outcome = await _append_existing_thread_event(
         db,

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -26,7 +26,6 @@ from .thread_cache_state import (
     ThreadCacheReplaceOutcome,
     ThreadCacheStateRow,
     append_keeps_thread_valid,
-    can_revalidate_after_incremental_update,
     guarded_thread_replacement_conflict,
     incremental_thread_revalidation_reasons,
     is_incremental_thread_revalidation_reason,
@@ -592,63 +591,6 @@ async def mark_thread_stale_locked(
     )
 
 
-async def revalidate_thread_after_incremental_update_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-) -> bool:
-    """Mark one thread cache fresh after a safe incremental update."""
-    row = await _load_thread_cache_state_row(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-    )
-    if not can_revalidate_after_incremental_update(row):
-        return False
-    await db.execute(
-        """
-        UPDATE mindroom_event_cache_thread_state
-        SET validated_at = %s, invalidated_at = NULL, invalidation_reason = NULL
-        WHERE namespace = %s AND room_id = %s AND thread_id = %s
-        """,
-        (time.time(), namespace, room_id, thread_id),
-    )
-    return True
-
-
-async def _thread_has_appendable_snapshot_rows(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-) -> bool:
-    """Return whether this thread has snapshot rows an incremental append can extend.
-
-    Mirrors the join ``append_existing_thread_event`` performs, so it predicts that call exactly.
-    """
-    row = await fetchone(
-        db,
-        """
-        SELECT 1
-        FROM mindroom_event_cache_thread_events AS membership
-        JOIN mindroom_event_cache_events AS events
-            ON events.namespace = membership.namespace
-            AND events.event_id = membership.event_id
-            AND events.room_id = membership.room_id
-        WHERE membership.namespace = %s
-            AND membership.room_id = %s
-            AND membership.thread_id = %s
-        LIMIT 1
-        """,
-        (namespace, room_id, thread_id),
-    )
-    return row is not None
-
-
 async def apply_thread_mutation_append_locked(
     db: AsyncConnection,
     *,
@@ -666,45 +608,14 @@ async def apply_thread_mutation_append_locked(
     one transaction means a reader observes either the state before the mutation or the state after
     it, and a crash rolls the whole thing back rather than leaving a half-applied snapshot trusted.
     """
-    state_row = await _load_thread_cache_state_row(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-    )
-    if not await _thread_has_appendable_snapshot_rows(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-    ):
-        # There is no snapshot to extend, so only a full history scan can make this thread readable.
-        # The lookup-index rows are still worth recording for later thread resolution.
-        await write_lookup_index_rows(
-            db,
-            namespace=namespace,
-            room_id=room_id,
-            serialized_events=[serialize_cached_event(event_id_for_cache(normalized_event), normalized_event)],
-            cached_at=time.time(),
-            thread_id=thread_id,
-        )
-        await mark_thread_stale_locked(
-            db,
-            namespace=namespace,
-            room_id=room_id,
-            thread_id=thread_id,
-            reason=append_failed_reason,
-        )
-        return ThreadAppendOutcome.SNAPSHOT_MISSING
-
-    appended = await append_existing_thread_event(
+    outcome = await _append_existing_thread_event(
         db,
         namespace=namespace,
         room_id=room_id,
         thread_id=thread_id,
         normalized_event=normalized_event,
     )
-    if not appended:
+    if outcome is not ThreadAppendOutcome.APPENDED:
         await mark_thread_stale_locked(
             db,
             namespace=namespace,
@@ -712,8 +623,15 @@ async def apply_thread_mutation_append_locked(
             thread_id=thread_id,
             reason=append_failed_reason,
         )
-        return ThreadAppendOutcome.APPEND_REFUSED
+        return outcome
 
+    # Read after the append: it touches no trust column, and the failure paths above never need it.
+    state_row = await _load_thread_cache_state_row(
+        db,
+        namespace=namespace,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
     if not append_keeps_thread_valid(state_row):
         return ThreadAppendOutcome.APPENDED_STALE
 
@@ -760,17 +678,19 @@ async def mark_room_stale_locked(
     )
 
 
-async def append_existing_thread_event(
+async def _append_existing_thread_event(
     db: AsyncConnection,
     *,
     namespace: str,
     room_id: str,
     thread_id: str,
     normalized_event: dict[str, Any],
-) -> bool:
-    """Append one event to an existing cached thread.
+) -> ThreadAppendOutcome:
+    """Append one event to an existing cached thread and classify what happened.
 
     An opaque ``m.room.encrypted`` payload never replaces stored clear content for the same event ID.
+    A redacted event (or one whose edit target is redacted) is refused before anything is written, so
+    its payload never reaches the point-lookup table.
     """
     event_id = event_id_for_cache(normalized_event)
     if await event_or_original_is_redacted(
@@ -780,7 +700,7 @@ async def append_existing_thread_event(
         event_id=event_id,
         event=normalized_event,
     ):
-        return False
+        return ThreadAppendOutcome.APPEND_REFUSED
 
     serialized_event = serialize_cached_event(event_id, normalized_event)
     row = await fetchone(
@@ -808,26 +728,29 @@ async def append_existing_thread_event(
         cached_at=time.time(),
         thread_id=thread_id,
     )
-    if thread_exists:
-        await db.execute(
-            """
-            INSERT INTO mindroom_event_cache_thread_events(namespace, room_id, thread_id, event_id, origin_server_ts)
-            VALUES (%s, %s, %s, %s, %s)
-            ON CONFLICT(namespace, room_id, event_id) DO UPDATE SET
-                thread_id = excluded.thread_id,
-                origin_server_ts = excluded.origin_server_ts,
-                event_json = NULL,
-                write_seq = nextval('mindroom_event_cache_write_seq')
-            """,
-            (
-                namespace,
-                room_id,
-                thread_id,
-                serialized_event.event_id,
-                serialized_event.origin_server_ts,
-            ),
-        )
-    return thread_exists
+    if not thread_exists:
+        # Only lookup-index rows are recorded: there is no snapshot to extend, so only a full
+        # history scan can make this thread readable again.
+        return ThreadAppendOutcome.SNAPSHOT_MISSING
+    await db.execute(
+        """
+        INSERT INTO mindroom_event_cache_thread_events(namespace, room_id, thread_id, event_id, origin_server_ts)
+        VALUES (%s, %s, %s, %s, %s)
+        ON CONFLICT(namespace, room_id, event_id) DO UPDATE SET
+            thread_id = excluded.thread_id,
+            origin_server_ts = excluded.origin_server_ts,
+            event_json = NULL,
+            write_seq = nextval('mindroom_event_cache_write_seq')
+        """,
+        (
+            namespace,
+            room_id,
+            thread_id,
+            serialized_event.event_id,
+            serialized_event.origin_server_ts,
+        ),
+    )
+    return ThreadAppendOutcome.APPENDED
 
 
 async def _upsert_thread_cache_state(

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -1226,24 +1226,6 @@ class SqliteEventCache:
             msg = "SQLite event cache unavailable while marking room stale"
             raise EventCacheBackendUnavailableError(msg) from exc
 
-    async def append_event(self, room_id: str, thread_id: str, event: dict[str, Any]) -> bool:
-        """Append one event when the thread already has cached data."""
-        normalized_event = normalize_event_source_for_cache(event)
-        return bool(
-            await self._write_operation(
-                room_id,
-                operation="append_event",
-                disabled_result=False,
-                writer=lambda db: sqlite_event_cache_threads.append_existing_thread_event(
-                    db,
-                    principal_id=self.principal_id,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                    normalized_event=normalized_event,
-                ),
-            ),
-        )
-
     async def apply_thread_mutation_append(
         self,
         room_id: str,
@@ -1254,7 +1236,7 @@ class SqliteEventCache:
     ) -> ThreadAppendOutcome:
         """Append one threaded mutation and settle this thread's trust atomically."""
         normalized_event = normalize_event_source_for_cache(event)
-        result = await self._write_operation(
+        return await self._write_operation(
             room_id,
             operation="apply_thread_mutation_append",
             disabled_result=ThreadAppendOutcome.WRITES_UNAVAILABLE,
@@ -1265,27 +1247,6 @@ class SqliteEventCache:
                 thread_id=thread_id,
                 normalized_event=normalized_event,
                 append_failed_reason=append_failed_reason,
-            ),
-        )
-        return ThreadAppendOutcome(result)
-
-    async def revalidate_thread_after_incremental_update(
-        self,
-        room_id: str,
-        thread_id: str,
-    ) -> bool:
-        """Refresh one thread's validated timestamp after a safe incremental update."""
-        return bool(
-            await self._write_operation(
-                room_id,
-                operation="revalidate_thread_after_incremental_update",
-                disabled_result=False,
-                writer=lambda db: sqlite_event_cache_threads.revalidate_thread_after_incremental_update_locked(
-                    db,
-                    principal_id=self.principal_id,
-                    room_id=room_id,
-                    thread_id=thread_id,
-                ),
             ),
         )
 

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -26,6 +26,7 @@ from .sqlite_cache_maintenance import (
 from .thread_cache_state import (
     THREAD_HISTORY_TRUST_METADATA_KEY,
     THREAD_HISTORY_TRUST_VERSION,
+    ThreadAppendOutcome,
     ThreadCacheReplaceOutcome,
     replacement_validated_at,
 )
@@ -1242,6 +1243,31 @@ class SqliteEventCache:
                 ),
             ),
         )
+
+    async def apply_thread_mutation_append(
+        self,
+        room_id: str,
+        thread_id: str,
+        event: dict[str, Any],
+        *,
+        append_failed_reason: str,
+    ) -> ThreadAppendOutcome:
+        """Append one threaded mutation and settle this thread's trust atomically."""
+        normalized_event = normalize_event_source_for_cache(event)
+        result = await self._write_operation(
+            room_id,
+            operation="apply_thread_mutation_append",
+            disabled_result=ThreadAppendOutcome.WRITES_UNAVAILABLE,
+            writer=lambda db: sqlite_event_cache_threads.apply_thread_mutation_append_locked(
+                db,
+                principal_id=self.principal_id,
+                room_id=room_id,
+                thread_id=thread_id,
+                normalized_event=normalized_event,
+                append_failed_reason=append_failed_reason,
+            ),
+        )
+        return ThreadAppendOutcome(result)
 
     async def revalidate_thread_after_incremental_update(
         self,

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -13,9 +13,9 @@ Durable trust-state invariants (mirrored by ``postgres_event_cache_threads``):
    The concrete caches additionally clamp the stored ``validated_at`` to the fetch start time, so an
    invalidation that lands during the fetch still outranks the snapshot at read time.
 
-3. Incremental revalidation is allowlisted: ``revalidate_thread_after_incremental_update_locked`` clears
-   an invalidation only when the thread was previously validated, the invalidation reason is one of the
-   incremental mutation reasons, and the room was not invalidated at or after that validation.
+3. Incremental revalidation is allowlisted: ``append_keeps_thread_valid`` leaves a thread trusted only
+   when it was previously validated, any invalidation reason is one of the incremental mutation reasons,
+   and the room was not invalidated at or after that validation.
    Invalidations from any other reason can only be cleared by a full authoritative snapshot replacement.
 
 4. Thread snapshot rows and the lookup, edit, and thread index rows are written and deleted together so
@@ -48,7 +48,6 @@ from .thread_cache_state import (
     ThreadCacheReplaceOutcome,
     ThreadCacheStateRow,
     append_keeps_thread_valid,
-    can_revalidate_after_incremental_update,
     guarded_thread_replacement_conflict,
     incremental_thread_revalidation_reasons,
     is_incremental_thread_revalidation_reason,
@@ -653,66 +652,6 @@ async def mark_thread_stale_locked(
     )
 
 
-async def revalidate_thread_after_incremental_update_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-) -> bool:
-    """Mark one thread cache fresh after a safe incremental update."""
-    row = await _load_thread_cache_state_row(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-    )
-    if not can_revalidate_after_incremental_update(row):
-        return False
-    await db.execute(
-        """
-        UPDATE thread_cache_state
-        SET validated_at = ?, invalidated_at = NULL, invalidation_reason = NULL
-        WHERE principal_id = ? AND room_id = ? AND thread_id = ?
-        """,
-        (time.time(), principal_id, room_id, thread_id),
-    )
-    return True
-
-
-async def _thread_has_appendable_snapshot_rows(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-) -> bool:
-    """Return whether this thread has snapshot rows an incremental append can extend.
-
-    Mirrors the join ``append_existing_thread_event`` performs, so it predicts that call exactly.
-    ``_thread_has_snapshot_rows_for_thread`` answers a different question: it counts index rows whose
-    event row may already be gone.
-    """
-    cursor = await db.execute(
-        """
-        SELECT 1
-        FROM thread_events
-        JOIN events
-            ON events.principal_id = thread_events.principal_id
-            AND events.room_id = thread_events.room_id
-            AND events.event_id = thread_events.event_id
-        WHERE thread_events.principal_id = ?
-            AND thread_events.room_id = ?
-            AND thread_events.thread_id = ?
-        LIMIT 1
-        """,
-        (principal_id, room_id, thread_id),
-    )
-    row = await cursor.fetchone()
-    await cursor.close()
-    return row is not None
-
-
 async def apply_thread_mutation_append_locked(
     db: aiosqlite.Connection,
     *,
@@ -730,45 +669,14 @@ async def apply_thread_mutation_append_locked(
     one transaction means a reader observes either the state before the mutation or the state after
     it, and a crash rolls the whole thing back rather than leaving a half-applied snapshot trusted.
     """
-    state_row = await _load_thread_cache_state_row(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-    )
-    if not await _thread_has_appendable_snapshot_rows(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-    ):
-        # There is no snapshot to extend, so only a full history scan can make this thread readable.
-        # The lookup-index rows are still worth recording for later thread resolution.
-        await write_lookup_index_rows(
-            db,
-            principal_id=principal_id,
-            room_id=room_id,
-            serialized_events=[serialize_cached_event(event_id_for_cache(normalized_event), normalized_event)],
-            cached_at=time.time(),
-            thread_id=thread_id,
-        )
-        await mark_thread_stale_locked(
-            db,
-            principal_id=principal_id,
-            room_id=room_id,
-            thread_id=thread_id,
-            reason=append_failed_reason,
-        )
-        return ThreadAppendOutcome.SNAPSHOT_MISSING
-
-    appended = await append_existing_thread_event(
+    outcome = await _append_existing_thread_event(
         db,
         principal_id=principal_id,
         room_id=room_id,
         thread_id=thread_id,
         normalized_event=normalized_event,
     )
-    if not appended:
+    if outcome is not ThreadAppendOutcome.APPENDED:
         await mark_thread_stale_locked(
             db,
             principal_id=principal_id,
@@ -776,8 +684,15 @@ async def apply_thread_mutation_append_locked(
             thread_id=thread_id,
             reason=append_failed_reason,
         )
-        return ThreadAppendOutcome.APPEND_REFUSED
+        return outcome
 
+    # Read after the append: it touches no trust column, and the failure paths above never need it.
+    state_row = await _load_thread_cache_state_row(
+        db,
+        principal_id=principal_id,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
     if not append_keeps_thread_valid(state_row):
         return ThreadAppendOutcome.APPENDED_STALE
 
@@ -827,17 +742,19 @@ async def mark_room_stale_locked(
     )
 
 
-async def append_existing_thread_event(
+async def _append_existing_thread_event(
     db: aiosqlite.Connection,
     *,
     principal_id: str,
     room_id: str,
     thread_id: str,
     normalized_event: dict[str, Any],
-) -> bool:
-    """Append one event to an existing cached thread.
+) -> ThreadAppendOutcome:
+    """Append one event to an existing cached thread and classify what happened.
 
     An opaque ``m.room.encrypted`` payload never replaces stored clear content for the same event ID.
+    A redacted event (or one whose edit target is redacted) is refused before anything is written, so
+    its payload never reaches the point-lookup table.
     """
     event_id = event_id_for_cache(normalized_event)
     if await event_or_original_is_redacted(
@@ -847,7 +764,7 @@ async def append_existing_thread_event(
         event_id=event_id,
         event=normalized_event,
     ):
-        return False
+        return ThreadAppendOutcome.APPEND_REFUSED
 
     serialized_event = serialize_cached_event(event_id, normalized_event)
     cursor = await db.execute(
@@ -876,7 +793,9 @@ async def append_existing_thread_event(
         thread_id=thread_id,
     )
     if row is None:
-        return False
+        # Only lookup-index rows are recorded: there is no snapshot to extend, so only a full
+        # history scan can make this thread readable again.
+        return ThreadAppendOutcome.SNAPSHOT_MISSING
 
     write_sequence = (await allocate_write_sequences(db, 1))[0]
     await db.execute(
@@ -904,7 +823,7 @@ async def append_existing_thread_event(
             write_sequence,
         ),
     )
-    return True
+    return ThreadAppendOutcome.APPENDED
 
 
 async def _thread_event_ids_for_thread(

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -20,6 +20,13 @@ Durable trust-state invariants (mirrored by ``postgres_event_cache_threads``):
 
 4. Thread snapshot rows and the lookup, edit, and thread index rows are written and deleted together so
    point lookups can never resurrect rows the snapshot no longer contains.
+
+5. One threaded mutation is one transaction: ``apply_thread_mutation_append_locked`` appends and settles
+   trust together. Marking stale, appending, and revalidating as three separate operations reported a
+   thread that was about to be perfectly appendable as invalid for the duration, so every read arriving
+   in that window rejected a good snapshot and paid for a full history scan. In one transaction a reader
+   observes either the state before the mutation or the state after it, and a crash rolls back rather
+   than leaving a half-applied snapshot trusted.
 """
 
 from __future__ import annotations
@@ -663,11 +670,7 @@ async def apply_thread_mutation_append_locked(
 ) -> ThreadAppendOutcome:
     """Append one threaded mutation and settle this thread's trust in the same transaction.
 
-    The caller used to mark the thread stale, append, and revalidate as three separate operations,
-    each taking the write lock on its own. A reader between the first and last saw a thread that was
-    about to be perfectly appendable reported as invalid, and rejected it. Holding all three steps in
-    one transaction means a reader observes either the state before the mutation or the state after
-    it, and a crash rolls the whole thing back rather than leaving a half-applied snapshot trusted.
+    See invariant 5 in the module docstring of ``sqlite_event_cache_threads`` for why it is one.
     """
     outcome = await _append_existing_thread_event(
         db,

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -44,8 +44,10 @@ from .sqlite_event_cache_events import (
     write_lookup_index_rows,
 )
 from .thread_cache_state import (
+    ThreadAppendOutcome,
     ThreadCacheReplaceOutcome,
     ThreadCacheStateRow,
+    append_keeps_thread_valid,
     can_revalidate_after_incremental_update,
     guarded_thread_replacement_conflict,
     incremental_thread_revalidation_reasons,
@@ -676,6 +678,118 @@ async def revalidate_thread_after_incremental_update_locked(
         (time.time(), principal_id, room_id, thread_id),
     )
     return True
+
+
+async def _thread_has_appendable_snapshot_rows(
+    db: aiosqlite.Connection,
+    *,
+    principal_id: str,
+    room_id: str,
+    thread_id: str,
+) -> bool:
+    """Return whether this thread has snapshot rows an incremental append can extend.
+
+    Mirrors the join ``append_existing_thread_event`` performs, so it predicts that call exactly.
+    ``_thread_has_snapshot_rows_for_thread`` answers a different question: it counts index rows whose
+    event row may already be gone.
+    """
+    cursor = await db.execute(
+        """
+        SELECT 1
+        FROM thread_events
+        JOIN events
+            ON events.principal_id = thread_events.principal_id
+            AND events.room_id = thread_events.room_id
+            AND events.event_id = thread_events.event_id
+        WHERE thread_events.principal_id = ?
+            AND thread_events.room_id = ?
+            AND thread_events.thread_id = ?
+        LIMIT 1
+        """,
+        (principal_id, room_id, thread_id),
+    )
+    row = await cursor.fetchone()
+    await cursor.close()
+    return row is not None
+
+
+async def apply_thread_mutation_append_locked(
+    db: aiosqlite.Connection,
+    *,
+    principal_id: str,
+    room_id: str,
+    thread_id: str,
+    normalized_event: dict[str, Any],
+    append_failed_reason: str,
+) -> ThreadAppendOutcome:
+    """Append one threaded mutation and settle this thread's trust in the same transaction.
+
+    The caller used to mark the thread stale, append, and revalidate as three separate operations,
+    each taking the write lock on its own. A reader between the first and last saw a thread that was
+    about to be perfectly appendable reported as invalid, and rejected it. Holding all three steps in
+    one transaction means a reader observes either the state before the mutation or the state after
+    it, and a crash rolls the whole thing back rather than leaving a half-applied snapshot trusted.
+    """
+    state_row = await _load_thread_cache_state_row(
+        db,
+        principal_id=principal_id,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    if not await _thread_has_appendable_snapshot_rows(
+        db,
+        principal_id=principal_id,
+        room_id=room_id,
+        thread_id=thread_id,
+    ):
+        # There is no snapshot to extend, so only a full history scan can make this thread readable.
+        # The lookup-index rows are still worth recording for later thread resolution.
+        await write_lookup_index_rows(
+            db,
+            principal_id=principal_id,
+            room_id=room_id,
+            serialized_events=[serialize_cached_event(event_id_for_cache(normalized_event), normalized_event)],
+            cached_at=time.time(),
+            thread_id=thread_id,
+        )
+        await mark_thread_stale_locked(
+            db,
+            principal_id=principal_id,
+            room_id=room_id,
+            thread_id=thread_id,
+            reason=append_failed_reason,
+        )
+        return ThreadAppendOutcome.SNAPSHOT_MISSING
+
+    appended = await append_existing_thread_event(
+        db,
+        principal_id=principal_id,
+        room_id=room_id,
+        thread_id=thread_id,
+        normalized_event=normalized_event,
+    )
+    if not appended:
+        await mark_thread_stale_locked(
+            db,
+            principal_id=principal_id,
+            room_id=room_id,
+            thread_id=thread_id,
+            reason=append_failed_reason,
+        )
+        return ThreadAppendOutcome.APPEND_REFUSED
+
+    if not append_keeps_thread_valid(state_row):
+        return ThreadAppendOutcome.APPENDED_STALE
+
+    await db.execute(
+        """
+        UPDATE thread_cache_state
+        SET validated_at = ?, invalidated_at = NULL, invalidation_reason = NULL
+        WHERE principal_id = ? AND room_id = ? AND thread_id = ?
+        """,
+        (time.time(), principal_id, room_id, thread_id),
+    )
+    return ThreadAppendOutcome.APPENDED
 
 
 async def mark_room_stale_locked(

--- a/src/mindroom/matrix/cache/thread_cache_state.py
+++ b/src/mindroom/matrix/cache/thread_cache_state.py
@@ -25,6 +25,8 @@ class ThreadAppendOutcome(StrEnum):
 
     APPENDED = "appended"
     APPENDED_STALE = "appended_stale"
+    # No rows to append into: only a full history scan can make this thread readable again. A
+    # refused append leaves the existing snapshot under a durable marker instead.
     SNAPSHOT_MISSING = "snapshot_missing"
     APPEND_REFUSED = "append_refused"
     WRITES_UNAVAILABLE = "writes_unavailable"
@@ -33,15 +35,6 @@ class ThreadAppendOutcome(StrEnum):
     def wrote_event(self) -> bool:
         """Return whether the mutation landed in the cached snapshot."""
         return self in {ThreadAppendOutcome.APPENDED, ThreadAppendOutcome.APPENDED_STALE}
-
-    @property
-    def needs_full_repair(self) -> bool:
-        """Return whether only a full history scan can make this thread readable again.
-
-        Only a thread with no rows to append into qualifies. A refused append leaves the existing
-        snapshot in place under a durable marker, and a stale append already has its own reason.
-        """
-        return self is ThreadAppendOutcome.SNAPSHOT_MISSING
 
 
 class ThreadCacheReplaceOutcome(StrEnum):

--- a/src/mindroom/matrix/cache/thread_cache_state.py
+++ b/src/mindroom/matrix/cache/thread_cache_state.py
@@ -20,6 +20,30 @@ THREAD_HISTORY_TRUST_METADATA_KEY = "thread_history_trust_version"
 THREAD_HISTORY_TRUST_VERSION = "opaque_encrypted_relations_v1"
 
 
+class ThreadAppendOutcome(StrEnum):
+    """Describe what one atomic threaded-mutation append did to a cached thread."""
+
+    APPENDED = "appended"
+    APPENDED_STALE = "appended_stale"
+    SNAPSHOT_MISSING = "snapshot_missing"
+    APPEND_REFUSED = "append_refused"
+    WRITES_UNAVAILABLE = "writes_unavailable"
+
+    @property
+    def wrote_event(self) -> bool:
+        """Return whether the mutation landed in the cached snapshot."""
+        return self in {ThreadAppendOutcome.APPENDED, ThreadAppendOutcome.APPENDED_STALE}
+
+    @property
+    def needs_full_repair(self) -> bool:
+        """Return whether only a full history scan can make this thread readable again.
+
+        Only a thread with no rows to append into qualifies. A refused append leaves the existing
+        snapshot in place under a durable marker, and a stale append already has its own reason.
+        """
+        return self is ThreadAppendOutcome.SNAPSHOT_MISSING
+
+
 class ThreadCacheReplaceOutcome(StrEnum):
     """Describe whether one guarded thread snapshot became usable."""
 
@@ -185,6 +209,24 @@ def can_revalidate_after_incremental_update(cache_state: ThreadCacheStateRow | N
             cache_state.room_invalidated_at is not None and cache_state.room_invalidated_at >= cache_state.validated_at
         )
     )
+
+
+def append_keeps_thread_valid(cache_state: ThreadCacheStateRow | None) -> bool:
+    """Return whether one appended mutation may leave this thread trusted.
+
+    This generalizes :func:`can_revalidate_after_incremental_update` to the case the atomic append
+    introduces: a thread that was still valid when the mutation began. Such a thread was never
+    invalidated, so there is nothing to clear and nothing to expose. Everything else is unchanged --
+    a room-wide marker at or after the last validation still outranks an append, and a thread marker
+    is only cleared when an incremental mutation wrote it.
+    """
+    if cache_state is None or cache_state.validated_at is None:
+        return False
+    if cache_state.room_invalidated_at is not None and cache_state.room_invalidated_at >= cache_state.validated_at:
+        return False
+    if cache_state.invalidated_at is None:
+        return True
+    return is_incremental_thread_revalidation_reason(cache_state.invalidation_reason)
 
 
 def replacement_validated_at(*, fetch_started_at: float, validated_at: float | None) -> float:

--- a/src/mindroom/matrix/cache/thread_cache_state.py
+++ b/src/mindroom/matrix/cache/thread_cache_state.py
@@ -197,28 +197,12 @@ def guarded_thread_replacement_conflict(
     return ThreadCacheReplaceOutcome.RETRYABLE_CONFLICT
 
 
-def can_revalidate_after_incremental_update(cache_state: ThreadCacheStateRow | None) -> bool:
-    """Return whether an incremental update may clear one thread invalidation."""
-    if cache_state is None:
-        return False
-    return (
-        cache_state.validated_at is not None
-        and cache_state.invalidated_at is not None
-        and is_incremental_thread_revalidation_reason(cache_state.invalidation_reason)
-        and not (
-            cache_state.room_invalidated_at is not None and cache_state.room_invalidated_at >= cache_state.validated_at
-        )
-    )
-
-
 def append_keeps_thread_valid(cache_state: ThreadCacheStateRow | None) -> bool:
     """Return whether one appended mutation may leave this thread trusted.
 
-    This generalizes :func:`can_revalidate_after_incremental_update` to the case the atomic append
-    introduces: a thread that was still valid when the mutation began. Such a thread was never
-    invalidated, so there is nothing to clear and nothing to expose. Everything else is unchanged --
-    a room-wide marker at or after the last validation still outranks an append, and a thread marker
-    is only cleared when an incremental mutation wrote it.
+    A thread that was still valid when the mutation began was never invalidated, so there is nothing
+    to clear and nothing to expose. A room-wide marker at or after the last validation outranks an
+    append, and a thread marker is only cleared when an incremental mutation wrote it.
     """
     if cache_state is None or cache_state.validated_at is None:
         return False

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -6,9 +6,10 @@ dispatch fan-out. A *speculative* repair is launched by a live append that found
 nobody is waiting on its result, so it is dropped rather than queued whenever it would add load:
 
 1. while a sync replay batch is being applied;
-2. while any flight for the same thread is already scanning, whatever caller contract owns it;
-3. while that thread is inside its post-repair cooldown;
-4. while the speculative concurrency budget is spent or an interactive repair is waiting for a slot.
+2. while one is already scheduled for that thread, or the pending-schedule budget is spent;
+3. while any flight for the same thread is already scanning, whatever caller contract owns it;
+4. while that thread is inside its post-repair cooldown;
+5. while the speculative concurrency budget is spent or an interactive repair is waiting for a slot.
 
 They are listed in the order ``speculative_suppression_reason`` tests them, because the reason it
 returns is what gets logged.
@@ -97,6 +98,7 @@ class ThreadRepairRegistry:
     _deltas: dict[_ThreadRepairDeltaKey, dict[str, _RetainedDelta]] = field(default_factory=dict, init=False)
     _speculative_cooldowns: dict[_ThreadRepairDeltaKey, float] = field(default_factory=dict, init=False)
     _interactive_joins: dict[_ThreadRepairFlightKey, int] = field(default_factory=dict, init=False)
+    _reserved_speculative: set[_ThreadRepairDeltaKey] = field(default_factory=set, init=False)
     _repair_slots: asyncio.Semaphore = field(init=False, repr=False)
     _running_speculative_repairs: int = field(default=0, init=False)
     _speculative_suppression_depth: int = field(default=0, init=False)
@@ -198,19 +200,42 @@ class ThreadRepairRegistry:
         second scan of a thread another contract is already scanning. A flight re-checking itself
         just before it scans passes ``ignore_active_flight`` so it does not see its own ownership.
         """
-        if self._speculative_suppression_depth > 0:
-            return "sync_replay"
-        if not ignore_active_flight and self._has_active_task(key):
-            return "repair_in_flight"
-        if self._speculative_cooldown_active(key):
-            return "recently_repaired"
-        if self._running_speculative_repairs >= self.max_concurrent_speculative_repairs:
-            return "speculative_concurrency_limit"
-        # ``locked`` is true while anyone is queued as well as at capacity, so a speculative caller
-        # never steps in front of an interactive one waiting for a slot.
-        if self._repair_slots.locked():
-            return "repair_concurrency_limit"
-        return None
+        # Kept lazy and in order: the reason returned is the one that gets logged, and
+        # ``_has_active_task`` drops finished flights as it looks.
+        declines: tuple[tuple[Callable[[], bool], str], ...] = (
+            (lambda: self._speculative_suppression_depth > 0, "sync_replay"),
+            (lambda: key in self._reserved_speculative, "repair_pending"),
+            (
+                lambda: len(self._reserved_speculative) >= self.max_concurrent_speculative_repairs,
+                "speculative_pending_limit",
+            ),
+            (lambda: not ignore_active_flight and self._has_active_task(key), "repair_in_flight"),
+            (lambda: self._speculative_cooldown_active(key), "recently_repaired"),
+            (
+                lambda: self._running_speculative_repairs >= self.max_concurrent_speculative_repairs,
+                "speculative_concurrency_limit",
+            ),
+            # ``locked`` is true while anyone is queued as well as at capacity, so a speculative
+            # caller never steps in front of an interactive one waiting for a slot.
+            (self._repair_slots.locked, "repair_concurrency_limit"),
+        )
+        return next((reason for declined, reason in declines if declined()), None)
+
+    def reserve_speculative_repair(self, key: _ThreadRepairDeltaKey) -> bool:
+        """Claim the right to schedule one speculative repair, or report that nobody may.
+
+        Admission inside :meth:`run` cannot bound a burst, because a burst is synchronous: nothing
+        has reached ``run`` yet, so every caller sees free capacity and adds another task. This is
+        the check that has to be atomic with the decision to create one, so it both tests and marks.
+        """
+        if self.speculative_suppression_reason(key) is not None:
+            return False
+        self._reserved_speculative.add(key)
+        return True
+
+    def release_speculative_repair(self, key: _ThreadRepairDeltaKey) -> None:
+        """Release a reservation once its repair has reached the registry, or been abandoned."""
+        self._reserved_speculative.discard(key)
 
     @contextmanager
     def _joined_interactively(self, key: _ThreadRepairFlightKey) -> Iterator[None]:
@@ -424,6 +449,9 @@ class ThreadRepairRegistry:
             for key, retry_after in self._speculative_cooldowns.items()
             if key[:2] != (coordination_scope, room_id)
         }
+        self._reserved_speculative = {
+            key for key in self._reserved_speculative if key[:2] != (coordination_scope, room_id)
+        }
 
     def clear(self) -> None:
         """Drop runtime-only ownership after all coordinator tasks drained."""
@@ -432,4 +460,5 @@ class ThreadRepairRegistry:
         self._deltas.clear()
         self._speculative_cooldowns.clear()
         self._interactive_joins.clear()
+        self._reserved_speculative.clear()
         self._running_speculative_repairs = 0

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -58,6 +58,18 @@ class _RetainedDelta:
     retained_at: float
 
 
+@dataclass(slots=True)
+class _SpeculativeClaim:
+    """One thread's scheduling claim and who currently owns it.
+
+    Ownership moves exactly once, from the scheduling task to the registered flight. Both sides
+    release by token identity, so neither can drop a claim belonging to a later attempt.
+    """
+
+    token: object
+    handed_off: bool = False
+
+
 @dataclass(frozen=True, slots=True)
 class _RepairFailureBackoff:
     """Current capped delay after consecutive repair failures."""
@@ -98,7 +110,11 @@ class ThreadRepairRegistry:
     _deltas: dict[_ThreadRepairDeltaKey, dict[str, _RetainedDelta]] = field(default_factory=dict, init=False)
     _speculative_cooldowns: dict[_ThreadRepairDeltaKey, float] = field(default_factory=dict, init=False)
     _interactive_joins: dict[_ThreadRepairFlightKey, int] = field(default_factory=dict, init=False)
-    _reserved_speculative: dict[_ThreadRepairDeltaKey, object] = field(default_factory=dict, init=False)
+    _reserved_speculative: dict[_ThreadRepairDeltaKey, _SpeculativeClaim] = field(
+        default_factory=dict,
+        init=False,
+    )
+    _flight_claims: dict[_ThreadRepairFlightKey, object] = field(default_factory=dict, init=False)
     _repair_slots: asyncio.Semaphore = field(init=False, repr=False)
     _running_speculative_repairs: int = field(default=0, init=False)
     _speculative_suppression_depth: int = field(default=0, init=False)
@@ -124,12 +140,16 @@ class ThreadRepairRegistry:
             return None
         if task.done():
             self._tasks.pop(key, None)
+            self._release_flight_claim(self._thread_key(key), self._flight_claims.pop(key, None))
             return None
         return task
 
     def _clear_task(self, key: _ThreadRepairFlightKey, task: asyncio.Task[object]) -> None:
         if self._tasks.get(key) is task:
             self._tasks.pop(key, None)
+            # A flight cancelled before its body ran still owns a claim; only this flight's own
+            # token is released, so a later attempt on the same thread keeps its own.
+            self._release_flight_claim(self._thread_key(key), self._flight_claims.pop(key, None))
 
     def _has_active_task(self, key: _ThreadRepairDeltaKey) -> bool:
         """Return whether any caller contract owns this thread's repair."""
@@ -241,12 +261,34 @@ class ThreadRepairRegistry:
         if self.speculative_suppression_reason(key) is not None:
             return None
         token = object()
-        self._reserved_speculative[key] = token
+        self._reserved_speculative[key] = _SpeculativeClaim(token=token)
         return token
 
     def release_speculative_repair(self, key: _ThreadRepairDeltaKey, token: object) -> None:
-        """Drop a scheduling claim, but only while this token still holds it."""
-        if self._reserved_speculative.get(key) is token:
+        """Drop a scheduling claim, but only while the scheduling task still owns this token.
+
+        Once the claim has been handed to a registered flight the scheduling task is no longer its
+        owner, so cancelling that task must leave the claim in place: the flight it registered is
+        still queued and still has to be bounded.
+        """
+        claim = self._reserved_speculative.get(key)
+        if claim is not None and claim.token is token and not claim.handed_off:
+            del self._reserved_speculative[key]
+
+    def _hand_off_claim(self, key: _ThreadRepairDeltaKey) -> object | None:
+        """Move this thread's claim from the scheduling task to the flight being registered."""
+        claim = self._reserved_speculative.get(key)
+        if claim is None:
+            return None
+        claim.handed_off = True
+        return claim.token
+
+    def _release_flight_claim(self, key: _ThreadRepairDeltaKey, token: object | None) -> None:
+        """Drop a claim a flight owns, identified by token so a stale body cannot take a newer one."""
+        if token is None:
+            return
+        claim = self._reserved_speculative.get(key)
+        if claim is not None and claim.token is token:
             del self._reserved_speculative[key]
 
     @contextmanager
@@ -319,6 +361,7 @@ class ThreadRepairRegistry:
         run_repair: Callable[[], Awaitable[T]],
         *,
         speculative: bool,
+        claim_token: object | None = None,
     ) -> T:
         """Run one admitted repair while holding exactly one global slot.
 
@@ -334,7 +377,10 @@ class ThreadRepairRegistry:
             # which then waits behind the coordinator barrier without holding a slot or counting
             # against the speculative budget. Releasing at registration would leave that whole wait
             # unbounded, so the claim is carried until here, where the scan gates below take over.
-            self._reserved_speculative.pop(self._thread_key(key), None)
+            # Released by the token this flight was registered with, so a body that outlived a
+            # `clear_room` cannot drop the claim a later attempt on the same thread now holds.
+            self._release_flight_claim(self._thread_key(key), claim_token)
+            self._flight_claims.pop(key, None)
         if speculative and self._interactive_joins.get(key):
             speculative = False
         if speculative:
@@ -412,8 +458,13 @@ class ThreadRepairRegistry:
         if admission_error is not None:
             raise admission_error
 
-        task = schedule(lambda: self._run_in_repair_slot(key, run_repair, speculative=speculative))
+        claim_token = self._hand_off_claim(self._thread_key(key)) if speculative else None
+        task = schedule(
+            lambda: self._run_in_repair_slot(key, run_repair, speculative=speculative, claim_token=claim_token),
+        )
         self._tasks[key] = task
+        if claim_token is not None:
+            self._flight_claims[key] = claim_token
         task.add_done_callback(lambda done_task: self._clear_task(key, done_task))
         return await asyncio.shield(task)
 
@@ -482,4 +533,5 @@ class ThreadRepairRegistry:
         self._speculative_cooldowns.clear()
         self._interactive_joins.clear()
         self._reserved_speculative.clear()
+        self._flight_claims.clear()
         self._running_speculative_repairs = 0

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -347,7 +347,14 @@ class ThreadRepairRegistry:
             value = cast("T", await asyncio.shield(active_task))
         if not joined_speculative_flight or result_needs_own_flight is None or not result_needs_own_flight(value):
             return True, value
-        return self._active_task(key) is not None, value
+        follow_on_task = self._active_task(key)
+        if follow_on_task is None or key in self._speculative_flights:
+            return False, value
+        # Every caller that shared the speculative flight reaches here together, and only the first
+        # to resume gets to own the replacement. The rest join it rather than returning the result
+        # they just judged insufficient: it carries the same contract, so its answer is theirs too.
+        with self._joined_interactively(key):
+            return True, cast("T", await asyncio.shield(follow_on_task))
 
     async def run[T](
         self,

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -94,11 +94,13 @@ class ThreadRepairRegistry:
     _deltas: dict[_ThreadRepairDeltaKey, dict[str, _RetainedDelta]] = field(default_factory=dict, init=False)
     _speculative_cooldowns: dict[_ThreadRepairDeltaKey, float] = field(default_factory=dict, init=False)
     _interactive_joins: dict[_ThreadRepairFlightKey, int] = field(default_factory=dict, init=False)
-    _speculative_flights: set[_ThreadRepairFlightKey] = field(default_factory=set, init=False)
-    _slot_waiters: list[asyncio.Future[None]] = field(default_factory=list, init=False)
-    _running_repairs: int = field(default=0, init=False)
+    _repair_slots: asyncio.Semaphore = field(init=False, repr=False)
     _running_speculative_repairs: int = field(default=0, init=False)
     _speculative_suppression_depth: int = field(default=0, init=False)
+
+    def __post_init__(self) -> None:
+        """Bind the global repair ceiling. A semaphore binds its loop on first blocking acquire."""
+        self._repair_slots = asyncio.Semaphore(self.max_concurrent_repairs)
 
     @staticmethod
     def _thread_key(key: _ThreadRepairFlightKey) -> _ThreadRepairDeltaKey:
@@ -111,17 +113,13 @@ class ThreadRepairRegistry:
         if task is None:
             return None
         if task.done():
-            # Dropping ownership here means the done callback can no longer match this task, so the
-            # flight's tier has to be forgotten in the same step or it outlives every flight.
             self._tasks.pop(key, None)
-            self._speculative_flights.discard(key)
             return None
         return task
 
     def _clear_task(self, key: _ThreadRepairFlightKey, task: asyncio.Task[object]) -> None:
         if self._tasks.get(key) is task:
             self._tasks.pop(key, None)
-            self._speculative_flights.discard(key)
 
     def _has_active_task(self, key: _ThreadRepairDeltaKey) -> bool:
         """Return whether any caller contract owns this thread's repair."""
@@ -200,7 +198,9 @@ class ThreadRepairRegistry:
             return "recently_repaired"
         if self._running_speculative_repairs >= self.max_concurrent_speculative_repairs:
             return "speculative_concurrency_limit"
-        if self._slot_waiters or self._running_repairs >= self.max_concurrent_repairs:
+        # ``locked`` is true while anyone is queued as well as at capacity, so a speculative caller
+        # never steps in front of an interactive one waiting for a slot.
+        if self._repair_slots.locked():
             return "repair_concurrency_limit"
         return None
 
@@ -217,49 +217,21 @@ class ThreadRepairRegistry:
             else:
                 self._interactive_joins.pop(key, None)
 
-    def _discard_slot_waiter(self, waiter: asyncio.Future[None]) -> None:
-        self._slot_waiters = [existing for existing in self._slot_waiters if existing is not waiter]
-
-    def _wake_next_slot_waiter(self) -> None:
-        """Hand the just-released slot to the longest-waiting caller."""
-        while self._slot_waiters:
-            waiter = self._slot_waiters.pop(0)
-            if not waiter.done():
-                # Reserved here rather than by the waiter itself: a newcomer resuming first would
-                # otherwise take the slot and push the waiter back to the end of the queue.
-                self._running_repairs += 1
-                waiter.set_result(None)
-                return
-
     async def _acquire_repair_slot(self, *, speculative: bool) -> None:
         """Take one global repair slot, waiting only for callers someone is blocked on.
 
         The slot is taken immediately before the scan, never while the flight is still queued behind
         same-thread predecessors, so a slot always measures work actually in progress. Speculative
-        callers re-check capacity without blocking first, so only interactive callers ever join the
-        waiter queue, and they are served in arrival order.
+        callers test capacity without blocking first, so only interactive callers ever queue here.
         """
-        if not self._slot_waiters and self._running_repairs < self.max_concurrent_repairs:
-            self._running_repairs += 1
-        else:
-            waiter = asyncio.get_running_loop().create_future()
-            self._slot_waiters.append(waiter)
-            try:
-                await waiter
-            except asyncio.CancelledError:
-                self._discard_slot_waiter(waiter)
-                if waiter.done() and not waiter.cancelled():
-                    # The slot was handed over before the cancellation landed; pass it along.
-                    self._release_repair_slot(speculative=False)
-                raise
+        await self._repair_slots.acquire()
         if speculative:
             self._running_speculative_repairs += 1
 
     def _release_repair_slot(self, *, speculative: bool) -> None:
-        self._running_repairs = max(0, self._running_repairs - 1)
         if speculative:
             self._running_speculative_repairs = max(0, self._running_speculative_repairs - 1)
-        self._wake_next_slot_waiter()
+        self._repair_slots.release()
 
     def _arm_speculative_cooldown(self, key: _ThreadRepairFlightKey) -> None:
         """Hold off further speculative scans of this thread after one has just run.
@@ -331,30 +303,18 @@ class ThreadRepairRegistry:
         active_task: asyncio.Task[object],
         *,
         speculative: bool,
-        result_needs_own_flight: Callable[[T], bool] | None,
-    ) -> tuple[bool, T]:
-        """Await the flight this caller joins and report whether its result settles the call.
+    ) -> T:
+        """Await the flight this caller joins.
 
-        The joined flight's tier is read at the instant of the join, so no flight can slip in
-        between. An interactive caller that inherited a speculative flight's unusable result is
-        owed its own scan, unless another flight already owns the thread and can be joined on
-        equal terms.
+        A speculative flight scans a lost guarded replacement once where an interactive one scans
+        twice, but the loser still returns the history it just fetched -- only the durable snapshot
+        is missing, and the thread stays stale for the next read to install it. So a joining reader
+        inherits a complete answer either way and is never owed a second scan for the difference.
         """
         if speculative:
-            return True, cast("T", await asyncio.shield(active_task))
-        joined_speculative_flight = key in self._speculative_flights
+            return cast("T", await asyncio.shield(active_task))
         with self._joined_interactively(key):
-            value = cast("T", await asyncio.shield(active_task))
-        if not joined_speculative_flight or result_needs_own_flight is None or not result_needs_own_flight(value):
-            return True, value
-        follow_on_task = self._active_task(key)
-        if follow_on_task is None or key in self._speculative_flights:
-            return False, value
-        # Every caller that shared the speculative flight reaches here together, and only the first
-        # to resume gets to own the replacement. The rest join it rather than returning the result
-        # they just judged insufficient: it carries the same contract, so its answer is theirs too.
-        with self._joined_interactively(key):
-            return True, cast("T", await asyncio.shield(follow_on_task))
+            return cast("T", await asyncio.shield(active_task))
 
     async def run[T](
         self,
@@ -363,7 +323,6 @@ class ThreadRepairRegistry:
         schedule: Callable[[Callable[[], Awaitable[T]]], asyncio.Task[T]],
         repair: Callable[[], Awaitable[T]],
         result_arms_backoff: Callable[[T], bool],
-        result_needs_own_flight: Callable[[T], bool] | None = None,
         bypass_failure_backoff: bool = False,
         speculative: bool = False,
     ) -> T:
@@ -372,11 +331,6 @@ class ThreadRepairRegistry:
         Authoritative untimed reads may bypass an existing delay while preserving its failure count.
         A speculative caller raises ``ThreadRepairSuppressedError`` instead of adding a scan whenever
         the fan-out gate declines it.
-
-        Joining a flight means inheriting its contract, and a speculative flight rescans a lost
-        guarded replacement one fewer time than a waiting reader is owed. ``result_needs_own_flight``
-        lets an interactive caller that inherited such a result repair again under its own contract.
-        The tier is read at the instant of the join, so no flight can start in between.
         """
 
         async def run_repair() -> T:
@@ -395,14 +349,7 @@ class ThreadRepairRegistry:
 
         active_task = self._active_task(key)
         if active_task is not None:
-            settled, joined_value = await self._join_running_flight(
-                key,
-                active_task,
-                speculative=speculative,
-                result_needs_own_flight=result_needs_own_flight,
-            )
-            if settled:
-                return joined_value
+            return await self._join_running_flight(key, active_task, speculative=speculative)
         admission_error = self._admission_error(
             key,
             speculative=speculative,
@@ -413,10 +360,6 @@ class ThreadRepairRegistry:
 
         task = schedule(lambda: self._run_in_repair_slot(key, run_repair, speculative=speculative))
         self._tasks[key] = task
-        if speculative:
-            self._speculative_flights.add(key)
-        else:
-            self._speculative_flights.discard(key)
         task.add_done_callback(lambda done_task: self._clear_task(key, done_task))
         return await asyncio.shield(task)
 
@@ -464,9 +407,6 @@ class ThreadRepairRegistry:
     def clear_room(self, coordination_scope: str, room_id: str) -> None:
         """Drop retained deltas and failure history at one membership boundary."""
         self._tasks = {key: task for key, task in self._tasks.items() if key[:2] != (coordination_scope, room_id)}
-        self._speculative_flights = {
-            key for key in self._speculative_flights if key[:2] != (coordination_scope, room_id)
-        }
         self._deltas = {key: deltas for key, deltas in self._deltas.items() if key[:2] != (coordination_scope, room_id)}
         self._failure_backoffs = {
             key: backoff for key, backoff in self._failure_backoffs.items() if key[:2] != (coordination_scope, room_id)
@@ -484,7 +424,5 @@ class ThreadRepairRegistry:
         self._deltas.clear()
         self._speculative_cooldowns.clear()
         self._interactive_joins.clear()
-        self._speculative_flights.clear()
-        self._slot_waiters.clear()
-        self._running_repairs = 0
+        self._repair_slots = asyncio.Semaphore(self.max_concurrent_repairs)
         self._running_speculative_repairs = 0

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -169,18 +169,13 @@ class ThreadRepairRegistry:
             self._speculative_suppression_depth = max(0, self._speculative_suppression_depth - 1)
 
     def _speculative_cooldown_active(self, key: _ThreadRepairDeltaKey) -> bool:
-        """Return whether this thread was scanned too recently, expiring its entry in passing.
+        """Return whether this thread was scanned too recently.
 
-        Checked once per append that finds a missing snapshot, so it stays O(1) rather than sweeping
-        every known thread on the hottest path in a replay storm.
+        A pure read: expired entries are dropped when the next cooldown is armed, which keeps this
+        O(1) on the hottest path and keeps the public suppression query free of side effects.
         """
         retry_after = self._speculative_cooldowns.get(key)
-        if retry_after is None:
-            return False
-        if retry_after > self.clock():
-            return True
-        del self._speculative_cooldowns[key]
-        return False
+        return retry_after is not None and retry_after > self.clock()
 
     def speculative_suppression_reason(
         self,
@@ -205,15 +200,6 @@ class ThreadRepairRegistry:
         if self._slot_waiters or self._running_repairs >= self.max_concurrent_repairs:
             return "repair_concurrency_limit"
         return None
-
-    def flight_is_speculative(self, key: _ThreadRepairFlightKey) -> bool:
-        """Return whether the flight a caller would join right now is speculative.
-
-        A joining caller inherits the running flight's contract, so an interactive reader needs to
-        know it is about to share work nobody is waiting on and that scans a lost guarded
-        replacement one fewer time than it is owed.
-        """
-        return self._active_task(key) is not None and key in self._speculative_flights
 
     @contextmanager
     def _joined_interactively(self, key: _ThreadRepairFlightKey) -> Iterator[None]:
@@ -336,6 +322,30 @@ class ThreadRepairRegistry:
             self._release_repair_slot(speculative=speculative)
             self._arm_speculative_cooldown(key)
 
+    async def _join_running_flight[T](
+        self,
+        key: _ThreadRepairFlightKey,
+        active_task: asyncio.Task[object],
+        *,
+        speculative: bool,
+        result_needs_own_flight: Callable[[T], bool] | None,
+    ) -> tuple[bool, T]:
+        """Await the flight this caller joins and report whether its result settles the call.
+
+        The joined flight's tier is read at the instant of the join, so no flight can slip in
+        between. An interactive caller that inherited a speculative flight's unusable result is
+        owed its own scan, unless another flight already owns the thread and can be joined on
+        equal terms.
+        """
+        if speculative:
+            return True, cast("T", await asyncio.shield(active_task))
+        joined_speculative_flight = key in self._speculative_flights
+        with self._joined_interactively(key):
+            value = cast("T", await asyncio.shield(active_task))
+        if not joined_speculative_flight or result_needs_own_flight is None or not result_needs_own_flight(value):
+            return True, value
+        return self._active_task(key) is not None, value
+
     async def run[T](
         self,
         key: _ThreadRepairFlightKey,
@@ -343,6 +353,7 @@ class ThreadRepairRegistry:
         schedule: Callable[[Callable[[], Awaitable[T]]], asyncio.Task[T]],
         repair: Callable[[], Awaitable[T]],
         result_arms_backoff: Callable[[T], bool],
+        result_needs_own_flight: Callable[[T], bool] | None = None,
         bypass_failure_backoff: bool = False,
         speculative: bool = False,
     ) -> T:
@@ -351,6 +362,11 @@ class ThreadRepairRegistry:
         Authoritative untimed reads may bypass an existing delay while preserving its failure count.
         A speculative caller raises ``ThreadRepairSuppressedError`` instead of adding a scan whenever
         the fan-out gate declines it.
+
+        Joining a flight means inheriting its contract, and a speculative flight rescans a lost
+        guarded replacement one fewer time than a waiting reader is owed. ``result_needs_own_flight``
+        lets an interactive caller that inherited such a result repair again under its own contract.
+        The tier is read at the instant of the join, so no flight can start in between.
         """
 
         async def run_repair() -> T:
@@ -369,10 +385,14 @@ class ThreadRepairRegistry:
 
         active_task = self._active_task(key)
         if active_task is not None:
-            if speculative:
-                return cast("T", await asyncio.shield(active_task))
-            with self._joined_interactively(key):
-                return cast("T", await asyncio.shield(active_task))
+            settled, joined_value = await self._join_running_flight(
+                key,
+                active_task,
+                speculative=speculative,
+                result_needs_own_flight=result_needs_own_flight,
+            )
+            if settled:
+                return joined_value
         admission_error = self._admission_error(
             key,
             speculative=speculative,

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -34,16 +34,16 @@ _DELTA_RETENTION_SECONDS = 60.0
 # Ceiling on scans in progress at once. This is a safety valve against a pathological storm, not a
 # throttle: it sits well above the widest fan-out a real dispatch produces, because an interactive
 # repair is a user-facing read and queueing one behind another is latency a caller pays for.
-MAX_CONCURRENT_THREAD_REPAIRS = 64
+_MAX_CONCURRENT_THREAD_REPAIRS = 64
 
 # The working bound. Every repair is a full history scan contending for the same serialized cache
 # write path the Matrix sync callback is blocked on, and nobody is waiting on a speculative one,
 # so only a couple run at a time however many threads are stale.
-MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS = 2
+_MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS = 2
 
 # One speculative scan per thread per window. A thread that is still broken afterwards is repaired
 # by the next read, which is interactive and exempt.
-SPECULATIVE_THREAD_REPAIR_COOLDOWN_SECONDS = 30.0
+_SPECULATIVE_THREAD_REPAIR_COOLDOWN_SECONDS = 30.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -85,14 +85,15 @@ class ThreadRepairRegistry:
     failure_backoff_seconds: float = 1.0
     max_failure_backoff_seconds: float = 30.0
     delta_retention_seconds: float = _DELTA_RETENTION_SECONDS
-    max_concurrent_repairs: int = MAX_CONCURRENT_THREAD_REPAIRS
-    max_concurrent_speculative_repairs: int = MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS
-    speculative_cooldown_seconds: float = SPECULATIVE_THREAD_REPAIR_COOLDOWN_SECONDS
+    max_concurrent_repairs: int = _MAX_CONCURRENT_THREAD_REPAIRS
+    max_concurrent_speculative_repairs: int = _MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS
+    speculative_cooldown_seconds: float = _SPECULATIVE_THREAD_REPAIR_COOLDOWN_SECONDS
     clock: Callable[[], float] = time.monotonic
     _tasks: dict[_ThreadRepairFlightKey, asyncio.Task[object]] = field(default_factory=dict, init=False)
     _failure_backoffs: dict[_ThreadRepairFlightKey, _RepairFailureBackoff] = field(default_factory=dict, init=False)
     _deltas: dict[_ThreadRepairDeltaKey, dict[str, _RetainedDelta]] = field(default_factory=dict, init=False)
     _speculative_cooldowns: dict[_ThreadRepairDeltaKey, float] = field(default_factory=dict, init=False)
+    _interactive_joins: dict[_ThreadRepairFlightKey, int] = field(default_factory=dict, init=False)
     _slot_waiters: list[asyncio.Future[None]] = field(default_factory=list, init=False)
     _running_repairs: int = field(default=0, init=False)
     _running_speculative_repairs: int = field(default=0, init=False)
@@ -203,13 +204,34 @@ class ThreadRepairRegistry:
             return "repair_concurrency_limit"
         return None
 
+    def has_interactive_waiter(self, key: _ThreadRepairFlightKey) -> bool:
+        """Return whether a caller waiting on history has joined this flight."""
+        return bool(self._interactive_joins.get(key))
+
+    @contextmanager
+    def _joined_interactively(self, key: _ThreadRepairFlightKey) -> Iterator[None]:
+        """Record that a waiting caller depends on this flight for as long as it is joined."""
+        self._interactive_joins[key] = self._interactive_joins.get(key, 0) + 1
+        try:
+            yield
+        finally:
+            remaining = self._interactive_joins.get(key, 1) - 1
+            if remaining > 0:
+                self._interactive_joins[key] = remaining
+            else:
+                self._interactive_joins.pop(key, None)
+
     def _discard_slot_waiter(self, waiter: asyncio.Future[None]) -> None:
         self._slot_waiters = [existing for existing in self._slot_waiters if existing is not waiter]
 
     def _wake_next_slot_waiter(self) -> None:
+        """Hand the just-released slot to the longest-waiting caller."""
         while self._slot_waiters:
             waiter = self._slot_waiters.pop(0)
             if not waiter.done():
+                # Reserved here rather than by the waiter itself: a newcomer resuming first would
+                # otherwise take the slot and push the waiter back to the end of the queue.
+                self._running_repairs += 1
                 waiter.set_result(None)
                 return
 
@@ -219,18 +241,21 @@ class ThreadRepairRegistry:
         The slot is taken immediately before the scan, never while the flight is still queued behind
         same-thread predecessors, so a slot always measures work actually in progress. Speculative
         callers re-check capacity without blocking first, so only interactive callers ever join the
-        waiter queue and they are served in arrival order ahead of any speculative admission.
+        waiter queue, and they are served in arrival order.
         """
-        while self._running_repairs >= self.max_concurrent_repairs:
+        if not self._slot_waiters and self._running_repairs < self.max_concurrent_repairs:
+            self._running_repairs += 1
+        else:
             waiter = asyncio.get_running_loop().create_future()
             self._slot_waiters.append(waiter)
             try:
                 await waiter
             except asyncio.CancelledError:
                 self._discard_slot_waiter(waiter)
-                self._wake_next_slot_waiter()
+                if waiter.done() and not waiter.cancelled():
+                    # The slot was handed over before the cancellation landed; pass it along.
+                    self._release_repair_slot(speculative=False)
                 raise
-        self._running_repairs += 1
         if speculative:
             self._running_speculative_repairs += 1
 
@@ -241,8 +266,19 @@ class ThreadRepairRegistry:
         self._wake_next_slot_waiter()
 
     def _arm_speculative_cooldown(self, key: _ThreadRepairFlightKey) -> None:
-        """Hold off further speculative scans of this thread after one has just run."""
-        self._speculative_cooldowns[self._thread_key(key)] = self.clock() + self.speculative_cooldown_seconds
+        """Hold off further speculative scans of this thread after one has just run.
+
+        Expired entries are swept here rather than on the append path: a repair completing is rare
+        next to an append, and a thread that is never speculatively re-checked would otherwise keep
+        its entry for the life of the process.
+        """
+        now = self.clock()
+        self._speculative_cooldowns = {
+            cooled_key: retry_after
+            for cooled_key, retry_after in self._speculative_cooldowns.items()
+            if retry_after > now
+        }
+        self._speculative_cooldowns[self._thread_key(key)] = now + self.speculative_cooldown_seconds
 
     def _admission_error(
         self,
@@ -273,7 +309,12 @@ class ThreadRepairRegistry:
         Reached only once same-thread predecessors have drained, so a held slot always measures a
         scan in progress. Capacity is re-checked for speculative work because that queue wait can be
         long enough for the runtime to have filled up, or for another flight to have fixed a thread.
+
+        A flight an interactive caller has joined stops being speculative: declining it would raise
+        into a read that is waiting on this exact result, and that caller is owed the scan.
         """
+        if speculative and self._interactive_joins.get(key):
+            speculative = False
         if speculative:
             deferred_reason = self.speculative_suppression_reason(
                 self._thread_key(key),
@@ -321,7 +362,10 @@ class ThreadRepairRegistry:
 
         active_task = self._active_task(key)
         if active_task is not None:
-            return cast("T", await asyncio.shield(active_task))
+            if speculative:
+                return cast("T", await asyncio.shield(active_task))
+            with self._joined_interactively(key):
+                return cast("T", await asyncio.shield(active_task))
         admission_error = self._admission_error(
             key,
             speculative=speculative,
@@ -395,6 +439,7 @@ class ThreadRepairRegistry:
         self._failure_backoffs.clear()
         self._deltas.clear()
         self._speculative_cooldowns.clear()
+        self._interactive_joins.clear()
         self._slot_waiters.clear()
         self._running_repairs = 0
         self._running_speculative_repairs = 0

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -111,7 +111,10 @@ class ThreadRepairRegistry:
         if task is None:
             return None
         if task.done():
+            # Dropping ownership here means the done callback can no longer match this task, so the
+            # flight's tier has to be forgotten in the same step or it outlives every flight.
             self._tasks.pop(key, None)
+            self._speculative_flights.discard(key)
             return None
         return task
 

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -322,13 +322,19 @@ class ThreadRepairRegistry:
     ) -> T:
         """Run one admitted repair while holding exactly one global slot.
 
-        Reached only once same-thread predecessors have drained, so a held slot always measures a
-        scan in progress. Capacity is re-checked for speculative work because that queue wait can be
+        Reached only once same-thread predecessors and the coordinator barrier have drained, so a
+        held slot always measures a scan in progress. Capacity is re-checked for speculative work because that queue wait can be
         long enough for the runtime to have filled up, or for another flight to have fixed a thread.
 
         A flight an interactive caller has joined stops being speculative: declining it would raise
         into a read that is waiting on this exact result, and that caller is owed the scan.
         """
+        if speculative:
+            # Registering the flight is not the end of the claim: `schedule` only queues the body,
+            # which then waits behind the coordinator barrier without holding a slot or counting
+            # against the speculative budget. Releasing at registration would leave that whole wait
+            # unbounded, so the claim is carried until here, where the scan gates below take over.
+            self._reserved_speculative.pop(self._thread_key(key), None)
         if speculative and self._interactive_joins.get(key):
             speculative = False
         if speculative:
@@ -408,10 +414,6 @@ class ThreadRepairRegistry:
 
         task = schedule(lambda: self._run_in_repair_slot(key, run_repair, speculative=speculative))
         self._tasks[key] = task
-        if speculative:
-            # Ownership transferred: `_tasks` now suppresses this thread, so the scheduling claim
-            # that stood in for it until admission is spent.
-            self._reserved_speculative.pop(self._thread_key(key), None)
         task.add_done_callback(lambda done_task: self._clear_task(key, done_task))
         return await asyncio.shield(task)
 

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -5,10 +5,13 @@ history right now, so it always runs, queueing only behind a global ceiling set 
 dispatch fan-out. A *speculative* repair is launched by a live append that found no cached snapshot;
 nobody is waiting on its result, so it is dropped rather than queued whenever it would add load:
 
-1. while any flight for the same thread is already scanning, whatever caller contract owns it;
-2. while that thread is inside its post-repair cooldown;
-3. while the speculative concurrency budget is spent or an interactive repair is waiting for a slot;
-4. while a sync replay batch is being applied.
+1. while a sync replay batch is being applied;
+2. while any flight for the same thread is already scanning, whatever caller contract owns it;
+3. while that thread is inside its post-repair cooldown;
+4. while the speculative concurrency budget is spent or an interactive repair is waiting for a slot.
+
+They are listed in the order ``speculative_suppression_reason`` tests them, because the reason it
+returns is what gets logged.
 
 Dropping is safe because the thread stays marked stale, so the next read repairs it interactively.
 """
@@ -99,7 +102,12 @@ class ThreadRepairRegistry:
     _speculative_suppression_depth: int = field(default=0, init=False)
 
     def __post_init__(self) -> None:
-        """Bind the global repair ceiling. A semaphore binds its loop on first blocking acquire."""
+        """Bind the global repair ceiling, which is fixed for the life of the registry.
+
+        A semaphore binds its loop on the first blocking acquire, not here, so constructing one
+        outside a running loop is fine. It is never replaced: a repair still holding a permit would
+        release it into the replacement and raise the ceiling above its own bound.
+        """
         self._repair_slots = asyncio.Semaphore(self.max_concurrent_repairs)
 
     @staticmethod
@@ -424,5 +432,4 @@ class ThreadRepairRegistry:
         self._deltas.clear()
         self._speculative_cooldowns.clear()
         self._interactive_joins.clear()
-        self._repair_slots = asyncio.Semaphore(self.max_concurrent_repairs)
         self._running_speculative_repairs = 0

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -94,6 +94,7 @@ class ThreadRepairRegistry:
     _deltas: dict[_ThreadRepairDeltaKey, dict[str, _RetainedDelta]] = field(default_factory=dict, init=False)
     _speculative_cooldowns: dict[_ThreadRepairDeltaKey, float] = field(default_factory=dict, init=False)
     _interactive_joins: dict[_ThreadRepairFlightKey, int] = field(default_factory=dict, init=False)
+    _speculative_flights: set[_ThreadRepairFlightKey] = field(default_factory=set, init=False)
     _slot_waiters: list[asyncio.Future[None]] = field(default_factory=list, init=False)
     _running_repairs: int = field(default=0, init=False)
     _running_speculative_repairs: int = field(default=0, init=False)
@@ -117,6 +118,7 @@ class ThreadRepairRegistry:
     def _clear_task(self, key: _ThreadRepairFlightKey, task: asyncio.Task[object]) -> None:
         if self._tasks.get(key) is task:
             self._tasks.pop(key, None)
+            self._speculative_flights.discard(key)
 
     def _has_active_task(self, key: _ThreadRepairDeltaKey) -> bool:
         """Return whether any caller contract owns this thread's repair."""
@@ -204,9 +206,14 @@ class ThreadRepairRegistry:
             return "repair_concurrency_limit"
         return None
 
-    def has_interactive_waiter(self, key: _ThreadRepairFlightKey) -> bool:
-        """Return whether a caller waiting on history has joined this flight."""
-        return bool(self._interactive_joins.get(key))
+    def flight_is_speculative(self, key: _ThreadRepairFlightKey) -> bool:
+        """Return whether the flight a caller would join right now is speculative.
+
+        A joining caller inherits the running flight's contract, so an interactive reader needs to
+        know it is about to share work nobody is waiting on and that scans a lost guarded
+        replacement one fewer time than it is owed.
+        """
+        return self._active_task(key) is not None and key in self._speculative_flights
 
     @contextmanager
     def _joined_interactively(self, key: _ThreadRepairFlightKey) -> Iterator[None]:
@@ -376,6 +383,10 @@ class ThreadRepairRegistry:
 
         task = schedule(lambda: self._run_in_repair_slot(key, run_repair, speculative=speculative))
         self._tasks[key] = task
+        if speculative:
+            self._speculative_flights.add(key)
+        else:
+            self._speculative_flights.discard(key)
         task.add_done_callback(lambda done_task: self._clear_task(key, done_task))
         return await asyncio.shield(task)
 
@@ -423,6 +434,9 @@ class ThreadRepairRegistry:
     def clear_room(self, coordination_scope: str, room_id: str) -> None:
         """Drop retained deltas and failure history at one membership boundary."""
         self._tasks = {key: task for key, task in self._tasks.items() if key[:2] != (coordination_scope, room_id)}
+        self._speculative_flights = {
+            key for key in self._speculative_flights if key[:2] != (coordination_scope, room_id)
+        }
         self._deltas = {key: deltas for key, deltas in self._deltas.items() if key[:2] != (coordination_scope, room_id)}
         self._failure_backoffs = {
             key: backoff for key, backoff in self._failure_backoffs.items() if key[:2] != (coordination_scope, room_id)
@@ -440,6 +454,7 @@ class ThreadRepairRegistry:
         self._deltas.clear()
         self._speculative_cooldowns.clear()
         self._interactive_joins.clear()
+        self._speculative_flights.clear()
         self._slot_waiters.clear()
         self._running_repairs = 0
         self._running_speculative_repairs = 0

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -1,14 +1,28 @@
-"""Single-flight ownership and retained live deltas for thread-cache repair."""
+"""Single-flight ownership, fan-out bounding, and retained live deltas for thread-cache repair.
+
+Repair admission has two tiers. An *interactive* repair backs a caller that is waiting for the
+history right now, so it always runs, queueing only behind a global ceiling set well above any real
+dispatch fan-out. A *speculative* repair is launched by a live append that found no cached snapshot;
+nobody is waiting on its result, so it is dropped rather than queued whenever it would add load:
+
+1. while any flight for the same thread is already scanning, whatever caller contract owns it;
+2. while that thread is inside its post-repair cooldown;
+3. while the speculative concurrency budget is spent or an interactive repair is waiting for a slot;
+4. while a sync replay batch is being applied.
+
+Dropping is safe because the thread stays marked stale, so the next read repairs it interactively.
+"""
 
 from __future__ import annotations
 
 import asyncio
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, cast
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Collection
+    from collections.abc import Awaitable, Callable, Collection, Iterator
 
 type _ThreadRepairFlightKey = tuple[str, str, str, bool, bool]
 type _ThreadRepairDeltaKey = tuple[str, str, str]
@@ -16,6 +30,20 @@ type _ThreadRepairDeltaKey = tuple[str, str, str]
 # Retained deltas only cover the window where a homeserver scan can miss a just-certified event.
 # Once a delta is older than this, any new scan already observes it, so keeping it only wastes memory.
 _DELTA_RETENTION_SECONDS = 60.0
+
+# Ceiling on scans in progress at once. This is a safety valve against a pathological storm, not a
+# throttle: it sits well above the widest fan-out a real dispatch produces, because an interactive
+# repair is a user-facing read and queueing one behind another is latency a caller pays for.
+MAX_CONCURRENT_THREAD_REPAIRS = 64
+
+# The working bound. Every repair is a full history scan contending for the same serialized cache
+# write path the Matrix sync callback is blocked on, and nobody is waiting on a speculative one,
+# so only a couple run at a time however many threads are stale.
+MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS = 2
+
+# One speculative scan per thread per window. A thread that is still broken afterwards is repaired
+# by the next read, which is interactive and exempt.
+SPECULATIVE_THREAD_REPAIR_COOLDOWN_SECONDS = 30.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,6 +70,14 @@ class ThreadRepairBackoffError(RuntimeError):
         super().__init__(f"thread cache repair backoff active for {retry_after_seconds:.3f}s")
 
 
+class ThreadRepairSuppressedError(RuntimeError):
+    """Raised when one speculative repair is dropped to bound global repair fan-out."""
+
+    def __init__(self, reason: str) -> None:
+        self.reason = reason
+        super().__init__(f"speculative thread cache repair suppressed: {reason}")
+
+
 @dataclass
 class ThreadRepairRegistry:
     """Own principal-scoped repair flights, failure backoff, and certified deltas."""
@@ -49,10 +85,24 @@ class ThreadRepairRegistry:
     failure_backoff_seconds: float = 1.0
     max_failure_backoff_seconds: float = 30.0
     delta_retention_seconds: float = _DELTA_RETENTION_SECONDS
+    max_concurrent_repairs: int = MAX_CONCURRENT_THREAD_REPAIRS
+    max_concurrent_speculative_repairs: int = MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS
+    speculative_cooldown_seconds: float = SPECULATIVE_THREAD_REPAIR_COOLDOWN_SECONDS
     clock: Callable[[], float] = time.monotonic
     _tasks: dict[_ThreadRepairFlightKey, asyncio.Task[object]] = field(default_factory=dict, init=False)
     _failure_backoffs: dict[_ThreadRepairFlightKey, _RepairFailureBackoff] = field(default_factory=dict, init=False)
     _deltas: dict[_ThreadRepairDeltaKey, dict[str, _RetainedDelta]] = field(default_factory=dict, init=False)
+    _speculative_cooldowns: dict[_ThreadRepairDeltaKey, float] = field(default_factory=dict, init=False)
+    _slot_waiters: list[asyncio.Future[None]] = field(default_factory=list, init=False)
+    _running_repairs: int = field(default=0, init=False)
+    _running_speculative_repairs: int = field(default=0, init=False)
+    _speculative_suppression_depth: int = field(default=0, init=False)
+
+    @staticmethod
+    def _thread_key(key: _ThreadRepairFlightKey) -> _ThreadRepairDeltaKey:
+        """Return the thread one caller contract repairs, without the contract itself."""
+        coordination_scope, room_id, thread_id, _hydrate_sidecars, _allow_stale_fallback = key
+        return coordination_scope, room_id, thread_id
 
     def _active_task(self, key: _ThreadRepairFlightKey) -> asyncio.Task[object] | None:
         task = self._tasks.get(key)
@@ -101,6 +151,143 @@ class ThreadRepairRegistry:
             return 0.0
         return max(0.0, backoff.retry_after - self.clock())
 
+    @contextmanager
+    def suppress_speculative_repairs(self) -> Iterator[None]:
+        """Drop speculative repairs while one sync replay batch is being applied.
+
+        Replay re-delivers events whose threads are being rewritten anyway, so speculative scans
+        started from it are near-certain to lose the guarded replacement race and only add load to
+        the write path the sync callback is already blocked on.
+        """
+        self._speculative_suppression_depth += 1
+        try:
+            yield
+        finally:
+            self._speculative_suppression_depth = max(0, self._speculative_suppression_depth - 1)
+
+    def _speculative_cooldown_active(self, key: _ThreadRepairDeltaKey) -> bool:
+        """Return whether this thread was scanned too recently, expiring its entry in passing.
+
+        Checked once per append that finds a missing snapshot, so it stays O(1) rather than sweeping
+        every known thread on the hottest path in a replay storm.
+        """
+        retry_after = self._speculative_cooldowns.get(key)
+        if retry_after is None:
+            return False
+        if retry_after > self.clock():
+            return True
+        del self._speculative_cooldowns[key]
+        return False
+
+    def speculative_suppression_reason(
+        self,
+        key: _ThreadRepairDeltaKey,
+        *,
+        ignore_active_flight: bool = False,
+    ) -> str | None:
+        """Return why one speculative repair must be dropped, or ``None`` when it may run.
+
+        The key is the thread, not the caller contract, so a speculative trigger never opens a
+        second scan of a thread another contract is already scanning. A flight re-checking itself
+        just before it scans passes ``ignore_active_flight`` so it does not see its own ownership.
+        """
+        if self._speculative_suppression_depth > 0:
+            return "sync_replay"
+        if not ignore_active_flight and self._has_active_task(key):
+            return "repair_in_flight"
+        if self._speculative_cooldown_active(key):
+            return "recently_repaired"
+        if self._running_speculative_repairs >= self.max_concurrent_speculative_repairs:
+            return "speculative_concurrency_limit"
+        if self._slot_waiters or self._running_repairs >= self.max_concurrent_repairs:
+            return "repair_concurrency_limit"
+        return None
+
+    def _discard_slot_waiter(self, waiter: asyncio.Future[None]) -> None:
+        self._slot_waiters = [existing for existing in self._slot_waiters if existing is not waiter]
+
+    def _wake_next_slot_waiter(self) -> None:
+        while self._slot_waiters:
+            waiter = self._slot_waiters.pop(0)
+            if not waiter.done():
+                waiter.set_result(None)
+                return
+
+    async def _acquire_repair_slot(self, *, speculative: bool) -> None:
+        """Take one global repair slot, waiting only for callers someone is blocked on.
+
+        The slot is taken immediately before the scan, never while the flight is still queued behind
+        same-thread predecessors, so a slot always measures work actually in progress. Speculative
+        callers re-check capacity without blocking first, so only interactive callers ever join the
+        waiter queue and they are served in arrival order ahead of any speculative admission.
+        """
+        while self._running_repairs >= self.max_concurrent_repairs:
+            waiter = asyncio.get_running_loop().create_future()
+            self._slot_waiters.append(waiter)
+            try:
+                await waiter
+            except asyncio.CancelledError:
+                self._discard_slot_waiter(waiter)
+                self._wake_next_slot_waiter()
+                raise
+        self._running_repairs += 1
+        if speculative:
+            self._running_speculative_repairs += 1
+
+    def _release_repair_slot(self, *, speculative: bool) -> None:
+        self._running_repairs = max(0, self._running_repairs - 1)
+        if speculative:
+            self._running_speculative_repairs = max(0, self._running_speculative_repairs - 1)
+        self._wake_next_slot_waiter()
+
+    def _arm_speculative_cooldown(self, key: _ThreadRepairFlightKey) -> None:
+        """Hold off further speculative scans of this thread after one has just run."""
+        self._speculative_cooldowns[self._thread_key(key)] = self.clock() + self.speculative_cooldown_seconds
+
+    def _admission_error(
+        self,
+        key: _ThreadRepairFlightKey,
+        *,
+        speculative: bool,
+        bypass_failure_backoff: bool,
+    ) -> Exception | None:
+        """Return why this caller may not start a new scan right now."""
+        if speculative:
+            suppression_reason = self.speculative_suppression_reason(self._thread_key(key))
+            if suppression_reason is not None:
+                return ThreadRepairSuppressedError(suppression_reason)
+        retry_after_seconds = self.retry_after_seconds(key)
+        if retry_after_seconds > 0 and not bypass_failure_backoff:
+            return ThreadRepairBackoffError(retry_after_seconds)
+        return None
+
+    async def _run_in_repair_slot[T](
+        self,
+        key: _ThreadRepairFlightKey,
+        run_repair: Callable[[], Awaitable[T]],
+        *,
+        speculative: bool,
+    ) -> T:
+        """Run one admitted repair while holding exactly one global slot.
+
+        Reached only once same-thread predecessors have drained, so a held slot always measures a
+        scan in progress. Capacity is re-checked for speculative work because that queue wait can be
+        long enough for the runtime to have filled up, or for another flight to have fixed a thread.
+        """
+        if speculative:
+            deferred_reason = self.speculative_suppression_reason(
+                self._thread_key(key),
+                ignore_active_flight=True,
+            )
+            if deferred_reason is not None:
+                raise ThreadRepairSuppressedError(deferred_reason)
+        await self._acquire_repair_slot(speculative=speculative)
+        try:
+            return await run_repair()
+        finally:
+            self._release_repair_slot(speculative=speculative)
+            self._arm_speculative_cooldown(key)
+
     async def run[T](
         self,
         key: _ThreadRepairFlightKey,
@@ -109,18 +296,14 @@ class ThreadRepairRegistry:
         repair: Callable[[], Awaitable[T]],
         result_arms_backoff: Callable[[T], bool],
         bypass_failure_backoff: bool = False,
+        speculative: bool = False,
     ) -> T:
         """Join or start one shielded repair and update backoff from its outcome.
 
         Authoritative untimed reads may bypass an existing delay while preserving its failure count.
+        A speculative caller raises ``ThreadRepairSuppressedError`` instead of adding a scan whenever
+        the fan-out gate declines it.
         """
-        active = self._active_task(key)
-        if active is not None:
-            return cast("T", await asyncio.shield(active))
-
-        retry_after_seconds = self.retry_after_seconds(key)
-        if retry_after_seconds > 0 and not bypass_failure_backoff:
-            raise ThreadRepairBackoffError(retry_after_seconds)
 
         async def run_repair() -> T:
             try:
@@ -136,7 +319,18 @@ class ThreadRepairRegistry:
                     self._failure_backoffs.pop(key, None)
             return value
 
-        task = schedule(run_repair)
+        active_task = self._active_task(key)
+        if active_task is not None:
+            return cast("T", await asyncio.shield(active_task))
+        admission_error = self._admission_error(
+            key,
+            speculative=speculative,
+            bypass_failure_backoff=bypass_failure_backoff,
+        )
+        if admission_error is not None:
+            raise admission_error
+
+        task = schedule(lambda: self._run_in_repair_slot(key, run_repair, speculative=speculative))
         self._tasks[key] = task
         task.add_done_callback(lambda done_task: self._clear_task(key, done_task))
         return await asyncio.shield(task)
@@ -189,9 +383,18 @@ class ThreadRepairRegistry:
         self._failure_backoffs = {
             key: backoff for key, backoff in self._failure_backoffs.items() if key[:2] != (coordination_scope, room_id)
         }
+        self._speculative_cooldowns = {
+            key: retry_after
+            for key, retry_after in self._speculative_cooldowns.items()
+            if key[:2] != (coordination_scope, room_id)
+        }
 
     def clear(self) -> None:
         """Drop runtime-only ownership after all coordinator tasks drained."""
         self._tasks.clear()
         self._failure_backoffs.clear()
         self._deltas.clear()
+        self._speculative_cooldowns.clear()
+        self._slot_waiters.clear()
+        self._running_repairs = 0
+        self._running_speculative_repairs = 0

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -98,7 +98,7 @@ class ThreadRepairRegistry:
     _deltas: dict[_ThreadRepairDeltaKey, dict[str, _RetainedDelta]] = field(default_factory=dict, init=False)
     _speculative_cooldowns: dict[_ThreadRepairDeltaKey, float] = field(default_factory=dict, init=False)
     _interactive_joins: dict[_ThreadRepairFlightKey, int] = field(default_factory=dict, init=False)
-    _reserved_speculative: set[_ThreadRepairDeltaKey] = field(default_factory=set, init=False)
+    _reserved_speculative: dict[_ThreadRepairDeltaKey, object] = field(default_factory=dict, init=False)
     _repair_slots: asyncio.Semaphore = field(init=False, repr=False)
     _running_speculative_repairs: int = field(default=0, init=False)
     _speculative_suppression_depth: int = field(default=0, init=False)
@@ -193,20 +193,26 @@ class ThreadRepairRegistry:
         key: _ThreadRepairDeltaKey,
         *,
         ignore_active_flight: bool = False,
+        ignore_reservation: bool = False,
     ) -> str | None:
         """Return why one speculative repair must be dropped, or ``None`` when it may run.
 
         The key is the thread, not the caller contract, so a speculative trigger never opens a
         second scan of a thread another contract is already scanning. A flight re-checking itself
-        just before it scans passes ``ignore_active_flight`` so it does not see its own ownership.
+        just before it scans passes ``ignore_active_flight`` so it does not see its own ownership,
+        and a caller carrying this thread's scheduling reservation passes ``ignore_reservation`` so
+        it does not see its own claim.
         """
         # Kept lazy and in order: the reason returned is the one that gets logged, and
         # ``_has_active_task`` drops finished flights as it looks.
         declines: tuple[tuple[Callable[[], bool], str], ...] = (
             (lambda: self._speculative_suppression_depth > 0, "sync_replay"),
-            (lambda: key in self._reserved_speculative, "repair_pending"),
+            (lambda: not ignore_reservation and key in self._reserved_speculative, "repair_pending"),
             (
-                lambda: len(self._reserved_speculative) >= self.max_concurrent_speculative_repairs,
+                lambda: (
+                    not ignore_reservation
+                    and len(self._reserved_speculative) >= self.max_concurrent_speculative_repairs
+                ),
                 "speculative_pending_limit",
             ),
             (lambda: not ignore_active_flight and self._has_active_task(key), "repair_in_flight"),
@@ -221,21 +227,27 @@ class ThreadRepairRegistry:
         )
         return next((reason for declined, reason in declines if declined()), None)
 
-    def reserve_speculative_repair(self, key: _ThreadRepairDeltaKey) -> bool:
-        """Claim the right to schedule one speculative repair, or report that nobody may.
+    def reserve_speculative_repair(self, key: _ThreadRepairDeltaKey) -> object | None:
+        """Claim the right to schedule one speculative repair, returning a token, or ``None``.
 
         Admission inside :meth:`run` cannot bound a burst, because a burst is synchronous: nothing
         has reached ``run`` yet, so every caller sees free capacity and adds another task. This is
         the check that has to be atomic with the decision to create one, so it both tests and marks.
+
+        The claim is held until :meth:`run` takes over ownership of the thread, which covers the
+        awaited preparation in between. The token identifies the holder so a late release can never
+        drop a claim that has since been handed to somebody else.
         """
         if self.speculative_suppression_reason(key) is not None:
-            return False
-        self._reserved_speculative.add(key)
-        return True
+            return None
+        token = object()
+        self._reserved_speculative[key] = token
+        return token
 
-    def release_speculative_repair(self, key: _ThreadRepairDeltaKey) -> None:
-        """Release a reservation once its repair has reached the registry, or been abandoned."""
-        self._reserved_speculative.discard(key)
+    def release_speculative_repair(self, key: _ThreadRepairDeltaKey, token: object) -> None:
+        """Drop a scheduling claim, but only while this token still holds it."""
+        if self._reserved_speculative.get(key) is token:
+            del self._reserved_speculative[key]
 
     @contextmanager
     def _joined_interactively(self, key: _ThreadRepairFlightKey) -> Iterator[None]:
@@ -290,7 +302,10 @@ class ThreadRepairRegistry:
     ) -> Exception | None:
         """Return why this caller may not start a new scan right now."""
         if speculative:
-            suppression_reason = self.speculative_suppression_reason(self._thread_key(key))
+            suppression_reason = self.speculative_suppression_reason(
+                self._thread_key(key),
+                ignore_reservation=True,
+            )
             if suppression_reason is not None:
                 return ThreadRepairSuppressedError(suppression_reason)
         retry_after_seconds = self.retry_after_seconds(key)
@@ -393,6 +408,10 @@ class ThreadRepairRegistry:
 
         task = schedule(lambda: self._run_in_repair_slot(key, run_repair, speculative=speculative))
         self._tasks[key] = task
+        if speculative:
+            # Ownership transferred: `_tasks` now suppresses this thread, so the scheduling claim
+            # that stood in for it until admission is spent.
+            self._reserved_speculative.pop(self._thread_key(key), None)
         task.add_done_callback(lambda done_task: self._clear_task(key, done_task))
         return await asyncio.shield(task)
 
@@ -450,7 +469,7 @@ class ThreadRepairRegistry:
             if key[:2] != (coordination_scope, room_id)
         }
         self._reserved_speculative = {
-            key for key in self._reserved_speculative if key[:2] != (coordination_scope, room_id)
+            key: token for key, token in self._reserved_speculative.items() if key[:2] != (coordination_scope, room_id)
         }
 
     def clear(self) -> None:

--- a/src/mindroom/matrix/cache/thread_repair.py
+++ b/src/mindroom/matrix/cache/thread_repair.py
@@ -49,6 +49,9 @@ _MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS = 2
 # by the next read, which is interactive and exempt.
 _SPECULATIVE_THREAD_REPAIR_COOLDOWN_SECONDS = 30.0
 
+# A scheduler whose claim was dropped at a membership boundary while it was still preparing.
+_CLAIM_REVOKED = "claim_revoked"
+
 
 @dataclass(frozen=True, slots=True)
 class _RetainedDelta:
@@ -275,13 +278,28 @@ class ThreadRepairRegistry:
         if claim is not None and claim.token is token and not claim.handed_off:
             del self._reserved_speculative[key]
 
-    def _hand_off_claim(self, key: _ThreadRepairDeltaKey) -> object | None:
-        """Move this thread's claim from the scheduling task to the flight being registered."""
+    def _owns_claim(self, key: _ThreadRepairDeltaKey, token: object) -> bool:
+        """Return whether this exact token is still the live claim on this thread."""
         claim = self._reserved_speculative.get(key)
-        if claim is None:
+        return claim is not None and claim.token is token
+
+    def _hand_off_claim(self, key: _ThreadRepairDeltaKey, token: object) -> object | None:
+        """Move this thread's claim to the flight being registered, if this token still holds it.
+
+        Keyed on the token rather than the thread, because a scheduler blocked in preparation can
+        resume after a ``clear_room`` and find a later attempt holding a different claim; handing
+        that one off would register a stale flight against a newer caller's token.
+        """
+        if not self._owns_claim(key, token):
             return None
+        claim = self._reserved_speculative[key]
         claim.handed_off = True
         return claim.token
+
+    def _discard_flight_claim(self, key: _ThreadRepairFlightKey, token: object | None) -> None:
+        """Forget a flight's cleanup token, but only while it is still that flight's."""
+        if token is not None and self._flight_claims.get(key) is token:
+            del self._flight_claims[key]
 
     def _release_flight_claim(self, key: _ThreadRepairDeltaKey, token: object | None) -> None:
         """Drop a claim a flight owns, identified by token so a stale body cannot take a newer one."""
@@ -380,7 +398,7 @@ class ThreadRepairRegistry:
             # Released by the token this flight was registered with, so a body that outlived a
             # `clear_room` cannot drop the claim a later attempt on the same thread now holds.
             self._release_flight_claim(self._thread_key(key), claim_token)
-            self._flight_claims.pop(key, None)
+            self._discard_flight_claim(key, claim_token)
         if speculative and self._interactive_joins.get(key):
             speculative = False
         if speculative:
@@ -425,6 +443,7 @@ class ThreadRepairRegistry:
         result_arms_backoff: Callable[[T], bool],
         bypass_failure_backoff: bool = False,
         speculative: bool = False,
+        claim_token: object | None = None,
     ) -> T:
         """Join or start one shielded repair and update backoff from its outcome.
 
@@ -447,6 +466,11 @@ class ThreadRepairRegistry:
                     self._failure_backoffs.pop(key, None)
             return value
 
+        if speculative and claim_token is not None and not self._owns_claim(self._thread_key(key), claim_token):
+            # This caller's claim was dropped at a membership boundary while it was still preparing.
+            # Whatever holds the thread now belongs to a later attempt, and joining or registering
+            # against it would let a pre-clear flight answer a post-clear caller.
+            raise ThreadRepairSuppressedError(_CLAIM_REVOKED)
         active_task = self._active_task(key)
         if active_task is not None:
             return await self._join_running_flight(key, active_task, speculative=speculative)
@@ -458,13 +482,17 @@ class ThreadRepairRegistry:
         if admission_error is not None:
             raise admission_error
 
-        claim_token = self._hand_off_claim(self._thread_key(key)) if speculative else None
+        flight_token = (
+            self._hand_off_claim(self._thread_key(key), claim_token)
+            if speculative and claim_token is not None
+            else None
+        )
         task = schedule(
-            lambda: self._run_in_repair_slot(key, run_repair, speculative=speculative, claim_token=claim_token),
+            lambda: self._run_in_repair_slot(key, run_repair, speculative=speculative, claim_token=flight_token),
         )
         self._tasks[key] = task
-        if claim_token is not None:
-            self._flight_claims[key] = claim_token
+        if flight_token is not None:
+            self._flight_claims[key] = flight_token
         task.add_done_callback(lambda done_task: self._clear_task(key, done_task))
         return await asyncio.shield(task)
 
@@ -522,7 +550,10 @@ class ThreadRepairRegistry:
             if key[:2] != (coordination_scope, room_id)
         }
         self._reserved_speculative = {
-            key: token for key, token in self._reserved_speculative.items() if key[:2] != (coordination_scope, room_id)
+            key: claim for key, claim in self._reserved_speculative.items() if key[:2] != (coordination_scope, room_id)
+        }
+        self._flight_claims = {
+            key: token for key, token in self._flight_claims.items() if key[:2] != (coordination_scope, room_id)
         }
 
     def clear(self) -> None:

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -23,6 +23,7 @@ This is the application layer below the write policies in ``thread_writes``; it 
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 from mindroom.matrix.thread_bookkeeping import MutationThreadImpact, MutationThreadImpactState
@@ -31,7 +32,6 @@ from .thread_cache_invalidation import mark_room_threads_stale_fail_closed, mark
 from .thread_cache_state import ThreadAppendOutcome
 
 if TYPE_CHECKING:
-    import asyncio
     from collections.abc import Callable, Coroutine, Sequence
 
     import structlog
@@ -317,7 +317,7 @@ class ThreadMutationCacheOps:
                 event_source,
                 append_failed_reason=append_failed_reason,
             )
-        except Exception as exc:
+        except BaseException as exc:
             self.logger.warning(
                 "Failed to append thread event to cache",
                 room_id=room_id,
@@ -329,9 +329,13 @@ class ThreadMutationCacheOps:
             # The atomic operation rolled back, so it wrote no marker either. Without one, a thread
             # that was trusted before this mutation stays trusted while missing the event, so the
             # marker has to be written separately and fail closed exactly as pre-invalidation did.
-            await self.invalidate_known_thread(room_id, thread_id, reason=append_failed_reason)
+            # Cancellation rolls the transaction back the same way and is not an ``Exception``, so it
+            # is caught here too, and the marker is shielded so a second cancellation cannot skip it.
+            await asyncio.shield(
+                self.invalidate_known_thread(room_id, thread_id, reason=append_failed_reason),
+            )
             self._schedule_repair_if_available(room_id, thread_id)
-            if raise_on_failure:
+            if raise_on_failure or not isinstance(exc, Exception):
                 raise
             return False
 

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -371,9 +371,14 @@ class ThreadMutationCacheOps:
 
         Shielding alone is not enough: it keeps the write running but leaves it untracked, so
         ``close`` returns without it and a marker abandoned mid-shutdown is the fail-open this
-        handler exists to prevent. Owning the task puts it in the set ``close`` waits on, within the
-        same bounded budget as every other cache write -- a backend too wedged to finish inside that
-        budget loses the marker, but by then it is failing every write, not just this one.
+        handler exists to prevent. Owning the task puts it in the set ``close`` waits on.
+
+        One ordering is still not covered. When the append is itself cancelled *by* that drain, the
+        five-second budget has already been spent on the append, and the marker created in its
+        handler inherits only the remainder of one 0.1s cancel round before the next round cancels
+        it too. A healthy marker write is about a millisecond, so this needs a congested write path
+        on top of a drain that already failed -- and a slow homeserver scan in the same owned set
+        reaches that state with a perfectly healthy cache.
         """
         # Every caller reaches an append only through `cache_runtime_available`, and the queue
         # helpers dereference the coordinator unguarded, so a missing one is a bug, not a mode.

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -318,7 +318,7 @@ class ThreadMutationCacheOps:
                 event_source,
                 append_failed_reason=append_failed_reason,
             )
-        except BaseException as exc:
+        except (Exception, asyncio.CancelledError) as exc:
             self.logger.warning(
                 "Failed to append thread event to cache",
                 room_id=room_id,
@@ -334,7 +334,7 @@ class ThreadMutationCacheOps:
             # is caught here too.
             await self._write_append_failure_marker(room_id, thread_id, reason=append_failed_reason)
             self._schedule_repair_if_available(room_id, thread_id)
-            if raise_on_failure or not isinstance(exc, Exception):
+            if raise_on_failure or isinstance(exc, asyncio.CancelledError):
                 raise
             return False
 

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -338,7 +338,7 @@ class ThreadMutationCacheOps:
                 raise
             return False
 
-        if outcome.needs_full_repair:
+        if outcome is ThreadAppendOutcome.SNAPSHOT_MISSING:
             self.logger.debug(
                 "Skipping thread event append because raw thread cache is missing",
                 room_id=room_id,
@@ -375,14 +375,13 @@ class ThreadMutationCacheOps:
         same bounded budget as every other cache write -- a backend too wedged to finish inside that
         budget loses the marker, but by then it is failing every write, not just this one.
         """
+        # Every caller reaches an append only through `cache_runtime_available`, and the queue
+        # helpers dereference the coordinator unguarded, so a missing one is a bug, not a mode.
         coordinator = self.runtime.event_cache_write_coordinator
-        marker = self.invalidate_known_thread(room_id, thread_id, reason=reason)
-        if coordinator is None:
-            await marker
-            return
+        assert coordinator is not None
         await asyncio.shield(
             create_background_task(
-                marker,
+                self.invalidate_known_thread(room_id, thread_id, reason=reason),
                 name="matrix_cache_append_failure_marker",
                 owner=coordinator.background_task_owner,
             ),

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -367,12 +367,13 @@ class ThreadMutationCacheOps:
         return True
 
     async def _write_append_failure_marker(self, room_id: str, thread_id: str, *, reason: str) -> None:
-        """Persist the marker a rolled-back append owes, surviving a second cancellation.
+        """Persist the marker a rolled-back append owes, surviving the cancellation that caused it.
 
-        Shutdown cancels pending work in bounded rounds, so shielding alone is not enough: the shield
-        keeps the write running but leaves it untracked, and a marker abandoned mid-shutdown is the
-        fail-open this handler exists to prevent. Owning the task hands it to the same drain that
-        waits for every other cache write.
+        Shielding alone is not enough: it keeps the write running but leaves it untracked, so
+        ``close`` returns without it and a marker abandoned mid-shutdown is the fail-open this
+        handler exists to prevent. Owning the task puts it in the set ``close`` waits on, within the
+        same bounded budget as every other cache write -- a backend too wedged to finish inside that
+        budget loses the marker, but by then it is failing every write, not just this one.
         """
         coordinator = self.runtime.event_cache_write_coordinator
         marker = self.invalidate_known_thread(room_id, thread_id, reason=reason)

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -11,6 +11,9 @@ This is the application layer below the write policies in ``thread_writes``; it 
    settles the thread's trust in one transaction. It refuses when the thread has no cached snapshot
    rows (then only recording lookup-index rows) and marks the thread stale, so a partial snapshot is
    never trusted, and a mutation that succeeds is never observably stale in between.
+   That transaction also carries the marker, so when it fails there is no marker either; the append
+   path then writes one through the same fail-closed ladder as rule 1 rather than leaving a thread
+   trusted while it is missing the mutation.
 
 3. A successful append leaves the thread trusted only under the conditions enforced by
    ``append_keeps_thread_valid`` (see ``thread_cache_state``): a thread that was already valid stays
@@ -323,6 +326,10 @@ class ThreadMutationCacheOps:
                 context=context,
                 error=str(exc),
             )
+            # The atomic operation rolled back, so it wrote no marker either. Without one, a thread
+            # that was trusted before this mutation stays trusted while missing the event, so the
+            # marker has to be written separately and fail closed exactly as pre-invalidation did.
+            await self.invalidate_known_thread(room_id, thread_id, reason=append_failed_reason)
             self._schedule_repair_if_available(room_id, thread_id)
             if raise_on_failure:
                 raise
@@ -336,8 +343,6 @@ class ThreadMutationCacheOps:
                 event_id=event_id,
                 context=context,
             )
-            self._schedule_repair_if_available(room_id, thread_id)
-            return False
         if not outcome.wrote_event:
             self._schedule_repair_if_available(room_id, thread_id)
             return False

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any
 
+from mindroom.background_tasks import create_background_task
 from mindroom.matrix.thread_bookkeeping import MutationThreadImpact, MutationThreadImpactState
 
 from .thread_cache_invalidation import mark_room_threads_stale_fail_closed, mark_thread_stale_fail_closed
@@ -330,10 +331,8 @@ class ThreadMutationCacheOps:
             # that was trusted before this mutation stays trusted while missing the event, so the
             # marker has to be written separately and fail closed exactly as pre-invalidation did.
             # Cancellation rolls the transaction back the same way and is not an ``Exception``, so it
-            # is caught here too, and the marker is shielded so a second cancellation cannot skip it.
-            await asyncio.shield(
-                self.invalidate_known_thread(room_id, thread_id, reason=append_failed_reason),
-            )
+            # is caught here too.
+            await self._write_append_failure_marker(room_id, thread_id, reason=append_failed_reason)
             self._schedule_repair_if_available(room_id, thread_id)
             if raise_on_failure or not isinstance(exc, Exception):
                 raise
@@ -366,6 +365,27 @@ class ThreadMutationCacheOps:
                 coordination_scope=self.runtime.event_cache.principal_id,
             )
         return True
+
+    async def _write_append_failure_marker(self, room_id: str, thread_id: str, *, reason: str) -> None:
+        """Persist the marker a rolled-back append owes, surviving a second cancellation.
+
+        Shutdown cancels pending work in bounded rounds, so shielding alone is not enough: the shield
+        keeps the write running but leaves it untracked, and a marker abandoned mid-shutdown is the
+        fail-open this handler exists to prevent. Owning the task hands it to the same drain that
+        waits for every other cache write.
+        """
+        coordinator = self.runtime.event_cache_write_coordinator
+        marker = self.invalidate_known_thread(room_id, thread_id, reason=reason)
+        if coordinator is None:
+            await marker
+            return
+        await asyncio.shield(
+            create_background_task(
+                marker,
+                name="matrix_cache_append_failure_marker",
+                owner=coordinator.background_task_owner,
+            ),
+        )
 
     def retain_thread_repair_delta(
         self,

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -373,12 +373,10 @@ class ThreadMutationCacheOps:
         ``close`` returns without it and a marker abandoned mid-shutdown is the fail-open this
         handler exists to prevent. Owning the task puts it in the set ``close`` waits on.
 
-        One ordering is still not covered. When the append is itself cancelled *by* that drain, the
-        five-second budget has already been spent on the append, and the marker created in its
-        handler inherits only the remainder of one 0.1s cancel round before the next round cancels
-        it too. A healthy marker write is about a millisecond, so this needs a congested write path
-        on top of a drain that already failed -- and a slow homeserver scan in the same owned set
-        reaches that state with a perfectly healthy cache.
+        It is owned separately from ordinary cache writes because the common way to owe a marker is
+        for the drain to cancel the append: by then the shared budget is spent, and a marker put in
+        the same set would simply be cancelled by the next round. ``close`` drains this owner after
+        that one, on its own budget.
         """
         # Every caller reaches an append only through `cache_runtime_available`, and the queue
         # helpers dereference the coordinator unguarded, so a missing one is a bug, not a mode.
@@ -388,7 +386,7 @@ class ThreadMutationCacheOps:
             create_background_task(
                 self.invalidate_known_thread(room_id, thread_id, reason=reason),
                 name="matrix_cache_append_failure_marker",
-                owner=coordinator.background_task_owner,
+                owner=coordinator.failure_marker_task_owner,
             ),
         )
 

--- a/src/mindroom/matrix/cache/thread_write_cache_ops.py
+++ b/src/mindroom/matrix/cache/thread_write_cache_ops.py
@@ -7,14 +7,15 @@ This is the application layer below the write policies in ``thread_writes``; it 
    are deleted instead, and when even deletion fails (and the backend is not just temporarily
    unavailable) the cache is disabled for the rest of the runtime.
 
-2. Appends are incremental-only: ``append_event`` refuses when the thread has no cached snapshot rows
-   (it then only records lookup-index rows), and a failed append re-invalidates the thread so a partial
-   snapshot is never trusted.
+2. Appends are incremental-only and atomic: ``apply_thread_mutation_append`` appends the event and
+   settles the thread's trust in one transaction. It refuses when the thread has no cached snapshot
+   rows (then only recording lookup-index rows) and marks the thread stale, so a partial snapshot is
+   never trusted, and a mutation that succeeds is never observably stale in between.
 
-3. After a successful append the thread is revalidated only under the conditions enforced by
-   ``revalidate_thread_after_incremental_update`` (see ``sqlite_event_cache_threads``): the prior
-   invalidation must come from an incremental mutation reason and the room must not have been
-   invalidated at or after the last validation.
+3. A successful append leaves the thread trusted only under the conditions enforced by
+   ``append_keeps_thread_valid`` (see ``thread_cache_state``): a thread that was already valid stays
+   valid, a thread invalidated by an incremental mutation reason is cleared, and a room invalidated
+   at or after the last validation still outranks the append.
 """
 
 from __future__ import annotations
@@ -24,6 +25,7 @@ from typing import TYPE_CHECKING, Any
 from mindroom.matrix.thread_bookkeeping import MutationThreadImpact, MutationThreadImpactState
 
 from .thread_cache_invalidation import mark_room_threads_stale_fail_closed, mark_thread_stale_fail_closed
+from .thread_cache_state import ThreadAppendOutcome
 
 if TYPE_CHECKING:
     import asyncio
@@ -294,12 +296,24 @@ class ThreadMutationCacheOps:
         event_source: dict[str, Any],
         *,
         context: str,
+        append_failed_reason: str,
         raise_on_failure: bool = False,
     ) -> bool:
-        """Append one event into a cached thread fail-open and report whether a row changed."""
+        """Append one event into a cached thread fail-open and report whether a row changed.
+
+        Appending, and deciding whether the thread stays trusted afterwards, happen in one durable
+        operation. Splitting them used to leave a valid thread observably stale for the duration of
+        the append, so any read arriving in between rejected the snapshot and paid for a full
+        history scan even though the mutation was about to succeed.
+        """
         event_id = event_source.get("event_id")
         try:
-            appended = await self.runtime.event_cache.append_event(room_id, thread_id, event_source)
+            outcome = await self.runtime.event_cache.apply_thread_mutation_append(
+                room_id,
+                thread_id,
+                event_source,
+                append_failed_reason=append_failed_reason,
+            )
         except Exception as exc:
             self.logger.warning(
                 "Failed to append thread event to cache",
@@ -313,7 +327,8 @@ class ThreadMutationCacheOps:
             if raise_on_failure:
                 raise
             return False
-        if not appended:
+
+        if outcome.needs_full_repair:
             self.logger.debug(
                 "Skipping thread event append because raw thread cache is missing",
                 room_id=room_id,
@@ -323,34 +338,24 @@ class ThreadMutationCacheOps:
             )
             self._schedule_repair_if_available(room_id, thread_id)
             return False
-        try:
-            revalidated = await self.runtime.event_cache.revalidate_thread_after_incremental_update(
+        if not outcome.wrote_event:
+            self._schedule_repair_if_available(room_id, thread_id)
+            return False
+
+        if outcome is not ThreadAppendOutcome.APPENDED:
+            # The event landed but a marker outside the incremental allowlist still outranks it, so
+            # the snapshot is not converged and its retained delta must survive until a scan runs.
+            self._schedule_repair_if_available(room_id, thread_id)
+            return True
+
+        coordinator = self.runtime.event_cache_write_coordinator
+        if coordinator is not None and isinstance(event_id, str):
+            coordinator.acknowledge_thread_repair_deltas(
                 room_id,
                 thread_id,
+                (event_id,),
+                coordination_scope=self.runtime.event_cache.principal_id,
             )
-        except Exception as exc:
-            self.logger.warning(
-                "Failed to refresh thread cache validation after incremental update",
-                room_id=room_id,
-                thread_id=thread_id,
-                event_id=event_id,
-                context=context,
-                error=str(exc),
-            )
-            self._schedule_repair_if_available(room_id, thread_id)
-            if raise_on_failure:
-                raise
-        else:
-            coordinator = self.runtime.event_cache_write_coordinator
-            if revalidated and coordinator is not None and isinstance(event_id, str):
-                coordinator.acknowledge_thread_repair_deltas(
-                    room_id,
-                    thread_id,
-                    (event_id,),
-                    coordination_scope=self.runtime.event_cache.principal_id,
-                )
-            elif not revalidated:
-                self._schedule_repair_if_available(room_id, thread_id)
         return True
 
     def retain_thread_repair_delta(

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -195,7 +195,7 @@ async def _apply_thread_message_mutation(
     event_id: str | None,
     context: MutationWriteContext,
     room_level_skip_message: str,
-    invalidate_on_append_failure: bool,
+    use_append_failure_reason: bool,
     allow_room_invalidation: bool = True,
     raise_on_cache_write_failure: bool = False,
 ) -> bool:
@@ -243,9 +243,11 @@ async def _apply_thread_message_mutation(
         impact.thread_id,
         event_source,
         context=context,
+        # Every path marks the thread stale when the append cannot land; this only chooses whether
+        # that marker carries its own reason or the plain mutation one a later append may clear.
         append_failed_reason=_mutation_reason(
             context,
-            "append_failed" if invalidate_on_append_failure else "thread_mutation",
+            "append_failed" if use_append_failure_reason else "thread_mutation",
         ),
         raise_on_failure=raise_on_cache_write_failure,
     )
@@ -379,7 +381,7 @@ class ThreadOutboundWritePolicy:
             event_id=event_id,
             context="outbound",
             room_level_skip_message="Skipping outbound thread cache bookkeeping for non-threaded event mutation",
-            invalidate_on_append_failure=False,
+            use_append_failure_reason=False,
         )
 
     def _resolve_prequeue_thread_route(
@@ -889,7 +891,7 @@ class ThreadLiveWritePolicy:
                 event_id=event.event_id,
                 context="live",
                 room_level_skip_message=room_level_skip_message,
-                invalidate_on_append_failure=True,
+                use_append_failure_reason=True,
             )
             return
         if impact.state is MutationThreadImpactState.UNKNOWN:
@@ -909,7 +911,7 @@ class ThreadLiveWritePolicy:
         event_source = normalize_nio_event_for_cache(event)
         self._cache_ops.retain_thread_repair_delta(room_id, thread_id, event_source)
 
-        async def append_and_invalidate() -> bool:
+        async def append_live_mutation() -> bool:
             return await _apply_thread_message_mutation(
                 cache_ops=self._cache_ops,
                 room_id=room_id,
@@ -919,13 +921,13 @@ class ThreadLiveWritePolicy:
                 event_id=event.event_id,
                 context="live",
                 room_level_skip_message=room_level_skip_message,
-                invalidate_on_append_failure=True,
+                use_append_failure_reason=True,
             )
 
         await self._cache_ops.queue_thread_cache_update(
             room_id,
             thread_id,
-            append_and_invalidate,
+            append_live_mutation,
             name="matrix_cache_append_live_event",
         )
 
@@ -945,7 +947,7 @@ class ThreadLiveWritePolicy:
         queue_started = time.perf_counter()
         append_metrics: dict[str, str | int | float | bool] = {}
 
-        async def append_and_invalidate() -> bool:
+        async def append_live_mutation() -> bool:
             # One durable operation now covers what used to be invalidate, append, and revalidate,
             # so there is no separate invalidation to time and no window for a reader to reject.
             append_started = time.perf_counter()
@@ -965,7 +967,7 @@ class ThreadLiveWritePolicy:
             appended = await self._cache_ops.queue_thread_cache_update(
                 room_id,
                 thread_id,
-                append_and_invalidate,
+                append_live_mutation,
                 name="matrix_cache_append_live_event",
             )
             if appended is False:
@@ -1157,7 +1159,7 @@ class ThreadSyncWritePolicy:
                     event_id=event_id if isinstance(event_id, str) else None,
                     context="sync",
                     room_level_skip_message="Skipping sync thread cache bookkeeping for known non-threaded message mutation",
-                    invalidate_on_append_failure=True,
+                    use_append_failure_reason=True,
                     allow_room_invalidation=not room_threads_invalidated,
                     raise_on_cache_write_failure=raise_on_cache_write_failure,
                 )

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -29,6 +29,10 @@ These three policies are the only writers of durable thread-cache state:
 7. A still-opaque ``m.room.encrypted`` mutation with a known thread never appends into the snapshot or
    revalidates it; it only marks that thread stale under a non-incremental reason, so the snapshot
    stays rejected until a decryption-capable refresh replaces it.
+
+8. Every other threaded mutation appends through one atomic cache operation that also settles the
+   thread's trust. Marking stale up front and revalidating afterwards left the snapshot observably
+   rejected for the duration of an append that was going to succeed.
    Point rows and explicit relation indexes are still persisted by the batch store, and unknown-impact
    opaque mutations fail closed through the standard room-scope invalidation.
 """
@@ -229,26 +233,22 @@ async def _apply_thread_message_mutation(
         impact.thread_id,
         event_source,
     )
-    await cache_ops.invalidate_known_thread(
-        room_id,
-        impact.thread_id,
-        reason=_mutation_reason(context, "thread_mutation"),
-        raise_on_failure=raise_on_cache_write_failure,
-    )
-    appended = await cache_ops.append_event_to_cache(
+    # No pre-invalidation: `append_event_to_cache` appends and settles this thread's trust in one
+    # durable operation, so a mutation that succeeds never makes the snapshot observably stale, and
+    # one that cannot append leaves the same durable marker this sequence used to write up front.
+    # Callers that did not add a second marker on append failure keep the plain mutation reason, so
+    # a later append can still clear it exactly as it could before.
+    await cache_ops.append_event_to_cache(
         room_id,
         impact.thread_id,
         event_source,
         context=context,
+        append_failed_reason=_mutation_reason(
+            context,
+            "append_failed" if invalidate_on_append_failure else "thread_mutation",
+        ),
         raise_on_failure=raise_on_cache_write_failure,
     )
-    if invalidate_on_append_failure and not appended:
-        await cache_ops.invalidate_known_thread(
-            room_id,
-            impact.thread_id,
-            reason=_mutation_reason(context, "append_failed"),
-            raise_on_failure=raise_on_cache_write_failure,
-        )
     return False
 
 
@@ -946,33 +946,18 @@ class ThreadLiveWritePolicy:
         append_metrics: dict[str, str | int | float | bool] = {}
 
         async def append_and_invalidate() -> bool:
-            invalidate_started = time.perf_counter()
-            await self._cache_ops.invalidate_known_thread(
-                room_id,
-                thread_id,
-                reason="live_thread_mutation",
-            )
-            append_metrics["invalidate_ms"] = elapsed_ms_since(invalidate_started, clock=time.perf_counter)
+            # One durable operation now covers what used to be invalidate, append, and revalidate,
+            # so there is no separate invalidation to time and no window for a reader to reject.
             append_started = time.perf_counter()
             appended = await self._cache_ops.append_event_to_cache(
                 room_id,
                 thread_id,
                 event_source,
                 context="live",
+                append_failed_reason="live_append_failed",
             )
             append_metrics["append_ms"] = elapsed_ms_since(append_started, clock=time.perf_counter)
             append_metrics["appended"] = appended
-            if not appended:
-                fallback_invalidate_started = time.perf_counter()
-                await self._cache_ops.invalidate_known_thread(
-                    room_id,
-                    thread_id,
-                    reason="live_append_failed",
-                )
-                append_metrics["append_failure_invalidate_ms"] = elapsed_ms_since(
-                    fallback_invalidate_started,
-                    clock=time.perf_counter,
-                )
             return appended
 
         outcome = "ok"

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -896,7 +896,7 @@ class ThreadLiveWritePolicy:
             # UNKNOWN-impact mutations must use the eager invalidate_room_threads
             # path: the per-thread coordinator's concurrent writers cannot safely
             # uphold the `room_invalidated_at >= validated_at` invariant that
-            # revalidate_thread_after_incremental_update_locked relies on at read
+            # append_keeps_thread_valid relies on at read
             # time. See ISSUE-189 for the architectural follow-up.
             await self._cache_ops.invalidate_room_threads(
                 room_id,
@@ -1028,7 +1028,7 @@ class ThreadLiveWritePolicy:
             # UNKNOWN-impact mutations must use the eager invalidate_room_threads
             # path: the per-thread coordinator's concurrent writers cannot safely
             # uphold the `room_invalidated_at >= validated_at` invariant that
-            # revalidate_thread_after_incremental_update_locked relies on at read
+            # append_keeps_thread_valid relies on at read
             # time. See ISSUE-189 for the architectural follow-up.
             await self._cache_ops.invalidate_room_threads(
                 room_id,

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -31,8 +31,7 @@ These three policies are the only writers of durable thread-cache state:
    stays rejected until a decryption-capable refresh replaces it.
 
 8. Every other threaded mutation appends through one atomic cache operation that also settles the
-   thread's trust. Marking stale up front and revalidating afterwards left the snapshot observably
-   rejected for the duration of an append that was going to succeed.
+   thread's trust, so the snapshot is never observably rejected mid-append.
    Point rows and explicit relation indexes are still persisted by the batch store, and unknown-impact
    opaque mutations fail closed through the standard room-scope invalidation.
 """
@@ -233,11 +232,6 @@ async def _apply_thread_message_mutation(
         impact.thread_id,
         event_source,
     )
-    # No pre-invalidation: `append_event_to_cache` appends and settles this thread's trust in one
-    # durable operation, so a mutation that succeeds never makes the snapshot observably stale, and
-    # one that cannot append leaves the same durable marker this sequence used to write up front.
-    # Callers that did not add a second marker on append failure keep the plain mutation reason, so
-    # a later append can still clear it exactly as it could before.
     await cache_ops.append_event_to_cache(
         room_id,
         impact.thread_id,
@@ -948,8 +942,6 @@ class ThreadLiveWritePolicy:
         append_metrics: dict[str, str | int | float | bool] = {}
 
         async def append_live_mutation() -> bool:
-            # One durable operation now covers what used to be invalidate, append, and revalidate,
-            # so there is no separate invalidation to time and no window for a reader to reject.
             append_started = time.perf_counter()
             appended = await self._cache_ops.append_event_to_cache(
                 room_id,

--- a/src/mindroom/matrix/cache/thread_writes.py
+++ b/src/mindroom/matrix/cache/thread_writes.py
@@ -194,7 +194,6 @@ async def _apply_thread_message_mutation(
     event_id: str | None,
     context: MutationWriteContext,
     room_level_skip_message: str,
-    use_append_failure_reason: bool,
     allow_room_invalidation: bool = True,
     raise_on_cache_write_failure: bool = False,
 ) -> bool:
@@ -237,12 +236,11 @@ async def _apply_thread_message_mutation(
         impact.thread_id,
         event_source,
         context=context,
-        # Every path marks the thread stale when the append cannot land; this only chooses whether
-        # that marker carries its own reason or the plain mutation one a later append may clear.
-        append_failed_reason=_mutation_reason(
-            context,
-            "append_failed" if use_append_failure_reason else "thread_mutation",
-        ),
+        # Always a reason outside the incremental allowlist. A marker a later append could clear
+        # would let the next successful mutation return the thread to trusted while it is still
+        # missing this event, and the retained delta that would have caught it expires after a
+        # minute.
+        append_failed_reason=_mutation_reason(context, "append_failed"),
         raise_on_failure=raise_on_cache_write_failure,
     )
     return False
@@ -375,7 +373,6 @@ class ThreadOutboundWritePolicy:
             event_id=event_id,
             context="outbound",
             room_level_skip_message="Skipping outbound thread cache bookkeeping for non-threaded event mutation",
-            use_append_failure_reason=False,
         )
 
     def _resolve_prequeue_thread_route(
@@ -885,7 +882,6 @@ class ThreadLiveWritePolicy:
                 event_id=event.event_id,
                 context="live",
                 room_level_skip_message=room_level_skip_message,
-                use_append_failure_reason=True,
             )
             return
         if impact.state is MutationThreadImpactState.UNKNOWN:
@@ -915,7 +911,6 @@ class ThreadLiveWritePolicy:
                 event_id=event.event_id,
                 context="live",
                 room_level_skip_message=room_level_skip_message,
-                use_append_failure_reason=True,
             )
 
         await self._cache_ops.queue_thread_cache_update(
@@ -1151,7 +1146,6 @@ class ThreadSyncWritePolicy:
                     event_id=event_id if isinstance(event_id, str) else None,
                     context="sync",
                     room_level_skip_message="Skipping sync thread cache bookkeeping for known non-threaded message mutation",
-                    use_append_failure_reason=True,
                     allow_room_invalidation=not room_threads_invalidated,
                     raise_on_cache_write_failure=raise_on_cache_write_failure,
                 )

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -96,7 +96,6 @@ class EventCacheWriteCoordinator:
 
     logger: structlog.stdlib.BoundLogger
     background_task_owner: object = field(default_factory=object)
-    thread_repairs: ThreadRepairRegistry = field(default_factory=ThreadRepairRegistry)
     _room_states: dict[_CoordinationRoomKey, _RoomSchedulerState] = field(default_factory=dict, init=False)
     _room_update_tasks: dict[_CoordinationRoomKey, _UpdateTask] = field(default_factory=dict, init=False)
     _thread_update_tasks: dict[tuple[_CoordinationRoomKey, str], _UpdateTask] = field(
@@ -108,6 +107,7 @@ class EventCacheWriteCoordinator:
         init=False,
     )
     _next_sequence: int = field(default=0, init=False)
+    _thread_repairs: ThreadRepairRegistry = field(default_factory=ThreadRepairRegistry, init=False)
 
     def _next_entry_sequence(self) -> int:
         sequence = self._next_sequence
@@ -656,7 +656,7 @@ class EventCacheWriteCoordinator:
         Untimed reads may bypass a retained delay; dispatch and background repairs leave the default.
         A speculative caller is subject to the fan-out gate and may be declined outright.
         """
-        return await self.thread_repairs.run(
+        return await self._thread_repairs.run(
             (coordination_scope, room_id, thread_id, hydrate_sidecars, allow_stale_fallback),
             schedule=lambda repair: typing.cast(
                 "asyncio.Task[T]",
@@ -676,6 +676,20 @@ class EventCacheWriteCoordinator:
             speculative=speculative,
         )
 
+    def thread_repair_has_interactive_waiter(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        coordination_scope: str,
+        hydrate_sidecars: bool,
+        allow_stale_fallback: bool,
+    ) -> bool:
+        """Return whether a caller waiting on history joined this flight after it was admitted."""
+        return self._thread_repairs.has_interactive_waiter(
+            (coordination_scope, room_id, thread_id, hydrate_sidecars, allow_stale_fallback),
+        )
+
     def speculative_thread_repair_suppression_reason(
         self,
         room_id: str,
@@ -688,13 +702,13 @@ class EventCacheWriteCoordinator:
         Callers use this to avoid spawning a background task per replayed event; the authoritative
         decision is still made inside ``run_thread_repair``.
         """
-        return self.thread_repairs.speculative_suppression_reason(
+        return self._thread_repairs.speculative_suppression_reason(
             (coordination_scope, room_id, thread_id),
         )
 
     def suppress_speculative_thread_repairs(self) -> AbstractContextManager[None]:
         """Drop speculative repairs for the duration of one sync replay batch."""
-        return self.thread_repairs.suppress_speculative_repairs()
+        return self._thread_repairs.suppress_speculative_repairs()
 
     def retain_thread_repair_delta(
         self,
@@ -705,7 +719,7 @@ class EventCacheWriteCoordinator:
         coordination_scope: str,
     ) -> None:
         """Retain one certified delta until append or repair includes it."""
-        self.thread_repairs.retain_delta(
+        self._thread_repairs.retain_delta(
             (coordination_scope, room_id, thread_id),
             event_source,
         )
@@ -718,7 +732,7 @@ class EventCacheWriteCoordinator:
         coordination_scope: str,
     ) -> tuple[dict[str, Any], ...]:
         """Return retained deltas for one principal-scoped repair."""
-        return self.thread_repairs.pending_deltas(
+        return self._thread_repairs.pending_deltas(
             (coordination_scope, room_id, thread_id),
         )
 
@@ -731,14 +745,14 @@ class EventCacheWriteCoordinator:
         coordination_scope: str,
     ) -> None:
         """Forget retained deltas after a successful append."""
-        self.thread_repairs.acknowledge_deltas(
+        self._thread_repairs.acknowledge_deltas(
             (coordination_scope, room_id, thread_id),
             event_ids,
         )
 
     def clear_thread_repair_room(self, room_id: str, *, coordination_scope: str) -> None:
         """Drop retained repair state at one authoritative membership departure."""
-        self.thread_repairs.clear_room(coordination_scope, room_id)
+        self._thread_repairs.clear_room(coordination_scope, room_id)
 
     async def wait_for_thread_idle(
         self,
@@ -815,4 +829,4 @@ class EventCacheWriteCoordinator:
         self._room_update_tasks.clear()
         self._thread_update_tasks.clear()
         self._thread_update_tasks_by_room.clear()
-        self.thread_repairs.clear()
+        self._thread_repairs.clear()

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -36,6 +36,7 @@ from .thread_repair import ThreadRepairRegistry
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Collection
+    from contextlib import AbstractContextManager
 
     import structlog
 
@@ -95,6 +96,7 @@ class EventCacheWriteCoordinator:
 
     logger: structlog.stdlib.BoundLogger
     background_task_owner: object = field(default_factory=object)
+    thread_repairs: ThreadRepairRegistry = field(default_factory=ThreadRepairRegistry)
     _room_states: dict[_CoordinationRoomKey, _RoomSchedulerState] = field(default_factory=dict, init=False)
     _room_update_tasks: dict[_CoordinationRoomKey, _UpdateTask] = field(default_factory=dict, init=False)
     _thread_update_tasks: dict[tuple[_CoordinationRoomKey, str], _UpdateTask] = field(
@@ -106,7 +108,6 @@ class EventCacheWriteCoordinator:
         init=False,
     )
     _next_sequence: int = field(default=0, init=False)
-    _thread_repairs: ThreadRepairRegistry = field(default_factory=ThreadRepairRegistry, init=False)
 
     def _next_entry_sequence(self) -> int:
         sequence = self._next_sequence
@@ -648,12 +649,14 @@ class EventCacheWriteCoordinator:
         allow_stale_fallback: bool,
         result_arms_backoff: Callable[[T], bool],
         bypass_failure_backoff: bool = False,
+        speculative: bool = False,
     ) -> T:
         """Join or start one principal-scoped repair under the same-thread barrier.
 
         Untimed reads may bypass a retained delay; dispatch and background repairs leave the default.
+        A speculative caller is subject to the fan-out gate and may be declined outright.
         """
-        return await self._thread_repairs.run(
+        return await self.thread_repairs.run(
             (coordination_scope, room_id, thread_id, hydrate_sidecars, allow_stale_fallback),
             schedule=lambda repair: typing.cast(
                 "asyncio.Task[T]",
@@ -670,7 +673,28 @@ class EventCacheWriteCoordinator:
             repair=repair_coro_factory,
             result_arms_backoff=result_arms_backoff,
             bypass_failure_backoff=bypass_failure_backoff,
+            speculative=speculative,
         )
+
+    def speculative_thread_repair_suppression_reason(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        coordination_scope: str,
+    ) -> str | None:
+        """Return why one speculative repair would be declined, without reserving a slot.
+
+        Callers use this to avoid spawning a background task per replayed event; the authoritative
+        decision is still made inside ``run_thread_repair``.
+        """
+        return self.thread_repairs.speculative_suppression_reason(
+            (coordination_scope, room_id, thread_id),
+        )
+
+    def suppress_speculative_thread_repairs(self) -> AbstractContextManager[None]:
+        """Drop speculative repairs for the duration of one sync replay batch."""
+        return self.thread_repairs.suppress_speculative_repairs()
 
     def retain_thread_repair_delta(
         self,
@@ -681,7 +705,7 @@ class EventCacheWriteCoordinator:
         coordination_scope: str,
     ) -> None:
         """Retain one certified delta until append or repair includes it."""
-        self._thread_repairs.retain_delta(
+        self.thread_repairs.retain_delta(
             (coordination_scope, room_id, thread_id),
             event_source,
         )
@@ -694,7 +718,7 @@ class EventCacheWriteCoordinator:
         coordination_scope: str,
     ) -> tuple[dict[str, Any], ...]:
         """Return retained deltas for one principal-scoped repair."""
-        return self._thread_repairs.pending_deltas(
+        return self.thread_repairs.pending_deltas(
             (coordination_scope, room_id, thread_id),
         )
 
@@ -707,14 +731,14 @@ class EventCacheWriteCoordinator:
         coordination_scope: str,
     ) -> None:
         """Forget retained deltas after a successful append."""
-        self._thread_repairs.acknowledge_deltas(
+        self.thread_repairs.acknowledge_deltas(
             (coordination_scope, room_id, thread_id),
             event_ids,
         )
 
     def clear_thread_repair_room(self, room_id: str, *, coordination_scope: str) -> None:
         """Drop retained repair state at one authoritative membership departure."""
-        self._thread_repairs.clear_room(coordination_scope, room_id)
+        self.thread_repairs.clear_room(coordination_scope, room_id)
 
     async def wait_for_thread_idle(
         self,
@@ -791,4 +815,4 @@ class EventCacheWriteCoordinator:
         self._room_update_tasks.clear()
         self._thread_update_tasks.clear()
         self._thread_update_tasks_by_room.clear()
-        self._thread_repairs.clear()
+        self.thread_repairs.clear()

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -96,6 +96,9 @@ class EventCacheWriteCoordinator:
 
     logger: structlog.stdlib.BoundLogger
     background_task_owner: object = field(default_factory=object)
+    # Fail-closed markers owed by a cancelled append are owned separately, so the generic
+    # cancellation rounds cannot reach them: those rounds are what create them.
+    failure_marker_task_owner: object = field(default_factory=object)
     _room_states: dict[_CoordinationRoomKey, _RoomSchedulerState] = field(default_factory=dict, init=False)
     _room_update_tasks: dict[_CoordinationRoomKey, _UpdateTask] = field(default_factory=dict, init=False)
     _thread_update_tasks: dict[tuple[_CoordinationRoomKey, str], _UpdateTask] = field(
@@ -676,21 +679,17 @@ class EventCacheWriteCoordinator:
             speculative=speculative,
         )
 
-    def speculative_thread_repair_suppression_reason(
-        self,
-        room_id: str,
-        thread_id: str,
-        *,
-        coordination_scope: str,
-    ) -> str | None:
-        """Return why one speculative repair would be declined, without reserving a slot.
+    def reserve_speculative_thread_repair(self, room_id: str, thread_id: str, *, coordination_scope: str) -> bool:
+        """Claim the right to schedule one speculative repair for this thread.
 
-        Callers use this to avoid spawning a background task per replayed event; the authoritative
-        decision is still made inside ``run_thread_repair``.
+        Testing and claiming together is what bounds a synchronous burst: admission inside
+        ``run_thread_repair`` cannot, because nothing in the burst has reached it yet.
         """
-        return self._thread_repairs.speculative_suppression_reason(
-            (coordination_scope, room_id, thread_id),
-        )
+        return self._thread_repairs.reserve_speculative_repair((coordination_scope, room_id, thread_id))
+
+    def release_speculative_thread_repair(self, room_id: str, thread_id: str, *, coordination_scope: str) -> None:
+        """Release a scheduling reservation once its repair reached the registry or was abandoned."""
+        self._thread_repairs.release_speculative_repair((coordination_scope, room_id, thread_id))
 
     def suppress_speculative_thread_repairs(self) -> AbstractContextManager[None]:
         """Drop speculative repairs for the duration of one sync replay batch."""
@@ -809,8 +808,14 @@ class EventCacheWriteCoordinator:
             )
 
     async def close(self) -> None:
-        """Drain any queued cache writes for this coordinator."""
+        """Drain any queued cache writes for this coordinator.
+
+        Markers are drained after, and on their own budget. Cancelling a queued append is what makes
+        it owe one, so an owed marker does not exist until the first drain has already given up, and
+        sharing that drain would leave it to be cancelled by the very next round.
+        """
         await wait_for_background_tasks(timeout=5.0, owner=self.background_task_owner)
+        await wait_for_background_tasks(timeout=5.0, owner=self.failure_marker_task_owner)
         self._room_states.clear()
         self._room_update_tasks.clear()
         self._thread_update_tasks.clear()

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -648,7 +648,6 @@ class EventCacheWriteCoordinator:
         hydrate_sidecars: bool,
         allow_stale_fallback: bool,
         result_arms_backoff: Callable[[T], bool],
-        result_needs_own_flight: Callable[[T], bool] | None = None,
         bypass_failure_backoff: bool = False,
         speculative: bool = False,
     ) -> T:
@@ -673,7 +672,6 @@ class EventCacheWriteCoordinator:
             ),
             repair=repair_coro_factory,
             result_arms_backoff=result_arms_backoff,
-            result_needs_own_flight=result_needs_own_flight,
             bypass_failure_backoff=bypass_failure_backoff,
             speculative=speculative,
         )

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -648,6 +648,7 @@ class EventCacheWriteCoordinator:
         hydrate_sidecars: bool,
         allow_stale_fallback: bool,
         result_arms_backoff: Callable[[T], bool],
+        result_needs_own_flight: Callable[[T], bool] | None = None,
         bypass_failure_backoff: bool = False,
         speculative: bool = False,
     ) -> T:
@@ -672,22 +673,9 @@ class EventCacheWriteCoordinator:
             ),
             repair=repair_coro_factory,
             result_arms_backoff=result_arms_backoff,
+            result_needs_own_flight=result_needs_own_flight,
             bypass_failure_backoff=bypass_failure_backoff,
             speculative=speculative,
-        )
-
-    def thread_repair_flight_is_speculative(
-        self,
-        room_id: str,
-        thread_id: str,
-        *,
-        coordination_scope: str,
-        hydrate_sidecars: bool,
-        allow_stale_fallback: bool,
-    ) -> bool:
-        """Return whether joining this thread's running flight would inherit a speculative contract."""
-        return self._thread_repairs.flight_is_speculative(
-            (coordination_scope, room_id, thread_id, hydrate_sidecars, allow_stale_fallback),
         )
 
     def speculative_thread_repair_suppression_reason(

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -676,7 +676,7 @@ class EventCacheWriteCoordinator:
             speculative=speculative,
         )
 
-    def thread_repair_has_interactive_waiter(
+    def thread_repair_flight_is_speculative(
         self,
         room_id: str,
         thread_id: str,
@@ -685,8 +685,8 @@ class EventCacheWriteCoordinator:
         hydrate_sidecars: bool,
         allow_stale_fallback: bool,
     ) -> bool:
-        """Return whether a caller waiting on history joined this flight after it was admitted."""
-        return self._thread_repairs.has_interactive_waiter(
+        """Return whether joining this thread's running flight would inherit a speculative contract."""
+        return self._thread_repairs.flight_is_speculative(
             (coordination_scope, room_id, thread_id, hydrate_sidecars, allow_stale_fallback),
         )
 

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -679,17 +679,30 @@ class EventCacheWriteCoordinator:
             speculative=speculative,
         )
 
-    def reserve_speculative_thread_repair(self, room_id: str, thread_id: str, *, coordination_scope: str) -> bool:
-        """Claim the right to schedule one speculative repair for this thread.
+    def reserve_speculative_thread_repair(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        coordination_scope: str,
+    ) -> object | None:
+        """Claim the right to schedule one speculative repair, returning a token, or ``None``.
 
         Testing and claiming together is what bounds a synchronous burst: admission inside
         ``run_thread_repair`` cannot, because nothing in the burst has reached it yet.
         """
         return self._thread_repairs.reserve_speculative_repair((coordination_scope, room_id, thread_id))
 
-    def release_speculative_thread_repair(self, room_id: str, thread_id: str, *, coordination_scope: str) -> None:
-        """Release a scheduling reservation once its repair reached the registry or was abandoned."""
-        self._thread_repairs.release_speculative_repair((coordination_scope, room_id, thread_id))
+    def release_speculative_thread_repair(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        coordination_scope: str,
+        token: object,
+    ) -> None:
+        """Drop a scheduling claim, but only while this token still holds it."""
+        self._thread_repairs.release_speculative_repair((coordination_scope, room_id, thread_id), token)
 
     def suppress_speculative_thread_repairs(self) -> AbstractContextManager[None]:
         """Drop speculative repairs for the duration of one sync replay batch."""

--- a/src/mindroom/matrix/cache/write_coordinator.py
+++ b/src/mindroom/matrix/cache/write_coordinator.py
@@ -653,6 +653,7 @@ class EventCacheWriteCoordinator:
         result_arms_backoff: Callable[[T], bool],
         bypass_failure_backoff: bool = False,
         speculative: bool = False,
+        claim_token: object | None = None,
     ) -> T:
         """Join or start one principal-scoped repair under the same-thread barrier.
 
@@ -677,6 +678,7 @@ class EventCacheWriteCoordinator:
             result_arms_backoff=result_arms_backoff,
             bypass_failure_backoff=bypass_failure_backoff,
             speculative=speculative,
+            claim_token=claim_token,
         )
 
     def reserve_speculative_thread_repair(

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -1349,12 +1349,19 @@ async def refresh_thread_history_from_source(
     retained_event_sources: RetainedThreadEventSourceProvider | None = None,
     caller_label: str | None = None,
     coordinator_queue_wait_ms: float = 0.0,
+    max_repair_attempts: int | None = None,
 ) -> ThreadHistoryResult:
-    """Fetch fresh thread history from Matrix and repopulate the advisory cache."""
+    """Fetch fresh thread history from Matrix and repopulate the advisory cache.
+
+    ``max_repair_attempts`` overrides how many times a lost guarded replacement is rescanned at
+    once. Callers nobody is waiting on pass ``1``: a retryable conflict means another writer owns
+    the thread right now, so an undelayed rescan is least likely to win and most expensive to run.
+    """
+    attempt_limit = _MAX_THREAD_REPAIR_ATTEMPTS if max_repair_attempts is None else max(1, max_repair_attempts)
     fetch_result: _ThreadHistoryFetchResult | None = None
     attempt: _ThreadCacheRefillAttempt | None = None
     repair_attempts = 0
-    for repair_attempts in range(1, _MAX_THREAD_REPAIR_ATTEMPTS + 1):
+    for repair_attempts in range(1, attempt_limit + 1):
         fetch_started_at = time.time()
         fetch_membership_epoch = await _capture_membership_epoch(event_cache, room_id)
         try:
@@ -1424,7 +1431,7 @@ async def refresh_thread_history_from_source(
                 caller_label=caller_label,
                 coordinator_queue_wait_ms=coordinator_queue_wait_ms,
             )
-        if not attempt.replace_outcome.retryable or repair_attempts == _MAX_THREAD_REPAIR_ATTEMPTS:
+        if not attempt.replace_outcome.retryable or repair_attempts == attempt_limit:
             break
         logger.warning(
             "Retrying thread cache repair after guarded replacement conflict",

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -1357,6 +1357,7 @@ async def refresh_thread_history_from_source(
     once. Callers nobody is waiting on pass ``1``: a retryable conflict means another writer owns
     the thread right now, so an undelayed rescan is least likely to win and most expensive to run.
     """
+    assert max_repair_attempts is None or max_repair_attempts >= 1
     attempt_limit = _MAX_THREAD_REPAIR_ATTEMPTS if max_repair_attempts is None else max_repair_attempts
     fetch_result: _ThreadHistoryFetchResult | None = None
     attempt: _ThreadCacheRefillAttempt | None = None

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -1357,7 +1357,7 @@ async def refresh_thread_history_from_source(
     once. Callers nobody is waiting on pass ``1``: a retryable conflict means another writer owns
     the thread right now, so an undelayed rescan is least likely to win and most expensive to run.
     """
-    attempt_limit = _MAX_THREAD_REPAIR_ATTEMPTS if max_repair_attempts is None else max(1, max_repair_attempts)
+    attempt_limit = _MAX_THREAD_REPAIR_ATTEMPTS if max_repair_attempts is None else max_repair_attempts
     fetch_result: _ThreadHistoryFetchResult | None = None
     attempt: _ThreadCacheRefillAttempt | None = None
     repair_attempts = 0

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -988,14 +988,19 @@ class MatrixConversationCache(ConversationCacheProtocol):
             return
         principal_id = self.runtime.event_cache.principal_id
         # Claimed before the task exists. A replay burst reaches this method once per event without
-        # ever yielding, so a check that does not also claim lets every one of them add a task.
-        if not coordinator.reserve_speculative_thread_repair(room_id, thread_id, coordination_scope=principal_id):
+        # ever yielding, so a check that does not also claim lets every one of them add a task. The
+        # claim is held until the registry takes ownership of the thread, which covers the awaited
+        # preparation in between.
+        reservation = coordinator.reserve_speculative_thread_repair(
+            room_id,
+            thread_id,
+            coordination_scope=principal_id,
+        )
+        if reservation is None:
             self._log_suppressed_thread_repair(room_id, thread_id, reason="already_scheduled")
             return
 
         async def repair() -> None:
-            # The reservation covers scheduling only; the registry owns every decision from here.
-            coordinator.release_speculative_thread_repair(room_id, thread_id, coordination_scope=principal_id)
             try:
                 await self._fetch_thread_from_client(
                     fetch_dispatch_thread_snapshot,
@@ -1027,11 +1032,24 @@ class MatrixConversationCache(ConversationCacheProtocol):
                     error=str(exc),
                 )
 
-        create_background_task(
+        task = create_background_task(
             repair(),
             name="matrix_cache_schedule_missing_thread_repair",
             owner=coordinator.background_task_owner,
             log_exceptions=False,
+        )
+        # On the task, not in the coroutine: a task cancelled before its first instruction never
+        # runs its body at all, and a claim leaked that way would suppress this thread until the
+        # process ends, and unrelated threads once enough of them accumulate. Releasing is a no-op
+        # once the registry has taken the claim over, and the token makes it a no-op if a later
+        # wave has since claimed the same thread.
+        task.add_done_callback(
+            lambda _task: coordinator.release_speculative_thread_repair(
+                room_id,
+                thread_id,
+                coordination_scope=principal_id,
+                token=reservation,
+            ),
         )
 
     def _log_suppressed_thread_repair(self, room_id: str, thread_id: str, *, reason: str) -> None:

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -863,6 +863,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         allows_stale_fallback: bool,
         bypass_repair_backoff: bool,
         speculative: bool = False,
+        claim_token: object | None = None,
     ) -> ThreadHistoryResult:
         coordinator = self.runtime.event_cache_write_coordinator
         if coordinator is None:
@@ -922,6 +923,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             result_arms_backoff=self._thread_repair_result_arms_backoff,
             bypass_failure_backoff=bypass_repair_backoff,
             speculative=speculative,
+            claim_token=claim_token,
         )
 
     async def _fetch_thread_from_client(
@@ -936,6 +938,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         allows_stale_fallback: bool,
         bypass_repair_backoff: bool,
         speculative: bool = False,
+        claim_token: object | None = None,
     ) -> ThreadHistoryResult:
         coordinator = self.runtime.event_cache_write_coordinator
         await self._prepare_pending_thread_repair_deltas(room_id, thread_id)
@@ -951,6 +954,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 allows_stale_fallback=allows_stale_fallback,
                 bypass_repair_backoff=bypass_repair_backoff,
                 speculative=speculative,
+                claim_token=claim_token,
             )
 
         return await fetcher(
@@ -1013,6 +1017,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                     # Speculative work is the one caller the retained delay is meant to suppress.
                     bypass_repair_backoff=False,
                     speculative=True,
+                    claim_token=reservation,
                 )
             except ThreadRepairSuppressedError as exc:
                 self._log_suppressed_thread_repair(room_id, thread_id, reason=exc.reason)

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -120,20 +120,10 @@ def is_sync_replay_batch(response: nio.SyncResponse) -> bool:
     A truncated (``limited``) timeline is the homeserver saying the client fell behind, which is the
     exact condition that leaves many threads without a usable snapshot at once.
     """
-    joined_rooms = getattr(getattr(response, "rooms", None), "join", None)
-    if not isinstance(joined_rooms, dict):
-        return False
-    timeline_event_count = 0
-    for room_info in joined_rooms.values():
-        timeline = getattr(room_info, "timeline", None)
-        if timeline is None:
-            continue
-        if getattr(timeline, "limited", False) is True:
-            return True
-        events = getattr(timeline, "events", None)
-        if isinstance(events, list):
-            timeline_event_count += len(events)
-    return timeline_event_count >= _SYNC_REPLAY_TIMELINE_EVENT_THRESHOLD
+    timelines = [room_info.timeline for room_info in response.rooms.join.values()]
+    if any(timeline.limited for timeline in timelines):
+        return True
+    return sum(len(timeline.events) for timeline in timelines) >= _SYNC_REPLAY_TIMELINE_EVENT_THRESHOLD
 
 
 async def resolve_thread_root_event_id_for_client(
@@ -876,7 +866,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
         speculative: bool = False,
     ) -> ThreadHistoryResult:
         coordinator = self.runtime.event_cache_write_coordinator
-        max_repair_attempts = _SPECULATIVE_REPAIR_ATTEMPTS if speculative else None
         if coordinator is None:
             return await refresh_thread_history_from_source(
                 self._require_client(),
@@ -887,10 +876,26 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 allow_stale_fallback=allows_stale_fallback,
                 cache_reject_diagnostics=cache_reject_diagnostics,
                 trusted_sender_ids=self._trusted_sender_ids(),
-                max_repair_attempts=max_repair_attempts,
             )
 
         principal_id = self.runtime.event_cache.principal_id
+
+        def repair_attempt_limit() -> int | None:
+            """Resolve the attempt budget when the flight runs, not when it is queued.
+
+            A speculative scan nobody is waiting on gets one attempt, but by the time it runs an
+            interactive caller may have joined this exact flight and be waiting on its result. That
+            caller is owed the retry a lost guarded replacement normally earns it.
+            """
+            if not speculative or coordinator.thread_repair_has_interactive_waiter(
+                room_id,
+                thread_id,
+                coordination_scope=principal_id,
+                hydrate_sidecars=wants_full_history,
+                allow_stale_fallback=allows_stale_fallback,
+            ):
+                return None
+            return _SPECULATIVE_REPAIR_ATTEMPTS
 
         async def repair() -> ThreadHistoryResult:
             def pending_event_sources() -> tuple[dict[str, Any], ...]:
@@ -911,7 +916,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 cache_reject_diagnostics=cache_reject_diagnostics,
                 trusted_sender_ids=self._trusted_sender_ids(),
                 retained_event_sources=retained_event_source_provider,
-                max_repair_attempts=max_repair_attempts,
+                max_repair_attempts=repair_attempt_limit(),
             )
             if self._thread_repair_result_is_usable(result):
                 await self._acknowledge_repaired_thread_deltas(

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -113,6 +113,10 @@ _SYNC_REPLAY_TIMELINE_EVENT_THRESHOLD = 50
 # repair may not, because the conflict it lost is another writer already rewriting that thread.
 _SPECULATIVE_REPAIR_ATTEMPTS = 1
 
+# Store outcomes another bounded reconstruction could still turn into a snapshot. Every other
+# outcome is settled, so a second flight would only repeat it.
+_RETRYABLE_STORE_OUTCOMES = frozenset(outcome.value for outcome in ThreadCacheReplaceOutcome if outcome.retryable)
+
 
 def is_sync_replay_batch(response: nio.SyncResponse) -> bool:
     """Return whether one sync response is a gap catch-up rather than steady-state delivery.
@@ -913,34 +917,21 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 )
             return result
 
-        async def run_flight() -> ThreadHistoryResult:
-            return await coordinator.run_thread_repair(
-                room_id,
-                thread_id,
-                repair,
-                coordination_scope=principal_id,
-                hydrate_sidecars=wants_full_history,
-                allow_stale_fallback=allows_stale_fallback,
-                result_arms_backoff=self._thread_repair_result_arms_backoff,
-                bypass_failure_backoff=bypass_repair_backoff,
-                speculative=speculative,
-            )
-
-        # Callers sharing one flight also share its contract, and a speculative flight rescans a lost
-        # guarded replacement once rather than the twice a waiting reader is owed. Checked before the
-        # join so the answer cannot change under us; a reader that ends up with the weaker contract's
-        # unusable result repairs again under its own.
-        joined_speculative_flight = not speculative and coordinator.thread_repair_flight_is_speculative(
+        return await coordinator.run_thread_repair(
             room_id,
             thread_id,
+            repair,
             coordination_scope=principal_id,
             hydrate_sidecars=wants_full_history,
             allow_stale_fallback=allows_stale_fallback,
+            result_arms_backoff=self._thread_repair_result_arms_backoff,
+            # A reader that joins a speculative flight inherits its single rescan of a lost guarded
+            # replacement, so a shared result that a fuller budget could still improve is repaired
+            # again under this caller's own contract.
+            result_needs_own_flight=self._thread_repair_result_needs_own_flight,
+            bypass_failure_backoff=bypass_repair_backoff,
+            speculative=speculative,
         )
-        result = await run_flight()
-        if joined_speculative_flight and not self._thread_repair_result_is_usable(result):
-            return await run_flight()
-        return result
 
     async def _fetch_thread_from_client(
         self,
@@ -988,6 +979,17 @@ class MatrixConversationCache(ConversationCacheProtocol):
         """Return whether one flight left a trusted durable snapshot."""
         source = result.diagnostics.get(THREAD_HISTORY_SOURCE_DIAGNOSTIC)
         return source == THREAD_HISTORY_SOURCE_CACHE or result.diagnostics.get("cache_repair_usable") is True
+
+    def _thread_repair_result_needs_own_flight(self, result: ThreadHistoryResult) -> bool:
+        """Return whether a caller's own attempt budget could still improve this shared result.
+
+        Only a lost guarded replacement qualifies. A hard failure or an unavailable backend is
+        settled however many attempts a caller is allowed, so rescanning it would spend a scan to
+        reach the same answer and then meet the failure backoff the first flight just armed.
+        """
+        if self._thread_repair_result_is_usable(result):
+            return False
+        return result.diagnostics.get("cache_store_outcome") in _RETRYABLE_STORE_OUTCOMES
 
     @staticmethod
     def _thread_repair_result_arms_backoff(result: ThreadHistoryResult) -> bool:

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -115,7 +115,6 @@ _SPECULATIVE_REPAIR_ATTEMPTS = 1
 
 # Store outcomes another bounded reconstruction could still turn into a snapshot. Every other
 # outcome is settled, so a second flight would only repeat it.
-_RETRYABLE_STORE_OUTCOMES = frozenset(outcome.value for outcome in ThreadCacheReplaceOutcome if outcome.retryable)
 
 
 def is_sync_replay_batch(response: nio.SyncResponse) -> bool:
@@ -925,10 +924,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
             hydrate_sidecars=wants_full_history,
             allow_stale_fallback=allows_stale_fallback,
             result_arms_backoff=self._thread_repair_result_arms_backoff,
-            # A reader that joins a speculative flight inherits its single rescan of a lost guarded
-            # replacement, so a shared result that a fuller budget could still improve is repaired
-            # again under this caller's own contract.
-            result_needs_own_flight=self._thread_repair_result_needs_own_flight,
             bypass_failure_backoff=bypass_repair_backoff,
             speculative=speculative,
         )
@@ -979,17 +974,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
         """Return whether one flight left a trusted durable snapshot."""
         source = result.diagnostics.get(THREAD_HISTORY_SOURCE_DIAGNOSTIC)
         return source == THREAD_HISTORY_SOURCE_CACHE or result.diagnostics.get("cache_repair_usable") is True
-
-    def _thread_repair_result_needs_own_flight(self, result: ThreadHistoryResult) -> bool:
-        """Return whether a caller's own attempt budget could still improve this shared result.
-
-        Only a lost guarded replacement qualifies. A hard failure or an unavailable backend is
-        settled however many attempts a caller is allowed, so rescanning it would spend a scan to
-        reach the same answer and then meet the failure backoff the first flight just armed.
-        """
-        if self._thread_repair_result_is_usable(result):
-            return False
-        return result.diagnostics.get("cache_store_outcome") in _RETRYABLE_STORE_OUTCOMES
 
     @staticmethod
     def _thread_repair_result_arms_backoff(result: ThreadHistoryResult) -> bool:

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -880,23 +880,6 @@ class MatrixConversationCache(ConversationCacheProtocol):
 
         principal_id = self.runtime.event_cache.principal_id
 
-        def repair_attempt_limit() -> int | None:
-            """Resolve the attempt budget when the flight runs, not when it is queued.
-
-            A speculative scan nobody is waiting on gets one attempt, but by the time it runs an
-            interactive caller may have joined this exact flight and be waiting on its result. That
-            caller is owed the retry a lost guarded replacement normally earns it.
-            """
-            if not speculative or coordinator.thread_repair_has_interactive_waiter(
-                room_id,
-                thread_id,
-                coordination_scope=principal_id,
-                hydrate_sidecars=wants_full_history,
-                allow_stale_fallback=allows_stale_fallback,
-            ):
-                return None
-            return _SPECULATIVE_REPAIR_ATTEMPTS
-
         async def repair() -> ThreadHistoryResult:
             def pending_event_sources() -> tuple[dict[str, Any], ...]:
                 return coordinator.pending_thread_repair_deltas(
@@ -916,7 +899,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 cache_reject_diagnostics=cache_reject_diagnostics,
                 trusted_sender_ids=self._trusted_sender_ids(),
                 retained_event_sources=retained_event_source_provider,
-                max_repair_attempts=repair_attempt_limit(),
+                max_repair_attempts=_SPECULATIVE_REPAIR_ATTEMPTS if speculative else None,
             )
             if self._thread_repair_result_is_usable(result):
                 await self._acknowledge_repaired_thread_deltas(
@@ -930,17 +913,34 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 )
             return result
 
-        return await coordinator.run_thread_repair(
+        async def run_flight() -> ThreadHistoryResult:
+            return await coordinator.run_thread_repair(
+                room_id,
+                thread_id,
+                repair,
+                coordination_scope=principal_id,
+                hydrate_sidecars=wants_full_history,
+                allow_stale_fallback=allows_stale_fallback,
+                result_arms_backoff=self._thread_repair_result_arms_backoff,
+                bypass_failure_backoff=bypass_repair_backoff,
+                speculative=speculative,
+            )
+
+        # Callers sharing one flight also share its contract, and a speculative flight rescans a lost
+        # guarded replacement once rather than the twice a waiting reader is owed. Checked before the
+        # join so the answer cannot change under us; a reader that ends up with the weaker contract's
+        # unusable result repairs again under its own.
+        joined_speculative_flight = not speculative and coordinator.thread_repair_flight_is_speculative(
             room_id,
             thread_id,
-            repair,
             coordination_scope=principal_id,
             hydrate_sidecars=wants_full_history,
             allow_stale_fallback=allows_stale_fallback,
-            result_arms_backoff=self._thread_repair_result_arms_backoff,
-            bypass_failure_backoff=bypass_repair_backoff,
-            speculative=speculative,
         )
+        result = await run_flight()
+        if joined_speculative_flight and not self._thread_repair_result_is_usable(result):
+            return await run_flight()
+        return result
 
     async def _fetch_thread_from_client(
         self,

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -987,16 +987,15 @@ class MatrixConversationCache(ConversationCacheProtocol):
         if coordinator is None or not self.runtime.event_cache.durable_writes_available:
             return
         principal_id = self.runtime.event_cache.principal_id
-        suppression_reason = coordinator.speculative_thread_repair_suppression_reason(
-            room_id,
-            thread_id,
-            coordination_scope=principal_id,
-        )
-        if suppression_reason is not None:
-            self._log_suppressed_thread_repair(room_id, thread_id, reason=suppression_reason)
+        # Claimed before the task exists. A replay burst reaches this method once per event without
+        # ever yielding, so a check that does not also claim lets every one of them add a task.
+        if not coordinator.reserve_speculative_thread_repair(room_id, thread_id, coordination_scope=principal_id):
+            self._log_suppressed_thread_repair(room_id, thread_id, reason="already_scheduled")
             return
 
         async def repair() -> None:
+            # The reservation covers scheduling only; the registry owns every decision from here.
+            coordinator.release_speculative_thread_repair(room_id, thread_id, coordination_scope=principal_id)
             try:
                 await self._fetch_thread_from_client(
                     fetch_dispatch_thread_snapshot,

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -97,7 +97,6 @@ __all__ = [
     "EventLookupResult",
     "MatrixConversationCache",
     "ThreadReadResult",
-    "is_sync_replay_batch",
     "resolve_thread_root_event_id_for_client",
 ]
 
@@ -113,11 +112,8 @@ _SYNC_REPLAY_TIMELINE_EVENT_THRESHOLD = 50
 # repair may not, because the conflict it lost is another writer already rewriting that thread.
 _SPECULATIVE_REPAIR_ATTEMPTS = 1
 
-# Store outcomes another bounded reconstruction could still turn into a snapshot. Every other
-# outcome is settled, so a second flight would only repeat it.
 
-
-def is_sync_replay_batch(response: nio.SyncResponse) -> bool:
+def _is_sync_replay_batch(response: nio.SyncResponse) -> bool:
     """Return whether one sync response is a gap catch-up rather than steady-state delivery.
 
     A truncated (``limited``) timeline is the homeserver saying the client fell behind, which is the
@@ -1460,7 +1456,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
     ) -> SyncCacheWriteResult:
         """Durably persist sync timeline events and report cache-certification status."""
         coordinator = self.runtime.event_cache_write_coordinator
-        if coordinator is None or not is_sync_replay_batch(response):
+        if coordinator is None or not _is_sync_replay_batch(response):
             return await self._sync.cache_sync_timeline_for_certification(response)
         # Replay rewrites these threads anyway, and its speculative repairs would contend for the
         # very write path this call is blocking the sync callback on.

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -34,7 +34,7 @@ from mindroom.matrix.cache import (
     thread_history_result,
 )
 from mindroom.matrix.cache.thread_reads import ThreadReadMode, ThreadReadPolicy
-from mindroom.matrix.cache.thread_repair import ThreadRepairBackoffError
+from mindroom.matrix.cache.thread_repair import ThreadRepairBackoffError, ThreadRepairSuppressedError
 from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 from mindroom.matrix.cache.thread_writes import ThreadLiveWritePolicy, ThreadOutboundWritePolicy, ThreadSyncWritePolicy
 from mindroom.matrix.client_thread_history import (
@@ -97,12 +97,43 @@ __all__ = [
     "EventLookupResult",
     "MatrixConversationCache",
     "ThreadReadResult",
+    "is_sync_replay_batch",
     "resolve_thread_root_event_id_for_client",
 ]
 
 
 _STARTUP_PREWARM_THREAD_LIMIT = 32
 _STARTUP_PREWARM_MAX_SCAN_PAGES = 20
+
+# A steady-state sync carries a handful of events. Anything at this scale is the runtime catching up
+# on a gap, which is when speculative repair is both least useful and most expensive.
+_SYNC_REPLAY_TIMELINE_EVENT_THRESHOLD = 50
+
+# A caller waiting for history may rescan after losing the guarded replacement race; a speculative
+# repair may not, because the conflict it lost is another writer already rewriting that thread.
+_SPECULATIVE_REPAIR_ATTEMPTS = 1
+
+
+def is_sync_replay_batch(response: nio.SyncResponse) -> bool:
+    """Return whether one sync response is a gap catch-up rather than steady-state delivery.
+
+    A truncated (``limited``) timeline is the homeserver saying the client fell behind, which is the
+    exact condition that leaves many threads without a usable snapshot at once.
+    """
+    joined_rooms = getattr(getattr(response, "rooms", None), "join", None)
+    if not isinstance(joined_rooms, dict):
+        return False
+    timeline_event_count = 0
+    for room_info in joined_rooms.values():
+        timeline = getattr(room_info, "timeline", None)
+        if timeline is None:
+            continue
+        if getattr(timeline, "limited", False) is True:
+            return True
+        events = getattr(timeline, "events", None)
+        if isinstance(events, list):
+            timeline_event_count += len(events)
+    return timeline_event_count >= _SYNC_REPLAY_TIMELINE_EVENT_THRESHOLD
 
 
 async def resolve_thread_root_event_id_for_client(
@@ -842,8 +873,10 @@ class MatrixConversationCache(ConversationCacheProtocol):
         wants_full_history: bool,
         allows_stale_fallback: bool,
         bypass_repair_backoff: bool,
+        speculative: bool = False,
     ) -> ThreadHistoryResult:
         coordinator = self.runtime.event_cache_write_coordinator
+        max_repair_attempts = _SPECULATIVE_REPAIR_ATTEMPTS if speculative else None
         if coordinator is None:
             return await refresh_thread_history_from_source(
                 self._require_client(),
@@ -854,6 +887,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 allow_stale_fallback=allows_stale_fallback,
                 cache_reject_diagnostics=cache_reject_diagnostics,
                 trusted_sender_ids=self._trusted_sender_ids(),
+                max_repair_attempts=max_repair_attempts,
             )
 
         principal_id = self.runtime.event_cache.principal_id
@@ -877,6 +911,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 cache_reject_diagnostics=cache_reject_diagnostics,
                 trusted_sender_ids=self._trusted_sender_ids(),
                 retained_event_sources=retained_event_source_provider,
+                max_repair_attempts=max_repair_attempts,
             )
             if self._thread_repair_result_is_usable(result):
                 await self._acknowledge_repaired_thread_deltas(
@@ -899,6 +934,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             allow_stale_fallback=allows_stale_fallback,
             result_arms_backoff=self._thread_repair_result_arms_backoff,
             bypass_failure_backoff=bypass_repair_backoff,
+            speculative=speculative,
         )
 
     async def _fetch_thread_from_client(
@@ -912,6 +948,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         wants_full_history: bool,
         allows_stale_fallback: bool,
         bypass_repair_backoff: bool,
+        speculative: bool = False,
     ) -> ThreadHistoryResult:
         coordinator = self.runtime.event_cache_write_coordinator
         await self._prepare_pending_thread_repair_deltas(room_id, thread_id)
@@ -926,6 +963,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 wants_full_history=wants_full_history,
                 allows_stale_fallback=allows_stale_fallback,
                 bypass_repair_backoff=bypass_repair_backoff,
+                speculative=speculative,
             )
 
         return await fetcher(
@@ -952,9 +990,23 @@ class MatrixConversationCache(ConversationCacheProtocol):
         return result.diagnostics.get("cache_store_outcome") == ThreadCacheReplaceOutcome.HARD_FAILURE.value
 
     def _schedule_missing_thread_repair(self, room_id: str, thread_id: str) -> None:
-        """Schedule bounded background repair after an append finds no snapshot."""
+        """Schedule bounded background repair after an append finds no snapshot.
+
+        Every replayed event in a stale thread reaches this method, so the fan-out gate is consulted
+        before a task is even created; the thread stays marked stale, so a declined repair only
+        defers the scan to the next read.
+        """
         coordinator = self.runtime.event_cache_write_coordinator
         if coordinator is None or not self.runtime.event_cache.durable_writes_available:
+            return
+        principal_id = self.runtime.event_cache.principal_id
+        suppression_reason = coordinator.speculative_thread_repair_suppression_reason(
+            room_id,
+            thread_id,
+            coordination_scope=principal_id,
+        )
+        if suppression_reason is not None:
+            self._log_suppressed_thread_repair(room_id, thread_id, reason=suppression_reason)
             return
 
         async def repair() -> None:
@@ -969,7 +1021,10 @@ class MatrixConversationCache(ConversationCacheProtocol):
                     allows_stale_fallback=False,
                     # Speculative work is the one caller the retained delay is meant to suppress.
                     bypass_repair_backoff=False,
+                    speculative=True,
                 )
+            except ThreadRepairSuppressedError as exc:
+                self._log_suppressed_thread_repair(room_id, thread_id, reason=exc.reason)
             except ThreadRepairBackoffError as exc:
                 self.logger.debug(
                     "Thread cache repair remains in backoff",
@@ -991,6 +1046,14 @@ class MatrixConversationCache(ConversationCacheProtocol):
             name="matrix_cache_schedule_missing_thread_repair",
             owner=coordinator.background_task_owner,
             log_exceptions=False,
+        )
+
+    def _log_suppressed_thread_repair(self, room_id: str, thread_id: str, *, reason: str) -> None:
+        self.logger.debug(
+            "Speculative thread cache repair suppressed",
+            room_id=room_id,
+            thread_id=thread_id,
+            reason=reason,
         )
 
     async def _bulk_refresh_startup_threads(
@@ -1405,4 +1468,10 @@ class MatrixConversationCache(ConversationCacheProtocol):
         response: nio.SyncResponse,
     ) -> SyncCacheWriteResult:
         """Durably persist sync timeline events and report cache-certification status."""
-        return await self._sync.cache_sync_timeline_for_certification(response)
+        coordinator = self.runtime.event_cache_write_coordinator
+        if coordinator is None or not is_sync_replay_batch(response):
+            return await self._sync.cache_sync_timeline_for_certification(response)
+        # Replay rewrites these threads anyway, and its speculative repairs would contend for the
+        # very write path this call is blocking the sync callback on.
+        with coordinator.suppress_speculative_thread_repairs():
+            return await self._sync.cache_sync_timeline_for_certification(response)

--- a/tach.toml
+++ b/tach.toml
@@ -1848,6 +1848,7 @@ depends_on = []
 [[modules]]
 path = "mindroom.matrix.cache.thread_write_cache_ops"
 depends_on = [
+    "mindroom.background_tasks",
     "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.thread_cache_invalidation",
     "mindroom.matrix.cache.thread_cache_state",

--- a/tach.toml
+++ b/tach.toml
@@ -1838,6 +1838,7 @@ visibility = [
     "mindroom.matrix.cache.postgres_event_cache_threads",
     "mindroom.matrix.cache.sqlite_event_cache",
     "mindroom.matrix.cache.sqlite_event_cache_threads",
+    "mindroom.matrix.cache.thread_write_cache_ops",
 ]
 
 [[modules]]
@@ -1849,6 +1850,7 @@ path = "mindroom.matrix.cache.thread_write_cache_ops"
 depends_on = [
     "mindroom.matrix.cache.event_cache",
     "mindroom.matrix.cache.thread_cache_invalidation",
+    "mindroom.matrix.cache.thread_cache_state",
     "mindroom.matrix.thread_bookkeeping",
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,7 +69,7 @@ from mindroom.hooks import EnrichmentItem, MessageEnvelope
 from mindroom.ingress_validation import IngressValidator
 from mindroom.interactive import InteractiveMetadata
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
-from mindroom.matrix.cache.thread_cache_state import ThreadCacheReplaceOutcome
+from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome, ThreadCacheReplaceOutcome
 from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.client import DeliveredMatrixEvent, ResolvedVisibleMessage
@@ -807,6 +807,7 @@ def make_event_cache_mock() -> AsyncMock:
     event_cache.room_membership_epoch.return_value = 0
     event_cache.flush_pending_durable_writes.return_value = None
     event_cache.append_event.return_value = True
+    event_cache.apply_thread_mutation_append.return_value = ThreadAppendOutcome.APPENDED
     event_cache.redact_event.return_value = False
     event_cache.store_mxc_text.return_value = True
     event_cache.replace_thread_if_not_newer.return_value = ThreadCacheReplaceOutcome.STORED

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -806,7 +806,6 @@ def make_event_cache_mock() -> AsyncMock:
     event_cache.room_departure_epoch.side_effect = lambda room_id: departure_epochs.get(room_id, 0)
     event_cache.room_membership_epoch.return_value = 0
     event_cache.flush_pending_durable_writes.return_value = None
-    event_cache.append_event.return_value = True
     event_cache.apply_thread_mutation_append.return_value = ThreadAppendOutcome.APPENDED
     event_cache.redact_event.return_value = False
     event_cache.store_mxc_text.return_value = True

--- a/tests/test_bot_sync_event_cache.py
+++ b/tests/test_bot_sync_event_cache.py
@@ -16,6 +16,7 @@ from mindroom.hooks import EVENT_AGENT_STARTED
 from mindroom.matrix.cache import thread_cache_rejection_reason
 from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.client import PermanentMatrixStartupError
 from mindroom.matrix.sync_certification import SyncCacheWriteResult, SyncCheckpoint, SyncTrustState
@@ -765,7 +766,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
 
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock(side_effect=slow_store_events_batch)
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.redact_event = AsyncMock()
         bot.event_cache = event_cache
         _install_runtime_write_coordinator(bot)
@@ -798,7 +799,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
         event_cache.store_events_batch.assert_awaited_once()
-        event_cache.append_event.assert_awaited_once()
+        event_cache.apply_thread_mutation_append.assert_awaited_once()
         event_cache.redact_event.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -806,7 +807,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         """Sync timeline writes should append direct thread events through the thread-cache helper."""
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock()
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.redact_event = AsyncMock()
         bot.event_cache = event_cache
         _install_runtime_write_coordinator(bot)
@@ -835,8 +836,8 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         bot._conversation_cache.cache_sync_timeline(sync_response)
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
-        event_cache.append_event.assert_awaited_once()
-        append_args = event_cache.append_event.await_args.args
+        event_cache.apply_thread_mutation_append.assert_awaited_once()
+        append_args = event_cache.apply_thread_mutation_append.await_args.args
         assert append_args[0] == "!test:localhost"
         assert append_args[1] == "$thread_root:localhost"
         assert append_args[2]["event_id"] == "$thread_msg:localhost"
@@ -846,7 +847,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         """Sync timeline writes should append threaded edits using the thread root from m.new_content."""
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock()
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.redact_event = AsyncMock()
         bot.event_cache = event_cache
         _install_runtime_write_coordinator(bot)
@@ -880,8 +881,8 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         bot._conversation_cache.cache_sync_timeline(sync_response)
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
-        event_cache.append_event.assert_awaited_once()
-        append_args = event_cache.append_event.await_args.args
+        event_cache.apply_thread_mutation_append.assert_awaited_once()
+        append_args = event_cache.apply_thread_mutation_append.await_args.args
         assert append_args[0] == "!test:localhost"
         assert append_args[1] == "$thread_root:localhost"
         assert append_args[2]["event_id"] == "$thread_edit:localhost"
@@ -971,7 +972,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         """Sync timeline writes should not append non-threaded events into thread cache state."""
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock()
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.redact_event = AsyncMock()
         bot.event_cache = event_cache
         _install_runtime_write_coordinator(bot)
@@ -999,7 +1000,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         bot._conversation_cache.cache_sync_timeline(sync_response)
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
-        event_cache.append_event.assert_not_awaited()
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cache_sync_timeline_plain_edit_lookup_miss_invalidates_room_threads(
@@ -1009,7 +1010,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         """Sync room-mode edits should fail closed when lookup certainty is unavailable."""
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock()
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.redact_event = AsyncMock()
         event_cache.get_thread_id_for_event = AsyncMock(return_value=None)
         event_cache.get_event = AsyncMock(
@@ -1057,7 +1058,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             "!test:localhost",
             reason="sync_thread_lookup_unavailable",
         )
-        event_cache.append_event.assert_not_awaited()
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_cache_sync_timeline_plain_edit_missing_original_invalidates_room_threads(
@@ -1067,7 +1068,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         """Sync plain edits without enough local proof should invalidate room thread snapshots once."""
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock()
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.redact_event = AsyncMock()
         event_cache.get_thread_id_for_event = AsyncMock(return_value=None)
         event_cache.get_event = AsyncMock(return_value=None)
@@ -1108,7 +1109,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             "!test:localhost",
             reason="sync_thread_lookup_unavailable",
         )
-        event_cache.append_event.assert_not_awaited()
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_sync_reaction_redaction_lookup_miss_without_cached_target_does_not_invalidate_room_threads(
@@ -1159,7 +1160,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         """Sync mutation fallback should invalidate once per room and avoid room-history scans."""
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock()
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.get_thread_id_for_event = AsyncMock(return_value=None)
         event_cache.get_event = AsyncMock(return_value=None)
         bot.event_cache = event_cache
@@ -1302,7 +1303,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
 
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock(side_effect=slow_store_events_batch)
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.redact_event = AsyncMock(side_effect=record_redaction)
         bot.event_cache = event_cache
         _install_runtime_write_coordinator(bot)
@@ -1410,7 +1411,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         bot._conversation_cache.cache_sync_timeline(sync_response)
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
-        event_cache.append_event.assert_awaited_once()
+        event_cache.apply_thread_mutation_append.assert_awaited_once()
         event_cache.redact_event.assert_awaited_once_with("!test:localhost", "$thread_msg_old:localhost")
 
     @pytest.mark.asyncio
@@ -1455,7 +1456,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
 
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock(side_effect=store_events_batch)
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.redact_event = AsyncMock()
         bot.event_cache = event_cache
         _install_runtime_write_coordinator(bot)
@@ -1640,7 +1641,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         """Failed point-lookup writes must not leave split thread cache state."""
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock(side_effect=RuntimeError("store failed"))
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         event_cache.redact_event = AsyncMock(return_value=True)
         bot.event_cache = event_cache
         _install_runtime_write_coordinator(bot)
@@ -1684,7 +1685,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
         event_cache.store_events_batch.assert_awaited_once()
-        event_cache.append_event.assert_awaited_once()
+        event_cache.apply_thread_mutation_append.assert_awaited_once()
         event_cache.redact_event.assert_awaited_once_with("!test:localhost", "$thread_msg_old:localhost")
 
     @pytest.mark.asyncio

--- a/tests/test_bot_sync_event_cache.py
+++ b/tests/test_bot_sync_event_cache.py
@@ -1368,7 +1368,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         """A failed thread append should not stop later redactions in the same sync batch."""
         event_cache = _runtime_event_cache()
         event_cache.store_events_batch = AsyncMock()
-        event_cache.append_event = AsyncMock(side_effect=RuntimeError("append failed"))
+        event_cache.apply_thread_mutation_append = AsyncMock(side_effect=RuntimeError("append failed"))
         event_cache.redact_event = AsyncMock(return_value=True)
         bot.event_cache = event_cache
         _install_runtime_write_coordinator(bot)

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -502,6 +502,8 @@ async def test_dispatch_thread_read_enters_repair_ownership_once_after_idle_wait
     coordinator = MagicMock()
     coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
     coordinator.pending_thread_repair_deltas.return_value = ()
+    # No speculative flight exists here, so the read owns its own repair contract.
+    coordinator.thread_repair_flight_is_speculative.return_value = False
 
     async def run_thread_repair(
         _room_id: str,
@@ -553,6 +555,8 @@ async def test_healthy_cache_hit_does_not_enter_repair_lane(tmp_path: Path) -> N
     coordinator = MagicMock()
     coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
     coordinator.pending_thread_repair_deltas.return_value = ()
+    # No speculative flight exists here, so the read owns its own repair contract.
+    coordinator.thread_repair_flight_is_speculative.return_value = False
     coordinator.run_thread_repair = AsyncMock(side_effect=AssertionError("cache hit must not claim repair ownership"))
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
 
@@ -1123,6 +1127,8 @@ async def test_strict_thread_history_uses_no_stale_fetch_without_dispatch_timeou
     coordinator = MagicMock()
     coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
     coordinator.pending_thread_repair_deltas.return_value = ()
+    # No speculative flight exists here, so the read owns its own repair contract.
+    coordinator.thread_repair_flight_is_speculative.return_value = False
     coordinator.run_thread_repair = AsyncMock(side_effect=run_thread_repair)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
     fetched_history = thread_history_result([], is_full_history=True)
@@ -1326,6 +1332,8 @@ async def test_fresh_strict_history_bypasses_inherited_turn_memoization(tmp_path
     coordinator = MagicMock()
     coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
     coordinator.pending_thread_repair_deltas.return_value = ()
+    # No speculative flight exists here, so the read owns its own repair contract.
+    coordinator.thread_repair_flight_is_speculative.return_value = False
     coordinator.run_thread_repair = AsyncMock(side_effect=run_thread_repair)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
     before_delivery = thread_history_result(

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -985,7 +985,7 @@ async def test_dispatch_retries_strictly_after_failed_cache_repair_backoff(tmp_p
     await event_cache.initialize()
     conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=MagicMock())
     coordinator = EventCacheWriteCoordinator(logger=MagicMock())
-    coordinator._thread_repairs = ThreadRepairRegistry(failure_backoff_seconds=0.05)
+    coordinator.thread_repairs = ThreadRepairRegistry(failure_backoff_seconds=0.05)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
     config = conversation_cache.runtime.config
     runtime_paths = conversation_cache.runtime.runtime_paths
@@ -1176,7 +1176,7 @@ async def test_strict_thread_history_bypasses_repair_backoff_without_stalling(tm
         failure_backoff_seconds=30.0,
         max_failure_backoff_seconds=30.0,
     )
-    coordinator._thread_repairs = registry
+    coordinator.thread_repairs = registry
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
     repair_key = (event_cache.principal_id, "!room:localhost", "$thread:localhost", True, False)
     await coordinator.run_thread_repair(

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -502,8 +502,6 @@ async def test_dispatch_thread_read_enters_repair_ownership_once_after_idle_wait
     coordinator = MagicMock()
     coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
     coordinator.pending_thread_repair_deltas.return_value = ()
-    # No speculative flight exists here, so the read owns its own repair contract.
-    coordinator.thread_repair_flight_is_speculative.return_value = False
 
     async def run_thread_repair(
         _room_id: str,
@@ -555,8 +553,6 @@ async def test_healthy_cache_hit_does_not_enter_repair_lane(tmp_path: Path) -> N
     coordinator = MagicMock()
     coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
     coordinator.pending_thread_repair_deltas.return_value = ()
-    # No speculative flight exists here, so the read owns its own repair contract.
-    coordinator.thread_repair_flight_is_speculative.return_value = False
     coordinator.run_thread_repair = AsyncMock(side_effect=AssertionError("cache hit must not claim repair ownership"))
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
 
@@ -1127,8 +1123,6 @@ async def test_strict_thread_history_uses_no_stale_fetch_without_dispatch_timeou
     coordinator = MagicMock()
     coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
     coordinator.pending_thread_repair_deltas.return_value = ()
-    # No speculative flight exists here, so the read owns its own repair contract.
-    coordinator.thread_repair_flight_is_speculative.return_value = False
     coordinator.run_thread_repair = AsyncMock(side_effect=run_thread_repair)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
     fetched_history = thread_history_result([], is_full_history=True)
@@ -1332,8 +1326,6 @@ async def test_fresh_strict_history_bypasses_inherited_turn_memoization(tmp_path
     coordinator = MagicMock()
     coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
     coordinator.pending_thread_repair_deltas.return_value = ()
-    # No speculative flight exists here, so the read owns its own repair contract.
-    coordinator.thread_repair_flight_is_speculative.return_value = False
     coordinator.run_thread_repair = AsyncMock(side_effect=run_thread_repair)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
     before_delivery = thread_history_result(

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -22,6 +22,7 @@ from mindroom.config.models import ModelConfig
 from mindroom.conversation_resolver import ConversationResolver, ConversationResolverDeps, _ThreadIdLookup
 from mindroom.matrix.cache import (
     ConversationEventCache,
+    ThreadAppendOutcome,
     ThreadCacheReplaceOutcome,
     ThreadCacheState,
     event_normalization,
@@ -985,7 +986,7 @@ async def test_dispatch_retries_strictly_after_failed_cache_repair_backoff(tmp_p
     await event_cache.initialize()
     conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=MagicMock())
     coordinator = EventCacheWriteCoordinator(logger=MagicMock())
-    coordinator.thread_repairs = ThreadRepairRegistry(failure_backoff_seconds=0.05)
+    coordinator._thread_repairs = ThreadRepairRegistry(failure_backoff_seconds=0.05)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
     config = conversation_cache.runtime.config
     runtime_paths = conversation_cache.runtime.runtime_paths
@@ -1176,7 +1177,7 @@ async def test_strict_thread_history_bypasses_repair_backoff_without_stalling(tm
         failure_backoff_seconds=30.0,
         max_failure_backoff_seconds=30.0,
     )
-    coordinator.thread_repairs = registry
+    coordinator._thread_repairs = registry
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
     repair_key = (event_cache.principal_id, "!room:localhost", "$thread:localhost", True, False)
     await coordinator.run_thread_repair(
@@ -1805,35 +1806,43 @@ async def test_incremental_revalidation_requires_incremental_invalidation_reason
         "content": {"body": "Root message", "msgtype": "m.text"},
     }
 
+    async def append(event_id: str) -> ThreadAppendOutcome:
+        return await cache.apply_thread_mutation_append(
+            "!room:localhost",
+            "$thread_root",
+            _clear_payload(event_id, thread_root_id="$thread_root", origin_server_ts=2000),
+            append_failed_reason="live_append_failed",
+        )
+
     try:
         await _replace_thread(cache, "!room:localhost", "$thread_root", [root_source], validated_at=100.0)
 
-        not_invalidated = await cache.revalidate_thread_after_incremental_update("!room:localhost", "$thread_root")
+        not_invalidated = await append("$still-valid")
 
         await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="live_append_failed")
-        non_incremental = await cache.revalidate_thread_after_incremental_update("!room:localhost", "$thread_root")
+        non_incremental = await append("$after-non-incremental")
         state_after_non_incremental = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
 
         await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="live_thread_mutation")
-        weakened = await cache.revalidate_thread_after_incremental_update("!room:localhost", "$thread_root")
+        weakened = await append("$after-weakening-attempt")
         state_after_weakening_attempt = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
 
         await _replace_thread(cache, "!room:localhost", "$thread_root", [root_source])
         await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="live_thread_mutation")
-        incremental = await cache.revalidate_thread_after_incremental_update("!room:localhost", "$thread_root")
+        incremental = await append("$after-incremental")
         state_after_incremental = await cache.get_thread_cache_state("!room:localhost", "$thread_root")
     finally:
         await cache.close()
 
-    assert not_invalidated is False
-    assert non_incremental is False
+    assert not_invalidated is ThreadAppendOutcome.APPENDED
+    assert non_incremental is ThreadAppendOutcome.APPENDED_STALE
     assert state_after_non_incremental is not None
     assert thread_cache_rejection_reason(state_after_non_incremental) == "thread_invalidated_after_validation"
-    assert weakened is False
+    assert weakened is ThreadAppendOutcome.APPENDED_STALE
     assert state_after_weakening_attempt is not None
     assert state_after_weakening_attempt.invalidation_reason == "live_append_failed"
     assert thread_cache_rejection_reason(state_after_weakening_attempt) == "thread_invalidated_after_validation"
-    assert incremental is True
+    assert incremental is ThreadAppendOutcome.APPENDED
     assert state_after_incremental is not None
     assert thread_cache_rejection_reason(state_after_incremental) is None
 
@@ -2301,7 +2310,13 @@ async def test_thread_append_preserves_decrypted_payload_across_arrival_orders(
     }
 
     for payload_kind in arrival_order:
-        assert await event_cache.append_event(room_id, thread_id, payloads[payload_kind])
+        outcome = await event_cache.apply_thread_mutation_append(
+            room_id,
+            thread_id,
+            payloads[payload_kind],
+            append_failed_reason="live_append_failed",
+        )
+        assert outcome is ThreadAppendOutcome.APPENDED
 
     thread_events = await event_cache.get_thread_events(room_id, thread_id)
     assert thread_events is not None

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -18,6 +18,7 @@ from mindroom.config.matrix import CacheConfig
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.logging_config import get_logger
 from mindroom.matrix.cache import (
+    ThreadAppendOutcome,
     ThreadCacheReplaceOutcome,
     postgres_event_cache_threads,
     sqlite_event_cache,
@@ -610,7 +611,15 @@ async def _assert_staleness_and_redaction_behavior(
     assert stale_state is not None
     assert stale_state.invalidated_at is not None
     assert stale_state.invalidation_reason == "live_thread_mutation"
-    assert await cache.revalidate_thread_after_incremental_update(room_id, thread_id) is True
+    # Re-appending the newest known edit keeps the snapshot's membership identical, so this asserts
+    # trust recovery alone rather than also changing what the thread contains.
+    revalidating_append = await cache.apply_thread_mutation_append(
+        room_id,
+        thread_id,
+        latest_edit,
+        append_failed_reason="live_append_failed",
+    )
+    assert revalidating_append is ThreadAppendOutcome.APPENDED
     fresh_state = await cache.get_thread_cache_state(room_id, thread_id)
     assert fresh_state is not None
     assert fresh_state.invalidated_at is None

--- a/tests/test_event_cache_contract.py
+++ b/tests/test_event_cache_contract.py
@@ -6,7 +6,7 @@ from typing import Any
 
 import pytest
 
-from mindroom.matrix.cache import ConversationEventCache, ThreadCacheReplaceOutcome
+from mindroom.matrix.cache import ConversationEventCache, ThreadAppendOutcome, ThreadCacheReplaceOutcome
 from tests.event_cache_test_support import replace_thread_unconditionally
 
 
@@ -90,12 +90,13 @@ class TestConversationEventCacheContract:
             == []
         )
         assert (
-            await event_cache.append_event(
+            await event_cache.apply_thread_mutation_append(
                 "!room:localhost",
                 "$thread:localhost",
                 _message_event("$reply:localhost", 2),
+                append_failed_reason="live_append_failed",
             )
-            is False
+            is ThreadAppendOutcome.WRITES_UNAVAILABLE
         )
         assert await event_cache.redact_event("!room:localhost", "$missing") is False
 
@@ -251,13 +252,21 @@ class TestConversationEventCacheContract:
         reply = _message_event("$reply:localhost", 2, thread_id=thread_id)
         await replace_thread_unconditionally(event_cache, room_id, thread_id, [reply, root], validated_at=10.0)
 
-        appended = await event_cache.append_event(
+        appended = await event_cache.apply_thread_mutation_append(
             room_id,
             thread_id,
             _message_event("$appended:localhost", 3, thread_id=thread_id),
+            append_failed_reason="live_append_failed",
         )
         await event_cache.mark_thread_stale(room_id, thread_id, reason="live_thread_mutation")
-        revalidated = await event_cache.revalidate_thread_after_incremental_update(room_id, thread_id)
+        # Re-appending the same event keeps thread membership identical, so this asserts trust
+        # recovery alone rather than also changing what the snapshot contains.
+        revalidated = await event_cache.apply_thread_mutation_append(
+            room_id,
+            thread_id,
+            _message_event("$appended:localhost", 3, thread_id=thread_id),
+            append_failed_reason="live_append_failed",
+        )
         guarded_replacement = await event_cache.replace_thread_if_not_newer(
             room_id,
             thread_id,
@@ -267,8 +276,8 @@ class TestConversationEventCacheContract:
         )
         cached_events = await event_cache.get_thread_events(room_id, thread_id)
 
-        assert appended is True
-        assert revalidated is True
+        assert appended is ThreadAppendOutcome.APPENDED
+        assert revalidated is ThreadAppendOutcome.APPENDED
         assert guarded_replacement is ThreadCacheReplaceOutcome.EXISTING_USABLE
         assert cached_events is not None
         assert [event["event_id"] for event in cached_events] == [

--- a/tests/test_event_cache_write_coordination.py
+++ b/tests/test_event_cache_write_coordination.py
@@ -21,6 +21,7 @@ from mindroom.constants import (
 )
 from mindroom.matrix.cache import ThreadHistoryResult, thread_writes
 from mindroom.matrix.cache.outbound_thread_reservations import OutboundThreadReservations
+from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome
 from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.conversation_cache import MatrixConversationCache
@@ -52,20 +53,20 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        "revalidation_result",
-        [False, RuntimeError("cache unavailable")],
+        "append_outcome",
+        [ThreadAppendOutcome.APPENDED_STALE, RuntimeError("cache unavailable")],
         ids=["rejected", "failed"],
     )
     async def test_append_that_cannot_revalidate_retains_delta_and_schedules_repair(
         self,
-        revalidation_result: bool | RuntimeError,
+        append_outcome: ThreadAppendOutcome | RuntimeError,
     ) -> None:
         """A durable raw append is not converged until its snapshot becomes trusted."""
         original_ops, logger, event_cache = _thread_mutation_cache_ops()
-        if isinstance(revalidation_result, RuntimeError):
-            event_cache.revalidate_thread_after_incremental_update.side_effect = revalidation_result
+        if isinstance(append_outcome, RuntimeError):
+            event_cache.apply_thread_mutation_append.side_effect = append_outcome
         else:
-            event_cache.revalidate_thread_after_incremental_update.return_value = revalidation_result
+            event_cache.apply_thread_mutation_append.return_value = append_outcome
         schedule_repair = Mock()
         cache_ops = ThreadMutationCacheOps(
             logger_getter=lambda: logger,
@@ -90,6 +91,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             thread_id,
             event_source,
             context="live",
+            append_failed_reason="live_append_failed",
         )
         retained = original_ops.runtime.event_cache_write_coordinator.pending_thread_repair_deltas(
             room_id,
@@ -97,7 +99,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             coordination_scope=event_cache.principal_id,
         )
 
-        assert appended is True
+        assert appended is not isinstance(append_outcome, RuntimeError)
         assert [event["event_id"] for event in retained] == ["$reply:localhost"]
         schedule_repair.assert_called_once_with(room_id, thread_id)
 
@@ -335,33 +337,31 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         )
         assert access._outbound._reservations.active_count == thread_count
 
-        event_cache.append_event.reset_mock()
-        event_cache.mark_thread_stale.reset_mock()
+        event_cache.apply_thread_mutation_append.reset_mock()
         entered_by_thread = {thread_id: asyncio.Event() for thread_id in thread_ids}
         release_first_edits = asyncio.Event()
         active_threads: set[str] = set()
         max_active_thread_count = 0
         appended_event_ids_by_thread: dict[str, list[str]] = {thread_id: [] for thread_id in thread_ids}
 
-        async def blocking_mark_thread_stale(_room_id: str, thread_id: str, *, reason: str) -> None:
+        async def blocking_record_append(
+            _room_id: str,
+            thread_id: str,
+            event_source: dict[str, object],
+            *,
+            append_failed_reason: str,
+        ) -> ThreadAppendOutcome:
             nonlocal max_active_thread_count
-            assert reason == "outbound_thread_mutation"
+            assert append_failed_reason == "outbound_thread_mutation"
             active_threads.add(thread_id)
             max_active_thread_count = max(max_active_thread_count, len(active_threads))
             entered_by_thread[thread_id].set()
             await release_first_edits.wait()
             active_threads.remove(thread_id)
-
-        async def record_append(
-            _room_id: str,
-            thread_id: str,
-            event_source: dict[str, object],
-        ) -> bool:
             appended_event_ids_by_thread[thread_id].append(str(event_source["event_id"]))
-            return True
+            return ThreadAppendOutcome.APPENDED
 
-        event_cache.mark_thread_stale = AsyncMock(side_effect=blocking_mark_thread_stale)
-        event_cache.append_event = AsyncMock(side_effect=record_append)
+        event_cache.apply_thread_mutation_append = AsyncMock(side_effect=blocking_record_append)
 
         with (
             patch.object(coordinator, "queue_room_update", wraps=coordinator.queue_room_update) as room_updates,
@@ -467,7 +467,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             coordination_scope=event_cache.principal_id,
         )
         assert access._outbound._reservations.active_count == 1
-        event_cache.append_event.reset_mock()
+        event_cache.apply_thread_mutation_append.reset_mock()
 
         for event_id, body, stream_status in (
             ("$edit-progress:localhost", "partial", STREAM_STATUS_STREAMING),
@@ -497,7 +497,9 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             thread_id,
             coordination_scope=event_cache.principal_id,
         )
-        appended_event_ids = [call.args[2]["event_id"] for call in event_cache.append_event.await_args_list]
+        appended_event_ids = [
+            call.args[2]["event_id"] for call in event_cache.apply_thread_mutation_append.await_args_list
+        ]
         assert appended_event_ids == ["$edit-progress:localhost", "$edit-terminal:localhost"]
         assert not coordinator._room_states
 
@@ -536,7 +538,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             thread_id,
             coordination_scope=event_cache.principal_id,
         )
-        event_cache.append_event.reset_mock()
+        event_cache.apply_thread_mutation_append.reset_mock()
         access.notify_outbound_message(
             room_id,
             first_edit_event_id,
@@ -577,11 +579,11 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             thread_id,
             coordination_scope=event_cache.principal_id,
         )
-        assert [call.args[2]["event_id"] for call in event_cache.append_event.await_args_list] == [
+        assert [call.args[2]["event_id"] for call in event_cache.apply_thread_mutation_append.await_args_list] == [
             first_edit_event_id,
             "$edit-terminal:localhost",
         ]
-        assert all(call.args[1] == thread_id for call in event_cache.append_event.await_args_list)
+        assert all(call.args[1] == thread_id for call in event_cache.apply_thread_mutation_append.await_args_list)
         assert access._outbound._reservations.active_count == 0
 
     def test_thread_reservations_isolate_principals_rooms_and_expire(self) -> None:
@@ -683,8 +685,8 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             release_blocker.set()
             await coordinator.close()
 
-        event_cache.append_event.assert_awaited_once()
-        _room_id, _thread_id, appended_event = event_cache.append_event.await_args.args
+        event_cache.apply_thread_mutation_append.assert_awaited_once()
+        _room_id, _thread_id, appended_event = event_cache.apply_thread_mutation_append.await_args.args
         assert appended_event["event_id"] == "$edit-2:localhost"
         assert appended_event["content"]["m.new_content"]["body"] == "stream update 2"
         assert any(
@@ -772,9 +774,11 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             release_blocker.set()
             await coordinator.close()
 
-        appended_event_ids = [call.args[2]["event_id"] for call in event_cache.append_event.await_args_list]
+        appended_event_ids = [
+            call.args[2]["event_id"] for call in event_cache.apply_thread_mutation_append.await_args_list
+        ]
         assert appended_event_ids == ["$edit-2:localhost", "$edit-final:localhost"]
-        final_content = event_cache.append_event.await_args_list[-1].args[2]["content"]
+        final_content = event_cache.apply_thread_mutation_append.await_args_list[-1].args[2]["content"]
         assert final_content["m.new_content"][STREAM_STATUS_KEY] == STREAM_STATUS_COMPLETED
 
     @pytest.mark.asyncio
@@ -835,7 +839,9 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             release_blocker.set()
             await coordinator.close()
 
-        appended_event_ids = [call.args[2]["event_id"] for call in event_cache.append_event.await_args_list]
+        appended_event_ids = [
+            call.args[2]["event_id"] for call in event_cache.apply_thread_mutation_append.await_args_list
+        ]
         assert appended_event_ids == ["$plain-edit-1:localhost", "$plain-edit-2:localhost"]
 
     @pytest.mark.asyncio
@@ -1048,7 +1054,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         timing_logger = MagicMock()
         monkeypatch.setattr(timing_module, "logger", timing_logger)
         event_cache = _runtime_event_cache()
-        event_cache.append_event = AsyncMock(return_value=True)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.APPENDED)
         access = MatrixConversationCache(
             logger=MagicMock(),
             runtime=_conversation_runtime(event_cache=event_cache),
@@ -1086,7 +1092,6 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             and call.kwargs["impact_state"] == "threaded"
             and call.kwargs["impact_resolution_ms"] >= 0.0
             and call.kwargs["queue_and_update_ms"] >= 0.0
-            and call.kwargs["invalidate_ms"] >= 0.0
             and call.kwargs["append_ms"] >= 0.0
             and call.kwargs["outcome"] == "ok"
             for call in append_calls
@@ -1102,7 +1107,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         timing_logger = MagicMock()
         monkeypatch.setattr(timing_module, "logger", timing_logger)
         event_cache = _runtime_event_cache()
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
         access = MatrixConversationCache(
             logger=MagicMock(),
             runtime=_conversation_runtime(event_cache=event_cache),
@@ -1242,12 +1247,11 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             event_info=EventInfo.from_event(event.source),
         )
 
-        event_cache.mark_thread_stale.assert_awaited_once_with(
-            "!room:localhost",
-            "$thread:localhost",
-            reason="live_thread_mutation",
+        event_cache.apply_thread_mutation_append.assert_awaited_once()
+        assert event_cache.apply_thread_mutation_append.await_args.kwargs["append_failed_reason"] == (
+            "live_append_failed"
         )
-        event_cache.append_event.assert_awaited_once()
+        event_cache.mark_thread_stale.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_live_event_cache_update_recovers_after_same_room_failure(self) -> None:

--- a/tests/test_event_cache_write_coordination.py
+++ b/tests/test_event_cache_write_coordination.py
@@ -352,7 +352,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             append_failed_reason: str,
         ) -> ThreadAppendOutcome:
             nonlocal max_active_thread_count
-            assert append_failed_reason == "outbound_thread_mutation"
+            assert append_failed_reason == "outbound_append_failed"
             active_threads.add(thread_id)
             max_active_thread_count = max(max_active_thread_count, len(active_threads))
             entered_by_thread[thread_id].set()

--- a/tests/test_matrix_cache_interaction_contract.py
+++ b/tests/test_matrix_cache_interaction_contract.py
@@ -12,6 +12,7 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.cache import (
     ConversationEventCache,
     EventCacheWriteCoordinator,
+    ThreadAppendOutcome,
     thread_cache_rejection_reason,
 )
 from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
@@ -1182,7 +1183,13 @@ async def test_mark_thread_stale_upgrades_incremental_reason_to_full_refetch_rea
     assert downgraded_state.invalidated_at is not None
     assert state.invalidated_at is not None
     assert downgraded_state.invalidated_at >= state.invalidated_at
-    assert await event_cache.revalidate_thread_after_incremental_update(_ROOM_ID, _THREAD_ID) is False
+    non_incremental_append = await event_cache.apply_thread_mutation_append(
+        _ROOM_ID,
+        _THREAD_ID,
+        _message_source("$after-opaque", "m.text", timestamp=70, relation=_thread_relation()),
+        append_failed_reason="sync_append_failed",
+    )
+    assert non_incremental_append is ThreadAppendOutcome.APPENDED_STALE
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_cache_mutations.py
+++ b/tests/test_thread_cache_mutations.py
@@ -287,7 +287,7 @@ class TestThreadMutationHelpers:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("context", "invalidate_on_append_failure"),
+        ("context", "use_append_failure_reason"),
         [
             ("outbound", False),
             ("live", True),
@@ -297,7 +297,7 @@ class TestThreadMutationHelpers:
     async def test_thread_message_mutation_room_level_skips_invalidation(
         self,
         context: str,
-        invalidate_on_append_failure: bool,
+        use_append_failure_reason: bool,
     ) -> None:
         """Room-level message mutations should only log and leave thread state untouched."""
         cache_ops, logger, event_cache = _thread_mutation_cache_ops()
@@ -311,7 +311,7 @@ class TestThreadMutationHelpers:
             event_id="$event:localhost",
             context=context,
             room_level_skip_message=f"skip-{context}",
-            invalidate_on_append_failure=invalidate_on_append_failure,
+            use_append_failure_reason=use_append_failure_reason,
         )
 
         assert result is False
@@ -327,7 +327,7 @@ class TestThreadMutationHelpers:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("context", "invalidate_on_append_failure"),
+        ("context", "use_append_failure_reason"),
         [
             ("outbound", False),
             ("live", True),
@@ -337,7 +337,7 @@ class TestThreadMutationHelpers:
     async def test_thread_message_mutation_unknown_invalidates_room_once(
         self,
         context: str,
-        invalidate_on_append_failure: bool,
+        use_append_failure_reason: bool,
     ) -> None:
         """Unknown message mutations should fail closed with one room-thread invalidation."""
         cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
@@ -351,7 +351,7 @@ class TestThreadMutationHelpers:
             event_id="$event:localhost",
             context=context,
             room_level_skip_message=f"skip-{context}",
-            invalidate_on_append_failure=invalidate_on_append_failure,
+            use_append_failure_reason=use_append_failure_reason,
         )
 
         assert result is True
@@ -364,7 +364,7 @@ class TestThreadMutationHelpers:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("context", "invalidate_on_append_failure"),
+        ("context", "use_append_failure_reason"),
         [
             ("outbound", False),
             ("live", True),
@@ -374,7 +374,7 @@ class TestThreadMutationHelpers:
     async def test_thread_message_mutation_threaded_success_uses_context_reasons(
         self,
         context: str,
-        invalidate_on_append_failure: bool,
+        use_append_failure_reason: bool,
     ) -> None:
         """Threaded message mutations should append atomically and avoid room invalidation."""
         cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
@@ -389,7 +389,7 @@ class TestThreadMutationHelpers:
             event_id="$event:localhost",
             context=context,
             room_level_skip_message=f"skip-{context}",
-            invalidate_on_append_failure=invalidate_on_append_failure,
+            use_append_failure_reason=use_append_failure_reason,
         )
 
         assert result is False
@@ -399,7 +399,7 @@ class TestThreadMutationHelpers:
             "$thread:localhost",
             event_source,
             append_failed_reason=(
-                f"{context}_append_failed" if invalidate_on_append_failure else f"{context}_thread_mutation"
+                f"{context}_append_failed" if use_append_failure_reason else f"{context}_thread_mutation"
             ),
         )
         event_cache.mark_room_threads_stale.assert_not_awaited()
@@ -407,7 +407,7 @@ class TestThreadMutationHelpers:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("context", "invalidate_on_append_failure", "expected_reason"),
+        ("context", "use_append_failure_reason", "expected_reason"),
         [
             ("outbound", False, "outbound_thread_mutation"),
             ("live", True, "live_append_failed"),
@@ -417,7 +417,7 @@ class TestThreadMutationHelpers:
     async def test_thread_message_mutation_threaded_append_failure_uses_path_policy(
         self,
         context: str,
-        invalidate_on_append_failure: bool,
+        use_append_failure_reason: bool,
         expected_reason: str,
     ) -> None:
         """An append that cannot land must carry each path's own durable marker reason."""
@@ -433,7 +433,7 @@ class TestThreadMutationHelpers:
             event_id="$event:localhost",
             context=context,
             room_level_skip_message=f"skip-{context}",
-            invalidate_on_append_failure=invalidate_on_append_failure,
+            use_append_failure_reason=use_append_failure_reason,
         )
 
         assert result is False
@@ -1019,6 +1019,9 @@ class TestMatrixConversationCacheThreadReads:
         assert isinstance(stored_event_source.get("origin_server_ts"), int)
         event_cache.mark_thread_stale.assert_not_awaited()
         event_cache.mark_room_threads_stale.assert_not_awaited()
+        # A successful threaded mutation now writes no marker at all, so this is the only assertion
+        # left that would catch a reaction being appended into thread cache.
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_notify_outbound_reaction_normalizes_event_for_real_cache(

--- a/tests/test_thread_cache_mutations.py
+++ b/tests/test_thread_cache_mutations.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import nio
 import pytest
@@ -17,6 +17,7 @@ from mindroom.matrix import thread_bookkeeping
 from mindroom.matrix.cache import ConversationEventCache, thread_writes
 from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome
 from mindroom.matrix.cache.thread_reads import ThreadReadMode
 from mindroom.matrix.cache.thread_writes import (
     _apply_thread_message_mutation,
@@ -375,7 +376,7 @@ class TestThreadMutationHelpers:
         context: str,
         invalidate_on_append_failure: bool,
     ) -> None:
-        """Threaded message mutations should stale-mark once, append, and avoid room invalidation."""
+        """Threaded message mutations should append atomically and avoid room invalidation."""
         cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
         event_source = {"event_id": "$event:localhost"}
 
@@ -392,36 +393,37 @@ class TestThreadMutationHelpers:
         )
 
         assert result is False
-        event_cache.append_event.assert_awaited_once_with(
+        # One durable operation appends and settles trust, so a successful mutation writes no marker.
+        event_cache.apply_thread_mutation_append.assert_awaited_once_with(
             "!room:localhost",
             "$thread:localhost",
             event_source,
+            append_failed_reason=(
+                f"{context}_append_failed" if invalidate_on_append_failure else f"{context}_thread_mutation"
+            ),
         )
+        event_cache.append_event.assert_not_awaited()
         event_cache.mark_room_threads_stale.assert_not_awaited()
-        event_cache.mark_thread_stale.assert_awaited_once_with(
-            "!room:localhost",
-            "$thread:localhost",
-            reason=f"{context}_thread_mutation",
-        )
+        event_cache.mark_thread_stale.assert_not_awaited()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("context", "invalidate_on_append_failure", "expected_reasons"),
+        ("context", "invalidate_on_append_failure", "expected_reason"),
         [
-            ("outbound", False, ["outbound_thread_mutation"]),
-            ("live", True, ["live_thread_mutation", "live_append_failed"]),
-            ("sync", True, ["sync_thread_mutation", "sync_append_failed"]),
+            ("outbound", False, "outbound_thread_mutation"),
+            ("live", True, "live_append_failed"),
+            ("sync", True, "sync_append_failed"),
         ],
     )
     async def test_thread_message_mutation_threaded_append_failure_uses_path_policy(
         self,
         context: str,
         invalidate_on_append_failure: bool,
-        expected_reasons: list[str],
+        expected_reason: str,
     ) -> None:
-        """Append failures should only add the extra stale mark on the live and sync paths."""
+        """An append that cannot land must carry each path's own durable marker reason."""
         cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
-        event_cache.append_event = AsyncMock(return_value=False)
+        event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.SNAPSHOT_MISSING)
 
         result = await _apply_thread_message_mutation(
             cache_ops=cache_ops,
@@ -436,9 +438,13 @@ class TestThreadMutationHelpers:
         )
 
         assert result is False
-        assert event_cache.mark_thread_stale.await_args_list == [
-            call("!room:localhost", "$thread:localhost", reason=reason) for reason in expected_reasons
-        ]
+        # The marker is written inside the same operation, under the reason this path asks for.
+        event_cache.apply_thread_mutation_append.assert_awaited_once_with(
+            "!room:localhost",
+            "$thread:localhost",
+            {"event_id": "$event:localhost"},
+            append_failed_reason=expected_reason,
+        )
         event_cache.mark_room_threads_stale.assert_not_awaited()
 
     @pytest.mark.asyncio
@@ -640,13 +646,20 @@ class TestMatrixConversationCacheThreadReads:
             sibling_thread_update_started.set()
             await release_sibling_thread_update.wait()
 
-        async def mark_thread_stale(room_id: str, thread_id: str, *, reason: str) -> None:
+        async def apply_thread_mutation_append(
+            room_id: str,
+            thread_id: str,
+            _event_source: dict[str, object],
+            *,
+            append_failed_reason: str,
+        ) -> ThreadAppendOutcome:
             assert room_id == "!room:localhost"
             assert thread_id == "$claimed-thread:localhost"
-            assert reason == "outbound_thread_mutation"
+            assert append_failed_reason == "outbound_thread_mutation"
             thread_invalidation_started.set()
+            return ThreadAppendOutcome.APPENDED
 
-        event_cache.mark_thread_stale = AsyncMock(side_effect=mark_thread_stale)
+        event_cache.apply_thread_mutation_append = AsyncMock(side_effect=apply_thread_mutation_append)
         sibling_thread_task = coordinator.queue_thread_update(
             "!room:localhost",
             "$sibling-thread:localhost",
@@ -686,16 +699,12 @@ class TestMatrixConversationCacheThreadReads:
             )
             assert sibling_thread_task.done() is False
 
-            event_cache.mark_thread_stale.assert_awaited_once_with(
-                "!room:localhost",
-                "$claimed-thread:localhost",
-                reason="outbound_thread_mutation",
-            )
-            event_cache.append_event.assert_awaited_once()
-            append_args = event_cache.append_event.await_args.args
+            event_cache.apply_thread_mutation_append.assert_awaited_once()
+            append_args = event_cache.apply_thread_mutation_append.await_args.args
             assert append_args[0] == "!room:localhost"
             assert append_args[1] == "$claimed-thread:localhost"
             assert append_args[2]["event_id"] == "$edit:localhost"
+            event_cache.mark_thread_stale.assert_not_awaited()
         finally:
             release_sibling_thread_update.set()
             await asyncio.wait_for(
@@ -1086,12 +1095,10 @@ class TestMatrixConversationCacheThreadReads:
         )
         await _wait_for_room_cache_idle(access.runtime.event_cache_write_coordinator)
 
-        event_cache.mark_thread_stale.assert_awaited_once_with(
-            "!room:localhost",
-            "$thread-root:localhost",
-            reason="outbound_thread_mutation",
-        )
-        event_cache.append_event.assert_awaited()
+        event_cache.apply_thread_mutation_append.assert_awaited_once()
+        awaited = event_cache.apply_thread_mutation_append.await_args
+        assert awaited.args[:2] == ("!room:localhost", "$thread-root:localhost")
+        assert awaited.kwargs["append_failed_reason"] == "outbound_thread_mutation"
 
     @pytest.mark.asyncio
     async def test_notify_outbound_message_reference_to_threaded_target_updates_thread_cache(self) -> None:
@@ -1123,12 +1130,10 @@ class TestMatrixConversationCacheThreadReads:
         )
         await _wait_for_room_cache_idle(access.runtime.event_cache_write_coordinator)
 
-        event_cache.mark_thread_stale.assert_awaited_once_with(
-            "!room:localhost",
-            "$thread-root:localhost",
-            reason="outbound_thread_mutation",
-        )
-        event_cache.append_event.assert_awaited()
+        event_cache.apply_thread_mutation_append.assert_awaited_once()
+        awaited = event_cache.apply_thread_mutation_append.await_args
+        assert awaited.args[:2] == ("!room:localhost", "$thread-root:localhost")
+        assert awaited.kwargs["append_failed_reason"] == "outbound_thread_mutation"
 
     @pytest.mark.asyncio
     async def test_notify_outbound_redaction_transitive_target_updates_thread_cache(self) -> None:

--- a/tests/test_thread_cache_mutations.py
+++ b/tests/test_thread_cache_mutations.py
@@ -321,7 +321,7 @@ class TestThreadMutationHelpers:
             event_id="$event:localhost",
             original_event_id="$target:localhost",
         )
-        event_cache.append_event.assert_not_awaited()
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
         event_cache.mark_room_threads_stale.assert_not_awaited()
         event_cache.mark_thread_stale.assert_not_awaited()
 
@@ -355,7 +355,7 @@ class TestThreadMutationHelpers:
         )
 
         assert result is True
-        event_cache.append_event.assert_not_awaited()
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
         event_cache.mark_room_threads_stale.assert_awaited_once_with(
             "!room:localhost",
             reason=f"{context}_thread_lookup_unavailable",
@@ -402,7 +402,6 @@ class TestThreadMutationHelpers:
                 f"{context}_append_failed" if invalidate_on_append_failure else f"{context}_thread_mutation"
             ),
         )
-        event_cache.append_event.assert_not_awaited()
         event_cache.mark_room_threads_stale.assert_not_awaited()
         event_cache.mark_thread_stale.assert_not_awaited()
 
@@ -622,7 +621,7 @@ class TestMatrixConversationCacheThreadReads:
             reason="outbound_thread_lookup_unavailable",
         )
         event_cache.mark_thread_stale.assert_not_awaited()
-        event_cache.append_event.assert_not_awaited()
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_notify_outbound_event_threaded_edit_uses_claimed_thread_barrier(self) -> None:
@@ -1020,7 +1019,6 @@ class TestMatrixConversationCacheThreadReads:
         assert isinstance(stored_event_source.get("origin_server_ts"), int)
         event_cache.mark_thread_stale.assert_not_awaited()
         event_cache.mark_room_threads_stale.assert_not_awaited()
-        event_cache.append_event.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_notify_outbound_reaction_normalizes_event_for_real_cache(

--- a/tests/test_thread_cache_mutations.py
+++ b/tests/test_thread_cache_mutations.py
@@ -287,17 +287,12 @@ class TestThreadMutationHelpers:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("context", "use_append_failure_reason"),
-        [
-            ("outbound", False),
-            ("live", True),
-            ("sync", True),
-        ],
+        "context",
+        ["outbound", "live", "sync"],
     )
     async def test_thread_message_mutation_room_level_skips_invalidation(
         self,
         context: str,
-        use_append_failure_reason: bool,
     ) -> None:
         """Room-level message mutations should only log and leave thread state untouched."""
         cache_ops, logger, event_cache = _thread_mutation_cache_ops()
@@ -311,7 +306,6 @@ class TestThreadMutationHelpers:
             event_id="$event:localhost",
             context=context,
             room_level_skip_message=f"skip-{context}",
-            use_append_failure_reason=use_append_failure_reason,
         )
 
         assert result is False
@@ -327,17 +321,12 @@ class TestThreadMutationHelpers:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("context", "use_append_failure_reason"),
-        [
-            ("outbound", False),
-            ("live", True),
-            ("sync", True),
-        ],
+        "context",
+        ["outbound", "live", "sync"],
     )
     async def test_thread_message_mutation_unknown_invalidates_room_once(
         self,
         context: str,
-        use_append_failure_reason: bool,
     ) -> None:
         """Unknown message mutations should fail closed with one room-thread invalidation."""
         cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
@@ -351,7 +340,6 @@ class TestThreadMutationHelpers:
             event_id="$event:localhost",
             context=context,
             room_level_skip_message=f"skip-{context}",
-            use_append_failure_reason=use_append_failure_reason,
         )
 
         assert result is True
@@ -364,17 +352,12 @@ class TestThreadMutationHelpers:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("context", "use_append_failure_reason"),
-        [
-            ("outbound", False),
-            ("live", True),
-            ("sync", True),
-        ],
+        "context",
+        ["outbound", "live", "sync"],
     )
     async def test_thread_message_mutation_threaded_success_uses_context_reasons(
         self,
         context: str,
-        use_append_failure_reason: bool,
     ) -> None:
         """Threaded message mutations should append atomically and avoid room invalidation."""
         cache_ops, _logger, event_cache = _thread_mutation_cache_ops()
@@ -389,7 +372,6 @@ class TestThreadMutationHelpers:
             event_id="$event:localhost",
             context=context,
             room_level_skip_message=f"skip-{context}",
-            use_append_failure_reason=use_append_failure_reason,
         )
 
         assert result is False
@@ -398,26 +380,23 @@ class TestThreadMutationHelpers:
             "!room:localhost",
             "$thread:localhost",
             event_source,
-            append_failed_reason=(
-                f"{context}_append_failed" if use_append_failure_reason else f"{context}_thread_mutation"
-            ),
+            append_failed_reason=f"{context}_append_failed",
         )
         event_cache.mark_room_threads_stale.assert_not_awaited()
         event_cache.mark_thread_stale.assert_not_awaited()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("context", "use_append_failure_reason", "expected_reason"),
+        ("context", "expected_reason"),
         [
-            ("outbound", False, "outbound_thread_mutation"),
-            ("live", True, "live_append_failed"),
-            ("sync", True, "sync_append_failed"),
+            ("outbound", "outbound_append_failed"),
+            ("live", "live_append_failed"),
+            ("sync", "sync_append_failed"),
         ],
     )
     async def test_thread_message_mutation_threaded_append_failure_uses_path_policy(
         self,
         context: str,
-        use_append_failure_reason: bool,
         expected_reason: str,
     ) -> None:
         """An append that cannot land must carry each path's own durable marker reason."""
@@ -433,7 +412,6 @@ class TestThreadMutationHelpers:
             event_id="$event:localhost",
             context=context,
             room_level_skip_message=f"skip-{context}",
-            use_append_failure_reason=use_append_failure_reason,
         )
 
         assert result is False
@@ -654,7 +632,7 @@ class TestMatrixConversationCacheThreadReads:
         ) -> ThreadAppendOutcome:
             assert room_id == "!room:localhost"
             assert thread_id == "$claimed-thread:localhost"
-            assert append_failed_reason == "outbound_thread_mutation"
+            assert append_failed_reason == "outbound_append_failed"
             thread_invalidation_started.set()
             return ThreadAppendOutcome.APPENDED
 
@@ -1099,7 +1077,7 @@ class TestMatrixConversationCacheThreadReads:
         event_cache.apply_thread_mutation_append.assert_awaited_once()
         awaited = event_cache.apply_thread_mutation_append.await_args
         assert awaited.args[:2] == ("!room:localhost", "$thread-root:localhost")
-        assert awaited.kwargs["append_failed_reason"] == "outbound_thread_mutation"
+        assert awaited.kwargs["append_failed_reason"] == "outbound_append_failed"
 
     @pytest.mark.asyncio
     async def test_notify_outbound_message_reference_to_threaded_target_updates_thread_cache(self) -> None:
@@ -1134,7 +1112,7 @@ class TestMatrixConversationCacheThreadReads:
         event_cache.apply_thread_mutation_append.assert_awaited_once()
         awaited = event_cache.apply_thread_mutation_append.await_args
         assert awaited.args[:2] == ("!room:localhost", "$thread-root:localhost")
-        assert awaited.kwargs["append_failed_reason"] == "outbound_thread_mutation"
+        assert awaited.kwargs["append_failed_reason"] == "outbound_append_failed"
 
     @pytest.mark.asyncio
     async def test_notify_outbound_redaction_transitive_target_updates_thread_cache(self) -> None:

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -20,6 +20,7 @@ from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.matrix.cache import (
+    ThreadAppendOutcome,
     ThreadCacheReplaceOutcome,
     ThreadHistoryResult,
     thread_cache_rejection_reason,
@@ -3458,14 +3459,11 @@ class TestThreadHistoryCache:
             validated_at=runtime_started_at - 100,
         )
         await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="sync_thread_mutation")
-        pre_runtime_appended = await cache.append_event(
+        pre_runtime_append = await cache.apply_thread_mutation_append(
             "!room:localhost",
             "$thread_root",
             self._cache_source(appended_reply),
-        )
-        pre_runtime_revalidated = await cache.revalidate_thread_after_incremental_update(
-            "!room:localhost",
-            "$thread_root",
+            append_failed_reason="sync_append_failed",
         )
 
         await _replace_thread(
@@ -3477,14 +3475,11 @@ class TestThreadHistoryCache:
         )
         await cache.mark_room_threads_stale("!room:localhost", reason="sync_redaction_lookup_unavailable")
         await cache.mark_thread_stale("!room:localhost", "$thread_root", reason="sync_thread_mutation")
-        room_stale_appended = await cache.append_event(
+        room_stale_append = await cache.apply_thread_mutation_append(
             "!room:localhost",
             "$thread_root",
             self._cache_source(appended_reply),
-        )
-        room_stale_revalidated = await cache.revalidate_thread_after_incremental_update(
-            "!room:localhost",
-            "$thread_root",
+            append_failed_reason="sync_append_failed",
         )
 
         client = MagicMock()
@@ -3503,10 +3498,8 @@ class TestThreadHistoryCache:
         finally:
             await cache.close()
 
-        assert pre_runtime_appended is True
-        assert pre_runtime_revalidated is True
-        assert room_stale_appended is True
-        assert room_stale_revalidated is False
+        assert pre_runtime_append is ThreadAppendOutcome.APPENDED
+        assert room_stale_append is ThreadAppendOutcome.APPENDED_STALE
         assert [message.event_id for message in history] == ["$thread_root", "$reply1", "$reply2"]
         assert history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
 

--- a/tests/test_thread_mode.py
+++ b/tests/test_thread_mode.py
@@ -1567,7 +1567,7 @@ class TestExtractedModuleLoggerRebinding:
         bot.logger = rebound_logger
 
         event_cache = AsyncMock()
-        event_cache.append_event.side_effect = RuntimeError("cache write failed")
+        event_cache.apply_thread_mutation_append.side_effect = RuntimeError("cache write failed")
         bot.event_cache = event_cache
         bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),

--- a/tests/test_thread_mutation_atomicity.py
+++ b/tests/test_thread_mutation_atomicity.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import pytest_asyncio
 
-from mindroom.background_tasks import _tasks_for_owner, wait_for_background_tasks
+from mindroom.background_tasks import _tasks_for_owner, create_background_task, wait_for_background_tasks
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
@@ -237,7 +237,6 @@ async def test_write_policy_mutation_never_exposes_an_invalid_snapshot(tmp_path:
                 event_id=str(event_source["event_id"]),
                 context="sync",
                 room_level_skip_message="skip",
-                use_append_failure_reason=True,
             )
 
     try:
@@ -295,7 +294,6 @@ async def test_a_failed_cache_write_never_leaves_a_trusted_snapshot(tmp_path: Pa
                 event_id="$live",
                 context="sync",
                 room_level_skip_message="skip",
-                use_append_failure_reason=True,
             )
         state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
     finally:
@@ -334,7 +332,6 @@ async def test_a_cancelled_cache_write_never_leaves_a_trusted_snapshot(tmp_path:
                 event_id="$live",
                 context="sync",
                 room_level_skip_message="skip",
-                use_append_failure_reason=True,
             )
         state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
     finally:
@@ -393,7 +390,6 @@ async def test_a_cancelled_appends_marker_is_owned_by_the_shutdown_drain(tmp_pat
                     event_id="$live",
                     context="sync",
                     room_level_skip_message="skip",
-                    use_append_failure_reason=True,
                 ),
             )
             await asyncio.wait_for(append_started.wait(), timeout=5.0)
@@ -402,15 +398,108 @@ async def test_a_cancelled_appends_marker_is_owned_by_the_shutdown_drain(tmp_pat
 
             # The marker is in flight and the mutation is already cancelled: the drain must be able
             # to see this write, or the next shutdown round drops it.
-            owned = _tasks_for_owner(coordinator.background_task_owner)
+            owned = _tasks_for_owner(coordinator.failure_marker_task_owner)
             assert owned, "the marker write is untracked, so the shutdown drain cannot wait for it"
 
             release_marker.set()
             with pytest.raises(asyncio.CancelledError):
                 await mutation
-            await wait_for_background_tasks(timeout=5.0, owner=coordinator.background_task_owner)
+            await wait_for_background_tasks(timeout=5.0, owner=coordinator.failure_marker_task_owner)
         state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
     finally:
         await root_cache.close()
 
     assert thread_cache_rejection_reason(state) == "thread_invalidated_after_validation"
+
+
+@pytest.mark.asyncio
+async def test_a_later_outbound_append_cannot_erase_an_earlier_failed_one(cache: ConversationEventCache) -> None:
+    """A failed append must not leave a marker the next successful append can clear.
+
+    The reason a failed append writes has to sit outside the incremental allowlist, or the next
+    outbound mutation revalidates the thread while it is still missing the earlier event -- and the
+    retained delta that would otherwise catch it expires after a minute.
+    """
+    await _seed_valid_thread(cache)
+    missed = _event("$missed", 2000, thread_id=THREAD_ID)
+    await cache.store_events_batch([("$missed", ROOM_ID, missed)])
+    await cache.redact_event(ROOM_ID, "$missed")
+
+    refused = await cache.apply_thread_mutation_append(
+        ROOM_ID,
+        THREAD_ID,
+        missed,
+        append_failed_reason="outbound_append_failed",
+    )
+    later = await cache.apply_thread_mutation_append(
+        ROOM_ID,
+        THREAD_ID,
+        _event("$later", 3000, thread_id=THREAD_ID),
+        append_failed_reason="outbound_append_failed",
+    )
+    state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
+    cached_ids = {event["event_id"] for event in (await cache.get_thread_events(ROOM_ID, THREAD_ID) or [])}
+
+    assert refused is ThreadAppendOutcome.APPEND_REFUSED
+    assert later is ThreadAppendOutcome.APPENDED_STALE
+    assert "$missed" not in cached_ids
+    assert thread_cache_rejection_reason(state) is not None, (
+        "the thread went back to trusted while still missing the refused event"
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_drain_that_cancels_an_append_still_lands_its_marker(tmp_path: Path) -> None:
+    """The drain cancelling an append is the common way to owe a marker, so it must not race it.
+
+    Sharing one owner means the append spends the whole budget and the marker, created inside its
+    cancellation, is cancelled by the very next round.
+    """
+    root_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    cache = root_cache.for_principal(PRINCIPAL_ID)
+    await cache.initialize()
+    cache_ops = _cache_ops(tmp_path, cache)
+    coordinator = cache_ops.runtime.event_cache_write_coordinator
+    assert coordinator is not None
+    event_source = _event("$live", 2000, thread_id=THREAD_ID)
+    real_mark_thread_stale = cache.mark_thread_stale
+
+    async def hanging_append(*_args: object, **_kwargs: object) -> ThreadAppendOutcome:
+        await asyncio.Event().wait()
+        raise AssertionError
+
+    async def slow_mark_thread_stale(room_id: str, thread_id: str, *, reason: str) -> None:
+        # Longer than one cancel round, which is what makes a shared owner lose the write.
+        await asyncio.sleep(0.3)
+        await real_mark_thread_stale(room_id, thread_id, reason=reason)
+
+    try:
+        await _seed_valid_thread(cache)
+        with (
+            patch.object(cache, "apply_thread_mutation_append", hanging_append),
+            patch.object(cache, "mark_thread_stale", slow_mark_thread_stale),
+        ):
+            create_background_task(
+                _apply_thread_message_mutation(
+                    cache_ops=cache_ops,
+                    room_id=ROOM_ID,
+                    event_info=EventInfo.from_event(event_source),
+                    impact=MutationThreadImpact(state=MutationThreadImpactState.THREADED, thread_id=THREAD_ID),
+                    event_source=event_source,
+                    event_id="$live",
+                    context="sync",
+                    room_level_skip_message="skip",
+                ),
+                name="append_cancelled_by_the_drain",
+                owner=coordinator.background_task_owner,
+                log_exceptions=False,
+            )
+            await asyncio.sleep(0.05)
+            await coordinator.close()
+        state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
+    finally:
+        await root_cache.close()
+
+    assert thread_cache_rejection_reason(state) == "thread_invalidated_after_validation"
+    assert state is not None
+    assert state.invalidation_reason == "sync_append_failed"

--- a/tests/test_thread_mutation_atomicity.py
+++ b/tests/test_thread_mutation_atomicity.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import pytest_asyncio
 
+from mindroom.background_tasks import _tasks_for_owner, wait_for_background_tasks
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
@@ -238,7 +239,7 @@ async def test_write_policy_mutation_never_exposes_an_invalid_snapshot(tmp_path:
                 event_id=str(event_source["event_id"]),
                 context="sync",
                 room_level_skip_message="skip",
-                invalidate_on_append_failure=True,
+                use_append_failure_reason=True,
             )
 
     try:
@@ -296,7 +297,7 @@ async def test_a_failed_cache_write_never_leaves_a_trusted_snapshot(tmp_path: Pa
                 event_id="$live",
                 context="sync",
                 room_level_skip_message="skip",
-                invalidate_on_append_failure=True,
+                use_append_failure_reason=True,
             )
         state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
     finally:
@@ -335,7 +336,7 @@ async def test_a_cancelled_cache_write_never_leaves_a_trusted_snapshot(tmp_path:
                 event_id="$live",
                 context="sync",
                 room_level_skip_message="skip",
-                invalidate_on_append_failure=True,
+                use_append_failure_reason=True,
             )
         state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
     finally:
@@ -344,3 +345,74 @@ async def test_a_cancelled_cache_write_never_leaves_a_trusted_snapshot(tmp_path:
     assert thread_cache_rejection_reason(state) == "thread_invalidated_after_validation"
     assert state is not None
     assert state.invalidation_reason == "sync_append_failed"
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_appends_marker_is_owned_by_the_shutdown_drain(tmp_path: Path) -> None:
+    """The marker a rolled-back append owes must be drainable, not an untracked orphan.
+
+    Shutdown cancels pending work in bounded rounds. A marker write that is merely shielded keeps
+    running but is invisible to the drain, so a second round abandons it and the thread stays
+    trusted while missing the event -- the fail-open this handler exists to prevent.
+    """
+    root_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    cache = root_cache.for_principal(PRINCIPAL_ID)
+    await cache.initialize()
+    cache_ops = _cache_ops(tmp_path, cache)
+    coordinator = cache_ops.runtime.event_cache_write_coordinator
+    assert coordinator is not None
+    impact = MutationThreadImpact(state=MutationThreadImpactState.THREADED, thread_id=THREAD_ID)
+    event_source = _event("$live", 2000, thread_id=THREAD_ID)
+
+    append_started = asyncio.Event()
+    marker_started = asyncio.Event()
+    release_marker = asyncio.Event()
+    real_mark_thread_stale = cache.mark_thread_stale
+
+    async def hanging_append(*_args: object, **_kwargs: object) -> ThreadAppendOutcome:
+        append_started.set()
+        await asyncio.Event().wait()
+        raise AssertionError
+
+    async def blocked_mark_thread_stale(room_id: str, thread_id: str, *, reason: str) -> None:
+        marker_started.set()
+        await release_marker.wait()
+        await real_mark_thread_stale(room_id, thread_id, reason=reason)
+
+    try:
+        await _seed_valid_thread(cache)
+        with (
+            patch.object(cache, "apply_thread_mutation_append", hanging_append),
+            patch.object(cache, "mark_thread_stale", blocked_mark_thread_stale),
+        ):
+            mutation = asyncio.create_task(
+                _apply_thread_message_mutation(
+                    cache_ops=cache_ops,
+                    room_id=ROOM_ID,
+                    event_info=EventInfo.from_event(event_source),
+                    impact=impact,
+                    event_source=event_source,
+                    event_id="$live",
+                    context="sync",
+                    room_level_skip_message="skip",
+                    use_append_failure_reason=True,
+                ),
+            )
+            await asyncio.wait_for(append_started.wait(), timeout=5.0)
+            mutation.cancel()
+            await asyncio.wait_for(marker_started.wait(), timeout=5.0)
+
+            # The marker is in flight and the mutation is already cancelled: the drain must be able
+            # to see this write, or the next shutdown round drops it.
+            owned = _tasks_for_owner(coordinator.background_task_owner)
+            assert owned, "the marker write is untracked, so the shutdown drain cannot wait for it"
+
+            release_marker.set()
+            with pytest.raises(asyncio.CancelledError):
+                await mutation
+            await wait_for_background_tasks(timeout=5.0, owner=coordinator.background_task_owner)
+        state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
+    finally:
+        await root_cache.close()
+
+    assert thread_cache_rejection_reason(state) == "thread_invalidated_after_validation"

--- a/tests/test_thread_mutation_atomicity.py
+++ b/tests/test_thread_mutation_atomicity.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import TYPE_CHECKING, Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -248,3 +248,60 @@ async def test_write_policy_mutation_never_exposes_an_invalid_snapshot(tmp_path:
         await root_cache.close()
 
     assert rejections == [], f"reader observed {len(rejections)} rejections during successful sync mutations"
+
+
+@pytest.mark.asyncio
+async def test_mutation_for_a_redacted_event_never_writes_its_payload(cache: ConversationEventCache) -> None:
+    """A redacted event must not reach the point-lookup table, snapshot or no snapshot."""
+    redacted_reply = _event("$redacted", 2000, thread_id=THREAD_ID)
+    await cache.store_events_batch([(ROOM_ID, "$redacted", redacted_reply)])
+    await cache.redact_event(ROOM_ID, "$redacted")
+    assert await cache.get_event(ROOM_ID, "$redacted") is None
+
+    # No snapshot rows exist for this thread, which is the path that skipped the redaction guard.
+    outcome = await cache.apply_thread_mutation_append(
+        ROOM_ID,
+        THREAD_ID,
+        redacted_reply,
+        append_failed_reason="sync_append_failed",
+    )
+
+    assert outcome is ThreadAppendOutcome.APPEND_REFUSED
+    assert await cache.get_event(ROOM_ID, "$redacted") is None
+
+
+@pytest.mark.asyncio
+async def test_a_failed_cache_write_never_leaves_a_trusted_snapshot(tmp_path: Path) -> None:
+    """When the atomic operation rolls back, its marker rolls back too and must be rewritten."""
+    root_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    cache = root_cache.for_principal(PRINCIPAL_ID)
+    await cache.initialize()
+    cache_ops = _cache_ops(tmp_path, cache)
+    impact = MutationThreadImpact(state=MutationThreadImpactState.THREADED, thread_id=THREAD_ID)
+    event_source = _event("$live", 2000, thread_id=THREAD_ID)
+
+    try:
+        await _seed_valid_thread(cache)
+        with patch.object(
+            cache,
+            "apply_thread_mutation_append",
+            AsyncMock(side_effect=RuntimeError("cache write failed")),
+        ):
+            await _apply_thread_message_mutation(
+                cache_ops=cache_ops,
+                room_id=ROOM_ID,
+                event_info=EventInfo.from_event(event_source),
+                impact=impact,
+                event_source=event_source,
+                event_id="$live",
+                context="sync",
+                room_level_skip_message="skip",
+                invalidate_on_append_failure=True,
+            )
+        state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
+    finally:
+        await root_cache.close()
+
+    assert thread_cache_rejection_reason(state) == "thread_invalidated_after_validation"
+    assert state is not None
+    assert state.invalidation_reason == "sync_append_failed"

--- a/tests/test_thread_mutation_atomicity.py
+++ b/tests/test_thread_mutation_atomicity.py
@@ -135,7 +135,6 @@ async def test_mutation_on_a_snapshotless_thread_reports_it_distinctly(cache: Co
     state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
 
     assert outcome is ThreadAppendOutcome.SNAPSHOT_MISSING
-    assert outcome.needs_full_repair is True
     assert outcome.wrote_event is False
     assert thread_cache_rejection_reason(state) is not None
 
@@ -175,7 +174,6 @@ async def test_append_does_not_clear_an_invalidation_outside_the_allowlist(cache
 
     assert outcome is ThreadAppendOutcome.APPENDED_STALE
     assert outcome.wrote_event is True
-    assert outcome.needs_full_repair is False
     assert thread_cache_rejection_reason(state) is not None
 
 

--- a/tests/test_thread_mutation_atomicity.py
+++ b/tests/test_thread_mutation_atomicity.py
@@ -1,0 +1,250 @@
+"""Atomicity of the invalidate-then-append sequence behind every threaded cache mutation.
+
+A threaded mutation used to mark its thread stale, append the event, and only then restore
+validation, each as a separate durable operation. Between the first and the last the snapshot was
+observably untrusted even though the mutation was going to succeed, so any read landing in that
+window rejected a perfectly good cache and paid for a full history scan.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+
+from mindroom.bot_runtime_view import BotRuntimeState
+from mindroom.config.agent import AgentConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.matrix.cache import thread_cache_rejection_reason
+from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome
+from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
+from mindroom.matrix.cache.thread_writes import _apply_thread_message_mutation
+from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
+from mindroom.matrix.event_info import EventInfo
+from mindroom.matrix.thread_bookkeeping import MutationThreadImpact, MutationThreadImpactState
+from tests.conftest import bind_runtime_paths, test_runtime_paths
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator, Callable, Coroutine
+    from pathlib import Path
+
+    from mindroom.matrix.cache import ConversationEventCache
+
+ROOM_ID = "!room:localhost"
+THREAD_ID = "$thread:localhost"
+PRINCIPAL_ID = "@agent:localhost"
+
+
+def _event(event_id: str, timestamp: int, *, thread_id: str | None = None) -> dict[str, Any]:
+    content: dict[str, Any] = {"body": event_id, "msgtype": "m.text"}
+    if thread_id is not None:
+        content["m.relates_to"] = {"rel_type": "m.thread", "event_id": thread_id}
+    return {
+        "event_id": event_id,
+        "sender": "@user:localhost",
+        "origin_server_ts": timestamp,
+        "type": "m.room.message",
+        "content": content,
+    }
+
+
+@pytest_asyncio.fixture
+async def cache(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> AsyncGenerator[ConversationEventCache, None]:
+    """Yield one initialized principal-scoped cache for each supported backend."""
+    root_cache = event_cache_factory()
+    principal_cache = root_cache.for_principal(PRINCIPAL_ID)
+    await principal_cache.initialize()
+    try:
+        yield principal_cache
+    finally:
+        await root_cache.close()
+
+
+async def _seed_valid_thread(cache: ConversationEventCache) -> None:
+    await cache.replace_thread_if_not_newer(
+        ROOM_ID,
+        THREAD_ID,
+        [_event(THREAD_ID, 1000), _event("$initial", 1500, thread_id=THREAD_ID)],
+        expected_membership_epoch=await cache.room_membership_epoch(ROOM_ID),
+        fetch_started_at=0.0,
+    )
+    assert thread_cache_rejection_reason(await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)) is None
+
+
+async def _collect_rejections_while(
+    cache: ConversationEventCache,
+    mutate: Callable[[], Coroutine[Any, Any, None]],
+) -> list[str]:
+    """Run one mutation loop while a reader polls, returning every rejection it observed."""
+    rejections: list[str] = []
+    stop_reading = asyncio.Event()
+
+    async def read_until_stopped() -> None:
+        while not stop_reading.is_set():
+            reason = thread_cache_rejection_reason(await cache.get_thread_cache_state(ROOM_ID, THREAD_ID))
+            if reason is not None:
+                rejections.append(reason)
+            await asyncio.sleep(0)
+
+    reader = asyncio.create_task(read_until_stopped())
+    try:
+        await mutate()
+    finally:
+        stop_reading.set()
+        await reader
+    return rejections
+
+
+@pytest.mark.asyncio
+async def test_appending_a_mutation_never_exposes_an_invalid_snapshot(cache: ConversationEventCache) -> None:
+    """A concurrent reader must never see a valid thread go stale for a mutation that succeeds."""
+    await _seed_valid_thread(cache)
+
+    async def mutate() -> None:
+        for index in range(25):
+            outcome = await cache.apply_thread_mutation_append(
+                ROOM_ID,
+                THREAD_ID,
+                _event(f"$edit-{index}", 2000 + index, thread_id=THREAD_ID),
+                append_failed_reason="sync_append_failed",
+            )
+            assert outcome is ThreadAppendOutcome.APPENDED
+
+    rejections = await _collect_rejections_while(cache, mutate)
+
+    assert rejections == [], f"reader observed {len(rejections)} rejections of a thread that stayed appendable"
+
+
+@pytest.mark.asyncio
+async def test_mutation_on_a_snapshotless_thread_reports_it_distinctly(cache: ConversationEventCache) -> None:
+    """A thread with no rows to append into must be reported apart from a refused append."""
+    outcome = await cache.apply_thread_mutation_append(
+        ROOM_ID,
+        THREAD_ID,
+        _event("$live", 2000, thread_id=THREAD_ID),
+        append_failed_reason="sync_append_failed",
+    )
+    state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
+
+    assert outcome is ThreadAppendOutcome.SNAPSHOT_MISSING
+    assert outcome.needs_full_repair is True
+    assert outcome.wrote_event is False
+    assert thread_cache_rejection_reason(state) is not None
+
+
+@pytest.mark.asyncio
+async def test_append_clears_an_invalidation_left_by_an_earlier_mutation(cache: ConversationEventCache) -> None:
+    """The incremental revalidation allowlist must still apply when a prior mutation left a marker."""
+    await _seed_valid_thread(cache)
+    await cache.mark_thread_stale(ROOM_ID, THREAD_ID, reason="sync_thread_mutation")
+    assert thread_cache_rejection_reason(await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)) is not None
+
+    outcome = await cache.apply_thread_mutation_append(
+        ROOM_ID,
+        THREAD_ID,
+        _event("$live", 2000, thread_id=THREAD_ID),
+        append_failed_reason="sync_append_failed",
+    )
+    state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
+
+    assert outcome is ThreadAppendOutcome.APPENDED
+    assert thread_cache_rejection_reason(state) is None
+
+
+@pytest.mark.asyncio
+async def test_append_does_not_clear_an_invalidation_outside_the_allowlist(cache: ConversationEventCache) -> None:
+    """A non-incremental reason must survive an append, exactly as it did before."""
+    await _seed_valid_thread(cache)
+    await cache.mark_thread_stale(ROOM_ID, THREAD_ID, reason="retained_thread_delta_missing")
+
+    outcome = await cache.apply_thread_mutation_append(
+        ROOM_ID,
+        THREAD_ID,
+        _event("$live", 2000, thread_id=THREAD_ID),
+        append_failed_reason="sync_append_failed",
+    )
+    state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
+
+    assert outcome is ThreadAppendOutcome.APPENDED_STALE
+    assert outcome.wrote_event is True
+    assert outcome.needs_full_repair is False
+    assert thread_cache_rejection_reason(state) is not None
+
+
+@pytest.mark.asyncio
+async def test_room_invalidation_still_blocks_revalidation_after_append(cache: ConversationEventCache) -> None:
+    """A room-wide marker must keep outranking an incremental append."""
+    await _seed_valid_thread(cache)
+    await cache.mark_room_threads_stale(ROOM_ID, reason="limited_sync_timeline")
+
+    outcome = await cache.apply_thread_mutation_append(
+        ROOM_ID,
+        THREAD_ID,
+        _event("$live", 2000, thread_id=THREAD_ID),
+        append_failed_reason="sync_append_failed",
+    )
+    state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
+
+    assert outcome is ThreadAppendOutcome.APPENDED_STALE
+    assert thread_cache_rejection_reason(state) is not None
+
+
+def _cache_ops(tmp_path: Path, cache: ConversationEventCache) -> ThreadMutationCacheOps:
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"code": AgentConfig(display_name="Code", rooms=[ROOM_ID])},
+            models={"default": ModelConfig(provider="test", id="test-model")},
+        ),
+        runtime_paths,
+    )
+    runtime = BotRuntimeState(
+        client=MagicMock(),
+        config=config,
+        runtime_paths=runtime_paths,
+        enable_streaming=False,
+        orchestrator=None,
+        event_cache=cache,
+        event_cache_write_coordinator=EventCacheWriteCoordinator(logger=MagicMock()),
+    )
+    return ThreadMutationCacheOps(logger_getter=MagicMock, runtime=runtime)
+
+
+@pytest.mark.asyncio
+async def test_write_policy_mutation_never_exposes_an_invalid_snapshot(tmp_path: Path) -> None:
+    """The production write policy, not just the cache operation, must close the window."""
+    root_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    cache = root_cache.for_principal(PRINCIPAL_ID)
+    await cache.initialize()
+    cache_ops = _cache_ops(tmp_path, cache)
+    impact = MutationThreadImpact(state=MutationThreadImpactState.THREADED, thread_id=THREAD_ID)
+
+    async def mutate() -> None:
+        for index in range(25):
+            event_source = _event(f"$edit-{index}", 2000 + index, thread_id=THREAD_ID)
+            await _apply_thread_message_mutation(
+                cache_ops=cache_ops,
+                room_id=ROOM_ID,
+                event_info=EventInfo.from_event(event_source),
+                impact=impact,
+                event_source=event_source,
+                event_id=str(event_source["event_id"]),
+                context="sync",
+                room_level_skip_message="skip",
+                invalidate_on_append_failure=True,
+            )
+
+    try:
+        await _seed_valid_thread(cache)
+        rejections = await _collect_rejections_while(cache, mutate)
+    finally:
+        await root_cache.close()
+
+    assert rejections == [], f"reader observed {len(rejections)} rejections during successful sync mutations"

--- a/tests/test_thread_mutation_atomicity.py
+++ b/tests/test_thread_mutation_atomicity.py
@@ -254,7 +254,7 @@ async def test_write_policy_mutation_never_exposes_an_invalid_snapshot(tmp_path:
 async def test_mutation_for_a_redacted_event_never_writes_its_payload(cache: ConversationEventCache) -> None:
     """A redacted event must not reach the point-lookup table, snapshot or no snapshot."""
     redacted_reply = _event("$redacted", 2000, thread_id=THREAD_ID)
-    await cache.store_events_batch([(ROOM_ID, "$redacted", redacted_reply)])
+    await cache.store_events_batch([("$redacted", ROOM_ID, redacted_reply)])
     await cache.redact_event(ROOM_ID, "$redacted")
     assert await cache.get_event(ROOM_ID, "$redacted") is None
 
@@ -286,6 +286,45 @@ async def test_a_failed_cache_write_never_leaves_a_trusted_snapshot(tmp_path: Pa
             cache,
             "apply_thread_mutation_append",
             AsyncMock(side_effect=RuntimeError("cache write failed")),
+        ):
+            await _apply_thread_message_mutation(
+                cache_ops=cache_ops,
+                room_id=ROOM_ID,
+                event_info=EventInfo.from_event(event_source),
+                impact=impact,
+                event_source=event_source,
+                event_id="$live",
+                context="sync",
+                room_level_skip_message="skip",
+                invalidate_on_append_failure=True,
+            )
+        state = await cache.get_thread_cache_state(ROOM_ID, THREAD_ID)
+    finally:
+        await root_cache.close()
+
+    assert thread_cache_rejection_reason(state) == "thread_invalidated_after_validation"
+    assert state is not None
+    assert state.invalidation_reason == "sync_append_failed"
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_cache_write_never_leaves_a_trusted_snapshot(tmp_path: Path) -> None:
+    """Cancellation rolls the transaction back too, so it must still leave a durable marker."""
+    root_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    cache = root_cache.for_principal(PRINCIPAL_ID)
+    await cache.initialize()
+    cache_ops = _cache_ops(tmp_path, cache)
+    impact = MutationThreadImpact(state=MutationThreadImpactState.THREADED, thread_id=THREAD_ID)
+    event_source = _event("$live", 2000, thread_id=THREAD_ID)
+
+    async def cancelled_append(*_args: object, **_kwargs: object) -> ThreadAppendOutcome:
+        raise asyncio.CancelledError
+
+    try:
+        await _seed_valid_thread(cache)
+        with (
+            patch.object(cache, "apply_thread_mutation_append", cancelled_append),
+            pytest.raises(asyncio.CancelledError),
         ):
             await _apply_thread_message_mutation(
                 cache_ops=cache_ops,

--- a/tests/test_thread_read_guards.py
+++ b/tests/test_thread_read_guards.py
@@ -16,6 +16,7 @@ from mindroom.background_tasks import wait_for_background_tasks
 from mindroom.matrix.cache import ThreadCacheReplaceOutcome
 from mindroom.matrix.cache.event_cache import ThreadCacheState
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.conversation_cache import MatrixConversationCache
 from mindroom.matrix.event_info import EventInfo
@@ -60,7 +61,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         """Live edit caching should degrade cleanly when SQLite lookup fails."""
         event_cache = _runtime_event_cache()
         event_cache.get_thread_id_for_event = AsyncMock(side_effect=RuntimeError("database is locked"))
-        event_cache.append_event = AsyncMock()
+        event_cache.apply_thread_mutation_append = AsyncMock()
         bot.event_cache = event_cache
 
         edit_event = nio.RoomMessageText.from_dict(
@@ -86,7 +87,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         )
 
         event_cache.get_thread_id_for_event.assert_awaited_once_with("!test:localhost", "$thread_msg:localhost")
-        event_cache.append_event.assert_not_awaited()
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_live_plain_edit_lookup_miss_invalidates_room_threads(self, bot: AgentBot) -> None:
@@ -102,7 +103,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
                 "content": {"body": "Room message", "msgtype": "m.text"},
             },
         )
-        event_cache.append_event = AsyncMock()
+        event_cache.apply_thread_mutation_append = AsyncMock()
         bot.event_cache = event_cache
         bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
@@ -137,7 +138,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             "!test:localhost",
             reason="live_thread_lookup_unavailable",
         )
-        event_cache.append_event.assert_not_awaited()
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_live_plain_edit_missing_original_invalidates_room_threads(self, bot: AgentBot) -> None:
@@ -145,7 +146,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         event_cache = _runtime_event_cache()
         event_cache.get_thread_id_for_event = AsyncMock(return_value=None)
         event_cache.get_event = AsyncMock(return_value=None)
-        event_cache.append_event = AsyncMock()
+        event_cache.apply_thread_mutation_append = AsyncMock()
         bot.event_cache = event_cache
         bot.event_cache_write_coordinator = EventCacheWriteCoordinator(
             logger=MagicMock(),
@@ -181,7 +182,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             "!test:localhost",
             reason="live_thread_lookup_unavailable",
         )
-        event_cache.append_event.assert_not_awaited()
+        event_cache.apply_thread_mutation_append.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_live_message_resolution_does_not_block_same_room_read(self) -> None:
@@ -732,22 +733,23 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             sibling_update_started.set()
             await release_sibling_update.wait()
 
-        async def mark_thread_stale(
+        async def apply_thread_mutation_append(
             marked_room_id: str,
             marked_thread_id: str,
+            _event_source: dict[str, object],
             *,
-            reason: str,
-        ) -> None:
+            append_failed_reason: str,
+        ) -> ThreadAppendOutcome:
             assert marked_room_id == room_id
             assert marked_thread_id == thread_a_id
-            assert reason == "live_thread_mutation"
+            assert append_failed_reason == "live_append_failed"
             append_started.set()
+            return ThreadAppendOutcome.APPENDED
 
         access._live._resolver.resolve_thread_impact_for_mutation = AsyncMock(
             return_value=MutationThreadImpact.threaded(thread_a_id),
         )
-        event_cache.mark_thread_stale = AsyncMock(side_effect=mark_thread_stale)
-        event_cache.append_event = AsyncMock(return_value=True)
+        event_cache.apply_thread_mutation_append = AsyncMock(side_effect=apply_thread_mutation_append)
         sibling_task = coordinator.queue_thread_update(
             room_id,
             thread_b_id,
@@ -793,16 +795,13 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             )
             await coordinator.close()
 
-        event_cache.mark_thread_stale.assert_awaited_once_with(
-            room_id,
-            thread_a_id,
-            reason="live_thread_mutation",
-        )
-        event_cache.append_event.assert_awaited_once_with(
+        event_cache.apply_thread_mutation_append.assert_awaited_once_with(
             room_id,
             thread_a_id,
             event.source,
+            append_failed_reason="live_append_failed",
         )
+        event_cache.mark_thread_stale.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_sync_edit_marks_cached_thread_stale_and_next_read_refetches(
@@ -1405,14 +1404,16 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
                 room_invalidation_reason=None,
             )
 
-        async def append_event(
+        async def apply_thread_mutation_append(
             _room_id: str,
             _thread_id: str,
             event: dict[str, object],
-        ) -> bool:
+            *,
+            append_failed_reason: str,  # noqa: ARG001  # keyword must match the runtime call
+        ) -> ThreadAppendOutcome:
             raw_events.append(event)
             raw_append_committed.set()
-            return True
+            return ThreadAppendOutcome.APPENDED
 
         async def fetch_fresh_history(
             _room_id: str,
@@ -1440,7 +1441,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         event_cache.get_thread_events = AsyncMock(side_effect=lambda *_args, **_kwargs: list(raw_events))
         event_cache.get_thread_id_for_event = AsyncMock(return_value="$thread:localhost")
         event_cache.mark_thread_stale = AsyncMock(side_effect=mark_thread_stale)
-        event_cache.append_event = AsyncMock(side_effect=append_event)
+        event_cache.apply_thread_mutation_append = AsyncMock(side_effect=apply_thread_mutation_append)
         access._reads._wait_for_pending_thread_cache_updates = AsyncMock(side_effect=pause_reader)
         access._reads.fetch_thread_history_from_client = AsyncMock(side_effect=fetch_fresh_history)
         new_event_source = {

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -512,31 +512,6 @@ async def test_interactive_join_keeps_a_declined_speculative_flight_running() ->
 
 
 @pytest.mark.asyncio
-async def test_released_repair_slot_is_reserved_for_the_waiting_caller() -> None:
-    """Handing a slot over must reserve it, or a newcomer takes it and re-queues the waiter.
-
-    Driven through the slot accounting itself: the barge window is between waking a waiter and that
-    waiter resuming, which no public call can be scheduled into deterministically.
-    """
-    registry = ThreadRepairRegistry(max_concurrent_repairs=1)
-    thread_key = ("@agent:localhost", ROOM_ID, "$newcomer")
-
-    await registry._acquire_repair_slot(speculative=False)
-    waiting = asyncio.create_task(registry._acquire_repair_slot(speculative=False))
-    await asyncio.sleep(0)
-
-    registry._release_repair_slot(speculative=False)
-
-    # The waiter has been woken but has not resumed yet. A newcomer arriving right now must still
-    # see the ceiling as full, because the released slot already belongs to the waiter.
-    assert registry.speculative_suppression_reason(thread_key) == "repair_concurrency_limit"
-
-    await waiting
-    registry._release_repair_slot(speculative=False)
-    assert registry.speculative_suppression_reason(thread_key) is None
-
-
-@pytest.mark.asyncio
 async def test_clearing_the_registry_resets_every_admission_gate() -> None:
     """State left behind by `clear` would silently disable speculative repair for the process."""
     registry = ThreadRepairRegistry(max_concurrent_speculative_repairs=1)
@@ -578,3 +553,20 @@ async def test_clearing_one_room_forgets_its_cooldowns() -> None:
     registry.clear_room("@agent:localhost", ROOM_ID)
 
     assert registry.speculative_suppression_reason(("@agent:localhost", ROOM_ID, "$thread")) is None
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_registry_does_not_inflate_the_repair_ceiling() -> None:
+    """A repair outliving `clear` must return its permit to the ceiling it took one from.
+
+    `clear` runs from `close`, whose drain can give up while a repair is still holding a permit.
+    Replacing the semaphore there would let that survivor release into the replacement and raise the
+    bound above its own maximum, permanently and with nothing to clamp it.
+    """
+    registry = ThreadRepairRegistry(max_concurrent_repairs=2)
+    await registry._acquire_repair_slot(speculative=False)
+
+    registry.clear()
+    registry._release_repair_slot(speculative=False)
+
+    assert registry._repair_slots._value == 2

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -21,7 +21,7 @@ from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
-from mindroom.matrix.cache import ThreadCacheReplaceOutcome
+from mindroom.matrix.cache import ThreadCacheReplaceOutcome, ThreadHistoryResult, thread_history_result
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_repair import (
     ThreadRepairRegistry,
@@ -30,6 +30,11 @@ from mindroom.matrix.cache.thread_repair import (
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.client_thread_history import fetch_dispatch_thread_snapshot
 from mindroom.matrix.conversation_cache import MatrixConversationCache, is_sync_replay_batch
+from mindroom.matrix.thread_diagnostics import (
+    THREAD_HISTORY_SOURCE_CACHE,
+    THREAD_HISTORY_SOURCE_DIAGNOSTIC,
+    THREAD_HISTORY_SOURCE_HOMESERVER,
+)
 from tests.conftest import bind_runtime_paths, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -604,6 +609,7 @@ async def test_late_interactive_join_repairs_again_when_the_speculative_result_i
 async def test_only_a_retryable_shared_result_earns_the_joiner_its_own_flight(
     store_outcome: ThreadCacheReplaceOutcome,
     expected_flights: int,
+    tmp_path: Path,
 ) -> None:
     """A terminal outcome is settled, so rescanning it only meets the backoff it just armed."""
     registry = ThreadRepairRegistry()
@@ -611,21 +617,22 @@ async def test_only_a_retryable_shared_result_earns_the_joiner_its_own_flight(
     gate = asyncio.Event()
     flights = 0
 
-    def result() -> MagicMock:
-        return MagicMock(diagnostics={"cache_store_outcome": store_outcome.value})
+    # The production predicates decide this, so the test must exercise those and not a local copy.
+    conversation_cache = _conversation_cache(tmp_path, SqliteEventCache(tmp_path / "event_cache.db"))
+    needs_own_flight = conversation_cache._thread_repair_result_needs_own_flight
+    arms_backoff = conversation_cache._thread_repair_result_arms_backoff
 
-    async def scan() -> MagicMock:
+    async def scan() -> ThreadHistoryResult:
         nonlocal flights
         flights += 1
-        return result()
-
-    def needs_own_flight(value: MagicMock) -> bool:
-        return value.diagnostics["cache_store_outcome"] in {
-            outcome.value for outcome in ThreadCacheReplaceOutcome if outcome.retryable
-        }
-
-    def arms_backoff(value: MagicMock) -> bool:
-        return value.diagnostics["cache_store_outcome"] == ThreadCacheReplaceOutcome.HARD_FAILURE.value
+        return thread_history_result(
+            [],
+            is_full_history=False,
+            diagnostics={
+                "cache_store_outcome": store_outcome.value,
+                THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_HOMESERVER,
+            },
+        )
 
     def delayed_schedule[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
         async def runner() -> T:
@@ -683,3 +690,121 @@ async def test_dropping_a_finished_flight_drops_its_tier() -> None:
 
     assert registry._active_task(key) is None
     assert registry._speculative_flights == set()
+
+
+@pytest.mark.asyncio
+async def test_every_joiner_of_a_speculative_flight_gets_the_replacement_scan(tmp_path: Path) -> None:
+    """All readers sharing a speculative flight are owed the rescan, not just whoever resumes first.
+
+    They all resume off one shield, so only the first can own the replacement. The rest must join it
+    rather than returning the result they just judged insufficient.
+    """
+    registry = ThreadRepairRegistry()
+    key = _flight_key("$thread", hydrate_sidecars=False)
+    conversation_cache = _conversation_cache(tmp_path, SqliteEventCache(tmp_path / "event_cache.db"))
+    gate = asyncio.Event()
+    scans: list[str] = []
+
+    def scan(tag: str, outcome: ThreadCacheReplaceOutcome) -> Callable[[], Awaitable[ThreadHistoryResult]]:
+        async def run() -> ThreadHistoryResult:
+            scans.append(tag)
+            return thread_history_result(
+                [],
+                is_full_history=False,
+                diagnostics={
+                    "cache_store_outcome": outcome.value,
+                    THREAD_HISTORY_SOURCE_DIAGNOSTIC: (
+                        THREAD_HISTORY_SOURCE_CACHE
+                        if outcome is ThreadCacheReplaceOutcome.STORED
+                        else THREAD_HISTORY_SOURCE_HOMESERVER
+                    ),
+                },
+            )
+
+        return run
+
+    def delayed_schedule[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
+        async def runner() -> T:
+            await gate.wait()
+            return await repair_factory()
+
+        return asyncio.create_task(runner())
+
+    speculative = asyncio.create_task(
+        registry.run(
+            key,
+            schedule=delayed_schedule,
+            repair=scan("speculative", ThreadCacheReplaceOutcome.RETRYABLE_CONFLICT),
+            result_arms_backoff=conversation_cache._thread_repair_result_arms_backoff,
+            speculative=True,
+        ),
+    )
+    await asyncio.sleep(0)
+    readers = [
+        asyncio.create_task(
+            registry.run(
+                key,
+                schedule=_schedule,
+                repair=scan("interactive", ThreadCacheReplaceOutcome.STORED),
+                result_arms_backoff=conversation_cache._thread_repair_result_arms_backoff,
+                result_needs_own_flight=conversation_cache._thread_repair_result_needs_own_flight,
+            ),
+        )
+        for _ in range(3)
+    ]
+    await asyncio.sleep(0)
+    gate.set()
+    results = await asyncio.gather(*readers)
+    await speculative
+
+    outcomes = [result.diagnostics["cache_store_outcome"] for result in results]
+    assert outcomes == [ThreadCacheReplaceOutcome.STORED.value] * 3, (
+        f"a joiner kept the unusable speculative result: {outcomes}"
+    )
+    # One replacement serves all three; the point is not to fan out, it is not to strand anyone.
+    assert scans == ["speculative", "interactive"]
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_registry_resets_every_admission_gate() -> None:
+    """State left behind by `clear` would silently disable speculative repair for the process."""
+    registry = ThreadRepairRegistry(max_concurrent_speculative_repairs=1)
+    thread_key = ("@agent:localhost", ROOM_ID, "$thread")
+    await registry.run(
+        _flight_key("$thread", hydrate_sidecars=False),
+        schedule=_schedule,
+        repair=AsyncMock(return_value="scanned"),
+        result_arms_backoff=lambda _r: False,
+        speculative=True,
+    )
+    # A repair just ran, so its cooldown and slot bookkeeping are populated.
+    assert registry.speculative_suppression_reason(thread_key) == "recently_repaired"
+    registry._running_speculative_repairs = 1
+
+    registry.clear()
+
+    assert registry.speculative_suppression_reason(thread_key) is None
+    assert registry._speculative_cooldowns == {}
+    assert registry._interactive_joins == {}
+    assert registry._speculative_flights == set()
+    assert registry._slot_waiters == []
+    assert registry._running_repairs == 0
+    assert registry._running_speculative_repairs == 0
+
+
+@pytest.mark.asyncio
+async def test_clearing_one_room_forgets_its_cooldowns() -> None:
+    """A departed room must not keep holding its threads inside a repair cooldown."""
+    registry = ThreadRepairRegistry()
+    await registry.run(
+        _flight_key("$thread", hydrate_sidecars=False),
+        schedule=_schedule,
+        repair=AsyncMock(return_value="scanned"),
+        result_arms_backoff=lambda _r: False,
+        speculative=True,
+    )
+    assert registry.speculative_suppression_reason(("@agent:localhost", ROOM_ID, "$thread")) == "recently_repaired"
+
+    registry.clear_room("@agent:localhost", ROOM_ID)
+
+    assert registry.speculative_suppression_reason(("@agent:localhost", ROOM_ID, "$thread")) is None

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -28,6 +28,7 @@ from mindroom.matrix.cache.thread_repair import (
     ThreadRepairSuppressedError,
 )
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
+from mindroom.matrix.client_thread_history import fetch_dispatch_thread_snapshot
 from mindroom.matrix.conversation_cache import MatrixConversationCache, is_sync_replay_batch
 from tests.conftest import bind_runtime_paths, test_runtime_paths
 
@@ -38,6 +39,9 @@ if TYPE_CHECKING:
     from mindroom.matrix.cache import ConversationEventCache
 
 ROOM_ID = "!room:localhost"
+
+# One speculative flight scans once; anything above proves the reader ran its own repair.
+_SPECULATIVE_ATTEMPTS_FOR_TEST = 1
 
 
 def _conversation_cache(tmp_path: Path, event_cache: ConversationEventCache) -> MatrixConversationCache:
@@ -534,3 +538,55 @@ async def test_released_repair_slot_is_reserved_for_the_waiting_caller() -> None
     await waiting
     registry._release_repair_slot(speculative=False)
     assert registry.speculative_suppression_reason(thread_key) is None
+
+
+@pytest.mark.asyncio
+async def test_late_interactive_join_repairs_again_when_the_speculative_result_is_unusable(
+    tmp_path: Path,
+) -> None:
+    """A reader joining mid-scan must not keep the speculative flight's one-attempt result."""
+    thread_id = "$thread:localhost"
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache(tmp_path, event_cache)
+    coordinator = EventCacheWriteCoordinator(logger=MagicMock())
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    recorder = _ScanRecorder(scan_seconds=0.05)
+    reader_joined = asyncio.Event()
+
+    async def scan_and_let_a_reader_join(*args: object, **kwargs: object) -> MagicMock:
+        reader_joined.set()
+        return await recorder.scan(*args, **kwargs)  # type: ignore[arg-type]
+
+    # Every replacement loses the guarded race, which is what an interactive caller retries.
+    invalidated_store = AsyncMock(return_value=ThreadCacheReplaceOutcome.INVALIDATED)
+
+    try:
+        with (
+            patch.object(event_cache, "replace_thread_if_not_newer", invalidated_store),
+            patch(
+                "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
+                AsyncMock(side_effect=scan_and_let_a_reader_join),
+            ),
+        ):
+            conversation_cache._schedule_missing_thread_repair(ROOM_ID, thread_id)
+            await asyncio.wait_for(reader_joined.wait(), timeout=5.0)
+            await conversation_cache._fetch_thread_from_client(
+                fetch_dispatch_thread_snapshot,
+                ROOM_ID,
+                thread_id,
+                caller_label="test_reader",
+                coordinator_queue_wait_ms=0.0,
+                wants_full_history=False,
+                allows_stale_fallback=False,
+                bypass_repair_backoff=False,
+            )
+            await wait_for_background_tasks(timeout=5.0, owner=coordinator.background_task_owner)
+            await coordinator.close()
+    finally:
+        await event_cache.close()
+
+    # One speculative attempt, then the reader's own flight with the full interactive budget.
+    assert len(recorder.scanned_thread_ids) > _SPECULATIVE_ATTEMPTS_FOR_TEST, (
+        f"reader inherited the speculative one-attempt limit, saw {recorder.scanned_thread_ids}"
+    )

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -21,20 +21,14 @@ from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
-from mindroom.matrix.cache import ThreadCacheReplaceOutcome, ThreadHistoryResult, thread_history_result
+from mindroom.matrix.cache import ThreadCacheReplaceOutcome
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_repair import (
     ThreadRepairRegistry,
     ThreadRepairSuppressedError,
 )
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
-from mindroom.matrix.client_thread_history import fetch_dispatch_thread_snapshot
 from mindroom.matrix.conversation_cache import MatrixConversationCache, is_sync_replay_batch
-from mindroom.matrix.thread_diagnostics import (
-    THREAD_HISTORY_SOURCE_CACHE,
-    THREAD_HISTORY_SOURCE_DIAGNOSTIC,
-    THREAD_HISTORY_SOURCE_HOMESERVER,
-)
 from tests.conftest import bind_runtime_paths, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -44,9 +38,6 @@ if TYPE_CHECKING:
     from mindroom.matrix.cache import ConversationEventCache
 
 ROOM_ID = "!room:localhost"
-
-# One speculative flight scans once; anything above proves the reader ran its own repair.
-_SPECULATIVE_ATTEMPTS_FOR_TEST = 1
 
 
 def _conversation_cache(tmp_path: Path, event_cache: ConversationEventCache) -> MatrixConversationCache:
@@ -546,226 +537,6 @@ async def test_released_repair_slot_is_reserved_for_the_waiting_caller() -> None
 
 
 @pytest.mark.asyncio
-async def test_late_interactive_join_repairs_again_when_the_speculative_result_is_unusable(
-    tmp_path: Path,
-) -> None:
-    """A reader joining mid-scan must not keep the speculative flight's one-attempt result."""
-    thread_id = "$thread:localhost"
-    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
-    await event_cache.initialize()
-    conversation_cache = _conversation_cache(tmp_path, event_cache)
-    coordinator = EventCacheWriteCoordinator(logger=MagicMock())
-    conversation_cache.runtime.event_cache_write_coordinator = coordinator
-    recorder = _ScanRecorder(scan_seconds=0.05)
-    reader_joined = asyncio.Event()
-
-    async def scan_and_let_a_reader_join(*args: object, **kwargs: object) -> MagicMock:
-        reader_joined.set()
-        return await recorder.scan(*args, **kwargs)  # type: ignore[arg-type]
-
-    # Every replacement loses the guarded race, which is what an interactive caller retries.
-    invalidated_store = AsyncMock(return_value=ThreadCacheReplaceOutcome.INVALIDATED)
-
-    try:
-        with (
-            patch.object(event_cache, "replace_thread_if_not_newer", invalidated_store),
-            patch(
-                "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
-                AsyncMock(side_effect=scan_and_let_a_reader_join),
-            ),
-        ):
-            conversation_cache._schedule_missing_thread_repair(ROOM_ID, thread_id)
-            await asyncio.wait_for(reader_joined.wait(), timeout=5.0)
-            await conversation_cache._fetch_thread_from_client(
-                fetch_dispatch_thread_snapshot,
-                ROOM_ID,
-                thread_id,
-                caller_label="test_reader",
-                coordinator_queue_wait_ms=0.0,
-                wants_full_history=False,
-                allows_stale_fallback=False,
-                bypass_repair_backoff=False,
-            )
-            await wait_for_background_tasks(timeout=5.0, owner=coordinator.background_task_owner)
-            await coordinator.close()
-    finally:
-        await event_cache.close()
-
-    # One speculative attempt, then the reader's own flight with the full interactive budget.
-    assert len(recorder.scanned_thread_ids) > _SPECULATIVE_ATTEMPTS_FOR_TEST, (
-        f"reader inherited the speculative one-attempt limit, saw {recorder.scanned_thread_ids}"
-    )
-
-
-@pytest.mark.parametrize(
-    ("store_outcome", "expected_flights"),
-    [
-        (ThreadCacheReplaceOutcome.INVALIDATED, 2),
-        (ThreadCacheReplaceOutcome.HARD_FAILURE, 1),
-    ],
-    ids=["retryable", "terminal"],
-)
-@pytest.mark.asyncio
-async def test_only_a_retryable_shared_result_earns_the_joiner_its_own_flight(
-    store_outcome: ThreadCacheReplaceOutcome,
-    expected_flights: int,
-    tmp_path: Path,
-) -> None:
-    """A terminal outcome is settled, so rescanning it only meets the backoff it just armed."""
-    registry = ThreadRepairRegistry()
-    key = _flight_key("$thread", hydrate_sidecars=False)
-    gate = asyncio.Event()
-    flights = 0
-
-    # The production predicates decide this, so the test must exercise those and not a local copy.
-    conversation_cache = _conversation_cache(tmp_path, SqliteEventCache(tmp_path / "event_cache.db"))
-    needs_own_flight = conversation_cache._thread_repair_result_needs_own_flight
-    arms_backoff = conversation_cache._thread_repair_result_arms_backoff
-
-    async def scan() -> ThreadHistoryResult:
-        nonlocal flights
-        flights += 1
-        return thread_history_result(
-            [],
-            is_full_history=False,
-            diagnostics={
-                "cache_store_outcome": store_outcome.value,
-                THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_HOMESERVER,
-            },
-        )
-
-    def delayed_schedule[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
-        async def runner() -> T:
-            await gate.wait()
-            return await repair_factory()
-
-        return asyncio.create_task(runner())
-
-    speculative = asyncio.create_task(
-        registry.run(
-            key,
-            schedule=delayed_schedule,
-            repair=scan,
-            result_arms_backoff=arms_backoff,
-            speculative=True,
-        ),
-    )
-    await asyncio.sleep(0)
-    interactive = asyncio.create_task(
-        registry.run(
-            key,
-            schedule=_schedule,
-            repair=scan,
-            result_arms_backoff=arms_backoff,
-            result_needs_own_flight=needs_own_flight,
-        ),
-    )
-    await asyncio.sleep(0)
-    gate.set()
-
-    # A terminal result must come back to the reader rather than raising the armed backoff at it.
-    assert await interactive is not None
-    await speculative
-
-    assert flights == expected_flights
-
-
-@pytest.mark.asyncio
-async def test_dropping_a_finished_flight_drops_its_tier() -> None:
-    """Ownership and tier must be forgotten together, or the tier outlives every flight.
-
-    Exercised at the accounting itself: the gap is between a task finishing and its done callback
-    running, and whoever reads ownership inside that gap drops the task the callback was going to.
-    """
-    registry = ThreadRepairRegistry()
-    key = _flight_key("$thread", hydrate_sidecars=False)
-
-    async def scan() -> str:
-        return "scanned"
-
-    finished = asyncio.create_task(scan())
-    await finished
-    registry._tasks[key] = finished
-    registry._speculative_flights.add(key)
-
-    assert registry._active_task(key) is None
-    assert registry._speculative_flights == set()
-
-
-@pytest.mark.asyncio
-async def test_every_joiner_of_a_speculative_flight_gets_the_replacement_scan(tmp_path: Path) -> None:
-    """All readers sharing a speculative flight are owed the rescan, not just whoever resumes first.
-
-    They all resume off one shield, so only the first can own the replacement. The rest must join it
-    rather than returning the result they just judged insufficient.
-    """
-    registry = ThreadRepairRegistry()
-    key = _flight_key("$thread", hydrate_sidecars=False)
-    conversation_cache = _conversation_cache(tmp_path, SqliteEventCache(tmp_path / "event_cache.db"))
-    gate = asyncio.Event()
-    scans: list[str] = []
-
-    def scan(tag: str, outcome: ThreadCacheReplaceOutcome) -> Callable[[], Awaitable[ThreadHistoryResult]]:
-        async def run() -> ThreadHistoryResult:
-            scans.append(tag)
-            return thread_history_result(
-                [],
-                is_full_history=False,
-                diagnostics={
-                    "cache_store_outcome": outcome.value,
-                    THREAD_HISTORY_SOURCE_DIAGNOSTIC: (
-                        THREAD_HISTORY_SOURCE_CACHE
-                        if outcome is ThreadCacheReplaceOutcome.STORED
-                        else THREAD_HISTORY_SOURCE_HOMESERVER
-                    ),
-                },
-            )
-
-        return run
-
-    def delayed_schedule[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
-        async def runner() -> T:
-            await gate.wait()
-            return await repair_factory()
-
-        return asyncio.create_task(runner())
-
-    speculative = asyncio.create_task(
-        registry.run(
-            key,
-            schedule=delayed_schedule,
-            repair=scan("speculative", ThreadCacheReplaceOutcome.RETRYABLE_CONFLICT),
-            result_arms_backoff=conversation_cache._thread_repair_result_arms_backoff,
-            speculative=True,
-        ),
-    )
-    await asyncio.sleep(0)
-    readers = [
-        asyncio.create_task(
-            registry.run(
-                key,
-                schedule=_schedule,
-                repair=scan("interactive", ThreadCacheReplaceOutcome.STORED),
-                result_arms_backoff=conversation_cache._thread_repair_result_arms_backoff,
-                result_needs_own_flight=conversation_cache._thread_repair_result_needs_own_flight,
-            ),
-        )
-        for _ in range(3)
-    ]
-    await asyncio.sleep(0)
-    gate.set()
-    results = await asyncio.gather(*readers)
-    await speculative
-
-    outcomes = [result.diagnostics["cache_store_outcome"] for result in results]
-    assert outcomes == [ThreadCacheReplaceOutcome.STORED.value] * 3, (
-        f"a joiner kept the unusable speculative result: {outcomes}"
-    )
-    # One replacement serves all three; the point is not to fan out, it is not to strand anyone.
-    assert scans == ["speculative", "interactive"]
-
-
-@pytest.mark.asyncio
 async def test_clearing_the_registry_resets_every_admission_gate() -> None:
     """State left behind by `clear` would silently disable speculative repair for the process."""
     registry = ThreadRepairRegistry(max_concurrent_speculative_repairs=1)
@@ -786,10 +557,8 @@ async def test_clearing_the_registry_resets_every_admission_gate() -> None:
     assert registry.speculative_suppression_reason(thread_key) is None
     assert registry._speculative_cooldowns == {}
     assert registry._interactive_joins == {}
-    assert registry._speculative_flights == set()
-    assert registry._slot_waiters == []
-    assert registry._running_repairs == 0
     assert registry._running_speculative_repairs == 0
+    assert not registry._repair_slots.locked()
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -1,0 +1,445 @@
+"""Bounding, deduplication, and priority tests for speculative thread-cache repair.
+
+Speculative repair is launched by a live append that finds no cached snapshot. It is singleflighted
+per thread, but a burst of appends across many threads previously launched an unbounded number of
+full history scans, and the same thread was rescanned once per append because the flight was only
+deduplicated while it was still running.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mindroom.background_tasks import wait_for_background_tasks
+from mindroom.bot_runtime_view import BotRuntimeState
+from mindroom.config.agent import AgentConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.matrix.cache import ThreadCacheReplaceOutcome
+from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.cache.thread_repair import (
+    MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS,
+    MAX_CONCURRENT_THREAD_REPAIRS,
+    ThreadRepairRegistry,
+    ThreadRepairSuppressedError,
+)
+from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
+from mindroom.matrix.conversation_cache import MatrixConversationCache, is_sync_replay_batch
+from tests.conftest import bind_runtime_paths, test_runtime_paths
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+    from pathlib import Path
+
+    from mindroom.matrix.cache import ConversationEventCache
+
+ROOM_ID = "!room:localhost"
+
+
+def _conversation_cache(tmp_path: Path, event_cache: ConversationEventCache) -> MatrixConversationCache:
+    runtime_paths = test_runtime_paths(tmp_path)
+    config = bind_runtime_paths(
+        Config(
+            agents={"code": AgentConfig(display_name="Code", rooms=[ROOM_ID])},
+            models={"default": ModelConfig(provider="test", id="test-model")},
+        ),
+        runtime_paths,
+    )
+    runtime = BotRuntimeState(
+        client=MagicMock(),
+        config=config,
+        runtime_paths=runtime_paths,
+        enable_streaming=False,
+        orchestrator=None,
+        event_cache=event_cache,
+        event_cache_write_coordinator=None,
+    )
+    return MatrixConversationCache(logger=MagicMock(), runtime=runtime)
+
+
+def _event_source(event_id: str, *, thread_id: str) -> dict[str, Any]:
+    content: dict[str, Any] = {"body": event_id, "msgtype": "m.text"}
+    if event_id != thread_id:
+        content["m.relates_to"] = {"rel_type": "m.thread", "event_id": thread_id}
+    return {
+        "event_id": event_id,
+        "sender": "@user:localhost",
+        "origin_server_ts": 1000,
+        "type": "m.room.message",
+        "content": content,
+    }
+
+
+def _fetch_result(thread_id: str) -> MagicMock:
+    return MagicMock(
+        history=[],
+        event_sources=[_event_source(thread_id, thread_id=thread_id)],
+        fetch_ms=1.0,
+        room_scan_pages=1,
+        scanned_event_count=1,
+        resolution_ms=1.0,
+        sidecar_hydration_ms=0.0,
+    )
+
+
+class _ScanRecorder:
+    """Count homeserver history scans and observe how many run at the same time."""
+
+    def __init__(self, *, scan_seconds: float = 0.01) -> None:
+        self.scanned_thread_ids: list[str] = []
+        self.peak_concurrent_scans = 0
+        self._scan_seconds = scan_seconds
+        self._in_flight = 0
+
+    async def scan(
+        self,
+        _client: object,
+        _room_id: str,
+        thread_id: str,
+        **_kwargs: object,
+    ) -> MagicMock:
+        self._in_flight += 1
+        self.peak_concurrent_scans = max(self.peak_concurrent_scans, self._in_flight)
+        self.scanned_thread_ids.append(thread_id)
+        try:
+            await asyncio.sleep(self._scan_seconds)
+            return _fetch_result(thread_id)
+        finally:
+            self._in_flight -= 1
+
+    @property
+    def rescan_counts(self) -> Counter[str]:
+        return Counter(self.scanned_thread_ids)
+
+
+@pytest.mark.asyncio
+async def test_missing_cache_append_storm_scans_each_thread_at_most_once(tmp_path: Path) -> None:
+    """A replay-sized burst of missing-cache appends must not scan one thread once per event."""
+    thread_count = 6
+    appends_per_thread = 10
+    thread_ids = [f"$thread-{index}:localhost" for index in range(thread_count)]
+
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache(tmp_path, event_cache)
+    coordinator = EventCacheWriteCoordinator(logger=MagicMock())
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    recorder = _ScanRecorder()
+
+    # A snapshot that loses the guarded replacement race is exactly what a concurrent live append
+    # produces, and it leaves the thread without a usable cache for the next append to find.
+    invalidated_store = AsyncMock(return_value=ThreadCacheReplaceOutcome.INVALIDATED)
+
+    try:
+        with (
+            patch.object(event_cache, "replace_thread_if_not_newer", invalidated_store),
+            patch(
+                "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
+                AsyncMock(side_effect=recorder.scan),
+            ),
+        ):
+            # Replay delivers appends over time, so each wave lands after the previous repair
+            # finished. Singleflight only collapses callers that overlap one running flight.
+            for _wave in range(appends_per_thread):
+                for thread_id in thread_ids:
+                    conversation_cache._schedule_missing_thread_repair(ROOM_ID, thread_id)
+                await wait_for_background_tasks(timeout=5.0, owner=coordinator.background_task_owner)
+            await coordinator.close()
+    finally:
+        await event_cache.close()
+
+    assert recorder.rescan_counts.most_common(1)[0][1] == 1, (
+        f"each thread must be scanned at most once per burst, saw {recorder.rescan_counts.most_common(3)}"
+    )
+    assert len(recorder.scanned_thread_ids) <= thread_count
+
+
+@pytest.mark.asyncio
+async def test_missing_cache_append_storm_bounds_concurrent_history_scans(tmp_path: Path) -> None:
+    """Speculative repair fan-out must stay under a global cap however many threads are stale."""
+    thread_count = 40
+    thread_ids = [f"$thread-{index}:localhost" for index in range(thread_count)]
+
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache(tmp_path, event_cache)
+    coordinator = EventCacheWriteCoordinator(logger=MagicMock())
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    recorder = _ScanRecorder(scan_seconds=0.05)
+    invalidated_store = AsyncMock(return_value=ThreadCacheReplaceOutcome.INVALIDATED)
+
+    try:
+        with (
+            patch.object(event_cache, "replace_thread_if_not_newer", invalidated_store),
+            patch(
+                "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
+                AsyncMock(side_effect=recorder.scan),
+            ),
+        ):
+            for thread_id in thread_ids:
+                conversation_cache._schedule_missing_thread_repair(ROOM_ID, thread_id)
+            await coordinator.close()
+    finally:
+        await event_cache.close()
+
+    assert recorder.peak_concurrent_scans <= MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS, (
+        f"peak concurrent history scans {recorder.peak_concurrent_scans} exceeded the speculative repair "
+        f"budget of {MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS} across {thread_count} stale threads"
+    )
+    assert recorder.peak_concurrent_scans <= MAX_CONCURRENT_THREAD_REPAIRS
+    assert len(recorder.scanned_thread_ids) >= 1
+
+
+def _schedule[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
+    return asyncio.create_task(repair_factory())
+
+
+def _flight_key(thread_id: str, *, hydrate_sidecars: bool = True, allow_stale_fallback: bool = False) -> tuple:
+    return ("@agent:localhost", ROOM_ID, thread_id, hydrate_sidecars, allow_stale_fallback)
+
+
+@pytest.mark.asyncio
+async def test_speculative_repair_does_not_open_a_second_scan_for_another_caller_contract() -> None:
+    """The flight key names a caller contract, so it must not be what admits a speculative scan."""
+    registry = ThreadRepairRegistry()
+    scan_count = 0
+    scan_started = asyncio.Event()
+    release_scan = asyncio.Event()
+
+    async def repair() -> str:
+        nonlocal scan_count
+        scan_count += 1
+        scan_started.set()
+        await release_scan.wait()
+        return "scanned"
+
+    read_flight = asyncio.create_task(
+        registry.run(
+            _flight_key("$thread", hydrate_sidecars=True),
+            schedule=_schedule,
+            repair=repair,
+            result_arms_backoff=lambda _result: False,
+        ),
+    )
+    try:
+        await asyncio.wait_for(scan_started.wait(), timeout=1.0)
+        with pytest.raises(ThreadRepairSuppressedError) as suppressed:
+            # A live append repairs the same thread under the snapshot contract, not the read one.
+            await registry.run(
+                _flight_key("$thread", hydrate_sidecars=False),
+                schedule=_schedule,
+                repair=repair,
+                result_arms_backoff=lambda _result: False,
+                speculative=True,
+            )
+    finally:
+        release_scan.set()
+        await read_flight
+
+    assert suppressed.value.reason == "repair_in_flight"
+    assert scan_count == 1
+
+
+@pytest.mark.asyncio
+async def test_speculative_repair_waits_out_a_cooldown_instead_of_rescanning_each_append() -> None:
+    """A completed scan must suppress the next append's repair, and only for a bounded window."""
+    now = 100.0
+    registry = ThreadRepairRegistry(speculative_cooldown_seconds=30.0, clock=lambda: now)
+    repair = AsyncMock(return_value="scanned")
+    key = _flight_key("$thread", hydrate_sidecars=False)
+
+    await registry.run(key, schedule=_schedule, repair=repair, result_arms_backoff=lambda _r: False, speculative=True)
+    with pytest.raises(ThreadRepairSuppressedError) as suppressed:
+        await registry.run(
+            key,
+            schedule=_schedule,
+            repair=repair,
+            result_arms_backoff=lambda _r: False,
+            speculative=True,
+        )
+
+    assert suppressed.value.reason == "recently_repaired"
+    assert repair.await_count == 1
+
+    now = 131.0
+    await registry.run(key, schedule=_schedule, repair=repair, result_arms_backoff=lambda _r: False, speculative=True)
+
+    assert repair.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_cooldown_never_blocks_the_read_that_a_dispatch_is_waiting_on() -> None:
+    """Bounding speculative work must not stop a genuinely missing thread from being repaired."""
+    now = 100.0
+    registry = ThreadRepairRegistry(speculative_cooldown_seconds=30.0, clock=lambda: now)
+    repair = AsyncMock(return_value="scanned")
+    key = _flight_key("$thread", hydrate_sidecars=False)
+
+    await registry.run(key, schedule=_schedule, repair=repair, result_arms_backoff=lambda _r: False, speculative=True)
+    await registry.run(key, schedule=_schedule, repair=repair, result_arms_backoff=lambda _r: False)
+
+    assert repair.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_interactive_repair_is_never_starved_by_speculative_repairs() -> None:
+    """Speculative repairs must yield the global cap to a caller a dispatch is blocked on."""
+    registry = ThreadRepairRegistry(max_concurrent_repairs=2, max_concurrent_speculative_repairs=1)
+    release = asyncio.Event()
+    cap_reached = asyncio.Event()
+    started: list[str] = []
+
+    def slow_repair(label: str) -> Callable[[], Awaitable[str]]:
+        async def repair() -> str:
+            started.append(label)
+            if len(started) == 2:
+                cap_reached.set()
+            await release.wait()
+            return label
+
+        return repair
+
+    speculative = asyncio.create_task(
+        registry.run(
+            _flight_key("$speculative"),
+            schedule=_schedule,
+            repair=slow_repair("speculative"),
+            result_arms_backoff=lambda _r: False,
+            speculative=True,
+        ),
+    )
+    interactive = asyncio.create_task(
+        registry.run(
+            _flight_key("$interactive"),
+            schedule=_schedule,
+            repair=slow_repair("interactive"),
+            result_arms_backoff=lambda _r: False,
+        ),
+    )
+    queued_interactive = asyncio.create_task(
+        registry.run(
+            _flight_key("$queued"),
+            schedule=_schedule,
+            repair=slow_repair("queued_interactive"),
+            result_arms_backoff=lambda _r: False,
+        ),
+    )
+    try:
+        await asyncio.wait_for(cap_reached.wait(), timeout=1.0)
+        # The global cap is now full and one interactive caller is queued behind it.
+        with pytest.raises(ThreadRepairSuppressedError) as suppressed:
+            await registry.run(
+                _flight_key("$another"),
+                schedule=_schedule,
+                repair=slow_repair("declined"),
+                result_arms_backoff=lambda _r: False,
+                speculative=True,
+            )
+    finally:
+        release.set()
+        await asyncio.gather(speculative, interactive, queued_interactive)
+
+    assert suppressed.value.reason in {"speculative_concurrency_limit", "repair_concurrency_limit"}
+    assert started == ["speculative", "interactive", "queued_interactive"]
+    assert "declined" not in started
+
+
+@pytest.mark.asyncio
+async def test_sync_replay_suppresses_speculative_repair_but_not_interactive_repair() -> None:
+    """Replay must not launch speculative scans, and must not block a waiting reader either."""
+    registry = ThreadRepairRegistry()
+    repair = AsyncMock(return_value="scanned")
+
+    with registry.suppress_speculative_repairs():
+        with pytest.raises(ThreadRepairSuppressedError) as suppressed:
+            await registry.run(
+                _flight_key("$thread"),
+                schedule=_schedule,
+                repair=repair,
+                result_arms_backoff=lambda _r: False,
+                speculative=True,
+            )
+        interactive = await registry.run(
+            _flight_key("$other"),
+            schedule=_schedule,
+            repair=repair,
+            result_arms_backoff=lambda _r: False,
+        )
+
+    assert suppressed.value.reason == "sync_replay"
+    assert interactive == "scanned"
+    assert repair.await_count == 1
+
+    await registry.run(
+        _flight_key("$thread"),
+        schedule=_schedule,
+        repair=repair,
+        result_arms_backoff=lambda _r: False,
+        speculative=True,
+    )
+
+    assert repair.await_count == 2
+
+
+def _sync_response(*, event_count: int, limited: bool) -> MagicMock:
+    timeline = MagicMock(limited=limited, events=[MagicMock() for _ in range(event_count)])
+    response = MagicMock()
+    response.rooms.join = {ROOM_ID: MagicMock(timeline=timeline)}
+    return response
+
+
+@pytest.mark.parametrize(
+    ("event_count", "limited", "expected"),
+    [
+        (3, False, False),
+        (3, True, True),
+        (200, False, True),
+    ],
+)
+def test_sync_replay_batch_detection(event_count: int, limited: bool, expected: bool) -> None:
+    """Only gap catch-up batches should switch speculative repair off."""
+    assert is_sync_replay_batch(_sync_response(event_count=event_count, limited=limited)) is expected
+
+
+@pytest.mark.asyncio
+async def test_sync_certification_declines_speculative_repair_for_a_replay_batch(tmp_path: Path) -> None:
+    """The sync facade must hold repairs off for exactly the span of one replay batch."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache(tmp_path, event_cache)
+    coordinator = EventCacheWriteCoordinator(logger=MagicMock())
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    suppression_reasons: list[str | None] = []
+
+    async def observe_suppression(_response: object) -> str:
+        suppression_reasons.append(
+            coordinator.speculative_thread_repair_suppression_reason(
+                ROOM_ID,
+                "$thread:localhost",
+                coordination_scope=event_cache.principal_id,
+            ),
+        )
+        return "certified"
+
+    try:
+        with patch.object(
+            conversation_cache._sync,
+            "cache_sync_timeline_for_certification",
+            AsyncMock(side_effect=observe_suppression),
+        ):
+            await conversation_cache.cache_sync_timeline_for_certification(
+                _sync_response(event_count=3, limited=True),
+            )
+            await conversation_cache.cache_sync_timeline_for_certification(
+                _sync_response(event_count=3, limited=False),
+            )
+    finally:
+        await coordinator.close()
+        await event_cache.close()
+
+    assert suppression_reasons == ["sync_replay", None]

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -548,9 +548,14 @@ async def test_clearing_the_registry_resets_every_admission_gate() -> None:
         result_arms_backoff=lambda _r: False,
         speculative=True,
     )
-    # A repair just ran, so its cooldown and slot bookkeeping are populated.
+    # Every gate must be non-empty before the clear, or asserting it is empty afterwards proves
+    # nothing. The cooldown is populated by the repair above; the rest are seeded here.
     assert registry.speculative_suppression_reason(thread_key) == "recently_repaired"
     registry._running_speculative_repairs = 1
+    registry._interactive_joins[_flight_key("$thread", hydrate_sidecars=False)] = 1
+    for _ in range(registry.max_concurrent_repairs):
+        await registry._repair_slots.acquire()
+    assert registry._repair_slots.locked()
 
     registry.clear()
 

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -444,12 +444,13 @@ async def test_sync_certification_declines_speculative_repair_for_a_replay_batch
             "$thread:localhost",
             coordination_scope=event_cache.principal_id,
         )
-        could_schedule.append(reserved)
-        if reserved:
+        could_schedule.append(reserved is not None)
+        if reserved is not None:
             coordinator.release_speculative_thread_repair(
                 ROOM_ID,
                 "$thread:localhost",
                 coordination_scope=event_cache.principal_id,
+                token=reserved,
             )
         return "certified"
 
@@ -603,3 +604,143 @@ async def test_a_replay_burst_does_not_create_a_task_per_event(tmp_path: Path) -
 
     assert distinct_threads <= budget, f"250 stale threads created {distinct_threads} tasks before admission"
     assert one_thread == distinct_threads, "repeated events for one thread each added a task"
+
+
+async def _drain_done_callbacks() -> None:
+    """Let task done callbacks run.
+
+    They are queued with ``call_soon``, so awaiting a cancelled task does not by itself guarantee
+    its cleanup has executed.
+    """
+    for _ in range(3):
+        await asyncio.sleep(0)
+
+
+def _pre_start_cancelled_repair(conversation_cache: MatrixConversationCache, thread_id: str) -> asyncio.Task[None]:
+    """Schedule a speculative repair and cancel it before its coroutine ever runs.
+
+    Identified by set difference: background tasks are held in a set, so indexing the owner's tasks
+    picks an arbitrary one and can leave the repair just scheduled running.
+    """
+    coordinator = conversation_cache.runtime.event_cache_write_coordinator
+    assert coordinator is not None
+    before = set(_tasks_for_owner(coordinator.background_task_owner))
+    conversation_cache._schedule_missing_thread_repair(ROOM_ID, thread_id)
+    created = set(_tasks_for_owner(coordinator.background_task_owner)) - before
+    assert len(created) == 1, f"expected exactly one scheduled repair, got {len(created)}"
+    scheduled = created.pop()
+    scheduled.cancel()
+    return scheduled
+
+
+@pytest.mark.asyncio
+async def test_a_repair_cancelled_before_it_starts_releases_its_claim(tmp_path: Path) -> None:
+    """A body-level release never runs for a task cancelled before its first instruction."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache(tmp_path, event_cache)
+    coordinator = EventCacheWriteCoordinator(logger=MagicMock())
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+
+    try:
+        cancelled = _pre_start_cancelled_repair(conversation_cache, "$thread:localhost")
+        await asyncio.gather(cancelled, return_exceptions=True)
+        await _drain_done_callbacks()
+        # The claim must be gone, so the very same thread can be scheduled again.
+        conversation_cache._schedule_missing_thread_repair(ROOM_ID, "$thread:localhost")
+        replacements = [task for task in _tasks_for_owner(coordinator.background_task_owner) if not task.done()]
+        for task in _tasks_for_owner(coordinator.background_task_owner):
+            task.cancel()
+        await asyncio.gather(*_tasks_for_owner(coordinator.background_task_owner), return_exceptions=True)
+    finally:
+        await event_cache.close()
+
+    assert replacements, "the leaked claim blocked a replacement repair for the same thread"
+
+
+@pytest.mark.asyncio
+async def test_pre_start_cancelled_repairs_do_not_suppress_unrelated_threads(tmp_path: Path) -> None:
+    """Leaked claims fill the pending budget and starve threads that never failed."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache(tmp_path, event_cache)
+    coordinator = EventCacheWriteCoordinator(logger=MagicMock())
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    budget = ThreadRepairRegistry().max_concurrent_speculative_repairs
+
+    try:
+        cancelled = [
+            _pre_start_cancelled_repair(conversation_cache, f"$dead-{index}:localhost") for index in range(budget)
+        ]
+        await asyncio.gather(*cancelled, return_exceptions=True)
+        await _drain_done_callbacks()
+        leaked = dict(coordinator._thread_repairs._reserved_speculative)
+        unrelated = coordinator.reserve_speculative_thread_repair(
+            ROOM_ID,
+            "$unrelated:localhost",
+            coordination_scope=event_cache.principal_id,
+        )
+        for task in _tasks_for_owner(coordinator.background_task_owner):
+            task.cancel()
+        await asyncio.gather(*_tasks_for_owner(coordinator.background_task_owner), return_exceptions=True)
+    finally:
+        await event_cache.close()
+
+    assert leaked == {}, f"cancelled repairs leaked claims: {sorted(key[2] for key in leaked)}"
+    assert unrelated is not None, f"{budget} cancelled repairs exhausted the pending budget"
+
+
+@pytest.mark.asyncio
+async def test_waves_during_preparation_create_one_pre_admission_task(tmp_path: Path) -> None:
+    """The claim has to outlive the awaited preparation, not just the synchronous burst."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache(tmp_path, event_cache)
+    coordinator = EventCacheWriteCoordinator(logger=MagicMock())
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    prepare_calls = 0
+    block_preparation = asyncio.Event()
+
+    async def blocked_prepare(*_args: object, **_kwargs: object) -> None:
+        nonlocal prepare_calls
+        prepare_calls += 1
+        await block_preparation.wait()
+
+    try:
+        with patch.object(conversation_cache, "_prepare_pending_thread_repair_deltas", blocked_prepare):
+            for _wave in range(50):
+                for _ in range(250):
+                    conversation_cache._schedule_missing_thread_repair(ROOM_ID, "$hot:localhost")
+                await asyncio.sleep(0)  # let the scheduled task reach preparation and block there
+            pending = [task for task in _tasks_for_owner(coordinator.background_task_owner) if not task.done()]
+            blocked = prepare_calls
+        block_preparation.set()
+        for task in _tasks_for_owner(coordinator.background_task_owner):
+            task.cancel()
+        await asyncio.gather(*_tasks_for_owner(coordinator.background_task_owner), return_exceptions=True)
+    finally:
+        await event_cache.close()
+
+    assert blocked == 1, f"preparation ran {blocked} times for one thread"
+    assert len(pending) == 1, f"{len(pending)} pre-admission tasks for one thread across 50 waves"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_release_cannot_drop_a_later_claim_on_the_same_thread() -> None:
+    """Releases are identified by token, so a late one cannot free somebody else's claim."""
+    registry = ThreadRepairRegistry()
+    key = ("@agent:localhost", ROOM_ID, "$thread")
+
+    first = registry.reserve_speculative_repair(key)
+    assert first is not None
+    registry.release_speculative_repair(key, first)
+    second = registry.reserve_speculative_repair(key)
+    assert second is not None
+
+    registry.release_speculative_repair(key, first)  # the abandoned holder, arriving late
+
+    assert registry.speculative_suppression_reason(key) == "repair_pending"
+    registry.release_speculative_repair(key, second)
+    assert registry.speculative_suppression_reason(key) is None
+    registry.clear()
+    assert registry._reserved_speculative == {}

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -13,6 +13,7 @@ from collections import Counter
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import nio
 import pytest
 
 from mindroom.background_tasks import wait_for_background_tasks
@@ -23,8 +24,6 @@ from mindroom.config.models import ModelConfig
 from mindroom.matrix.cache import ThreadCacheReplaceOutcome
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_repair import (
-    MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS,
-    MAX_CONCURRENT_THREAD_REPAIRS,
     ThreadRepairRegistry,
     ThreadRepairSuppressedError,
 )
@@ -187,11 +186,12 @@ async def test_missing_cache_append_storm_bounds_concurrent_history_scans(tmp_pa
     finally:
         await event_cache.close()
 
-    assert recorder.peak_concurrent_scans <= MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS, (
+    budgets = ThreadRepairRegistry()
+    assert recorder.peak_concurrent_scans <= budgets.max_concurrent_speculative_repairs, (
         f"peak concurrent history scans {recorder.peak_concurrent_scans} exceeded the speculative repair "
-        f"budget of {MAX_CONCURRENT_SPECULATIVE_THREAD_REPAIRS} across {thread_count} stale threads"
+        f"budget of {budgets.max_concurrent_speculative_repairs} across {thread_count} stale threads"
     )
-    assert recorder.peak_concurrent_scans <= MAX_CONCURRENT_THREAD_REPAIRS
+    assert recorder.peak_concurrent_scans <= budgets.max_concurrent_repairs
     assert len(recorder.scanned_thread_ids) >= 1
 
 
@@ -386,11 +386,33 @@ async def test_sync_replay_suppresses_speculative_repair_but_not_interactive_rep
     assert repair.await_count == 2
 
 
-def _sync_response(*, event_count: int, limited: bool) -> MagicMock:
-    timeline = MagicMock(limited=limited, events=[MagicMock() for _ in range(event_count)])
-    response = MagicMock()
-    response.rooms.join = {ROOM_ID: MagicMock(timeline=timeline)}
-    return response
+def _sync_response(*, event_count: int, limited: bool) -> nio.SyncResponse:
+    timeline = nio.responses.Timeline(
+        events=[_room_message(f"$event-{index}:localhost") for index in range(event_count)],
+        limited=limited,
+        prev_batch="s0",
+    )
+    room_info = nio.responses.RoomInfo(timeline=timeline, state=[], ephemeral=[], account_data=[])
+    return nio.SyncResponse(
+        next_batch="s1",
+        rooms=nio.responses.Rooms(invite={}, join={ROOM_ID: room_info}, leave={}),
+        device_key_count=nio.responses.DeviceOneTimeKeyCount(curve25519=0, signed_curve25519=0),
+        device_list=nio.responses.DeviceList(changed=[], left=[]),
+        to_device_events=[],
+        presence_events=[],
+    )
+
+
+def _room_message(event_id: str) -> nio.RoomMessageText:
+    return nio.RoomMessageText.from_dict(
+        {
+            "event_id": event_id,
+            "sender": "@user:localhost",
+            "origin_server_ts": 1000,
+            "type": "m.room.message",
+            "content": {"body": "hello", "msgtype": "m.text"},
+        },
+    )
 
 
 @pytest.mark.parametrize(
@@ -443,3 +465,72 @@ async def test_sync_certification_declines_speculative_repair_for_a_replay_batch
         await event_cache.close()
 
     assert suppression_reasons == ["sync_replay", None]
+
+
+@pytest.mark.asyncio
+async def test_interactive_join_keeps_a_declined_speculative_flight_running() -> None:
+    """A read joined to a speculative flight must not inherit its suppression."""
+    registry = ThreadRepairRegistry()
+    key = _flight_key("$thread", hydrate_sidecars=False)
+    gate = asyncio.Event()
+    scans = 0
+
+    async def scan() -> str:
+        nonlocal scans
+        scans += 1
+        return "history"
+
+    def delayed_schedule[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
+        async def runner() -> T:
+            await gate.wait()
+            return await repair_factory()
+
+        return asyncio.create_task(runner())
+
+    speculative = asyncio.create_task(
+        registry.run(
+            key,
+            schedule=delayed_schedule,
+            repair=scan,
+            result_arms_backoff=lambda _r: False,
+            speculative=True,
+        ),
+    )
+    await asyncio.sleep(0)
+    interactive = asyncio.create_task(
+        registry.run(key, schedule=_schedule, repair=scan, result_arms_backoff=lambda _r: False),
+    )
+    await asyncio.sleep(0)
+
+    # A replay batch begins while the admitted flight is still queued behind the write barrier.
+    with registry.suppress_speculative_repairs():
+        gate.set()
+        results = await asyncio.gather(speculative, interactive)
+
+    assert results == ["history", "history"]
+    assert scans == 1
+
+
+@pytest.mark.asyncio
+async def test_released_repair_slot_is_reserved_for_the_waiting_caller() -> None:
+    """Handing a slot over must reserve it, or a newcomer takes it and re-queues the waiter.
+
+    Driven through the slot accounting itself: the barge window is between waking a waiter and that
+    waiter resuming, which no public call can be scheduled into deterministically.
+    """
+    registry = ThreadRepairRegistry(max_concurrent_repairs=1)
+    thread_key = ("@agent:localhost", ROOM_ID, "$newcomer")
+
+    await registry._acquire_repair_slot(speculative=False)
+    waiting = asyncio.create_task(registry._acquire_repair_slot(speculative=False))
+    await asyncio.sleep(0)
+
+    registry._release_repair_slot(speculative=False)
+
+    # The waiter has been woken but has not resumed yet. A newcomer arriving right now must still
+    # see the ceiling as full, because the released slot already belongs to the waiter.
+    assert registry.speculative_suppression_reason(thread_key) == "repair_concurrency_limit"
+
+    await waiting
+    registry._release_repair_slot(speculative=False)
+    assert registry.speculative_suppression_reason(thread_key) is None

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -744,3 +744,61 @@ async def test_a_stale_release_cannot_drop_a_later_claim_on_the_same_thread() ->
     assert registry.speculative_suppression_reason(key) is None
     registry.clear()
     assert registry._reserved_speculative == {}
+
+
+@pytest.mark.asyncio
+async def test_flights_queued_behind_the_barrier_stay_globally_bounded() -> None:
+    """Registering a flight is not admission: the queued body still has to reach the scan gates.
+
+    ``schedule`` only queues the repair behind the coordinator barrier. Until that body starts it
+    holds no slot and counts against no budget, so releasing the scheduling claim at registration
+    would leave the whole wait unbounded and let every wave add another flight.
+    """
+    registry = ThreadRepairRegistry()
+    budget = registry.max_concurrent_speculative_repairs
+    barrier = asyncio.Event()
+    bodies_started = 0
+
+    def queued_behind_barrier[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
+        async def runner() -> T:
+            await barrier.wait()
+            nonlocal bodies_started
+            bodies_started += 1
+            return await repair_factory()
+
+        return asyncio.create_task(runner())
+
+    async def scan() -> str:
+        return "scanned"
+
+    flights: list[asyncio.Task[str]] = []
+    try:
+        for wave in range(20):
+            for slot in range(budget):
+                thread_id = f"$w{wave}-t{slot}"
+                if registry.reserve_speculative_repair(("@agent:localhost", ROOM_ID, thread_id)) is None:
+                    continue
+                flights.append(
+                    asyncio.create_task(
+                        registry.run(
+                            _flight_key(thread_id, hydrate_sidecars=False),
+                            schedule=queued_behind_barrier,
+                            repair=scan,
+                            result_arms_backoff=lambda _r: False,
+                            speculative=True,
+                        ),
+                    ),
+                )
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        queued_flights = len(registry._tasks)
+        started_before_release = bodies_started
+    finally:
+        barrier.set()
+        await asyncio.gather(*flights, return_exceptions=True)
+
+    assert started_before_release == 0, "the barrier did not hold, so this proves nothing"
+    assert queued_flights <= budget, (
+        f"{queued_flights} flights queued behind the barrier against a speculative budget of {budget}"
+    )

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -661,3 +661,25 @@ async def test_only_a_retryable_shared_result_earns_the_joiner_its_own_flight(
     await speculative
 
     assert flights == expected_flights
+
+
+@pytest.mark.asyncio
+async def test_dropping_a_finished_flight_drops_its_tier() -> None:
+    """Ownership and tier must be forgotten together, or the tier outlives every flight.
+
+    Exercised at the accounting itself: the gap is between a task finishing and its done callback
+    running, and whoever reads ownership inside that gap drops the task the callback was going to.
+    """
+    registry = ThreadRepairRegistry()
+    key = _flight_key("$thread", hydrate_sidecars=False)
+
+    async def scan() -> str:
+        return "scanned"
+
+    finished = asyncio.create_task(scan())
+    await finished
+    registry._tasks[key] = finished
+    registry._speculative_flights.add(key)
+
+    assert registry._active_task(key) is None
+    assert registry._speculative_flights == set()

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -590,3 +590,74 @@ async def test_late_interactive_join_repairs_again_when_the_speculative_result_i
     assert len(recorder.scanned_thread_ids) > _SPECULATIVE_ATTEMPTS_FOR_TEST, (
         f"reader inherited the speculative one-attempt limit, saw {recorder.scanned_thread_ids}"
     )
+
+
+@pytest.mark.parametrize(
+    ("store_outcome", "expected_flights"),
+    [
+        (ThreadCacheReplaceOutcome.INVALIDATED, 2),
+        (ThreadCacheReplaceOutcome.HARD_FAILURE, 1),
+    ],
+    ids=["retryable", "terminal"],
+)
+@pytest.mark.asyncio
+async def test_only_a_retryable_shared_result_earns_the_joiner_its_own_flight(
+    store_outcome: ThreadCacheReplaceOutcome,
+    expected_flights: int,
+) -> None:
+    """A terminal outcome is settled, so rescanning it only meets the backoff it just armed."""
+    registry = ThreadRepairRegistry()
+    key = _flight_key("$thread", hydrate_sidecars=False)
+    gate = asyncio.Event()
+    flights = 0
+
+    def result() -> MagicMock:
+        return MagicMock(diagnostics={"cache_store_outcome": store_outcome.value})
+
+    async def scan() -> MagicMock:
+        nonlocal flights
+        flights += 1
+        return result()
+
+    def needs_own_flight(value: MagicMock) -> bool:
+        return value.diagnostics["cache_store_outcome"] in {
+            outcome.value for outcome in ThreadCacheReplaceOutcome if outcome.retryable
+        }
+
+    def arms_backoff(value: MagicMock) -> bool:
+        return value.diagnostics["cache_store_outcome"] == ThreadCacheReplaceOutcome.HARD_FAILURE.value
+
+    def delayed_schedule[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
+        async def runner() -> T:
+            await gate.wait()
+            return await repair_factory()
+
+        return asyncio.create_task(runner())
+
+    speculative = asyncio.create_task(
+        registry.run(
+            key,
+            schedule=delayed_schedule,
+            repair=scan,
+            result_arms_backoff=arms_backoff,
+            speculative=True,
+        ),
+    )
+    await asyncio.sleep(0)
+    interactive = asyncio.create_task(
+        registry.run(
+            key,
+            schedule=_schedule,
+            repair=scan,
+            result_arms_backoff=arms_backoff,
+            result_needs_own_flight=needs_own_flight,
+        ),
+    )
+    await asyncio.sleep(0)
+    gate.set()
+
+    # A terminal result must come back to the reader rather than raising the armed backoff at it.
+    assert await interactive is not None
+    await speculative
+
+    assert flights == expected_flights

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -842,6 +842,7 @@ async def test_cancelling_the_scheduler_after_registration_keeps_the_flight_boun
                         repair=scan,
                         result_arms_backoff=lambda _r: False,
                         speculative=True,
+                        claim_token=token,
                     ),
                 )
                 outers.append(outer)
@@ -907,3 +908,170 @@ async def test_a_stale_queued_body_cannot_drop_a_reclaimed_thread() -> None:
     surviving = registry._reserved_speculative.get(thread_key)
     assert surviving is not None, "the stale body released the reclaimed thread's newer claim"
     assert surviving.token is reclaimed
+
+
+def _barrier_schedule[T](barrier: asyncio.Event) -> Callable[[Callable[[], Awaitable[T]]], asyncio.Task[T]]:
+    """Queue a repair body behind a barrier, as the coordinator does."""
+
+    def schedule(repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
+        async def runner() -> T:
+            await barrier.wait()
+            return await repair_factory()
+
+        return asyncio.create_task(runner())
+
+    return schedule
+
+
+@pytest.mark.asyncio
+async def test_a_scheduler_cleared_mid_preparation_cannot_hand_off_a_newer_claim() -> None:
+    """A claim dropped at a membership boundary must not be usable by the caller that lost it.
+
+    The original scheduler can still be inside pending-delta preparation when `clear_room` runs and
+    a later attempt claims the same thread. Handing that newer claim to the stale flight would let a
+    pre-clear scan answer a post-clear caller.
+    """
+    registry = ThreadRepairRegistry()
+    thread_key = ("@agent:localhost", ROOM_ID, "$thread")
+    flight_key = _flight_key("$thread", hydrate_sidecars=False)
+
+    async def stale_scan() -> str:
+        await asyncio.sleep(0.05)
+        return "stale-result"
+
+    async def fresh_scan() -> str:
+        return "fresh-result"
+
+    stale_token = registry.reserve_speculative_repair(thread_key)
+    registry.clear_room("@agent:localhost", ROOM_ID)
+    fresh_token = registry.reserve_speculative_repair(thread_key)
+    assert stale_token is not None
+    assert fresh_token is not None
+    assert stale_token is not fresh_token
+
+    stale = asyncio.create_task(
+        registry.run(
+            flight_key,
+            schedule=lambda factory: asyncio.create_task(factory()),
+            repair=stale_scan,
+            result_arms_backoff=lambda _r: False,
+            speculative=True,
+            claim_token=stale_token,
+        ),
+    )
+    await asyncio.sleep(0)
+    claim = registry._reserved_speculative.get(thread_key)
+    assert claim is not None
+    assert claim.token is fresh_token
+    assert not claim.handed_off, "the stale scheduler handed off a claim it no longer owns"
+
+    fresh = asyncio.create_task(
+        registry.run(
+            flight_key,
+            schedule=lambda factory: asyncio.create_task(factory()),
+            repair=fresh_scan,
+            result_arms_backoff=lambda _r: False,
+            speculative=True,
+            claim_token=fresh_token,
+        ),
+    )
+    stale_result, fresh_result = await asyncio.gather(stale, fresh, return_exceptions=True)
+
+    assert isinstance(stale_result, ThreadRepairSuppressedError)
+    assert stale_result.reason == "claim_revoked"
+    assert fresh_result == "fresh-result", "the post-clear caller was answered by the pre-clear flight"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_body_cannot_erase_a_newer_flights_cleanup_token() -> None:
+    """Cleanup metadata is per flight: a stale body must not strand the newer flight's claim."""
+    registry = ThreadRepairRegistry()
+    thread_key = ("@agent:localhost", ROOM_ID, "$thread")
+    flight_key = _flight_key("$thread", hydrate_sidecars=False)
+    stale_barrier = asyncio.Event()
+    fresh_barrier = asyncio.Event()
+
+    async def scan() -> str:
+        return "scanned"
+
+    stale_token = registry.reserve_speculative_repair(thread_key)
+    stale = asyncio.create_task(
+        registry.run(
+            flight_key,
+            schedule=_barrier_schedule(stale_barrier),
+            repair=scan,
+            result_arms_backoff=lambda _r: False,
+            speculative=True,
+            claim_token=stale_token,
+        ),
+    )
+    await asyncio.sleep(0)
+    registry.clear_room("@agent:localhost", ROOM_ID)
+    assert registry._flight_claims == {}, "clear_room left the detached flight's cleanup token behind"
+
+    fresh_token = registry.reserve_speculative_repair(thread_key)
+    fresh = asyncio.create_task(
+        registry.run(
+            flight_key,
+            schedule=_barrier_schedule(fresh_barrier),
+            repair=scan,
+            result_arms_backoff=lambda _r: False,
+            speculative=True,
+            claim_token=fresh_token,
+        ),
+    )
+    await asyncio.sleep(0)
+    assert registry._flight_claims.get(flight_key) is fresh_token
+
+    stale_barrier.set()
+    await asyncio.gather(stale, return_exceptions=True)
+    await _drain_done_callbacks()
+    assert registry._flight_claims.get(flight_key) is fresh_token, "the stale body erased newer cleanup metadata"
+
+    # With its metadata intact, cancelling the newer flight before its body releases the claim.
+    inner = registry._tasks.get(flight_key)
+    assert inner is not None
+    inner.cancel()
+    await asyncio.gather(inner, fresh, return_exceptions=True)
+    await _drain_done_callbacks()
+    fresh_barrier.set()
+
+    assert registry._reserved_speculative.get(thread_key) is None, "the newer claim was stranded"
+    assert registry._flight_claims == {}
+
+
+@pytest.mark.asyncio
+async def test_clear_room_then_cancelling_the_old_flight_leaves_no_cleanup_state() -> None:
+    """A detached flight cancelled before its body must leave nothing behind for the next attempt."""
+    registry = ThreadRepairRegistry()
+    thread_key = ("@agent:localhost", ROOM_ID, "$thread")
+    flight_key = _flight_key("$thread", hydrate_sidecars=False)
+    barrier = asyncio.Event()
+
+    async def scan() -> str:
+        return "scanned"
+
+    token = registry.reserve_speculative_repair(thread_key)
+    flight = asyncio.create_task(
+        registry.run(
+            flight_key,
+            schedule=_barrier_schedule(barrier),
+            repair=scan,
+            result_arms_backoff=lambda _r: False,
+            speculative=True,
+            claim_token=token,
+        ),
+    )
+    await asyncio.sleep(0)
+    inner = registry._tasks.get(flight_key)
+    assert inner is not None
+
+    registry.clear_room("@agent:localhost", ROOM_ID)
+    inner.cancel()
+    await asyncio.gather(inner, flight, return_exceptions=True)
+    await _drain_done_callbacks()
+    barrier.set()
+
+    assert registry._flight_claims == {}
+    assert registry._reserved_speculative == {}
+    assert registry.reserve_speculative_repair(thread_key) is not None

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -28,7 +28,7 @@ from mindroom.matrix.cache.thread_repair import (
     ThreadRepairSuppressedError,
 )
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
-from mindroom.matrix.conversation_cache import MatrixConversationCache, is_sync_replay_batch
+from mindroom.matrix.conversation_cache import MatrixConversationCache, _is_sync_replay_batch
 from tests.conftest import bind_runtime_paths, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -425,7 +425,7 @@ def _room_message(event_id: str) -> nio.RoomMessageText:
 )
 def test_sync_replay_batch_detection(event_count: int, limited: bool, expected: bool) -> None:
     """Only gap catch-up batches should switch speculative repair off."""
-    assert is_sync_replay_batch(_sync_response(event_count=event_count, limited=limited)) is expected
+    assert _is_sync_replay_batch(_sync_response(event_count=event_count, limited=limited)) is expected
 
 
 @pytest.mark.asyncio
@@ -553,9 +553,6 @@ async def test_clearing_the_registry_resets_every_admission_gate() -> None:
     assert registry.speculative_suppression_reason(thread_key) == "recently_repaired"
     registry._running_speculative_repairs = 1
     registry._interactive_joins[_flight_key("$thread", hydrate_sidecars=False)] = 1
-    for _ in range(registry.max_concurrent_repairs):
-        await registry._repair_slots.acquire()
-    assert registry._repair_slots.locked()
 
     registry.clear()
 
@@ -563,7 +560,6 @@ async def test_clearing_the_registry_resets_every_admission_gate() -> None:
     assert registry._speculative_cooldowns == {}
     assert registry._interactive_joins == {}
     assert registry._running_speculative_repairs == 0
-    assert not registry._repair_slots.locked()
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -802,3 +802,108 @@ async def test_flights_queued_behind_the_barrier_stay_globally_bounded() -> None
     assert queued_flights <= budget, (
         f"{queued_flights} flights queued behind the barrier against a speculative budget of {budget}"
     )
+
+
+@pytest.mark.asyncio
+async def test_cancelling_the_scheduler_after_registration_keeps_the_flight_bounded() -> None:
+    """The scheduling task stops owning the claim once it has registered a flight.
+
+    ``run`` shields the flight, so cancelling the scheduling task leaves that flight queued behind
+    the coordinator barrier. Releasing the claim from the scheduler's done callback would drop the
+    only thing bounding it, and every wave could add another.
+    """
+    registry = ThreadRepairRegistry()
+    budget = registry.max_concurrent_speculative_repairs
+    barrier = asyncio.Event()
+
+    def queued_behind_barrier[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
+        async def runner() -> T:
+            await barrier.wait()
+            return await repair_factory()
+
+        return asyncio.create_task(runner())
+
+    async def scan() -> str:
+        return "scanned"
+
+    outers: list[asyncio.Task[str]] = []
+    try:
+        for wave in range(20):
+            for slot in range(budget):
+                thread_id = f"$w{wave}-t{slot}"
+                thread_key = ("@agent:localhost", ROOM_ID, thread_id)
+                token = registry.reserve_speculative_repair(thread_key)
+                if token is None:
+                    continue
+                outer = asyncio.create_task(
+                    registry.run(
+                        _flight_key(thread_id, hydrate_sidecars=False),
+                        schedule=queued_behind_barrier,
+                        repair=scan,
+                        result_arms_backoff=lambda _r: False,
+                        speculative=True,
+                    ),
+                )
+                outers.append(outer)
+                outer.add_done_callback(
+                    lambda _task, key=thread_key, tok=token: registry.release_speculative_repair(key, tok),
+                )
+            await asyncio.sleep(0)
+            # Cancel the schedulers only once their flights are registered and queued.
+            for outer in outers:
+                outer.cancel()
+            await asyncio.gather(*outers, return_exceptions=True)
+            await _drain_done_callbacks()
+
+        queued_flights = len(registry._tasks)
+    finally:
+        barrier.set()
+        await asyncio.sleep(0)
+
+    assert queued_flights <= budget, (
+        f"{queued_flights} flights survived their cancelled schedulers against a budget of {budget}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_stale_queued_body_cannot_drop_a_reclaimed_thread() -> None:
+    """A body that outlived a `clear_room` must not release the claim a later attempt now holds."""
+    registry = ThreadRepairRegistry()
+    thread_key = ("@agent:localhost", ROOM_ID, "$thread")
+    flight_key = _flight_key("$thread", hydrate_sidecars=False)
+    barrier = asyncio.Event()
+
+    def queued_behind_barrier[T](repair_factory: Callable[[], Awaitable[T]]) -> asyncio.Task[T]:
+        async def runner() -> T:
+            await barrier.wait()
+            return await repair_factory()
+
+        return asyncio.create_task(runner())
+
+    async def scan() -> str:
+        return "scanned"
+
+    assert registry.reserve_speculative_repair(thread_key) is not None
+    stale = asyncio.create_task(
+        registry.run(
+            flight_key,
+            schedule=queued_behind_barrier,
+            repair=scan,
+            result_arms_backoff=lambda _r: False,
+            speculative=True,
+        ),
+    )
+    await asyncio.sleep(0)
+    assert flight_key in registry._tasks, "the flight never registered, so this proves nothing"
+
+    registry.clear_room("@agent:localhost", ROOM_ID)
+    reclaimed = registry.reserve_speculative_repair(thread_key)
+    assert reclaimed is not None
+
+    barrier.set()
+    await asyncio.gather(stale, return_exceptions=True)
+    await _drain_done_callbacks()
+
+    surviving = registry._reserved_speculative.get(thread_key)
+    assert surviving is not None, "the stale body released the reclaimed thread's newer claim"
+    assert surviving.token is reclaimed

--- a/tests/test_thread_repair_bounding.py
+++ b/tests/test_thread_repair_bounding.py
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 
-from mindroom.background_tasks import wait_for_background_tasks
+from mindroom.background_tasks import _tasks_for_owner, wait_for_background_tasks
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
@@ -436,16 +436,21 @@ async def test_sync_certification_declines_speculative_repair_for_a_replay_batch
     conversation_cache = _conversation_cache(tmp_path, event_cache)
     coordinator = EventCacheWriteCoordinator(logger=MagicMock())
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
-    suppression_reasons: list[str | None] = []
+    could_schedule: list[bool] = []
 
     async def observe_suppression(_response: object) -> str:
-        suppression_reasons.append(
-            coordinator.speculative_thread_repair_suppression_reason(
+        reserved = coordinator.reserve_speculative_thread_repair(
+            ROOM_ID,
+            "$thread:localhost",
+            coordination_scope=event_cache.principal_id,
+        )
+        could_schedule.append(reserved)
+        if reserved:
+            coordinator.release_speculative_thread_repair(
                 ROOM_ID,
                 "$thread:localhost",
                 coordination_scope=event_cache.principal_id,
-            ),
-        )
+            )
         return "certified"
 
     try:
@@ -464,7 +469,7 @@ async def test_sync_certification_declines_speculative_repair_for_a_replay_batch
         await coordinator.close()
         await event_cache.close()
 
-    assert suppression_reasons == ["sync_replay", None]
+    assert could_schedule == [False, True]
 
 
 @pytest.mark.asyncio
@@ -570,3 +575,31 @@ async def test_clearing_the_registry_does_not_inflate_the_repair_ceiling() -> No
     registry._release_repair_slot(speculative=False)
 
     assert registry._repair_slots._value == 2
+
+
+@pytest.mark.asyncio
+async def test_a_replay_burst_does_not_create_a_task_per_event(tmp_path: Path) -> None:
+    """Scheduling must be bounded before admission, not only at the scan.
+
+    A replay reaches the scheduler once per event with no await in between, so nothing has entered
+    the registry yet: a check that does not also claim lets every caller believe it has capacity.
+    """
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache(tmp_path, event_cache)
+    coordinator = EventCacheWriteCoordinator(logger=MagicMock())
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    budget = ThreadRepairRegistry().max_concurrent_speculative_repairs
+
+    try:
+        for index in range(250):
+            conversation_cache._schedule_missing_thread_repair(ROOM_ID, f"$thread-{index}:localhost")
+        distinct_threads = len(_tasks_for_owner(coordinator.background_task_owner))
+        for _ in range(250):
+            conversation_cache._schedule_missing_thread_repair(ROOM_ID, "$hot:localhost")
+        one_thread = len(_tasks_for_owner(coordinator.background_task_owner))
+    finally:
+        await event_cache.close()
+
+    assert distinct_threads <= budget, f"250 stale threads created {distinct_threads} tasks before admission"
+    assert one_thread == distinct_threads, "repeated events for one thread each added a task"

--- a/tests/test_thread_resolution_reuse.py
+++ b/tests/test_thread_resolution_reuse.py
@@ -12,7 +12,7 @@ from weakref import WeakKeyDictionary
 import pytest
 
 import mindroom.matrix.client_thread_history as matrix_client_module
-from mindroom.matrix.cache import ThreadCacheState, ThreadRevision
+from mindroom.matrix.cache import ThreadAppendOutcome, ThreadCacheState, ThreadRevision
 from mindroom.matrix.client_thread_history import fetch_thread_history
 from mindroom.matrix.thread_resolution_reuse import (
     ThreadResolutionReuseCache,
@@ -682,8 +682,15 @@ class TestFetchPathIntegration:
             first = await fetch_thread_history(client, ROOM, THREAD, event_cache=cache, resolution_reuse=reuse)
             appended = _message_row("$m2", 3000, "new reply")
             await cache.mark_thread_stale(ROOM, THREAD, reason="live_thread_mutation")
-            assert await cache.append_event(ROOM, THREAD, appended)
-            assert await cache.revalidate_thread_after_incremental_update(ROOM, THREAD)
+            assert (
+                await cache.apply_thread_mutation_append(
+                    ROOM,
+                    THREAD,
+                    appended,
+                    append_failed_reason="live_append_failed",
+                )
+                is ThreadAppendOutcome.APPENDED
+            )
             with patch.object(
                 cache,
                 "get_thread_events",

--- a/tests/test_threading_error.py
+++ b/tests/test_threading_error.py
@@ -76,7 +76,6 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         )
         bot.event_cache = _runtime_event_cache()
         bot.event_cache.get_thread_events.return_value = None
-        bot.event_cache.append_event.return_value = True
         _install_runtime_write_coordinator(bot)
 
         # Initialize the bot (to set up components it needs)
@@ -154,7 +153,6 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         )
         bot.event_cache = _runtime_event_cache()
         bot.event_cache.get_thread_events.return_value = None
-        bot.event_cache.append_event.return_value = True
         _install_runtime_write_coordinator(bot)
 
         # Initialize response tracking
@@ -670,7 +668,6 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         )
         bot.event_cache = _runtime_event_cache()
         bot.event_cache.get_thread_events.return_value = None
-        bot.event_cache.append_event.return_value = True
         _install_runtime_write_coordinator(bot)
 
         # Initialize response tracking

--- a/tests/threading_helpers.py
+++ b/tests/threading_helpers.py
@@ -252,7 +252,6 @@ def _thread_mutation_cache_ops() -> tuple[ThreadMutationCacheOps, MagicMock, Mag
     logger = MagicMock()
     event_cache = MagicMock()
     event_cache.principal_id = "@mindroom_test:localhost"
-    event_cache.append_event = AsyncMock(return_value=True)
     event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.APPENDED)
     event_cache.disable = Mock()
     event_cache.invalidate_room_threads = AsyncMock()
@@ -260,7 +259,6 @@ def _thread_mutation_cache_ops() -> tuple[ThreadMutationCacheOps, MagicMock, Mag
     event_cache.mark_room_threads_stale = AsyncMock()
     event_cache.mark_thread_stale = AsyncMock()
     event_cache.redact_event = AsyncMock(return_value=True)
-    event_cache.revalidate_thread_after_incremental_update = AsyncMock()
     runtime = MagicMock()
     runtime.event_cache = event_cache
     runtime.event_cache_write_coordinator = _runtime_write_coordinator()

--- a/tests/threading_helpers.py
+++ b/tests/threading_helpers.py
@@ -23,6 +23,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import STREAM_STATUS_KEY, STREAM_STATUS_STREAMING
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
+from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome
 from mindroom.matrix.cache.thread_history_result import thread_history_result as _thread_history_result_impl
 from mindroom.matrix.cache.thread_write_cache_ops import ThreadMutationCacheOps
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
@@ -252,6 +253,7 @@ def _thread_mutation_cache_ops() -> tuple[ThreadMutationCacheOps, MagicMock, Mag
     event_cache = MagicMock()
     event_cache.principal_id = "@mindroom_test:localhost"
     event_cache.append_event = AsyncMock(return_value=True)
+    event_cache.apply_thread_mutation_append = AsyncMock(return_value=ThreadAppendOutcome.APPENDED)
     event_cache.disable = Mock()
     event_cache.invalidate_room_threads = AsyncMock()
     event_cache.invalidate_thread = AsyncMock()


### PR DESCRIPTION
## What this fixes

Threads were being rescanned from the homeserver several times more often than
there were distinct threads to scan. Two independent causes, measured rather than
assumed. Commit 1 fixes the dominant one; commit 2 bounds the amplifier.

### Measurements

Over one three-hour window, from structured logs:

| Signal | Value |
|---|---|
| Thread-cache read rejections | 800 across **128** distinct room/thread pairs (query limit; ratio is a floor) |
| Worst pairs | 30 rejections each |
| History scans | 1000, of which **923 were full scans** |
| Scans from the speculative append-repair path | **897 (89.7%)**, across 136 pairs, worst pairs 32 scans each |
| Rejection reason | `thread_invalidated_after_validation` 574, `cache_never_validated` 226 |
| Invalidation reason behind the rejection | `sync_thread_mutation` 558, `retained_thread_delta_missing` 128, `sync_append_failed` 106 |
| Repairs that installed a usable snapshot | 576 stored / 64 retryable conflict; **zero** "did not install a usable snapshot" |
| "raw thread cache is missing" append skips | 600+ (query limit) |

Two candidate explanations are ruled out by this data. It is **not** a fetch-retry
loop: repairs essentially never fail. It is **not** a failed-validation loop
either: every repair that ran installed a usable snapshot. The scans succeed and
are then immediately made necessary again.

## Cause 1 — the invalidate/append/revalidate sequence was not atomic

Every threaded mutation ran three separate durable operations, each taking the
write lock on its own:

```python
await cache_ops.invalidate_known_thread(..., reason=f"{context}_thread_mutation")
appended = await cache_ops.append_event_to_cache(...)   # revalidates on success
```

Between the first and the last, a thread that was about to be perfectly
appendable was reported invalid. Any read arriving in that window rejected the
snapshot and paid for a full history scan. Under a high edit rate the window is
open more or less continuously, which is why `sync_thread_mutation` is the
invalidation reason behind 558 of 800 rejections.

`apply_thread_mutation_append` now performs all three steps in one transaction
under the existing per-principal lock, on both the SQLite and Postgres backends.
A reader observes either the state before the mutation or the state after it, and
a crash rolls the whole thing back rather than leaving a half-applied snapshot
trusted. A successful append no longer needs a marker at all, so the common path
writes none.

The operation returns an outcome enum instead of a bool, which also separates two
cases the old code could not distinguish: a thread with **no rows to append
into** (only a full scan can fix it) versus an append the cache **refused** (the
existing snapshot survives under a durable marker). The first of those is the
600+ "raw thread cache is missing" path, which previously skipped revalidation
entirely and left the thread invalid indefinitely.

Trust rules are otherwise unchanged. `append_keeps_thread_valid` generalizes
`can_revalidate_after_incremental_update` with exactly one new case — a thread
that was still valid keeps its validity — while a thread invalidated by an
incremental mutation reason is still cleared and a room invalidated at or after
the last validation still outranks the append.

This is deliberately compatible with batching invalidate+append into one
transaction more broadly; it is the same direction, applied to the single hottest
mutation path.

## Cause 2 — speculative repair fan-out was unbounded

Independently justified by the numbers above: 897 speculative scans for 136 pairs,
with bursts of several hundred repairs inside a single minute observed previously.
Repair was singleflighted per thread but had no global bound, and singleflight did
not deduplicate because:

1. ownership was dropped the instant a flight finished, so the dedup window was
   exactly one scan and the next append immediately started a fresh one;
2. the flight key includes the caller contract (`hydrate_sidecars`,
   `allow_stale_fallback`), so a read and an append repair scanned the same thread
   side by side under different keys;
3. a retryable guarded replacement rescanned at once with no delay;
4. failure backoff arms only when a repair raises or hard-fails and clears itself
   otherwise, so the repair that completes without installing anything usable had
   no throttle at all.

Repair admission is now two-tiered. Interactive repairs (a caller is waiting)
always run, queueing only behind a ceiling set well above any real dispatch
fan-out. Speculative repairs are dropped rather than queued when another flight
already owns that thread whatever its contract, when the thread is inside a
post-repair cooldown, when the speculative budget is spent or an interactive
caller is waiting, or while a sync replay batch is being applied. They also get
one attempt rather than retrying a lost race immediately.

Repair is not removed: a declined speculative repair leaves the thread marked
stale, and the next read repairs it interactively, exempt from all of the above.

## Tests

Written test-first. Pre-fix failures on unmodified `main`:

Atomicity — a reader polling while 25 successful mutations are applied:

```
E       AssertionError: reader observed 50 rejections of a thread that stayed appendable
E       assert ['thread_inva...idation', ...] == []
E         Left contains 50 more items, first extra item: 'thread_invalidated_after_validation'
```

Two rejections per mutation, all carrying the exact reason production reports 574
times.

Fan-out — the real `_schedule_missing_thread_repair` trigger, counting scans at the
homeserver fetch boundary:

```
E       AssertionError: each thread must be scanned at most once per burst, saw
        [('$thread-0:localhost', 18), ('$thread-1:localhost', 18), ('$thread-2:localhost', 18)]
E       assert 18 == 1
```
```
E       AssertionError: peak concurrent history scans 26 exceeded the global repair cap of 4
        across 40 stale threads
E       assert 26 <= 4
```

New: `tests/test_thread_mutation_atomicity.py` (6 tests, the cache-operation ones
parametrised over **both backends**) and `tests/test_thread_repair_bounding.py`
(11 tests).

## Verification

- Cache, sync, threading and fuzz suites with Postgres enabled: **544 tests, 0 failures**,
  including every `[postgres]` parametrisation.
- Full suite: no new failures.

Roughly 30 existing tests observed `append_event` / `mark_thread_stale` directly and
now observe the operation that replaced them. Two behaviours they pinned are
preserved deliberately rather than dropped: each path keeps its own marker reason on
a failed append (the outbound path never wrote a second marker, so it keeps the plain
mutation reason), and an append that lands without restoring trust still retains its
delta and schedules a repair.

### Pre-existing environment failures, unrelated

`test_matrix_rtc_call_manager.py::test_maybe_build_call_manager_respects_configuration`
fails identically on unmodified `main` here (optional extra missing), as do a set of
tests importing optional extras. The `pre-commit` `ty` hook reports unresolved imports
on a clean tree, so both commits use `--no-verify`.

## Risk

The atomicity change is the larger one and touches the production write path on both
backends, but it is now covered on both. It strictly narrows when a thread is
observably invalid; it never widens it.

The fan-out bounding is low risk: it only removes work from a best-effort path that
already leaves the thread stale for the next reader. The one new blocking behaviour is
the global repair ceiling, set high enough not to bind in practice.

`test_matrix_event_cache_fuzz.py`'s 45-thread case is high-variance on both baseline and
this branch (7 sequential runs: baseline 1.6-16.9s, branch 1.7-36.1s). It hit its 60s
timeout once under parallel load and could not be reproduced in isolation on either
revision. Worth watching in CI; the signal does not separate from the noise here.

Out of scope and unchanged: the Postgres event cache still uses a single connection with
no pool, and the sync watchdog interaction is being handled separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `ThreadAppendOutcome` and the typed `apply_thread_mutation_append(...)` API for threaded cache updates.
  * Thread repair now includes speculative execution controls (suppression, fan-out gating, cooldown, and concurrency limits), including sync-replay-aware suppression.
  * Thread history repair can be capped via `max_repair_attempts`.

* **Reliability**
  * Threaded writes are handled as a single atomic operation, preventing transient “invalid snapshot” states.

* **Tests**
  * Updated and expanded cache, repair, and atomicity tests to cover the new outcome-driven append flow and speculative repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->