### PR TITLE
Probe the candidate collection before Agno can create it

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1768,11 +1768,16 @@ class KnowledgeManager:
             vector_db = _require_chroma_vector_db(knowledge)
             await asyncio.to_thread(self._reset_vector_db, vector_db)
         else:
-            knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
-            vector_db = _require_chroma_vector_db(knowledge)
-            if await asyncio.to_thread(vector_db.exists):
-                resumed = True
-            else:
+            # Probed before ``Knowledge`` is built: Agno's ``Knowledge`` creates a
+            # missing collection on construction, so asked afterwards this always
+            # answers yes and a candidate whose vectors are gone is resumed still
+            # carrying claims nothing backs.
+            candidate_exists = await asyncio.to_thread(
+                chroma_collection_exists,
+                self._base_storage_path,
+                checkpoint.collection,
+            )
+            if not candidate_exists:
                 logger.warning(
                     "Knowledge candidate collection is missing; rebuilding it from scratch",
                     base_id=self.base_id,
@@ -1780,6 +1785,11 @@ class KnowledgeManager:
                 )
                 checkpoint = replace(checkpoint, completed={}, failed={})
                 checkpoint = await asyncio.to_thread(save_candidate_checkpoint, self._base_storage_path, checkpoint)
+            knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
+            vector_db = _require_chroma_vector_db(knowledge)
+            if candidate_exists:
+                resumed = True
+            else:
                 await asyncio.to_thread(self._reset_vector_db, vector_db)
 
         run = _CandidateRun(

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -234,6 +234,21 @@ class _FakeKnowledge:
         return self.vector_db.search(query=query, limit=max_results or self.max_results)
 
 
+class _AutoCreatingFakeKnowledge(_FakeKnowledge):
+    """Knowledge that creates a missing collection on construction, like Agno's.
+
+    ``Knowledge.__post_init__`` runs ``if not vector_db.exists():
+    vector_db.create()``, so any existence probe taken after building it always
+    answers yes. A test that cares whether a candidate's vectors really survived
+    has to model that, or it proves nothing about production.
+    """
+
+    def __init__(self, vector_db: _FakeVectorDb | None = None) -> None:
+        super().__init__(vector_db)
+        if vector_db is not None and not vector_db.exists():
+            vector_db.create()
+
+
 class _RecordingNonBatchEmbedder(Embedder):
     """Recording embedder with no batch surface at all, like Ollama.
 
@@ -3075,3 +3090,49 @@ def test_vector_verification_records_that_it_had_to_split(tmp_path: Path) -> Non
 
     split_logs = [entry for entry in logs if entry["event"] == "Split a refused knowledge vector verification query"]
     assert [entry["paths"] for entry in split_logs] == [8, 4, 4]
+
+
+# --------------------------------------------------------------------------
+# Resuming a candidate whose collection is gone
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_candidate_whose_collection_vanished_is_rebuilt_rather_than_resumed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Existence has to be probed before Agno can auto-create the collection.
+
+    Agno creates a missing collection when ``Knowledge`` is built, so the probe
+    taken afterwards always answered yes and this repair never ran. A candidate
+    whose vectors are gone was resumed still carrying claims nothing backs, and
+    every one of them then went through the vector-existence query to be dropped
+    a batch at a time -- at full corpus size, through the query whose row
+    ceiling this module already has to work around.
+    """
+    monkeypatch.setattr(knowledge_manager_module, "Knowledge", _AutoCreatingFakeKnowledge)
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    original_index = KnowledgeManager._index_file_locked
+
+    async def _fail_last(self: KnowledgeManager, resolved_path: Path, **kwargs: object) -> bool:
+        if resolved_path.name == names[-1]:
+            return False
+        return await original_index(self, resolved_path, **kwargs)
+
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", _fail_last)
+    await _manager(config).reindex_all()
+    monkeypatch.setattr(KnowledgeManager, "_index_file_locked", original_index)
+
+    checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
+    assert checkpoint is not None
+    assert len(checkpoint.completed) == 2, "the candidate should have kept the files it did index"
+    _FakeVectorDb.store.pop(checkpoint.collection)
+
+    run = await _manager(config)._open_candidate_run()
+
+    assert run.resumed is False
+    assert run.completed == {}, "claims survived a collection that no longer holds their vectors"


### PR DESCRIPTION
A repair branch that has never run, because the check it depends on is asked one
line too late.

## The bug

`_open_candidate_run` decides whether a resumable candidate's vectors still
exist:

```python
knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
vector_db = _require_chroma_vector_db(knowledge)
if await asyncio.to_thread(vector_db.exists):
    resumed = True
else:
    # "Knowledge candidate collection is missing; rebuilding it from scratch"
```

Agno's `Knowledge.__post_init__` is:

```python
if self.vector_db and not self.vector_db.exists():
    self.vector_db.create()
```

So `_build_knowledge` creates the collection, and the probe on the next line
can only ever answer yes. Measured against a real persistent ChromaDB:

```
exists() before building Knowledge: False
exists() after  building Knowledge: True
exists() on a fresh handle:         True
```

The `else` branch is dead in production.

## What that costs

A candidate whose collection was lost — wiped volume, restored-from-backup
storage directory, a sweep that removed the wrong thing — is resumed instead of
rebuilt, carrying a checkpoint full of claims that nothing backs. Agno hands it
a freshly created empty collection and the refresh proceeds as if the work were
still there.

It does self-heal: `_candidate_paths_missing_vectors` eventually finds every
completed entry unbacked and drops them. But that is the expensive route — one
`$in` query per batch of 128 across the entire corpus, which is the query whose
per-returned-row bind-variable ceiling #1707 had to teach itself to split. The
cheap answer, "this collection is gone, start over", was right there.

## The fix

Probe before building the handle, with `chroma_collection_exists` — the helper
whose docstring already says *"Check collection existence without constructing
Agno Knowledge"*. Its existence suggests someone had already met this hazard
somewhere else.

Six lines move; the repair branch itself is unchanged.

## Why no test caught it

Every `Knowledge` fake in the suite is inert on construction, so `exists()`
after building has always answered honestly in tests and never in production.
That is the actual defect behind the defect.

`_AutoCreatingFakeKnowledge` now models agno's behaviour, and the new test drives
a real candidate — index two files, fail the third so the candidate survives
unpublished, then delete its collection — and asserts the candidate is rebuilt
rather than resumed.

Against the old ordering it fails with:

```
AssertionError: assert True is False
 +  where True = _CandidateRun(...).resumed
```

## Scope

Split out of #1708, where I hit it while restructuring this function. It is
unrelated to that PR's subject and predates it, so it belongs on its own.

## Summary by Sourcery

Ensure resumable knowledge candidates are rebuilt when their vector collections are missing instead of being incorrectly resumed.

Bug Fixes:
- Probe Chroma collection existence before constructing Agno Knowledge so missing candidate collections trigger a full rebuild rather than a resumed run with empty vectors.

Tests:
- Add an auto-creating fake Knowledge implementation that mirrors Agno’s collection-creation behavior and a regression test covering candidates whose collections vanished.