### PR TITLE
refactor(knowledge): drop dead per-refresh state from KnowledgeManager

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -673,10 +673,7 @@ class KnowledgeManager:
     _indexing_settings_path: Path = field(init=False)
     _git_lfs_hydrated_head_path: Path = field(init=False)
     _knowledge: Knowledge = field(init=False)
-    _indexed_files: set[str] = field(default_factory=set, init=False)
-    _indexed_signatures: dict[str, FileSignature] = field(default_factory=dict, init=False)
     _lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
-    _state_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _git_sync_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _git_last_successful_commit: str | None = field(default=None, init=False)
     _last_refresh_error: str | None = field(default=None, init=False)
@@ -1103,10 +1100,9 @@ class KnowledgeManager:
         self,
         relative_path: str,
         *,
-        knowledge: Knowledge | None = None,
+        knowledge: Knowledge,
     ) -> bool:
-        target_knowledge = knowledge or self._knowledge
-        vector_db = target_knowledge.vector_db
+        vector_db = knowledge.vector_db
         if not isinstance(vector_db, ChromaDb):
             return True
         if not vector_db.exists():
@@ -1119,7 +1115,7 @@ class KnowledgeManager:
         self,
         relative_path: str,
         *,
-        knowledge: Knowledge | None = None,
+        knowledge: Knowledge,
     ) -> bool:
         """Retry post-insert visibility checks to tolerate brief vector-store lag."""
         for attempt, delay_seconds in enumerate(_POST_INDEX_VECTOR_VISIBILITY_RETRY_DELAYS_SECONDS):
@@ -1276,24 +1272,10 @@ class KnowledgeManager:
             return True
         return False
 
-    async def _adopt_candidate_vector_db(
-        self,
-        *,
-        candidate_vector_db: ChromaDb,
-        indexed_files: set[str],
-        indexed_signatures: dict[str, FileSignature],
-    ) -> None:
-        self._knowledge.vector_db = candidate_vector_db
-        async with self._state_lock:
-            self._indexed_files = indexed_files
-            self._indexed_signatures = indexed_signatures
-
     async def _publish_candidate_after_metadata_save(
         self,
         *,
         candidate_vector_db: ChromaDb,
-        indexed_files: set[str],
-        indexed_signatures: dict[str, FileSignature],
         indexed_count: int,
         source_signature: str,
         publish_state: _CandidatePublishState,
@@ -1304,11 +1286,10 @@ class KnowledgeManager:
             source_signature=source_signature,
         )
         publish_state.index_published = True
-        await self._adopt_candidate_vector_db(
-            candidate_vector_db=candidate_vector_db,
-            indexed_files=indexed_files,
-            indexed_signatures=indexed_signatures,
-        )
+        # Adopt the candidate as this manager's live vector database:
+        # `_cleanup_superseded_collections` runs right after publish and reads
+        # `self._knowledge.vector_db` to obtain the Chroma client it lists with.
+        self._knowledge.vector_db = candidate_vector_db
         if publish_cancelled:
             _raise_cancelled()
 
@@ -1344,9 +1325,8 @@ class KnowledgeManager:
         resolved_path: Path,
         *,
         upsert: bool,
-        knowledge: Knowledge | None = None,
-        indexed_files: set[str] | None = None,
-        indexed_signatures: dict[str, FileSignature] | None = None,
+        knowledge: Knowledge,
+        indexed_signatures: dict[str, FileSignature],
     ) -> bool:
         """Index one file while the caller owns the operation lock."""
         relative_path = self._relative_path(resolved_path)
@@ -1368,13 +1348,12 @@ class KnowledgeManager:
                 error=str(exc),
             )
             return False
-        target_knowledge = knowledge or self._knowledge
 
         async def _insert_once() -> None:
             if upsert:
                 # Agno/Chroma upsert keys by content hash, so stale chunks from an older
                 # version of the same file can remain unless we clear by source metadata first.
-                await asyncio.to_thread(target_knowledge.remove_vectors_by_metadata, {_SOURCE_PATH_KEY: relative_path})
+                await asyncio.to_thread(knowledge.remove_vectors_by_metadata, {_SOURCE_PATH_KEY: relative_path})
             # Knowledge.ainsert is async by name only: it eventually calls into the
             # vector database's synchronous batch upsert (e.g. ChromaDB's Rust
             # _upsert) on the running event loop, blocking every other coroutine
@@ -1383,7 +1362,7 @@ class KnowledgeManager:
             # worker thread and the loop stays responsive to Matrix sync, tool
             # calls, and cache writes.
             await asyncio.to_thread(
-                target_knowledge.insert,
+                knowledge.insert,
                 path=str(resolved_path),
                 metadata=metadata,
                 upsert=upsert,
@@ -1411,24 +1390,16 @@ class KnowledgeManager:
 
         has_vectors = await self._wait_for_source_vectors(
             relative_path,
-            knowledge=target_knowledge,
+            knowledge=knowledge,
         )
         if not has_vectors:
-            return await self._handle_vectorless_file(
+            return self._handle_vectorless_file(
                 relative_path,
                 (source_mtime_ns, source_size, source_digest),
-                indexed_files=indexed_files,
                 indexed_signatures=indexed_signatures,
             )
 
-        if indexed_signatures is not None:
-            if indexed_files is not None:
-                indexed_files.add(relative_path)
-            indexed_signatures[relative_path] = (source_mtime_ns, source_size, source_digest)
-        else:
-            async with self._state_lock:
-                self._indexed_files.add(relative_path)
-                self._indexed_signatures[relative_path] = (source_mtime_ns, source_size, source_digest)
+        indexed_signatures[relative_path] = (source_mtime_ns, source_size, source_digest)
         self._file_index_errors.pop(relative_path, None)
         self._note_embedder_success()
         # DEBUG, not INFO: a large corpus is 10^5 of these lines per refresh.
@@ -1436,37 +1407,22 @@ class KnowledgeManager:
         logger.debug("Indexed knowledge file", base_id=self.base_id, path=relative_path)
         return True
 
-    async def _handle_vectorless_file(
+    def _handle_vectorless_file(
         self,
         relative_path: str,
         signature: FileSignature,
         *,
-        indexed_files: set[str] | None,
-        indexed_signatures: dict[str, FileSignature] | None,
+        indexed_signatures: dict[str, FileSignature],
     ) -> bool:
         """Record one insert that produced no vectors; success only for empty sources."""
         source_size = signature[1]
         if source_size == 0:
-            if indexed_signatures is not None:
-                if indexed_files is not None:
-                    indexed_files.add(relative_path)
-                indexed_signatures[relative_path] = signature
-            else:
-                async with self._state_lock:
-                    self._indexed_files.add(relative_path)
-                    self._indexed_signatures[relative_path] = signature
+            indexed_signatures[relative_path] = signature
             logger.debug("Scanned empty knowledge file with no vectors", base_id=self.base_id, path=relative_path)
             return True
 
         logger.warning("Indexing produced no vectors for file", base_id=self.base_id, path=relative_path)
-        if indexed_signatures is not None:
-            if indexed_files is not None:
-                indexed_files.discard(relative_path)
-            indexed_signatures.pop(relative_path, None)
-        else:
-            async with self._state_lock:
-                self._indexed_files.discard(relative_path)
-                self._indexed_signatures.pop(relative_path, None)
+        indexed_signatures.pop(relative_path, None)
         return False
 
     def _record_embedding_retry(self) -> None:
@@ -1622,9 +1578,8 @@ class KnowledgeManager:
         self,
         files: list[Path],
         *,
-        knowledge: Knowledge | None = None,
-        indexed_files: set[str] | None = None,
-        indexed_signatures: dict[str, FileSignature] | None = None,
+        knowledge: Knowledge,
+        indexed_signatures: dict[str, FileSignature],
         vanished_files: set[str] | None = None,
         embedder: BatchPrefetchEmbedder | None = None,
         on_file_result: Callable[[Path], Awaitable[None]] | None = None,
@@ -1650,7 +1605,6 @@ class KnowledgeManager:
             indexed_count += await self._index_file_batch(
                 batch,
                 knowledge=knowledge,
-                indexed_files=indexed_files,
                 indexed_signatures=indexed_signatures,
                 vanished_files=vanished_files,
                 on_file_result=on_file_result,
@@ -1674,9 +1628,8 @@ class KnowledgeManager:
         self,
         file_path: Path,
         *,
-        knowledge: Knowledge | None,
-        indexed_files: set[str] | None,
-        indexed_signatures: dict[str, FileSignature] | None,
+        knowledge: Knowledge,
+        indexed_signatures: dict[str, FileSignature],
         vanished_files: set[str] | None,
     ) -> bool:
         try:
@@ -1684,7 +1637,6 @@ class KnowledgeManager:
                 file_path,
                 upsert=True,
                 knowledge=knowledge,
-                indexed_files=indexed_files,
                 indexed_signatures=indexed_signatures,
             )
         except FileNotFoundError:
@@ -1708,9 +1660,8 @@ class KnowledgeManager:
         self,
         batch: Sequence[Path],
         *,
-        knowledge: Knowledge | None,
-        indexed_files: set[str] | None,
-        indexed_signatures: dict[str, FileSignature] | None,
+        knowledge: Knowledge,
+        indexed_signatures: dict[str, FileSignature],
         vanished_files: set[str] | None,
         on_file_result: Callable[[Path], Awaitable[None]] | None = None,
     ) -> int:
@@ -1722,7 +1673,6 @@ class KnowledgeManager:
             indexed = await self._index_file_or_skip_vanished(
                 file_path,
                 knowledge=knowledge,
-                indexed_files=indexed_files,
                 indexed_signatures=indexed_signatures,
                 vanished_files=vanished_files,
             )
@@ -2534,7 +2484,6 @@ class KnowledgeManager:
                 progress.indexed_this_run += await self._reindex_files_locked(
                     list(plan.pending),
                     knowledge=run.knowledge,
-                    indexed_files=None,
                     indexed_signatures=run.completed,
                     vanished_files=run.vanished,
                     embedder=run.embedder,
@@ -2595,8 +2544,6 @@ class KnowledgeManager:
         try:
             await self._publish_candidate_after_metadata_save(
                 candidate_vector_db=run.vector_db,
-                indexed_files=set(run.completed),
-                indexed_signatures=dict(run.completed),
                 indexed_count=len(run.completed),
                 source_signature=source_signature,
                 publish_state=publish_state,

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1580,7 +1580,7 @@ class KnowledgeManager:
         *,
         knowledge: Knowledge,
         indexed_signatures: dict[str, FileSignature],
-        vanished_files: set[str] | None = None,
+        vanished_files: set[str],
         embedder: BatchPrefetchEmbedder | None = None,
         on_file_result: Callable[[Path], Awaitable[None]] | None = None,
         on_batch_complete: Callable[[Sequence[Path]], Awaitable[None]] | None = None,
@@ -1630,7 +1630,7 @@ class KnowledgeManager:
         *,
         knowledge: Knowledge,
         indexed_signatures: dict[str, FileSignature],
-        vanished_files: set[str] | None,
+        vanished_files: set[str],
     ) -> bool:
         try:
             return await self._index_file_locked(
@@ -1652,8 +1652,7 @@ class KnowledgeManager:
                 base_id=self.base_id,
                 path=relative_path,
             )
-            if vanished_files is not None:
-                vanished_files.add(relative_path)
+            vanished_files.add(relative_path)
             return False
 
     async def _index_file_batch(
@@ -1662,7 +1661,7 @@ class KnowledgeManager:
         *,
         knowledge: Knowledge,
         indexed_signatures: dict[str, FileSignature],
-        vanished_files: set[str] | None,
+        vanished_files: set[str],
         on_file_result: Callable[[Path], Awaitable[None]] | None = None,
     ) -> int:
         """Index one bounded batch, capping live tasks at the concurrency limit."""

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -1711,8 +1711,15 @@ async def test_reindex_files_locked_records_files_vanishing_during_refresh(tmp_p
 
     vanished = (docs_path / "gone.md").resolve()
     vanished_files: set[str] = set()
-    indexed = await manager._reindex_files_locked([vanished], vanished_files=vanished_files)
+    indexed_signatures: dict[str, tuple[int, int, str]] = {}
+    indexed = await manager._reindex_files_locked(
+        [vanished],
+        knowledge=manager._knowledge,
+        indexed_signatures=indexed_signatures,
+        vanished_files=vanished_files,
+    )
     assert indexed == 0
+    assert indexed_signatures == {}
     assert vanished_files == {"gone.md"}
 
 
@@ -1745,8 +1752,8 @@ async def test_reindex_publishes_surviving_files_when_one_vanishes_mid_refresh(
 
     assert await manager.reindex_all() == 1
     assert manager._last_refresh_error is None
-    assert "kept.md" in manager._indexed_files
-    assert "doomed.md" not in manager._indexed_files
+    assert manager._has_vectors_for_source_path("kept.md", knowledge=manager._knowledge)
+    assert not manager._has_vectors_for_source_path("doomed.md", knowledge=manager._knowledge)
 
 
 def test_knowledge_file_listing_filters_unsupported_extensions_before_filesystem_safety_checks(
@@ -3182,11 +3189,10 @@ async def test_existing_published_index_is_used_while_refresh_runs(
         resolved_path: Path,
         *,
         upsert: bool,
-        knowledge: object | None = None,
-        indexed_files: set[str] | None = None,
-        indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
+        knowledge: object,
+        indexed_signatures: dict[str, tuple[int, int, str]],
     ) -> bool:
-        if knowledge is not None and knowledge is not self._knowledge and not started.is_set():
+        if knowledge is not self._knowledge and not started.is_set():
             started.set()
             await release.wait()
         return await original_index_file_locked(
@@ -3194,7 +3200,6 @@ async def test_existing_published_index_is_used_while_refresh_runs(
             resolved_path,
             upsert=upsert,
             knowledge=knowledge,
-            indexed_files=indexed_files,
             indexed_signatures=indexed_signatures,
         )
 
@@ -3236,11 +3241,10 @@ async def test_cancelled_refresh_keeps_unpublished_candidate_for_resume(
         resolved_path: Path,
         *,
         upsert: bool,
-        knowledge: object | None = None,
-        indexed_files: set[str] | None = None,
-        indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
+        knowledge: object,
+        indexed_signatures: dict[str, tuple[int, int, str]],
     ) -> bool:
-        if knowledge is not None and knowledge is not self._knowledge:
+        if knowledge is not self._knowledge:
             candidate_started.set()
             await asyncio.Event().wait()
         return await original_index_file_locked(
@@ -3248,7 +3252,6 @@ async def test_cancelled_refresh_keeps_unpublished_candidate_for_resume(
             resolved_path,
             upsert=upsert,
             knowledge=knowledge,
-            indexed_files=indexed_files,
             indexed_signatures=indexed_signatures,
         )
 
@@ -3915,11 +3918,10 @@ async def test_failed_refresh_preserves_last_good_index(tmp_path: Path, monkeypa
         resolved_path: Path,
         *,
         upsert: bool,
-        knowledge: object | None = None,
-        indexed_files: set[str] | None = None,
-        indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
+        knowledge: object,
+        indexed_signatures: dict[str, tuple[int, int, str]],
     ) -> bool:
-        if knowledge is not None and knowledge is not self._knowledge:
+        if knowledge is not self._knowledge:
             msg = "candidate failed"
             raise RuntimeError(msg)
         return await original_index_file_locked(
@@ -3927,7 +3929,6 @@ async def test_failed_refresh_preserves_last_good_index(tmp_path: Path, monkeypa
             resolved_path,
             upsert=upsert,
             knowledge=knowledge,
-            indexed_files=indexed_files,
             indexed_signatures=indexed_signatures,
         )
 
@@ -4016,9 +4017,8 @@ async def test_partial_refresh_after_cached_index_updates_failed_availability(
         resolved_path: Path,
         *,
         upsert: bool,
-        knowledge: object | None = None,
-        indexed_files: set[str] | None = None,
-        indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
+        knowledge: object,
+        indexed_signatures: dict[str, tuple[int, int, str]],
     ) -> bool:
         if resolved_path.name == "bad.md":
             return False
@@ -4027,7 +4027,6 @@ async def test_partial_refresh_after_cached_index_updates_failed_availability(
             resolved_path,
             upsert=upsert,
             knowledge=knowledge,
-            indexed_files=indexed_files,
             indexed_signatures=indexed_signatures,
         )
 
@@ -4447,11 +4446,10 @@ async def test_failed_refresh_after_config_change_preserves_published_settings(
         resolved_path: Path,
         *,
         upsert: bool,
-        knowledge: object | None = None,
-        indexed_files: set[str] | None = None,
-        indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
+        knowledge: object,
+        indexed_signatures: dict[str, tuple[int, int, str]],
     ) -> bool:
-        _ = (self, resolved_path, upsert, knowledge, indexed_files, indexed_signatures)
+        _ = (self, resolved_path, upsert, knowledge, indexed_signatures)
         msg = "candidate failed"
         raise RuntimeError(msg)
 
@@ -4625,9 +4623,8 @@ async def test_first_time_partial_refresh_does_not_publish_ready_index(
         resolved_path: Path,
         *,
         upsert: bool,
-        knowledge: object | None = None,
-        indexed_files: set[str] | None = None,
-        indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
+        knowledge: object,
+        indexed_signatures: dict[str, tuple[int, int, str]],
     ) -> bool:
         if resolved_path.name == "bad.md":
             return False
@@ -4636,7 +4633,6 @@ async def test_first_time_partial_refresh_does_not_publish_ready_index(
             resolved_path,
             upsert=upsert,
             knowledge=knowledge,
-            indexed_files=indexed_files,
             indexed_signatures=indexed_signatures,
         )
 
@@ -4907,11 +4903,10 @@ async def test_embedder_changing_partial_refresh_does_not_publish_old_index_unde
         resolved_path: Path,
         *,
         upsert: bool,
-        knowledge: object | None = None,
-        indexed_files: set[str] | None = None,
-        indexed_signatures: dict[str, tuple[int, int, str] | None] | None = None,
+        knowledge: object,
+        indexed_signatures: dict[str, tuple[int, int, str]],
     ) -> bool:
-        _ = (self, resolved_path, upsert, knowledge, indexed_files, indexed_signatures)
+        _ = (self, resolved_path, upsert, knowledge, indexed_signatures)
         return False
 
     monkeypatch.setattr(KnowledgeManager, "_index_file_locked", _partial_candidate)

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -2658,7 +2658,6 @@ async def test_journal_compaction_bound_survives_restart(
             final_path,
             upsert=True,
             knowledge=run.knowledge,
-            indexed_files=None,
             indexed_signatures=run.completed,
         )
         await manager._persist_candidate_batch(run, (final_path,))


### PR DESCRIPTION
## Context: `KnowledgeManager` is per-refresh-scoped

`KnowledgeManager` is constructed in exactly three places, all in `src/mindroom/knowledge/refresh_runner.py` (lines 521, 638, 664). Each instance handles one refresh and is then discarded, and nothing else in `src/` constructs or holds one.

It was nevertheless written as if it were a long-lived shared service. That mismatch accumulated state that nothing reads. This PR deletes it. No behavior change.

## Verified dead state

1. **`_indexed_files` and `_indexed_signatures` were write-only.** Declared at `manager.py:676-677`, with six write sites (`manager.py:1288-1289`, `1430-1431`, `1456-1457`, `1468-1469`) and zero readers anywhere in `src/`. The only reader in the whole tree was one test assertion.

2. **`_state_lock` (`manager.py:679`) existed solely to guard those two fields.** It could not contend anyway: the instance is per-refresh and unreachable by a second caller. Real serialization happens a layer up, in `refresh_runner._acquire_refresh_lock` + `_acquire_refresh_file_lock`.

3. **The `else:` branches at `manager.py:1428`, `1454`, and `1466` were unreachable in production.** The only production call chain is `_advance_candidate` -> `_reindex_files_locked(indexed_signatures=run.completed, indexed_files=None)` -> `_index_file_or_skip_vanished` -> `_index_file_locked`, where `indexed_signatures` is never `None`. Those branches survived only because one test called `_reindex_files_locked` without the kwarg, which the Refactor Policy in `CLAUDE.md` explicitly rules out as a reason to keep a production branch alive.

## What changed

- Removed the fields `_indexed_files`, `_indexed_signatures`, and `_state_lock`.
- Made `indexed_signatures` and `knowledge` required across the indexing chain (`_index_file_locked`, `_handle_vectorless_file`, `_index_file_or_skip_vanished`, `_index_file_batch`, `_reindex_files_locked`, plus `_wait_for_source_vectors` / `_has_vectors_for_source_path`), and dropped the `indexed_files` parameter entirely. This collapses four duplicated `if/else` arms and three `knowledge or self._knowledge` fallbacks down to the single live path, where the caller always supplies the candidate run's own knowledge handle and signature map.
- Removed the `indexed_files=set(run.completed)` / `indexed_signatures=dict(run.completed)` plumbing from `_publish_candidate`, which existed only to feed the dead fields.
- `_handle_vectorless_file` no longer awaits anything once its lock arms are gone, so it became a plain `def` (otherwise `RUF029` fires under `select = ["ALL"]`).

## The `_adopt_candidate_vector_db` trap, and how it was resolved

`_adopt_candidate_vector_db` looked entirely dead, and its two `self._indexed_*` assignments were. Its first line was **not** dead:

```python
self._knowledge.vector_db = candidate_vector_db
```

`_cleanup_superseded_collections` (`manager.py:1177`) reads `self._knowledge.vector_db` to obtain the Chroma client it lists collections with, and it runs immediately after publish (`manager.py:2610-2613`).

Both vector databases are built by `_build_vector_db` against the same `_base_storage_path`, so the client is arguably equivalent either way — but this PR does not rely on that argument. **The reassignment is kept**, verbatim; only the two dead dict writes were deleted. Since that left a one-line `async` method with a single caller, it is inlined into `_publish_candidate_after_metadata_save` with a comment recording why the assignment matters, so it does not read as orphaned later. `_cleanup_superseded_collections` is untouched.

Ordering is preserved exactly: the deleted `async with self._state_lock` on an uncontended `asyncio.Lock` never yields to the event loop, so removing it introduces no scheduling or cancellation-point difference.

## Test updates

- Seven `_index_file_locked` monkeypatch wrappers in `tests/test_knowledge_manager.py` updated for the new signature. In three of them the guard `knowledge is not None and knowledge is not self._knowledge` reduces to `knowledge is not self._knowledge`, since `knowledge` is now always supplied.
- `test_reindex_files_locked_records_files_vanishing_during_refresh` now passes `knowledge` and `indexed_signatures` explicitly, and additionally asserts the vanished file left no signature behind.
- `test_reindex_publishes_surviving_files_when_one_vanishes_mid_refresh` asserted against the removed `manager._indexed_files`. It now asserts the same property against the real published collection via `_has_vectors_for_source_path`, which is a strictly stronger check: it reads actual vectors rather than a mirror that nothing consumed.

## Net

**-60 lines** across 3 files (57 insertions, 117 deletions); `src/mindroom/knowledge/manager.py` alone is **-54** (28 insertions, 82 deletions).

## Follow-up commit: `vanished_files`

Round-1 review caught that `vanished_files` was the last per-refresh collector in this chain still typed optional, and that it fails the identical test as `knowledge` and `indexed_signatures`: `_CandidateRun.vanished` is a `set[str]` from `field(default_factory=set)` and is never `None`, and the sole production call site passes `vanished_files=run.vanished`.

It is a stricter case than the ones the first commit fixed. The `= None` default on `_reindex_files_locked` was reachable from nothing at all -- not even a test: both direct callers pass the argument explicitly, and the monkeypatch wrappers forward `**kwargs` straight from the production caller. The guard it protected, `if vanished_files is not None`, could therefore never be false. A `None` collector would have meant silently discarding the record of a file that vanished mid-refresh, which is exactly what the trailing source-signature comparison relies on to decide whether the surviving corpus is publishable.

Narrowed to a required `set[str]` in the three signatures and dropped the guard. No test changes and no behavior change.

`on_file_result` and `on_batch_complete` are the same "always supplied in production" shape but **stay optional**: an absent observer is deliberate API design, unlike an absent output collector. Making them required would also force the vanished-file test to construct two no-op callbacks purely to satisfy the signature -- adding ceremony rather than removing dead code, which is the opposite of this PR's point.

## Verification

- `uv run pytest tests/test_knowledge_manager.py tests/test_knowledge_resumable_refresh.py tests/test_bot_knowledge.py -nauto --no-cov` — all pass.
- `uv run pre-commit run --all-files` — all Python hooks pass.
- `uv run tach check --dependencies --interfaces` — `All modules validated!`
- Full suite `uv run pytest -nauto --no-cov` — two failures, both timing-sensitive flakes under parallel load in `tests/test_live_message_coalescing.py` and `tests/test_coalescing.py`, in modules this PR does not touch. Both pass when rerun with `-n0`.

This is PR 1 of a 6-part knowledge-module refactor, scoped to keep it mergeable alongside the sibling PRs touching the same file.

## Summary by Sourcery

Remove unused per-refresh indexing state from KnowledgeManager and simplify the indexing pipeline to operate solely on caller-supplied knowledge and signature maps.

Enhancements:
- Make knowledge and indexed_signatures explicit, required parameters throughout the indexing and reindexing helper methods, eliminating fallback paths and dead branches.
- Inline candidate vector DB adoption into the publish path while preserving behavior needed by cleanup of superseded collections.
- Simplify handling of vectorless files by updating only the live indexed_signatures map and removing unnecessary async locking.

Tests:
- Update knowledge manager tests to use the new method signatures and assert behavior via the actual vector store rather than removed internal state.
