### PR TITLE
Treat files-prefixed embedding inputs as text

### DIFF
--- a/src/mindroom/openai_embedder.py
+++ b/src/mindroom/openai_embedder.py
@@ -84,8 +84,13 @@ class MindRoomOpenAIEmbedder(OpenAIEmbedder):
         return self.dimensions is not None and (self._dimensions_explicit or self.id in OPENAI_EMBEDDING_DIMENSIONS)
 
     def _request_params(self, input_value: str | list[str]) -> dict[str, Any]:
+        # LiteLLM reserves files/... for Gemini file references; MindRoom inputs are text.
+        if isinstance(input_value, str):
+            request_input = f" {input_value}" if input_value.startswith("files/") else input_value
+        else:
+            request_input = [f" {text}" if text.startswith("files/") else text for text in input_value]
         request: dict[str, Any] = {
-            "input": input_value,
+            "input": request_input,
             "model": self.id,
             "encoding_format": self.encoding_format,
         }

--- a/tests/test_openai_embedder.py
+++ b/tests/test_openai_embedder.py
@@ -41,9 +41,9 @@ def _auth_error() -> AuthenticationError:
     return AuthenticationError(f"Incorrect API key provided: {SECRET}", response=response, body=None)
 
 
-def _success_response() -> SimpleNamespace:
+def _success_response(*, count: int = 1) -> SimpleNamespace:
     return SimpleNamespace(
-        data=[SimpleNamespace(embedding=[1.0, 2.0])],
+        data=[SimpleNamespace(embedding=[1.0, 2.0]) for _ in range(count)],
         usage=SimpleNamespace(model_dump=lambda: {"total_tokens": 1}),
     )
 
@@ -241,6 +241,21 @@ def test_get_embedding_and_usage_success_returns_vector_and_usage() -> None:
 
     assert embedding == [1.0, 2.0]
     assert usage == {"total_tokens": 1}
+
+
+def test_file_reference_like_inputs_are_sent_as_literal_text() -> None:
+    """Text beginning with LiteLLM's files/ sentinel cannot become a file reference."""
+    text = "files/bootsel.service#L9> If the embedded daemons do not start"
+    client = MagicMock()
+    client.embeddings.create.side_effect = [_success_response(), _success_response(count=2)]
+    embedder = MindRoomOpenAIEmbedder(id="gemini-embedding-001", api_key=SECRET, openai_client=client)
+
+    assert embedder.get_embedding(text) == [1.0, 2.0]
+    assert embedder.get_embeddings_batch(["ordinary text", text]) == [[1.0, 2.0], [1.0, 2.0]]
+
+    first_request, second_request = client.embeddings.create.call_args_list
+    assert first_request.kwargs["input"] == f" {text}"
+    assert second_request.kwargs["input"] == ["ordinary text", f" {text}"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- protect literal embedding text beginning with `files/` from being interpreted as an uploaded-file reference
- apply the normalization centrally to single and batched embedding requests
- add a regression test covering both request shapes

## Testing

- `uv run pytest -x --lf -q tests/test_openai_embedder.py`
- `uv run ruff check src/mindroom/openai_embedder.py tests/test_openai_embedder.py`
- `uv run ruff format --check src/mindroom/openai_embedder.py tests/test_openai_embedder.py`
- `uv run tach check`

## Summary by Sourcery

Normalize embedding inputs to ensure text beginning with the files/ sentinel is treated as literal text for both single and batch embedding calls and cover this behavior with tests.

Bug Fixes:
- Prevent LiteLLM Gemini embeddings from misinterpreting files/-prefixed text inputs as file references.

Enhancements:
- Centralize embedding input normalization in the request parameter builder for single and batched requests.

Tests:
- Add regression test verifying files/-prefixed inputs are sent as literal text for both single and batched embedding requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed embedding requests for text resembling file references, ensuring these values are treated as literal text.
  * Applied consistent handling for both individual and batch embedding requests.

* **Tests**
  * Added coverage verifying the exact request payloads for file-reference-like inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->