### PR TITLE
Publish only wheel artifacts to PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
       - name: Build
-        run: uv build
+        run: uv build --wheel
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
 


### PR DESCRIPTION
## Summary

- publish only the universal Python wheel to PyPI
- stop uploading the redundant source distribution, reducing each future release by roughly 72%
- leave trusted publishing and packaged dashboard assets unchanged

## Why

The MindRoom project reached PyPI's 10 GiB project limit.
Release 2026.7.281 uploaded its 4.6 MiB wheel successfully, then failed while uploading the 11.7 MiB source distribution.
The related quota increase request is https://github.com/pypi/support/issues/11661.

## Testing

- `uv build --wheel`: one wheel, zero source distributions
- `twine check`: passed
- `uv run pytest`: 11,960 passed, 54 skipped
- `uv run pre-commit run --all-files`: passed

## Summary by Sourcery

Build:
- Update the GitHub release workflow to invoke `uv build` with the `--wheel` flag so that only wheel artifacts are built and uploaded to PyPI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release process to produce Python wheel packages explicitly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->