### PR TITLE
Extract Chroma collection lifecycle out of the knowledge manager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ Matrix sync callback
 | `memory/` | Mem0 memory: agent and team-scoped |
 | `knowledge/` | Knowledge base / RAG file indexing with watcher |
 | `knowledge/file_listing.py` | Which files belong to a knowledge base: include patterns, traversal, symlink-safe inclusion rules |
+| `knowledge/collections.py` | Chroma collection lifecycle for one knowledge base: naming, opening, probing, deleting, reclaiming |
 | `tool_system/skills.py` | Skill integration system (OpenClaw-compatible) |
 | `tool_system/plugins.py` | Plugin loading and tool/skill extension |
 | `scheduling.py` | Cron and natural-language task scheduling |

--- a/src/mindroom/knowledge/collections.py
+++ b/src/mindroom/knowledge/collections.py
@@ -1,0 +1,337 @@
+"""Chroma collection lifecycle for one knowledge base.
+
+Naming, opening, probing, deleting and reclaiming the collections a knowledge
+base owns. None of that depends on the refresh advancing the base: a base's
+collections are a function of where it stores vectors and what those vectors
+are called, so this deliberately holds no per-refresh state and takes what it
+needs as arguments.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from agno.vectordb.chroma import ChromaDb
+from chromadb.errors import InternalError, NotFoundError
+
+from mindroom.knowledge.indexing_config import storage_key_for_base
+from mindroom.logging_config import get_logger
+from mindroom.strict_knowledge import StrictInsertKnowledge as Knowledge
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
+    from pathlib import Path
+
+    from agno.knowledge.embedder.base import Embedder
+    from agno.vectordb.base import VectorDb
+    from chromadb.api.models.Collection import Collection
+
+logger = get_logger(__name__)
+
+_COLLECTION_PREFIX = "mindroom_knowledge"
+
+#: Source identity every indexed chunk carries, so a collection doubles as an
+#: index from source path to the vectors and signature that path produced.
+SOURCE_PATH_KEY = "source_path"
+SOURCE_MTIME_NS_KEY = "source_mtime_ns"
+SOURCE_SIZE_KEY = "source_size"
+SOURCE_DIGEST_KEY = "source_digest"
+
+#: Completed candidate entries whose vectors are confirmed in one Chroma query.
+#: Only a starting point: the query splits itself when the store refuses it,
+#: because the real limit is matched rows, which this cannot know up front.
+VECTOR_VERIFY_BATCH = 128
+#: Source paths whose vectors are dropped in one Chroma delete. Independent of
+#: the verify batch: a delete binds no variable per matched row, so this bounds
+#: only how much work one call does.
+_VECTOR_DELETE_BATCH = 128
+
+
+@runtime_checkable
+class _CollectionListingClient(Protocol):
+    """Vector client surface needed for best-effort collection cleanup."""
+
+    def list_collections(self) -> list[object]:
+        """Return collection names or collection objects."""
+        ...
+
+
+@runtime_checkable
+class _NamedCollection(Protocol):
+    """Collection object shape returned by Chroma clients."""
+
+    name: str
+
+
+@dataclass(frozen=True)
+class CollectionSpace:
+    """One knowledge base's private storage directory and the names it owns.
+
+    ``embedder_factory`` stays a factory rather than an embedder because a
+    handle opened only to delete a collection should not cost an embedder
+    unless one is really built.
+    """
+
+    base_id: str
+    storage_path: Path
+    default_collection: str
+    embedder_factory: Callable[[], Embedder]
+
+
+def collection_name_for_base(base_id: str, knowledge_path: Path) -> str:
+    """Return the published collection name one base's resolved source path owns."""
+    return f"{_COLLECTION_PREFIX}_{storage_key_for_base(base_id, knowledge_path)}"
+
+
+def candidate_collection_name(space: CollectionSpace) -> str:
+    """Return a fresh candidate name under the prefix this base provably owns."""
+    return f"{space.default_collection}_candidate_{uuid.uuid4().hex[:16]}"
+
+
+def build_vector_db(
+    space: CollectionSpace,
+    collection_name: str,
+    *,
+    embedder: Embedder | None = None,
+) -> ChromaDb:
+    """Open one collection handle in this base's storage directory."""
+    return ChromaDb(
+        collection=collection_name,
+        path=str(space.storage_path),
+        persistent_client=True,
+        embedder=embedder if embedder is not None else space.embedder_factory(),
+    )
+
+
+def build_knowledge(
+    space: CollectionSpace,
+    collection_name: str,
+    *,
+    embedder: Embedder | None = None,
+) -> Knowledge:
+    """Return the Agno knowledge surface backing one collection."""
+    return Knowledge(vector_db=build_vector_db(space, collection_name, embedder=embedder))
+
+
+def require_chroma_vector_db(knowledge: Knowledge) -> ChromaDb:
+    """Narrow one knowledge surface to the Chroma database the candidate needs."""
+    vector_db = knowledge.vector_db
+    if not isinstance(vector_db, ChromaDb):
+        msg = "Knowledge reindex candidate collection requires a ChromaDb vector database"
+        raise TypeError(msg)
+    return vector_db
+
+
+def reset_vector_db(vector_db: ChromaDb) -> None:
+    """Empty one collection by dropping and recreating it."""
+    vector_db.delete()
+    vector_db.create()
+
+
+def collection_has_source_path(collection: Collection, relative_path: str) -> bool:
+    """Return whether one source path has any vector, at one row of cost.
+
+    Chroma binds one SQL variable per *returned* row, so an unbounded probe on
+    a heavily chunked file exceeds SQLite's ceiling and fails outright. One row
+    is all existence needs, and ``limit=1`` is what keeps this answerable at
+    any file size. Do not widen it.
+    """
+    result = collection.get(where={SOURCE_PATH_KEY: relative_path}, limit=1, include=[])
+    return bool(result.get("ids"))
+
+
+def _collection_paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -> set[str]:
+    """Return which of `relative_paths` have at least one vector in the collection.
+
+    Chroma binds one SQL variable per *matched row*, not one per queried path,
+    so a fixed batch of paths does not bound the query at all: whether it fits
+    under SQLite's ceiling depends on how many chunks those particular files
+    produced. That makes any batch size chosen up front a gamble. Small files
+    leave a batch of 128 far below the ceiling, a handful of large ones puts
+    the same batch over it, and once over, every verification query for that
+    base fails identically and the candidate is stranded for good.
+
+    So the batch is not guessed, it is *adapted*: ask for the whole thing, and
+    on refusal halve it and ask again. Each split halves the matched rows too,
+    so it converges, and a store that can answer the batch pays nothing.
+
+    A single path is the floor, where splitting can no longer help, so it is
+    asked for a single row instead, which stays under any ceiling however many
+    chunks the file has. That floor is what makes the recursion total, and it
+    is also where a failure that was never about query size finally surfaces.
+    """
+    if len(relative_paths) == 1:
+        relative_path = relative_paths[0]
+        return {relative_path} if collection_has_source_path(collection, relative_path) else set()
+
+    try:
+        result = collection.get(where={SOURCE_PATH_KEY: {"$in": list(relative_paths)}}, include=["metadatas"])
+    except NotFoundError:
+        # Splitting answers "the store refused this query for its size". A
+        # collection that is gone is not that, and stays gone however small the
+        # query gets, so descending would only cost log2(batch) + 1 doomed
+        # queries before raising exactly the same error from the first leaf.
+        raise
+    except InternalError as error:
+        if "too many SQL variables" not in str(error):
+            raise
+        # Splitting stays correct but multiplies the queries, and how far it
+        # degrades depends on chunk counts nothing here can see. Without a
+        # trace, a base whose files outgrew the ceiling just gets quietly
+        # slower -- the same invisibility that let the unsplit query strand
+        # candidates undiagnosed.
+        logger.debug("Split a refused knowledge vector verification query", paths=len(relative_paths))
+        midpoint = len(relative_paths) // 2
+        return _collection_paths_with_vectors(collection, relative_paths[:midpoint]) | _collection_paths_with_vectors(
+            collection,
+            relative_paths[midpoint:],
+        )
+
+    found: set[str] = set()
+    for metadata in result.get("metadatas") or []:
+        source_path = metadata.get(SOURCE_PATH_KEY)
+        if isinstance(source_path, str):
+            found.add(source_path)
+    return found
+
+
+def paths_with_vectors(vector_db: ChromaDb, relative_paths: Sequence[str]) -> set[str]:
+    """Return which of the given source paths actually have vectors in one collection."""
+    collection = vector_db.client.get_collection(name=vector_db.collection_name)
+    return _collection_paths_with_vectors(collection, relative_paths)
+
+
+def delete_source_path_vectors(vector_db: ChromaDb, relative_paths: Sequence[str]) -> None:
+    """Delete vectors for many source paths in one vector-store round trip.
+
+    Agno's ``delete_by_metadata`` wraps values in ``$eq`` and so can only
+    take one path per call, which turns a large source update into one
+    thread hop and one get+delete per file. The collection accepts ``$in``
+    directly.
+
+    Unlike the ``$in`` the verification query issues, this one needs no
+    ceiling protection: a delete does not bind one SQL variable per matched
+    row, so the batch size alone bounds it. Measured on ChromaDB 1.5.8,
+    deleting 51,200 rows across 128 paths in one call succeeds, where the
+    equivalent read fails with ``too many SQL variables``.
+    """
+    collection = vector_db.client.get_collection(name=vector_db.collection_name)
+    for start in range(0, len(relative_paths), _VECTOR_DELETE_BATCH):
+        batch = list(relative_paths[start : start + _VECTOR_DELETE_BATCH])
+        collection.delete(where={SOURCE_PATH_KEY: {"$in": batch}})
+
+
+async def delete_collection(space: CollectionSpace, collection_name: str) -> bool:
+    """Delete one candidate collection, reporting whether it is really gone.
+
+    Agno's ``ChromaDb.delete`` swallows the provider error and returns
+    ``False`` rather than raising, so catching exceptions alone would
+    report every real failure as a success. A ``False`` result is also
+    returned when the collection simply was not there, which is the
+    outcome we want, so the two are told apart by probing existence.
+    """
+    try:
+        deleted = await asyncio.to_thread(_delete_collection_sync, space, collection_name)
+    except Exception:
+        logger.warning(
+            "Failed to delete knowledge candidate collection",
+            base_id=space.base_id,
+            collection=collection_name,
+            exc_info=True,
+        )
+        return False
+    if deleted:
+        return True
+    logger.warning(
+        "Knowledge candidate collection still exists after deletion failed",
+        base_id=space.base_id,
+        collection=collection_name,
+    )
+    return False
+
+
+def _delete_collection_sync(space: CollectionSpace, collection_name: str) -> bool:
+    """Delete one candidate, treating an already-absent collection as success."""
+    vector_db = build_vector_db(space, collection_name)
+    if vector_db.delete():
+        return True
+    try:
+        vector_db.client.get_collection(name=vector_db.collection_name)
+    except NotFoundError:
+        return True
+    return False
+
+
+def cleanup_superseded_collections(
+    space: CollectionSpace,
+    *,
+    vector_db: VectorDb | None,
+    preserved: frozenset[str],
+    candidates_only: bool = False,
+) -> None:
+    """Delete this base's superseded collections, preserving proven-live ones.
+
+    Ownership is proven by name: both the default collection and the
+    candidate prefix embed this base's identity and resolved source path,
+    and both live in this base's own private storage directory. Anything
+    else in that directory is left alone and reported rather than deleted,
+    because nothing here can prove who owns it.
+    """
+    if not isinstance(vector_db, ChromaDb):
+        return
+    client = vector_db.client
+    if client is None or not isinstance(client, _CollectionListingClient):
+        return
+
+    default_collection = space.default_collection
+    candidate_prefix = f"{default_collection}_candidate_"
+
+    try:
+        collection_names = _listed_collection_names(client)
+    except Exception:
+        logger.warning(
+            "Failed to list superseded knowledge collections for cleanup",
+            base_id=space.base_id,
+            exc_info=True,
+        )
+        return
+
+    unowned: list[str] = []
+    for collection_name in collection_names:
+        if collection_name in preserved:
+            continue
+        is_candidate = collection_name.startswith(candidate_prefix)
+        if not is_candidate and (candidates_only or collection_name != default_collection):
+            # Reclaiming abandoned candidates must never race a legacy
+            # published collection whose metadata predates this layout.
+            if collection_name != default_collection:
+                unowned.append(collection_name)
+            continue
+        try:
+            build_vector_db(space, collection_name).delete()
+        except Exception:
+            logger.warning(
+                "Failed to clean superseded knowledge collection",
+                base_id=space.base_id,
+                collection=collection_name,
+                exc_info=True,
+            )
+    if unowned:
+        logger.info(
+            "Preserved knowledge collections with unprovable ownership",
+            base_id=space.base_id,
+            collections=sorted(unowned),
+        )
+
+
+def _listed_collection_names(client: _CollectionListingClient) -> tuple[str, ...]:
+    names: list[str] = []
+    for collection in client.list_collections():
+        if isinstance(collection, str):
+            names.append(collection)
+        elif isinstance(collection, _NamedCollection):
+            names.append(collection.name)
+    return tuple(dict.fromkeys(names))

--- a/src/mindroom/knowledge/collections.py
+++ b/src/mindroom/knowledge/collections.py
@@ -70,18 +70,29 @@ class _NamedCollection(Protocol):
 class CollectionSpace:
     """One knowledge base's private storage directory and the names it owns.
 
-    ``embedder_factory`` stays a factory rather than an embedder because a
-    handle opened only to delete a collection should not cost an embedder
-    unless one is really built.
+    ``default_collection`` is *derived*, never accepted. Cleanup treats it as
+    proof of ownership -- a collection is deletable only if it matches that
+    name or carries its candidate prefix -- so a space that could be handed the
+    name would be able to authorize deleting a collection this base does not
+    own. Computing it from ``base_id`` and the resolved source path keeps the
+    answer to "is this mine?" a function of identity rather than an assertion.
+
+    ``embedder_factory`` stays a factory rather than an embedder so that a base
+    which never opens a collection never constructs one.
     """
 
     base_id: str
+    knowledge_path: Path
     storage_path: Path
-    default_collection: str
     embedder_factory: Callable[[], Embedder]
 
+    @property
+    def default_collection(self) -> str:
+        """Return the published collection name this base's identity owns."""
+        return _collection_name_for_base(self.base_id, self.knowledge_path)
 
-def collection_name_for_base(base_id: str, knowledge_path: Path) -> str:
+
+def _collection_name_for_base(base_id: str, knowledge_path: Path) -> str:
     """Return the published collection name one base's resolved source path owns."""
     return f"{_COLLECTION_PREFIX}_{storage_key_for_base(base_id, knowledge_path)}"
 
@@ -162,7 +173,15 @@ def _collection_paths_with_vectors(collection: Collection, relative_paths: Seque
     asked for a single row instead, which stays under any ceiling however many
     chunks the file has. That floor is what makes the recursion total, and it
     is also where a failure that was never about query size finally surfaces.
+
+    No paths is answerable without asking: Chroma rejects an empty ``$in``
+    operand outright, so the empty case has to be a base case rather than a
+    query. Splitting never reaches it -- every half of a batch of two or more
+    is non-empty -- but a caller can.
     """
+    if not relative_paths:
+        return set()
+
     if len(relative_paths) == 1:
         relative_path = relative_paths[0]
         return {relative_path} if collection_has_source_path(collection, relative_path) else set()
@@ -200,6 +219,10 @@ def _collection_paths_with_vectors(collection: Collection, relative_paths: Seque
 
 def paths_with_vectors(vector_db: ChromaDb, relative_paths: Sequence[str]) -> set[str]:
     """Return which of the given source paths actually have vectors in one collection."""
+    if not relative_paths:
+        # Answered before resolving a handle: asking about no paths has one
+        # obvious answer, and resolving would raise if the collection is gone.
+        return set()
     collection = vector_db.client.get_collection(name=vector_db.collection_name)
     return _collection_paths_with_vectors(collection, relative_paths)
 

--- a/src/mindroom/knowledge/collections.py
+++ b/src/mindroom/knowledge/collections.py
@@ -225,7 +225,7 @@ def delete_source_path_vectors(vector_db: ChromaDb, relative_paths: Sequence[str
 
 
 async def delete_collection(space: CollectionSpace, collection_name: str) -> bool:
-    """Delete one candidate collection, reporting whether it is really gone.
+    """Delete one collection this base owns, reporting whether it is really gone.
 
     Agno's ``ChromaDb.delete`` swallows the provider error and returns
     ``False`` rather than raising, so catching exceptions alone would
@@ -237,7 +237,7 @@ async def delete_collection(space: CollectionSpace, collection_name: str) -> boo
         deleted = await asyncio.to_thread(_delete_collection_sync, space, collection_name)
     except Exception:
         logger.warning(
-            "Failed to delete knowledge candidate collection",
+            "Failed to delete knowledge collection",
             base_id=space.base_id,
             collection=collection_name,
             exc_info=True,
@@ -246,7 +246,7 @@ async def delete_collection(space: CollectionSpace, collection_name: str) -> boo
     if deleted:
         return True
     logger.warning(
-        "Knowledge candidate collection still exists after deletion failed",
+        "Knowledge collection still exists after deletion failed",
         base_id=space.base_id,
         collection=collection_name,
     )
@@ -254,7 +254,7 @@ async def delete_collection(space: CollectionSpace, collection_name: str) -> boo
 
 
 def _delete_collection_sync(space: CollectionSpace, collection_name: str) -> bool:
-    """Delete one candidate, treating an already-absent collection as success."""
+    """Delete one collection, treating an already-absent one as success."""
     vector_db = build_vector_db(space, collection_name)
     if vector_db.delete():
         return True

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -61,7 +61,6 @@ from mindroom.knowledge.collections import (
     candidate_collection_name,
     cleanup_superseded_collections,
     collection_has_source_path,
-    collection_name_for_base,
     delete_collection,
     delete_source_path_vectors,
     paths_with_vectors,
@@ -669,8 +668,8 @@ class KnowledgeManager:
         self._git_lfs_hydrated_head_path = self._base_storage_path / "git_lfs_hydrated_head.txt"
         self._collections = CollectionSpace(
             base_id=self.base_id,
+            knowledge_path=self.knowledge_path,
             storage_path=self._base_storage_path,
-            default_collection=collection_name_for_base(self.base_id, self.knowledge_path),
             # A factory, not an embedder: this runs for every base, including
             # non-semantic ones that never open a collection, and a status read
             # must construct no embedder at all. Deferring puts the cost only

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -671,8 +671,11 @@ class KnowledgeManager:
             base_id=self.base_id,
             storage_path=self._base_storage_path,
             default_collection=collection_name_for_base(self.base_id, self.knowledge_path),
-            # A factory, not an embedder: opening a handle purely to delete a
-            # collection must not construct one.
+            # A factory, not an embedder: this runs for every base, including
+            # non-semantic ones that never open a collection, and a status read
+            # must construct no embedder at all. Deferring puts the cost only
+            # where a handle is really built -- for a cleanup sweep, once per
+            # collection it actually deletes, and nothing when it deletes none.
             embedder_factory=lambda: create_configured_embedder(self.config, self.runtime_paths),
         )
         persisted_state = self._load_persisted_index_state()
@@ -1202,8 +1205,9 @@ class KnowledgeManager:
         )
         publish_state.index_published = True
         # Adopt the candidate as this manager's live vector database:
-        # `_cleanup_superseded_collections` runs right after publish and reads
-        # `self._knowledge.vector_db` to obtain the Chroma client it lists with.
+        # `cleanup_superseded_collections` runs right after publish and is handed
+        # `self._knowledge.vector_db` as the Chroma client it lists with, so the
+        # adoption has to land before that call reads the attribute.
         self._knowledge.vector_db = candidate_vector_db
         if publish_cancelled:
             _raise_cancelled()

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -7,19 +7,17 @@ import base64
 import hashlib
 import os
 import time
-import uuid
 from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeVar, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, Literal, NoReturn, TypeVar, cast
 from urllib.parse import quote, urlparse, urlunparse
 
 from agno.knowledge.reader import ReaderFactory
 from agno.knowledge.reader.markdown_reader import MarkdownReader
 from agno.knowledge.reader.text_reader import TextReader
 from agno.vectordb.chroma import ChromaDb
-from chromadb.errors import InternalError, NotFoundError
 
 from mindroom.chunking import SafeFixedSizeChunking
 from mindroom.constants import (
@@ -45,6 +43,25 @@ from mindroom.knowledge.candidate_checkpoint import (
     file_signature_from_fields,
     load_candidate_checkpoint,
     save_candidate_checkpoint,
+)
+from mindroom.knowledge.collections import (
+    SOURCE_DIGEST_KEY,
+    SOURCE_MTIME_NS_KEY,
+    SOURCE_PATH_KEY,
+    SOURCE_SIZE_KEY,
+    VECTOR_VERIFY_BATCH,
+    CollectionSpace,
+    build_knowledge,
+    build_vector_db,
+    candidate_collection_name,
+    cleanup_superseded_collections,
+    collection_has_source_path,
+    collection_name_for_base,
+    delete_collection,
+    delete_source_path_vectors,
+    paths_with_vectors,
+    require_chroma_vector_db,
+    reset_vector_db,
 )
 from mindroom.knowledge.embedding_batch import (
     DEFAULT_MAX_EMBEDDING_BATCH_ITEMS,
@@ -87,7 +104,6 @@ if TYPE_CHECKING:
     from agno.knowledge.document.base import Document
     from agno.knowledge.embedder.base import Embedder
     from agno.knowledge.reader.base import Reader
-    from chromadb.api.models.Collection import Collection
     from chromadb.api.types import Embeddings, Metadata
 
     from mindroom.config.knowledge import KnowledgeGitConfig
@@ -95,11 +111,6 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_COLLECTION_PREFIX = "mindroom_knowledge"
-_SOURCE_PATH_KEY = "source_path"
-_SOURCE_MTIME_NS_KEY = "source_mtime_ns"
-_SOURCE_SIZE_KEY = "source_size"
-_SOURCE_DIGEST_KEY = "source_digest"
 _POST_INDEX_VECTOR_VISIBILITY_RETRY_DELAYS_SECONDS = (0.0, 0.01, 0.05)
 _INDEXING_STATUS_RESETTING = "resetting"
 _INDEXING_STATUS_INDEXING = "indexing"
@@ -120,14 +131,6 @@ _MAX_PREFETCH_TEXT_BYTES = 8_000_000
 #: Source files whose signatures are computed per thread hop, so a huge corpus
 #: still yields to the event loop and to cancellation while it is scanned.
 _SIGNATURE_SCAN_CHUNK = 512
-#: Completed candidate entries whose vectors are confirmed in one Chroma query.
-#: Only a starting point: the query splits itself when the store refuses it,
-#: because the real limit is matched rows, which this cannot know up front.
-_VECTOR_VERIFY_BATCH = 128
-#: Source paths whose vectors are dropped in one Chroma delete. Independent of
-#: the verify batch: a delete binds no variable per matched row, so this bounds
-#: only how much work one call does.
-_VECTOR_DELETE_BATCH = 128
 #: Published chunk rows read in one copy query. Chroma binds one SQL variable
 #: per *returned* row and SQLite caps a statement at 32,766, so nothing about
 #: the file or path count bounds a copy query -- only the rows it may return.
@@ -167,22 +170,6 @@ def _max_concurrent_knowledge_file_indexes() -> int:
         )
         raise ValueError(msg)
     return value
-
-
-@runtime_checkable
-class _CollectionListingClient(Protocol):
-    """Vector client surface needed for best-effort collection cleanup."""
-
-    def list_collections(self) -> list[object]:
-        """Return collection names or collection objects."""
-        ...
-
-
-@runtime_checkable
-class _NamedCollection(Protocol):
-    """Collection object shape returned by Chroma clients."""
-
-    name: str
 
 
 @dataclass(frozen=True)
@@ -365,81 +352,6 @@ def _iter_file_batches(files: Sequence[Path], batch_size: int) -> Iterator[list[
         yield list(files[start : start + size])
 
 
-def _collection_has_source_path(collection: Collection, relative_path: str) -> bool:
-    """Return whether one source path has any vector, at one row of cost.
-
-    Chroma binds one SQL variable per *returned* row, so an unbounded probe on
-    a heavily chunked file exceeds SQLite's ceiling and fails outright. One row
-    is all existence needs, and ``limit=1`` is what keeps this answerable at
-    any file size. Do not widen it.
-    """
-    result = collection.get(where={_SOURCE_PATH_KEY: relative_path}, limit=1, include=[])
-    return bool(result.get("ids"))
-
-
-def _paths_with_vectors(collection: Collection, relative_paths: Sequence[str]) -> set[str]:
-    """Return which of `relative_paths` have at least one vector in the collection.
-
-    Chroma binds one SQL variable per *matched row*, not one per queried path,
-    so a fixed batch of paths does not bound the query at all: whether it fits
-    under SQLite's ceiling depends on how many chunks those particular files
-    produced. That makes any batch size chosen up front a gamble. Small files
-    leave a batch of 128 far below the ceiling, a handful of large ones puts
-    the same batch over it, and once over, every verification query for that
-    base fails identically and the candidate is stranded for good.
-
-    So the batch is not guessed, it is *adapted*: ask for the whole thing, and
-    on refusal halve it and ask again. Each split halves the matched rows too,
-    so it converges, and a store that can answer the batch pays nothing.
-
-    A single path is the floor, where splitting can no longer help, so it is
-    asked for a single row instead, which stays under any ceiling however many
-    chunks the file has. That floor is what makes the recursion total, and it
-    is also where a failure that was never about query size finally surfaces.
-    """
-    if len(relative_paths) == 1:
-        relative_path = relative_paths[0]
-        return {relative_path} if _collection_has_source_path(collection, relative_path) else set()
-
-    try:
-        result = collection.get(where={_SOURCE_PATH_KEY: {"$in": list(relative_paths)}}, include=["metadatas"])
-    except NotFoundError:
-        # Splitting answers "the store refused this query for its size". A
-        # collection that is gone is not that, and stays gone however small the
-        # query gets, so descending would only cost log2(batch) + 1 doomed
-        # queries before raising exactly the same error from the first leaf.
-        raise
-    except InternalError as error:
-        if "too many SQL variables" not in str(error):
-            raise
-        # Splitting stays correct but multiplies the queries, and how far it
-        # degrades depends on chunk counts nothing here can see. Without a
-        # trace, a base whose files outgrew the ceiling just gets quietly
-        # slower -- the same invisibility that let the unsplit query strand
-        # candidates undiagnosed.
-        logger.debug("Split a refused knowledge vector verification query", paths=len(relative_paths))
-        midpoint = len(relative_paths) // 2
-        return _paths_with_vectors(collection, relative_paths[:midpoint]) | _paths_with_vectors(
-            collection,
-            relative_paths[midpoint:],
-        )
-
-    found: set[str] = set()
-    for metadata in result.get("metadatas") or []:
-        source_path = metadata.get(_SOURCE_PATH_KEY)
-        if isinstance(source_path, str):
-            found.add(source_path)
-    return found
-
-
-def _require_chroma_vector_db(knowledge: Knowledge) -> ChromaDb:
-    vector_db = knowledge.vector_db
-    if not isinstance(vector_db, ChromaDb):
-        msg = "Knowledge reindex candidate collection requires a ChromaDb vector database"
-        raise TypeError(msg)
-    return vector_db
-
-
 def _resolve_knowledge_path(
     path: str,
     runtime_paths: RuntimePaths,
@@ -452,10 +364,6 @@ def _ensure_knowledge_directory_ready(knowledge_path: Path) -> None:
         msg = f"Knowledge path {knowledge_path} must be a directory"
         raise ValueError(msg)
     knowledge_path.mkdir(parents=True, exist_ok=True)
-
-
-def _collection_name(base_id: str, knowledge_path: Path) -> str:
-    return f"{_COLLECTION_PREFIX}_{storage_key_for_base(base_id, knowledge_path)}"
 
 
 def _semantic_indexing_enabled(config: Config, base_id: str) -> bool:
@@ -631,13 +539,13 @@ def _reusable_row_signature(
     managed_paths: frozenset[str],
 ) -> tuple[str, FileSignature] | None:
     """Return the managed source path and signature one published chunk carries."""
-    source_path = metadata.get(_SOURCE_PATH_KEY)
+    source_path = metadata.get(SOURCE_PATH_KEY)
     if not isinstance(source_path, str) or source_path not in managed_paths:
         return None
     signature = file_signature_from_fields(
-        metadata.get(_SOURCE_MTIME_NS_KEY),
-        metadata.get(_SOURCE_SIZE_KEY),
-        metadata.get(_SOURCE_DIGEST_KEY),
+        metadata.get(SOURCE_MTIME_NS_KEY),
+        metadata.get(SOURCE_SIZE_KEY),
+        metadata.get(SOURCE_DIGEST_KEY),
     )
     if signature is None:
         return None
@@ -672,6 +580,7 @@ class KnowledgeManager:
     _base_storage_path: Path = field(init=False)
     _indexing_settings_path: Path = field(init=False)
     _git_lfs_hydrated_head_path: Path = field(init=False)
+    _collections: CollectionSpace = field(init=False, repr=False)
     _knowledge: Knowledge = field(init=False)
     _indexed_files: set[str] = field(default_factory=set, init=False)
     _indexed_signatures: dict[str, FileSignature] = field(default_factory=dict, init=False)
@@ -712,6 +621,14 @@ class KnowledgeManager:
         self._base_storage_path.mkdir(parents=True, exist_ok=True)
         self._indexing_settings_path = self._base_storage_path / "indexing_settings.json"
         self._git_lfs_hydrated_head_path = self._base_storage_path / "git_lfs_hydrated_head.txt"
+        self._collections = CollectionSpace(
+            base_id=self.base_id,
+            storage_path=self._base_storage_path,
+            default_collection=collection_name_for_base(self.base_id, self.knowledge_path),
+            # A factory, not an embedder: opening a handle purely to delete a
+            # collection must not construct one.
+            embedder_factory=lambda: create_configured_embedder(self.config, self.runtime_paths),
+        )
         persisted_state = self._load_persisted_index_state()
         if not _semantic_indexing_enabled(self.config, self.base_id):
             self._persisted_collection_missing_on_init = False
@@ -725,9 +642,9 @@ class KnowledgeManager:
                 and persisted_state.collection is not None
                 and not self._persisted_collection_missing_on_init
             )
-            else self._default_collection_name()
+            else self._collections.default_collection
         )
-        self._knowledge = self._build_knowledge(collection_name)
+        self._knowledge = build_knowledge(self._collections, collection_name)
 
     def _set_settings(
         self,
@@ -757,7 +674,7 @@ class KnowledgeManager:
     def _persisted_collection_missing(self, persisted_state: _PersistedIndexState | None) -> bool:
         if persisted_state is None or persisted_state.status != _INDEXING_STATUS_COMPLETE:
             return False
-        collection_name = persisted_state.collection or self._default_collection_name()
+        collection_name = persisted_state.collection or self._collections.default_collection
         try:
             return not chroma_collection_exists(self._base_storage_path, collection_name)
         except Exception:
@@ -1113,7 +1030,7 @@ class KnowledgeManager:
             return False
 
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        return _collection_has_source_path(collection, relative_path)
+        return collection_has_source_path(collection, relative_path)
 
     async def _wait_for_source_vectors(
         self,
@@ -1156,97 +1073,6 @@ class KnowledgeManager:
         configured_reader.chunk_size = chunking_strategy.chunk_size
         configured_reader.chunking_strategy = chunking_strategy
         return configured_reader
-
-    def _default_collection_name(self) -> str:
-        return _collection_name(self.base_id, self._knowledge_source_path())
-
-    def _candidate_collection_name(self) -> str:
-        return f"{self._default_collection_name()}_candidate_{uuid.uuid4().hex[:16]}"
-
-    def _build_vector_db(self, collection_name: str, *, embedder: Embedder | None = None) -> ChromaDb:
-        return ChromaDb(
-            collection=collection_name,
-            path=str(self._base_storage_path),
-            persistent_client=True,
-            embedder=embedder if embedder is not None else create_configured_embedder(self.config, self.runtime_paths),
-        )
-
-    def _build_knowledge(self, collection_name: str, *, embedder: Embedder | None = None) -> Knowledge:
-        return Knowledge(vector_db=self._build_vector_db(collection_name, embedder=embedder))
-
-    def _cleanup_superseded_collections(
-        self,
-        *,
-        preserved: frozenset[str],
-        candidates_only: bool = False,
-    ) -> None:
-        """Delete this base's superseded collections, preserving proven-live ones.
-
-        Ownership is proven by name: both the default collection and the
-        candidate prefix embed this base's identity and resolved source path,
-        and both live in this base's own private storage directory. Anything
-        else in that directory is left alone and reported rather than deleted,
-        because nothing here can prove who owns it.
-        """
-        vector_db = self._knowledge.vector_db
-        if not isinstance(vector_db, ChromaDb):
-            return
-        client = vector_db.client
-        if client is None or not isinstance(client, _CollectionListingClient):
-            return
-
-        default_collection = self._default_collection_name()
-        candidate_prefix = f"{default_collection}_candidate_"
-
-        try:
-            collection_names = self._listed_collection_names(client)
-        except Exception:
-            logger.warning(
-                "Failed to list superseded knowledge collections for cleanup",
-                base_id=self.base_id,
-                exc_info=True,
-            )
-            return
-
-        unowned: list[str] = []
-        for collection_name in collection_names:
-            if collection_name in preserved:
-                continue
-            is_candidate = collection_name.startswith(candidate_prefix)
-            if not is_candidate and (candidates_only or collection_name != default_collection):
-                # Reclaiming abandoned candidates must never race a legacy
-                # published collection whose metadata predates this layout.
-                if collection_name != default_collection:
-                    unowned.append(collection_name)
-                continue
-            try:
-                self._build_vector_db(collection_name).delete()
-            except Exception:
-                logger.warning(
-                    "Failed to clean superseded knowledge collection",
-                    base_id=self.base_id,
-                    collection=collection_name,
-                    exc_info=True,
-                )
-        if unowned:
-            logger.info(
-                "Preserved knowledge collections with unprovable ownership",
-                base_id=self.base_id,
-                collections=sorted(unowned),
-            )
-
-    def _listed_collection_names(self, client: _CollectionListingClient) -> tuple[str, ...]:
-        names: list[str] = []
-        for collection in client.list_collections():
-            if isinstance(collection, str):
-                names.append(collection)
-            elif isinstance(collection, _NamedCollection):
-                names.append(collection.name)
-        return tuple(dict.fromkeys(names))
-
-    def _reset_vector_db(self, vector_db: ChromaDb) -> None:
-        vector_db.delete()
-        vector_db.create()
 
     async def _save_candidate_publish_metadata(
         self,
@@ -1352,10 +1178,10 @@ class KnowledgeManager:
         relative_path = self._relative_path(resolved_path)
         source_mtime_ns, source_size, source_digest = await asyncio.to_thread(self._file_signature, resolved_path)
         metadata = {
-            _SOURCE_PATH_KEY: relative_path,
-            _SOURCE_MTIME_NS_KEY: source_mtime_ns,
-            _SOURCE_SIZE_KEY: source_size,
-            _SOURCE_DIGEST_KEY: source_digest,
+            SOURCE_PATH_KEY: relative_path,
+            SOURCE_MTIME_NS_KEY: source_mtime_ns,
+            SOURCE_SIZE_KEY: source_size,
+            SOURCE_DIGEST_KEY: source_digest,
         }
         try:
             reader = self._build_reader(resolved_path)
@@ -1374,7 +1200,7 @@ class KnowledgeManager:
             if upsert:
                 # Agno/Chroma upsert keys by content hash, so stale chunks from an older
                 # version of the same file can remain unless we clear by source metadata first.
-                await asyncio.to_thread(target_knowledge.remove_vectors_by_metadata, {_SOURCE_PATH_KEY: relative_path})
+                await asyncio.to_thread(target_knowledge.remove_vectors_by_metadata, {SOURCE_PATH_KEY: relative_path})
             # Knowledge.ainsert is async by name only: it eventually calls into the
             # vector database's synchronous batch upsert (e.g. ChromaDB's Rust
             # _upsert) on the running event loop, blocking every other coroutine
@@ -1758,15 +1584,6 @@ class KnowledgeManager:
             raise first_error
         return sum(1 for result in results if result is True)
 
-    def _candidate_paths_with_vectors(
-        self,
-        vector_db: ChromaDb,
-        relative_paths: Sequence[str],
-    ) -> set[str]:
-        """Return which of the given source paths actually have candidate vectors."""
-        collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        return _paths_with_vectors(collection, relative_paths)
-
     async def _candidate_paths_missing_vectors(self, run: _CandidateRun, relative_paths: Sequence[str]) -> set[str]:
         """Return completed entries the candidate cannot actually serve.
 
@@ -1782,9 +1599,9 @@ class KnowledgeManager:
         ]
         run.verified.update(set(relative_paths) - set(verifiable))
         missing: set[str] = set()
-        for start in range(0, len(verifiable), _VECTOR_VERIFY_BATCH):
-            batch = verifiable[start : start + _VECTOR_VERIFY_BATCH]
-            found = await asyncio.to_thread(self._candidate_paths_with_vectors, run.vector_db, batch)
+        for start in range(0, len(verifiable), VECTOR_VERIFY_BATCH):
+            batch = verifiable[start : start + VECTOR_VERIFY_BATCH]
+            found = await asyncio.to_thread(paths_with_vectors, run.vector_db, batch)
             missing.update(set(batch) - found)
             run.verified.update(found)
         return missing
@@ -1913,7 +1730,7 @@ class KnowledgeManager:
                 collection=published_collection,
                 exc_info=True,
             )
-            await asyncio.to_thread(self._reset_vector_db, candidate_vector_db)
+            await asyncio.to_thread(reset_vector_db, candidate_vector_db)
             return {}
         logger.info(
             "Reused published knowledge vectors in a new candidate",
@@ -1941,7 +1758,7 @@ class KnowledgeManager:
         """
         if checkpoint.completed:
             return False
-        vector_db = self._build_vector_db(checkpoint.collection, embedder=embedder)
+        vector_db = build_vector_db(self._collections, checkpoint.collection, embedder=embedder)
         if not vector_db.exists():
             return False
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
@@ -1974,9 +1791,9 @@ class KnowledgeManager:
             self._base_storage_path,
             replace(checkpoint, completed={}, failed={}),
         )
-        knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
-        vector_db = _require_chroma_vector_db(knowledge)
-        await asyncio.to_thread(self._reset_vector_db, vector_db)
+        knowledge = build_knowledge(self._collections, checkpoint.collection, embedder=embedder)
+        vector_db = require_chroma_vector_db(knowledge)
+        await asyncio.to_thread(reset_vector_db, vector_db)
         if published_collection is None:
             return _OpenedCandidate(checkpoint=checkpoint, knowledge=knowledge, vector_db=vector_db)
         reused = await self._seed_candidate_from_published(
@@ -2018,11 +1835,11 @@ class KnowledgeManager:
             # Rebuilt without a copy: whatever lost this collection may equally
             # have damaged the published one, and a full rebuild is the safe repair.
             return await self._rebuild_candidate_collection(checkpoint, embedder=embedder, published_collection=None)
-        knowledge = self._build_knowledge(checkpoint.collection, embedder=embedder)
+        knowledge = build_knowledge(self._collections, checkpoint.collection, embedder=embedder)
         return _OpenedCandidate(
             checkpoint=checkpoint,
             knowledge=knowledge,
-            vector_db=_require_chroma_vector_db(knowledge),
+            vector_db=require_chroma_vector_db(knowledge),
             resumed=True,
         )
 
@@ -2067,7 +1884,7 @@ class KnowledgeManager:
             # A failed delete must not block indexing: an incompatible candidate
             # is never published or resumed, and the superseded-collection sweep
             # below reclaims it on this same run, or on a later one.
-            await self._delete_candidate_collection(checkpoint.collection)
+            await delete_collection(self._collections, checkpoint.collection)
             await asyncio.to_thread(delete_candidate_checkpoint, self._base_storage_path)
             checkpoint = None
         if checkpoint is not None and force_reindex:
@@ -2081,7 +1898,7 @@ class KnowledgeManager:
                 collection=checkpoint.collection,
                 completed=len(checkpoint.completed),
             )
-            await self._delete_candidate_collection(checkpoint.collection)
+            await delete_collection(self._collections, checkpoint.collection)
             await asyncio.to_thread(delete_candidate_checkpoint, self._base_storage_path)
             checkpoint = None
 
@@ -2089,7 +1906,7 @@ class KnowledgeManager:
         rebuild = checkpoint is None
         if checkpoint is None:
             checkpoint = CandidateCheckpoint(
-                collection=self._candidate_collection_name(),
+                collection=candidate_collection_name(self._collections),
                 settings=self._indexing_settings,
             )
         elif await asyncio.to_thread(self._candidate_holds_unclaimed_rows, checkpoint, embedder=embedder):
@@ -2128,7 +1945,9 @@ class KnowledgeManager:
         if cleanup_is_safe:
             preserved = {checkpoint.collection, *published_collections}
             await asyncio.to_thread(
-                self._cleanup_superseded_collections,
+                cleanup_superseded_collections,
+                self._collections,
+                vector_db=self._knowledge.vector_db,
                 preserved=frozenset(preserved),
                 candidates_only=True,
             )
@@ -2170,7 +1989,8 @@ class KnowledgeManager:
         checkpoint = await asyncio.to_thread(load_candidate_checkpoint, self._base_storage_path)
         if checkpoint is None:
             return
-        if checkpoint.collection != published_collection and not await self._delete_candidate_collection(
+        if checkpoint.collection != published_collection and not await delete_collection(
+            self._collections,
             checkpoint.collection,
         ):
             return
@@ -2181,45 +2001,6 @@ class KnowledgeManager:
             collection=checkpoint.collection,
             completed=len(checkpoint.completed),
         )
-
-    async def _delete_candidate_collection(self, collection_name: str) -> bool:
-        """Delete one candidate collection, reporting whether it is really gone.
-
-        Agno's ``ChromaDb.delete`` swallows the provider error and returns
-        ``False`` rather than raising, so catching exceptions alone would
-        report every real failure as a success. A ``False`` result is also
-        returned when the collection simply was not there, which is the
-        outcome we want, so the two are told apart by probing existence.
-        """
-        try:
-            deleted = await asyncio.to_thread(self._delete_candidate_collection_sync, collection_name)
-        except Exception:
-            logger.warning(
-                "Failed to delete knowledge candidate collection",
-                base_id=self.base_id,
-                collection=collection_name,
-                exc_info=True,
-            )
-            return False
-        if deleted:
-            return True
-        logger.warning(
-            "Knowledge candidate collection still exists after deletion failed",
-            base_id=self.base_id,
-            collection=collection_name,
-        )
-        return False
-
-    def _delete_candidate_collection_sync(self, collection_name: str) -> bool:
-        """Delete one candidate, treating an already-absent collection as success."""
-        vector_db = self._build_vector_db(collection_name)
-        if vector_db.delete():
-            return True
-        try:
-            vector_db.client.get_collection(name=vector_db.collection_name)
-        except NotFoundError:
-            return True
-        return False
 
     async def _file_signatures_for(self, files: Sequence[Path]) -> dict[str, tuple[FileSignature, Path]]:
         """Return current signatures for the listed files, skipping vanished ones."""
@@ -2244,30 +2025,11 @@ class KnowledgeManager:
                 signatures[relative_path] = (signature, file_path)
         return signatures
 
-    def _delete_candidate_vectors(self, vector_db: ChromaDb, relative_paths: Sequence[str]) -> None:
-        """Delete vectors for many source paths in one vector-store round trip.
-
-        Agno's ``delete_by_metadata`` wraps values in ``$eq`` and so can only
-        take one path per call, which turns a large source update into one
-        thread hop and one get+delete per file. The collection accepts ``$in``
-        directly.
-
-        Unlike the ``$in`` the verification query issues, this one needs no
-        ceiling protection: a delete does not bind one SQL variable per matched
-        row, so the batch size alone bounds it. Measured on ChromaDB 1.5.8,
-        deleting 51,200 rows across 128 paths in one call succeeds, where the
-        equivalent read fails with ``too many SQL variables``.
-        """
-        collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        for start in range(0, len(relative_paths), _VECTOR_DELETE_BATCH):
-            batch = list(relative_paths[start : start + _VECTOR_DELETE_BATCH])
-            collection.delete(where={_SOURCE_PATH_KEY: {"$in": batch}})
-
     async def _drop_candidate_paths(self, run: _CandidateRun, relative_paths: Sequence[str]) -> None:
         """Remove candidate vectors and checkpoint entries for gone or stale paths."""
         if not relative_paths:
             return
-        await asyncio.to_thread(self._delete_candidate_vectors, run.vector_db, relative_paths)
+        await asyncio.to_thread(delete_source_path_vectors, run.vector_db, relative_paths)
         for relative_path in relative_paths:
             run.completed.pop(relative_path, None)
             run.failed.pop(relative_path, None)
@@ -2608,6 +2370,8 @@ class KnowledgeManager:
             run.published = publish_state.index_published
         await asyncio.to_thread(delete_candidate_checkpoint, self._base_storage_path)
         await asyncio.to_thread(
-            self._cleanup_superseded_collections,
+            cleanup_superseded_collections,
+            self._collections,
+            vector_db=self._knowledge.vector_db,
             preserved=frozenset({run.vector_db.collection_name}),
         )

--- a/tach.toml
+++ b/tach.toml
@@ -231,6 +231,7 @@ visibility = [
 path = "mindroom.strict_knowledge"
 depends_on = []
 visibility = [
+    "mindroom.knowledge.collections",
     "mindroom.knowledge.manager",
     "mindroom.knowledge.registry",
     "mindroom.knowledge_source_descriptions",
@@ -3499,6 +3500,15 @@ visibility = [
 ]
 
 [[modules]]
+path = "mindroom.knowledge.collections"
+depends_on = [
+    "mindroom.knowledge.indexing_config",
+    "mindroom.logging_config",
+    "mindroom.strict_knowledge",
+]
+visibility = ["mindroom.knowledge.manager"]
+
+[[modules]]
 path = "mindroom.knowledge.embedding_batch"
 depends_on = [
     "mindroom.embedding_errors",
@@ -3538,6 +3548,7 @@ depends_on = [
     "mindroom.embedding_errors",
     "mindroom.embedding_factory",
     "mindroom.knowledge.candidate_checkpoint",
+    "mindroom.knowledge.collections",
     "mindroom.knowledge.embedding_batch",
     "mindroom.knowledge.file_listing",
     "mindroom.knowledge.index_metadata",

--- a/tests/api/test_knowledge_api.py
+++ b/tests/api/test_knowledge_api.py
@@ -308,8 +308,10 @@ def test_status_reports_persisted_count_without_loading_collection(tmp_path: Pat
             msg = "corrupt collection"
             raise RuntimeError(msg)
 
+    # One tripwire per module that can construct a collection handle. The
+    # manager builds none: it narrows types against ChromaDb but delegates
+    # construction to mindroom.knowledge.collections.
     with (
-        patch("mindroom.knowledge.manager.ChromaDb", _BrokenVectorDb),
         patch("mindroom.knowledge.collections.ChromaDb", _BrokenVectorDb),
         patch("mindroom.knowledge.registry.ChromaDb", _BrokenVectorDb),
         patch("mindroom.knowledge.indexing_config.ChromaDb", _BrokenVectorDb),

--- a/tests/api/test_knowledge_api.py
+++ b/tests/api/test_knowledge_api.py
@@ -310,6 +310,7 @@ def test_status_reports_persisted_count_without_loading_collection(tmp_path: Pat
 
     with (
         patch("mindroom.knowledge.manager.ChromaDb", _BrokenVectorDb),
+        patch("mindroom.knowledge.collections.ChromaDb", _BrokenVectorDb),
         patch("mindroom.knowledge.registry.ChromaDb", _BrokenVectorDb),
         patch("mindroom.knowledge.indexing_config.ChromaDb", _BrokenVectorDb),
         patch(

--- a/tests/knowledge_test_support.py
+++ b/tests/knowledge_test_support.py
@@ -8,6 +8,23 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
+def validate_where_operands(where: dict[str, Any] | None) -> None:
+    """Reject the ``where`` shapes ChromaDB refuses before it reaches the store.
+
+    Chroma validates an empty ``$in`` operand and raises, so a fake that only
+    filtered records would answer "nothing matched" for a query production
+    cannot issue at all -- and would answer it most convincingly on an empty
+    collection, where no record is ever tested. Checking the operand rather
+    than the records is what makes that case visible.
+    """
+    if not where:
+        return
+    for condition in where.values():
+        if isinstance(condition, dict) and "$in" in condition and not condition["$in"]:
+            msg = "empty $in operand: ChromaDB rejects this before querying the store"
+            raise AssertionError(msg)
+
+
 def metadata_matches(metadata: dict[str, Any], key: str, condition: object) -> bool:
     """Mirror the subset of ChromaDB ``where`` matching the indexer relies on.
 

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -44,6 +44,7 @@ from mindroom.credentials_sync import get_embedder_api_key
 from mindroom.knowledge import KnowledgeRefreshScheduler, resolve_agent_knowledge_access
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.candidate_checkpoint import load_candidate_checkpoint
+from mindroom.knowledge.collections import build_vector_db, candidate_collection_name
 from mindroom.knowledge.file_listing import (
     git_checkout_present,
     knowledge_files_from_relative_paths,
@@ -269,7 +270,9 @@ def patch_vector_store(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     """Use an in-memory vector store for published knowledge index tests."""
     _VectorDb.collections = {}
     monkeypatch.setattr("mindroom.knowledge.manager.ChromaDb", _VectorDb)
+    monkeypatch.setattr("mindroom.knowledge.collections.ChromaDb", _VectorDb)
     monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _Knowledge)
+    monkeypatch.setattr("mindroom.knowledge.collections.Knowledge", _Knowledge)
     monkeypatch.setattr(
         "mindroom.knowledge.manager.create_configured_embedder",
         lambda *_args, **_kwargs: _FakeEmbedder(),
@@ -643,7 +646,7 @@ async def test_file_mode_git_refresh_marks_same_source_semantic_alias_stale(
         "semantic_docs",
         config=config,
         runtime_paths=runtime_paths,
-    )._default_collection_name()
+    )._collections.default_collection
     _VectorDb.collections[semantic_collection] = [
         {"content": "Use grep for this source.", "metadata": {"source_path": "guide.md"}},
     ]
@@ -2175,7 +2178,7 @@ def test_source_changed_updates_refresh_state_without_changing_index(tmp_path: P
     runtime_paths = runtime_paths_for(config)
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths)
-    default_collection = manager._default_collection_name()
+    default_collection = manager._collections.default_collection
     _VectorDb.collections[default_collection] = [
         {"content": "published old", "metadata": {"source_path": "guide.md"}},
     ]
@@ -3348,7 +3351,7 @@ async def test_publish_metadata_save_finishes_before_repeated_cancellation_escap
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths)
-    candidate_vector_db = manager._build_vector_db(manager._candidate_collection_name())
+    candidate_vector_db = build_vector_db(manager._collections, candidate_collection_name(manager._collections))
     loop = asyncio.get_running_loop()
     save_started = asyncio.Event()
     release_save = Event()
@@ -3389,7 +3392,7 @@ async def test_cancelled_publish_metadata_save_surfaces_a_failed_write(
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     runtime_paths = runtime_paths_for(config)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths)
-    candidate_vector_db = manager._build_vector_db(manager._candidate_collection_name())
+    candidate_vector_db = build_vector_db(manager._collections, candidate_collection_name(manager._collections))
     loop = asyncio.get_running_loop()
     save_started = asyncio.Event()
     release_save = Event()
@@ -3845,7 +3848,7 @@ async def test_refresh_rebuilds_malformed_metadata_without_serving_old_collectio
     runtime_paths = runtime_paths_for(config)
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths)
-    default_collection = manager._default_collection_name()
+    default_collection = manager._collections.default_collection
     _VectorDb.collections[default_collection] = [
         {"content": "stale list old", "metadata": {"source_path": "doc.md"}},
     ]
@@ -4697,7 +4700,7 @@ async def test_partial_refresh_error_includes_first_classified_file_error(
                 raise _embedder_auth_error()
             super().insert(path=path, metadata=metadata, upsert=upsert, reader=reader)
 
-    monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _AuthFailingKnowledge)
+    monkeypatch.setattr("mindroom.knowledge.collections.Knowledge", _AuthFailingKnowledge)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
 
     assert await manager.reindex_all() == 1
@@ -4731,7 +4734,7 @@ async def test_vectorless_file_does_not_inherit_process_global_embedder_health(
             del path, metadata, upsert, reader
             embedder_health.capture_embedder_health_recorder().record("embedder authentication failed (HTTP 401)")
 
-    monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _SwallowingKnowledge)
+    monkeypatch.setattr("mindroom.knowledge.collections.Knowledge", _SwallowingKnowledge)
     embedder_health.capture_embedder_health_recorder().record(None)
     manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
     try:
@@ -4866,7 +4869,7 @@ async def test_cold_refresh_publishes_when_empty_file_produces_no_vectors(
             if Path(path).read_text(encoding="utf-8"):
                 super().insert(path=path, metadata=metadata, upsert=upsert, reader=reader)
 
-    monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _SkipEmptyKnowledge)
+    monkeypatch.setattr("mindroom.knowledge.collections.Knowledge", _SkipEmptyKnowledge)
 
     result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
@@ -7296,7 +7299,7 @@ async def test_git_noop_refresh_rebuilds_when_collection_is_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An unchanged Git poll must not let Agno auto-create a Chroma collection for a missing index."""
-    monkeypatch.setattr("mindroom.knowledge.manager.Knowledge", _AutoCreatingKnowledge)
+    monkeypatch.setattr("mindroom.knowledge.collections.Knowledge", _AutoCreatingKnowledge)
     docs_path = tmp_path / "docs"
     docs_path.mkdir()
     (docs_path / "doc.md").write_text("git repaired", encoding="utf-8")

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -25,6 +25,7 @@ from agno.knowledge.embedder.base import Embedder
 from chromadb.errors import InternalError, NotFoundError
 from structlog.testing import capture_logs
 
+import mindroom.knowledge.collections as knowledge_collections_module
 import mindroom.knowledge.manager as knowledge_manager_module
 import mindroom.knowledge.registry as knowledge_registry
 from mindroom.config.agent import AgentConfig
@@ -47,6 +48,11 @@ from mindroom.knowledge.candidate_checkpoint import (
     delete_candidate_checkpoint,
     load_candidate_checkpoint,
     save_candidate_checkpoint,
+)
+from mindroom.knowledge.collections import (
+    _collection_paths_with_vectors,
+    candidate_collection_name,
+    paths_with_vectors,
 )
 from mindroom.knowledge.embedding_batch import BatchPrefetchEmbedder, plan_embedding_batches
 from mindroom.knowledge.index_metadata import write_index_metadata_payload
@@ -404,7 +410,9 @@ def fake_vector_store(
     _FakeVectorDb.max_writes = 1_000_000
     _FakeVectorDb.writes = []
     monkeypatch.setattr(knowledge_manager_module, "ChromaDb", _FakeVectorDb)
+    monkeypatch.setattr(knowledge_collections_module, "ChromaDb", _FakeVectorDb)
     monkeypatch.setattr(knowledge_manager_module, "Knowledge", _FakeKnowledge)
+    monkeypatch.setattr(knowledge_collections_module, "Knowledge", _FakeKnowledge)
     monkeypatch.setattr(knowledge_manager_module, "create_configured_embedder", lambda *_a, **_k: embedder)
     monkeypatch.setattr("mindroom.knowledge.indexing_config.ChromaDb", _FakeVectorDb)
     monkeypatch.setattr(knowledge_registry, "ChromaDb", _FakeVectorDb)
@@ -859,7 +867,7 @@ async def test_incompatible_candidate_delete_failure_does_not_block_refresh(
     config = _config(tmp_path, docs_path)
     runtime_paths = runtime_paths_for(config)
     manager = _manager(config)
-    stale_candidate = f"{manager._default_collection_name()}_candidate_stale"
+    stale_candidate = f"{manager._collections.default_collection}_candidate_stale"
     _FakeVectorDb.store[stale_candidate] = []
     save_candidate_checkpoint(
         _storage_path(config, runtime_paths),
@@ -894,7 +902,7 @@ async def test_incompatible_missing_candidate_is_already_deleted(tmp_path: Path)
     config = _config(tmp_path, docs_path)
     runtime_paths = runtime_paths_for(config)
     manager = _manager(config)
-    missing_candidate = f"{manager._default_collection_name()}_candidate_missing"
+    missing_candidate = f"{manager._collections.default_collection}_candidate_missing"
     save_candidate_checkpoint(
         _storage_path(config, runtime_paths),
         CandidateCheckpoint(
@@ -1115,7 +1123,7 @@ async def test_cleanup_preserves_published_active_and_unknown_collections(
     runtime_paths = runtime_paths_for(config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     published_collection = _published_state(config, runtime_paths).collection
-    default_collection = _manager(config)._default_collection_name()
+    default_collection = _manager(config)._collections.default_collection
 
     abandoned = f"{default_collection}_candidate_abandonedabandoned"
     unknown = "some_other_service_collection"
@@ -1845,7 +1853,7 @@ async def test_candidate_cleanup_does_not_report_the_bases_own_default_collectio
     _write_corpus(docs_path, 2)
     config = _config(tmp_path, docs_path)
     manager = _manager(config)
-    default_collection = manager._default_collection_name()
+    default_collection = manager._collections.default_collection
     _FakeVectorDb.store[default_collection] = []
     _FakeVectorDb.store["some_unrelated_collection"] = []
 
@@ -3491,7 +3499,7 @@ async def test_a_candidate_whose_collection_vanished_is_rebuilt_rather_than_resu
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Probe existence before Agno can auto-create a vanished collection."""
-    monkeypatch.setattr(knowledge_manager_module, "Knowledge", _AutoCreatingFakeKnowledge)
+    monkeypatch.setattr(knowledge_collections_module, "Knowledge", _AutoCreatingFakeKnowledge)
     docs_path = tmp_path / "docs"
     names = _write_corpus(docs_path, 3)
     config = _config(tmp_path, docs_path)
@@ -3530,7 +3538,7 @@ async def test_unclaimed_row_probe_reuses_the_refresh_embedder(
     config = _config(tmp_path, docs_path)
     runtime_paths = runtime_paths_for(config)
     manager = _manager(config)
-    collection = manager._candidate_collection_name()
+    collection = candidate_collection_name(manager._collections)
     save_candidate_checkpoint(
         _storage_path(config, runtime_paths),
         CandidateCheckpoint(collection=collection, settings=manager._indexing_settings),
@@ -3738,15 +3746,15 @@ async def test_a_rebuild_that_dies_before_emptying_the_collection_still_recovers
 
     (docs_path / names[0]).unlink()
     die_before_reset = True
-    original_reset = KnowledgeManager._reset_vector_db
+    original_reset = knowledge_manager_module.reset_vector_db
 
-    def _maybe_die(self: KnowledgeManager, vector_db: _FakeVectorDb) -> None:
+    def _maybe_die(vector_db: _FakeVectorDb) -> None:
         if die_before_reset:
             message = "host lost power before the collection was emptied"
             raise RuntimeError(message)
-        original_reset(self, vector_db)
+        original_reset(vector_db)
 
-    monkeypatch.setattr(KnowledgeManager, "_reset_vector_db", _maybe_die)
+    monkeypatch.setattr(knowledge_manager_module, "reset_vector_db", _maybe_die)
     with pytest.raises(RuntimeError):
         await _manager(config).reindex_all()
     die_before_reset = False
@@ -3867,17 +3875,14 @@ def _seed_chunked_paths(collection: str, paths: Sequence[str], chunks_per_path: 
     ]
 
 
-def _verification_manager(tmp_path: Path) -> tuple[KnowledgeManager, _FakeVectorDb]:
-    """Return a manager and a created, empty candidate collection to verify against."""
-    docs_path = tmp_path / "docs"
-    docs_path.mkdir()
-    manager = _manager(_config(tmp_path, docs_path))
+def _verification_collection() -> _FakeVectorDb:
+    """Return a created, empty candidate collection to verify against."""
     vector_db = _FakeVectorDb(collection="verification_target")
     vector_db.create()
-    return manager, vector_db
+    return vector_db
 
 
-def test_vector_verification_splits_a_batch_the_store_cannot_answer(tmp_path: Path) -> None:
+def test_vector_verification_splits_a_batch_the_store_cannot_answer() -> None:
     """A batch matching more rows than the store allows must still be verified.
 
     Chroma binds one SQL variable per matched chunk row, so a fixed batch of
@@ -3885,12 +3890,12 @@ def test_vector_verification_splits_a_batch_the_store_cannot_answer(tmp_path: Pa
     chunks those files produced. A corpus of large files makes every
     verification query fail, which strands the candidate permanently.
     """
-    manager, vector_db = _verification_manager(tmp_path)
+    vector_db = _verification_collection()
     paths = [f"doc{index:02d}.md" for index in range(8)]
     _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=100)
     _FakeVectorDb.max_rows_per_get = 250
 
-    assert manager._candidate_paths_with_vectors(vector_db, paths) == set(paths)
+    assert paths_with_vectors(vector_db, paths) == set(paths)
 
     # Halving is the property that makes this affordable, and correctness alone
     # does not pin it: splitting one path off at a time also terminates and also
@@ -3900,48 +3905,48 @@ def test_vector_verification_splits_a_batch_the_store_cannot_answer(tmp_path: Pa
     assert _FakeVectorDb.get_calls == 7
 
 
-def test_vector_verification_confirms_a_file_larger_than_the_store_ceiling(tmp_path: Path) -> None:
+def test_vector_verification_confirms_a_file_larger_than_the_store_ceiling() -> None:
     """One file with more chunks than the ceiling must still be confirmed.
 
     Splitting alone cannot rescue this: a single path is the smallest batch
     there is, so the query has to stop asking for every row it matches.
     """
-    manager, vector_db = _verification_manager(tmp_path)
+    vector_db = _verification_collection()
     _seed_chunked_paths(vector_db.collection_name, ["huge.md"], chunks_per_path=500)
     _FakeVectorDb.max_rows_per_get = 250
 
-    assert manager._candidate_paths_with_vectors(vector_db, ["huge.md"]) == {"huge.md"}
+    assert paths_with_vectors(vector_db, ["huge.md"]) == {"huge.md"}
 
 
-def test_vector_verification_still_reports_paths_without_vectors_after_splitting(tmp_path: Path) -> None:
+def test_vector_verification_still_reports_paths_without_vectors_after_splitting() -> None:
     """Splitting must not turn an unverifiable path into a verified one."""
-    manager, vector_db = _verification_manager(tmp_path)
+    vector_db = _verification_collection()
     present = [f"present{index:02d}.md" for index in range(6)]
     _seed_chunked_paths(vector_db.collection_name, present, chunks_per_path=100)
     _FakeVectorDb.max_rows_per_get = 250
     missing = ["missing0.md", "missing1.md"]
 
-    found = manager._candidate_paths_with_vectors(vector_db, [*present, *missing])
+    found = paths_with_vectors(vector_db, [*present, *missing])
 
     assert found == set(present)
 
 
-def test_vector_verification_uses_one_query_when_the_store_answers(tmp_path: Path) -> None:
+def test_vector_verification_uses_one_query_when_the_store_answers() -> None:
     """A store that can answer the whole batch must be asked exactly once.
 
     Splitting is a fallback, not the normal path: verifying per file would turn
     one query per 128 files into 128, which is the cost this batching exists to
     avoid.
     """
-    manager, vector_db = _verification_manager(tmp_path)
+    vector_db = _verification_collection()
     paths = [f"doc{index:02d}.md" for index in range(8)]
     _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=100)
 
-    assert manager._candidate_paths_with_vectors(vector_db, paths) == set(paths)
+    assert paths_with_vectors(vector_db, paths) == set(paths)
     assert _FakeVectorDb.get_calls == 1
 
 
-def test_vector_verification_does_not_split_when_the_collection_is_gone(tmp_path: Path) -> None:
+def test_vector_verification_does_not_split_when_the_collection_is_gone() -> None:
     """A missing collection must surface at once instead of being re-asked per path.
 
     Splitting exists to shrink a query the store found too large, and a missing
@@ -3951,7 +3956,7 @@ def test_vector_verification_does_not_split_when_the_collection_is_gone(tmp_path
     verification aborts on this batch either way. Failing on the first query is
     the cheaper of two identical outcomes, which is what the count below pins.
     """
-    manager, vector_db = _verification_manager(tmp_path)
+    vector_db = _verification_collection()
     paths = [f"doc{index:02d}.md" for index in range(8)]
     # No rows are seeded: every ``get`` raises before reading the store, so
     # seeding would only suggest the contents mattered. ``create()`` in the
@@ -3959,17 +3964,14 @@ def test_vector_verification_does_not_split_when_the_collection_is_gone(tmp_path
     _FakeVectorDb.vanished_on_get = {vector_db.collection_name}
 
     with pytest.raises(NotFoundError):
-        manager._candidate_paths_with_vectors(vector_db, paths)
+        paths_with_vectors(vector_db, paths)
 
     assert _FakeVectorDb.get_calls == 1
 
 
-def test_vector_verification_does_not_split_unrelated_internal_error(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_vector_verification_does_not_split_unrelated_internal_error(monkeypatch: pytest.MonkeyPatch) -> None:
     """Only SQLite's bind-variable failure may trigger recursive splitting."""
-    _, vector_db = _verification_manager(tmp_path)
+    vector_db = _verification_collection()
     collection = vector_db.client.get_collection(vector_db.collection_name)
     paths = [f"doc{index:02d}.md" for index in range(8)]
     calls = 0
@@ -3983,12 +3985,12 @@ def test_vector_verification_does_not_split_unrelated_internal_error(
     monkeypatch.setattr(collection, "get", refuse_query)
 
     with pytest.raises(InternalError, match="database connection unexpectedly closed"):
-        knowledge_manager_module._paths_with_vectors(collection, paths)
+        _collection_paths_with_vectors(collection, paths)
 
     assert calls == 1
 
 
-def test_vector_verification_records_that_it_had_to_split(tmp_path: Path) -> None:
+def test_vector_verification_records_that_it_had_to_split() -> None:
     """A store refusing batches must leave a trace, not degrade silently.
 
     Splitting keeps verification correct but multiplies its queries, and how
@@ -3997,13 +3999,13 @@ def test_vector_verification_records_that_it_had_to_split(tmp_path: Path) -> Non
     signal anywhere, which is the same invisibility that let the original
     failure go undiagnosed.
     """
-    manager, vector_db = _verification_manager(tmp_path)
+    vector_db = _verification_collection()
     paths = [f"doc{index:02d}.md" for index in range(8)]
     _seed_chunked_paths(vector_db.collection_name, paths, chunks_per_path=100)
     _FakeVectorDb.max_rows_per_get = 250
 
     with capture_logs() as logs:
-        assert manager._candidate_paths_with_vectors(vector_db, paths) == set(paths)
+        assert paths_with_vectors(vector_db, paths) == set(paths)
 
     split_logs = [entry for entry in logs if entry["event"] == "Split a refused knowledge vector verification query"]
     assert [entry["paths"] for entry in split_logs] == [8, 4, 4]

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -50,6 +50,8 @@ from mindroom.knowledge.candidate_checkpoint import (
     save_candidate_checkpoint,
 )
 from mindroom.knowledge.collections import (
+    CollectionSpace,
+    _collection_name_for_base,
     _collection_paths_with_vectors,
     candidate_collection_name,
     paths_with_vectors,
@@ -69,7 +71,7 @@ from mindroom.knowledge.registry import (
 )
 from mindroom.knowledge.status import get_knowledge_index_status
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
-from tests.knowledge_test_support import chroma_get_result, metadata_matches
+from tests.knowledge_test_support import chroma_get_result, metadata_matches, validate_where_operands
 
 if TYPE_CHECKING:
     from collections.abc import Iterator, Sequence
@@ -118,6 +120,7 @@ class _FakeCollection:
         offset: int = 0,
         where: dict[str, object] | None = None,
     ) -> dict[str, object]:
+        validate_where_operands(where)
         _FakeVectorDb.get_calls += 1
         if self._name in _FakeVectorDb.vanished_on_get:
             message = f"Collection {self._name!r} does not exist"
@@ -159,6 +162,7 @@ class _FakeCollection:
         )
 
     def delete(self, *, where: dict[str, object]) -> None:
+        validate_where_operands(where)
         key, condition = next(iter(where.items()))
         _FakeVectorDb.store[self._name] = [
             record
@@ -4008,3 +4012,52 @@ def test_vector_verification_records_that_it_had_to_split() -> None:
 
     split_logs = [entry for entry in logs if entry["event"] == "Split a refused knowledge vector verification query"]
     assert [entry["paths"] for entry in split_logs] == [8, 4, 4]
+
+
+def test_vector_verification_answers_an_empty_batch_without_asking_the_store() -> None:
+    """No paths has an answer the store cannot give.
+
+    Chroma rejects an empty ``$in`` operand outright, so asking would raise
+    rather than return nothing. Splitting never reaches this case -- both
+    halves of a batch of two or more are non-empty -- but the query is a public
+    entry point and its recursion is documented as total, so the floor has to
+    exist. Resolving the collection handle is skipped too: the answer does not
+    depend on it, and an absent collection would otherwise turn a question with
+    an obvious answer into a ``NotFoundError``.
+    """
+    uncreated = _FakeVectorDb(collection="never_created")
+
+    assert paths_with_vectors(uncreated, []) == set()
+    assert _FakeVectorDb.get_calls == 0
+
+    created = _verification_collection()
+    collection = created.client.get_collection(created.collection_name)
+    assert _collection_paths_with_vectors(collection, []) == set()
+    assert _FakeVectorDb.get_calls == 0
+
+
+def test_collection_ownership_is_derived_from_identity_not_supplied() -> None:
+    """The name cleanup deletes by must be computed from the base's identity.
+
+    ``default_collection`` is what proves a collection is this base's to delete,
+    so it is derived from ``base_id`` and the resolved source path rather than
+    accepted as a field. A space that could be handed the name could authorize
+    deleting a collection the base does not own.
+    """
+    docs = Path("/srv/knowledge/docs")
+    space = CollectionSpace(
+        base_id="docs",
+        knowledge_path=docs,
+        storage_path=Path("/srv/state/docs"),
+        embedder_factory=lambda: pytest.fail("ownership must not need an embedder"),
+    )
+
+    assert space.default_collection == _collection_name_for_base("docs", docs)
+    assert "default_collection" not in CollectionSpace.__dataclass_fields__, (
+        "default_collection is a constructor field again, so it can be supplied instead of derived"
+    )
+
+    other_base = replace(space, base_id="wiki")
+    other_path = replace(space, knowledge_path=Path("/srv/knowledge/wiki"))
+    assert other_base.default_collection != space.default_collection
+    assert other_path.default_collection != space.default_collection


### PR DESCRIPTION
## What moved

`src/mindroom/knowledge/collections.py` (new, 337 lines) now owns Chroma collection lifecycle for one knowledge base.
`manager.py` drops from 2613 to 2377 lines: **236 lines out**, across 364 changed lines.

Moved from `manager.py`, behaviour unchanged:

| Was | Now |
| --- | --- |
| `_COLLECTION_PREFIX`, `_collection_name` | `collection_name_for_base(base_id, knowledge_path)` |
| `KnowledgeManager._default_collection_name` | `CollectionSpace.default_collection` |
| `KnowledgeManager._candidate_collection_name` | `candidate_collection_name(space)` |
| `KnowledgeManager._build_vector_db` / `_build_knowledge` | `build_vector_db(space, name, *, embedder=None)` / `build_knowledge(...)` |
| `_require_chroma_vector_db` | `require_chroma_vector_db(knowledge)` |
| `KnowledgeManager._reset_vector_db` | `reset_vector_db(vector_db)` |
| `_collection_has_source_path` | `collection_has_source_path(collection, relative_path)` |
| `_paths_with_vectors` | `_collection_paths_with_vectors(collection, relative_paths)` |
| `KnowledgeManager._candidate_paths_with_vectors` | `paths_with_vectors(vector_db, relative_paths)` |
| `KnowledgeManager._delete_candidate_vectors` | `delete_source_path_vectors(vector_db, relative_paths)` |
| `KnowledgeManager._delete_candidate_collection` / `_sync` | `delete_collection(space, name)` / `_delete_collection_sync` |
| `KnowledgeManager._cleanup_superseded_collections` | `cleanup_superseded_collections(space, *, vector_db, preserved, candidates_only=False)` |
| `KnowledgeManager._listed_collection_names` | `_listed_collection_names(client)` |
| `_CollectionListingClient`, `_NamedCollection` protocols | carried over verbatim; they only type the cleanup path |
| `_SOURCE_PATH_KEY` / `_SOURCE_MTIME_NS_KEY` / `_SOURCE_SIZE_KEY` / `_SOURCE_DIGEST_KEY` | `SOURCE_*_KEY`, shared (not duplicated) — the indexing path imports them back |
| `_VECTOR_VERIFY_BATCH`, `_VECTOR_DELETE_BATCH` | moved with comments intact; `VECTOR_VERIFY_BATCH` is imported back by the verification loop, which still lives on the manager because it takes a `_CandidateRun` |

### `CollectionSpace`

The one structural addition: a frozen 4-field record (`base_id`, `knowledge_path`, `storage_path`, `embedder_factory`) built once in `__post_init__`.
It is a value, not a manager: no mutable state, no caching, nothing per-refresh.

`default_collection` is a **derived property, never a field**. Cleanup treats it as proof of ownership — a collection is deletable only if it matches that name or carries its candidate prefix — so a space that could be *handed* the name could authorize deleting a collection the base does not own. An earlier revision of this PR accepted it as a field, which silently weakened invariant 4's precondition even though the cleanup body stayed byte-identical to `main`. It is now computed from `base_id` and the resolved source path, and a test asserts it is not a dataclass field so it cannot come back as something a caller supplies.
Without it, `cleanup_superseded_collections` alone would take seven positional arguments at two call sites.

`embedder_factory` stays a factory rather than an eagerly-built embedder because the laziness is load-bearing: cleanup builds an embedder only per collection it actually deletes, and `test_unclaimed_row_probe_reuses_the_refresh_embedder` pins that a candidate open constructs exactly one configured embedder.
It closes over the manager's module-global `create_configured_embedder`, so existing test patches of that name keep working unchanged.

## Invariants preserved, and what covers each

All five are carried over verbatim, docstrings included.

1. **`limit=1` existence probe** (`collection_has_source_path`) — `test_vector_verification_confirms_a_file_larger_than_the_store_ceiling`: one file with 500 chunks under a 250-row store ceiling. Only `limit=1` makes it answerable.
2. **Adaptive query splitting** (`_collection_paths_with_vectors`) — five tests, all in `tests/test_knowledge_resumable_refresh.py`:
   - `test_vector_verification_splits_a_batch_the_store_cannot_answer` pins halving at exactly 7 queries (per-path descent would also be correct, just O(n)).
   - `test_vector_verification_does_not_split_when_the_collection_is_gone` pins the `NotFoundError` re-raise at 1 query.
   - `test_vector_verification_does_not_split_unrelated_internal_error` pins that only `too many SQL variables` triggers a split.
   - `test_vector_verification_records_that_it_had_to_split` pins the `logger.debug` trace as `[8, 4, 4]`.
   - `test_vector_verification_uses_one_query_when_the_store_answers` pins that an answerable batch pays nothing.
3. **Deletes get no ceiling protection** (`delete_source_path_vectors`) — `test_candidate_path_removal_is_batched` covers the batching. ⚠️ **Finding: the "no splitting" half of this invariant has no test.** The fake store enforces a row ceiling on `get` only, never on `delete`, so adding splitting to the delete path would still pass — it would just be slower. The property survives as the docstring's measurement (51,200 rows across 128 paths on ChromaDB 1.5.8). Reporting it rather than papering over it; adding a delete-side ceiling to the fake is out of scope for a move.
4. **Preserve what you cannot prove you own** (`cleanup_superseded_collections`) — `preserved` set, `candidates_only` flag and unowned reporting are byte-for-byte. Covered by `test_candidate_cleanup_does_not_report_the_bases_own_default_collection` (asserts the unowned list is exactly the unrelated collection, and that the default survives), `test_incomplete_published_metadata_still_preserves_its_collection`, `test_unreadable_published_metadata_never_costs_the_live_collection`, and `test_successful_refreshes_keep_only_published_index`.
5. **Failed delete vs. already-absent** (`_delete_collection_sync`) — two tests pin both branches: `test_incompatible_candidate_delete_failure_does_not_block_refresh` (collection exists, `delete()` returns `False`, probe finds it, reported as failure) and `test_incompatible_missing_candidate_is_already_deleted` (collection never existed, probe raises `NotFoundError`, treated as success).

6. **Ownership is derived, not asserted** (`CollectionSpace.default_collection`) — `test_collection_ownership_is_derived_from_identity_not_supplied`. Added after review found the extraction had turned a computed name into an accepted field; see the `CollectionSpace` note above.
7. **The empty batch is total** (`paths_with_vectors`, `_collection_paths_with_vectors`) — `test_vector_verification_answers_an_empty_batch_without_asking_the_store`. ChromaDB's `validate_where` rejects an empty `$in`, so this had to be a base case rather than a query. This also required a fake fix: it filtered records instead of validating operands, so an empty `$in` matched nothing and looked like success — most convincingly on an empty collection, where no record is ever tested. Both halves were confirmed by reverting each separately and watching the assertion fail.

## Other notes

- `cleanup_superseded_collections` now takes the vector database explicitly instead of reading `self._knowledge.vector_db`. The manager passes exactly that object at both call sites, so behaviour is identical — this resolves toward the direction a sibling PR is taking the same function.
- Test churn is confined to seams that moved: the two autouse fixtures now patch `ChromaDb`/`Knowledge` on both modules, and `_verification_manager` became `_verification_collection` (those tests never needed a manager — the collection is standalone, which is the evidence this was already its own seam).
- `tach.toml` gains `mindroom.knowledge.collections` (visible only to `mindroom.knowledge.manager`), the new manager dependency, and `mindroom.strict_knowledge` visibility.
- **Deliberate follow-up:** candidate-build orchestration (`_open_candidate_run`, `_rebuild_candidate_collection`, `_resume_candidate_collection`, `_seed_candidate_from_published`, `_copy_published_vectors`) stays on the manager. It is refresh state, a later PR owns it, and it collides with sibling PRs in flight.

## On whether this was worth doing

Being straight about the justification: of the repo's four tests for a larger refactor, **"removes active duplication" barely applies** — there was little duplication to remove. The win is separation and testability, not de-duplication.

The concrete evidence is the test change rather than an assertion about it. `_verification_manager(tmp_path)` built an entire `KnowledgeManager` — config, storage paths, a knowledge object — to exercise one collection query. It is now `_verification_collection()`: no manager, no config, no `tmp_path`, and six tests dropped the fixture parameter entirely. That is a measured coupling reduction.

Every extracted method was deleted rather than left as a delegating wrapper, so there is no second way to reach any of this.

## Verification

- `pytest tests/test_knowledge_manager.py tests/test_knowledge_resumable_refresh.py tests/test_bot_knowledge.py tests/api/test_knowledge_api.py` — green
- `pytest tests/test_import_graph.py` — green
- `pre-commit run --all-files` — green
- `tach check --dependencies --interfaces` — green
