### PR TITLE
Measure thread-refresh and event-loop scheduling latency

### DIFF
--- a/docs/dev/matrix-event-cache-interaction-contract.md
+++ b/docs/dev/matrix-event-cache-interaction-contract.md
@@ -112,8 +112,8 @@ A snapshot without its thread root or one still containing opaque `m.room.encryp
 
 Only a rejected or absent snapshot enters an authoritative homeserver room-history scan and cache refill.
 
-Every refill fetches the thread itself.
-There is no single-flight, no admission gate and no failure backoff: concurrent readers of one gapped thread each pay their own scan rather than sharing one.
+A cache-miss refill is single-flight per full read contract, so concurrent matching readers share one homeserver scan.
+There is no admission gate, failure backoff, or cooldown.
 A refill that completes without installing a snapshot still returns its homeserver history, so reads stay fail-open.
 
 A degraded dispatch proof for an unproven thread candidate retries strict proof before it may demote the event to room level.
@@ -132,7 +132,7 @@ The advisory read path may use a labelled stale-cache fallback when a required r
 
 Dispatch reads reject stale fallback and propagate the refill failure.
 
-Every completed cache or source fetch emits its own `matrix_cache_thread_history_refreshed` event with `mode`, `cache_read_ms`, `homeserver_fetch_ms`, page and event counts, `cache_reject_reason`, `thread_read_source`, degradation state, and error state.
+Every completed cache or source fetch emits its own `matrix_cache_thread_history_refreshed` event with `mode`, `cache_read_ms`, `homeserver_fetch_ms`, `homeserver_scan_parse_cpu_ms`, `resolution_ms`, `sidecar_hydration_ms`, `coordinator_queue_wait_ms`, `post_coordinator_read_ms`, `thread_read_total_ms`, `refill_singleflight_wait_ms`, `refill_singleflight_shared`, page and event counts, `cache_reject_reason`, `thread_read_source`, degradation state, and error state.
 Refilled reads add `cache_store_written` and `cache_store_failed`, and a rejected snapshot adds `cache_gap_marked_at`, `cache_gap_age_ms`, and `cache_gap_reason`.
 A dispatch read cut short by a coordinator timeout or a fetch timeout instead emits `matrix_cache_thread_read_degraded`.
 

--- a/docs/dev/matrix-event-cache-interaction-contract.md
+++ b/docs/dev/matrix-event-cache-interaction-contract.md
@@ -132,8 +132,9 @@ The advisory read path may use a labelled stale-cache fallback when a required r
 
 Dispatch reads reject stale fallback and propagate the refill failure.
 
-Every completed cache or source fetch emits its own `matrix_cache_thread_history_refreshed` event with `mode`, `cache_read_ms`, `homeserver_fetch_ms`, `homeserver_scan_parse_cpu_ms`, `resolution_ms`, `sidecar_hydration_ms`, `coordinator_queue_wait_ms`, `post_coordinator_read_ms`, `thread_read_total_ms`, `refill_singleflight_wait_ms`, `refill_singleflight_shared`, page and event counts, `cache_reject_reason`, `thread_read_source`, degradation state, and error state.
-Refilled reads add `cache_store_written` and `cache_store_failed`, and a rejected snapshot adds `cache_gap_marked_at`, `cache_gap_age_ms`, and `cache_gap_reason`.
+Every completed labelled cache or source read emits its own `matrix_cache_thread_history_refreshed` event with `mode`, `cache_read_ms`, `homeserver_fetch_ms`, `homeserver_scan_parse_cpu_ms`, `resolution_ms`, `sidecar_hydration_ms`, `coordinator_queue_wait_ms`, `post_coordinator_read_ms`, `thread_read_total_ms`, `refill_singleflight_wait_ms`, `refill_singleflight_shared`, page and event counts, `cache_reject_reason`, `thread_read_source`, degradation state, and error state.
+Refilled labelled reads add `cache_store_written` and `cache_store_failed`.
+A rejected snapshot instead emits `Thread cache rejected for read` with `cache_gap_marked_at`, `cache_gap_age_ms`, and `cache_gap_reason` when its gap carries that metadata.
 A dispatch read cut short by a coordinator timeout or a fetch timeout instead emits `matrix_cache_thread_read_degraded`.
 
 ## Disposable live audit

--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -109,14 +109,14 @@ class EventLoopStallDetector:
         self._heartbeat_handle = self._loop.call_at(scheduled_loop_time, self._beat, scheduled_loop_time)
 
     def _beat(self, scheduled_loop_time: float) -> None:
-        """Refresh heartbeat, sample callback lag, and re-arm from scheduled time."""
+        """Refresh heartbeat, sample callback lag, and re-arm from actual loop time."""
         assert self._loop is not None
         actual_loop_time = self._loop.time()
         self._last_beat = time.monotonic()
         with self._scheduler_lag_lock:
             self._scheduler_lag_samples.append(max(0.0, actual_loop_time - scheduled_loop_time))
         if not self._stop_event.is_set():
-            self._schedule_heartbeat(scheduled_loop_time + self.heartbeat_interval_seconds)
+            self._schedule_heartbeat(actual_loop_time + self.heartbeat_interval_seconds)
 
     def _report_scheduler_lag(self, now: float) -> None:
         """Emit one completed scheduler-lag window from the native watcher."""

--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -57,6 +57,9 @@ class EventLoopStallDetector:
         poll_interval_seconds: float | None = None,
     ) -> None:
         """Configure thresholds; ``start()`` arms the heartbeat and thread."""
+        if not math.isfinite(heartbeat_interval_seconds) or heartbeat_interval_seconds <= 0:
+            msg = "heartbeat_interval_seconds must be finite and > 0"
+            raise ValueError(msg)
         self.threshold_seconds = threshold_seconds
         self.heartbeat_interval_seconds = heartbeat_interval_seconds
         self.repeat_log_interval_seconds = repeat_log_interval_seconds

--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -13,10 +13,12 @@ where external profilers such as py-spy cannot attach.
 from __future__ import annotations
 
 import asyncio
+import math
 import sys
 import threading
 import time
 import traceback
+from collections import deque
 from typing import TYPE_CHECKING
 
 from mindroom.logging_config import get_logger
@@ -28,7 +30,8 @@ logger = get_logger(__name__)
 
 _EVENT_LOOP_STALL_THRESHOLD_ENV = "MINDROOM_EVENT_LOOP_STALL_THRESHOLD_SECONDS"
 _DEFAULT_EVENT_LOOP_STALL_THRESHOLD_SECONDS = 5.0
-_HEARTBEAT_INTERVAL_SECONDS = 1.0
+_HEARTBEAT_INTERVAL_SECONDS = 0.05
+_SCHEDULER_LAG_WINDOW_SECONDS = 60.0
 _REPEAT_LOG_INTERVAL_SECONDS = 30.0
 _THREAD_JOIN_TIMEOUT_SECONDS = 2.0
 
@@ -63,6 +66,11 @@ class EventLoopStallDetector:
         self._last_beat: float = 0.0
         self._stalled_beat: float | None = None
         self._next_repeat_log: float = 0.0
+        self._scheduler_lag_samples: deque[float] = deque(
+            maxlen=max(1, math.ceil(_SCHEDULER_LAG_WINDOW_SECONDS / heartbeat_interval_seconds)),
+        )
+        self._scheduler_lag_window_started_at: float = 0.0
+        self._scheduler_lag_lock = threading.Lock()
         self._stop_event = threading.Event()
         self._thread: threading.Thread | None = None
 
@@ -71,7 +79,8 @@ class EventLoopStallDetector:
         self._loop = asyncio.get_running_loop()
         self._loop_thread_ident = threading.get_ident()
         self._last_beat = time.monotonic()
-        self._heartbeat_handle = self._loop.call_later(self.heartbeat_interval_seconds, self._beat)
+        self._scheduler_lag_window_started_at = time.monotonic()
+        self._schedule_heartbeat(self._loop.time() + self.heartbeat_interval_seconds)
         self._thread = threading.Thread(
             target=self._watch,
             name="event-loop-stall-detector",
@@ -94,11 +103,40 @@ class EventLoopStallDetector:
             self._thread.join(timeout=_THREAD_JOIN_TIMEOUT_SECONDS)
             self._thread = None
 
-    def _beat(self) -> None:
-        """Refresh the heartbeat on the loop and re-arm the next beat."""
+    def _schedule_heartbeat(self, scheduled_loop_time: float) -> None:
+        """Schedule one heartbeat while retaining its requested loop time."""
+        assert self._loop is not None
+        self._heartbeat_handle = self._loop.call_at(scheduled_loop_time, self._beat, scheduled_loop_time)
+
+    def _beat(self, scheduled_loop_time: float) -> None:
+        """Refresh heartbeat, sample callback lag, and re-arm from scheduled time."""
+        assert self._loop is not None
+        actual_loop_time = self._loop.time()
         self._last_beat = time.monotonic()
-        if not self._stop_event.is_set() and self._loop is not None:
-            self._heartbeat_handle = self._loop.call_later(self.heartbeat_interval_seconds, self._beat)
+        with self._scheduler_lag_lock:
+            self._scheduler_lag_samples.append(max(0.0, actual_loop_time - scheduled_loop_time))
+        if not self._stop_event.is_set():
+            self._schedule_heartbeat(scheduled_loop_time + self.heartbeat_interval_seconds)
+
+    def _report_scheduler_lag(self, now: float) -> None:
+        """Emit one completed scheduler-lag window from the native watcher."""
+        with self._scheduler_lag_lock:
+            if now - self._scheduler_lag_window_started_at < _SCHEDULER_LAG_WINDOW_SECONDS:
+                return
+            samples = list(self._scheduler_lag_samples)
+            self._scheduler_lag_samples.clear()
+            self._scheduler_lag_window_started_at = now
+        if not samples:
+            return
+        milliseconds = sorted(round(sample * 1000, 3) for sample in samples)
+        logger.info(
+            "event_loop_scheduler_lag_summary",
+            sample_count=len(milliseconds),
+            p50_ms=_nearest_rank_percentile(milliseconds, 50),
+            p95_ms=_nearest_rank_percentile(milliseconds, 95),
+            p99_ms=_nearest_rank_percentile(milliseconds, 99),
+            max_ms=milliseconds[-1],
+        )
 
     def _loop_thread_stack(self) -> str | None:
         """Return the loop thread's current stack, formatted for logging."""
@@ -143,11 +181,17 @@ class EventLoopStallDetector:
         """Poll the heartbeat off-loop and log stalls with the blocking stack."""
         while not self._stop_event.wait(self.poll_interval_seconds):
             now = time.monotonic()
+            self._report_scheduler_lag(now)
             last_beat = self._last_beat
             if self._stalled_beat is not None and last_beat != self._stalled_beat:
                 self._note_stall_ended(last_beat)
             if now - last_beat > self.threshold_seconds:
                 self._note_stalled(now, last_beat)
+
+
+def _nearest_rank_percentile(samples: list[float], percentile: int) -> float:
+    """Return one nearest-rank percentile from sorted non-empty samples."""
+    return samples[math.ceil(len(samples) * percentile / 100) - 1]
 
 
 def start_event_loop_stall_detector(runtime_paths: RuntimePaths) -> EventLoopStallDetector | None:

--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -22,6 +22,7 @@ from collections import deque
 from typing import TYPE_CHECKING
 
 from mindroom.logging_config import get_logger
+from mindroom.timing import elapsed_ms_between
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
@@ -128,7 +129,7 @@ class EventLoopStallDetector:
             self._scheduler_lag_window_started_at = now
         if not samples:
             return
-        milliseconds = sorted(round(sample * 1000, 3) for sample in samples)
+        milliseconds = sorted(elapsed_ms_between(0.0, sample, ndigits=3) for sample in samples)
         logger.info(
             "event_loop_scheduler_lag_summary",
             sample_count=len(milliseconds),

--- a/src/mindroom/matrix/cache/thread_reads.py
+++ b/src/mindroom/matrix/cache/thread_reads.py
@@ -13,10 +13,8 @@ Read-side invariants:
    (``THREAD_HISTORY_SOURCE_DEGRADED``) instead of blocking dispatch; consumers must treat that result
    as unusable for caching and root proofs.
 
-3. Every cache-miss refill fetches the thread itself. There is no single-flight and no admission gate,
-   so concurrent readers of one gapped thread each pay their own homeserver scan rather than a shared
-   wait. See ``conversation_cache._refill_thread_from_client`` for why that trade is acceptable - it is
-   the measured 1.244x fan-out, not the cost of one scan.
+3. Each cache-miss refill is single-flight per full read contract, so one leader runs the homeserver
+   scan and concurrent matching readers share it. There is no admission gate, failure backoff, or cooldown.
    ``ADVISORY_FULL``, ``STRICT_FULL``, and ``STRICT_SOURCE_REFRESH`` have no dispatch timeout; strict
    modes are intentionally not dispatch-safe because they may block for authoritative post-lock model
    context or a direct source refresh.

--- a/src/mindroom/matrix/client_thread_history.py
+++ b/src/mindroom/matrix/client_thread_history.py
@@ -157,6 +157,7 @@ class _ThreadHistoryFetchResult:
     scanned_event_count: int
     resolution_ms: float
     sidecar_hydration_ms: float
+    homeserver_scan_parse_cpu_ms: float = 0.0
 
 
 @dataclass(slots=True)
@@ -166,6 +167,7 @@ class _ThreadEventSourceScanResult:
     event_sources: list[dict[str, Any]]
     page_count: int
     scanned_event_count: int
+    homeserver_scan_parse_cpu_ms: float = 0.0
 
 
 def _thread_history_result(
@@ -186,8 +188,10 @@ def log_thread_history_refresh(
     mode: str,
     diagnostics: Mapping[str, _ThreadHistoryDiagnosticValue],
     coordinator_queue_wait_ms: float,
+    post_coordinator_read_started: float,
 ) -> None:
     """Emit one structured INFO line for a completed thread read."""
+    post_coordinator_read_ms = elapsed_ms_since(post_coordinator_read_started, clock=time.perf_counter)
     log_fields: dict[str, _ThreadHistoryDiagnosticValue] = {
         "room_id": room_id,
         "thread_id": thread_id,
@@ -201,6 +205,11 @@ def log_thread_history_refresh(
         "resolution_ms": diagnostics.get("resolution_ms", 0.0),
         "sidecar_hydration_ms": diagnostics.get("sidecar_hydration_ms", 0.0),
         "coordinator_queue_wait_ms": coordinator_queue_wait_ms,
+        "post_coordinator_read_ms": post_coordinator_read_ms,
+        "thread_read_total_ms": coordinator_queue_wait_ms + post_coordinator_read_ms,
+        "refill_singleflight_wait_ms": diagnostics.get("refill_singleflight_wait_ms", 0.0),
+        "refill_singleflight_shared": diagnostics.get("refill_singleflight_shared", False),
+        "homeserver_scan_parse_cpu_ms": diagnostics.get("homeserver_scan_parse_cpu_ms", 0.0),
         "cache_reject_reason": diagnostics.get(THREAD_HISTORY_CACHE_REJECT_REASON_DIAGNOSTIC),
         "thread_read_source": diagnostics.get(THREAD_HISTORY_SOURCE_DIAGNOSTIC),
         "thread_read_degraded": diagnostics.get(THREAD_HISTORY_DEGRADED_DIAGNOSTIC, False),
@@ -222,6 +231,7 @@ def _report_direct_source_refresh(
     thread_id: str,
     caller_label: str | None,
     coordinator_queue_wait_ms: float,
+    post_coordinator_read_started: float,
 ) -> ThreadHistoryResult:
     """Log one direct source refresh under its caller's label."""
     if caller_label is not None:
@@ -232,6 +242,7 @@ def _report_direct_source_refresh(
             mode="full_scan",
             diagnostics=result.diagnostics,
             coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            post_coordinator_read_started=post_coordinator_read_started,
         )
     return result
 
@@ -804,6 +815,7 @@ async def _store_reconstructed_thread_snapshot(
         homeserver_scan_pages=fetch_result.room_scan_pages,
         homeserver_scanned_event_count=fetch_result.scanned_event_count,
         homeserver_thread_event_count=len(fetch_result.event_sources),
+        homeserver_scan_parse_cpu_ms=fetch_result.homeserver_scan_parse_cpu_ms,
     )
     return store_result
 
@@ -824,6 +836,7 @@ def _homeserver_thread_history_result(
         "homeserver_thread_event_count": len(fetch_result.event_sources),
         "resolution_ms": fetch_result.resolution_ms,
         "sidecar_hydration_ms": fetch_result.sidecar_hydration_ms,
+        "homeserver_scan_parse_cpu_ms": fetch_result.homeserver_scan_parse_cpu_ms,
         "cache_store_written": store_result.written,
         "cache_store_failed": store_result.failed,
         THREAD_HISTORY_SOURCE_DIAGNOSTIC: THREAD_HISTORY_SOURCE_HOMESERVER,
@@ -849,12 +862,16 @@ async def refresh_thread_history_from_source(
     trusted_sender_ids: Collection[str] = (),
     caller_label: str | None = None,
     coordinator_queue_wait_ms: float = 0.0,
+    post_coordinator_read_started: float | None = None,
 ) -> ThreadHistoryResult:
     """Fetch fresh thread history from Matrix and repopulate the advisory cache.
 
     One fetch, one store. There is no retry loop: a replacement cannot lose a race any more, and a
     gap that lands mid-fetch survives the store so the next read refetches it.
     """
+    resolved_post_coordinator_read_started = (
+        time.perf_counter() if post_coordinator_read_started is None else post_coordinator_read_started
+    )
     fetch_started_at = time.time()
     fetch_membership_epoch = await _capture_membership_epoch(event_cache, room_id)
     try:
@@ -892,6 +909,7 @@ async def refresh_thread_history_from_source(
                 thread_id=thread_id,
                 caller_label=caller_label,
                 coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+                post_coordinator_read_started=resolved_post_coordinator_read_started,
             )
         raise
     store_result = await _store_reconstructed_thread_snapshot(
@@ -921,6 +939,7 @@ async def refresh_thread_history_from_source(
         thread_id=thread_id,
         caller_label=caller_label,
         coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+        post_coordinator_read_started=resolved_post_coordinator_read_started,
     )
 
 
@@ -1064,9 +1083,13 @@ async def _fetch_thread_history_with_cache_policy(
     trusted_sender_ids: Collection[str] = (),
     caller_label: str = "unknown",
     coordinator_queue_wait_ms: float = 0.0,
+    post_coordinator_read_started: float | None,
     refill: _ThreadHistoryRefill | None = None,
 ) -> ThreadHistoryResult:
     """Serve one trusted cache hit or delegate only the required refill."""
+    resolved_post_coordinator_read_started = (
+        time.perf_counter() if post_coordinator_read_started is None else post_coordinator_read_started
+    )
     cache_reject_diagnostics: dict[str, str | int | float | bool] | None = None
     cached_history: ThreadHistoryResult | None = None
     try:
@@ -1107,6 +1130,7 @@ async def _fetch_thread_history_with_cache_policy(
         mode="cache_hit" if cached_history is not None else "full_scan",
         diagnostics=result.diagnostics,
         coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+        post_coordinator_read_started=resolved_post_coordinator_read_started,
     )
     return result
 
@@ -1120,6 +1144,7 @@ async def fetch_thread_history(
     trusted_sender_ids: Collection[str] = (),
     caller_label: str = "unknown",
     coordinator_queue_wait_ms: float = 0.0,
+    post_coordinator_read_started: float | None = None,
     refill: _ThreadHistoryRefill | None = None,
 ) -> ThreadHistoryResult:
     """Fetch all messages in a thread, allowing advisory stale fallback.
@@ -1139,6 +1164,7 @@ async def fetch_thread_history(
         trusted_sender_ids=trusted_sender_ids,
         caller_label=caller_label,
         coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+        post_coordinator_read_started=post_coordinator_read_started,
         refill=refill,
     )
 
@@ -1152,6 +1178,7 @@ async def fetch_dispatch_thread_history(
     trusted_sender_ids: Collection[str] = (),
     caller_label: str = "unknown",
     coordinator_queue_wait_ms: float = 0.0,
+    post_coordinator_read_started: float | None = None,
     refill: _ThreadHistoryRefill | None = None,
 ) -> ThreadHistoryResult:
     """Fetch strict full thread history from trusted cache or a fresh refill."""
@@ -1166,6 +1193,7 @@ async def fetch_dispatch_thread_history(
         trusted_sender_ids=trusted_sender_ids,
         caller_label=caller_label,
         coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+        post_coordinator_read_started=post_coordinator_read_started,
         refill=refill,
     )
 
@@ -1179,6 +1207,7 @@ async def fetch_dispatch_thread_snapshot(
     trusted_sender_ids: Collection[str] = (),
     caller_label: str = "unknown",
     coordinator_queue_wait_ms: float = 0.0,
+    post_coordinator_read_started: float | None = None,
     refill: _ThreadHistoryRefill | None = None,
 ) -> ThreadHistoryResult:
     """Fetch strict lightweight dispatch context from trusted cache or a fresh refill."""
@@ -1193,6 +1222,7 @@ async def fetch_dispatch_thread_snapshot(
         trusted_sender_ids=trusted_sender_ids,
         caller_label=caller_label,
         coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+        post_coordinator_read_started=post_coordinator_read_started,
         refill=refill,
     )
 
@@ -1230,6 +1260,7 @@ async def _fetch_thread_history_via_room_messages_with_events(
         scanned_event_count=scan_result.scanned_event_count,
         resolution_ms=elapsed_ms_since(resolution_started, clock=time.perf_counter),
         sidecar_hydration_ms=resolution.sidecar_hydration_ms,
+        homeserver_scan_parse_cpu_ms=scan_result.homeserver_scan_parse_cpu_ms,
     )
 
 
@@ -1300,6 +1331,7 @@ async def fetch_thread_event_sources_via_room_messages(
         event_sources=scan_result.thread_event_sources[thread_id],
         page_count=scan_result.page_count,
         scanned_event_count=scan_result.scanned_event_count,
+        homeserver_scan_parse_cpu_ms=scan_result.homeserver_scan_parse_cpu_ms,
     )
 
 
@@ -1313,6 +1345,7 @@ class _BulkThreadScanResult:
     page_count: int
     scanned_event_count: int
     scan_truncated: bool
+    homeserver_scan_parse_cpu_ms: float = 0.0
 
 
 @dataclass(frozen=True)
@@ -1446,6 +1479,7 @@ async def _bulk_scan_thread_event_sources(
     page_count = 0
     scanned_event_count = 0
     scan_truncated = False
+    homeserver_scan_parse_cpu_ms = 0.0
 
     while remaining_root_ids:
         if max_scan_pages is not None and page_count >= max_scan_pages:
@@ -1465,6 +1499,7 @@ async def _bulk_scan_thread_event_sources(
         if not response.chunk:
             break
         page_count += 1
+        parse_cpu_started = time.thread_time()
         for event in response.chunk:
             if not isinstance(event, nio.Event):
                 continue
@@ -1476,6 +1511,7 @@ async def _bulk_scan_thread_event_sources(
             )
             if recorded_event_id is not None:
                 remaining_root_ids.discard(recorded_event_id)
+        homeserver_scan_parse_cpu_ms += elapsed_ms_since(parse_cpu_started, clock=time.thread_time)
         if not response.end:
             break
         from_token = response.end
@@ -1493,6 +1529,7 @@ async def _bulk_scan_thread_event_sources(
         page_count=page_count,
         scanned_event_count=scanned_event_count,
         scan_truncated=scan_truncated,
+        homeserver_scan_parse_cpu_ms=homeserver_scan_parse_cpu_ms,
     )
 
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -393,6 +393,15 @@ async def _cached_room_get_event(
 type _ThreadRefillKey = tuple[str, str, str, bool, bool]
 
 
+@dataclass(frozen=True, slots=True)
+class _ThreadRefillSingleFlightResult:
+    """One caller's view of a shared thread refill."""
+
+    result: ThreadReadResult
+    wait_ms: float
+    shared: bool
+
+
 @dataclass(slots=True)
 class _ThreadRefillSingleFlight:
     """Join concurrent refills of one thread onto a single homeserver scan.
@@ -417,9 +426,11 @@ class _ThreadRefillSingleFlight:
         self,
         key: _ThreadRefillKey,
         refill: Callable[[], Coroutine[Any, Any, ThreadReadResult]],
-    ) -> ThreadReadResult:
+    ) -> _ThreadRefillSingleFlightResult:
         """Run one refill, or join the one already running for this key."""
         in_flight = self._in_flight.get(key)
+        shared = in_flight is not None
+        wait_started = time.perf_counter() if shared else None
         if in_flight is None:
             in_flight = create_background_task(
                 refill(),
@@ -429,7 +440,12 @@ class _ThreadRefillSingleFlight:
             )
             self._in_flight[key] = in_flight
             in_flight.add_done_callback(lambda _task: self._in_flight.pop(key, None))
-        return await asyncio.shield(in_flight)
+        result = await asyncio.shield(in_flight)
+        return _ThreadRefillSingleFlightResult(
+            result=result,
+            wait_ms=elapsed_ms_since(wait_started, clock=time.perf_counter) if wait_started is not None else 0.0,
+            shared=shared,
+        )
 
 
 @dataclass
@@ -682,6 +698,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         coordinator_queue_wait_ms: float,
     ) -> ThreadHistoryResult:
         """Refresh one thread from Matrix without accepting a cache hit or stale fallback."""
+        post_coordinator_read_started = time.perf_counter()
         result = await self._refill_thread_from_client(
             room_id,
             thread_id,
@@ -696,6 +713,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             mode="full_scan",
             diagnostics=result.diagnostics,
             coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            post_coordinator_read_started=post_coordinator_read_started,
         )
         return result
 
@@ -733,9 +751,18 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 trusted_sender_ids=self._trusted_sender_ids(),
             )
 
-        return await self._refill_single_flight.run(
+        refill_result = await self._refill_single_flight.run(
             (principal_id, room_id, thread_id, wants_full_history, allows_stale_fallback),
             refill,
+        )
+        return ThreadHistoryResult(
+            messages=list(refill_result.result),
+            is_full_history=refill_result.result.is_full_history,
+            diagnostics={
+                **refill_result.result.diagnostics,
+                "refill_singleflight_wait_ms": refill_result.wait_ms,
+                "refill_singleflight_shared": refill_result.shared,
+            },
         )
 
     async def _fetch_thread_from_client(
@@ -749,6 +776,8 @@ class MatrixConversationCache(ConversationCacheProtocol):
         wants_full_history: bool,
         allows_stale_fallback: bool,
     ) -> ThreadHistoryResult:
+        post_coordinator_read_started = time.perf_counter()
+
         async def refill(
             cache_reject_diagnostics: Mapping[str, str | int | float | bool] | None,
         ) -> ThreadHistoryResult:
@@ -768,6 +797,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
             trusted_sender_ids=self._trusted_sender_ids(),
             caller_label=caller_label,
             coordinator_queue_wait_ms=coordinator_queue_wait_ms,
+            post_coordinator_read_started=post_coordinator_read_started,
             refill=refill,
         )
 

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -333,6 +333,11 @@ async def test_conversation_cache_thread_reads_forward_client_fetch_metadata(
         ("get_dispatch_thread_snapshot", "fetch_dispatch_thread_snapshot", False, 75.0),
         ("get_dispatch_thread_history", "fetch_dispatch_thread_history", True, 100.0),
     ]
+    post_coordinator_read_starts = {
+        "get_thread_history": 1.06,
+        "get_dispatch_thread_snapshot": 2.08,
+        "get_dispatch_thread_history": 3.11,
+    }
     fetchers = {
         name: AsyncMock(return_value=thread_history_result([], is_full_history=is_full_history))
         for _method_name, name, is_full_history, _queue_wait_ms in read_modes
@@ -351,7 +356,23 @@ async def test_conversation_cache_thread_reads_forward_client_fetch_metadata(
             ),
             patch(
                 "mindroom.matrix.cache.thread_reads.time.perf_counter",
-                side_effect=[1.0, 1.05, 2.0, 2.01, 2.075, 2.075, 2.075, 3.0, 3.01, 3.1, 3.1, 3.1],
+                side_effect=[
+                    1.0,
+                    1.05,
+                    1.06,
+                    2.0,
+                    2.01,
+                    2.075,
+                    2.075,
+                    2.075,
+                    2.08,
+                    3.0,
+                    3.01,
+                    3.1,
+                    3.1,
+                    3.1,
+                    3.11,
+                ],
             ),
         ):
             read_methods = {
@@ -376,6 +397,7 @@ async def test_conversation_cache_thread_reads_forward_client_fetch_metadata(
                 trusted_sender_ids=conversation_cache._trusted_sender_ids(),
                 caller_label=f"caller-{method_name}",
                 coordinator_queue_wait_ms=queue_wait_ms,
+                post_coordinator_read_started=post_coordinator_read_starts[method_name],
                 # Always supplied now: the refill no longer depends on a write coordinator.
                 refill=ANY,
             )

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from structlog.testing import capture_logs
@@ -18,6 +19,9 @@ from mindroom.event_loop_stall import (
     start_event_loop_stall_detector,
 )
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
 _STALL_EVENTS = {"event_loop_stall_detected", "event_loop_stall_ongoing", "event_loop_stall_ended"}
 
 
@@ -26,14 +30,21 @@ class _LoopClock:
 
     def __init__(self) -> None:
         self.now = 0.0
-        self.scheduled: list[float] = []
+        self.scheduled: list[tuple[float, Callable[[float], None], float]] = []
 
     def time(self) -> float:
         return self.now
 
-    def call_at(self, when: float, _callback: object, *_args: object) -> object:
-        self.scheduled.append(when)
+    def call_at(self, when: float, callback: Callable[[float], None], scheduled_loop_time: float) -> object:
+        self.scheduled.append((when, callback, scheduled_loop_time))
         return object()
+
+    def next_scheduled_time(self) -> float:
+        return self.scheduled[0][0]
+
+    def run_next(self) -> None:
+        _, callback, scheduled_loop_time = self.scheduled.pop(0)
+        callback(scheduled_loop_time)
 
 
 def _fake_runtime_paths(**env_overrides: str) -> RuntimePaths:
@@ -70,11 +81,12 @@ def test_scheduler_lag_summary_aggregates_delayed_heartbeats() -> None:
     loop = _LoopClock()
     detector._loop = loop
     detector._scheduler_lag_window_started_at = 0.0
+    detector._schedule_heartbeat(1.0)
 
     with capture_logs() as logs:
-        for scheduled, lag_seconds in ((1.0, 0.001), (2.0, 0.002), (3.0, 0.003), (4.0, 0.004), (5.0, 0.005)):
-            loop.now = scheduled + lag_seconds
-            detector._beat(scheduled)
+        for lag_seconds in (0.001, 0.002, 0.003, 0.004, 0.005):
+            loop.now = loop.next_scheduled_time() + lag_seconds
+            loop.run_next()
         detector._report_scheduler_lag(60.0)
 
     summaries = [entry for entry in logs if entry["event"] == "event_loop_scheduler_lag_summary"]
@@ -95,14 +107,15 @@ def test_scheduler_lag_summary_resets_completed_window_samples() -> None:
     loop = _LoopClock()
     detector._loop = loop
     detector._scheduler_lag_window_started_at = 0.0
+    detector._schedule_heartbeat(1.0)
 
     with capture_logs() as logs:
-        loop.now = 1.001
-        detector._beat(1.0)
+        loop.now = loop.next_scheduled_time() + 0.001
+        loop.run_next()
         detector._report_scheduler_lag(60.0)
         detector._report_scheduler_lag(60.1)
-        loop.now = 61.004
-        detector._beat(61.0)
+        loop.now = loop.next_scheduled_time() + 0.004
+        loop.run_next()
         detector._report_scheduler_lag(120.0)
 
     summaries = [entry for entry in logs if entry["event"] == "event_loop_scheduler_lag_summary"]
@@ -110,6 +123,22 @@ def test_scheduler_lag_summary_resets_completed_window_samples() -> None:
         (entry["sample_count"], entry["p50_ms"], entry["p95_ms"], entry["p99_ms"], entry["max_ms"])
         for entry in summaries
     ] == [(1, 1.0, 1.0, 1.0, 1.0), (1, 4.0, 4.0, 4.0, 4.0)]
+
+
+def test_scheduler_lag_heartbeat_rearms_from_actual_time_after_stall() -> None:
+    """A recovered heartbeat must schedule future 50 ms samples, not replay missed ones."""
+    detector = EventLoopStallDetector(heartbeat_interval_seconds=0.05)
+    loop = _LoopClock()
+    detector._loop = loop
+    detector._schedule_heartbeat(1.0)
+
+    loop.now = 1.31
+    loop.run_next()
+    assert loop.next_scheduled_time() == pytest.approx(1.36)
+
+    loop.now = 1.36
+    loop.run_next()
+    assert loop.next_scheduled_time() == pytest.approx(1.41)
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -21,6 +21,21 @@ from mindroom.event_loop_stall import (
 _STALL_EVENTS = {"event_loop_stall_detected", "event_loop_stall_ongoing", "event_loop_stall_ended"}
 
 
+class _LoopClock:
+    """Tiny loop clock for deterministic scheduled-callback lag tests."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+        self.scheduled: list[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    def call_at(self, when: float, _callback: object, *_args: object) -> object:
+        self.scheduled.append(when)
+        return object()
+
+
 def _fake_runtime_paths(**env_overrides: str) -> RuntimePaths:
     fake = Path("/var/empty/mindroom-test")
     return RuntimePaths(
@@ -47,6 +62,54 @@ def _detector(
 
 def _stall_logs(logs: list[dict[str, object]]) -> list[dict[str, object]]:
     return [entry for entry in logs if entry["event"] in _STALL_EVENTS]
+
+
+def test_scheduler_lag_summary_aggregates_delayed_heartbeats() -> None:
+    """Delayed callbacks emit one nearest-rank aggregate, never sample logs."""
+    detector = _detector()
+    loop = _LoopClock()
+    detector._loop = loop
+    detector._scheduler_lag_window_started_at = 0.0
+
+    with capture_logs() as logs:
+        for scheduled, lag_seconds in ((1.0, 0.001), (2.0, 0.002), (3.0, 0.003), (4.0, 0.004), (5.0, 0.005)):
+            loop.now = scheduled + lag_seconds
+            detector._beat(scheduled)
+        detector._report_scheduler_lag(60.0)
+
+    summaries = [entry for entry in logs if entry["event"] == "event_loop_scheduler_lag_summary"]
+    assert len(summaries) == 1
+    assert {field: summaries[0][field] for field in ("sample_count", "p50_ms", "p95_ms", "p99_ms", "max_ms")} == {
+        "sample_count": 5,
+        "p50_ms": 3.0,
+        "p95_ms": 5.0,
+        "p99_ms": 5.0,
+        "max_ms": 5.0,
+    }
+    assert [entry["event"] for entry in logs] == ["event_loop_scheduler_lag_summary"]
+
+
+def test_scheduler_lag_summary_resets_completed_window_samples() -> None:
+    """One completed window reports once; next window contains only new samples."""
+    detector = _detector()
+    loop = _LoopClock()
+    detector._loop = loop
+    detector._scheduler_lag_window_started_at = 0.0
+
+    with capture_logs() as logs:
+        loop.now = 1.001
+        detector._beat(1.0)
+        detector._report_scheduler_lag(60.0)
+        detector._report_scheduler_lag(60.1)
+        loop.now = 61.004
+        detector._beat(61.0)
+        detector._report_scheduler_lag(120.0)
+
+    summaries = [entry for entry in logs if entry["event"] == "event_loop_scheduler_lag_summary"]
+    assert [
+        (entry["sample_count"], entry["p50_ms"], entry["p95_ms"], entry["p99_ms"], entry["max_ms"])
+        for entry in summaries
+    ] == [(1, 1.0, 1.0, 1.0, 1.0), (1, 4.0, 4.0, 4.0, 4.0)]
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -75,6 +75,15 @@ def _stall_logs(logs: list[dict[str, object]]) -> list[dict[str, object]]:
     return [entry for entry in logs if entry["event"] in _STALL_EVENTS]
 
 
+@pytest.mark.parametrize("heartbeat_interval_seconds", [0.0, -0.05, float("inf"), float("-inf"), float("nan")])
+def test_detector_rejects_non_positive_or_nonfinite_heartbeat_intervals(
+    heartbeat_interval_seconds: float,
+) -> None:
+    """Heartbeat scheduling requires a finite interval greater than zero."""
+    with pytest.raises(ValueError, match="finite and > 0"):
+        EventLoopStallDetector(heartbeat_interval_seconds=heartbeat_interval_seconds)
+
+
 def test_scheduler_lag_summary_aggregates_delayed_heartbeats() -> None:
     """Delayed callbacks emit one nearest-rank aggregate, never sample logs."""
     detector = _detector()

--- a/tests/test_thread_history.py
+++ b/tests/test_thread_history.py
@@ -1768,6 +1768,73 @@ class TestThreadHistory:
         assert history[1].body == "Final answer"
 
     @pytest.mark.asyncio
+    async def test_room_scan_parse_cpu_accumulates_per_page_and_reaches_refresh_log(self) -> None:
+        """Count only synchronous event parsing CPU across paginated room-history responses."""
+        client = AsyncMock()
+        logger = MagicMock()
+        root_event = self._make_text_event(
+            event_id="$thread_root",
+            sender="@user:localhost",
+            body="root",
+            server_timestamp=1000,
+            source_content={"body": "root"},
+        )
+        thread_message = self._make_text_event(
+            event_id="$agent_msg",
+            sender="@agent:localhost",
+            body="reply",
+            server_timestamp=2000,
+            source_content={
+                "body": "reply",
+                "m.relates_to": {
+                    "rel_type": "m.thread",
+                    "event_id": "$thread_root",
+                },
+            },
+        )
+        first_page = MagicMock(spec=nio.RoomMessagesResponse)
+        first_page.chunk = [thread_message]
+        first_page.end = "page_2"
+        second_page = MagicMock(spec=nio.RoomMessagesResponse)
+        second_page.chunk = [root_event]
+        second_page.end = None
+        pages = iter((first_page, second_page))
+        page_index = 0
+
+        with (
+            patch.object(matrix_client_module, "logger", logger),
+            patch(
+                "mindroom.matrix.client_thread_history.time.thread_time",
+                side_effect=[10.0, 10.003, 20.0, 20.007],
+            ) as thread_cpu_clock,
+        ):
+
+            async def room_messages(*_args: object, **_kwargs: object) -> MagicMock:
+                nonlocal page_index
+                assert thread_cpu_clock.call_count == page_index * 2
+                page_index += 1
+                return next(pages)
+
+            client.room_messages.side_effect = room_messages
+            history = await fetch_thread_history(
+                client,
+                "!room:localhost",
+                "$thread_root",
+                event_cache=_event_cache(),
+                caller_label="parse_cpu_test",
+            )
+
+        refreshed_log = next(
+            call
+            for call in logger.info.call_args_list
+            if call.args and call.args[0] == "matrix_cache_thread_history_refreshed"
+        )
+        assert [message.event_id for message in history] == ["$thread_root", "$agent_msg"]
+        assert thread_cpu_clock.call_count == 4
+        assert history.diagnostics["homeserver_scan_parse_cpu_ms"] == pytest.approx(10.0)
+        assert refreshed_log.kwargs["homeserver_scan_parse_cpu_ms"] == pytest.approx(10.0)
+
+    @pytest.mark.asyncio
     async def test_fetch_thread_history_stops_when_root_is_found(self) -> None:
         """Stop pagination once the thread root has been seen."""
         client = AsyncMock()
@@ -2198,13 +2265,22 @@ class TestThreadHistoryCache:
             await asyncio.wait_for(first_scan_started.wait(), timeout=10)
             await asyncio.sleep(0.2)
             release_scan.set()
-            await asyncio.gather(*readers)
+            histories = await asyncio.gather(*readers)
         finally:
             release_scan.set()
             await coordinator.close()
             await cache.close()
 
         assert scans_started == 1, f"{scans_started} concurrent readers each ran their own homeserver scan"
+        assert sum(history.diagnostics["refill_singleflight_shared"] is False for history in histories) == 1
+        assert sum(history.diagnostics["refill_singleflight_shared"] is True for history in histories) == 19
+        leader = next(history for history in histories if history.diagnostics["refill_singleflight_shared"] is False)
+        joiners = [history for history in histories if history.diagnostics["refill_singleflight_shared"] is True]
+        assert leader.diagnostics["refill_singleflight_wait_ms"] == 0.0
+        assert all(history.diagnostics["refill_singleflight_wait_ms"] > 0.0 for history in joiners)
+        assert len({id(history.diagnostics) for history in histories}) == len(histories)
+        histories[0].diagnostics["caller_only"] = True
+        assert all("caller_only" not in history.diagnostics for history in histories[1:])
 
     @staticmethod
     def _conversation_cache_for_runtime(
@@ -3198,6 +3274,7 @@ class TestThreadHistoryCache:
                         scanned_event_count=42,
                         resolution_ms=8.6,
                         sidecar_hydration_ms=4.4,
+                        homeserver_scan_parse_cpu_ms=6.25,
                     ),
                 ),
             ),
@@ -3207,6 +3284,7 @@ class TestThreadHistoryCache:
                     return_value=matrix_client_module._ThreadCacheStoreResult(written=True, failed=False),
                 ),
             ),
+            patch("mindroom.matrix.client_thread_history.time.perf_counter", return_value=100.125),
         ):
             history = await matrix_client_module.fetch_thread_history(
                 AsyncMock(),
@@ -3215,6 +3293,7 @@ class TestThreadHistoryCache:
                 event_cache=_event_cache(),
                 caller_label="cache_miss_test",
                 coordinator_queue_wait_ms=45.6,
+                post_coordinator_read_started=100.0,
             )
 
         assert [message.event_id for message in history] == ["$thread_root"]
@@ -3236,6 +3315,11 @@ class TestThreadHistoryCache:
             "resolution_ms": 8.6,
             "sidecar_hydration_ms": 4.4,
             "coordinator_queue_wait_ms": 45.6,
+            "post_coordinator_read_ms": 125.0,
+            "thread_read_total_ms": 170.6,
+            "refill_singleflight_wait_ms": 0.0,
+            "refill_singleflight_shared": False,
+            "homeserver_scan_parse_cpu_ms": 6.25,
             "cache_reject_reason": "no_cache_state",
             "thread_read_source": THREAD_HISTORY_SOURCE_HOMESERVER,
             "thread_read_degraded": False,
@@ -3289,6 +3373,7 @@ class TestThreadHistoryCache:
                 "mindroom.matrix.client_thread_history._fetch_thread_history_with_events",
                 new=homeserver_fetch,
             ),
+            patch("mindroom.matrix.client_thread_history.time.perf_counter", return_value=200.25),
         ):
             history = await getattr(matrix_client_module, fetcher_name)(
                 AsyncMock(),
@@ -3297,6 +3382,7 @@ class TestThreadHistoryCache:
                 event_cache=_event_cache(),
                 caller_label="cache_hit_test",
                 coordinator_queue_wait_ms=34.5,
+                post_coordinator_read_started=200.0,
             )
 
         assert history == cached_history
@@ -3319,6 +3405,11 @@ class TestThreadHistoryCache:
             "resolution_ms": 3.2,
             "sidecar_hydration_ms": 1.4,
             "coordinator_queue_wait_ms": 34.5,
+            "post_coordinator_read_ms": 250.0,
+            "thread_read_total_ms": 284.5,
+            "refill_singleflight_wait_ms": 0.0,
+            "refill_singleflight_shared": False,
+            "homeserver_scan_parse_cpu_ms": 0.0,
             "cache_reject_reason": None,
             "thread_read_source": THREAD_HISTORY_SOURCE_CACHE,
             "thread_read_degraded": False,

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -408,6 +408,7 @@ class TestAgentBot(AgentBotTestBase):
             trusted_sender_ids=trusted_sender_ids,
             caller_label="dispatch_context",
             coordinator_queue_wait_ms=ANY,
+            post_coordinator_read_started=ANY,
             refill=ANY,
         )
 


### PR DESCRIPTION
## Summary

- aggregate event-loop scheduler lag in the existing stall detector
- attribute thread-history refresh time to coordinator waiting, post-coordinator work, and shared-refill waiting
- measure synchronous room-history scan parsing CPU

## Why

Stress runs show response delays that homeserver fetch duration alone does not explain.
These fields distinguish event-loop starvation, single-flight waiting, scan parsing, and remaining post-coordinator work without changing cache behavior.

## Validation

- focused thread-read, timing, and event-loop tests
- full pytest suite
- pre-commit

## Summary by Sourcery

Track event-loop scheduler lag and attribute thread refresh latency components, including homeserver scan parse CPU and single-flight refill waiting, through diagnostics and logging.

New Features:
- Aggregate event-loop scheduler callback lag over time and emit periodic percentile summaries.
- Record homeserver room-history scan parsing CPU time and propagate it through thread history diagnostics and logs.
- Track and expose per-caller single-flight thread refill wait time and whether a refill was shared among readers.
- Capture total post-coordinator thread read duration and overall thread read time in refresh diagnostics.

Enhancements:
- Refine event-loop stall detector heartbeat scheduling to rearm based on actual loop time after delays.
- Extend thread history fetching APIs to accept and forward post-coordinator read start timestamps for accurate latency accounting.

Tests:
- Add deterministic tests for scheduler lag aggregation and heartbeat rescheduling after stalls.
- Add thread history tests covering scan parse CPU accounting, single-flight refill sharing semantics, and extended diagnostics propagation.
- Update cache and dispatch pipeline tests to assert new timing and diagnostic fields in thread read logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event-loop scheduler-lag monitoring with periodic percentile and maximum lag summaries.
  * Added detailed thread-history timing diagnostics, including post-read duration and total read time.
  * Added CPU-time diagnostics for homeserver room-history parsing.
  * Added telemetry for shared thread-history refills, including wait duration and sharing status.

* **Bug Fixes**
  * Improved heartbeat scheduling after event-loop stalls to avoid replaying missed samples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->