### PR TITLE
Reuse published vectors for files a refresh did not change

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -58,6 +58,7 @@ Chat uses the last successfully published index and continues without blocking w
 When a watched file changes, MindRoom marks the published index stale, refreshes in the background, and atomically publishes the replacement when it succeeds.
 A refresh builds that replacement by reusing the published index's stored vectors for every file whose content is unchanged, so it only embeds files that were added or edited.
 Changing `chunk_size`, `chunk_overlap`, the embedder, or any corpus filter invalidates the stored vectors, and the next refresh re-embeds the whole base.
+An explicit reindex from the dashboard or API rebuilds every vector instead of reusing any, which is how you replace an index you no longer trust.
 When `watch: false`, direct external file edits require explicit reindex, while dashboard/API upload and delete actions still schedule refresh after a successful mutation.
 Knowledge base IDs are the keys under `knowledge_bases`.
 Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, names containing `/` or `\`, or names containing line breaks.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -56,6 +56,8 @@ agents:
 Place files in `./knowledge_docs/`, then trigger a reindex from the dashboard/API or let MindRoom watch shared local bases with `watch: true`.
 Chat uses the last successfully published index and continues without blocking when a base is missing, stale, or failed.
 When a watched file changes, MindRoom marks the published index stale, refreshes in the background, and atomically publishes the replacement when it succeeds.
+A refresh builds that replacement by reusing the published index's stored vectors for every file whose content is unchanged, so it only embeds files that were added or edited.
+Changing `chunk_size`, `chunk_overlap`, the embedder, or any corpus filter invalidates the stored vectors, and the next refresh re-embeds the whole base.
 When `watch: false`, direct external file edits require explicit reindex, while dashboard/API upload and delete actions still schedule refresh after a successful mutation.
 Knowledge base IDs are the keys under `knowledge_bases`.
 Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, names containing `/` or `\`, or names containing line breaks.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12965,6 +12965,7 @@ Chat uses the last successfully published index and continues without blocking w
 When a watched file changes, MindRoom marks the published index stale, refreshes in the background, and atomically publishes the replacement when it succeeds.
 A refresh builds that replacement by reusing the published index's stored vectors for every file whose content is unchanged, so it only embeds files that were added or edited.
 Changing `chunk_size`, `chunk_overlap`, the embedder, or any corpus filter invalidates the stored vectors, and the next refresh re-embeds the whole base.
+An explicit reindex from the dashboard or API rebuilds every vector instead of reusing any, which is how you replace an index you no longer trust.
 When `watch: false`, direct external file edits require explicit reindex, while dashboard/API upload and delete actions still schedule refresh after a successful mutation.
 Knowledge base IDs are the keys under `knowledge_bases`.
 Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, names containing `/` or `\`, or names containing line breaks.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12963,6 +12963,8 @@ agents:
 Place files in `./knowledge_docs/`, then trigger a reindex from the dashboard/API or let MindRoom watch shared local bases with `watch: true`.
 Chat uses the last successfully published index and continues without blocking when a base is missing, stale, or failed.
 When a watched file changes, MindRoom marks the published index stale, refreshes in the background, and atomically publishes the replacement when it succeeds.
+A refresh builds that replacement by reusing the published index's stored vectors for every file whose content is unchanged, so it only embeds files that were added or edited.
+Changing `chunk_size`, `chunk_overlap`, the embedder, or any corpus filter invalidates the stored vectors, and the next refresh re-embeds the whole base.
 When `watch: false`, direct external file edits require explicit reindex, while dashboard/API upload and delete actions still schedule refresh after a successful mutation.
 Knowledge base IDs are the keys under `knowledge_bases`.
 Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, names containing `/` or `\`, or names containing line breaks.

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -52,6 +52,8 @@ agents:
 Place files in `./knowledge_docs/`, then trigger a reindex from the dashboard/API or let MindRoom watch shared local bases with `watch: true`.
 Chat uses the last successfully published index and continues without blocking when a base is missing, stale, or failed.
 When a watched file changes, MindRoom marks the published index stale, refreshes in the background, and atomically publishes the replacement when it succeeds.
+A refresh builds that replacement by reusing the published index's stored vectors for every file whose content is unchanged, so it only embeds files that were added or edited.
+Changing `chunk_size`, `chunk_overlap`, the embedder, or any corpus filter invalidates the stored vectors, and the next refresh re-embeds the whole base.
 When `watch: false`, direct external file edits require explicit reindex, while dashboard/API upload and delete actions still schedule refresh after a successful mutation.
 Knowledge base IDs are the keys under `knowledge_bases`.
 Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, names containing `/` or `\`, or names containing line breaks.

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -54,6 +54,7 @@ Chat uses the last successfully published index and continues without blocking w
 When a watched file changes, MindRoom marks the published index stale, refreshes in the background, and atomically publishes the replacement when it succeeds.
 A refresh builds that replacement by reusing the published index's stored vectors for every file whose content is unchanged, so it only embeds files that were added or edited.
 Changing `chunk_size`, `chunk_overlap`, the embedder, or any corpus filter invalidates the stored vectors, and the next refresh re-embeds the whole base.
+An explicit reindex from the dashboard or API rebuilds every vector instead of reusing any, which is how you replace an index you no longer trust.
 When `watch: false`, direct external file edits require explicit reindex, while dashboard/API upload and delete actions still schedule refresh after a successful mutation.
 Knowledge base IDs are the keys under `knowledge_bases`.
 Use a non-empty single path component such as `docs` or `company_docs`, not `""`, `.`, `..`, names containing `/` or `\`, or names containing line breaks.

--- a/src/mindroom/knowledge/candidate_checkpoint.py
+++ b/src/mindroom/knowledge/candidate_checkpoint.py
@@ -51,6 +51,21 @@ FileSignature = tuple[int, int, str]
 _CandidateStatus = Literal["building", "failed"]
 
 
+def file_signature_from_fields(
+    source_mtime_ns: object,
+    source_size: object,
+    source_digest: object,
+) -> FileSignature | None:
+    """Return a validated file signature, or None for malformed fields."""
+    if isinstance(source_mtime_ns, bool) or isinstance(source_size, bool):
+        return None
+    if not isinstance(source_mtime_ns, int) or not isinstance(source_size, int) or source_size < 0:
+        return None
+    if not isinstance(source_digest, str) or not source_digest:
+        return None
+    return source_mtime_ns, source_size, source_digest
+
+
 def _utc_now() -> str:
     return datetime.now(tz=UTC).isoformat()
 
@@ -102,14 +117,7 @@ def _candidate_journal_path(base_storage_path: Path) -> Path:
 def _parse_signature(value: object) -> FileSignature | None:
     if not isinstance(value, list) or len(value) != 3:
         return None
-    source_mtime_ns, source_size, source_digest = value
-    if isinstance(source_mtime_ns, bool) or isinstance(source_size, bool):
-        return None
-    if not isinstance(source_mtime_ns, int) or not isinstance(source_size, int) or source_size < 0:
-        return None
-    if not isinstance(source_digest, str) or not source_digest:
-        return None
-    return source_mtime_ns, source_size, source_digest
+    return file_signature_from_fields(*value)
 
 
 def _parse_failure(value: object) -> CandidateFailure | None:

--- a/src/mindroom/knowledge/candidate_checkpoint.py
+++ b/src/mindroom/knowledge/candidate_checkpoint.py
@@ -71,11 +71,6 @@ class CandidateCheckpoint:
     collection: str
     settings: IndexingSettings
     status: _CandidateStatus = "building"
-    #: Set while vectors are being copied into this candidate from a published
-    #: index, and cleared only once the copy's claims are durable. Rows written
-    #: by a copy that never got to record them are attributable to nothing, so a
-    #: candidate still carrying this marker is rebuilt rather than resumed.
-    seeding: bool = False
     target_revision: str | None = None
     total_files: int = 0
     completed: Mapping[str, FileSignature] = field(default_factory=dict)
@@ -138,7 +133,6 @@ def _snapshot_payload(checkpoint: CandidateCheckpoint) -> dict[str, object]:
         "schema_version": _CANDIDATE_CHECKPOINT_SCHEMA_VERSION,
         "collection": checkpoint.collection,
         "status": checkpoint.status,
-        "seeding": checkpoint.seeding,
         "settings": checkpoint.settings.to_metadata(),
         "target_revision": checkpoint.target_revision,
         "total_files": checkpoint.total_files,
@@ -212,9 +206,6 @@ def _parse_snapshot(payload: Mapping[str, object]) -> CandidateCheckpoint | None
         collection=collection,
         settings=settings,
         status="failed" if status == "failed" else "building",
-        # Absent in snapshots written before the marker existed, which is
-        # exactly right: no copy was ever in flight for those candidates.
-        seeding=payload.get("seeding") is True,
         target_revision=target_revision if isinstance(target_revision, str) and target_revision else None,
         total_files=total_files if isinstance(total_files, int) and not isinstance(total_files, bool) else 0,
         completed=completed,

--- a/src/mindroom/knowledge/candidate_checkpoint.py
+++ b/src/mindroom/knowledge/candidate_checkpoint.py
@@ -71,6 +71,11 @@ class CandidateCheckpoint:
     collection: str
     settings: IndexingSettings
     status: _CandidateStatus = "building"
+    #: Set while vectors are being copied into this candidate from a published
+    #: index, and cleared only once the copy's claims are durable. Rows written
+    #: by a copy that never got to record them are attributable to nothing, so a
+    #: candidate still carrying this marker is rebuilt rather than resumed.
+    seeding: bool = False
     target_revision: str | None = None
     total_files: int = 0
     completed: Mapping[str, FileSignature] = field(default_factory=dict)
@@ -133,6 +138,7 @@ def _snapshot_payload(checkpoint: CandidateCheckpoint) -> dict[str, object]:
         "schema_version": _CANDIDATE_CHECKPOINT_SCHEMA_VERSION,
         "collection": checkpoint.collection,
         "status": checkpoint.status,
+        "seeding": checkpoint.seeding,
         "settings": checkpoint.settings.to_metadata(),
         "target_revision": checkpoint.target_revision,
         "total_files": checkpoint.total_files,
@@ -206,6 +212,9 @@ def _parse_snapshot(payload: Mapping[str, object]) -> CandidateCheckpoint | None
         collection=collection,
         settings=settings,
         status="failed" if status == "failed" else "building",
+        # Absent in snapshots written before the marker existed, which is
+        # exactly right: no copy was ever in flight for those candidates.
+        seeding=payload.get("seeding") is True,
         target_revision=target_revision if isinstance(target_revision, str) and target_revision else None,
         total_files=total_files if isinstance(total_files, int) and not isinstance(total_files, bool) else 0,
         completed=completed,

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -42,6 +42,7 @@ from mindroom.knowledge.candidate_checkpoint import (
     FileSignature,
     append_candidate_journal,
     delete_candidate_checkpoint,
+    file_signature_from_fields,
     load_candidate_checkpoint,
     save_candidate_checkpoint,
 )
@@ -319,21 +320,24 @@ def _raise_cancelled() -> NoReturn:
     raise asyncio.CancelledError
 
 
-async def _complete_task_before_cancelling(task: asyncio.Task[_ShieldedResult]) -> _ShieldedResult:
-    """Drain one owned task before propagating cancellation, however often requested."""
-    try:
-        return await asyncio.shield(task)
-    except asyncio.CancelledError:
-        while not task.done():
-            try:
-                await asyncio.shield(task)
-            except asyncio.CancelledError:
-                continue
-            except Exception:
-                break
+async def _drain_owned_task_after_cancellation(
+    task: asyncio.Task[_ShieldedResult],
+    *,
+    suppress_errors: bool,
+) -> None:
+    """Drain one owned task despite repeated cancellation."""
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            continue
+        except Exception:
+            break
+    if suppress_errors:
         with suppress(Exception):
             task.result()
-        raise
+        return
+    task.result()
 
 
 async def _shielded_write(write: Coroutine[Any, Any, _ShieldedResult]) -> _ShieldedResult:
@@ -346,7 +350,12 @@ async def _shielded_write(write: Coroutine[Any, Any, _ShieldedResult]) -> _Shiel
     this treats a lost write as recoverable and cancellation as authoritative.
     The shared drain also defers repeated cancellation until the write finishes.
     """
-    return await _complete_task_before_cancelling(asyncio.create_task(write))
+    task = asyncio.create_task(write)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        await _drain_owned_task_after_cancellation(task, suppress_errors=True)
+        raise
 
 
 def _iter_file_batches(files: Sequence[Path], batch_size: int) -> Iterator[list[Path]]:
@@ -623,16 +632,14 @@ def _reusable_row_signature(
     source_path = metadata.get(_SOURCE_PATH_KEY)
     if not isinstance(source_path, str) or source_path not in managed_paths:
         return None
-    source_mtime_ns = metadata.get(_SOURCE_MTIME_NS_KEY)
-    source_size = metadata.get(_SOURCE_SIZE_KEY)
-    source_digest = metadata.get(_SOURCE_DIGEST_KEY)
-    if isinstance(source_mtime_ns, bool) or isinstance(source_size, bool):
+    signature = file_signature_from_fields(
+        metadata.get(_SOURCE_MTIME_NS_KEY),
+        metadata.get(_SOURCE_SIZE_KEY),
+        metadata.get(_SOURCE_DIGEST_KEY),
+    )
+    if signature is None:
         return None
-    if not isinstance(source_mtime_ns, int) or not isinstance(source_size, int) or source_size < 0:
-        return None
-    if not isinstance(source_digest, str) or not source_digest:
-        return None
-    return source_path, (source_mtime_ns, source_size, source_digest)
+    return source_path, signature
 
 
 def _source_signature_from_file_signatures(file_signatures: Mapping[str, FileSignature]) -> str:
@@ -1260,11 +1267,10 @@ class KnowledgeManager:
         try:
             await asyncio.shield(save_task)
         except asyncio.CancelledError:
-            # Drained without ``_shielded_write``'s suppression on purpose: the
-            # caller marks the index published on a cancelled-but-saved outcome,
-            # so a write that failed has to surface instead of being reported
-            # as a cancellation that saved.
-            await save_task
+            # Use the shared repeated-cancellation drain without suppressing
+            # task errors: the caller marks the index published on a
+            # cancelled-but-saved outcome, so a failed write must surface.
+            await _drain_owned_task_after_cancellation(save_task, suppress_errors=False)
             return True
         return False
 
@@ -1821,9 +1827,11 @@ class KnowledgeManager:
             offset += len(ids)
             # Chroma types every one of these optional because the caller may
             # not have asked for it; this one did, in the ``include`` above.
+            # The annotation keeps the TYPE_CHECKING-only Embeddings import
+            # visible to vulture; the string cast avoids a runtime import.
             embeddings: Embeddings = cast("Embeddings", page["embeddings"])
-            documents: list[str] = cast("list[str]", page["documents"])
-            metadatas: list[Metadata] = cast("list[Metadata]", page["metadatas"])
+            documents = cast("list[str]", page["documents"])
+            metadatas = cast("list[Metadata]", page["metadatas"])
             kept: list[int] = []
             for index, metadata in enumerate(metadatas):
                 entry = _reusable_row_signature(metadata, managed_paths)
@@ -1885,14 +1893,12 @@ class KnowledgeManager:
             self._relative_path(file_path) for file_path in await asyncio.to_thread(self.list_files)
         )
         try:
-            reused = await _complete_task_before_cancelling(
-                asyncio.create_task(
-                    asyncio.to_thread(
-                        self._copy_published_vectors,
-                        published_collection=published_collection,
-                        candidate_vector_db=candidate_vector_db,
-                        managed_paths=managed_paths,
-                    ),
+            reused = await _shielded_write(
+                asyncio.to_thread(
+                    self._copy_published_vectors,
+                    published_collection=published_collection,
+                    candidate_vector_db=candidate_vector_db,
+                    managed_paths=managed_paths,
                 ),
             )
         except Exception:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -19,6 +19,7 @@ from agno.knowledge.reader import ReaderFactory
 from agno.knowledge.reader.markdown_reader import MarkdownReader
 from agno.knowledge.reader.text_reader import TextReader
 from agno.vectordb.chroma import ChromaDb
+from chromadb.api.types import Embeddings, Metadata
 from chromadb.errors import NotFoundError
 
 from mindroom.chunking import SafeFixedSizeChunking
@@ -119,6 +120,11 @@ _MAX_PREFETCH_TEXT_BYTES = 8_000_000
 _SIGNATURE_SCAN_CHUNK = 512
 #: Completed candidate entries whose vectors are confirmed in one Chroma query.
 _VECTOR_VERIFY_BATCH = 128
+#: Published chunk rows read in one copy query. Chroma binds one SQL variable
+#: per *returned* row and SQLite caps a statement at 32,766, so nothing about
+#: the file or path count bounds a copy query -- only the rows it may return.
+#: The page also bounds how much vector data the copy holds in memory at once.
+_PUBLISHED_VECTOR_COPY_PAGE_ROWS = 500
 #: Reconciliation passes before a refresh gives up for now. A source that keeps
 #: changing keeps its candidate and converges over successive refreshes instead
 #: of thrashing inside one.
@@ -493,6 +499,22 @@ def knowledge_source_signature(
         digest.update(source_digest.encode("ascii"))
         digest.update(b"\0")
     return digest.hexdigest()
+
+
+def _reusable_row_signature(
+    metadata: Metadata,
+    managed_paths: frozenset[str],
+) -> tuple[str, FileSignature] | None:
+    """Return the managed source path and signature one published chunk carries."""
+    source_path = metadata.get(_SOURCE_PATH_KEY)
+    if not isinstance(source_path, str) or source_path not in managed_paths:
+        return None
+    source_mtime_ns = metadata.get(_SOURCE_MTIME_NS_KEY)
+    source_size = metadata.get(_SOURCE_SIZE_KEY)
+    source_digest = metadata.get(_SOURCE_DIGEST_KEY)
+    if not isinstance(source_mtime_ns, int) or not isinstance(source_size, int) or not isinstance(source_digest, str):
+        return None
+    return source_path, (source_mtime_ns, source_size, source_digest)
 
 
 def _source_signature_from_file_signatures(file_signatures: Mapping[str, FileSignature]) -> str:
@@ -1653,6 +1675,128 @@ class KnowledgeManager:
             run.verified.update(found)
         return missing
 
+    def _copy_published_vectors(
+        self,
+        *,
+        published_collection: str,
+        candidate_vector_db: ChromaDb,
+        managed_paths: frozenset[str],
+    ) -> dict[str, FileSignature]:
+        """Copy stored chunks for currently-managed paths into the candidate.
+
+        Every published chunk carries the signature of the file it came from,
+        so the published collection is already an index from source path to
+        vectors. Chunks are copied verbatim -- ids, embeddings, documents and
+        metadata -- because ids key content in the vector store and
+        regenerating them would corrupt the candidate.
+
+        Reads are paged because Chroma binds one SQL variable per *returned*
+        row and SQLite caps a statement at 32,766 of them. Neither the file
+        count nor the path count bounds that, so a single large file can refuse
+        an unpaged read on its own; only bounding the returned rows escapes.
+
+        Returns the signature published for each path that actually received
+        rows, so a path the published index cannot serve is never claimed.
+        """
+        client = candidate_vector_db.client
+        published = client.get_collection(name=published_collection)
+        candidate = client.get_collection(name=candidate_vector_db.collection_name)
+        reused: dict[str, FileSignature] = {}
+        offset = 0
+        while True:
+            page = published.get(
+                limit=_PUBLISHED_VECTOR_COPY_PAGE_ROWS,
+                offset=offset,
+                include=["embeddings", "documents", "metadatas"],
+            )
+            ids = page["ids"]
+            if not ids:
+                return reused
+            offset += len(ids)
+            # Unquoted so the name is a runtime reference: quoting it would make
+            # the import look unused to the dead-code check.
+            embeddings = cast(Embeddings, page["embeddings"])  # noqa: TC006
+            documents = cast("list[str]", page["documents"])
+            metadatas = cast("list[Metadata]", page["metadatas"])
+            kept: list[int] = []
+            for index, metadata in enumerate(metadatas):
+                entry = _reusable_row_signature(metadata, managed_paths)
+                if entry is None:
+                    continue
+                relative_path, signature = entry
+                reused[relative_path] = signature
+                kept.append(index)
+            if kept:
+                candidate.add(
+                    ids=[ids[index] for index in kept],
+                    embeddings=[embeddings[index] for index in kept],
+                    documents=[documents[index] for index in kept],
+                    metadatas=[dict(metadatas[index]) for index in kept],
+                )
+
+    async def _seed_candidate_from_published(
+        self,
+        *,
+        candidate_vector_db: ChromaDb,
+        persisted_state: _PersistedIndexState | None,
+    ) -> dict[str, FileSignature]:
+        """Start a fresh candidate from the published index instead of from zero.
+
+        Publication retires the candidate checkpoint, so without this the next
+        refresh mints an empty candidate and re-embeds the whole corpus to
+        reproduce chunks byte-identical to ones already stored: every refresh
+        costs O(corpus) provider requests where the change was one file.
+
+        Matching ``IndexingSettings`` is what makes the copy sound. It pins the
+        chunker, the embedder identity and every corpus filter, so identical
+        bytes under identical settings produce identical chunks and identical
+        vectors. Whether the bytes are still identical is not assumed: each
+        copied path is recorded with the signature the published index stored
+        for it, and reconciliation compares that against the file on disk,
+        dropping and re-indexing whatever moved. Reuse is therefore an
+        optimization on top of the existing correctness check, not a new one.
+
+        The published collection is only ever read. Publication stays an atomic
+        swap into a separate collection.
+        """
+        if (
+            persisted_state is None
+            or persisted_state.status != _INDEXING_STATUS_COMPLETE
+            or persisted_state.collection is None
+            or persisted_state.settings != self._indexing_settings
+        ):
+            return {}
+        managed_paths = frozenset(
+            self._relative_path(file_path) for file_path in await asyncio.to_thread(self.list_files)
+        )
+        try:
+            reused = await asyncio.to_thread(
+                self._copy_published_vectors,
+                published_collection=persisted_state.collection,
+                candidate_vector_db=candidate_vector_db,
+                managed_paths=managed_paths,
+            )
+        except Exception:
+            # Reuse is an optimization, so a vector store that cannot serve the
+            # copy must cost a full rebuild rather than a failed refresh. The
+            # partially filled candidate is reset so the rebuild starts clean.
+            logger.warning(
+                "Falling back to a full knowledge rebuild after the published index could not be copied",
+                base_id=self.base_id,
+                collection=persisted_state.collection,
+                exc_info=True,
+            )
+            await asyncio.to_thread(self._reset_vector_db, candidate_vector_db)
+            return {}
+        logger.info(
+            "Reused published knowledge vectors in a new candidate",
+            base_id=self.base_id,
+            collection=candidate_vector_db.collection_name,
+            reused_files=len(reused),
+            managed_files=len(managed_paths),
+        )
+        return reused
+
     async def _open_candidate_run(self) -> _CandidateRun:
         """Resolve the durable candidate to continue, or start one clean candidate."""
         checkpoint = await asyncio.to_thread(load_candidate_checkpoint, self._base_storage_path)
@@ -1700,6 +1844,7 @@ class KnowledgeManager:
 
         embedder = BatchPrefetchEmbedder(inner=create_configured_embedder(self.config, self.runtime_paths))
         resumed = False
+        reused: dict[str, FileSignature] = {}
         if checkpoint is None:
             checkpoint = CandidateCheckpoint(
                 collection=self._candidate_collection_name(),
@@ -1711,6 +1856,15 @@ class KnowledgeManager:
             knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
             vector_db = _require_chroma_vector_db(knowledge)
             await asyncio.to_thread(self._reset_vector_db, vector_db)
+            reused = await self._seed_candidate_from_published(
+                candidate_vector_db=vector_db,
+                persisted_state=persisted_state,
+            )
+            checkpoint = await asyncio.to_thread(
+                save_candidate_checkpoint,
+                self._base_storage_path,
+                replace(checkpoint, completed=reused),
+            )
         else:
             knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
             vector_db = _require_chroma_vector_db(knowledge)
@@ -1733,6 +1887,9 @@ class KnowledgeManager:
             embedder=embedder,
             completed=dict(checkpoint.completed),
             failed=dict(checkpoint.failed),
+            # Rows this process just copied need no vector-existence probe: the
+            # copy already reported which paths actually received them.
+            verified=set(reused),
             journal_appends=checkpoint.replayed_journal_entries,
             resumed=resumed,
         )

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -19,7 +19,6 @@ from agno.knowledge.reader import ReaderFactory
 from agno.knowledge.reader.markdown_reader import MarkdownReader
 from agno.knowledge.reader.text_reader import TextReader
 from agno.vectordb.chroma import ChromaDb
-from chromadb.api.types import Embeddings, Metadata
 from chromadb.errors import NotFoundError
 
 from mindroom.chunking import SafeFixedSizeChunking
@@ -87,6 +86,7 @@ if TYPE_CHECKING:
     from agno.knowledge.document.base import Document
     from agno.knowledge.embedder.base import Embedder
     from agno.knowledge.reader.base import Reader
+    from chromadb.api.types import Embeddings, Metadata
 
     from mindroom.config.knowledge import KnowledgeGitConfig
     from mindroom.config.main import Config
@@ -214,6 +214,17 @@ class _CandidateRun:
     journal_appends: int = 0
     resumed: bool = False
     published: bool = False
+
+
+@dataclass(frozen=True)
+class _OpenedCandidate:
+    """One candidate collection made ready for a refresh to advance."""
+
+    checkpoint: CandidateCheckpoint
+    knowledge: Knowledge
+    vector_db: ChromaDb
+    reused: dict[str, FileSignature] = field(default_factory=dict)
+    resumed: bool = False
 
 
 @dataclass(frozen=True)
@@ -1713,9 +1724,7 @@ class KnowledgeManager:
             if not ids:
                 return reused
             offset += len(ids)
-            # Unquoted so the name is a runtime reference: quoting it would make
-            # the import look unused to the dead-code check.
-            embeddings = cast(Embeddings, page["embeddings"])  # noqa: TC006
+            embeddings: Embeddings = cast("Embeddings", page["embeddings"])
             documents = cast("list[str]", page["documents"])
             metadatas = cast("list[Metadata]", page["metadatas"])
             kept: list[int] = []
@@ -1734,11 +1743,36 @@ class KnowledgeManager:
                     metadatas=[dict(metadatas[index]) for index in kept],
                 )
 
+    def _reusable_published_collection(self, persisted_state: _PersistedIndexState | None) -> str | None:
+        """Return the published collection a fresh candidate may copy, if any.
+
+        Matching ``IndexingSettings`` is what makes a copy sound. They pin the
+        chunker, the embedder identity and every corpus filter, so identical
+        bytes under identical settings produce identical chunks and identical
+        vectors. Whether the bytes are still identical is not assumed here:
+        each copied path is recorded with the signature the published index
+        stored for it, and reconciliation compares that against the file on
+        disk, dropping and re-indexing whatever moved. Reuse is therefore an
+        optimization on top of the existing correctness check, not a new one.
+
+        Only a collection the metadata calls published is provably finished:
+        the rest of the candidate lifecycle treats any other collection as an
+        abandoned candidate it may reclaim.
+        """
+        if (
+            persisted_state is None
+            or persisted_state.status != _INDEXING_STATUS_COMPLETE
+            or persisted_state.collection is None
+            or persisted_state.settings != self._indexing_settings
+        ):
+            return None
+        return persisted_state.collection
+
     async def _seed_candidate_from_published(
         self,
         *,
         candidate_vector_db: ChromaDb,
-        persisted_state: _PersistedIndexState | None,
+        published_collection: str,
     ) -> dict[str, FileSignature]:
         """Start a fresh candidate from the published index instead of from zero.
 
@@ -1747,32 +1781,16 @@ class KnowledgeManager:
         reproduce chunks byte-identical to ones already stored: every refresh
         costs O(corpus) provider requests where the change was one file.
 
-        Matching ``IndexingSettings`` is what makes the copy sound. It pins the
-        chunker, the embedder identity and every corpus filter, so identical
-        bytes under identical settings produce identical chunks and identical
-        vectors. Whether the bytes are still identical is not assumed: each
-        copied path is recorded with the signature the published index stored
-        for it, and reconciliation compares that against the file on disk,
-        dropping and re-indexing whatever moved. Reuse is therefore an
-        optimization on top of the existing correctness check, not a new one.
-
         The published collection is only ever read. Publication stays an atomic
         swap into a separate collection.
         """
-        if (
-            persisted_state is None
-            or persisted_state.status != _INDEXING_STATUS_COMPLETE
-            or persisted_state.collection is None
-            or persisted_state.settings != self._indexing_settings
-        ):
-            return {}
         managed_paths = frozenset(
             self._relative_path(file_path) for file_path in await asyncio.to_thread(self.list_files)
         )
         try:
             reused = await asyncio.to_thread(
                 self._copy_published_vectors,
-                published_collection=persisted_state.collection,
+                published_collection=published_collection,
                 candidate_vector_db=candidate_vector_db,
                 managed_paths=managed_paths,
             )
@@ -1783,7 +1801,7 @@ class KnowledgeManager:
             logger.warning(
                 "Falling back to a full knowledge rebuild after the published index could not be copied",
                 base_id=self.base_id,
-                collection=persisted_state.collection,
+                collection=published_collection,
                 exc_info=True,
             )
             await asyncio.to_thread(self._reset_vector_db, candidate_vector_db)
@@ -1797,7 +1815,79 @@ class KnowledgeManager:
         )
         return reused
 
-    async def _open_candidate_run(self) -> _CandidateRun:
+    async def _record_seeded_candidate(self, checkpoint: CandidateCheckpoint) -> CandidateCheckpoint:
+        """Record a finished copy's claims even while the refresh is being cancelled.
+
+        The rows are already on disk; only this write makes them attributable.
+        Losing it is recoverable -- the seeding marker sends the next refresh
+        through a rebuild -- but that discards a whole corpus copy, so the write
+        is shielded and completed rather than abandoned.
+        """
+        save_task = asyncio.create_task(
+            asyncio.to_thread(save_candidate_checkpoint, self._base_storage_path, checkpoint),
+        )
+        try:
+            return await asyncio.shield(save_task)
+        except asyncio.CancelledError:
+            with suppress(Exception):
+                await save_task
+            raise
+
+    async def _rebuild_candidate_collection(
+        self,
+        checkpoint: CandidateCheckpoint,
+        *,
+        embedder: BatchPrefetchEmbedder,
+        published_collection: str | None,
+    ) -> _OpenedCandidate:
+        """Empty one candidate collection and seed it from the published index.
+
+        Two orderings here are load-bearing. The checkpoint names the
+        collection before ``Knowledge`` is built, because Agno creates a
+        missing collection on construction and a crash must never strand a
+        collection nothing references. And the checkpoint records that a copy
+        is in flight before the first row lands, because a crash between the
+        copy and its claims would leave rows nothing can attribute:
+        reconciliation deletes only what the checkpoint records.
+        """
+        checkpoint = await asyncio.to_thread(
+            save_candidate_checkpoint,
+            self._base_storage_path,
+            replace(checkpoint, completed={}, failed={}, seeding=published_collection is not None),
+        )
+        knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
+        vector_db = _require_chroma_vector_db(knowledge)
+        await asyncio.to_thread(self._reset_vector_db, vector_db)
+        if published_collection is None:
+            return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db)
+        reused = await self._seed_candidate_from_published(
+            candidate_vector_db=vector_db,
+            published_collection=published_collection,
+        )
+        checkpoint = await self._record_seeded_candidate(replace(checkpoint, completed=reused, seeding=False))
+        return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db, reused=reused)
+
+    async def _resume_candidate_collection(
+        self,
+        checkpoint: CandidateCheckpoint,
+        *,
+        embedder: BatchPrefetchEmbedder,
+    ) -> _OpenedCandidate:
+        """Continue a candidate whose recorded work is still backed by its collection."""
+        knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
+        vector_db = _require_chroma_vector_db(knowledge)
+        if await asyncio.to_thread(vector_db.exists):
+            return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db, resumed=True)
+        logger.warning(
+            "Knowledge candidate collection is missing; rebuilding it from scratch",
+            base_id=self.base_id,
+            collection=checkpoint.collection,
+        )
+        # Rebuilt without a copy: whatever lost this collection may equally have
+        # damaged the published one, and a full rebuild is the safe repair.
+        return await self._rebuild_candidate_collection(checkpoint, embedder=embedder, published_collection=None)
+
+    async def _open_candidate_run(self, *, force_reindex: bool = False) -> _CandidateRun:
         """Resolve the durable candidate to continue, or start one clean candidate."""
         checkpoint = await asyncio.to_thread(load_candidate_checkpoint, self._base_storage_path)
         persisted_state = await asyncio.to_thread(self._load_persisted_index_state)
@@ -1843,55 +1933,45 @@ class KnowledgeManager:
             checkpoint = None
 
         embedder = BatchPrefetchEmbedder(inner=create_configured_embedder(self.config, self.runtime_paths))
-        resumed = False
-        reused: dict[str, FileSignature] = {}
+        rebuild = checkpoint is None or checkpoint.seeding
         if checkpoint is None:
             checkpoint = CandidateCheckpoint(
                 collection=self._candidate_collection_name(),
                 settings=self._indexing_settings,
             )
-            # Persist the candidate's identity before its collection exists, so
-            # a crash can never strand a collection nothing references.
-            checkpoint = await asyncio.to_thread(save_candidate_checkpoint, self._base_storage_path, checkpoint)
-            knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
-            vector_db = _require_chroma_vector_db(knowledge)
-            await asyncio.to_thread(self._reset_vector_db, vector_db)
-            reused = await self._seed_candidate_from_published(
-                candidate_vector_db=vector_db,
-                persisted_state=persisted_state,
+        elif rebuild:
+            # The collection holds rows a cancelled copy never claimed, and
+            # nothing downstream can attribute them: reconciliation deletes
+            # only what the checkpoint records, so rows for a path that has
+            # since left the corpus would survive into the published index.
+            logger.warning(
+                "Rebuilding a knowledge candidate whose published-vector copy was interrupted",
+                base_id=self.base_id,
+                collection=checkpoint.collection,
             )
-            checkpoint = await asyncio.to_thread(
-                save_candidate_checkpoint,
-                self._base_storage_path,
-                replace(checkpoint, completed=reused),
+
+        if rebuild:
+            opened = await self._rebuild_candidate_collection(
+                checkpoint,
+                embedder=embedder,
+                published_collection=None if force_reindex else self._reusable_published_collection(persisted_state),
             )
         else:
-            knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
-            vector_db = _require_chroma_vector_db(knowledge)
-            if await asyncio.to_thread(vector_db.exists):
-                resumed = True
-            else:
-                logger.warning(
-                    "Knowledge candidate collection is missing; rebuilding it from scratch",
-                    base_id=self.base_id,
-                    collection=checkpoint.collection,
-                )
-                checkpoint = replace(checkpoint, completed={}, failed={})
-                checkpoint = await asyncio.to_thread(save_candidate_checkpoint, self._base_storage_path, checkpoint)
-                await asyncio.to_thread(self._reset_vector_db, vector_db)
+            opened = await self._resume_candidate_collection(checkpoint, embedder=embedder)
+        checkpoint = opened.checkpoint
 
         run = _CandidateRun(
             checkpoint=checkpoint,
-            knowledge=knowledge,
-            vector_db=vector_db,
+            knowledge=opened.knowledge,
+            vector_db=opened.vector_db,
             embedder=embedder,
             completed=dict(checkpoint.completed),
             failed=dict(checkpoint.failed),
             # Rows this process just copied need no vector-existence probe: the
             # copy already reported which paths actually received them.
-            verified=set(reused),
+            verified=set(opened.reused),
             journal_appends=checkpoint.replayed_journal_entries,
-            resumed=resumed,
+            resumed=opened.resumed,
         )
         # Reconcile candidates abandoned by earlier crashed refreshes now, so
         # storage stays bounded even when a build never reaches publication.
@@ -2171,8 +2251,14 @@ class KnowledgeManager:
         )
         run.journal_appends = 0
 
-    async def reindex_all(self) -> int:
-        """Advance the durable candidate index and publish it when it matches the source."""
+    async def reindex_all(self, *, force_reindex: bool = False) -> int:
+        """Advance the durable candidate index and publish it when it matches the source.
+
+        ``force_reindex`` is the operator asking for vectors to be rebuilt
+        rather than trusted, so it suppresses copying them from the published
+        index. Every other reason a rebuild is forced -- changed settings, a
+        missing collection -- the reuse gates already reject on their own.
+        """
         if not _semantic_indexing_enabled(self.config, self.base_id):
             self._last_refresh_error = None
             return 0
@@ -2184,7 +2270,7 @@ class KnowledgeManager:
             self._file_index_errors.clear()
             self._embedder_failure_streak = 0
             self._global_embedder_failure = None
-            run = await self._open_candidate_run()
+            run = await self._open_candidate_run(force_reindex=force_reindex)
             progress = _CandidateProgress(
                 base_id=self.base_id,
                 resumed=run.resumed,

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -12,7 +12,7 @@ from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeVar, cast, runtime_checkable
 from urllib.parse import quote, urlparse, urlunparse
 
 from agno.knowledge.reader import ReaderFactory
@@ -80,7 +80,7 @@ from mindroom.logging_config import get_logger
 from mindroom.strict_knowledge import StrictInsertKnowledge as Knowledge
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Iterable, Iterator, Mapping, Sequence
+    from collections.abc import Awaitable, Callable, Coroutine, Iterable, Iterator, Mapping, Sequence
     from pathlib import Path
 
     from agno.knowledge.document.base import Document
@@ -137,6 +137,7 @@ _PROGRESS_LOG_INTERVAL_SECONDS = 30.0
 #: taken as proof the fault is global rather than specific to a few files.
 _GLOBAL_EMBEDDER_FAILURE_STREAK = 20
 _EMBEDDING_RETRY_POLICY = EmbeddingRetryPolicy()
+_ShieldedResult = TypeVar("_ShieldedResult")
 #: Indirection point so fault-injection tests can drive backoff without waiting.
 _EMBEDDING_RETRY_SLEEP: Callable[[float], Awaitable[None]] = asyncio.sleep
 
@@ -309,6 +310,24 @@ class _PermanentEmbeddingError(Exception):
 
 def _raise_cancelled() -> NoReturn:
     raise asyncio.CancelledError
+
+
+async def _shielded_write(write: Coroutine[Any, Any, _ShieldedResult]) -> _ShieldedResult:
+    """Run one durable write to completion even if the caller is cancelled.
+
+    ``asyncio.shield`` only detaches the wait: the shielded task keeps running
+    either way, so a cancelled caller that does not drain it leaves the write
+    racing process exit. Draining swallows the write's own failure so that
+    cancellation, not the failure, is what the caller sees -- every user of
+    this treats a lost write as recoverable and cancellation as authoritative.
+    """
+    task = asyncio.create_task(write)
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        with suppress(Exception):
+            await task
+        raise
 
 
 def _iter_file_batches(files: Sequence[Path], batch_size: int) -> Iterator[list[Path]]:
@@ -1159,6 +1178,10 @@ class KnowledgeManager:
         try:
             await asyncio.shield(save_task)
         except asyncio.CancelledError:
+            # Drained without ``_shielded_write``'s suppression on purpose: the
+            # caller marks the index published on a cancelled-but-saved outcome,
+            # so a write that failed has to surface instead of being reported
+            # as a cancellation that saved.
             await save_task
             return True
         return False
@@ -1724,9 +1747,11 @@ class KnowledgeManager:
             if not ids:
                 return reused
             offset += len(ids)
+            # Chroma types every one of these optional because the caller may
+            # not have asked for it; this one did, in the ``include`` above.
             embeddings: Embeddings = cast("Embeddings", page["embeddings"])
-            documents = cast("list[str]", page["documents"])
-            metadatas = cast("list[Metadata]", page["metadatas"])
+            documents: list[str] = cast("list[str]", page["documents"])
+            metadatas: list[Metadata] = cast("list[Metadata]", page["metadatas"])
             kept: list[int] = []
             for index, metadata in enumerate(metadatas):
                 entry = _reusable_row_signature(metadata, managed_paths)
@@ -1815,24 +1840,6 @@ class KnowledgeManager:
         )
         return reused
 
-    async def _record_seeded_candidate(self, checkpoint: CandidateCheckpoint) -> CandidateCheckpoint:
-        """Record a finished copy's claims even while the refresh is being cancelled.
-
-        The rows are already on disk; only this write makes them attributable.
-        Losing it is recoverable -- the seeding marker sends the next refresh
-        through a rebuild -- but that discards a whole corpus copy, so the write
-        is shielded and completed rather than abandoned.
-        """
-        save_task = asyncio.create_task(
-            asyncio.to_thread(save_candidate_checkpoint, self._base_storage_path, checkpoint),
-        )
-        try:
-            return await asyncio.shield(save_task)
-        except asyncio.CancelledError:
-            with suppress(Exception):
-                await save_task
-            raise
-
     async def _rebuild_candidate_collection(
         self,
         checkpoint: CandidateCheckpoint,
@@ -1840,31 +1847,49 @@ class KnowledgeManager:
         embedder: BatchPrefetchEmbedder,
         published_collection: str | None,
     ) -> _OpenedCandidate:
-        """Empty one candidate collection and seed it from the published index.
+        """Empty one candidate collection, seeding it when a copy source is given.
 
-        Two orderings here are load-bearing. The checkpoint names the
-        collection before ``Knowledge`` is built, because Agno creates a
-        missing collection on construction and a crash must never strand a
-        collection nothing references. And the checkpoint records that a copy
-        is in flight before the first row lands, because a crash between the
-        copy and its claims would leave rows nothing can attribute:
-        reconciliation deletes only what the checkpoint records.
+        Three orderings here are load-bearing, and the ``seeding`` marker is
+        what makes the middle one survive a crash.
+
+        The checkpoint names the collection before ``Knowledge`` is built,
+        because Agno creates a missing collection on construction and a crash
+        must never strand a collection nothing references.
+
+        The marker is then set for the whole rebuild, not just the copy. A
+        rebuild inherits a collection whose rows the checkpoint has stopped
+        claiming, and only the reset makes that true; until the reset lands and
+        the new claims are recorded, the rows in there are attributable to
+        nothing. Reconciliation deletes only what the checkpoint records, so a
+        candidate resumed inside that window would carry rows for paths that
+        have since left the corpus straight into the published index.
+
+        The marker is therefore cleared last, once the collection is known
+        empty and whatever replaced its contents is durable.
         """
         checkpoint = await asyncio.to_thread(
             save_candidate_checkpoint,
             self._base_storage_path,
-            replace(checkpoint, completed={}, failed={}, seeding=published_collection is not None),
+            replace(checkpoint, completed={}, failed={}, seeding=True),
         )
         knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
         vector_db = _require_chroma_vector_db(knowledge)
         await asyncio.to_thread(self._reset_vector_db, vector_db)
-        if published_collection is None:
-            return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db)
-        reused = await self._seed_candidate_from_published(
-            candidate_vector_db=vector_db,
-            published_collection=published_collection,
+        reused = (
+            {}
+            if published_collection is None
+            else await self._seed_candidate_from_published(
+                candidate_vector_db=vector_db,
+                published_collection=published_collection,
+            )
         )
-        checkpoint = await self._record_seeded_candidate(replace(checkpoint, completed=reused, seeding=False))
+        checkpoint = await _shielded_write(
+            asyncio.to_thread(
+                save_candidate_checkpoint,
+                self._base_storage_path,
+                replace(checkpoint, completed=reused, seeding=False),
+            ),
+        )
         return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db, reused=reused)
 
     async def _resume_candidate_collection(
@@ -1873,19 +1898,33 @@ class KnowledgeManager:
         *,
         embedder: BatchPrefetchEmbedder,
     ) -> _OpenedCandidate:
-        """Continue a candidate whose recorded work is still backed by its collection."""
+        """Continue a candidate whose recorded work is still backed by its collection.
+
+        The collection is probed before ``Knowledge`` is built, because Agno
+        creates a missing collection on construction: asked afterwards, the
+        probe always answers yes and a candidate whose vectors are gone would
+        be resumed still carrying claims nothing backs.
+        """
+        if not await asyncio.to_thread(
+            chroma_collection_exists,
+            self._base_storage_path,
+            checkpoint.collection,
+        ):
+            logger.warning(
+                "Knowledge candidate collection is missing; rebuilding it from scratch",
+                base_id=self.base_id,
+                collection=checkpoint.collection,
+            )
+            # Rebuilt without a copy: whatever lost this collection may equally
+            # have damaged the published one, and a full rebuild is the safe repair.
+            return await self._rebuild_candidate_collection(checkpoint, embedder=embedder, published_collection=None)
         knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
-        vector_db = _require_chroma_vector_db(knowledge)
-        if await asyncio.to_thread(vector_db.exists):
-            return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db, resumed=True)
-        logger.warning(
-            "Knowledge candidate collection is missing; rebuilding it from scratch",
-            base_id=self.base_id,
-            collection=checkpoint.collection,
+        return _OpenedCandidate(
+            checkpoint=checkpoint,
+            knowledge=knowledge,
+            vector_db=_require_chroma_vector_db(knowledge),
+            resumed=True,
         )
-        # Rebuilt without a copy: whatever lost this collection may equally have
-        # damaged the published one, and a full rebuild is the safe repair.
-        return await self._rebuild_candidate_collection(checkpoint, embedder=embedder, published_collection=None)
 
     async def _open_candidate_run(self, *, force_reindex: bool = False) -> _CandidateRun:
         """Resolve the durable candidate to continue, or start one clean candidate."""
@@ -1931,6 +1970,20 @@ class KnowledgeManager:
             await self._delete_candidate_collection(checkpoint.collection)
             await asyncio.to_thread(delete_candidate_checkpoint, self._base_storage_path)
             checkpoint = None
+        if checkpoint is not None and force_reindex:
+            # A refresh that never published leaves its candidate behind, and
+            # that candidate's claims are exactly the vectors a forced rebuild
+            # was asked to stop trusting. Suppressing the copy alone would keep
+            # every file the interrupted build had already embedded.
+            logger.info(
+                "Discarding knowledge candidate because a rebuild was forced",
+                base_id=self.base_id,
+                collection=checkpoint.collection,
+                completed=len(checkpoint.completed),
+            )
+            await self._delete_candidate_collection(checkpoint.collection)
+            await asyncio.to_thread(delete_candidate_checkpoint, self._base_storage_path)
+            checkpoint = None
 
         embedder = BatchPrefetchEmbedder(inner=create_configured_embedder(self.config, self.runtime_paths))
         rebuild = checkpoint is None or checkpoint.seeding
@@ -1939,7 +1992,7 @@ class KnowledgeManager:
                 collection=self._candidate_collection_name(),
                 settings=self._indexing_settings,
             )
-        elif rebuild:
+        elif checkpoint.seeding:
             # The collection holds rows a cancelled copy never claimed, and
             # nothing downstream can attribute them: reconciliation deletes
             # only what the checkpoint records, so rows for a path that has
@@ -2296,13 +2349,8 @@ class KnowledgeManager:
         Per-batch journal appends already made progress durable, so this is a
         compaction, not the write that protects the work.
         """
-        compact_task = asyncio.create_task(self._compact_candidate_checkpoint(run, force=True))
         try:
-            await asyncio.shield(compact_task)
-        except asyncio.CancelledError:
-            with suppress(Exception):
-                await compact_task
-            raise
+            await _shielded_write(self._compact_candidate_checkpoint(run, force=True))
         except Exception:
             logger.warning(
                 "Failed to compact knowledge candidate checkpoint",

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1896,6 +1896,27 @@ class KnowledgeManager:
         )
         return reused
 
+    def _candidate_holds_unclaimed_rows(self, checkpoint: CandidateCheckpoint) -> bool:
+        """Return whether a candidate holds vectors its checkpoint never claimed.
+
+        The candidate's invariant is that its collection only holds rows the
+        checkpoint accounts for, because reconciliation derives every deletion
+        from the checkpoint: rows outside it are invisible, and would ride into
+        the published index even for a path that has left the corpus.
+
+        A copy is the only thing that writes rows before recording them, and it
+        records every path in one write once the last row lands. Violating the
+        invariant therefore has exactly one shape -- no claims at all, and a
+        collection that is not empty -- which one bounded query answers.
+        """
+        if checkpoint.completed:
+            return False
+        vector_db = self._build_vector_db(checkpoint.collection)
+        if not vector_db.exists():
+            return False
+        collection = vector_db.client.get_collection(name=vector_db.collection_name)
+        return bool(collection.get(limit=1, include=[])["ids"])
+
     async def _rebuild_candidate_collection(
         self,
         checkpoint: CandidateCheckpoint,
@@ -1905,47 +1926,41 @@ class KnowledgeManager:
     ) -> _OpenedCandidate:
         """Empty one candidate collection, seeding it when a copy source is given.
 
-        Three orderings here are load-bearing, and the ``seeding`` marker is
-        what makes the middle one survive a crash.
+        Two orderings are load-bearing. The checkpoint names the collection
+        before ``Knowledge`` is built, because Agno creates a missing collection
+        on construction and a crash must never strand a collection nothing
+        references. And the copy's claims are recorded in one write after the
+        last row lands, never per page, because a file's chunks can span pages
+        and a claim covering only some of them would publish a silently
+        truncated file.
 
-        The checkpoint names the collection before ``Knowledge`` is built,
-        because Agno creates a missing collection on construction and a crash
-        must never strand a collection nothing references.
-
-        The marker is then set for the whole rebuild, not just the copy. A
-        rebuild inherits a collection whose rows the checkpoint has stopped
-        claiming, and only the reset makes that true; until the reset lands and
-        the new claims are recorded, the rows in there are attributable to
-        nothing. Reconciliation deletes only what the checkpoint records, so a
-        candidate resumed inside that window would carry rows for paths that
-        have since left the corpus straight into the published index.
-
-        The marker is therefore cleared last, once the collection is known
-        empty and whatever replaced its contents is durable.
+        Recording the claims last means a crash can leave rows the checkpoint
+        does not account for. That state is recoverable rather than prevented:
+        it is exactly ``completed`` empty with a non-empty collection, which
+        ``_candidate_holds_unclaimed_rows`` detects on the next open.
         """
         checkpoint = await asyncio.to_thread(
             save_candidate_checkpoint,
             self._base_storage_path,
-            replace(checkpoint, completed={}, failed={}, seeding=True),
+            replace(checkpoint, completed={}, failed={}),
         )
         knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
         vector_db = _require_chroma_vector_db(knowledge)
         await asyncio.to_thread(self._reset_vector_db, vector_db)
-        reused = (
-            {}
-            if published_collection is None
-            else await self._seed_candidate_from_published(
-                candidate_vector_db=vector_db,
-                published_collection=published_collection,
+        if published_collection is None:
+            return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db)
+        reused = await self._seed_candidate_from_published(
+            candidate_vector_db=vector_db,
+            published_collection=published_collection,
+        )
+        if reused:
+            checkpoint = await _shielded_write(
+                asyncio.to_thread(
+                    save_candidate_checkpoint,
+                    self._base_storage_path,
+                    replace(checkpoint, completed=reused),
+                ),
             )
-        )
-        checkpoint = await _shielded_write(
-            asyncio.to_thread(
-                save_candidate_checkpoint,
-                self._base_storage_path,
-                replace(checkpoint, completed=reused, seeding=False),
-            ),
-        )
         return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db, reused=reused)
 
     async def _resume_candidate_collection(
@@ -1954,33 +1969,19 @@ class KnowledgeManager:
         *,
         embedder: BatchPrefetchEmbedder,
     ) -> _OpenedCandidate:
-        """Continue a candidate whose recorded work is still backed by its collection.
-
-        The collection is probed before ``Knowledge`` is built, because Agno
-        creates a missing collection on construction: asked afterwards, the
-        probe always answers yes and a candidate whose vectors are gone would
-        be resumed still carrying claims nothing backs.
-        """
-        if not await asyncio.to_thread(
-            chroma_collection_exists,
-            self._base_storage_path,
-            checkpoint.collection,
-        ):
-            logger.warning(
-                "Knowledge candidate collection is missing; rebuilding it from scratch",
-                base_id=self.base_id,
-                collection=checkpoint.collection,
-            )
-            # Rebuilt without a copy: whatever lost this collection may equally
-            # have damaged the published one, and a full rebuild is the safe repair.
-            return await self._rebuild_candidate_collection(checkpoint, embedder=embedder, published_collection=None)
+        """Continue a candidate whose recorded work is still backed by its collection."""
         knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
-        return _OpenedCandidate(
-            checkpoint=checkpoint,
-            knowledge=knowledge,
-            vector_db=_require_chroma_vector_db(knowledge),
-            resumed=True,
+        vector_db = _require_chroma_vector_db(knowledge)
+        if await asyncio.to_thread(vector_db.exists):
+            return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db, resumed=True)
+        logger.warning(
+            "Knowledge candidate collection is missing; rebuilding it from scratch",
+            base_id=self.base_id,
+            collection=checkpoint.collection,
         )
+        # Rebuilt without a copy: whatever lost this collection may equally have
+        # damaged the published one, and a full rebuild is the safe repair.
+        return await self._rebuild_candidate_collection(checkpoint, embedder=embedder, published_collection=None)
 
     async def _open_candidate_run(self, *, force_reindex: bool = False) -> _CandidateRun:
         """Resolve the durable candidate to continue, or start one clean candidate."""
@@ -2042,22 +2043,19 @@ class KnowledgeManager:
             checkpoint = None
 
         embedder = BatchPrefetchEmbedder(inner=create_configured_embedder(self.config, self.runtime_paths))
-        rebuild = checkpoint is None or checkpoint.seeding
+        rebuild = checkpoint is None
         if checkpoint is None:
             checkpoint = CandidateCheckpoint(
                 collection=self._candidate_collection_name(),
                 settings=self._indexing_settings,
             )
-        elif checkpoint.seeding:
-            # The collection holds rows a cancelled copy never claimed, and
-            # nothing downstream can attribute them: reconciliation deletes
-            # only what the checkpoint records, so rows for a path that has
-            # since left the corpus would survive into the published index.
+        elif await asyncio.to_thread(self._candidate_holds_unclaimed_rows, checkpoint):
             logger.warning(
-                "Rebuilding a knowledge candidate whose published-vector copy was interrupted",
+                "Rebuilding a knowledge candidate holding vectors it never claimed",
                 base_id=self.base_id,
                 collection=checkpoint.collection,
             )
+            rebuild = True
 
         if rebuild:
             opened = await self._rebuild_candidate_collection(

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -319,6 +319,23 @@ def _raise_cancelled() -> NoReturn:
     raise asyncio.CancelledError
 
 
+async def _complete_task_before_cancelling(task: asyncio.Task[_ShieldedResult]) -> _ShieldedResult:
+    """Drain one owned task before propagating cancellation, however often requested."""
+    try:
+        return await asyncio.shield(task)
+    except asyncio.CancelledError:
+        while not task.done():
+            try:
+                await asyncio.shield(task)
+            except asyncio.CancelledError:
+                continue
+            except Exception:
+                break
+        with suppress(Exception):
+            task.result()
+        raise
+
+
 async def _shielded_write(write: Coroutine[Any, Any, _ShieldedResult]) -> _ShieldedResult:
     """Run one durable write to completion even if the caller is cancelled.
 
@@ -327,14 +344,9 @@ async def _shielded_write(write: Coroutine[Any, Any, _ShieldedResult]) -> _Shiel
     racing process exit. Draining swallows the write's own failure so that
     cancellation, not the failure, is what the caller sees -- every user of
     this treats a lost write as recoverable and cancellation as authoritative.
+    The shared drain also defers repeated cancellation until the write finishes.
     """
-    task = asyncio.create_task(write)
-    try:
-        return await asyncio.shield(task)
-    except asyncio.CancelledError:
-        with suppress(Exception):
-            await task
-        raise
+    return await _complete_task_before_cancelling(asyncio.create_task(write))
 
 
 def _iter_file_batches(files: Sequence[Path], batch_size: int) -> Iterator[list[Path]]:
@@ -614,7 +626,11 @@ def _reusable_row_signature(
     source_mtime_ns = metadata.get(_SOURCE_MTIME_NS_KEY)
     source_size = metadata.get(_SOURCE_SIZE_KEY)
     source_digest = metadata.get(_SOURCE_DIGEST_KEY)
-    if not isinstance(source_mtime_ns, int) or not isinstance(source_size, int) or not isinstance(source_digest, str):
+    if isinstance(source_mtime_ns, bool) or isinstance(source_size, bool):
+        return None
+    if not isinstance(source_mtime_ns, int) or not isinstance(source_size, int) or source_size < 0:
+        return None
+    if not isinstance(source_digest, str) or not source_digest:
         return None
     return source_path, (source_mtime_ns, source_size, source_digest)
 
@@ -1869,11 +1885,15 @@ class KnowledgeManager:
             self._relative_path(file_path) for file_path in await asyncio.to_thread(self.list_files)
         )
         try:
-            reused = await asyncio.to_thread(
-                self._copy_published_vectors,
-                published_collection=published_collection,
-                candidate_vector_db=candidate_vector_db,
-                managed_paths=managed_paths,
+            reused = await _complete_task_before_cancelling(
+                asyncio.create_task(
+                    asyncio.to_thread(
+                        self._copy_published_vectors,
+                        published_collection=published_collection,
+                        candidate_vector_db=candidate_vector_db,
+                        managed_paths=managed_paths,
+                    ),
+                ),
             )
         except Exception:
             # Reuse is an optimization, so a vector store that cannot serve the
@@ -1896,22 +1916,24 @@ class KnowledgeManager:
         )
         return reused
 
-    def _candidate_holds_unclaimed_rows(self, checkpoint: CandidateCheckpoint) -> bool:
-        """Return whether a candidate holds vectors its checkpoint never claimed.
+    def _candidate_holds_unclaimed_rows(
+        self,
+        checkpoint: CandidateCheckpoint,
+        *,
+        embedder: Embedder,
+    ) -> bool:
+        """Return whether an interrupted bulk copy is visible from candidate shape.
 
-        The candidate's invariant is that its collection only holds rows the
-        checkpoint accounts for, because reconciliation derives every deletion
-        from the checkpoint: rows outside it are invisible, and would ride into
-        the published index even for a path that has left the corpus.
-
-        A copy is the only thing that writes rows before recording them, and it
-        records every path in one write once the last row lands. Violating the
-        invariant therefore has exactly one shape -- no claims at all, and a
-        collection that is not empty -- which one bounded query answers.
+        The published-vector copy writes many paths before recording any claim,
+        then records every copied path in one write after the last row lands.
+        Its interrupted shape is therefore no claims and a non-empty collection,
+        which one bounded query answers. Ordinary indexing records each file
+        immediately after its rows land, so its pre-existing unclaimed window is
+        bounded by the in-flight file rather than the whole copied corpus.
         """
         if checkpoint.completed:
             return False
-        vector_db = self._build_vector_db(checkpoint.collection)
+        vector_db = self._build_vector_db(checkpoint.collection, embedder=embedder)
         if not vector_db.exists():
             return False
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
@@ -1934,10 +1956,10 @@ class KnowledgeManager:
         and a claim covering only some of them would publish a silently
         truncated file.
 
-        Recording the claims last means a crash can leave rows the checkpoint
-        does not account for. That state is recoverable rather than prevented:
-        it is exactly ``completed`` empty with a non-empty collection, which
-        ``_candidate_holds_unclaimed_rows`` detects on the next open.
+        An interrupted published copy can leave rows the checkpoint does not
+        account for. That copy-specific state is recoverable rather than
+        prevented: it leaves ``completed`` empty with a non-empty collection,
+        which ``_candidate_holds_unclaimed_rows`` detects on the next open.
         """
         checkpoint = await asyncio.to_thread(
             save_candidate_checkpoint,
@@ -1969,19 +1991,32 @@ class KnowledgeManager:
         *,
         embedder: BatchPrefetchEmbedder,
     ) -> _OpenedCandidate:
-        """Continue a candidate whose recorded work is still backed by its collection."""
+        """Continue a candidate whose recorded work is still backed by its collection.
+
+        Probe before building ``Knowledge`` because Agno creates a missing
+        collection on construction, after which an existence check always
+        answers yes.
+        """
+        if not await asyncio.to_thread(
+            chroma_collection_exists,
+            self._base_storage_path,
+            checkpoint.collection,
+        ):
+            logger.warning(
+                "Knowledge candidate collection is missing; rebuilding it from scratch",
+                base_id=self.base_id,
+                collection=checkpoint.collection,
+            )
+            # Rebuilt without a copy: whatever lost this collection may equally
+            # have damaged the published one, and a full rebuild is the safe repair.
+            return await self._rebuild_candidate_collection(checkpoint, embedder=embedder, published_collection=None)
         knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
-        vector_db = _require_chroma_vector_db(knowledge)
-        if await asyncio.to_thread(vector_db.exists):
-            return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db, resumed=True)
-        logger.warning(
-            "Knowledge candidate collection is missing; rebuilding it from scratch",
-            base_id=self.base_id,
-            collection=checkpoint.collection,
+        return _OpenedCandidate(
+            checkpoint=checkpoint,
+            knowledge=knowledge,
+            vector_db=_require_chroma_vector_db(knowledge),
+            resumed=True,
         )
-        # Rebuilt without a copy: whatever lost this collection may equally have
-        # damaged the published one, and a full rebuild is the safe repair.
-        return await self._rebuild_candidate_collection(checkpoint, embedder=embedder, published_collection=None)
 
     async def _open_candidate_run(self, *, force_reindex: bool = False) -> _CandidateRun:
         """Resolve the durable candidate to continue, or start one clean candidate."""
@@ -2049,7 +2084,7 @@ class KnowledgeManager:
                 collection=self._candidate_collection_name(),
                 settings=self._indexing_settings,
             )
-        elif await asyncio.to_thread(self._candidate_holds_unclaimed_rows, checkpoint):
+        elif await asyncio.to_thread(self._candidate_holds_unclaimed_rows, checkpoint, embedder=embedder):
             logger.warning(
                 "Rebuilding a knowledge candidate holding vectors it never claimed",
                 base_id=self.base_id,

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -533,7 +533,7 @@ async def _refresh_knowledge_binding_locked(
         )
         if unchanged_result is not None:
             return unchanged_result
-        indexed_count = await manager.reindex_all()
+        indexed_count = await manager.reindex_all(force_reindex=force_reindex)
         if manager._last_refresh_error is not None:
             error = redact_credentials_in_text(manager._last_refresh_error)
             await asyncio.to_thread(mark_published_index_refresh_failed_preserving_last_good, key, error=error)

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -3338,6 +3338,47 @@ async def test_cancelled_publish_metadata_save_keeps_published_candidate_collect
 
 
 @pytest.mark.asyncio
+async def test_publish_metadata_save_finishes_before_repeated_cancellation_escapes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repeated cancellation must not interrupt the metadata save drain."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths)
+    candidate_vector_db = manager._build_vector_db(manager._candidate_collection_name())
+    loop = asyncio.get_running_loop()
+    save_started = asyncio.Event()
+    release_save = Event()
+
+    def _blocked_save(_self: KnowledgeManager, *_args: object, **_kwargs: object) -> None:
+        loop.call_soon_threadsafe(save_started.set)
+        assert release_save.wait(timeout=5)
+
+    monkeypatch.setattr(KnowledgeManager, "_save_persisted_index_state", _blocked_save)
+    save = asyncio.create_task(
+        manager._save_candidate_publish_metadata(
+            candidate_vector_db=candidate_vector_db,
+            indexed_count=0,
+            source_signature="source-signature",
+        ),
+    )
+    await save_started.wait()
+    try:
+        save.cancel()
+        await asyncio.sleep(0)
+        save.cancel()
+        await asyncio.sleep(0)
+        assert not save.done(), "repeated cancellation escaped before the metadata save finished"
+    finally:
+        release_save.set()
+
+    assert await save is True
+
+
+@pytest.mark.asyncio
 async def test_refresh_never_publishes_while_source_keeps_changing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -7934,8 +7934,13 @@ async def test_git_query_and_fragment_tokens_stay_out_of_persistent_remote_and_m
 
 
 @pytest.mark.asyncio
-async def test_git_pull_that_changes_one_file_only_reindexes_that_file(tmp_path: Path) -> None:
+async def test_git_pull_that_changes_one_file_only_reindexes_that_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A one-file commit must cost one file's indexing, not the whole checkout's."""
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
     remote_work = tmp_path / "remote-work"
     remote_work.mkdir()
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -2054,10 +2054,11 @@ async def test_cancelled_refresh_waiting_for_source_lock_does_not_touch_running_
         original_save_refreshing(*args, **kwargs)
         refreshing_write_count += 1
 
-    async def _blocked_reindex(self: KnowledgeManager) -> int:
+    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+        _ = force_reindex
         first_entered.set()
         await release_first.wait()
-        return await original_reindex(self)
+        return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(knowledge_refresh_runner, "mark_published_index_refresh_running", _track_refreshing_state)
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _blocked_reindex)
@@ -3449,7 +3450,8 @@ async def test_same_physical_binding_refreshes_are_serialized_across_config_chan
     max_active_refreshes = 0
     call_count = 0
 
-    async def _blocked_reindex(self: KnowledgeManager) -> int:
+    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+        _ = force_reindex
         _ = self
         nonlocal active_refreshes, max_active_refreshes, call_count
         active_refreshes += 1
@@ -3500,7 +3502,8 @@ async def test_shared_source_mutation_waits_for_duplicate_base_refresh(
     release_refresh = asyncio.Event()
     mutation_entered = asyncio.Event()
 
-    async def _blocked_reindex(self: KnowledgeManager) -> int:
+    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+        _ = force_reindex
         _ = self
         refresh_entered.set()
         await release_refresh.wait()
@@ -4857,7 +4860,8 @@ async def test_cold_refresh_exception_surfaces_failed_availability_and_backoff(
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
 
-    async def _raise_reindex(self: KnowledgeManager) -> int:
+    async def _raise_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+        _ = force_reindex
         _ = self
         msg = "cold refresh failed"
         raise RuntimeError(msg)
@@ -5066,7 +5070,8 @@ async def test_api_status_reports_direct_refresh_runner_reindex(
     started = asyncio.Event()
     release = asyncio.Event()
 
-    async def _blocked_reindex(self: KnowledgeManager) -> int:
+    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+        _ = force_reindex
         _ = self
         started.set()
         await release.wait()
@@ -6673,13 +6678,13 @@ async def test_local_noop_refresh_reports_published_index(tmp_path: Path, monkey
     reindex_count = 0
     original_reindex = KnowledgeManager.reindex_all
 
-    async def _track_reindex(self: KnowledgeManager) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
         nonlocal reindex_count
         reindex_count += 1
         if reindex_count > 1:
             msg = "unchanged local refresh should not reindex"
             raise AssertionError(msg)
-        return await original_reindex(self)
+        return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
 
@@ -6707,10 +6712,10 @@ async def test_local_refresh_reindexes_when_content_changes_with_same_mtime_and_
     reindex_count = 0
     original_reindex = KnowledgeManager.reindex_all
 
-    async def _track_reindex(self: KnowledgeManager) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
         nonlocal reindex_count
         reindex_count += 1
-        return await original_reindex(self)
+        return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
 
@@ -6741,8 +6746,8 @@ async def test_refresh_does_not_synthesize_missing_published_metadata(
     runtime_paths = runtime_paths_for(config)
     original_reindex = KnowledgeManager.reindex_all
 
-    async def _delete_metadata_after_reindex(self: KnowledgeManager) -> int:
-        indexed_count = await original_reindex(self)
+    async def _delete_metadata_after_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+        indexed_count = await original_reindex(self, force_reindex=force_reindex)
         self._indexing_settings_path.unlink()
         return indexed_count
 
@@ -6824,9 +6829,9 @@ async def test_git_refresh_syncs_before_reindex_and_publishes_revision_without_s
         _set_git_tracked_files(self, "doc.md")
         return {"updated": True, "changed_count": 1, "removed_count": 0}
 
-    async def _track_reindex(self: KnowledgeManager) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
         order.append("reindex")
-        return await original_reindex(self)
+        return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync_success)
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
@@ -6936,13 +6941,13 @@ async def test_git_noop_refresh_skips_full_reindex_when_index_is_complete(
     reindex_count = 0
     original_reindex = KnowledgeManager.reindex_all
 
-    async def _track_reindex(self: KnowledgeManager) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
         nonlocal reindex_count
         reindex_count += 1
         if reindex_count > 1:
             msg = "unchanged git poll should not reindex"
             raise AssertionError(msg)
-        return await original_reindex(self)
+        return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
 
@@ -7187,10 +7192,10 @@ async def test_git_noop_refresh_ignores_untracked_indexable_file_changes(
         _set_git_tracked_files(self, "doc.md")
         return result
 
-    async def _track_reindex(self: KnowledgeManager) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
         nonlocal reindex_count
         reindex_count += 1
-        return await original_reindex(self)
+        return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync)
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
@@ -7239,10 +7244,10 @@ async def test_git_noop_refresh_rebuilds_when_collection_is_missing(
         _set_git_tracked_files(self, "doc.md")
         return result
 
-    async def _track_reindex(self: KnowledgeManager) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
         nonlocal reindex_count
         reindex_count += 1
-        return await original_reindex(self)
+        return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync)
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
@@ -7330,10 +7335,10 @@ async def test_git_noop_refresh_rebuilds_after_chunking_config_change(
         _set_git_tracked_files(self, "doc.md")
         return result
 
-    async def _track_reindex(self: KnowledgeManager) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
         nonlocal reindex_count
         reindex_count += 1
-        return await original_reindex(self)
+        return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync)
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
@@ -7382,10 +7387,10 @@ async def test_force_git_reindex_bypasses_noop_fast_path(
         _set_git_tracked_files(self, "doc.md")
         return result
 
-    async def _track_reindex(self: KnowledgeManager) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
         nonlocal reindex_count
         reindex_count += 1
-        return await original_reindex(self)
+        return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(KnowledgeManager, "sync_git_source", _sync)
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, replace
 from itertools import count
 from pathlib import Path
 from threading import Event, Lock, get_ident
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, ClassVar, cast
 from unittest.mock import MagicMock
 
 import httpx
@@ -101,7 +101,7 @@ class _Collection:
             ids=[str(item["id"]) for item in selected],
             metadatas=[dict(item["metadata"]) for item in selected],
             documents=[str(item["content"]) for item in selected],
-            embeddings=[list(item["embedding"]) for item in selected],  # type: ignore[arg-type]
+            embeddings=[list(cast("list[float]", item["embedding"])) for item in selected],
             include=include,
         )
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -3379,6 +3379,45 @@ async def test_publish_metadata_save_finishes_before_repeated_cancellation_escap
 
 
 @pytest.mark.asyncio
+async def test_cancelled_publish_metadata_save_surfaces_a_failed_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled-but-failed metadata save must not report a publication."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths)
+    candidate_vector_db = manager._build_vector_db(manager._candidate_collection_name())
+    loop = asyncio.get_running_loop()
+    save_started = asyncio.Event()
+    release_save = Event()
+
+    def _failed_save(_self: KnowledgeManager, *_args: object, **_kwargs: object) -> None:
+        loop.call_soon_threadsafe(save_started.set)
+        assert release_save.wait(timeout=5)
+        msg = "publish metadata write failed"
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(KnowledgeManager, "_save_persisted_index_state", _failed_save)
+    save = asyncio.create_task(
+        manager._save_candidate_publish_metadata(
+            candidate_vector_db=candidate_vector_db,
+            indexed_count=0,
+            source_signature="source-signature",
+        ),
+    )
+    await save_started.wait()
+    save.cancel()
+    await asyncio.sleep(0)
+    release_save.set()
+
+    with pytest.raises(RuntimeError, match="publish metadata write failed"):
+        await save
+
+
+@pytest.mark.asyncio
 async def test_refresh_never_publishes_while_source_keeps_changing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -10,6 +10,7 @@ import subprocess
 import sys
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
+from itertools import count
 from pathlib import Path
 from threading import Event, Lock, get_ident
 from typing import TYPE_CHECKING, ClassVar
@@ -75,6 +76,9 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
 
 
+_vector_row_ids = count()
+
+
 class _Collection:
     def __init__(self, name: str) -> None:
         self._name = name
@@ -87,15 +91,51 @@ class _Collection:
         include: list[str] | None = None,
         where: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        _ = include
         with _VectorDb.lock:
             selected_all = list(_VectorDb.collections.get(self._name, []))
         if where:
             key, condition = next(iter(where.items()))
             selected_all = [item for item in selected_all if metadata_matches(item["metadata"], key, condition)]
         selected = selected_all[offset:] if limit is None else selected_all[offset : offset + limit]
-        ids = [str(index) for index in range(offset, offset + len(selected))]
-        return {"ids": ids, "metadatas": [dict(item["metadata"]) for item in selected]}
+        included = set(include or [])
+        payload: dict[str, object] = {
+            "ids": [str(item["id"]) for item in selected],
+            "metadatas": [dict(item["metadata"]) for item in selected],
+        }
+        if "documents" in included:
+            payload["documents"] = [str(item["content"]) for item in selected]
+        if "embeddings" in included:
+            payload["embeddings"] = [list(item["embedding"]) for item in selected]
+        return payload
+
+    def add(
+        self,
+        *,
+        ids: list[str],
+        embeddings: list[list[float]],
+        documents: list[str],
+        metadatas: list[dict[str, object]],
+    ) -> None:
+        if not ids:
+            # Chroma rejects an empty write rather than treating it as a no-op.
+            message = "Expected Embeddings to be non-empty list or numpy array, got [] in add."
+            raise ValueError(message)
+        with _VectorDb.lock:
+            _VectorDb.collections.setdefault(self._name, []).extend(
+                {
+                    "id": identifier,
+                    "content": document,
+                    "embedding": list(embedding),
+                    "metadata": dict(metadata),
+                }
+                for identifier, embedding, document, metadata in zip(
+                    ids,
+                    embeddings,
+                    documents,
+                    metadatas,
+                    strict=True,
+                )
+            )
 
     def delete(self, *, where: dict[str, object]) -> None:
         key, condition = next(iter(where.items()))
@@ -174,7 +214,12 @@ class _Knowledge:
         _ = (upsert, reader)
         with _VectorDb.lock:
             _VectorDb.collections.setdefault(self.vector_db.collection_name, []).append(
-                {"content": Path(path).read_text(encoding="utf-8"), "metadata": dict(metadata)},
+                {
+                    "id": f"row-{next(_vector_row_ids)}",
+                    "content": Path(path).read_text(encoding="utf-8"),
+                    "embedding": [1.0],
+                    "metadata": dict(metadata),
+                },
             )
 
     async def ainsert(
@@ -7884,6 +7929,69 @@ async def test_git_query_and_fragment_tokens_stay_out_of_persistent_remote_and_m
     assert "query-secret" not in metadata_text
     assert "frag-secret" not in metadata_text
     assert redact_url_credentials(config.knowledge_bases["docs"].git.repo_url) == clean_url
+
+
+@pytest.mark.asyncio
+async def test_git_pull_that_changes_one_file_only_reindexes_that_file(tmp_path: Path) -> None:
+    """A one-file commit must cost one file's indexing, not the whole checkout's."""
+    remote_work = tmp_path / "remote-work"
+    remote_work.mkdir()
+
+    async def _git(cwd: Path, *args: str) -> None:
+        await asyncio.to_thread(
+            subprocess.run,
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    await _git(remote_work, "init", "-b", "main")
+    await _git(remote_work, "config", "user.email", "tests@example.com")
+    await _git(remote_work, "config", "user.name", "MindRoom Tests")
+    for index in range(5):
+        (remote_work / f"doc{index}.md").write_text(f"original body {index}", encoding="utf-8")
+    await _git(remote_work, "add", ".")
+    await _git(remote_work, "commit", "-m", "seed")
+    remote_bare = tmp_path / "remote.git"
+    await asyncio.to_thread(
+        subprocess.run,
+        ["git", "clone", "--bare", str(remote_work), str(remote_bare)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    docs_path = tmp_path / "checkout"
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={"docs": KnowledgeGitConfig(repo_url=str(remote_bare), branch="main")},
+    )
+    runtime_paths = runtime_paths_for(config)
+    first = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    assert first.indexed_count == 5
+
+    (remote_work / "doc2.md").write_text("rewritten body 2", encoding="utf-8")
+    await _git(remote_work, "commit", "-am", "change one file")
+    await _git(remote_work, "push", str(remote_bare), "main")
+
+    second = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert second.index_published is True
+    assert second.indexed_count == 1, "the whole checkout was reindexed for a one-file commit"
+    lookup = get_published_index("docs", config=config, runtime_paths=runtime_paths)
+    assert lookup.index is not None
+    contents = sorted(document.content for document in lookup.index.knowledge.search("body", max_results=10))
+    assert contents == [
+        "original body 0",
+        "original body 1",
+        "original body 3",
+        "original body 4",
+        "rewritten body 2",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -12,6 +12,7 @@ all progress lived in process memory.
 from __future__ import annotations
 
 import asyncio
+import itertools
 import os
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -83,9 +84,18 @@ class _SupportsRead(Protocol):
 
 @dataclass
 class _Record:
+    identifier: str
     content: str
     embedding: list[float]
     metadata: dict[str, Any]
+
+
+_record_ids = itertools.count()
+
+
+def _next_record_id() -> str:
+    """Return a chunk id unique across every collection in one test."""
+    return f"chunk-{next(_record_ids)}"
 
 
 class _FakeCollection:
@@ -100,16 +110,48 @@ class _FakeCollection:
         include: list[str] | None = None,
         where: dict[str, object] | None = None,
     ) -> dict[str, object]:
-        _ = include
         records = list(_FakeVectorDb.store.get(self._name, []))
         if where:
             key, condition = next(iter(where.items()))
             records = [record for record in records if metadata_matches(record.metadata, key, condition)]
         selected = records[offset:] if limit is None else records[offset : offset + limit]
-        return {
-            "ids": [str(index) for index in range(len(selected))],
+        _FakeVectorDb.queries.append((len(selected), where))
+        if len(selected) > _FakeVectorDb.max_rows_per_query:
+            # Chroma binds one SQL variable per *returned* row, so a query is
+            # refused for how much it hands back, not for how much it asks about.
+            message = f"too many SQL variables ({len(selected)})"
+            raise RuntimeError(message)
+        included = set(include or [])
+        payload: dict[str, object] = {
+            "ids": [record.identifier for record in selected],
             "metadatas": [dict(record.metadata) for record in selected],
         }
+        if "documents" in included:
+            payload["documents"] = [record.content for record in selected]
+        if "embeddings" in included:
+            payload["embeddings"] = [list(record.embedding) for record in selected]
+        return payload
+
+    def add(
+        self,
+        *,
+        ids: list[str],
+        embeddings: list[list[float]],
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+    ) -> None:
+        if not ids:
+            # Chroma rejects an empty write rather than treating it as a no-op.
+            message = "Expected Embeddings to be non-empty list or numpy array, got [] in add."
+            raise ValueError(message)
+        _FakeVectorDb.writes.append(len(ids))
+        if len(_FakeVectorDb.writes) > _FakeVectorDb.max_writes:
+            message = "vector store refused the write"
+            raise RuntimeError(message)
+        _FakeVectorDb.store.setdefault(self._name, []).extend(
+            _Record(identifier=identifier, content=document, embedding=list(embedding), metadata=dict(metadata))
+            for identifier, embedding, document, metadata in zip(ids, embeddings, documents, metadatas, strict=True)
+        )
 
     def delete(self, *, where: dict[str, object]) -> None:
         key, condition = next(iter(where.items()))
@@ -133,6 +175,16 @@ class _FakeClient:
 
 class _FakeVectorDb:
     store: ClassVar[dict[str, list[_Record]]] = {}
+    #: Rows one ``get`` may return before the store refuses it, mirroring the
+    #: real backend's per-returned-row SQL variable ceiling.
+    max_rows_per_query: ClassVar[int] = 1_000_000
+    #: Rows returned by each ``get``, with its filter, so tests can prove a copy
+    #: query was paged and that a verification probe was or was not issued.
+    queries: ClassVar[list[tuple[int, dict[str, object] | None]]] = []
+    #: Copy writes accepted before the store starts refusing them.
+    max_writes: ClassVar[int] = 1_000_000
+    #: Rows handed to each accepted or refused ``add``.
+    writes: ClassVar[list[int]] = []
 
     def __init__(self, *, collection: str, embedder: Embedder | None = None, **_: object) -> None:
         self.collection_name = collection
@@ -191,7 +243,14 @@ class _FakeKnowledge:
             embedder = self.vector_db.embedder
             assert embedder is not None
             embedding, _usage = embedder.get_embedding_and_usage(document.content)
-            embedded.append(_Record(content=document.content, embedding=embedding, metadata=dict(metadata)))
+            embedded.append(
+                _Record(
+                    identifier=_next_record_id(),
+                    content=document.content,
+                    embedding=embedding,
+                    metadata=dict(metadata),
+                ),
+            )
         records.extend(embedded)
 
     def remove_vectors_by_metadata(self, metadata: dict[str, Any]) -> bool:
@@ -314,6 +373,10 @@ def fake_vector_store(
 ) -> Iterator[None]:
     """Install the in-memory vector store, fake Knowledge and recording embedder."""
     _FakeVectorDb.store = {}
+    _FakeVectorDb.max_rows_per_query = 1_000_000
+    _FakeVectorDb.queries = []
+    _FakeVectorDb.max_writes = 1_000_000
+    _FakeVectorDb.writes = []
     monkeypatch.setattr(knowledge_manager_module, "ChromaDb", _FakeVectorDb)
     monkeypatch.setattr(knowledge_manager_module, "Knowledge", _FakeKnowledge)
     monkeypatch.setattr(knowledge_manager_module, "create_configured_embedder", lambda *_a, **_k: embedder)
@@ -330,6 +393,8 @@ def fake_vector_store(
     yield
     knowledge_registry._published_indexes.clear()
     _FakeVectorDb.store = {}
+    _FakeVectorDb.queries = []
+    _FakeVectorDb.writes = []
 
 
 # --------------------------------------------------------------------------
@@ -2916,3 +2981,326 @@ async def test_file_skipped_by_overlap_expansion_still_indexes_and_publishes(
     assert state.indexed_count == 4
     stored = sorted(record.metadata["source_path"] for record in _FakeVectorDb.store[state.collection])
     assert "expanding.md" in stored
+
+
+# --------------------------------------------------------------------------
+# 14. Reusing published vectors for files a refresh did not change
+# --------------------------------------------------------------------------
+
+
+def _stored_paths(collection: str) -> list[str]:
+    return sorted(record.metadata["source_path"] for record in _FakeVectorDb.store[collection])
+
+
+@pytest.mark.asyncio
+async def test_refresh_after_publish_reuses_vectors_for_unchanged_files(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """Changing one file must cost one embedding, not one per file in the corpus."""
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    assert await _manager(config).reindex_all() == 3
+    first_state = _published_state(config, runtime_paths)
+    assert first_state is not None
+    first_collection = first_state.collection
+    assert first_collection is not None
+    published_ids = {record.identifier for record in _FakeVectorDb.store[first_collection]}
+
+    (docs_path / names[1]).write_text("rewritten body", encoding="utf-8")
+    embedder.embedded_texts.clear()
+
+    assert await _manager(config).reindex_all() == 1, "the whole corpus was embedded again"
+
+    assert embedder.embedded_count("content 0") == 0
+    assert embedder.embedded_count("content 2") == 0
+    assert embedder.embedded_count("rewritten body") == 1
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.status == "complete"
+    assert state.indexed_count == 3
+    assert state.collection is not None
+    assert state.collection != first_collection, "publication must still swap in a separate collection"
+    assert _stored_paths(state.collection) == sorted(names)
+    reused_ids = {
+        record.identifier
+        for record in _FakeVectorDb.store[state.collection]
+        if record.metadata["source_path"] != names[1]
+    }
+    assert reused_ids <= published_ids, "copied chunks must keep their published ids"
+
+
+@pytest.mark.asyncio
+async def test_published_vector_reuse_leaves_the_published_collection_untouched(
+    tmp_path: Path,
+) -> None:
+    """The published index serves live queries throughout; the copy may only read it."""
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    await _manager(config).reindex_all()
+    first_state = _published_state(config, runtime_paths)
+    assert first_state is not None
+    first_collection = first_state.collection
+    assert first_collection is not None
+    before = [replace(record) for record in _FakeVectorDb.store[first_collection]]
+
+    (docs_path / names[0]).write_text("rewritten body", encoding="utf-8")
+    run = await _manager(config)._open_candidate_run()
+
+    assert run.checkpoint.collection != first_collection
+    assert _FakeVectorDb.store[first_collection] == before, "the live published collection was mutated"
+
+
+@pytest.mark.asyncio
+async def test_published_vector_reuse_requires_matching_indexing_settings(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """Settings pin the chunker and the embedder, so a change invalidates every vector."""
+    docs_path = tmp_path / "docs"
+    _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+
+    await _manager(config).reindex_all()
+
+    rechunked = _config(tmp_path, docs_path, chunk_size=256, chunk_overlap=8)
+    embedder.embedded_texts.clear()
+
+    assert await _manager(rechunked).reindex_all() == 3, "vectors built under other settings were reused"
+    assert embedder.embedded_count("content 0") == 1
+
+
+@pytest.mark.asyncio
+async def test_published_vector_reuse_skips_paths_that_left_the_corpus(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A published path that is no longer managed must never enter the candidate."""
+    # One row per page, so the removed file's row is the only row of its page
+    # and the copy has to cope with a page that contributes nothing.
+    monkeypatch.setattr(knowledge_manager_module, "_PUBLISHED_VECTOR_COPY_PAGE_ROWS", 1)
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+
+    await _manager(config).reindex_all()
+    (docs_path / names[0]).unlink()
+
+    run = await _manager(config)._open_candidate_run()
+
+    assert sorted(run.completed) == [names[1], names[2]]
+    assert _stored_paths(run.checkpoint.collection) == [names[1], names[2]]
+
+
+@pytest.mark.asyncio
+async def test_published_vector_reuse_needs_a_completely_published_index(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """Only a collection the metadata calls published is provably finished and stable.
+
+    The rest of the candidate lifecycle treats any other collection as an
+    abandoned candidate it may reclaim, so copying from one would read a
+    collection nothing keeps alive.
+    """
+    docs_path = tmp_path / "docs"
+    _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    await _manager(config).reindex_all()
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    write_index_metadata_payload(
+        published_index_metadata_path(resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)),
+        settings=state.settings.to_metadata(),
+        status="indexing",
+        collection=state.collection,
+        indexed_count=state.indexed_count,
+        source_signature=state.source_signature,
+    )
+    embedder.embedded_texts.clear()
+
+    assert await _manager(config).reindex_all() == 3, "vectors from an unpublished collection were reused"
+
+
+@pytest.mark.asyncio
+async def test_published_vector_reuse_never_claims_a_path_the_published_index_cannot_serve(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """A path is claimed by the rows copied for it, never by the corpus listing.
+
+    Copied paths skip the vector-existence probe because the copy already
+    proved them, so a path claimed without rows would publish a file that
+    semantic search cannot find.
+    """
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    await _manager(config).reindex_all()
+    first_state = _published_state(config, runtime_paths)
+    assert first_state is not None
+    assert first_state.collection is not None
+    _FakeVectorDb.store[first_state.collection] = [
+        record for record in _FakeVectorDb.store[first_state.collection] if record.metadata["source_path"] != names[2]
+    ]
+    embedder.embedded_texts.clear()
+
+    assert await _manager(config).reindex_all() == 1
+
+    assert embedder.embedded_count("content 2") == 1, "a path with no published rows was claimed as indexed"
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.collection is not None
+    assert _stored_paths(state.collection) == sorted(names)
+
+
+@pytest.mark.asyncio
+async def test_published_vector_copy_is_paged_so_no_query_exceeds_the_store_ceiling(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """Chroma binds one SQL variable per returned row, so only the page size bounds a copy.
+
+    An unpaged read of a published collection is refused outright once the
+    corpus is large enough, and no bound on files or paths can prevent that.
+    """
+    monkeypatch.setattr(knowledge_manager_module, "_PUBLISHED_VECTOR_COPY_PAGE_ROWS", 4)
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 12)
+    config = _config(tmp_path, docs_path)
+
+    await _manager(config).reindex_all()
+    _FakeVectorDb.max_rows_per_query = 4
+    _FakeVectorDb.queries = []
+    (docs_path / names[0]).write_text("rewritten body", encoding="utf-8")
+    embedder.embedded_texts.clear()
+
+    assert await _manager(config).reindex_all() == 1
+
+    assert max(rows for rows, _where in _FakeVectorDb.queries) <= 4
+    assert [where for _rows, where in _FakeVectorDb.queries if where and "$in" in str(where)] == [], (
+        "copied paths were sent back through the vector-existence probe"
+    )
+
+
+@pytest.mark.asyncio
+async def test_published_vector_reuse_falls_back_when_the_published_collection_is_gone(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """A vanished published collection must cost a full rebuild, never a failed refresh."""
+    docs_path = tmp_path / "docs"
+    _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    await _manager(config).reindex_all()
+    first_state = _published_state(config, runtime_paths)
+    assert first_state is not None
+    assert first_state.collection is not None
+    _FakeVectorDb.store.pop(first_state.collection)
+    embedder.embedded_texts.clear()
+
+    assert await _manager(config).reindex_all() == 3
+
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.status == "complete"
+    assert state.indexed_count == 3
+
+
+@pytest.mark.asyncio
+async def test_a_failed_vector_copy_leaves_no_partial_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A copy that dies part-way must hand the rebuild an empty candidate.
+
+    Rows copied for a path the candidate never records are invisible to
+    reconciliation, so a later listing that drops that path would publish
+    vectors for a file the corpus no longer contains.
+    """
+    monkeypatch.setattr(knowledge_manager_module, "_PUBLISHED_VECTOR_COPY_PAGE_ROWS", 1)
+    docs_path = tmp_path / "docs"
+    _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+
+    await _manager(config).reindex_all()
+    _FakeVectorDb.writes = []
+    _FakeVectorDb.max_writes = 1
+
+    run = await _manager(config)._open_candidate_run()
+
+    assert run.completed == {}, "a failed copy must claim nothing"
+    assert _FakeVectorDb.store[run.checkpoint.collection] == [], "partially copied rows survived the failure"
+
+
+@pytest.mark.asyncio
+async def test_published_vector_reuse_survives_a_checkout_that_only_rewrites_mtimes(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """Copied rows carry the published mtime, which a checkout routinely invalidates.
+
+    Reconciliation adopts the new stamp for byte-identical content, so the
+    signature the copy records must survive that comparison rather than send
+    every reused file back through the embedder.
+    """
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    await _manager(config).reindex_all()
+    (docs_path / names[1]).write_text("rewritten body", encoding="utf-8")
+    for name in names:
+        path = docs_path / name
+        stat = path.stat()
+        os.utime(path, ns=(stat.st_atime_ns + 10**9, stat.st_mtime_ns + 10**9))
+    embedder.embedded_texts.clear()
+
+    assert await _manager(config).reindex_all() == 1, "an mtime rewrite re-embedded unchanged content"
+
+    assert embedder.embedded_count("content 0") == 0
+    assert embedder.embedded_count("content 2") == 0
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.collection is not None
+    assert _stored_paths(state.collection) == sorted(names)
+
+
+@pytest.mark.asyncio
+async def test_published_vector_reuse_rescans_an_empty_file_it_cannot_claim(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """A zero-length file legitimately has no vectors, so no copy can prove it indexed."""
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 2)
+    (docs_path / "empty.md").write_text("", encoding="utf-8")
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    await _manager(config).reindex_all()
+    (docs_path / names[0]).write_text("rewritten body", encoding="utf-8")
+    embedder.embedded_texts.clear()
+
+    assert await _manager(config).reindex_all() == 2, "the empty file was claimed or lost"
+
+    assert embedder.embedded_count("content 1") == 0
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.status == "complete"
+    assert state.indexed_count == 3
+    assert _stored_paths(state.collection or "") == sorted(names)

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -16,6 +16,7 @@ import itertools
 import os
 from dataclasses import dataclass, field, replace
 from pathlib import Path
+from threading import Event
 from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 
 import pytest
@@ -281,6 +282,15 @@ class _FakeKnowledge:
     def search(self, query: str, max_results: int | None = None) -> list[Document]:
         assert self.vector_db is not None
         return self.vector_db.search(query=query, limit=max_results or self.max_results)
+
+
+class _AutoCreatingFakeKnowledge(_FakeKnowledge):
+    """Knowledge that creates a missing collection on construction, like Agno's."""
+
+    def __init__(self, vector_db: _FakeVectorDb | None = None) -> None:
+        super().__init__(vector_db)
+        if vector_db is not None and not vector_db.exists():
+            vector_db.create()
 
 
 class _RecordingNonBatchEmbedder(Embedder):
@@ -3018,6 +3028,28 @@ def _vector_existence_probe_count() -> int:
     return probes
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("source_mtime_ns", True),
+        ("source_size", True),
+        ("source_size", -1),
+        ("source_digest", ""),
+    ],
+)
+def test_reusable_row_signature_rejects_invalid_values(field: str, value: object) -> None:
+    """Published metadata must satisfy the same signature contract as checkpoints."""
+    metadata: dict[str, Any] = {
+        "source_path": "doc.md",
+        "source_mtime_ns": 1,
+        "source_size": 1,
+        "source_digest": "digest",
+    }
+    metadata[field] = value
+
+    assert knowledge_manager_module._reusable_row_signature(metadata, frozenset({"doc.md"})) is None
+
+
 @pytest.mark.asyncio
 async def test_refresh_after_publish_reuses_vectors_for_unchanged_files(
     tmp_path: Path,
@@ -3332,20 +3364,45 @@ async def test_published_vector_reuse_rescans_an_empty_file_it_cannot_claim(
 
 
 @pytest.mark.asyncio
+async def test_shielded_write_finishes_before_repeated_cancellation_escapes() -> None:
+    """A second cancellation must not interrupt the drain of a durable write."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+    finished = False
+
+    async def _write() -> None:
+        nonlocal finished
+        started.set()
+        await release.wait()
+        finished = True
+
+    outer = asyncio.create_task(knowledge_manager_module._shielded_write(_write()))
+    await started.wait()
+    try:
+        outer.cancel()
+        await asyncio.sleep(0)
+        outer.cancel()
+        await asyncio.sleep(0)
+        assert not outer.done(), "repeated cancellation escaped before the durable write finished"
+    finally:
+        release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await outer
+    assert finished
+
+
+@pytest.mark.asyncio
 async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
     tmp_path: Path,
     embedder: _RecordingEmbedder,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A copy interrupted between writing rows and recording them must not survive.
+    """Cancellation must wait for the copy worker before releasing the refresh lock.
 
-    ``asyncio.to_thread`` cannot be cancelled, so the copy finishes writing
-    while the awaiting refresh raises ``CancelledError`` -- which is a
-    ``BaseException`` and so escapes the copy's own error handling. Nothing
-    downstream can attribute the rows it left: reconciliation derives every
-    deletion from the checkpoint, and the checkpoint claims nothing. A path
-    that leaves the corpus before the next refresh would otherwise keep serving
-    its old content from the published index.
+    ``asyncio.to_thread`` cannot cancel its worker, so the coroutine must drain
+    that worker before propagating ``CancelledError``. Claims intentionally
+    remain empty after cancellation; shape recovery then rebuilds the completed
+    copy before a departed path can reach publication.
     """
     docs_path = tmp_path / "docs"
     names = _write_corpus(docs_path, 3)
@@ -3354,27 +3411,36 @@ async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
 
     await _manager(config).reindex_all()
     original_copy = KnowledgeManager._copy_published_vectors
+    copy_started = Event()
+    release_copy = Event()
 
-    def _copy_then_cancel(
+    def _blocked_copy(
         self: KnowledgeManager,
         *,
         published_collection: str,
         candidate_vector_db: _FakeVectorDb,
         managed_paths: frozenset[str],
     ) -> dict[str, FileSignature]:
-        # The copy runs to completion and then the await raises, which is what
-        # cancelling an uncancellable ``asyncio.to_thread`` call really does.
-        original_copy(
+        copy_started.set()
+        release_copy.wait()
+        return original_copy(
             self,
             published_collection=published_collection,
             candidate_vector_db=candidate_vector_db,
             managed_paths=managed_paths,
         )
-        raise asyncio.CancelledError
 
-    monkeypatch.setattr(KnowledgeManager, "_copy_published_vectors", _copy_then_cancel)
+    monkeypatch.setattr(KnowledgeManager, "_copy_published_vectors", _blocked_copy)
+    refresh = asyncio.create_task(_manager(config).reindex_all())
+    assert await asyncio.to_thread(copy_started.wait, 5), "the vector copy never started"
+    try:
+        refresh.cancel()
+        await asyncio.sleep(0)
+        assert not refresh.done(), "the refresh lock escaped while its copy worker was still running"
+    finally:
+        release_copy.set()
     with pytest.raises(asyncio.CancelledError):
-        await _manager(config).reindex_all()
+        await refresh
     monkeypatch.setattr(KnowledgeManager, "_copy_published_vectors", original_copy)
 
     interrupted = load_candidate_checkpoint(_storage_path(config, runtime_paths))
@@ -3395,6 +3461,71 @@ async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
     # Recovery rebuilds the collection, so it must copy again rather than fall
     # back to embedding: losing a corpus copy is the bug's secondary cost.
     assert indexed == 0, "recovery re-embedded instead of copying the published vectors again"
+
+
+@pytest.mark.asyncio
+async def test_a_candidate_whose_collection_vanished_is_rebuilt_rather_than_resumed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Probe existence before Agno can auto-create a vanished collection."""
+    monkeypatch.setattr(knowledge_manager_module, "Knowledge", _AutoCreatingFakeKnowledge)
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    original_index = KnowledgeManager._index_file_locked
+
+    async def _fail_last(self: KnowledgeManager, resolved_path: Path, **kwargs: object) -> bool:
+        if resolved_path.name == names[-1]:
+            return False
+        return await original_index(self, resolved_path, **kwargs)
+
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", _fail_last)
+    await _manager(config).reindex_all()
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", original_index)
+
+    checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
+    assert checkpoint is not None
+    assert len(checkpoint.completed) == 2, "the candidate should have kept the files it did index"
+    _FakeVectorDb.store.pop(checkpoint.collection)
+
+    run = await _manager(config)._open_candidate_run()
+
+    assert run.resumed is False
+    assert run.completed == {}, "claims survived a collection that no longer holds their vectors"
+
+
+@pytest.mark.asyncio
+async def test_unclaimed_row_probe_reuses_the_refresh_embedder(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty-checkpoint probe must not construct a second configured embedder."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    manager = _manager(config)
+    collection = manager._candidate_collection_name()
+    save_candidate_checkpoint(
+        _storage_path(config, runtime_paths),
+        CandidateCheckpoint(collection=collection, settings=manager._indexing_settings),
+    )
+    _FakeVectorDb(collection=collection, embedder=embedder).create()
+    created: list[Embedder] = []
+
+    def _record_factory(*_args: object, **_kwargs: object) -> Embedder:
+        created.append(embedder)
+        return embedder
+
+    monkeypatch.setattr(knowledge_manager_module, "create_configured_embedder", _record_factory)
+
+    run = await manager._open_candidate_run()
+
+    assert run.resumed is True
+    assert len(created) == 1, "the shape probe constructed another configured embedder"
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -39,6 +39,7 @@ from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.candidate_checkpoint import (
     CandidateCheckpoint,
     CandidateFailure,
+    FileSignature,
     _candidate_checkpoint_path,
     _candidate_journal_path,
     append_candidate_journal,
@@ -267,6 +268,21 @@ class _FakeKnowledge:
     def search(self, query: str, max_results: int | None = None) -> list[Document]:
         assert self.vector_db is not None
         return self.vector_db.search(query=query, limit=max_results or self.max_results)
+
+
+class _AutoCreatingFakeKnowledge(_FakeKnowledge):
+    """Knowledge that creates a missing collection on construction, like Agno's.
+
+    ``Knowledge.__post_init__`` calls ``vector_db.create()`` whenever the
+    collection is absent, so any existence probe taken after building it always
+    answers yes. Tests that care whether a candidate's vectors really survived
+    have to model that, or they prove nothing about production.
+    """
+
+    def __init__(self, vector_db: _FakeVectorDb | None = None) -> None:
+        super().__init__(vector_db)
+        if vector_db is not None and not vector_db.exists():
+            vector_db.create()
 
 
 class _RecordingNonBatchEmbedder(Embedder):
@@ -2992,7 +3008,7 @@ def _stored_paths(collection: str) -> list[str]:
     return sorted(record.metadata["source_path"] for record in _FakeVectorDb.store[collection])
 
 
-def _vector_existence_probes() -> int:
+def _vector_existence_probe_count() -> int:
     """Return how many ``$in`` source-path existence probes the store was asked."""
     probes = 0
     for _rows, where in _FakeVectorDb.queries:
@@ -3199,7 +3215,7 @@ async def test_published_vector_copy_is_paged_so_no_query_exceeds_the_store_ceil
     assert await _manager(config).reindex_all() == 1
 
     assert max(rows for rows, _where in _FakeVectorDb.queries) <= 4
-    assert _vector_existence_probes() == 0, "copied paths were sent back through the vector-existence probe"
+    assert _vector_existence_probe_count() == 0, "copied paths were sent back through the vector-existence probe"
 
 
 @pytest.mark.asyncio
@@ -3319,6 +3335,7 @@ async def test_published_vector_reuse_rescans_an_empty_file_it_cannot_claim(
 async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
     tmp_path: Path,
     embedder: _RecordingEmbedder,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A copy interrupted between writing rows and recording them must not survive.
 
@@ -3338,18 +3355,27 @@ async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
     await _manager(config).reindex_all()
     original_copy = KnowledgeManager._copy_published_vectors
 
-    def _copy_then_cancel(self: KnowledgeManager, **kwargs: object) -> dict[str, tuple[int, int, str]]:
+    def _copy_then_cancel(
+        self: KnowledgeManager,
+        *,
+        published_collection: str,
+        candidate_vector_db: _FakeVectorDb,
+        managed_paths: frozenset[str],
+    ) -> dict[str, FileSignature]:
         # The copy runs to completion and then the await raises, which is what
         # cancelling an uncancellable ``asyncio.to_thread`` call really does.
-        original_copy(self, **kwargs)  # type: ignore[arg-type]
+        original_copy(
+            self,
+            published_collection=published_collection,
+            candidate_vector_db=candidate_vector_db,
+            managed_paths=managed_paths,
+        )
         raise asyncio.CancelledError
 
-    KnowledgeManager._copy_published_vectors = _copy_then_cancel  # type: ignore[method-assign]
-    try:
-        with pytest.raises(asyncio.CancelledError):
-            await _manager(config).reindex_all()
-    finally:
-        KnowledgeManager._copy_published_vectors = original_copy  # type: ignore[method-assign]
+    monkeypatch.setattr(KnowledgeManager, "_copy_published_vectors", _copy_then_cancel)
+    with pytest.raises(asyncio.CancelledError):
+        await _manager(config).reindex_all()
+    monkeypatch.setattr(KnowledgeManager, "_copy_published_vectors", original_copy)
 
     interrupted = load_candidate_checkpoint(_storage_path(config, runtime_paths))
     assert interrupted is not None
@@ -3369,6 +3395,46 @@ async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
     # Recovery rebuilds the collection, so it must copy again rather than fall
     # back to embedding: losing a corpus copy is the bug's secondary cost.
     assert indexed == 0, "recovery re-embedded instead of copying the published vectors again"
+
+
+@pytest.mark.asyncio
+async def test_a_candidate_whose_collection_vanished_is_rebuilt_rather_than_resumed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existence has to be probed before Agno can auto-create the collection.
+
+    Agno creates a missing collection when ``Knowledge`` is built, so a probe
+    taken afterwards always answers yes. A candidate whose vectors are gone
+    would then be resumed still carrying claims nothing backs, and every one of
+    them would go through the vector-existence query to be dropped one batch at
+    a time instead of the candidate simply starting over.
+    """
+    monkeypatch.setattr(knowledge_manager_module, "Knowledge", _AutoCreatingFakeKnowledge)
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    original_index = KnowledgeManager._index_file_locked
+
+    async def _fail_last(self: KnowledgeManager, resolved_path: Path, **kwargs: object) -> bool:
+        if resolved_path.name == names[-1]:
+            return False
+        return await original_index(self, resolved_path, **kwargs)
+
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", _fail_last)
+    await _manager(config).reindex_all()
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", original_index)
+
+    checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
+    assert checkpoint is not None
+    assert len(checkpoint.completed) == 2, "the candidate should have kept the files it did index"
+    _FakeVectorDb.store.pop(checkpoint.collection)
+
+    run = await _manager(config)._open_candidate_run()
+
+    assert run.resumed is False
+    assert run.completed == {}, "claims survived a collection that no longer holds their vectors"
 
 
 @pytest.mark.asyncio
@@ -3403,12 +3469,10 @@ async def test_an_interruption_after_the_copy_still_resumes_the_work_it_finished
         indexed.append(resolved_path.name)
         return await original_index(self, resolved_path, **kwargs)
 
-    KnowledgeManager._index_file_locked = _stop_after_two  # type: ignore[method-assign]
-    try:
-        with pytest.raises(asyncio.CancelledError):
-            await _manager(config).reindex_all()
-    finally:
-        KnowledgeManager._index_file_locked = original_index  # type: ignore[method-assign]
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", _stop_after_two)
+    with pytest.raises(asyncio.CancelledError):
+        await _manager(config).reindex_all()
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", original_index)
 
     checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
     assert checkpoint is not None
@@ -3420,6 +3484,133 @@ async def test_an_interruption_after_the_copy_still_resumes_the_work_it_finished
 
     for body in already_embedded:
         assert embedder.embedded_count(body) == 1, "an interrupted refresh re-embedded work it had finished"
+
+
+@pytest.mark.asyncio
+async def test_a_rebuild_that_dies_before_emptying_the_collection_still_recovers(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The copy marker has to outlive the reset, not just the copy.
+
+    A rebuild inherits a collection whose rows the checkpoint no longer claims,
+    and only the reset makes that true. Clearing the marker before the reset
+    leaves a window where the checkpoint says the candidate is resumable while
+    it still holds unattributable rows.
+    """
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    await _manager(config).reindex_all()
+
+    cancel_copy = True
+    original_copy = KnowledgeManager._copy_published_vectors
+
+    def _copy_then_maybe_cancel(
+        self: KnowledgeManager,
+        *,
+        published_collection: str,
+        candidate_vector_db: _FakeVectorDb,
+        managed_paths: frozenset[str],
+    ) -> dict[str, FileSignature]:
+        reused = original_copy(
+            self,
+            published_collection=published_collection,
+            candidate_vector_db=candidate_vector_db,
+            managed_paths=managed_paths,
+        )
+        if cancel_copy:
+            raise asyncio.CancelledError
+        return reused
+
+    monkeypatch.setattr(KnowledgeManager, "_copy_published_vectors", _copy_then_maybe_cancel)
+    with pytest.raises(asyncio.CancelledError):
+        await _manager(config).reindex_all()
+    cancel_copy = False
+
+    # A forced rebuild of that marked candidate copies nothing, so it takes the
+    # path where the marker used to be cleared before the collection was reset.
+    (docs_path / names[0]).unlink()
+    die_before_reset = True
+    original_reset = KnowledgeManager._reset_vector_db
+
+    def _maybe_die(self: KnowledgeManager, vector_db: _FakeVectorDb) -> None:
+        if die_before_reset:
+            message = "host lost power before the collection was emptied"
+            raise RuntimeError(message)
+        original_reset(self, vector_db)
+
+    monkeypatch.setattr(KnowledgeManager, "_reset_vector_db", _maybe_die)
+    with pytest.raises(RuntimeError):
+        await _manager(config).reindex_all(force_reindex=True)
+    die_before_reset = False
+
+    interrupted = load_candidate_checkpoint(_storage_path(config, runtime_paths))
+    assert interrupted is not None
+    assert interrupted.seeding is True, "the marker was cleared while the collection still held rows"
+    embedder.embedded_texts.clear()
+
+    indexed = await _manager(config).reindex_all()
+
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.collection is not None
+    assert _stored_paths(state.collection) == sorted(names[1:]), "a departed path survived in the published index"
+    assert indexed == 0, "recovery re-embedded instead of copying the published vectors again"
+    assert embedder.embedded_texts == []
+
+
+@pytest.mark.asyncio
+async def test_forced_reindex_discards_a_candidate_that_survived_a_failed_refresh(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refresh that never published leaves a candidate, and forcing must drop it too.
+
+    Suppressing the copy is not enough: a surviving candidate carries its own
+    claims, so the files it already embedded would be kept by the very rebuild
+    the operator asked for because the index is not trusted.
+    """
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    for index, name in enumerate(names):
+        (docs_path / name).write_text(f"revised {index}", encoding="utf-8")
+    fail_last = True
+    original_index = KnowledgeManager._index_file_locked
+
+    async def _maybe_fail_last(self: KnowledgeManager, resolved_path: Path, **kwargs: object) -> bool:
+        if fail_last and resolved_path.name == names[-1]:
+            return False
+        return await original_index(self, resolved_path, **kwargs)
+
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", _maybe_fail_last)
+    failed = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    assert failed.index_published is False
+    surviving = load_candidate_checkpoint(_storage_path(config, runtime_paths))
+    assert surviving is not None
+    assert len(surviving.completed) == 2, "the candidate should carry the work the failed refresh finished"
+
+    fail_last = False
+    embedder.embedded_texts.clear()
+
+    result = await refresh_knowledge_binding(
+        "docs",
+        config=config,
+        runtime_paths=runtime_paths,
+        force_reindex=True,
+    )
+
+    assert result.index_published is True
+    assert result.indexed_count == 3, "a forced rebuild kept the candidate's claims"
+    for index in range(3):
+        assert embedder.embedded_count(f"revised {index}") == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -2992,6 +2992,16 @@ def _stored_paths(collection: str) -> list[str]:
     return sorted(record.metadata["source_path"] for record in _FakeVectorDb.store[collection])
 
 
+def _vector_existence_probes() -> int:
+    """Return how many ``$in`` source-path existence probes the store was asked."""
+    probes = 0
+    for _rows, where in _FakeVectorDb.queries:
+        condition = where.get("source_path") if isinstance(where, dict) else None
+        if isinstance(condition, dict) and "$in" in condition:
+            probes += 1
+    return probes
+
+
 @pytest.mark.asyncio
 async def test_refresh_after_publish_reuses_vectors_for_unchanged_files(
     tmp_path: Path,
@@ -3189,9 +3199,7 @@ async def test_published_vector_copy_is_paged_so_no_query_exceeds_the_store_ceil
     assert await _manager(config).reindex_all() == 1
 
     assert max(rows for rows, _where in _FakeVectorDb.queries) <= 4
-    assert [where for _rows, where in _FakeVectorDb.queries if where and "$in" in str(where)] == [], (
-        "copied paths were sent back through the vector-existence probe"
-    )
+    assert _vector_existence_probes() == 0, "copied paths were sent back through the vector-existence probe"
 
 
 @pytest.mark.asyncio
@@ -3303,4 +3311,142 @@ async def test_published_vector_reuse_rescans_an_empty_file_it_cannot_claim(
     assert state is not None
     assert state.status == "complete"
     assert state.indexed_count == 3
-    assert _stored_paths(state.collection or "") == sorted(names)
+    assert state.collection is not None
+    assert _stored_paths(state.collection) == sorted(names)
+
+
+@pytest.mark.asyncio
+async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """A copy interrupted between writing rows and recording them must not survive.
+
+    ``asyncio.to_thread`` cannot be cancelled, so the copy finishes writing
+    while the awaiting refresh raises ``CancelledError`` -- which is a
+    ``BaseException`` and so escapes the copy's own error handling. Nothing
+    downstream can attribute the rows it left: reconciliation derives every
+    deletion from the checkpoint, and the checkpoint claims nothing. A path
+    that leaves the corpus before the next refresh would otherwise keep serving
+    its old content from the published index.
+    """
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    await _manager(config).reindex_all()
+    original_copy = KnowledgeManager._copy_published_vectors
+
+    def _copy_then_cancel(self: KnowledgeManager, **kwargs: object) -> dict[str, tuple[int, int, str]]:
+        # The copy runs to completion and then the await raises, which is what
+        # cancelling an uncancellable ``asyncio.to_thread`` call really does.
+        original_copy(self, **kwargs)  # type: ignore[arg-type]
+        raise asyncio.CancelledError
+
+    KnowledgeManager._copy_published_vectors = _copy_then_cancel  # type: ignore[method-assign]
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await _manager(config).reindex_all()
+    finally:
+        KnowledgeManager._copy_published_vectors = original_copy  # type: ignore[method-assign]
+
+    interrupted = load_candidate_checkpoint(_storage_path(config, runtime_paths))
+    assert interrupted is not None
+    assert interrupted.completed == {}, "a cancelled copy must claim nothing"
+    assert _stored_paths(interrupted.collection) == sorted(names), "the copy did write rows before cancelling"
+
+    (docs_path / names[0]).unlink()
+    embedder.embedded_texts.clear()
+
+    indexed = await _manager(config).reindex_all()
+
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.status == "complete"
+    assert state.collection is not None
+    assert _stored_paths(state.collection) == sorted(names[1:]), "a departed path survived in the published index"
+    # Recovery rebuilds the collection, so it must copy again rather than fall
+    # back to embedding: losing a corpus copy is the bug's secondary cost.
+    assert indexed == 0, "recovery re-embedded instead of copying the published vectors again"
+
+
+@pytest.mark.asyncio
+async def test_an_interruption_after_the_copy_still_resumes_the_work_it_finished(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Clearing the copy marker is what keeps the rest of the refresh resumable.
+
+    A candidate that still claims a copy is in flight gets rebuilt on sight, so
+    a marker left set after the copy finished would throw away every file the
+    refresh went on to embed.
+    """
+    monkeypatch.setenv("MINDROOM_KNOWLEDGE_FILE_INDEX_CONCURRENCY", "1")
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 4)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    await _manager(config).reindex_all()
+
+    for index, name in enumerate(names):
+        (docs_path / name).write_text(f"revised {index}", encoding="utf-8")
+    embedder.embedded_texts.clear()
+
+    indexed: list[str] = []
+    original_index = KnowledgeManager._index_file_locked
+
+    async def _stop_after_two(self: KnowledgeManager, resolved_path: Path, **kwargs: object) -> bool:
+        if len(indexed) >= 2:
+            raise asyncio.CancelledError
+        indexed.append(resolved_path.name)
+        return await original_index(self, resolved_path, **kwargs)
+
+    KnowledgeManager._index_file_locked = _stop_after_two  # type: ignore[method-assign]
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            await _manager(config).reindex_all()
+    finally:
+        KnowledgeManager._index_file_locked = original_index  # type: ignore[method-assign]
+
+    checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
+    assert checkpoint is not None
+    assert checkpoint.seeding is False, "a finished copy must stop claiming to be in flight"
+    assert len(checkpoint.completed) == 2
+    already_embedded = {f"revised {names.index(name)}" for name in checkpoint.completed}
+
+    assert await _manager(config).reindex_all() == len(names) - 2
+
+    for body in already_embedded:
+        assert embedder.embedded_count(body) == 1, "an interrupted refresh re-embedded work it had finished"
+
+
+@pytest.mark.asyncio
+async def test_forced_reindex_rebuilds_every_vector_instead_of_copying_it(
+    tmp_path: Path,
+    embedder: _RecordingEmbedder,
+) -> None:
+    """An operator forces a rebuild because the index is not trusted, so reuse must stop.
+
+    Every other reason a rebuild is forced -- changed settings, a missing
+    collection -- the reuse gates already reject. This one they cannot see.
+    """
+    docs_path = tmp_path / "docs"
+    _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    embedder.embedded_texts.clear()
+
+    result = await refresh_knowledge_binding(
+        "docs",
+        config=config,
+        runtime_paths=runtime_paths,
+        force_reindex=True,
+    )
+
+    assert result.index_published is True
+    assert result.indexed_count == 3, "a forced rebuild reused the vectors it was asked to replace"
+    for index in range(3):
+        assert embedder.embedded_count(f"content {index}") == 1

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -3447,6 +3447,43 @@ async def test_an_interruption_after_the_copy_still_resumes_the_work_it_finished
 
 
 @pytest.mark.asyncio
+async def test_a_candidate_with_no_vectors_and_no_claims_is_still_resumed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Claiming nothing is not itself a violation; holding unclaimed rows is.
+
+    A candidate whose every file failed to index claims nothing and holds no
+    vectors, which satisfies the invariant. Condemning it on the empty claim
+    map alone would rebuild it on every refresh and reset the retry ledger that
+    records how many attempts each file has cost.
+    """
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 2)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+
+    async def _fail_everything(_self: KnowledgeManager, resolved_path: Path, **kwargs: object) -> bool:
+        _ = (resolved_path, kwargs)
+        return False
+
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", _fail_everything)
+    await _manager(config).reindex_all()
+    first = load_candidate_checkpoint(_storage_path(config, runtime_paths))
+    assert first is not None
+    assert first.completed == {}
+    assert sorted(first.failed) == sorted(names)
+    assert _stored_paths(first.collection) == []
+
+    await _manager(config).reindex_all()
+
+    second = load_candidate_checkpoint(_storage_path(config, runtime_paths))
+    assert second is not None
+    assert second.collection == first.collection, "an empty candidate was needlessly rebuilt"
+    assert [second.failed[name].attempts for name in sorted(names)] == [2, 2], "the retry ledger was reset"
+
+
+@pytest.mark.asyncio
 async def test_a_copy_records_its_claims_only_after_every_row_has_landed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -3222,7 +3222,7 @@ async def test_published_vector_copy_is_paged_so_no_query_exceeds_the_store_ceil
     config = _config(tmp_path, docs_path)
 
     await _manager(config).reindex_all()
-    _FakeVectorDb.max_rows_per_query = 4
+    _FakeVectorDb.max_rows_per_get = 4
     _FakeVectorDb.queries = []
     (docs_path / names[0]).write_text("rewritten body", encoding="utf-8")
     embedder.embedded_texts.clear()

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -283,21 +283,6 @@ class _FakeKnowledge:
         return self.vector_db.search(query=query, limit=max_results or self.max_results)
 
 
-class _AutoCreatingFakeKnowledge(_FakeKnowledge):
-    """Knowledge that creates a missing collection on construction, like Agno's.
-
-    ``Knowledge.__post_init__`` calls ``vector_db.create()`` whenever the
-    collection is absent, so any existence probe taken after building it always
-    answers yes. Tests that care whether a candidate's vectors really survived
-    have to model that, or they prove nothing about production.
-    """
-
-    def __init__(self, vector_db: _FakeVectorDb | None = None) -> None:
-        super().__init__(vector_db)
-        if vector_db is not None and not vector_db.exists():
-            vector_db.create()
-
-
 class _RecordingNonBatchEmbedder(Embedder):
     """Recording embedder with no batch surface at all, like Ollama.
 
@@ -3413,55 +3398,16 @@ async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
 
 
 @pytest.mark.asyncio
-async def test_a_candidate_whose_collection_vanished_is_rebuilt_rather_than_resumed(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Existence has to be probed before Agno can auto-create the collection.
-
-    Agno creates a missing collection when ``Knowledge`` is built, so a probe
-    taken afterwards always answers yes. A candidate whose vectors are gone
-    would then be resumed still carrying claims nothing backs, and every one of
-    them would go through the vector-existence query to be dropped one batch at
-    a time instead of the candidate simply starting over.
-    """
-    monkeypatch.setattr(knowledge_manager_module, "Knowledge", _AutoCreatingFakeKnowledge)
-    docs_path = tmp_path / "docs"
-    names = _write_corpus(docs_path, 3)
-    config = _config(tmp_path, docs_path)
-    runtime_paths = runtime_paths_for(config)
-    original_index = KnowledgeManager._index_file_locked
-
-    async def _fail_last(self: KnowledgeManager, resolved_path: Path, **kwargs: object) -> bool:
-        if resolved_path.name == names[-1]:
-            return False
-        return await original_index(self, resolved_path, **kwargs)
-
-    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", _fail_last)
-    await _manager(config).reindex_all()
-    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", original_index)
-
-    checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
-    assert checkpoint is not None
-    assert len(checkpoint.completed) == 2, "the candidate should have kept the files it did index"
-    _FakeVectorDb.store.pop(checkpoint.collection)
-
-    run = await _manager(config)._open_candidate_run()
-
-    assert run.resumed is False
-    assert run.completed == {}, "claims survived a collection that no longer holds their vectors"
-
-
-@pytest.mark.asyncio
 async def test_an_interruption_after_the_copy_still_resumes_the_work_it_finished(
     tmp_path: Path,
     embedder: _RecordingEmbedder,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Clearing the copy marker is what keeps the rest of the refresh resumable.
+    """A candidate that holds only rows it claims stays resumable.
 
-    A candidate that still claims a copy is in flight gets rebuilt on sight, so
-    a marker left set after the copy finished would throw away every file the
+    Rebuilding on sight of unclaimed rows is what keeps a cancelled copy from
+    publishing them, but the test for that has to be narrow: a check that
+    condemned any candidate holding vectors would throw away every file the
     refresh went on to embed.
     """
     monkeypatch.setenv("MINDROOM_KNOWLEDGE_FILE_INDEX_CONCURRENCY", "1")
@@ -3491,7 +3437,6 @@ async def test_an_interruption_after_the_copy_still_resumes_the_work_it_finished
 
     checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
     assert checkpoint is not None
-    assert checkpoint.seeding is False, "a finished copy must stop claiming to be in flight"
     assert len(checkpoint.completed) == 2
     already_embedded = {f"revised {names.index(name)}" for name in checkpoint.completed}
 
@@ -3502,17 +3447,73 @@ async def test_an_interruption_after_the_copy_still_resumes_the_work_it_finished
 
 
 @pytest.mark.asyncio
+async def test_a_copy_records_its_claims_only_after_every_row_has_landed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Recovery is sound only because a copy's claims land in one write, last.
+
+    An interrupted copy is recoverable because it leaves exactly one shape: no
+    claims and a non-empty collection. A copy that recorded claims as it went
+    would instead leave a claim covering only part of a file, which
+    ``_candidate_paths_missing_vectors`` confirms on sight -- one row is enough
+    -- so the candidate would publish a silently truncated file.
+
+    Nothing else in the design notices that, and every other test here would
+    stay green, so this is the pin. Chunks are paged one row at a time to give
+    a per-page write somewhere to happen.
+    """
+    monkeypatch.setattr(knowledge_manager_module, "_PUBLISHED_VECTOR_COPY_PAGE_ROWS", 1)
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    await _manager(config).reindex_all()
+
+    events: list[str] = []
+    original_save = knowledge_manager_module.save_candidate_checkpoint
+    original_add = _FakeCollection.add
+
+    def _record_save(base_storage_path: Path, checkpoint: CandidateCheckpoint) -> CandidateCheckpoint:
+        events.append(f"claims:{len(checkpoint.completed)}")
+        return original_save(base_storage_path, checkpoint)
+
+    def _record_add(
+        self: _FakeCollection,
+        *,
+        ids: list[str],
+        embeddings: list[list[float]],
+        documents: list[str],
+        metadatas: list[dict[str, Any]],
+    ) -> None:
+        events.append("rows")
+        original_add(self, ids=ids, embeddings=embeddings, documents=documents, metadatas=metadatas)
+
+    monkeypatch.setattr(knowledge_manager_module, "save_candidate_checkpoint", _record_save)
+    monkeypatch.setattr(_FakeCollection, "add", _record_add)
+    (docs_path / names[0]).write_text("rewritten body", encoding="utf-8")
+
+    await _manager(config).reindex_all()
+
+    copied_rows = [index for index, event in enumerate(events) if event == "rows"]
+    recorded_claims = [
+        index for index, event in enumerate(events) if event.startswith("claims:") and event != "claims:0"
+    ]
+    assert copied_rows, "the copy wrote no rows, so this proves nothing"
+    assert recorded_claims, "the copy never recorded its claims"
+    assert min(recorded_claims) > max(copied_rows), "claims were recorded before every copied row had landed"
+
+
+@pytest.mark.asyncio
 async def test_a_rebuild_that_dies_before_emptying_the_collection_still_recovers(
     tmp_path: Path,
     embedder: _RecordingEmbedder,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The copy marker has to outlive the reset, not just the copy.
+    """Dying part-way through a rebuild must not leave a resumable-looking candidate.
 
-    A rebuild inherits a collection whose rows the checkpoint no longer claims,
-    and only the reset makes that true. Clearing the marker before the reset
-    leaves a window where the checkpoint says the candidate is resumable while
-    it still holds unattributable rows.
+    A rebuild empties the collection and then records what replaced it, so a
+    crash between the two leaves rows the checkpoint does not account for --
+    the same shape a cancelled copy leaves, reached from the other direction.
     """
     docs_path = tmp_path / "docs"
     names = _write_corpus(docs_path, 3)
@@ -3545,8 +3546,6 @@ async def test_a_rebuild_that_dies_before_emptying_the_collection_still_recovers
         await _manager(config).reindex_all()
     cancel_copy = False
 
-    # A forced rebuild of that marked candidate copies nothing, so it takes the
-    # path where the marker used to be cleared before the collection was reset.
     (docs_path / names[0]).unlink()
     die_before_reset = True
     original_reset = KnowledgeManager._reset_vector_db
@@ -3559,12 +3558,13 @@ async def test_a_rebuild_that_dies_before_emptying_the_collection_still_recovers
 
     monkeypatch.setattr(KnowledgeManager, "_reset_vector_db", _maybe_die)
     with pytest.raises(RuntimeError):
-        await _manager(config).reindex_all(force_reindex=True)
+        await _manager(config).reindex_all()
     die_before_reset = False
 
     interrupted = load_candidate_checkpoint(_storage_path(config, runtime_paths))
     assert interrupted is not None
-    assert interrupted.seeding is True, "the marker was cleared while the collection still held rows"
+    assert interrupted.completed == {}
+    assert _stored_paths(interrupted.collection) == sorted(names), "the crash left rows nothing claims"
     embedder.embedded_texts.clear()
 
     indexed = await _manager(config).reindex_all()

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -3392,6 +3392,28 @@ async def test_shielded_write_finishes_before_repeated_cancellation_escapes() ->
 
 
 @pytest.mark.asyncio
+async def test_shielded_write_keeps_cancellation_authoritative_when_the_write_fails() -> None:
+    """A failed recoverable write must not replace the caller's cancellation."""
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _write() -> None:
+        started.set()
+        await release.wait()
+        msg = "recoverable write failed"
+        raise RuntimeError(msg)
+
+    outer = asyncio.create_task(knowledge_manager_module._shielded_write(_write()))
+    await started.wait()
+    outer.cancel()
+    await asyncio.sleep(0)
+    release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await outer
+
+
+@pytest.mark.asyncio
 async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
     tmp_path: Path,
     embedder: _RecordingEmbedder,


### PR DESCRIPTION
Every semantic knowledge refresh re-embeds the whole corpus, however little
changed. A base that takes an hour to index takes an hour again to absorb a
one-line edit, and pays the provider for it.

## The defect

Publishing a candidate index deletes its checkpoint. The next refresh therefore
finds no checkpoint in `_open_candidate_run`, mints a fresh candidate collection
with `completed={}`, resets it, and starts from zero — even though the
collection it just published holds vectors for every file that did not change.

Reproduced on a three-file base with the recording embedder:

```
1st refresh: indexed 3 files
change one file
2nd refresh: indexed 3 files, embedded "content 0", "content 1", "content 2"
```

`test_refresh_after_publish_reuses_vectors_for_unchanged_files` fails on `main`
with `AssertionError: the whole corpus was embedded again / assert 3 == 1`.

The cost is O(corpus) per refresh where the delta is O(changed files), so it
grows without bound as a base grows, and it repeats on every poll interval.

## The mechanism

The published collection is already an index from source path to vectors. Every
chunk was written with the metadata `_index_file_locked` attaches:

```python
metadata = {
    _SOURCE_PATH_KEY: relative_path,
    _SOURCE_MTIME_NS_KEY: source_mtime_ns,
    _SOURCE_SIZE_KEY: source_size,
    _SOURCE_DIGEST_KEY: source_digest,
}
```

So a fresh candidate no longer starts empty. It copies those chunks **verbatim**
— ids, embeddings, documents and metadata — for every currently-managed path,
and records each copied path in the checkpoint with the signature the published
index stored for it. Only paths the copy did not cover are embedded.

Nothing new decides whether the copy was right. `_reconcile_candidate` already
runs immediately afterwards, compares every recorded signature against the file
on disk, and drops and re-indexes whatever moved. Reuse is an optimization
layered on the existing correctness check, not a second one.

This deliberately does not use a Git diff. The digest already in the metadata is
a stronger signal than a revision range, and reconciliation already enforces it,
so a diff would only avoid copying rows for the few files that changed — a
fraction of one refresh's local I/O, in exchange for a subprocess call, a
fallback path, and a Git-only restriction. Without it the reuse also covers
non-Git watched folders.

## When reuse is allowed

All of these must hold, or the candidate is built from zero exactly as before:

| Condition | Why |
|---|---|
| `IndexingSettings` are equal | Pins the chunker (`chunk_size`, `chunk_overlap`), the embedder identity (provider, model, host, dimensions) and every corpus filter (branch, LFS, hidden, include/exclude patterns and extensions). Identical bytes under identical settings produce identical chunks and identical vectors. |
| Persisted status is `complete` | Any other collection is one the candidate lifecycle treats as an abandoned candidate it may reclaim. Copying from one would read a collection nothing keeps alive. |
| A collection is named | Type narrowing for the copy call. Unreachable at runtime: `status_when_missing="indexing"` is only written when there is no prior state, so no collection is named. |
| The refresh is not forced | An operator forcing a rebuild does not trust the index. A forced refresh both suppresses the copy and discards any surviving candidate, because that candidate's claims are the same suspect vectors. |
| The copy succeeds | Any exception resets the candidate and returns nothing, so the refresh degrades to a full rebuild instead of failing. |

Per path, the claim is derived from the rows actually copied, never from the
corpus listing, so a path the published index cannot serve is never claimed and
gets embedded normally.

## Recovering an interrupted copy

The copy writes rows before it records them, so an interruption can leave the
candidate holding vectors its checkpoint does not account for. That matters
because reconciliation derives every deletion from the checkpoint: rows outside
it are invisible to it and would ride into the published index — including rows
for a path that has since left the corpus, which would then keep serving its old
content from search.

`asyncio.to_thread` cannot be cancelled, so this is not exotic: the copy thread
runs to completion while the awaiting refresh raises `CancelledError`, and
`KnowledgeRefreshScheduler.shutdown()` cancels in-flight refreshes on any
ordinary restart.

Rather than record that a copy is in progress, the candidate carries an
invariant: **its collection may only hold rows the checkpoint claims.**

The published-vector copy writes many paths before recording any, then records
every copied path in one write after the last row lands. Ordinary indexing also
has an unclaimed window, but records each file immediately after its rows land,
so that window is bounded by the in-flight file rather than the whole copied
corpus. In either case, no claims plus a non-empty collection means rows exist
outside checkpoint accounting, which one bounded query detects when the
candidate is opened. A candidate in that state is rebuilt and copied again
rather than resumed over.

Two things follow that a stored flag would not have given:

- There is nothing to set early or clear late, so the class of ordering bugs a
  marker invites does not exist. The same check also covers a crash *during* a
  rebuild, between the claims being dropped and the collection being emptied.
- No persisted format change, which is the one part of this that would have been
  expensive to undo.

Claims are **not** written per page, and that is load-bearing rather than
incidental: a file's chunks can span pages, so a partial claim would name a path
holding only some of its chunks, and `_candidate_paths_missing_vectors` confirms
a path from a single row — the candidate would publish a silently truncated
file. `test_a_copy_records_its_claims_only_after_every_row_has_landed` pins it,
because nothing else in the design would notice.

## The traps

**1. mtime restamping.** Copied rows carry the published mtime, which a checkout
routinely invalidates without changing content. Recording that signature is
correct precisely because `_reconcile_candidate` compares only size and digest to
decide whether vectors survive, and adopts a new stamp for byte-identical
content through `_restamp_candidate_paths` — one batched journal append, no
re-embedding. The test bumps every mtime and asserts the *embed* count, not the
file count.

**2. Row-bounded copy query.** Chroma binds one SQL variable per *returned* row
and SQLite caps a statement at 32,766, so nothing about the file or path count
bounds a copy query. Measured against the pinned ChromaDB 1.5.8, on a collection
of 40,000 rows:

| Query | Result |
|---|---|
| `get(include=[embeddings, documents, metadatas])`, unpaged | `too many SQL variables` |
| same, `limit=1000` | ok |
| same, `limit=20000` | ok |
| same, `limit=40000` | `too many SQL variables` |

The copy pages at `_PUBLISHED_VECTOR_COPY_PAGE_ROWS = 500`, ~40x under the
observed ceiling, which also bounds how much vector data is held at once (a
3072-dimension embedder is ~12 MB of float per page).

Reuse also *removes* pressure from the query #1707 had to teach itself to split:
copied paths are marked `verified`, because the copy already reported which
paths received rows, so they never reach `_candidate_paths_missing_vectors`.

**3. Zero-length files.** They legitimately produce no vectors, so no copy can
prove them indexed; they are not claimed, and are rescanned at the cost of a read
and no embedding.

**4. The published collection is never mutated.** The copy reads it and writes
only into the candidate.

**5. Deleted and renamed paths.** Only paths in the current listing are copied, so
a published path that left the corpus never enters the candidate.

**6. Chunk ids.** Preserved on copy. Agno/Chroma key content by hash, and
regenerating ids would corrupt the candidate.

**7. Publication stays atomic.** The candidate is still built separately and
swapped in.

## Verified against real ChromaDB, not only the fake

The fake can only prove the logic is self-consistent, so the production
`KnowledgeManager` was run against a real `chromadb.PersistentClient` with a
deterministic embedder: three files, 40 chunks.

```
1. cold build: indexed 3 files / 40 chunks, 40 embed calls

2. one file changed: indexed 1, 14 embed calls
   reused 27 chunks, ids all published: True
   max vector difference: 5.960e-08

3. forced rebuild: indexed 3, 41 embed calls

4. copy cancelled after writing its rows
   stranded candidate holds: ['alpha.md', 'beta.md', 'gamma.md']
   after deleting gamma.md and resuming: indexed 1, 8 embed calls
   published paths: ['alpha.md', 'beta.md']

5. candidate survived a failed refresh with 2 claims
   forced rebuild over it: indexed 3, 24 embed calls
   published paths: ['alpha.md', 'beta.md', 'gamma.md']
   checkpoint retired: True
```

Step 4 is the recovery end to end: the stranded candidate holds `gamma.md`, the
next refresh rebuilds and copies again rather than re-embedding (8 calls, not
40), and `gamma.md` does not reach the published index.

**Copied vectors are not bit-identical, and cannot be made so.** Chroma stores a
cosine-space collection as a normalized vector plus its norm in float32 and
reconstructs on read, so a value loses up to one float32 ULP per write. 11 of 27
rows came back bit-identical; the rest differ by 6e-8. Two measurements make that
acceptable:

- The drift **converges** rather than accumulating. Over 100 successive copy hops
  at 1536 dimensions, maximum relative drift stops growing after the second hop
  and stays at 2.6e-7, with cosine similarity to the original at 1 − 2e-15. A
  file untouched for a thousand refreshes is no further from its original vector
  than after two.
- An `l2`-space collection round-trips exactly, so the drift is the cosine
  reconstruction, not the copy.

The nearest *other* chunk in the same corpus sits at cosine distance 0.16 — seven
orders of magnitude above the drift.

## Mutation checks

Every testable production branch was broken deliberately and confirmed caught:
**23 of 23**. Not assumed covered — earlier passes found branches with no test
behind them, which is where several of these tests came from.

| Mutation | Test that failed | Message |
|---|---|---|
| disable reuse entirely | `test_git_pull_that_changes_one_file_only_reindexes_that_file` | `the whole checkout was reindexed for a one-file commit` |
| drop the `IndexingSettings` gate | `test_published_vector_reuse_requires_matching_indexing_settings` | `vectors built under other settings were reused` |
| drop the `status == complete` gate | `test_published_vector_reuse_needs_a_completely_published_index` | `vectors from an unpublished collection were reused` |
| ignore `force_reindex` for the copy | `test_forced_reindex_rebuilds_every_vector_instead_of_copying_it` | `a forced rebuild reused the vectors it was asked to replace` |
| stop discarding a surviving candidate when forced | `test_forced_reindex_discards_a_candidate_that_survived_a_failed_refresh` | `a forced rebuild kept the candidate's claims` |
| drop `limit=` from the copy query | `test_published_vector_copy_is_paged_so_no_query_exceeds_the_store_ceiling` | `assert 12 == 1` |
| drop the managed-path filter | `test_published_vector_reuse_skips_paths_that_left_the_corpus` | `assert ['doc0000.md', ...] == ['doc0001.md', 'doc0002.md']` |
| drop the empty-page write guard | `test_published_vector_reuse_skips_paths_that_left_the_corpus` | `assert [] == ['doc0001.md', 'doc0002.md']` |
| narrow the copy-failure fallback | `test_published_vector_reuse_falls_back_when_the_published_collection_is_gone` | `chromadb.errors.NotFoundError` |
| drop the candidate reset after a failed copy | `test_a_failed_vector_copy_leaves_no_partial_candidate` | `partially copied rows survived the failure` |
| stop marking copied paths verified | `test_published_vector_copy_is_paged_so_no_query_exceeds_the_store_ceiling` | `assert 11 <= 4` |
| corrupt the digest in the recorded signature | `test_refresh_after_publish_reuses_vectors_for_unchanged_files` | `the whole corpus was embedded again` |
| claim paths from the listing instead of from copied rows | `test_published_vector_reuse_never_claims_a_path_the_published_index_cannot_serve` | `assert 0 == 1` |
| regenerate chunk ids on copy | `test_refresh_after_publish_reuses_vectors_for_unchanged_files` | `copied chunks must keep their published ids` |
| write into the published collection instead of the candidate | `test_published_vector_reuse_leaves_the_published_collection_untouched` | copy never terminates, killed by `pytest-timeout` |
| skip saving reused signatures into the checkpoint | `test_refresh_after_publish_reuses_vectors_for_unchanged_files` | `the whole corpus was embedded again` |
| stop rebuilding a candidate holding unclaimed rows | `test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim` | `a departed path survived in the published index` |
| condemn a candidate that has claims | `test_an_interruption_after_the_copy_still_resumes_the_work_it_finished` | `assert 4 == (4 - 2)` |
| condemn a candidate whose collection is empty | `test_a_candidate_with_no_vectors_and_no_claims_is_still_resumed` | `the retry ledger was reset` |
| record claims per page instead of once at the end | `test_a_copy_records_its_claims_only_after_every_row_has_landed` | `claims were recorded before every copied row had landed` |
| probe candidate existence after building `Knowledge` | `test_a_candidate_whose_collection_vanished_is_rebuilt_rather_than_resumed` | `claims survived a collection that no longer holds their vectors` |
| let a recoverable write failure replace cancellation | `test_shielded_write_keeps_cancellation_authoritative_when_the_write_fails` | `RuntimeError: recoverable write failed` |
| suppress a failed publish-metadata write after cancellation | `test_cancelled_publish_metadata_save_surfaces_a_failed_write` | `DID NOT RAISE RuntimeError` |

Two conditionals are not in that table, both stated rather than hidden:

- `persisted_state.collection is None` is type narrowing for the copy call, and
  unreachable at runtime as noted above.
- **`asyncio.shield` in `_shielded_write` has no mutation pair, because removing
  it changes nothing observable.** The write goes through `asyncio.to_thread`,
  which is itself uncancellable, so the file lands either way; the shield only
  makes the coroutine wait for it before propagating the cancellation, which
  matters solely if the loop closes and the process exits first. That window
  resisted a deterministic test. It is kept because it closes it, matches the
  module's existing pattern, and costs nothing — but it is untested and saying so
  is better than a test that only looks like it covers it.

## Test fake changes

Both knowledge test fakes grew what the copy needs, so neither silently takes the
exception fallback: stored chunk ids, `include=["embeddings", "documents"]`, and
an `add` that rejects an empty write the way real Chroma does (`Expected
Embeddings to be non-empty list or numpy array, got [] in add.`, verified against
1.5.8). `chroma_get_result` gained `documents` and `embeddings` and now raises
when `include` asks for a field the fake was not given, so a query shape it
cannot serve says so instead of looking like an empty store.

Without this, ~140 tests in `test_knowledge_manager.py` would have exercised the
fallback instead of the copy, and the paging and reset branches would have had no
coverage at all.

## Deliberately not changed

- **No Git diff pre-filter**, for the reasons above.
- **The 500-row page size is not adaptive.** #1707 adapts the *verification*
  query by splitting on failure; a fixed page needs no such machinery because it
  never asks for more than it can be given.

## Defect found and not fixed

Chroma's cosine-space storage perturbs every vector it writes by up to one
float32 ULP, so a vector is never bit-stable across a write even when the value
came straight out of the same store. It converges after two hops and sits seven
orders of magnitude under the nearest-neighbour gap, so it needs no action here —
but anything that ever compares stored vectors for equality should compare with a
tolerance, not with `==`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge-base refreshes reuse vectors for unchanged files to reduce unnecessary re-embedding.
  * Added a force option to perform a full reindex (rebuilds every vector without reuse).
* **Bug Fixes**
  * Improved interruption/cancellation handling so refreshes publish only after durable completion and can safely resume or reconcile.
* **Documentation**
  * Clarified refresh reuse rules and when stored vectors are invalidated (chunking, embedder, corpus filters), plus how explicit reindex differs.
* **Tests**
  * Expanded reuse/resume/forced-reindex coverage, added Git-based partial-reindex validation, and strengthened cancellation and paging/edge-case assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->