### PR TITLE
Write the thread-cache statements once for both backends

### DIFF
--- a/src/mindroom/matrix/cache/event_cache_sql_dialect.py
+++ b/src/mindroom/matrix/cache/event_cache_sql_dialect.py
@@ -1,0 +1,143 @@
+"""Rendering differences between the two durable Matrix event-cache backends.
+
+The backends run the same statements against schemas that differ only in table names, the name of
+the scope column, the parameter marker, and a short list of expressions. This module holds those
+differences so each statement can be written once, in ``event_cache_thread_statements``.
+
+Scope of this shim, deliberately narrow: it renders SQL text and nothing else. It does not open
+connections, run statements, or decide transaction boundaries. The things that genuinely differ
+between the backends stay where they are and are *not* modelled here:
+
+* the PostgreSQL advisory lock taken alongside the connection lock,
+* SQLite's ``PRAGMA busy_timeout=0`` plus ``BEGIN IMMEDIATE`` model, under which reads take the
+  write lock and a losing reader reports ``disabled_result`` rather than an empty result,
+* the two schema-migration paths, which are per-namespace and version-gated on PostgreSQL and a
+  destructive reset on SQLite.
+
+Those are backend semantics. Smoothing them over here would turn a rendering shim into a
+correctness surface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Final, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+# Logical table names used by the shared statements. The physical name each one maps to is the
+# only place a backend's table naming is written down.
+EVENTS: Final = "events"
+EVENT_EDITS: Final = "event_edits"
+THREAD_EVENTS: Final = "thread_events"
+THREAD_STATE: Final = "thread_state"
+ROOM_STATE: Final = "room_state"
+
+
+@dataclass(frozen=True)
+class _ThreadEventUpsertShape:
+    """How one backend writes ``write_seq`` on the thread-membership upsert.
+
+    The two backends allocate write sequences differently and that difference reaches into the
+    statement itself. SQLite has no sequence object, so ``allocate_write_sequences`` hands out
+    values from a counter row and the statement binds them. PostgreSQL defaults the column from
+    ``nextval`` and re-draws on conflict, so the statement never names a value.
+
+    ``conflict_assignments`` also carries PostgreSQL's ``event_json = NULL``: its thread-membership
+    table has a legacy payload column that SQLite's does not, and the upsert clears it.
+    """
+
+    insert_column: str
+    insert_value: str
+    conflict_assignments: str
+
+
+@dataclass(frozen=True)
+class SqlDialect:
+    """One backend's rendering rules for the shared cache statements."""
+
+    name: Literal["sqlite", "postgres"]
+    scope_column: str
+    tables: Mapping[str, str]
+    named_parameter: str
+    binary_collation: str
+    thread_event_upsert: _ThreadEventUpsertShape
+
+    def table(self, logical: str) -> str:
+        """Return the physical table name for one logical table."""
+        return self.tables[logical]
+
+    def table_as(self, logical: str, alias: str | None = None) -> str:
+        """Return a ``FROM``/``JOIN`` reference, aliased when the physical name differs."""
+        physical = self.tables[logical]
+        target = logical if alias is None else alias
+        return physical if physical == target else f"{physical} AS {target}"
+
+    def parameter(self, name: str) -> str:
+        """Return the placeholder for one named bind parameter.
+
+        Every shared statement binds by name. Positional binding is what let one statement pass
+        the same value three times in a row and made the argument order load-bearing.
+        """
+        return self.named_parameter.format(name=name)
+
+    def monotonic_max(self, column: str, incoming: str) -> str:
+        """Return an expression advancing ``column`` to ``incoming`` only when that moves forward.
+
+        ``incoming`` must not be NULL. PostgreSQL's ``GREATEST`` ignores NULL arguments while
+        SQLite's scalar ``MAX`` returns NULL if any argument is NULL, so the two agree only when
+        the incoming value is known present. Every call site passes a freshly read clock, so the
+        precondition holds; a NULL there would silently erase a marker on SQLite alone, which no
+        production monitoring covers.
+        """
+        if self.name == "postgres":
+            return f"GREATEST({column}, {incoming})"
+        return f"MAX(COALESCE({column}, {incoming}), {incoming})"
+
+
+SQLITE_DIALECT: Final = SqlDialect(
+    name="sqlite",
+    scope_column="principal_id",
+    tables={
+        EVENTS: "events",
+        EVENT_EDITS: "event_edits",
+        THREAD_EVENTS: "thread_events",
+        THREAD_STATE: "thread_cache_state",
+        ROOM_STATE: "room_cache_state",
+    },
+    named_parameter=":{name}",
+    # SQLite compares TEXT bytewise already, so the tie-break needs no override to agree with the
+    # fold and with PostgreSQL's pinned ``COLLATE "C"``.
+    binary_collation="",
+    thread_event_upsert=_ThreadEventUpsertShape(
+        insert_column=",\n            write_seq",
+        insert_value=",\n            :write_seq",
+        conflict_assignments="            write_seq = excluded.write_seq",
+    ),
+)
+
+POSTGRES_DIALECT: Final = SqlDialect(
+    name="postgres",
+    scope_column="namespace",
+    tables={
+        EVENTS: "mindroom_event_cache_events",
+        EVENT_EDITS: "mindroom_event_cache_event_edits",
+        THREAD_EVENTS: "mindroom_event_cache_thread_events",
+        THREAD_STATE: "mindroom_event_cache_thread_state",
+        ROOM_STATE: "mindroom_event_cache_room_state",
+    },
+    named_parameter="%({name})s",
+    # Load-bearing, not decoration: the tie-break has to agree with SQLite and with the fold, and
+    # both compare event IDs by byte. Without it a glibc cluster ('a' < 'B') ships a different
+    # surviving edit for two edits sharing a timestamp, so the same message renders differently per
+    # backend. Invisible to CI, whose fixture pins a musl image where every locale behaves like C.
+    binary_collation=' COLLATE "C"',
+    thread_event_upsert=_ThreadEventUpsertShape(
+        insert_column="",
+        insert_value="",
+        conflict_assignments=(
+            "            event_json = NULL,\n            write_seq = nextval('mindroom_event_cache_write_seq')"
+        ),
+    ),
+)

--- a/src/mindroom/matrix/cache/event_cache_thread_ops.py
+++ b/src/mindroom/matrix/cache/event_cache_thread_ops.py
@@ -1,0 +1,926 @@
+"""Thread snapshot and gap storage for the Matrix event cache, written once for both backends.
+
+Durable gap-state invariants:
+
+1. Gap markers are monotonic: ``mark_thread_gap_locked`` never lets an older marker overwrite a
+   newer one. There is no reason precedence, because every reason means the same thing — refetch.
+
+2. ``mark_room_gap_locked`` is the room-scoped (wildcard-thread) form. It fans the marker out
+   across the room's thread-state rows *and* records it once on the room-state row. The fan-out
+   cannot reach a thread whose first fetch is still in flight, because that thread has no row yet;
+   the room-level copy is what the replacement then consults.
+
+3. A replacement clears the marker only when the marker predates the fetch that produced it.
+   A gap detected mid-fetch is not covered by that fetch, so it survives and the next read refetches.
+
+4. Thread snapshot rows and the lookup, edit, and thread index rows are written and deleted together
+   so point lookups can never resurrect rows the snapshot no longer contains.
+
+5. One threaded mutation is one transaction: ``apply_thread_mutation_append_locked`` appends and,
+   when the append cannot land, records the gap marker in the same transaction. Marking and
+   appending separately left a thread readable while it was missing the event, and a crash between
+   them left a half-applied snapshot unmarked.
+
+Everything here is backend-neutral. The statements come from ``event_cache_thread_statements``,
+rendered through the dialect; the handful of operations that cannot be expressed as one shared
+statement — the write-sequence strategy and bulk delete by event ID — sit behind ``ThreadBackend``.
+
+What deliberately does *not* live here, because it is genuine backend semantics rather than
+duplication: the PostgreSQL advisory lock, SQLite's ``BEGIN IMMEDIATE`` locking model and its
+``disabled_result`` reader outcome, and the two schema-migration paths. Callers own those.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
+
+from .event_cache_events import (
+    event_id_for_cache,
+    serialize_cacheable_events,
+    serialize_cached_event,
+)
+from .event_normalization import normalize_event_source_for_cache
+from .thread_cache_state import (
+    ThreadAppendOutcome,
+    ThreadCacheGap,
+    thread_cache_gap_row,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping, Sequence
+
+    from .event_cache_events import SerializedCachedEvent
+    from .event_cache_thread_statements import ThreadStatements
+
+_ConnectionT = TypeVar("_ConnectionT")
+
+
+class ThreadBackend(Protocol[_ConnectionT]):
+    """One backend's connection plumbing and event-row helpers.
+
+    The scope key is positional throughout: the two backends name the same column differently
+    (``principal_id`` and ``namespace``), and threading that naming difference through every shared
+    signature is what kept the two modules from being one.
+    """
+
+    @property
+    def statements(self) -> ThreadStatements:
+        """Return the statements rendered for this backend."""
+        ...
+
+    async def execute(
+        self,
+        db: _ConnectionT,
+        sql: str,
+        params: Mapping[str, object],
+    ) -> None:
+        """Run one statement that returns no rows."""
+        ...
+
+    async def fetchone(
+        self,
+        db: _ConnectionT,
+        sql: str,
+        params: Mapping[str, object],
+    ) -> tuple[Any, ...] | None:
+        """Run one query and return its first row, if any."""
+        ...
+
+    async def fetchall(
+        self,
+        db: _ConnectionT,
+        sql: str,
+        params: Mapping[str, object],
+    ) -> list[tuple[Any, ...]]:
+        """Run one query and return every row."""
+        ...
+
+    async def upsert_thread_membership_rows(
+        self,
+        db: _ConnectionT,
+        rows: Sequence[Mapping[str, object]],
+    ) -> None:
+        """Write thread-membership rows, supplying each row's write sequence.
+
+        The write-sequence strategy is the backend's own: SQLite hands out values from a counter
+        row because it has no sequence object, while PostgreSQL draws from ``nextval``.
+        """
+        ...
+
+    async def delete_thread_membership_by_event_ids(
+        self,
+        db: _ConnectionT,
+        scope: str,
+        room_id: str,
+        event_ids: Sequence[str],
+    ) -> None:
+        """Delete thread-membership rows for an explicit list of event IDs."""
+        ...
+
+    async def filter_cacheable_events(
+        self,
+        db: _ConnectionT,
+        scope: str,
+        room_id: str,
+        candidates: list[tuple[str, dict[str, Any]]],
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Drop candidates this cache must refuse to store."""
+        ...
+
+    async def write_lookup_index_rows(
+        self,
+        db: _ConnectionT,
+        scope: str,
+        room_id: str,
+        *,
+        serialized_events: list[SerializedCachedEvent],
+        cached_at: float,
+        thread_id: str | None = None,
+    ) -> None:
+        """Persist point-lookup, edit-index, and thread-index rows for cached events."""
+        ...
+
+    async def delete_cached_events(
+        self,
+        db: _ConnectionT,
+        scope: str,
+        room_id: str,
+        event_ids: Sequence[str],
+    ) -> None:
+        """Delete point-lookup payload rows for these event IDs."""
+        ...
+
+    async def delete_event_edit_rows(
+        self,
+        db: _ConnectionT,
+        scope: str,
+        room_id: str,
+        *,
+        event_ids: Sequence[str],
+        original_event_id: str | None,
+    ) -> None:
+        """Delete edit-index rows for these event IDs."""
+        ...
+
+    async def delete_event_thread_rows(
+        self,
+        db: _ConnectionT,
+        scope: str,
+        room_id: str,
+        *,
+        event_ids: Sequence[str],
+        current_self_root_ids: Collection[str] = (),
+    ) -> None:
+        """Delete thread-index rows for these event IDs."""
+        ...
+
+    async def event_or_original_is_redacted(
+        self,
+        db: _ConnectionT,
+        scope: str,
+        room_id: str,
+        *,
+        event_id: str,
+        event: dict[str, Any],
+    ) -> bool:
+        """Return whether this event, or the event it edits, is redacted."""
+        ...
+
+
+def _scoped(scope: str, room_id: str, **extra: object) -> dict[str, object]:
+    """Return the bind parameters every scoped statement starts from."""
+    return {"scope": scope, "room_id": room_id, **extra}
+
+
+# ``load_thread_events`` returns the edits that survive a collapsed read: one per message, from the
+# right sender.
+#
+# A thread stores every edit ever sent. Returning them all makes the caller's fold re-derive per
+# message what one window function derives once, and hauls the whole superseded history across
+# the wire to do it.
+#
+# Edit density depends partly on homeserver policy. The mindroom-tuwunel fork can collapse
+# superseded m.replace events in sync responses with ``mindroom_compact_edits_enabled`` and can
+# delete aged superseded edits with ``mindroom_edit_purge_enabled``. Both flags default to false,
+# so a default-configured fork can expose the same accumulated edit history as a stock homeserver.
+#
+# The fork's opt-in collapse groups by (target, sender), the same key this query uses. It also
+# orders by ``event_id.cmp()``, bytewise, so the binary collation pinned in the dialect has to hold
+# for this read to agree with the homeserver as well as with SQLite and the fold.
+#
+# So be precise about what this buys, because two earlier revisions of this comment were not. It
+# does not reduce writes - it is a read-side query, and every edit is still stored. It does not
+# change what the fold produces either; the fold already picked one edit per message. What it buys
+# is fewer rows off disk and over the wire, and less fold work, paid for with a window function and
+# three joins on every read. The correctness fixes that came with it are the substantial part; no
+# universal speedup is claimed because the result depends on edit density and database statistics.
+#
+# Upstream pruning is available in the fork but remains opt-in. Where edit purge is enabled,
+# deleting superseded edits after the configured minimum age settles the rollback trade at that
+# boundary: redacting the current winning edit is contractually supposed to reveal the previous one
+# (``test_redacting_latest_edit_falls_back_to_previous_cached_edit``), and past that age there is
+# no previous one left to reveal, wherever the read is served from. It was already close to
+# unreachable - redacting a MESSAGE removes the original and every dependent edit together, and
+# mindroom-cinny's delete targets the original event ID, since ``MessageDeleteItem`` passes
+# ``mEvent.getId()`` and a replacement is only ever reached through ``replacingEvent()``, never a
+# redaction target there. Reaching the rollback path needs the raw API,
+# ``/redact <edit-event-id>``, or moderation tooling. Element was not checked.
+#
+# This cache must still handle deployments where those opt-in controls are disabled, including a
+# default-configured fork or a stock homeserver where superseded edits arrive and stay.
+#
+# The contract to implement, if it is built: keep only the current legitimate edit per (original,
+# sender); redacting an already-pruned edit tombstones it and is otherwise a no-op; redacting the
+# retained winner deletes it, marks the thread stale and refetches full history, which
+# ``invalidate_after_redaction`` in ``thread_writes`` already does on the live redaction path; if
+# the homeserver is unreachable at that moment, fail or degrade explicitly rather than serving the
+# pre-edit body as confirmed history; and keep tombstones, so out-of-order sync cannot resurrect a
+# deleted edit.
+#
+# "Surviving" is per (original, sender): a replacement is only legitimate from the sender of the
+# event it replaces, so keeping a single newest-overall edit lets any room member starve the fold
+# of the author's own and pin the message at its pre-edit body. Membership is joined in there rather
+# than filtered later, because ranking over edits the outer query will discard lets an
+# out-of-thread edit suppress the in-thread runner-up.
+#
+# The sender comparison there is an optimization, not the security boundary. The fold re-checks
+# every candidate against the JSON sender (``ThreadEditCandidates.winner_for``), so if this
+# filter ever admits a foreign replacement the fold still finds nothing in the author's bucket
+# and renders the pre-edit body - wrong, but not the attacker's text. Doing it in SQL keeps a
+# foreign edit from being ranked as the survivor and hiding the author's own.
+#
+# The original is LEFT joined, not required. An edit can outlive the message it replaces -
+# the edit index holds no foreign key to the payload table - and the fold synthesizes a message from
+# such an edit rather than dropping it, carrying the editor's own sender because an original nobody
+# has seen cannot be impersonated. Requiring the original would delete those messages from the read
+# outright. The sender filter is skipped exactly when there is no original to compare against,
+# which is also when ``winner_for`` stops applying it, for the same reason.
+#
+# The original is read out of the payload table alone, with no thread membership required. Two
+# narrower lookups were tried first and both silently disabled the filter. Scoping it to this thread
+# made an original cached in a sibling thread read as absent. Routing it through thread membership
+# at all then did the same to any original cached by a point lookup, because ``store_event`` writes
+# the payload with no membership row - so ``original_events`` came back NULL, the sender filter was
+# skipped, and the newest edit across all senders won, which is the exact suppression this filter
+# exists to prevent (``test_a_point_cached_original_still_scopes_edits_to_its_sender``). The
+# comparison needs the payload and nothing else, so asking for more can only lose a sender it could
+# have compared against.
+#
+# ROW_NUMBER over one pass rather than a correlated NOT EXISTS per candidate: 5.3 ms against
+# 8.7 ms on a synthetic 2,021-event thread with current table statistics. Policy stays in Python;
+# this is only "latest per group", which is what a window function is for. Splitting
+# present-original and absent-original edits into two CTEs scans the edit index twice and timed out
+# a 2,000-edit PostgreSQL test that one pass completes.
+#
+# MATERIALIZED is a hint, not a correctness requirement: measured 3.7 ms materialized against
+# 4.1 ms inlinable. It is kept only to stop the planner re-deriving the survivors per row.
+async def load_thread_events(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+) -> list[dict[str, Any]] | None:
+    """Return one thread's cached events oldest first, collapsed to one edit per message."""
+    rows = await backend.fetchall(
+        db,
+        backend.statements.thread_events,
+        _scoped(scope, room_id, thread_id=thread_id),
+    )
+    return [json.loads(row[2]) for row in rows] if rows else None
+
+
+async def load_thread_event_ids(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+) -> set[str]:
+    """Return every raw event ID this thread holds, superseded edits included.
+
+    Membership and visibility are different questions, and collapsing is what made them differ:
+    the visible read shows one edit per message, while this returns every row the thread owns. The
+    repair bookkeeping this was written for is gone; the surviving caller is the edit-sender rule's
+    coverage, which needs the membership set to state its precondition.
+
+    Joined to the payload table rather than reading membership alone: a membership row whose payload
+    is gone is not durably present, and reporting it as present would suppress a refill that should
+    happen. That join is also what the pre-collapse code did implicitly, since it derived these IDs
+    from a read that required the payload.
+    """
+    rows = await backend.fetchall(
+        db,
+        backend.statements.thread_event_ids,
+        _scoped(scope, room_id, thread_id=thread_id),
+    )
+    return {str(row[0]) for row in rows}
+
+
+async def load_recent_room_thread_ids(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    limit: int,
+) -> list[str]:
+    """Return thread IDs for one room ordered by the newest locally cached event timestamp."""
+    rows = await backend.fetchall(
+        db,
+        backend.statements.recent_room_thread_ids,
+        _scoped(scope, room_id, limit=limit),
+    )
+    return [str(row[0]) for row in rows]
+
+
+async def load_thread_cache_gap(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+) -> ThreadCacheGap | None:
+    """Return the durable gap marker recorded against one cached thread, if any.
+
+    Room-scoped gaps are fanned out across the room's thread rows when they are marked, so this is
+    a single-table read with no room-state join.
+    """
+    row = await backend.fetchone(
+        db,
+        backend.statements.thread_cache_gap,
+        _scoped(scope, room_id, thread_id=thread_id),
+    )
+    return thread_cache_gap_row(row)
+
+
+async def load_room_membership_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+) -> tuple[str, int]:
+    """Return the durable membership state and transition epoch for one scope-room."""
+    row = await backend.fetchone(
+        db,
+        backend.statements.room_membership,
+        _scoped(scope, room_id),
+    )
+    return ("joined", 0) if row is None else (str(row[0]), int(row[1]))
+
+
+async def certify_room_membership_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+) -> int:
+    """Create a durable generation row and return its current epoch."""
+    await backend.execute(
+        db,
+        backend.statements.certify_room_membership,
+        _scoped(scope, room_id),
+    )
+    _membership_state, membership_epoch = await load_room_membership_locked(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+    )
+    return membership_epoch
+
+
+async def set_room_membership_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    membership_state: Literal["joined", "departed"],
+    reason: str,
+) -> None:
+    """Advance one durable room-membership transition and gap-mark prior refills."""
+    await mark_room_gap_locked(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+        reason=reason,
+    )
+    # 🔒 ``mark_room_gap_locked`` has already upserted the row, so the epoch below always has
+    # something to advance. A missing row and a fresh one both read as ``('joined', 0)``.
+    await backend.execute(
+        db,
+        backend.statements.set_room_membership,
+        _scoped(scope, room_id, membership_state=membership_state),
+    )
+
+
+async def _store_thread_events_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+    events: list[dict[str, Any]],
+    stored_at: float,
+    fetch_started_at: float,
+) -> frozenset[str]:
+    """Persist one authoritative thread snapshot within an existing DB transaction."""
+    normalized_events = [normalize_event_source_for_cache(event) for event in events]
+    cacheable_events = await backend.filter_cacheable_events(
+        db,
+        scope,
+        room_id,
+        [(event_id_for_cache(event), event) for event in normalized_events],
+    )
+    serialized_events = serialize_cacheable_events(cacheable_events)
+    if serialized_events:
+        await backend.write_lookup_index_rows(
+            db,
+            scope,
+            room_id,
+            serialized_events=serialized_events,
+            cached_at=stored_at,
+            thread_id=thread_id,
+        )
+        await backend.upsert_thread_membership_rows(
+            db,
+            [
+                _scoped(
+                    scope,
+                    room_id,
+                    thread_id=thread_id,
+                    event_id=event.event_id,
+                    origin_server_ts=event.origin_server_ts,
+                )
+                for event in serialized_events
+            ],
+        )
+    await _clear_thread_gap_covered_by_fetch(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+        thread_id=thread_id,
+        fetch_started_at=fetch_started_at,
+    )
+    return frozenset(event.event_id for event in serialized_events)
+
+
+async def _thread_snapshot_is_newer_than_fetch(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+    fetch_started_at: float,
+) -> bool:
+    """Return whether an installed snapshot came from a strictly newer fetch than this one."""
+    row = await backend.fetchone(
+        db,
+        backend.statements.snapshot_fetch_started_at,
+        _scoped(scope, room_id, thread_id=thread_id),
+    )
+    if row is None or row[0] is None:
+        return False
+    return float(row[0]) > fetch_started_at
+
+
+async def _uncovered_room_gap(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    fetch_started_at: float,
+) -> tuple[float, str | None] | None:
+    """Return the room-scoped gap one fetch does not cover, if there is one."""
+    row = await backend.fetchone(db, backend.statements.room_gap, _scoped(scope, room_id))
+    if row is None or row[0] is None or float(row[0]) <= fetch_started_at:
+        return None
+    return (float(row[0]), row[1] if isinstance(row[1], str) else None)
+
+
+async def _clear_thread_gap_covered_by_fetch(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+    fetch_started_at: float,
+) -> None:
+    """Record this thread's snapshot, keeping any gap the replacing fetch does not cover.
+
+    A gap marked after the fetch began describes events the fetch could not have seen, so it
+    survives and the next read refetches. Both scopes have to be asked about, and the room one
+    cannot be answered by the fan-out alone: a thread whose first fetch was in flight when the room
+    was gapped has no row for the fan-out to update, so without the room-level copy this insert
+    would record a clean snapshot for events fetched from before the gap.
+    """
+    room_gap = await _uncovered_room_gap(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+        fetch_started_at=fetch_started_at,
+    )
+    room_gap_marked_at, room_gap_reason = room_gap if room_gap is not None else (None, None)
+    await backend.execute(
+        db,
+        backend.statements.record_snapshot_keeping_uncovered_gap,
+        _scoped(
+            scope,
+            room_id,
+            thread_id=thread_id,
+            room_gap_marked_at=room_gap_marked_at,
+            room_gap_reason=room_gap_reason,
+            fetch_started_at=fetch_started_at,
+        ),
+    )
+
+
+async def replace_thread_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+    events: list[dict[str, Any]],
+    stored_at: float,
+    fetch_started_at: float,
+) -> None:
+    """Replace one thread snapshot atomically within an existing DB transaction.
+
+    Replacement is ordered by ``fetch_started_at``, not by arrival: because installing a snapshot
+    deletes the events it omits, a slow fetch landing after a newer one would otherwise bury the
+    newer thread contents and leave no gap marker behind to force a refetch. An older fetch is
+    therefore skipped outright. This is one comparison, not a conflict classifier — the loser has
+    nothing to retry, since the snapshot already installed is strictly fresher than its own.
+
+    The gap marker is separately conditional — see ``_clear_thread_gap_covered_by_fetch``.
+    """
+    if await _thread_snapshot_is_newer_than_fetch(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+        thread_id=thread_id,
+        fetch_started_at=fetch_started_at,
+    ):
+        return
+    existing_event_ids = await _thread_event_ids_for_thread(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    replacement_event_ids = await _store_thread_events_locked(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+        thread_id=thread_id,
+        events=events,
+        stored_at=stored_at,
+        fetch_started_at=fetch_started_at,
+    )
+    removed_event_ids = sorted(set(existing_event_ids) - replacement_event_ids)
+    if removed_event_ids:
+        await backend.delete_thread_membership_by_event_ids(db, scope, room_id, removed_event_ids)
+        await backend.delete_cached_events(db, scope, room_id, removed_event_ids)
+        await backend.delete_event_edit_rows(
+            db,
+            scope,
+            room_id,
+            event_ids=removed_event_ids,
+            original_event_id=None,
+        )
+        await backend.delete_event_thread_rows(
+            db,
+            scope,
+            room_id,
+            event_ids=removed_event_ids,
+            current_self_root_ids={thread_id} if thread_id in replacement_event_ids else (),
+        )
+
+
+async def invalidate_thread_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+) -> None:
+    """Delete cached events and state for one thread within an existing transaction."""
+    event_ids = await _thread_event_ids_for_thread(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
+    await backend.execute(
+        db,
+        backend.statements.delete_thread_membership_by_thread,
+        _scoped(scope, room_id, thread_id=thread_id),
+    )
+    if event_ids:
+        await _delete_event_rows(backend, db, scope=scope, room_id=room_id, event_ids=event_ids)
+    await backend.execute(
+        db,
+        backend.statements.delete_thread_state_by_thread,
+        _scoped(scope, room_id, thread_id=thread_id),
+    )
+
+
+async def invalidate_room_threads_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+) -> None:
+    """Delete every cached thread snapshot while preserving durable room membership."""
+    event_ids = await _thread_event_ids_for_room(backend, db, scope=scope, room_id=room_id)
+    await backend.execute(
+        db,
+        backend.statements.delete_thread_membership_by_room,
+        _scoped(scope, room_id),
+    )
+    if event_ids:
+        await _delete_event_rows(backend, db, scope=scope, room_id=room_id, event_ids=event_ids)
+    await backend.execute(
+        db,
+        backend.statements.delete_thread_state_by_room,
+        _scoped(scope, room_id),
+    )
+
+
+async def _delete_event_rows(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    event_ids: list[str],
+) -> None:
+    """Delete the payload, edit-index, and thread-index rows for events an invalidation removed."""
+    await backend.delete_cached_events(db, scope, room_id, event_ids)
+    await backend.delete_event_edit_rows(
+        db,
+        scope,
+        room_id,
+        event_ids=event_ids,
+        original_event_id=None,
+    )
+    await backend.delete_event_thread_rows(db, scope, room_id, event_ids=event_ids)
+
+
+async def mark_thread_gap_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+    reason: str,
+    gap_marked_at: float | None = None,
+) -> None:
+    """Record one durable thread gap marker within an active transaction.
+
+    The marker is monotonic: a later gap never loses to an earlier one. There is no reason
+    precedence — every reason means the same thing, that this snapshot must be refetched.
+
+    ``gap_marked_at`` replays a marker a caller already stamped, which is how a pending marker
+    buffered while durable writes were unavailable keeps its original time instead of being
+    back-dated to the flush. Left unset it stamps now.
+    """
+    marked_at = time.time() if gap_marked_at is None else gap_marked_at
+    await backend.execute(
+        db,
+        backend.statements.mark_thread_gap,
+        _scoped(
+            scope,
+            room_id,
+            thread_id=thread_id,
+            gap_marked_at=marked_at,
+            gap_reason=reason,
+        ),
+    )
+
+
+async def apply_thread_mutation_append_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+    normalized_event: dict[str, Any],
+    append_failed_reason: str,
+) -> ThreadAppendOutcome:
+    """Append one threaded mutation, recording a gap marker in the same transaction when it cannot land.
+
+    See invariant 5 in this module's docstring for why it is one transaction. A successful append
+    clears nothing: an append extends a snapshot, it does not prove the snapshot complete.
+    """
+    outcome = await _append_existing_thread_event(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+        thread_id=thread_id,
+        normalized_event=normalized_event,
+    )
+    if outcome is not ThreadAppendOutcome.APPENDED:
+        await mark_thread_gap_locked(
+            backend,
+            db,
+            scope=scope,
+            room_id=room_id,
+            thread_id=thread_id,
+            reason=append_failed_reason,
+        )
+    return outcome
+
+
+async def mark_room_gap_locked(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    reason: str,
+    gap_marked_at: float | None = None,
+) -> None:
+    """Record one room-scoped (wildcard-thread) gap across the room's threads and on the room itself.
+
+    The fan-out reaches every thread that already holds a thread-state row. That is not all of
+    them: a thread whose first fetch is still in flight has no row yet, so the fan-out skips it and
+    the replacement that lands afterwards would insert a clean row for a snapshot fetched from before
+    the gap. The room-level copy is what that replacement consults, so the two together cover the room
+    whether or not a thread's row existed when the gap was recorded.
+    """
+    marked_at = time.time() if gap_marked_at is None else gap_marked_at
+    gap_params = _scoped(scope, room_id, gap_marked_at=marked_at, gap_reason=reason)
+    await backend.execute(db, backend.statements.fan_out_room_gap, gap_params)
+    await backend.execute(db, backend.statements.upsert_room_gap, gap_params)
+
+
+async def _append_existing_thread_event(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+    normalized_event: dict[str, Any],
+) -> ThreadAppendOutcome:
+    """Append one event to an existing cached thread and classify what happened.
+
+    An opaque ``m.room.encrypted`` payload never replaces stored clear content for the same event ID.
+    A redacted event (or one whose edit target is redacted) is refused before anything is written, so
+    its payload never reaches the point-lookup table.
+    """
+    event_id = event_id_for_cache(normalized_event)
+    if await backend.event_or_original_is_redacted(
+        db,
+        scope,
+        room_id,
+        event_id=event_id,
+        event=normalized_event,
+    ):
+        return ThreadAppendOutcome.APPEND_REFUSED
+
+    serialized_event = serialize_cached_event(event_id, normalized_event)
+    row = await backend.fetchone(
+        db,
+        backend.statements.thread_has_readable_event,
+        _scoped(scope, room_id, thread_id=thread_id),
+    )
+    thread_exists = row is not None
+    await backend.write_lookup_index_rows(
+        db,
+        scope,
+        room_id,
+        serialized_events=[serialized_event],
+        cached_at=time.time(),
+        thread_id=thread_id,
+    )
+    if not thread_exists:
+        # Only lookup-index rows are recorded: there is no snapshot to extend, so only a full
+        # history scan can make this thread readable again.
+        return ThreadAppendOutcome.SNAPSHOT_MISSING
+
+    await backend.upsert_thread_membership_rows(
+        db,
+        [
+            _scoped(
+                scope,
+                room_id,
+                thread_id=thread_id,
+                event_id=serialized_event.event_id,
+                origin_server_ts=serialized_event.origin_server_ts,
+            ),
+        ],
+    )
+    await _advance_snapshot_watermark(
+        backend,
+        db,
+        scope=scope,
+        room_id=room_id,
+        thread_id=thread_id,
+        reflected_at=time.time(),
+    )
+    return ThreadAppendOutcome.APPENDED
+
+
+async def _advance_snapshot_watermark(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+    reflected_at: float,
+) -> None:
+    """Record that this snapshot now reflects the thread as of ``reflected_at``.
+
+    An append mutates the snapshot, so a fetch that started before it cannot represent the thread
+    any more. Moving the watermark forward makes ``replace_thread_locked`` refuse such a fetch,
+    which is what stops a slow scan from deleting a live event that landed while it was running.
+    """
+    await backend.execute(
+        db,
+        backend.statements.advance_snapshot_watermark,
+        _scoped(scope, room_id, thread_id=thread_id, reflected_at=reflected_at),
+    )
+
+
+async def _thread_event_ids_for_thread(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+) -> list[str]:
+    """Return cached event IDs currently stored for one thread."""
+    rows = await backend.fetchall(
+        db,
+        backend.statements.event_ids_for_thread,
+        _scoped(scope, room_id, thread_id=thread_id),
+    )
+    return [str(row[0]) for row in rows]
+
+
+async def thread_snapshot_exists(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+    thread_id: str,
+) -> bool:
+    """Return whether one thread has at least one durably present snapshot row.
+
+    Joined to the payload table rather than reading membership alone: a membership row whose payload
+    is gone is not durably present, and answering yes for one reports a thread as cached that no read
+    can serve, which is how startup prewarm silently skips it.
+    """
+    row = await backend.fetchone(
+        db,
+        backend.statements.thread_has_readable_event,
+        _scoped(scope, room_id, thread_id=thread_id),
+    )
+    return row is not None
+
+
+async def _thread_event_ids_for_room(
+    backend: ThreadBackend[_ConnectionT],
+    db: _ConnectionT,
+    *,
+    scope: str,
+    room_id: str,
+) -> list[str]:
+    """Return cached event IDs currently stored for every thread in one room."""
+    rows = await backend.fetchall(
+        db,
+        backend.statements.event_ids_for_room,
+        _scoped(scope, room_id),
+    )
+    return [str(row[0]) for row in rows]

--- a/src/mindroom/matrix/cache/event_cache_thread_statements.py
+++ b/src/mindroom/matrix/cache/event_cache_thread_statements.py
@@ -1,0 +1,378 @@
+"""The thread-cache statements, written once and rendered per backend.
+
+Every statement here was previously transcribed by hand into both backend modules. The pair had
+already drifted twice by the time this was written, in ways a reader could only find by diffing
+them: the same upsert expressed as ``GREATEST`` on one side and ``MAX(COALESCE(...))`` on the
+other, and ``excluded`` spelled in two cases.
+
+The statements bind every parameter by name. The positional form is what allowed one statement to
+pass the same value three times running, where the argument order was load-bearing and silent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from .event_cache_sql_dialect import (
+    EVENT_EDITS,
+    EVENTS,
+    ROOM_STATE,
+    THREAD_EVENTS,
+    THREAD_STATE,
+)
+
+if TYPE_CHECKING:
+    from .event_cache_sql_dialect import SqlDialect
+
+
+def _surviving_edits_cte(d: SqlDialect) -> str:
+    """Return the CTE selecting the edits that survive a collapsed read.
+
+    One per (original, sender). The prose behind every clause - why the sender comparison here is
+    an optimization rather than the security boundary, why the original is LEFT joined out of the
+    events table alone, why ROW_NUMBER rather than a correlated NOT EXISTS, and what a write-time
+    prune would have to preserve - is recorded once above ``load_thread_events`` in
+    ``event_cache_thread_ops``.
+
+    Do not rewrite the ranking as ``DISTINCT ON (original_event_id)``: that shape materialises
+    every row of the thread before it can pick winners.
+
+    Do not re-derive this query's cost without ANALYZE. On unanalyzed tables an unseen scope
+    estimates 1 row against thousands actual, every join degrades to a nested loop with a join
+    filter, and every shape collapses - a plain unfiltered read of the same thread included.
+    """
+    scope = d.scope_column
+    return f"""
+WITH surviving_edits AS MATERIALIZED (
+    SELECT edit_event_id
+    FROM (
+        SELECT event_edits.edit_event_id AS edit_event_id,
+               ROW_NUMBER() OVER (
+                   PARTITION BY event_edits.original_event_id
+                   ORDER BY event_edits.origin_server_ts DESC,
+                            event_edits.edit_event_id{d.binary_collation} DESC
+               ) AS edit_rank
+        FROM {d.table_as(EVENT_EDITS)}
+        JOIN {d.table_as(THREAD_EVENTS, "edit_membership")}
+            ON edit_membership.{scope} = event_edits.{scope}
+            AND edit_membership.room_id = event_edits.room_id
+            AND edit_membership.event_id = event_edits.edit_event_id
+            AND edit_membership.thread_id = {d.parameter("thread_id")}
+        JOIN {d.table_as(EVENTS, "edit_events")}
+            ON edit_events.{scope} = event_edits.{scope}
+            AND edit_events.room_id = event_edits.room_id
+            AND edit_events.event_id = event_edits.edit_event_id
+        LEFT JOIN {d.table_as(EVENTS, "original_events")}
+            ON original_events.{scope} = event_edits.{scope}
+            AND original_events.room_id = event_edits.room_id
+            AND original_events.event_id = event_edits.original_event_id
+        WHERE event_edits.{scope} = {d.parameter("scope")}
+            AND event_edits.room_id = {d.parameter("room_id")}
+            AND (original_events.event_id IS NULL OR edit_events.sender = original_events.sender)
+    ) AS ranked
+    WHERE edit_rank = 1
+)
+"""  # noqa: S608 - every interpolation is a dialect-rendered literal; params stay bound
+
+
+@dataclass(frozen=True)
+class ThreadStatements:
+    """Every thread-cache statement, rendered for one backend."""
+
+    thread_events: str
+    thread_event_ids: str
+    recent_room_thread_ids: str
+    thread_cache_gap: str
+    room_membership: str
+    certify_room_membership: str
+    set_room_membership: str
+    upsert_thread_membership: str
+    snapshot_fetch_started_at: str
+    room_gap: str
+    record_snapshot_keeping_uncovered_gap: str
+    delete_thread_membership_by_thread: str
+    delete_thread_membership_by_room: str
+    delete_thread_state_by_thread: str
+    delete_thread_state_by_room: str
+    mark_thread_gap: str
+    fan_out_room_gap: str
+    upsert_room_gap: str
+    thread_has_readable_event: str
+    advance_snapshot_watermark: str
+    event_ids_for_thread: str
+    event_ids_for_room: str
+
+    @classmethod
+    def build(cls, d: SqlDialect) -> ThreadStatements:
+        """Render every thread-cache statement for one backend."""
+        scope = d.scope_column
+        p_scope = d.parameter("scope")
+        p_room = d.parameter("room_id")
+        p_thread = d.parameter("thread_id")
+        scoped_room = f"{scope} = {p_scope} AND room_id = {p_room}"
+        thread_events = d.table(THREAD_EVENTS)
+        thread_state = d.table(THREAD_STATE)
+        room_state = d.table(ROOM_STATE)
+        upsert = d.thread_event_upsert
+
+        # One thread, collapsed: every non-edit row, plus the one surviving edit per edited message.
+        thread_events_sql = (
+            _surviving_edits_cte(d)  # noqa: S608 - dialect-rendered literals only; params stay bound
+            + f"""
+SELECT thread_events.origin_server_ts, thread_events.write_seq, events.event_json
+FROM {d.table_as(THREAD_EVENTS)}
+JOIN {d.table_as(EVENTS)}
+    ON events.{scope} = thread_events.{scope}
+    AND events.room_id = thread_events.room_id
+    AND events.event_id = thread_events.event_id
+WHERE thread_events.{scope} = {p_scope}
+    AND thread_events.room_id = {p_room}
+    AND thread_events.thread_id = {p_thread}
+    AND (
+        NOT EXISTS (
+            SELECT 1
+            FROM {d.table_as(EVENT_EDITS, "row_is_an_edit")}
+            WHERE row_is_an_edit.{scope} = thread_events.{scope}
+                AND row_is_an_edit.room_id = thread_events.room_id
+                AND row_is_an_edit.edit_event_id = thread_events.event_id
+        )
+        OR thread_events.event_id IN (SELECT edit_event_id FROM surviving_edits)
+    )
+ORDER BY thread_events.origin_server_ts ASC, thread_events.write_seq ASC
+"""  # noqa: S608 - every interpolation is a dialect-rendered literal; params stay bound
+        )
+
+        # Joined to the payload table rather than reading membership alone: a membership row whose
+        # payload is gone is not durably present, and reporting it as present suppresses a refill
+        # that should happen.
+        readable_thread_rows = f"""
+        FROM {d.table_as(THREAD_EVENTS)}
+        JOIN {d.table_as(EVENTS)}
+            ON events.{scope} = thread_events.{scope}
+            AND events.room_id = thread_events.room_id
+            AND events.event_id = thread_events.event_id
+        WHERE thread_events.{scope} = {p_scope}
+            AND thread_events.room_id = {p_room}
+            AND thread_events.thread_id = {p_thread}
+        """
+
+        return cls(
+            thread_events=thread_events_sql,
+            thread_event_ids=f"SELECT thread_events.event_id{readable_thread_rows}",
+            thread_has_readable_event=f"SELECT 1{readable_thread_rows}LIMIT 1",
+            recent_room_thread_ids=f"""
+        SELECT thread_id
+        FROM {thread_events}
+        WHERE {scoped_room}
+        GROUP BY thread_id
+        ORDER BY MAX(origin_server_ts) DESC, thread_id ASC
+        LIMIT {d.parameter("limit")}
+        """,  # noqa: S608
+            thread_cache_gap=f"""
+        SELECT gap_marked_at, gap_reason
+        FROM {thread_state}
+        WHERE {scoped_room} AND thread_id = {p_thread}
+        """,  # noqa: S608
+            room_membership=f"""
+        SELECT membership_state, membership_epoch
+        FROM {room_state}
+        WHERE {scoped_room}
+        """,  # noqa: S608
+            # ``DO NOTHING`` rather than SQLite's former ``INSERT OR IGNORE``: the statement
+            # supplies every NOT NULL column, so the primary key is the only constraint either
+            # form could have been ignoring, and naming it is the narrower of the two.
+            certify_room_membership=f"""
+        INSERT INTO {room_state}(
+            {scope},
+            room_id,
+            membership_state,
+            membership_epoch
+        )
+        VALUES ({p_scope}, {p_room}, 'joined', 0)
+        ON CONFLICT({scope}, room_id) DO NOTHING
+        """,  # noqa: S608
+            set_room_membership=f"""
+        UPDATE {room_state}
+        SET membership_state = {d.parameter("membership_state")},
+            membership_epoch = membership_epoch + 1
+        WHERE {scoped_room}
+        """,  # noqa: S608
+            upsert_thread_membership=f"""
+        INSERT INTO {thread_events}(
+            {scope},
+            room_id,
+            thread_id,
+            event_id,
+            origin_server_ts{upsert.insert_column}
+        )
+        VALUES (
+            {p_scope},
+            {p_room},
+            {p_thread},
+            {d.parameter("event_id")},
+            {d.parameter("origin_server_ts")}{upsert.insert_value}
+        )
+        ON CONFLICT({scope}, room_id, event_id) DO UPDATE SET
+            thread_id = excluded.thread_id,
+            origin_server_ts = excluded.origin_server_ts,
+{upsert.conflict_assignments}
+        """,  # noqa: S608
+            snapshot_fetch_started_at=f"""
+        SELECT snapshot_fetch_started_at
+        FROM {thread_state}
+        WHERE {scoped_room} AND thread_id = {p_thread}
+        """,  # noqa: S608
+            room_gap=f"""
+        SELECT room_gap_marked_at, room_gap_reason
+        FROM {room_state}
+        WHERE {scoped_room}
+        """,  # noqa: S608
+            # A gap marked after the fetch began describes events the fetch could not have seen, so
+            # it survives and the next read refetches.
+            record_snapshot_keeping_uncovered_gap=f"""
+        INSERT INTO {thread_state}(
+            {scope},
+            room_id,
+            thread_id,
+            gap_marked_at,
+            gap_reason,
+            snapshot_fetch_started_at
+        )
+        VALUES (
+            {p_scope},
+            {p_room},
+            {p_thread},
+            {d.parameter("room_gap_marked_at")},
+            {d.parameter("room_gap_reason")},
+            {d.parameter("fetch_started_at")}
+        )
+        ON CONFLICT({scope}, room_id, thread_id) DO UPDATE SET
+            snapshot_fetch_started_at = excluded.snapshot_fetch_started_at,
+            gap_marked_at = CASE
+                WHEN {thread_state}.gap_marked_at IS NULL
+                    OR {thread_state}.gap_marked_at <= {d.parameter("fetch_started_at")}
+                    THEN excluded.gap_marked_at
+                ELSE {thread_state}.gap_marked_at
+            END,
+            gap_reason = CASE
+                WHEN {thread_state}.gap_marked_at IS NULL
+                    OR {thread_state}.gap_marked_at <= {d.parameter("fetch_started_at")}
+                    THEN excluded.gap_reason
+                ELSE {thread_state}.gap_reason
+            END
+        """,  # noqa: S608
+            delete_thread_membership_by_thread=f"""
+        DELETE FROM {thread_events}
+        WHERE {scoped_room} AND thread_id = {p_thread}
+        """,  # noqa: S608
+            delete_thread_membership_by_room=f"""
+        DELETE FROM {thread_events}
+        WHERE {scoped_room}
+        """,  # noqa: S608
+            delete_thread_state_by_thread=f"""
+        DELETE FROM {thread_state}
+        WHERE {scoped_room} AND thread_id = {p_thread}
+        """,  # noqa: S608
+            delete_thread_state_by_room=f"""
+        DELETE FROM {thread_state}
+        WHERE {scoped_room}
+        """,  # noqa: S608
+            # Monotonic: a later gap never loses to an earlier one. There is no reason precedence -
+            # every reason means the same thing, that this snapshot must be refetched.
+            mark_thread_gap=f"""
+        INSERT INTO {thread_state}(
+            {scope},
+            room_id,
+            thread_id,
+            gap_marked_at,
+            gap_reason
+        )
+        VALUES (
+            {p_scope},
+            {p_room},
+            {p_thread},
+            {d.parameter("gap_marked_at")},
+            {d.parameter("gap_reason")}
+        )
+        ON CONFLICT({scope}, room_id, thread_id) DO UPDATE SET
+            gap_marked_at = {d.monotonic_max(f"{thread_state}.gap_marked_at", "excluded.gap_marked_at")},
+            gap_reason = CASE
+                WHEN {thread_state}.gap_marked_at IS NULL
+                    OR excluded.gap_marked_at >= {thread_state}.gap_marked_at
+                    THEN excluded.gap_reason
+                ELSE {thread_state}.gap_reason
+            END
+        """,  # noqa: S608
+            # The room-scoped fan-out. Every SET expression reads the pre-update row, so the two
+            # assignments are order-independent.
+            fan_out_room_gap=f"""
+        UPDATE {thread_state}
+        SET gap_reason = CASE
+                WHEN gap_marked_at IS NULL
+                    OR {d.parameter("gap_marked_at")} >= gap_marked_at
+                    THEN {d.parameter("gap_reason")}
+                ELSE gap_reason
+            END,
+            gap_marked_at = {d.monotonic_max("gap_marked_at", d.parameter("gap_marked_at"))}
+        WHERE {scoped_room}
+        """,  # noqa: S608
+            upsert_room_gap=f"""
+        INSERT INTO {room_state}(
+            {scope},
+            room_id,
+            room_gap_marked_at,
+            room_gap_reason
+        )
+        VALUES (
+            {p_scope},
+            {p_room},
+            {d.parameter("gap_marked_at")},
+            {d.parameter("gap_reason")}
+        )
+        ON CONFLICT({scope}, room_id) DO UPDATE SET
+            room_gap_reason = CASE
+                WHEN {room_state}.room_gap_marked_at IS NULL
+                    OR excluded.room_gap_marked_at >= {room_state}.room_gap_marked_at
+                    THEN excluded.room_gap_reason
+                ELSE {room_state}.room_gap_reason
+            END,
+            room_gap_marked_at = {
+                d.monotonic_max(
+                    f"{room_state}.room_gap_marked_at",
+                    "excluded.room_gap_marked_at",
+                )
+            }
+        """,  # noqa: S608
+            advance_snapshot_watermark=f"""
+        INSERT INTO {thread_state}(
+            {scope},
+            room_id,
+            thread_id,
+            snapshot_fetch_started_at
+        )
+        VALUES (
+            {p_scope},
+            {p_room},
+            {p_thread},
+            {d.parameter("reflected_at")}
+        )
+        ON CONFLICT({scope}, room_id, thread_id) DO UPDATE SET
+            snapshot_fetch_started_at = {
+                d.monotonic_max(
+                    f"{thread_state}.snapshot_fetch_started_at",
+                    "excluded.snapshot_fetch_started_at",
+                )
+            }
+        """,  # noqa: S608
+            event_ids_for_thread=f"""
+        SELECT event_id
+        FROM {thread_events}
+        WHERE {scoped_room} AND thread_id = {p_thread}
+        """,  # noqa: S608
+            event_ids_for_room=f"""
+        SELECT event_id
+        FROM {thread_events}
+        WHERE {scoped_room}
+        """,  # noqa: S608
+        )

--- a/src/mindroom/matrix/cache/postgres_agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/postgres_agent_message_snapshot.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any
 
 import psycopg
 
+from . import event_cache_thread_ops as thread_ops
 from . import postgres_event_cache_events, postgres_event_cache_threads
 from .agent_message_snapshot import AgentMessageSnapshot, AgentMessageSnapshotUnavailable
 from .agent_message_snapshot_semantics import (
@@ -32,9 +33,10 @@ async def _reject_thread_scope_with_gap(
         return
 
     reject_snapshot_scope_with_gap(
-        await postgres_event_cache_threads.load_thread_cache_gap(
+        await thread_ops.load_thread_cache_gap(
+            postgres_event_cache_threads.BACKEND,
             db,
-            namespace=namespace,
+            scope=namespace,
             room_id=room_id,
             thread_id=thread_id,
         ),

--- a/src/mindroom/matrix/cache/postgres_event_cache.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache.py
@@ -14,6 +14,7 @@ import psycopg
 
 from mindroom.logging_config import get_logger
 
+from . import event_cache_thread_ops as thread_ops
 from . import postgres_event_cache_events, postgres_event_cache_threads
 from .event_batching import group_lookup_events_by_room
 from .event_cache import EventCacheBackendUnavailableError
@@ -1200,9 +1201,10 @@ class PostgresEventCache:
         if flushed_pending.room_purge or flushed_pending.principal_purge:
             result = disabled_result
         elif not allow_departed:
-            membership_state, membership_epoch = await postgres_event_cache_threads.load_room_membership_locked(
+            membership_state, membership_epoch = await thread_ops.load_room_membership_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
             )
             if membership_state != "joined":
@@ -1235,9 +1237,10 @@ class PostgresEventCache:
                 namespace=self._runtime.namespace,
                 room_id=room_id,
             )
-            await postgres_event_cache_threads.set_room_membership_locked(
+            await thread_ops.set_room_membership_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 membership_state="departed",
                 reason="room_departed",
@@ -1248,9 +1251,10 @@ class PostgresEventCache:
         room_pending = self._runtime.pending_room_gap(room_id)
         thread_pending = self._runtime.pending_thread_gaps(room_id)
         if room_pending is not None:
-            await postgres_event_cache_threads.mark_room_gap_locked(
+            await thread_ops.mark_room_gap_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 gap_marked_at=room_pending.gap_marked_at,
                 reason=room_pending.reason,
@@ -1260,9 +1264,10 @@ class PostgresEventCache:
         for thread_id, pending_gap in thread_pending:
             if room_pending is not None and pending_gap.gap_marked_at <= room_pending.gap_marked_at:
                 continue
-            await postgres_event_cache_threads.mark_thread_gap_locked(
+            await thread_ops.mark_thread_gap_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 thread_id=thread_id,
                 gap_marked_at=pending_gap.gap_marked_at,
@@ -1299,9 +1304,10 @@ class PostgresEventCache:
             room_id,
             operation="get_thread_events",
             disabled_result=None,
-            callback=lambda db: postgres_event_cache_threads.load_thread_events(
+            callback=lambda db: thread_ops.load_thread_events(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -1313,9 +1319,10 @@ class PostgresEventCache:
             room_id,
             operation="get_thread_event_ids",
             disabled_result=set(),
-            callback=lambda db: postgres_event_cache_threads.load_thread_event_ids(
+            callback=lambda db: thread_ops.load_thread_event_ids(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -1327,9 +1334,10 @@ class PostgresEventCache:
             room_id,
             operation="has_thread_snapshot",
             disabled_result=False,
-            callback=lambda db: postgres_event_cache_threads.thread_snapshot_exists(
+            callback=lambda db: thread_ops.thread_snapshot_exists(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -1341,9 +1349,10 @@ class PostgresEventCache:
             room_id,
             operation="get_recent_room_thread_ids",
             disabled_result=[],
-            callback=lambda db: postgres_event_cache_threads.load_recent_room_thread_ids(
+            callback=lambda db: thread_ops.load_recent_room_thread_ids(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 limit=limit,
             ),
@@ -1355,9 +1364,10 @@ class PostgresEventCache:
             room_id,
             operation="get_thread_cache_gap",
             disabled_result=CACHE_GAP_UNAVAILABLE,
-            callback=lambda db: postgres_event_cache_threads.load_thread_cache_gap(
+            callback=lambda db: thread_ops.load_thread_cache_gap(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -1586,9 +1596,10 @@ class PostgresEventCache:
         events: list[dict[str, Any]],
         fetch_started_at: float,
     ) -> bool:
-        await postgres_event_cache_threads.replace_thread_locked(
+        await thread_ops.replace_thread_locked(
+            postgres_event_cache_threads.BACKEND,
             db,
-            namespace=self._runtime.namespace,
+            scope=self._runtime.namespace,
             room_id=room_id,
             thread_id=thread_id,
             events=events,
@@ -1603,9 +1614,10 @@ class PostgresEventCache:
             room_id,
             operation="invalidate_thread",
             disabled_result=None,
-            callback=lambda db: postgres_event_cache_threads.invalidate_thread_locked(
+            callback=lambda db: thread_ops.invalidate_thread_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -1617,9 +1629,10 @@ class PostgresEventCache:
             room_id,
             operation="invalidate_room_threads",
             disabled_result=None,
-            callback=lambda db: postgres_event_cache_threads.invalidate_room_threads_locked(
+            callback=lambda db: thread_ops.invalidate_room_threads_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
             ),
         )
@@ -1632,9 +1645,10 @@ class PostgresEventCache:
                 room_id,
                 operation="mark_thread_gap",
                 disabled_result=None,
-                callback=lambda db: postgres_event_cache_threads.mark_thread_gap_locked(
+                callback=lambda db: thread_ops.mark_thread_gap_locked(
+                    postgres_event_cache_threads.BACKEND,
                     db,
-                    namespace=self._runtime.namespace,
+                    scope=self._runtime.namespace,
                     room_id=room_id,
                     thread_id=thread_id,
                     gap_marked_at=gap_marked_at,
@@ -1658,9 +1672,10 @@ class PostgresEventCache:
                 room_id,
                 operation="mark_room_threads_gap",
                 disabled_result=None,
-                callback=lambda db: postgres_event_cache_threads.mark_room_gap_locked(
+                callback=lambda db: thread_ops.mark_room_gap_locked(
+                    postgres_event_cache_threads.BACKEND,
                     db,
-                    namespace=self._runtime.namespace,
+                    scope=self._runtime.namespace,
                     room_id=room_id,
                     gap_marked_at=gap_marked_at,
                     reason=reason,
@@ -1688,9 +1703,10 @@ class PostgresEventCache:
             room_id,
             operation="apply_thread_mutation_append",
             disabled_result=ThreadAppendOutcome.WRITES_UNAVAILABLE,
-            callback=lambda db: postgres_event_cache_threads.apply_thread_mutation_append_locked(
+            callback=lambda db: thread_ops.apply_thread_mutation_append_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 thread_id=thread_id,
                 normalized_event=normalized_event,
@@ -1759,9 +1775,10 @@ class PostgresEventCache:
             room_id,
             operation="room_membership_epoch",
             disabled_result=None,
-            callback=lambda db: postgres_event_cache_threads.certify_room_membership_locked(
+            callback=lambda db: thread_ops.certify_room_membership_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
             ),
             allow_departed=True,
@@ -1793,15 +1810,17 @@ class PostgresEventCache:
         async def join_if_current(db: psycopg.AsyncConnection) -> bool:
             if self.room_departure_epoch(room_id) != expected_departure_epoch:
                 return False
-            membership_state, _membership_epoch = await postgres_event_cache_threads.load_room_membership_locked(
+            membership_state, _membership_epoch = await thread_ops.load_room_membership_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
             )
             if membership_state != "joined":
-                await postgres_event_cache_threads.set_room_membership_locked(
+                await thread_ops.set_room_membership_locked(
+                    postgres_event_cache_threads.BACKEND,
                     db,
-                    namespace=self._runtime.namespace,
+                    scope=self._runtime.namespace,
                     room_id=room_id,
                     membership_state="joined",
                     reason="room_rejoined",
@@ -1813,9 +1832,10 @@ class PostgresEventCache:
                 namespace=self._runtime.namespace,
                 room_id=room_id,
             )
-            await postgres_event_cache_threads.set_room_membership_locked(
+            await thread_ops.set_room_membership_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=self._runtime.namespace,
+                scope=self._runtime.namespace,
                 room_id=room_id,
                 membership_state="departed",
                 reason="room_departed",

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -1,18 +1,17 @@
-"""PostgreSQL thread snapshot and freshness storage helpers for the Matrix event cache."""
+"""PostgreSQL binding for the shared thread-cache operations.
+
+The operations themselves live in ``event_cache_thread_ops`` and the statements in
+``event_cache_thread_statements``. What is left here is what PostgreSQL genuinely does
+differently: its cursor handling, its array-valued bulk delete, and a write-sequence column that
+defaults from ``nextval`` rather than being allocated in Python.
+"""
 
 from __future__ import annotations
 
-import json
-import time
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Final, cast
 
-from .event_cache_events import (
-    event_id_for_cache,
-    serialize_cacheable_events,
-    serialize_cached_event,
-)
-from .event_normalization import normalize_event_source_for_cache
-from .postgres_cursor import fetchall, fetchone
+from .event_cache_sql_dialect import POSTGRES_DIALECT
+from .event_cache_thread_statements import ThreadStatements
 from .postgres_event_cache_events import (
     delete_cached_events,
     delete_event_edit_rows,
@@ -21,911 +20,186 @@ from .postgres_event_cache_events import (
     filter_cacheable_events,
     write_lookup_index_rows,
 )
-from .thread_cache_state import (
-    ThreadAppendOutcome,
-    ThreadCacheGap,
-    thread_cache_gap_row,
-)
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping, Sequence
+    from typing import LiteralString
+
     from psycopg import AsyncConnection
 
+    from .event_cache_events import SerializedCachedEvent
+    from .event_cache_thread_ops import ThreadBackend
 
-# The edits that survive a collapsed read: one per message, from the right sender.
-#
-# This query mirrors the SQLite one. What it selects and why - the per (original, sender) rule, why
-# the sender comparison here is an optimization rather than the security boundary, why the original
-# is LEFT joined out of ``events`` alone, why ROW_NUMBER rather than a correlated NOT EXISTS, why
-# MATERIALIZED, and what a write-time prune would have to preserve - is recorded once above
-# ``_SURVIVING_EDITS_CTE``
-# in sqlite_event_cache_threads.py. Only the PostgreSQL-specific notes live here; keep it that way,
-# because the two copies had already drifted when this was last deduplicated.
-#
-# Do not rewrite the ranking as ``DISTINCT ON (original_event_id)``: that shape materialises every
-# row of the thread before it can pick winners.
-#
-# Do not re-derive this query's cost without ANALYZE. On unanalyzed tables an unseen namespace
-# estimates 1 row against thousands actual, every join degrades to a nested loop with a join filter,
-# and every shape collapses - a plain unfiltered read of the same thread included, by 77x. A
-# comparison made in that state measures the planner, not the query.
-#
-# ``COLLATE "C"`` is load-bearing, not decoration. The tie-break has to agree with SQLite and
-# with the fold, and both compare event IDs by byte: SQLite TEXT comparison is always BINARY and
-# ``_edit_candidate_is_newer`` compares Python strings by code point. Without the override this
-# ORDER BY uses the database's default collation, so on a glibc cluster ('a' < 'B') the read
-# ships a different surviving edit than SQLite does for the same two edits sharing a timestamp -
-# and the fold applies whichever single edit it is handed, so the message renders differently per
-# backend. Matrix v4+ event IDs are mixed-case base64url, the input where the two orders diverge
-# most.
-#
-# It is nearly free, not free. A different collation is a different OID, so this ORDER BY no
-# longer matches idx_..._event_edits_room_original_ts and the plan gains an Incremental Sort
-# above it - on a C-collation database too, since "C" (950) is not the default OID (100) even
-# when datcollate is C. The presorted prefix survives, so the residual sort covers one
-# (original, timestamp) group, which is a single row outside the tie this exists to fix.
-# Measured end to end on a 540-row 94%-edit thread: 11.8 ms with, 10.7 ms without.
-#
-# The behavioural divergence is invisible to CI: the fixture pins postgres:15-alpine and musl
-# has no real locale support, so every libc collation there behaves like C and a seeded read
-# cannot fail whether or not this pin is present. test_edit_ranking_is_scoped_to_this_thread
-# _and_this_sender therefore asserts the pin structurally, which is what can actually fail.
-_SURVIVING_EDITS_CTE = """
-WITH surviving_edits AS MATERIALIZED (
-    SELECT edit_event_id
-    FROM (
-        SELECT event_edits.edit_event_id AS edit_event_id,
-               ROW_NUMBER() OVER (
-                   PARTITION BY event_edits.original_event_id
-                   ORDER BY event_edits.origin_server_ts DESC,
-                            event_edits.edit_event_id COLLATE "C" DESC
-               ) AS edit_rank
-        FROM mindroom_event_cache_event_edits AS event_edits
-        JOIN mindroom_event_cache_thread_events AS edit_membership
-            ON edit_membership.namespace = event_edits.namespace
-            AND edit_membership.room_id = event_edits.room_id
-            AND edit_membership.event_id = event_edits.edit_event_id
-            AND edit_membership.thread_id = %(thread_id)s
-        JOIN mindroom_event_cache_events AS edit_events
-            ON edit_events.namespace = event_edits.namespace
-            AND edit_events.room_id = event_edits.room_id
-            AND edit_events.event_id = event_edits.edit_event_id
-        LEFT JOIN mindroom_event_cache_events AS original_events
-            ON original_events.namespace = event_edits.namespace
-            AND original_events.room_id = event_edits.room_id
-            AND original_events.event_id = event_edits.original_event_id
-        WHERE event_edits.namespace = %(namespace)s
-            AND event_edits.room_id = %(room_id)s
-            AND (original_events.event_id IS NULL OR edit_events.sender = original_events.sender)
-    ) AS ranked
-    WHERE edit_rank = 1
-)
+_STATEMENTS: Final = ThreadStatements.build(POSTGRES_DIALECT)
+
+_DELETE_THREAD_MEMBERSHIP_BY_EVENT_IDS: Final = """
+DELETE FROM mindroom_event_cache_thread_events
+WHERE namespace = %(scope)s AND room_id = %(room_id)s AND event_id = ANY(%(event_ids)s)
 """
 
-# One thread, collapsed: every non-edit row, plus the one surviving edit per edited message.
-_THREAD_EVENTS_SQL = (
-    _SURVIVING_EDITS_CTE  # noqa: S608 - both operands are literals; params stay bound
-    + """
-SELECT thread_events.origin_server_ts, thread_events.write_seq, events.event_json
-FROM mindroom_event_cache_thread_events AS thread_events
-JOIN mindroom_event_cache_events AS events
-    ON events.namespace = thread_events.namespace
-    AND events.room_id = thread_events.room_id
-    AND events.event_id = thread_events.event_id
-WHERE thread_events.namespace = %(namespace)s
-    AND thread_events.room_id = %(room_id)s
-    AND thread_events.thread_id = %(thread_id)s
-    AND (
-        NOT EXISTS (
-            SELECT 1
-            FROM mindroom_event_cache_event_edits AS row_is_an_edit
-            WHERE row_is_an_edit.namespace = thread_events.namespace
-                AND row_is_an_edit.room_id = thread_events.room_id
-                AND row_is_an_edit.edit_event_id = thread_events.event_id
-        )
-        OR thread_events.event_id IN (SELECT edit_event_id FROM surviving_edits)
-    )
-ORDER BY thread_events.origin_server_ts ASC, thread_events.write_seq ASC
-"""
-)
 
+def _query(sql: str) -> LiteralString:
+    """Narrow a rendered statement to the query type psycopg accepts.
 
-async def load_thread_events(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-) -> list[dict[str, Any]] | None:
-    """Return one thread's cached events oldest first, collapsed to one edit per message."""
-    rows = await fetchall(
-        db,
-        _THREAD_EVENTS_SQL,
-        {"namespace": namespace, "room_id": room_id, "thread_id": thread_id},
-    )
-    return [json.loads(row[2]) for row in rows] if rows else None
-
-
-async def load_thread_event_ids(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-) -> set[str]:
-    """Return every raw event ID this thread holds, superseded edits included.
-
-    Membership and visibility are different questions, and collapsing is what made them differ:
-    the visible read shows one edit per message, while this returns every row the thread owns. The
-    repair bookkeeping this was written for is gone; the surviving caller is the edit-sender rule's
-    coverage, which needs the membership set to state its precondition.
-
-    Joined to ``events`` rather than reading membership alone: a membership row whose payload is
-    gone is not durably present, and reporting it as present would suppress a refill that should
-    happen. That join is also what the pre-collapse code did implicitly, since it derived these IDs
-    from a read that required the payload.
+    Every statement reaching here is assembled by ``ThreadStatements`` from a closed set of literal
+    table names, column names, and parameter markers. Caller values stay bound, so no runtime data
+    reaches the text and the ``LiteralString`` contract holds even though the string is built at
+    import time rather than written inline.
     """
-    rows = await fetchall(
-        db,
-        """
-        SELECT thread_events.event_id
-        FROM mindroom_event_cache_thread_events AS thread_events
-        JOIN mindroom_event_cache_events AS events
-            ON events.namespace = thread_events.namespace
-            AND events.room_id = thread_events.room_id
-            AND events.event_id = thread_events.event_id
-        WHERE thread_events.namespace = %s AND thread_events.room_id = %s AND thread_events.thread_id = %s
-        """,
-        (namespace, room_id, thread_id),
-    )
-    return {str(row[0]) for row in rows}
+    return cast("LiteralString", sql)
 
 
-async def load_recent_room_thread_ids(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    limit: int,
-) -> list[str]:
-    """Return thread IDs for one room ordered by the newest locally cached event timestamp."""
-    rows = await fetchall(
-        db,
-        """
-        SELECT thread_id
-        FROM mindroom_event_cache_thread_events
-        WHERE namespace = %s AND room_id = %s
-        GROUP BY thread_id
-        ORDER BY MAX(origin_server_ts) DESC, thread_id ASC
-        LIMIT %s
-        """,
-        (namespace, room_id, limit),
-    )
-    return [str(row[0]) for row in rows]
+class _PostgresThreadBackend:
+    """Run the shared thread-cache operations against a psycopg connection."""
 
+    statements = _STATEMENTS
 
-async def load_thread_cache_gap(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-) -> ThreadCacheGap | None:
-    """Return the durable gap marker recorded against one cached thread, if any.
+    async def execute(
+        self,
+        db: AsyncConnection,
+        sql: str,
+        params: Mapping[str, object],
+    ) -> None:
+        """Run one statement that returns no rows."""
+        await db.execute(_query(sql), params)
 
-    Room-scoped gaps are fanned out across the room's thread rows when they are marked, so this is
-    a single-table read with no room-state join.
-    """
-    row = await fetchone(
-        db,
-        """
-        SELECT gap_marked_at, gap_reason
-        FROM mindroom_event_cache_thread_state
-        WHERE namespace = %s AND room_id = %s AND thread_id = %s
-        """,
-        (namespace, room_id, thread_id),
-    )
-    return thread_cache_gap_row(row)
+    async def fetchone(
+        self,
+        db: AsyncConnection,
+        sql: str,
+        params: Mapping[str, object],
+    ) -> tuple[Any, ...] | None:
+        """Run one query and return its first row, if any."""
+        cursor = await db.execute(_query(sql), params)
+        try:
+            row = await cursor.fetchone()
+        finally:
+            await cursor.close()
+        return None if row is None else tuple(row)
 
+    async def fetchall(
+        self,
+        db: AsyncConnection,
+        sql: str,
+        params: Mapping[str, object],
+    ) -> list[tuple[Any, ...]]:
+        """Run one query and return every row."""
+        cursor = await db.execute(_query(sql), params)
+        try:
+            rows = await cursor.fetchall()
+        finally:
+            await cursor.close()
+        return [tuple(row) for row in rows]
 
-async def load_room_membership_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-) -> tuple[str, int]:
-    """Return the durable membership state and transition epoch for one principal-room."""
-    row = await fetchone(
-        db,
-        """
-        SELECT membership_state, membership_epoch
-        FROM mindroom_event_cache_room_state
-        WHERE namespace = %s AND room_id = %s
-        """,
-        (namespace, room_id),
-    )
-    return ("joined", 0) if row is None else (str(row[0]), int(row[1]))
+    async def upsert_thread_membership_rows(
+        self,
+        db: AsyncConnection,
+        rows: Sequence[Mapping[str, object]],
+    ) -> None:
+        """Write thread-membership rows, letting the column default draw each write sequence."""
+        for row in rows:
+            await db.execute(_query(self.statements.upsert_thread_membership), row)
 
-
-async def certify_room_membership_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-) -> int:
-    """Create a durable generation row and return its current epoch."""
-    await db.execute(
-        """
-        INSERT INTO mindroom_event_cache_room_state(
-            namespace,
-            room_id,
-            membership_state,
-            membership_epoch
-        )
-        VALUES (%s, %s, 'joined', 0)
-        ON CONFLICT(namespace, room_id) DO NOTHING
-        """,
-        (namespace, room_id),
-    )
-    _membership_state, membership_epoch = await load_room_membership_locked(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-    )
-    return membership_epoch
-
-
-async def set_room_membership_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    membership_state: Literal["joined", "departed"],
-    reason: str,
-) -> None:
-    """Advance one durable room-membership transition and gap-mark prior refills."""
-    await mark_room_gap_locked(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        reason=reason,
-    )
-    # 🔒 ``mark_room_gap_locked`` has already upserted the row, so the epoch below always has
-    # something to advance. A missing row and a fresh one both read as ``('joined', 0)``.
-    await db.execute(
-        """
-        UPDATE mindroom_event_cache_room_state
-        SET membership_state = %s, membership_epoch = membership_epoch + 1
-        WHERE namespace = %s AND room_id = %s
-        """,
-        (membership_state, namespace, room_id),
-    )
-
-
-async def _store_thread_events_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-    events: list[dict[str, Any]],
-    stored_at: float,
-    fetch_started_at: float,
-) -> frozenset[str]:
-    """Persist one authoritative thread snapshot within an existing DB transaction."""
-    normalized_events = [normalize_event_source_for_cache(event) for event in events]
-    cacheable_events = await filter_cacheable_events(
-        db,
-        namespace,
-        room_id,
-        [(event_id_for_cache(event), event) for event in normalized_events],
-    )
-    serialized_events = serialize_cacheable_events(cacheable_events)
-    await write_lookup_index_rows(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        serialized_events=serialized_events,
-        cached_at=stored_at,
-        thread_id=thread_id,
-    )
-    for event in serialized_events:
+    async def delete_thread_membership_by_event_ids(
+        self,
+        db: AsyncConnection,
+        scope: str,
+        room_id: str,
+        event_ids: Sequence[str],
+    ) -> None:
+        """Delete thread-membership rows for an explicit list of event IDs."""
         await db.execute(
-            """
-            INSERT INTO mindroom_event_cache_thread_events(namespace, room_id, thread_id, event_id, origin_server_ts)
-            VALUES (%s, %s, %s, %s, %s)
-            ON CONFLICT(namespace, room_id, event_id) DO UPDATE SET
-                thread_id = excluded.thread_id,
-                origin_server_ts = excluded.origin_server_ts,
-                event_json = NULL,
-                write_seq = nextval('mindroom_event_cache_write_seq')
-            """,
-            (
-                namespace,
-                room_id,
-                thread_id,
-                event.event_id,
-                event.origin_server_ts,
-            ),
+            _query(_DELETE_THREAD_MEMBERSHIP_BY_EVENT_IDS),
+            {"scope": scope, "room_id": room_id, "event_ids": list(event_ids)},
         )
-    await _clear_thread_gap_covered_by_fetch(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-        fetch_started_at=fetch_started_at,
-    )
-    return frozenset(event.event_id for event in serialized_events)
 
+    async def filter_cacheable_events(
+        self,
+        db: AsyncConnection,
+        scope: str,
+        room_id: str,
+        candidates: list[tuple[str, dict[str, Any]]],
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Drop candidates this cache must refuse to store."""
+        return await filter_cacheable_events(db, scope, room_id, candidates)
 
-async def replace_thread_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-    events: list[dict[str, Any]],
-    stored_at: float,
-    fetch_started_at: float,
-) -> None:
-    """Replace one thread snapshot atomically within an existing DB transaction.
-
-    Replacement is ordered by ``fetch_started_at``, not by arrival: because installing a snapshot
-    deletes the events it omits, a slow fetch landing after a newer one would otherwise bury the
-    newer thread contents and leave no gap marker behind to force a refetch. An older fetch is
-    therefore skipped outright. This is one comparison, not a conflict classifier — the loser has
-    nothing to retry, since the snapshot already installed is strictly fresher than its own.
-
-    The gap marker is separately conditional — see ``_clear_thread_gap_covered_by_fetch``.
-    """
-    if await _thread_snapshot_is_newer_than_fetch(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-        fetch_started_at=fetch_started_at,
-    ):
-        return
-    existing_event_ids = await _thread_event_ids_for_thread(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-    )
-    replacement_event_ids = await _store_thread_events_locked(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-        events=events,
-        stored_at=stored_at,
-        fetch_started_at=fetch_started_at,
-    )
-    removed_event_ids = sorted(set(existing_event_ids) - replacement_event_ids)
-    if removed_event_ids:
-        await db.execute(
-            """
-            DELETE FROM mindroom_event_cache_thread_events
-            WHERE namespace = %s AND room_id = %s AND event_id = ANY(%s)
-            """,
-            (namespace, room_id, removed_event_ids),
-        )
-        await delete_cached_events(
+    async def write_lookup_index_rows(
+        self,
+        db: AsyncConnection,
+        scope: str,
+        room_id: str,
+        *,
+        serialized_events: list[SerializedCachedEvent],
+        cached_at: float,
+        thread_id: str | None = None,
+    ) -> None:
+        """Persist point-lookup, edit-index, and thread-index rows for cached events."""
+        await write_lookup_index_rows(
             db,
-            namespace=namespace,
+            namespace=scope,
             room_id=room_id,
-            event_ids=removed_event_ids,
-        )
-        await delete_event_edit_rows(
-            db,
-            namespace,
-            room_id,
-            event_ids=removed_event_ids,
-            original_event_id=None,
-        )
-        await delete_event_thread_rows(
-            db,
-            namespace,
-            room_id,
-            event_ids=removed_event_ids,
-            current_self_root_ids={thread_id} if thread_id in replacement_event_ids else (),
-        )
-
-
-async def invalidate_thread_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-) -> None:
-    """Delete cached events and state for one thread within an existing transaction."""
-    event_ids = await _thread_event_ids_for_thread(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-    )
-    await db.execute(
-        """
-        DELETE FROM mindroom_event_cache_thread_events
-        WHERE namespace = %s AND room_id = %s AND thread_id = %s
-        """,
-        (namespace, room_id, thread_id),
-    )
-    if event_ids:
-        await delete_cached_events(db, namespace=namespace, room_id=room_id, event_ids=event_ids)
-        await delete_event_edit_rows(
-            db,
-            namespace,
-            room_id,
-            event_ids=event_ids,
-            original_event_id=None,
-        )
-        await delete_event_thread_rows(
-            db,
-            namespace,
-            room_id,
-            event_ids=event_ids,
-        )
-    await db.execute(
-        """
-        DELETE FROM mindroom_event_cache_thread_state
-        WHERE namespace = %s AND room_id = %s AND thread_id = %s
-        """,
-        (namespace, room_id, thread_id),
-    )
-
-
-async def invalidate_room_threads_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-) -> None:
-    """Delete every cached thread snapshot while preserving durable room membership."""
-    event_ids = await _thread_event_ids_for_room(db, namespace=namespace, room_id=room_id)
-    await db.execute(
-        """
-        DELETE FROM mindroom_event_cache_thread_events
-        WHERE namespace = %s AND room_id = %s
-        """,
-        (namespace, room_id),
-    )
-    if event_ids:
-        await delete_cached_events(db, namespace=namespace, room_id=room_id, event_ids=event_ids)
-        await delete_event_edit_rows(
-            db,
-            namespace,
-            room_id,
-            event_ids=event_ids,
-            original_event_id=None,
-        )
-        await delete_event_thread_rows(
-            db,
-            namespace,
-            room_id,
-            event_ids=event_ids,
-        )
-    await db.execute(
-        """
-        DELETE FROM mindroom_event_cache_thread_state
-        WHERE namespace = %s AND room_id = %s
-        """,
-        (namespace, room_id),
-    )
-
-
-async def mark_thread_gap_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-    reason: str,
-    gap_marked_at: float | None = None,
-) -> None:
-    """Record one durable thread gap marker within an active transaction.
-
-    The marker is monotonic: a later gap never loses to an earlier one. There is no reason
-    precedence — every reason means the same thing, that this snapshot must be refetched.
-    """
-    marked_at = time.time() if gap_marked_at is None else gap_marked_at
-    await db.execute(
-        """
-        INSERT INTO mindroom_event_cache_thread_state(
-            namespace,
-            room_id,
-            thread_id,
-            gap_marked_at,
-            gap_reason
-        )
-        VALUES (%s, %s, %s, %s, %s)
-        ON CONFLICT(namespace, room_id, thread_id) DO UPDATE SET
-            gap_marked_at = GREATEST(
-                mindroom_event_cache_thread_state.gap_marked_at,
-                excluded.gap_marked_at
-            ),
-            gap_reason = CASE
-                WHEN mindroom_event_cache_thread_state.gap_marked_at IS NULL
-                    OR excluded.gap_marked_at >= mindroom_event_cache_thread_state.gap_marked_at
-                    THEN excluded.gap_reason
-                ELSE mindroom_event_cache_thread_state.gap_reason
-            END
-        """,
-        (namespace, room_id, thread_id, marked_at, reason),
-    )
-
-
-async def apply_thread_mutation_append_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-    normalized_event: dict[str, Any],
-    append_failed_reason: str,
-) -> ThreadAppendOutcome:
-    """Append one threaded mutation, recording a gap marker in the same transaction when it cannot land.
-
-    Appending and marking are one operation so a mutation that fails can never leave a snapshot
-    readable while it is missing the event. A successful append clears nothing: an append extends a
-    snapshot, it does not prove the snapshot complete.
-    """
-    outcome = await _append_existing_thread_event(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-        normalized_event=normalized_event,
-    )
-    if outcome is not ThreadAppendOutcome.APPENDED:
-        await mark_thread_gap_locked(
-            db,
-            namespace=namespace,
-            room_id=room_id,
+            serialized_events=serialized_events,
+            cached_at=cached_at,
             thread_id=thread_id,
-            reason=append_failed_reason,
         )
-    return outcome
 
+    async def delete_cached_events(
+        self,
+        db: AsyncConnection,
+        scope: str,
+        room_id: str,
+        event_ids: Sequence[str],
+    ) -> None:
+        """Delete point-lookup payload rows for these event IDs."""
+        await delete_cached_events(db, namespace=scope, room_id=room_id, event_ids=list(event_ids))
 
-async def mark_room_gap_locked(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    reason: str,
-    gap_marked_at: float | None = None,
-) -> None:
-    """Record one room-scoped (wildcard-thread) gap across the room's threads and on the room itself.
-
-    The fan-out reaches every thread that already holds a ``thread_state`` row. That is not all of
-    them: a thread whose first fetch is still in flight has no row yet, so the fan-out skips it and
-    the replacement that lands afterwards would insert a clean row for a snapshot fetched from before
-    the gap. The room-level copy is what that replacement consults, so the two together cover the room
-    whether or not a thread's row existed when the gap was recorded.
-    """
-    marked_at = time.time() if gap_marked_at is None else gap_marked_at
-    await db.execute(
-        """
-        UPDATE mindroom_event_cache_thread_state
-        SET gap_marked_at = GREATEST(gap_marked_at, %s),
-            gap_reason = CASE
-                WHEN gap_marked_at IS NULL OR %s >= gap_marked_at THEN %s
-                ELSE gap_reason
-            END
-        WHERE namespace = %s AND room_id = %s
-        """,
-        (marked_at, marked_at, reason, namespace, room_id),
-    )
-    await db.execute(
-        """
-        INSERT INTO mindroom_event_cache_room_state(namespace, room_id, room_gap_marked_at, room_gap_reason)
-        VALUES (%s, %s, %s, %s)
-        ON CONFLICT(namespace, room_id) DO UPDATE SET
-            room_gap_reason = CASE
-                WHEN mindroom_event_cache_room_state.room_gap_marked_at IS NULL
-                    OR EXCLUDED.room_gap_marked_at >= mindroom_event_cache_room_state.room_gap_marked_at
-                    THEN EXCLUDED.room_gap_reason
-                ELSE mindroom_event_cache_room_state.room_gap_reason
-            END,
-            room_gap_marked_at = GREATEST(
-                mindroom_event_cache_room_state.room_gap_marked_at,
-                EXCLUDED.room_gap_marked_at
-            )
-        """,
-        (namespace, room_id, marked_at, reason),
-    )
-
-
-async def _append_existing_thread_event(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-    normalized_event: dict[str, Any],
-) -> ThreadAppendOutcome:
-    """Append one event to an existing cached thread and classify what happened.
-
-    An opaque ``m.room.encrypted`` payload never replaces stored clear content for the same event ID.
-    A redacted event (or one whose edit target is redacted) is refused before anything is written, so
-    its payload never reaches the point-lookup table.
-    """
-    event_id = event_id_for_cache(normalized_event)
-    if await event_or_original_is_redacted(
-        db,
-        namespace,
-        room_id,
-        event_id=event_id,
-        event=normalized_event,
-    ):
-        return ThreadAppendOutcome.APPEND_REFUSED
-
-    serialized_event = serialize_cached_event(event_id, normalized_event)
-    row = await fetchone(
-        db,
-        """
-        SELECT 1
-        FROM mindroom_event_cache_thread_events AS membership
-        JOIN mindroom_event_cache_events AS events
-            ON events.namespace = membership.namespace
-            AND events.event_id = membership.event_id
-            AND events.room_id = membership.room_id
-        WHERE membership.namespace = %s
-            AND membership.room_id = %s
-            AND membership.thread_id = %s
-        LIMIT 1
-        """,
-        (namespace, room_id, thread_id),
-    )
-    thread_exists = row is not None
-    await write_lookup_index_rows(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        serialized_events=[serialized_event],
-        cached_at=time.time(),
-        thread_id=thread_id,
-    )
-    if not thread_exists:
-        # Only lookup-index rows are recorded: there is no snapshot to extend, so only a full
-        # history scan can make this thread readable again.
-        return ThreadAppendOutcome.SNAPSHOT_MISSING
-    await db.execute(
-        """
-        INSERT INTO mindroom_event_cache_thread_events(namespace, room_id, thread_id, event_id, origin_server_ts)
-        VALUES (%s, %s, %s, %s, %s)
-        ON CONFLICT(namespace, room_id, event_id) DO UPDATE SET
-            thread_id = excluded.thread_id,
-            origin_server_ts = excluded.origin_server_ts,
-            event_json = NULL,
-            write_seq = nextval('mindroom_event_cache_write_seq')
-        """,
-        (
-            namespace,
+    async def delete_event_edit_rows(
+        self,
+        db: AsyncConnection,
+        scope: str,
+        room_id: str,
+        *,
+        event_ids: Sequence[str],
+        original_event_id: str | None,
+    ) -> None:
+        """Delete edit-index rows for these event IDs."""
+        await delete_event_edit_rows(
+            db,
+            scope,
             room_id,
-            thread_id,
-            serialized_event.event_id,
-            serialized_event.origin_server_ts,
-        ),
-    )
-    await _advance_snapshot_watermark(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        thread_id=thread_id,
-        reflected_at=time.time(),
-    )
-    return ThreadAppendOutcome.APPENDED
-
-
-async def _thread_snapshot_is_newer_than_fetch(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-    fetch_started_at: float,
-) -> bool:
-    """Return whether an installed snapshot came from a strictly newer fetch than this one."""
-    row = await fetchone(
-        db,
-        """
-        SELECT snapshot_fetch_started_at
-        FROM mindroom_event_cache_thread_state
-        WHERE namespace = %s AND room_id = %s AND thread_id = %s
-        """,
-        (namespace, room_id, thread_id),
-    )
-    if row is None or row[0] is None:
-        return False
-    return float(row[0]) > fetch_started_at
-
-
-async def _uncovered_room_gap(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    fetch_started_at: float,
-) -> tuple[float, str | None] | None:
-    """Return the room-scoped gap one fetch does not cover, if there is one."""
-    cursor = await db.execute(
-        """
-        SELECT room_gap_marked_at, room_gap_reason
-        FROM mindroom_event_cache_room_state
-        WHERE namespace = %s AND room_id = %s
-        """,
-        (namespace, room_id),
-    )
-    row = await cursor.fetchone()
-    await cursor.close()
-    if row is None or row[0] is None or float(row[0]) <= fetch_started_at:
-        return None
-    return (float(row[0]), row[1] if isinstance(row[1], str) else None)
-
-
-async def _clear_thread_gap_covered_by_fetch(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-    fetch_started_at: float,
-) -> None:
-    """Record this thread's snapshot, keeping any gap the replacing fetch does not cover.
-
-    A gap marked after the fetch began describes events the fetch could not have seen, so it
-    survives and the next read refetches. Both scopes have to be asked about, and the room one
-    cannot be answered by the fan-out alone: a thread whose first fetch was in flight when the room
-    was gapped has no row for the fan-out to update, so without the room-level copy this insert
-    would record a clean snapshot for events fetched from before the gap.
-    """
-    room_gap = await _uncovered_room_gap(
-        db,
-        namespace=namespace,
-        room_id=room_id,
-        fetch_started_at=fetch_started_at,
-    )
-    room_gap_marked_at, room_gap_reason = room_gap if room_gap is not None else (None, None)
-    await db.execute(
-        """
-        INSERT INTO mindroom_event_cache_thread_state(
-            namespace,
-            room_id,
-            thread_id,
-            gap_marked_at,
-            gap_reason,
-            snapshot_fetch_started_at
+            event_ids=list(event_ids),
+            original_event_id=original_event_id,
         )
-        VALUES (%s, %s, %s, %s, %s, %s)
-        ON CONFLICT(namespace, room_id, thread_id) DO UPDATE SET
-            snapshot_fetch_started_at = EXCLUDED.snapshot_fetch_started_at,
-            gap_marked_at = CASE
-                WHEN mindroom_event_cache_thread_state.gap_marked_at IS NULL
-                    OR mindroom_event_cache_thread_state.gap_marked_at <= %s
-                    THEN EXCLUDED.gap_marked_at
-                ELSE mindroom_event_cache_thread_state.gap_marked_at
-            END,
-            gap_reason = CASE
-                WHEN mindroom_event_cache_thread_state.gap_marked_at IS NULL
-                    OR mindroom_event_cache_thread_state.gap_marked_at <= %s
-                    THEN EXCLUDED.gap_reason
-                ELSE mindroom_event_cache_thread_state.gap_reason
-            END
-        """,
-        (
-            namespace,
+
+    async def delete_event_thread_rows(
+        self,
+        db: AsyncConnection,
+        scope: str,
+        room_id: str,
+        *,
+        event_ids: Sequence[str],
+        current_self_root_ids: Collection[str] = (),
+    ) -> None:
+        """Delete thread-index rows for these event IDs."""
+        await delete_event_thread_rows(
+            db,
+            scope,
             room_id,
-            thread_id,
-            room_gap_marked_at,
-            room_gap_reason,
-            fetch_started_at,
-            fetch_started_at,
-            fetch_started_at,
-        ),
-    )
-
-
-async def _advance_snapshot_watermark(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-    reflected_at: float,
-) -> None:
-    """Record that this snapshot now reflects the thread as of ``reflected_at``.
-
-    An append mutates the snapshot, so a fetch that started before it cannot represent the thread
-    any more. Moving the watermark forward makes ``replace_thread_locked`` refuse such a fetch,
-    which is what stops a slow scan from deleting a live event that landed while it was running.
-    """
-    await db.execute(
-        """
-        INSERT INTO mindroom_event_cache_thread_state(
-            namespace,
-            room_id,
-            thread_id,
-            snapshot_fetch_started_at
+            event_ids=list(event_ids),
+            current_self_root_ids=current_self_root_ids,
         )
-        VALUES (%s, %s, %s, %s)
-        ON CONFLICT(namespace, room_id, thread_id) DO UPDATE SET
-            snapshot_fetch_started_at = GREATEST(
-                mindroom_event_cache_thread_state.snapshot_fetch_started_at,
-                EXCLUDED.snapshot_fetch_started_at
-            )
-        """,
-        (namespace, room_id, thread_id, reflected_at),
-    )
+
+    async def event_or_original_is_redacted(
+        self,
+        db: AsyncConnection,
+        scope: str,
+        room_id: str,
+        *,
+        event_id: str,
+        event: dict[str, Any],
+    ) -> bool:
+        """Return whether this event, or the event it edits, is redacted."""
+        return await event_or_original_is_redacted(db, scope, room_id, event_id=event_id, event=event)
 
 
-async def _thread_event_ids_for_thread(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-) -> list[str]:
-    """Return cached event IDs currently stored for one thread."""
-    rows = await fetchall(
-        db,
-        """
-        SELECT event_id
-        FROM mindroom_event_cache_thread_events
-        WHERE namespace = %s AND room_id = %s AND thread_id = %s
-        """,
-        (namespace, room_id, thread_id),
-    )
-    return [str(row[0]) for row in rows]
-
-
-async def thread_snapshot_exists(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-    thread_id: str,
-) -> bool:
-    """Return whether one thread has at least one durably present snapshot row.
-
-    Joined to ``events`` rather than reading membership alone: a membership row whose payload is
-    gone is not durably present, and answering yes for one reports a thread as cached that no read
-    can serve, which is how startup prewarm silently skips it.
-    """
-    cursor = await db.execute(
-        """
-        SELECT 1
-        FROM mindroom_event_cache_thread_events AS thread_events
-        JOIN mindroom_event_cache_events AS events
-            ON events.namespace = thread_events.namespace
-            AND events.room_id = thread_events.room_id
-            AND events.event_id = thread_events.event_id
-        WHERE thread_events.namespace = %s AND thread_events.room_id = %s AND thread_events.thread_id = %s
-        LIMIT 1
-        """,
-        (namespace, room_id, thread_id),
-    )
-    row = await cursor.fetchone()
-    await cursor.close()
-    return row is not None
-
-
-async def _thread_event_ids_for_room(
-    db: AsyncConnection,
-    *,
-    namespace: str,
-    room_id: str,
-) -> list[str]:
-    """Return cached event IDs currently stored for every thread in one room."""
-    rows = await fetchall(
-        db,
-        """
-        SELECT event_id
-        FROM mindroom_event_cache_thread_events
-        WHERE namespace = %s AND room_id = %s
-        """,
-        (namespace, room_id),
-    )
-    return [str(row[0]) for row in rows]
+BACKEND: Final[ThreadBackend[AsyncConnection]] = _PostgresThreadBackend()

--- a/src/mindroom/matrix/cache/sqlite_agent_message_snapshot.py
+++ b/src/mindroom/matrix/cache/sqlite_agent_message_snapshot.py
@@ -6,6 +6,7 @@ import json
 import sqlite3
 from typing import TYPE_CHECKING, Any
 
+from . import event_cache_thread_ops as thread_ops
 from . import sqlite_event_cache_events, sqlite_event_cache_threads
 from .agent_message_snapshot import AgentMessageSnapshot, AgentMessageSnapshotUnavailable
 from .agent_message_snapshot_semantics import (
@@ -31,9 +32,10 @@ async def _reject_thread_scope_with_gap(
         return
 
     reject_snapshot_scope_with_gap(
-        await sqlite_event_cache_threads.load_thread_cache_gap(
+        await thread_ops.load_thread_cache_gap(
+            sqlite_event_cache_threads.BACKEND,
             db,
-            principal_id=principal_id,
+            scope=principal_id,
             room_id=room_id,
             thread_id=thread_id,
         ),

--- a/src/mindroom/matrix/cache/sqlite_event_cache.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache.py
@@ -14,6 +14,7 @@ import aiosqlite
 
 from mindroom.logging_config import get_logger
 
+from . import event_cache_thread_ops as thread_ops
 from . import sqlite_event_cache_events, sqlite_event_cache_threads
 from .event_batching import group_lookup_events_by_room
 from .event_cache import EventCacheBackendUnavailableError
@@ -739,9 +740,10 @@ class SqliteEventCache:
                     )
                     result = disabled_result
                 else:
-                    membership_state, membership_epoch = await sqlite_event_cache_threads.load_room_membership_locked(
+                    membership_state, membership_epoch = await thread_ops.load_room_membership_locked(
+                        sqlite_event_cache_threads.BACKEND,
                         db,
-                        principal_id=self.principal_id,
+                        scope=self.principal_id,
                         room_id=room_id,
                     )
                     result = (
@@ -805,9 +807,10 @@ class SqliteEventCache:
                         principal_id=self.principal_id,
                         room_id=room_id,
                     )
-                    await sqlite_event_cache_threads.set_room_membership_locked(
+                    await thread_ops.set_room_membership_locked(
+                        sqlite_event_cache_threads.BACKEND,
                         db,
-                        principal_id=self.principal_id,
+                        scope=self.principal_id,
                         room_id=room_id,
                         membership_state="departed",
                         reason="room_departed",
@@ -817,14 +820,16 @@ class SqliteEventCache:
                 elif allow_departed:
                     result = await writer(db)
                 else:
-                    await sqlite_event_cache_threads.certify_room_membership_locked(
+                    await thread_ops.certify_room_membership_locked(
+                        sqlite_event_cache_threads.BACKEND,
                         db,
-                        principal_id=self.principal_id,
+                        scope=self.principal_id,
                         room_id=room_id,
                     )
-                    membership_state, membership_epoch = await sqlite_event_cache_threads.load_room_membership_locked(
+                    membership_state, membership_epoch = await thread_ops.load_room_membership_locked(
+                        sqlite_event_cache_threads.BACKEND,
                         db,
-                        principal_id=self.principal_id,
+                        scope=self.principal_id,
                         room_id=room_id,
                     )
                     if membership_state != "joined":
@@ -867,9 +872,10 @@ class SqliteEventCache:
             room_id,
             operation="get_thread_events",
             disabled_result=None,
-            reader=lambda db: sqlite_event_cache_threads.load_thread_events(
+            reader=lambda db: thread_ops.load_thread_events(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -881,9 +887,10 @@ class SqliteEventCache:
             room_id,
             operation="get_thread_event_ids",
             disabled_result=set(),
-            reader=lambda db: sqlite_event_cache_threads.load_thread_event_ids(
+            reader=lambda db: thread_ops.load_thread_event_ids(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -895,9 +902,10 @@ class SqliteEventCache:
             room_id,
             operation="has_thread_snapshot",
             disabled_result=False,
-            reader=lambda db: sqlite_event_cache_threads.thread_snapshot_exists(
+            reader=lambda db: thread_ops.thread_snapshot_exists(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -909,9 +917,10 @@ class SqliteEventCache:
             room_id,
             operation="get_recent_room_thread_ids",
             disabled_result=[],
-            reader=lambda db: sqlite_event_cache_threads.load_recent_room_thread_ids(
+            reader=lambda db: thread_ops.load_recent_room_thread_ids(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
                 limit=limit,
             ),
@@ -923,9 +932,10 @@ class SqliteEventCache:
             room_id,
             operation="get_thread_cache_gap",
             disabled_result=CACHE_GAP_UNAVAILABLE,
-            reader=lambda db: sqlite_event_cache_threads.load_thread_cache_gap(
+            reader=lambda db: thread_ops.load_thread_cache_gap(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -1154,9 +1164,10 @@ class SqliteEventCache:
         events: list[dict[str, Any]],
         fetch_started_at: float,
     ) -> bool:
-        await sqlite_event_cache_threads.replace_thread_locked(
+        await thread_ops.replace_thread_locked(
+            sqlite_event_cache_threads.BACKEND,
             db,
-            principal_id=self.principal_id,
+            scope=self.principal_id,
             room_id=room_id,
             thread_id=thread_id,
             events=events,
@@ -1171,9 +1182,10 @@ class SqliteEventCache:
             room_id,
             operation="invalidate_thread",
             disabled_result=None,
-            writer=lambda db: sqlite_event_cache_threads.invalidate_thread_locked(
+            writer=lambda db: thread_ops.invalidate_thread_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
                 thread_id=thread_id,
             ),
@@ -1185,9 +1197,10 @@ class SqliteEventCache:
             room_id,
             operation="invalidate_room_threads",
             disabled_result=None,
-            writer=lambda db: sqlite_event_cache_threads.invalidate_room_threads_locked(
+            writer=lambda db: thread_ops.invalidate_room_threads_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
             ),
         )
@@ -1199,9 +1212,10 @@ class SqliteEventCache:
                 room_id,
                 operation="mark_thread_gap",
                 disabled_result=None,
-                writer=lambda db: sqlite_event_cache_threads.mark_thread_gap_locked(
+                writer=lambda db: thread_ops.mark_thread_gap_locked(
+                    sqlite_event_cache_threads.BACKEND,
                     db,
-                    principal_id=self.principal_id,
+                    scope=self.principal_id,
                     room_id=room_id,
                     thread_id=thread_id,
                     reason=reason,
@@ -1221,9 +1235,10 @@ class SqliteEventCache:
                 room_id,
                 operation="mark_room_threads_gap",
                 disabled_result=None,
-                writer=lambda db: sqlite_event_cache_threads.mark_room_gap_locked(
+                writer=lambda db: thread_ops.mark_room_gap_locked(
+                    sqlite_event_cache_threads.BACKEND,
                     db,
-                    principal_id=self.principal_id,
+                    scope=self.principal_id,
                     room_id=room_id,
                     reason=reason,
                 ),
@@ -1249,9 +1264,10 @@ class SqliteEventCache:
             room_id,
             operation="apply_thread_mutation_append",
             disabled_result=ThreadAppendOutcome.WRITES_UNAVAILABLE,
-            writer=lambda db: sqlite_event_cache_threads.apply_thread_mutation_append_locked(
+            writer=lambda db: thread_ops.apply_thread_mutation_append_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
                 thread_id=thread_id,
                 normalized_event=normalized_event,
@@ -1320,9 +1336,10 @@ class SqliteEventCache:
             room_id,
             operation="room_membership_epoch",
             disabled_result=None,
-            writer=lambda db: sqlite_event_cache_threads.certify_room_membership_locked(
+            writer=lambda db: thread_ops.certify_room_membership_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
             ),
             allow_departed=True,
@@ -1353,15 +1370,17 @@ class SqliteEventCache:
         async def join_if_current(db: aiosqlite.Connection) -> bool:
             if self.room_departure_epoch(room_id) != expected_departure_epoch:
                 return False
-            membership_state, _membership_epoch = await sqlite_event_cache_threads.load_room_membership_locked(
+            membership_state, _membership_epoch = await thread_ops.load_room_membership_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
             )
             if membership_state != "joined":
-                await sqlite_event_cache_threads.set_room_membership_locked(
+                await thread_ops.set_room_membership_locked(
+                    sqlite_event_cache_threads.BACKEND,
                     db,
-                    principal_id=self.principal_id,
+                    scope=self.principal_id,
                     room_id=room_id,
                     membership_state="joined",
                     reason="room_rejoined",
@@ -1373,9 +1392,10 @@ class SqliteEventCache:
                 principal_id=self.principal_id,
                 room_id=room_id,
             )
-            await sqlite_event_cache_threads.set_room_membership_locked(
+            await thread_ops.set_room_membership_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id=self.principal_id,
+                scope=self.principal_id,
                 room_id=room_id,
                 membership_state="departed",
                 reason="room_departed",

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -1,39 +1,17 @@
-"""Thread snapshot and gap storage helpers for the Matrix event cache.
+"""SQLite binding for the shared thread-cache operations.
 
-Durable gap-state invariants (mirrored by ``postgres_event_cache_threads``):
-
-1. Gap markers are monotonic: ``mark_thread_gap_locked`` never lets an older marker overwrite a
-   newer one. There is no reason precedence, because every reason means the same thing — refetch.
-
-2. ``mark_room_gap_locked`` is the room-scoped (wildcard-thread) form. It fans the marker out
-   across the room's ``thread_cache_state`` rows *and* records it once on ``room_cache_state``.
-   The fan-out cannot reach a thread whose first fetch is still in flight, because that thread has
-   no row yet; the room-level copy is what the replacement then consults.
-
-3. A replacement clears the marker only when the marker predates the fetch that produced it.
-   A gap detected mid-fetch is not covered by that fetch, so it survives and the next read refetches.
-
-4. Thread snapshot rows and the lookup, edit, and thread index rows are written and deleted together so
-   point lookups can never resurrect rows the snapshot no longer contains.
-
-5. One threaded mutation is one transaction: ``apply_thread_mutation_append_locked`` appends and, when
-   the append cannot land, records the gap marker in the same transaction. Marking and appending
-   separately left a thread readable while it was missing the event, and a crash between them left a
-   half-applied snapshot unmarked.
+The operations themselves live in ``event_cache_thread_ops`` and the statements in
+``event_cache_thread_statements``. What is left here is what SQLite genuinely does differently:
+its cursor handling, and its write-sequence allocation, which reads a counter row because SQLite
+has no sequence object.
 """
 
 from __future__ import annotations
 
-import json
-import time
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Final
 
-from .event_cache_events import (
-    event_id_for_cache,
-    serialize_cacheable_events,
-    serialize_cached_event,
-)
-from .event_normalization import normalize_event_source_for_cache
+from .event_cache_sql_dialect import SQLITE_DIALECT
+from .event_cache_thread_statements import ThreadStatements
 from .sqlite_event_cache_events import (
     allocate_write_sequences,
     delete_cached_events,
@@ -43,987 +21,180 @@ from .sqlite_event_cache_events import (
     filter_cacheable_events,
     write_lookup_index_rows,
 )
-from .thread_cache_state import (
-    ThreadAppendOutcome,
-    ThreadCacheGap,
-    thread_cache_gap_row,
-)
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Mapping, Sequence
+
     import aiosqlite
 
+    from .event_cache_events import SerializedCachedEvent
+    from .event_cache_thread_ops import ThreadBackend
 
-# The edits that survive a collapsed read: one per message, from the right sender.
-#
-# A thread stores every edit ever sent. Returning them all makes the caller's fold re-derive per
-# message what one window function derives once, and hauls the whole superseded history across
-# the wire to do it.
-#
-# Edit density depends partly on homeserver policy. The mindroom-tuwunel fork can collapse
-# superseded m.replace events in sync responses with ``mindroom_compact_edits_enabled`` and can
-# delete aged superseded edits with ``mindroom_edit_purge_enabled``. Both flags default to false,
-# so a default-configured fork can expose the same accumulated edit history as a stock homeserver.
-#
-# The fork's opt-in collapse groups by (target, sender), the same key this query uses. It also
-# orders by ``event_id.cmp()``, bytewise, so the COLLATE "C" pin below has to hold for this read to
-# agree with the homeserver as well as with SQLite and the fold.
-#
-# So be precise about what this buys, because two earlier revisions of this comment were not. It
-# does not reduce writes - it is a read-side query, and every edit is still stored. It does not
-# change what the fold produces either; the fold already picked one edit per message. What it buys
-# is fewer rows off disk and over the wire, and less fold work, paid for with a window function and
-# three joins on every read. The correctness fixes that came with it are the substantial part; no
-# universal speedup is claimed because the result depends on edit density and database statistics.
-#
-# Upstream pruning is available in the fork but remains opt-in. Where edit purge is enabled,
-# deleting superseded edits after the configured minimum age settles the rollback trade at that
-# boundary: redacting the current winning edit is contractually supposed to reveal the previous one
-# (``test_redacting_latest_edit_falls_back_to_previous_cached_edit``), and past that age there is
-# no previous one left to reveal, wherever the read is served from. It was already close to
-# unreachable - redacting a MESSAGE removes the original and every dependent edit together, and
-# mindroom-cinny's delete targets the original event ID, since ``MessageDeleteItem`` passes
-# ``mEvent.getId()`` and a replacement is only ever reached through ``replacingEvent()``, never a
-# redaction target there. Reaching the rollback path needs the raw API,
-# ``/redact <edit-event-id>``, or moderation tooling. Element was not checked.
-#
-# This cache must still handle deployments where those opt-in controls are disabled, including a
-# default-configured fork or a stock homeserver where superseded edits arrive and stay.
-#
-# The contract to implement, if it is built: keep only the current legitimate edit per (original,
-# sender); redacting an already-pruned edit tombstones it and is otherwise a no-op; redacting the
-# retained winner deletes it, marks the thread stale and refetches full history, which
-# ``invalidate_after_redaction`` in ``thread_writes`` already does on the live redaction path; if
-# the homeserver is unreachable at that moment, fail or degrade explicitly rather than serving the
-# pre-edit body as confirmed history; and keep tombstones, so out-of-order sync cannot resurrect a
-# deleted edit.
-#
-# "Surviving" is per (original, sender): a replacement is only legitimate from the sender of the
-# event it replaces, so keeping a single newest-overall edit lets any room member starve the fold
-# of the author's own and pin the message at its pre-edit body. Membership is joined in here rather
-# than filtered later, because ranking over edits the outer query will discard lets an
-# out-of-thread edit suppress the in-thread runner-up.
-#
-# The sender comparison here is an optimization, not the security boundary. The fold re-checks
-# every candidate against the JSON sender (``ThreadEditCandidates.winner_for``), so if this
-# filter ever admits a foreign replacement the fold still finds nothing in the author's bucket
-# and renders the pre-edit body - wrong, but not the attacker's text. Doing it in SQL keeps a
-# foreign edit from being ranked as the survivor and hiding the author's own.
-#
-# The original is LEFT joined, not required. An edit can outlive the message it replaces -
-# ``event_edits`` holds no foreign key to ``events`` - and the fold synthesizes a message from such
-# an edit rather than dropping it, carrying the editor's own sender because an original nobody has
-# seen cannot be impersonated. Requiring the original would delete those messages from the read
-# outright. The sender filter is skipped exactly when there is no original to compare against,
-# which is also when ``winner_for`` stops applying it, for the same reason.
-#
-# The original is read out of ``events`` alone, with no thread membership required. Two narrower
-# lookups were tried first and both silently disabled the filter. Scoping it to this thread made an
-# original cached in a sibling thread read as absent. Routing it through ``thread_events`` at all
-# then did the same to any original cached by a point lookup, because ``store_event`` writes the
-# payload with no membership row - so ``original_events`` came back NULL, the sender filter was
-# skipped, and the newest edit across all senders won, which is the exact suppression this filter
-# exists to prevent (``test_a_point_cached_original_still_scopes_edits_to_its_sender``). The
-# comparison needs the payload and nothing else, so asking for more can only lose a sender it could
-# have compared against.
-#
-# ROW_NUMBER over one pass rather than a correlated NOT EXISTS per candidate: 5.3 ms against
-# 8.7 ms on a synthetic 2,021-event thread with current table statistics. Policy stays in Python; this is
-# only "latest per group", which is what a window function is for. Splitting present-original and
-# absent-original edits into two CTEs scans ``event_edits`` twice and timed out a 2,000-edit
-# PostgreSQL test that one pass completes.
-#
-# MATERIALIZED is a hint, not a correctness requirement: measured 3.7 ms materialized against
-# 4.1 ms inlinable. It is kept only to stop the planner re-deriving the survivors per row.
-_SURVIVING_EDITS_CTE = """
-WITH surviving_edits AS MATERIALIZED (
-    SELECT edit_event_id
-    FROM (
-        SELECT event_edits.edit_event_id AS edit_event_id,
-               ROW_NUMBER() OVER (
-                   PARTITION BY event_edits.original_event_id
-                   ORDER BY event_edits.origin_server_ts DESC, event_edits.edit_event_id DESC
-               ) AS edit_rank
-        FROM event_edits
-        JOIN thread_events AS edit_membership
-            ON edit_membership.principal_id = event_edits.principal_id
-            AND edit_membership.room_id = event_edits.room_id
-            AND edit_membership.event_id = event_edits.edit_event_id
-            AND edit_membership.thread_id = :thread_id
-        JOIN events AS edit_events
-            ON edit_events.principal_id = event_edits.principal_id
-            AND edit_events.room_id = event_edits.room_id
-            AND edit_events.event_id = event_edits.edit_event_id
-        LEFT JOIN events AS original_events
-            ON original_events.principal_id = event_edits.principal_id
-            AND original_events.room_id = event_edits.room_id
-            AND original_events.event_id = event_edits.original_event_id
-        WHERE event_edits.principal_id = :principal_id
-            AND event_edits.room_id = :room_id
-            AND (original_events.event_id IS NULL OR edit_events.sender = original_events.sender)
-    )
-    WHERE edit_rank = 1
-)
+_STATEMENTS: Final = ThreadStatements.build(SQLITE_DIALECT)
+
+# SQLite has no array parameter, so a bulk membership delete is one statement per event ID.
+_DELETE_THREAD_MEMBERSHIP_BY_EVENT_ID: Final = """
+DELETE FROM thread_events
+WHERE principal_id = :scope AND room_id = :room_id AND event_id = :event_id
 """
 
-# One thread, collapsed: every non-edit row, plus the one surviving edit per edited message.
-_THREAD_EVENTS_SQL = (
-    _SURVIVING_EDITS_CTE  # noqa: S608 - both operands are literals; params stay bound
-    + """
-SELECT thread_events.origin_server_ts, thread_events.write_seq, events.event_json
-FROM thread_events
-JOIN events
-    ON events.principal_id = thread_events.principal_id
-    AND events.room_id = thread_events.room_id
-    AND events.event_id = thread_events.event_id
-WHERE thread_events.principal_id = :principal_id
-    AND thread_events.room_id = :room_id
-    AND thread_events.thread_id = :thread_id
-    AND (
-        NOT EXISTS (
-            SELECT 1
-            FROM event_edits AS row_is_an_edit
-            WHERE row_is_an_edit.principal_id = thread_events.principal_id
-                AND row_is_an_edit.room_id = thread_events.room_id
-                AND row_is_an_edit.edit_event_id = thread_events.event_id
+
+class _SqliteThreadBackend:
+    """Run the shared thread-cache operations against an aiosqlite connection."""
+
+    statements = _STATEMENTS
+
+    async def execute(
+        self,
+        db: aiosqlite.Connection,
+        sql: str,
+        params: Mapping[str, object],
+    ) -> None:
+        """Run one statement that returns no rows."""
+        await db.execute(sql, params)
+
+    async def fetchone(
+        self,
+        db: aiosqlite.Connection,
+        sql: str,
+        params: Mapping[str, object],
+    ) -> tuple[Any, ...] | None:
+        """Run one query and return its first row, if any."""
+        cursor = await db.execute(sql, params)
+        try:
+            row = await cursor.fetchone()
+        finally:
+            await cursor.close()
+        return None if row is None else tuple(row)
+
+    async def fetchall(
+        self,
+        db: aiosqlite.Connection,
+        sql: str,
+        params: Mapping[str, object],
+    ) -> list[tuple[Any, ...]]:
+        """Run one query and return every row."""
+        cursor = await db.execute(sql, params)
+        try:
+            rows = await cursor.fetchall()
+        finally:
+            await cursor.close()
+        return [tuple(row) for row in rows]
+
+    async def upsert_thread_membership_rows(
+        self,
+        db: aiosqlite.Connection,
+        rows: Sequence[Mapping[str, object]],
+    ) -> None:
+        """Write thread-membership rows, drawing each row's write sequence from the counter row."""
+        if not rows:
+            return
+        write_sequences = await allocate_write_sequences(db, len(rows))
+        await db.executemany(
+            self.statements.upsert_thread_membership,
+            [{**row, "write_seq": write_sequence} for row, write_sequence in zip(rows, write_sequences, strict=True)],
         )
-        OR thread_events.event_id IN (SELECT edit_event_id FROM surviving_edits)
-    )
-ORDER BY thread_events.origin_server_ts ASC, thread_events.write_seq ASC
-"""
-)
 
-
-async def load_thread_events(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-) -> list[dict[str, Any]] | None:
-    """Return one thread's cached events oldest first, collapsed to one edit per message."""
-    cursor = await db.execute(
-        _THREAD_EVENTS_SQL,
-        {"principal_id": principal_id, "room_id": room_id, "thread_id": thread_id},
-    )
-    rows = await cursor.fetchall()
-    await cursor.close()
-    return [json.loads(row[2]) for row in rows] if rows else None
-
-
-async def load_thread_event_ids(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-) -> set[str]:
-    """Return every raw event ID this thread holds, superseded edits included.
-
-    Membership and visibility are different questions, and collapsing is what made them differ:
-    the visible read shows one edit per message, while this returns every row the thread owns. The
-    repair bookkeeping this was written for is gone; the surviving caller is the edit-sender rule's
-    coverage, which needs the membership set to state its precondition.
-
-    Joined to ``events`` rather than reading membership alone: a membership row whose payload is
-    gone is not durably present, and reporting it as present would suppress a refill that should
-    happen. That join is also what the pre-collapse code did implicitly, since it derived these IDs
-    from a read that required the payload.
-    """
-    cursor = await db.execute(
-        """
-        SELECT thread_events.event_id
-        FROM thread_events
-        JOIN events
-            ON events.principal_id = thread_events.principal_id
-            AND events.room_id = thread_events.room_id
-            AND events.event_id = thread_events.event_id
-        WHERE thread_events.principal_id = ? AND thread_events.room_id = ? AND thread_events.thread_id = ?
-        """,
-        (principal_id, room_id, thread_id),
-    )
-    rows = await cursor.fetchall()
-    await cursor.close()
-    return {str(row[0]) for row in rows}
-
-
-async def load_recent_room_thread_ids(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    limit: int,
-) -> list[str]:
-    """Return thread IDs for one room ordered by the newest locally cached event timestamp."""
-    cursor = await db.execute(
-        """
-        SELECT thread_id
-        FROM thread_events
-        WHERE principal_id = ? AND room_id = ?
-        GROUP BY thread_id
-        ORDER BY MAX(origin_server_ts) DESC, thread_id ASC
-        LIMIT ?
-        """,
-        (principal_id, room_id, limit),
-    )
-    rows = await cursor.fetchall()
-    await cursor.close()
-    return [str(row[0]) for row in rows]
-
-
-async def load_thread_cache_gap(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-) -> ThreadCacheGap | None:
-    """Return the durable gap marker recorded against one cached thread, if any.
-
-    Room-scoped gaps are fanned out across the room's thread rows when they are marked, so this is
-    a single-table read with no room-state join.
-    """
-    cursor = await db.execute(
-        """
-        SELECT gap_marked_at, gap_reason
-        FROM thread_cache_state
-        WHERE principal_id = ? AND room_id = ? AND thread_id = ?
-        """,
-        (principal_id, room_id, thread_id),
-    )
-    row = await cursor.fetchone()
-    await cursor.close()
-    return thread_cache_gap_row(row)
-
-
-async def load_room_membership_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-) -> tuple[str, int]:
-    """Return the durable membership state and transition epoch for one principal-room."""
-    cursor = await db.execute(
-        """
-        SELECT membership_state, membership_epoch
-        FROM room_cache_state
-        WHERE principal_id = ? AND room_id = ?
-        """,
-        (principal_id, room_id),
-    )
-    row = await cursor.fetchone()
-    await cursor.close()
-    return ("joined", 0) if row is None else (str(row[0]), int(row[1]))
-
-
-async def certify_room_membership_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-) -> int:
-    """Create a durable generation row and return its current epoch."""
-    await db.execute(
-        """
-        INSERT OR IGNORE INTO room_cache_state(
-            principal_id,
-            room_id,
-            membership_state,
-            membership_epoch
+    async def delete_thread_membership_by_event_ids(
+        self,
+        db: aiosqlite.Connection,
+        scope: str,
+        room_id: str,
+        event_ids: Sequence[str],
+    ) -> None:
+        """Delete thread-membership rows for an explicit list of event IDs."""
+        await db.executemany(
+            _DELETE_THREAD_MEMBERSHIP_BY_EVENT_ID,
+            [{"scope": scope, "room_id": room_id, "event_id": event_id} for event_id in event_ids],
         )
-        VALUES (?, ?, 'joined', 0)
-        """,
-        (principal_id, room_id),
-    )
-    _membership_state, membership_epoch = await load_room_membership_locked(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-    )
-    return membership_epoch
 
+    async def filter_cacheable_events(
+        self,
+        db: aiosqlite.Connection,
+        scope: str,
+        room_id: str,
+        candidates: list[tuple[str, dict[str, Any]]],
+    ) -> list[tuple[str, dict[str, Any]]]:
+        """Drop candidates this cache must refuse to store."""
+        return await filter_cacheable_events(db, scope, room_id, candidates)
 
-async def set_room_membership_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    membership_state: Literal["joined", "departed"],
-    reason: str,
-) -> None:
-    """Advance one durable room-membership transition and gap-mark prior refills."""
-    await mark_room_gap_locked(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        reason=reason,
-    )
-    # 🔒 ``mark_room_gap_locked`` has already upserted the row, so the epoch below always has
-    # something to advance. A missing row and a fresh one both read as ``('joined', 0)``.
-    await db.execute(
-        """
-        UPDATE room_cache_state
-        SET membership_state = ?, membership_epoch = membership_epoch + 1
-        WHERE principal_id = ? AND room_id = ?
-        """,
-        (membership_state, principal_id, room_id),
-    )
-
-
-async def _store_thread_events_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-    events: list[dict[str, Any]],
-    stored_at: float,
-    fetch_started_at: float,
-) -> frozenset[str]:
-    """Persist one authoritative thread snapshot within an existing DB transaction."""
-    normalized_events = [normalize_event_source_for_cache(event) for event in events]
-    cacheable_events = await filter_cacheable_events(
-        db,
-        principal_id,
-        room_id,
-        [(event_id_for_cache(event), event) for event in normalized_events],
-    )
-    serialized_events = serialize_cacheable_events(cacheable_events)
-    if serialized_events:
+    async def write_lookup_index_rows(
+        self,
+        db: aiosqlite.Connection,
+        scope: str,
+        room_id: str,
+        *,
+        serialized_events: list[SerializedCachedEvent],
+        cached_at: float,
+        thread_id: str | None = None,
+    ) -> None:
+        """Persist point-lookup, edit-index, and thread-index rows for cached events."""
         await write_lookup_index_rows(
             db,
-            principal_id=principal_id,
+            principal_id=scope,
             room_id=room_id,
             serialized_events=serialized_events,
-            cached_at=stored_at,
+            cached_at=cached_at,
             thread_id=thread_id,
         )
-        write_sequences = await allocate_write_sequences(db, len(serialized_events))
-        await db.executemany(
-            """
-            INSERT INTO thread_events(
-                principal_id,
-                room_id,
-                thread_id,
-                event_id,
-                origin_server_ts,
-                write_seq
-            )
-            VALUES (?, ?, ?, ?, ?, ?)
-            ON CONFLICT(principal_id, room_id, event_id) DO UPDATE SET
-                thread_id = excluded.thread_id,
-                origin_server_ts = excluded.origin_server_ts,
-                write_seq = excluded.write_seq
-            """,
-            [
-                (
-                    principal_id,
-                    room_id,
-                    thread_id,
-                    event.event_id,
-                    event.origin_server_ts,
-                    write_sequence,
-                )
-                for event, write_sequence in zip(serialized_events, write_sequences, strict=True)
-            ],
-        )
-    await _clear_thread_gap_covered_by_fetch(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-        fetch_started_at=fetch_started_at,
-    )
-    return frozenset(event.event_id for event in serialized_events)
 
+    async def delete_cached_events(
+        self,
+        db: aiosqlite.Connection,
+        scope: str,
+        room_id: str,
+        event_ids: Sequence[str],
+    ) -> None:
+        """Delete point-lookup payload rows for these event IDs."""
+        await delete_cached_events(db, principal_id=scope, room_id=room_id, event_ids=list(event_ids))
 
-async def _thread_snapshot_is_newer_than_fetch(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-    fetch_started_at: float,
-) -> bool:
-    """Return whether an installed snapshot came from a strictly newer fetch than this one."""
-    async with db.execute(
-        """
-        SELECT snapshot_fetch_started_at
-        FROM thread_cache_state
-        WHERE principal_id = ? AND room_id = ? AND thread_id = ?
-        """,
-        (principal_id, room_id, thread_id),
-    ) as cursor:
-        row = await cursor.fetchone()
-    if row is None or row[0] is None:
-        return False
-    return float(row[0]) > fetch_started_at
-
-
-async def _uncovered_room_gap(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    fetch_started_at: float,
-) -> tuple[float, str | None] | None:
-    """Return the room-scoped gap one fetch does not cover, if there is one."""
-    async with db.execute(
-        """
-        SELECT room_gap_marked_at, room_gap_reason
-        FROM room_cache_state
-        WHERE principal_id = ? AND room_id = ?
-        """,
-        (principal_id, room_id),
-    ) as cursor:
-        row = await cursor.fetchone()
-    if row is None or row[0] is None or float(row[0]) <= fetch_started_at:
-        return None
-    return (float(row[0]), row[1] if isinstance(row[1], str) else None)
-
-
-async def _clear_thread_gap_covered_by_fetch(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-    fetch_started_at: float,
-) -> None:
-    """Record this thread's snapshot, keeping any gap the replacing fetch does not cover.
-
-    A gap marked after the fetch began describes events the fetch could not have seen, so it
-    survives and the next read refetches. Both scopes have to be asked about, and the room one
-    cannot be answered by the fan-out alone: a thread whose first fetch was in flight when the room
-    was gapped has no row for the fan-out to update, so without the room-level copy this insert
-    would record a clean snapshot for events fetched from before the gap.
-    """
-    room_gap = await _uncovered_room_gap(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        fetch_started_at=fetch_started_at,
-    )
-    room_gap_marked_at, room_gap_reason = room_gap if room_gap is not None else (None, None)
-    await db.execute(
-        """
-        INSERT INTO thread_cache_state(
-            principal_id,
-            room_id,
-            thread_id,
-            gap_marked_at,
-            gap_reason,
-            snapshot_fetch_started_at
-        )
-        VALUES (?, ?, ?, ?, ?, ?)
-        ON CONFLICT(principal_id, room_id, thread_id) DO UPDATE SET
-            snapshot_fetch_started_at = excluded.snapshot_fetch_started_at,
-            gap_marked_at = CASE
-                WHEN thread_cache_state.gap_marked_at IS NULL
-                    OR thread_cache_state.gap_marked_at <= ?
-                    THEN excluded.gap_marked_at
-                ELSE thread_cache_state.gap_marked_at
-            END,
-            gap_reason = CASE
-                WHEN thread_cache_state.gap_marked_at IS NULL
-                    OR thread_cache_state.gap_marked_at <= ?
-                    THEN excluded.gap_reason
-                ELSE thread_cache_state.gap_reason
-            END
-        """,
-        (
-            principal_id,
-            room_id,
-            thread_id,
-            room_gap_marked_at,
-            room_gap_reason,
-            fetch_started_at,
-            fetch_started_at,
-            fetch_started_at,
-        ),
-    )
-
-
-async def replace_thread_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-    events: list[dict[str, Any]],
-    stored_at: float,
-    fetch_started_at: float,
-) -> None:
-    """Replace one thread snapshot atomically within an existing DB transaction.
-
-    Replacement is ordered by ``fetch_started_at``, not by arrival: because installing a snapshot
-    deletes the events it omits, a slow fetch landing after a newer one would otherwise bury the
-    newer thread contents and leave no gap marker behind to force a refetch. An older fetch is
-    therefore skipped outright. This is one comparison, not a conflict classifier — the loser has
-    nothing to retry, since the snapshot already installed is strictly fresher than its own.
-
-    The gap marker is separately conditional — see ``_clear_thread_gap_covered_by_fetch``.
-    """
-    if await _thread_snapshot_is_newer_than_fetch(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-        fetch_started_at=fetch_started_at,
-    ):
-        return
-    existing_event_ids = await _thread_event_ids_for_thread(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-    )
-    replacement_event_ids = await _store_thread_events_locked(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-        events=events,
-        stored_at=stored_at,
-        fetch_started_at=fetch_started_at,
-    )
-    removed_event_ids = sorted(set(existing_event_ids) - replacement_event_ids)
-    if removed_event_ids:
-        await db.executemany(
-            """
-            DELETE FROM thread_events
-            WHERE principal_id = ? AND room_id = ? AND event_id = ?
-            """,
-            [(principal_id, room_id, event_id) for event_id in removed_event_ids],
-        )
-        await delete_cached_events(
-            db,
-            principal_id=principal_id,
-            room_id=room_id,
-            event_ids=removed_event_ids,
-        )
+    async def delete_event_edit_rows(
+        self,
+        db: aiosqlite.Connection,
+        scope: str,
+        room_id: str,
+        *,
+        event_ids: Sequence[str],
+        original_event_id: str | None,
+    ) -> None:
+        """Delete edit-index rows for these event IDs."""
         await delete_event_edit_rows(
             db,
-            principal_id,
+            scope,
             room_id,
-            event_ids=removed_event_ids,
-            original_event_id=None,
+            event_ids=list(event_ids),
+            original_event_id=original_event_id,
         )
+
+    async def delete_event_thread_rows(
+        self,
+        db: aiosqlite.Connection,
+        scope: str,
+        room_id: str,
+        *,
+        event_ids: Sequence[str],
+        current_self_root_ids: Collection[str] = (),
+    ) -> None:
+        """Delete thread-index rows for these event IDs."""
         await delete_event_thread_rows(
             db,
-            principal_id,
+            scope,
             room_id,
-            event_ids=removed_event_ids,
-            current_self_root_ids={thread_id} if thread_id in replacement_event_ids else (),
+            event_ids=list(event_ids),
+            current_self_root_ids=current_self_root_ids,
         )
 
-
-async def invalidate_thread_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-) -> None:
-    """Delete cached events and state for one thread within an existing transaction."""
-    event_ids = await _thread_event_ids_for_thread(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-    )
-    await db.execute(
-        """
-        DELETE FROM thread_events
-        WHERE principal_id = ? AND room_id = ? AND thread_id = ?
-        """,
-        (principal_id, room_id, thread_id),
-    )
-    if event_ids:
-        await delete_cached_events(
-            db,
-            principal_id=principal_id,
-            room_id=room_id,
-            event_ids=event_ids,
-        )
-        await delete_event_edit_rows(
-            db,
-            principal_id,
-            room_id,
-            event_ids=event_ids,
-            original_event_id=None,
-        )
-        await delete_event_thread_rows(
-            db,
-            principal_id,
-            room_id,
-            event_ids=event_ids,
-        )
-    await db.execute(
-        """
-        DELETE FROM thread_cache_state
-        WHERE principal_id = ? AND room_id = ? AND thread_id = ?
-        """,
-        (principal_id, room_id, thread_id),
-    )
+    async def event_or_original_is_redacted(
+        self,
+        db: aiosqlite.Connection,
+        scope: str,
+        room_id: str,
+        *,
+        event_id: str,
+        event: dict[str, Any],
+    ) -> bool:
+        """Return whether this event, or the event it edits, is redacted."""
+        return await event_or_original_is_redacted(db, scope, room_id, event_id=event_id, event=event)
 
 
-async def invalidate_room_threads_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-) -> None:
-    """Delete every cached thread snapshot while preserving durable room membership."""
-    event_ids = await _thread_event_ids_for_room(db, principal_id=principal_id, room_id=room_id)
-    await db.execute(
-        """
-        DELETE FROM thread_events
-        WHERE principal_id = ? AND room_id = ?
-        """,
-        (principal_id, room_id),
-    )
-    if event_ids:
-        await delete_cached_events(
-            db,
-            principal_id=principal_id,
-            room_id=room_id,
-            event_ids=event_ids,
-        )
-        await delete_event_edit_rows(
-            db,
-            principal_id,
-            room_id,
-            event_ids=event_ids,
-            original_event_id=None,
-        )
-        await delete_event_thread_rows(
-            db,
-            principal_id,
-            room_id,
-            event_ids=event_ids,
-        )
-    await db.execute(
-        """
-        DELETE FROM thread_cache_state
-        WHERE principal_id = ? AND room_id = ?
-        """,
-        (principal_id, room_id),
-    )
-
-
-async def mark_thread_gap_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-    reason: str,
-) -> None:
-    """Record one durable thread gap marker within an active transaction.
-
-    The marker is monotonic: a later gap never loses to an earlier one. There is no reason
-    precedence — every reason means the same thing, that this snapshot must be refetched.
-    """
-    await db.execute(
-        """
-        INSERT INTO thread_cache_state(
-            principal_id,
-            room_id,
-            thread_id,
-            gap_marked_at,
-            gap_reason
-        )
-        VALUES (?, ?, ?, ?, ?)
-        ON CONFLICT(principal_id, room_id, thread_id) DO UPDATE SET
-            gap_marked_at = CASE
-                WHEN thread_cache_state.gap_marked_at IS NULL
-                    OR excluded.gap_marked_at >= thread_cache_state.gap_marked_at
-                    THEN excluded.gap_marked_at
-                ELSE thread_cache_state.gap_marked_at
-            END,
-            gap_reason = CASE
-                WHEN thread_cache_state.gap_marked_at IS NULL
-                    OR excluded.gap_marked_at >= thread_cache_state.gap_marked_at
-                    THEN excluded.gap_reason
-                ELSE thread_cache_state.gap_reason
-            END
-        """,
-        (principal_id, room_id, thread_id, time.time(), reason),
-    )
-
-
-async def apply_thread_mutation_append_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-    normalized_event: dict[str, Any],
-    append_failed_reason: str,
-) -> ThreadAppendOutcome:
-    """Append one threaded mutation, recording a gap marker in the same transaction when it cannot land.
-
-    See invariant 5 in this module's docstring for why it is one transaction. A successful append
-    clears nothing: an append extends a snapshot, it does not prove the snapshot complete.
-    """
-    outcome = await _append_existing_thread_event(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-        normalized_event=normalized_event,
-    )
-    if outcome is not ThreadAppendOutcome.APPENDED:
-        await mark_thread_gap_locked(
-            db,
-            principal_id=principal_id,
-            room_id=room_id,
-            thread_id=thread_id,
-            reason=append_failed_reason,
-        )
-    return outcome
-
-
-async def mark_room_gap_locked(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    reason: str,
-) -> None:
-    """Record one room-scoped (wildcard-thread) gap across the room's threads and on the room itself.
-
-    The fan-out reaches every thread that already holds a ``thread_cache_state`` row. That is not all
-    of them: a thread whose first fetch is still in flight has no row yet, so the fan-out skips it and
-    the replacement that lands afterwards would insert a clean row for a snapshot fetched from before
-    the gap. The room-level copy is what that replacement consults, so the two together cover the room
-    whether or not a thread's row existed when the gap was recorded.
-    """
-    gap_marked_at = time.time()
-    await db.execute(
-        """
-        UPDATE thread_cache_state
-        SET gap_reason = CASE
-                WHEN gap_marked_at IS NULL OR ? >= gap_marked_at THEN ?
-                ELSE gap_reason
-            END,
-            gap_marked_at = CASE
-                WHEN gap_marked_at IS NULL OR ? >= gap_marked_at THEN ?
-                ELSE gap_marked_at
-            END
-        WHERE principal_id = ? AND room_id = ?
-        """,
-        (gap_marked_at, reason, gap_marked_at, gap_marked_at, principal_id, room_id),
-    )
-    await db.execute(
-        """
-        INSERT INTO room_cache_state(principal_id, room_id, room_gap_marked_at, room_gap_reason)
-        VALUES (?, ?, ?, ?)
-        ON CONFLICT(principal_id, room_id) DO UPDATE SET
-            room_gap_reason = CASE
-                WHEN room_cache_state.room_gap_marked_at IS NULL
-                    OR excluded.room_gap_marked_at >= room_cache_state.room_gap_marked_at
-                    THEN excluded.room_gap_reason
-                ELSE room_cache_state.room_gap_reason
-            END,
-            room_gap_marked_at = MAX(
-                COALESCE(room_cache_state.room_gap_marked_at, excluded.room_gap_marked_at),
-                excluded.room_gap_marked_at
-            )
-        """,
-        (principal_id, room_id, gap_marked_at, reason),
-    )
-
-
-async def _append_existing_thread_event(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-    normalized_event: dict[str, Any],
-) -> ThreadAppendOutcome:
-    """Append one event to an existing cached thread and classify what happened.
-
-    An opaque ``m.room.encrypted`` payload never replaces stored clear content for the same event ID.
-    A redacted event (or one whose edit target is redacted) is refused before anything is written, so
-    its payload never reaches the point-lookup table.
-    """
-    event_id = event_id_for_cache(normalized_event)
-    if await event_or_original_is_redacted(
-        db,
-        principal_id,
-        room_id,
-        event_id=event_id,
-        event=normalized_event,
-    ):
-        return ThreadAppendOutcome.APPEND_REFUSED
-
-    serialized_event = serialize_cached_event(event_id, normalized_event)
-    cursor = await db.execute(
-        """
-        SELECT 1
-        FROM thread_events
-        JOIN events
-            ON events.principal_id = thread_events.principal_id
-            AND events.room_id = thread_events.room_id
-            AND events.event_id = thread_events.event_id
-        WHERE thread_events.principal_id = ?
-            AND thread_events.room_id = ?
-            AND thread_events.thread_id = ?
-        LIMIT 1
-        """,
-        (principal_id, room_id, thread_id),
-    )
-    row = await cursor.fetchone()
-    await cursor.close()
-    await write_lookup_index_rows(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        serialized_events=[serialized_event],
-        cached_at=time.time(),
-        thread_id=thread_id,
-    )
-    if row is None:
-        # Only lookup-index rows are recorded: there is no snapshot to extend, so only a full
-        # history scan can make this thread readable again.
-        return ThreadAppendOutcome.SNAPSHOT_MISSING
-
-    write_sequence = (await allocate_write_sequences(db, 1))[0]
-    await db.execute(
-        """
-        INSERT INTO thread_events(
-            principal_id,
-            room_id,
-            thread_id,
-            event_id,
-            origin_server_ts,
-            write_seq
-        )
-        VALUES (?, ?, ?, ?, ?, ?)
-        ON CONFLICT(principal_id, room_id, event_id) DO UPDATE SET
-            thread_id = excluded.thread_id,
-            origin_server_ts = excluded.origin_server_ts,
-            write_seq = excluded.write_seq
-        """,
-        (
-            principal_id,
-            room_id,
-            thread_id,
-            serialized_event.event_id,
-            serialized_event.origin_server_ts,
-            write_sequence,
-        ),
-    )
-    await _advance_snapshot_watermark(
-        db,
-        principal_id=principal_id,
-        room_id=room_id,
-        thread_id=thread_id,
-        reflected_at=time.time(),
-    )
-    return ThreadAppendOutcome.APPENDED
-
-
-async def _advance_snapshot_watermark(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-    reflected_at: float,
-) -> None:
-    """Record that this snapshot now reflects the thread as of ``reflected_at``.
-
-    An append mutates the snapshot, so a fetch that started before it cannot represent the thread
-    any more. Moving the watermark forward makes ``replace_thread_locked`` refuse such a fetch,
-    which is what stops a slow scan from deleting a live event that landed while it was running.
-    """
-    await db.execute(
-        """
-        INSERT INTO thread_cache_state(
-            principal_id,
-            room_id,
-            thread_id,
-            snapshot_fetch_started_at
-        )
-        VALUES (?, ?, ?, ?)
-        ON CONFLICT(principal_id, room_id, thread_id) DO UPDATE SET
-            snapshot_fetch_started_at = MAX(
-                COALESCE(thread_cache_state.snapshot_fetch_started_at, ?),
-                ?
-            )
-        """,
-        (principal_id, room_id, thread_id, reflected_at, reflected_at, reflected_at),
-    )
-
-
-async def _thread_event_ids_for_thread(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-) -> list[str]:
-    """Return cached event IDs currently stored for one thread."""
-    cursor = await db.execute(
-        """
-        SELECT event_id
-        FROM thread_events
-        WHERE principal_id = ? AND room_id = ? AND thread_id = ?
-        """,
-        (principal_id, room_id, thread_id),
-    )
-    rows = await cursor.fetchall()
-    await cursor.close()
-    return [str(row[0]) for row in rows]
-
-
-async def thread_snapshot_exists(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-    thread_id: str,
-) -> bool:
-    """Return whether one thread has at least one durably present snapshot row.
-
-    Joined to ``events`` rather than reading membership alone: a membership row whose payload is
-    gone is not durably present, and answering yes for one reports a thread as cached that no read
-    can serve, which is how startup prewarm silently skips it.
-    """
-    async with db.execute(
-        """
-        SELECT 1
-        FROM thread_events
-        JOIN events
-            ON events.principal_id = thread_events.principal_id
-            AND events.room_id = thread_events.room_id
-            AND events.event_id = thread_events.event_id
-        WHERE thread_events.principal_id = ? AND thread_events.room_id = ? AND thread_events.thread_id = ?
-        LIMIT 1
-        """,
-        (principal_id, room_id, thread_id),
-    ) as cursor:
-        return await cursor.fetchone() is not None
-
-
-async def _thread_event_ids_for_room(
-    db: aiosqlite.Connection,
-    *,
-    principal_id: str,
-    room_id: str,
-) -> list[str]:
-    """Return cached event IDs currently stored for every thread in one room."""
-    cursor = await db.execute(
-        """
-        SELECT event_id
-        FROM thread_events
-        WHERE principal_id = ? AND room_id = ?
-        """,
-        (principal_id, room_id),
-    )
-    rows = await cursor.fetchall()
-    await cursor.close()
-    return [str(row[0]) for row in rows]
+BACKEND: Final[ThreadBackend[aiosqlite.Connection]] = _SqliteThreadBackend()

--- a/tach.toml
+++ b/tach.toml
@@ -1737,6 +1737,7 @@ path = "mindroom.matrix.cache.sqlite_agent_message_snapshot"
 depends_on = [
     "mindroom.matrix.cache.agent_message_snapshot",
     "mindroom.matrix.cache.agent_message_snapshot_semantics",
+    "mindroom.matrix.cache.event_cache_thread_ops",
     "mindroom.matrix.cache.sqlite_event_cache_events",
     "mindroom.matrix.cache.sqlite_event_cache_threads",
 ]
@@ -1747,6 +1748,7 @@ path = "mindroom.matrix.cache.postgres_agent_message_snapshot"
 depends_on = [
     "mindroom.matrix.cache.agent_message_snapshot",
     "mindroom.matrix.cache.agent_message_snapshot_semantics",
+    "mindroom.matrix.cache.event_cache_thread_ops",
     "mindroom.matrix.cache.postgres_event_cache_events",
     "mindroom.matrix.cache.postgres_event_cache_threads",
 ]
@@ -1755,20 +1757,48 @@ visibility = ["mindroom.matrix.cache.postgres_event_cache"]
 [[modules]]
 path = "mindroom.matrix.cache.sqlite_event_cache_threads"
 depends_on = [
-    "mindroom.matrix.cache.event_cache_events",
-    "mindroom.matrix.cache.event_normalization",
+    "mindroom.matrix.cache.event_cache_sql_dialect",
+    "mindroom.matrix.cache.event_cache_thread_statements",
     "mindroom.matrix.cache.sqlite_event_cache_events",
-    "mindroom.matrix.cache.thread_cache_state",
 ]
 
 [[modules]]
 path = "mindroom.matrix.cache.postgres_event_cache_threads"
 depends_on = [
+    "mindroom.matrix.cache.event_cache_sql_dialect",
+    "mindroom.matrix.cache.event_cache_thread_statements",
+    "mindroom.matrix.cache.postgres_event_cache_events",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.event_cache_sql_dialect"
+depends_on = []
+visibility = [
+    "mindroom.matrix.cache.event_cache_thread_statements",
+    "mindroom.matrix.cache.postgres_event_cache_threads",
+    "mindroom.matrix.cache.sqlite_event_cache_threads",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.event_cache_thread_statements"
+depends_on = ["mindroom.matrix.cache.event_cache_sql_dialect"]
+visibility = [
+    "mindroom.matrix.cache.postgres_event_cache_threads",
+    "mindroom.matrix.cache.sqlite_event_cache_threads",
+]
+
+[[modules]]
+path = "mindroom.matrix.cache.event_cache_thread_ops"
+depends_on = [
     "mindroom.matrix.cache.event_cache_events",
     "mindroom.matrix.cache.event_normalization",
-    "mindroom.matrix.cache.postgres_cursor",
-    "mindroom.matrix.cache.postgres_event_cache_events",
     "mindroom.matrix.cache.thread_cache_state",
+]
+visibility = [
+    "mindroom.matrix.cache.postgres_agent_message_snapshot",
+    "mindroom.matrix.cache.postgres_event_cache",
+    "mindroom.matrix.cache.sqlite_agent_message_snapshot",
+    "mindroom.matrix.cache.sqlite_event_cache",
 ]
 
 [[modules]]
@@ -1782,6 +1812,7 @@ depends_on = [
     "mindroom.matrix.sidecar_content",
 ]
 visibility = [
+    "mindroom.matrix.cache.event_cache_thread_ops",
     "mindroom.matrix.cache.postgres_event_cache_events",
     "mindroom.matrix.cache.postgres_event_cache_threads",
     "mindroom.matrix.cache.sqlite_event_cache_events",
@@ -1824,6 +1855,7 @@ path = "mindroom.matrix.cache.thread_cache_state"
 depends_on = ["mindroom.matrix.cache.event_cache"]
 visibility = [
     "mindroom.matrix.cache",
+    "mindroom.matrix.cache.event_cache_thread_ops",
     "mindroom.matrix.cache.postgres_event_cache",
     "mindroom.matrix.cache.postgres_event_cache_threads",
     "mindroom.matrix.cache.sqlite_event_cache",
@@ -1889,33 +1921,35 @@ depends_on = []
 [[modules]]
 path = "mindroom.matrix.cache.sqlite_event_cache"
 depends_on = [
-    "mindroom.matrix.cache.event_batching",
-    "mindroom.matrix.cache.cache_maintenance",
-    "mindroom.matrix.cache.event_cache",
-    "mindroom.matrix.cache.event_normalization",
-    "mindroom.matrix.cache.thread_cache_state",
     "mindroom.logging_config",
+    "mindroom.matrix.cache.cache_maintenance",
+    "mindroom.matrix.cache.event_batching",
+    "mindroom.matrix.cache.event_cache",
+    "mindroom.matrix.cache.event_cache_thread_ops",
+    "mindroom.matrix.cache.event_normalization",
     "mindroom.matrix.cache.sqlite_agent_message_snapshot",
     "mindroom.matrix.cache.sqlite_cache_maintenance",
     "mindroom.matrix.cache.sqlite_event_cache_events",
     "mindroom.matrix.cache.sqlite_event_cache_threads",
+    "mindroom.matrix.cache.thread_cache_state",
 ]
 visibility = ["mindroom.runtime_support"]
 
 [[modules]]
 path = "mindroom.matrix.cache.postgres_event_cache"
 depends_on = [
+    "mindroom.logging_config",
     "mindroom.matrix.cache.cache_maintenance",
     "mindroom.matrix.cache.event_batching",
     "mindroom.matrix.cache.event_cache",
+    "mindroom.matrix.cache.event_cache_thread_ops",
     "mindroom.matrix.cache.event_normalization",
-    "mindroom.matrix.cache.thread_cache_state",
-    "mindroom.logging_config",
     "mindroom.matrix.cache.postgres_agent_message_snapshot",
     "mindroom.matrix.cache.postgres_cache_maintenance",
     "mindroom.matrix.cache.postgres_event_cache_events",
     "mindroom.matrix.cache.postgres_event_cache_threads",
     "mindroom.matrix.cache.postgres_redaction",
+    "mindroom.matrix.cache.thread_cache_state",
 ]
 visibility = ["mindroom.runtime_support"]
 

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -29,6 +29,7 @@ from mindroom.matrix.cache import (
     sqlite_event_cache_threads,
     thread_cache_rejection_reason,
 )
+from mindroom.matrix.cache import event_cache_thread_ops as thread_ops
 from mindroom.matrix.cache.event_batching import group_lookup_events_by_room
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_history_result import thread_history_result
@@ -892,9 +893,10 @@ async def test_thread_snapshot_storage_exposes_direct_gap_reads(tmp_path: Path) 
     )
 
     try:
-        await sqlite_event_cache_threads.replace_thread_locked(
+        await thread_ops.replace_thread_locked(
+            sqlite_event_cache_threads.BACKEND,
             db,
-            principal_id="__mindroom_default_principal__",
+            scope="__mindroom_default_principal__",
             room_id="!room:localhost",
             thread_id="$thread_root",
             events=[
@@ -909,25 +911,28 @@ async def test_thread_snapshot_storage_exposes_direct_gap_reads(tmp_path: Path) 
             stored_at=100.0,
             fetch_started_at=100.0,
         )
-        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=200.0):
-            await sqlite_event_cache_threads.mark_thread_gap_locked(
+        with patch("mindroom.matrix.cache.event_cache_thread_ops.time.time", return_value=200.0):
+            await thread_ops.mark_thread_gap_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id="__mindroom_default_principal__",
+                scope="__mindroom_default_principal__",
                 room_id="!room:localhost",
                 thread_id="$thread_root",
                 reason="thread_stale",
             )
-            await sqlite_event_cache_threads.mark_room_gap_locked(
+            await thread_ops.mark_room_gap_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id="__mindroom_default_principal__",
+                scope="__mindroom_default_principal__",
                 room_id="!room:localhost",
                 reason="room_stale",
             )
         await db.commit()
 
-        gap = await sqlite_event_cache_threads.load_thread_cache_gap(
+        gap = await thread_ops.load_thread_cache_gap(
+            sqlite_event_cache_threads.BACKEND,
             db,
-            principal_id="__mindroom_default_principal__",
+            scope="__mindroom_default_principal__",
             room_id="!room:localhost",
             thread_id="$thread_root",
         )
@@ -950,39 +955,44 @@ async def test_sqlite_gap_markers_are_monotonic(tmp_path: Path) -> None:
     )
 
     try:
-        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=200.0):
-            await sqlite_event_cache_threads.mark_thread_gap_locked(
+        with patch("mindroom.matrix.cache.event_cache_thread_ops.time.time", return_value=200.0):
+            await thread_ops.mark_thread_gap_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id="__mindroom_default_principal__",
+                scope="__mindroom_default_principal__",
                 room_id="!room:localhost",
                 thread_id="$thread_root",
                 reason="newer_thread_marker",
             )
-            await sqlite_event_cache_threads.mark_room_gap_locked(
+            await thread_ops.mark_room_gap_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id="__mindroom_default_principal__",
+                scope="__mindroom_default_principal__",
                 room_id="!room:localhost",
                 reason="newer_room_marker",
             )
-        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=100.0):
-            await sqlite_event_cache_threads.mark_thread_gap_locked(
+        with patch("mindroom.matrix.cache.event_cache_thread_ops.time.time", return_value=100.0):
+            await thread_ops.mark_thread_gap_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id="__mindroom_default_principal__",
+                scope="__mindroom_default_principal__",
                 room_id="!room:localhost",
                 thread_id="$thread_root",
                 reason="older_thread_marker",
             )
-            await sqlite_event_cache_threads.mark_room_gap_locked(
+            await thread_ops.mark_room_gap_locked(
+                sqlite_event_cache_threads.BACKEND,
                 db,
-                principal_id="__mindroom_default_principal__",
+                scope="__mindroom_default_principal__",
                 room_id="!room:localhost",
                 reason="older_room_marker",
             )
         await db.commit()
 
-        gap = await sqlite_event_cache_threads.load_thread_cache_gap(
+        gap = await thread_ops.load_thread_cache_gap(
+            sqlite_event_cache_threads.BACKEND,
             db,
-            principal_id="__mindroom_default_principal__",
+            scope="__mindroom_default_principal__",
             room_id="!room:localhost",
             thread_id="$thread_root",
         )
@@ -1033,7 +1043,7 @@ async def test_thread_gap_marked_midflight_survives_the_replacement(tmp_path: Pa
 
     try:
         await _replace_thread(cache, "!room:localhost", "$thread_root", [root_source], fetch_started_at=100.0)
-        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=200.0):
+        with patch("mindroom.matrix.cache.event_cache_thread_ops.time.time", return_value=200.0):
             await cache.mark_thread_gap("!room:localhost", "$thread_root", reason="live_thread_mutation")
 
         # This fetch started before the marker, so it cannot have seen what the marker describes.
@@ -1084,7 +1094,7 @@ async def test_room_gap_marked_midflight_survives_the_replacement(tmp_path: Path
 
     try:
         await _replace_thread(cache, "!room:localhost", "$thread_root", [root_source], fetch_started_at=100.0)
-        with patch("mindroom.matrix.cache.sqlite_event_cache_threads.time.time", return_value=200.0):
+        with patch("mindroom.matrix.cache.event_cache_thread_ops.time.time", return_value=200.0):
             await cache.mark_room_threads_gap("!room:localhost", reason="sync_thread_lookup_unavailable")
 
         stored = await cache.replace_thread(

--- a/tests/test_event_cache_backends.py
+++ b/tests/test_event_cache_backends.py
@@ -21,8 +21,8 @@ from mindroom.matrix.cache import (
     ThreadAppendOutcome,
     postgres_event_cache_threads,
     sqlite_event_cache,
-    sqlite_event_cache_threads,
 )
+from mindroom.matrix.cache import event_cache_thread_ops as thread_ops
 from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.postgres_event_cache import (
     PostgresEventCache,
@@ -554,7 +554,7 @@ async def test_sqlite_event_cache_write_operation_rolls_back_cancelled_writer(
         raise asyncio.CancelledError(cancel_reason)
 
     monkeypatch.setattr(
-        sqlite_event_cache_threads,
+        thread_ops,
         "load_room_membership_locked",
         AsyncMock(return_value=("joined", 0)),
     )
@@ -1493,7 +1493,7 @@ async def test_postgres_event_cache_operation_rolls_back_cancelled_callback(
     )
     monkeypatch.setattr(cache, "_flush_pending_writes", AsyncMock(return_value=_FlushedPendingWrites()))
     monkeypatch.setattr(
-        postgres_event_cache_threads,
+        thread_ops,
         "load_room_membership_locked",
         AsyncMock(return_value=("joined", 0)),
     )
@@ -1862,7 +1862,7 @@ async def test_postgres_event_cache_preserves_pending_marker_recorded_during_flu
     )
     namespace = f"tenant_{uuid.uuid4().hex}"
     cache = PostgresEventCache(database_url=postgres_event_cache_url, namespace=namespace)
-    original_mark_thread_gap_locked = postgres_event_cache_threads.mark_thread_gap_locked
+    original_mark_thread_gap_locked = thread_ops.mark_thread_gap_locked
     injected_newer_pending_marker = False
 
     async def racing_mark_thread_gap_locked(*args: object, **kwargs: object) -> None:
@@ -1878,7 +1878,7 @@ async def test_postgres_event_cache_preserves_pending_marker_recorded_during_flu
         await original_mark_thread_gap_locked(*args, **kwargs)
 
     monkeypatch.setattr(
-        postgres_event_cache_threads,
+        thread_ops,
         "mark_thread_gap_locked",
         racing_mark_thread_gap_locked,
     )
@@ -1937,9 +1937,10 @@ async def test_postgres_event_cache_pending_thread_flush_does_not_downgrade_newe
             reason="older_pending_marker",
         )
         async with cache._runtime.acquire_db_operation(operation="test_newer_thread_marker") as db:
-            await postgres_event_cache_threads.mark_thread_gap_locked(
+            await thread_ops.mark_thread_gap_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=namespace,
+                scope=namespace,
                 room_id=room_id,
                 thread_id=thread_id,
                 gap_marked_at=200.0,
@@ -1986,9 +1987,10 @@ async def test_postgres_event_cache_pending_room_flush_does_not_downgrade_newer_
             reason="older_pending_room_marker",
         )
         async with cache._runtime.acquire_db_operation(operation="test_newer_room_marker") as db:
-            await postgres_event_cache_threads.mark_room_gap_locked(
+            await thread_ops.mark_room_gap_locked(
+                postgres_event_cache_threads.BACKEND,
                 db,
-                namespace=namespace,
+                scope=namespace,
                 room_id=room_id,
                 gap_marked_at=200.0,
                 reason="newer_durable_room_marker",

--- a/tests/test_event_cache_contract.py
+++ b/tests/test_event_cache_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -462,6 +463,47 @@ class TestConversationEventCacheContract:
         gap = await event_cache.get_thread_cache_gap(room_id, thread_id)
         assert gap is not None, "an unreadable gap marker read as a clean thread"
         assert thread_cache_rejection_reason(gap) == "cache_gap_read_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_gap_markers_are_monotonic_at_both_scopes(
+        self,
+        event_cache: ConversationEventCache,
+    ) -> None:
+        """An older marker must never downgrade a newer one, at either scope, on either backend.
+
+        The monotonic advance is the one expression the two backends cannot spell the same way:
+        PostgreSQL's ``GREATEST`` ignores NULL arguments, while SQLite's scalar ``MAX`` returns
+        NULL if any argument is NULL and so has to wrap the stored value in a ``COALESCE``. The two
+        agree only while the incoming value is known present, which is a precondition no type
+        signature carries.
+
+        Only the SQLite spelling had a regression test, so the PostgreSQL one could drift without
+        anything failing - and a downgraded marker is a stale thread served as complete, which is
+        silent by construction.
+        """
+        room_id = "!monotonic:localhost"
+        thread_id = "$root:localhost"
+        await replace_thread_unconditionally(
+            event_cache,
+            room_id,
+            thread_id,
+            [_message_event(thread_id, 1)],
+        )
+
+        # ``event_cache_thread_ops.time`` is the stdlib module, so this reaches whichever side
+        # stamps the marker: the shared operation on SQLite, the backend facade on PostgreSQL.
+        clock = "mindroom.matrix.cache.event_cache_thread_ops.time.time"
+        with patch(clock, return_value=200.0):
+            await event_cache.mark_thread_gap(room_id, thread_id, reason="newer_thread_marker")
+            await event_cache.mark_room_threads_gap(room_id, reason="newer_room_marker")
+        with patch(clock, return_value=100.0):
+            await event_cache.mark_thread_gap(room_id, thread_id, reason="older_thread_marker")
+            await event_cache.mark_room_threads_gap(room_id, reason="older_room_marker")
+
+        gap = await event_cache.get_thread_cache_gap(room_id, thread_id)
+        assert gap is not None
+        assert gap.gap_marked_at == 200.0, "an older marker overwrote a newer one"
+        assert gap.gap_reason == "newer_room_marker"
 
     @pytest.mark.asyncio
     async def test_older_fetch_cannot_bury_a_newer_snapshot(

--- a/tests/test_matrix_event_cache_security.py
+++ b/tests/test_matrix_event_cache_security.py
@@ -18,11 +18,10 @@ from mindroom.matrix.cache import (
     ConversationEventCache,
     SharedConversationEventCache,
     postgres_event_cache_events,
-    postgres_event_cache_threads,
     sqlite_event_cache,
     sqlite_event_cache_events,
-    sqlite_event_cache_threads,
 )
+from mindroom.matrix.cache import event_cache_thread_ops as thread_ops
 from mindroom.matrix.cache.postgres_event_cache import PostgresEventCache
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_cache_gap import mark_thread_gap_fail_closed
@@ -1333,13 +1332,10 @@ async def test_newer_departure_during_rejoin_closes_durable_room(
     expected_departure_epoch = cache.room_departure_epoch(room_id)
     load_started = asyncio.Event()
     release_load = asyncio.Event()
-    if isinstance(cache, SqliteEventCache):
-        original_load = sqlite_event_cache_threads.load_room_membership_locked
-        module = sqlite_event_cache_threads
-    else:
-        assert isinstance(cache, PostgresEventCache)
-        original_load = postgres_event_cache_threads.load_room_membership_locked
-        module = postgres_event_cache_threads
+    assert isinstance(cache, SqliteEventCache | PostgresEventCache)
+    # Both backends route this read through the one shared operation, so the pause is installed
+    # once. The fixture still parametrizes the backend, so each still runs its own path here.
+    original_load = thread_ops.load_room_membership_locked
 
     async def pause_membership_load(*args: object, **kwargs: object) -> tuple[str, int]:
         result = await original_load(*args, **kwargs)
@@ -1347,7 +1343,7 @@ async def test_newer_departure_during_rejoin_closes_durable_room(
         await release_load.wait()
         return result
 
-    monkeypatch.setattr(module, "load_room_membership_locked", pause_membership_load)
+    monkeypatch.setattr(thread_ops, "load_room_membership_locked", pause_membership_load)
     join_task = asyncio.create_task(
         cache.mark_room_joined(
             room_id,

--- a/tests/test_thread_read_collapse.py
+++ b/tests/test_thread_read_collapse.py
@@ -36,6 +36,7 @@ from mindroom.matrix.cache import (
     postgres_event_cache_threads,
     sqlite_event_cache_threads,
 )
+from mindroom.matrix.cache.event_cache_sql_dialect import POSTGRES_DIALECT, SQLITE_DIALECT
 from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage, ThreadEditCandidates
 from mindroom.matrix.event_info import EventInfo
 from tests.event_cache_test_support import replace_thread_unconditionally
@@ -581,8 +582,8 @@ def test_edit_ranking_is_scoped_to_this_thread_and_this_sender() -> None:
     shipped as bugs, and both are invisible to a test that only exercises the fold.
     """
     for sql in (
-        sqlite_event_cache_threads._THREAD_EVENTS_SQL,
-        postgres_event_cache_threads._THREAD_EVENTS_SQL,
+        sqlite_event_cache_threads.BACKEND.statements.thread_events,
+        postgres_event_cache_threads.BACKEND.statements.thread_events,
     ):
         assert "PARTITION BY" in sql, "edit ranking is not grouped at all"
         assert "sender" in sql, "edit ranking does not compare senders"
@@ -592,8 +593,15 @@ def test_edit_ranking_is_scoped_to_this_thread_and_this_sender() -> None:
     # collation where 'a' sorts before 'B'; the CI fixture pins postgres:15-alpine and musl has no
     # real locale support, so every libc collation there behaves like C and a seeded read cannot
     # fail whether or not the pin is present. This assertion fails wherever the pin is deleted.
-    assert 'edit_event_id COLLATE "C" DESC' in postgres_event_cache_threads._THREAD_EVENTS_SQL, (
+    assert 'edit_event_id COLLATE "C" DESC' in postgres_event_cache_threads.BACKEND.statements.thread_events, (
         "the Postgres tie-break is back on the database default collation"
+    )
+
+    # The same pin, stated against the dialect the statement is rendered from, so deleting the
+    # collation there fails here even if the statement above is later restructured.
+    assert POSTGRES_DIALECT.binary_collation == ' COLLATE "C"'
+    assert SQLITE_DIALECT.binary_collation == "", (
+        "SQLite compares TEXT bytewise already; an override here would diverge from the fold"
     )
 
 

--- a/tests/test_thread_read_guards.py
+++ b/tests/test_thread_read_guards.py
@@ -11,8 +11,8 @@ import nio
 import pytest
 
 import mindroom.matrix.cache as matrix_cache
-import mindroom.matrix.cache.sqlite_event_cache_threads as sqlite_event_cache_threads_module
 from mindroom.background_tasks import wait_for_background_tasks
+from mindroom.matrix.cache import event_cache_thread_ops as thread_ops
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome, ThreadCacheGap
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
@@ -1091,7 +1091,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         )
         write_entered = asyncio.Event()
         allow_write_commit = asyncio.Event()
-        original_replace = sqlite_event_cache_threads_module.replace_thread_locked
+        original_replace = thread_ops.replace_thread_locked
 
         async def blocked_replace(*args: object, **kwargs: object) -> None:
             write_entered.set()
@@ -1101,7 +1101,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         try:
             fetch_started_at = time.time()
             with patch(
-                "mindroom.matrix.cache.sqlite_event_cache_threads.replace_thread_locked",
+                "mindroom.matrix.cache.event_cache_thread_ops.replace_thread_locked",
                 new=blocked_replace,
             ):
                 write_task = asyncio.create_task(


### PR DESCRIPTION
`matrix/cache/` carried two hand-maintained transcriptions of the same thread-cache logic, one per database backend. The two modules had an **identical public surface** — 22 top-level functions, same names — and differed only in table names, the scope column (`principal_id` / `namespace`), the parameter marker, and a short list of expressions. Every change to thread caching was written twice and reviewed twice, and the pair had already drifted.

This collapses the shared part behind a statement builder plus a thin dialect shim, keeping both backends working.

## Shape

| module | role |
|---|---|
| `event_cache_sql_dialect.py` | table names, scope column, parameter marker, binary collation, monotonic-max, write-seq shape |
| `event_cache_thread_statements.py` | every statement, written once, rendered per dialect |
| `event_cache_thread_ops.py` | the 22 operations, written once, over a `ThreadBackend` protocol |
| `sqlite_event_cache_threads.py` | binding: cursor handling, counter-row write sequences, per-id bulk delete |
| `postgres_event_cache_threads.py` | binding: cursor handling, `nextval` write sequences, `ANY()` bulk delete |

Statements now bind every parameter **by name**. The positional form is what let `_clear_thread_gap_covered_by_fetch` pass the same value three times running with the argument order load-bearing and silent.

## The `excluded` asymmetry, resolved

The counts that motivated this were `17` on SQLite against `7` on PostgreSQL. **That gap is mostly a case-sensitivity artifact**: PostgreSQL had 7 lowercase `excluded` *and* 7 uppercase `EXCLUDED`, so the real split is 17 vs 14. Everything is lowercase now.

The remaining 3 are one real difference and it is dialect-forced:

- **Monotonic marker advance.** PostgreSQL used `GREATEST(a, b)`; SQLite used a `CASE` chain, or `MAX(COALESCE(a, b), b)`. These agree **only while the incoming value is non-NULL** — `GREATEST` ignores NULL arguments, while SQLite's scalar `MAX` returns NULL if any argument is NULL. Every call site passes a freshly read clock, so the precondition holds. It is now stated on `monotonic_max`, and SQLite renders the `COALESCE` form to keep it. A NULL there would erase a marker on SQLite alone.

Other drift found while unifying:

- The "does this thread have a readable row" probe was **the same join written two ways inside the PostgreSQL module** (aliased `membership` behind an append, `thread_events` in `thread_snapshot_exists`). Now one.
- The room-gap fan-out assigned its two columns in opposite orders on the two backends. `UPDATE ... SET` reads the pre-update row, so this was cosmetic; unified.
- SQLite's `INSERT OR IGNORE` becomes `ON CONFLICT(pk) DO NOTHING`. The statement supplies every NOT NULL column, so the primary key is the only constraint either form could have been ignoring, and naming it is the narrower of the two.
- The SQLite collapsed read gains `AS ranked` on its derived table, which PostgreSQL requires and SQLite accepts.

## Evidence the SQL did not change

Every SQL literal in both original modules was extracted with `ast` and matched, whitespace- and placeholder-normalised, against the rendered statements. **41 of 50 match exactly.** The 9 that do not are the deltas listed above plus the two bulk deletes that are deliberately per-backend. The PostgreSQL collapsed read is byte-identical; the SQLite one differs only by `AS ranked`.

## Testing

- Full suite green: `uv run pytest -nauto` → **11,881 passed, 54 skipped, 0 failed** (54 skips is the unchanged baseline).
- The cache suites were run **before and after** on both backends: **472 passed, 0 skipped** each time, with Postgres genuinely exercised rather than skipped.
- Gap-marker monotonicity previously had a **SQLite-only** regression test, so the PostgreSQL spelling of the same rule could drift with nothing failing. It is now a contract test parametrized over both backends. It **passes unchanged against the pre-refactor tree**, so it checks the behaviour and not the new shape; breaking `monotonic_max` fails it on both backends.
- Tests that patched the moved functions were repointed at the shared module. None stopped covering the backend it covered before — the `COLLATE "C"` structural pin now asserts against both the rendered statement and the dialect it comes from.

## Deliberately untouched

The PostgreSQL advisory lock, SQLite's `PRAGMA busy_timeout=0` + `BEGIN IMMEDIATE` model and its `disabled_result` reader outcome (which stays distinct from an empty result), and both schema-migration paths. Zero schema lines changed; no diff line mentions any of them.

## Size, measured rather than estimated

1,960 lines across the pair become 1,852 across five files — **net −108** (code lines 1,535 → 1,335). That is far short of what the raw duplication suggested, for two honest reasons: much of the larger module was prose that existed only once, and the typed `ThreadBackend` seam is new plumbing. **The velocity claim is the real one** — 22 operations and 22 statements now have one definition each. No performance change is claimed.

A follow-up on the `events` pair can delete roughly 200 lines of forwarding here, once both `*_event_cache_events` modules name the scope parameter the same way.

## Summary by Sourcery

Deduplicate thread cache logic across SQLite and PostgreSQL by introducing shared backend-agnostic thread operations and SQL statement builders, and rewire existing caches, snapshots, and tests to use the common implementation while preserving behaviour.

Enhancements:
- Introduce a backend-neutral ThreadBackend protocol and shared thread-cache operations module used by both SQLite and PostgreSQL implementations.
- Add SQL dialect and thread-statement builder modules so all thread cache SQL is defined once and rendered per backend, including named-parameter bindings and monotonic gap handling.
- Refactor SQLite and PostgreSQL thread cache bindings to delegate core logic to the shared operations while keeping backend-specific cursor and write-sequence behaviour.
- Update cache backends, agent message snapshots, and thread read guards to call into the shared thread-cache operations rather than backend-specific functions.
- Tighten and extend tests to exercise the shared implementation across both backends, including monotonic gap marker contract tests and structural assertions on rendered SQL, and adjust mocking/patching to target the new shared module.
- Adjust build/module metadata to declare dependencies and visibility for the new shared thread-cache modules and their consumers.