### PR TITLE
Do not count terminal failure notes as substantive replies

### DIFF
--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -268,7 +268,7 @@ def build_restart_interrupted_body(text: str) -> str:
 
 @dataclass(frozen=True)
 class _CommittedDeliveryState:
-    """One frozen non-terminal stream state that definitely reached Matrix."""
+    """One frozen stream state that definitely reached Matrix."""
 
     accumulated_text: str
     tool_trace: list[ToolTraceEntry]
@@ -276,6 +276,7 @@ class _CommittedDeliveryState:
     rendered_body: str
     visible_body_state: Literal["placeholder_only", "visible_body"]
     interactive_metadata: interactive.InteractiveMetadata | None
+    stream_status: str
 
 
 def _normalize_stream_accumulated_text(text: str) -> str:
@@ -409,6 +410,7 @@ def _prepare_delivery_from_snapshot(snapshot: _StreamingDeliverySnapshot) -> _Pr
                 "placeholder_only" if canonical_visible_body == _PROGRESS_PLACEHOLDER else "visible_body"
             ),
             interactive_metadata=response.interactive_metadata,
+            stream_status=snapshot.stream_status,
         ),
         had_warmup_suffix=bool(snapshot.warmup_suffix_lines),
     )
@@ -1081,7 +1083,11 @@ class StreamingResponse:
     def _mark_first_visible_reply_if_needed(self, delivered_state: _CommittedDeliveryState) -> None:
         """Mark first visible reply timing from the payload acknowledged by Matrix."""
         if self.pipeline_timing is not None and delivered_state.visible_body_state == "visible_body":
-            self.pipeline_timing.mark_first_visible_reply("stream_update", substantive=True)
+            self.pipeline_timing.mark_first_visible_reply(
+                "stream_update",
+                substantive=delivered_state.stream_status
+                in {STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING, STREAM_STATUS_COMPLETED},
+            )
 
     async def _send_initial_content(
         self,

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -28,6 +28,7 @@ from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.constants import (
     STREAM_STATUS_CANCELLED,
     STREAM_STATUS_COMPLETED,
+    STREAM_STATUS_ERROR,
     STREAM_STATUS_KEY,
     STREAM_STATUS_PENDING,
     STREAM_STATUS_STREAMING,
@@ -332,6 +333,56 @@ async def test_placeholder_ack_waits_for_answer_ack_before_marking_substantive(c
     ]
     assert "first_substantive_reply" in timing.marks
     assert timing.metadata["first_substantive_kind"] == "stream_update"
+
+
+@pytest.mark.parametrize(
+    ("stream_status", "terminal_note"),
+    [
+        (STREAM_STATUS_ERROR, "**[Response interrupted by an error: boom]**"),
+        (STREAM_STATUS_CANCELLED, _CANCELLED_RESPONSE_NOTE),
+    ],
+)
+@pytest.mark.asyncio
+async def test_terminal_failure_note_ack_is_visible_but_not_substantive(
+    config: Config,
+    stream_status: str,
+    terminal_note: str,
+) -> None:
+    """Acknowledged failure notes are visible transport output, not substantive replies."""
+    timing = DispatchPipelineTiming(source_event_id="$request", room_id="!test:localhost")
+    streaming = StreamingResponse(
+        target=MessageTarget.resolve("!test:localhost", None, "$original_123", room_mode=True),
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        pipeline_timing=timing,
+    )
+    streaming.event_id = "$placeholder"
+    streaming.placeholder_progress_sent = True
+    streaming.accumulated_text = terminal_note
+
+    async def fake_edit(
+        _client: object,
+        _room_id: str,
+        _event_id: str,
+        new_content: dict[str, Any],
+        _new_text: str,
+        *,
+        retry_sync_recovery: bool = False,  # noqa: ARG001
+    ) -> DeliveredMatrixEvent:
+        return DeliveredMatrixEvent(event_id="$terminal-edit", content_sent=dict(new_content))
+
+    with patch("mindroom.streaming.edit_message_result", new=fake_edit):
+        sent = await streaming._send_or_edit_message(
+            make_matrix_client_mock(user_id="@mindroom_helper:localhost"),
+            is_final=True,
+            stream_status=stream_status,
+        )
+
+    assert sent is True
+    assert "first_visible_reply" in timing.marks
+    assert timing.metadata["first_visible_kind"] == "stream_update"
+    assert "first_substantive_reply" not in timing.marks
+    assert "first_substantive_kind" not in timing.metadata
 
 
 def test_delivery_snapshot_isolates_tool_trace(config: Config) -> None:


### PR DESCRIPTION
## Summary

- Preserve first-visible timing when terminal error or cancellation notes reach Matrix.
- Mark first-substantive timing only for pending, streaming, or completed payloads.
- Cover both error and cancellation terminal edits.

## Testing

- `PYTHONPATH=src uv run pytest -q -n 0 --no-cov tests/test_streaming.py tests/test_final_delivery.py tests/test_timing.py tests/test_response_runner_focused.py`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Adjust streaming reply timing to treat terminal failure notes as visible but non-substantive replies.

Bug Fixes:
- Prevent terminal error and cancellation notes from being counted as substantive replies in timing metadata.

Enhancements:
- Extend committed delivery state to track stream status so visibility timing can distinguish terminal from non-terminal updates.

Tests:
- Add parametrized streaming tests to assert that terminal failure and cancellation notes only mark first-visible timing and never first-substantive timing.