### PR TITLE
Cache Agno Pydantic version lookup

### DIFF
--- a/src/mindroom/agno_function_patch.py
+++ b/src/mindroom/agno_function_patch.py
@@ -5,7 +5,13 @@ from typing import Any, cast
 
 import agno.tools.function as agno_function
 
+_PATCHED_VERSIONS: set[Any] = set()
+
 
 def apply_patch() -> None:
     """Cache Agno's Pydantic package-version lookup once per process."""
-    agno_function.version = cast("Any", lru_cache(maxsize=1)(agno_function.version))
+    if agno_function.version in _PATCHED_VERSIONS:
+        return
+    patched_version = cast("Any", lru_cache(maxsize=1)(agno_function.version))
+    _PATCHED_VERSIONS.add(patched_version)
+    agno_function.version = patched_version

--- a/src/mindroom/agno_function_patch.py
+++ b/src/mindroom/agno_function_patch.py
@@ -1,0 +1,11 @@
+"""Temporary Agno Function performance patch pending agno-agi/agno#9210."""
+
+from functools import lru_cache
+from typing import Any, cast
+
+import agno.tools.function as agno_function
+
+
+def apply_patch() -> None:
+    """Cache Agno's Pydantic package-version lookup once per process."""
+    agno_function.version = cast("Any", lru_cache(maxsize=1)(agno_function.version))

--- a/src/mindroom/tool_system/output_files.py
+++ b/src/mindroom/tool_system/output_files.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal, cast, get_type_hints
 from agno.tools.function import Function, ToolResult
 from pydantic import BaseModel
 
+from mindroom import agno_function_patch
 from mindroom.constants import DEFAULT_TOOL_OUTPUT_AUTO_SAVE_THRESHOLD_BYTES
 from mindroom.logging_config import get_logger
 from mindroom.workspaces import resolve_relative_path_within_root_preserving_leaf
@@ -27,6 +28,8 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
 
 logger = get_logger(__name__)
+
+agno_function_patch.apply_patch()
 
 OUTPUT_PATH_ARGUMENT = "mindroom_output_path"
 _OUTPUT_PATH_ARGUMENT_DESCRIPTION = (

--- a/tests/test_agno_function_patch.py
+++ b/tests/test_agno_function_patch.py
@@ -1,12 +1,10 @@
 """Tests for MindRoom's temporary Agno Function patch."""
 
-from importlib import reload
+from importlib import import_module, reload
 
 import agno.tools.function as agno_function
 import pytest
 from agno.tools.function import Function
-
-from mindroom.tool_system import output_files
 
 
 def test_pydantic_version_lookup_is_cached_across_function_wraps(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -20,6 +18,9 @@ def test_pydantic_version_lookup_is_cached_across_function_wraps(monkeypatch: py
         return "2.13.3"
 
     monkeypatch.setattr(agno_function, "version", version)
+    output_files = import_module("mindroom.tool_system.output_files")
+    reload(output_files)
+    patched_version = agno_function.version
     reload(output_files)
 
     def tool(value: str) -> str:
@@ -28,4 +29,5 @@ def test_pydantic_version_lookup_is_cached_across_function_wraps(monkeypatch: py
     for _ in range(100):
         Function._wrap_callable(tool)
 
+    assert agno_function.version is patched_version
     assert lookups == 1

--- a/tests/test_agno_function_patch.py
+++ b/tests/test_agno_function_patch.py
@@ -1,0 +1,31 @@
+"""Tests for MindRoom's temporary Agno Function patch."""
+
+from importlib import reload
+
+import agno.tools.function as agno_function
+import pytest
+from agno.tools.function import Function
+
+from mindroom.tool_system import output_files
+
+
+def test_pydantic_version_lookup_is_cached_across_function_wraps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeated Agno wraps should read Pydantic package metadata only once."""
+    lookups = 0
+
+    def version(package: str) -> str:
+        nonlocal lookups
+        assert package == "pydantic"
+        lookups += 1
+        return "2.13.3"
+
+    monkeypatch.setattr(agno_function, "version", version)
+    reload(output_files)
+
+    def tool(value: str) -> str:
+        return value
+
+    for _ in range(100):
+        Function._wrap_callable(tool)
+
+    assert lookups == 1


### PR DESCRIPTION
## Summary

- Cache Agno’s repeated Pydantic package-metadata lookup once per process.
- Apply the temporary patch from `src/mindroom/tool_system/output_files.py`, where repeated schema processing reaches `Function._wrap_callable`.
- Keep the shim isolated for removal when [agno-agi/agno#9210](https://github.com/agno-agi/agno/pull/9210) ships.

## Why

Agno 2.6.12 calls `importlib.metadata.version("pydantic")` for every function wrap. MindRoom tool-schema processing repeatedly enters this path, and metadata reads on network-backed installs caused multi-second event-loop stalls.

Local 100-wrap benchmark: 73.42 ms → 5.55 ms; metadata lookups: 100 → 1.

## Testing

- `PYTHONPATH=src uv run pytest` — 12,008 passed, 54 skipped
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Cache Agno’s Pydantic version lookup to reduce overhead during MindRoom tool-function wrapping.

Enhancements:
- Introduce a temporary patch module that wraps Agno’s Pydantic version lookup with a per-process cache and apply it at tool system startup.

Tests:
- Add a regression test to ensure repeated Agno Function wraps only trigger a single Pydantic version lookup per process.