### PR TITLE
Skip the worker shared-credential copy loop when the allowlist is empty

### DIFF
--- a/src/mindroom/credentials.py
+++ b/src/mindroom/credentials.py
@@ -687,7 +687,6 @@ def sync_shared_credentials_to_worker(
     """
     manager = credentials_manager
     worker_shared_manager = manager.for_worker(worker_key).shared_manager()
-    source_manager = _shared_credentials_manager(manager)
     mirrored_services = set(worker_shared_manager.list_services())
     copied_services: set[str] = set()
     logger.debug(
@@ -696,23 +695,29 @@ def sync_shared_credentials_to_worker(
         allowed_services=sorted(allowed_services),
     )
 
-    for service in source_manager.list_services():
-        shared_credentials = load_worker_grantable_shared_credentials(
-            service,
-            shared_manager=source_manager,
-            allowed_services=allowed_services,
-        )
-        if shared_credentials is None:
-            if service not in allowed_services:
-                logger.info(
-                    "Skipping non-grantable shared credentials during worker sync",
-                    worker_key=worker_key,
-                    service=service,
-                )
-            continue
+    # An empty allowlist can grant nothing, so the copy loop is a guaranteed no-op that would only
+    # re-scan the shared-credential store from disk and log one skip per service. This is the
+    # default configuration and it runs on every worker-routed tool call, so short-circuit it and
+    # fall straight through to the cleanup pass, which still tears down any stale mirror.
+    if allowed_services:
+        source_manager = _shared_credentials_manager(manager)
+        for service in source_manager.list_services():
+            shared_credentials = load_worker_grantable_shared_credentials(
+                service,
+                shared_manager=source_manager,
+                allowed_services=allowed_services,
+            )
+            if shared_credentials is None:
+                if service not in allowed_services:
+                    logger.debug(
+                        "Skipping non-grantable shared credentials during worker sync",
+                        worker_key=worker_key,
+                        service=service,
+                    )
+                continue
 
-        copied_services.add(service)
-        worker_shared_manager.save_credentials(service, shared_credentials)
+            copied_services.add(service)
+            worker_shared_manager.save_credentials(service, shared_credentials)
 
     for service in mirrored_services - copied_services:
         worker_shared_manager.delete_credentials(service)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -968,12 +968,22 @@ class TestCredentialsManager:
     def test_sync_shared_credentials_to_worker_empty_allowlist_mirrors_nothing(
         self,
         temp_credentials_dir: Path,
+        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """An explicit empty worker allowlist should deny all shared credential mirroring."""
+        """An empty allowlist should skip the shared store while cleaning stale mirrors."""
         manager = CredentialsManager(temp_credentials_dir)
         manager.save_credentials("google", {"api_key": "env-key", "_source": "env"})
         worker_shared_manager = manager.for_worker("worker-a").shared_manager()
         worker_shared_manager.save_credentials("google", {"api_key": "stale-key", "_source": "env"})
+
+        def fail_shared_store_lookup(_manager: CredentialsManager) -> CredentialsManager:
+            pytest.fail("empty allowlist must not open the shared credential store")
+
+        monkeypatch.setattr(
+            credentials_module,
+            "_shared_credentials_manager",
+            fail_shared_store_lookup,
+        )
 
         sync_shared_credentials_to_worker(
             "worker-a",


### PR DESCRIPTION
## Problem

`sync_shared_credentials_to_worker` runs on **every worker-routed tool call** (through `ensure_worker`), under the per-worker lock. With the **default** empty `worker_grantable_credentials` allowlist, the copy loop can grant nothing — `load_worker_grantable_shared_credentials` returns `None` for every service — yet it still:

- globs the shared-credential store from disk (`source_manager.list_services()`), and
- emits one **info-level** `Skipping non-grantable shared credentials during worker sync` log **per shared service** (~17 services) on every call.

Under load that is thousands of log events and repeated disk scans on the hot path, all for a guaranteed no-op. (Measured in load testing: ~986 of these log lines per 100-message storm; production journald showed 5950 occurrences over 3 days, exactly 352 per service.)

## Fix

Short-circuit the copy loop when `allowed_services` is empty and fall straight through to the existing cleanup pass. Demote the remaining per-service skip log from `info` to `debug`.

## Why it is behavior-preserving

- **Empty allowlist (default):** the loop was already a pure no-op for copying (every service returns `None`), so skipping it copies nothing — exactly as before. The cleanup pass still runs, so a previously-mirrored service is still deleted. Covered by `test_sync_shared_credentials_to_worker_empty_allowlist_mirrors_nothing` (asserts a stale mirror is removed).
- **Non-empty allowlist:** unchanged code path — allowlisted services copied, stale skips deleted. Covered by `test_sync_shared_credentials_to_worker_only_copies_allowed_services_and_deletes_stale_skips`.
- Only the wasted disk scan and the info-log spam are removed.

## Tests

`tests/test_credentials.py` + `tests/test_credential_policy.py`: **118 passed**, including both sync tests above.

## Note

The `Skipping non-grantable…` line was added as an `info`-level audit log in #627 (2026-04), before the current high-concurrency tool-call volume made it hot-path spam.

## Summary by Sourcery

Short-circuit worker shared-credential synchronization when the allowlist is empty to avoid unnecessary disk scans and log spam, while preserving the cleanup of stale mirrored credentials.

Enhancements:
- Skip the shared-credential copy loop entirely when no services are allowlisted, relying only on the cleanup pass in that case.
- Reduce verbosity of per-service non-grantable credential logs by demoting them from info to debug during worker syncs.