### PR TITLE
Fix the thread-cache refetch loop with a same-thread refill barrier

### DIFF
--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -690,7 +690,19 @@ async def _append_existing_thread_event(
     )
     if not thread_exists:
         # Only lookup-index rows are recorded: there is no snapshot to extend, so only a full
-        # history scan can make this thread readable again.
+        # history scan can make this thread readable again. Advance the watermark anyway: a fetch
+        # already in flight when this event landed cannot represent the thread, so it must not be
+        # allowed to install a snapshot that predates the event and then keep the gap this append
+        # is about to mark. Moving the watermark makes replace_thread_locked refuse that stale
+        # fetch, exactly as it does after an APPENDED live event -- otherwise a live event landing
+        # mid-fetch re-gaps the just-stored snapshot on every cycle and the thread refetches forever.
+        await _advance_snapshot_watermark(
+            db,
+            namespace=namespace,
+            room_id=room_id,
+            thread_id=thread_id,
+            reflected_at=time.time(),
+        )
         return ThreadAppendOutcome.SNAPSHOT_MISSING
     await db.execute(
         """

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -680,12 +680,13 @@ async def _append_existing_thread_event(
         (namespace, room_id, thread_id),
     )
     thread_exists = row is not None
+    reflected_at = time.time()
     await write_lookup_index_rows(
         db,
         namespace=namespace,
         room_id=room_id,
         serialized_events=[serialized_event],
-        cached_at=time.time(),
+        cached_at=reflected_at,
         thread_id=thread_id,
     )
     if not thread_exists:
@@ -700,7 +701,7 @@ async def _append_existing_thread_event(
             namespace=namespace,
             room_id=room_id,
             thread_id=thread_id,
-            reflected_at=time.time(),
+            reflected_at=reflected_at,
         )
         return ThreadAppendOutcome.SNAPSHOT_MISSING
     await db.execute(
@@ -726,7 +727,7 @@ async def _append_existing_thread_event(
         namespace=namespace,
         room_id=room_id,
         thread_id=thread_id,
-        reflected_at=time.time(),
+        reflected_at=reflected_at,
     )
     return ThreadAppendOutcome.APPENDED
 

--- a/src/mindroom/matrix/cache/postgres_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/postgres_event_cache_threads.py
@@ -692,10 +692,9 @@ async def _append_existing_thread_event(
         # Only lookup-index rows are recorded: there is no snapshot to extend, so only a full
         # history scan can make this thread readable again. Advance the watermark anyway: a fetch
         # already in flight when this event landed cannot represent the thread, so it must not be
-        # allowed to install a snapshot that predates the event and then keep the gap this append
-        # is about to mark. Moving the watermark makes replace_thread_locked refuse that stale
-        # fetch, exactly as it does after an APPENDED live event -- otherwise a live event landing
-        # mid-fetch re-gaps the just-stored snapshot on every cycle and the thread refetches forever.
+        # allowed to install a snapshot that predates the event. The runtime coordinator normally
+        # serializes same-thread refills and appends; this watermark also protects off-lane startup,
+        # prewarm, and cross-process races.
         await _advance_snapshot_watermark(
             db,
             namespace=namespace,

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -887,7 +887,19 @@ async def _append_existing_thread_event(
     )
     if row is None:
         # Only lookup-index rows are recorded: there is no snapshot to extend, so only a full
-        # history scan can make this thread readable again.
+        # history scan can make this thread readable again. Advance the watermark anyway: a fetch
+        # already in flight when this event landed cannot represent the thread, so it must not be
+        # allowed to install a snapshot that predates the event and then keep the gap this append
+        # is about to mark. Moving the watermark makes replace_thread_locked refuse that stale
+        # fetch, exactly as it does after an APPENDED live event -- otherwise a live event landing
+        # mid-fetch re-gaps the just-stored snapshot on every cycle and the thread refetches forever.
+        await _advance_snapshot_watermark(
+            db,
+            principal_id=principal_id,
+            room_id=room_id,
+            thread_id=thread_id,
+            reflected_at=time.time(),
+        )
         return ThreadAppendOutcome.SNAPSHOT_MISSING
 
     write_sequence = (await allocate_write_sequences(db, 1))[0]

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -889,10 +889,9 @@ async def _append_existing_thread_event(
         # Only lookup-index rows are recorded: there is no snapshot to extend, so only a full
         # history scan can make this thread readable again. Advance the watermark anyway: a fetch
         # already in flight when this event landed cannot represent the thread, so it must not be
-        # allowed to install a snapshot that predates the event and then keep the gap this append
-        # is about to mark. Moving the watermark makes replace_thread_locked refuse that stale
-        # fetch, exactly as it does after an APPENDED live event -- otherwise a live event landing
-        # mid-fetch re-gaps the just-stored snapshot on every cycle and the thread refetches forever.
+        # allowed to install a snapshot that predates the event. The runtime coordinator normally
+        # serializes same-thread refills and appends; this watermark also protects off-lane startup,
+        # prewarm, and cross-process races.
         await _advance_snapshot_watermark(
             db,
             principal_id=principal_id,

--- a/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
+++ b/src/mindroom/matrix/cache/sqlite_event_cache_threads.py
@@ -877,12 +877,13 @@ async def _append_existing_thread_event(
     )
     row = await cursor.fetchone()
     await cursor.close()
+    reflected_at = time.time()
     await write_lookup_index_rows(
         db,
         principal_id=principal_id,
         room_id=room_id,
         serialized_events=[serialized_event],
-        cached_at=time.time(),
+        cached_at=reflected_at,
         thread_id=thread_id,
     )
     if row is None:
@@ -897,7 +898,7 @@ async def _append_existing_thread_event(
             principal_id=principal_id,
             room_id=room_id,
             thread_id=thread_id,
-            reflected_at=time.time(),
+            reflected_at=reflected_at,
         )
         return ThreadAppendOutcome.SNAPSHOT_MISSING
 
@@ -932,7 +933,7 @@ async def _append_existing_thread_event(
         principal_id=principal_id,
         room_id=room_id,
         thread_id=thread_id,
-        reflected_at=time.time(),
+        reflected_at=reflected_at,
     )
     return ThreadAppendOutcome.APPENDED
 

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -728,11 +728,10 @@ class MatrixConversationCache(ConversationCacheProtocol):
     ) -> ThreadHistoryResult:
         """Rebuild one thread from Matrix and reinstall its snapshot.
 
-        Single-flight, and nothing else. The admission policy that used to wrap this - interactive
-        versus speculative tiers, five suppression conditions, a fan-out budget, cooldowns and
-        capped exponential backoff - is gone, and stays gone. What is kept is the one property that
-        is about cost rather than policy: a full room scan takes seconds under load, so N readers of
-        one gapped thread join a single scan instead of running N.
+        Matching readers join one single-flight, and its fetch-plus-store owns the same-thread write
+        lane. Mutations queued before the refill run first; mutations arriving while it runs wait
+        until the snapshot is installed, then extend that snapshot instead of repeatedly re-gapping
+        a snapshotless thread.
 
         The 126 ms figure quoted elsewhere in this subsystem prices a warm *cache* read and does not
         apply here.
@@ -740,16 +739,23 @@ class MatrixConversationCache(ConversationCacheProtocol):
         principal_id = self.runtime.event_cache.principal_id
 
         async def refill() -> ThreadReadResult:
-            return await refresh_thread_history_from_source(
-                self._require_client(),
+            result = await self._write_cache_ops.queue_thread_cache_update(
                 room_id,
                 thread_id,
-                self.runtime.event_cache,
-                hydrate_sidecars=wants_full_history,
-                allow_stale_fallback=allows_stale_fallback,
-                cache_reject_diagnostics=cache_reject_diagnostics,
-                trusted_sender_ids=self._trusted_sender_ids(),
+                lambda: refresh_thread_history_from_source(
+                    self._require_client(),
+                    room_id,
+                    thread_id,
+                    self.runtime.event_cache,
+                    hydrate_sidecars=wants_full_history,
+                    allow_stale_fallback=allows_stale_fallback,
+                    cache_reject_diagnostics=cache_reject_diagnostics,
+                    trusted_sender_ids=self._trusted_sender_ids(),
+                ),
+                name="matrix_cache_thread_refill",
+                emit_timing=True,
             )
+            return cast("ThreadReadResult", result)
 
         refill_result = await self._refill_single_flight.run(
             (principal_id, room_id, thread_id, wants_full_history, allows_stale_fallback),

--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -738,6 +738,7 @@ class MatrixConversationCache(ConversationCacheProtocol):
         apply here.
         """
         principal_id = self.runtime.event_cache.principal_id
+        coordinator = self.runtime.event_cache_write_coordinator
 
         async def refill() -> ThreadReadResult:
             return await refresh_thread_history_from_source(
@@ -751,9 +752,30 @@ class MatrixConversationCache(ConversationCacheProtocol):
                 trusted_sender_ids=self._trusted_sender_ids(),
             )
 
+        async def barriered_refill() -> ThreadReadResult:
+            # Run the whole fetch+store inside this thread's write lane. A live append that lands
+            # while the ~250ms homeserver scan is in flight is queued *behind* the store instead of
+            # racing it; it then extends the freshly installed snapshot (APPENDED) rather than
+            # re-marking a gap the store cannot clear. Without this barrier the thread refetches
+            # forever under sustained message flow. The coordinator's done-callback releases the
+            # lane on success, exception, or cancellation, and the single-flight below shields the
+            # queued task, so a caller giving up (e.g. a dispatch timeout) never leaves it hanging.
+            # Startup bulk prewarm deliberately bypasses this path and relies on the snapshot
+            # watermark instead; a None coordinator (test/degraded runtimes) runs the refill inline.
+            if coordinator is None:
+                return await refill()
+            lane_task = coordinator.queue_thread_update(
+                room_id,
+                thread_id,
+                refill,
+                name="matrix_cache_thread_refill",
+                coordination_scope=principal_id,
+            )
+            return cast("ThreadReadResult", await asyncio.shield(lane_task))
+
         refill_result = await self._refill_single_flight.run(
             (principal_id, room_id, thread_id, wants_full_history, allows_stale_fallback),
-            refill,
+            barriered_refill,
         )
         return ThreadHistoryResult(
             messages=list(refill_result.result),

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -707,13 +707,17 @@ async def test_strict_thread_history_uses_no_stale_fetch_without_dispatch_timeou
     client = MagicMock()
     conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=client)
 
-    coordinator = MagicMock()
-    coordinator.wait_for_thread_idle = AsyncMock(return_value=None)
+    coordinator = EventCacheWriteCoordinator(logger=conversation_cache.logger)
     conversation_cache.runtime.event_cache_write_coordinator = coordinator
     fetched_history = thread_history_result([], is_full_history=True)
 
     try:
         with (
+            patch.object(
+                coordinator,
+                "wait_for_thread_idle",
+                wraps=coordinator.wait_for_thread_idle,
+            ) as wait_for_thread_idle,
             patch(
                 "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
                 AsyncMock(return_value=fetched_history),
@@ -729,10 +733,11 @@ async def test_strict_thread_history_uses_no_stale_fetch_without_dispatch_timeou
                 caller_label="dispatch_post_lock_refresh",
             )
     finally:
+        await coordinator.close()
         await event_cache.close()
 
     assert result.is_full_history is True
-    coordinator.wait_for_thread_idle.assert_awaited_once()
+    wait_for_thread_idle.assert_awaited_once()
     refresh_thread_history.assert_awaited_once()
     assert refresh_thread_history.await_args.kwargs["allow_stale_fallback"] is False
 

--- a/tests/test_event_cache_contract.py
+++ b/tests/test_event_cache_contract.py
@@ -575,21 +575,19 @@ class TestConversationEventCacheContract:
         assert [event["event_id"] for event in cached] == [thread_id, "$live:localhost"]
 
     @pytest.mark.asyncio
-    async def test_in_flight_fetch_over_a_snapshotless_thread_does_not_refetch_forever(
+    async def test_in_flight_fetch_cannot_install_snapshot_after_snapshotless_live_append(
         self,
         event_cache: ConversationEventCache,
     ) -> None:
-        """A live append onto a not-yet-cached thread makes an in-flight fetch too old, once.
+        """A live append onto a not-yet-cached thread makes an in-flight fetch too old.
 
         This is the SNAPSHOT_MISSING sibling of the append-shaped burial test above. A thread has
         no cached rows yet. A refill scan starts; while it runs, a live event lands in the thread.
         The append finds no snapshot to extend (SNAPSHOT_MISSING), records the point row, and marks
         a gap. Because that append advances the ordering watermark, the in-flight scan is now too
-        old to install its snapshot, so its store is refused and the gap it would otherwise keep
-        forever survives for exactly one more read. A *fresh* fetch (which genuinely saw the live
-        event) then clears the gap and installs a clean snapshot -- so the thread stops refetching.
-        Without the watermark advance on SNAPSHOT_MISSING, the stale store lands, keeps the
-        post-fetch gap, and every subsequent read refetches in a loop.
+        old to install its snapshot, so its store is refused and the gap survives. The runtime
+        write barrier supplies liveness by keeping same-thread appends out of the fetch-and-store
+        window; this contract supplies safety for off-lane and cross-process races.
         """
         room_id = "!race-missing:localhost"
         thread_id = "$thread-missing:localhost"
@@ -624,18 +622,19 @@ class TestConversationEventCacheContract:
             expected_membership_epoch=await event_cache.room_membership_epoch(room_id),
             fetch_started_at=fetch_started_at,
         )
-        assert (
-            thread_cache_rejection_reason(await event_cache.get_thread_cache_gap(room_id, thread_id)) is not None
-        ), "stale in-flight store must not clear the gap"
+        assert thread_cache_rejection_reason(await event_cache.get_thread_cache_gap(room_id, thread_id)) is not None, (
+            "stale in-flight store must not clear the gap"
+        )
 
-        # A fresh fetch that started after the live event landed (so it genuinely saw it) clears
-        # the gap and installs the full snapshot, breaking the refetch loop.
+        # A fresh fetch that started after the live event landed (so it genuinely saw it) may clear
+        # the gap and install the full snapshot.
+        fresh_fetch_started_at = time.time()
         await replace_thread_unconditionally(
             event_cache,
             room_id,
             thread_id,
             [root, live],
-            fetch_started_at=time.time() + 1.0,
+            fetch_started_at=fresh_fetch_started_at,
         )
         assert thread_cache_rejection_reason(await event_cache.get_thread_cache_gap(room_id, thread_id)) is None
         cached = await event_cache.get_thread_events(room_id, thread_id)

--- a/tests/test_event_cache_contract.py
+++ b/tests/test_event_cache_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 import pytest
@@ -569,6 +570,74 @@ class TestConversationEventCacheContract:
         )
 
         assert stored
+        cached = await event_cache.get_thread_events(room_id, thread_id)
+        assert cached is not None
+        assert [event["event_id"] for event in cached] == [thread_id, "$live:localhost"]
+
+    @pytest.mark.asyncio
+    async def test_in_flight_fetch_over_a_snapshotless_thread_does_not_refetch_forever(
+        self,
+        event_cache: ConversationEventCache,
+    ) -> None:
+        """A live append onto a not-yet-cached thread makes an in-flight fetch too old, once.
+
+        This is the SNAPSHOT_MISSING sibling of the append-shaped burial test above. A thread has
+        no cached rows yet. A refill scan starts; while it runs, a live event lands in the thread.
+        The append finds no snapshot to extend (SNAPSHOT_MISSING), records the point row, and marks
+        a gap. Because that append advances the ordering watermark, the in-flight scan is now too
+        old to install its snapshot, so its store is refused and the gap it would otherwise keep
+        forever survives for exactly one more read. A *fresh* fetch (which genuinely saw the live
+        event) then clears the gap and installs a clean snapshot -- so the thread stops refetching.
+        Without the watermark advance on SNAPSHOT_MISSING, the stale store lands, keeps the
+        post-fetch gap, and every subsequent read refetches in a loop.
+        """
+        room_id = "!race-missing:localhost"
+        thread_id = "$thread-missing:localhost"
+        root = _message_event(thread_id, 1)
+
+        # A scan starts over a thread with no cached snapshot. The gap the live append marks below
+        # is stamped with real wall-clock time, so the in-flight fetch must be dated just before it
+        # for the interleaving to be realistic; the fresh fetch afterwards is dated just after.
+        before_append = time.time()
+        fetch_started_at = before_append - 1.0
+
+        # ...and a live event lands in the thread while it is still running. No snapshot exists yet,
+        # so the append is SNAPSHOT_MISSING and marks a gap.
+        live = _message_event("$live:localhost", 3, thread_id=thread_id)
+        assert (
+            await event_cache.apply_thread_mutation_append(
+                room_id,
+                thread_id,
+                live,
+                append_failed_reason="live_append_failed",
+            )
+            is ThreadAppendOutcome.SNAPSHOT_MISSING
+        )
+        assert thread_cache_rejection_reason(await event_cache.get_thread_cache_gap(room_id, thread_id)) is not None
+
+        # The in-flight scan finishes carrying only the root (it predates the live event). The
+        # watermark advanced by the append must refuse this stale store, leaving the gap in place.
+        await event_cache.replace_thread(
+            room_id,
+            thread_id,
+            [root],
+            expected_membership_epoch=await event_cache.room_membership_epoch(room_id),
+            fetch_started_at=fetch_started_at,
+        )
+        assert (
+            thread_cache_rejection_reason(await event_cache.get_thread_cache_gap(room_id, thread_id)) is not None
+        ), "stale in-flight store must not clear the gap"
+
+        # A fresh fetch that started after the live event landed (so it genuinely saw it) clears
+        # the gap and installs the full snapshot, breaking the refetch loop.
+        await replace_thread_unconditionally(
+            event_cache,
+            room_id,
+            thread_id,
+            [root, live],
+            fetch_started_at=time.time() + 1.0,
+        )
+        assert thread_cache_rejection_reason(await event_cache.get_thread_cache_gap(room_id, thread_id)) is None
         cached = await event_cache.get_thread_events(room_id, thread_id)
         assert cached is not None
         assert [event["event_id"] for event in cached] == [thread_id, "$live:localhost"]

--- a/tests/test_event_cache_contract.py
+++ b/tests/test_event_cache_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -640,6 +641,41 @@ class TestConversationEventCacheContract:
         cached = await event_cache.get_thread_events(room_id, thread_id)
         assert cached is not None
         assert [event["event_id"] for event in cached] == [thread_id, "$live:localhost"]
+
+    @pytest.mark.asyncio
+    async def test_clock_rollback_during_snapshotless_append_does_not_admit_stale_fetch(
+        self,
+        event_cache: ConversationEventCache,
+    ) -> None:
+        """One append timestamp must fence a fetch even if the wall clock steps backward."""
+        room_id = "!clock-rollback:localhost"
+        thread_id = "$thread-clock-rollback:localhost"
+        root = _message_event(thread_id, 1)
+        live = _message_event("$live-clock-rollback:localhost", 2, thread_id=thread_id)
+        backend = event_cache.runtime_diagnostics()["cache_backend"]
+        clock_target = f"mindroom.matrix.cache.{backend}_event_cache_threads.time.time"
+
+        with patch(clock_target, side_effect=[200.0, 100.0, 100.0]):
+            assert (
+                await event_cache.apply_thread_mutation_append(
+                    room_id,
+                    thread_id,
+                    live,
+                    append_failed_reason="live_append_failed",
+                )
+                is ThreadAppendOutcome.SNAPSHOT_MISSING
+            )
+
+        await event_cache.replace_thread(
+            room_id,
+            thread_id,
+            [root],
+            expected_membership_epoch=await event_cache.room_membership_epoch(room_id),
+            fetch_started_at=150.0,
+        )
+
+        assert await event_cache.get_thread_events(room_id, thread_id) is None
+        assert thread_cache_rejection_reason(await event_cache.get_thread_cache_gap(room_id, thread_id)) is not None
 
     @pytest.mark.asyncio
     async def test_redaction_tombstones_original_edits_and_late_replays(

--- a/tests/test_thread_cache_mutations.py
+++ b/tests/test_thread_cache_mutations.py
@@ -1621,9 +1621,161 @@ class TestMatrixConversationCacheThreadReads:
                 runtime=_conversation_runtime(client=reader_client, event_cache=event_cache),
             )
 
-            history = await second_access.get_thread_history("!test:localhost", "$thread:localhost")
+            history = await second_access.refresh_strict_thread_history_from_source("!test:localhost", "$thread:localhost")
         finally:
             await event_cache.close()
 
         assert [message.body for message in history] == ["Root", "Fresh reply"]
         reader_client.room_messages.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_refill_runs_under_same_thread_write_barrier() -> None:
+    """A thread refill holds the same-thread write lane, so a mid-refill append waits for it.
+
+    Restores the invariant test_get_thread_history_refresh_runs_under_same_thread_write_barrier
+    (removed in #1690) that the watermark change alone did not provide. An append that lands while
+    the refill's homeserver scan is in flight must be queued *behind* the store rather than racing
+    it: otherwise it re-gaps the just-installed snapshot and the thread refetches forever under
+    sustained load.
+    """
+    access = MatrixConversationCache(
+        logger=MagicMock(),
+        runtime=_conversation_runtime(client=_make_client_mock()),
+    )
+    access.runtime.event_cache.get_thread_cache_state = AsyncMock(return_value=None)
+    access.runtime.event_cache.get_thread_events = AsyncMock(return_value=[{"event_id": "$thread:localhost"}])
+    refresh_started = asyncio.Event()
+    allow_refresh = asyncio.Event()
+    queued_update_started = asyncio.Event()
+
+    async def slow_refresh(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
+        refresh_started.set()
+        await allow_refresh.wait()
+        return thread_history_result(
+            [_message(event_id="$thread:localhost", body="Root")],
+            is_full_history=True,
+        )
+
+    async def queued_update() -> None:
+        queued_update_started.set()
+
+    with patch(
+        "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+        new=AsyncMock(side_effect=slow_refresh),
+    ):
+        refresh_task = asyncio.create_task(access.refresh_strict_thread_history_from_source("!test:localhost", "$thread:localhost"))
+        await asyncio.wait_for(refresh_started.wait(), timeout=1.0)
+
+        access.runtime.event_cache_write_coordinator.queue_thread_update(
+            "!test:localhost",
+            "$thread:localhost",
+            queued_update,
+            name="matrix_cache_follow_up_update",
+            coordination_scope=access.runtime.event_cache.principal_id,
+        )
+        await asyncio.sleep(0)
+        # The append queued during the refill must NOT run while the refill holds the lane.
+        assert queued_update_started.is_set() is False
+
+        allow_refresh.set()
+        await refresh_task
+    await _wait_for_room_cache_idle(access.runtime.event_cache_write_coordinator)
+
+    # Once the refill's store released the lane, the queued append runs.
+    assert queued_update_started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_refill_does_not_block_a_different_thread() -> None:
+    """The refill barrier is per-thread: a write to a different thread proceeds concurrently."""
+    access = MatrixConversationCache(
+        logger=MagicMock(),
+        runtime=_conversation_runtime(client=_make_client_mock()),
+    )
+    access.runtime.event_cache.get_thread_cache_state = AsyncMock(return_value=None)
+    access.runtime.event_cache.get_thread_events = AsyncMock(return_value=[{"event_id": "$thread:localhost"}])
+    refresh_started = asyncio.Event()
+    allow_refresh = asyncio.Event()
+    other_thread_ran = asyncio.Event()
+
+    async def slow_refresh(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
+        refresh_started.set()
+        await allow_refresh.wait()
+        return thread_history_result(
+            [_message(event_id="$thread:localhost", body="Root")],
+            is_full_history=True,
+        )
+
+    async def other_thread_update() -> None:
+        other_thread_ran.set()
+
+    with patch(
+        "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+        new=AsyncMock(side_effect=slow_refresh),
+    ):
+        refresh_task = asyncio.create_task(access.refresh_strict_thread_history_from_source("!test:localhost", "$thread:localhost"))
+        await asyncio.wait_for(refresh_started.wait(), timeout=1.0)
+
+        access.runtime.event_cache_write_coordinator.queue_thread_update(
+            "!test:localhost",
+            "$other-thread:localhost",
+            other_thread_update,
+            name="matrix_cache_other_thread_update",
+            coordination_scope=access.runtime.event_cache.principal_id,
+        )
+        await asyncio.wait_for(other_thread_ran.wait(), timeout=1.0)
+        # A different thread's write ran while the refill still held the first thread's lane.
+        assert other_thread_ran.is_set()
+
+        allow_refresh.set()
+        await refresh_task
+    await _wait_for_room_cache_idle(access.runtime.event_cache_write_coordinator)
+
+
+@pytest.mark.asyncio
+async def test_refill_failure_releases_the_thread_lane() -> None:
+    """If the refill's fetch raises, the lane is released so queued appends still run."""
+    access = MatrixConversationCache(
+        logger=MagicMock(),
+        runtime=_conversation_runtime(client=_make_client_mock()),
+    )
+    access.runtime.event_cache.get_thread_cache_state = AsyncMock(return_value=None)
+    access.runtime.event_cache.get_thread_events = AsyncMock(return_value=[{"event_id": "$thread:localhost"}])
+    refresh_started = asyncio.Event()
+    allow_refresh = asyncio.Event()
+    queued_update_started = asyncio.Event()
+
+    async def failing_refresh(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
+        refresh_started.set()
+        await allow_refresh.wait()
+        raise RuntimeError("homeserver scan failed")
+
+    async def queued_update() -> None:
+        queued_update_started.set()
+
+    with patch(
+        "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+        new=AsyncMock(side_effect=failing_refresh),
+    ):
+        refresh_task = asyncio.create_task(
+            access.refresh_strict_thread_history_from_source("!test:localhost", "$thread:localhost")
+        )
+        await asyncio.wait_for(refresh_started.wait(), timeout=1.0)
+        access.runtime.event_cache_write_coordinator.queue_thread_update(
+            "!test:localhost",
+            "$thread:localhost",
+            queued_update,
+            name="matrix_cache_follow_up_update",
+            coordination_scope=access.runtime.event_cache.principal_id,
+        )
+        await asyncio.sleep(0)
+        assert queued_update_started.is_set() is False  # still waits behind the in-flight refill
+
+        allow_refresh.set()
+        with pytest.raises(RuntimeError, match="homeserver scan failed"):
+            await refresh_task
+    await _wait_for_room_cache_idle(access.runtime.event_cache_write_coordinator)
+
+    # The failed refill released the lane, so the queued append ran.
+    assert queued_update_started.is_set()

--- a/tests/test_thread_read_guards.py
+++ b/tests/test_thread_read_guards.py
@@ -12,7 +12,6 @@ import pytest
 
 import mindroom.matrix.cache as matrix_cache
 import mindroom.matrix.cache.sqlite_event_cache_threads as sqlite_event_cache_threads_module
-from mindroom.background_tasks import wait_for_background_tasks
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome, ThreadCacheGap
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
@@ -251,13 +250,11 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         await _wait_for_room_cache_idle(coordinator)
 
     @pytest.mark.asyncio
-    async def test_live_append_without_a_snapshot_is_recovered_by_the_next_read(self, tmp_path: Path) -> None:
-        """A live event arriving with no cached snapshot is not lost; the next read refetches it.
-
-        There is no scheduled repair and no retained delta any more. The append finds no snapshot,
-        records a gap, and the homeserver -- which has the event -- is what the next read rebuilds
-        from. Same guarantee, one mechanism instead of three.
-        """
+    async def test_live_append_during_snapshotless_refill_converges_without_second_scan(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A refill owns the thread lane so a racing live append extends its installed snapshot."""
         room_id = "!test:localhost"
         thread_id = "$thread:localhost"
         event_cache = SqliteEventCache(tmp_path / "event_cache.db")
@@ -284,6 +281,16 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             thread_events=[live_event],
             next_batch="s_initial",
         )
+        room_messages_response = client.room_messages.return_value
+        fetch_started = asyncio.Event()
+        release_fetch = asyncio.Event()
+
+        async def blocking_room_messages(*_args: object, **_kwargs: object) -> nio.RoomMessagesResponse:
+            fetch_started.set()
+            await release_fetch.wait()
+            return room_messages_response
+
+        client.room_messages = AsyncMock(side_effect=blocking_room_messages)
         access = MatrixConversationCache(
             logger=MagicMock(),
             runtime=_conversation_runtime(
@@ -292,27 +299,50 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
                 coordinator=coordinator,
             ),
         )
+        read_task = asyncio.create_task(access.get_dispatch_thread_history(room_id, thread_id))
+        mutation_task: asyncio.Task[object] | None = None
 
         try:
-            await access.append_live_event(
+            await asyncio.wait_for(fetch_started.wait(), timeout=1.0)
+            mutation_task = access._write_cache_ops.queue_thread_cache_update(
                 room_id,
-                live_event,
-                event_info=EventInfo.from_event(live_event.source),
+                thread_id,
+                lambda: event_cache.apply_thread_mutation_append(
+                    room_id,
+                    thread_id,
+                    live_event.source,
+                    append_failed_reason="live_append_failed",
+                ),
+                name="matrix_cache_test_live_append",
             )
-            await wait_for_background_tasks(timeout=1.0, owner=coordinator.background_task_owner)
-            history = await access.get_dispatch_thread_history(room_id, thread_id)
+            await asyncio.sleep(0)
+            assert mutation_task.done() is False
+
+            release_fetch.set()
+            history = await asyncio.wait_for(read_task, timeout=1.0)
+            mutation_outcome = await asyncio.wait_for(mutation_task, timeout=1.0)
+            cached_history = await access.get_dispatch_thread_history(room_id, thread_id)
             cached_rows = await event_cache.get_thread_events(room_id, thread_id)
             gap_after_read = await event_cache.get_thread_cache_gap(room_id, thread_id)
         finally:
-            await wait_for_background_tasks(timeout=1.0, owner=coordinator.background_task_owner)
+            release_fetch.set()
+            await asyncio.gather(
+                read_task,
+                *(task for task in [mutation_task] if task is not None),
+                return_exceptions=True,
+            )
+            await coordinator.close()
             await event_cache.close()
 
         expected_event_ids = [thread_id, "$live:localhost"]
         assert [message.event_id for message in history] == expected_event_ids
+        assert mutation_outcome is ThreadAppendOutcome.APPENDED
+        assert [message.event_id for message in cached_history] == expected_event_ids
+        assert cached_history.diagnostics[THREAD_HISTORY_SOURCE_DIAGNOSTIC] == THREAD_HISTORY_SOURCE_CACHE
         assert cached_rows is not None
         assert [event["event_id"] for event in cached_rows] == expected_event_ids
-        # The refetch covered the gap, so the rebuilt snapshot is usable.
         assert matrix_cache.thread_cache_rejection_reason(gap_after_read) is None
+        assert client.room_messages.await_count == 1
 
     @pytest.mark.asyncio
     async def test_live_redaction_resolution_does_not_block_same_room_read(self) -> None:


### PR DESCRIPTION
## Problem

A snapshotless thread can enter a permanent homeserver-refetch loop under sustained live traffic.
A refill fetches off the write lane while live appends mutate the cache on it.
When an append lands during the fetch, it cannot extend a snapshot that does not exist, so it records `SNAPSHOT_MISSING` plus a gap.
The completing refill cannot cover that newer gap, and the next read scans again.
Continuous arrivals keep repeating the race.

## Fix

This PR separates safety from liveness:

- Advance the snapshot watermark when a live append finds no snapshot, so an already-running stale fetch cannot install older rows.
- Run the complete per-thread fetch-plus-store operation through the existing `ThreadMutationCacheOps` same-thread write lane.
- Keep single-flight outside that lane, so concurrent readers still share one scan.
- Let appends arriving during the refill wait and then extend the installed snapshot instead of re-marking a gap.
- Reuse one timestamp for each logical append's lookup metadata and snapshot watermark, preventing an intra-append wall-clock rollback from weakening the fence.

Startup bulk prewarm remains off the live coordinator and relies on the watermark.
Different threads remain concurrent because the barrier is thread-scoped, not room-scoped.

## Why this version

A concurrent implementation used the same core barrier idea.
The final version keeps the typed cache-write facade and its timing, avoids a test-only production fallback for missing coordinators, avoids double queueing/shielding, and preserves the ordinary-read recovery test.
Its useful cross-thread-parallelism assertion was folded into the realistic convergence regression.

## Tests

- `tests/test_thread_read_guards.py` blocks a real snapshotless refill, proves a different-thread write proceeds, proves the same-thread append waits and becomes `APPENDED`, and proves the next read is a cache hit with no second homeserver scan.
- `tests/test_event_cache_contract.py` covers stale-store refusal and clock rollback on SQLite and Postgres.
- Existing coordinator tests cover same-thread ordering, distinct-thread parallelism, failure release, and cancellation release.
- Existing single-flight coverage still proves concurrent cold readers share one homeserver scan.

Focused cache/read/coordinator selection: 275 passed.
`pre-commit run --all-files`: passed.

The full repository suite was intentionally not run locally; CI remains authoritative for it.
