### PR TITLE
Add Kimi K3 provider backed by the Kimi Code CLI login

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Coding model training data often lags recent releases, so never trust memorized 
 | Anthropic | Fast / cheap | Claude Haiku 4.5 | `claude-haiku-4-5` |
 | OpenAI | Frontier default | GPT-5.6 | `gpt-5.6` |
 | OpenAI Codex ChatGPT login | Frontier via Codex CLI | GPT-5.6 | `gpt-5.6` |
+| Moonshot Kimi Code login | Frontier via Kimi Code CLI | Kimi K3 | `k3` |
 | Google (Gemini API) | Max intelligence | Gemini 3.1 Pro Preview | `gemini-3.1-pro-preview` |
 | Google (Gemini API) | Standard text / coding | Gemini 3.5 Flash | `gemini-3.5-flash` |
 | Google (Gemini API) | Fast / cheap text | Gemini 3.1 Flash-Lite Preview | `gemini-3.1-flash-lite-preview` |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -873,7 +873,7 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 Create a starter `config.yaml` with the personal Mind agent, one model, file-based memory, and sensible defaults.
 
 Matrix server presets (`--matrix-server`) choose where MindRoom should create Matrix users and rooms: `mindroom.chat` (default hosted Matrix) or `self-hosted` (your own homeserver).
-Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `llama.cpp`, `ollama`, `openai`, `openrouter`, or `vertexai_claude`.
+Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `kimi`, `llama.cpp`, `ollama`, `openai`, `openrouter`, or `vertexai_claude`.
 Generated configs include commented model alternatives for providers that have common variants, such as OpenAI mini/nano models.
 
 ```bash
@@ -909,6 +909,9 @@ The `--provider codex` preset generates `provider: codex` with `id: gpt-5.6` and
 They set `extra_kwargs.reasoning_effort: medium`.
 Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key.
 Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
+
+The `--provider kimi` preset generates `provider: kimi` with `id: k3` and `context_window: 1048576`.
+Run `kimi` and `/login` first so MindRoom can read `~/.kimi-code/credentials/kimi-code.json`.
 
 The `--provider ollama` preset generates `provider: ollama` with `id: gemma4`, an additional `qwen3_6_27b` model using `qwen3.6:27b`, and `OLLAMA_HOST=http://localhost:11434`.
 Pull both local models before running MindRoom:

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -13,6 +13,7 @@ Models define the AI providers and model IDs used by agents.
 - `azure` - OpenAI models through Azure OpenAI deployments
 - `openai` - GPT models and OpenAI-compatible endpoints
 - `codex` or `openai_codex` - OpenAI models available through a local Codex CLI ChatGPT login
+- `kimi` or `kimi_code` - Kimi models available through a local Kimi Code CLI login
 - `google` or `gemini` - Google Gemini models
 - `vertexai_claude` - Anthropic Claude models on Google Vertex AI
 - `ollama` - Local models via Ollama
@@ -73,6 +74,12 @@ models:
     provider: codex
     id: gpt-5.6
     context_window: 258000
+
+  # Kimi K3 via a Kimi Code CLI login
+  kimi:
+    provider: kimi
+    id: k3
+    context_window: 1048576
 
   # Google Gemini (both 'google' and 'gemini' work as provider names)
   gemini:
@@ -214,6 +221,33 @@ You can set `extra_kwargs.prompt_cache_key` to override that derived key for a m
 Live testing against the Codex ChatGPT endpoint reported `cached_tokens` only when the request included Codex CLI-style session headers tied to the prompt-cache key.
 Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected.
 Treat Codex prompt caching as best-effort rather than guaranteed.
+
+## Kimi Models with Kimi Code Login
+
+Use `provider: kimi` when you want MindRoom to call Kimi models through an authenticated local Kimi Code CLI session (Kimi Code subscription) instead of the billed Moonshot API.
+Run `kimi` and `/login` first so `~/.kimi-code/credentials/kimi-code.json` contains OAuth tokens.
+MindRoom refreshes the access token when needed and sends requests to the Kimi Code OpenAI-compatible endpoint at `https://api.kimi.com/coding/v1`.
+
+| Model | Model ID | Best fit |
+|-------|----------|----------|
+| Kimi K3 | `k3` | Flagship reasoning, long-horizon coding, and agent work with a 1M-token context |
+| Kimi K3 256k | `k3-256k` | The same K3 generation with a 256k-token context |
+| Kimi for Coding | `kimi-for-coding` | Coding-tuned tier exposed by the Kimi Code CLI |
+
+The CLI-config-style form `kimi-code/k3` is accepted as an alternative to the bare slug.
+If you keep Kimi Code state outside `~/.kimi-code`, set `KIMI_CODE_HOME` or pass `extra_kwargs.kimi_home`; user-home prefixes such as `~/custom-kimi` are expanded.
+For starter config generation, use `mindroom config init --provider kimi`.
+
+```yaml
+models:
+  default:
+    provider: kimi
+    id: k3
+    context_window: 1048576
+```
+
+Kimi K3 always reasons before replying, so responses include reasoning tokens even for short answers.
+This adapter follows the local Kimi Code CLI authentication-file and backend contracts, so upstream Kimi Code changes can require a MindRoom update.
 
 ## OpenRouter Provider Routing
 

--- a/docs/configuration/models.md
+++ b/docs/configuration/models.md
@@ -249,6 +249,10 @@ models:
 Kimi K3 always reasons before replying, so responses include reasoning tokens even for short answers.
 This adapter follows the local Kimi Code CLI authentication-file and backend contracts, so upstream Kimi Code changes can require a MindRoom update.
 
+Prompt caching is automatic on the Kimi Code endpoint: repeated request prefixes come back as `cached_tokens` with no opt-in.
+Like the Kimi Code CLI, MindRoom pins each active agent session to a stable `prompt_cache_key` derived from the execution identity (the same derivation the Codex provider uses), which keeps cache routing stable per Matrix thread.
+You can set `extra_kwargs.prompt_cache_key` to override the derived key for a model.
+
 ## OpenRouter Provider Routing
 
 OpenRouter routes each request to one of several upstream providers serving the model, and upstream quality varies (we have seen a third-party host leak raw tool-call markup into a visible reply).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -79,6 +79,7 @@ For hosted providers, set the credentials for the provider you selected:
 - `OPENAI_API_KEY=...`, or
 - `OPENROUTER_API_KEY=...`, or
 - For Codex CLI ChatGPT authentication: run `codex login`.
+- For Kimi Code CLI authentication: run `kimi` and `/login`.
 - For Vertex AI Claude: set `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` and authenticate with `gcloud auth application-default login`.
 Skip this step for `--provider ollama` or `--provider llama.cpp` unless you also add a remote provider.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2580,6 +2580,10 @@ models:
 Kimi K3 always reasons before replying, so responses include reasoning tokens even for short answers.
 This adapter follows the local Kimi Code CLI authentication-file and backend contracts, so upstream Kimi Code changes can require a MindRoom update.
 
+Prompt caching is automatic on the Kimi Code endpoint: repeated request prefixes come back as `cached_tokens` with no opt-in.
+Like the Kimi Code CLI, MindRoom pins each active agent session to a stable `prompt_cache_key` derived from the execution identity (the same derivation the Codex provider uses), which keeps cache routing stable per Matrix thread.
+You can set `extra_kwargs.prompt_cache_key` to override the derived key for a model.
+
 ## OpenRouter Provider Routing
 
 OpenRouter routes each request to one of several upstream providers serving the model, and upstream quality varies (we have seen a third-party host leak raw tool-call markup into a visible reply).

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -303,6 +303,7 @@ For hosted providers, set the credentials for the provider you selected:
 - `OPENAI_API_KEY=...`, or
 - `OPENROUTER_API_KEY=...`, or
 - For Codex CLI ChatGPT authentication: run `codex login`.
+- For Kimi Code CLI authentication: run `kimi` and `/login`.
 - For Vertex AI Claude: set `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` and authenticate with `gcloud auth application-default login`.
 Skip this step for `--provider ollama` or `--provider llama.cpp` unless you also add a remote provider.
 
@@ -2343,6 +2344,7 @@ Models define the AI providers and model IDs used by agents.
 - `azure` - OpenAI models through Azure OpenAI deployments
 - `openai` - GPT models and OpenAI-compatible endpoints
 - `codex` or `openai_codex` - OpenAI models available through a local Codex CLI ChatGPT login
+- `kimi` or `kimi_code` - Kimi models available through a local Kimi Code CLI login
 - `google` or `gemini` - Google Gemini models
 - `vertexai_claude` - Anthropic Claude models on Google Vertex AI
 - `ollama` - Local models via Ollama
@@ -2403,6 +2405,12 @@ models:
     provider: codex
     id: gpt-5.6
     context_window: 258000
+
+  # Kimi K3 via a Kimi Code CLI login
+  kimi:
+    provider: kimi
+    id: k3
+    context_window: 1048576
 
   # Google Gemini (both 'google' and 'gemini' work as provider names)
   gemini:
@@ -2544,6 +2552,33 @@ You can set `extra_kwargs.prompt_cache_key` to override that derived key for a m
 Live testing against the Codex ChatGPT endpoint reported `cached_tokens` only when the request included Codex CLI-style session headers tied to the prompt-cache key.
 Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected.
 Treat Codex prompt caching as best-effort rather than guaranteed.
+
+## Kimi Models with Kimi Code Login
+
+Use `provider: kimi` when you want MindRoom to call Kimi models through an authenticated local Kimi Code CLI session (Kimi Code subscription) instead of the billed Moonshot API.
+Run `kimi` and `/login` first so `~/.kimi-code/credentials/kimi-code.json` contains OAuth tokens.
+MindRoom refreshes the access token when needed and sends requests to the Kimi Code OpenAI-compatible endpoint at `https://api.kimi.com/coding/v1`.
+
+| Model | Model ID | Best fit |
+|-------|----------|----------|
+| Kimi K3 | `k3` | Flagship reasoning, long-horizon coding, and agent work with a 1M-token context |
+| Kimi K3 256k | `k3-256k` | The same K3 generation with a 256k-token context |
+| Kimi for Coding | `kimi-for-coding` | Coding-tuned tier exposed by the Kimi Code CLI |
+
+The CLI-config-style form `kimi-code/k3` is accepted as an alternative to the bare slug.
+If you keep Kimi Code state outside `~/.kimi-code`, set `KIMI_CODE_HOME` or pass `extra_kwargs.kimi_home`; user-home prefixes such as `~/custom-kimi` are expanded.
+For starter config generation, use `mindroom config init --provider kimi`.
+
+```yaml
+models:
+  default:
+    provider: kimi
+    id: k3
+    context_window: 1048576
+```
+
+Kimi K3 always reasons before replying, so responses include reasoning tokens even for short answers.
+This adapter follows the local Kimi Code CLI authentication-file and backend contracts, so upstream Kimi Code changes can require a MindRoom update.
 
 ## OpenRouter Provider Routing
 
@@ -19523,7 +19558,7 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 Create a starter `config.yaml` with the personal Mind agent, one model, file-based memory, and sensible defaults.
 
 Matrix server presets (`--matrix-server`) choose where MindRoom should create Matrix users and rooms: `mindroom.chat` (default hosted Matrix) or `self-hosted` (your own homeserver).
-Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `llama.cpp`, `ollama`, `openai`, `openrouter`, or `vertexai_claude`.
+Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `kimi`, `llama.cpp`, `ollama`, `openai`, `openrouter`, or `vertexai_claude`.
 Generated configs include commented model alternatives for providers that have common variants, such as OpenAI mini/nano models.
 
 ```bash
@@ -19559,6 +19594,9 @@ The `--provider codex` preset generates `provider: codex` with `id: gpt-5.6` and
 They set `extra_kwargs.reasoning_effort: medium`.
 Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key.
 Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
+
+The `--provider kimi` preset generates `provider: kimi` with `id: k3` and `context_window: 1048576`.
+Run `kimi` and `/login` first so MindRoom can read `~/.kimi-code/credentials/kimi-code.json`.
 
 The `--provider ollama` preset generates `provider: ollama` with `id: gemma4`, an additional `qwen3_6_27b` model using `qwen3.6:27b`, and `OLLAMA_HOST=http://localhost:11434`.
 Pull both local models before running MindRoom:

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -869,7 +869,7 @@ The `config` subgroup contains commands for creating, viewing, editing, and vali
 Create a starter `config.yaml` with the personal Mind agent, one model, file-based memory, and sensible defaults.
 
 Matrix server presets (`--matrix-server`) choose where MindRoom should create Matrix users and rooms: `mindroom.chat` (default hosted Matrix) or `self-hosted` (your own homeserver).
-Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `llama.cpp`, `ollama`, `openai`, `openrouter`, or `vertexai_claude`.
+Provider presets (`--provider`) set the default model: `anthropic`, `codex`, `kimi`, `llama.cpp`, `ollama`, `openai`, `openrouter`, or `vertexai_claude`.
 Generated configs include commented model alternatives for providers that have common variants, such as OpenAI mini/nano models.
 
 ```bash
@@ -905,6 +905,9 @@ The `--provider codex` preset generates `provider: codex` with `id: gpt-5.6` and
 They set `extra_kwargs.reasoning_effort: medium`.
 Prompt caching is enabled automatically per active agent session; leave `prompt_cache_key` unset unless you intentionally want to override the derived key.
 Run `codex login` first so MindRoom can read `~/.codex/auth.json`.
+
+The `--provider kimi` preset generates `provider: kimi` with `id: k3` and `context_window: 1048576`.
+Run `kimi` and `/login` first so MindRoom can read `~/.kimi-code/credentials/kimi-code.json`.
 
 The `--provider ollama` preset generates `provider: ollama` with `id: gemma4`, an additional `qwen3_6_27b` model using `qwen3.6:27b`, and `OLLAMA_HOST=http://localhost:11434`.
 Pull both local models before running MindRoom:

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -245,6 +245,10 @@ models:
 Kimi K3 always reasons before replying, so responses include reasoning tokens even for short answers.
 This adapter follows the local Kimi Code CLI authentication-file and backend contracts, so upstream Kimi Code changes can require a MindRoom update.
 
+Prompt caching is automatic on the Kimi Code endpoint: repeated request prefixes come back as `cached_tokens` with no opt-in.
+Like the Kimi Code CLI, MindRoom pins each active agent session to a stable `prompt_cache_key` derived from the execution identity (the same derivation the Codex provider uses), which keeps cache routing stable per Matrix thread.
+You can set `extra_kwargs.prompt_cache_key` to override the derived key for a model.
+
 ## OpenRouter Provider Routing
 
 OpenRouter routes each request to one of several upstream providers serving the model, and upstream quality varies (we have seen a third-party host leak raw tool-call markup into a visible reply).

--- a/skills/mindroom-docs/references/page__configuration__models__index.md
+++ b/skills/mindroom-docs/references/page__configuration__models__index.md
@@ -9,6 +9,7 @@ Models define the AI providers and model IDs used by agents.
 - `azure` - OpenAI models through Azure OpenAI deployments
 - `openai` - GPT models and OpenAI-compatible endpoints
 - `codex` or `openai_codex` - OpenAI models available through a local Codex CLI ChatGPT login
+- `kimi` or `kimi_code` - Kimi models available through a local Kimi Code CLI login
 - `google` or `gemini` - Google Gemini models
 - `vertexai_claude` - Anthropic Claude models on Google Vertex AI
 - `ollama` - Local models via Ollama
@@ -69,6 +70,12 @@ models:
     provider: codex
     id: gpt-5.6
     context_window: 258000
+
+  # Kimi K3 via a Kimi Code CLI login
+  kimi:
+    provider: kimi
+    id: k3
+    context_window: 1048576
 
   # Google Gemini (both 'google' and 'gemini' work as provider names)
   gemini:
@@ -210,6 +217,33 @@ You can set `extra_kwargs.prompt_cache_key` to override that derived key for a m
 Live testing against the Codex ChatGPT endpoint reported `cached_tokens` only when the request included Codex CLI-style session headers tied to the prompt-cache key.
 Repeated long requests then reported cache hits, while requests without those headers stayed at `cached_tokens: 0`, and `prompt_cache_retention` was rejected.
 Treat Codex prompt caching as best-effort rather than guaranteed.
+
+## Kimi Models with Kimi Code Login
+
+Use `provider: kimi` when you want MindRoom to call Kimi models through an authenticated local Kimi Code CLI session (Kimi Code subscription) instead of the billed Moonshot API.
+Run `kimi` and `/login` first so `~/.kimi-code/credentials/kimi-code.json` contains OAuth tokens.
+MindRoom refreshes the access token when needed and sends requests to the Kimi Code OpenAI-compatible endpoint at `https://api.kimi.com/coding/v1`.
+
+| Model | Model ID | Best fit |
+|-------|----------|----------|
+| Kimi K3 | `k3` | Flagship reasoning, long-horizon coding, and agent work with a 1M-token context |
+| Kimi K3 256k | `k3-256k` | The same K3 generation with a 256k-token context |
+| Kimi for Coding | `kimi-for-coding` | Coding-tuned tier exposed by the Kimi Code CLI |
+
+The CLI-config-style form `kimi-code/k3` is accepted as an alternative to the bare slug.
+If you keep Kimi Code state outside `~/.kimi-code`, set `KIMI_CODE_HOME` or pass `extra_kwargs.kimi_home`; user-home prefixes such as `~/custom-kimi` are expanded.
+For starter config generation, use `mindroom config init --provider kimi`.
+
+```yaml
+models:
+  default:
+    provider: kimi
+    id: k3
+    context_window: 1048576
+```
+
+Kimi K3 always reasons before replying, so responses include reasoning tokens even for short answers.
+This adapter follows the local Kimi Code CLI authentication-file and backend contracts, so upstream Kimi Code changes can require a MindRoom update.
 
 ## OpenRouter Provider Routing
 

--- a/skills/mindroom-docs/references/page__getting-started__index.md
+++ b/skills/mindroom-docs/references/page__getting-started__index.md
@@ -75,6 +75,7 @@ For hosted providers, set the credentials for the provider you selected:
 - `OPENAI_API_KEY=...`, or
 - `OPENROUTER_API_KEY=...`, or
 - For Codex CLI ChatGPT authentication: run `codex login`.
+- For Kimi Code CLI authentication: run `kimi` and `/login`.
 - For Vertex AI Claude: set `ANTHROPIC_VERTEX_PROJECT_ID` and `CLOUD_ML_REGION` and authenticate with `gcloud auth application-default login`.
 Skip this step for `--provider ollama` or `--provider llama.cpp` unless you also add a remote provider.
 

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -93,8 +93,6 @@ _PROVIDER_PRESET_ALIASES: dict[str, _ProviderPreset] = {
     "claude": "anthropic",
     "codex": "codex",
     "kimi": "kimi",
-    "kimi-code": "kimi",
-    "kimi_code": "kimi",
     "llama.cpp": "llama_cpp",
     "llama-cpp": "llama_cpp",
     "llama_cpp": "llama_cpp",

--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -74,6 +74,7 @@ _ProviderPreset = Literal[
     "bedrock_claude",
     "azure",
     "codex",
+    "kimi",
     "llama_cpp",
     "ollama",
     "openai",
@@ -91,6 +92,9 @@ _PROVIDER_PRESET_ALIASES: dict[str, _ProviderPreset] = {
     "azure-openai": "azure",
     "claude": "anthropic",
     "codex": "codex",
+    "kimi": "kimi",
+    "kimi-code": "kimi",
+    "kimi_code": "kimi",
     "llama.cpp": "llama_cpp",
     "llama-cpp": "llama_cpp",
     "llama_cpp": "llama_cpp",
@@ -117,7 +121,7 @@ _MATRIX_SERVER_HELP = (
 )
 _PROVIDER_HELP = "Default model provider for the generated config."
 _PROVIDER_CHOICES_TEXT = (
-    "anthropic, azure, bedrock_claude, codex, llama.cpp, ollama, openai, openrouter, or vertexai_claude"
+    "anthropic, azure, bedrock_claude, codex, kimi, llama.cpp, ollama, openai, openrouter, or vertexai_claude"
 )
 
 
@@ -255,6 +259,7 @@ def _config_init_env_hint(matrix_server: _MatrixServerPreset, selected_preset: _
         "azure": "Set your Azure OpenAI key/endpoint and confirm the config model deployment name",
         "bedrock_claude": "Set AWS Bedrock region and credentials (Matrix homeserver is prefilled)",
         "codex": "Run `codex login` before starting MindRoom (Matrix homeserver is prefilled)",
+        "kimi": "Run `kimi` and `/login` before starting MindRoom (Matrix homeserver is prefilled)",
         "vertexai_claude": "Set your Vertex AI project/region and Google auth (Matrix homeserver is prefilled)",
         "ollama": "Start Ollama and pull the local models (Matrix homeserver is prefilled)",
         "llama_cpp": "Start llama.cpp server with the local model (Matrix homeserver is prefilled)",
@@ -263,6 +268,7 @@ def _config_init_env_hint(matrix_server: _MatrixServerPreset, selected_preset: _
         "azure": "Set your Matrix homeserver, Azure OpenAI key/endpoint, and config model deployment name",
         "bedrock_claude": "Set your Matrix homeserver, AWS Bedrock region, and AWS credentials",
         "codex": "Set your Matrix homeserver and run `codex login` before starting MindRoom",
+        "kimi": "Set your Matrix homeserver and run `kimi` and `/login` before starting MindRoom",
         "vertexai_claude": "Set your Matrix homeserver, Vertex AI project/region, and Google auth",
         "ollama": "Set your Matrix homeserver, start Ollama, and pull the local models",
         "llama_cpp": "Set your Matrix homeserver and start llama.cpp server with the local model",
@@ -823,7 +829,7 @@ def _prompt_provider_preset() -> _ProviderPreset:
     """Prompt the user for a starter provider preset."""
     while True:
         raw_value = typer.prompt(
-            "Choose provider preset [anthropic/azure/bedrock_claude/codex/llama.cpp/ollama/openai/openrouter/vertexai_claude]",
+            "Choose provider preset [anthropic/azure/bedrock_claude/codex/kimi/llama.cpp/ollama/openai/openrouter/vertexai_claude]",
             default="openai",
             show_default=True,
         )
@@ -1118,6 +1124,14 @@ def _provider_env_template(provider_preset: _ProviderPreset) -> str:  # noqa: PL
         # Run `codex login` before starting MindRoom.
         # MindRoom reads ChatGPT OAuth tokens from ~/.codex/auth.json by default.
         # CODEX_HOME=~/.codex
+        """).rstrip()
+
+    if provider_preset == "kimi":
+        return textwrap.dedent("""\
+        # Kimi Code CLI OAuth authentication
+        # Run `kimi` and `/login` before starting MindRoom.
+        # MindRoom reads OAuth tokens from ~/.kimi-code/credentials/kimi-code.json by default.
+        # KIMI_CODE_HOME=~/.kimi-code
         """).rstrip()
 
     if provider_preset == "vertexai_claude":

--- a/src/mindroom/cli/main.py
+++ b/src/mindroom/cli/main.py
@@ -44,7 +44,9 @@ AI agents that live in Matrix and work everywhere via bridges.
   [cyan]mindroom config init[/cyan]   Create a starter config
   [cyan]mindroom run[/cyan]           Start the system\
 """
-_CONFIG_INIT_PROVIDER_CHOICES = "{openrouter,ollama,openai,azure,bedrock_claude,codex,claude,llama.cpp,vertexai_claude}"
+_CONFIG_INIT_PROVIDER_CHOICES = (
+    "{openrouter,ollama,openai,azure,bedrock_claude,codex,kimi,claude,llama.cpp,vertexai_claude}"
+)
 
 app = typer.Typer(
     help=_HELP,

--- a/src/mindroom/codex_model.py
+++ b/src/mindroom/codex_model.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import base64
-import hashlib
 import json
 import os
 import time
@@ -19,6 +18,7 @@ from openai import AsyncOpenAI, OpenAI
 from mindroom.file_locks import advisory_file_lock
 from mindroom.model_defaults import CODEX_GPT, CODEX_GPT_ENDPOINT
 from mindroom.openai_models import MindRoomOpenAIResponses
+from mindroom.prompt_cache_key import derive_session_prompt_cache_key
 from mindroom.prompts import CODEX_DEFAULT_INSTRUCTIONS
 
 if TYPE_CHECKING:
@@ -192,20 +192,7 @@ def _update_tokens(tokens: dict[str, Any], refreshed: dict[str, Any]) -> None:
 
 def derive_codex_prompt_cache_key(identity: ToolExecutionIdentity) -> str | None:
     """Derive a stable Codex prompt-cache routing key for one active execution."""
-    if identity.session_id is None:
-        return None
-    source = ":".join(
-        (
-            identity.channel,
-            identity.agent_name,
-            identity.requester_id or "",
-            identity.room_id or "",
-            identity.resolved_thread_id or identity.thread_id or "",
-            identity.session_id,
-        ),
-    )
-    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:32]
-    return f"{_CODEX_PROMPT_CACHE_KEY_PREFIX}-{digest}"
+    return derive_session_prompt_cache_key(identity, prefix=_CODEX_PROMPT_CACHE_KEY_PREFIX)
 
 
 def _codex_prompt_cache_headers(prompt_cache_key: str) -> dict[str, str]:

--- a/src/mindroom/codex_model.py
+++ b/src/mindroom/codex_model.py
@@ -18,15 +18,12 @@ from openai import AsyncOpenAI, OpenAI
 from mindroom.file_locks import advisory_file_lock
 from mindroom.model_defaults import CODEX_GPT, CODEX_GPT_ENDPOINT
 from mindroom.openai_models import MindRoomOpenAIResponses
-from mindroom.prompt_cache_key import derive_session_prompt_cache_key
 from mindroom.prompts import CODEX_DEFAULT_INSTRUCTIONS
 
 if TYPE_CHECKING:
     from agno.models.message import Message
     from agno.run.agent import RunOutput
     from pydantic import BaseModel
-
-    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_REFRESH_URL = "https://auth.openai.com/oauth/token"
@@ -35,7 +32,6 @@ _CODEX_REFRESH_SKEW_SECONDS = 30
 _CODEX_MODEL_PREFIX = "openai-codex/"
 _CODEX_MODEL_ALIASES = {CODEX_GPT: CODEX_GPT_ENDPOINT}
 _CODEX_UNSUPPORTED_REQUEST_PARAMS = {"max_output_tokens", "temperature"}
-_CODEX_PROMPT_CACHE_KEY_PREFIX = "mindroom"
 _CODEX_INSTALLATION_ID_HEADER = "x-codex-installation-id"
 _CODEX_WINDOW_ID_HEADER = "x-codex-window-id"
 
@@ -188,11 +184,6 @@ def _update_tokens(tokens: dict[str, Any], refreshed: dict[str, Any]) -> None:
     for key in ("access_token", "id_token", "refresh_token"):
         if refreshed.get(key):
             tokens[key] = refreshed[key]
-
-
-def derive_codex_prompt_cache_key(identity: ToolExecutionIdentity) -> str | None:
-    """Derive a stable Codex prompt-cache routing key for one active execution."""
-    return derive_session_prompt_cache_key(identity, prefix=_CODEX_PROMPT_CACHE_KEY_PREFIX)
 
 
 def _codex_prompt_cache_headers(prompt_cache_key: str) -> dict[str, str]:

--- a/src/mindroom/kimi_model.py
+++ b/src/mindroom/kimi_model.py
@@ -16,7 +16,6 @@ from openai import AsyncOpenAI, OpenAI
 from mindroom.file_locks import advisory_file_lock
 from mindroom.model_defaults import KIMI_K3
 from mindroom.openai_models import MindRoomOpenAIChat
-from mindroom.prompt_cache_key import derive_session_prompt_cache_key
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -25,15 +24,12 @@ if TYPE_CHECKING:
     from agno.run.team import TeamRunOutput
     from pydantic import BaseModel
 
-    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
-
 _KIMI_BASE_URL = "https://api.kimi.com/coding/v1"
 _KIMI_REFRESH_URL = "https://auth.kimi.com/api/oauth/token"
 _KIMI_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098"
 _KIMI_REFRESH_SKEW_SECONDS = 30
 _KIMI_MODEL_PREFIX = "kimi-code/"
 _KIMI_CREDENTIALS_RELATIVE_PATH = Path("credentials") / "kimi-code.json"
-_KIMI_PROMPT_CACHE_KEY_PREFIX = "mindroom"
 
 
 class _KimiAuthError(ValueError):
@@ -157,11 +153,6 @@ def _update_credentials(credentials: dict[str, Any], refreshed: dict[str, Any]) 
     elif isinstance(refreshed.get("expires_in"), int | float):
         credentials["expires_in"] = refreshed["expires_in"]
         credentials["expires_at"] = int(time.time()) + int(refreshed["expires_in"])
-
-
-def derive_kimi_prompt_cache_key(identity: ToolExecutionIdentity) -> str | None:
-    """Derive a stable Kimi prompt-cache routing key for one active execution."""
-    return derive_session_prompt_cache_key(identity, prefix=_KIMI_PROMPT_CACHE_KEY_PREFIX)
 
 
 @dataclass

--- a/src/mindroom/kimi_model.py
+++ b/src/mindroom/kimi_model.py
@@ -1,0 +1,198 @@
+"""Kimi model support via the Kimi Code CLI OAuth state."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import httpx
+from agno.utils.http import get_default_async_client, get_default_sync_client
+from openai import AsyncOpenAI, OpenAI
+
+from mindroom.file_locks import advisory_file_lock
+from mindroom.model_defaults import KIMI_K3
+from mindroom.openai_models import MindRoomOpenAIChat
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_KIMI_BASE_URL = "https://api.kimi.com/coding/v1"
+_KIMI_REFRESH_URL = "https://auth.kimi.com/api/oauth/token"
+_KIMI_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098"
+_KIMI_REFRESH_SKEW_SECONDS = 30
+_KIMI_MODEL_PREFIX = "kimi-code/"
+_KIMI_CREDENTIALS_RELATIVE_PATH = Path("credentials") / "kimi-code.json"
+
+
+class _KimiAuthError(ValueError):
+    """Raised when the local Kimi Code CLI OAuth state cannot provide a usable token."""
+
+
+def normalize_kimi_model_id(model_id: str) -> str:
+    """Return the Kimi endpoint model slug from either bare or CLI-config-style IDs."""
+    normalized = model_id.strip()
+    if normalized.startswith(_KIMI_MODEL_PREFIX):
+        normalized = normalized.removeprefix(_KIMI_MODEL_PREFIX)
+    return normalized
+
+
+def _borrow_kimi_token(*, kimi_home: str | Path | None = None) -> str:
+    """Return a valid Kimi Code CLI OAuth access token, refreshing it when expired."""
+    credentials_path = _kimi_credentials_path(kimi_home=kimi_home)
+    credentials = _read_kimi_credentials(credentials_path)
+
+    usable_token = _usable_access_token(credentials)
+    if usable_token is not None:
+        return usable_token
+
+    with advisory_file_lock(credentials_path.with_name(f"{credentials_path.name}.lock")):
+        credentials = _read_kimi_credentials(credentials_path)
+        usable_token = _usable_access_token(credentials)
+        if usable_token is not None:
+            return usable_token
+
+        refresh_token = credentials.get("refresh_token")
+        if not refresh_token:
+            msg = "No Kimi Code refresh token found. Run `kimi` and `/login` to re-authenticate."
+            raise _KimiAuthError(msg)
+
+        refreshed = _refresh_kimi_tokens(str(refresh_token))
+        if not refreshed.get("access_token"):
+            msg = "Kimi token refresh response did not include an access token."
+            raise _KimiAuthError(msg)
+
+        _update_credentials(credentials, refreshed)
+        _write_kimi_credentials(credentials_path, credentials)
+        return str(credentials["access_token"])
+
+
+def _kimi_credentials_path(*, kimi_home: str | Path | None) -> Path:
+    credentials_path = _kimi_home_path(kimi_home=kimi_home) / _KIMI_CREDENTIALS_RELATIVE_PATH
+    if not credentials_path.exists():
+        msg = f"Kimi Code credentials not found at {credentials_path}. Run `kimi` and `/login` first."
+        raise _KimiAuthError(msg)
+    return credentials_path
+
+
+def _kimi_home_path(*, kimi_home: str | Path | None) -> Path:
+    configured_home = kimi_home if kimi_home is not None else os.environ.get("KIMI_CODE_HOME", "~/.kimi-code")
+    return Path(configured_home).expanduser()
+
+
+def _read_kimi_credentials(credentials_path: Path) -> dict[str, Any]:
+    with credentials_path.open(encoding="utf-8") as credentials_file:
+        credentials = json.load(credentials_file)
+    if not isinstance(credentials, dict) or not credentials.get("access_token"):
+        msg = "No Kimi Code access token found in credentials. Run `kimi` and `/login` first."
+        raise _KimiAuthError(msg)
+    return credentials
+
+
+def _usable_access_token(credentials: Mapping[str, Any]) -> str | None:
+    access_token = str(credentials["access_token"])
+    expires_at = credentials.get("expires_at")
+    if not isinstance(expires_at, int | float) or time.time() >= expires_at - _KIMI_REFRESH_SKEW_SECONDS:
+        return None
+    return access_token
+
+
+def _write_kimi_credentials(credentials_path: Path, credentials: dict[str, Any]) -> None:
+    temp_path = credentials_path.with_name(f"{credentials_path.name}.tmp")
+    temp_path.unlink(missing_ok=True)
+    fd = os.open(temp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as temp_file:
+        temp_file.write(json.dumps(credentials, indent=2))
+    temp_path.replace(credentials_path)
+    credentials_path.chmod(0o600)
+
+
+def _refresh_kimi_tokens(refresh_token: str) -> dict[str, Any]:
+    payload = {
+        "client_id": _KIMI_CLIENT_ID,
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+    }
+    try:
+        response = httpx.post(_KIMI_REFRESH_URL, data=payload, timeout=10)
+    except httpx.HTTPError as exc:
+        msg = f"Kimi token refresh failed: {exc}"
+        raise _KimiAuthError(msg) from exc
+
+    if not response.is_success:
+        msg = (
+            f"Kimi token refresh failed (HTTP {response.status_code}): {response.text}. "
+            "Run `kimi` and `/login` to re-authenticate if the refresh token expired."
+        )
+        raise _KimiAuthError(msg) from None
+
+    try:
+        refreshed = response.json()
+    except json.JSONDecodeError as exc:
+        msg = "Kimi token refresh returned invalid JSON."
+        raise _KimiAuthError(msg) from exc
+    if not isinstance(refreshed, dict):
+        msg = "Kimi token refresh returned an unexpected payload."
+        raise _KimiAuthError(msg)
+    return refreshed
+
+
+def _update_credentials(credentials: dict[str, Any], refreshed: dict[str, Any]) -> None:
+    for key in ("access_token", "refresh_token", "token_type", "scope"):
+        if refreshed.get(key):
+            credentials[key] = refreshed[key]
+    if isinstance(refreshed.get("expires_at"), int | float):
+        credentials["expires_at"] = refreshed["expires_at"]
+    elif isinstance(refreshed.get("expires_in"), int | float):
+        credentials["expires_in"] = refreshed["expires_in"]
+        credentials["expires_at"] = int(time.time()) + int(refreshed["expires_in"])
+
+
+@dataclass
+class KimiChat(MindRoomOpenAIChat):
+    """Agno Chat model backed by the local Kimi Code CLI OAuth credentials."""
+
+    id: str = KIMI_K3
+    name: str = "KimiChat"
+    provider: str = "Kimi"
+    base_url: str = _KIMI_BASE_URL
+    kimi_home: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize CLI-config-style model IDs before Agno uses the model id."""
+        self.id = normalize_kimi_model_id(self.id)
+        super().__post_init__()
+
+    def _get_client_params(self) -> dict[str, Any]:
+        base_params = {
+            "api_key": _borrow_kimi_token(kimi_home=self.kimi_home),
+            "organization": self.organization,
+            "base_url": self.base_url,
+            "timeout": self.timeout,
+            "max_retries": self.max_retries,
+            "default_headers": self.default_headers,
+            "default_query": self.default_query,
+        }
+        client_params = {key: value for key, value in base_params.items() if value is not None}
+        if self.client_params:
+            client_params.update(self.client_params)
+        return client_params
+
+    def get_client(self) -> OpenAI:
+        """Return a fresh sync client so expired Kimi tokens are refreshed between requests."""
+        client_params = self._get_client_params()
+        client_params["http_client"] = (
+            self.http_client if isinstance(self.http_client, httpx.Client) else get_default_sync_client()
+        )
+        return OpenAI(**client_params)
+
+    def get_async_client(self) -> AsyncOpenAI:
+        """Return a fresh async client so expired Kimi tokens are refreshed between requests."""
+        client_params = self._get_client_params()
+        client_params["http_client"] = (
+            self.http_client if isinstance(self.http_client, httpx.AsyncClient) else get_default_async_client()
+        )
+        return AsyncOpenAI(**client_params)

--- a/src/mindroom/kimi_model.py
+++ b/src/mindroom/kimi_model.py
@@ -16,9 +16,16 @@ from openai import AsyncOpenAI, OpenAI
 from mindroom.file_locks import advisory_file_lock
 from mindroom.model_defaults import KIMI_K3
 from mindroom.openai_models import MindRoomOpenAIChat
+from mindroom.prompt_cache_key import derive_session_prompt_cache_key
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+
+    from agno.run.agent import RunOutput
+    from agno.run.team import TeamRunOutput
+    from pydantic import BaseModel
+
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 _KIMI_BASE_URL = "https://api.kimi.com/coding/v1"
 _KIMI_REFRESH_URL = "https://auth.kimi.com/api/oauth/token"
@@ -26,6 +33,7 @@ _KIMI_CLIENT_ID = "17e5f671-d194-4dfb-9706-5516cb48c098"
 _KIMI_REFRESH_SKEW_SECONDS = 30
 _KIMI_MODEL_PREFIX = "kimi-code/"
 _KIMI_CREDENTIALS_RELATIVE_PATH = Path("credentials") / "kimi-code.json"
+_KIMI_PROMPT_CACHE_KEY_PREFIX = "mindroom"
 
 
 class _KimiAuthError(ValueError):
@@ -151,6 +159,11 @@ def _update_credentials(credentials: dict[str, Any], refreshed: dict[str, Any]) 
         credentials["expires_at"] = int(time.time()) + int(refreshed["expires_in"])
 
 
+def derive_kimi_prompt_cache_key(identity: ToolExecutionIdentity) -> str | None:
+    """Derive a stable Kimi prompt-cache routing key for one active execution."""
+    return derive_session_prompt_cache_key(identity, prefix=_KIMI_PROMPT_CACHE_KEY_PREFIX)
+
+
 @dataclass
 class KimiChat(MindRoomOpenAIChat):
     """Agno Chat model backed by the local Kimi Code CLI OAuth credentials."""
@@ -160,11 +173,34 @@ class KimiChat(MindRoomOpenAIChat):
     provider: str = "Kimi"
     base_url: str = _KIMI_BASE_URL
     kimi_home: str | None = None
+    prompt_cache_key: str | None = None
 
     def __post_init__(self) -> None:
         """Normalize CLI-config-style model IDs before Agno uses the model id."""
         self.id = normalize_kimi_model_id(self.id)
         super().__post_init__()
+        if self.role_map is None:
+            # Agno maps system messages to OpenAI's newer "developer" role, which
+            # the Kimi Code endpoint rejects; keep the classic "system" role.
+            self.role_map = {**self.default_role_map, "system": "system"}
+
+    def get_request_params(
+        self,
+        response_format: dict[Any, Any] | type[BaseModel] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        run_response: RunOutput | TeamRunOutput | None = None,
+    ) -> dict[str, Any]:
+        """Pin requests to a stable prompt-cache namespace like the Kimi Code CLI does."""
+        request_params = super().get_request_params(
+            response_format=response_format,
+            tools=tools,
+            tool_choice=tool_choice,
+            run_response=run_response,
+        )
+        if self.prompt_cache_key:
+            request_params.setdefault("prompt_cache_key", self.prompt_cache_key)
+        return request_params
 
     def _get_client_params(self) -> dict[str, Any]:
         base_params = {

--- a/src/mindroom/model_defaults.py
+++ b/src/mindroom/model_defaults.py
@@ -25,6 +25,7 @@ __all__ = (
     "GOOGLE_VEO",
     "GROQ_TRANSCRIPTION",
     "GROQ_TTS",
+    "KIMI_K3",
     "LLAMA_CPP_BASE_URL_DEFAULT",
     "LLAMA_CPP_GEMMA",
     "LLAMA_CPP_QWEN",
@@ -95,6 +96,7 @@ _AWS_BEDROCK_CLAUDE_SONNET = "global.anthropic.claude-sonnet-5"
 _AWS_BEDROCK_CLAUDE_HAIKU = "global.anthropic.claude-haiku-4-5"
 CODEX_GPT = "gpt-5.6"
 CODEX_GPT_ENDPOINT = "gpt-5.6-sol"
+KIMI_K3 = "k3"
 _OPENAI_GPT = "gpt-5.6"
 # OpenAI's Responses-API tool_search tool requires gpt-5.4 or newer; gating
 # parses the gpt-N.M version from the model id so new releases take the
@@ -159,6 +161,7 @@ CONFIG_INIT_MODEL_PRESETS: Mapping[str, ModelPreset] = MappingProxyType(
         "bedrock_claude": ModelPreset("bedrock_claude", AWS_BEDROCK_CLAUDE_OPUS, 1_000_000),
         "azure": ModelPreset("azure", AZURE_OPENAI_DEFAULT_DEPLOYMENT),
         "codex": ModelPreset("codex", CODEX_GPT, 258_000),
+        "kimi": ModelPreset("kimi", KIMI_K3, 1_048_576),
         "llama_cpp": ModelPreset("llama_cpp", LLAMA_CPP_GEMMA, 128_000),
         "ollama": ModelPreset("ollama", OLLAMA_GEMMA, 128_000),
         "openai": ModelPreset("openai", _OPENAI_GPT, 1_050_000),

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -13,6 +13,7 @@ from mindroom.google_adc import load_google_application_credentials
 from mindroom.llm_request_logging import install_llm_request_logging
 from mindroom.logging_config import get_logger
 from mindroom.model_defaults import OLLAMA_HOST_DEFAULT, ZAI_BASE_URL_DEFAULT
+from mindroom.prompt_cache_key import derive_session_prompt_cache_key
 from mindroom.runtime_env_policy import (
     AWS_BEDROCK_CLAUDE_ENV_BY_KEY,
     AZURE_OPENAI_ENV_BY_KEY,
@@ -137,6 +138,18 @@ def _set_bedrock_claude_session(extra_kwargs: dict[str, Any], aws_profile: str |
     extra_kwargs["session"] = boto3.session.Session(**session_kwargs)
 
 
+def _set_session_prompt_cache_key(
+    extra_kwargs: dict[str, Any],
+    execution_identity: ToolExecutionIdentity | None,
+) -> None:
+    """Pin the model to a stable per-session prompt-cache key unless explicitly overridden."""
+    if "prompt_cache_key" in extra_kwargs or execution_identity is None:
+        return
+    prompt_cache_key = derive_session_prompt_cache_key(execution_identity)
+    if prompt_cache_key is not None:
+        extra_kwargs["prompt_cache_key"] = prompt_cache_key
+
+
 def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
     provider: str,
     model_id: str,
@@ -250,29 +263,18 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
     if canonical_provider_key in {"codex", "openai_codex"}:
         from mindroom.codex_model import (  # noqa: PLC0415
             CodexResponses,
-            derive_codex_prompt_cache_key,
             normalize_codex_model_id,
         )
 
         extra_kwargs.pop("api_key", None)
-        if "prompt_cache_key" not in extra_kwargs and execution_identity is not None:
-            prompt_cache_key = derive_codex_prompt_cache_key(execution_identity)
-            if prompt_cache_key is not None:
-                extra_kwargs["prompt_cache_key"] = prompt_cache_key
+        _set_session_prompt_cache_key(extra_kwargs, execution_identity)
         return CodexResponses(id=normalize_codex_model_id(model_id), **extra_kwargs)
 
     if canonical_provider_key in {"kimi", "kimi_code"}:
-        from mindroom.kimi_model import (  # noqa: PLC0415
-            KimiChat,
-            derive_kimi_prompt_cache_key,
-            normalize_kimi_model_id,
-        )
+        from mindroom.kimi_model import KimiChat, normalize_kimi_model_id  # noqa: PLC0415
 
         extra_kwargs.pop("api_key", None)
-        if "prompt_cache_key" not in extra_kwargs and execution_identity is not None:
-            prompt_cache_key = derive_kimi_prompt_cache_key(execution_identity)
-            if prompt_cache_key is not None:
-                extra_kwargs["prompt_cache_key"] = prompt_cache_key
+        _set_session_prompt_cache_key(extra_kwargs, execution_identity)
         return KimiChat(id=normalize_kimi_model_id(model_id), **extra_kwargs)
 
     if canonical_provider_key == _BEDROCK_CLAUDE_PROVIDER:

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -262,9 +262,17 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         return CodexResponses(id=normalize_codex_model_id(model_id), **extra_kwargs)
 
     if canonical_provider_key in {"kimi", "kimi_code"}:
-        from mindroom.kimi_model import KimiChat, normalize_kimi_model_id  # noqa: PLC0415
+        from mindroom.kimi_model import (  # noqa: PLC0415
+            KimiChat,
+            derive_kimi_prompt_cache_key,
+            normalize_kimi_model_id,
+        )
 
         extra_kwargs.pop("api_key", None)
+        if "prompt_cache_key" not in extra_kwargs and execution_identity is not None:
+            prompt_cache_key = derive_kimi_prompt_cache_key(execution_identity)
+            if prompt_cache_key is not None:
+                extra_kwargs["prompt_cache_key"] = prompt_cache_key
         return KimiChat(id=normalize_kimi_model_id(model_id), **extra_kwargs)
 
     if canonical_provider_key == _BEDROCK_CLAUDE_PROVIDER:

--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -162,6 +162,8 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
             "codex",
             "openai_codex",
             "synthetic",
+            "kimi",
+            "kimi_code",
             _BEDROCK_CLAUDE_PROVIDER,
         }
         and "api_key" not in extra_kwargs
@@ -258,6 +260,12 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
             if prompt_cache_key is not None:
                 extra_kwargs["prompt_cache_key"] = prompt_cache_key
         return CodexResponses(id=normalize_codex_model_id(model_id), **extra_kwargs)
+
+    if canonical_provider_key in {"kimi", "kimi_code"}:
+        from mindroom.kimi_model import KimiChat, normalize_kimi_model_id  # noqa: PLC0415
+
+        extra_kwargs.pop("api_key", None)
+        return KimiChat(id=normalize_kimi_model_id(model_id), **extra_kwargs)
 
     if canonical_provider_key == _BEDROCK_CLAUDE_PROVIDER:
         extra_kwargs.pop("api_key", None)

--- a/src/mindroom/prompt_cache_key.py
+++ b/src/mindroom/prompt_cache_key.py
@@ -1,0 +1,29 @@
+"""Stable prompt-cache routing keys derived from execution identity."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+
+__all__ = ["derive_session_prompt_cache_key"]
+
+
+def derive_session_prompt_cache_key(identity: ToolExecutionIdentity, *, prefix: str) -> str | None:
+    """Derive a stable prompt-cache routing key for one active execution."""
+    if identity.session_id is None:
+        return None
+    source = ":".join(
+        (
+            identity.channel,
+            identity.agent_name,
+            identity.requester_id or "",
+            identity.room_id or "",
+            identity.resolved_thread_id or identity.thread_id or "",
+            identity.session_id,
+        ),
+    )
+    digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:32]
+    return f"{prefix}-{digest}"

--- a/src/mindroom/prompt_cache_key.py
+++ b/src/mindroom/prompt_cache_key.py
@@ -10,8 +10,10 @@ if TYPE_CHECKING:
 
 __all__ = ["derive_session_prompt_cache_key"]
 
+_PROMPT_CACHE_KEY_PREFIX = "mindroom"
 
-def derive_session_prompt_cache_key(identity: ToolExecutionIdentity, *, prefix: str) -> str | None:
+
+def derive_session_prompt_cache_key(identity: ToolExecutionIdentity) -> str | None:
     """Derive a stable prompt-cache routing key for one active execution."""
     if identity.session_id is None:
         return None
@@ -26,4 +28,4 @@ def derive_session_prompt_cache_key(identity: ToolExecutionIdentity, *, prefix: 
         ),
     )
     digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:32]
-    return f"{prefix}-{digest}"
+    return f"{_PROMPT_CACHE_KEY_PREFIX}-{digest}"

--- a/tach.toml
+++ b/tach.toml
@@ -301,6 +301,7 @@ depends_on = [
     "mindroom.claude_prompt_cache",
     "mindroom.claude_stream_retry",
     "mindroom.codex_model",
+    "mindroom.kimi_model",
     "mindroom.openai_models",
     "mindroom.openai_tool_search",
     "mindroom.vertex_claude_compat",

--- a/tach.toml
+++ b/tach.toml
@@ -304,6 +304,7 @@ depends_on = [
     "mindroom.kimi_model",
     "mindroom.openai_models",
     "mindroom.openai_tool_search",
+    "mindroom.prompt_cache_key",
     "mindroom.vertex_claude_compat",
 ]
 visibility = [

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -2017,7 +2017,7 @@ class TestRunErrorHandling:
         assert "No config found" in result.output
         assert "mindroom config init" in result.output
         provider_guidance = (
-            "mindroom config init --provider {openrouter,ollama,openai,azure,bedrock_claude,codex,claude"
+            "mindroom config init --provider {openrouter,ollama,openai,azure,bedrock_claude,codex,kimi,claude"
         )
         assert provider_guidance in result.output
         mock_main.assert_not_awaited()

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -765,6 +765,33 @@ class TestConfigInit:
         assert "mindroom connect --pair-code" in output
         assert "codex login" in output
 
+    def test_init_mindroom_chat_kimi_writes_hosted_kimi_defaults(self, tmp_path: Path) -> None:
+        """Hosted Kimi config should use Kimi defaults and hosted Matrix settings."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(
+            app,
+            ["config", "init", "--path", str(target), "--matrix-server", "mindroom.chat", "--provider", "kimi"],
+        )
+        assert result.exit_code == 0
+
+        config = yaml.safe_load(target.read_text())
+        assert "mindroom_user" not in config
+        assert config["models"]["default"]["provider"] == "kimi"
+        assert config["models"]["default"]["id"] == CONFIG_INIT_MODEL_PRESETS["kimi"].id
+        assert config["models"]["default"]["context_window"] == CONFIG_INIT_MODEL_PRESETS["kimi"].context_window
+
+        env_content = (tmp_path / ".env").read_text()
+        assert "MATRIX_HOMESERVER=https://mindroom.chat" in env_content
+        assert "Run `kimi` and `/login` before starting MindRoom." in env_content
+        assert "# KIMI_CODE_HOME=~/.kimi-code" in env_content
+        assert "\nANTHROPIC_API_KEY=" not in env_content
+        assert "\nOPENAI_API_KEY=" not in env_content
+        assert "\nOPENROUTER_API_KEY=" not in env_content
+
+        output = normalize_console_output(result.output)
+        assert "mindroom connect --pair-code" in output
+        assert "/login" in output
+
     def test_init_mindroom_chat_ollama_writes_hosted_ollama_defaults(
         self,
         tmp_path: Path,
@@ -1299,6 +1326,30 @@ class TestConfigInit:
         assert "Run `codex login` before starting MindRoom." in env_content
         assert "# CODEX_HOME=~/.codex" in env_content
         assert "OPENAI_API_KEY=your-openai-key-here" not in env_content
+
+    def test_init_kimi_preset_uses_kimi_models(self, tmp_path: Path) -> None:
+        """Config init --provider kimi uses Kimi Code CLI login defaults."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--provider", "kimi"])
+        assert result.exit_code == 0
+
+        config = yaml.safe_load(target.read_text())
+        assert config["models"]["default"]["provider"] == "kimi"
+        assert config["models"]["default"]["id"] == CONFIG_INIT_MODEL_PRESETS["kimi"].id
+        assert config["models"]["default"]["context_window"] == CONFIG_INIT_MODEL_PRESETS["kimi"].context_window
+
+        env_content = (tmp_path / ".env").read_text()
+        assert "Run `kimi` and `/login` before starting MindRoom." in env_content
+        assert "# KIMI_CODE_HOME=~/.kimi-code" in env_content
+        assert "OPENAI_API_KEY=your-openai-key-here" not in env_content
+
+    @pytest.mark.parametrize("provider", ["kimi-code", "kimi_code"])
+    def test_init_rejects_kimi_provider_aliases(self, tmp_path: Path, provider: str) -> None:
+        """Config init should accept kimi as the provider preset without extra aliases."""
+        target = tmp_path / "config.yaml"
+        result = runner.invoke(app, ["config", "init", "--path", str(target), "--provider", provider])
+        assert result.exit_code == 1
+        assert "Invalid --provider value" in normalize_console_output(result.output)
 
     @pytest.mark.parametrize("provider", ["openai-codex", "openai_codex", "c"])
     def test_init_rejects_openai_codex_provider_aliases(self, tmp_path: Path, provider: str) -> None:

--- a/tests/test_kimi_model.py
+++ b/tests/test_kimi_model.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from agno.models.message import Message
 
 from mindroom import kimi_model
 from mindroom.config.main import Config
@@ -24,6 +25,7 @@ from mindroom.kimi_model import (
     normalize_kimi_model_id,
 )
 from mindroom.model_loading import get_model_instance
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 
 def _write_kimi_credentials(kimi_home: Path, access_token: str, refresh_value: str, *, expires_at: int) -> None:
@@ -199,6 +201,55 @@ def test_kimi_chat_fresh_clients_refresh_expired_tokens(tmp_path: Path, monkeypa
         return_value={"access_token": "refreshed-access", "expires_in": 900},
     ):
         assert model._get_client_params()["api_key"] == "refreshed-access"
+
+
+def test_kimi_chat_keeps_system_role_for_kimi_endpoint() -> None:
+    """Agno's system-to-developer role mapping must not leak to the Kimi Code endpoint."""
+    model = KimiChat(id="k3")
+    wire = model._format_message(Message(role="system", content="Be helpful."))
+    assert wire["role"] == "system"
+
+
+def test_kimi_chat_request_params_include_prompt_cache_key() -> None:
+    """KimiChat should pin requests to its prompt-cache namespace like the Kimi Code CLI."""
+    model = KimiChat(id="k3", prompt_cache_key="mindroom-code-agent")
+    assert model.get_request_params()["prompt_cache_key"] == "mindroom-code-agent"
+
+    model_without_key = KimiChat(id="k3")
+    assert "prompt_cache_key" not in model_without_key.get_request_params()
+
+
+def test_kimi_model_loader_derives_prompt_cache_key_from_execution_identity(tmp_path: Path) -> None:
+    """MindRoom should use a stable per-agent/session Kimi cache key by default."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={},
+    )
+    config = Config(
+        models={
+            "default": ModelConfig(
+                provider="kimi",
+                id="k3",
+            ),
+        },
+        agents={},
+    )
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="code",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id="$thread:example.org",
+        resolved_thread_id="$thread:example.org",
+        session_id="!room:example.org:$thread:example.org",
+    )
+
+    model = get_model_instance(config, runtime_paths, execution_identity=identity)
+
+    assert isinstance(model, KimiChat)
+    assert model.prompt_cache_key == "mindroom-7ac97f304c4001bd9939c88ddba8b0e2"
+    assert model.get_request_params()["prompt_cache_key"] == "mindroom-7ac97f304c4001bd9939c88ddba8b0e2"
 
 
 @pytest.mark.parametrize("provider", ["kimi", "kimi_code"])

--- a/tests/test_kimi_model.py
+++ b/tests/test_kimi_model.py
@@ -185,8 +185,8 @@ def test_kimi_chat_client_params_use_kimi_endpoint_and_borrowed_token(tmp_path: 
     assert params["base_url"] == _KIMI_BASE_URL
 
 
-def test_kimi_chat_fresh_clients_refresh_expired_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Each new client should re-read the OAuth state so expired tokens refresh between requests."""
+def test_kimi_chat_client_params_refresh_expired_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each client-params build should re-read the OAuth state so expired tokens refresh between requests."""
     kimi_home = tmp_path / ".kimi-code"
     _write_kimi_credentials(kimi_home, "first-access", "refresh-value", expires_at=int(time.time()) + 3600)
     model = KimiChat(id="k3", kimi_home=str(kimi_home))

--- a/tests/test_kimi_model.py
+++ b/tests/test_kimi_model.py
@@ -1,0 +1,234 @@
+"""Tests for the Kimi Code CLI OAuth-backed chat model provider."""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import threading
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from mindroom import kimi_model
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.constants import resolve_runtime_paths
+from mindroom.kimi_model import (
+    _KIMI_BASE_URL,
+    KimiChat,
+    _borrow_kimi_token,
+    _kimi_home_path,
+    normalize_kimi_model_id,
+)
+from mindroom.model_loading import get_model_instance
+
+
+def _write_kimi_credentials(kimi_home: Path, access_token: str, refresh_value: str, *, expires_at: int) -> None:
+    credentials_dir = kimi_home / "credentials"
+    credentials_dir.mkdir(parents=True, exist_ok=True)
+    credentials = {
+        "access_token": access_token,
+        "refresh_token": refresh_value,
+        "expires_at": expires_at,
+        "expires_in": 900,
+        "token_type": "Bearer",
+        "scope": "kimi-code",
+    }
+    (credentials_dir / "kimi-code.json").write_text(json.dumps(credentials), encoding="utf-8")
+
+
+@pytest.mark.parametrize(
+    ("configured_id", "endpoint_id"),
+    [
+        ("k3", "k3"),
+        ("kimi-code/k3", "k3"),
+        ("k3-256k", "k3-256k"),
+        ("kimi-code/kimi-for-coding", "kimi-for-coding"),
+    ],
+)
+def test_normalize_kimi_model_id_strips_cli_prefix(configured_id: str, endpoint_id: str) -> None:
+    """The kimi-code/ prefix from CLI config model names should resolve to the bare slug."""
+    assert normalize_kimi_model_id(configured_id) == endpoint_id
+
+
+def test_kimi_home_expands_explicit_tilde(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit Kimi home paths should expand a user-home prefix like the default path."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+
+    assert _kimi_home_path(kimi_home="~/custom-kimi") == tmp_path / "custom-kimi"
+
+
+def test_borrow_kimi_token_uses_unexpired_access_token(tmp_path: Path) -> None:
+    """A valid Kimi Code CLI token should be reused directly."""
+    kimi_home = tmp_path / ".kimi-code"
+    _write_kimi_credentials(kimi_home, "access-value", "refresh-value", expires_at=int(time.time()) + 3600)
+
+    assert _borrow_kimi_token(kimi_home=kimi_home) == "access-value"
+
+
+def test_borrow_kimi_token_refreshes_expired_access_token(tmp_path: Path) -> None:
+    """Expired Kimi Code CLI tokens should be refreshed and persisted."""
+    kimi_home = tmp_path / ".kimi-code"
+    _write_kimi_credentials(kimi_home, "old-access", "refresh-value", expires_at=int(time.time()) - 60)
+    refreshed_access = "new-access"
+    rotated_refresh = "new-refresh-value"
+
+    with patch(
+        "mindroom.kimi_model._refresh_kimi_tokens",
+        return_value={
+            "access_token": refreshed_access,
+            "refresh_token": rotated_refresh,
+            "expires_in": 900,
+        },
+    ):
+        token = _borrow_kimi_token(kimi_home=kimi_home)
+
+    credentials = json.loads((kimi_home / "credentials" / "kimi-code.json").read_text(encoding="utf-8"))
+    assert token == refreshed_access
+    assert credentials["access_token"] == refreshed_access
+    assert credentials["refresh_token"] == rotated_refresh
+    assert credentials["expires_at"] > int(time.time())
+
+
+def test_write_kimi_credentials_creates_private_temp_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Refreshed Kimi OAuth tokens should never be written through a world-readable temp file."""
+    credentials_dir = tmp_path / "credentials"
+    credentials_dir.mkdir()
+    credentials_path = credentials_dir / "kimi-code.json"
+    observed_temp_modes: list[int] = []
+    original_replace = Path.replace
+
+    def spy_replace(self: Path, target: str | Path) -> Path:
+        if self.name == "kimi-code.json.tmp":
+            observed_temp_modes.append(stat.S_IMODE(self.stat().st_mode))
+        return original_replace(self, target)
+
+    monkeypatch.setattr(Path, "replace", spy_replace)
+    old_umask = os.umask(0o022)
+    try:
+        kimi_model._write_kimi_credentials(credentials_path, {"access_token": "token"})
+    finally:
+        os.umask(old_umask)
+
+    assert observed_temp_modes == [0o600]
+    assert stat.S_IMODE(credentials_path.stat().st_mode) == 0o600
+
+
+def test_borrow_kimi_token_serializes_concurrent_refreshes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent expired-token readers should share one refreshed token instead of racing refresh-token rotation."""
+    kimi_home = tmp_path / ".kimi-code"
+    _write_kimi_credentials(kimi_home, "old-access", "refresh-value", expires_at=int(time.time()) - 60)
+    refresh_started = threading.Event()
+    release_refresh = threading.Event()
+    refresh_call_count = 0
+    refresh_call_count_lock = threading.Lock()
+    results: list[str] = []
+    errors: list[BaseException] = []
+
+    def fake_refresh(received_refresh: str) -> dict[str, object]:
+        nonlocal refresh_call_count
+        assert received_refresh == "refresh-value"
+        with refresh_call_count_lock:
+            refresh_call_count += 1
+        refresh_started.set()
+        assert release_refresh.wait(timeout=2)
+        return {
+            "access_token": "new-access",
+            "refresh_token": "new-refresh-value",
+            "expires_in": 900,
+        }
+
+    def borrow_token() -> None:
+        try:
+            results.append(_borrow_kimi_token(kimi_home=kimi_home))
+        except BaseException as exc:
+            errors.append(exc)
+
+    monkeypatch.setattr(kimi_model, "_refresh_kimi_tokens", fake_refresh)
+
+    first_thread = threading.Thread(target=borrow_token)
+    first_thread.start()
+    assert refresh_started.wait(timeout=2)
+
+    second_thread = threading.Thread(target=borrow_token)
+    second_thread.start()
+    release_refresh.set()
+    first_thread.join(timeout=2)
+    second_thread.join(timeout=2)
+
+    assert not first_thread.is_alive()
+    assert not second_thread.is_alive()
+    assert errors == []
+    assert refresh_call_count == 1
+    assert results == ["new-access", "new-access"]
+
+
+def test_kimi_chat_client_params_use_kimi_endpoint_and_borrowed_token(tmp_path: Path) -> None:
+    """KimiChat should translate Kimi Code CLI auth into OpenAI client params."""
+    kimi_home = tmp_path / ".kimi-code"
+    _write_kimi_credentials(kimi_home, "access-value", "refresh-value", expires_at=int(time.time()) + 3600)
+
+    model = KimiChat(id="k3", kimi_home=str(kimi_home))
+
+    params = model._get_client_params()
+
+    assert params["api_key"] == "access-value"
+    assert params["base_url"] == _KIMI_BASE_URL
+
+
+def test_kimi_chat_fresh_clients_refresh_expired_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each new client should re-read the OAuth state so expired tokens refresh between requests."""
+    kimi_home = tmp_path / ".kimi-code"
+    _write_kimi_credentials(kimi_home, "first-access", "refresh-value", expires_at=int(time.time()) + 3600)
+    model = KimiChat(id="k3", kimi_home=str(kimi_home))
+
+    assert model._get_client_params()["api_key"] == "first-access"
+
+    _write_kimi_credentials(kimi_home, "second-access", "refresh-value", expires_at=int(time.time()) + 3600)
+    monkeypatch.setattr(kimi_model, "_KIMI_REFRESH_SKEW_SECONDS", 7200)
+
+    with patch(
+        "mindroom.kimi_model._refresh_kimi_tokens",
+        return_value={"access_token": "refreshed-access", "expires_in": 900},
+    ):
+        assert model._get_client_params()["api_key"] == "refreshed-access"
+
+
+@pytest.mark.parametrize("provider", ["kimi", "kimi_code"])
+def test_get_model_instance_supports_kimi_provider(tmp_path: Path, provider: str) -> None:
+    """The model loader should expose Kimi as a first-class model provider."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={},
+    )
+    config = Config(
+        models={
+            "default": ModelConfig(
+                provider=provider,
+                id="kimi-code/k3",
+            ),
+        },
+        agents={},
+    )
+
+    with patch("mindroom.model_loading.logger.info") as log_info:
+        model = get_model_instance(config, runtime_paths)
+
+    assert isinstance(model, KimiChat)
+    assert model.id == "k3"
+    assert str(model.base_url) == _KIMI_BASE_URL
+    log_info.assert_called_once_with(
+        "Using AI model",
+        model="default",
+        provider=provider,
+        configured_id="kimi-code/k3",
+        effective_id="k3",
+    )


### PR DESCRIPTION
## Summary

Adds `kimi` / `kimi_code` as a first-class model provider that runs on a **Kimi Code subscription** via the local Kimi Code CLI OAuth login — mirroring the existing `codex` (ChatGPT login) adapter.

- **`src/mindroom/kimi_model.py`** (new): `KimiChat` (extends `MindRoomOpenAIChat`) targeting the Kimi Code OpenAI-compatible endpoint `https://api.kimi.com/coding/v1`. Borrows OAuth tokens from `~/.kimi-code/credentials/kimi-code.json` (override via `KIMI_CODE_HOME` or `extra_kwargs.kimi_home`), refreshes them via `https://auth.kimi.com/api/oauth/token` with the Kimi Code client ID, with advisory file-lock serialization, atomic `0600` credential writes, and fresh clients per request so the 15-minute tokens refresh between turns. Accepts bare (`k3`) and CLI-style (`kimi-code/k3`) model IDs.
- **Endpoint compatibility fix**: Agno maps `system` messages to OpenAI's newer `developer` role, which the Kimi Code endpoint rejects with a 400 — `KimiChat` keeps the classic `system` role (every real MindRoom agent has a system prompt, so this would have broken real usage).
- **Prompt caching** (`src/mindroom/prompt_cache_key.py`, new shared leaf): caching on the endpoint is automatic for repeated prefixes, and like the Kimi Code CLI, MindRoom now pins each active agent session to a stable `prompt_cache_key` derived from the execution identity. The derivation is shared with the Codex provider (its per-provider wrapper is removed; the loader sets the key for both providers via one helper). Override with `extra_kwargs.prompt_cache_key`.
- **`model_loading.py`**: `kimi` / `kimi_code` provider branch (no API key resolution, like `codex`).
- **`model_defaults.py`**: `KIMI_K3` constant and a `kimi` preset (`k3`, 1,048,576 context).
- **CLI**: `mindroom config init --provider kimi` preset with `.env` template and post-init hints (no aliases, matching the codex preset convention).
- **Docs**: provider list + dedicated section in `docs/configuration/models.md`, `docs/cli.md`, `docs/getting-started.md`, `CLAUDE.md` model table, regenerated `skills/mindroom-docs/references/`.
- **`tach.toml`**: `mindroom.kimi_model` + `mindroom.prompt_cache_key` added to the `model_loading` boundary.
- **Tests**: `tests/test_kimi_model.py` (token borrow, forced refresh + persistence, atomic `0600` writes, concurrent-refresh serialization, client params, system-role mapping, cache-key wiring, loader integration incl. alias) and `config init` preset tests for `kimi` (standalone, hosted, alias rejection) mirroring the Codex coverage.

## Live verification (real Kimi Code subscription)

- Direct `chat/completions` with model `k3` → 200
- Through `get_model_instance(provider="kimi")`: non-streaming invoke, sync streaming, async streaming (the path MindRoom responses use), an Agno agent run with a tool call, and a system-prompt conversation — all correct
- Real OAuth refresh: forced the stored token into expiry, refresh against `auth.kimi.com` rotated both tokens back into the credentials file, and a follow-up K3 call with the refreshed token returned 200
- Prompt caching: repeated 15k-token prefixes return full `cached_tokens` through the MindRoom model path, with the derived `prompt_cache_key` on the wire
- `mindroom config init --provider kimi --print` generates correct YAML

## Checks

- Full `pytest` suite passes; `tach check --dependencies --interfaces` clean
- pre-commit clean on all touched files (two pre-existing host-specific failures unrelated to this PR: `ty` on macOS-only `AppKit`/`Quartz` imports under Linux, and `prettier` on untouched frontend files)

Note: K3 always reasons before replying, so even short answers consume reasoning tokens — documented in the new section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Kimi Code provider, including Kimi K3 model configuration.
  * Added `kimi` to configuration initialization options and generated setup templates.
  * Added automatic local credential use and token refresh through Kimi Code CLI authentication.
  * Added stable prompt caching for supported model sessions, with optional overrides.

* **Documentation**
  * Updated setup, configuration, CLI, and model references with Kimi authentication and usage instructions.

* **Tests**
  * Added coverage for Kimi configuration, authentication, token refresh, model loading, and prompt caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->