### PR TITLE
Cut redaction, timing and plugin-scan overhead on the event loop

### DIFF
--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -403,9 +403,12 @@ async def _watched_config_mtimes(api_app: FastAPI) -> tuple[constants.RuntimePat
     The scan stats every config source on each poll, so it runs in a worker
     thread rather than on the event loop.
     """
-    snapshot = _app_context(api_app)
-    paths = snapshot.source_files or frozenset({snapshot.runtime_paths.config_path})
-    return snapshot.runtime_paths, await asyncio.to_thread(file_watcher.paths_mtime_snapshot, paths)
+    while True:
+        snapshot = _app_context(api_app)
+        paths = snapshot.source_files or frozenset({snapshot.runtime_paths.config_path})
+        mtimes = await asyncio.to_thread(file_watcher.paths_mtime_snapshot, paths)
+        if _app_context(api_app).generation == snapshot.generation:
+            return snapshot.runtime_paths, mtimes
 
 
 async def _watch_config(

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -397,11 +397,15 @@ async def _reload_config_after_file_change(
     await _reload_config_into_app(api_app, runtime_paths)
 
 
-def _watched_config_mtimes(api_app: FastAPI) -> tuple[constants.RuntimePaths, dict[Path, int]]:
-    """Return the runtime paths and mtimes of the config file plus its !include files."""
+async def _watched_config_mtimes(api_app: FastAPI) -> tuple[constants.RuntimePaths, dict[Path, int]]:
+    """Return the runtime paths and mtimes of the config file plus its !include files.
+
+    The scan stats every config source on each poll, so it runs in a worker
+    thread rather than on the event loop.
+    """
     snapshot = _app_context(api_app)
     paths = snapshot.source_files or frozenset({snapshot.runtime_paths.config_path})
-    return snapshot.runtime_paths, file_watcher.paths_mtime_snapshot(paths)
+    return snapshot.runtime_paths, await asyncio.to_thread(file_watcher.paths_mtime_snapshot, paths)
 
 
 async def _watch_config(
@@ -416,7 +420,7 @@ async def _watch_config(
     them instead of reloading, so multi-file updates (git pull, rsync) land
     completely before the reload reads the tree.
     """
-    runtime_paths, last_mtimes = _watched_config_mtimes(api_app)
+    runtime_paths, last_mtimes = await _watched_config_mtimes(api_app)
     watched_config_path: Path = runtime_paths.config_path
     pending_paths: set[Path] = set()
 
@@ -428,7 +432,7 @@ async def _watch_config(
             pass
 
         try:
-            runtime_paths, current_mtimes = _watched_config_mtimes(api_app)
+            runtime_paths, current_mtimes = await _watched_config_mtimes(api_app)
             if runtime_paths.config_path != watched_config_path:
                 # Runtime swap: rebaseline the new source set without reloading.
                 watched_config_path = runtime_paths.config_path

--- a/src/mindroom/file_watcher.py
+++ b/src/mindroom/file_watcher.py
@@ -81,15 +81,18 @@ async def watch_paths(
     and no newly vanished files. Multi-file updates (git pull, rsync) thus land
     completely before a reload reads the tree, at the cost of one extra scan
     interval of latency.
+
+    Each scan stats every watched file, so it runs in a worker thread rather than
+    on the event loop.
     """
-    last_snapshot = paths_mtime_snapshot(paths_provider())
+    last_snapshot = await asyncio.to_thread(paths_mtime_snapshot, paths_provider())
     dirty = False
 
     while stop_event is None or not stop_event.is_set():
         await asyncio.sleep(_WATCH_SCAN_INTERVAL_SECONDS)
 
         try:
-            current_snapshot = paths_mtime_snapshot(paths_provider())
+            current_snapshot = await asyncio.to_thread(paths_mtime_snapshot, paths_provider())
             changed = bool(changed_watched_paths(last_snapshot, current_snapshot))
             vanished = any_paths_newly_missing(last_snapshot, current_snapshot)
             last_snapshot = current_snapshot

--- a/src/mindroom/matrix/state.py
+++ b/src/mindroom/matrix/state.py
@@ -177,10 +177,16 @@ def get_room_alias_from_id(room_id: str, runtime_paths: constants.RuntimePaths) 
 
 
 def _matrix_state_cache_key(state_file: Path) -> tuple[Path, int | None, int | None]:
-    """Return one cache key that invalidates when the state file changes."""
-    if not state_file.exists():
+    """Return one cache key that invalidates when the state file changes.
+
+    Every cached read rebuilds this key, so it stats once and treats an
+    unreadable file as absent rather than paying a second syscall for a separate
+    existence check.
+    """
+    try:
+        stat = state_file.stat()
+    except OSError:
         return state_file, None, None
-    stat = state_file.stat()
     return state_file, stat.st_mtime_ns, stat.st_size
 
 

--- a/src/mindroom/matrix/state.py
+++ b/src/mindroom/matrix/state.py
@@ -10,6 +10,8 @@ from pydantic import BaseModel, Field, field_serializer
 
 from mindroom import constants, yaml_io
 
+_matrix_state_write_generation = 0
+
 
 class MatrixAccount(BaseModel):
     """Represents a Matrix account (user or agent)."""
@@ -47,10 +49,10 @@ class MatrixState(BaseModel):
     def load(cls, runtime_paths: constants.RuntimePaths) -> "MatrixState":
         """Load state from file.
 
-        Reads come from a process-wide cache keyed by the state file's
-        ``(path, st_mtime_ns, st_size)`` so repeated calls against an unchanged
-        file skip the YAML parse. A deep copy is returned so callers may safely
-        mutate the result before ``save`` without polluting the cache.
+        Reads come from a process-wide cache keyed by the state file path and
+        in-process write generation, so repeated calls between writes skip the
+        YAML parse. A deep copy is returned so callers may safely mutate the
+        result before ``save`` without polluting the cache.
         """
         return matrix_state_for_runtime(runtime_paths).model_copy(deep=True)
 
@@ -119,7 +121,7 @@ class MatrixState(BaseModel):
 
 
 def matrix_state_for_runtime(runtime_paths: constants.RuntimePaths) -> MatrixState:
-    """Return persisted Matrix state for one runtime, cached by file mtime/size.
+    """Return persisted Matrix state for one runtime, cached by write generation.
 
     The returned object is shared across callers; **read-only callers** should
     prefer this helper for the lowest overhead. Callers that intend to mutate
@@ -128,7 +130,8 @@ def matrix_state_for_runtime(runtime_paths: constants.RuntimePaths) -> MatrixSta
     """
     state_file = constants.matrix_state_file(runtime_paths=runtime_paths)
     return _load_matrix_state_file_cached(
-        *_matrix_state_cache_key(state_file),
+        state_file,
+        _matrix_state_write_generation,
         current_domain=_current_runtime_domain(runtime_paths),
     )
 
@@ -176,30 +179,15 @@ def get_room_alias_from_id(room_id: str, runtime_paths: constants.RuntimePaths) 
     return None
 
 
-def _matrix_state_cache_key(state_file: Path) -> tuple[Path, int | None, int | None]:
-    """Return one cache key that invalidates when the state file changes.
-
-    Every cached read rebuilds this key, so it stats once and treats an
-    unreadable file as absent rather than paying a second syscall for a separate
-    existence check.
-    """
-    try:
-        stat = state_file.stat()
-    except OSError:
-        return state_file, None, None
-    return state_file, stat.st_mtime_ns, stat.st_size
-
-
 @lru_cache(maxsize=64)
 def _load_matrix_state_file_cached(
     state_file: Path,
-    mtime_ns: int | None,
-    size: int | None,
+    write_generation: int,
     *,
     current_domain: str,
 ) -> MatrixState:
-    """Load Matrix state through a file-change-sensitive cache."""
-    del mtime_ns, size
+    """Load Matrix state through an in-process-write-sensitive cache."""
+    del write_generation
     return _load_matrix_state_file(state_file, current_domain=current_domain)
 
 
@@ -239,6 +227,8 @@ def _load_matrix_state_file(state_file: Path, *, current_domain: str) -> MatrixS
 
 def _write_matrix_state_file(state_file: Path, data: dict[str, object]) -> None:
     """Atomically persist Matrix state without cross-process advisory locking."""
+    global _matrix_state_write_generation
+
     state_file.parent.mkdir(parents=True, exist_ok=True)
     temp_path: Path | None = None
     try:
@@ -255,6 +245,7 @@ def _write_matrix_state_file(state_file: Path, data: dict[str, object]) -> None:
             temp_file.flush()
             os.fsync(temp_file.fileno())
         temp_path.replace(state_file)
+        _matrix_state_write_generation += 1
         _fsync_directory(state_file.parent)
     finally:
         if temp_path is not None and temp_path.exists():

--- a/src/mindroom/matrix/state.py
+++ b/src/mindroom/matrix/state.py
@@ -5,11 +5,13 @@ from datetime import UTC, datetime
 from functools import lru_cache
 from pathlib import Path
 from tempfile import NamedTemporaryFile
+from time import monotonic
 
 from pydantic import BaseModel, Field, field_serializer
 
 from mindroom import constants, yaml_io
 
+_MATRIX_STATE_STAT_TTL_SECONDS = 1.0
 _matrix_state_write_generation = 0
 
 
@@ -49,10 +51,10 @@ class MatrixState(BaseModel):
     def load(cls, runtime_paths: constants.RuntimePaths) -> "MatrixState":
         """Load state from file.
 
-        Reads come from a process-wide cache keyed by the state file path and
-        in-process write generation, so repeated calls between writes skip the
-        YAML parse. A deep copy is returned so callers may safely mutate the
-        result before ``save`` without polluting the cache.
+        Reads come from a process-wide cache keyed by the state file path,
+        in-process write generation, and a short-TTL file signature. A deep
+        copy is returned so callers may safely mutate the result before
+        ``save`` without polluting the cache.
         """
         return matrix_state_for_runtime(runtime_paths).model_copy(deep=True)
 
@@ -121,7 +123,7 @@ class MatrixState(BaseModel):
 
 
 def matrix_state_for_runtime(runtime_paths: constants.RuntimePaths) -> MatrixState:
-    """Return persisted Matrix state for one runtime, cached by write generation.
+    """Return persisted Matrix state cached by write generation and file signature.
 
     The returned object is shared across callers; **read-only callers** should
     prefer this helper for the lowest overhead. Callers that intend to mutate
@@ -130,8 +132,7 @@ def matrix_state_for_runtime(runtime_paths: constants.RuntimePaths) -> MatrixSta
     """
     state_file = constants.matrix_state_file(runtime_paths=runtime_paths)
     return _load_matrix_state_file_cached(
-        state_file,
-        _matrix_state_write_generation,
+        *_matrix_state_cache_key(state_file),
         current_domain=_current_runtime_domain(runtime_paths),
     )
 
@@ -179,15 +180,35 @@ def get_room_alias_from_id(room_id: str, runtime_paths: constants.RuntimePaths) 
     return None
 
 
+def _matrix_state_cache_key(state_file: Path) -> tuple[Path, int, int | None, int | None]:
+    """Return a key with eager local invalidation and bounded external staleness."""
+    stat_ttl_bucket = int(monotonic() / _MATRIX_STATE_STAT_TTL_SECONDS)
+    mtime_ns, size = _matrix_state_file_signature(state_file, stat_ttl_bucket)
+    return state_file, _matrix_state_write_generation, mtime_ns, size
+
+
+@lru_cache(maxsize=64)
+def _matrix_state_file_signature(state_file: Path, stat_ttl_bucket: int) -> tuple[int | None, int | None]:
+    """Stat one state file at most once per TTL bucket."""
+    del stat_ttl_bucket
+    try:
+        stat = state_file.stat()
+    except OSError:
+        return None, None
+    return stat.st_mtime_ns, stat.st_size
+
+
 @lru_cache(maxsize=64)
 def _load_matrix_state_file_cached(
     state_file: Path,
     write_generation: int,
+    mtime_ns: int | None,
+    size: int | None,
     *,
     current_domain: str,
 ) -> MatrixState:
-    """Load Matrix state through an in-process-write-sensitive cache."""
-    del write_generation
+    """Load Matrix state through a local-write and external-file-sensitive cache."""
+    del write_generation, mtime_ns, size
     return _load_matrix_state_file(state_file, current_domain=current_domain)
 
 

--- a/src/mindroom/redaction.py
+++ b/src/mindroom/redaction.py
@@ -16,7 +16,6 @@ from pydantic import BaseModel
 REDACTED = "***redacted***"
 __all__ = [
     "REDACTED",
-    "key_normalization_cache_size",
     "redact_log_event",
     "redact_sensitive_data",
     "redact_sensitive_text",
@@ -228,32 +227,11 @@ def _classify_key_text(key: str) -> _KeyClassification:
 _classify_key_text_cached = lru_cache(maxsize=_KEY_CLASSIFICATION_CACHE_SIZE)(_classify_key_text)
 
 
-def key_normalization_cache_size() -> int:
-    """Return how many distinct log keys are currently classified in the cache."""
-    return _classify_key_text_cached.cache_info().currsize
-
-
 def _classify_key(value: object) -> _KeyClassification:
     key = _safe_str(value)
     if len(key) > _MAX_CACHED_KEY_LENGTH:
         return _classify_key_text(key)
     return _classify_key_text_cached(key)
-
-
-def _normalize_key(value: object) -> str:
-    return _classify_key(value).normalized
-
-
-def _is_secret_key(value: object) -> bool:
-    return _classify_key(value).is_secret
-
-
-def _is_secret_container_key(value: object) -> bool:
-    return _classify_key(value).is_secret_container
-
-
-def _is_secret_container_suffix_key(value: object) -> bool:
-    return _classify_key(value).is_secret_container_suffix
 
 
 def _is_sensitive_key(value: object) -> bool:
@@ -271,10 +249,6 @@ def _is_redacted_query_key(value: object) -> bool:
 
 def _is_context_secret_label_key(value: object) -> bool:
     return _classify_key(value).is_context_secret_label
-
-
-def _is_context_secret_value_key(value: object) -> bool:
-    return _classify_key(value).is_context_secret_value
 
 
 def _mapping_has_secret_context_label(value: Mapping[object, object]) -> bool:

--- a/src/mindroom/redaction.py
+++ b/src/mindroom/redaction.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import math
 import re
 from collections.abc import Mapping
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, cast
 from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
@@ -13,7 +14,13 @@ from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 from pydantic import BaseModel
 
 REDACTED = "***redacted***"
-__all__ = ["REDACTED", "redact_log_event", "redact_sensitive_data", "redact_sensitive_text"]
+__all__ = [
+    "REDACTED",
+    "key_normalization_cache_size",
+    "redact_log_event",
+    "redact_sensitive_data",
+    "redact_sensitive_text",
+]
 _TRUNCATED = "... [truncated]"
 _URL_PATTERN = re.compile(r"https?://[^\s'\"<>]+")
 _BEARER_TOKEN_PATTERN = re.compile(
@@ -143,15 +150,41 @@ def _safe_repr(value: object) -> str:
         return f"<unrepresentable: {type(value).__name__}>"
 
 
-def _normalize_key(value: object) -> str:
-    key = _safe_str(value)
-    key = re.sub(r"([A-Z]+)([A-Z][a-z])", r"\1_\2", key.strip())
-    key = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", key)
-    return re.sub(r"[^a-z0-9]+", "_", key.lower()).strip("_")
+_ACRONYM_BOUNDARY_PATTERN = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_CAMEL_BOUNDARY_PATTERN = re.compile(r"([a-z0-9])([A-Z])")
+_NON_ALPHANUMERIC_RUN_PATTERN = re.compile(r"[^a-z0-9]+")
+
+# Structured logs repeat a small set of keys at very high frequency, so classifying
+# each distinct key once and reusing the result removes the dominant per-event cost.
+# The cache is bounded on both axes: entry count, and the key length allowed in.
+# Oversized keys bypass it entirely rather than evicting real keys or pinning
+# arbitrarily large strings in memory.
+_KEY_CLASSIFICATION_CACHE_SIZE = 4096
+_MAX_CACHED_KEY_LENGTH = 256
 
 
-def _is_secret_key(value: object) -> bool:
-    normalized = _normalize_key(value)
+@dataclass(frozen=True, slots=True)
+class _KeyClassification:
+    """Every redaction decision that depends only on one key's normalized spelling."""
+
+    normalized: str
+    is_secret: bool
+    is_secret_container: bool
+    is_secret_container_suffix: bool
+    is_query_container: bool
+    is_redacted_query: bool
+    is_context_secret_label: bool
+    is_context_secret_value: bool
+
+
+def _normalize_key_text(key: str) -> str:
+    """Return the canonical snake_case spelling of one key."""
+    collapsed = _ACRONYM_BOUNDARY_PATTERN.sub(r"\1_\2", key.strip())
+    collapsed = _CAMEL_BOUNDARY_PATTERN.sub(r"\1_\2", collapsed)
+    return _NON_ALPHANUMERIC_RUN_PATTERN.sub("_", collapsed.lower()).strip("_")
+
+
+def _normalized_key_is_secret(normalized: str) -> bool:
     parts = tuple(part for part in normalized.split("_") if part)
     compact = normalized.replace("_", "")
     for key, compact_key, key_parts in _SECRET_KEY_VARIANTS:
@@ -172,39 +205,76 @@ def _is_secret_key(value: object) -> bool:
     return False
 
 
+def _classify_key_text(key: str) -> _KeyClassification:
+    """Resolve every key-derived redaction predicate in one pass."""
+    normalized = _normalize_key_text(key)
+    is_secret = _normalized_key_is_secret(normalized)
+    is_container_suffix = normalized not in _SECRET_CONTAINER_KEYS and any(
+        container_key != "tokens" and normalized.endswith(f"_{container_key}")
+        for container_key in _SECRET_CONTAINER_KEYS
+    )
+    return _KeyClassification(
+        normalized=normalized,
+        is_secret=is_secret,
+        is_secret_container=normalized in _SECRET_CONTAINER_KEYS or is_container_suffix,
+        is_secret_container_suffix=is_container_suffix,
+        is_query_container=normalized in _QUERY_CONTAINER_KEYS,
+        is_redacted_query=is_secret or normalized in _OAUTH_QUERY_KEYS or normalized in _URL_QUERY_SECRET_KEYS,
+        is_context_secret_label=normalized in _CONTEXT_SECRET_LABEL_KEYS,
+        is_context_secret_value=normalized in _CONTEXT_SECRET_VALUE_KEYS,
+    )
+
+
+_classify_key_text_cached = lru_cache(maxsize=_KEY_CLASSIFICATION_CACHE_SIZE)(_classify_key_text)
+
+
+def key_normalization_cache_size() -> int:
+    """Return how many distinct log keys are currently classified in the cache."""
+    return _classify_key_text_cached.cache_info().currsize
+
+
+def _classify_key(value: object) -> _KeyClassification:
+    key = _safe_str(value)
+    if len(key) > _MAX_CACHED_KEY_LENGTH:
+        return _classify_key_text(key)
+    return _classify_key_text_cached(key)
+
+
+def _normalize_key(value: object) -> str:
+    return _classify_key(value).normalized
+
+
+def _is_secret_key(value: object) -> bool:
+    return _classify_key(value).is_secret
+
+
 def _is_secret_container_key(value: object) -> bool:
-    normalized = _normalize_key(value)
-    if normalized in _SECRET_CONTAINER_KEYS:
-        return True
-    return _is_secret_container_suffix_key(value)
+    return _classify_key(value).is_secret_container
 
 
 def _is_secret_container_suffix_key(value: object) -> bool:
-    normalized = _normalize_key(value)
-    if normalized in _SECRET_CONTAINER_KEYS:
-        return False
-    return any(key != "tokens" and normalized.endswith(f"_{key}") for key in _SECRET_CONTAINER_KEYS)
+    return _classify_key(value).is_secret_container_suffix
 
 
 def _is_sensitive_key(value: object) -> bool:
-    return _is_secret_key(value) or _is_secret_container_key(value)
+    classification = _classify_key(value)
+    return classification.is_secret or classification.is_secret_container
 
 
 def _is_query_container(value: str | None) -> bool:
-    return value is not None and _normalize_key(value) in _QUERY_CONTAINER_KEYS
+    return value is not None and _classify_key(value).is_query_container
 
 
 def _is_redacted_query_key(value: object) -> bool:
-    normalized = _normalize_key(value)
-    return _is_secret_key(value) or normalized in _OAUTH_QUERY_KEYS or normalized in _URL_QUERY_SECRET_KEYS
+    return _classify_key(value).is_redacted_query
 
 
 def _is_context_secret_label_key(value: object) -> bool:
-    return _normalize_key(value) in _CONTEXT_SECRET_LABEL_KEYS
+    return _classify_key(value).is_context_secret_label
 
 
 def _is_context_secret_value_key(value: object) -> bool:
-    return _normalize_key(value) in _CONTEXT_SECRET_VALUE_KEYS
+    return _classify_key(value).is_context_secret_value
 
 
 def _mapping_has_secret_context_label(value: Mapping[object, object]) -> bool:
@@ -221,11 +291,12 @@ def _should_force_redact_container_value(value: object) -> bool:
 
 
 def _should_redact_value_for_key(key: object, value: object) -> bool:
-    if _is_secret_key(key):
+    classification = _classify_key(key)
+    if classification.is_secret:
         return True
-    if _is_secret_container_suffix_key(key):
+    if classification.is_secret_container_suffix:
         return _should_force_redact_container_value(value)
-    return _is_secret_container_key(key)
+    return classification.is_secret_container
 
 
 def _redact_matched_token(match: re.Match[str], group_name: str = "token") -> str:
@@ -251,8 +322,9 @@ def _redact_nested_assignment_value(match: re.Match[str]) -> str:
 
 def _redact_secret_assignment(match: re.Match[str]) -> str:
     key = match.group("key")
-    normalized_key = _normalize_key(key)
-    if not _is_secret_key(key):
+    classification = _classify_key(key)
+    normalized_key = classification.normalized
+    if not classification.is_secret:
         return _redact_nested_assignment_value(match)
     value = match.group("value")
     if (
@@ -375,15 +447,17 @@ def _redact_mapping(
 ) -> dict[str, _RedactedValue]:
     redacted: dict[str, _RedactedValue] = {}
     has_secret_context_label = _mapping_has_secret_context_label(value)
+    parent_is_query_container = _is_query_container(parent_key)
     for index, (key, item) in enumerate(value.items()):
         if max_collection_items is not None and index >= max_collection_items:
             redacted["__truncated__"] = f"{len(value) - max_collection_items} more items"
             break
         key_text = _safe_str(key)
+        classification = _classify_key(key)
         redact_key = (
             _should_redact_value_for_key(key, item)
-            or (_is_query_container(parent_key) and _is_redacted_query_key(key))
-            or (has_secret_context_label and _is_context_secret_value_key(key))
+            or (parent_is_query_container and classification.is_redacted_query)
+            or (has_secret_context_label and classification.is_context_secret_value)
         )
         redacted[key_text] = redact_sensitive_data(
             item,

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -42,11 +42,11 @@ def _debug_enabled(bound_logger: object) -> bool:
     loggers must never lose a diagnostic to this check.
     """
     is_enabled_for = getattr(bound_logger, "isEnabledFor", None)
-    if is_enabled_for is None:
+    if not callable(is_enabled_for):
         return True
     try:
         return bool(is_enabled_for(logging.DEBUG))
-    except AttributeError:
+    except Exception:
         return True
 
 

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import functools
 import inspect
+import logging
 import os
 import time
 from contextlib import contextmanager
@@ -31,6 +32,22 @@ _DISPATCH_PIPELINE_TIMING_KEY = "com.mindroom.dispatch_pipeline_timing"
 
 def _is_enabled() -> bool:
     return os.environ.get("MINDROOM_TIMING", "") == "1"
+
+
+def _debug_enabled(bound_logger: object) -> bool:
+    """Return whether one logger would keep a debug event.
+
+    Only used to skip work that would be discarded, so anything that cannot
+    answer the question counts as enabled: test doubles and non-stdlib structlog
+    loggers must never lose a diagnostic to this check.
+    """
+    is_enabled_for = getattr(bound_logger, "isEnabledFor", None)
+    if is_enabled_for is None:
+        return True
+    try:
+        return bool(is_enabled_for(logging.DEBUG))
+    except AttributeError:
+        return True
 
 
 def timing_enabled() -> bool:
@@ -134,6 +151,8 @@ class DispatchPipelineTiming:
         if self.summary_emitted:
             return
         self.summary_emitted = True
+        if not _debug_enabled(logger):
+            return
         summary: dict[str, Any] = {
             "source_event_id": self.source_event_id,
             "room_id": self.room_id,
@@ -190,11 +209,10 @@ def emit_timing_event(event_name: str, **event_data: object) -> None:
 
     Emitted at ``debug`` level so callers can keep ``MINDROOM_TIMING=1`` enabled
     in long-running processes and still flip emission off cheaply via the global
-    log level. With ``MINDROOM_TIMING=1`` and log level at INFO or above, the
-    stdlib ``isEnabledFor(DEBUG)`` check short-circuits before formatting and
-    handler dispatch.
+    log level. The ``isEnabledFor`` check runs before the payload is assembled,
+    so a dropped event costs one level lookup rather than a discarded dict.
     """
-    if not _is_enabled():
+    if not _is_enabled() or not _debug_enabled(logger):
         return
     scope = event_data.pop("timing_scope", None)
     if not isinstance(scope, str) or not scope:

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -807,17 +807,6 @@ def _module_origin_within_root(module: ModuleType, root: Path) -> bool:
     return _module_file_within_root(module_file, str(root))
 
 
-def _clear_module_origin_caches() -> None:
-    """Drop cached module-origin results.
-
-    Loaded modules keep the ``__file__`` they were imported from, so these entries
-    stay valid for the life of the process; clearing exists for tests that install
-    modules at synthetic paths.
-    """
-    _resolved_module_file.cache_clear()
-    _module_file_within_root.cache_clear()
-
-
 def _execute_validation_plugin_module(
     plugin_name: str,
     plugin_root: Path,

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -792,13 +792,30 @@ def _resolved_module_file(module_file: str) -> Path | None:
         return None
 
 
+@functools.lru_cache(maxsize=8192)
+def _module_file_within_root(module_file: str, root: str) -> bool:
+    """Return whether one module file lives under one plugin root, cached across calls."""
+    resolved = _resolved_module_file(module_file)
+    return resolved is not None and resolved.is_relative_to(root)
+
+
 def _module_origin_within_root(module: ModuleType, root: Path) -> bool:
     """Return whether one loaded module originates from within one plugin root."""
     module_file = getattr(module, "__file__", None)
     if not isinstance(module_file, str):
         return False
-    resolved = _resolved_module_file(module_file)
-    return resolved is not None and resolved.is_relative_to(root)
+    return _module_file_within_root(module_file, str(root))
+
+
+def _clear_module_origin_caches() -> None:
+    """Drop cached module-origin results.
+
+    Loaded modules keep the ``__file__`` they were imported from, so these entries
+    stay valid for the life of the process; clearing exists for tests that install
+    modules at synthetic paths.
+    """
+    _resolved_module_file.cache_clear()
+    _module_file_within_root.cache_clear()
 
 
 def _execute_validation_plugin_module(

--- a/tests/api/test_config_includes.py
+++ b/tests/api/test_config_includes.py
@@ -546,6 +546,36 @@ async def test_watch_config_recovers_after_fixing_a_broken_new_include(
 
 
 @pytest.mark.asyncio
+async def test_watched_config_mtimes_retries_when_snapshot_changes_during_scan(
+    monkeypatch: pytest.MonkeyPatch,
+    split_app: FastAPI,
+    tmp_path: Path,
+) -> None:
+    """A completed scan must belong to the snapshot returned with it."""
+    replacement_config_path = _write_split_config(tmp_path / "replacement")
+    replacement_runtime_paths = constants.resolve_primary_runtime_paths(
+        config_path=replacement_config_path,
+        storage_path=tmp_path / "replacement-storage",
+        process_env={},
+    )
+    scanned_paths: list[frozenset[Path]] = []
+
+    async def fake_to_thread(function: Callable[..., object], paths: frozenset[Path]) -> object:
+        scanned_paths.append(paths)
+        if len(scanned_paths) == 1:
+            main.initialize_api_app(split_app, replacement_runtime_paths)
+        return function(paths)
+
+    monkeypatch.setattr(main.asyncio, "to_thread", fake_to_thread)
+
+    runtime_paths, mtimes = await main._watched_config_mtimes(split_app)
+
+    assert runtime_paths == replacement_runtime_paths
+    assert set(mtimes) == {replacement_config_path}
+    assert len(scanned_paths) == 2
+
+
+@pytest.mark.asyncio
 async def test_api_config_watcher_scans_off_the_event_loop(
     monkeypatch: pytest.MonkeyPatch,
     split_runtime_paths: constants.RuntimePaths,

--- a/tests/api/test_config_includes.py
+++ b/tests/api/test_config_includes.py
@@ -543,3 +543,29 @@ async def test_watch_config_recovers_after_fixing_a_broken_new_include(
 
     stop_event.set()
     await watch_task
+
+
+@pytest.mark.asyncio
+async def test_api_config_watcher_scans_off_the_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    split_runtime_paths: constants.RuntimePaths,
+) -> None:
+    """The API watcher stats every config source each poll, so it must offload the scan."""
+    main.initialize_api_app(main.app, split_runtime_paths)
+    assert config_lifecycle.load_config_into_app(split_runtime_paths, main.app) is True
+
+    offloaded: list[str] = []
+    stop_event = asyncio.Event()
+
+    async def fake_to_thread(function: Callable[..., object], *args: object, **kwargs: object) -> object:
+        offloaded.append(getattr(function, "__name__", repr(function)))
+        return function(*args, **kwargs)
+
+    monkeypatch.setattr(main.asyncio, "to_thread", fake_to_thread)
+
+    watch_task = asyncio.create_task(main._watch_config(stop_event, main.app, poll_interval_seconds=0.01))
+    await asyncio.sleep(0.05)
+    stop_event.set()
+    await asyncio.wait_for(watch_task, timeout=2)
+
+    assert offloaded.count("paths_mtime_snapshot") >= 2

--- a/tests/test_config_yaml_includes.py
+++ b/tests/test_config_yaml_includes.py
@@ -6,7 +6,7 @@ import asyncio
 import os
 import time
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 import yaml
@@ -20,6 +20,9 @@ from mindroom.config.yaml_includes import ConfigIncludeError, load_yaml_config_s
 from mindroom.constants import resolve_runtime_paths
 from mindroom.orchestration.config_lifecycle import ConfigReloadLifecycle
 from mindroom.response_admission import ResponseAdmissionGate
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 runner = CliRunner()
 
@@ -457,6 +460,34 @@ class TestRoundTripEquivalence:
 
 class TestWatchPaths:
     """The dynamic multi-file watcher backing include-aware hot reload."""
+
+    @pytest.mark.asyncio
+    async def test_scans_run_off_the_event_loop(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Stat scans must cross the thread offload boundary, not block the loop."""
+        monkeypatch.setattr(file_watcher, "_WATCH_SCAN_INTERVAL_SECONDS", 0.001)
+        path = _write(tmp_path / "config.yaml", "a: 1\n")
+        offloaded: list[str] = []
+        stop_event = asyncio.Event()
+
+        async def fake_to_thread(function: Callable[..., object], *args: object, **kwargs: object) -> object:
+            offloaded.append(getattr(function, "__name__", repr(function)))
+            return function(*args, **kwargs)
+
+        async def on_change() -> None:
+            return
+
+        monkeypatch.setattr(file_watcher.asyncio, "to_thread", fake_to_thread)
+        watch_task = asyncio.create_task(file_watcher.watch_paths(lambda: (path,), on_change, stop_event))
+        await asyncio.sleep(0.05)
+        stop_event.set()
+        await asyncio.wait_for(watch_task, timeout=2)
+
+        assert offloaded
+        assert set(offloaded) == {"paths_mtime_snapshot"}
 
     @pytest.mark.asyncio
     async def test_change_to_any_watched_file_triggers_callback(

--- a/tests/test_dynamic_workflows.py
+++ b/tests/test_dynamic_workflows.py
@@ -33,6 +33,7 @@ from mindroom.dynamic_workflows.service import DynamicWorkflowService
 from mindroom.dynamic_workflows.store import DynamicWorkflowStore
 from mindroom.dynamic_workflows.validation import DynamicWorkflowError
 from mindroom.entity_resolution import entity_identity_registry
+from mindroom.matrix.state import MatrixState
 from mindroom.message_target import MessageTarget
 from mindroom.tool_approval import ToolCallWorkflowOrigin, _matching_tool_approval_rule, _shutdown_approval_store
 from mindroom.tool_system.metadata import TOOL_METADATA
@@ -2010,12 +2011,9 @@ def test_room_agent_participant_rebinds_context_and_uses_isolated_state(tmp_path
         context.runtime_paths,
     )
     runtime_paths = runtime_paths_for(config)
-    (runtime_paths.storage_root / "matrix_state.yaml").write_text(
-        yaml.safe_dump(
-            {"rooms": {"lobby": {"room_id": "!room:localhost", "alias": "#lobby:localhost", "name": "Lobby"}}},
-        ),
-        encoding="utf-8",
-    )
+    state = MatrixState.load(runtime_paths=runtime_paths)
+    state.add_room("lobby", room_id="!room:localhost", alias="#lobby:localhost", name="Lobby")
+    state.save(runtime_paths=runtime_paths)
     persist_entity_accounts(config, runtime_paths)
     context = replace(context, config=config, runtime_paths=runtime_paths)
     parent_loop = asyncio.new_event_loop()

--- a/tests/test_matrix_identity.py
+++ b/tests/test_matrix_identity.py
@@ -22,7 +22,7 @@ from mindroom.matrix.identity import (
     parse_historical_matrix_user_id,
     try_parse_historical_matrix_user_id,
 )
-from mindroom.matrix.state import MatrixState
+from mindroom.matrix.state import MatrixState, _write_matrix_state_file
 from mindroom.matrix_identifiers import agent_username_localpart, unnamespaced_agent_name_from_username_localpart
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 from tests.identity_helpers import entity_ids, persist_entity_accounts
@@ -371,20 +371,17 @@ class TestHelperFunctions:
         self.config = _bind_runtime_paths(self.config, tmp_path)
         runtime_paths = runtime_paths_for(self.config)
         state_file = constants_mod.matrix_state_file(runtime_paths=runtime_paths)
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        state_file.write_text(
-            yaml.safe_dump(
-                {
-                    "accounts": {
-                        "agent_general": {
-                            "username": "mindroom_general_oldns",
-                            "password": "pw",
-                            "known_user_ids": ["@mindroom_general_oldns:legacy.example.com"],
-                        },
+        _write_matrix_state_file(
+            state_file,
+            {
+                "accounts": {
+                    "agent_general": {
+                        "username": "mindroom_general_oldns",
+                        "password": "pw",
+                        "known_user_ids": ["@mindroom_general_oldns:legacy.example.com"],
                     },
                 },
-                sort_keys=False,
-            ),
+            },
         )
 
         state = MatrixState.load(runtime_paths=runtime_paths)
@@ -399,21 +396,17 @@ class TestHelperFunctions:
         self.config = _bind_runtime_paths(self.config, tmp_path)
         runtime_paths = runtime_paths_for(self.config)
         state_file = constants_mod.matrix_state_file(runtime_paths=runtime_paths)
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        state_file.write_text(
-            yaml.safe_dump(
-                {
-                    "accounts": {
-                        "agent_general": {
-                            "username": "actual_general",
-                            "password": "pw",
-                            "domain": "matrix.example",
-                        },
+        _write_matrix_state_file(
+            state_file,
+            {
+                "accounts": {
+                    "agent_general": {
+                        "username": "actual_general",
+                        "password": "pw",
+                        "domain": "matrix.example",
                     },
                 },
-                sort_keys=False,
-            ),
-            encoding="utf-8",
+            },
         )
 
         state = MatrixState.load(runtime_paths=runtime_paths)
@@ -432,20 +425,16 @@ class TestHelperFunctions:
         self.config = _bind_runtime_paths(self.config, tmp_path)
         runtime_paths = runtime_paths_for(self.config)
         state_file = constants_mod.matrix_state_file(runtime_paths=runtime_paths)
-        state_file.parent.mkdir(parents=True, exist_ok=True)
-        state_file.write_text(
-            yaml.safe_dump(
-                {
-                    "accounts": {
-                        "agent_general": {
-                            "username": "mindroom_general_oldns",
-                            "password": "pw",
-                        },
+        _write_matrix_state_file(
+            state_file,
+            {
+                "accounts": {
+                    "agent_general": {
+                        "username": "mindroom_general_oldns",
+                        "password": "pw",
                     },
                 },
-                sort_keys=False,
-            ),
-            encoding="utf-8",
+            },
         )
 
         def _fail_flock(*_args: object, **_kwargs: object) -> None:

--- a/tests/test_matrix_state_cache.py
+++ b/tests/test_matrix_state_cache.py
@@ -140,6 +140,7 @@ def test_matrix_state_cached_reads_do_not_stat_the_file(tmp_path: Path, monkeypa
     runtime_paths = test_runtime_paths(tmp_path)
     state_file = _seed_state(runtime_paths, "dev", "!dev:localhost")
     _load_matrix_state_file_cached.cache_clear()
+    monkeypatch.setattr(matrix_state, "monotonic", lambda: 0.0)
     first = matrix_state_for_runtime(runtime_paths)
     stat_calls = 0
     original_stat = Path.stat
@@ -173,3 +174,31 @@ def test_matrix_state_cache_observes_first_write_after_missing_read(tmp_path: Pa
     written = matrix_state_for_runtime(runtime_paths)
     assert written is not missing
     assert written.get_room("dev") is not None
+
+
+def test_matrix_state_cache_observes_external_write_after_stat_ttl(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """A write from another process must become visible after the stat TTL."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    state_file = _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _load_matrix_state_file_cached.cache_clear()
+    now = 0.0
+    monkeypatch.setattr(matrix_state, "monotonic", lambda: now)
+    monkeypatch.setattr(matrix_state, "_MATRIX_STATE_STAT_TTL_SECONDS", 1.0)
+
+    first = matrix_state_for_runtime(runtime_paths)
+    external = first.model_copy(deep=True)
+    external.add_room("research", room_id="!research:localhost", alias="#research:localhost", name="research")
+    state_file.write_text(
+        matrix_state.yaml_io.safe_dump(
+            external.model_dump(mode="json"),
+            default_flow_style=False,
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    now = 1.0
+
+    second = matrix_state_for_runtime(runtime_paths)
+
+    assert second is not first
+    assert second.get_room("research") is not None

--- a/tests/test_matrix_state_cache.py
+++ b/tests/test_matrix_state_cache.py
@@ -3,15 +3,12 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 from mindroom import constants
 from mindroom.matrix import state as matrix_state
 from mindroom.matrix.state import MatrixState, _load_matrix_state_file_cached, matrix_state_for_runtime
 from tests.conftest import test_runtime_paths
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _seed_state(runtime_paths: constants.RuntimePaths, room_key: str, room_id: str) -> Path:
@@ -136,3 +133,33 @@ def test_resolve_room_aliases_does_not_reparse_yaml(
     matrix_state.resolve_room_aliases(["dev"], runtime_paths)
 
     assert safe_load_calls == 1
+
+
+def test_matrix_state_cache_key_stats_the_file_once(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """The cache key is built on every read, so it must not stat the file twice."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    state_file = _seed_state(runtime_paths, "dev", "!dev:localhost")
+    stat_calls = 0
+    original_stat = Path.stat
+
+    def counting_stat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
+        nonlocal stat_calls
+        if self == state_file:
+            stat_calls += 1
+        return original_stat(self, *args, **kwargs)
+
+    monkeypatch.setattr(matrix_state.Path, "stat", counting_stat)
+
+    key = matrix_state._matrix_state_cache_key(state_file)
+
+    assert key[0] == state_file
+    assert key[1] is not None
+    assert key[2] is not None
+    assert stat_calls == 1
+
+
+def test_matrix_state_cache_key_reports_missing_file_without_stat_details(tmp_path: Path) -> None:
+    """A missing state file must still key as absent rather than raising."""
+    missing = tmp_path / "nonexistent" / "matrix_state.yaml"
+
+    assert matrix_state._matrix_state_cache_key(missing) == (missing, None, None)

--- a/tests/test_matrix_state_cache.py
+++ b/tests/test_matrix_state_cache.py
@@ -1,14 +1,17 @@
-"""Tests for the file-mtime-keyed cache around the Matrix state YAML."""
+"""Tests for the generation-keyed cache around the Matrix state YAML."""
 
 from __future__ import annotations
 
-import os
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from mindroom import constants
 from mindroom.matrix import state as matrix_state
 from mindroom.matrix.state import MatrixState, _load_matrix_state_file_cached, matrix_state_for_runtime
 from tests.conftest import test_runtime_paths
+
+if TYPE_CHECKING:
+    import os
 
 
 def _seed_state(runtime_paths: constants.RuntimePaths, room_key: str, room_id: str) -> Path:
@@ -34,10 +37,10 @@ def test_matrix_state_cache_hits_when_file_unchanged(tmp_path: Path) -> None:
     assert info.misses == 1
 
 
-def test_matrix_state_cache_invalidates_when_file_mtime_changes(tmp_path: Path) -> None:
-    """Touching the state file should bypass the cache and produce a fresh state."""
+def test_matrix_state_cache_invalidates_after_write(tmp_path: Path) -> None:
+    """Saving state should bypass the cache and make the next read fresh."""
     runtime_paths = test_runtime_paths(tmp_path)
-    state_file = _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _seed_state(runtime_paths, "dev", "!dev:localhost")
     _load_matrix_state_file_cached.cache_clear()
 
     first = matrix_state_for_runtime(runtime_paths)
@@ -47,9 +50,6 @@ def test_matrix_state_cache_invalidates_when_file_mtime_changes(tmp_path: Path) 
     fresh = MatrixState.load(runtime_paths=runtime_paths)
     fresh.add_room("research", room_id="!research:localhost", alias="#research:localhost", name="research")
     fresh.save(runtime_paths=runtime_paths)
-
-    stat = state_file.stat()
-    os.utime(state_file, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
 
     second = matrix_state_for_runtime(runtime_paths)
     assert second is not first
@@ -135,10 +135,12 @@ def test_resolve_room_aliases_does_not_reparse_yaml(
     assert safe_load_calls == 1
 
 
-def test_matrix_state_cache_key_stats_the_file_once(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
-    """The cache key is built on every read, so it must not stat the file twice."""
+def test_matrix_state_cached_reads_do_not_stat_the_file(tmp_path: Path, monkeypatch) -> None:  # noqa: ANN001
+    """Repeated reads of cached state must not stat the file."""
     runtime_paths = test_runtime_paths(tmp_path)
     state_file = _seed_state(runtime_paths, "dev", "!dev:localhost")
+    _load_matrix_state_file_cached.cache_clear()
+    first = matrix_state_for_runtime(runtime_paths)
     stat_calls = 0
     original_stat = Path.stat
 
@@ -150,16 +152,24 @@ def test_matrix_state_cache_key_stats_the_file_once(tmp_path: Path, monkeypatch)
 
     monkeypatch.setattr(matrix_state.Path, "stat", counting_stat)
 
-    key = matrix_state._matrix_state_cache_key(state_file)
+    second = matrix_state_for_runtime(runtime_paths)
+    third = matrix_state_for_runtime(runtime_paths)
 
-    assert key[0] == state_file
-    assert key[1] is not None
-    assert key[2] is not None
-    assert stat_calls == 1
+    assert second is first
+    assert third is first
+    assert stat_calls == 0
 
 
-def test_matrix_state_cache_key_reports_missing_file_without_stat_details(tmp_path: Path) -> None:
-    """A missing state file must still key as absent rather than raising."""
-    missing = tmp_path / "nonexistent" / "matrix_state.yaml"
+def test_matrix_state_cache_observes_first_write_after_missing_read(tmp_path: Path) -> None:
+    """A write must invalidate a cached empty state for a previously missing file."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    _load_matrix_state_file_cached.cache_clear()
 
-    assert matrix_state._matrix_state_cache_key(missing) == (missing, None, None)
+    missing = matrix_state_for_runtime(runtime_paths)
+    assert missing.rooms == {}
+
+    _seed_state(runtime_paths, "dev", "!dev:localhost")
+
+    written = matrix_state_for_runtime(runtime_paths)
+    assert written is not missing
+    assert written.get_room("dev") is not None

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -329,6 +329,11 @@ def _count_key_normalizations(monkeypatch: pytest.MonkeyPatch) -> Callable[[], i
     return take
 
 
+def _key_normalization_cache_size() -> int:
+    """Return the cache size for test assertions."""
+    return redaction._classify_key_text_cached.cache_info().currsize
+
+
 def test_repeated_log_events_normalize_each_key_only_once(monkeypatch: pytest.MonkeyPatch) -> None:
     """High-frequency structured logs repeat the same keys and must not re-normalize them."""
     # Unique keys keep the first event cold regardless of what earlier tests cached.
@@ -358,18 +363,18 @@ def test_key_normalization_cache_is_bounded() -> None:
 
     redact_log_event(None, "debug", {f"field_{index}": index for index in range(distinct_keys)})
 
-    assert 0 < redaction.key_normalization_cache_size() < distinct_keys
+    assert 0 < _key_normalization_cache_size() < distinct_keys
 
 
 def test_oversized_log_keys_are_not_cached_but_still_redact() -> None:
     """Pathologically long keys must bypass the cache so its memory stays bounded."""
     long_secret_key = "x" * 4096 + "_api_key"
-    before = redaction.key_normalization_cache_size()
+    before = _key_normalization_cache_size()
 
     redacted = redact_sensitive_data({long_secret_key: "plain-secret"})
 
     assert redacted == {long_secret_key: REDACTED}
-    assert redaction.key_normalization_cache_size() == before
+    assert _key_normalization_cache_size() == before
 
 
 # Key classification is security-relevant, so it is pinned explicitly rather than

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -4,8 +4,16 @@ from __future__ import annotations
 
 import json
 import time
+from typing import TYPE_CHECKING
+from uuid import uuid4
 
-from mindroom.redaction import REDACTED, redact_sensitive_data, redact_sensitive_text
+import pytest
+
+from mindroom import redaction
+from mindroom.redaction import REDACTED, redact_log_event, redact_sensitive_data, redact_sensitive_text
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def test_redact_sensitive_data_redacts_nested_dicts_lists_and_header_variants() -> None:
@@ -295,3 +303,167 @@ def test_redact_sensitive_text_still_redacts_assignments_at_run_boundaries() -> 
     assert "hunter2" not in redacted
     assert "abc" not in redacted
     assert "api_key" in redacted
+
+
+def _count_key_normalizations(monkeypatch: pytest.MonkeyPatch) -> Callable[[], int]:
+    """Count how many keys get normalized from scratch rather than served from cache.
+
+    ``_classify_key_text`` resolves ``_normalize_key_text`` as a module global on
+    every call, so this probe sees the work even when it runs behind the cache.
+    """
+    calls = 0
+    original_normalize = redaction._normalize_key_text
+
+    def counting_normalize(key: str) -> str:
+        nonlocal calls
+        calls += 1
+        return original_normalize(key)
+
+    monkeypatch.setattr(redaction, "_normalize_key_text", counting_normalize)
+
+    def take() -> int:
+        nonlocal calls
+        count, calls = calls, 0
+        return count
+
+    return take
+
+
+def test_repeated_log_events_normalize_each_key_only_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """High-frequency structured logs repeat the same keys and must not re-normalize them."""
+    # Unique keys keep the first event cold regardless of what earlier tests cached.
+    unique = uuid4().hex
+    event = {
+        f"event_{unique}": "dispatch delivery timing",
+        f"phase_{unique}": "queued",
+        f"queue_size_{unique}": 7,
+        f"progress_hint_{unique}": True,
+        f"boundary_refresh_{unique}": False,
+        f"timing_scope_{unique}": "scope-value",
+    }
+    take_count = _count_key_normalizations(monkeypatch)
+
+    redact_log_event(None, "debug", dict(event))
+    first_event_calls = take_count()
+    redact_log_event(None, "debug", dict(event))
+    second_event_calls = take_count()
+
+    assert first_event_calls == len(event)
+    assert second_event_calls == 0
+
+
+def test_key_normalization_cache_is_bounded() -> None:
+    """An unbounded cache keyed on arbitrary log keys would leak, so it must evict."""
+    distinct_keys = 50_000
+
+    redact_log_event(None, "debug", {f"field_{index}": index for index in range(distinct_keys)})
+
+    assert 0 < redaction.key_normalization_cache_size() < distinct_keys
+
+
+def test_oversized_log_keys_are_not_cached_but_still_redact() -> None:
+    """Pathologically long keys must bypass the cache so its memory stays bounded."""
+    long_secret_key = "x" * 4096 + "_api_key"
+    before = redaction.key_normalization_cache_size()
+
+    redacted = redact_sensitive_data({long_secret_key: "plain-secret"})
+
+    assert redacted == {long_secret_key: REDACTED}
+    assert redaction.key_normalization_cache_size() == before
+
+
+# Key classification is security-relevant, so it is pinned explicitly rather than
+# derived: a cache that reclassified any of these would silently change redaction.
+_REDACTED_KEYS = (
+    "ACCESS-TOKEN",
+    "API_KEY",
+    "AUTHORIZATION",
+    "ApiKey",
+    "Bearer_Token",
+    "Cookie",
+    "HTTPAPIKey",
+    "Password",
+    "TOKEN",
+    "Token",
+    "X-Api-Key",
+    "accessToken",
+    "access_token",
+    "api-key",
+    "apiKey",
+    "api_key",
+    "api_keys",
+    "auth_token",
+    "authentication-info",
+    "authorization",
+    "backup_credentials",
+    "clientSecret",
+    "client_secret",
+    "cookie",
+    "credentials",
+    "has_credentials",
+    "id_token",
+    "num_secrets",
+    "oauth_tokens",
+    "openai_api_key",
+    "password",
+    "password_policy",
+    "refreshToken",
+    "secret_sauce_recipe",
+    "secrets",
+    "security_token",
+    "session_token",
+    "set-cookie",
+    "show_passwords",
+    "token",
+    "tokens",
+    "user-password",
+    "user.password",
+    "www-authenticate",
+    "x-api-key",
+    "x_token",
+)
+_KEPT_KEYS = (
+    "XMLHttpToken",
+    "input_tokens",
+    "max_tokens",
+    "message",
+    "my_token",
+    "name",
+    "next_token",
+    "output_tokens",
+    "queue_size",
+    "tokenCount",
+    "tokenizer",
+    "x-ratelimit-remaining-tokens",
+)
+
+
+@pytest.mark.parametrize("key", _REDACTED_KEYS)
+def test_secret_key_variants_redact_identically_when_cached_and_uncached(key: str) -> None:
+    """Memoized lookups must classify every case/format variant exactly as a cold lookup does."""
+    cold = redact_sensitive_data({key: "plain-secret"})
+    warm = redact_sensitive_data({key: "plain-secret"})
+
+    assert cold == {key: REDACTED}
+    assert warm == cold
+
+
+@pytest.mark.parametrize("key", _KEPT_KEYS)
+def test_non_secret_key_variants_survive_identically_when_cached_and_uncached(key: str) -> None:
+    """Memoization must not start redacting keys that a cold lookup keeps."""
+    cold = redact_sensitive_data({key: "kept-value"})
+    warm = redact_sensitive_data({key: "kept-value"})
+
+    assert cold == {key: "kept-value"}
+    assert warm == cold
+
+
+def test_cache_eviction_does_not_change_key_classification() -> None:
+    """Classification must survive eviction: a re-resolved key must match its first result."""
+    probe_keys = (*_REDACTED_KEYS, *_KEPT_KEYS)
+    before = {key: redact_sensitive_data({key: "probe-value"}) for key in probe_keys}
+
+    # Flood the cache with far more distinct keys than it can hold.
+    redact_log_event(None, "debug", {f"flood_{index}": index for index in range(50_000)})
+
+    assert {key: redact_sensitive_data({key: "probe-value"}) for key in probe_keys} == before

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -601,6 +601,32 @@ def test_emit_timing_event_emits_when_the_level_check_is_unsupported(
     logger.debug.assert_called_once()
 
 
+def test_emit_timing_event_emits_when_the_level_check_is_not_callable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A non-callable compatibility attribute must not break timing events."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+    logger.isEnabledFor = False
+
+    emit_timing_event("dispatch delivery timing", phase="queued")
+
+    logger.debug.assert_called_once()
+
+
+def test_emit_timing_event_emits_when_the_level_check_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing compatibility level check must not break timing events."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+    logger.isEnabledFor.side_effect = RuntimeError("level check failed")
+
+    emit_timing_event("dispatch delivery timing", phase="queued")
+
+    logger.debug.assert_called_once()
+
+
 def test_dispatch_pipeline_summary_emits_when_the_level_check_is_unsupported() -> None:
     """The summary must survive loggers that cannot answer isEnabledFor."""
     logger = Mock()

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -529,3 +529,88 @@ def test_dispatch_pipeline_first_visible_reply_is_first_write_wins(
 
     assert timing.marks["first_visible_reply"] == 1.5
     assert timing.metadata["first_visible_kind"] == "placeholder"
+
+
+def test_emit_timing_event_builds_no_payload_when_debug_is_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """High-frequency timing events must not be assembled just to be dropped downstream."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+    logger.isEnabledFor.return_value = False
+
+    emit_timing_event("dispatch delivery timing", phase="queued", queue_size=7, progress_hint=True)
+
+    logger.debug.assert_not_called()
+
+
+def test_emit_timing_event_still_emits_when_debug_is_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The level guard must not change what an enabled timing event reports."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+    logger.isEnabledFor.return_value = True
+
+    emit_timing_event("dispatch delivery timing", phase="queued", queue_size=7, dropped=None)
+
+    logger.debug.assert_called_once()
+    assert logger.debug.call_args.args == ("dispatch delivery timing",)
+    assert logger.debug.call_args.kwargs == {"phase": "queued", "queue_size": 7}
+
+
+def test_dispatch_pipeline_summary_builds_no_payload_when_debug_is_disabled() -> None:
+    """The end-to-end summary walks every span pair, so it must not run when dropped."""
+    logger = Mock()
+    logger.isEnabledFor.return_value = False
+    timing = DispatchPipelineTiming(
+        source_event_id="$event",
+        room_id="!room",
+        marks={"message_received": 1.0, "response_complete": 2.0},
+    )
+
+    timing.emit_summary(logger, outcome="edited")
+
+    logger.debug.assert_not_called()
+    assert timing.summary_emitted
+
+
+def test_emit_timing_event_emits_when_the_logger_has_no_level_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Loggers without the stdlib level API must keep receiving timing events."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = Mock(spec_set=["debug"])
+    monkeypatch.setattr(timing_module, "logger", logger)
+
+    emit_timing_event("dispatch delivery timing", phase="queued")
+
+    logger.debug.assert_called_once()
+
+
+def test_emit_timing_event_emits_when_the_level_check_is_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A wrapped logger that cannot answer isEnabledFor must not silence the event."""
+    monkeypatch.setenv("MINDROOM_TIMING", "1")
+    logger = _mock_timing_logger(monkeypatch)
+    logger.isEnabledFor.side_effect = AttributeError("'ReturnLogger' object has no attribute 'isEnabledFor'")
+
+    emit_timing_event("dispatch delivery timing", phase="queued")
+
+    logger.debug.assert_called_once()
+
+
+def test_dispatch_pipeline_summary_emits_when_the_level_check_is_unsupported() -> None:
+    """The summary must survive loggers that cannot answer isEnabledFor."""
+    logger = Mock()
+    logger.isEnabledFor.side_effect = AttributeError("'ReturnLogger' object has no attribute 'isEnabledFor'")
+    timing = DispatchPipelineTiming(
+        source_event_id="$event",
+        room_id="!room",
+        marks={"message_received": 1.0, "response_complete": 2.0},
+    )
+
+    timing.emit_summary(logger, outcome="edited")
+
+    logger.debug.assert_called_once()

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -68,6 +68,12 @@ def _restore_builtin_tool_metadata_state() -> None:
     TOOL_METADATA.update(_BASE_TOOL_METADATA)
 
 
+def _clear_module_origin_caches() -> None:
+    """Clear module-origin caches between tests."""
+    metadata_module._resolved_module_file.cache_clear()
+    metadata_module._module_file_within_root.cache_clear()
+
+
 def test_reconcile_dynamic_tool_state_replaces_only_owned_entries() -> None:
     """Dynamic registry reconciliation should preserve unrelated tools and remove stale owned entries."""
     factory = TOOL_REGISTRY["shell"]
@@ -401,13 +407,13 @@ def test_module_origin_within_root_caches_path_resolution(
             resolve_calls += 1
         return original_resolve(self, *args, **kwargs)
 
-    metadata_module._clear_module_origin_caches()
+    _clear_module_origin_caches()
     monkeypatch.setattr(metadata_module.Path, "resolve", counted_resolve)
     try:
         assert metadata_module._module_origin_within_root(module, plugin_root)
         assert metadata_module._module_origin_within_root(module, plugin_root)
     finally:
-        metadata_module._clear_module_origin_caches()
+        _clear_module_origin_caches()
 
     assert resolve_calls == 1
 
@@ -433,14 +439,14 @@ def test_module_origin_within_root_caches_containment_checks(
         containment_calls += 1
         return original_is_relative_to(self, *args, **kwargs)
 
-    metadata_module._clear_module_origin_caches()
+    _clear_module_origin_caches()
     monkeypatch.setattr(metadata_module.Path, "is_relative_to", counted_is_relative_to)
     try:
         for _ in range(5):
             assert metadata_module._module_origin_within_root(module, plugin_root)
             assert not metadata_module._module_origin_within_root(outside_module, plugin_root)
     finally:
-        metadata_module._clear_module_origin_caches()
+        _clear_module_origin_caches()
 
     assert containment_calls == 2
 

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -401,15 +401,48 @@ def test_module_origin_within_root_caches_path_resolution(
             resolve_calls += 1
         return original_resolve(self, *args, **kwargs)
 
-    metadata_module._resolved_module_file.cache_clear()
+    metadata_module._clear_module_origin_caches()
     monkeypatch.setattr(metadata_module.Path, "resolve", counted_resolve)
     try:
         assert metadata_module._module_origin_within_root(module, plugin_root)
         assert metadata_module._module_origin_within_root(module, plugin_root)
     finally:
-        metadata_module._resolved_module_file.cache_clear()
+        metadata_module._clear_module_origin_caches()
 
     assert resolve_calls == 1
+
+
+def test_module_origin_within_root_caches_containment_checks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Plugin validation rescans all of sys.modules, so containment must resolve once."""
+    plugin_root = tmp_path / "plugins" / "demo"
+    plugin_root.mkdir(parents=True)
+    module_path = plugin_root / "helper.py"
+    module_path.write_text("VALUE = 1\n", encoding="utf-8")
+    module = ModuleType("demo.helper")
+    module.__file__ = str(module_path)
+    outside_module = ModuleType("outside.helper")
+    outside_module.__file__ = str(tmp_path / "outside.py")
+    containment_calls = 0
+    original_is_relative_to = Path.is_relative_to
+
+    def counted_is_relative_to(self: Path, *args: object, **kwargs: object) -> bool:
+        nonlocal containment_calls
+        containment_calls += 1
+        return original_is_relative_to(self, *args, **kwargs)
+
+    metadata_module._clear_module_origin_caches()
+    monkeypatch.setattr(metadata_module.Path, "is_relative_to", counted_is_relative_to)
+    try:
+        for _ in range(5):
+            assert metadata_module._module_origin_within_root(module, plugin_root)
+            assert not metadata_module._module_origin_within_root(outside_module, plugin_root)
+    finally:
+        metadata_module._clear_module_origin_caches()
+
+    assert containment_calls == 2
 
 
 def test_restore_tool_registry_snapshot_uses_sys_modules_snapshot(


### PR DESCRIPTION
Removes avoidable synchronous and repeated work from event-loop hot paths while preserving existing behavior.

## Matrix state cache

A synchronous stat on the event loop, executed per inbound event, can starve the Matrix sync task and cascade into delivery retries.

`matrix_state_for_runtime` no longer probes the filesystem on every lookup. The cache is keyed by the state path, runtime domain, an in-process write generation, and the file signature. `_write_matrix_state_file` advances the generation immediately after the atomic replacement becomes visible, so the next read after every in-process write observes the new file with no staleness window.

A second process may write the same runtime storage root, so a generation counter alone is unsafe. The file-signature stat is therefore cached in one-second buckets. Repeated reads inside a bucket perform no filesystem stat, while an external write becomes visible on the first read after the bucket changes. This bounds external staleness without putting a synchronous filesystem call back on every inbound event.

The writer search covered `mindroom connect`, provisioning, background workers, and runtime storage configuration. CLI pairing and provisioning do not write `matrix_state.yaml`, and background workers either use separate state roots or do not access Matrix state. Shared runtime storage remains a possible second-writer path, which is why the bounded stat probe is retained.

The read-only and mutating APIs remain separate: `matrix_state_for_runtime` returns the shared cached object, while `MatrixState.load` returns a deep copy.

## Other hot-path reductions

- Structured-log redaction classifies each distinct key once and uses a bounded cache. Long keys bypass the cache, and classification preserves the existing redaction verdicts.
- Timing diagnostics check the debug level before assembling payloads. Loggers without the standard level API remain fail-open so diagnostics are not silently lost.
- Plugin validation caches module-origin containment checks whose inputs remain stable for the process lifetime.
- Watched-config filesystem scans run outside the event loop while preserving scan cadence and reload behavior.

## Correctness

- Redaction tests pin secret and non-secret key variants, cache bounds, eviction behavior, and equivalence with the previous classifier.
- Timing tests cover disabled logging, enabled logging, emit-once behavior, and logger compatibility.
- Plugin tests cover warm containment lookups and cache clearing.
- Matrix-state tests cover cache hits with no filesystem stats inside the TTL, immediate invalidation after in-process writes, bounded discovery of external writes, first writes after a cached missing file, schema migration, and deep-copy isolation.
- Watcher tests cover off-loop scans and unchanged reload semantics.

## Scope

This PR does not add metadata-version memoization, queued logging handlers, or thread offloading for database work. Those changes belong in separate reviews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness by moving configuration and file-watcher scans off the main event loop.
  * Matrix state now reliably reflects newly saved changes, including after previously missing files and external updates.
  * Enhanced credential and sensitive-data redaction across varied key formats.
* **Performance**
  * Reduced unnecessary debug-log processing when debug output is disabled.
  * Improved efficiency for repeated redaction by caching bounded key normalization results.
* **Developer-facing**
  * Added a way to query the current redaction key-normalization cache size.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
