### PR TITLE
Measure time to first substantive reply

### DIFF
--- a/src/mindroom/final_delivery.py
+++ b/src/mindroom/final_delivery.py
@@ -63,6 +63,16 @@ class FinalDeliveryOutcome:  # noqa: D101
         return self.event_id is not None and self.is_visible_response and not self.suppressed
 
     @property
+    def delivered_substantive_content(self) -> bool:
+        """Return whether this outcome proves that nonblank response text reached Matrix."""
+        return (
+            self.is_visible_response
+            and self.delivery_kind is not None
+            and self.final_visible_body is not None
+            and bool(self.final_visible_body.strip())
+        )
+
+    @property
     def response_text(self) -> str:  # noqa: D102
         return self.final_visible_body or ""
 

--- a/src/mindroom/final_delivery.py
+++ b/src/mindroom/final_delivery.py
@@ -66,7 +66,8 @@ class FinalDeliveryOutcome:  # noqa: D101
     def delivered_substantive_content(self) -> bool:
         """Return whether this outcome proves that nonblank response text reached Matrix."""
         return (
-            self.is_visible_response
+            self.terminal_status == "completed"
+            and self.is_visible_response
             and self.delivery_kind is not None
             and self.final_visible_body is not None
             and bool(self.final_visible_body.strip())

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1937,7 +1937,7 @@ class ResponseRunner:
                 if request.pipeline_timing is not None:
                     request.pipeline_timing.mark_first_visible_reply(
                         "final",
-                        substantive=delivery.is_visible_response,
+                        substantive=delivery.delivered_substantive_content,
                     )
                     request.pipeline_timing.mark("response_complete")
             else:
@@ -2055,7 +2055,7 @@ class ResponseRunner:
                 if request.pipeline_timing is not None:
                     request.pipeline_timing.mark_first_visible_reply(
                         "final",
-                        substantive=delivery.is_visible_response,
+                        substantive=delivery.delivered_substantive_content,
                     )
                     request.pipeline_timing.mark("response_complete")
 
@@ -2583,7 +2583,7 @@ class ResponseRunner:
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark_first_visible_reply(
                 "final",
-                substantive=delivery.is_visible_response,
+                substantive=delivery.delivered_substantive_content,
             )
             request.pipeline_timing.mark("response_complete")
         return build_outcome(delivery)
@@ -2769,7 +2769,7 @@ class ResponseRunner:
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark_first_visible_reply(
                 "final",
-                substantive=delivery.is_visible_response,
+                substantive=delivery.delivered_substantive_content,
             )
             request.pipeline_timing.mark("response_complete")
         return build_outcome(delivery)

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1932,11 +1932,13 @@ class ResponseRunner:
                     existing_event_id=request.existing_event_id,
                     existing_event_is_placeholder=request.existing_event_is_placeholder,
                 )
-                progress.settle(
-                    await self.deps.delivery_gateway.finalize_streamed_response(finalize_request),
-                )
+                delivery = await self.deps.delivery_gateway.finalize_streamed_response(finalize_request)
+                progress.settle(delivery)
                 if request.pipeline_timing is not None:
-                    request.pipeline_timing.mark_first_visible_reply("final")
+                    request.pipeline_timing.mark_first_visible_reply(
+                        "final",
+                        substantive=delivery.is_visible_response,
+                    )
                     request.pipeline_timing.mark("response_complete")
             else:
                 try:
@@ -2023,23 +2025,22 @@ class ResponseRunner:
 
                 progress.note_delivery_started(None)
                 try:
-                    progress.settle(
-                        await self.deps.delivery_gateway.deliver_final(
-                            FinalDeliveryRequest(
-                                target=delivery_target,
-                                existing_event_id=message_id,
-                                existing_event_is_placeholder=delivery_request.existing_event_is_placeholder,
-                                response_text=response_text,
-                                identity=response_identity,
-                                tool_trace=None,
-                                extra_content=_merge_response_extra_content(
-                                    team_run_metadata_content
-                                    or ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
-                                    request.attachment_ids,
-                                ),
+                    delivery = await self.deps.delivery_gateway.deliver_final(
+                        FinalDeliveryRequest(
+                            target=delivery_target,
+                            existing_event_id=message_id,
+                            existing_event_is_placeholder=delivery_request.existing_event_is_placeholder,
+                            response_text=response_text,
+                            identity=response_identity,
+                            tool_trace=None,
+                            extra_content=_merge_response_extra_content(
+                                team_run_metadata_content
+                                or ai_run_extra_content_from_metadata(team_turn_recorder.run_metadata),
+                                request.attachment_ids,
                             ),
                         ),
                     )
+                    progress.settle(delivery)
                 except asyncio.CancelledError:
                     await self._persist_interrupted_recorder_off_loop(
                         recorder=team_turn_recorder,
@@ -2052,7 +2053,10 @@ class ResponseRunner:
                     )
                     raise
                 if request.pipeline_timing is not None:
-                    request.pipeline_timing.mark_first_visible_reply("final")
+                    request.pipeline_timing.mark_first_visible_reply(
+                        "final",
+                        substantive=delivery.is_visible_response,
+                    )
                     request.pipeline_timing.mark("response_complete")
 
         async def settle_team_streaming_delivery_error(error: StreamingDeliveryError) -> FinalDeliveryOutcome:
@@ -2577,7 +2581,10 @@ class ResponseRunner:
             )
             raise
         if request.pipeline_timing is not None:
-            request.pipeline_timing.mark_first_visible_reply("final")
+            request.pipeline_timing.mark_first_visible_reply(
+                "final",
+                substantive=delivery.is_visible_response,
+            )
             request.pipeline_timing.mark("response_complete")
         return build_outcome(delivery)
 
@@ -2760,7 +2767,10 @@ class ResponseRunner:
         )
         delivery = await self.deps.delivery_gateway.finalize_streamed_response(finalize_request)
         if request.pipeline_timing is not None:
-            request.pipeline_timing.mark_first_visible_reply("final")
+            request.pipeline_timing.mark_first_visible_reply(
+                "final",
+                substantive=delivery.is_visible_response,
+            )
             request.pipeline_timing.mark("response_complete")
         return build_outcome(delivery)
 

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -1080,7 +1080,7 @@ class StreamingResponse:
     def _mark_first_visible_reply_if_needed(self) -> None:
         """Mark first visible reply timing once visible text exists."""
         if self.pipeline_timing is not None and self.accumulated_text.strip():
-            self.pipeline_timing.mark_first_visible_reply("stream_update")
+            self.pipeline_timing.mark_first_visible_reply("stream_update", substantive=True)
 
     async def _send_initial_content(
         self,

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -928,6 +928,7 @@ class StreamingResponse:
                 raise RuntimeError(msg)
             return False
 
+        self._mark_first_visible_reply_if_needed(prepared_delivery.committed_state)
         if not is_final:
             self._warmup_state.note_nonterminal_delivery(
                 had_warmup_suffix=prepared_delivery.had_warmup_suffix,
@@ -1077,9 +1078,9 @@ class StreamingResponse:
             return
         self.conversation_cache.release_outbound_thread(self.room_id, self.event_id)
 
-    def _mark_first_visible_reply_if_needed(self) -> None:
-        """Mark first visible reply timing once visible text exists."""
-        if self.pipeline_timing is not None and self.accumulated_text.strip():
+    def _mark_first_visible_reply_if_needed(self, delivered_state: _CommittedDeliveryState) -> None:
+        """Mark first visible reply timing from the payload acknowledged by Matrix."""
+        if self.pipeline_timing is not None and delivered_state.visible_body_state == "visible_body":
             self.pipeline_timing.mark_first_visible_reply("stream_update", substantive=True)
 
     async def _send_initial_content(
@@ -1103,7 +1104,6 @@ class StreamingResponse:
         if self.visible_event_id_callback is not None:
             self.visible_event_id_callback(delivered.event_id)
         await self._record_streaming_send(delivered.event_id, delivered.content_sent)
-        self._mark_first_visible_reply_if_needed()
         logger.debug("Initial streaming message sent", event_id=self.event_id)
         return True
 
@@ -1128,7 +1128,6 @@ class StreamingResponse:
         if delivered is None:
             return False
         await self._record_streaming_edit(delivered.event_id, content_sent=delivered.content_sent)
-        self._mark_first_visible_reply_if_needed()
         return True
 
     async def _send_content(

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -83,6 +83,7 @@ _PRIMARY_SEGMENTS: tuple[tuple[str, str, str], ...] = (
 
 _PRIMARY_TOTALS: tuple[tuple[str, str, str], ...] = (
     ("time_to_first_visible_reply_ms", "message_received", "first_visible_reply"),
+    ("time_to_first_substantive_reply_ms", "message_received", "first_substantive_reply"),
     ("total_pipeline_ms", "message_received", "response_complete"),
 )
 
@@ -105,6 +106,16 @@ _DIAGNOSTIC_SPANS: tuple[tuple[str, str, str], ...] = (
     ("diag_prompt_assembly_ms", "prompt_assembly_start", "prompt_assembly_ready"),
     ("diag_history_ready_to_model_request_ms", "history_ready", "model_request_sent"),
     ("diag_provider_ttft_ms", "model_request_sent", "model_first_token"),
+    (
+        "diag_first_visible_to_first_substantive_reply_ms",
+        "first_visible_reply",
+        "first_substantive_reply",
+    ),
+    (
+        "diag_model_first_token_to_first_substantive_reply_ms",
+        "model_first_token",
+        "first_substantive_reply",
+    ),
     ("diag_first_visible_to_stream_complete_ms", "first_visible_reply", "streaming_complete"),
     ("diag_model_request_to_completion_ms", "model_request_sent", "response_complete"),
 )
@@ -132,11 +143,18 @@ class DispatchPipelineTiming:
                 self.metadata[key] = value
 
     def mark_first_visible_reply(self, kind: str) -> None:
-        """Record the first user-visible response milestone once."""
-        if "first_visible_reply" in self.marks:
+        """Record the first visible and first non-placeholder response milestones."""
+        needs_visible = "first_visible_reply" not in self.marks
+        needs_substantive = kind != "placeholder" and "first_substantive_reply" not in self.marks
+        if not needs_visible and not needs_substantive:
             return
-        self.marks["first_visible_reply"] = time.perf_counter()
-        self.metadata["first_visible_kind"] = kind
+        now = time.perf_counter()
+        if needs_visible:
+            self.marks["first_visible_reply"] = now
+            self.metadata["first_visible_kind"] = kind
+        if needs_substantive:
+            self.marks["first_substantive_reply"] = now
+            self.metadata["first_substantive_kind"] = kind
 
     def elapsed_ms(self, start_label: str, end_label: str) -> float | None:
         """Return elapsed time between two recorded phase boundaries."""

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -142,10 +142,10 @@ class DispatchPipelineTiming:
             if value is not None:
                 self.metadata[key] = value
 
-    def mark_first_visible_reply(self, kind: str) -> None:
-        """Record the first visible and first non-placeholder response milestones."""
+    def mark_first_visible_reply(self, kind: str, *, substantive: bool = False) -> None:
+        """Record the first visible reply and, when confirmed, the first substantive reply."""
         needs_visible = "first_visible_reply" not in self.marks
-        needs_substantive = kind != "placeholder" and "first_substantive_reply" not in self.marks
+        needs_substantive = substantive and "first_substantive_reply" not in self.marks
         if not needs_visible and not needs_substantive:
             return
         now = time.perf_counter()

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1728,7 +1728,7 @@ class TurnController:
                 )
                 self._mark_source_events_responded(replace(handled_turn, response_event_id=response_event_id))
                 if dispatch_timing is not None and response_event_id is not None:
-                    dispatch_timing.mark_first_visible_reply("final")
+                    dispatch_timing.mark_first_visible_reply("final", substantive=True)
                     dispatch_timing.mark("response_complete")
                     dispatch_timing.emit_summary(self.deps.logger, outcome="reject")
                 return

--- a/tests/test_final_delivery.py
+++ b/tests/test_final_delivery.py
@@ -127,6 +127,18 @@ def test_final_delivery_outcome_cancelled_for_empty_prompt_is_not_retryable() ->
         ),
         pytest.param(
             FinalDeliveryOutcome(
+                terminal_status="error",
+                event_id="$placeholder",
+                is_visible_response=True,
+                final_visible_body="Response delivery failed.",
+                delivery_kind="edited",
+                failure_reason="delivery_failed",
+            ),
+            False,
+            id="delivered-failure-note",
+        ),
+        pytest.param(
+            FinalDeliveryOutcome(
                 terminal_status="completed",
                 event_id="$existing",
                 is_visible_response=True,

--- a/tests/test_final_delivery.py
+++ b/tests/test_final_delivery.py
@@ -101,6 +101,50 @@ def test_final_delivery_outcome_cancelled_for_empty_prompt_is_not_retryable() ->
     assert outcome.mark_handled is False
 
 
+@pytest.mark.parametrize(
+    ("outcome", "expected"),
+    [
+        pytest.param(
+            FinalDeliveryOutcome(
+                terminal_status="completed",
+                event_id="$final",
+                is_visible_response=True,
+                final_visible_body="hello",
+                delivery_kind="sent",
+            ),
+            True,
+            id="successful-visible-body",
+        ),
+        pytest.param(
+            FinalDeliveryOutcome(
+                terminal_status="error",
+                event_id="$existing",
+                is_visible_response=True,
+                failure_reason="delivery_failed",
+            ),
+            False,
+            id="preserved-existing-body",
+        ),
+        pytest.param(
+            FinalDeliveryOutcome(
+                terminal_status="completed",
+                event_id="$existing",
+                is_visible_response=True,
+                delivery_kind="edited",
+            ),
+            False,
+            id="empty-existing-stream",
+        ),
+    ],
+)
+def test_final_delivery_outcome_identifies_substantive_delivery(
+    outcome: FinalDeliveryOutcome,
+    expected: bool,
+) -> None:
+    """Only a confirmed delivery with nonblank body text is substantive."""
+    assert outcome.delivered_substantive_content is expected
+
+
 def test_stream_transport_outcome_accepts_placeholder_only_visible_state() -> None:
     """Placeholder-only visibility must remain distinct from visible body."""
     outcome = StreamTransportOutcome(

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -828,6 +828,40 @@ async def test_non_streaming_invisible_delivery_does_not_mark_substantive_reply(
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_failed_edit_preserving_old_body_does_not_mark_substantive_reply(
+    tmp_path: Path,
+) -> None:
+    """A preserved old answer must not count as newly delivered substantive content."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    delivery = FinalDeliveryOutcome(
+        terminal_status="error",
+        event_id="$existing",
+        is_visible_response=True,
+        failure_reason="delivery_failed",
+    )
+    timing = DispatchPipelineTiming(source_event_id="$request", room_id="!room:localhost")
+    request = replace(
+        _plain_request(_target()),
+        existing_event_id="$existing",
+        pipeline_timing=timing,
+    )
+
+    with (
+        patch.object(DeliveryGateway, "deliver_final", new=AsyncMock(return_value=delivery)),
+        patch_response_runner_module(
+            ai_response=AsyncMock(return_value="replacement text"),
+            typing_indicator=_noop_typing,
+        ),
+    ):
+        generation = await coordinator.process_and_respond(request)
+
+    assert generation.delivery is delivery
+    assert "first_substantive_reply" not in timing.marks
+    assert "first_substantive_kind" not in timing.metadata
+
+
+@pytest.mark.asyncio
 async def test_streaming_response_streams_then_finalizes_through_gateway(tmp_path: Path) -> None:
     """The streaming path delivers via deliver_stream, then finalizes the same transport outcome."""
     bot = _bot(tmp_path)

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -918,8 +918,7 @@ async def test_streaming_placeholder_only_delivery_does_not_mark_substantive_rep
     request = replace(_plain_request(_target()), pipeline_timing=timing)
 
     async def fake_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
-        if False:
-            yield ""
+        yield ""
 
     with (
         patch.object(DeliveryGateway, "deliver_stream", new=AsyncMock(return_value=transport)),

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -46,6 +46,7 @@ from mindroom.response_runner import (
 from mindroom.stop import StopManager
 from mindroom.streaming import StreamingDeliveryError
 from mindroom.thread_summary import thread_summary_message_count_hint
+from mindroom.timing import DispatchPipelineTiming
 from mindroom.turn_policy import PreparedDispatch
 from tests.conftest import (
     make_matrix_client_mock,
@@ -798,6 +799,35 @@ async def test_non_streaming_response_delivers_through_deliver_final(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_invisible_delivery_does_not_mark_substantive_reply(tmp_path: Path) -> None:
+    """A failed final delivery must not turn a thinking placeholder into a substantive reply."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    delivery = FinalDeliveryOutcome(
+        terminal_status="error",
+        event_id=None,
+        failure_reason="delivery_failed",
+    )
+    timing = DispatchPipelineTiming(source_event_id="$request", room_id="!room:localhost")
+    timing.mark_first_visible_reply("placeholder")
+    request = replace(_plain_request(_target()), pipeline_timing=timing)
+
+    with (
+        patch.object(DeliveryGateway, "deliver_final", new=AsyncMock(return_value=delivery)),
+        patch_response_runner_module(
+            ai_response=AsyncMock(return_value="final text"),
+            typing_indicator=_noop_typing,
+        ),
+    ):
+        generation = await coordinator.process_and_respond(request)
+
+    assert generation.delivery is delivery
+    assert timing.metadata["first_visible_kind"] == "placeholder"
+    assert "first_substantive_reply" not in timing.marks
+    assert "first_substantive_kind" not in timing.metadata
+
+
+@pytest.mark.asyncio
 async def test_streaming_response_streams_then_finalizes_through_gateway(tmp_path: Path) -> None:
     """The streaming path delivers via deliver_stream, then finalizes the same transport outcome."""
     bot = _bot(tmp_path)
@@ -832,6 +862,45 @@ async def test_streaming_response_streams_then_finalizes_through_gateway(tmp_pat
     assert finalize_request.stream_transport_outcome is transport
     assert finalize_request.initial_delivery_kind == "sent"
     assert finalize_request.identity.response_kind == "ai"
+
+
+@pytest.mark.asyncio
+async def test_streaming_placeholder_only_delivery_does_not_mark_substantive_reply(tmp_path: Path) -> None:
+    """Placeholder-only stream finalization must not report visible answer text."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    transport = StreamTransportOutcome(
+        last_physical_stream_event_id="$placeholder",
+        terminal_status="completed",
+        rendered_body="Thinking...",
+        visible_body_state="placeholder_only",
+    )
+    delivery = FinalDeliveryOutcome(
+        terminal_status="completed",
+        event_id=None,
+    )
+    timing = DispatchPipelineTiming(source_event_id="$request", room_id="!room:localhost")
+    timing.mark_first_visible_reply("placeholder")
+    request = replace(_plain_request(_target()), pipeline_timing=timing)
+
+    async def fake_stream(*_args: object, **_kwargs: object) -> AsyncIterator[str]:
+        if False:
+            yield ""
+
+    with (
+        patch.object(DeliveryGateway, "deliver_stream", new=AsyncMock(return_value=transport)),
+        patch.object(DeliveryGateway, "finalize_streamed_response", new=AsyncMock(return_value=delivery)),
+        patch_response_runner_module(
+            stream_agent_response=fake_stream,
+            typing_indicator=_noop_typing,
+        ),
+    ):
+        generation = await coordinator.process_and_respond_streaming(request)
+
+    assert generation.delivery is delivery
+    assert timing.metadata["first_visible_kind"] == "placeholder"
+    assert "first_substantive_reply" not in timing.marks
+    assert "first_substantive_kind" not in timing.metadata
 
 
 @pytest.mark.asyncio

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -41,6 +41,7 @@ from mindroom.streaming import (
     StreamingResponse,
     send_streaming_response,
 )
+from mindroom.timing import DispatchPipelineTiming
 from mindroom.tool_system.events import _TOOL_TRACE_KEY, ToolTraceEntry
 from tests.conftest import (
     bind_runtime_paths,
@@ -270,6 +271,67 @@ async def test_nonterminal_delivery_formats_off_event_loop_thread(config: Config
     assert all(thread_id != loop_thread_id for thread_id in format_thread_ids)
     assert delivered_content["body"] == "Hello **world**"
     assert "<strong>world</strong>" in delivered_content["formatted_body"]
+
+
+@pytest.mark.asyncio
+async def test_placeholder_ack_waits_for_answer_ack_before_marking_substantive(config: Config) -> None:
+    """Substantive timing must describe the acknowledged payload, not newer buffered text."""
+    timing = DispatchPipelineTiming(source_event_id="$request", room_id="!test:localhost")
+    streaming = StreamingResponse(
+        target=MessageTarget.resolve("!test:localhost", None, "$original_123", room_mode=True),
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        pipeline_timing=timing,
+    )
+    delivered_bodies: list[str] = []
+
+    async def fake_send(
+        _client: object,
+        _room_id: str,
+        content: dict[str, Any],
+        *,
+        retry_sync_recovery: bool = False,  # noqa: ARG001
+    ) -> DeliveredMatrixEvent:
+        delivered_bodies.append(content["body"])
+        streaming.accumulated_text = "Answer buffered while the placeholder is in flight"
+        return DeliveredMatrixEvent(event_id="$placeholder", content_sent=dict(content))
+
+    async def fake_edit(
+        _client: object,
+        _room_id: str,
+        _event_id: str,
+        new_content: dict[str, Any],
+        _new_text: str,
+        *,
+        retry_sync_recovery: bool = False,  # noqa: ARG001
+    ) -> DeliveredMatrixEvent:
+        delivered_bodies.append(new_content["body"])
+        return DeliveredMatrixEvent(event_id="$answer-edit", content_sent=dict(new_content))
+
+    with (
+        patch("mindroom.streaming.send_message_result", new=fake_send),
+        patch("mindroom.streaming.edit_message_result", new=fake_edit),
+    ):
+        placeholder_sent = await streaming._send_or_edit_message(
+            make_matrix_client_mock(user_id="@mindroom_helper:localhost"),
+            allow_empty_progress=True,
+        )
+        assert placeholder_sent is True
+        assert delivered_bodies == [_PROGRESS_PLACEHOLDER]
+        assert "first_substantive_reply" not in timing.marks
+        assert "first_substantive_kind" not in timing.metadata
+
+        answer_sent = await streaming._send_or_edit_message(
+            make_matrix_client_mock(user_id="@mindroom_helper:localhost"),
+        )
+
+    assert answer_sent is True
+    assert delivered_bodies == [
+        _PROGRESS_PLACEHOLDER,
+        "Answer buffered while the placeholder is in flight",
+    ]
+    assert "first_substantive_reply" in timing.marks
+    assert timing.metadata["first_substantive_kind"] == "stream_update"
 
 
 def test_delivery_snapshot_isolates_tool_trace(config: Config) -> None:

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -432,6 +432,7 @@ def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> 
     logger = Mock()
     timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
     timing.metadata["first_visible_kind"] = "stream_update"
+    timing.metadata["first_substantive_kind"] = "stream_update"
     timing.marks.update(
         {
             "message_received": 0.0,
@@ -472,6 +473,7 @@ def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> 
             "model_request_sent": 18.0,
             "model_first_token": 19.5,
             "first_visible_reply": 20.0,
+            "first_substantive_reply": 22.0,
             "streaming_complete": 24.0,
             "response_complete": 25.0,
         },
@@ -483,6 +485,7 @@ def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> 
     assert logger.debug.call_args.args == ("Dispatch pipeline timing",)
     summary = logger.debug.call_args.kwargs
     assert summary["first_visible_kind"] == "stream_update"
+    assert summary["first_substantive_kind"] == "stream_update"
     assert summary["seg_ingress_ms"] == 1000.0
     assert summary["seg_coalescing_ms"] == 2000.0
     assert summary["seg_dispatch_ms"] == 7000.0
@@ -490,6 +493,7 @@ def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> 
     assert summary["seg_first_visible_reply_ms"] == 8000.0
     assert summary["seg_after_first_visible_ms"] == 5000.0
     assert summary["time_to_first_visible_reply_ms"] == 20000.0
+    assert summary["time_to_first_substantive_reply_ms"] == 22000.0
     assert summary["total_pipeline_ms"] == 25000.0
     assert summary["diag_ingress_cache_append_ms"] == 500.0
     assert summary["diag_ingress_normalize_ms"] == 500.0
@@ -509,6 +513,8 @@ def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> 
     assert summary["diag_prompt_assembly_ms"] == 200.0
     assert summary["diag_history_ready_to_model_request_ms"] == 1000.0
     assert summary["diag_provider_ttft_ms"] == 1500.0
+    assert summary["diag_first_visible_to_first_substantive_reply_ms"] == 2000.0
+    assert summary["diag_model_first_token_to_first_substantive_reply_ms"] == 2500.0
     assert summary["diag_first_visible_to_stream_complete_ms"] == 4000.0
     assert summary["diag_model_request_to_completion_ms"] == 7000.0
     assert "model_first_token_to_first_visible_stream_update_ms" not in summary
@@ -516,19 +522,43 @@ def test_dispatch_pipeline_summary_emits_additive_segments_and_diagnostics() -> 
     assert "model_request_to_completion_ms" not in summary
 
 
-def test_dispatch_pipeline_first_visible_reply_is_first_write_wins(
+def test_dispatch_pipeline_visible_reply_milestones_are_first_write_wins(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The first visible reply mark should preserve the earliest visible milestone."""
+    """Placeholder and substantive reply marks should preserve their earliest milestones."""
     perf_counter = Mock(side_effect=[1.5, 9.0])
     monkeypatch.setattr(timing_module.time, "perf_counter", perf_counter)
     timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
 
     timing.mark_first_visible_reply("placeholder")
+    timing.mark_first_visible_reply("stream_update")
     timing.mark_first_visible_reply("final")
 
     assert timing.marks["first_visible_reply"] == 1.5
     assert timing.metadata["first_visible_kind"] == "placeholder"
+    assert timing.marks["first_substantive_reply"] == 9.0
+    assert timing.metadata["first_substantive_kind"] == "stream_update"
+    assert perf_counter.call_count == 2
+
+
+def test_dispatch_pipeline_placeholder_only_omits_substantive_reply_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed turn with only a placeholder should not report words as delivered."""
+    monkeypatch.setattr(timing_module.time, "perf_counter", Mock(return_value=1.5))
+    logger = Mock()
+    timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
+    timing.marks["message_received"] = 0.0
+
+    timing.mark_first_visible_reply("placeholder")
+    timing.emit_summary(logger, outcome="failed")
+
+    summary = logger.debug.call_args.kwargs
+    assert summary["time_to_first_visible_reply_ms"] == 1500.0
+    assert "first_substantive_reply" not in timing.marks
+    assert "first_substantive_kind" not in summary
+    assert "time_to_first_substantive_reply_ms" not in summary
+    assert "diag_first_visible_to_first_substantive_reply_ms" not in summary
 
 
 def test_emit_timing_event_builds_no_payload_when_debug_is_disabled(

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -531,8 +531,8 @@ def test_dispatch_pipeline_visible_reply_milestones_are_first_write_wins(
     timing = DispatchPipelineTiming(source_event_id="$event", room_id="!room")
 
     timing.mark_first_visible_reply("placeholder")
-    timing.mark_first_visible_reply("stream_update")
-    timing.mark_first_visible_reply("final")
+    timing.mark_first_visible_reply("stream_update", substantive=True)
+    timing.mark_first_visible_reply("final", substantive=True)
 
     assert timing.marks["first_visible_reply"] == 1.5
     assert timing.metadata["first_visible_kind"] == "placeholder"


### PR DESCRIPTION
## Summary

- preserve the existing placeholder-based first-visible timing
- record the first confirmed non-placeholder Matrix response separately
- emit message-to-words, placeholder-to-words, and model-token-to-words durations
- omit substantive timing when delivery fails, is suppressed, or only preserves an older visible event

## Why

The existing `time_to_first_visible_reply_ms` stops when the Thinking placeholder appears.
That is useful for acknowledgement latency, but it does not measure when the user sees an actual answer.
This adds a separate milestone without changing existing dashboards or response behavior.

## New fields

- `time_to_first_substantive_reply_ms`
- `diag_first_visible_to_first_substantive_reply_ms`
- `diag_model_first_token_to_first_substantive_reply_ms`
- `first_substantive_kind`

## Validation

- 167 adjacent timing, delivery, agent, team, streaming, and controller tests passed
- full pre-commit suite passed
- full pytest exercised twice; only known parallel-load dispatch and shell-background flakes failed, and every failed case passed serially
- fresh read-only review approved the final diff

## Summary by Sourcery

Track and report separate timing metrics for the first substantive (non-placeholder) reply reaching the user, without changing existing first-visible reply behavior.

Enhancements:
- Extend dispatch pipeline timing to record first substantive reply milestones and derive new timing diagnostics from them.
- Teach final delivery and streaming paths to identify when substantive response content was actually delivered and feed that into timing metrics.
- Refine timing summary emission to omit substantive reply metrics for turns that never deliver non-placeholder content.

Tests:
- Add unit tests around final delivery outcomes, timing summaries, and response runner flows to validate substantive delivery detection and the new timing milestones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for the first substantive response separately from placeholder or visible acknowledgments.
  * Added timing metrics for measuring when substantive replies become available.
  * Improved delivery detection to distinguish completed responses containing meaningful text from empty or placeholder-only outcomes.

* **Bug Fixes**
  * Prevented placeholder, invisible, or failed deliveries from being counted as substantive replies.
  * Improved streaming response timing so milestones reflect content successfully delivered to Matrix.

* **Tests**
  * Added coverage for substantive delivery detection, streaming behavior, and new timing metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->