### PR TITLE
Pin thread-cache replacement fuzz coverage

### DIFF
--- a/scripts/testing/fuzz_matrix_event_cache.py
+++ b/scripts/testing/fuzz_matrix_event_cache.py
@@ -109,8 +109,9 @@ class FuzzOperation:
         if not isinstance(raw_kind, str):
             msg = "Matrix cache fuzz operation kind must be a string"
             raise TypeError(msg)
+        kind = OperationKind.MARK_ROOM_GAP if raw_kind == "mark_room_stale" else OperationKind(raw_kind)
         return cls(
-            kind=OperationKind(raw_kind),
+            kind=kind,
             room=_required_int(value, "room"),
             thread=_required_int(value, "thread"),
             slot=_required_int(value, "slot"),

--- a/scripts/testing/fuzz_matrix_event_cache.py
+++ b/scripts/testing/fuzz_matrix_event_cache.py
@@ -86,8 +86,8 @@ class OperationKind(StrEnum):
     REPLACE_THREAD = "replace_thread"
     STALE_REPLACE_THREAD = "stale_replace_thread"
     INVALIDATE_THREAD = "invalidate_thread"
-    MARK_THREAD_STALE = "mark_thread_gap"
-    MARK_ROOM_STALE = "mark_room_stale"
+    MARK_THREAD_GAP = "mark_thread_gap"
+    MARK_ROOM_GAP = "mark_room_gap"
     LIMITED_SYNC = "limited_sync"
 
 
@@ -590,8 +590,8 @@ class CacheFuzzRunner:
             OperationKind.REPLACE_THREAD: self._apply_thread_replacement,
             OperationKind.STALE_REPLACE_THREAD: self._apply_stale_thread_replacement,
             OperationKind.INVALIDATE_THREAD: self._apply_thread_invalidation,
-            OperationKind.MARK_THREAD_STALE: self._apply_thread_stale_marker,
-            OperationKind.MARK_ROOM_STALE: self._apply_room_stale_marker,
+            OperationKind.MARK_THREAD_GAP: self._apply_thread_gap_marker,
+            OperationKind.MARK_ROOM_GAP: self._apply_room_gap_marker,
             OperationKind.LIMITED_SYNC: self._apply_limited_sync,
         }
         handler = handlers.get(operation.kind)
@@ -679,7 +679,7 @@ class CacheFuzzRunner:
             thread_id(operation.room, operation.thread),
         )
 
-    async def _apply_thread_stale_marker(self, operation: FuzzOperation) -> None:
+    async def _apply_thread_gap_marker(self, operation: FuzzOperation) -> None:
         current_room_id = room_id(operation.room)
         current_thread_id = thread_id(operation.room, operation.thread)
         reason = "sync_thread_mutation" if operation.variant % 3 else "sync_opaque_encrypted_event"
@@ -699,7 +699,7 @@ class CacheFuzzRunner:
                 append_failed_reason="sync_append_failed",
             )
 
-    async def _apply_room_stale_marker(self, operation: FuzzOperation) -> None:
+    async def _apply_room_gap_marker(self, operation: FuzzOperation) -> None:
         await self.cache.mark_room_threads_gap(
             room_id(operation.room),
             reason="sync_thread_lookup_unavailable",
@@ -901,8 +901,8 @@ _WEIGHTED_KINDS = (
     OperationKind.REPLACE_THREAD,
     OperationKind.STALE_REPLACE_THREAD,
     OperationKind.INVALIDATE_THREAD,
-    OperationKind.MARK_THREAD_STALE,
-    OperationKind.MARK_ROOM_STALE,
+    OperationKind.MARK_THREAD_GAP,
+    OperationKind.MARK_ROOM_GAP,
     OperationKind.LIMITED_SYNC,
 )
 

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -729,7 +729,8 @@ async def _thread_snapshot_is_newer_than_fetch(
     fetch_started_at: float,
 ) -> bool:
     """Return whether an installed snapshot came from a strictly newer fetch than this one."""
-    cursor = await db.execute(
+    row = await fetchone(
+        db,
         """
         SELECT snapshot_fetch_started_at
         FROM mindroom_event_cache_thread_state
@@ -737,7 +738,6 @@ async def _thread_snapshot_is_newer_than_fetch(
         """,
         (namespace, room_id, thread_id),
     )
-    row = await cursor.fetchone()
     if row is None or row[0] is None:
         return False
     return float(row[0]) > fetch_started_at

--- a/tests/test_bulk_thread_backfill.py
+++ b/tests/test_bulk_thread_backfill.py
@@ -203,17 +203,14 @@ async def test_bulk_refresh_page_budget_stores_found_threads_and_reports_remaini
     assert event_cache.replace_thread.await_args.args[1] == "$a:localhost"
 
 
-def _cached_message_source(event_id: str, *, thread_id: str | None = None) -> dict[str, Any]:
-    content: dict[str, Any] = {"body": event_id, "msgtype": "m.text"}
-    if thread_id is not None:
-        content["m.relates_to"] = {"rel_type": "m.thread", "event_id": thread_id}
+def _cached_message_source(event_id: str) -> dict[str, Any]:
     return {
         "event_id": event_id,
         "sender": "@alice:localhost",
         "origin_server_ts": 1_000,
         "room_id": _ROOM_ID,
         "type": "m.room.message",
-        "content": content,
+        "content": {"body": event_id, "msgtype": "m.text"},
     }
 
 

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -1734,10 +1734,10 @@ async def test_postgres_event_cache_recovers_after_backend_connection_terminatio
 
 
 @pytest.mark.asyncio
-async def test_postgres_event_cache_flushes_pending_invalidations_before_guarded_replace(
+async def test_postgres_event_cache_flushes_pending_gaps_before_replace(
     postgres_event_cache_url: str,
 ) -> None:
-    """A deferred stale marker must be persisted before a guarded cache replacement can win."""
+    """A deferred gap marker must be persisted before a cache replacement lands."""
     room_id = "!room:localhost"
     thread_id = "$thread"
     root_event = _message_event(
@@ -1922,7 +1922,7 @@ async def test_postgres_event_cache_preserves_pending_marker_recorded_during_flu
 async def test_postgres_event_cache_pending_thread_flush_does_not_downgrade_newer_durable_marker(
     postgres_event_cache_url: str,
 ) -> None:
-    """An older pending thread marker must not overwrite a newer durable invalidation."""
+    """An older pending thread marker must not overwrite a newer durable gap marker."""
     room_id = "!room:localhost"
     thread_id = "$thread"
     namespace = f"tenant_{uuid.uuid4().hex}"
@@ -2042,8 +2042,8 @@ def test_postgres_transient_classifier_rejects_authentication_failures_without_s
     assert not _is_transient_postgres_failure(exc)
 
 
-def test_postgres_pending_invalidation_records_are_monotonic() -> None:
-    """Pending invalidation buffers should keep the newest marker for each scope."""
+def test_postgres_pending_gap_records_are_monotonic() -> None:
+    """Pending gap buffers should keep the newest marker for each scope."""
     runtime = _PostgresEventCacheRuntime("postgresql://cache:secret@db.internal/mindroom", namespace="tenant")
 
     runtime.record_pending_thread_gap(

--- a/tests/test_matrix_event_cache_fuzz.py
+++ b/tests/test_matrix_event_cache_fuzz.py
@@ -122,6 +122,39 @@ async def test_seeded_concurrent_trace_matches_every_cache_backend(
 
 
 @pytest.mark.asyncio
+async def test_fuzz_seed_allows_newer_replacement_and_rejects_stale_replacement(
+    event_cache_factory: Callable[[], ConversationEventCache],
+) -> None:
+    """The seed watermark must leave both replacement-ordering branches reachable."""
+    state = await run_scenario(
+        event_cache_factory,
+        FuzzScenario(
+            batches=(
+                (FuzzOperation(OperationKind.REPLACE_THREAD, 0, 0, 0, 0, 4),),
+                (FuzzOperation(OperationKind.STALE_REPLACE_THREAD, 0, 0, 0, 0, 1),),
+            ),
+        ),
+        room_count=1,
+        thread_count=1,
+        verify_restart=False,
+    )
+
+    assert state.threads == (
+        (
+            "!fuzz-room-0:localhost",
+            "$fuzz-r0-t0-root",
+            (
+                "$fuzz-r0-t0-root",
+                "$fuzz-r0-t0-message-0",
+                "$fuzz-r0-t0-message-1",
+                "$fuzz-r0-t0-message-2",
+                "$fuzz-r0-t0-message-3",
+            ),
+        ),
+    )
+
+
+@pytest.mark.asyncio
 async def test_forty_five_thread_fanout_matches_every_cache_backend(
     event_cache_factory: Callable[[], ConversationEventCache],
 ) -> None:

--- a/tests/test_matrix_event_cache_fuzz.py
+++ b/tests/test_matrix_event_cache_fuzz.py
@@ -189,3 +189,28 @@ def test_fuzz_trace_json_round_trip_is_exact() -> None:
         )
         == scenario
     )
+
+
+def test_fuzz_trace_json_accepts_legacy_room_gap_operation() -> None:
+    """Version-one traces using the former room-gap name remain replayable."""
+    scenario = FuzzScenario.from_json(
+        """
+        {
+          "version": 1,
+          "batches": [[
+            {
+              "kind": "mark_room_stale",
+              "room": 0,
+              "thread": 1,
+              "slot": 2,
+              "target": 3,
+              "variant": 4
+            }
+          ]]
+        }
+        """,
+    )
+
+    assert scenario == FuzzScenario(
+        batches=((FuzzOperation(OperationKind.MARK_ROOM_GAP, 0, 1, 2, 3, 4),),),
+    )

--- a/tests/test_thread_read_guards.py
+++ b/tests/test_thread_read_guards.py
@@ -1461,127 +1461,17 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         )
 
     @pytest.mark.asyncio
-    async def test_dispatch_thread_snapshot_racing_unknown_live_mutation_leaves_gap_marked(  # noqa: PLR0915
+    async def test_dispatch_thread_snapshot_racing_unknown_live_mutation_leaves_gap_marked(
         self,
         tmp_path: Path,
     ) -> None:
         """A gap raised mid-fetch survives, so the next dispatch-snapshot read refetches."""
-        room_id = "!test:localhost"
-        thread_id = "$thread:localhost"
-        event_cache = SqliteEventCache(tmp_path / "event_cache.db")
-        await event_cache.initialize()
-        root_event = _text_event(
-            event_id=thread_id,
-            body="Root",
-            sender="@user:localhost",
-            server_timestamp=1000,
-            room_id=room_id,
+        await _assert_racing_unknown_live_mutation_leaves_thread_gap_marked(
+            tmp_path,
+            read_thread=MatrixConversationCache.get_dispatch_thread_snapshot,
+            force_refetch_reason="test_force_dispatch_refetch",
+            expected_full_history=False,
         )
-        old_reply = _text_event(
-            event_id="$reply-old:localhost",
-            body="Old reply",
-            sender="@agent:localhost",
-            server_timestamp=2000,
-            room_id=room_id,
-            thread_id=thread_id,
-        )
-        coordinator = _runtime_write_coordinator()
-        client = _relations_client(
-            root_event=root_event,
-            thread_events=[old_reply],
-            next_batch="s_initial",
-        )
-        await _replace_thread(
-            event_cache,
-            room_id,
-            thread_id,
-            [root_event.source, old_reply.source],
-        )
-        await event_cache.mark_thread_gap(room_id, thread_id, reason="test_force_dispatch_refetch")
-        room_messages_response = client.room_messages.return_value
-        fetch_started = asyncio.Event()
-        release_fetch = asyncio.Event()
-        room_invalidation_finished = asyncio.Event()
-        dispatch_snapshot: ThreadHistoryResult | None = None
-        live_task: asyncio.Task[None] | None = None
-
-        async def blocking_room_messages(*_args: object, **_kwargs: object) -> nio.RoomMessagesResponse:
-            fetch_started.set()
-            await release_fetch.wait()
-            return room_messages_response
-
-        client.room_messages = AsyncMock(side_effect=blocking_room_messages)
-        access = MatrixConversationCache(
-            logger=MagicMock(),
-            runtime=_conversation_runtime(
-                client=client,
-                event_cache=event_cache,
-                coordinator=coordinator,
-            ),
-        )
-        real_mark_room_threads_gap = event_cache.mark_room_threads_gap
-
-        async def mark_room_threads_gap(room_id_arg: str, *, reason: str) -> None:
-            assert room_id_arg == room_id
-            assert reason == "live_thread_lookup_unavailable"
-            await real_mark_room_threads_gap(room_id_arg, reason=reason)
-            room_invalidation_finished.set()
-
-        async def resolve_unknown_impact(*_args: object, **_kwargs: object) -> MutationThreadImpact:
-            return MutationThreadImpact.unknown()
-
-        event_cache.mark_room_threads_gap = AsyncMock(side_effect=mark_room_threads_gap)
-        access._live._resolver.resolve_thread_impact_for_mutation = AsyncMock(side_effect=resolve_unknown_impact)
-        unknown_event = _text_event(
-            event_id="$unknown-edit:localhost",
-            body="* Updated",
-            sender="@agent:localhost",
-            server_timestamp=3000,
-            room_id=room_id,
-            replacement_of="$missing:localhost",
-            new_body="Updated",
-        )
-        read_task = asyncio.create_task(access.get_dispatch_thread_snapshot(room_id, thread_id))
-
-        try:
-            await asyncio.wait_for(fetch_started.wait(), timeout=1.0)
-            live_task = asyncio.create_task(
-                access.append_live_event(
-                    room_id,
-                    unknown_event,
-                    event_info=EventInfo.from_event(unknown_event.source),
-                ),
-            )
-            await asyncio.wait_for(room_invalidation_finished.wait(), timeout=1.0)
-
-            release_fetch.set()
-            dispatch_snapshot = await asyncio.wait_for(read_task, timeout=1.0)
-            await asyncio.wait_for(live_task, timeout=1.0)
-            await _wait_for_room_cache_idle(coordinator)
-            thread_state = await event_cache.get_thread_cache_gap(room_id, thread_id)
-        finally:
-            release_fetch.set()
-            await asyncio.wait_for(
-                asyncio.gather(
-                    read_task,
-                    *(task for task in [live_task] if task is not None),
-                    return_exceptions=True,
-                ),
-                timeout=1.0,
-            )
-            await _wait_for_room_cache_idle(coordinator)
-            await event_cache.close()
-
-        assert dispatch_snapshot is not None
-        assert dispatch_snapshot.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_HOMESERVER
-        assert [message.body for message in dispatch_snapshot] == ["Root", "Old reply"]
-        # The racing gap was raised after the fetch started, so the replacement that fetch
-        # installed does not cover it: the marker survives and the next read refetches.
-        assert thread_state is not None
-        assert thread_state.gap_reason == "live_thread_lookup_unavailable"
-        assert matrix_cache.thread_cache_rejection_reason(thread_state) == "live_thread_lookup_unavailable"
-        # One fetch, not two: the read no longer retries in-place to re-establish trust.
-        assert client.room_messages.await_count == 1
 
     @pytest.mark.asyncio
     async def test_latest_thread_event_lookup_refetches_invalidated_thread_tail(


### PR DESCRIPTION
## What

- Add a cross-backend regression test proving the fuzz seed allows a newer replacement while rejecting an older replacement.
- Finish gap-marker terminology in the fuzzer and PostgreSQL cache tests.
- Use the shared PostgreSQL `fetchone` helper so the snapshot-ordering read closes its cursor.
- Remove a dead bulk-refresh fixture branch.
- Reuse the existing racing-gap test helper for dispatch snapshots, deleting 110 duplicate lines.

## Why

PR #1690 replaced an infinite fuzz seed timestamp with a finite timestamp because the infinite value silently disabled every replacement operation. The fix worked, but no assertion protected it: restoring infinity still let the fuzz scenario pass while leaving only the seeded root.

This follow-up asserts the observable thread contents after one newer replacement and one stale replacement. The same test runs against SQLite and PostgreSQL.

## Verification

- Mutation check: restoring the infinite seed fails the new test with one cached root instead of five expected events.
- Focused cache fuzz and gap tests pass on SQLite and PostgreSQL.
- Full suite: 11,878 passed, 54 skipped.
- All pre-commit hooks pass, including Ruff, ty, vulture, Tach, frontend checks, and lockfile checks.

## Summary by Sourcery

Add regression coverage and terminology cleanup around thread gap markers and replacement ordering across cache backends.

New Features:
- Add a fuzz scenario test ensuring newer thread replacements succeed while stale replacements are rejected across cache backends.

Enhancements:
- Refactor dispatch snapshot gap-handling test to reuse a shared racing-gap helper instead of duplicating logic.
- Align gap-marker terminology in fuzzing scripts and PostgreSQL cache tests, including renaming operation kinds and test names for clarity.
- Switch PostgreSQL thread snapshot freshness check to use the shared fetchone helper for snapshot-ordering queries.
- Simplify bulk thread backfill cached message helper to remove unused thread-related content handling.

Tests:
- Extend matrix event cache fuzz tests with coverage that validates replacement watermark ordering for both SQLite and PostgreSQL backends.
- Update PostgreSQL event cache tests to use consistent gap-marker terminology and more accurate test names.