### PR TITLE
perf(knowledge): stop re-reading the corpus on every refresh check

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -291,6 +291,8 @@ Bundled container images already include it.
 - Semantic Git refresh then advances a candidate index, while files-only Git refresh publishes source metadata.
 - When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
+- Change detection for Git-backed bases is the tracked revision, not file contents: while the checkout stays on the revision the index was published from, MindRoom republishes the existing index without reading the corpus.
+- Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged. The checkout is MindRoom-owned; edit the repository and sync, or force a reindex, instead of editing the working tree.
 - Git-backed bases reject dashboard/API file upload and delete mutations; update the repository and sync or reindex instead.
 - Successful refresh publishes a new last successfully published index while failed refresh preserves the previous one and records the error in status metadata.
 - Semantic refresh is resumable: an interrupted or failed build keeps its private candidate index and continues it on the next refresh instead of restarting from zero.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -292,7 +292,8 @@ Bundled container images already include it.
 - When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
 - Change detection for Git-backed bases is the tracked revision, not file contents: while the checkout stays on the revision the index was published from, MindRoom republishes the existing index without reading the corpus.
-- Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged. The checkout is MindRoom-owned; edit the repository and sync, or force a reindex, instead of editing the working tree.
+- Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged.
+- The checkout is MindRoom-owned; edit the repository and sync, or force a reindex, instead of editing the working tree.
 - Git-backed bases reject dashboard/API file upload and delete mutations; update the repository and sync or reindex instead.
 - Successful refresh publishes a new last successfully published index while failed refresh preserves the previous one and records the error in status metadata.
 - Semantic refresh is resumable: an interrupted or failed build keeps its private candidate index and continues it on the next refresh instead of restarting from zero.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13199,7 +13199,8 @@ Bundled container images already include it.
 - When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
 - Change detection for Git-backed bases is the tracked revision, not file contents: while the checkout stays on the revision the index was published from, MindRoom republishes the existing index without reading the corpus.
-- Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged. The checkout is MindRoom-owned; edit the repository and sync, or force a reindex, instead of editing the working tree.
+- Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged.
+- The checkout is MindRoom-owned; edit the repository and sync, or force a reindex, instead of editing the working tree.
 - Git-backed bases reject dashboard/API file upload and delete mutations; update the repository and sync or reindex instead.
 - Successful refresh publishes a new last successfully published index while failed refresh preserves the previous one and records the error in status metadata.
 - Semantic refresh is resumable: an interrupted or failed build keeps its private candidate index and continues it on the next refresh instead of restarting from zero.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13198,6 +13198,8 @@ Bundled container images already include it.
 - Semantic Git refresh then advances a candidate index, while files-only Git refresh publishes source metadata.
 - When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
+- Change detection for Git-backed bases is the tracked revision, not file contents: while the checkout stays on the revision the index was published from, MindRoom republishes the existing index without reading the corpus.
+- Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged. The checkout is MindRoom-owned; edit the repository and sync, or force a reindex, instead of editing the working tree.
 - Git-backed bases reject dashboard/API file upload and delete mutations; update the repository and sync or reindex instead.
 - Successful refresh publishes a new last successfully published index while failed refresh preserves the previous one and records the error in status metadata.
 - Semantic refresh is resumable: an interrupted or failed build keeps its private candidate index and continues it on the next refresh instead of restarting from zero.

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -288,7 +288,8 @@ Bundled container images already include it.
 - When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
 - Change detection for Git-backed bases is the tracked revision, not file contents: while the checkout stays on the revision the index was published from, MindRoom republishes the existing index without reading the corpus.
-- Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged. The checkout is MindRoom-owned; edit the repository and sync, or force a reindex, instead of editing the working tree.
+- Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged.
+- The checkout is MindRoom-owned; edit the repository and sync, or force a reindex, instead of editing the working tree.
 - Git-backed bases reject dashboard/API file upload and delete mutations; update the repository and sync or reindex instead.
 - Successful refresh publishes a new last successfully published index while failed refresh preserves the previous one and records the error in status metadata.
 - Semantic refresh is resumable: an interrupted or failed build keeps its private candidate index and continues it on the next refresh instead of restarting from zero.

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -287,6 +287,8 @@ Bundled container images already include it.
 - Semantic Git refresh then advances a candidate index, while files-only Git refresh publishes source metadata.
 - When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
+- Change detection for Git-backed bases is the tracked revision, not file contents: while the checkout stays on the revision the index was published from, MindRoom republishes the existing index without reading the corpus.
+- Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged. The checkout is MindRoom-owned; edit the repository and sync, or force a reindex, instead of editing the working tree.
 - Git-backed bases reject dashboard/API file upload and delete mutations; update the repository and sync or reindex instead.
 - Successful refresh publishes a new last successfully published index while failed refresh preserves the previous one and records the error in status metadata.
 - Semantic refresh is resumable: an interrupted or failed build keeps its private candidate index and continues it on the next refresh instead of restarting from zero.

--- a/src/mindroom/api/knowledge.py
+++ b/src/mindroom/api/knowledge.py
@@ -55,6 +55,13 @@ class _FileListInfo:
     error: str | None = None
 
 
+@dataclass(frozen=True)
+class _FileCountInfo:
+    count: int
+    degraded: bool = False
+    error: str | None = None
+
+
 def _ensure_base_exists(config: Config, base_id: str) -> None:
     if base_id not in config.knowledge_bases:
         raise HTTPException(status_code=404, detail=f"Knowledge base '{base_id}' not found")
@@ -122,6 +129,24 @@ async def _list_file_info(
         )
 
     return _FileListInfo(files=files, total_size=total_size)
+
+
+async def _count_managed_files(config: Config, base_id: str, root: Path) -> _FileCountInfo:
+    """Count managed files without stating each one.
+
+    The base list and per-base status report only a count. Collecting per-file
+    sizes and modification times to derive it is unbounded work that scales with
+    the corpus on every request; ``/bases/{base_id}/files`` still serves the full
+    listing for callers that need it.
+    """
+    resolved_root = root.resolve()
+    if not resolved_root.is_dir():
+        return _FileCountInfo(count=0)
+
+    managed_paths, error = await _list_managed_file_paths(config, base_id, resolved_root)
+    if error is not None:
+        return _FileCountInfo(count=0, degraded=True, error=error)
+    return _FileCountInfo(count=len(managed_paths))
 
 
 async def _list_managed_file_paths(config: Config, base_id: str, root: Path) -> tuple[set[Path], str | None]:
@@ -580,7 +605,7 @@ async def list_knowledge_bases(request: Request) -> dict[str, Any]:
     for base_id in sorted(config.knowledge_bases):
         base_config = config.knowledge_bases[base_id]
         root = _knowledge_root(config, base_id, runtime_paths)
-        file_info = await _list_file_info(config, base_id, root)
+        file_info = await _count_managed_files(config, base_id, root)
         index_status = await _index_status(config, base_id, runtime_paths)
         git_status = await _git_status(
             config,
@@ -597,7 +622,7 @@ async def list_knowledge_bases(request: Request) -> dict[str, Any]:
             "mode": base_config.mode,
             "path": str(root),
             "watch": base_config.watch,
-            "file_count": len(file_info.files),
+            "file_count": file_info.count,
             "indexed_count": index_status.indexed_count,
             "refreshing": refreshing,
             "refresh_state": index_status.refresh_state,
@@ -736,7 +761,7 @@ async def knowledge_status(base_id: str, request: Request) -> dict[str, Any]:
     root = _knowledge_root(config, base_id, runtime_paths)
     base_config = config.knowledge_bases[base_id]
     index_status = await _index_status(config, base_id, runtime_paths)
-    file_info = await _list_file_info(config, base_id, root)
+    file_info = await _count_managed_files(config, base_id, root)
     git_status = await _git_status(
         config,
         base_id,
@@ -752,7 +777,7 @@ async def knowledge_status(base_id: str, request: Request) -> dict[str, Any]:
         "mode": base_config.mode,
         "folder_path": str(root),
         "watch": base_config.watch,
-        "file_count": len(file_info.files),
+        "file_count": file_info.count,
         "indexed_count": index_status.indexed_count,
         "refreshing": refreshing,
         "refresh_state": index_status.refresh_state,

--- a/src/mindroom/knowledge/file_listing.py
+++ b/src/mindroom/knowledge/file_listing.py
@@ -235,11 +235,12 @@ def _iter_target_files(target: _ListingTarget, guard: _DirectoryGuard) -> Iterat
             yield current_dir / filename
 
 
-def _resolve_safe_file(candidate: Path) -> Path | None:
+def _safe_regular_file(candidate: Path) -> Path | None:
     """Return a chain-vetted candidate when it is a regular file inside the knowledge root.
 
-    ``_DirectoryGuard`` has already vetted every directory component and rejected
-    ".." traversal, so a candidate that is not itself a symlink cannot resolve
+    The candidate is returned as given, not canonicalized: ``_DirectoryGuard`` has
+    already vetted every directory component and rejected ".." traversal, so a
+    candidate that is not itself a symlink is already canonical and cannot point
     outside the root. A single ``lstat`` therefore settles both questions, where
     ``resolve(strict=True)`` re-walked the whole path for every file — several
     extra round trips per file on a network filesystem.
@@ -264,9 +265,9 @@ def list_knowledge_files(config: Config, base_id: str, knowledge_root: Path) -> 
         for candidate in _iter_target_files(target, guard):
             if not include_knowledge_relative_path(config, base_id, candidate.relative_to(root).as_posix()):
                 continue
-            resolved = _resolve_safe_file(candidate)
-            if resolved is not None:
-                files.add(resolved)
+            safe_file = _safe_regular_file(candidate)
+            if safe_file is not None:
+                files.add(safe_file)
     return sorted(files)
 
 
@@ -286,9 +287,9 @@ def knowledge_files_from_relative_paths(
         candidate = root / relative_path
         if not guard.is_safe(candidate.parent):
             continue
-        resolved = _resolve_safe_file(candidate)
-        if resolved is not None:
-            files.append(resolved)
+        safe_file = _safe_regular_file(candidate)
+        if safe_file is not None:
+            files.append(safe_file)
     return files
 
 

--- a/src/mindroom/knowledge/file_listing.py
+++ b/src/mindroom/knowledge/file_listing.py
@@ -5,12 +5,13 @@ include patterns derive listing targets that bound where traversal looks, traver
 yields only candidates whose directory chain is vetted, and per-file rules run cheap
 relative-path checks before filesystem safety checks.
 Every path returned by the listing functions is a regular file, not a symlink, with no
-symlinked ancestors, whose strictly resolved location stays inside the knowledge root.
+symlinked ancestors and no ".." traversal, so it always stays inside the knowledge root.
 """
 
 from __future__ import annotations
 
 import os
+import stat
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -200,6 +201,9 @@ class _DirectoryGuard:
             relative_path = directory.relative_to(self.root)
         except ValueError:
             return False
+        # ``relative_to`` is lexical, so it happily walks back out through "..".
+        if ".." in relative_path.parts:
+            return False
 
         current = self.root
         for part in relative_path.parts:
@@ -231,18 +235,20 @@ def _iter_target_files(target: _ListingTarget, guard: _DirectoryGuard) -> Iterat
             yield current_dir / filename
 
 
-def _resolve_safe_file(root: Path, candidate: Path) -> Path | None:
-    """Return the resolved path when a chain-vetted candidate is a regular file inside root."""
-    if candidate.is_symlink():
-        return None
+def _resolve_safe_file(candidate: Path) -> Path | None:
+    """Return a chain-vetted candidate when it is a regular file inside the knowledge root.
+
+    ``_DirectoryGuard`` has already vetted every directory component and rejected
+    ".." traversal, so a candidate that is not itself a symlink cannot resolve
+    outside the root. A single ``lstat`` therefore settles both questions, where
+    ``resolve(strict=True)`` re-walked the whole path for every file — several
+    extra round trips per file on a network filesystem.
+    """
     try:
-        resolved = candidate.resolve(strict=True)
-        resolved.relative_to(root)
-    except (OSError, ValueError):
+        status = candidate.lstat()
+    except OSError:
         return None
-    if not candidate.is_file():
-        return None
-    return resolved
+    return candidate if stat.S_ISREG(status.st_mode) else None
 
 
 def list_knowledge_files(config: Config, base_id: str, knowledge_root: Path) -> list[Path]:
@@ -258,7 +264,7 @@ def list_knowledge_files(config: Config, base_id: str, knowledge_root: Path) -> 
         for candidate in _iter_target_files(target, guard):
             if not include_knowledge_relative_path(config, base_id, candidate.relative_to(root).as_posix()):
                 continue
-            resolved = _resolve_safe_file(root, candidate)
+            resolved = _resolve_safe_file(candidate)
             if resolved is not None:
                 files.add(resolved)
     return sorted(files)
@@ -280,7 +286,7 @@ def knowledge_files_from_relative_paths(
         candidate = root / relative_path
         if not guard.is_safe(candidate.parent):
             continue
-        resolved = _resolve_safe_file(root, candidate)
+        resolved = _resolve_safe_file(candidate)
         if resolved is not None:
             files.append(resolved)
     return files

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -2074,30 +2074,41 @@ class KnowledgeManager:
             return None
         return await self._git_rev_parse("HEAD")
 
-    async def _source_moved_during_pass(
+    async def _candidate_matches_source(
         self,
         round_revision: str | None,
+        candidate_signatures: Mapping[str, FileSignature],
         candidate_source_signature: str,
     ) -> bool:
-        """Return whether the source changed while one indexing pass ran.
+        """Return whether the candidate still matches the source after one pass.
 
-        A Git checkout is program-owned and realigned with a hard reset, so its
-        tracked content is fully determined by HEAD: re-reading the revision the
-        round started at detects a mid-pass move without touching the corpus. A
-        source with no usable revision falls back to hashing every managed file,
-        which is the dominant cost of a refresh on a large or network-mounted
-        source.
+        Two independent things must hold. The source must not have moved while the
+        pass ran, and the candidate must cover every managed file: a file whose
+        signature scan or read failed is dropped from the pass's own completeness
+        accounting (``_file_signatures_for``, ``run.vanished``), so without a
+        coverage check a transient I/O error would publish a silently truncated
+        index -- and the unchanged fast path would then republish it at the same
+        revision forever.
+
+        Hashing the corpus proves both at once, but reads every byte. For a Git
+        checkout the revision proves content, because the checkout is
+        program-owned and realigned with a hard reset, and re-listing proves
+        coverage. Neither reads file contents.
         """
-        if round_revision is not None:
-            return await self._git_rev_parse("HEAD") != round_revision
-        live_source_signature = await asyncio.to_thread(
-            knowledge_source_signature,
-            self.config,
-            self.base_id,
-            self._knowledge_source_path(),
-            tracked_relative_paths=self._git_tracked_relative_paths,
-        )
-        return live_source_signature != candidate_source_signature
+        if round_revision is None:
+            live_source_signature = await asyncio.to_thread(
+                knowledge_source_signature,
+                self.config,
+                self.base_id,
+                self._knowledge_source_path(),
+                tracked_relative_paths=self._git_tracked_relative_paths,
+            )
+            return live_source_signature == candidate_source_signature
+
+        if await self._git_rev_parse("HEAD") != round_revision:
+            return False
+        current_files = await asyncio.to_thread(self.list_files)
+        return {self._relative_path(path) for path in current_files} == set(candidate_signatures)
 
     async def _advance_candidate(self, run: _CandidateRun, progress: _CandidateProgress) -> None:
         """Reconcile, index and publish until the candidate matches the live source."""
@@ -2160,7 +2171,11 @@ class KnowledgeManager:
                 return
 
             candidate_source_signature = _source_signature_from_file_signatures(candidate_signatures)
-            if await self._source_moved_during_pass(round_revision, candidate_source_signature):
+            if not await self._candidate_matches_source(
+                round_revision,
+                candidate_signatures,
+                candidate_source_signature,
+            ):
                 # The source moved while this pass ran. Keep every unchanged
                 # vector and reconcile the delta instead of discarding the
                 # candidate; only the changed files are re-embedded.

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -2068,9 +2068,41 @@ class KnowledgeManager:
                 exc_info=True,
             )
 
+    async def _source_revision(self) -> str | None:
+        """Return the current Git revision, or None when the source is not Git-backed."""
+        if self._git_config() is None:
+            return None
+        return await self._git_rev_parse("HEAD")
+
+    async def _source_moved_during_pass(
+        self,
+        round_revision: str | None,
+        candidate_source_signature: str,
+    ) -> bool:
+        """Return whether the source changed while one indexing pass ran.
+
+        A Git checkout is program-owned and realigned with a hard reset, so its
+        tracked content is fully determined by HEAD: re-reading the revision the
+        round started at detects a mid-pass move without touching the corpus. A
+        source with no usable revision falls back to hashing every managed file,
+        which is the dominant cost of a refresh on a large or network-mounted
+        source.
+        """
+        if round_revision is not None:
+            return await self._git_rev_parse("HEAD") != round_revision
+        live_source_signature = await asyncio.to_thread(
+            knowledge_source_signature,
+            self.config,
+            self.base_id,
+            self._knowledge_source_path(),
+            tracked_relative_paths=self._git_tracked_relative_paths,
+        )
+        return live_source_signature != candidate_source_signature
+
     async def _advance_candidate(self, run: _CandidateRun, progress: _CandidateProgress) -> None:
         """Reconcile, index and publish until the candidate matches the live source."""
         for _round in range(_MAX_CANDIDATE_RECONCILE_ROUNDS):
+            round_revision = await self._source_revision()
             files = await asyncio.to_thread(self.list_files)
             plan = await self._reconcile_candidate(run, files)
             progress.total = len(plan.expected)
@@ -2128,14 +2160,7 @@ class KnowledgeManager:
                 return
 
             candidate_source_signature = _source_signature_from_file_signatures(candidate_signatures)
-            live_source_signature = await asyncio.to_thread(
-                knowledge_source_signature,
-                self.config,
-                self.base_id,
-                self._knowledge_source_path(),
-                tracked_relative_paths=self._git_tracked_relative_paths,
-            )
-            if live_source_signature != candidate_source_signature:
+            if await self._source_moved_during_pass(round_revision, candidate_source_signature):
                 # The source moved while this pass ran. Keep every unchanged
                 # vector and reconcile the delta instead of discarding the
                 # candidate; only the changed files are re-embedded.

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -794,6 +794,19 @@ async def _refresh_result_from_persisted_state(
     )
 
 
+def _revision_proves_source_unchanged(state: PublishedIndexState, published_revision: str | None) -> bool:
+    """Return whether a matching Git revision already proves the indexed corpus is unchanged.
+
+    MindRoom owns the checkout and realigns it with ``git reset --hard``, so a tracked
+    file's content is fully determined by HEAD. Every corpus filter (branch, LFS, hidden
+    paths, include/exclude patterns and extensions) lives in ``IndexingSettings``, which
+    the caller has already compared. An unmoved revision therefore means byte-identical
+    indexed content, and hashing the corpus to learn the same thing costs a full read of
+    every file — the dominant cost on a large or network-mounted source.
+    """
+    return published_revision is not None and state.published_revision == published_revision
+
+
 async def _publish_unchanged_index(
     manager: KnowledgeManager,
     key: PublishedIndexKey,
@@ -812,13 +825,16 @@ async def _publish_unchanged_index(
     ):
         return None
 
-    current_source_signature = await asyncio.to_thread(
-        knowledge_source_signature,
-        manager.config,
-        manager.base_id,
-        manager._knowledge_source_path(),
-        tracked_relative_paths=manager._git_tracked_relative_paths,
-    )
+    if _revision_proves_source_unchanged(state, published_revision):
+        current_source_signature = state.source_signature
+    else:
+        current_source_signature = await asyncio.to_thread(
+            knowledge_source_signature,
+            manager.config,
+            manager.base_id,
+            manager._knowledge_source_path(),
+            tracked_relative_paths=manager._git_tracked_relative_paths,
+        )
     if current_source_signature != state.source_signature:
         if mark_stale_on_source_change:
             await mark_knowledge_source_changed_async(

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -846,9 +846,9 @@ async def _publish_unchanged_index(
             )
         return None
 
+    # Settings already matched at the top of this function, so only the revision
+    # and publish stamp can still move.
     updated_state = state
-    if state.settings != key.indexing_settings:
-        updated_state = replace(updated_state, settings=key.indexing_settings)
     if published_revision is not None:
         updated_state = replace(
             updated_state,

--- a/tests/api/test_knowledge_api.py
+++ b/tests/api/test_knowledge_api.py
@@ -612,11 +612,11 @@ async def test_git_status_probe_does_not_block_event_loop(
         time.sleep(0.2)
         return False
 
-    async def _empty_file_info(*_args: object, **_kwargs: object) -> knowledge_api._FileListInfo:
-        return knowledge_api._FileListInfo(files=[], total_size=0)
+    async def _empty_file_count(*_args: object, **_kwargs: object) -> knowledge_api._FileCountInfo:
+        return knowledge_api._FileCountInfo(count=0)
 
     monkeypatch.setattr(knowledge_api, "git_checkout_present", _slow_git_checkout_present)
-    monkeypatch.setattr(knowledge_api, "_list_file_info", _empty_file_info)
+    monkeypatch.setattr(knowledge_api, "_count_managed_files", _empty_file_count)
 
     status_task = asyncio.create_task(
         knowledge_api.knowledge_status(

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -44,6 +44,7 @@ from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.candidate_checkpoint import load_candidate_checkpoint
 from mindroom.knowledge.file_listing import (
     git_checkout_present,
+    knowledge_files_from_relative_paths,
     list_git_tracked_knowledge_files,
     list_knowledge_files,
 )
@@ -58,6 +59,7 @@ from mindroom.knowledge.registry import (
     published_index_metadata_path,
     published_index_refresh_state,
     resolve_published_index_key,
+    save_published_index_state,
 )
 from mindroom.knowledge.utils import KnowledgeAvailabilityDetail
 from mindroom.knowledge.watch import KnowledgeSourceWatcher
@@ -1462,6 +1464,81 @@ def test_knowledge_file_listing_rejects_symlinked_directory_escape(tmp_path: Pat
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
 
     assert list_knowledge_files(config, "docs", docs_path) == []
+
+
+def test_tracked_path_listing_skips_per_file_strict_resolution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Chain-vetted candidates must not pay a strict resolve walk per file.
+
+    ``resolve(strict=True)`` re-walks every path component and ignores the
+    directory guard's symlink cache, so on a network filesystem it turns one
+    listing pass into several round trips per file.
+    """
+    docs_path = tmp_path / "docs"
+    nested = docs_path / "guide"
+    nested.mkdir(parents=True)
+    (docs_path / "root.md").write_text("root", encoding="utf-8")
+    (nested / "deep.md").write_text("deep", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    original_resolve = Path.resolve
+
+    def _resolve(self: Path, *args: object, **kwargs: object) -> Path:
+        strict = bool(args[0]) if args else bool(kwargs.get("strict", False))
+        if strict:
+            msg = "chain-vetted candidates must not be strictly resolved per file"
+            raise AssertionError(msg)
+        return original_resolve(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "resolve", _resolve)
+
+    files = knowledge_files_from_relative_paths(config, "docs", docs_path, ["root.md", "guide/deep.md"])
+
+    assert sorted(path.name for path in files) == ["deep.md", "root.md"]
+
+
+def test_tracked_path_listing_rejects_symlinked_file_escape(tmp_path: Path) -> None:
+    """A symlinked tracked path must not expose files outside the knowledge root."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    secret = tmp_path / "secret.md"
+    secret.write_text("secret outside root", encoding="utf-8")
+    try:
+        (docs_path / "leak.md").symlink_to(secret)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+
+    assert knowledge_files_from_relative_paths(config, "docs", docs_path, ["leak.md"]) == []
+
+
+def test_tracked_path_listing_rejects_symlinked_directory_escape(tmp_path: Path) -> None:
+    """A tracked path reached through a symlinked directory must stay excluded."""
+    docs_path = tmp_path / "docs"
+    outside = tmp_path / "outside"
+    docs_path.mkdir()
+    outside.mkdir()
+    (outside / "secret.md").write_text("secret through directory", encoding="utf-8")
+    try:
+        (docs_path / "linked").symlink_to(outside, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"symlinks unavailable: {exc}")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+
+    assert knowledge_files_from_relative_paths(config, "docs", docs_path, ["linked/secret.md"]) == []
+
+
+def test_tracked_path_listing_rejects_directories_and_missing_paths(tmp_path: Path) -> None:
+    """Only regular files survive the tracked-path safety checks."""
+    docs_path = tmp_path / "docs"
+    (docs_path / "directory.md").mkdir(parents=True)
+    (docs_path / "kept.md").write_text("kept", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+
+    files = knowledge_files_from_relative_paths(config, "docs", docs_path, ["kept.md", "directory.md", "gone.md"])
+
+    assert [path.name for path in files] == ["kept.md"]
 
 
 def test_knowledge_file_listing_skips_hidden_files_for_directory_bases(tmp_path: Path) -> None:
@@ -6703,6 +6780,132 @@ async def test_git_noop_refresh_skips_full_reindex_when_index_is_complete(
     assert state_after_noop.last_published_at is not None
     assert state_after_noop.last_published_at != state_before_noop.last_published_at
     assert reindex_count == 1
+
+
+def _git_noop_config(tmp_path: Path) -> tuple[Config, RuntimePaths, Path]:
+    """Build a Git-backed single-file base used by the revision-gating tests."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("git index", encoding="utf-8")
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={"docs": KnowledgeGitConfig(repo_url="https://example.com/org/repo.git", branch="main")},
+    )
+    return config, runtime_paths_for(config), docs_path
+
+
+def _install_git_sync_results(
+    monkeypatch: pytest.MonkeyPatch,
+    results: list[dict[str, object]],
+) -> None:
+    """Drive ``sync_git_source`` through a fixed sequence of poll outcomes."""
+
+    async def _sync(self: KnowledgeManager) -> dict[str, object]:
+        result = results.pop(0)
+        self._git_last_successful_commit = str(result["commit"])
+        _set_git_tracked_files(self, "doc.md")
+        return result
+
+    monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync)
+
+
+@pytest.mark.asyncio
+async def test_git_noop_refresh_skips_corpus_hash_when_revision_is_unchanged(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unmoved Git revision proves the corpus is unchanged without reading every file."""
+    config, runtime_paths, _ = _git_noop_config(tmp_path)
+    _install_git_sync_results(
+        monkeypatch,
+        [
+            {"updated": True, "changed_count": 1, "removed_count": 0, "commit": "rev-a"},
+            {"updated": False, "changed_count": 0, "removed_count": 0, "commit": "rev-a"},
+        ],
+    )
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    def _unexpected_signature(*_args: object, **_kwargs: object) -> str:
+        msg = "an unchanged Git revision must not re-hash the corpus"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(knowledge_refresh_runner, "knowledge_source_signature", _unexpected_signature)
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    state = load_published_index_state(published_index_metadata_path(key))
+    assert result.index_published is True
+    assert result.availability is KnowledgeAvailability.READY
+    assert state is not None
+    assert state.published_revision == "rev-a"
+
+
+@pytest.mark.asyncio
+async def test_git_noop_refresh_hashes_corpus_when_revision_moved(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A revision the published index was not built from still needs content verification."""
+    config, runtime_paths, _ = _git_noop_config(tmp_path)
+    _install_git_sync_results(
+        monkeypatch,
+        [
+            {"updated": True, "changed_count": 1, "removed_count": 0, "commit": "rev-a"},
+            {"updated": False, "changed_count": 0, "removed_count": 0, "commit": "rev-b"},
+        ],
+    )
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    signature_calls = 0
+    original_signature = knowledge_refresh_runner.knowledge_source_signature
+
+    def _counting_signature(*args: object, **kwargs: object) -> str:
+        nonlocal signature_calls
+        signature_calls += 1
+        return original_signature(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(knowledge_refresh_runner, "knowledge_source_signature", _counting_signature)
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert signature_calls == 1
+    assert result.index_published is True
+
+
+@pytest.mark.asyncio
+async def test_git_noop_refresh_hashes_corpus_when_index_predates_revision_tracking(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An index published without a recorded revision cannot be trusted by revision alone."""
+    config, runtime_paths, _ = _git_noop_config(tmp_path)
+    _install_git_sync_results(
+        monkeypatch,
+        [
+            {"updated": True, "changed_count": 1, "removed_count": 0, "commit": "rev-a"},
+            {"updated": False, "changed_count": 0, "removed_count": 0, "commit": "rev-a"},
+        ],
+    )
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    metadata_path = published_index_metadata_path(key)
+    published = load_published_index_state(metadata_path)
+    assert published is not None
+    save_published_index_state(metadata_path, replace(published, published_revision=None))
+
+    signature_calls = 0
+    original_signature = knowledge_refresh_runner.knowledge_source_signature
+
+    def _counting_signature(*args: object, **kwargs: object) -> str:
+        nonlocal signature_calls
+        signature_calls += 1
+        return original_signature(*args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(knowledge_refresh_runner, "knowledge_source_signature", _counting_signature)
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert signature_calls == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -1531,6 +1531,60 @@ def test_tracked_path_listing_rejects_symlinked_directory_escape(tmp_path: Path)
     assert knowledge_files_from_relative_paths(config, "docs", docs_path, ["linked/secret.md"]) == []
 
 
+def test_bases_endpoint_counts_files_without_building_the_file_listing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The base list reports a count, so it must not build the whole file payload.
+
+    ``_list_file_info`` stats every managed file a second time (the listing itself
+    already checked each one) and materializes a dict per file. Both scale with the
+    corpus on every request, and ``/bases`` uses none of it beyond the count;
+    ``/bases/{base_id}/files`` still serves the full listing.
+    """
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    for index in range(3):
+        (docs_path / f"doc{index}.md").write_text("body", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+
+    async def _unexpected_list_file_info(*_args: object, **_kwargs: object) -> object:
+        msg = "the base list must not build the full file listing"
+        raise AssertionError(msg)
+
+    main.initialize_api_app(main.app, runtime_paths)
+    _publish_api_config(main.app, config)
+    monkeypatch.setattr(knowledge_api, "_list_file_info", _unexpected_list_file_info)
+    response = TestClient(main.app).get("/api/knowledge/bases")
+
+    assert response.status_code == 200
+    entry = next(base for base in response.json()["bases"] if base["name"] == "docs")
+    assert entry["file_count"] == 3
+    assert entry["file_listing_degraded"] is False
+
+
+def test_base_files_endpoint_still_returns_sizes_and_timestamps(tmp_path: Path) -> None:
+    """The dedicated listing endpoint keeps the per-file detail the base list dropped."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("body", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+
+    main.initialize_api_app(main.app, runtime_paths)
+    _publish_api_config(main.app, config)
+    response = TestClient(main.app).get("/api/knowledge/bases/docs/files")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["file_count"] == 1
+    assert payload["total_size"] == len(b"body")
+    assert payload["files"][0]["path"] == "doc.md"
+    assert payload["files"][0]["size"] == len(b"body")
+    assert payload["files"][0]["modified"]
+
+
 def test_directory_guard_rejects_parent_traversal(tmp_path: Path) -> None:
     """The guard must reject "..", which pathlib's lexical ``relative_to`` lets through.
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -1711,31 +1711,22 @@ def test_knowledge_file_listing_filters_unsupported_extensions_before_filesystem
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Unsupported files should not pay per-file symlink or strict resolve checks."""
+    """Unsupported files should not pay the per-file filesystem safety check."""
     docs_path = tmp_path / "docs"
     docs_path.mkdir()
     ignored_path = docs_path / "ignored.bin"
     ignored_path.write_bytes(b"not semantic")
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
 
-    original_is_symlink = Path.is_symlink
-    original_resolve = Path.resolve
+    original_lstat = Path.lstat
 
-    def _is_symlink(self: Path) -> bool:
+    def _lstat(self: Path, *args: object, **kwargs: object) -> os.stat_result:
         if self.name == ignored_path.name:
-            msg = "unsupported files should be filtered before symlink checks"
+            msg = "unsupported files should be filtered before the safety check"
             raise AssertionError(msg)
-        return original_is_symlink(self)
+        return original_lstat(self, *args, **kwargs)
 
-    def _resolve(self: Path, *args: object, **kwargs: object) -> Path:
-        strict = bool(args[0]) if args else bool(kwargs.get("strict", False))
-        if self.name == ignored_path.name and strict:
-            msg = "unsupported files should be filtered before strict resolution"
-            raise AssertionError(msg)
-        return original_resolve(self, *args, **kwargs)
-
-    monkeypatch.setattr(Path, "is_symlink", _is_symlink)
-    monkeypatch.setattr(Path, "resolve", _resolve)
+    monkeypatch.setattr(Path, "lstat", _lstat)
 
     assert list_knowledge_files(config, "docs", docs_path) == []
 
@@ -6814,11 +6805,12 @@ async def test_git_refresh_syncs_before_reindex_and_publishes_revision_without_s
     assert "x-oauth-basic" not in metadata_text
 
 
-def _git_noop_config(tmp_path: Path) -> tuple[Config, RuntimePaths]:
-    """Build a Git-backed single-file base used by the revision-gating tests."""
+def _git_noop_config(tmp_path: Path, *, files: tuple[str, ...] = ("doc.md",)) -> tuple[Config, RuntimePaths]:
+    """Build a Git-backed base used by the revision-gating tests."""
     docs_path = tmp_path / "docs"
     docs_path.mkdir()
-    (docs_path / "doc.md").write_text("git index", encoding="utf-8")
+    for name in files:
+        (docs_path / name).write_text("git index", encoding="utf-8")
     config = _config(
         tmp_path,
         bases={"docs": docs_path},
@@ -6831,13 +6823,15 @@ def _git_noop_config(tmp_path: Path) -> tuple[Config, RuntimePaths]:
 def _install_git_sync_results(
     monkeypatch: pytest.MonkeyPatch,
     results: list[dict[str, object]],
+    *,
+    tracked: tuple[str, ...] = ("doc.md",),
 ) -> None:
     """Drive ``sync_git_source`` through a fixed sequence of poll outcomes."""
 
     async def _sync(self: KnowledgeManager) -> dict[str, object]:
         result = results.pop(0)
         self._git_last_successful_commit = str(result["commit"])
-        _set_git_tracked_files(self, "doc.md")
+        _set_git_tracked_files(self, *tracked)
         return result
 
     monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync)
@@ -7033,6 +7027,46 @@ async def test_reindex_skips_live_corpus_hash_when_revision_is_stable(
 
 
 @pytest.mark.asyncio
+async def test_reindex_does_not_publish_a_corpus_truncated_by_a_transient_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A file lost to a transient stat error must not publish as a complete index.
+
+    Files whose signature scan raises are dropped from the pass's own completeness
+    accounting, so the post-pass check is the only thing standing between a
+    truncated corpus and publication. Once published at a revision, the unchanged
+    fast path would keep republishing it, so the file would never come back.
+    """
+    config, runtime_paths = _git_noop_config(tmp_path, files=("keep.md", "flaky.md"))
+    _install_git_sync_results(
+        monkeypatch,
+        [{"updated": True, "changed_count": 2, "removed_count": 0, "commit": "rev-a"}],
+        tracked=("keep.md", "flaky.md"),
+    )
+    _install_git_revisions(monkeypatch, ["rev-a"])
+
+    original_file_signature = KnowledgeManager._file_signature
+    remaining_failures = {"flaky.md": 1}
+
+    def _flaky_signature(self: KnowledgeManager, file_path: Path) -> tuple[int, int, str]:
+        if remaining_failures.get(file_path.name):
+            remaining_failures[file_path.name] -= 1
+            raise OSError(116, "Stale file handle")
+        return original_file_signature(self, file_path)
+
+    monkeypatch.setattr(KnowledgeManager, "_file_signature", _flaky_signature)
+
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert result.indexed_count == 2
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    state = load_published_index_state(published_index_metadata_path(key))
+    assert state is not None
+    assert state.indexed_count == 2
+
+
+@pytest.mark.asyncio
 async def test_reindex_reconciles_when_revision_moves_mid_pass(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -7078,7 +7112,12 @@ async def test_git_noop_refresh_ignores_untracked_indexable_file_changes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Git-backed corpora use tracked files only and ignore untracked checkout files."""
+    """Git-backed corpora use tracked files only and ignore untracked checkout files.
+
+    The second poll reports a moved revision on purpose. An unmoved revision
+    short-circuits change detection entirely, which would let this test pass
+    without ever exercising the tracked-only filtering it exists to pin.
+    """
     docs_path = tmp_path / "docs"
     docs_path.mkdir()
     (docs_path / "doc.md").write_text("git tracked index", encoding="utf-8")
@@ -7092,7 +7131,7 @@ async def test_git_noop_refresh_ignores_untracked_indexable_file_changes(
     runtime_paths = runtime_paths_for(config)
     sync_results = [
         {"updated": True, "changed_count": 1, "removed_count": 0, "commit": "rev-a"},
-        {"updated": False, "changed_count": 0, "removed_count": 0, "commit": "rev-a"},
+        {"updated": False, "changed_count": 0, "removed_count": 0, "commit": "rev-b"},
     ]
     reindex_count = 0
     original_reindex = KnowledgeManager.reindex_all

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -9,7 +9,7 @@ import os
 import subprocess
 import sys
 from contextlib import asynccontextmanager
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from pathlib import Path
 from threading import Event, Lock, get_ident
 from typing import TYPE_CHECKING, ClassVar
@@ -21,6 +21,7 @@ from agno.knowledge.document.base import Document
 from agno.knowledge.embedder.base import Embedder
 from fastapi.testclient import TestClient
 from openai import AuthenticationError
+from pydantic import ValidationError
 from structlog.testing import capture_logs
 from watchfiles import Change
 
@@ -68,7 +69,8 @@ from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_p
 from tests.knowledge_test_support import metadata_matches
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Coroutine, Iterator
+    from collections.abc import AsyncIterator, Coroutine, Iterable, Iterator
+    from types import ModuleType
 
     from mindroom.constants import RuntimePaths
 
@@ -1527,6 +1529,42 @@ def test_tracked_path_listing_rejects_symlinked_directory_escape(tmp_path: Path)
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
 
     assert knowledge_files_from_relative_paths(config, "docs", docs_path, ["linked/secret.md"]) == []
+
+
+def test_directory_guard_rejects_parent_traversal(tmp_path: Path) -> None:
+    """The guard must reject "..", which pathlib's lexical ``relative_to`` lets through.
+
+    This is the containment control that replaced ``resolve(strict=True)``. Without
+    it a "../*.md" include pattern yields a listing target at the parent directory
+    whose candidates pass every remaining per-file safety check.
+    """
+    root = tmp_path / "docs"
+    root.mkdir()
+    guard = knowledge_file_listing_module._DirectoryGuard(root=root)
+
+    assert guard.is_safe(root) is True
+    assert guard.is_safe(root / "..") is False
+    assert guard.is_safe(root / ".." / "..") is False
+    assert guard.is_safe(root / "nested" / ".." / ".." / "outside") is False
+
+
+def test_tracked_path_listing_rejects_parent_traversal_escape(tmp_path: Path) -> None:
+    """A tracked relative path that walks out of the knowledge root must stay excluded."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (tmp_path / "secret.md").write_text("secret outside root", encoding="utf-8")
+    (docs_path / "kept.md").write_text("kept", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+
+    files = knowledge_files_from_relative_paths(config, "docs", docs_path, ["kept.md", "../secret.md"])
+
+    assert [path.name for path in files] == ["kept.md"]
+
+
+def test_knowledge_base_config_rejects_parent_traversal_patterns() -> None:
+    """Config validation is the first containment layer, so the guard is never reached this way."""
+    with pytest.raises(ValidationError):
+        KnowledgeBaseConfig(path="./docs", include_patterns=["../*.md"])
 
 
 def test_tracked_path_listing_rejects_directories_and_missing_paths(tmp_path: Path) -> None:
@@ -6722,35 +6760,88 @@ async def test_git_refresh_syncs_before_reindex_and_publishes_revision_without_s
     assert "x-oauth-basic" not in metadata_text
 
 
+def _git_noop_config(tmp_path: Path) -> tuple[Config, RuntimePaths]:
+    """Build a Git-backed single-file base used by the revision-gating tests."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("git index", encoding="utf-8")
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={"docs": KnowledgeGitConfig(repo_url="https://example.com/org/repo.git", branch="main")},
+    )
+    return config, runtime_paths_for(config)
+
+
+def _install_git_sync_results(
+    monkeypatch: pytest.MonkeyPatch,
+    results: list[dict[str, object]],
+) -> None:
+    """Drive ``sync_git_source`` through a fixed sequence of poll outcomes."""
+
+    async def _sync(self: KnowledgeManager) -> dict[str, object]:
+        result = results.pop(0)
+        self._git_last_successful_commit = str(result["commit"])
+        _set_git_tracked_files(self, "doc.md")
+        return result
+
+    monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync)
+
+
+def _install_git_revisions(monkeypatch: pytest.MonkeyPatch, revisions: list[str | None]) -> None:
+    """Return a fixed sequence of ``git rev-parse`` results, repeating the last."""
+    pending = list(revisions)
+
+    async def _rev_parse(self: KnowledgeManager, ref: str) -> str | None:
+        del self, ref
+        return pending.pop(0) if len(pending) > 1 else pending[0]
+
+    monkeypatch.setattr(KnowledgeManager, "_git_rev_parse", _rev_parse)
+
+
+@dataclass
+class _SignatureCounter:
+    """Count corpus-hash calls made through one module's imported binding."""
+
+    calls: int = 0
+
+
+def _install_counting_signature(monkeypatch: pytest.MonkeyPatch, module: ModuleType) -> _SignatureCounter:
+    """Count ``knowledge_source_signature`` calls without changing its behavior."""
+    counter = _SignatureCounter()
+    original_signature = module.knowledge_source_signature
+
+    def _counting_signature(
+        config: Config,
+        base_id: str,
+        knowledge_root: Path,
+        *,
+        tracked_relative_paths: Iterable[str] | None = None,
+    ) -> str:
+        counter.calls += 1
+        return original_signature(config, base_id, knowledge_root, tracked_relative_paths=tracked_relative_paths)
+
+    monkeypatch.setattr(module, "knowledge_source_signature", _counting_signature)
+    return counter
+
+
 @pytest.mark.asyncio
 async def test_git_noop_refresh_skips_full_reindex_when_index_is_complete(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An unchanged Git poll should update sync metadata without rebuilding the collection."""
-    docs_path = tmp_path / "docs"
-    docs_path.mkdir()
-    (docs_path / "doc.md").write_text("git index", encoding="utf-8")
-    git_config = KnowledgeGitConfig(repo_url="https://example.com/org/repo.git", branch="main")
-    config = _config(
-        tmp_path,
-        bases={"docs": docs_path},
-        agent_bases=["docs"],
-        git_configs={"docs": git_config},
+    config, runtime_paths = _git_noop_config(tmp_path)
+    _install_git_sync_results(
+        monkeypatch,
+        [
+            {"updated": True, "changed_count": 1, "removed_count": 0, "commit": "rev-a"},
+            {"updated": False, "changed_count": 0, "removed_count": 0, "commit": "rev-b"},
+        ],
     )
-    runtime_paths = runtime_paths_for(config)
-    sync_results = [
-        {"updated": True, "changed_count": 1, "removed_count": 0, "commit": "rev-a"},
-        {"updated": False, "changed_count": 0, "removed_count": 0, "commit": "rev-b"},
-    ]
     reindex_count = 0
     original_reindex = KnowledgeManager.reindex_all
-
-    async def _sync(self: KnowledgeManager) -> dict[str, object]:
-        result = sync_results.pop(0)
-        self._git_last_successful_commit = str(result["commit"])
-        _set_git_tracked_files(self, "doc.md")
-        return result
 
     async def _track_reindex(self: KnowledgeManager) -> int:
         nonlocal reindex_count
@@ -6760,7 +6851,6 @@ async def test_git_noop_refresh_skips_full_reindex_when_index_is_complete(
             raise AssertionError(msg)
         return await original_reindex(self)
 
-    monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync)
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
 
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
@@ -6782,42 +6872,13 @@ async def test_git_noop_refresh_skips_full_reindex_when_index_is_complete(
     assert reindex_count == 1
 
 
-def _git_noop_config(tmp_path: Path) -> tuple[Config, RuntimePaths, Path]:
-    """Build a Git-backed single-file base used by the revision-gating tests."""
-    docs_path = tmp_path / "docs"
-    docs_path.mkdir()
-    (docs_path / "doc.md").write_text("git index", encoding="utf-8")
-    config = _config(
-        tmp_path,
-        bases={"docs": docs_path},
-        agent_bases=["docs"],
-        git_configs={"docs": KnowledgeGitConfig(repo_url="https://example.com/org/repo.git", branch="main")},
-    )
-    return config, runtime_paths_for(config), docs_path
-
-
-def _install_git_sync_results(
-    monkeypatch: pytest.MonkeyPatch,
-    results: list[dict[str, object]],
-) -> None:
-    """Drive ``sync_git_source`` through a fixed sequence of poll outcomes."""
-
-    async def _sync(self: KnowledgeManager) -> dict[str, object]:
-        result = results.pop(0)
-        self._git_last_successful_commit = str(result["commit"])
-        _set_git_tracked_files(self, "doc.md")
-        return result
-
-    monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync)
-
-
 @pytest.mark.asyncio
 async def test_git_noop_refresh_skips_corpus_hash_when_revision_is_unchanged(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An unmoved Git revision proves the corpus is unchanged without reading every file."""
-    config, runtime_paths, _ = _git_noop_config(tmp_path)
+    config, runtime_paths = _git_noop_config(tmp_path)
     _install_git_sync_results(
         monkeypatch,
         [
@@ -6848,7 +6909,7 @@ async def test_git_noop_refresh_hashes_corpus_when_revision_moved(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A revision the published index was not built from still needs content verification."""
-    config, runtime_paths, _ = _git_noop_config(tmp_path)
+    config, runtime_paths = _git_noop_config(tmp_path)
     _install_git_sync_results(
         monkeypatch,
         [
@@ -6858,18 +6919,10 @@ async def test_git_noop_refresh_hashes_corpus_when_revision_moved(
     )
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
-    signature_calls = 0
-    original_signature = knowledge_refresh_runner.knowledge_source_signature
-
-    def _counting_signature(*args: object, **kwargs: object) -> str:
-        nonlocal signature_calls
-        signature_calls += 1
-        return original_signature(*args, **kwargs)  # type: ignore[arg-type]
-
-    monkeypatch.setattr(knowledge_refresh_runner, "knowledge_source_signature", _counting_signature)
+    counter = _install_counting_signature(monkeypatch, knowledge_refresh_runner)
     result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
-    assert signature_calls == 1
+    assert counter.calls == 1
     assert result.index_published is True
 
 
@@ -6879,7 +6932,7 @@ async def test_git_noop_refresh_hashes_corpus_when_index_predates_revision_track
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An index published without a recorded revision cannot be trusted by revision alone."""
-    config, runtime_paths, _ = _git_noop_config(tmp_path)
+    config, runtime_paths = _git_noop_config(tmp_path)
     _install_git_sync_results(
         monkeypatch,
         [
@@ -6894,18 +6947,76 @@ async def test_git_noop_refresh_hashes_corpus_when_index_predates_revision_track
     assert published is not None
     save_published_index_state(metadata_path, replace(published, published_revision=None))
 
-    signature_calls = 0
-    original_signature = knowledge_refresh_runner.knowledge_source_signature
-
-    def _counting_signature(*args: object, **kwargs: object) -> str:
-        nonlocal signature_calls
-        signature_calls += 1
-        return original_signature(*args, **kwargs)  # type: ignore[arg-type]
-
-    monkeypatch.setattr(knowledge_refresh_runner, "knowledge_source_signature", _counting_signature)
+    counter = _install_counting_signature(monkeypatch, knowledge_refresh_runner)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
-    assert signature_calls == 1
+    assert counter.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_reindex_skips_live_corpus_hash_when_revision_is_stable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Git revision that held still proves the source did not move while the pass ran."""
+    config, runtime_paths = _git_noop_config(tmp_path)
+    _install_git_sync_results(
+        monkeypatch,
+        [{"updated": True, "changed_count": 1, "removed_count": 0, "commit": "rev-a"}],
+    )
+    _install_git_revisions(monkeypatch, ["rev-a"])
+
+    def _unexpected_signature(*_args: object, **_kwargs: object) -> str:
+        msg = "a stable Git revision must not re-hash the corpus after indexing"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr(knowledge_manager_module, "knowledge_source_signature", _unexpected_signature)
+
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert result.index_published is True
+    assert result.indexed_count == 1
+
+
+@pytest.mark.asyncio
+async def test_reindex_reconciles_when_revision_moves_mid_pass(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A revision that moved while the pass ran must reconcile before publishing."""
+    config, runtime_paths = _git_noop_config(tmp_path)
+    _install_git_sync_results(
+        monkeypatch,
+        [{"updated": True, "changed_count": 1, "removed_count": 0, "commit": "rev-a"}],
+    )
+    # Round one starts at rev-a and finds rev-b after indexing; round two is stable.
+    _install_git_revisions(monkeypatch, ["rev-a", "rev-b", "rev-b"])
+
+    with capture_logs() as logs:
+        result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    events = [entry.get("event") for entry in logs]
+    assert "Knowledge source changed during refresh; reconciling candidate" in events
+    assert result.index_published is True
+
+
+@pytest.mark.asyncio
+async def test_reindex_hashes_live_corpus_for_non_git_bases(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A local base has no revision to trust, so it still verifies by content."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("local index", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+
+    counter = _install_counting_signature(monkeypatch, knowledge_manager_module)
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert counter.calls >= 1
+    assert result.index_published is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Three related reads of the entire knowledge corpus, removed. Each is invisible on a local disk and dominates everything else on a large or network-mounted source.

Kept deliberately small: 9 files, ~500 added lines, mostly tests. The larger items are listed at the bottom as follow-ups rather than folded in here.

## 1. The "nothing changed" fast path hashed the whole corpus

`_publish_unchanged_index` (`refresh_runner.py`) exists to skip work when the source has not moved — but it proved that by SHA-256'ing every file via `_file_content_digest`. Embedding was incremental; I/O was not.

For a Git-backed base the answer is already known. `_maybe_publish_unchanged_index` only reaches this path when `sync_git_source()` reported `updated=False`, meaning `_sync_git_source_once` already compared `before_head == remote_head`.

An unmoved revision now short-circuits the hash. This is safe rather than convenient:

- MindRoom owns the checkout and hard-resets it onto the configured remote ref, so tracked content is fully determined by HEAD.
- Every corpus filter — branch, LFS, hidden paths, include/exclude patterns and extensions — lives in `IndexingSettings`, which the same function compares *before* the gate.

A moved revision, or an index published without a recorded revision, still verifies by content.

## 2. Every actual reindex re-hashed the corpus again at the end

`_advance_candidate` (`manager.py`) asked "did the source move while this pass ran?" by hashing everything a second time.

That hash proved **two** things, and the first attempt at this only replaced one of them. It proved the source had not moved, and it proved the candidate actually covered every managed file. The second matters: `_file_signatures_for` drops any file whose stat or read raises `OSError`, and `run.vanished` drops any file that disappears mid-index, both deliberately excluded from the pass's own completeness accounting. A revision-only check let a transient I/O error publish a silently truncated index, which the fast path in section 1 would then republish at the same revision indefinitely. Transient per-file errors are exactly what a network-mounted source produces.

`_candidate_matches_source` now requires both: the revision must be unmoved, **and** a fresh listing must match the indexed path set. Re-listing costs one stat per file and reads no file contents, so the corpus is still never read to answer this. Non-Git sources are unchanged and still compare content signatures.

This was caught by an adversarial review pass and is pinned by `test_reindex_does_not_publish_a_corpus_truncated_by_a_transient_error`, which fails against the revision-only version with `indexed_count=1, availability=READY`.

## 3. Listing paid a strict resolve walk per file

`_resolve_safe_file` ran `is_symlink()`, then `resolve(strict=True)`, then `is_file()` on every candidate. `resolve(strict=True)` re-walks every path component and ignores `_DirectoryGuard`'s symlink cache.

Renamed to `_safe_regular_file` (it no longer canonicalizes anything) and reduced to one `lstat` + `S_ISREG`. The directory chain is already vetted, and `_DirectoryGuard` now also rejects `".."` parts — `Path.relative_to` is lexical and would otherwise let `..` walk back out.

That `".."` check is load-bearing, not padding. With it removed, a `../*.md` include pattern produces a listing target at the parent directory whose candidates pass every remaining per-file check:

```
with '..' guard: survives safety check -> []
without:        survives safety check -> ['secret.md']
```

Config validation rejects such patterns first, so there is no live leak — both layers are now pinned by tests.

## 4. The dashboard base list was O(corpus) per request

`GET /bases` and the per-base status endpoint report `file_count` and nothing else from the listing, yet both went through `_list_file_info`, which stats every managed file a second time and builds a dict per file. `_count_managed_files` reuses the same managed-path listing and returns just the count, so it still matches exactly what would be indexed. `/bases/{base_id}/files` is unchanged and still serves sizes and timestamps.

## Tests

Fifteen new tests, each written failing first:

| Test | Guards |
|---|---|
| `test_git_noop_refresh_skips_corpus_hash_when_revision_is_unchanged` | the optimization fires |
| `test_git_noop_refresh_hashes_corpus_when_revision_moved` | no false skip on a moved revision |
| `test_git_noop_refresh_hashes_corpus_when_index_predates_revision_tracking` | no false skip when the revision is unrecorded |
| `test_reindex_skips_live_corpus_hash_when_revision_is_stable` | mid-pass gate fires |
| `test_reindex_does_not_publish_a_corpus_truncated_by_a_transient_error` | a file lost to a transient error never publishes as complete |
| `test_reindex_reconciles_when_revision_moves_mid_pass` | a mid-pass move still reconciles |
| `test_reindex_hashes_live_corpus_for_non_git_bases` | local bases still verify by content |
| `test_directory_guard_rejects_parent_traversal` | the `..` containment control itself |
| `test_tracked_path_listing_rejects_parent_traversal_escape` | `..` containment end to end |
| `test_knowledge_base_config_rejects_parent_traversal_patterns` | config validation as the first layer |
| `test_tracked_path_listing_skips_per_file_strict_resolution` | no strict resolve per file |
| `test_tracked_path_listing_rejects_symlinked_file_escape` | containment preserved |
| `test_tracked_path_listing_rejects_symlinked_directory_escape` | containment preserved |
| `test_tracked_path_listing_rejects_directories_and_missing_paths` | only regular files survive |
| `test_bases_endpoint_counts_files_without_building_the_file_listing` | base list stays off the full listing |
| `test_base_files_endpoint_still_returns_sizes_and_timestamps` | the detail endpoint keeps its detail |

`test_git_noop_refresh_skips_full_reindex_when_index_is_complete` was refactored onto the new shared helpers rather than left as a second copy of them. The event-loop test in `tests/api/test_knowledge_api.py` was repointed from `_list_file_info` to the seam the status endpoint now uses.

Two existing tests that this branch had quietly hollowed out were repaired, each verified by mutation:

- `test_git_noop_refresh_ignores_untracked_indexable_file_changes` now polls a *moved* revision. Against an unmoved one the new fast path skips change detection entirely, so the test passed without exercising the tracked-only filtering it exists to pin. Breaking that filtering now fails it again.
- `test_knowledge_file_listing_filters_unsupported_extensions_before_filesystem_safety_checks` patched `is_symlink` and `resolve`, neither of which the safety check calls any more, so both tripwires were dead. It patches `lstat` now, and reordering the check against its docstring fails it again.

Full suite green apart from two pre-existing timing flakes in `tests/test_shell_supervisor.py` that pass in isolation and are unrelated.

## Behavior change worth knowing

Under an unmoved revision, an out-of-band edit to a Git-backed working tree is no longer picked up — previously the content hash would notice it and trigger a reindex. The checkout is MindRoom-owned and is hard-reset on sync, so such edits were already transient. Documented in `docs/knowledge.md` under "Sync Behavior".

## Follow-ups, deliberately not in this PR

- **`_reconcile_candidate` still hashes the whole corpus before every pass** (`manager.py`, via `_file_signatures_for` → `_file_signature` → `_file_content_digest`). This is the dominant restart cost for a base that has not published yet, because `_publish_unchanged_index` returns early on a non-complete state and the gate in this PR never engages. Git already computes the delta (`git diff --name-only` in `_sync_git_source_once`) and discards it. It needs its own PR: the reuse invariant between `checkpoint.target_revision` and `run.completed` is subtle enough to deserve separate review.
- **Every indexed file is read twice** — `_index_file_locked` computes the digest, then the reader reads the same file again. Reading once requires changing how readers are fed, and the path-based readers (PDF, docx) do not accept bytes.
- **Non-Git bases still hash on every check.** Refreshes run in a subprocess, so there are no in-memory signatures to reuse, and keying on `mtime_ns + size` alone would be wrong: `_reconcile_candidate` deliberately ignores mtime because a Git checkout changes it without changing content.
- **Files-mode bases hash the corpus to publish metadata for an index that has no vectors.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved knowledge-file safety by rejecting directory traversal, symlink escapes, missing paths, and non-file entries.
  * Dashboard knowledge-base counts now load more efficiently without generating full file listings.
  * Git-backed knowledge bases avoid unnecessary re-indexing when the tracked revision is unchanged, while still detecting revision updates.
  * Candidate refreshes now verify source coverage and revision consistency more reliably.

* **Documentation**
  * Clarified that Git syncs track repository revisions rather than out-of-band working-tree edits. Such edits require a repository update and sync or a forced reindex.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->