### PR TITLE
Index malformed JSON knowledge files as text

### DIFF
--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -150,6 +150,11 @@ Non-text formats such as `.pdf`, `.docx`, or `.pptx` require their reader packag
 When a reader package is missing, the refresh indexes every other file, logs a warning naming the file and the missing package, and records a partial-index error instead of publishing an index without the opted-in content.
 Extension filtering does not apply in `files` mode, which exposes every managed file.
 
+A `.json` file is normally split into one document per top-level JSON value, which keeps structured entries separately searchable.
+When such a file is not valid JSON, the refresh indexes its raw text instead of failing the file, and logs a warning naming the file and the line and column of the parse error.
+The file then counts as successfully indexed, so its content stays searchable, but it is chunked like plain text rather than split per JSON value.
+Fix the reported parse error to get structured chunking back.
+
 ### Private Agent Knowledge
 
 Use `agents.<name>.private.knowledge` when one shared agent definition should index PrivateAgentKnowledge from that requester's private root.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13057,6 +13057,11 @@ Non-text formats such as `.pdf`, `.docx`, or `.pptx` require their reader packag
 When a reader package is missing, the refresh indexes every other file, logs a warning naming the file and the missing package, and records a partial-index error instead of publishing an index without the opted-in content.
 Extension filtering does not apply in `files` mode, which exposes every managed file.
 
+A `.json` file is normally split into one document per top-level JSON value, which keeps structured entries separately searchable.
+When such a file is not valid JSON, the refresh indexes its raw text instead of failing the file, and logs a warning naming the file and the line and column of the parse error.
+The file then counts as successfully indexed, so its content stays searchable, but it is chunked like plain text rather than split per JSON value.
+Fix the reported parse error to get structured chunking back.
+
 ### Private Agent Knowledge
 
 Use `agents.<name>.private.knowledge` when one shared agent definition should index PrivateAgentKnowledge from that requester's private root.

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -146,6 +146,11 @@ Non-text formats such as `.pdf`, `.docx`, or `.pptx` require their reader packag
 When a reader package is missing, the refresh indexes every other file, logs a warning naming the file and the missing package, and records a partial-index error instead of publishing an index without the opted-in content.
 Extension filtering does not apply in `files` mode, which exposes every managed file.
 
+A `.json` file is normally split into one document per top-level JSON value, which keeps structured entries separately searchable.
+When such a file is not valid JSON, the refresh indexes its raw text instead of failing the file, and logs a warning naming the file and the line and column of the parse error.
+The file then counts as successfully indexed, so its content stays searchable, but it is chunked like plain text rather than split per JSON value.
+Fix the reported parse error to get structured chunking back.
+
 ### Private Agent Knowledge
 
 Use `agents.<name>.private.knowledge` when one shared agent definition should index PrivateAgentKnowledge from that requester's private root.

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -13,9 +13,10 @@ from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeVar, cast, runtime_checkable
+from typing import IO, TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeVar, cast, runtime_checkable
 from urllib.parse import quote, urlparse, urlunparse
 
+from agno.knowledge.document.base import Document
 from agno.knowledge.reader import ReaderFactory
 from agno.knowledge.reader.json_reader import JSONReader
 from agno.knowledge.reader.markdown_reader import MarkdownReader
@@ -86,7 +87,6 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Coroutine, Iterable, Iterator, Mapping, Sequence
     from pathlib import Path
 
-    from agno.knowledge.document.base import Document
     from agno.knowledge.embedder.base import Embedder
     from agno.knowledge.reader.base import Reader
     from chromadb.api.models.Collection import Collection
@@ -96,6 +96,51 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
 
 logger = get_logger(__name__)
+
+
+class _MalformedJSONSourceError(Exception):
+    """A JSON parser failure carrying the already-read source text."""
+
+    def __init__(self, source_text: str, *, line: int, column: int) -> None:
+        super().__init__("Malformed JSON knowledge source")
+        self.source_text = source_text
+        self.line = line
+        self.column = column
+
+
+class _FallbackAwareJSONReader(JSONReader):
+    """Tag only JSON decoding failures raised inside the source reader."""
+
+    def read(self, path: Path | IO[Any], name: str | None = None) -> list[Document]:
+        malformed_error: _MalformedJSONSourceError | None = None
+        try:
+            return super().read(path, name=name)
+        except json.JSONDecodeError as error:
+            malformed_error = _MalformedJSONSourceError(
+                error.doc,
+                line=error.lineno,
+                column=error.colno,
+            )
+        raise malformed_error
+
+
+class _InMemoryTextReader(TextReader):
+    """Read the malformed JSON text already retained by its parse error."""
+
+    def __init__(self, source_text: str) -> None:
+        super().__init__()
+        self._source_text = source_text
+
+    def read(self, file: Path | IO[Any], name: str | None = None) -> list[Document]:
+        document = Document(
+            name=name or str(file),
+            id=str(uuid.uuid4()),
+            content=self._source_text,
+        )
+        if not self.chunk:
+            return [document]
+        return self.chunk_document(document)
+
 
 _COLLECTION_PREFIX = "mindroom_knowledge"
 _SOURCE_PATH_KEY = "source_path"
@@ -1144,14 +1189,8 @@ class KnowledgeManager:
             overlap=base_config.chunk_overlap,
         )
 
-    def _build_reader(self, file_path: Path) -> Reader:
-        """Build a per-file reader with conservative chunking for text-like content."""
-        reader = ReaderFactory.get_reader_for_extension(file_path.suffix.lower())
-
-        # Large markdown/plain-text files are the common source of oversized embed requests.
-        if not isinstance(reader, (TextReader, MarkdownReader)):
-            return reader
-
+    def _configure_text_reader(self, reader: TextReader | MarkdownReader) -> TextReader | MarkdownReader:
+        """Apply this base's text chunking policy to a private reader copy."""
         chunking_strategy = self._chunking_strategy()
         configured_reader = deepcopy(reader)
         configured_reader.chunk = True
@@ -1159,10 +1198,22 @@ class KnowledgeManager:
         configured_reader.chunking_strategy = chunking_strategy
         return configured_reader
 
+    def _build_reader(self, file_path: Path) -> Reader:
+        """Build a per-file reader with conservative chunking for text-like content."""
+        reader = ReaderFactory.get_reader_for_extension(file_path.suffix.lower())
+
+        if isinstance(reader, JSONReader):
+            return _FallbackAwareJSONReader(**deepcopy(vars(reader)))
+
+        # Large markdown/plain-text files are the common source of oversized embed requests.
+        if not isinstance(reader, (TextReader, MarkdownReader)):
+            return reader
+
+        return self._configure_text_reader(reader)
+
     async def _insert_with_malformed_json_fallback(
         self,
         insert: Callable[[Reader], Awaitable[None]],
-        file_path: Path,
         relative_path: str,
         reader: Reader,
     ) -> None:
@@ -1181,25 +1232,15 @@ class KnowledgeManager:
 
         try:
             await _insert_with_retry(reader)
-        except json.JSONDecodeError as error:
-            if not isinstance(reader, JSONReader):
-                raise
-            source_text = await asyncio.to_thread(file_path.read_text, encoding=reader.encoding or "utf-8")
-            if error.doc != source_text:
-                raise
+        except _MalformedJSONSourceError as error:
             logger.warning(
                 "Malformed JSON knowledge file; indexing as text",
                 base_id=self.base_id,
                 path=relative_path,
-                line=error.lineno,
-                column=error.colno,
+                line=error.line,
+                column=error.column,
             )
-            chunking_strategy = self._chunking_strategy()
-            fallback_reader = TextReader(
-                chunk=True,
-                chunk_size=chunking_strategy.chunk_size,
-                chunking_strategy=chunking_strategy,
-            )
+            fallback_reader = self._configure_text_reader(_InMemoryTextReader(error.source_text))
             await _insert_with_retry(fallback_reader)
 
     def _default_collection_name(self) -> str:
@@ -1440,7 +1481,6 @@ class KnowledgeManager:
             # costs one retry of this file instead of the whole refresh.
             await self._insert_with_malformed_json_fallback(
                 _insert_once,
-                resolved_path,
                 relative_path,
                 reader,
             )

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -13,6 +13,7 @@ from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
+from functools import partial
 from typing import IO, TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeVar, cast, runtime_checkable
 from urllib.parse import quote, urlparse, urlunparse
 
@@ -112,20 +113,20 @@ class _FallbackAwareJSONReader(JSONReader):
     """Tag only JSON decoding failures raised inside the source reader."""
 
     def read(self, path: Path | IO[Any], name: str | None = None) -> list[Document]:
-        malformed_error: _MalformedJSONSourceError | None = None
         try:
             return super().read(path, name=name)
         except json.JSONDecodeError as error:
-            malformed_error = _MalformedJSONSourceError(
-                error.doc,
-                line=error.lineno,
-                column=error.colno,
-            )
-        raise malformed_error
+            raise _MalformedJSONSourceError(error.doc, line=error.lineno, column=error.colno) from error
 
 
 class _InMemoryTextReader(TextReader):
-    """Read the malformed JSON text already retained by its parse error."""
+    """Read the malformed JSON text already retained by its parse error.
+
+    Only ``read`` is overridden, because indexing goes through the synchronous
+    ``Knowledge.insert`` path. ``TextReader.async_read`` does not delegate to
+    ``read``, so anything switching this to ``Knowledge.ainsert`` must override
+    it too or it will re-read the source instead of serving the retained text.
+    """
 
     def __init__(self, source_text: str) -> None:
         super().__init__()
@@ -1190,41 +1191,42 @@ class KnowledgeManager:
         )
 
     def _configure_text_reader(self, reader: TextReader | MarkdownReader) -> TextReader | MarkdownReader:
-        """Apply this base's text chunking policy to a private reader copy."""
+        """Apply this base's text chunking policy to ``reader`` in place."""
         chunking_strategy = self._chunking_strategy()
-        configured_reader = deepcopy(reader)
-        configured_reader.chunk = True
-        configured_reader.chunk_size = chunking_strategy.chunk_size
-        configured_reader.chunking_strategy = chunking_strategy
-        return configured_reader
+        reader.chunk = True
+        reader.chunk_size = chunking_strategy.chunk_size
+        reader.chunking_strategy = chunking_strategy
+        return reader
 
     def _build_reader(self, file_path: Path) -> Reader:
         """Build a per-file reader with conservative chunking for text-like content."""
         reader = ReaderFactory.get_reader_for_extension(file_path.suffix.lower())
 
+        # ReaderFactory hands out cached shared instances, so any branch that
+        # configures a reader copies it first instead of mutating the cache.
         if isinstance(reader, JSONReader):
+            # Carry the factory reader's configuration (encoding, chunking) onto
+            # the subclass that tags its own decode failures for the text fallback.
             return _FallbackAwareJSONReader(**deepcopy(vars(reader)))
 
         # Large markdown/plain-text files are the common source of oversized embed requests.
         if not isinstance(reader, (TextReader, MarkdownReader)):
             return reader
 
-        return self._configure_text_reader(reader)
+        return self._configure_text_reader(deepcopy(reader))
 
     async def _insert_with_malformed_json_fallback(
         self,
         insert: Callable[[Reader], Awaitable[None]],
+        *,
         relative_path: str,
         reader: Reader,
     ) -> None:
         """Insert through the selected reader, falling back only for malformed source JSON."""
 
         async def _insert_with_retry(selected_reader: Reader) -> None:
-            async def _insert_once() -> None:
-                await insert(selected_reader)
-
             await run_with_embedding_retry(
-                _insert_once,
+                partial(insert, selected_reader),
                 policy=_EMBEDDING_RETRY_POLICY,
                 sleep=_EMBEDDING_RETRY_SLEEP,
                 on_retry=self._record_embedding_retry,
@@ -1456,7 +1458,7 @@ class KnowledgeManager:
             return False
         target_knowledge = knowledge or self._knowledge
 
-        async def _insert_once(reader: Reader) -> None:
+        async def _insert_once(selected_reader: Reader) -> None:
             if upsert:
                 # Agno/Chroma upsert keys by content hash, so stale chunks from an older
                 # version of the same file can remain unless we clear by source metadata first.
@@ -1473,7 +1475,7 @@ class KnowledgeManager:
                 path=str(resolved_path),
                 metadata=metadata,
                 upsert=upsert,
-                reader=reader,
+                reader=selected_reader,
             )
 
         try:
@@ -1481,8 +1483,8 @@ class KnowledgeManager:
             # costs one retry of this file instead of the whole refresh.
             await self._insert_with_malformed_json_fallback(
                 _insert_once,
-                relative_path,
-                reader,
+                relative_path=relative_path,
+                reader=reader,
             )
         except Exception as exc:
             classified = classified_embedder_error(exc)

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
+import json
 import os
 import time
 import uuid
@@ -16,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeVar, cas
 from urllib.parse import quote, urlparse, urlunparse
 
 from agno.knowledge.reader import ReaderFactory
+from agno.knowledge.reader.json_reader import JSONReader
 from agno.knowledge.reader.markdown_reader import MarkdownReader
 from agno.knowledge.reader.text_reader import TextReader
 from agno.vectordb.chroma import ChromaDb
@@ -1157,6 +1159,49 @@ class KnowledgeManager:
         configured_reader.chunking_strategy = chunking_strategy
         return configured_reader
 
+    async def _insert_with_malformed_json_fallback(
+        self,
+        insert: Callable[[Reader], Awaitable[None]],
+        file_path: Path,
+        relative_path: str,
+        reader: Reader,
+    ) -> None:
+        """Insert through the selected reader, falling back only for malformed source JSON."""
+
+        async def _insert_with_retry(selected_reader: Reader) -> None:
+            async def _insert_once() -> None:
+                await insert(selected_reader)
+
+            await run_with_embedding_retry(
+                _insert_once,
+                policy=_EMBEDDING_RETRY_POLICY,
+                sleep=_EMBEDDING_RETRY_SLEEP,
+                on_retry=self._record_embedding_retry,
+            )
+
+        try:
+            await _insert_with_retry(reader)
+        except json.JSONDecodeError as error:
+            if not isinstance(reader, JSONReader):
+                raise
+            source_text = await asyncio.to_thread(file_path.read_text, encoding=reader.encoding or "utf-8")
+            if error.doc != source_text:
+                raise
+            logger.warning(
+                "Malformed JSON knowledge file; indexing as text",
+                base_id=self.base_id,
+                path=relative_path,
+                line=error.lineno,
+                column=error.colno,
+            )
+            chunking_strategy = self._chunking_strategy()
+            fallback_reader = TextReader(
+                chunk=True,
+                chunk_size=chunking_strategy.chunk_size,
+                chunking_strategy=chunking_strategy,
+            )
+            await _insert_with_retry(fallback_reader)
+
     def _default_collection_name(self) -> str:
         return _collection_name(self.base_id, self._knowledge_source_path())
 
@@ -1370,7 +1415,7 @@ class KnowledgeManager:
             return False
         target_knowledge = knowledge or self._knowledge
 
-        async def _insert_once() -> None:
+        async def _insert_once(reader: Reader) -> None:
             if upsert:
                 # Agno/Chroma upsert keys by content hash, so stale chunks from an older
                 # version of the same file can remain unless we clear by source metadata first.
@@ -1393,11 +1438,11 @@ class KnowledgeManager:
         try:
             # Remove-then-insert is idempotent, so a transient embedding fault
             # costs one retry of this file instead of the whole refresh.
-            await run_with_embedding_retry(
+            await self._insert_with_malformed_json_fallback(
                 _insert_once,
-                policy=_EMBEDDING_RETRY_POLICY,
-                sleep=_EMBEDDING_RETRY_SLEEP,
-                on_retry=self._record_embedding_retry,
+                resolved_path,
+                relative_path,
+                reader,
             )
         except Exception as exc:
             classified = classified_embedder_error(exc)

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -8905,10 +8905,21 @@ async def test_malformed_json_falls_back_to_text_and_publishes(
     docs_path = tmp_path / "docs"
     docs_path.mkdir()
     malformed = '{\n  "claim": "still useful",\n  “broken”: true\n}\n'
-    (docs_path / "claim.json").write_text(malformed, encoding="utf-8")
+    source_path = docs_path / "claim.json"
+    source_path.write_text(malformed, encoding="utf-8")
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
     monkeypatch.setattr(_Knowledge, "insert", _insert_with_real_reader)
+    original_read_text = Path.read_text
+    source_reads = 0
+
+    def _count_source_reads(path: Path, *args: object, **kwargs: object) -> str:
+        nonlocal source_reads
+        if path == source_path:
+            source_reads += 1
+        return original_read_text(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _count_source_reads)
 
     with capture_logs() as logs:
         result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
@@ -8922,6 +8933,7 @@ async def test_malformed_json_falls_back_to_text_and_publishes(
     assert "“broken”: true" in documents[0].content
     fallback = [entry for entry in logs if entry["event"] == "Malformed JSON knowledge file; indexing as text"]
     assert [(entry["path"], entry["line"], entry["column"]) for entry in fallback] == [("claim.json", 3, 3)]
+    assert source_reads == 1
 
 
 @pytest.mark.asyncio
@@ -8970,7 +8982,9 @@ async def test_valid_json_does_not_hide_downstream_json_decode_error(
         upsert: bool,
         reader: object | None = None,
     ) -> None:
-        _ = (self, path, metadata, upsert, reader)
+        _ = (self, metadata, upsert)
+        selected_reader = cast("Reader", reader)
+        selected_reader.read(Path(path), name=Path(path).name)
         message = "downstream response was not JSON"
         raise json.JSONDecodeError(message, "<html>", 0)
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -73,6 +73,8 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Coroutine, Iterable, Iterator, Sequence
     from types import ModuleType
 
+    from agno.knowledge.reader.base import Reader
+
     from mindroom.constants import RuntimePaths
 
 
@@ -241,6 +243,30 @@ class _Knowledge:
 
     def search(self, query: str, max_results: int | None = None) -> list[Document]:
         return self.vector_db.search(query=query, limit=max_results or 5)
+
+
+def _insert_with_real_reader(
+    self: _Knowledge,
+    *,
+    path: str,
+    metadata: dict[str, object],
+    upsert: bool,
+    reader: object | None = None,
+) -> None:
+    """Exercise the selected Agno reader while keeping vectors in the test store."""
+    _ = upsert
+    selected_reader = cast("Reader", reader)
+    documents = selected_reader.read(Path(path), name=Path(path).name)
+    with _VectorDb.lock:
+        _VectorDb.collections.setdefault(self.vector_db.collection_name, []).extend(
+            {
+                "id": f"row-{next(_vector_row_ids)}",
+                "content": document.content,
+                "embedding": [1.0],
+                "metadata": {**metadata, **document.meta_data},
+            }
+            for document in documents
+        )
 
 
 class _FakeEmbedder(Embedder):
@@ -8868,3 +8894,94 @@ async def test_index_file_locked_runs_off_event_loop_thread(
             f"Knowledge.insert ran on the asyncio main thread (id={thread_id}); "
             "it must run on a worker thread via asyncio.to_thread."
         )
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_falls_back_to_text_and_publishes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed JSON remains searchable instead of blocking the whole candidate."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    malformed = '{\n  "claim": "still useful",\n  “broken”: true\n}\n'
+    (docs_path / "claim.json").write_text(malformed, encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    monkeypatch.setattr(_Knowledge, "insert", _insert_with_real_reader)
+
+    with capture_logs() as logs:
+        result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    lookup = get_published_index("docs", config=config, runtime_paths=runtime_paths)
+
+    assert result.index_published is True
+    assert lookup.index is not None
+    documents = lookup.index.knowledge.search("still useful", max_results=5)
+    assert len(documents) == 1
+    assert '"claim": "still useful"' in documents[0].content
+    assert "“broken”: true" in documents[0].content
+    fallback = [entry for entry in logs if entry["event"] == "Malformed JSON knowledge file; indexing as text"]
+    assert [(entry["path"], entry["line"], entry["column"]) for entry in fallback] == [("claim.json", 3, 3)]
+
+
+@pytest.mark.asyncio
+async def test_valid_json_keeps_structured_reader(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Valid JSON lists remain separate structured documents."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "claims.json").write_text('[{"claim": "one"}, {"claim": "two"}]', encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    monkeypatch.setattr(_Knowledge, "insert", _insert_with_real_reader)
+
+    with capture_logs() as logs:
+        result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    lookup = get_published_index("docs", config=config, runtime_paths=runtime_paths)
+
+    assert result.index_published is True
+    assert lookup.index is not None
+    assert [document.content for document in lookup.index.knowledge.search("claim", max_results=5)] == [
+        '{"claim": "one"}',
+        '{"claim": "two"}',
+    ]
+    assert all(entry["event"] != "Malformed JSON knowledge file; indexing as text" for entry in logs)
+
+
+@pytest.mark.asyncio
+async def test_valid_json_does_not_hide_downstream_json_decode_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A downstream JSONDecodeError remains a failure when source JSON is valid."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "claim.json").write_text('{"claim": "valid"}', encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+
+    def _fail_after_read(
+        self: _Knowledge,
+        *,
+        path: str,
+        metadata: dict[str, object],
+        upsert: bool,
+        reader: object | None = None,
+    ) -> None:
+        _ = (self, path, metadata, upsert, reader)
+        message = "downstream response was not JSON"
+        raise json.JSONDecodeError(message, "<html>", 0)
+
+    monkeypatch.setattr(_Knowledge, "insert", _fail_after_read)
+
+    with capture_logs() as logs:
+        result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert result.index_published is False
+    assert (
+        result.last_error
+        == "Indexed 0 of 1 managed knowledge files (first error: knowledge indexing failed (JSONDecodeError))"
+    )
+    assert all(entry["event"] != "Malformed JSON knowledge file; indexing as text" for entry in logs)


### PR DESCRIPTION
## Summary

- retain structured JSON reading for valid knowledge files
- fall back to the configured text chunker when the source file itself is malformed JSON
- keep unrelated downstream JSON decode failures visible
- log the malformed source path, line, and column

## Testing

- `uv run pytest -x --lf -q tests/test_knowledge_manager.py`
- `uv run ruff check src/mindroom/knowledge/manager.py tests/test_knowledge_manager.py`
- `uv run ruff format --check src/mindroom/knowledge/manager.py tests/test_knowledge_manager.py`
- `uv run ty check src/mindroom/knowledge/manager.py tests/test_knowledge_manager.py`
- `uv run tach check`

## Summary by Sourcery

Handle malformed JSON knowledge files by falling back to text indexing while preserving behavior for valid JSON and downstream JSON errors.

New Features:
- Add a malformed-JSON-aware insertion path that retries indexing with a text reader when the source knowledge file is invalid JSON but still readable as text.

Enhancements:
- Log malformed JSON knowledge files with base ID, relative path, and precise line and column information.
- Refactor file indexing to route reader insertion through a helper that can switch readers without changing the vector store behavior.

Tests:
- Add integration-style tests covering malformed JSON fallback to text indexing, preservation of structured JSON behavior for valid lists, and visibility of downstream JSON decode failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Knowledge indexing now handles malformed JSON files by treating them as searchable plain text instead of failing.
  * Valid JSON files continue to receive structured indexing for improved document segmentation.
  * Genuine processing errors that occur after JSON parsing are still reported correctly rather than being hidden.
  * Indexing logs now provide details when malformed JSON fallback is used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->