### PR TITLE
Improve deferred tool capability discovery

### DIFF
--- a/docs/tools/dynamic-tools.md
+++ b/docs/tools/dynamic-tools.md
@@ -36,6 +36,7 @@ Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `ve
 On this path every deferred tool ships in every request tagged `defer_loading: true` together with the provider's tool-search entry, so deferred schemas stay out of the model's rendered context until the model searches for them.
 Tool discovery never invalidates the prompt cache: Anthropic expands discovered tool references inline in the message stream, and OpenAI loads discovered tools at the end of the context window.
 The `dynamic_tools` manager, its prompt blocks, and session loaded-tool state are not used on this path; all deferred toolkits are attached at agent build, so discovered calls execute directly.
+MindRoom adds a compact system-prompt hint listing the deferred toolkit names and tells the model to search those capability domains before concluding that a tool is unavailable.
 `defer: true, initial: true` tools stay in the rendered schema list as plain non-deferred tools.
 Instructions attached to a toolkit or its functions remain inline when any function in that toolkit is initially active.
 MindRoom omits those instructions only when every function is deferred and non-initial because native tool search cannot extend the already-sent system prompt when it discovers a tool.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3294,6 +3294,7 @@ Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `ve
 On this path every deferred tool ships in every request tagged `defer_loading: true` together with the provider's tool-search entry, so deferred schemas stay out of the model's rendered context until the model searches for them.
 Tool discovery never invalidates the prompt cache: Anthropic expands discovered tool references inline in the message stream, and OpenAI loads discovered tools at the end of the context window.
 The `dynamic_tools` manager, its prompt blocks, and session loaded-tool state are not used on this path; all deferred toolkits are attached at agent build, so discovered calls execute directly.
+MindRoom adds a compact system-prompt hint listing the deferred toolkit names and tells the model to search those capability domains before concluding that a tool is unavailable.
 `defer: true, initial: true` tools stay in the rendered schema list as plain non-deferred tools.
 Instructions attached to a toolkit or its functions remain inline when any function in that toolkit is initially active.
 MindRoom omits those instructions only when every function is deferred and non-initial because native tool search cannot extend the already-sent system prompt when it discovers a tool.

--- a/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__dynamic-tools__index.md
@@ -36,6 +36,7 @@ Claude models since Opus 4.5 / Sonnet 4.5 / Haiku 4.5 on the `anthropic` and `ve
 On this path every deferred tool ships in every request tagged `defer_loading: true` together with the provider's tool-search entry, so deferred schemas stay out of the model's rendered context until the model searches for them.
 Tool discovery never invalidates the prompt cache: Anthropic expands discovered tool references inline in the message stream, and OpenAI loads discovered tools at the end of the context window.
 The `dynamic_tools` manager, its prompt blocks, and session loaded-tool state are not used on this path; all deferred toolkits are attached at agent build, so discovered calls execute directly.
+MindRoom adds a compact system-prompt hint listing the deferred toolkit names and tells the model to search those capability domains before concluding that a tool is unavailable.
 `defer: true, initial: true` tools stay in the rendered schema list as plain non-deferred tools.
 Instructions attached to a toolkit or its functions remain inline when any function in that toolkit is initially active.
 MindRoom omits those instructions only when every function is deferred and non-initial because native tool search cannot extend the already-sent system prompt when it discovers a tool.

--- a/src/mindroom/agents.py
+++ b/src/mindroom/agents.py
@@ -133,6 +133,8 @@ class _AgentToolAssembly:
     loaded_tools: tuple[str, ...]
     hidden_toolkits: frozenset[str]
     selected_dynamic_tools: tuple[str, ...]
+    # Authored toolkit names whose schemas use native deferred loading.
+    deferred_tool_names: tuple[str, ...]
     # Wire-level function names to send with defer_loading on the native
     # server-side tool-search path (Anthropic and OpenAI Responses); empty on
     # the homegrown dynamic-tools path.
@@ -912,6 +914,21 @@ def _build_dynamic_tooling_instruction_block(
     )
 
 
+def _build_native_tool_search_instruction_blocks(
+    config: Config,
+    deferred_tool_names: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Return compact discovery guidance for provider-native deferred tools."""
+    if not deferred_tool_names:
+        return ()
+    return (
+        config.render_prompt(
+            "NATIVE_TOOL_SEARCH_INSTRUCTION_TEMPLATE",
+            tool_domains=", ".join(deferred_tool_names),
+        ),
+    )
+
+
 def _build_dynamic_tooling_state_suffix(
     config: Config,
     agent_name: str,
@@ -1354,6 +1371,7 @@ def _assemble_agent_toolkits(
         )
     entity_view = config.resolve_entity(agent_name)
     tools: list[Toolkit] = []
+    deferred_tool_names: list[str] = []
     deferred_wire_tool_names: set[str] = set()
     for tool_name, tool_entry in resolved_tool_configs.items():
         try:
@@ -1389,6 +1407,7 @@ def _assemble_agent_toolkits(
                 # the rendered prompt prefix as plain non-deferred tools.
                 if native_deferred_tools and tool_entry.defer and not tool_entry.initial:
                     suppress_fully_deferred_toolkit_instructions(toolkit)
+                    deferred_tool_names.append(tool_entry.authored_name or tool_name)
                     deferred_wire_tool_names.update(toolkit.get_functions())
                     deferred_wire_tool_names.update(toolkit.get_async_functions())
         except (ValueError, ImportError) as exc:
@@ -1403,6 +1422,7 @@ def _assemble_agent_toolkits(
         loaded_tools=loaded_tools,
         hidden_toolkits=hidden_toolkits,
         selected_dynamic_tools=dynamic_tool_selection.loaded_tools,
+        deferred_tool_names=tuple(dict.fromkeys(deferred_tool_names)),
         deferred_wire_tool_names=frozenset(deferred_wire_tool_names),
     )
 
@@ -1499,6 +1519,7 @@ def _build_agent_instructions(
     disable_runtime_capabilities: bool,
     hidden_toolkits: frozenset[str],
     loaded_tools: tuple[str, ...],
+    native_deferred_tool_names: tuple[str, ...],
     all_deferred_tools_eager: bool,
 ) -> list[str]:
     """Accumulate the configured and runtime instruction blocks for one agent instance."""
@@ -1506,6 +1527,13 @@ def _build_agent_instructions(
 
     if skills and skills.get_skill_names():
         instructions.append(config.get_prompt("SKILLS_TOOL_USAGE_PROMPT"))
+
+    instructions.extend(
+        _build_native_tool_search_instruction_blocks(
+            config,
+            native_deferred_tool_names,
+        ),
+    )
 
     # Native server-side tool search replaces the load_tool catalog and
     # loaded-state prompt blocks, so the native path emits neither.
@@ -1799,6 +1827,7 @@ def create_agent(
         disable_runtime_capabilities=disable_runtime_capabilities,
         hidden_toolkits=tool_assembly.hidden_toolkits,
         loaded_tools=tool_assembly.loaded_tools,
+        native_deferred_tool_names=tool_assembly.deferred_tool_names,
         all_deferred_tools_eager=native_deferred_tools or eager_deferred_tools,
     )
 

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -31,6 +31,7 @@ __all__ = [
     "MEMORY_EXISTING_SNIPPETS_TEMPLATE",
     "MEMORY_NO_EXISTING_SNIPPETS",
     "MIXED_PARTIAL_REPLY_HEADER",
+    "NATIVE_TOOL_SEARCH_INSTRUCTION_TEMPLATE",
     "OPENAI_COMPAT_AGENT_IDENTITY_CONTEXT_TEMPLATE",
     "OPENAI_COMPAT_HISTORY_GUIDANCE",
     "OUTPUT_REDIRECT_PROMPT",
@@ -174,6 +175,10 @@ Use load_tool(tool_name) to load one by exact name.
 Use tool_search(query) for keyword lookup across deferred tools.
 A loaded tool becomes callable once it appears in your available tools; do not call it in the same parallel tool-call batch as load_tool.
 In team conversations, each member manages its own dynamic tool state."""
+
+NATIVE_TOOL_SEARCH_INSTRUCTION_TEMPLATE = """## Deferred Tool Discovery
+Deferred capability domains available through native tool search: {tool_domains}.
+When a request may need one of these domains, search the deferred tool catalog before concluding that the capability is unavailable."""
 
 PREVIOUS_CONVERSATION_THREAD_HEADER = "Previous conversation in this thread:"
 CURRENT_MESSAGE_PROMPT_INTRO = "Current message:\n"
@@ -501,6 +506,7 @@ PROMPT_TEMPLATE_FIELDS = MappingProxyType(
         "DATETIME_CONTEXT_TEMPLATE": frozenset({"date_str", "timezone_str", "timezone_abbrev"}),
         "DELEGATE_TOOLKIT_INSTRUCTIONS_TEMPLATE": frozenset({"agent_descriptions"}),
         "DYNAMIC_TOOLING_INSTRUCTION_TEMPLATE": frozenset({"tool_catalog"}),
+        "NATIVE_TOOL_SEARCH_INSTRUCTION_TEMPLATE": frozenset({"tool_domains"}),
         "MEMORY_AUTO_FLUSH_EXTRACT_PROMPT_TEMPLATE": frozenset(
             {"no_reply_token", "existing_block", "excerpt"},
         ),

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -1041,6 +1041,37 @@ def test_native_tool_search_attaches_deferred_toolkits_and_skips_homegrown_machi
     assert ("code", "thread-a") not in dynamic_toolkits_module._loaded_tools
 
 
+@pytest.mark.parametrize(
+    ("provider", "model_id"),
+    [
+        ("anthropic", "claude-opus-4-8"),
+        ("openai", "gpt-5.6"),
+    ],
+)
+def test_native_tool_search_prompt_lists_deferred_capability_domains(
+    tmp_path: Path,
+    provider: str,
+    model_id: str,
+) -> None:
+    """Native tool search should tell the model which capability domains it can discover."""
+    raw = _base_config_data()
+    raw["models"]["native"] = {"provider": provider, "id": model_id}  # type: ignore[index]
+    raw["agents"]["code"]["model"] = "native"  # type: ignore[index]
+    raw["agents"]["code"]["tools"] = [  # type: ignore[index]
+        {"sleep": {"defer": True}},
+        {"calculator": {"defer": True, "initial": True}},
+    ]
+    config = _validated_config(tmp_path, raw)
+
+    agent = create_agent("code", config, _runtime_paths(tmp_path), execution_identity=None, session_id="thread-a")
+
+    discovery_block = next(block for block in agent.instructions if block.startswith("## Deferred Tool Discovery"))
+    assert discovery_block in _render_system_prompt(agent)
+    assert "Deferred capability domains available through native tool search: sleep." in discovery_block
+    assert "search the deferred tool catalog before concluding that the capability is unavailable" in discovery_block
+    assert "calculator" not in discovery_block
+
+
 def test_native_tool_search_omits_fully_deferred_toolkit_instructions(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- add a compact system-prompt list of native-deferred toolkit domains
- tell agents to search deferred tools before declaring a capability unavailable
- exclude initial tools whose schemas are already visible and preserve native schema deferral
- document the native discovery behavior

## Testing

- `uv run pytest` (12,069 passed, 54 skipped)
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Improve native deferred tool discovery guidance in system prompts and ensure agents consult provider-native deferred tool catalogs before declaring capabilities unavailable.

New Features:
- Add a native tool search instruction block that lists deferred capability domains and advises models to search the deferred catalog before concluding a capability is unavailable.

Enhancements:
- Track authored toolkit names that use native deferred loading and surface them compactly in the agent system prompt.
- Exclude initially-active deferred tools from the native discovery hint so their schemas remain inline while preserving native schema deferral for fully deferred toolkits.

Documentation:
- Document native deferred tool discovery behavior and the new system-prompt hint in dynamic tools user-facing docs.

Tests:
- Add parametrized tests validating that native tool search prompts include the deferred capability domains, exclude initial tools, and instruct models to search the deferred catalog before declaring capabilities unavailable.