### PR TITLE
Split vector verification queries the store cannot answer

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -353,6 +353,12 @@ def _paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -
         # queries before raising exactly the same error from the first leaf.
         raise
     except ChromaError:
+        # Splitting stays correct but multiplies the queries, and how far it
+        # degrades depends on chunk counts nothing here can see. Without a
+        # trace, a base whose files outgrew the ceiling just gets quietly
+        # slower -- the same invisibility that let the unsplit query strand
+        # candidates undiagnosed.
+        logger.debug("Split a refused knowledge vector verification query", paths=len(relative_paths))
         midpoint = len(relative_paths) // 2
         return _paths_with_vectors(collection, relative_paths[:midpoint]) | _paths_with_vectors(
             collection,

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -19,7 +19,7 @@ from agno.knowledge.reader import ReaderFactory
 from agno.knowledge.reader.markdown_reader import MarkdownReader
 from agno.knowledge.reader.text_reader import TextReader
 from agno.vectordb.chroma import ChromaDb
-from chromadb.errors import NotFoundError
+from chromadb.errors import ChromaError, NotFoundError
 
 from mindroom.chunking import SafeFixedSizeChunking
 from mindroom.constants import (
@@ -86,6 +86,8 @@ if TYPE_CHECKING:
     from agno.knowledge.document.base import Document
     from agno.knowledge.embedder.base import Embedder
     from agno.knowledge.reader.base import Reader
+    from chromadb.api.models.Collection import Collection
+    from chromadb.api.types import GetResult, Metadata
 
     from mindroom.config.knowledge import KnowledgeGitConfig
     from mindroom.config.main import Config
@@ -299,6 +301,60 @@ def _iter_file_batches(files: Sequence[Path], batch_size: int) -> Iterator[list[
     size = max(batch_size, 1)
     for start in range(0, len(files), size):
         yield list(files[start : start + size])
+
+
+def _paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -> set[str]:
+    """Return which of `relative_paths` have at least one vector in the collection.
+
+    Chroma binds one SQL variable per *matched row*, not one per queried path,
+    so a fixed batch of paths does not bound the query at all: whether it fits
+    under SQLite's ceiling depends on how many chunks those particular files
+    produced. That makes any batch size chosen up front a gamble. Small files
+    leave a batch of 128 far below the ceiling, a handful of large ones puts
+    the same batch over it, and once over, every verification query for that
+    base fails identically and the candidate is stranded for good.
+
+    So the batch is not guessed, it is *adapted*: ask for the whole thing, and
+    on refusal halve it and ask again. Each split halves the matched rows too,
+    so it converges, and a store that can answer the batch pays nothing.
+
+    A single path is the floor, where splitting can no longer help, so it is
+    asked with ``limit=1`` instead: one row is all the proof of existence this
+    needs, and a one-row result stays under any ceiling no matter how many
+    chunks the file has. That floor is what makes the recursion total, and it
+    is also where a failure that was never about query size finally surfaces.
+    """
+    if not relative_paths:
+        return set()
+    if len(relative_paths) == 1:
+        relative_path = relative_paths[0]
+        result = collection.get(where={_SOURCE_PATH_KEY: relative_path}, include=["metadatas"], limit=1)
+        return {relative_path} if _result_metadatas(result) else set()
+
+    try:
+        result = collection.get(where={_SOURCE_PATH_KEY: {"$in": list(relative_paths)}}, include=["metadatas"])
+    except NotFoundError:
+        # A collection that is gone stays gone however small the query gets, and
+        # splitting would turn one honest failure into a storm of them per batch.
+        raise
+    except ChromaError:
+        midpoint = len(relative_paths) // 2
+        return _paths_with_vectors(collection, relative_paths[:midpoint]) | _paths_with_vectors(
+            collection,
+            relative_paths[midpoint:],
+        )
+
+    found: set[str] = set()
+    for metadata in _result_metadatas(result):
+        source_path = metadata.get(_SOURCE_PATH_KEY)
+        if isinstance(source_path, str):
+            found.add(source_path)
+    return found
+
+
+def _result_metadatas(result: GetResult) -> list[Metadata]:
+    """Return the metadata rows of a Chroma ``get`` result."""
+    return result.get("metadatas") or []
 
 
 def _require_chroma_vector_db(knowledge: Knowledge) -> ChromaDb:
@@ -1619,17 +1675,7 @@ class KnowledgeManager:
     ) -> set[str]:
         """Return which of the given source paths actually have candidate vectors."""
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        result = collection.get(
-            where={_SOURCE_PATH_KEY: {"$in": list(relative_paths)}},
-            include=["metadatas"],
-        )
-        metadatas = result.get("metadatas") or []
-        found: set[str] = set()
-        for metadata in metadatas:
-            source_path = metadata.get(_SOURCE_PATH_KEY) if isinstance(metadata, dict) else None
-            if isinstance(source_path, str):
-                found.add(source_path)
-        return found
+        return _paths_with_vectors(collection, list(relative_paths))
 
     async def _candidate_paths_missing_vectors(self, run: _CandidateRun, relative_paths: Sequence[str]) -> set[str]:
         """Return completed entries the candidate cannot actually serve.

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -308,6 +308,18 @@ def _iter_file_batches(files: Sequence[Path], batch_size: int) -> Iterator[list[
         yield list(files[start : start + size])
 
 
+def _collection_has_source_path(collection: Collection, relative_path: str) -> bool:
+    """Return whether one source path has any vector, at one row of cost.
+
+    Chroma binds one SQL variable per *returned* row, so an unbounded probe on
+    a heavily chunked file exceeds SQLite's ceiling and fails outright. One row
+    is all existence needs, and ``limit=1`` is what keeps this answerable at
+    any file size. Do not widen it.
+    """
+    result = collection.get(where={_SOURCE_PATH_KEY: relative_path}, limit=1, include=[])
+    return bool(result.get("ids"))
+
+
 def _paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -> set[str]:
     """Return which of `relative_paths` have at least one vector in the collection.
 
@@ -353,18 +365,6 @@ def _paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -
         if isinstance(source_path, str):
             found.add(source_path)
     return found
-
-
-def _collection_has_source_path(collection: Collection, relative_path: str) -> bool:
-    """Return whether one source path has any vector, at one row of cost.
-
-    Chroma binds one SQL variable per *returned* row, so an unbounded probe on
-    a heavily chunked file exceeds SQLite's ceiling and fails outright. One row
-    is all existence needs, and ``limit=1`` is what keeps this answerable at
-    any file size. Do not widen it.
-    """
-    result = collection.get(where={_SOURCE_PATH_KEY: relative_path}, limit=1, include=[])
-    return bool(result.get("ids"))
 
 
 def _require_chroma_vector_db(knowledge: Knowledge) -> ChromaDb:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -87,7 +87,6 @@ if TYPE_CHECKING:
     from agno.knowledge.embedder.base import Embedder
     from agno.knowledge.reader.base import Reader
     from chromadb.api.models.Collection import Collection
-    from chromadb.api.types import GetResult, Metadata
 
     from mindroom.config.knowledge import KnowledgeGitConfig
     from mindroom.config.main import Config
@@ -120,7 +119,13 @@ _MAX_PREFETCH_TEXT_BYTES = 8_000_000
 #: still yields to the event loop and to cancellation while it is scanned.
 _SIGNATURE_SCAN_CHUNK = 512
 #: Completed candidate entries whose vectors are confirmed in one Chroma query.
+#: Only a starting point: the query splits itself when the store refuses it,
+#: because the real limit is matched rows, which this cannot know up front.
 _VECTOR_VERIFY_BATCH = 128
+#: Source paths whose vectors are dropped in one Chroma delete. Independent of
+#: the verify batch: a delete binds no variable per matched row, so this bounds
+#: only how much work one call does.
+_VECTOR_DELETE_BATCH = 128
 #: Reconciliation passes before a refresh gives up for now. A source that keeps
 #: changing keeps its candidate and converges over successive refreshes instead
 #: of thrashing inside one.
@@ -319,23 +324,21 @@ def _paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -
     so it converges, and a store that can answer the batch pays nothing.
 
     A single path is the floor, where splitting can no longer help, so it is
-    asked with ``limit=1`` instead: one row is all the proof of existence this
-    needs, and a one-row result stays under any ceiling no matter how many
+    asked one row at a time instead, which stays under any ceiling however many
     chunks the file has. That floor is what makes the recursion total, and it
     is also where a failure that was never about query size finally surfaces.
     """
-    if not relative_paths:
-        return set()
     if len(relative_paths) == 1:
         relative_path = relative_paths[0]
-        result = collection.get(where={_SOURCE_PATH_KEY: relative_path}, include=["metadatas"], limit=1)
-        return {relative_path} if _result_metadatas(result) else set()
+        return {relative_path} if _collection_has_source_path(collection, relative_path) else set()
 
     try:
         result = collection.get(where={_SOURCE_PATH_KEY: {"$in": list(relative_paths)}}, include=["metadatas"])
     except NotFoundError:
-        # A collection that is gone stays gone however small the query gets, and
-        # splitting would turn one honest failure into a storm of them per batch.
+        # Splitting answers "the store refused this query for its size". A
+        # collection that is gone is not that, and stays gone however small the
+        # query gets, so descending would only cost log2(batch) + 1 doomed
+        # queries before raising exactly the same error from the first leaf.
         raise
     except ChromaError:
         midpoint = len(relative_paths) // 2
@@ -345,16 +348,23 @@ def _paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -
         )
 
     found: set[str] = set()
-    for metadata in _result_metadatas(result):
+    for metadata in result.get("metadatas") or []:
         source_path = metadata.get(_SOURCE_PATH_KEY)
         if isinstance(source_path, str):
             found.add(source_path)
     return found
 
 
-def _result_metadatas(result: GetResult) -> list[Metadata]:
-    """Return the metadata rows of a Chroma ``get`` result."""
-    return result.get("metadatas") or []
+def _collection_has_source_path(collection: Collection, relative_path: str) -> bool:
+    """Return whether one source path has any vector, at one row of cost.
+
+    Chroma binds one SQL variable per *returned* row, so an unbounded probe on
+    a heavily chunked file exceeds SQLite's ceiling and fails outright. One row
+    is all existence needs, and ``limit=1`` is what keeps this answerable at
+    any file size. Do not widen it.
+    """
+    result = collection.get(where={_SOURCE_PATH_KEY: relative_path}, limit=1, include=[])
+    return bool(result.get("ids"))
 
 
 def _require_chroma_vector_db(knowledge: Knowledge) -> ChromaDb:
@@ -1020,13 +1030,7 @@ class KnowledgeManager:
             return False
 
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        result = collection.get(
-            where={_SOURCE_PATH_KEY: relative_path},
-            limit=1,
-            include=[],
-        )
-        ids = result.get("ids", []) or []
-        return bool(ids)
+        return _collection_has_source_path(collection, relative_path)
 
     async def _wait_for_source_vectors(
         self,
@@ -1675,7 +1679,7 @@ class KnowledgeManager:
     ) -> set[str]:
         """Return which of the given source paths actually have candidate vectors."""
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        return _paths_with_vectors(collection, list(relative_paths))
+        return _paths_with_vectors(collection, relative_paths)
 
     async def _candidate_paths_missing_vectors(self, run: _CandidateRun, relative_paths: Sequence[str]) -> set[str]:
         """Return completed entries the candidate cannot actually serve.
@@ -1909,11 +1913,17 @@ class KnowledgeManager:
         Agno's ``delete_by_metadata`` wraps values in ``$eq`` and so can only
         take one path per call, which turns a large source update into one
         thread hop and one get+delete per file. The collection accepts ``$in``
-        directly, the same seam the vector verification query already uses.
+        directly.
+
+        Unlike the ``$in`` the verification query issues, this one needs no
+        ceiling protection: a delete does not bind one SQL variable per matched
+        row, so the batch size alone bounds it. Measured on ChromaDB 1.5.8,
+        deleting 51,200 rows across 128 paths in one call succeeds, where the
+        equivalent read fails with ``too many SQL variables``.
         """
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        for start in range(0, len(relative_paths), _VECTOR_VERIFY_BATCH):
-            batch = list(relative_paths[start : start + _VECTOR_VERIFY_BATCH])
+        for start in range(0, len(relative_paths), _VECTOR_DELETE_BATCH):
+            batch = list(relative_paths[start : start + _VECTOR_DELETE_BATCH])
             collection.delete(where={_SOURCE_PATH_KEY: {"$in": batch}})
 
     async def _drop_candidate_paths(self, run: _CandidateRun, relative_paths: Sequence[str]) -> None:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -336,7 +336,7 @@ def _paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -
     so it converges, and a store that can answer the batch pays nothing.
 
     A single path is the floor, where splitting can no longer help, so it is
-    asked one row at a time instead, which stays under any ceiling however many
+    asked for a single row instead, which stays under any ceiling however many
     chunks the file has. That floor is what makes the recursion total, and it
     is also where a failure that was never about query size finally surfaces.
     """

--- a/tests/knowledge_test_support.py
+++ b/tests/knowledge_test_support.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
 
 
 def metadata_matches(metadata: dict[str, Any], key: str, condition: object) -> bool:
@@ -19,3 +22,28 @@ def metadata_matches(metadata: dict[str, Any], key: str, condition: object) -> b
         msg = f"unsupported where condition: {condition!r}"
         raise AssertionError(msg)
     return metadata.get(key) == condition
+
+
+def chroma_get_result(
+    *,
+    ids: list[str],
+    metadatas: list[dict[str, Any]],
+    include: Sequence[str],
+) -> dict[str, Any]:
+    """Shape a Chroma ``get`` result, honoring ``include`` the way Chroma does.
+
+    Chroma omits whatever was not requested: ``include=[]`` returns
+    ``metadatas: None`` while still returning ids. That asymmetry is the whole
+    reason an existence probe must read ids, so a fake that returned metadatas
+    regardless would let a probe reading them pass in tests while reporting
+    "no vectors" for every file in production.
+
+    ``include`` is required rather than defaulted. Every production caller
+    passes it explicitly, and guessing a default here would model a shape
+    nothing exercises.
+    """
+    unsupported = set(include) - {"metadatas"}
+    if unsupported:
+        msg = f"unsupported include fields: {sorted(unsupported)}"
+        raise AssertionError(msg)
+    return {"ids": ids, "metadatas": metadatas if "metadatas" in include else None}

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -66,10 +66,10 @@ from mindroom.knowledge.utils import KnowledgeAvailabilityDetail
 from mindroom.knowledge.watch import KnowledgeSourceWatcher
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
-from tests.knowledge_test_support import metadata_matches
+from tests.knowledge_test_support import chroma_get_result, metadata_matches
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Coroutine, Iterable, Iterator
+    from collections.abc import AsyncIterator, Coroutine, Iterable, Iterator, Sequence
     from types import ModuleType
 
     from mindroom.constants import RuntimePaths
@@ -82,20 +82,22 @@ class _Collection:
     def get(
         self,
         *,
+        include: Sequence[str],
         limit: int | None = None,
         offset: int = 0,
-        include: list[str] | None = None,
         where: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        _ = include
         with _VectorDb.lock:
             selected_all = list(_VectorDb.collections.get(self._name, []))
         if where:
             key, condition = next(iter(where.items()))
             selected_all = [item for item in selected_all if metadata_matches(item["metadata"], key, condition)]
         selected = selected_all[offset:] if limit is None else selected_all[offset : offset + limit]
-        ids = [str(index) for index in range(offset, offset + len(selected))]
-        return {"ids": ids, "metadatas": [dict(item["metadata"]) for item in selected]}
+        return chroma_get_result(
+            ids=[str(index) for index in range(offset, offset + len(selected))],
+            metadatas=[dict(item["metadata"]) for item in selected],
+            include=include,
+        )
 
     def delete(self, *, where: dict[str, object]) -> None:
         key, condition = next(iter(where.items()))

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -3054,3 +3054,24 @@ def test_vector_verification_does_not_split_when_the_collection_is_gone(tmp_path
         manager._candidate_paths_with_vectors(vector_db, paths)
 
     assert _FakeVectorDb.get_calls == 1
+
+
+def test_vector_verification_records_that_it_had_to_split(tmp_path: Path) -> None:
+    """A store refusing batches must leave a trace, not degrade silently.
+
+    Splitting keeps verification correct but multiplies its queries, and how
+    far it degrades depends on chunk counts nothing here can see. A base whose
+    files grew past the ceiling would otherwise get quietly slower with no
+    signal anywhere, which is the same invisibility that let the original
+    failure go undiagnosed.
+    """
+    manager, vector_db = _verification_manager(tmp_path)
+    paths = [f"doc{index:02d}.md" for index in range(8)]
+    _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=100)
+    _FakeVectorDb.max_rows_per_get = 250
+
+    with capture_logs() as logs:
+        assert manager._candidate_paths_with_vectors(vector_db, paths) == set(paths)
+
+    split_logs = [entry for entry in logs if entry["event"] == "Split a refused knowledge vector verification query"]
+    assert [entry["paths"] for entry in split_logs] == [8, 4, 4]

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -60,7 +60,7 @@ from mindroom.knowledge.registry import (
 )
 from mindroom.knowledge.status import get_knowledge_index_status
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
-from tests.knowledge_test_support import metadata_matches
+from tests.knowledge_test_support import chroma_get_result, metadata_matches
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -95,9 +95,9 @@ class _FakeCollection:
     def get(
         self,
         *,
+        include: Sequence[str],
         limit: int | None = None,
         offset: int = 0,
-        include: list[str] | None = None,
         where: dict[str, object] | None = None,
     ) -> dict[str, object]:
         _FakeVectorDb.get_calls += 1
@@ -110,16 +110,11 @@ class _FakeCollection:
             records = [record for record in records if metadata_matches(record.metadata, key, condition)]
         selected = records[offset:] if limit is None else records[offset : offset + limit]
         _FakeVectorDb.enforce_row_ceiling(len(selected))
-        # Chroma omits whatever was not requested: ``include=[]`` returns
-        # ``metadatas: None`` while still returning ids. That asymmetry is why
-        # reading ids is the only safe existence check, so a fake that handed
-        # back metadatas regardless would let a probe reading them pass here
-        # and report "no vectors" for every file in production.
-        requested = include or []
-        return {
-            "ids": [str(index) for index in range(len(selected))],
-            "metadatas": ([dict(record.metadata) for record in selected] if "metadatas" in requested else None),
-        }
+        return chroma_get_result(
+            ids=[str(index) for index in range(len(selected))],
+            metadatas=[dict(record.metadata) for record in selected],
+            include=include,
+        )
 
     def delete(self, *, where: dict[str, object]) -> None:
         key, condition = next(iter(where.items()))
@@ -3050,7 +3045,9 @@ def test_vector_verification_does_not_split_when_the_collection_is_gone(tmp_path
     """
     manager, vector_db = _verification_manager(tmp_path)
     paths = [f"doc{index:02d}.md" for index in range(8)]
-    _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=1)
+    # No rows are seeded: every ``get`` raises before reading the store, so
+    # seeding would only suggest the contents mattered. ``create()`` in the
+    # helper is what registers the collection for ``get_collection``.
     _FakeVectorDb.vanished_on_get = {vector_db.collection_name}
 
     with pytest.raises(NotFoundError):

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -2981,8 +2981,16 @@ def test_vector_verification_splits_a_batch_the_store_cannot_answer(tmp_path: Pa
     paths = [f"doc{index:02d}.md" for index in range(8)]
     _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=100)
     _FakeVectorDb.max_rows_per_get = 250
+    _FakeVectorDb.get_calls = 0
 
     assert manager._candidate_paths_with_vectors(vector_db, paths) == set(paths)
+
+    # Halving is the property that makes this affordable, and correctness alone
+    # does not pin it: splitting one path off at a time also terminates and also
+    # returns the right answer, while turning O(log n) queries into O(n).
+    # 8 (800 rows, refused) -> 4 (400, refused) -> 2 + 2 (200 each, answered),
+    # then the same on the right half: 7 queries.
+    assert _FakeVectorDb.get_calls == 7
 
 
 def test_vector_verification_confirms_a_file_larger_than_the_store_ceiling(tmp_path: Path) -> None:

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 import pytest
 from agno.knowledge.document.base import Document
 from agno.knowledge.embedder.base import Embedder
-from chromadb.errors import NotFoundError
+from chromadb.errors import InternalError, NotFoundError
 from structlog.testing import capture_logs
 
 import mindroom.knowledge.manager as knowledge_manager_module
@@ -63,7 +63,7 @@ from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_p
 from tests.knowledge_test_support import metadata_matches
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
 
     from mindroom.constants import RuntimePaths
 
@@ -101,11 +101,16 @@ class _FakeCollection:
         where: dict[str, object] | None = None,
     ) -> dict[str, object]:
         _ = include
+        _FakeVectorDb.get_calls += 1
+        if self._name in _FakeVectorDb.vanished_on_get:
+            message = f"Collection {self._name!r} does not exist"
+            raise NotFoundError(message)
         records = list(_FakeVectorDb.store.get(self._name, []))
         if where:
             key, condition = next(iter(where.items()))
             records = [record for record in records if metadata_matches(record.metadata, key, condition)]
         selected = records[offset:] if limit is None else records[offset : offset + limit]
+        _FakeVectorDb.enforce_row_ceiling(len(selected))
         return {
             "ids": [str(index) for index in range(len(selected))],
             "metadatas": [dict(record.metadata) for record in selected],
@@ -133,6 +138,25 @@ class _FakeClient:
 
 class _FakeVectorDb:
     store: ClassVar[dict[str, list[_Record]]] = {}
+    #: Rows one ``get`` may return before the store rejects the whole query,
+    #: mirroring SQLite's bind-variable ceiling: Chroma binds one variable per
+    #: *returned row*, so the limit is a property of the result, not of the
+    #: ``$in`` list. ``None`` leaves the store unbounded.
+    max_rows_per_get: ClassVar[int | None] = None
+    #: ``get`` calls issued, so a test can prove a query was not needlessly split.
+    get_calls: ClassVar[int] = 0
+    #: Collections that still resolve through ``get_collection`` but are gone by
+    #: the time the query runs, as when a sweep deletes one mid-verification.
+    vanished_on_get: ClassVar[set[str]] = set()
+
+    @classmethod
+    def enforce_row_ceiling(cls, rows: int) -> None:
+        """Reject a query whose result would exceed the store's bind-variable ceiling."""
+        if cls.max_rows_per_get is not None and rows > cls.max_rows_per_get:
+            message = (
+                "Error executing plan: Internal error: error returned from database: (code: 1) too many SQL variables"
+            )
+            raise InternalError(message)
 
     def __init__(self, *, collection: str, embedder: Embedder | None = None, **_: object) -> None:
         self.collection_name = collection
@@ -314,6 +338,9 @@ def fake_vector_store(
 ) -> Iterator[None]:
     """Install the in-memory vector store, fake Knowledge and recording embedder."""
     _FakeVectorDb.store = {}
+    _FakeVectorDb.max_rows_per_get = None
+    _FakeVectorDb.get_calls = 0
+    _FakeVectorDb.vanished_on_get = set()
     monkeypatch.setattr(knowledge_manager_module, "ChromaDb", _FakeVectorDb)
     monkeypatch.setattr(knowledge_manager_module, "Knowledge", _FakeKnowledge)
     monkeypatch.setattr(knowledge_manager_module, "create_configured_embedder", lambda *_a, **_k: embedder)
@@ -2916,3 +2943,105 @@ async def test_file_skipped_by_overlap_expansion_still_indexes_and_publishes(
     assert state.indexed_count == 4
     stored = sorted(record.metadata["source_path"] for record in _FakeVectorDb.store[state.collection])
     assert "expanding.md" in stored
+
+
+# --------------------------------------------------------------------------
+# Vector verification against a store with a bind-variable ceiling
+# --------------------------------------------------------------------------
+
+
+def _seed_chunked_paths(collection: str, paths: Sequence[str], chunks_per_path: int) -> None:
+    """Fill one collection with `chunks_per_path` vectors for each of `paths`."""
+    _FakeVectorDb.store[collection] = [
+        _Record(content=f"{relative_path} chunk {index}", embedding=[0.0], metadata={"source_path": relative_path})
+        for relative_path in paths
+        for index in range(chunks_per_path)
+    ]
+
+
+def _verification_manager(tmp_path: Path) -> tuple[KnowledgeManager, _FakeVectorDb]:
+    """Return a manager and a created, empty candidate collection to verify against."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    manager = _manager(_config(tmp_path, docs_path))
+    vector_db = _FakeVectorDb(collection="verification_target")
+    vector_db.create()
+    return manager, vector_db
+
+
+def test_vector_verification_splits_a_batch_the_store_cannot_answer(tmp_path: Path) -> None:
+    """A batch matching more rows than the store allows must still be verified.
+
+    Chroma binds one SQL variable per matched chunk row, so a fixed batch of
+    paths is not a bound at all: whether the query fits depends on how many
+    chunks those files produced. A corpus of large files makes every
+    verification query fail, which strands the candidate permanently.
+    """
+    manager, vector_db = _verification_manager(tmp_path)
+    paths = [f"doc{index:02d}.md" for index in range(8)]
+    _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=100)
+    _FakeVectorDb.max_rows_per_get = 250
+
+    assert manager._candidate_paths_with_vectors(vector_db, paths) == set(paths)
+
+
+def test_vector_verification_confirms_a_file_larger_than_the_store_ceiling(tmp_path: Path) -> None:
+    """One file with more chunks than the ceiling must still be confirmed.
+
+    Splitting alone cannot rescue this: a single path is the smallest batch
+    there is, so the query has to stop asking for every row it matches.
+    """
+    manager, vector_db = _verification_manager(tmp_path)
+    _seed_chunked_paths(vector_db.collection_name, ["huge.md"], chunks_per_path=500)
+    _FakeVectorDb.max_rows_per_get = 250
+
+    assert manager._candidate_paths_with_vectors(vector_db, ["huge.md"]) == {"huge.md"}
+
+
+def test_vector_verification_still_reports_paths_without_vectors_after_splitting(tmp_path: Path) -> None:
+    """Splitting must not turn an unverifiable path into a verified one."""
+    manager, vector_db = _verification_manager(tmp_path)
+    present = [f"present{index:02d}.md" for index in range(6)]
+    _seed_chunked_paths(vector_db.collection_name, present, chunks_per_path=100)
+    _FakeVectorDb.max_rows_per_get = 250
+    missing = ["missing0.md", "missing1.md"]
+
+    found = manager._candidate_paths_with_vectors(vector_db, [*present, *missing])
+
+    assert found == set(present)
+
+
+def test_vector_verification_uses_one_query_when_the_store_answers(tmp_path: Path) -> None:
+    """A store that can answer the whole batch must be asked exactly once.
+
+    Splitting is a fallback, not the normal path: verifying per file would turn
+    one query per 128 files into 128, which is the cost this batching exists to
+    avoid.
+    """
+    manager, vector_db = _verification_manager(tmp_path)
+    paths = [f"doc{index:02d}.md" for index in range(8)]
+    _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=100)
+    _FakeVectorDb.get_calls = 0
+
+    assert manager._candidate_paths_with_vectors(vector_db, paths) == set(paths)
+    assert _FakeVectorDb.get_calls == 1
+
+
+def test_vector_verification_does_not_split_when_the_collection_is_gone(tmp_path: Path) -> None:
+    """A missing collection must surface at once instead of being re-asked per path.
+
+    Splitting exists to shrink a query the store found too large. A collection
+    that no longer exists stays missing however small the query gets, so
+    retrying the halves would turn one honest failure into a storm of them for
+    every batch of every base.
+    """
+    manager, vector_db = _verification_manager(tmp_path)
+    paths = [f"doc{index:02d}.md" for index in range(8)]
+    _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=1)
+    _FakeVectorDb.vanished_on_get = {vector_db.collection_name}
+    _FakeVectorDb.get_calls = 0
+
+    with pytest.raises(NotFoundError):
+        manager._candidate_paths_with_vectors(vector_db, paths)
+
+    assert _FakeVectorDb.get_calls == 1

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -100,7 +100,6 @@ class _FakeCollection:
         include: list[str] | None = None,
         where: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        _ = include
         _FakeVectorDb.get_calls += 1
         if self._name in _FakeVectorDb.vanished_on_get:
             message = f"Collection {self._name!r} does not exist"
@@ -111,9 +110,15 @@ class _FakeCollection:
             records = [record for record in records if metadata_matches(record.metadata, key, condition)]
         selected = records[offset:] if limit is None else records[offset : offset + limit]
         _FakeVectorDb.enforce_row_ceiling(len(selected))
+        # Chroma omits whatever was not requested: ``include=[]`` returns
+        # ``metadatas: None`` while still returning ids. That asymmetry is why
+        # reading ids is the only safe existence check, so a fake that handed
+        # back metadatas regardless would let a probe reading them pass here
+        # and report "no vectors" for every file in production.
+        requested = include or []
         return {
             "ids": [str(index) for index in range(len(selected))],
-            "metadatas": [dict(record.metadata) for record in selected],
+            "metadatas": ([dict(record.metadata) for record in selected] if "metadatas" in requested else None),
         }
 
     def delete(self, *, where: dict[str, object]) -> None:
@@ -2981,7 +2986,6 @@ def test_vector_verification_splits_a_batch_the_store_cannot_answer(tmp_path: Pa
     paths = [f"doc{index:02d}.md" for index in range(8)]
     _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=100)
     _FakeVectorDb.max_rows_per_get = 250
-    _FakeVectorDb.get_calls = 0
 
     assert manager._candidate_paths_with_vectors(vector_db, paths) == set(paths)
 
@@ -3029,7 +3033,6 @@ def test_vector_verification_uses_one_query_when_the_store_answers(tmp_path: Pat
     manager, vector_db = _verification_manager(tmp_path)
     paths = [f"doc{index:02d}.md" for index in range(8)]
     _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=100)
-    _FakeVectorDb.get_calls = 0
 
     assert manager._candidate_paths_with_vectors(vector_db, paths) == set(paths)
     assert _FakeVectorDb.get_calls == 1
@@ -3038,16 +3041,17 @@ def test_vector_verification_uses_one_query_when_the_store_answers(tmp_path: Pat
 def test_vector_verification_does_not_split_when_the_collection_is_gone(tmp_path: Path) -> None:
     """A missing collection must surface at once instead of being re-asked per path.
 
-    Splitting exists to shrink a query the store found too large. A collection
-    that no longer exists stays missing however small the query gets, so
-    retrying the halves would turn one honest failure into a storm of them for
-    every batch of every base.
+    Splitting exists to shrink a query the store found too large, and a missing
+    collection is not that: it stays missing however small the query gets.
+    Descending anyway costs ``log2(batch) + 1`` doomed queries before the
+    leftmost leaf raises the identical error, and the caller does not catch, so
+    verification aborts on this batch either way. Failing on the first query is
+    the cheaper of two identical outcomes, which is what the count below pins.
     """
     manager, vector_db = _verification_manager(tmp_path)
     paths = [f"doc{index:02d}.md" for index in range(8)]
     _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=1)
     _FakeVectorDb.vanished_on_get = {vector_db.collection_name}
-    _FakeVectorDb.get_calls = 0
 
     with pytest.raises(NotFoundError):
         manager._candidate_paths_with_vectors(vector_db, paths)


### PR DESCRIPTION
A verification query that scales with matched rows instead of queried paths, so
a base with large files fails it permanently and can never publish an index.

## The bug

Candidate vector verification asks Chroma one question per batch of 128 files:
which of these source paths actually have vectors? It asks like this:

```python
collection.get(where={"source_path": {"$in": paths}}, include=["metadatas"])
```

Chroma binds **one SQL variable per matched row**, not one per queried path, and
SQLite caps a statement at 32,766 of them. The batch size of 128 therefore
bounds nothing: whether the query fits depends entirely on how many chunks those
particular 128 files produced.

Measured against the pinned ChromaDB 1.5.8:

| Query | Rows matched | Result |
|---|---|---|
| 4,000 paths x 1 chunk | 4,000 | ok |
| 81 paths x 400 chunks | 32,400 | ok |
| 82 paths x 400 chunks | 32,800 | `too many SQL variables` |
| 1 path x 40,000 chunks, `$in` | 40,000 | `too many SQL variables` |
| 1 path x 40,000 chunks, `$eq` | 40,000 | `too many SQL variables` |
| 1 path x 40,000 chunks, `$eq` + `limit=1` | 1 | ok |

Two things follow from that table.

It is **not an `$in` problem**. Plain `$eq` on a single path fails identically,
so a base containing one file with enough chunks cannot be verified at *any*
batch size. Only bounding the returned rows escapes.

And the failure is **not transient**. A base whose files average more than about
256 chunks fails every verification query it will ever issue, at every batch, on
every attempt. The candidate never verifies, so it never publishes, so the base
stays unavailable for semantic search across every restart. Nothing about
retrying or restarting changes the arithmetic.

The query is also doing far more work than its own question needs: it asks "does
this path have any vectors?" and pays to fetch every chunk of every path to
answer it, then reduces the result to a set of path names.

## The fix

Do not guess a batch size, adapt it. Ask for the whole batch; if the store
refuses, halve it and ask again. Each split halves the matched rows too, so it
converges, and a store that can answer the batch pays nothing at all.

A single path is the floor, where splitting can no longer help, so it is asked
with `$eq` and `limit=1` instead: one row is all the existence proof this needs,
and a one-row result stays under any ceiling however many chunks the file has.
That floor is what makes the recursion total rather than merely usually
terminating, and it is also where a failure that was never about query size
finally surfaces.

`NotFoundError` is re-raised rather than split, because splitting answers "the
store refused this query for its size" and a missing collection is not that.
The cost of not doing this is modest and worth stating accurately: `a | b`
evaluates its left operand first, so the recursion descends to the leftmost
leaf and raises the identical error there, costing `log2(batch) + 1` doomed
queries on that one batch before the caller -- which does not catch -- aborts
verification. Fail-fast, not a correctness necessity.

## Verified against real ChromaDB, not only the fake

The test fake models the ceiling, so it can only prove the logic is
self-consistent. Run against a real persistent ChromaDB collection holding
91,200 rows (128 files x 400 chunks, plus one file of 40,000 chunks):

- querying all 131 paths returns the exactly correct set, in **15 queries**,
  where `main` raises `too many SQL variables` and returns nothing
- a healthy 128-path corpus still costs **exactly 1 query**, so the batching
  this code exists for is intact

## Deliberately not changed

`_delete_candidate_vectors` issues the same `$in` shape, so I checked it too:
deleting 51,200 rows across 128 paths in one call succeeds. `delete` compiles to
a different plan and does not bind per matched row, so it needs no protection
and gets none.

## Tests

Six new tests, each watched failing first:

| Test | Guards |
|---|---|
| `test_vector_verification_splits_a_batch_the_store_cannot_answer` | a batch over the ceiling is still verified, in a *halving* number of queries |
| `test_vector_verification_confirms_a_file_larger_than_the_store_ceiling` | the one-row floor, which splitting alone cannot provide |
| `test_vector_verification_still_reports_paths_without_vectors_after_splitting` | splitting never invents a verified path |
| `test_vector_verification_uses_one_query_when_the_store_answers` | no needless fan-out on a healthy store |
| `test_vector_verification_does_not_split_when_the_collection_is_gone` | a missing collection surfaces at once |
| `test_vector_verification_records_that_it_had_to_split` | the fallback is observable rather than silently slower |

Every new production branch was mutation-checked rather than assumed covered:

| Mutation | Caught by |
|---|---|
| drop `limit=1` from the probe | `..._confirms_a_file_larger_than_the_store_ceiling` |
| drop the `NotFoundError` re-raise | `..._does_not_split_when_the_collection_is_gone` (`assert 4 == 1`) |
| `midpoint = 1` instead of halving | `..._splits_a_batch_the_store_cannot_answer` (`assert 13 == 7`) |
| drop the split log | `..._records_that_it_had_to_split` |
| probe reads `metadatas` instead of `ids` | 52 tests in `test_knowledge_resumable_refresh.py`, 86 in `test_knowledge_manager.py` |

That last row is the one worth reading twice. Both test fakes previously
discarded `include` and returned metadatas unconditionally, while real Chroma
returns `metadatas: None` under `include=[]`. Switching the probe to
`bool(result.get("metadatas"))` -- a plausible tidy-up, since the multi-path
branch above it does read metadatas -- makes every existence probe return False
in production: every file reports no vectors, `_wait_for_source_vectors` burns
its retries, verification calls every large file missing. Against the old fakes
that mutation failed **zero** tests in either file.

So the Chroma `get` contract now lives once, as `chroma_get_result` in
`knowledge_test_support.py` next to `metadata_matches`, and both fakes delegate
to it. `include` is a required argument there: every production caller passes it
explicitly, and unsupported fields raise rather than be quietly modelled, the
same way `metadata_matches` refuses query shapes it does not implement.

## Consolidation note for #1708

`perf/knowledge-reuse-unchanged-vectors` reworks the same `_FakeCollection.get`
and `_FakeVectorDb`. Whoever merges second should reconcile the fakes
deliberately rather than resolving the conflict textually:

| | this PR | #1708 |
|---|---|---|
| ceiling refusal | `InternalError` | `RuntimeError` |
| ceiling knob | `max_rows_per_get` + `enforce_row_ceiling` | `max_rows_per_query`, inline |
| call tracking | `get_calls: int` | `queries: list[(rows, where)]` |
| ids | positional | `record.identifier` |
| `metadatas` | returned only when `include` asks | returned unconditionally |

Two of those matter here. `RuntimeError` is not a `ChromaError`, so
`_paths_with_vectors` would not catch it and the split tests would error
instead of exercising the split; `InternalError` is also simply what ChromaDB
1.5.8 raises, measured. And returning `metadatas` unconditionally silently
undoes the fidelity fix above -- that one fails no test in either direction.

`chroma_get_result` currently models only the fields this PR's callers use, so
supporting #1708's `documents` and `embeddings` is part of that reconciliation,
not something already provided.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved knowledge refresh reliability when verifying large numbers of stored vectors.
  * Added automatic query splitting to handle vector-store limits without missing valid paths.
  * Preserved correct behavior when a collection disappears during verification.
  * Improved vector deletion batching for more reliable cleanup.

* **Tests**
  * Expanded coverage for large-batch verification, query limits, collection removal, and retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->