### PR TITLE
Give indexing_settings.json one state type, loader and writer

### DIFF
--- a/src/mindroom/knowledge/index_metadata.py
+++ b/src/mindroom/knowledge/index_metadata.py
@@ -228,16 +228,35 @@ def _nonnegative_int(value: object) -> int | None:
             return None
         case int() if value >= 0:
             return value
+        # ``is_integer`` is false for both infinities and NaN, which are the
+        # only floats ``int`` refuses, and no finite float can exceed its
+        # reach: this conversion cannot raise.
         case float() if value.is_integer() and value >= 0:
             return int(value)
-        # ``isdecimal`` rather than ``isdigit``: superscripts such as "²" are
-        # digits that ``int`` refuses, so the wider test would raise out of a
-        # loader whose callers expect it to answer for any payload. Decimal
-        # digits outside ASCII, such as "١٢", stay accepted because ``int``
-        # takes them.
-        case str() if value.strip().isdecimal():
-            return int(value.strip())
+        case str():
+            return _nonnegative_int_from_text(value.strip())
     return None
+
+
+def _nonnegative_int_from_text(text: str) -> int | None:
+    """Parse a decimal count, treating anything ``int`` refuses as absent.
+
+    Catching the failure beats predicating on it. No property of the
+    characters decides whether ``int`` accepts them: ``isdigit`` admits
+    superscripts like "²" that it rejects, and even a well-formed all-ASCII
+    decimal string raises once it passes CPython's integer conversion limit,
+    which is not about characters at all. A caller of this loader treats it as
+    total, so one ``except`` covering both -- and whatever else ``int`` grows
+    -- is what makes that true. ``isdecimal`` still gates which shapes count
+    as a number, keeping "+1" and "1_000" out; it just no longer decides
+    whether converting is safe.
+    """
+    if not text.isdecimal():
+        return None
+    try:
+        return int(text)
+    except ValueError:
+        return None
 
 
 def _refresh_job(value: object) -> _RefreshJob:

--- a/src/mindroom/knowledge/index_metadata.py
+++ b/src/mindroom/knowledge/index_metadata.py
@@ -76,7 +76,9 @@ def load_published_index_state(metadata_path: Path) -> PublishedIndexState | Non
         return None
     settings = _parse_settings(payload.get("settings"))
     status = payload.get("status")
-    if settings is None or status not in _PUBLISHED_INDEX_STATUSES:
+    # A JSON array or object decodes to an unhashable value, so membership is
+    # only asked once the value is known to be a string.
+    if settings is None or not isinstance(status, str) or status not in _PUBLISHED_INDEX_STATUSES:
         return None
     state = PublishedIndexState(
         settings=settings,
@@ -189,6 +191,6 @@ def _nonnegative_int(value: object) -> int | None:
 
 
 def _refresh_job(value: object) -> _RefreshJob:
-    if value in _REFRESH_JOBS:
+    if isinstance(value, str) and value in _REFRESH_JOBS:
         return cast("_RefreshJob", value)
     return "idle"

--- a/src/mindroom/knowledge/index_metadata.py
+++ b/src/mindroom/knowledge/index_metadata.py
@@ -18,7 +18,8 @@ import json
 import os
 import uuid
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, cast
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Literal, cast, get_args
 
 from mindroom.knowledge.indexing_config import IndexingSettings
 
@@ -30,8 +31,11 @@ if TYPE_CHECKING:
 _PublishedIndexStatus = Literal["resetting", "indexing", "complete", "failed"]
 _RefreshJob = Literal["idle", "pending", "running", "failed"]
 
-_PUBLISHED_INDEX_STATUSES: frozenset[str] = frozenset({"resetting", "indexing", "complete", "failed"})
-_REFRESH_JOBS: frozenset[str] = frozenset({"idle", "pending", "running", "failed"})
+# Derived, never restated: a hand-written copy that drifts from the Literal
+# makes the loader silently refuse every record carrying the new value, or
+# makes the cast that follows the membership test a lie.
+_PUBLISHED_INDEX_STATUSES: frozenset[str] = frozenset(get_args(_PublishedIndexStatus))
+_REFRESH_JOBS: frozenset[str] = frozenset(get_args(_RefreshJob))
 
 
 @dataclass(frozen=True)
@@ -117,6 +121,44 @@ def _records_a_publication(state: PublishedIndexState) -> bool:
     )
 
 
+def state_for_publication(
+    *,
+    settings: IndexingSettings,
+    collection: str | None,
+    indexed_count: int,
+    source_signature: str,
+    published_revision: str | None,
+) -> PublishedIndexState:
+    """Return the whole state one successful publication leaves on disk.
+
+    Both publish paths -- the semantic one that swaps in a candidate
+    collection, and the file-mode one that publishes source metadata with no
+    collection at all -- differ only in those two values, so they share this.
+    Building the state twice is how a field gets left to its default by
+    omission, which is the failure this module exists to make impossible.
+
+    Publication also resolves the refresh job it belongs to: the work that job
+    tracked has just landed, so its reason, error and failure streak are
+    cleared by the same write rather than surviving into a ``complete`` record.
+    """
+    now = datetime.now(tz=UTC).isoformat()
+    return PublishedIndexState(
+        settings=settings,
+        status="complete",
+        collection=collection,
+        last_published_at=now,
+        published_revision=published_revision,
+        indexed_count=indexed_count,
+        source_signature=source_signature,
+        refresh_job="idle",
+        reason=None,
+        last_error=None,
+        updated_at=now,
+        last_refresh_at=now,
+        consecutive_refresh_failures=0,
+    )
+
+
 def save_published_index_state(metadata_path: Path, state: PublishedIndexState) -> None:
     """Atomically persist one whole state, so no field is lost by omission."""
     optional_fields: dict[str, object | None] = {
@@ -155,9 +197,12 @@ def write_json_atomic(path: Path, payload: Mapping[str, object]) -> None:
 
 
 def _load_payload(metadata_path: Path) -> dict[str, object] | None:
+    # ``ValueError`` rather than ``JSONDecodeError``: invalid UTF-8 bytes raise
+    # ``UnicodeDecodeError``, which is a ``ValueError`` and not an ``OSError``,
+    # and every caller of the loader treats an unreadable file as "no state".
     try:
         payload = json.loads(metadata_path.read_text(encoding="utf-8")) if metadata_path.exists() else None
-    except (OSError, json.JSONDecodeError):
+    except (OSError, ValueError):
         return None
     return dict(payload) if isinstance(payload, dict) else None
 
@@ -185,7 +230,12 @@ def _nonnegative_int(value: object) -> int | None:
             return value
         case float() if value.is_integer() and value >= 0:
             return int(value)
-        case str() if value.strip().isdigit():
+        # ``isdecimal`` rather than ``isdigit``: superscripts such as "²" are
+        # digits that ``int`` refuses, so the wider test would raise out of a
+        # loader whose callers expect it to answer for any payload. Decimal
+        # digits outside ASCII, such as "١٢", stay accepted because ``int``
+        # takes them.
+        case str() if value.strip().isdecimal():
             return int(value.strip())
     return None
 

--- a/src/mindroom/knowledge/index_metadata.py
+++ b/src/mindroom/knowledge/index_metadata.py
@@ -1,81 +1,142 @@
-"""Published knowledge index metadata JSON helpers."""
+"""The one persisted knowledge index state document.
+
+Each knowledge base keeps exactly one state file,
+``<storage_root>/knowledge_db/<storage_key>/indexing_settings.json``, and this
+module owns its whole schema: one dataclass, one loader, one writer.
+
+Two collaborators write that file. The indexing manager records a publication
+(which collection is live, what it contains, which revision produced it), and
+the registry records the refresh job around it (queued, running, failed, and
+the error and timestamps that go with it). Both go through
+``save_published_index_state`` with a *whole* state, so neither can reset the
+other's fields merely by not knowing about them.
+"""
 
 from __future__ import annotations
 
 import json
 import os
 import uuid
-from typing import TYPE_CHECKING
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal, cast
+
+from mindroom.knowledge.indexing_config import IndexingSettings
 
 if TYPE_CHECKING:
-    from collections.abc import Container, Mapping
+    from collections.abc import Mapping
     from pathlib import Path
 
 
-_IndexMetadataFields = tuple[dict[str, str], str, str | None, str | None, str | None, int | None, str | None]
+_PublishedIndexStatus = Literal["resetting", "indexing", "complete", "failed"]
+_RefreshJob = Literal["idle", "pending", "running", "failed"]
+
+_PUBLISHED_INDEX_STATUSES: frozenset[str] = frozenset({"resetting", "indexing", "complete", "failed"})
+_REFRESH_JOBS: frozenset[str] = frozenset({"idle", "pending", "running", "failed"})
 
 
-def load_index_metadata_payload(metadata_path: Path) -> dict[str, object] | None:  # noqa: D103
-    try:
-        payload = json.loads(metadata_path.read_text(encoding="utf-8")) if metadata_path.exists() else None
-    except (OSError, json.JSONDecodeError):
+@dataclass(frozen=True)
+class PublishedIndexState:
+    """Persisted state for the published knowledge index.
+
+    ``settings`` through ``source_signature`` describe one publication;
+    ``refresh_job`` through ``consecutive_refresh_failures`` describe the
+    refresh job that produced or is producing it.
+    """
+
+    settings: IndexingSettings
+    status: _PublishedIndexStatus
+    collection: str | None = None
+    last_published_at: str | None = None
+    published_revision: str | None = None
+    indexed_count: int | None = None
+    source_signature: str | None = None
+    refresh_job: _RefreshJob = "idle"
+    reason: str | None = None
+    last_error: str | None = None
+    updated_at: str | None = None
+    last_refresh_at: str | None = None
+    consecutive_refresh_failures: int = 0
+
+
+def load_published_index_state(metadata_path: Path) -> PublishedIndexState | None:
+    """Load the persisted state, or ``None`` when the file holds no usable state.
+
+    A field the payload does not carry becomes ``None`` rather than rejecting
+    the document, so an in-progress or failed record keeps everything it does
+    say -- including the collection a previous publication left live, which is
+    the only on-disk proof of which collection candidate cleanup must spare.
+
+    Two things can still refuse a payload. Settings and status give every other
+    field its meaning, so a record missing either identifies nothing. And a
+    record that calls itself ``complete`` without proving what it published is
+    corrupt rather than merely thin: see ``_records_a_publication``.
+    """
+    payload = _load_payload(metadata_path)
+    if payload is None:
         return None
-    return dict(payload) if isinstance(payload, dict) else None
-
-
-def optional_metadata_str(value: object) -> str | None:  # noqa: D103
-    return value if isinstance(value, str) and value else None
-
-
-def coerce_nonnegative_metadata_int(value: object) -> int | None:  # noqa: D103
-    match value:
-        case bool():
-            return None
-        case int() if value >= 0:
-            return value
-        case float() if value.is_integer() and value >= 0:
-            return int(value)
-        case str() if value.strip().isdigit():
-            return int(value.strip())
-    return None
-
-
-def parse_index_metadata_fields(
-    payload: Mapping[str, object],
-    *,
-    allowed_statuses: Container[str],
-    require_complete_fields_for_all_statuses: bool = False,
-) -> _IndexMetadataFields | None:
-    """Parse the shared published-index fields from a JSON object."""
-    raw_settings = payload.get("settings")
-    raw_status = payload.get("status")
-    if not isinstance(raw_settings, dict) or not isinstance(raw_status, str) or raw_status not in allowed_statuses:
+    settings = _parse_settings(payload.get("settings"))
+    status = payload.get("status")
+    if settings is None or status not in _PUBLISHED_INDEX_STATUSES:
         return None
-    settings: dict[str, str] = {}
-    for key, value in raw_settings.items():
-        if not isinstance(key, str) or not isinstance(value, str):
-            return None
-        settings[key] = value
-
-    collection = optional_metadata_str(payload.get("collection"))
-    indexed_count = coerce_nonnegative_metadata_int(payload.get("indexed_count"))
-    source_signature = optional_metadata_str(payload.get("source_signature"))
-    settings_mode = optional_metadata_str(settings.get("mode"))
-    require_complete_fields = require_complete_fields_for_all_statuses or raw_status == "complete"
-    collection_required = require_complete_fields and not (raw_status == "complete" and settings_mode == "files")
-    if require_complete_fields and (
-        (collection_required and collection is None) or indexed_count is None or source_signature is None
-    ):
+    state = PublishedIndexState(
+        settings=settings,
+        status=cast("_PublishedIndexStatus", status),
+        collection=_optional_str(payload.get("collection")),
+        last_published_at=_optional_str(payload.get("last_published_at")),
+        published_revision=_optional_str(payload.get("published_revision")),
+        indexed_count=_nonnegative_int(payload.get("indexed_count")),
+        source_signature=_optional_str(payload.get("source_signature")),
+        refresh_job=_refresh_job(payload.get("refresh_job")),
+        reason=_optional_str(payload.get("reason")),
+        last_error=_optional_str(payload.get("last_error")),
+        updated_at=_optional_str(payload.get("updated_at")),
+        last_refresh_at=_optional_str(payload.get("last_refresh_at")),
+        consecutive_refresh_failures=_nonnegative_int(payload.get("consecutive_refresh_failures")) or 0,
+    )
+    if state.status == "complete" and not _records_a_publication(state):
         return None
+    return state
 
+
+def _records_a_publication(state: PublishedIndexState) -> bool:
+    """Return whether a ``complete`` record proves the publication it claims.
+
+    Every writer of a ``complete`` record states how many files it indexed and
+    the corpus signature it indexed them from; a semantic base also names the
+    collection holding the vectors, while a file-mode base publishes source
+    metadata and has none. A record missing any of those describes an index
+    nothing can check, so it is treated as corrupt and the base is refreshed
+    rather than served from a publication it cannot substantiate.
+    """
     return (
-        settings,
-        raw_status,
-        collection,
-        optional_metadata_str(payload.get("last_published_at")),
-        optional_metadata_str(payload.get("published_revision")),
-        indexed_count,
-        source_signature,
+        state.indexed_count is not None
+        and state.source_signature is not None
+        and (state.collection is not None or state.settings.mode == "files")
+    )
+
+
+def save_published_index_state(metadata_path: Path, state: PublishedIndexState) -> None:
+    """Atomically persist one whole state, so no field is lost by omission."""
+    optional_fields: dict[str, object | None] = {
+        "collection": state.collection,
+        "last_published_at": state.last_published_at,
+        "published_revision": state.published_revision,
+        "indexed_count": state.indexed_count,
+        "source_signature": state.source_signature,
+        "reason": state.reason,
+        "last_error": state.last_error,
+        "updated_at": state.updated_at,
+        "last_refresh_at": state.last_refresh_at,
+    }
+    write_json_atomic(
+        metadata_path,
+        {
+            "settings": state.settings.to_metadata(),
+            "status": state.status,
+            "refresh_job": state.refresh_job,
+            "consecutive_refresh_failures": state.consecutive_refresh_failures,
+            **{name: value for name, value in optional_fields.items() if value is not None},
+        },
     )
 
 
@@ -91,18 +152,43 @@ def write_json_atomic(path: Path, payload: Mapping[str, object]) -> None:
         raise
 
 
-def write_index_metadata_payload(  # noqa: D103
-    metadata_path: Path,
-    *,
-    settings: Mapping[str, str],
-    status: str,
-    **fields: object | None,
-) -> None:
-    write_json_atomic(
-        metadata_path,
-        {
-            "settings": dict(settings),
-            "status": status,
-            **{key: value for key, value in fields.items() if value is not None},
-        },
-    )
+def _load_payload(metadata_path: Path) -> dict[str, object] | None:
+    try:
+        payload = json.loads(metadata_path.read_text(encoding="utf-8")) if metadata_path.exists() else None
+    except (OSError, json.JSONDecodeError):
+        return None
+    return dict(payload) if isinstance(payload, dict) else None
+
+
+def _parse_settings(raw_settings: object) -> IndexingSettings | None:
+    if not isinstance(raw_settings, dict):
+        return None
+    metadata: dict[str, str] = {}
+    for key, value in raw_settings.items():
+        if not isinstance(key, str) or not isinstance(value, str):
+            return None
+        metadata[key] = value
+    return IndexingSettings.from_metadata(metadata)
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _nonnegative_int(value: object) -> int | None:
+    match value:
+        case bool():
+            return None
+        case int() if value >= 0:
+            return value
+        case float() if value.is_integer() and value >= 0:
+            return int(value)
+        case str() if value.strip().isdigit():
+            return int(value.strip())
+    return None
+
+
+def _refresh_job(value: object) -> _RefreshJob:
+    if value in _REFRESH_JOBS:
+        return cast("_RefreshJob", value)
+    return "idle"

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -67,6 +67,7 @@ from mindroom.knowledge.index_metadata import (
     PublishedIndexState,
     load_published_index_state,
     save_published_index_state,
+    state_for_publication,
 )
 from mindroom.knowledge.index_retry import EmbeddingRetryPolicy, run_with_embedding_retry
 from mindroom.knowledge.indexing_config import (
@@ -1256,38 +1257,6 @@ class KnowledgeManager:
         vector_db.delete()
         vector_db.create()
 
-    def _state_for_publication(
-        self,
-        *,
-        collection: str,
-        indexed_count: int,
-        source_signature: str,
-    ) -> PublishedIndexState:
-        """Build the whole state one successful publication leaves on disk.
-
-        The writer takes a whole state, so every field is chosen here rather
-        than reverting to a default nobody asked for. Publication also resolves
-        the refresh job it belongs to -- the work that job tracked has just
-        landed -- so its reason, error and failure streak are cleared with the
-        same write instead of surviving into a state that says ``complete``.
-        """
-        now = datetime.now(tz=UTC).isoformat()
-        return PublishedIndexState(
-            settings=self._indexing_settings,
-            status="complete",
-            collection=collection,
-            last_published_at=now,
-            published_revision=self._git_last_successful_commit,
-            indexed_count=indexed_count,
-            source_signature=source_signature,
-            refresh_job="idle",
-            reason=None,
-            last_error=None,
-            updated_at=now,
-            last_refresh_at=now,
-            consecutive_refresh_failures=0,
-        )
-
     async def _save_candidate_publish_metadata(
         self,
         *,
@@ -1295,10 +1264,12 @@ class KnowledgeManager:
         indexed_count: int,
         source_signature: str,
     ) -> bool:
-        state = self._state_for_publication(
+        state = state_for_publication(
+            settings=self._indexing_settings,
             collection=candidate_vector_db.collection_name,
             indexed_count=indexed_count,
             source_signature=source_signature,
+            published_revision=self._git_last_successful_commit,
         )
         save_task = asyncio.create_task(
             asyncio.to_thread(save_published_index_state, self._indexing_settings_path, state),
@@ -2024,7 +1995,6 @@ class KnowledgeManager:
         # Trusting a narrower reading would let a surviving checkpoint reopen
         # the published collection, or delete it as an incompatible candidate.
         published_collection = None if persisted_state is None else persisted_state.collection
-        published_collections: set[str] = set() if published_collection is None else {published_collection}
 
         if checkpoint is not None and not cleanup_is_safe:
             # The checkpoint may name the live collection whose identity was
@@ -2036,7 +2006,7 @@ class KnowledgeManager:
                 collection=checkpoint.collection,
             )
             checkpoint = None
-        if checkpoint is not None and checkpoint.collection in published_collections:
+        if checkpoint is not None and checkpoint.collection == published_collection:
             # The candidate already became the published index and the process
             # died before its checkpoint was cleaned up. Writing into it again
             # would mutate a live queryable index.
@@ -2110,10 +2080,10 @@ class KnowledgeManager:
         # Reconcile candidates abandoned by earlier crashed refreshes now, so
         # storage stays bounded even when a build never reaches publication.
         if cleanup_is_safe:
-            preserved = {checkpoint.collection, *published_collections}
+            preserved = {checkpoint.collection, published_collection} - {None}
             await asyncio.to_thread(
                 self._cleanup_superseded_collections,
-                preserved=frozenset(preserved),
+                preserved=frozenset(cast("set[str]", preserved)),
                 candidates_only=True,
             )
         else:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -12,7 +12,7 @@ from contextlib import suppress
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, Literal, NoReturn, Protocol, TypeVar, cast, runtime_checkable
+from typing import TYPE_CHECKING, Any, NoReturn, Protocol, TypeVar, cast, runtime_checkable
 from urllib.parse import quote, urlparse, urlunparse
 
 from agno.knowledge.reader import ReaderFactory
@@ -60,9 +60,9 @@ from mindroom.knowledge.file_listing import (
     list_knowledge_files,
 )
 from mindroom.knowledge.index_metadata import (
-    load_index_metadata_payload,
-    parse_index_metadata_fields,
-    write_index_metadata_payload,
+    PublishedIndexState,
+    load_published_index_state,
+    save_published_index_state,
 )
 from mindroom.knowledge.index_retry import EmbeddingRetryPolicy, run_with_embedding_retry
 from mindroom.knowledge.indexing_config import (
@@ -101,14 +101,6 @@ _SOURCE_MTIME_NS_KEY = "source_mtime_ns"
 _SOURCE_SIZE_KEY = "source_size"
 _SOURCE_DIGEST_KEY = "source_digest"
 _POST_INDEX_VECTOR_VISIBILITY_RETRY_DELAYS_SECONDS = (0.0, 0.01, 0.05)
-_INDEXING_STATUS_RESETTING = "resetting"
-_INDEXING_STATUS_INDEXING = "indexing"
-_INDEXING_STATUS_COMPLETE = "complete"
-_INDEXING_STATUSES = {
-    _INDEXING_STATUS_RESETTING,
-    _INDEXING_STATUS_INDEXING,
-    _INDEXING_STATUS_COMPLETE,
-}
 #: Files pulled into one prepare/embed/write batch. This bounds live asyncio
 #: tasks and peak memory independently of corpus size; the provider request
 #: bounds are applied separately when the batch's chunks are planned.
@@ -183,17 +175,6 @@ class _NamedCollection(Protocol):
     """Collection object shape returned by Chroma clients."""
 
     name: str
-
-
-@dataclass(frozen=True)
-class _PersistedIndexState:
-    settings: IndexingSettings
-    status: Literal["resetting", "indexing", "complete"]
-    collection: str | None = None
-    last_published_at: str | None = None
-    published_revision: str | None = None
-    indexed_count: int | None = None
-    source_signature: str | None = None
 
 
 @dataclass
@@ -712,7 +693,7 @@ class KnowledgeManager:
         self._base_storage_path.mkdir(parents=True, exist_ok=True)
         self._indexing_settings_path = self._base_storage_path / "indexing_settings.json"
         self._git_lfs_hydrated_head_path = self._base_storage_path / "git_lfs_hydrated_head.txt"
-        persisted_state = self._load_persisted_index_state()
+        persisted_state = load_published_index_state(self._indexing_settings_path)
         if not _semantic_indexing_enabled(self.config, self.base_id):
             self._persisted_collection_missing_on_init = False
             self._knowledge = Knowledge()
@@ -754,8 +735,8 @@ class KnowledgeManager:
             raise RuntimeError(msg)
         return knowledge_path
 
-    def _persisted_collection_missing(self, persisted_state: _PersistedIndexState | None) -> bool:
-        if persisted_state is None or persisted_state.status != _INDEXING_STATUS_COMPLETE:
+    def _persisted_collection_missing(self, persisted_state: PublishedIndexState | None) -> bool:
+        if persisted_state is None or persisted_state.status != "complete":
             return False
         collection_name = persisted_state.collection or self._default_collection_name()
         try:
@@ -768,61 +749,6 @@ class KnowledgeManager:
                 exc_info=True,
             )
             return True
-
-    def _load_persisted_index_state(self) -> _PersistedIndexState | None:
-        payload = load_index_metadata_payload(self._indexing_settings_path)
-        if payload is None:
-            return None
-        fields = parse_index_metadata_fields(
-            payload,
-            allowed_statuses=_INDEXING_STATUSES,
-            require_complete_fields_for_all_statuses=True,
-        )
-        if fields is None:
-            return None
-        (
-            settings,
-            status,
-            collection,
-            last_published_at,
-            published_revision,
-            indexed_count,
-            source_signature,
-        ) = fields
-        indexing_settings = IndexingSettings.from_metadata(settings)
-        if indexing_settings is None:
-            return None
-        return _PersistedIndexState(
-            indexing_settings,
-            cast('Literal["resetting", "indexing", "complete"]', status),
-            collection=collection,
-            last_published_at=last_published_at,
-            published_revision=published_revision,
-            indexed_count=indexed_count,
-            source_signature=source_signature,
-        )
-
-    def _save_persisted_index_state(
-        self,
-        status: Literal["resetting", "indexing", "complete"],
-        *,
-        settings: IndexingSettings | None = None,
-        collection: str | None = None,
-        last_published_at: str | None = None,
-        published_revision: str | None = None,
-        indexed_count: int | None = None,
-        source_signature: str | None = None,
-    ) -> None:
-        write_index_metadata_payload(
-            self._indexing_settings_path,
-            settings=(settings or self._indexing_settings).to_metadata(),
-            status=status,
-            collection=collection,
-            last_published_at=last_published_at,
-            published_revision=published_revision,
-            indexed_count=indexed_count,
-            source_signature=source_signature,
-        )
 
     def _load_git_lfs_hydrated_head(self) -> str | None:
         try:
@@ -844,12 +770,10 @@ class KnowledgeManager:
     def _needs_full_reindex_on_create(self) -> bool:
         if self._persisted_collection_missing_on_init:
             return True
-        persisted_state = self._load_persisted_index_state()
+        persisted_state = load_published_index_state(self._indexing_settings_path)
         if persisted_state is None:
             return self._indexing_settings_path.exists() and self._has_existing_index()
-        return (
-            persisted_state.settings != self._indexing_settings or persisted_state.status == _INDEXING_STATUS_RESETTING
-        )
+        return persisted_state.settings != self._indexing_settings or persisted_state.status == "resetting"
 
     def _git_config(self) -> KnowledgeGitConfig | None:
         return self.config.get_knowledge_base_config(self.base_id).git
@@ -1248,6 +1172,38 @@ class KnowledgeManager:
         vector_db.delete()
         vector_db.create()
 
+    def _state_for_publication(
+        self,
+        *,
+        collection: str,
+        indexed_count: int,
+        source_signature: str,
+    ) -> PublishedIndexState:
+        """Build the whole state one successful publication leaves on disk.
+
+        The writer takes a whole state, so every field is chosen here rather
+        than reverting to a default nobody asked for. Publication also resolves
+        the refresh job it belongs to -- the work that job tracked has just
+        landed -- so its reason, error and failure streak are cleared with the
+        same write instead of surviving into a state that says ``complete``.
+        """
+        now = datetime.now(tz=UTC).isoformat()
+        return PublishedIndexState(
+            settings=self._indexing_settings,
+            status="complete",
+            collection=collection,
+            last_published_at=now,
+            published_revision=self._git_last_successful_commit,
+            indexed_count=indexed_count,
+            source_signature=source_signature,
+            refresh_job="idle",
+            reason=None,
+            last_error=None,
+            updated_at=now,
+            last_refresh_at=now,
+            consecutive_refresh_failures=0,
+        )
+
     async def _save_candidate_publish_metadata(
         self,
         *,
@@ -1255,16 +1211,13 @@ class KnowledgeManager:
         indexed_count: int,
         source_signature: str,
     ) -> bool:
+        state = self._state_for_publication(
+            collection=candidate_vector_db.collection_name,
+            indexed_count=indexed_count,
+            source_signature=source_signature,
+        )
         save_task = asyncio.create_task(
-            asyncio.to_thread(
-                self._save_persisted_index_state,
-                _INDEXING_STATUS_COMPLETE,
-                collection=candidate_vector_db.collection_name,
-                last_published_at=datetime.now(tz=UTC).isoformat(),
-                published_revision=self._git_last_successful_commit,
-                indexed_count=indexed_count,
-                source_signature=source_signature,
-            ),
+            asyncio.to_thread(save_published_index_state, self._indexing_settings_path, state),
         )
         try:
             await asyncio.shield(save_task)
@@ -1850,7 +1803,7 @@ class KnowledgeManager:
                     metadatas=[dict(metadatas[index]) for index in kept],
                 )
 
-    def _reusable_published_collection(self, persisted_state: _PersistedIndexState | None) -> str | None:
+    def _reusable_published_collection(self, persisted_state: PublishedIndexState | None) -> str | None:
         """Return the published collection a fresh candidate may copy, if any.
 
         Matching ``IndexingSettings`` is what makes a copy sound. They pin the
@@ -1868,7 +1821,7 @@ class KnowledgeManager:
         """
         if (
             persisted_state is None
-            or persisted_state.status != _INDEXING_STATUS_COMPLETE
+            or persisted_state.status != "complete"
             or persisted_state.collection is None
             or persisted_state.settings != self._indexing_settings
         ):
@@ -2029,18 +1982,13 @@ class KnowledgeManager:
     async def _open_candidate_run(self, *, force_reindex: bool = False) -> _CandidateRun:
         """Resolve the durable candidate to continue, or start one clean candidate."""
         checkpoint = await asyncio.to_thread(load_candidate_checkpoint, self._base_storage_path)
-        persisted_state = await asyncio.to_thread(self._load_persisted_index_state)
-        published_collection = (
-            persisted_state.collection
-            if persisted_state is not None and persisted_state.status == _INDEXING_STATUS_COMPLETE
-            else None
-        )
-        live_collection, cleanup_is_safe = await asyncio.to_thread(self._published_collection_for_cleanup)
-        # Both names matter: the strict parser drops the collection when any
-        # required field is missing, while the raw payload still records it.
-        # Trusting only the strict one would let a surviving checkpoint reopen
+        persisted_state, cleanup_is_safe = await asyncio.to_thread(self._published_state_and_cleanup_safety)
+        # A collection name is only ever recorded by a publication, so whatever
+        # the state names is the live index whatever its current status says.
+        # Trusting a narrower reading would let a surviving checkpoint reopen
         # the published collection, or delete it as an incompatible candidate.
-        published_collections = {name for name in (published_collection, live_collection) if name is not None}
+        published_collection = None if persisted_state is None else persisted_state.collection
+        published_collections: set[str] = set() if published_collection is None else {published_collection}
 
         if checkpoint is not None and not cleanup_is_safe:
             # The checkpoint may name the live collection whose identity was
@@ -2139,22 +2087,21 @@ class KnowledgeManager:
             )
         return run
 
-    def _published_collection_for_cleanup(self) -> tuple[str | None, bool]:
-        """Return the live collection to protect, and whether cleanup may run at all.
+    def _published_state_and_cleanup_safety(self) -> tuple[PublishedIndexState | None, bool]:
+        """Return the persisted state, and whether candidate cleanup may run at all.
 
         A published collection is itself candidate-named, so the only proof of
-        which candidate-prefixed collections are superseded is the published
-        metadata. The strict state parser rejects metadata that is merely
-        incomplete, which would silently drop that proof, so the collection
-        name is read straight from the payload. If the file exists but yields
-        no payload at all, nothing can be proven and cleanup is skipped rather
-        than risking the last good index.
+        which candidate-prefixed collections are superseded is this state file.
+        If it exists but yields no state, nothing about the live index can be
+        proven, and cleanup is skipped rather than guessing from a rawer read
+        of the same bytes and risking the last good index.
+
+        One read answers both questions: an in-progress or failed record still
+        parses and still names whatever collection the last publication left
+        live, so protecting it never needs a second, looser look.
         """
-        payload = load_index_metadata_payload(self._indexing_settings_path)
-        if payload is None:
-            return None, not self._indexing_settings_path.exists()
-        collection = payload.get("collection")
-        return (collection if isinstance(collection, str) and collection else None), True
+        state = load_published_index_state(self._indexing_settings_path)
+        return state, state is not None or not self._indexing_settings_path.exists()
 
     async def discard_superseded_candidate(self, *, published_collection: str | None) -> None:
         """Drop candidate state that publishing an unchanged index made obsolete.

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -22,6 +22,7 @@ from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths, runtime_env_values
 from mindroom.file_locks import async_exclusive_file_lock
 from mindroom.knowledge.availability import KnowledgeAvailability
+from mindroom.knowledge.index_metadata import state_for_publication
 from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
 from mindroom.knowledge.redaction import redact_credentials_in_text
 from mindroom.knowledge.registry import (
@@ -568,23 +569,15 @@ async def _publish_file_mode_source_metadata(
         manager._knowledge_source_path(),
         tracked_relative_paths=manager._git_tracked_relative_paths,
     )
-    now = datetime.now(tz=UTC).isoformat()
     await asyncio.to_thread(
         save_published_index_state,
         published_index_metadata_path(key),
-        PublishedIndexState(
+        state_for_publication(
             settings=key.indexing_settings,
-            status="complete",
             collection=None,
-            last_published_at=now,
-            published_revision=manager._git_last_successful_commit,
             indexed_count=0,
             source_signature=source_signature,
-            refresh_job="idle",
-            reason=None,
-            last_error=None,
-            updated_at=now,
-            last_refresh_at=now,
+            published_revision=manager._git_last_successful_commit,
         ),
     )
     return KnowledgeRefreshResult(

--- a/src/mindroom/knowledge/registry.py
+++ b/src/mindroom/knowledge/registry.py
@@ -18,11 +18,9 @@ from agno.vectordb.chroma import ChromaDb
 from mindroom.embedding_factory import create_configured_embedder, embedder_client_signature
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.index_metadata import (
-    coerce_nonnegative_metadata_int,
-    load_index_metadata_payload,
-    optional_metadata_str,
-    parse_index_metadata_fields,
-    write_index_metadata_payload,
+    PublishedIndexState,
+    load_published_index_state,
+    save_published_index_state,
 )
 from mindroom.knowledge.indexing_config import (
     IndexingSettings,
@@ -79,25 +77,6 @@ class KnowledgeSourceRoot:
 
 
 @dataclass(frozen=True)
-class PublishedIndexState:
-    """Persisted state for the published knowledge index."""
-
-    settings: IndexingSettings
-    status: Literal["resetting", "indexing", "complete", "failed"]
-    collection: str | None = None
-    last_published_at: str | None = None
-    published_revision: str | None = None
-    indexed_count: int | None = None
-    source_signature: str | None = None
-    refresh_job: Literal["idle", "pending", "running", "failed"] = "idle"
-    reason: str | None = None
-    last_error: str | None = None
-    updated_at: str | None = None
-    last_refresh_at: str | None = None
-    consecutive_refresh_failures: int = 0
-
-
-@dataclass(frozen=True)
 class _PublishedIndexHandle:
     """Read handle for the published knowledge index."""
 
@@ -132,7 +111,6 @@ _published_indexes: dict[PublishedIndexKey, _PublishedIndexHandle] = {}
 _CONSECUTIVE_REFRESH_FAILURE_ALERT_THRESHOLD = 3
 _PRIVATE_KNOWLEDGE_BASE_ID_PREFIX = "__agent_private__:"
 _MAX_PRIVATE_PUBLISHED_INDEXES = 128
-_PUBLISHED_INDEX_STATUSES = {"resetting", "indexing", "complete", "failed"}
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
@@ -261,70 +239,6 @@ def published_index_storage_path(key: PublishedIndexKey) -> Path:
 def published_index_metadata_path(key: PublishedIndexKey) -> Path:
     """Return the single persisted state file for one knowledge base."""
     return published_index_storage_path(key) / "indexing_settings.json"
-
-
-def _coerce_refresh_job(value: object) -> Literal["idle", "pending", "running", "failed"]:
-    if value in {"idle", "pending", "running", "failed"}:
-        return cast('Literal["idle", "pending", "running", "failed"]', value)
-    return "idle"
-
-
-def load_published_index_state(metadata_path: Path) -> PublishedIndexState | None:
-    """Load published index metadata."""
-    payload = load_index_metadata_payload(metadata_path)
-    if payload is None:
-        return None
-    fields = parse_index_metadata_fields(payload, allowed_statuses=_PUBLISHED_INDEX_STATUSES)
-    if fields is None:
-        return None
-    (
-        settings,
-        status,
-        collection,
-        last_published_at,
-        published_revision,
-        indexed_count,
-        source_signature,
-    ) = fields
-    indexing_settings = IndexingSettings.from_metadata(settings)
-    if indexing_settings is None:
-        return None
-
-    return PublishedIndexState(
-        settings=indexing_settings,
-        status=cast('Literal["resetting", "indexing", "complete", "failed"]', status),
-        collection=collection,
-        last_published_at=last_published_at,
-        published_revision=published_revision,
-        indexed_count=indexed_count,
-        source_signature=source_signature,
-        refresh_job=_coerce_refresh_job(payload.get("refresh_job")),
-        reason=optional_metadata_str(payload.get("reason")),
-        last_error=optional_metadata_str(payload.get("last_error")),
-        updated_at=optional_metadata_str(payload.get("updated_at")),
-        last_refresh_at=optional_metadata_str(payload.get("last_refresh_at")),
-        consecutive_refresh_failures=coerce_nonnegative_metadata_int(payload.get("consecutive_refresh_failures")) or 0,
-    )
-
-
-def save_published_index_state(metadata_path: Path, state: PublishedIndexState) -> None:
-    """Atomically persist published index metadata."""
-    write_index_metadata_payload(
-        metadata_path,
-        settings=state.settings.to_metadata(),
-        status=state.status,
-        collection=state.collection,
-        last_published_at=state.last_published_at,
-        published_revision=state.published_revision,
-        indexed_count=state.indexed_count,
-        source_signature=state.source_signature,
-        refresh_job=state.refresh_job,
-        reason=state.reason,
-        last_error=state.last_error,
-        updated_at=state.updated_at,
-        last_refresh_at=state.last_refresh_at,
-        consecutive_refresh_failures=state.consecutive_refresh_failures,
-    )
 
 
 def published_index_refresh_state(

--- a/tach.toml
+++ b/tach.toml
@@ -3480,7 +3480,7 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.knowledge.index_metadata"
-depends_on = []
+depends_on = ["mindroom.knowledge.indexing_config"]
 visibility = [
     "mindroom.knowledge.candidate_checkpoint",
     "mindroom.knowledge.manager",

--- a/tach.toml
+++ b/tach.toml
@@ -3484,6 +3484,7 @@ depends_on = ["mindroom.knowledge.indexing_config"]
 visibility = [
     "mindroom.knowledge.candidate_checkpoint",
     "mindroom.knowledge.manager",
+    "mindroom.knowledge.refresh_runner",
     "mindroom.knowledge.registry",
 ]
 
@@ -3579,6 +3580,7 @@ depends_on = [
     "mindroom.config.main",
     "mindroom.constants",
     "mindroom.knowledge.availability",
+    "mindroom.knowledge.index_metadata",
     "mindroom.knowledge.manager",
     "mindroom.knowledge.redaction",
     "mindroom.knowledge.registry",

--- a/tests/test_knowledge_index_metadata.py
+++ b/tests/test_knowledge_index_metadata.py
@@ -95,12 +95,13 @@ def test_an_unfinished_record_keeps_the_collection_the_last_publication_left(tmp
 
     The collection name is the only on-disk proof of which candidate-prefixed
     collection candidate cleanup must spare, so a record that carries nothing
-    else must still carry that.
+    else must still carry that. ``indexing`` with a collection is the shape
+    older versions wrote for every in-progress refresh.
     """
     metadata_path = tmp_path / "indexing_settings.json"
     write_json_atomic(
         metadata_path,
-        {"settings": _settings().to_metadata(), "status": "failed", "collection": "published_collection"},
+        {"settings": _settings().to_metadata(), "status": "indexing", "collection": "published_collection"},
     )
 
     state = load_published_index_state(metadata_path)
@@ -202,6 +203,46 @@ def test_a_torn_or_missing_file_is_no_state_at_all(tmp_path: Path) -> None:
 
     assert load_published_index_state(missing_path) is None
     assert load_published_index_state(torn_path) is None
+
+
+def test_bytes_that_are_not_utf8_are_no_state_at_all(tmp_path: Path) -> None:
+    """Undecodable bytes raise ``UnicodeDecodeError``, which is not an ``OSError``."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    metadata_path.write_bytes(b'{"status": "\xff\xfe"}')
+
+    assert load_published_index_state(metadata_path) is None
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param(7, 7, id="int"),
+        pytest.param(7.0, 7, id="whole_float"),
+        pytest.param("7", 7, id="ascii_digits"),
+        pytest.param("١٢", 12, id="arabic_indic_digits"),
+        pytest.param("²", None, id="superscript_int_refuses"),
+        pytest.param(-1, None, id="negative"),
+        pytest.param(True, None, id="bool"),
+        pytest.param(7.5, None, id="fractional"),
+    ],
+)
+def test_counts_accept_only_values_int_can_take(tmp_path: Path, raw: object, expected: int | None) -> None:
+    """A digit ``int`` refuses must read as absent, not raise out of the loader.
+
+    ``"²".isdigit()`` is true while ``int("²")`` raises, so the wider test
+    would turn one hostile byte in a state file into a failed manager
+    construction instead of a base that simply refreshes itself.
+    """
+    metadata_path = tmp_path / "indexing_settings.json"
+    write_json_atomic(
+        metadata_path,
+        {"settings": _settings().to_metadata(), "status": "indexing", "indexed_count": raw},
+    )
+
+    state = load_published_index_state(metadata_path)
+
+    assert state is not None
+    assert state.indexed_count == expected
 
 
 def test_write_json_atomic_uses_unique_temp_and_cleans_failed_replace(

--- a/tests/test_knowledge_index_metadata.py
+++ b/tests/test_knowledge_index_metadata.py
@@ -166,21 +166,26 @@ def test_a_record_without_usable_settings_is_no_state_at_all(tmp_path: Path, pay
     assert load_published_index_state(metadata_path) is None
 
 
-@pytest.mark.parametrize("status", [None, "", "publishing", 3])
+@pytest.mark.parametrize("status", [None, "", "publishing", 3, ["complete"], {"status": "complete"}])
 def test_an_unknown_status_is_no_state_at_all(tmp_path: Path, status: object) -> None:
-    """A status outside the schema leaves the rest of the record meaningless."""
+    """A status outside the schema leaves the rest of the record meaningless.
+
+    A JSON array or object decodes to an unhashable value, so a record must be
+    refused rather than raising out of a loader every caller treats as total.
+    """
     metadata_path = tmp_path / "indexing_settings.json"
     write_json_atomic(metadata_path, {"settings": _settings().to_metadata(), "status": status})
 
     assert load_published_index_state(metadata_path) is None
 
 
-def test_an_unknown_refresh_job_falls_back_to_idle(tmp_path: Path) -> None:
+@pytest.mark.parametrize("refresh_job", ["sprinting", 4, ["running"], {"job": "running"}])
+def test_an_unknown_refresh_job_falls_back_to_idle(tmp_path: Path, refresh_job: object) -> None:
     """Refresh-job bookkeeping never invalidates a record that is otherwise usable."""
     metadata_path = tmp_path / "indexing_settings.json"
     write_json_atomic(
         metadata_path,
-        {"settings": _settings().to_metadata(), "status": "indexing", "refresh_job": "sprinting"},
+        {"settings": _settings().to_metadata(), "status": "indexing", "refresh_job": refresh_job},
     )
 
     state = load_published_index_state(metadata_path)

--- a/tests/test_knowledge_index_metadata.py
+++ b/tests/test_knowledge_index_metadata.py
@@ -1,124 +1,205 @@
-"""Knowledge published-index metadata codec tests."""
+"""Knowledge published-index state codec tests."""
 
 from __future__ import annotations
 
+import dataclasses
 import json
 from pathlib import Path
 
 import pytest
 
 from mindroom.knowledge.index_metadata import (
-    load_index_metadata_payload,
-    parse_index_metadata_fields,
-    write_index_metadata_payload,
+    PublishedIndexState,
+    load_published_index_state,
+    save_published_index_state,
+    write_json_atomic,
 )
+from mindroom.knowledge.indexing_config import IndexingSettings
 
 
-def test_index_metadata_fields_support_registry_and_manager_strictness(tmp_path: Path) -> None:
-    """Metadata parsing keeps registry leniency separate from manager strictness."""
-    metadata_path = tmp_path / "indexing_settings.json"
-    metadata_path.write_text(
-        json.dumps(
-            {
-                "settings": {"base": "storage"},
-                "status": "indexing",
-                "refresh_job": "running",
-            },
-        ),
-        encoding="utf-8",
+def _settings(**overrides: str) -> IndexingSettings:
+    settings = IndexingSettings(
+        base_id="docs",
+        storage_root="/storage",
+        knowledge_path="/knowledge/docs",
+        mode="semantic",
+        embedder_provider="openai",
+        embedder_model="text-embedding-3-small",
+        embedder_host="",
+        embedder_dimensions="1536",
+        chunk_size="1000",
+        chunk_overlap="100",
+        repo_identity="",
+        git_branch="",
+        git_lfs="",
+        git_skip_hidden="",
+        git_include_patterns="",
+        git_exclude_patterns="",
+        include_patterns="",
+        exclude_patterns="",
+        include_extensions=".md",
+        exclude_extensions="",
     )
-
-    payload = load_index_metadata_payload(metadata_path)
-    assert payload is not None
-    assert (
-        parse_index_metadata_fields(
-            payload,
-            allowed_statuses={"resetting", "indexing", "complete"},
-            require_complete_fields_for_all_statuses=True,
-        )
-        is None
-    )
-
-    fields = parse_index_metadata_fields(
-        payload,
-        allowed_statuses={"resetting", "indexing", "complete", "failed"},
-        require_complete_fields_for_all_statuses=False,
-    )
-
-    assert fields == ({"base": "storage"}, "indexing", None, None, None, None, None)
+    # Empty filter keys normalize on the way in, so parse once to get settings
+    # that are already in the shape the codec round-trips unchanged.
+    normalized = IndexingSettings.from_metadata(dataclasses.replace(settings, **overrides).to_metadata())
+    assert normalized is not None
+    return normalized
 
 
-def test_strict_index_metadata_parsing_requires_collection_except_complete_file_mode() -> None:
-    """Strict metadata parsing should only omit collection for completed file-mode records."""
-    indexing_payload = {
-        "settings": {"base": "storage", "mode": "files"},
-        "status": "indexing",
-        "indexed_count": 0,
-        "source_signature": "source-signature",
-    }
-
-    assert (
-        parse_index_metadata_fields(
-            indexing_payload,
-            allowed_statuses={"indexing", "complete"},
-            require_complete_fields_for_all_statuses=True,
-        )
-        is None
-    )
-    assert parse_index_metadata_fields(
-        {**indexing_payload, "status": "complete"},
-        allowed_statuses={"indexing", "complete"},
-        require_complete_fields_for_all_statuses=True,
-    ) == ({"base": "storage", "mode": "files"}, "complete", None, None, None, 0, "source-signature")
-
-
-def test_strict_index_metadata_parsing_accepts_complete_file_mode_from_settings() -> None:
-    """Published file-mode metadata stores file mode in indexing settings."""
-    payload = {
-        "settings": {"base": "storage", "mode": "files"},
-        "status": "complete",
-        "indexed_count": 0,
-        "source_signature": "source-signature",
-    }
-
-    assert parse_index_metadata_fields(
-        payload,
-        allowed_statuses={"indexing", "complete"},
-        require_complete_fields_for_all_statuses=True,
-    ) == ({"base": "storage", "mode": "files"}, "complete", None, None, None, 0, "source-signature")
-
-
-def test_write_index_metadata_payload_preserves_field_names_and_omits_none_values(tmp_path: Path) -> None:
-    """Payload building preserves on-disk field names and omits absent optional fields."""
-    metadata_path = tmp_path / "indexing_settings.json"
-
-    write_index_metadata_payload(
-        metadata_path,
-        settings={"base": "storage"},
+def _full_state() -> PublishedIndexState:
+    return PublishedIndexState(
+        settings=_settings(),
         status="complete",
         collection="published_collection",
         last_published_at="2026-01-02T03:04:05+00:00",
+        published_revision="deadbeef",
         indexed_count=7,
         source_signature="source-signature",
-        refresh_job="idle",
-        reason=None,
-        last_refresh_at="2026-01-02T03:05:06+00:00",
+        refresh_job="running",
+        reason="refreshing",
+        last_error="boom",
+        updated_at="2026-01-02T03:05:06+00:00",
+        last_refresh_at="2026-01-02T03:06:07+00:00",
+        consecutive_refresh_failures=3,
     )
 
+
+def test_every_state_field_round_trips_through_the_single_writer(tmp_path: Path) -> None:
+    """One writer and one loader must carry the whole schema, field for field."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    state = _full_state()
+
+    save_published_index_state(metadata_path, state)
+
+    assert load_published_index_state(metadata_path) == state
     payload = json.loads(metadata_path.read_text(encoding="utf-8"))
-    assert payload == {
-        "settings": {"base": "storage"},
+    # Every field of the type is on disk, so no writer can drop one by omission.
+    assert set(payload) == {field.name for field in dataclasses.fields(state)}
+
+
+def test_absent_optional_fields_are_omitted_rather_than_written_as_null(tmp_path: Path) -> None:
+    """Fields the state does not carry stay off disk, and reload as their defaults."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    state = PublishedIndexState(settings=_settings(), status="indexing")
+
+    save_published_index_state(metadata_path, state)
+
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert set(payload) == {"settings", "status", "refresh_job", "consecutive_refresh_failures"}
+    assert load_published_index_state(metadata_path) == state
+
+
+def test_an_unfinished_record_keeps_the_collection_the_last_publication_left(tmp_path: Path) -> None:
+    """A record that is not a publication still names the collection that is live.
+
+    The collection name is the only on-disk proof of which candidate-prefixed
+    collection candidate cleanup must spare, so a record that carries nothing
+    else must still carry that.
+    """
+    metadata_path = tmp_path / "indexing_settings.json"
+    write_json_atomic(
+        metadata_path,
+        {"settings": _settings().to_metadata(), "status": "failed", "collection": "published_collection"},
+    )
+
+    state = load_published_index_state(metadata_path)
+
+    assert state is not None
+    assert state.collection == "published_collection"
+    assert state.indexed_count is None
+    assert state.source_signature is None
+
+
+@pytest.mark.parametrize(
+    "missing_field",
+    ["collection", "indexed_count", "source_signature"],
+)
+def test_a_complete_record_that_proves_nothing_is_no_state_at_all(tmp_path: Path, missing_field: str) -> None:
+    """A publication nothing can check is corrupt, not merely thin."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    payload: dict[str, object] = {
+        "settings": _settings().to_metadata(),
         "status": "complete",
         "collection": "published_collection",
-        "last_published_at": "2026-01-02T03:04:05+00:00",
         "indexed_count": 7,
         "source_signature": "source-signature",
-        "refresh_job": "idle",
-        "last_refresh_at": "2026-01-02T03:05:06+00:00",
     }
+    del payload[missing_field]
+    write_json_atomic(metadata_path, payload)
+
+    assert load_published_index_state(metadata_path) is None
 
 
-def test_write_index_metadata_payload_uses_unique_temp_and_cleans_failed_replace(
+def test_file_mode_metadata_keeps_its_mode_without_a_collection(tmp_path: Path) -> None:
+    """File-mode bases publish source metadata and never name a collection."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    state = PublishedIndexState(
+        settings=_settings(mode="files"),
+        status="complete",
+        indexed_count=0,
+        source_signature="source-signature",
+    )
+
+    save_published_index_state(metadata_path, state)
+    loaded = load_published_index_state(metadata_path)
+
+    assert loaded is not None
+    assert loaded.settings.mode == "files"
+    assert loaded.collection is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        pytest.param({"status": "complete"}, id="settings_missing"),
+        pytest.param({"settings": {"base": "storage"}, "status": "complete"}, id="settings_unrecognized"),
+        pytest.param({"settings": {"base_id": 1}, "status": "complete"}, id="settings_not_strings"),
+        pytest.param({"settings": None, "status": "complete"}, id="settings_not_an_object"),
+    ],
+)
+def test_a_record_without_usable_settings_is_no_state_at_all(tmp_path: Path, payload: dict[str, object]) -> None:
+    """Settings identify what the index was built under; without them nothing is known."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    write_json_atomic(metadata_path, payload)
+
+    assert load_published_index_state(metadata_path) is None
+
+
+@pytest.mark.parametrize("status", [None, "", "publishing", 3])
+def test_an_unknown_status_is_no_state_at_all(tmp_path: Path, status: object) -> None:
+    """A status outside the schema leaves the rest of the record meaningless."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    write_json_atomic(metadata_path, {"settings": _settings().to_metadata(), "status": status})
+
+    assert load_published_index_state(metadata_path) is None
+
+
+def test_an_unknown_refresh_job_falls_back_to_idle(tmp_path: Path) -> None:
+    """Refresh-job bookkeeping never invalidates a record that is otherwise usable."""
+    metadata_path = tmp_path / "indexing_settings.json"
+    write_json_atomic(
+        metadata_path,
+        {"settings": _settings().to_metadata(), "status": "indexing", "refresh_job": "sprinting"},
+    )
+
+    state = load_published_index_state(metadata_path)
+
+    assert state is not None
+    assert state.refresh_job == "idle"
+
+
+def test_a_torn_or_missing_file_is_no_state_at_all(tmp_path: Path) -> None:
+    """Neither a missing file nor a partially written one may raise."""
+    missing_path = tmp_path / "missing.json"
+    torn_path = tmp_path / "torn.json"
+    torn_path.write_text("{ truncated", encoding="utf-8")
+
+    assert load_published_index_state(missing_path) is None
+    assert load_published_index_state(torn_path) is None
+
+
+def test_write_json_atomic_uses_unique_temp_and_cleans_failed_replace(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -137,11 +218,7 @@ def test_write_index_metadata_payload_uses_unique_temp_and_cleans_failed_replace
     monkeypatch.setattr(Path, "replace", _fail_temp_replace)
 
     with pytest.raises(OSError, match="replace failed"):
-        write_index_metadata_payload(
-            metadata_path,
-            settings={"base": "storage"},
-            status="complete",
-        )
+        save_published_index_state(metadata_path, PublishedIndexState(settings=_settings(), status="complete"))
 
     assert attempted_temp_paths
     assert attempted_temp_paths[0].name != "indexing_settings.json.tmp"

--- a/tests/test_knowledge_index_metadata.py
+++ b/tests/test_knowledge_index_metadata.py
@@ -221,28 +221,38 @@ def test_bytes_that_are_not_utf8_are_no_state_at_all(tmp_path: Path) -> None:
         pytest.param("7", 7, id="ascii_digits"),
         pytest.param("١٢", 12, id="arabic_indic_digits"),
         pytest.param("²", None, id="superscript_int_refuses"),
+        pytest.param("1" * 5000, None, id="past_the_integer_conversion_limit"),
         pytest.param(-1, None, id="negative"),
         pytest.param(True, None, id="bool"),
         pytest.param(7.5, None, id="fractional"),
     ],
 )
 def test_counts_accept_only_values_int_can_take(tmp_path: Path, raw: object, expected: int | None) -> None:
-    """A digit ``int`` refuses must read as absent, not raise out of the loader.
+    """A number ``int`` refuses must read as absent, not raise out of the loader.
 
-    ``"²".isdigit()`` is true while ``int("²")`` raises, so the wider test
-    would turn one hostile byte in a state file into a failed manager
-    construction instead of a base that simply refreshes itself.
+    Two independent ways to be refused, neither of them a property of the
+    payload's shape: ``"²".isdigit()`` is true while ``int("²")`` raises, and a
+    perfectly well-formed decimal string raises once it is longer than
+    CPython's integer conversion limit. Either would turn one hostile field in
+    a state file into a failed manager construction instead of a base that
+    simply refreshes itself. Both counts are parsed by the same helper.
     """
     metadata_path = tmp_path / "indexing_settings.json"
     write_json_atomic(
         metadata_path,
-        {"settings": _settings().to_metadata(), "status": "indexing", "indexed_count": raw},
+        {
+            "settings": _settings().to_metadata(),
+            "status": "indexing",
+            "indexed_count": raw,
+            "consecutive_refresh_failures": raw,
+        },
     )
 
     state = load_published_index_state(metadata_path)
 
     assert state is not None
     assert state.indexed_count == expected
+    assert state.consecutive_refresh_failures == (expected or 0)
 
 
 def test_write_json_atomic_uses_unique_temp_and_cleans_failed_replace(

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -50,12 +50,12 @@ from mindroom.knowledge.file_listing import (
     list_git_tracked_knowledge_files,
     list_knowledge_files,
 )
-from mindroom.knowledge.index_metadata import write_index_metadata_payload
 from mindroom.knowledge.indexing_config import IndexingSettings
 from mindroom.knowledge.manager import KnowledgeManager, knowledge_source_signature
 from mindroom.knowledge.redaction import credential_free_repo_url, credential_free_url_identity, redact_url_credentials
 from mindroom.knowledge.refresh_runner import knowledge_binding_mutation_lock, refresh_knowledge_binding
 from mindroom.knowledge.registry import (
+    PublishedIndexState,
     get_published_index,
     load_published_index_state,
     published_index_metadata_path,
@@ -389,12 +389,9 @@ def test_load_published_index_state_preserves_file_mode_from_settings(tmp_path: 
     """Published file-mode metadata derives mode from indexing settings."""
     metadata_path = tmp_path / "indexing_settings.json"
     settings = replace(_test_indexing_settings(), mode="files")
-    write_index_metadata_payload(
+    save_published_index_state(
         metadata_path,
-        settings=settings.to_metadata(),
-        status="complete",
-        indexed_count=0,
-        source_signature="source-signature",
+        PublishedIndexState(settings=settings, status="complete", indexed_count=0, source_signature="source-signature"),
     )
 
     state = load_published_index_state(metadata_path)
@@ -3299,19 +3296,17 @@ async def test_cancelled_publish_metadata_save_keeps_published_candidate_collect
     loop = asyncio.get_running_loop()
     metadata_saved = asyncio.Event()
     release_metadata_save = Event()
-    original_save = KnowledgeManager._save_persisted_index_state
 
-    def _block_after_candidate_metadata_save(
-        self: KnowledgeManager,
-        status: object,
-        **kwargs: object,
-    ) -> None:
-        original_save(self, status, **kwargs)
-        if status == "complete" and "_candidate_" in str(kwargs.get("collection")):
+    def _block_after_candidate_metadata_save(metadata_path: Path, state: PublishedIndexState) -> None:
+        save_published_index_state(metadata_path, state)
+        if state.status == "complete" and "_candidate_" in str(state.collection):
             loop.call_soon_threadsafe(metadata_saved.set)
             assert release_metadata_save.wait(timeout=5)
 
-    monkeypatch.setattr(KnowledgeManager, "_save_persisted_index_state", _block_after_candidate_metadata_save)
+    monkeypatch.setattr(
+        "mindroom.knowledge.manager.save_published_index_state",
+        _block_after_candidate_metadata_save,
+    )
 
     refresh_task = asyncio.create_task(refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths))
     await metadata_saved.wait()
@@ -3353,11 +3348,11 @@ async def test_publish_metadata_save_finishes_before_repeated_cancellation_escap
     save_started = asyncio.Event()
     release_save = Event()
 
-    def _blocked_save(_self: KnowledgeManager, *_args: object, **_kwargs: object) -> None:
+    def _blocked_save(*_args: object, **_kwargs: object) -> None:
         loop.call_soon_threadsafe(save_started.set)
         assert release_save.wait(timeout=5)
 
-    monkeypatch.setattr(KnowledgeManager, "_save_persisted_index_state", _blocked_save)
+    monkeypatch.setattr("mindroom.knowledge.manager.save_published_index_state", _blocked_save)
     save = asyncio.create_task(
         manager._save_candidate_publish_metadata(
             candidate_vector_db=candidate_vector_db,
@@ -3394,13 +3389,13 @@ async def test_cancelled_publish_metadata_save_surfaces_a_failed_write(
     save_started = asyncio.Event()
     release_save = Event()
 
-    def _failed_save(_self: KnowledgeManager, *_args: object, **_kwargs: object) -> None:
+    def _failed_save(*_args: object, **_kwargs: object) -> None:
         loop.call_soon_threadsafe(save_started.set)
         assert release_save.wait(timeout=5)
         msg = "publish metadata write failed"
         raise RuntimeError(msg)
 
-    monkeypatch.setattr(KnowledgeManager, "_save_persisted_index_state", _failed_save)
+    monkeypatch.setattr("mindroom.knowledge.manager.save_published_index_state", _failed_save)
     save = asyncio.create_task(
         manager._save_candidate_publish_metadata(
             candidate_vector_db=candidate_vector_db,
@@ -3415,6 +3410,71 @@ async def test_cancelled_publish_metadata_save_surfaces_a_failed_write(
 
     with pytest.raises(RuntimeError, match="publish metadata write failed"):
         await save
+
+
+@pytest.mark.asyncio
+async def test_publishing_states_every_field_of_the_state_file(tmp_path: Path) -> None:
+    """Publishing writes a whole state instead of dropping the fields it does not own.
+
+    The publish path used to hand a writer only the seven publication fields,
+    so the six the refresh job owns reverted to defaults nobody chose: the
+    timestamps went missing entirely and the failure streak silently reset,
+    and only the caller that marks the refresh succeeded put them back. The
+    writer now takes a whole state, so publication has to say what it means.
+    """
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths)
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    metadata_path = published_index_metadata_path(key)
+    earlier = "2026-01-02T03:04:05+00:00"
+    save_published_index_state(
+        metadata_path,
+        PublishedIndexState(
+            settings=key.indexing_settings,
+            status="complete",
+            collection="docs_previous",
+            last_published_at=earlier,
+            published_revision="cafebabe",
+            indexed_count=1,
+            source_signature="previous-signature",
+            refresh_job="running",
+            reason="refreshing",
+            last_error="boom",
+            updated_at=earlier,
+            last_refresh_at=earlier,
+            consecutive_refresh_failures=3,
+        ),
+    )
+    candidate_vector_db = manager._build_vector_db(manager._candidate_collection_name())
+
+    assert (
+        await manager._save_candidate_publish_metadata(
+            candidate_vector_db=candidate_vector_db,
+            indexed_count=4,
+            source_signature="new-signature",
+        )
+        is False
+    )
+
+    payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+    assert {"refresh_job", "consecutive_refresh_failures", "updated_at", "last_refresh_at"} <= set(payload)
+    state = load_published_index_state(metadata_path)
+    assert state is not None
+    assert (state.collection, state.indexed_count, state.source_signature) == (
+        candidate_vector_db.collection_name,
+        4,
+        "new-signature",
+    )
+    # Publication resolves the refresh job it belongs to, and stamps the write.
+    assert (state.refresh_job, state.reason, state.last_error) == ("idle", None, None)
+    assert state.consecutive_refresh_failures == 0
+    assert state.updated_at is not None
+    assert state.last_refresh_at is not None
+    assert state.updated_at > earlier
+    assert state.last_refresh_at > earlier
 
 
 @pytest.mark.asyncio
@@ -3963,19 +4023,14 @@ async def test_metadata_save_failure_after_candidate_index_keeps_serving_last_go
     runtime_paths = runtime_paths_for(config)
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     doc.write_text("uncommitted candidate index", encoding="utf-8")
-    original_save = KnowledgeManager._save_persisted_index_state
 
-    def _fail_candidate_metadata_save(
-        self: KnowledgeManager,
-        status: object,
-        **kwargs: object,
-    ) -> None:
-        if status == "complete" and "_candidate_" in str(kwargs.get("collection")):
+    def _fail_candidate_metadata_save(metadata_path: Path, state: PublishedIndexState) -> None:
+        if state.status == "complete" and "_candidate_" in str(state.collection):
             msg = "metadata commit failed"
             raise OSError(msg)
-        original_save(self, status, **kwargs)
+        save_published_index_state(metadata_path, state)
 
-    monkeypatch.setattr(KnowledgeManager, "_save_persisted_index_state", _fail_candidate_metadata_save)
+    monkeypatch.setattr("mindroom.knowledge.manager.save_published_index_state", _fail_candidate_metadata_save)
     with pytest.raises(OSError, match="metadata commit failed"):
         await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
@@ -4750,13 +4805,15 @@ def test_refresh_failure_counter_increments_and_resets_preserving_last_good(tmp_
     runtime_paths = runtime_paths_for(config)
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
     metadata_path = published_index_metadata_path(key)
-    write_index_metadata_payload(
+    save_published_index_state(
         metadata_path,
-        settings=key.indexing_settings.to_metadata(),
-        status="complete",
-        collection="docs_live",
-        indexed_count=1,
-        source_signature="sig",
+        PublishedIndexState(
+            settings=key.indexing_settings,
+            status="complete",
+            collection="docs_live",
+            indexed_count=1,
+            source_signature="sig",
+        ),
     )
 
     knowledge_registry.mark_published_index_refresh_failed_preserving_last_good(key, error="boom 1")

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -1811,7 +1811,7 @@ async def test_unreadable_published_metadata_never_reuses_live_collection_checkp
 
 
 @pytest.mark.asyncio
-async def test_a_failed_refresh_record_still_protects_the_collection_it_names(
+async def test_an_unfinished_refresh_record_still_protects_the_collection_it_names(
     tmp_path: Path,
 ) -> None:
     """An unfinished record names the live collection, and cleanup keeps running.
@@ -1833,16 +1833,17 @@ async def test_a_failed_refresh_record_still_protects_the_collection_it_names(
     abandoned_collection = f"{manager._default_collection_name()}_candidate_abandoned"
     _FakeVectorDb.store[abandoned_collection] = []
 
-    # A publication followed by a refresh that failed before publishing again.
+    # A publication followed by a refresh that is running and has not published
+    # again yet: the shape older versions wrote for every in-progress refresh.
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
     save_published_index_state(
         published_index_metadata_path(key),
         PublishedIndexState(
             settings=state.settings,
-            status="failed",
+            status="indexing",
             collection=published_collection,
-            refresh_job="failed",
-            last_error="boom",
+            refresh_job="running",
+            reason="refreshing",
         ),
     )
     assert load_published_index_state(published_index_metadata_path(key)) is not None
@@ -2366,7 +2367,7 @@ async def test_vectors_prefetched_before_a_later_fallback_are_still_reused(
 
 
 @pytest.mark.asyncio
-async def test_checkpoint_naming_a_published_collection_is_rejected_after_a_failed_refresh(
+async def test_checkpoint_naming_a_published_collection_is_rejected_during_a_running_refresh(
     tmp_path: Path,
 ) -> None:
     """The published collection must never be reopened as a candidate.
@@ -2391,10 +2392,10 @@ async def test_checkpoint_naming_a_published_collection_is_rejected_after_a_fail
         published_index_metadata_path(key),
         PublishedIndexState(
             settings=state.settings,
-            status="failed",
+            status="indexing",
             collection=published_collection,
-            refresh_job="failed",
-            last_error="boom",
+            refresh_job="running",
+            reason="refreshing",
         ),
     )
     manager = _manager(config)
@@ -2430,10 +2431,10 @@ async def test_incompatible_checkpoint_never_deletes_a_published_collection(
         published_index_metadata_path(key),
         PublishedIndexState(
             settings=state.settings,
-            status="failed",
+            status="indexing",
             collection=published_collection,
-            refresh_job="failed",
-            last_error="boom",
+            refresh_job="running",
+            reason="refreshing",
         ),
     )
     # A checkpoint naming the published collection, recorded under settings the

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import asyncio
 import itertools
+import json
 import os
 from dataclasses import dataclass, field, replace
 from pathlib import Path
@@ -49,6 +50,7 @@ from mindroom.knowledge.candidate_checkpoint import (
     save_candidate_checkpoint,
 )
 from mindroom.knowledge.embedding_batch import BatchPrefetchEmbedder, plan_embedding_batches
+from mindroom.knowledge.index_metadata import write_json_atomic
 from mindroom.knowledge.index_retry import EmbeddingRetryPolicy, run_with_embedding_retry
 from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.refresh_runner import refresh_knowledge_binding
@@ -1465,17 +1467,23 @@ async def test_legacy_published_metadata_without_candidate_fields_stays_queryabl
     published_collection = state.collection
 
     # Strip every field this change introduced, leaving pre-candidate metadata.
+    # Written as raw JSON on purpose: the current writer always emits the newer
+    # keys, so only a hand-built payload can be the shape an old version left.
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
-    save_published_index_state(
-        published_index_metadata_path(key),
-        PublishedIndexState(
-            settings=state.settings,
-            status="complete",
-            collection=published_collection,
-            indexed_count=state.indexed_count,
-            source_signature=state.source_signature,
-            last_published_at=state.last_published_at,
-        ),
+    metadata_path = published_index_metadata_path(key)
+    write_json_atomic(
+        metadata_path,
+        {
+            "settings": state.settings.to_metadata(),
+            "status": "complete",
+            "collection": published_collection,
+            "indexed_count": state.indexed_count,
+            "source_signature": state.source_signature,
+            "last_published_at": state.last_published_at,
+        },
+    )
+    assert not {"refresh_job", "reason", "last_error", "updated_at", "last_refresh_at"} & set(
+        json.loads(metadata_path.read_text(encoding="utf-8")),
     )
     delete_candidate_checkpoint(_storage_path(config, runtime_paths))
 
@@ -1803,10 +1811,16 @@ async def test_unreadable_published_metadata_never_reuses_live_collection_checkp
 
 
 @pytest.mark.asyncio
-async def test_incomplete_published_metadata_still_preserves_its_collection(
+async def test_a_failed_refresh_record_still_protects_the_collection_it_names(
     tmp_path: Path,
 ) -> None:
-    """A parseable-but-incomplete metadata file still names the live collection."""
+    """An unfinished record names the live collection, and cleanup keeps running.
+
+    Skipping cleanup whenever a record is not a finished publication would be
+    safe but would strand every abandoned candidate. The record still names the
+    collection the last publication left live, so cleanup can tell the live
+    index from the candidates it is there to reclaim.
+    """
     docs_path = tmp_path / "docs"
     _write_corpus(docs_path, 2)
     config = _config(tmp_path, docs_path)
@@ -1815,17 +1829,28 @@ async def test_incomplete_published_metadata_still_preserves_its_collection(
     state = _published_state(config, runtime_paths)
     assert state is not None
     published_collection = state.collection
+    manager = _manager(config)
+    abandoned_collection = f"{manager._default_collection_name()}_candidate_abandoned"
+    _FakeVectorDb.store[abandoned_collection] = []
 
-    # Drop the fields the strict parser demands, keeping the collection name.
+    # A publication followed by a refresh that failed before publishing again.
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
     save_published_index_state(
         published_index_metadata_path(key),
-        PublishedIndexState(settings=state.settings, status="complete", collection=published_collection),
+        PublishedIndexState(
+            settings=state.settings,
+            status="failed",
+            collection=published_collection,
+            refresh_job="failed",
+            last_error="boom",
+        ),
     )
+    assert load_published_index_state(published_index_metadata_path(key)) is not None
 
-    await _manager(config)._open_candidate_run()
+    await manager._open_candidate_run()
 
     assert published_collection in _FakeVectorDb.store
+    assert abandoned_collection not in _FakeVectorDb.store, "cleanup was skipped instead of sparing the live index"
 
 
 @pytest.mark.asyncio
@@ -2341,16 +2366,15 @@ async def test_vectors_prefetched_before_a_later_fallback_are_still_reused(
 
 
 @pytest.mark.asyncio
-async def test_checkpoint_naming_a_published_collection_is_rejected_even_if_metadata_is_incomplete(
+async def test_checkpoint_naming_a_published_collection_is_rejected_after_a_failed_refresh(
     tmp_path: Path,
 ) -> None:
     """The published collection must never be reopened as a candidate.
 
-    The guard compared only the strictly parsed collection name. Metadata that
-    is parseable but missing a required field makes that name null while the
-    raw payload still names the live collection, so a surviving checkpoint
-    could reopen the published collection and write candidate reconciliation
-    into it.
+    The guard used to compare only a name the strict parser dropped whenever
+    the record was not a finished publication, while the live collection kept
+    serving under it. A surviving checkpoint could then reopen the published
+    collection and write candidate reconciliation into it.
     """
     docs_path = tmp_path / "docs"
     _write_corpus(docs_path, 2)
@@ -2365,7 +2389,13 @@ async def test_checkpoint_naming_a_published_collection_is_rejected_even_if_meta
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
     save_published_index_state(
         published_index_metadata_path(key),
-        PublishedIndexState(settings=state.settings, status="complete", collection=published_collection),
+        PublishedIndexState(
+            settings=state.settings,
+            status="failed",
+            collection=published_collection,
+            refresh_job="failed",
+            last_error="boom",
+        ),
     )
     manager = _manager(config)
     save_candidate_checkpoint(
@@ -2398,7 +2428,13 @@ async def test_incompatible_checkpoint_never_deletes_a_published_collection(
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
     save_published_index_state(
         published_index_metadata_path(key),
-        PublishedIndexState(settings=state.settings, status="complete", collection=published_collection),
+        PublishedIndexState(
+            settings=state.settings,
+            status="failed",
+            collection=published_collection,
+            refresh_job="failed",
+            last_error="boom",
+        ),
     )
     # A checkpoint naming the published collection, recorded under settings the
     # current runtime no longer matches.

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -49,7 +49,6 @@ from mindroom.knowledge.candidate_checkpoint import (
     save_candidate_checkpoint,
 )
 from mindroom.knowledge.embedding_batch import BatchPrefetchEmbedder, plan_embedding_batches
-from mindroom.knowledge.index_metadata import write_index_metadata_payload
 from mindroom.knowledge.index_retry import EmbeddingRetryPolicy, run_with_embedding_retry
 from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.refresh_runner import refresh_knowledge_binding
@@ -60,6 +59,7 @@ from mindroom.knowledge.registry import (
     published_index_metadata_path,
     published_index_storage_path,
     resolve_published_index_key,
+    save_published_index_state,
 )
 from mindroom.knowledge.status import get_knowledge_index_status
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
@@ -1037,6 +1037,7 @@ async def test_concurrent_refreshes_share_one_candidate_and_do_not_rebuild_twice
 @pytest.mark.asyncio
 async def test_cancellation_around_publication_never_produces_a_false_complete(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     cancel_before_metadata_save: bool,
 ) -> None:
     """Cancelling at either side of the metadata write leaves consistent state."""
@@ -1045,23 +1046,19 @@ async def test_cancellation_around_publication_never_produces_a_false_complete(
     config = _config(tmp_path, docs_path)
     runtime_paths = runtime_paths_for(config)
     manager = _manager(config)
-    original_save = KnowledgeManager._save_persisted_index_state
 
-    def _cancelling_save(self: KnowledgeManager, *args: object, **kwargs: object) -> None:
+    def _cancelling_save(metadata_path: Path, state: PublishedIndexState) -> None:
         if cancel_before_metadata_save:
             msg = "metadata save failed"
             raise OSError(msg)
-        original_save(self, *args, **kwargs)
+        save_published_index_state(metadata_path, state)
 
-    KnowledgeManager._save_persisted_index_state = _cancelling_save  # type: ignore[method-assign]
-    try:
-        if cancel_before_metadata_save:
-            with pytest.raises(OSError, match="metadata save failed"):
-                await manager.reindex_all()
-        else:
+    monkeypatch.setattr("mindroom.knowledge.manager.save_published_index_state", _cancelling_save)
+    if cancel_before_metadata_save:
+        with pytest.raises(OSError, match="metadata save failed"):
             await manager.reindex_all()
-    finally:
-        KnowledgeManager._save_persisted_index_state = original_save  # type: ignore[method-assign]
+    else:
+        await manager.reindex_all()
 
     state = _published_state(config, runtime_paths)
     if cancel_before_metadata_save:
@@ -1469,14 +1466,16 @@ async def test_legacy_published_metadata_without_candidate_fields_stays_queryabl
 
     # Strip every field this change introduced, leaving pre-candidate metadata.
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
-    write_index_metadata_payload(
+    save_published_index_state(
         published_index_metadata_path(key),
-        settings=state.settings.to_metadata(),
-        status="complete",
-        collection=published_collection,
-        indexed_count=state.indexed_count,
-        source_signature=state.source_signature,
-        last_published_at=state.last_published_at,
+        PublishedIndexState(
+            settings=state.settings,
+            status="complete",
+            collection=published_collection,
+            indexed_count=state.indexed_count,
+            source_signature=state.source_signature,
+            last_published_at=state.last_published_at,
+        ),
     )
     delete_candidate_checkpoint(_storage_path(config, runtime_paths))
 
@@ -1819,11 +1818,9 @@ async def test_incomplete_published_metadata_still_preserves_its_collection(
 
     # Drop the fields the strict parser demands, keeping the collection name.
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
-    write_index_metadata_payload(
+    save_published_index_state(
         published_index_metadata_path(key),
-        settings=state.settings.to_metadata(),
-        status="complete",
-        collection=published_collection,
+        PublishedIndexState(settings=state.settings, status="complete", collection=published_collection),
     )
 
     await _manager(config)._open_candidate_run()
@@ -2366,11 +2363,9 @@ async def test_checkpoint_naming_a_published_collection_is_rejected_even_if_meta
     assert published_collection is not None
 
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
-    write_index_metadata_payload(
+    save_published_index_state(
         published_index_metadata_path(key),
-        settings=state.settings.to_metadata(),
-        status="complete",
-        collection=published_collection,
+        PublishedIndexState(settings=state.settings, status="complete", collection=published_collection),
     )
     manager = _manager(config)
     save_candidate_checkpoint(
@@ -2401,11 +2396,9 @@ async def test_incompatible_checkpoint_never_deletes_a_published_collection(
     assert published_collection is not None
 
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
-    write_index_metadata_payload(
+    save_published_index_state(
         published_index_metadata_path(key),
-        settings=state.settings.to_metadata(),
-        status="complete",
-        collection=published_collection,
+        PublishedIndexState(settings=state.settings, status="complete", collection=published_collection),
     )
     # A checkpoint naming the published collection, recorded under settings the
     # current runtime no longer matches.
@@ -3175,13 +3168,15 @@ async def test_published_vector_reuse_needs_a_completely_published_index(
     await _manager(config).reindex_all()
     state = _published_state(config, runtime_paths)
     assert state is not None
-    write_index_metadata_payload(
+    save_published_index_state(
         published_index_metadata_path(resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)),
-        settings=state.settings.to_metadata(),
-        status="indexing",
-        collection=state.collection,
-        indexed_count=state.indexed_count,
-        source_signature=state.source_signature,
+        PublishedIndexState(
+            settings=state.settings,
+            status="indexing",
+            collection=state.collection,
+            indexed_count=state.indexed_count,
+            source_signature=state.source_signature,
+        ),
     )
     embedder.embedded_texts.clear()
 


### PR DESCRIPTION
## The defect: one file, two schemas, three parsers

Every knowledge base keeps exactly one state file at
`<storage_root>/knowledge_db/<storage_key>/indexing_settings.json`. Both of these resolved to it, by construction from the same `storage_root`, `base_id` and resolved `knowledge_path`:

| | `manager._PersistedIndexState` | `registry.PublishedIndexState` |
| --- | --- | --- |
| Fields | 7 | the same 7 plus `refresh_job`, `reason`, `last_error`, `updated_at`, `last_refresh_at`, `consecutive_refresh_failures` |
| Statuses | `resetting`, `indexing`, `complete` | those plus `failed` |
| Parse | `parse_index_metadata_fields(..., require_complete_fields_for_all_statuses=True)` — rejects any record missing `indexed_count`, `source_signature` or a collection, whatever its status | the same helper, lenient — only a `complete` record must prove itself |
| Path | built inline in `__post_init__` | `published_index_metadata_path` |

A third reader, `manager._published_collection_for_cleanup`, bypassed both parsers and read the raw JSON payload. Its docstring said why: the strict parser "rejects metadata that is merely incomplete, which would silently drop that proof" — and the proof it dropped decides whether a live published collection is deleted as a stale candidate.

### The field-dropping sequence

1. `_save_candidate_publish_metadata` called `write_index_metadata_payload(...)` with seven keyword arguments.
2. That writer wrote exactly the keys it was given, so the six refresh-job fields were **not written**.
3. Reloading the file produced dataclass defaults for all six: both timestamps became `None` and `consecutive_refresh_failures` reset to `0`.
4. `registry._state_with_refresh_fields` then load-modify-wrote them back on the next registry call — two uncoordinated writers to one file, and the drop was invisible only because the refresh runner happened to overwrite the same six fields immediately afterwards.

## What changed

`PublishedIndexState` now lives in `knowledge/index_metadata.py` with one loader and one writer. That module was already the leaf both `manager` and `registry` are allowed to import, and it already owned this file's JSON encoding and `write_json_atomic` (shared with `candidate_checkpoint`); a separate `index_state.py` would have been a third file for one document's schema, either duplicating those primitives or importing them straight back. `registry` imports and uses all three names for its own work, and `refresh_runner`, `status` and `refresh_scheduler` keep reaching them *through* `registry` — a pass-through for those three, kept deliberately so this PR does not churn files other in-flight work is editing.

Deleted: `_PersistedIndexState`, `_load_persisted_index_state`, `_save_persisted_index_state`, the `_INDEXING_STATUS_*` constants, `parse_index_metadata_fields` and its `require_complete_fields_for_all_statuses` flag, `write_index_metadata_payload`, `load_index_metadata_payload`, and `registry._coerce_refresh_job`.

**The writer takes a whole state.** The guarantee this buys is narrower than "no field can be dropped", and worth stating precisely: *the writer cannot drop a field the caller set*. The **type does not enforce completeness** — dataclass defaults mean `PublishedIndexState(settings=..., status=...)` compiles and the writer will happily persist it. Publication is safe because `state_for_publication` states every field and the loader refuses a `complete` record that proves nothing, not because anything at the type level prevents a partial write. Eleven of the thirteen fields keep defaults — they must, so legacy records parse. What is gone is the old failure mode where a writer silently discarded fields the caller never mentioned because they were not in its signature.

Both publish paths now go through one `state_for_publication` factory in `index_metadata.py`, which states all thirteen: the seven publication fields, plus the refresh-job fields resolved to what a publication means — `refresh_job="idle"`, `reason=None`, `last_error=None`, failure streak `0`, both timestamps stamped. That factory also fixes a live instance of the remaining gap: the file-mode publish in `refresh_runner.py` built the same state inline and omitted `consecutive_refresh_failures`, taking the dataclass default — correct today only by coincidence.

### Why publication resolves the refresh fields instead of preserving them

**This is what keeps behaviour identical.** On `main` the publish write emits none of those four keys, so reloading the file yields exactly `refresh_job="idle"`, `reason=None`, `last_error=None`, `consecutive_refresh_failures=0`. Stating those same values explicitly reproduces `main`'s effective state bit for bit. *Preserving* them would have been the behaviour change, not the fix.

And it would have been a bad one. A publish runs while `refresh_job="running"`/`reason="refreshing"` is on disk (`_save_refreshing_state` writes it before the manager starts). Preserving that makes the just-published `complete` record read as `refreshing` → availability `STALE` → the `READY` guard in `_reconcile_cancelled_refresh` (`refresh_runner.py:967`) fails → a fully-published index gets marked stale. `test_cancelled_publish_metadata_save_keeps_published_candidate_collection` asserts the opposite today. Making preservation safe needs reconciliation to tell "a new publication landed" from "the refresh moved" by comparing against `initial_state` — exactly PR 2's `RefreshOutcome` territory.

The only real delta versus `main` is that `updated_at` and `last_refresh_at` are now stamped by the publish write instead of being blanked and refilled a moment later; no reader consults either. `test_publishing_states_every_field_of_the_state_file` pins this and **fails on `main`**, where all four keys are absent from the file after a publish.

### `_published_collection_for_cleanup` loses its escape hatch

Replaced by `_published_state_and_cleanup_safety`, which returns `(state, cleanup_is_safe)` from **one** read:

```python
state = load_published_index_state(self._indexing_settings_path)
return state, state is not None or not self._indexing_settings_path.exists()
```

Safety semantics are unchanged where it matters:

- **File absent** → nothing published, cleanup runs, nothing to protect.
- **File present, no state** (torn JSON, unusable settings, unknown status, or a `complete` record that proves nothing) → `cleanup_is_safe=False`. Cleanup is skipped and the surviving checkpoint is discarded rather than resumed. Never guessed at, never deleted.
- **File present with a state** → whatever collection it names is protected, whatever its status. A collection name is only ever recorded by a publication, so an `indexing` or `failed` record still names the live index — that is the case the raw-payload read existed for, and it is now covered by the one parser.

`_open_candidate_run` consequently reads the file once instead of twice, and its two collection names (`published_collection` from the strict parse, `live_collection` from the raw payload) collapse into one.

## On-disk compatibility: no migration, and none needed

**Decision: the unified parser accepts every payload the previous version wrote, so no existing corpus is re-embedded.** No schema version, no migration step, no shim.

- Fields absent from older files (`refresh_job`, `consecutive_refresh_failures`, the timestamps) already parsed as `idle`/`0`/`None`, and still do — `test_legacy_metadata_without_failure_counter_parses_as_zero` covers this.
- The one validity rule that survives is the registry's: a record that calls itself `complete` must carry `indexed_count`, `source_signature`, and a collection unless it is file-mode. Every writer of a `complete` record has always filled those, so this rejects only corrupt or hand-edited files — and the base is refreshed rather than served from a publication it cannot substantiate (`test_index_metadata_without_source_signature_is_unavailable_and_schedules_refresh`).
- The manager's side becomes strictly *more* accepting: records it used to reject (status `failed`, or a non-`complete` record missing bookkeeping) now parse, which removes spurious forced full reindexes rather than causing any.

The parser is therefore not *fully* non-lossy: an unprovable `complete` record is still no state at all. Making it total would have changed what the registry serves — a behaviour change in availability semantics, not a unification — so it stayed out.

## Deferred follow-up

Moving persistence out of `KnowledgeManager` entirely, so it returns an outcome and `refresh_runner` performs the single write, is deliberately **not** in this PR. It depended on `RefreshOutcome`, which **has now landed on `main` in #1714 and is merged into this branch** — so the follow-up is unblocked, just not done here.

That follow-up is where the two remaining gaps close together: giving the write a single owner is what lets reconciliation know whether a publication landed during the refresh it is reconciling (so publication can preserve the refresh-job fields instead of resolving them), and it is also what makes a lock over the read-modify-write in `_state_with_refresh_fields` meaningful.

## Verification

- `uv run pytest tests/test_knowledge_manager.py tests/test_knowledge_resumable_refresh.py tests/test_knowledge_index_metadata.py tests/test_knowledge_indexing_config.py tests/test_bot_knowledge.py -nauto --no-cov` → **385 passed**
- `uv run pytest tests/api/test_knowledge_api.py -nauto --no-cov` → **62 passed**
- `uv run pre-commit run --all-files` → all hooks pass
- `uv run tach check --dependencies --interfaces` → pass (`index_metadata` now declares its `indexing_config` dependency)

## Review follow-ups (c9a780a)

- **Malformed enum values crashed the loader.** `[] in frozenset({...})` raises `TypeError: unhashable type: 'list'`, so a payload with a JSON array or object in `status` or `refresh_job` escaped a loader every caller treats as total, taking manager initialization and every registry read with it. For `status` this was a regression in this PR (the parser it replaced guarded with `isinstance`); for `refresh_job` it was pre-existing in `registry._coerce_refresh_job`. Both now check for a string first, with array and object cases in the parametrized loader tests.
- **Two candidate-cleanup tests had stopped exercising their target.** Their fixture wrote a `complete` record with no proof of what it published, which the unified loader refuses, so the assertions passed through the "metadata unreadable, skip cleanup" branch rather than through collection-name protection. They now write a `failed` refresh record that still names the live collection, and the cleanup test additionally asserts an abandoned candidate is still reclaimed — an assertion that fails if cleanup is skipped, which is what made the old version vacuous.
- **The pre-candidate compatibility fixture went back to raw JSON.** With one canonical writer that always emits `refresh_job` and `consecutive_refresh_failures`, only a hand-built payload can be the shape an older version left behind; the test now asserts the newer keys really are absent before exercising the loader.


## What this PR does *not* fix

**The lost-update window is untouched.** The opening line of this description is "two uncoordinated writers, one file, no transaction" — what shipped fixes the field-dropping half only. `registry._state_with_refresh_fields` is still load-then-save with no lock, reachable from the file watcher (`watch.py:255`) and the API (`api/knowledge.py:228`), unsynchronised against the manager's publish. A watcher read landing before a publish whose write lands after would `replace()` the fresh publication's `collection`/`indexed_count`/`source_signature` back to the previous values. This is identical on `main` — neither caused nor worsened here — but the file is not transactional now, and the next reader should not assume it is. Closing it belongs with the same follow-up as the persistence move, since that is what gives the write a single owner.

## Round-2 follow-ups (loader totality, duplicated publication state)

- **The loader was still not total, and this PR declared it so.** Two holes, both byte-identical to `main` and therefore pre-existing, but called out because the module docstring and this description assert totality and two of the four holes were already closed here. `"²".isdigit()` is `True` while `int("²")` raises `ValueError`, reaching `indexed_count` and `consecutive_refresh_failures` — now `isdecimal()`, which still accepts `"١٢"` because `int` takes it. And `except (OSError, json.JSONDecodeError)` missed `UnicodeDecodeError`, a `ValueError`, so invalid UTF-8 bytes raised out — now `except (OSError, ValueError)`. Both matter because `manager.py` and every registry read treat the loader as total, so an exception takes manager construction down instead of degrading to "no state, refresh the base". Parametrized regression coverage added for both; verified failing against the old bodies.
- **Each enumeration was declared twice** — a `Literal` plus a hand-written `frozenset`. Now `frozenset(get_args(...))`, matching the existing idiom at `custom_tools/matrix_voice_message.py:33`. Adding a status can no longer half-land.
- **`published_collections` was vestigial.** The set existed because there were two names to hold (strict parse plus raw payload); collapsing to one is the headline of this PR, so the container went too.
- **Three rewritten fixtures used an unreachable shape.** `status="failed"` with a non-null `collection` cannot be produced: only the two publish paths set `collection` and both write `"complete"`, and every registry marker either `replace()`s the loaded state or writes `collection=None`. `status="indexing"` with a collection **is** a real historical shape (`b41727cdb` wrote exactly that) and is the legacy record the collection-protection rule exists to serve. Since these were rewritten on fidelity grounds, they now use the faithful shape.


## Round-3 follow-up (the loader fix was necessary but not sufficient)

`isdecimal()` closed the superscript case but not the class. **An arbitrarily long, perfectly well-formed decimal string passes `isdecimal()` and then makes `int()` raise CPython's integer-conversion-limit `ValueError`** (4300 digits by default), reachable on both `indexed_count` and `consecutive_refresh_failures`. Reproduced: `("1" * 5000).isdecimal()` is `True`, `int(...)` raises.

The general lesson, now written into the helper's docstring: **for this class, catching the failure beats predicating on it.** `isdecimal()` is a claim about characters; `int()` has failure modes that are not about characters at all, so no predicate can stand in for the conversion. The conversion is now wrapped in `try/except ValueError`. `isdecimal()` stays, but only to decide *which shapes count as a number* (keeping `"+1"` and `"1_000"` out) — never to decide whether converting is safe.

Audited every other coercion in the loader for the same predicate-then-convert shape:

| Site | Converts? | Verdict |
| --- | --- | --- |
| `_nonnegative_int` float arm | `int(float)` | Safe — `is_integer()` is false for both infinities and NaN, the only floats `int` refuses, and no finite float exceeds its reach |
| `_load_payload` | `json.loads` | Already `except (OSError, ValueError)`, which also covers a huge integer *literal* in the JSON itself |
| `_optional_str`, `_refresh_job`, status check, `_parse_settings` | none | `isinstance`/membership only; nothing to raise |

