### PR TITLE
Return a refresh outcome from reindex_all

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -2433,7 +2433,6 @@ class KnowledgeManager:
         missing collection -- the reuse gates already reject on their own.
         """
         if not _semantic_indexing_enabled(self.config, self.base_id):
-            self._last_refresh_error = None
             return RefreshOutcome(indexed_count=0, published=False, error=None)
 
         async with self._lock:
@@ -2459,9 +2458,12 @@ class KnowledgeManager:
                 raise
             finally:
                 progress.retrying = self._embedding_retry_count
-                # The accumulator carries provider text, so redact once here:
-                # everything that reads the failure -- the log line, the caller,
-                # the persisted metadata -- reads this one string.
+                # Redact at the seam rather than at each assignment site. Every
+                # source feeding the accumulator today is already safe --
+                # describe_embedder_error never echoes provider text, the git
+                # path redacts before raising, and the raising path below
+                # redacts -- so this pins the property for future error sources
+                # instead of cleaning up a known leak.
                 raw_error = self._last_refresh_error
                 outcome = RefreshOutcome(
                     indexed_count=progress.indexed_this_run,

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -244,6 +244,23 @@ class _CandidateReconciliation:
     pending: tuple[Path, ...]
 
 
+@dataclass(frozen=True, slots=True)
+class RefreshOutcome:
+    """What one ``KnowledgeManager.reindex_all`` call actually did.
+
+    A refresh either publishes a candidate that matches the source or explains
+    why it could not, so callers need both facts and the file count. ``error``
+    is already credential-redacted and is safe to persist or show.
+    """
+
+    #: Files this pass embedded, as opposed to reused from an earlier candidate.
+    indexed_count: int
+    #: Whether this pass swapped a complete candidate in as the published index.
+    published: bool
+    #: Why the refresh finished without publishing, or ``None`` on success.
+    error: str | None
+
+
 @dataclass
 class _CandidateProgress:
     """Throttled progress accounting for one candidate build."""
@@ -298,12 +315,12 @@ class _CandidateProgress:
         self._last_logged_completed = self.completed
         logger.info("knowledge_candidate_progress", **self._fields())
 
-    def log_summary(self, *, published: bool, error: str | None) -> None:
+    def log_summary(self, outcome: RefreshOutcome) -> None:
         """Emit the single terminal summary for this refresh."""
         logger.info(
             "knowledge_candidate_finished",
-            published=published,
-            error=error,
+            published=outcome.published,
+            error=outcome.error,
             **self._fields(),
         )
 
@@ -2407,7 +2424,7 @@ class KnowledgeManager:
         )
         run.journal_appends = 0
 
-    async def reindex_all(self, *, force_reindex: bool = False) -> int:
+    async def reindex_all(self, *, force_reindex: bool = False) -> RefreshOutcome:
         """Advance the durable candidate index and publish it when it matches the source.
 
         ``force_reindex`` is the operator asking for vectors to be rebuilt
@@ -2417,7 +2434,7 @@ class KnowledgeManager:
         """
         if not _semantic_indexing_enabled(self.config, self.base_id):
             self._last_refresh_error = None
-            return 0
+            return RefreshOutcome(indexed_count=0, published=False, error=None)
 
         async with self._lock:
             self._last_refresh_error = None
@@ -2442,9 +2459,18 @@ class KnowledgeManager:
                 raise
             finally:
                 progress.retrying = self._embedding_retry_count
-                progress.log_summary(published=run.published, error=self._last_refresh_error)
+                # The accumulator carries provider text, so redact once here:
+                # everything that reads the failure -- the log line, the caller,
+                # the persisted metadata -- reads this one string.
+                raw_error = self._last_refresh_error
+                outcome = RefreshOutcome(
+                    indexed_count=progress.indexed_this_run,
+                    published=run.published,
+                    error=None if raw_error is None else redact_credentials_in_text(raw_error),
+                )
+                progress.log_summary(outcome)
                 await self._finalize_candidate_checkpoint(run)
-            return progress.indexed_this_run
+            return outcome
 
     async def _finalize_candidate_checkpoint(self, run: _CandidateRun) -> None:
         """Compact the candidate snapshot even when the refresh is being cancelled.

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -81,6 +81,7 @@ from mindroom.knowledge.redaction import (
     redact_credentials_in_text,
     redact_url_credentials,
 )
+from mindroom.knowledge.refresh_outcome import RefreshOutcome
 from mindroom.logging_config import get_logger
 from mindroom.strict_knowledge import StrictInsertKnowledge as Knowledge
 
@@ -290,23 +291,6 @@ class _CandidateReconciliation:
 
     expected: frozenset[str]
     pending: tuple[Path, ...]
-
-
-@dataclass(frozen=True, slots=True)
-class RefreshOutcome:
-    """What one ``KnowledgeManager.reindex_all`` call actually did.
-
-    A refresh either publishes a candidate that matches the source or explains
-    why it could not, so callers need both facts and the file count. ``error``
-    is already credential-redacted and is safe to persist or show.
-    """
-
-    #: Files this pass embedded, as opposed to reused from an earlier candidate.
-    indexed_count: int
-    #: Whether this pass swapped a complete candidate in as the published index.
-    published: bool
-    #: Why the refresh finished without publishing, or ``None`` on success.
-    error: str | None
 
 
 @dataclass
@@ -2460,6 +2444,18 @@ class KnowledgeManager:
         )
         run.journal_appends = 0
 
+    def _record_refresh_error(self, detail: str) -> None:
+        """Store why this refresh failed, redacted once at the point of record.
+
+        Redacting here rather than when the outcome is built keeps the stored
+        string and the reported one identical, so an operator reading the
+        attribute in a debugger sees exactly what was logged and persisted. It
+        also keeps ``redact_credentials_in_text`` -- which is not total -- out
+        of the ``finally`` that owns checkpoint compaction, where a raise would
+        both mask the real failure and skip durability work.
+        """
+        self._last_refresh_error = redact_credentials_in_text(detail)
+
     async def reindex_all(self, *, force_reindex: bool = False) -> RefreshOutcome:
         """Advance the durable candidate index and publish it when it matches the source.
 
@@ -2490,21 +2486,14 @@ class KnowledgeManager:
                 await self._advance_candidate(run, progress)
             except Exception as exc:
                 if self._last_refresh_error is None:
-                    self._last_refresh_error = redact_credentials_in_text(str(exc))
+                    self._record_refresh_error(str(exc))
                 raise
             finally:
                 progress.retrying = self._embedding_retry_count
-                # Redact at the seam rather than at each assignment site. Every
-                # source feeding the accumulator today is already safe --
-                # describe_embedder_error never echoes provider text, the git
-                # path redacts before raising, and the raising path below
-                # redacts -- so this pins the property for future error sources
-                # instead of cleaning up a known leak.
-                raw_error = self._last_refresh_error
                 outcome = RefreshOutcome(
                     indexed_count=progress.indexed_this_run,
                     published=run.published,
-                    error=None if raw_error is None else redact_credentials_in_text(raw_error),
+                    error=self._last_refresh_error,
                 )
                 progress.log_summary(outcome)
                 await self._finalize_candidate_checkpoint(run)
@@ -2613,7 +2602,7 @@ class KnowledgeManager:
                 summary = f"Indexed {len(run.completed)} of {len(plan.expected)} managed knowledge files"
                 if self._last_file_index_error is not None:
                     summary = f"{summary} (first error: {self._last_file_index_error})"
-                self._last_refresh_error = summary
+                self._record_refresh_error(summary)
                 return
 
             candidate_signatures = {
@@ -2622,8 +2611,8 @@ class KnowledgeManager:
                 if relative_path in expected_paths
             }
             if set(candidate_signatures) != expected_paths:
-                self._last_refresh_error = (
-                    f"Indexed signatures covered {len(candidate_signatures)} of {len(expected_paths)} managed files"
+                self._record_refresh_error(
+                    f"Indexed signatures covered {len(candidate_signatures)} of {len(expected_paths)} managed files",
                 )
                 return
 
@@ -2646,8 +2635,8 @@ class KnowledgeManager:
             await self._publish_candidate(run, candidate_source_signature)
             return
 
-        self._last_refresh_error = (
-            "Knowledge source kept changing during refresh; candidate progress was kept for the next refresh"
+        self._record_refresh_error(
+            "Knowledge source kept changing during refresh; candidate progress was kept for the next refresh",
         )
 
     async def _publish_candidate(self, run: _CandidateRun, source_signature: str) -> None:

--- a/src/mindroom/knowledge/refresh_outcome.py
+++ b/src/mindroom/knowledge/refresh_outcome.py
@@ -1,0 +1,30 @@
+"""The result contract between a knowledge refresh and its caller."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RefreshOutcome:
+    """What one ``KnowledgeManager.reindex_all`` call actually did.
+
+    Three outcomes are possible, so ``published`` and ``error`` are
+    independent facts rather than two views of one flag:
+
+    * **published** -- a candidate matching the source became the published
+      index.
+    * **no-op** -- the base builds no vectors (``mode`` is not ``semantic``),
+      so there was nothing to publish and nothing failed.
+    * **failed** -- the pass could not publish, and ``error`` says why.
+
+    ``error`` is already credential-redacted and is safe to persist or show.
+    """
+
+    #: Files this pass embedded, as opposed to reused from an earlier candidate.
+    indexed_count: int
+    #: Whether this pass swapped a complete candidate in as the published index.
+    published: bool
+    #: Why this refresh failed, or ``None`` when nothing failed. ``None`` does
+    #: not imply a publication -- a non-semantic base reports neither.
+    error: str | None

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -22,7 +22,7 @@ from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths, runtime_env_values
 from mindroom.file_locks import async_exclusive_file_lock
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.manager import KnowledgeManager, RefreshOutcome, knowledge_source_signature
+from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
 from mindroom.knowledge.redaction import redact_credentials_in_text
 from mindroom.knowledge.registry import (
     KnowledgeRefreshTarget,
@@ -532,11 +532,7 @@ async def _refresh_knowledge_binding_locked(
         )
         if unchanged_result is not None:
             return unchanged_result
-        # The annotation is load-bearing, not decoration: privata treats
-        # RefreshOutcome as legitimately public because this module imports it
-        # by name, and without a use here ruff would delete that import. Do not
-        # "simplify" it away.
-        outcome: RefreshOutcome = await manager.reindex_all(force_reindex=force_reindex)
+        outcome = await manager.reindex_all(force_reindex=force_reindex)
         if outcome.error is not None:
             await asyncio.to_thread(
                 mark_published_index_refresh_failed_preserving_last_good,

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -500,7 +500,6 @@ async def _refresh_knowledge_binding_locked(
     force_reindex: bool = False,
 ) -> KnowledgeRefreshResult:
     base_id = key.base_id
-    manager: KnowledgeManager | None = None
     try:
         if config.get_knowledge_base_config(base_id).mode == "files":
             return await _refresh_file_mode_binding_locked(
@@ -533,6 +532,10 @@ async def _refresh_knowledge_binding_locked(
         )
         if unchanged_result is not None:
             return unchanged_result
+        # The annotation is load-bearing, not decoration: privata treats
+        # RefreshOutcome as legitimately public because this module imports it
+        # by name, and without a use here ruff would delete that import. Do not
+        # "simplify" it away.
         outcome: RefreshOutcome = await manager.reindex_all(force_reindex=force_reindex)
         if outcome.error is not None:
             await asyncio.to_thread(

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -22,7 +22,7 @@ from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths, runtime_env_values
 from mindroom.file_locks import async_exclusive_file_lock
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
+from mindroom.knowledge.manager import KnowledgeManager, RefreshOutcome, knowledge_source_signature
 from mindroom.knowledge.redaction import redact_credentials_in_text
 from mindroom.knowledge.registry import (
     KnowledgeRefreshTarget,
@@ -533,16 +533,19 @@ async def _refresh_knowledge_binding_locked(
         )
         if unchanged_result is not None:
             return unchanged_result
-        indexed_count = await manager.reindex_all(force_reindex=force_reindex)
-        if manager._last_refresh_error is not None:
-            error = redact_credentials_in_text(manager._last_refresh_error)
-            await asyncio.to_thread(mark_published_index_refresh_failed_preserving_last_good, key, error=error)
+        outcome: RefreshOutcome = await manager.reindex_all(force_reindex=force_reindex)
+        if outcome.error is not None:
+            await asyncio.to_thread(
+                mark_published_index_refresh_failed_preserving_last_good,
+                key,
+                error=outcome.error,
+            )
             return KnowledgeRefreshResult(
                 key=key,
-                indexed_count=indexed_count,
+                indexed_count=outcome.indexed_count,
                 index_published=False,
                 availability=KnowledgeAvailability.REFRESH_FAILED,
-                last_error=error,
+                last_error=outcome.error,
             )
     except Exception as exc:
         error = redact_credentials_in_text(str(exc))
@@ -550,7 +553,7 @@ async def _refresh_knowledge_binding_locked(
         raise
     return await _refresh_result_from_persisted_state(
         key,
-        indexed_count=indexed_count,
+        indexed_count=outcome.indexed_count,
         config=config,
         runtime_paths=runtime_paths,
     )

--- a/tach.toml
+++ b/tach.toml
@@ -3531,6 +3531,10 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.knowledge.refresh_outcome"
+depends_on = []
+
+[[modules]]
 path = "mindroom.knowledge.manager"
 depends_on = [
     "mindroom.chunking",
@@ -3544,6 +3548,7 @@ depends_on = [
     "mindroom.knowledge.index_retry",
     "mindroom.knowledge.indexing_config",
     "mindroom.knowledge.redaction",
+    "mindroom.knowledge.refresh_outcome",
     "mindroom.strict_knowledge",
 ]
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -52,8 +52,9 @@ from mindroom.knowledge.file_listing import (
 )
 from mindroom.knowledge.index_metadata import write_index_metadata_payload
 from mindroom.knowledge.indexing_config import IndexingSettings
-from mindroom.knowledge.manager import KnowledgeManager, RefreshOutcome, knowledge_source_signature
+from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
 from mindroom.knowledge.redaction import credential_free_repo_url, credential_free_url_identity, redact_url_credentials
+from mindroom.knowledge.refresh_outcome import RefreshOutcome
 from mindroom.knowledge.refresh_runner import knowledge_binding_mutation_lock, refresh_knowledge_binding
 from mindroom.knowledge.registry import (
     get_published_index,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -52,7 +52,7 @@ from mindroom.knowledge.file_listing import (
 )
 from mindroom.knowledge.index_metadata import write_index_metadata_payload
 from mindroom.knowledge.indexing_config import IndexingSettings
-from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
+from mindroom.knowledge.manager import KnowledgeManager, RefreshOutcome, knowledge_source_signature
 from mindroom.knowledge.redaction import credential_free_repo_url, credential_free_url_identity, redact_url_credentials
 from mindroom.knowledge.refresh_runner import knowledge_binding_mutation_lock, refresh_knowledge_binding
 from mindroom.knowledge.registry import (
@@ -727,8 +727,7 @@ async def test_file_mode_reindex_noop_clears_previous_manager_refresh_error(tmp_
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths)
     manager._last_refresh_error = "previous semantic failure"
 
-    assert await manager.reindex_all() == 0
-    assert manager._last_refresh_error is None
+    assert await manager.reindex_all() == RefreshOutcome(indexed_count=0, published=False, error=None)
 
 
 def test_file_mode_source_signature_tracks_non_semantic_files(tmp_path: Path) -> None:
@@ -1743,8 +1742,7 @@ async def test_reindex_publishes_surviving_files_when_one_vanishes_mid_refresh(
 
     monkeypatch.setattr(KnowledgeManager, "_file_signature", vanishing_signature)
 
-    assert await manager.reindex_all() == 1
-    assert manager._last_refresh_error is None
+    assert await manager.reindex_all() == RefreshOutcome(indexed_count=1, published=True, error=None)
     assert "kept.md" in manager._indexed_files
     assert "doomed.md" not in manager._indexed_files
 
@@ -1874,8 +1872,11 @@ async def test_reindex_skips_files_whose_reader_dependency_is_missing(
     monkeypatch.setattr(knowledge_manager_module.ReaderFactory, "get_reader_for_extension", failing_get_reader)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
 
-    assert await manager.reindex_all() == 1
-    assert manager._last_refresh_error == "Indexed 1 of 2 managed knowledge files"
+    assert await manager.reindex_all() == RefreshOutcome(
+        indexed_count=1,
+        published=False,
+        error="Indexed 1 of 2 managed knowledge files",
+    )
 
 
 @pytest.mark.asyncio
@@ -2051,7 +2052,7 @@ async def test_cancelled_refresh_waiting_for_source_lock_does_not_touch_running_
         original_save_refreshing(*args, **kwargs)
         refreshing_write_count += 1
 
-    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         _ = force_reindex
         first_entered.set()
         await release_first.wait()
@@ -3527,7 +3528,7 @@ async def test_same_physical_binding_refreshes_are_serialized_across_config_chan
     max_active_refreshes = 0
     call_count = 0
 
-    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         _ = force_reindex
         _ = self
         nonlocal active_refreshes, max_active_refreshes, call_count
@@ -3540,7 +3541,7 @@ async def test_same_physical_binding_refreshes_are_serialized_across_config_chan
                 await release_first.wait()
             else:
                 second_entered.set()
-            return 0
+            return RefreshOutcome(indexed_count=0, published=False, error=None)
         finally:
             active_refreshes -= 1
 
@@ -3579,12 +3580,12 @@ async def test_shared_source_mutation_waits_for_duplicate_base_refresh(
     release_refresh = asyncio.Event()
     mutation_entered = asyncio.Event()
 
-    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         _ = force_reindex
         _ = self
         refresh_entered.set()
         await release_refresh.wait()
-        return 0
+        return RefreshOutcome(indexed_count=0, published=False, error=None)
 
     async def _mutate_shared_source() -> None:
         async with knowledge_binding_mutation_lock("beta", config=config, runtime_paths=runtime_paths):
@@ -4700,9 +4701,10 @@ async def test_partial_refresh_error_includes_first_classified_file_error(
     monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _AuthFailingKnowledge)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
 
-    assert await manager.reindex_all() == 1
-    assert manager._last_refresh_error == (
-        "Indexed 1 of 2 managed knowledge files (first error: embedder authentication failed (HTTP 401))"
+    assert await manager.reindex_all() == RefreshOutcome(
+        indexed_count=1,
+        published=False,
+        error="Indexed 1 of 2 managed knowledge files (first error: embedder authentication failed (HTTP 401))",
     )
 
 
@@ -4735,11 +4737,15 @@ async def test_vectorless_file_does_not_inherit_process_global_embedder_health(
     embedder_health.capture_embedder_health_recorder().record(None)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
     try:
-        assert await manager.reindex_all() == 0
+        outcome = await manager.reindex_all()
     finally:
         embedder_health.capture_embedder_health_recorder().record(None)
 
-    assert manager._last_refresh_error == "Indexed 0 of 1 managed knowledge files"
+    assert outcome == RefreshOutcome(
+        indexed_count=0,
+        published=False,
+        error="Indexed 0 of 1 managed knowledge files",
+    )
 
 
 def test_refresh_failure_counter_increments_and_resets_preserving_last_good(tmp_path: Path) -> None:
@@ -4937,7 +4943,7 @@ async def test_cold_refresh_exception_surfaces_failed_availability_and_backoff(
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
 
-    async def _raise_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _raise_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         _ = force_reindex
         _ = self
         msg = "cold refresh failed"
@@ -5147,12 +5153,12 @@ async def test_api_status_reports_direct_refresh_runner_reindex(
     started = asyncio.Event()
     release = asyncio.Event()
 
-    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _blocked_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         _ = force_reindex
         _ = self
         started.set()
         await release.wait()
-        return 0
+        return RefreshOutcome(indexed_count=0, published=False, error=None)
 
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _blocked_reindex)
     refresh_task = asyncio.create_task(
@@ -6755,7 +6761,7 @@ async def test_local_noop_refresh_reports_published_index(tmp_path: Path, monkey
     reindex_count = 0
     original_reindex = KnowledgeManager.reindex_all
 
-    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         nonlocal reindex_count
         reindex_count += 1
         if reindex_count > 1:
@@ -6789,7 +6795,7 @@ async def test_local_refresh_reindexes_when_content_changes_with_same_mtime_and_
     reindex_count = 0
     original_reindex = KnowledgeManager.reindex_all
 
-    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         nonlocal reindex_count
         reindex_count += 1
         return await original_reindex(self, force_reindex=force_reindex)
@@ -6823,10 +6829,10 @@ async def test_refresh_does_not_synthesize_missing_published_metadata(
     runtime_paths = runtime_paths_for(config)
     original_reindex = KnowledgeManager.reindex_all
 
-    async def _delete_metadata_after_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
-        indexed_count = await original_reindex(self, force_reindex=force_reindex)
+    async def _delete_metadata_after_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
+        outcome = await original_reindex(self, force_reindex=force_reindex)
         self._indexing_settings_path.unlink()
-        return indexed_count
+        return outcome
 
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _delete_metadata_after_reindex)
 
@@ -6906,7 +6912,7 @@ async def test_git_refresh_syncs_before_reindex_and_publishes_revision_without_s
         _set_git_tracked_files(self, "doc.md")
         return {"updated": True, "changed_count": 1, "removed_count": 0}
 
-    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         order.append("reindex")
         return await original_reindex(self, force_reindex=force_reindex)
 
@@ -7018,7 +7024,7 @@ async def test_git_noop_refresh_skips_full_reindex_when_index_is_complete(
     reindex_count = 0
     original_reindex = KnowledgeManager.reindex_all
 
-    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         nonlocal reindex_count
         reindex_count += 1
         if reindex_count > 1:
@@ -7269,7 +7275,7 @@ async def test_git_noop_refresh_ignores_untracked_indexable_file_changes(
         _set_git_tracked_files(self, "doc.md")
         return result
 
-    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         nonlocal reindex_count
         reindex_count += 1
         return await original_reindex(self, force_reindex=force_reindex)
@@ -7321,7 +7327,7 @@ async def test_git_noop_refresh_rebuilds_when_collection_is_missing(
         _set_git_tracked_files(self, "doc.md")
         return result
 
-    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         nonlocal reindex_count
         reindex_count += 1
         return await original_reindex(self, force_reindex=force_reindex)
@@ -7412,7 +7418,7 @@ async def test_git_noop_refresh_rebuilds_after_chunking_config_change(
         _set_git_tracked_files(self, "doc.md")
         return result
 
-    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         nonlocal reindex_count
         reindex_count += 1
         return await original_reindex(self, force_reindex=force_reindex)
@@ -7464,7 +7470,7 @@ async def test_force_git_reindex_bypasses_noop_fast_path(
         _set_git_tracked_files(self, "doc.md")
         return result
 
-    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> int:
+    async def _track_reindex(self: KnowledgeManager, *, force_reindex: bool = False) -> RefreshOutcome:
         nonlocal reindex_count
         reindex_count += 1
         return await original_reindex(self, force_reindex=force_reindex)

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -713,8 +713,8 @@ async def test_file_mode_cancelled_refresh_after_metadata_publish_stays_complete
 
 
 @pytest.mark.asyncio
-async def test_file_mode_reindex_noop_clears_previous_manager_refresh_error(tmp_path: Path) -> None:
-    """File-only reindex no-ops should not leave stale manager-local errors."""
+async def test_file_mode_reindex_reports_an_empty_unpublished_outcome(tmp_path: Path) -> None:
+    """A file-only base builds no vectors, so its refresh publishes nothing and reports no failure."""
     docs_path = tmp_path / "docs"
     docs_path.mkdir()
     config = _config(
@@ -725,7 +725,6 @@ async def test_file_mode_reindex_noop_clears_previous_manager_refresh_error(tmp_
     )
     runtime_paths = runtime_paths_for(config)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths)
-    manager._last_refresh_error = "previous semantic failure"
 
     assert await manager.reindex_all() == RefreshOutcome(indexed_count=0, published=False, error=None)
 

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -51,7 +51,7 @@ from mindroom.knowledge.candidate_checkpoint import (
 from mindroom.knowledge.embedding_batch import BatchPrefetchEmbedder, plan_embedding_batches
 from mindroom.knowledge.index_metadata import write_index_metadata_payload
 from mindroom.knowledge.index_retry import EmbeddingRetryPolicy, run_with_embedding_retry
-from mindroom.knowledge.manager import KnowledgeManager
+from mindroom.knowledge.manager import KnowledgeManager, RefreshOutcome
 from mindroom.knowledge.refresh_runner import refresh_knowledge_binding
 from mindroom.knowledge.registry import (
     PublishedIndexState,
@@ -544,7 +544,7 @@ async def test_interrupted_cold_build_resumes_same_candidate_without_reembedding
 
     # A brand new manager models a process restart: nothing survives in memory.
     resumed_manager = _manager(config)
-    assert await resumed_manager.reindex_all() == len(names) - interrupt_after
+    assert (await resumed_manager.reindex_all()).indexed_count == len(names) - interrupt_after
 
     resumed_checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
     assert resumed_checkpoint is None, "publication retires the checkpoint"
@@ -629,8 +629,7 @@ async def test_transient_embedding_failure_retries_only_the_failed_work(
     embedder.failures["content 4"] = [EmbedderRequestError("embedder request failed (HTTP 503)")]
 
     manager = _manager(config)
-    assert await manager.reindex_all() == 5
-    assert manager._last_refresh_error is None
+    assert await manager.reindex_all() == RefreshOutcome(indexed_count=5, published=True, error=None)
 
     state = _published_state(config, runtime_paths)
     assert state is not None
@@ -665,9 +664,11 @@ async def test_exhausted_transient_retries_keep_candidate_and_resume_only_unreso
     embedder.failures["content 3"] = [EmbedderRequestError("embedder request failed (HTTP 503)") for _ in range(20)]
 
     manager = _manager(config)
-    assert await manager.reindex_all() == 3
-    assert manager._last_refresh_error is not None
-    assert "Indexed 3 of 4" in manager._last_refresh_error
+    outcome = await manager.reindex_all()
+    assert outcome.indexed_count == 3
+    assert not outcome.published
+    assert outcome.error is not None
+    assert "Indexed 3 of 4" in outcome.error
     assert _published_state(config, runtime_paths) is None
 
     checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
@@ -679,7 +680,7 @@ async def test_exhausted_transient_retries_keep_candidate_and_resume_only_unreso
 
     embedder.failures.pop("content 3")
     embedded_before = dict.fromkeys(embedder.embedded_texts)
-    assert await _manager(config).reindex_all() == 1
+    assert (await _manager(config).reindex_all()).indexed_count == 1
     for text in embedded_before:
         assert embedder.embedded_count(text) == 1, "resume must not re-embed resolved files"
     state = _published_state(config, runtime_paths)
@@ -952,7 +953,7 @@ async def test_source_revision_advancement_reuses_unchanged_candidate_work(
     (docs_path / "added.md").write_text("added body", encoding="utf-8")
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 2
+    assert (await _manager(config).reindex_all()).indexed_count == 2
 
     assert embedder.embedded_count("keep me") == 0, "unchanged work is reused"
     assert embedder.embedded_count("new body") == 1
@@ -988,12 +989,11 @@ async def test_source_change_during_final_verification_reconciles_without_losing
 
     knowledge_manager_module.knowledge_source_signature = _mutate_during_verification  # type: ignore[assignment]
     try:
-        indexed = await manager.reindex_all()
+        outcome = await manager.reindex_all()
     finally:
         knowledge_manager_module.knowledge_source_signature = original_signature  # type: ignore[assignment]
 
-    assert indexed == 4
-    assert manager._last_refresh_error is None
+    assert outcome == RefreshOutcome(indexed_count=4, published=True, error=None)
     assert embedder.embedded_count("content 0") == 1, "the racing change costs no re-embedding"
     state = _published_state(config, runtime_paths)
     assert state is not None
@@ -1187,7 +1187,7 @@ async def test_embedding_request_count_scales_with_batches_not_files(
     _write_corpus(docs_path, file_count)
     config = _config(tmp_path, docs_path)
 
-    assert await _manager(config).reindex_all() == file_count
+    assert (await _manager(config).reindex_all()).indexed_count == file_count
 
     assert embedder.single_requests == [], "every chunk was served from a batch prefetch"
     assert len(embedder.batch_requests) <= 4, f"expected batched requests, got {len(embedder.batch_requests)}"
@@ -1213,7 +1213,7 @@ async def test_batch_failure_falls_back_to_per_file_without_reembedding_successe
     # "content 1" poisons the batch twice, exhausting the batch-level retry.
     embedder.failures["content 1"] = [EmbedderRequestError("embedder request failed (HTTP 503)") for _ in range(2)]
 
-    assert await _manager(config).reindex_all() == 3
+    assert (await _manager(config).reindex_all()).indexed_count == 3
 
     assert embedder.single_requests, "the fallback path re-embedded per file"
     for index in range(3):
@@ -1264,7 +1264,7 @@ async def test_large_corpus_keeps_live_tasks_bounded(
 
     KnowledgeManager._index_file_locked = _observe  # type: ignore[method-assign]
     try:
-        assert await manager.reindex_all() == file_count
+        assert (await manager.reindex_all()).indexed_count == file_count
     finally:
         KnowledgeManager._index_file_locked = original_index  # type: ignore[method-assign]
 
@@ -1359,7 +1359,7 @@ async def test_refresh_logs_aggregate_progress_instead_of_one_line_per_file(
     config = _config(tmp_path, docs_path)
 
     with capture_logs() as logs:
-        assert await _manager(config).reindex_all() == 128
+        assert (await _manager(config).reindex_all()).indexed_count == 128
 
     info_events = [entry["event"] for entry in logs if entry.get("log_level") == "info"]
     assert "Indexed knowledge file" not in info_events
@@ -1415,7 +1415,7 @@ async def test_completed_checkpoint_entry_without_vectors_is_requeued(
     (docs_path / "blocker.md").unlink()
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 1
+    assert (await _manager(config).reindex_all()).indexed_count == 1
     assert embedder.embedded_count("lost body") == 1
     assert embedder.embedded_count("kept body") == 0
     stored = sorted(record.metadata["source_path"] for record in _FakeVectorDb.store[checkpoint.collection])
@@ -1586,7 +1586,7 @@ async def test_scale_refresh_resumes_after_ninety_percent_and_stays_bounded(
     embedder.batch_requests.clear()
     embedder.single_requests.clear()
 
-    assert await _manager(config).reindex_all() == file_count - completed_after_interrupt
+    assert (await _manager(config).reindex_all()).indexed_count == file_count - completed_after_interrupt
 
     remaining = file_count - completed_after_interrupt
     assert len(embedder.embedded_texts) == remaining, "resume embeds only the outstanding files"
@@ -1618,7 +1618,7 @@ async def test_scale_refresh_issues_batched_requests_for_a_large_corpus(
     _write_corpus(docs_path, file_count)
     config = _config(tmp_path, docs_path)
 
-    assert await _manager(config).reindex_all() == file_count
+    assert (await _manager(config).reindex_all()).indexed_count == file_count
 
     assert embedder.single_requests == []
     assert embedder.request_count == pytest.approx(file_count / 64, abs=2)
@@ -1736,7 +1736,7 @@ async def test_compaction_decision_does_not_reread_the_journal(
     _write_corpus(docs_path, 40)
     config = _config(tmp_path, docs_path)
 
-    assert await _manager(config).reindex_all() == 40
+    assert (await _manager(config).reindex_all()).indexed_count == 40
 
     # Ten batches, none of which may parse the journal just to decide.
     assert reads == 0, f"journal was re-read {reads} times while deciding whether to compact"
@@ -1888,7 +1888,7 @@ async def test_candidate_pending_count_is_visible_while_the_build_runs(
 
     KnowledgeManager._index_file_locked = _observe_status  # type: ignore[method-assign]
     try:
-        assert await _manager(config).reindex_all() == 6
+        assert (await _manager(config).reindex_all()).indexed_count == 6
     finally:
         KnowledgeManager._index_file_locked = original_index  # type: ignore[method-assign]
 
@@ -1985,7 +1985,7 @@ async def test_short_batch_response_falls_back_to_per_item_and_publishes(
     runtime_paths = runtime_paths_for(config)
     embedder.short_batch = True
 
-    assert await _manager(config).reindex_all() == 5
+    assert (await _manager(config).reindex_all()).indexed_count == 5
 
     state = _published_state(config, runtime_paths)
     assert state is not None
@@ -2008,7 +2008,7 @@ async def test_batch_capability_failure_disables_batching_for_the_rest_of_the_ru
     config = _config(tmp_path, docs_path)
     embedder.short_batch = True
 
-    assert await _manager(config).reindex_all() == 16
+    assert (await _manager(config).reindex_all()).indexed_count == 16
 
     multi_input_requests = [batch for batch in embedder.batch_requests if len(batch) > 1]
     assert len(multi_input_requests) == 1, (
@@ -2034,10 +2034,10 @@ async def test_ordinary_permanent_batch_error_fails_fast_without_a_request_storm
     embedder.batch_error = EmbedderRequestError("embedder request failed (HTTP 400)")
 
     manager = _manager(config)
-    await manager.reindex_all()
+    outcome = await manager.reindex_all()
 
-    assert manager._last_refresh_error is not None
-    assert "embedder request failed (HTTP 400)" in manager._last_refresh_error
+    assert outcome.error is not None
+    assert "embedder request failed (HTTP 400)" in outcome.error
     assert _published_state(config, runtime_paths) is None
     assert embedder.request_count <= 4, f"degraded into a request storm: {embedder.request_count}"
 
@@ -2079,10 +2079,10 @@ async def test_single_input_wrong_cardinality_still_fails_and_does_not_publish(
     ]
 
     manager = _manager(config)
-    await manager.reindex_all()
+    outcome = await manager.reindex_all()
 
-    assert manager._last_refresh_error is not None
-    assert "Indexed 1 of 2" in manager._last_refresh_error
+    assert outcome.error is not None
+    assert "Indexed 1 of 2" in outcome.error
     assert _published_state(config, runtime_paths) is None
     checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
     assert checkpoint is not None
@@ -2140,11 +2140,11 @@ async def test_permanent_per_item_failure_after_fallback_is_recorded_per_file(
     embedder.failures["content 2"] = [EmbedderRequestError("embedder request failed (HTTP 422)") for _ in range(10)]
 
     manager = _manager(config)
-    await manager.reindex_all()
+    outcome = await manager.reindex_all()
 
-    assert manager._last_refresh_error is not None
-    assert "Indexed 3 of 4" in manager._last_refresh_error
-    assert "embedder request failed (HTTP 422)" in manager._last_refresh_error
+    assert outcome.error is not None
+    assert "Indexed 3 of 4" in outcome.error
+    assert "embedder request failed (HTTP 422)" in outcome.error
     assert _published_state(config, runtime_paths) is None, "an incomplete snapshot must not publish"
     checkpoint = load_candidate_checkpoint(_storage_path(config, runtime_paths))
     assert checkpoint is not None
@@ -2166,10 +2166,10 @@ async def test_credential_rejection_during_fallback_still_fails_fast(
     embedder.fail_everything = EmbedderRequestError("embedder authentication failed (HTTP 401)")
 
     manager = _manager(config)
-    await manager.reindex_all()
+    outcome = await manager.reindex_all()
 
-    assert manager._last_refresh_error is not None
-    assert "embedder authentication failed (HTTP 401)" in manager._last_refresh_error
+    assert outcome.error is not None
+    assert "embedder authentication failed (HTTP 401)" in outcome.error
     assert _published_state(config, runtime_paths) is None
     assert embedder.request_count <= 4, f"kept probing a rejected credential: {embedder.request_count}"
     assert load_candidate_checkpoint(_storage_path(config, runtime_paths)) is not None
@@ -2205,7 +2205,7 @@ async def test_restart_during_batch_fallback_resumes_the_same_candidate(
     assert len(checkpoint.completed) == 5
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 1
+    assert (await _manager(config).reindex_all()).indexed_count == 1
 
     for index in range(5):
         assert embedder.embedded_count(f"content {index}") == 0, "checkpointed files were re-embedded"
@@ -2326,7 +2326,7 @@ async def test_vectors_prefetched_before_a_later_fallback_are_still_reused(
 
     monkeypatch.setattr(_RecordingEmbedder, "get_embeddings_batch", _short_after_first_batch)
 
-    assert await _manager(config).reindex_all() == 12
+    assert (await _manager(config).reindex_all()).indexed_count == 12
 
     multi_input = [batch for batch in embedder.batch_requests if len(batch) > 1]
     assert len(multi_input) == 2, "batching stopped after the batch that proved it broken"
@@ -2463,7 +2463,7 @@ async def test_mtime_only_change_keeps_completed_vectors(
         os.utime(path, ns=(stat.st_atime_ns + 10**9, stat.st_mtime_ns + 10**9))
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 1, "only the previously failed file is indexed"
+    assert (await _manager(config).reindex_all()).indexed_count == 1, "only the previously failed file is indexed"
 
     for index in range(4):
         assert embedder.embedded_count(f"content {index}") == 0, "an mtime change re-embedded unchanged content"
@@ -2493,10 +2493,10 @@ async def test_globally_failing_embedder_stops_a_non_batching_refresh(
     embedder.fail_everything = EmbedderRequestError("embedder authentication failed (HTTP 401)")
 
     manager = _manager(config)
-    await manager.reindex_all()
+    outcome = await manager.reindex_all()
 
-    assert manager._last_refresh_error is not None
-    assert "embedder authentication failed (HTTP 401)" in manager._last_refresh_error
+    assert outcome.error is not None
+    assert "embedder authentication failed (HTTP 401)" in outcome.error
     assert _published_state(config, runtime_paths) is None
     assert embedder.request_count <= 4, f"issued one doomed request per file: {embedder.request_count}"
     assert load_candidate_checkpoint(_storage_path(config, runtime_paths)) is not None
@@ -2610,7 +2610,7 @@ async def test_candidate_path_removal_is_batched(
     monkeypatch.setattr(_FakeCollection, "delete", _counting_delete)
     monkeypatch.setattr(_FakeKnowledge, "remove_vectors_by_metadata", _counting_remove)
 
-    assert await _manager(config).reindex_all() == 40
+    assert (await _manager(config).reindex_all()).indexed_count == 40
 
     # 39 dropped paths must not cost 39 round trips; the upsert path still
     # clears each file it rewrites, so allow one per re-indexed file plus a
@@ -2900,7 +2900,7 @@ async def test_oversized_file_still_indexes_and_publishes(
     config = _config(tmp_path, docs_path, chunk_size=100_000)
     runtime_paths = runtime_paths_for(config)
 
-    assert await _manager(config).reindex_all() == 4
+    assert (await _manager(config).reindex_all()).indexed_count == 4
 
     state = _published_state(config, runtime_paths)
     assert state is not None
@@ -2969,7 +2969,7 @@ async def test_overlapping_chunks_are_batch_prefetched_and_published(
     config = _config(tmp_path, docs_path, chunk_size=1_000, chunk_overlap=100)
     runtime_paths = runtime_paths_for(config)
 
-    assert await _manager(config).reindex_all() == 1
+    assert (await _manager(config).reindex_all()).indexed_count == 1
 
     assert [batch for batch in embedder.batch_requests if len(batch) > 1], "no multi-input request was issued"
     assert embedder.single_requests == [], "every overlapping chunk was served from the batch prefetch"
@@ -2999,7 +2999,7 @@ async def test_file_skipped_by_overlap_expansion_still_indexes_and_publishes(
     config = _config(tmp_path, docs_path, chunk_size=1_000, chunk_overlap=100)
     runtime_paths = runtime_paths_for(config)
 
-    assert await _manager(config).reindex_all() == 4
+    assert (await _manager(config).reindex_all()).indexed_count == 4
 
     state = _published_state(config, runtime_paths)
     assert state is not None
@@ -3061,7 +3061,7 @@ async def test_refresh_after_publish_reuses_vectors_for_unchanged_files(
     config = _config(tmp_path, docs_path)
     runtime_paths = runtime_paths_for(config)
 
-    assert await _manager(config).reindex_all() == 3
+    assert (await _manager(config).reindex_all()).indexed_count == 3
     first_state = _published_state(config, runtime_paths)
     assert first_state is not None
     first_collection = first_state.collection
@@ -3071,7 +3071,7 @@ async def test_refresh_after_publish_reuses_vectors_for_unchanged_files(
     (docs_path / names[1]).write_text("rewritten body", encoding="utf-8")
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 1, "the whole corpus was embedded again"
+    assert (await _manager(config).reindex_all()).indexed_count == 1, "the whole corpus was embedded again"
 
     assert embedder.embedded_count("content 0") == 0
     assert embedder.embedded_count("content 2") == 0
@@ -3130,7 +3130,9 @@ async def test_published_vector_reuse_requires_matching_indexing_settings(
     rechunked = _config(tmp_path, docs_path, chunk_size=256, chunk_overlap=8)
     embedder.embedded_texts.clear()
 
-    assert await _manager(rechunked).reindex_all() == 3, "vectors built under other settings were reused"
+    assert (await _manager(rechunked).reindex_all()).indexed_count == 3, (
+        "vectors built under other settings were reused"
+    )
     assert embedder.embedded_count("content 0") == 1
 
 
@@ -3185,7 +3187,9 @@ async def test_published_vector_reuse_needs_a_completely_published_index(
     )
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 3, "vectors from an unpublished collection were reused"
+    assert (await _manager(config).reindex_all()).indexed_count == 3, (
+        "vectors from an unpublished collection were reused"
+    )
 
 
 @pytest.mark.asyncio
@@ -3213,7 +3217,7 @@ async def test_published_vector_reuse_never_claims_a_path_the_published_index_ca
     ]
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 1
+    assert (await _manager(config).reindex_all()).indexed_count == 1
 
     assert embedder.embedded_count("content 2") == 1, "a path with no published rows was claimed as indexed"
     state = _published_state(config, runtime_paths)
@@ -3244,7 +3248,7 @@ async def test_published_vector_copy_is_paged_so_no_query_exceeds_the_store_ceil
     (docs_path / names[0]).write_text("rewritten body", encoding="utf-8")
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 1
+    assert (await _manager(config).reindex_all()).indexed_count == 1
 
     assert max(rows for rows, _where in _FakeVectorDb.queries) <= 4
     assert _vector_existence_probe_count() == 0, "copied paths were sent back through the vector-existence probe"
@@ -3268,7 +3272,7 @@ async def test_published_vector_reuse_falls_back_when_the_published_collection_i
     _FakeVectorDb.store.pop(first_state.collection)
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 3
+    assert (await _manager(config).reindex_all()).indexed_count == 3
 
     state = _published_state(config, runtime_paths)
     assert state is not None
@@ -3326,7 +3330,7 @@ async def test_published_vector_reuse_survives_a_checkout_that_only_rewrites_mti
         os.utime(path, ns=(stat.st_atime_ns + 10**9, stat.st_mtime_ns + 10**9))
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 1, "an mtime rewrite re-embedded unchanged content"
+    assert (await _manager(config).reindex_all()).indexed_count == 1, "an mtime rewrite re-embedded unchanged content"
 
     assert embedder.embedded_count("content 0") == 0
     assert embedder.embedded_count("content 2") == 0
@@ -3352,7 +3356,7 @@ async def test_published_vector_reuse_rescans_an_empty_file_it_cannot_claim(
     (docs_path / names[0]).write_text("rewritten body", encoding="utf-8")
     embedder.embedded_texts.clear()
 
-    assert await _manager(config).reindex_all() == 2, "the empty file was claimed or lost"
+    assert (await _manager(config).reindex_all()).indexed_count == 2, "the empty file was claimed or lost"
 
     assert embedder.embedded_count("content 1") == 0
     state = _published_state(config, runtime_paths)
@@ -3473,7 +3477,7 @@ async def test_a_cancelled_vector_copy_never_publishes_rows_it_could_not_claim(
     (docs_path / names[0]).unlink()
     embedder.embedded_texts.clear()
 
-    indexed = await _manager(config).reindex_all()
+    indexed = (await _manager(config).reindex_all()).indexed_count
 
     state = _published_state(config, runtime_paths)
     assert state is not None
@@ -3593,7 +3597,7 @@ async def test_an_interruption_after_the_copy_still_resumes_the_work_it_finished
     assert len(checkpoint.completed) == 2
     already_embedded = {f"revised {names.index(name)}" for name in checkpoint.completed}
 
-    assert await _manager(config).reindex_all() == len(names) - 2
+    assert (await _manager(config).reindex_all()).indexed_count == len(names) - 2
 
     for body in already_embedded:
         assert embedder.embedded_count(body) == 1, "an interrupted refresh re-embedded work it had finished"
@@ -3757,7 +3761,7 @@ async def test_a_rebuild_that_dies_before_emptying_the_collection_still_recovers
     assert _stored_paths(interrupted.collection) == sorted(names), "the crash left rows nothing claims"
     embedder.embedded_texts.clear()
 
-    indexed = await _manager(config).reindex_all()
+    indexed = (await _manager(config).reindex_all()).indexed_count
 
     state = _published_state(config, runtime_paths)
     assert state is not None

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -51,7 +51,8 @@ from mindroom.knowledge.candidate_checkpoint import (
 from mindroom.knowledge.embedding_batch import BatchPrefetchEmbedder, plan_embedding_batches
 from mindroom.knowledge.index_metadata import write_index_metadata_payload
 from mindroom.knowledge.index_retry import EmbeddingRetryPolicy, run_with_embedding_retry
-from mindroom.knowledge.manager import KnowledgeManager, RefreshOutcome
+from mindroom.knowledge.manager import KnowledgeManager
+from mindroom.knowledge.refresh_outcome import RefreshOutcome
 from mindroom.knowledge.refresh_runner import refresh_knowledge_binding
 from mindroom.knowledge.registry import (
     PublishedIndexState,


### PR DESCRIPTION
## Why

`KnowledgeManager.reindex_all()` was typed `-> int` and returned only `progress.indexed_this_run`. The rest of what a refresh did lived in private instance state, so `refresh_runner` reached across the module boundary to read it:

```python
indexed_count = await manager.reindex_all(force_reindex=force_reindex)
if manager._last_refresh_error is not None:
    error = redact_credentials_in_text(manager._last_refresh_error)
```

That was the only `manager._`-prefixed error read outside `manager.py`, and it made the return type a lie: the file count is the least interesting part of a refresh result.

## What the outcome carries

```python
@dataclass(frozen=True, slots=True)
class RefreshOutcome:
    indexed_count: int   # files this pass embedded, not reused
    published: bool      # whether a complete candidate was swapped in
    error: str | None    # why it finished without publishing; already redacted
```

Three facts, all of which had a reader already:

| Field | Was |
|---|---|
| `indexed_count` | the `-> int` return value |
| `published` | `run.published`, local to the call, only reachable by the log line |
| `error` | `_last_refresh_error`, read across the module boundary by `refresh_runner` |

The outcome is built once, in the `finally` that already ran the terminal summary, so the log line, the returned value, and the persisted metadata now describe the same run rather than three separately-assembled views of it.

Credential redaction moves to that construction. To be precise about why, since an earlier draft of this description overstated it: **no reachable value changes.** `describe_embedder_error` is contractually free of provider text, every `EmbedderRequestError` detail is a literal or a type name, the git path redacts before raising, and the raising path redacts at assignment. The move is worth making as a *seam guarantee* — a future error source feeding the accumulator does not have to remember to redact, and the caller does not have to know to — not because the accumulator is unsafe today.

Fields deliberately **not** added: `_file_index_errors` and `_embedding_retry_count` have no consumer outside the manager (per-file status and progress logging respectively), so they stay internal.

## What stayed internal

`_last_refresh_error` and `_last_file_index_error` remain as accumulation state. They collect a failure across a pass from several call sites; folding them into the outcome construction is a bigger change than this PR's point, which is the public seam.

`_global_embedder_failure` is untouched — it is embedder-health classification, not a refresh result.

## Tests

Of the 21 `manager._last_refresh_error` references in `tests/`, **20 were assertions about the refresh result and now assert on the returned `RefreshOutcome`**; several collapse a count assertion and an error assertion into one equality against the whole outcome, which also pins `published`. The 21st was a *precondition* write seeding a stale error; review found it inert (see below), so it is gone too — no test now reads `_last_refresh_error`.

38 `assert await ....reindex_all() == N` sites became `.indexed_count == N`, and 14 monkeypatched `reindex_all` fakes were retyped.

Left alone on purpose: the three `_global_embedder_failure` assertions genuinely probe internal classification state, not the refresh result.

## Follow-up commit (round-1 review)

Four findings, all verified against the code and all fixed:

1. **A dead write.** The non-semantic early return cleared `_last_refresh_error` and then returned a literal with no data dependency on it. Once `reindex_all` returns the outcome, the field's only readers are two lines inside the lock, both after the reset at the top of that block — so the pre-lock clear is unobservable, and deleting it leaves the suite green. The test that claimed to cover it was asserting on the literal; it now states what the disabled path actually guarantees and is renamed to match.
2. **A wrong comment**, corrected as described above.
3. **The `outcome: RefreshOutcome` annotation is load-bearing** and nothing said so. `privata` accepts the symbol as public because this module imports it by name; without a use, ruff deletes the import and `privata` then fails. A routine "drop the redundant annotation" cleanup would have broken the build on a behavior-free change. Comment added.
4. **`manager: KnowledgeManager | None = None`** was never read before its assignment. Deleted.

Noted but deliberately not changed: on the git-error path the same string is now redacted four times (`manager.py:936` → `:2458` → `:2469` → `api/knowledge.py:324`). `redact_credentials_in_text` is idempotent, and the innermost call keeps raw exception text out of instance state, so collapsing them would trade a real property for a cosmetic one.

## Round-2 review

`RefreshOutcome` moved to its own leaf module, `knowledge/refresh_outcome.py`. It is the contract *between* manager and runner, not manager internals, and the placement was what forced the `privata` workaround: with the type in `manager.py`, privata only accepted it as public because the runner imported it by name, and that import only survived ruff because of an annotation existing for no other reason. Verified empirically — leaf module, no annotation, no runner import, privata clean. The four-line "do not simplify this away" comment is deleted rather than kept.

The docstring described two outcomes while the code returns three: a non-semantic base reports `published=False` with no error, so tying `error is None` to success was wrong. It now names published / valid no-op / failed and says outright that a null error does not imply publication. `published` is **kept** rather than dropped: the terminal log line reads it, and removing it would re-split that summary into an outcome plus a loose flag, undoing the consolidation that makes the outcome one description of the run.

Redaction moved from the outcome construction to a `_record_refresh_error` helper at each assignment site. This resolves a divergence a reviewer caught: `_last_refresh_error` held the raw string while `outcome.error` held the redacted one, so for a single run the attribute could disagree with what was logged and persisted. It also takes `redact_credentials_in_text` — which is **not total**, an unparseable IPv6 URL raises `ValueError` — out of the `finally` that owns checkpoint compaction, where a raise would both mask the real failure and skip durability work. Making the redactor total is #1716's job, not this PR's.

## On whether this is worth it

`indexed_count` and `error` earn their place — the `-> int` return really was a lie about what a refresh produces, and the private reach-through it forced was the only one of its kind.

One criticism deserves a direct answer rather than silence: `refresh_runner` still reaches into eight other private manager members (`_knowledge_source_path()`, `_git_tracked_relative_paths`, `_git_last_successful_commit`, `_git_config()`, `_needs_full_reindex_on_create()`), three of them within a dozen lines of the seam this PR cleans. So this removes one private read of nine. That is a fair criticism of the PR in isolation and a misleading one about the programme: those eight are precisely what the `git_source.py` extraction (#1716) exists to remove, and splitting them across PRs is what keeps each diff reviewable against three siblings in flight.

## Verification

- `uv run pytest tests/test_knowledge_manager.py tests/test_knowledge_resumable_refresh.py tests/test_bot_knowledge.py -nauto --no-cov` — 357 passed
- `uv run pre-commit run --all-files` — all hooks pass
- `uv run tach check --dependencies --interfaces` — all modules validated

PR 2 of a 6-part knowledge-module refactor.
