### PR TITLE
Narrow vector verification fallback errors

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -19,7 +19,7 @@ from agno.knowledge.reader import ReaderFactory
 from agno.knowledge.reader.markdown_reader import MarkdownReader
 from agno.knowledge.reader.text_reader import TextReader
 from agno.vectordb.chroma import ChromaDb
-from chromadb.errors import ChromaError, NotFoundError
+from chromadb.errors import InternalError, NotFoundError
 
 from mindroom.chunking import SafeFixedSizeChunking
 from mindroom.constants import (
@@ -352,7 +352,9 @@ def _paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -
         # query gets, so descending would only cost log2(batch) + 1 doomed
         # queries before raising exactly the same error from the first leaf.
         raise
-    except ChromaError:
+    except InternalError as error:
+        if "too many SQL variables" not in str(error):
+            raise
         # Splitting stays correct but multiplies the queries, and how far it
         # degrades depends on chunk counts nothing here can see. Without a
         # trace, a base whose files outgrew the ceiling just gets quietly

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -3056,6 +3056,30 @@ def test_vector_verification_does_not_split_when_the_collection_is_gone(tmp_path
     assert _FakeVectorDb.get_calls == 1
 
 
+def test_vector_verification_does_not_split_unrelated_internal_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only SQLite's bind-variable failure may trigger recursive splitting."""
+    _, vector_db = _verification_manager(tmp_path)
+    collection = vector_db.client.get_collection(vector_db.collection_name)
+    paths = [f"doc{index:02d}.md" for index in range(8)]
+    calls = 0
+
+    def refuse_query(**_: object) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        message = "database connection unexpectedly closed"
+        raise InternalError(message)
+
+    monkeypatch.setattr(collection, "get", refuse_query)
+
+    with pytest.raises(InternalError, match="database connection unexpectedly closed"):
+        knowledge_manager_module._paths_with_vectors(collection, paths)
+
+    assert calls == 1
+
+
 def test_vector_verification_records_that_it_had_to_split(tmp_path: Path) -> None:
     """A store refusing batches must leave a trace, not degrade silently.
 


### PR DESCRIPTION
## Summary

- split vector-verification queries only for the known SQLite `too many SQL variables` failure
- re-raise unrelated Chroma internal failures immediately instead of recursively retrying
- add regression coverage proving unrelated failures do not fan out

## Verification

- `uv run pytest -x --lf tests/test_knowledge_resumable_refresh.py -k vector_verification`
- `uv run ruff check src/mindroom/knowledge/manager.py tests/test_knowledge_resumable_refresh.py`
- `uv run ruff format --check src/mindroom/knowledge/manager.py tests/test_knowledge_resumable_refresh.py`
- `uv run tach check`
- pre-commit hooks

## Summary by Sourcery

Constrain vector verification fallback splitting to known SQLite bind-variable failures and add regression coverage to ensure unrelated internal errors are surfaced directly.

Bug Fixes:
- Ensure vector verification only retries with split queries on the specific SQLite 'too many SQL variables' InternalError and re-raises other internal failures immediately.

Tests:
- Add a regression test verifying that non-SQLite internal errors during vector verification do not trigger recursive splitting and are raised once.