### PR TITLE
Fence config watcher scans by snapshot identity

### DIFF
--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -407,7 +407,7 @@ async def _watched_config_mtimes(api_app: FastAPI) -> tuple[constants.RuntimePat
         snapshot = _app_context(api_app)
         paths = snapshot.source_files or frozenset({snapshot.runtime_paths.config_path})
         mtimes = await asyncio.to_thread(file_watcher.paths_mtime_snapshot, paths)
-        if _app_context(api_app).generation == snapshot.generation:
+        if _app_context(api_app) is snapshot:
             return snapshot.runtime_paths, mtimes
 
 

--- a/tests/api/test_config_includes.py
+++ b/tests/api/test_config_includes.py
@@ -576,6 +576,44 @@ async def test_watched_config_mtimes_retries_when_snapshot_changes_during_scan(
 
 
 @pytest.mark.asyncio
+async def test_watched_config_mtimes_retries_when_same_generation_snapshot_replaces_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    split_app: FastAPI,
+) -> None:
+    """A source-set replacement must invalidate an in-flight scan even without a generation bump."""
+    initial_snapshot = _snapshot(split_app)
+    runtime_config = initial_snapshot.runtime_config
+    assert runtime_config is not None
+    flattened_source = yaml.safe_dump(runtime_config.authored_model_dump(), sort_keys=True)
+    scanned_paths: list[frozenset[Path]] = []
+
+    async def fake_to_thread(function: Callable[..., object], paths: frozenset[Path]) -> object:
+        scanned_paths.append(paths)
+        if len(scanned_paths) == 1:
+            initial_snapshot.runtime_paths.config_path.write_text(flattened_source, encoding="utf-8")
+            assert config_lifecycle._publish_runtime_config_into_app(
+                runtime_config,
+                initial_snapshot.runtime_paths,
+                split_app,
+            )
+            replacement_snapshot = _snapshot(split_app)
+            assert replacement_snapshot is not initial_snapshot
+            assert replacement_snapshot.generation == initial_snapshot.generation
+            assert replacement_snapshot.source_files == frozenset(
+                {initial_snapshot.runtime_paths.config_path.resolve()},
+            )
+        return function(paths)
+
+    monkeypatch.setattr(main.asyncio, "to_thread", fake_to_thread)
+
+    runtime_paths, mtimes = await main._watched_config_mtimes(split_app)
+
+    assert runtime_paths == initial_snapshot.runtime_paths
+    assert set(mtimes) == {initial_snapshot.runtime_paths.config_path.resolve()}
+    assert len(scanned_paths) == 2
+
+
+@pytest.mark.asyncio
 async def test_api_config_watcher_scans_off_the_event_loop(
     monkeypatch: pytest.MonkeyPatch,
     split_runtime_paths: constants.RuntimePaths,


### PR DESCRIPTION
## Summary

- retry an offloaded config-source scan whenever its captured API snapshot was replaced
- cover source-set replacements that intentionally keep the same config generation

## Why

A committed snapshot can replace its watched source set without bumping the config generation when the authored configuration is unchanged. A generation-only check can therefore accept mtimes from the old source set. Snapshot identity is the publication fence because API snapshots are replaced rather than mutated.

Follow-up to #1686.

## Verification

- `uv run pytest -q tests/api/test_config_includes.py`
- `uv run pre-commit run --all-files`
- full suite exercised; an unrelated shell-supervisor timing test failed under parallel load and passed when rerun alone

## Summary by Sourcery

Ensure the API config watcher validates file scan results against the current snapshot identity instead of only the generation, and add coverage for source-set replacements without generation bumps.

Bug Fixes:
- Prevent the config watcher from accepting stale mtime scans when a runtime snapshot is replaced but retains the same generation.

Tests:
- Add an async test verifying watched config mtimes are rescanned when a same-generation snapshot replaces its source files.