### PR TITLE
Skip the cold thread read for a spawned session's first summary

### DIFF
--- a/src/mindroom/custom_tools/subagents.py
+++ b/src/mindroom/custom_tools/subagents.py
@@ -414,6 +414,7 @@ async def _spawn_followup_warnings(
     tag: str,
     summary_message_count: int = 1,
     last_summary_count: int | None = 1,
+    known_latest_thread_event_id: str | None = None,
 ) -> list[str]:
     warnings: list[str] = []
     try:
@@ -425,6 +426,7 @@ async def _spawn_followup_warnings(
             summary_message_count,
             "manual",
             context.conversation_cache,
+            known_latest_thread_event_id=known_latest_thread_event_id,
         )
     except Exception as exc:
         warnings.append(f"Failed to set thread summary: {exc}")
@@ -486,6 +488,10 @@ async def _spawn_session_payload(
         event_id=event_id,
         summary=summary,
         tag=tag,
+        # The spawn message is this thread's only event, so the newest event is
+        # the root we just sent. Reading history here would scan the homeserver
+        # for a thread that has no cache snapshot yet.
+        known_latest_thread_event_id=event_id,
     )
     payload_kwargs: dict[str, object] = {
         "session_key": spawned_session_key,

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -579,8 +579,15 @@ async def send_thread_summary_event(
     conversation_cache: ConversationCacheProtocol,
     *,
     initial_enrichment_complete: bool | None = None,
+    known_latest_thread_event_id: str | None = None,
 ) -> str | None:
-    """Send a thread summary as a standard Matrix notice event."""
+    """Send a thread summary as a standard Matrix notice event.
+
+    ``known_latest_thread_event_id`` lets a caller that already knows the newest
+    event in the thread (for example the creator of a brand-new thread) supply it
+    directly, skipping the history read that would otherwise scan the homeserver
+    for a thread with no cache snapshot yet.
+    """
     normalized_summary = normalize_thread_summary_text(summary)
     if not normalized_summary:
         logger.warning(
@@ -596,20 +603,22 @@ async def send_thread_summary_event(
         if len(normalized_summary) > THREAD_SUMMARY_MAX_LENGTH
         else normalized_summary
     )
-    try:
-        latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
-            room_id,
-            thread_id,
-            caller_label="thread_summary_send",
-        )
-    except Exception as exc:
-        logger.warning(
-            "Falling back to thread root for summary send after latest-event lookup failure",
-            room_id=room_id,
-            thread_id=thread_id,
-            error=str(exc),
-        )
-        latest_thread_event_id = None
+    latest_thread_event_id = known_latest_thread_event_id
+    if latest_thread_event_id is None:
+        try:
+            latest_thread_event_id = await conversation_cache.get_latest_thread_event_id_if_needed(
+                room_id,
+                thread_id,
+                caller_label="thread_summary_send",
+            )
+        except Exception as exc:
+            logger.warning(
+                "Falling back to thread root for summary send after latest-event lookup failure",
+                room_id=room_id,
+                thread_id=thread_id,
+                error=str(exc),
+            )
+            latest_thread_event_id = None
     summary_metadata: dict[str, object] = {
         "version": 1,
         "summary": truncated_summary,

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -1157,8 +1157,73 @@ async def test_sessions_spawn_sets_summary_after_spawn(
         1,
         "manual",
         ctx.conversation_cache,
+        known_latest_thread_event_id="$event",
     )
     update_mock.assert_called_once_with(ctx.room_id, "$event", 1)
+
+
+@pytest.mark.asyncio
+async def test_sessions_spawn_summary_does_not_read_the_new_thread(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The initial spawn summary should relate to the new root without reading thread history.
+
+    A freshly created thread has no cache snapshot, so a latest-event lookup here
+    starts a homeserver scan that races the spawned agent's first outbound event.
+    """
+    monkeypatch.setattr(subagents_module, "_send_matrix_text", AsyncMock(return_value="$spawn-root:localhost"))
+    monkeypatch.setattr(subagents_module, "set_thread_tag", AsyncMock(return_value=SimpleNamespace()))
+    monkeypatch.setattr(subagents_module, "update_last_summary_count", MagicMock())
+    ctx = _make_context(tmp_path)
+    ctx.client.room_send = AsyncMock(
+        return_value=nio.RoomSendResponse(event_id="$summary:localhost", room_id=ctx.room_id),
+    )
+    ctx.conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value="$never-read:localhost")
+
+    with tool_runtime_context(ctx):
+        payload = json.loads(
+            await SubAgentsTools().sessions_spawn(task="do thing", summary=TEST_SUMMARY, tag=TEST_TAG),
+        )
+
+    assert payload["status"] == "ok"
+    ctx.conversation_cache.get_latest_thread_event_id_if_needed.assert_not_awaited()
+    relates_to = ctx.client.room_send.call_args.kwargs["content"]["m.relates_to"]
+    assert relates_to["rel_type"] == "m.thread"
+    assert relates_to["event_id"] == "$spawn-root:localhost"
+    assert relates_to["m.in_reply_to"] == {"event_id": "$spawn-root:localhost"}
+
+
+@pytest.mark.asyncio
+async def test_sessions_spawn_reuse_still_resolves_the_latest_thread_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Reusing a labelled session targets an existing thread, so its tail must still be resolved."""
+    summary_mock, _, _ = _stub_spawn_followups(monkeypatch)
+    ctx = _make_context(tmp_path)
+    monkeypatch.setattr(
+        subagents_module,
+        "_resolve_by_label",
+        lambda *_args, **_kwargs: (
+            create_session_id(ctx.room_id, "$existing-root:localhost"),
+            {"target_agent": "code"},
+        ),
+    )
+
+    with tool_runtime_context(ctx):
+        payload = json.loads(
+            await SubAgentsTools().sessions_spawn(
+                task="do thing",
+                summary=TEST_SUMMARY,
+                tag=TEST_TAG,
+                label="worklog",
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    assert payload["reused"] is True
+    assert summary_mock.await_args.kwargs["known_latest_thread_event_id"] is None
 
 
 @pytest.mark.asyncio
@@ -1417,6 +1482,7 @@ async def test_sessions_spawn_dedup_returns_existing_for_duplicate_label(
         1,
         "manual",
         ctx.conversation_cache,
+        known_latest_thread_event_id="$event",
     )
     tag_mock.assert_awaited_once_with(
         ctx.client,
@@ -1458,6 +1524,7 @@ async def test_sessions_spawn_dedup_returns_existing_for_duplicate_label(
         0,
         "manual",
         ctx.conversation_cache,
+        known_latest_thread_event_id=None,
     )
     tag_mock.assert_awaited_once_with(
         ctx.client,
@@ -1509,6 +1576,7 @@ async def test_sessions_spawn_skips_reuse_when_registry_entry_lacks_thread_id(
         1,
         "manual",
         ctx.conversation_cache,
+        known_latest_thread_event_id="$new-event",
     )
     tag_mock.assert_awaited_once_with(
         ctx.client,
@@ -1560,6 +1628,7 @@ async def test_sessions_spawn_reuse_derives_thread_id_from_session_key(
         0,
         "manual",
         ctx.conversation_cache,
+        known_latest_thread_event_id=None,
     )
     tag_mock.assert_awaited_once_with(
         ctx.client,
@@ -1605,6 +1674,7 @@ async def test_sessions_spawn_skips_room_level_reuse_candidates(
         1,
         "manual",
         ctx.conversation_cache,
+        known_latest_thread_event_id="$event",
     )
     tag_mock.assert_awaited_once_with(
         ctx.client,

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -1918,6 +1918,32 @@ class TestSendSummaryEvent:
         )
         conversation_cache.notify_outbound_message.assert_called_once_with("!room:x", "$s1", content)
 
+    async def test_known_latest_thread_event_id_skips_the_history_read(self) -> None:
+        """A caller that already knows the newest thread event should not trigger a history read."""
+        client = _mock_client()
+        client.room_send = AsyncMock(return_value=nio.RoomSendResponse(event_id="$s1", room_id="!r:x"))
+        conversation_cache = AsyncMock()
+        conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value="$never-read")
+        conversation_cache.notify_outbound_message = Mock()
+
+        result = await send_thread_summary_event(
+            client,
+            room_id="!room:x",
+            thread_id="$root1",
+            summary="Spawned an isolated session",
+            message_count=1,
+            model_name="manual",
+            conversation_cache=conversation_cache,
+            known_latest_thread_event_id="$root1",
+        )
+
+        assert result == "$s1"
+        conversation_cache.get_latest_thread_event_id_if_needed.assert_not_awaited()
+        relates_to = client.room_send.call_args.kwargs["content"]["m.relates_to"]
+        assert relates_to["rel_type"] == "m.thread"
+        assert relates_to["event_id"] == "$root1"
+        assert relates_to["m.in_reply_to"] == {"event_id": "$root1"}
+
     async def test_event_content_truncates_overlong_summary(self) -> None:
         """Overlong summaries should be truncated before sending to Matrix."""
         client = _mock_client()


### PR DESCRIPTION
## Problem

`sessions_spawn` sends a new Matrix thread root and then immediately writes that thread's initial summary. `send_thread_summary_event` resolved the newest thread event through `ConversationCache.get_latest_thread_event_id_if_needed(caller_label="thread_summary_send")` — but a thread created moments ago has no cache snapshot, so the lookup started a homeserver scan.

That scan races the spawned agent's first outbound event:

1. `thread_summary_send` starts a refresh (`cache_rows_missing`).
2. The spawned agent sends its placeholder before the scan installs a snapshot.
3. The outbound append finds no raw snapshot and correctly records an `outbound_append_failed` gap.
4. The in-flight scan cannot clear a gap opened after it started.
5. `dispatch_post_lock_refresh` therefore performs a second homeserver scan.

Under stress every new spawn thread took this path — two refreshes and two snapshot stores per thread, with no actual outbound append exception involved. At lower concurrency only a minority lost the race, which is what makes it timing-sensitive.

## Fix

The spawn caller already knows the answer: the root it just sent is the thread's only event, so the latest thread event *is* that root.

- `send_thread_summary_event` gains an optional keyword `known_latest_thread_event_id`. When supplied it is used directly as the MSC3440 latest-thread fallback and the history lookup is skipped entirely.
- `_spawn_session_payload` passes the newly created root for its initial summary.

The emitted event is byte-for-byte what it was before — same `m.thread` relation to the root, same `m.in_reply_to`. Only the lookup disappears.

## Deliberately unchanged

- Callers that do not know the latest event still resolve it exactly as before, including the lookup-failure fallback to the thread root.
- Reusing a labelled spawn session targets an *existing* thread with real history, so it does not pass a known event ID and still resolves the tail.
- Cache gap semantics, single-flight behavior, connection handling, and PostgreSQL locking are untouched.

## Tests

- `tests/test_subagents.py::test_sessions_spawn_summary_does_not_read_the_new_thread` — the initial spawn summary never awaits `get_latest_thread_event_id_if_needed`, and the sent relation points at the new root. The fake cache returns a distinct sentinel, so both assertions fail if the caller bypass is reverted (verified: reverting it fails on `Expected get_latest_thread_event_id_if_needed to not have been awaited. Awaited 1 times.`).
- `tests/test_subagents.py::test_sessions_spawn_reuse_still_resolves_the_latest_thread_event` — the reuse path passes no known event ID.
- `tests/test_thread_summary.py::TestSendSummaryEvent::test_known_latest_thread_event_id_skips_the_history_read` — direct coverage of the new parameter at its owning seam.
- The existing `test_event_content_structure` still asserts the lookup happens when no known event ID is supplied.

Full `pytest`, `ruff`, `ruff format`, `ty check`, `tach check --dependencies --interfaces`, and `pre-commit run --all-files` pass.