### PR TITLE
Attribute collapsed-read edit density to the homeserver, and retire a solved follow-up

### DIFF
--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -73,12 +73,21 @@ if TYPE_CHECKING:
 # message what one window function derives once, and hauls the whole superseded history across
 # the wire to do it.
 #
-# Two real agent workloads, and they differ by more than you would guess, so do not treat either
-# as the shape. One runs 53% edit rows at 6.30 edits per edited original, max 170 on one original,
-# with a thread at 94.5% edits. The other runs 28% edit rows but only ~1.07 per (original, sender),
-# so collapsing removes under 2% of its rows. Threads are small in both - p50 9 rows, max 538.
-# Where superseded edits do not accumulate this query costs about 1.3x the plain read and returns
-# almost the same rows; it earns its place on the correctness fixes below, not on that ratio.
+# Two real agent workloads measured 6x apart on edit density, and the homeserver is why. The
+# mindroom-tuwunel fork collapses superseded m.replace events per (target, sender) on read
+# (``collapse_superseded_edits``) and deletes them outright once they age past its edit-purge
+# minimum, 86,400 seconds by default. So a cache whose threads were re-read after that carries
+# ~1.07 edits per (original, sender) and loses under 2% of its rows here, for about 1.3x the plain
+# read, while one accumulating live sync inside the purge window runs 53% edit rows at 6.30 per
+# original, max 170, with a thread at 94.5% edits. Threads are small either way - p50 9 rows,
+# max 538. Expect the cheap case against that fork and the expensive one against a stock
+# homeserver; neither is the shape.
+#
+# That the fork groups by (target, sender) is worth saying twice. It is the same key this query
+# uses, arrived at independently, which is why grouping by original alone was a real defect rather
+# than a theoretical one. It also orders by ``event_id.cmp()``, bytewise, so the COLLATE "C" pin
+# below has to hold for this read to agree with the homeserver as well as with SQLite and the
+# fold.
 #
 # So be precise about what this buys, because two earlier revisions of this comment were not. It
 # does not reduce writes - it is a read-side query, and every edit is still stored. It does not
@@ -89,15 +98,21 @@ if TYPE_CHECKING:
 # is claimed, and the 2,021-row thread quoted here before was this repository's synthetic
 # fixture (20 messages x 100 edits), not a real one.
 #
-# The root fix is upstream of this query: prune superseded edits at write time and there is nothing
-# to collapse. Retention is deliberate rather than accidental, so that is a trade - redacting the
-# current winning edit is contractually supposed to reveal the previous one, which only works while
-# the older rows exist (``test_redacting_latest_edit_falls_back_to_previous_cached_edit``). The
-# trade looks sound because the case is close to unreachable: redacting a MESSAGE already removes
-# the original and every dependent edit together, and mindroom-cinny's delete targets the original
-# event ID - ``MessageDeleteItem`` passes ``mEvent.getId()``, and a replacement is only ever reached
-# through ``replacingEvent()``, which is never a redaction target there. Reaching the rollback path
-# needs the raw API, ``/redact <edit-event-id>``, or moderation tooling. Element was not checked.
+# The root fix is upstream of this query - prune superseded edits at the source and there is
+# nothing to collapse - and against the mindroom-tuwunel fork it is already built, so do not plan
+# it again as an open question. Its edit-purge service deletes superseded edits once they pass the
+# minimum age above, which also settles the trade this comment used to call undecided: redacting
+# the current winning edit is contractually supposed to reveal the previous one
+# (``test_redacting_latest_edit_falls_back_to_previous_cached_edit``), and past that age there is
+# no previous one left to reveal, wherever the read is served from. It was already close to
+# unreachable - redacting a MESSAGE removes the original and every dependent edit together, and
+# mindroom-cinny's delete targets the original event ID, since ``MessageDeleteItem`` passes
+# ``mEvent.getId()`` and a replacement is only ever reached through ``replacingEvent()``, never a
+# redaction target there. Reaching the rollback path needs the raw API,
+# ``/redact <edit-event-id>``, or moderation tooling. Element was not checked.
+#
+# What stays genuinely open is the case this cache must still handle alone: a stock homeserver that
+# neither collapses nor purges, where every superseded edit arrives and stays.
 #
 # The contract to implement, if it is built: keep only the current legitimate edit per (original,
 # sender); redacting an already-pruned edit tombstones it and is otherwise a no-op; redacting the

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -73,9 +73,12 @@ if TYPE_CHECKING:
 # message what one window function derives once, and hauls the whole superseded history across
 # the wire to do it.
 #
-# Measured on a representative agent workload: edits are 53% of all event rows, 6.30 per edited
-# original, max 170 on one original, and one thread is 94.5% edits. Threads themselves are
-# small - p50 9 rows, max 538.
+# Two real agent workloads, and they differ by more than you would guess, so do not treat either
+# as the shape. One runs 53% edit rows at 6.30 edits per edited original, max 170 on one original,
+# with a thread at 94.5% edits. The other runs 28% edit rows but only ~1.07 per (original, sender),
+# so collapsing removes under 2% of its rows. Threads are small in both - p50 9 rows, max 538.
+# Where superseded edits do not accumulate this query costs about 1.3x the plain read and returns
+# almost the same rows; it earns its place on the correctness fixes below, not on that ratio.
 #
 # So be precise about what this buys, because two earlier revisions of this comment were not. It
 # does not reduce writes - it is a read-side query, and every edit is still stored. It does not


### PR DESCRIPTION
Follow-up to #1689, which merged while this was in flight. **Comment-only; no behaviour change.**

Three claims in the merged comment were wrong or unexplained. Checking the `mindroom-tuwunel` fork
settled all three.

## 1. The 6× edit-density gap is the homeserver, not the users

The comment cited 53% edit rows at 6.30 per edited original as "representative". A second real
cache measures 28% edit rows at ~1.07 per `(original, sender)`, where collapse removes **under 2%**
of rows for ~1.3× the plain read.

The fork explains it. `collapse_superseded_edits` collapses `m.replace` events per
`(target, sender)` on read, and its edit-purge service deletes superseded edits past a minimum age
(86,400 s default). So density is a property of **when a thread was last re-read**, not of user
behaviour: re-read after the purge → ~1.07; accumulate live sync inside the window → 6.30. Both
numbers were real, neither was representative, and the comment now says which regime yields which.

## 2. The "needs a product decision" follow-up is already shipped

The comment described pruning at the source as future work requiring a decision, with retention
justified by redaction revealing the previous edit. That decision was taken upstream — past the
purge age there is no previous edit to reveal, wherever the read is served from. The genuinely open
case is narrower and now stated as such: a stock homeserver that neither collapses nor purges.

## 3. `COLLATE "C"` has a third justification

The fork tie-breaks on `event_id.cmp()`, which is bytewise. The pin keeps this read in agreement
with the **homeserver**, not only with SQLite and the Python fold.

## Corroboration worth recording

The fork groups by `(target, sender)` — the same key this query uses, arrived at independently.
That is the strongest available evidence that grouping by `original` alone was a real defect rather
than a theoretical one.

## Verification behind these numbers

`fold(collapsed)` vs `fold(raw)` on every thread of a real cache — **1,329 threads, zero
divergences** — with the shipped SQL extracted from the module rather than retyped. Read cost warm
and post-`ANALYZE`: 889 ms total / 26.0 ms slowest, against 675 ms / 17.3 ms raw. An index on
`thread_events(principal_id, room_id, thread_id, event_id)` looked like a 2.7× win on a cold,
unanalyzed database and is worth nothing warm — the exact trap the `ANALYZE` warning in that comment
already describes.