### PR TITLE
Show voice transcription progress immediately

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -75,6 +75,7 @@ MindRoom's architecture consists of several key components working together.
 | `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
 | `response_payload_preparation.py` | Execution-side, under-lock assembly of one response's payload from immutable ingress inputs |
 | `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
+| `visible_voice_echo.py` | Immediate router voice-placeholder delivery, replacement ordering, and deduplication |
 | `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `routing.py` | Intelligent agent or team selection when no entity is mentioned |
 | `streaming.py` | Streaming state machine: placeholder, progressive edits, tool traces, cancellation |

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -523,7 +523,7 @@ knowledge_bases:
 # Voice message handling (optional)
 voice:
   enabled: false                   # Default: false
-  visible_router_echo: true        # Optional: show the normalized voice text from the router
+  visible_router_echo: true        # Optional: show and replace a router transcription placeholder
   stt:
     provider: openai               # Default: openai
     model: gpt-4o-transcribe       # Default: gpt-4o-transcribe

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -523,7 +523,7 @@ knowledge_bases:
 # Voice message handling (optional)
 voice:
   enabled: false                   # Default: false
-  visible_router_echo: true        # Optional: show and replace a router transcription placeholder
+  visible_router_echo: true        # Optional: show router voice progress or direct fallback
   stt:
     provider: openai               # Default: openai
     model: gpt-4o-transcribe       # Default: gpt-4o-transcribe

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -103,7 +103,8 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized transcript or fallback text when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized transcript or fallback text when voice STT is enabled and it is allowed to reply.
+With STT disabled, the router posts the display-only fallback directly.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
 
 See [Voice Messages](../voice.md) for the detailed dispatch behavior.

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -103,7 +103,7 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized voice text when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized transcript or fallback text when it is allowed to reply.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
 
 See [Voice Messages](../voice.md) for the detailed dispatch behavior.

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -103,7 +103,7 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized voice text when it is allowed to reply.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
 
 See [Voice Messages](../voice.md) for the detailed dispatch behavior.

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -297,7 +297,7 @@ Enable voice message processing with speech-to-text:
 ```yaml
 voice:
   enabled: false
-  visible_router_echo: true  # Show placeholder, then replace with transcript or fallback text
+  visible_router_echo: true  # Show STT placeholder or direct fallback when STT is disabled
   stt:
     provider: openai
     model: gpt-4o-transcribe

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -297,7 +297,7 @@ Enable voice message processing with speech-to-text:
 ```yaml
 voice:
   enabled: false
-  visible_router_echo: true  # Post transcript as visible router message
+  visible_router_echo: true  # Show placeholder, then replace with transcript
   stt:
     provider: openai
     model: gpt-4o-transcribe

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -297,7 +297,7 @@ Enable voice message processing with speech-to-text:
 ```yaml
 voice:
   enabled: false
-  visible_router_echo: true  # Show placeholder, then replace with transcript
+  visible_router_echo: true  # Show placeholder, then replace with transcript or fallback text
   stt:
     provider: openai
     model: gpt-4o-transcribe

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -13,11 +13,11 @@ If STT is unavailable, disabled, or fails, the audio still remains available as 
 When a voice message is received:
 
 1. The audio event is handled through the shared media pipeline.
-2. If `voice.visible_router_echo` is enabled and the router is present and allowed to reply, the router immediately posts `Router agent is transcribing…`.
+2. If voice STT and `voice.visible_router_echo` are enabled and the router is present and allowed to reply, the router immediately posts `Router agent is transcribing…`.
 3. Audio is downloaded and decrypted, if needed, and registered as a context-scoped attachment while the placeholder is visible.
 4. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
 5. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
-6. The router replaces its placeholder with the normalized transcript or fallback text.
+6. The router replaces its placeholder with the normalized transcript or fallback text, or posts the fallback directly when STT is disabled.
 7. The normalized transcript or fallback prompt plus attachment metadata is dispatched using the normal routing and thread logic.
 8. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
 9. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
@@ -44,7 +44,8 @@ Or use the dashboard's Voice tab.
 
 With `voice.enabled: false`, audio messages are still surfaced as attachments with the fallback prompt.
 Enabling voice adds STT and command-recognition on top of that attachment flow.
-With `voice.visible_router_echo: true`, the router immediately posts a transcription placeholder and replaces that message with the normalized transcript or fallback text when it is present in the room and allowed to reply.
+With `voice.visible_router_echo: true` and `voice.enabled: true`, the router immediately posts a transcription placeholder and replaces that message with the normalized transcript or fallback text when it is present in the room and allowed to reply.
+When `voice.enabled: false`, the router posts the fallback text directly without claiming that transcription is running.
 
 ## STT Providers
 
@@ -154,7 +155,8 @@ If only one eligible agent or team is visible, that responder answers the normal
 If the audio caption or transcript explicitly mentions an agent or team, that targeted responder answers directly as well.
 In these cases, the router does not post an extra visible routing handoff.
 The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
-If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized transcript or fallback text, but responders ignore that echo and continue responding to the original audio event.
+If voice STT and `voice.visible_router_echo` are enabled, the router still posts a display-only placeholder and replaces it with the normalized transcript or fallback text, but responders ignore that echo and continue responding to the original audio event.
+With STT disabled, the router posts the display-only fallback directly.
 
 ### Multi-responder rooms where the router must choose
 
@@ -162,7 +164,8 @@ If multiple agents or teams are available and the audio does not already target 
 The router then posts a normal handoff message such as `@home could you help with this?`.
 The selected agent or team responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
 This is the case where a visible router message appears.
-If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized transcript or fallback text, and then posts the normal handoff.
+If voice STT and `voice.visible_router_echo` are enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized transcript or fallback text, and then posts the normal handoff.
+With STT disabled, the router posts the display-only fallback directly before the normal handoff.
 
 ### No router, or router cannot reply
 
@@ -174,7 +177,8 @@ If multiple eligible responders remain and the audio does not already target one
 
 ### Visibility rule
 
-By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized transcript or fallback text.
+By default, MindRoom immediately posts a display-only router transcription placeholder when voice STT is enabled and the router is allowed to process the event, then replaces it with the normalized transcript or fallback text.
+With STT disabled, MindRoom posts the display-only fallback directly.
 The router handoff message appears only when the router must disambiguate between multiple eligible responders.
 If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent or team replies directly to the original audio event.
 Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event responders actually answer.

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -13,14 +13,15 @@ If STT is unavailable, disabled, or fails, the audio still remains available as 
 When a voice message is received:
 
 1. The audio event is handled through the shared media pipeline.
-2. Audio is downloaded and decrypted, if needed, and registered as a context-scoped attachment.
-3. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
-4. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
-5. The normalized text plus attachment metadata is dispatched using the normal routing and thread logic.
-6. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
-7. If `voice.visible_router_echo` is enabled and the router is present and allowed to reply, the router also posts the normalized voice text as a display-only message.
-8. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
-9. The responding entity receives the original audio attachment alongside the normalized prompt.
+2. If `voice.visible_router_echo` is enabled and the router is present and allowed to reply, the router immediately posts `Router agent is transcribing…`.
+3. Audio is downloaded and decrypted, if needed, and registered as a context-scoped attachment while the placeholder is visible.
+4. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
+5. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
+6. The router replaces its placeholder with the normalized transcript or fallback text.
+7. The normalized text plus attachment metadata is dispatched using the normal routing and thread logic.
+8. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
+9. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
+10. The responding entity receives the original audio attachment alongside the normalized prompt.
 
 ## Configuration
 
@@ -43,7 +44,7 @@ Or use the dashboard's Voice tab.
 
 With `voice.enabled: false`, audio messages are still surfaced as attachments with the fallback prompt.
 Enabling voice adds STT and command-recognition on top of that attachment flow.
-With `voice.visible_router_echo: true`, the router also posts the normalized transcript or fallback text for inspection when it is present in the room and allowed to reply.
+With `voice.visible_router_echo: true`, the router immediately posts a transcription placeholder and replaces that message with the normalized transcript or fallback text when it is present in the room and allowed to reply.
 
 ## STT Providers
 
@@ -153,7 +154,7 @@ If only one eligible agent or team is visible, that responder answers the normal
 If the audio caption or transcript explicitly mentions an agent or team, that targeted responder answers directly as well.
 In these cases, the router does not post an extra visible routing handoff.
 The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
-If `voice.visible_router_echo` is enabled, the router still posts a display-only copy of the normalized voice text, but responders ignore that echo and continue responding to the original audio event.
+If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized voice text, but responders ignore that echo and continue responding to the original audio event.
 
 ### Multi-responder rooms where the router must choose
 
@@ -161,7 +162,7 @@ If multiple agents or teams are available and the audio does not already target 
 The router then posts a normal handoff message such as `@home could you help with this?`.
 The selected agent or team responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
 This is the case where a visible router message appears.
-If `voice.visible_router_echo` is also enabled, the router first posts the normalized voice text as a display-only echo and then posts the normal handoff.
+If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized voice text, and then posts the normal handoff.
 
 ### No router, or router cannot reply
 
@@ -173,7 +174,7 @@ If multiple eligible responders remain and the audio does not already target one
 
 ### Visibility rule
 
-By default, MindRoom posts a display-only router echo of normalized voice text when the router is allowed to process the event.
+By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized voice text.
 The router handoff message appears only when the router must disambiguate between multiple eligible responders.
 If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent or team replies directly to the original audio event.
 Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event responders actually answer.

--- a/docs/voice.md
+++ b/docs/voice.md
@@ -18,10 +18,10 @@ When a voice message is received:
 4. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
 5. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
 6. The router replaces its placeholder with the normalized transcript or fallback text.
-7. The normalized text plus attachment metadata is dispatched using the normal routing and thread logic.
+7. The normalized transcript or fallback prompt plus attachment metadata is dispatched using the normal routing and thread logic.
 8. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
 9. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
-10. The responding entity receives the original audio attachment alongside the normalized prompt.
+10. The responding entity receives the original audio attachment alongside the normalized transcript or fallback prompt.
 
 ## Configuration
 
@@ -154,7 +154,7 @@ If only one eligible agent or team is visible, that responder answers the normal
 If the audio caption or transcript explicitly mentions an agent or team, that targeted responder answers directly as well.
 In these cases, the router does not post an extra visible routing handoff.
 The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
-If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized voice text, but responders ignore that echo and continue responding to the original audio event.
+If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized transcript or fallback text, but responders ignore that echo and continue responding to the original audio event.
 
 ### Multi-responder rooms where the router must choose
 
@@ -162,7 +162,7 @@ If multiple agents or teams are available and the audio does not already target 
 The router then posts a normal handoff message such as `@home could you help with this?`.
 The selected agent or team responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
 This is the case where a visible router message appears.
-If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized voice text, and then posts the normal handoff.
+If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized transcript or fallback text, and then posts the normal handoff.
 
 ### No router, or router cannot reply
 
@@ -174,7 +174,7 @@ If multiple eligible responders remain and the audio does not already target one
 
 ### Visibility rule
 
-By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized voice text.
+By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized transcript or fallback text.
 The router handoff message appears only when the router must disambiguate between multiple eligible responders.
 If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent or team replies directly to the original audio event.
 Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event responders actually answer.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1380,7 +1380,7 @@ knowledge_bases:
 # Voice message handling (optional)
 voice:
   enabled: false                   # Default: false
-  visible_router_echo: true        # Optional: show the normalized voice text from the router
+  visible_router_echo: true        # Optional: show and replace a router transcription placeholder
   stt:
     provider: openai               # Default: openai
     model: gpt-4o-transcribe       # Default: gpt-4o-transcribe
@@ -3046,7 +3046,7 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized voice text when it is allowed to reply.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
 
 See [Voice Messages](https://docs.mindroom.chat/voice/) for the detailed dispatch behavior.
@@ -13679,14 +13679,15 @@ If STT is unavailable, disabled, or fails, the audio still remains available as 
 When a voice message is received:
 
 1. The audio event is handled through the shared media pipeline.
-2. Audio is downloaded and decrypted, if needed, and registered as a context-scoped attachment.
-3. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
-4. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
-5. The normalized text plus attachment metadata is dispatched using the normal routing and thread logic.
-6. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
-7. If `voice.visible_router_echo` is enabled and the router is present and allowed to reply, the router also posts the normalized voice text as a display-only message.
-8. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
-9. The responding entity receives the original audio attachment alongside the normalized prompt.
+2. If `voice.visible_router_echo` is enabled and the router is present and allowed to reply, the router immediately posts `Router agent is transcribing…`.
+3. Audio is downloaded and decrypted, if needed, and registered as a context-scoped attachment while the placeholder is visible.
+4. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
+5. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
+6. The router replaces its placeholder with the normalized transcript or fallback text.
+7. The normalized text plus attachment metadata is dispatched using the normal routing and thread logic.
+8. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
+9. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
+10. The responding entity receives the original audio attachment alongside the normalized prompt.
 
 ## Configuration
 
@@ -13709,7 +13710,7 @@ Or use the dashboard's Voice tab.
 
 With `voice.enabled: false`, audio messages are still surfaced as attachments with the fallback prompt.
 Enabling voice adds STT and command-recognition on top of that attachment flow.
-With `voice.visible_router_echo: true`, the router also posts the normalized transcript or fallback text for inspection when it is present in the room and allowed to reply.
+With `voice.visible_router_echo: true`, the router immediately posts a transcription placeholder and replaces that message with the normalized transcript or fallback text when it is present in the room and allowed to reply.
 
 ## STT Providers
 
@@ -13819,7 +13820,7 @@ If only one eligible agent or team is visible, that responder answers the normal
 If the audio caption or transcript explicitly mentions an agent or team, that targeted responder answers directly as well.
 In these cases, the router does not post an extra visible routing handoff.
 The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
-If `voice.visible_router_echo` is enabled, the router still posts a display-only copy of the normalized voice text, but responders ignore that echo and continue responding to the original audio event.
+If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized voice text, but responders ignore that echo and continue responding to the original audio event.
 
 ### Multi-responder rooms where the router must choose
 
@@ -13827,7 +13828,7 @@ If multiple agents or teams are available and the audio does not already target 
 The router then posts a normal handoff message such as `@home could you help with this?`.
 The selected agent or team responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
 This is the case where a visible router message appears.
-If `voice.visible_router_echo` is also enabled, the router first posts the normalized voice text as a display-only echo and then posts the normal handoff.
+If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized voice text, and then posts the normal handoff.
 
 ### No router, or router cannot reply
 
@@ -13839,7 +13840,7 @@ If multiple eligible responders remain and the audio does not already target one
 
 ### Visibility rule
 
-By default, MindRoom posts a display-only router echo of normalized voice text when the router is allowed to process the event.
+By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized voice text.
 The router handoff message appears only when the router must disambiguate between multiple eligible responders.
 If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent or team replies directly to the original audio event.
 Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event responders actually answer.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3046,7 +3046,7 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized voice text when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized transcript or fallback text when it is allowed to reply.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
 
 See [Voice Messages](https://docs.mindroom.chat/voice/) for the detailed dispatch behavior.
@@ -13684,10 +13684,10 @@ When a voice message is received:
 4. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
 5. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
 6. The router replaces its placeholder with the normalized transcript or fallback text.
-7. The normalized text plus attachment metadata is dispatched using the normal routing and thread logic.
+7. The normalized transcript or fallback prompt plus attachment metadata is dispatched using the normal routing and thread logic.
 8. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
 9. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
-10. The responding entity receives the original audio attachment alongside the normalized prompt.
+10. The responding entity receives the original audio attachment alongside the normalized transcript or fallback prompt.
 
 ## Configuration
 
@@ -13820,7 +13820,7 @@ If only one eligible agent or team is visible, that responder answers the normal
 If the audio caption or transcript explicitly mentions an agent or team, that targeted responder answers directly as well.
 In these cases, the router does not post an extra visible routing handoff.
 The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
-If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized voice text, but responders ignore that echo and continue responding to the original audio event.
+If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized transcript or fallback text, but responders ignore that echo and continue responding to the original audio event.
 
 ### Multi-responder rooms where the router must choose
 
@@ -13828,7 +13828,7 @@ If multiple agents or teams are available and the audio does not already target 
 The router then posts a normal handoff message such as `@home could you help with this?`.
 The selected agent or team responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
 This is the case where a visible router message appears.
-If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized voice text, and then posts the normal handoff.
+If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized transcript or fallback text, and then posts the normal handoff.
 
 ### No router, or router cannot reply
 
@@ -13840,7 +13840,7 @@ If multiple eligible responders remain and the audio does not already target one
 
 ### Visibility rule
 
-By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized voice text.
+By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized transcript or fallback text.
 The router handoff message appears only when the router must disambiguate between multiple eligible responders.
 If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent or team replies directly to the original audio event.
 Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event responders actually answer.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1380,7 +1380,7 @@ knowledge_bases:
 # Voice message handling (optional)
 voice:
   enabled: false                   # Default: false
-  visible_router_echo: true        # Optional: show and replace a router transcription placeholder
+  visible_router_echo: true        # Optional: show router voice progress or direct fallback
   stt:
     provider: openai               # Default: openai
     model: gpt-4o-transcribe       # Default: gpt-4o-transcribe
@@ -3046,7 +3046,8 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized transcript or fallback text when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized transcript or fallback text when voice STT is enabled and it is allowed to reply.
+With STT disabled, the router posts the display-only fallback directly.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
 
 See [Voice Messages](https://docs.mindroom.chat/voice/) for the detailed dispatch behavior.
@@ -13679,11 +13680,11 @@ If STT is unavailable, disabled, or fails, the audio still remains available as 
 When a voice message is received:
 
 1. The audio event is handled through the shared media pipeline.
-2. If `voice.visible_router_echo` is enabled and the router is present and allowed to reply, the router immediately posts `Router agent is transcribing…`.
+2. If voice STT and `voice.visible_router_echo` are enabled and the router is present and allowed to reply, the router immediately posts `Router agent is transcribing…`.
 3. Audio is downloaded and decrypted, if needed, and registered as a context-scoped attachment while the placeholder is visible.
 4. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
 5. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
-6. The router replaces its placeholder with the normalized transcript or fallback text.
+6. The router replaces its placeholder with the normalized transcript or fallback text, or posts the fallback directly when STT is disabled.
 7. The normalized transcript or fallback prompt plus attachment metadata is dispatched using the normal routing and thread logic.
 8. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
 9. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
@@ -13710,7 +13711,8 @@ Or use the dashboard's Voice tab.
 
 With `voice.enabled: false`, audio messages are still surfaced as attachments with the fallback prompt.
 Enabling voice adds STT and command-recognition on top of that attachment flow.
-With `voice.visible_router_echo: true`, the router immediately posts a transcription placeholder and replaces that message with the normalized transcript or fallback text when it is present in the room and allowed to reply.
+With `voice.visible_router_echo: true` and `voice.enabled: true`, the router immediately posts a transcription placeholder and replaces that message with the normalized transcript or fallback text when it is present in the room and allowed to reply.
+When `voice.enabled: false`, the router posts the fallback text directly without claiming that transcription is running.
 
 ## STT Providers
 
@@ -13820,7 +13822,8 @@ If only one eligible agent or team is visible, that responder answers the normal
 If the audio caption or transcript explicitly mentions an agent or team, that targeted responder answers directly as well.
 In these cases, the router does not post an extra visible routing handoff.
 The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
-If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized transcript or fallback text, but responders ignore that echo and continue responding to the original audio event.
+If voice STT and `voice.visible_router_echo` are enabled, the router still posts a display-only placeholder and replaces it with the normalized transcript or fallback text, but responders ignore that echo and continue responding to the original audio event.
+With STT disabled, the router posts the display-only fallback directly.
 
 ### Multi-responder rooms where the router must choose
 
@@ -13828,7 +13831,8 @@ If multiple agents or teams are available and the audio does not already target 
 The router then posts a normal handoff message such as `@home could you help with this?`.
 The selected agent or team responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
 This is the case where a visible router message appears.
-If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized transcript or fallback text, and then posts the normal handoff.
+If voice STT and `voice.visible_router_echo` are enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized transcript or fallback text, and then posts the normal handoff.
+With STT disabled, the router posts the display-only fallback directly before the normal handoff.
 
 ### No router, or router cannot reply
 
@@ -13840,7 +13844,8 @@ If multiple eligible responders remain and the audio does not already target one
 
 ### Visibility rule
 
-By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized transcript or fallback text.
+By default, MindRoom immediately posts a display-only router transcription placeholder when voice STT is enabled and the router is allowed to process the event, then replaces it with the normalized transcript or fallback text.
+With STT disabled, MindRoom posts the display-only fallback directly.
 The router handoff message appears only when the router must disambiguate between multiple eligible responders.
 If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent or team replies directly to the original audio event.
 Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event responders actually answer.
@@ -15999,6 +16004,7 @@ MindRoom's architecture consists of several key components working together.
 | `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
 | `response_payload_preparation.py` | Execution-side, under-lock assembly of one response's payload from immutable ingress inputs |
 | `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
+| `visible_voice_echo.py` | Immediate router voice-placeholder delivery, replacement ordering, and deduplication |
 | `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `routing.py` | Intelligent agent or team selection when no entity is mentioned |
 | `streaming.py` | Streaming state machine: placeholder, progressive edits, tool traces, cancellation |

--- a/skills/mindroom-docs/references/page__architecture__index.md
+++ b/skills/mindroom-docs/references/page__architecture__index.md
@@ -71,6 +71,7 @@ MindRoom's architecture consists of several key components working together.
 | `execution_preparation.py` | Request-scoped execution preparation for prompts and persisted replay |
 | `response_payload_preparation.py` | Execution-side, under-lock assembly of one response's payload from immutable ingress inputs |
 | `delivery_gateway.py` | Visible Matrix delivery for already-generated responses (send, edit, finalize) |
+| `visible_voice_echo.py` | Immediate router voice-placeholder delivery, replacement ordering, and deduplication |
 | `post_response_effects.py` | Shared post-response effects after Matrix delivery |
 | `routing.py` | Intelligent agent or team selection when no entity is mentioned |
 | `streaming.py` | Streaming state machine: placeholder, progressive edits, tool traces, cancellation |

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -519,7 +519,7 @@ knowledge_bases:
 # Voice message handling (optional)
 voice:
   enabled: false                   # Default: false
-  visible_router_echo: true        # Optional: show the normalized voice text from the router
+  visible_router_echo: true        # Optional: show and replace a router transcription placeholder
   stt:
     provider: openai               # Default: openai
     model: gpt-4o-transcribe       # Default: gpt-4o-transcribe

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -519,7 +519,7 @@ knowledge_bases:
 # Voice message handling (optional)
 voice:
   enabled: false                   # Default: false
-  visible_router_echo: true        # Optional: show and replace a router transcription placeholder
+  visible_router_echo: true        # Optional: show router voice progress or direct fallback
   stt:
     provider: openai               # Default: openai
     model: gpt-4o-transcribe       # Default: gpt-4o-transcribe

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -99,7 +99,7 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized voice text when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized transcript or fallback text when it is allowed to reply.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
 
 See [Voice Messages](https://docs.mindroom.chat/voice/) for the detailed dispatch behavior.

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -99,7 +99,8 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized transcript or fallback text when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized transcript or fallback text when voice STT is enabled and it is allowed to reply.
+With STT disabled, the router posts the display-only fallback directly.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
 
 See [Voice Messages](https://docs.mindroom.chat/voice/) for the detailed dispatch behavior.

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -99,7 +99,7 @@ That same reconciliation path also updates `m.room.power_levels` for managed roo
 Audio events are handled through the shared media pipeline on all bots.
 The router only posts a visible handoff when it must disambiguate between multiple eligible responders in a room.
 When the responder is already clear, normalized audio follows the normal direct agent or team dispatch rules without an extra router message.
-By default, `voice.visible_router_echo: true` also lets the router post the normalized voice text as a display-only message when it is allowed to reply.
+By default, `voice.visible_router_echo: true` also lets the router post an immediate display-only transcription placeholder and replace it with the normalized voice text when it is allowed to reply.
 Set `voice.visible_router_echo: false` to suppress that display-only echo.
 
 See [Voice Messages](https://docs.mindroom.chat/voice/) for the detailed dispatch behavior.

--- a/skills/mindroom-docs/references/page__voice__index.md
+++ b/skills/mindroom-docs/references/page__voice__index.md
@@ -14,10 +14,10 @@ When a voice message is received:
 4. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
 5. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
 6. The router replaces its placeholder with the normalized transcript or fallback text.
-7. The normalized text plus attachment metadata is dispatched using the normal routing and thread logic.
+7. The normalized transcript or fallback prompt plus attachment metadata is dispatched using the normal routing and thread logic.
 8. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
 9. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
-10. The responding entity receives the original audio attachment alongside the normalized prompt.
+10. The responding entity receives the original audio attachment alongside the normalized transcript or fallback prompt.
 
 ## Configuration
 
@@ -150,7 +150,7 @@ If only one eligible agent or team is visible, that responder answers the normal
 If the audio caption or transcript explicitly mentions an agent or team, that targeted responder answers directly as well.
 In these cases, the router does not post an extra visible routing handoff.
 The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
-If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized voice text, but responders ignore that echo and continue responding to the original audio event.
+If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized transcript or fallback text, but responders ignore that echo and continue responding to the original audio event.
 
 ### Multi-responder rooms where the router must choose
 
@@ -158,7 +158,7 @@ If multiple agents or teams are available and the audio does not already target 
 The router then posts a normal handoff message such as `@home could you help with this?`.
 The selected agent or team responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
 This is the case where a visible router message appears.
-If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized voice text, and then posts the normal handoff.
+If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized transcript or fallback text, and then posts the normal handoff.
 
 ### No router, or router cannot reply
 
@@ -170,7 +170,7 @@ If multiple eligible responders remain and the audio does not already target one
 
 ### Visibility rule
 
-By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized voice text.
+By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized transcript or fallback text.
 The router handoff message appears only when the router must disambiguate between multiple eligible responders.
 If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent or team replies directly to the original audio event.
 Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event responders actually answer.

--- a/skills/mindroom-docs/references/page__voice__index.md
+++ b/skills/mindroom-docs/references/page__voice__index.md
@@ -9,11 +9,11 @@ If STT is unavailable, disabled, or fails, the audio still remains available as 
 When a voice message is received:
 
 1. The audio event is handled through the shared media pipeline.
-2. If `voice.visible_router_echo` is enabled and the router is present and allowed to reply, the router immediately posts `Router agent is transcribing…`.
+2. If voice STT and `voice.visible_router_echo` are enabled and the router is present and allowed to reply, the router immediately posts `Router agent is transcribing…`.
 3. Audio is downloaded and decrypted, if needed, and registered as a context-scoped attachment while the placeholder is visible.
 4. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
 5. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
-6. The router replaces its placeholder with the normalized transcript or fallback text.
+6. The router replaces its placeholder with the normalized transcript or fallback text, or posts the fallback directly when STT is disabled.
 7. The normalized transcript or fallback prompt plus attachment metadata is dispatched using the normal routing and thread logic.
 8. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
 9. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
@@ -40,7 +40,8 @@ Or use the dashboard's Voice tab.
 
 With `voice.enabled: false`, audio messages are still surfaced as attachments with the fallback prompt.
 Enabling voice adds STT and command-recognition on top of that attachment flow.
-With `voice.visible_router_echo: true`, the router immediately posts a transcription placeholder and replaces that message with the normalized transcript or fallback text when it is present in the room and allowed to reply.
+With `voice.visible_router_echo: true` and `voice.enabled: true`, the router immediately posts a transcription placeholder and replaces that message with the normalized transcript or fallback text when it is present in the room and allowed to reply.
+When `voice.enabled: false`, the router posts the fallback text directly without claiming that transcription is running.
 
 ## STT Providers
 
@@ -150,7 +151,8 @@ If only one eligible agent or team is visible, that responder answers the normal
 If the audio caption or transcript explicitly mentions an agent or team, that targeted responder answers directly as well.
 In these cases, the router does not post an extra visible routing handoff.
 The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
-If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized transcript or fallback text, but responders ignore that echo and continue responding to the original audio event.
+If voice STT and `voice.visible_router_echo` are enabled, the router still posts a display-only placeholder and replaces it with the normalized transcript or fallback text, but responders ignore that echo and continue responding to the original audio event.
+With STT disabled, the router posts the display-only fallback directly.
 
 ### Multi-responder rooms where the router must choose
 
@@ -158,7 +160,8 @@ If multiple agents or teams are available and the audio does not already target 
 The router then posts a normal handoff message such as `@home could you help with this?`.
 The selected agent or team responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
 This is the case where a visible router message appears.
-If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized transcript or fallback text, and then posts the normal handoff.
+If voice STT and `voice.visible_router_echo` are enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized transcript or fallback text, and then posts the normal handoff.
+With STT disabled, the router posts the display-only fallback directly before the normal handoff.
 
 ### No router, or router cannot reply
 
@@ -170,7 +173,8 @@ If multiple eligible responders remain and the audio does not already target one
 
 ### Visibility rule
 
-By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized transcript or fallback text.
+By default, MindRoom immediately posts a display-only router transcription placeholder when voice STT is enabled and the router is allowed to process the event, then replaces it with the normalized transcript or fallback text.
+With STT disabled, MindRoom posts the display-only fallback directly.
 The router handoff message appears only when the router must disambiguate between multiple eligible responders.
 If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent or team replies directly to the original audio event.
 Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event responders actually answer.

--- a/skills/mindroom-docs/references/page__voice__index.md
+++ b/skills/mindroom-docs/references/page__voice__index.md
@@ -9,14 +9,15 @@ If STT is unavailable, disabled, or fails, the audio still remains available as 
 When a voice message is received:
 
 1. The audio event is handled through the shared media pipeline.
-2. Audio is downloaded and decrypted, if needed, and registered as a context-scoped attachment.
-3. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
-4. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
-5. The normalized text plus attachment metadata is dispatched using the normal routing and thread logic.
-6. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
-7. If `voice.visible_router_echo` is enabled and the router is present and allowed to reply, the router also posts the normalized voice text as a display-only message.
-8. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
-9. The responding entity receives the original audio attachment alongside the normalized prompt.
+2. If `voice.visible_router_echo` is enabled and the router is present and allowed to reply, the router immediately posts `Router agent is transcribing…`.
+3. Audio is downloaded and decrypted, if needed, and registered as a context-scoped attachment while the placeholder is visible.
+4. If STT is configured and succeeds, the audio is transcribed and lightly normalized for mentions and commands.
+5. If STT is unavailable, disabled, or fails, MindRoom falls back to `🎤 [Attached voice message]`.
+6. The router replaces its placeholder with the normalized transcript or fallback text.
+7. The normalized text plus attachment metadata is dispatched using the normal routing and thread logic.
+8. If routing is ambiguous in a multi-responder room, the router posts a visible handoff message.
+9. Otherwise, no extra router message is posted and the chosen agent or team replies directly.
+10. The responding entity receives the original audio attachment alongside the normalized prompt.
 
 ## Configuration
 
@@ -39,7 +40,7 @@ Or use the dashboard's Voice tab.
 
 With `voice.enabled: false`, audio messages are still surfaced as attachments with the fallback prompt.
 Enabling voice adds STT and command-recognition on top of that attachment flow.
-With `voice.visible_router_echo: true`, the router also posts the normalized transcript or fallback text for inspection when it is present in the room and allowed to reply.
+With `voice.visible_router_echo: true`, the router immediately posts a transcription placeholder and replaces that message with the normalized transcript or fallback text when it is present in the room and allowed to reply.
 
 ## STT Providers
 
@@ -149,7 +150,7 @@ If only one eligible agent or team is visible, that responder answers the normal
 If the audio caption or transcript explicitly mentions an agent or team, that targeted responder answers directly as well.
 In these cases, the router does not post an extra visible routing handoff.
 The transcript or fallback text is used internally for dispatch, not echoed to the room as a separate message.
-If `voice.visible_router_echo` is enabled, the router still posts a display-only copy of the normalized voice text, but responders ignore that echo and continue responding to the original audio event.
+If `voice.visible_router_echo` is enabled, the router still posts a display-only placeholder and replaces it with the normalized voice text, but responders ignore that echo and continue responding to the original audio event.
 
 ### Multi-responder rooms where the router must choose
 
@@ -157,7 +158,7 @@ If multiple agents or teams are available and the audio does not already target 
 The router then posts a normal handoff message such as `@home could you help with this?`.
 The selected agent or team responds to that router handoff, and the handoff carries the original audio attachment metadata forward.
 This is the case where a visible router message appears.
-If `voice.visible_router_echo` is also enabled, the router first posts the normalized voice text as a display-only echo and then posts the normal handoff.
+If `voice.visible_router_echo` is also enabled, the router immediately posts a display-only transcription placeholder, replaces it with the normalized voice text, and then posts the normal handoff.
 
 ### No router, or router cannot reply
 
@@ -169,7 +170,7 @@ If multiple eligible responders remain and the audio does not already target one
 
 ### Visibility rule
 
-By default, MindRoom posts a display-only router echo of normalized voice text when the router is allowed to process the event.
+By default, MindRoom immediately posts a display-only router transcription placeholder when the router is allowed to process the event, then replaces it with the normalized voice text.
 The router handoff message appears only when the router must disambiguate between multiple eligible responders.
 If the responder is already clear from room shape, thread context, or explicit targeting, the chosen agent or team replies directly to the original audio event.
 Set `voice.visible_router_echo: false` to suppress the display-only echo without changing which event responders actually answer.

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -118,6 +118,7 @@ from .sync_restart_retry import InterruptedTurnRooms
 from .turn_controller import TurnController, TurnControllerDeps
 from .turn_policy import IngressHookRunner, TurnPolicy, TurnPolicyDeps
 from .turn_store import TurnStore, TurnStoreDeps
+from .visible_voice_echo import VisibleVoiceEchoDeps, VisibleVoiceEchoLifecycle
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -299,6 +300,7 @@ class AgentBot:
     _response_runner: ResponseRunner
     _redacted_turn_cleanup: RedactedTurnCleanup
     _turn_store: TurnStore
+    _visible_voice_echo: VisibleVoiceEchoLifecycle
     _tool_runtime_support: ToolRuntimeSupport
     _post_response_effects_support: PostResponseEffectsSupport
     _ingress_hook_runner: IngressHookRunner
@@ -565,6 +567,16 @@ class AgentBot:
                 turn_store=self._turn_store,
             ),
         )
+        self._visible_voice_echo = VisibleVoiceEchoLifecycle(
+            VisibleVoiceEchoDeps(
+                runtime=self._runtime_view,
+                logger=self.logger,
+                agent_name=self.agent_name,
+                delivery_gateway=self._delivery_gateway,
+                turn_store=self._turn_store,
+                ingress=self._ingress_validator,
+            ),
+        )
         self._turn_controller = TurnController(
             TurnControllerDeps(
                 runtime=self._runtime_view,
@@ -585,6 +597,7 @@ class AgentBot:
                 edit_regenerator=self._edit_regenerator,
                 ingress=self._ingress_validator,
                 interrupted_turn_rooms=self._interrupted_turn_rooms,
+                visible_voice_echo=self._visible_voice_echo,
             ),
         )
 

--- a/src/mindroom/config/voice.py
+++ b/src/mindroom/config/voice.py
@@ -119,7 +119,7 @@ class VoiceConfig(BaseModel):
     enabled: bool = Field(default=False, description="Enable voice message processing")
     visible_router_echo: bool = Field(
         default=True,
-        description="Show a router transcription placeholder, then replace it with the normalized voice text",
+        description="Show a router transcription placeholder, then replace it with normalized transcript or fallback text",
     )
     stt: VoiceSTTConfig = Field(
         default_factory=VoiceSTTConfig,

--- a/src/mindroom/config/voice.py
+++ b/src/mindroom/config/voice.py
@@ -119,7 +119,7 @@ class VoiceConfig(BaseModel):
     enabled: bool = Field(default=False, description="Enable voice message processing")
     visible_router_echo: bool = Field(
         default=True,
-        description="Show a router transcription placeholder, then replace it with normalized transcript or fallback text",
+        description="Show router voice progress, or direct fallback text when transcription is disabled",
     )
     stt: VoiceSTTConfig = Field(
         default_factory=VoiceSTTConfig,

--- a/src/mindroom/config/voice.py
+++ b/src/mindroom/config/voice.py
@@ -119,7 +119,7 @@ class VoiceConfig(BaseModel):
     enabled: bool = Field(default=False, description="Enable voice message processing")
     visible_router_echo: bool = Field(
         default=True,
-        description="Post the normalized voice transcript or fallback as a visible router message",
+        description="Show a router transcription placeholder, then replace it with the normalized voice text",
     )
     stt: VoiceSTTConfig = Field(
         default_factory=VoiceSTTConfig,

--- a/src/mindroom/handled_turns.py
+++ b/src/mindroom/handled_turns.py
@@ -99,6 +99,7 @@ class TurnRecord:
     response_event_id: str | None = None
     completed: bool = True
     visible_echo_event_id: str | None = None
+    visible_echo_is_fallback: bool | None = None
     source_event_prompts: Mapping[str, str] | None = None
     source_event_revisions: Mapping[str, SourceEventRevision] | None = None
     suppressed_source_event_revisions: Mapping[str, SourceEventRevision] | None = None
@@ -167,8 +168,16 @@ class TurnRecord:
         object.__setattr__(self, "redacted_source_event_ids", redacted_source_event_ids)
         object.__setattr__(self, "pending_redaction_cleanup_event_ids", pending_redaction_cleanup_event_ids)
         object.__setattr__(self, "anchor_event_id", anchor_event_id)
-        object.__setattr__(self, "response_event_id", _normalize_string(self.response_event_id))
-        object.__setattr__(self, "visible_echo_event_id", _normalize_string(self.visible_echo_event_id))
+        response_event_id = _normalize_string(self.response_event_id)
+        visible_echo_event_id = _normalize_string(self.visible_echo_event_id)
+        visible_echo_is_fallback = (
+            self.visible_echo_is_fallback
+            if isinstance(self.visible_echo_is_fallback, bool) and visible_echo_event_id is not None
+            else None
+        )
+        object.__setattr__(self, "response_event_id", response_event_id)
+        object.__setattr__(self, "visible_echo_event_id", visible_echo_event_id)
+        object.__setattr__(self, "visible_echo_is_fallback", visible_echo_is_fallback)
         object.__setattr__(self, "source_event_prompts", source_event_prompts)
         object.__setattr__(self, "source_event_revisions", source_event_revisions)
         object.__setattr__(self, "suppressed_source_event_revisions", suppressed_source_event_revisions)
@@ -192,6 +201,7 @@ class TurnRecord:
         response_event_id: str | None = None,
         completed: bool = True,
         visible_echo_event_id: str | None = None,
+        visible_echo_is_fallback: bool | None = None,
         source_event_prompts: Mapping[str, str] | None = None,
         source_event_revisions: Mapping[str, object] | None = None,
         suppressed_source_event_revisions: Mapping[str, object] | None = None,
@@ -213,6 +223,7 @@ class TurnRecord:
             response_event_id=response_event_id,
             completed=completed,
             visible_echo_event_id=visible_echo_event_id,
+            visible_echo_is_fallback=visible_echo_is_fallback,
             source_event_prompts=source_event_prompts,
             source_event_revisions=typing.cast("Mapping[str, SourceEventRevision] | None", source_event_revisions),
             suppressed_source_event_revisions=typing.cast(
@@ -273,6 +284,8 @@ class TurnRecordCodec:
             payload["discovery_event_ids"] = list(record.discovery_event_ids)
         if record.visible_echo_event_id is not None:
             payload["visible_echo_event_id"] = record.visible_echo_event_id
+        if record.visible_echo_is_fallback is not None:
+            payload["visible_echo_is_fallback"] = record.visible_echo_is_fallback
         if record.source_event_prompts is not None:
             payload["source_event_prompts"] = dict(record.source_event_prompts)
         if record.source_event_revisions is not None:
@@ -340,6 +353,7 @@ class TurnRecordCodec:
             response_event_id=response_event_id,
             completed=completed,
             visible_echo_event_id=_normalize_string(record.get("visible_echo_event_id")),
+            visible_echo_is_fallback=_bool_or_none(record.get("visible_echo_is_fallback")),
             source_event_prompts=_mapping_or_none(record.get("source_event_prompts")),
             source_event_revisions=_mapping_or_none(record.get("source_event_revisions")),
             suppressed_source_event_revisions=_mapping_or_none(
@@ -950,12 +964,22 @@ def _merge_same_identity_records(candidate: TurnRecord, existing: TurnRecord) ->
             *older.redacted_source_event_ids,
         ),
         visible_echo_event_id=newer.visible_echo_event_id or older.visible_echo_event_id,
+        visible_echo_is_fallback=(
+            newer.visible_echo_is_fallback
+            if newer.visible_echo_is_fallback is not None
+            else older.visible_echo_is_fallback
+        ),
     )
 
 
 def _normalize_string(value: object) -> str | None:
     """Return a non-empty string or None."""
     return value if isinstance(value, str) and value else None
+
+
+def _bool_or_none(value: object) -> bool | None:
+    """Return a strict boolean or None."""
+    return value if isinstance(value, bool) else None
 
 
 def _mapping_or_none(value: object) -> Mapping[str, Any] | None:

--- a/src/mindroom/handled_turns.py
+++ b/src/mindroom/handled_turns.py
@@ -594,16 +594,6 @@ class HandledTurnLedger:
             record = self._responses.get(source_event_id)
             return record.visible_echo_event_id if record is not None else None
 
-    def visible_echo_event_id_for_sources(self, source_event_ids: Sequence[str]) -> str | None:
-        """Return the first visible echo already tracked for one or more source events."""
-        with self._state.lock:
-            self._ensure_loaded_locked()
-            for event_id in _normalize_source_event_ids(source_event_ids):
-                record = self._responses.get(event_id)
-                if record is not None and record.visible_echo_event_id is not None:
-                    return record.visible_echo_event_id
-        return None
-
     def get_turn_record(self, source_event_id: str) -> TurnRecord | None:
         """Return the canonical record for one source event."""
         with self._state.lock:

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1135,6 +1135,60 @@ class TurnController:
         )
         return visible_echo_event_id if edited else None
 
+    async def _finish_visible_voice_echo_best_effort(
+        self,
+        event: AudioMessageEvent,
+        *,
+        target: MessageTarget,
+        placeholder_task: asyncio.Task[str | None] | None,
+        normalized_event: PreparedTextEvent,
+        requester_user_id: str,
+    ) -> None:
+        """Replace a started voice placeholder without blocking canonical dispatch on failure."""
+        if placeholder_task is None:
+            return
+        try:
+            finish_task = self._start_visible_voice_echo_finish(
+                event,
+                target=target,
+                placeholder_task=placeholder_task,
+                text=normalized_event.body,
+                requester_user_id=requester_user_id,
+                normalized_source=normalized_event.source,
+            )
+            await asyncio.shield(finish_task)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.deps.logger.warning(
+                "Visible voice echo failed; continuing canonical voice dispatch",
+                event_id=event.event_id,
+                room_id=target.room_id,
+                exception_type=exc.__class__.__name__,
+                error=str(exc),
+            )
+
+    def _schedule_cancelled_visible_voice_echo_finish(
+        self,
+        event: AudioMessageEvent,
+        *,
+        target: MessageTarget,
+        placeholder_task: asyncio.Task[str | None] | None,
+        requester_user_id: str,
+    ) -> None:
+        """Leave a terminal raw-audio fallback when voice readiness is cancelled."""
+        if placeholder_task is None:
+            return
+        fallback_event = _raw_voice_fallback_event(event, thread_id=target.resolved_thread_id)
+        self._start_visible_voice_echo_finish(
+            event,
+            target=target,
+            placeholder_task=placeholder_task,
+            text=fallback_event.body,
+            requester_user_id=requester_user_id,
+            normalized_source=fallback_event.source,
+        )
+
     def _visible_router_voice_echo_extra_content(
         self,
         *,
@@ -2423,27 +2477,13 @@ class TurnController:
                 dispatch_timing=dispatch_timing,
             )
 
-            try:
-                if visible_echo_task is not None:
-                    finish_task = self._start_visible_voice_echo_finish(
-                        event,
-                        target=voice_target,
-                        placeholder_task=visible_echo_task,
-                        text=normalized_event.body,
-                        requester_user_id=prechecked_event.requester_user_id,
-                        normalized_source=normalized_event.source,
-                    )
-                    await asyncio.shield(finish_task)
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                self.deps.logger.warning(
-                    "Visible voice echo failed; continuing canonical voice dispatch",
-                    event_id=event.event_id,
-                    room_id=room.room_id,
-                    exception_type=exc.__class__.__name__,
-                    error=str(exc),
-                )
+            await self._finish_visible_voice_echo_best_effort(
+                event,
+                target=voice_target,
+                placeholder_task=visible_echo_task,
+                normalized_event=normalized_event,
+                requester_user_id=prechecked_event.requester_user_id,
+            )
 
             normalized_target = self.deps.resolver.build_message_target(
                 room_id=room.room_id,
@@ -2478,19 +2518,43 @@ class TurnController:
                 ),
             )
         except asyncio.CancelledError:
+            self._schedule_cancelled_visible_voice_echo_finish(
+                event,
+                target=voice_target,
+                placeholder_task=visible_echo_task,
+                requester_user_id=prechecked_event.requester_user_id,
+            )
             raise
         except Exception as exc:
             if queued_notice_reservation is not None:
                 queued_notice_reservation.cancel()
                 queued_notice_reservation = None
-            return await self._ready_voice_fallback_event(
-                room=room,
-                event=event,
+            try:
+                fallback_ready = await self._ready_voice_fallback_event(
+                    room=room,
+                    event=event,
+                    requester_user_id=prechecked_event.requester_user_id,
+                    thread_id=voice_target.resolved_thread_id,
+                    dispatch_timing=dispatch_timing,
+                    error=exc,
+                )
+            except asyncio.CancelledError:
+                self._schedule_cancelled_visible_voice_echo_finish(
+                    event,
+                    target=voice_target,
+                    placeholder_task=visible_echo_task,
+                    requester_user_id=prechecked_event.requester_user_id,
+                )
+                raise
+            fallback_event = cast("PreparedTextEvent", fallback_ready.pending_event.event)
+            await self._finish_visible_voice_echo_best_effort(
+                event,
+                target=voice_target,
+                placeholder_task=visible_echo_task,
+                normalized_event=fallback_event,
                 requester_user_id=prechecked_event.requester_user_id,
-                thread_id=voice_target.resolved_thread_id,
-                dispatch_timing=dispatch_timing,
-                error=exc,
             )
+            return fallback_ready
         finally:
             if not reservation_released_or_handed_off and queued_notice_reservation is not None:
                 queued_notice_reservation.cancel()

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -992,10 +992,6 @@ class TurnController:
         )
         return _IngressAdmissionOutcome.ADMITTED
 
-    def _visible_router_voice_echo_enabled(self) -> bool:
-        """Return whether this bot owns the visible voice-transcription lifecycle."""
-        return self.deps.agent_name == ROUTER_AGENT_NAME and self.deps.runtime.config.voice.visible_router_echo
-
     def _start_visible_voice_transcription_placeholder(
         self,
         event: AudioMessageEvent,
@@ -1004,7 +1000,7 @@ class TurnController:
         requester_user_id: str,
     ) -> asyncio.Task[str | None] | None:
         """Start or share the placeholder send for one raw voice event."""
-        if not self._visible_router_voice_echo_enabled():
+        if self.deps.agent_name != ROUTER_AGENT_NAME or not self.deps.runtime.config.voice.visible_router_echo:
             return None
         existing_task = self._visible_voice_placeholder_tasks.get(event.event_id)
         if existing_task is not None:
@@ -1079,6 +1075,7 @@ class TurnController:
             return existing_task
         task = create_background_task(
             self._finish_visible_voice_echo(
+                source_event_id=event.event_id,
                 target=target,
                 placeholder_task=placeholder_task,
                 text=text,
@@ -1109,6 +1106,7 @@ class TurnController:
     async def _finish_visible_voice_echo(
         self,
         *,
+        source_event_id: str,
         target: MessageTarget,
         placeholder_task: asyncio.Task[str | None],
         text: str,
@@ -1133,7 +1131,10 @@ class TurnController:
                 retry_sync_recovery=True,
             ),
         )
-        return visible_echo_event_id if edited else None
+        if not edited:
+            return None
+        self.deps.turn_store.record_finalized_visible_echo(source_event_id, visible_echo_event_id)
+        return visible_echo_event_id
 
     async def _finish_visible_voice_echo_best_effort(
         self,
@@ -1797,11 +1798,8 @@ class TurnController:
         handled_turn: TurnRecord,
     ) -> TurnRecord | None:
         """Return the terminal handled-turn outcome for one ignored router turn."""
-        visible_router_echo_event_id = (
-            handled_turn.visible_echo_event_id
-            or self.deps.turn_store.visible_echo_for_sources(
-                handled_turn.source_event_ids,
-            )
+        visible_router_echo_event_id = self.deps.turn_store.finalized_visible_echo_for_sources(
+            handled_turn.source_event_ids,
         )
         if visible_router_echo_event_id is None:
             return None

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import time
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from mindroom import interactive
 from mindroom.attachment_ids import merge_attachment_ids
 from mindroom.attachments import parse_attachment_ids_from_event_source
+from mindroom.background_tasks import create_background_task
 from mindroom.coalescing import CoalescingGate, IngressAdmissionClosedError, ReadyPendingEvent
 from mindroom.coalescing_batch import (
     CoalescedBatch,
@@ -144,6 +145,7 @@ if TYPE_CHECKING:
 
 _QUEUED_NOTICE_METADATA_KIND = "queued_notice_reservation"
 _PENDING_TURN_CLAIM_METADATA_KIND = "pending_turn_claim"
+_VOICE_TRANSCRIPTION_PLACEHOLDER = "Router agent is transcribing…"
 
 
 def _room_level_context_event(event: TextDispatchEvent) -> TextDispatchEvent:
@@ -335,6 +337,16 @@ class TurnController:
     """Own sequencing for one inbound text or media turn."""
 
     deps: TurnControllerDeps
+    _visible_voice_placeholder_tasks: dict[str, asyncio.Task[str | None]] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+    _visible_voice_finish_tasks: dict[str, asyncio.Task[str | None]] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
 
     def _client(self) -> nio.AsyncClient:
         client = self.deps.runtime.client
@@ -980,44 +992,148 @@ class TurnController:
         )
         return _IngressAdmissionOutcome.ADMITTED
 
-    async def _maybe_send_visible_voice_echo(
+    def _visible_router_voice_echo_enabled(self) -> bool:
+        """Return whether this bot owns the visible voice-transcription lifecycle."""
+        return self.deps.agent_name == ROUTER_AGENT_NAME and self.deps.runtime.config.voice.visible_router_echo
+
+    def _start_visible_voice_transcription_placeholder(
         self,
-        room: nio.MatrixRoom,
         event: AudioMessageEvent,
         *,
-        text: str,
-        thread_id: str | None,
+        target: MessageTarget,
         requester_user_id: str,
-        normalized_source: dict[str, Any],
-    ) -> str | None:
-        """Optionally post a visible router echo for normalized audio."""
-        if self.deps.agent_name != ROUTER_AGENT_NAME or not self.deps.runtime.config.voice.visible_router_echo:
+    ) -> asyncio.Task[str | None] | None:
+        """Start or share the placeholder send for one raw voice event."""
+        if not self._visible_router_voice_echo_enabled():
             return None
+        existing_task = self._visible_voice_placeholder_tasks.get(event.event_id)
+        if existing_task is not None:
+            return existing_task
+        task = create_background_task(
+            self._send_visible_voice_transcription_placeholder(
+                event,
+                target=target,
+                requester_user_id=requester_user_id,
+            ),
+            name=f"voice_placeholder:{target.room_id}:{event.event_id}",
+            owner=self.deps.runtime,
+        )
+        self._visible_voice_placeholder_tasks[event.event_id] = task
+        task.add_done_callback(
+            lambda completed_task: self._clear_visible_voice_placeholder_task(
+                event.event_id,
+                completed_task,
+            ),
+        )
+        return task
 
+    def _clear_visible_voice_placeholder_task(
+        self,
+        source_event_id: str,
+        completed_task: asyncio.Task[str | None],
+    ) -> None:
+        """Forget a completed placeholder task without evicting a newer retry."""
+        if self._visible_voice_placeholder_tasks.get(source_event_id) is completed_task:
+            self._visible_voice_placeholder_tasks.pop(source_event_id)
+
+    async def _send_visible_voice_transcription_placeholder(
+        self,
+        event: AudioMessageEvent,
+        *,
+        target: MessageTarget,
+        requester_user_id: str,
+    ) -> str | None:
+        """Post the router's visible voice placeholder before normalization finishes."""
         existing_visible_echo_event_id = self.deps.turn_store.visible_echo_for_source(event.event_id)
         if existing_visible_echo_event_id is not None:
             return existing_visible_echo_event_id
 
-        target = self.deps.resolver.build_message_target(
-            room_id=room.room_id,
-            thread_id=thread_id,
-            reply_to_event_id=event.event_id,
-            event_source=event.source,
-        )
         visible_echo_event_id = await self.deps.delivery_gateway.send_text(
             SendTextRequest(
                 target=target,
-                response_text=text,
+                response_text=_VOICE_TRANSCRIPTION_PLACEHOLDER,
                 skip_mentions=True,
                 extra_content=self._visible_router_voice_echo_extra_content(
                     requester_user_id=requester_user_id,
-                    normalized_source=normalized_source,
+                    normalized_source=event.source,
                 ),
             ),
         )
         if visible_echo_event_id is not None:
             self.deps.turn_store.record_visible_echo(event.event_id, visible_echo_event_id)
         return visible_echo_event_id
+
+    def _start_visible_voice_echo_finish(
+        self,
+        event: AudioMessageEvent,
+        *,
+        target: MessageTarget,
+        placeholder_task: asyncio.Task[str | None],
+        text: str,
+        requester_user_id: str,
+        normalized_source: dict[str, Any],
+    ) -> asyncio.Task[str | None]:
+        """Start or share replacement of one voice event's placeholder."""
+        existing_task = self._visible_voice_finish_tasks.get(event.event_id)
+        if existing_task is not None:
+            return existing_task
+        task = create_background_task(
+            self._finish_visible_voice_echo(
+                target=target,
+                placeholder_task=placeholder_task,
+                text=text,
+                requester_user_id=requester_user_id,
+                normalized_source=normalized_source,
+            ),
+            name=f"voice_placeholder_finish:{target.room_id}:{event.event_id}",
+            owner=self.deps.runtime,
+        )
+        self._visible_voice_finish_tasks[event.event_id] = task
+        task.add_done_callback(
+            lambda completed_task: self._clear_visible_voice_finish_task(
+                event.event_id,
+                completed_task,
+            ),
+        )
+        return task
+
+    def _clear_visible_voice_finish_task(
+        self,
+        source_event_id: str,
+        completed_task: asyncio.Task[str | None],
+    ) -> None:
+        """Forget a completed finish task without evicting a newer retry."""
+        if self._visible_voice_finish_tasks.get(source_event_id) is completed_task:
+            self._visible_voice_finish_tasks.pop(source_event_id)
+
+    async def _finish_visible_voice_echo(
+        self,
+        *,
+        target: MessageTarget,
+        placeholder_task: asyncio.Task[str | None],
+        text: str,
+        requester_user_id: str,
+        normalized_source: dict[str, Any],
+    ) -> str | None:
+        """Replace the router's voice placeholder with its normalized text."""
+        visible_echo_event_id = await asyncio.shield(placeholder_task)
+        if visible_echo_event_id is None:
+            return None
+
+        extra_content = self._visible_router_voice_echo_extra_content(
+            requester_user_id=requester_user_id,
+            normalized_source=normalized_source,
+        )
+        edited = await self.deps.delivery_gateway.edit_text(
+            EditTextRequest(
+                target=target,
+                event_id=visible_echo_event_id,
+                new_text=text,
+                extra_content=extra_content,
+                retry_sync_recovery=True,
+            ),
+        )
+        return visible_echo_event_id if edited else None
 
     def _visible_router_voice_echo_extra_content(
         self,
@@ -2283,6 +2399,11 @@ class TurnController:
         """Normalize a raw voice event after its conversation key is fixed."""
         event = prechecked_event.event
         queued_notice_reservation = None
+        visible_echo_task = self._start_visible_voice_transcription_placeholder(
+            event,
+            target=voice_target,
+            requester_user_id=prechecked_event.requester_user_id,
+        )
         reservation_released_or_handed_off = False
         try:
             envelope = self.deps.resolver.build_ingress_envelope(
@@ -2303,14 +2424,16 @@ class TurnController:
             )
 
             try:
-                await self._maybe_send_visible_voice_echo(
-                    room,
-                    event,
-                    text=normalized_event.body,
-                    thread_id=effective_thread_id,
-                    requester_user_id=prechecked_event.requester_user_id,
-                    normalized_source=normalized_event.source,
-                )
+                if visible_echo_task is not None:
+                    finish_task = self._start_visible_voice_echo_finish(
+                        event,
+                        target=voice_target,
+                        placeholder_task=visible_echo_task,
+                        text=normalized_event.body,
+                        requester_user_id=prechecked_event.requester_user_id,
+                        normalized_source=normalized_event.source,
+                    )
+                    await asyncio.shield(finish_task)
             except asyncio.CancelledError:
                 raise
             except Exception as exc:

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 import asyncio
 import time
-from dataclasses import dataclass, field, replace
+from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from mindroom import interactive
 from mindroom.attachment_ids import merge_attachment_ids
 from mindroom.attachments import parse_attachment_ids_from_event_source
-from mindroom.background_tasks import create_background_task
 from mindroom.coalescing import CoalescingGate, IngressAdmissionClosedError, ReadyPendingEvent
 from mindroom.coalescing_batch import (
     CoalescedBatch,
@@ -33,10 +32,8 @@ from mindroom.constants import (
     STREAM_STATUS_KEY,
     STREAM_STATUS_PENDING,
     STREAM_STATUS_STREAMING,
-    VISIBLE_ROUTER_VOICE_ECHO_KEY,
     VOICE_PREFIX,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
-    VOICE_TRANSCRIPT_KEY,
     RuntimePaths,
 )
 from mindroom.delivery_gateway import EditTextRequest, SendTextRequest
@@ -117,9 +114,9 @@ from mindroom.turn_origin import (
     TurnIntent,
     classify_turn_origin,
     original_sender_for_router_handoff,
-    original_sender_for_router_relay,
 )
 from mindroom.turn_policy import IngressHookRunner, PreparedDispatch, ResponseAction, TurnPolicy
+from mindroom.visible_voice_echo import VisibleVoiceEchoRequest
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
@@ -141,11 +138,11 @@ if TYPE_CHECKING:
     from mindroom.sync_restart_retry import InterruptedTurnRooms
     from mindroom.tool_system.runtime_context import ToolRuntimeSupport
     from mindroom.turn_store import TurnStore
+    from mindroom.visible_voice_echo import VisibleVoiceEchoLifecycle
 
 
 _QUEUED_NOTICE_METADATA_KIND = "queued_notice_reservation"
 _PENDING_TURN_CLAIM_METADATA_KIND = "pending_turn_claim"
-_VOICE_TRANSCRIPTION_PLACEHOLDER = "Router agent is transcribing…"
 
 
 def _room_level_context_event(event: TextDispatchEvent) -> TextDispatchEvent:
@@ -309,6 +306,14 @@ class _DispatchPreparation:
 
 
 @dataclass(frozen=True)
+class _ReadyVoiceFallback:
+    """Fallback event plus its ready ingress wrapper."""
+
+    event: PreparedTextEvent
+    ready: ReadyPendingEvent
+
+
+@dataclass(frozen=True)
 class TurnControllerDeps:
     """Collaborators needed for turn control, policy, and execution."""
 
@@ -330,6 +335,7 @@ class TurnControllerDeps:
     edit_regenerator: _EditRegenerator
     ingress: IngressValidator
     interrupted_turn_rooms: InterruptedTurnRooms
+    visible_voice_echo: VisibleVoiceEchoLifecycle
 
 
 @dataclass
@@ -337,16 +343,6 @@ class TurnController:
     """Own sequencing for one inbound text or media turn."""
 
     deps: TurnControllerDeps
-    _visible_voice_placeholder_tasks: dict[str, asyncio.Task[str | None]] = field(
-        default_factory=dict,
-        init=False,
-        repr=False,
-    )
-    _visible_voice_finish_tasks: dict[str, asyncio.Task[str | None]] = field(
-        default_factory=dict,
-        init=False,
-        repr=False,
-    )
 
     def _client(self) -> nio.AsyncClient:
         client = self.deps.runtime.client
@@ -991,237 +987,6 @@ class TurnController:
             timing_scope=timing_scope,
         )
         return _IngressAdmissionOutcome.ADMITTED
-
-    def _start_visible_voice_transcription_placeholder(
-        self,
-        event: AudioMessageEvent,
-        *,
-        target: MessageTarget,
-        requester_user_id: str,
-    ) -> asyncio.Task[str | None] | None:
-        """Start or share the placeholder send for one raw voice event."""
-        if self.deps.agent_name != ROUTER_AGENT_NAME or not self.deps.runtime.config.voice.visible_router_echo:
-            return None
-        existing_task = self._visible_voice_placeholder_tasks.get(event.event_id)
-        if existing_task is not None:
-            return existing_task
-        task = create_background_task(
-            self._send_visible_voice_transcription_placeholder(
-                event,
-                target=target,
-                requester_user_id=requester_user_id,
-            ),
-            name=f"voice_placeholder:{target.room_id}:{event.event_id}",
-            owner=self.deps.runtime,
-        )
-        self._visible_voice_placeholder_tasks[event.event_id] = task
-        task.add_done_callback(
-            lambda completed_task: self._clear_visible_voice_placeholder_task(
-                event.event_id,
-                completed_task,
-            ),
-        )
-        return task
-
-    def _clear_visible_voice_placeholder_task(
-        self,
-        source_event_id: str,
-        completed_task: asyncio.Task[str | None],
-    ) -> None:
-        """Forget a completed placeholder task without evicting a newer retry."""
-        if self._visible_voice_placeholder_tasks.get(source_event_id) is completed_task:
-            self._visible_voice_placeholder_tasks.pop(source_event_id)
-
-    async def _send_visible_voice_transcription_placeholder(
-        self,
-        event: AudioMessageEvent,
-        *,
-        target: MessageTarget,
-        requester_user_id: str,
-    ) -> str | None:
-        """Post the router's visible voice placeholder before normalization finishes."""
-        existing_visible_echo_event_id = self.deps.turn_store.visible_echo_for_source(event.event_id)
-        if existing_visible_echo_event_id is not None:
-            return existing_visible_echo_event_id
-
-        visible_echo_event_id = await self.deps.delivery_gateway.send_text(
-            SendTextRequest(
-                target=target,
-                response_text=_VOICE_TRANSCRIPTION_PLACEHOLDER,
-                skip_mentions=True,
-                extra_content=self._visible_router_voice_echo_extra_content(
-                    requester_user_id=requester_user_id,
-                    normalized_source=event.source,
-                ),
-            ),
-        )
-        if visible_echo_event_id is not None:
-            self.deps.turn_store.record_visible_echo(event.event_id, visible_echo_event_id)
-        return visible_echo_event_id
-
-    def _start_visible_voice_echo_finish(
-        self,
-        event: AudioMessageEvent,
-        *,
-        target: MessageTarget,
-        placeholder_task: asyncio.Task[str | None],
-        text: str,
-        requester_user_id: str,
-        normalized_source: dict[str, Any],
-    ) -> asyncio.Task[str | None]:
-        """Start or share replacement of one voice event's placeholder."""
-        existing_task = self._visible_voice_finish_tasks.get(event.event_id)
-        if existing_task is not None:
-            return existing_task
-        task = create_background_task(
-            self._finish_visible_voice_echo(
-                source_event_id=event.event_id,
-                target=target,
-                placeholder_task=placeholder_task,
-                text=text,
-                requester_user_id=requester_user_id,
-                normalized_source=normalized_source,
-            ),
-            name=f"voice_placeholder_finish:{target.room_id}:{event.event_id}",
-            owner=self.deps.runtime,
-        )
-        self._visible_voice_finish_tasks[event.event_id] = task
-        task.add_done_callback(
-            lambda completed_task: self._clear_visible_voice_finish_task(
-                event.event_id,
-                completed_task,
-            ),
-        )
-        return task
-
-    def _clear_visible_voice_finish_task(
-        self,
-        source_event_id: str,
-        completed_task: asyncio.Task[str | None],
-    ) -> None:
-        """Forget a completed finish task without evicting a newer retry."""
-        if self._visible_voice_finish_tasks.get(source_event_id) is completed_task:
-            self._visible_voice_finish_tasks.pop(source_event_id)
-
-    async def _finish_visible_voice_echo(
-        self,
-        *,
-        source_event_id: str,
-        target: MessageTarget,
-        placeholder_task: asyncio.Task[str | None],
-        text: str,
-        requester_user_id: str,
-        normalized_source: dict[str, Any],
-    ) -> str | None:
-        """Replace the router's voice placeholder with its normalized text."""
-        visible_echo_event_id = await asyncio.shield(placeholder_task)
-        if visible_echo_event_id is None:
-            return None
-
-        extra_content = self._visible_router_voice_echo_extra_content(
-            requester_user_id=requester_user_id,
-            normalized_source=normalized_source,
-        )
-        edited = await self.deps.delivery_gateway.edit_text(
-            EditTextRequest(
-                target=target,
-                event_id=visible_echo_event_id,
-                new_text=text,
-                extra_content=extra_content,
-                retry_sync_recovery=True,
-            ),
-        )
-        if not edited:
-            return None
-        self.deps.turn_store.record_finalized_visible_echo(source_event_id, visible_echo_event_id)
-        return visible_echo_event_id
-
-    async def _finish_visible_voice_echo_best_effort(
-        self,
-        event: AudioMessageEvent,
-        *,
-        target: MessageTarget,
-        placeholder_task: asyncio.Task[str | None] | None,
-        normalized_event: PreparedTextEvent,
-        requester_user_id: str,
-    ) -> None:
-        """Replace a started voice placeholder without blocking canonical dispatch on failure."""
-        if placeholder_task is None:
-            return
-        try:
-            finish_task = self._start_visible_voice_echo_finish(
-                event,
-                target=target,
-                placeholder_task=placeholder_task,
-                text=normalized_event.body,
-                requester_user_id=requester_user_id,
-                normalized_source=normalized_event.source,
-            )
-            await asyncio.shield(finish_task)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:
-            self.deps.logger.warning(
-                "Visible voice echo failed; continuing canonical voice dispatch",
-                event_id=event.event_id,
-                room_id=target.room_id,
-                exception_type=exc.__class__.__name__,
-                error=str(exc),
-            )
-
-    def _schedule_cancelled_visible_voice_echo_finish(
-        self,
-        event: AudioMessageEvent,
-        *,
-        target: MessageTarget,
-        placeholder_task: asyncio.Task[str | None] | None,
-        requester_user_id: str,
-    ) -> None:
-        """Leave a terminal raw-audio fallback when voice readiness is cancelled."""
-        if placeholder_task is None:
-            return
-        fallback_event = _raw_voice_fallback_event(event, thread_id=target.resolved_thread_id)
-        self._start_visible_voice_echo_finish(
-            event,
-            target=target,
-            placeholder_task=placeholder_task,
-            text=fallback_event.body,
-            requester_user_id=requester_user_id,
-            normalized_source=fallback_event.source,
-        )
-
-    def _visible_router_voice_echo_extra_content(
-        self,
-        *,
-        requester_user_id: str,
-        normalized_source: dict[str, Any],
-    ) -> dict[str, Any]:
-        """Return trusted relay metadata for a visible router voice echo."""
-        payload_metadata = payload_metadata_from_source(normalized_source, trust_internal_metadata=True)
-        inherited_original_sender = payload_metadata.original_sender
-        relay_original_sender = original_sender_for_router_relay(
-            requester_id=requester_user_id,
-            requester_entity_name=self.deps.ingress.managed_entity_name_for_sender(requester_user_id),
-            inherited_original_sender=inherited_original_sender,
-            inherited_original_sender_entity_name=(
-                self.deps.ingress.managed_entity_name_for_sender(inherited_original_sender)
-                if inherited_original_sender is not None
-                else None
-            ),
-        )
-        extra_content: dict[str, Any] = {
-            SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
-            VISIBLE_ROUTER_VOICE_ECHO_KEY: True,
-        }
-        if relay_original_sender is not None:
-            extra_content[ORIGINAL_SENDER_KEY] = relay_original_sender
-        if payload_metadata.attachment_ids:
-            extra_content[ATTACHMENT_IDS_KEY] = list(payload_metadata.attachment_ids)
-        if payload_metadata.raw_audio_fallback:
-            extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
-        if payload_metadata.voice_transcript:
-            extra_content[VOICE_TRANSCRIPT_KEY] = True
-        return extra_content
 
     async def _prepare_dispatch(
         self,
@@ -2451,10 +2216,13 @@ class TurnController:
         """Normalize a raw voice event after its conversation key is fixed."""
         event = prechecked_event.event
         queued_notice_reservation = None
-        visible_echo_task = self._start_visible_voice_transcription_placeholder(
-            event,
-            target=voice_target,
-            requester_user_id=prechecked_event.requester_user_id,
+        visible_echo = self.deps.visible_voice_echo.start(
+            VisibleVoiceEchoRequest(
+                source_event_id=event.event_id,
+                target=voice_target,
+                requester_user_id=prechecked_event.requester_user_id,
+                raw_source=event.source,
+            ),
         )
         reservation_released_or_handed_off = False
         try:
@@ -2475,13 +2243,7 @@ class TurnController:
                 dispatch_timing=dispatch_timing,
             )
 
-            await self._finish_visible_voice_echo_best_effort(
-                event,
-                target=voice_target,
-                placeholder_task=visible_echo_task,
-                normalized_event=normalized_event,
-                requester_user_id=prechecked_event.requester_user_id,
-            )
+            await self.deps.visible_voice_echo.finish(visible_echo, normalized_event)
 
             normalized_target = self.deps.resolver.build_message_target(
                 room_id=room.room_id,
@@ -2516,11 +2278,9 @@ class TurnController:
                 ),
             )
         except asyncio.CancelledError:
-            self._schedule_cancelled_visible_voice_echo_finish(
-                event,
-                target=voice_target,
-                placeholder_task=visible_echo_task,
-                requester_user_id=prechecked_event.requester_user_id,
+            self.deps.visible_voice_echo.finish_after_cancellation(
+                visible_echo,
+                _raw_voice_fallback_event(event, thread_id=voice_target.resolved_thread_id),
             )
             raise
         except Exception as exc:
@@ -2528,7 +2288,7 @@ class TurnController:
                 queued_notice_reservation.cancel()
                 queued_notice_reservation = None
             try:
-                fallback_ready = await self._ready_voice_fallback_event(
+                fallback = await self._ready_voice_fallback_event(
                     room=room,
                     event=event,
                     requester_user_id=prechecked_event.requester_user_id,
@@ -2537,22 +2297,13 @@ class TurnController:
                     error=exc,
                 )
             except asyncio.CancelledError:
-                self._schedule_cancelled_visible_voice_echo_finish(
-                    event,
-                    target=voice_target,
-                    placeholder_task=visible_echo_task,
-                    requester_user_id=prechecked_event.requester_user_id,
+                self.deps.visible_voice_echo.finish_after_cancellation(
+                    visible_echo,
+                    _raw_voice_fallback_event(event, thread_id=voice_target.resolved_thread_id),
                 )
                 raise
-            fallback_event = cast("PreparedTextEvent", fallback_ready.pending_event.event)
-            await self._finish_visible_voice_echo_best_effort(
-                event,
-                target=voice_target,
-                placeholder_task=visible_echo_task,
-                normalized_event=fallback_event,
-                requester_user_id=prechecked_event.requester_user_id,
-            )
-            return fallback_ready
+            await self.deps.visible_voice_echo.finish(visible_echo, fallback.event)
+            return fallback.ready
         finally:
             if not reservation_released_or_handed_off and queued_notice_reservation is not None:
                 queued_notice_reservation.cancel()
@@ -2594,7 +2345,7 @@ class TurnController:
         thread_id: str | None,
         dispatch_timing: DispatchPipelineTiming | None,
         error: Exception,
-    ) -> ReadyPendingEvent:
+    ) -> _ReadyVoiceFallback:
         """Return a raw-audio fallback when voice readiness fails before STT."""
         self.deps.logger.warning(
             "Voice readiness failed; dispatching raw-audio fallback",
@@ -2640,17 +2391,20 @@ class TurnController:
                 exception_type=metadata_error.__class__.__name__,
                 error=str(metadata_error),
             )
-        return ReadyPendingEvent(
-            pending_event=PendingEvent(
-                event=fallback_event,
-                room=room,
-                source_kind=VOICE_SOURCE_KIND,
-                requester_user_id=requester_user_id,
-                dispatch_policy_source_kind=dispatch_policy_source_kind,
-                hook_source=hook_source,
-                message_received_depth=message_received_depth,
-                trust_internal_payload_metadata=True,
-                dispatch_metadata=_queued_notice_dispatch_metadata(queued_notice_reservation, target),
+        return _ReadyVoiceFallback(
+            event=fallback_event,
+            ready=ReadyPendingEvent(
+                pending_event=PendingEvent(
+                    event=fallback_event,
+                    room=room,
+                    source_kind=VOICE_SOURCE_KIND,
+                    requester_user_id=requester_user_id,
+                    dispatch_policy_source_kind=dispatch_policy_source_kind,
+                    hook_source=hook_source,
+                    message_received_depth=message_received_depth,
+                    trust_internal_payload_metadata=True,
+                    dispatch_metadata=_queued_notice_dispatch_metadata(queued_notice_reservation, target),
+                ),
             ),
         )
 

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -144,9 +144,40 @@ class TurnStore:
 
         self._ledger.update_handled_turn((source_event_id,), visible_echo_record)
 
-    def visible_echo_for_sources(self, source_event_ids: tuple[str, ...]) -> str | None:
-        """Return the first visible echo already tracked for one or more source events."""
-        return self._ledger.visible_echo_event_id_for_sources(source_event_ids)
+    def record_finalized_visible_echo(self, source_event_id: str, echo_event_id: str) -> None:
+        """Mark a tracked visible echo as successfully replaced."""
+
+        def finalized_visible_echo_record(existing_records: Mapping[str, TurnRecord]) -> TurnRecord:
+            existing = existing_records.get(source_event_id)
+            if existing is None:
+                return TurnRecord.create(
+                    [source_event_id],
+                    response_event_id=echo_event_id,
+                    completed=False,
+                    visible_echo_event_id=echo_event_id,
+                )
+            if existing.completed or existing.visible_echo_event_id != echo_event_id:
+                return existing
+            return replace(
+                existing,
+                response_event_id=echo_event_id,
+                completed=False,
+                timestamp=0.0,
+            )
+
+        self._ledger.update_handled_turn((source_event_id,), finalized_visible_echo_record)
+
+    def finalized_visible_echo_for_sources(self, source_event_ids: tuple[str, ...]) -> str | None:
+        """Return the first visible echo whose replacement succeeded."""
+        for source_event_id in source_event_ids:
+            record = self.get_turn_record(source_event_id)
+            if (
+                record is not None
+                and record.visible_echo_event_id is not None
+                and record.response_event_id == record.visible_echo_event_id
+            ):
+                return record.visible_echo_event_id
+        return None
 
     def get_turn_record(self, source_event_id: str) -> TurnRecord | None:
         """Return the ledger-backed canonical record for one source event."""

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -53,6 +53,14 @@ class TurnStoreDeps:
     tool_runtime: ToolRuntimeSupport
 
 
+@dataclass(frozen=True)
+class _FinalizedVisibleEcho:
+    """Durable terminal state for one editable visible echo."""
+
+    event_id: str
+    is_fallback: bool
+
+
 @dataclass
 class TurnStore:
     """Own replication, precedence, backfill, and repair for one entity's turns.
@@ -144,7 +152,13 @@ class TurnStore:
 
         self._ledger.update_handled_turn((source_event_id,), visible_echo_record)
 
-    def record_finalized_visible_echo(self, source_event_id: str, echo_event_id: str) -> None:
+    def record_finalized_visible_echo(
+        self,
+        source_event_id: str,
+        echo_event_id: str,
+        *,
+        is_fallback: bool,
+    ) -> None:
         """Mark a tracked visible echo as successfully replaced."""
         tracked_record = self.get_turn_record(source_event_id)
         if tracked_record is None or tracked_record.visible_echo_event_id != echo_event_id:
@@ -152,27 +166,35 @@ class TurnStore:
 
         def finalized_visible_echo_record(existing_records: Mapping[str, TurnRecord]) -> TurnRecord:
             existing = existing_records[source_event_id]
-            if existing.completed or existing.visible_echo_event_id != echo_event_id:
+            if existing.visible_echo_event_id != echo_event_id or (
+                existing.visible_echo_is_fallback is False and is_fallback
+            ):
                 return existing
             return replace(
                 existing,
-                response_event_id=echo_event_id,
-                completed=False,
+                response_event_id=existing.response_event_id if existing.completed else echo_event_id,
+                visible_echo_is_fallback=is_fallback,
                 timestamp=0.0,
             )
 
         self._ledger.update_handled_turn((source_event_id,), finalized_visible_echo_record)
 
+    def finalized_visible_echo(self, source_event_id: str) -> _FinalizedVisibleEcho | None:
+        """Return named terminal state for one tracked visible echo."""
+        record = self.get_turn_record(source_event_id)
+        if record is None or record.visible_echo_event_id is None or record.visible_echo_is_fallback is None:
+            return None
+        return _FinalizedVisibleEcho(
+            event_id=record.visible_echo_event_id,
+            is_fallback=record.visible_echo_is_fallback,
+        )
+
     def finalized_visible_echo_for_sources(self, source_event_ids: tuple[str, ...]) -> str | None:
         """Return the first visible echo whose replacement succeeded."""
         for source_event_id in source_event_ids:
-            record = self.get_turn_record(source_event_id)
-            if (
-                record is not None
-                and record.visible_echo_event_id is not None
-                and record.response_event_id == record.visible_echo_event_id
-            ):
-                return record.visible_echo_event_id
+            finalized = self.finalized_visible_echo(source_event_id)
+            if finalized is not None:
+                return finalized.event_id
         return None
 
     def get_turn_record(self, source_event_id: str) -> TurnRecord | None:
@@ -719,6 +741,11 @@ def _backfill_missing_turn_facts(authority: TurnRecord, recovery: TurnRecord) ->
         ),
         response_event_id=authority.response_event_id or recovery.response_event_id,
         visible_echo_event_id=authority.visible_echo_event_id or recovery.visible_echo_event_id,
+        visible_echo_is_fallback=(
+            authority.visible_echo_is_fallback
+            if authority.visible_echo_is_fallback is not None
+            else recovery.visible_echo_is_fallback
+        ),
         source_event_prompts=(
             authority.source_event_prompts
             if authority.source_event_prompts is not None

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -146,16 +146,12 @@ class TurnStore:
 
     def record_finalized_visible_echo(self, source_event_id: str, echo_event_id: str) -> None:
         """Mark a tracked visible echo as successfully replaced."""
+        tracked_record = self.get_turn_record(source_event_id)
+        if tracked_record is None or tracked_record.visible_echo_event_id != echo_event_id:
+            return
 
         def finalized_visible_echo_record(existing_records: Mapping[str, TurnRecord]) -> TurnRecord:
-            existing = existing_records.get(source_event_id)
-            if existing is None:
-                return TurnRecord.create(
-                    [source_event_id],
-                    response_event_id=echo_event_id,
-                    completed=False,
-                    visible_echo_event_id=echo_event_id,
-                )
+            existing = existing_records[source_event_id]
             if existing.completed or existing.visible_echo_event_id != echo_event_id:
                 return existing
             return replace(

--- a/src/mindroom/visible_voice_echo.py
+++ b/src/mindroom/visible_voice_echo.py
@@ -1,0 +1,309 @@
+"""Own the router's visible voice-placeholder lifecycle."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from threading import Lock
+from typing import TYPE_CHECKING, Any
+
+from mindroom.background_tasks import create_background_task
+from mindroom.constants import (
+    ATTACHMENT_IDS_KEY,
+    ORIGINAL_SENDER_KEY,
+    ROUTER_AGENT_NAME,
+    SOURCE_KIND_KEY,
+    VISIBLE_ROUTER_VOICE_ECHO_KEY,
+    VOICE_RAW_AUDIO_FALLBACK_KEY,
+    VOICE_TRANSCRIPT_KEY,
+)
+from mindroom.delivery_gateway import EditTextRequest, SendTextRequest
+from mindroom.dispatch_handoff import PreparedTextEvent, payload_metadata_from_source
+from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+from mindroom.turn_origin import original_sender_for_router_relay
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    import structlog
+
+    from mindroom.bot_runtime_view import BotRuntimeView
+    from mindroom.delivery_gateway import DeliveryGateway
+    from mindroom.ingress_validation import IngressValidator
+    from mindroom.message_target import MessageTarget
+    from mindroom.turn_store import TurnStore
+
+
+_VOICE_TRANSCRIPTION_PLACEHOLDER = "Router agent is transcribing…"
+
+
+@dataclass
+class _UpdateLockEntry:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    borrowers: int = 0
+
+
+_update_locks: dict[tuple[str, str, str], _UpdateLockEntry] = {}
+_update_locks_guard = Lock()
+
+
+def _borrow_update_lock(key: tuple[str, str, str]) -> _UpdateLockEntry:
+    with _update_locks_guard:
+        entry = _update_locks.get(key)
+        if entry is None:
+            entry = _UpdateLockEntry()
+            _update_locks[key] = entry
+        entry.borrowers += 1
+        return entry
+
+
+def _release_update_lock(key: tuple[str, str, str], entry: _UpdateLockEntry) -> None:
+    with _update_locks_guard:
+        entry.borrowers -= 1
+        if entry.borrowers == 0 and _update_locks.get(key) is entry:
+            _update_locks.pop(key)
+
+
+@asynccontextmanager
+async def _serialize_update(key: tuple[str, str, str]) -> AsyncIterator[None]:
+    entry = _borrow_update_lock(key)
+    acquired = False
+    try:
+        await entry.lock.acquire()
+        acquired = True
+        yield
+    finally:
+        if acquired:
+            entry.lock.release()
+        _release_update_lock(key, entry)
+
+
+@dataclass(frozen=True)
+class VisibleVoiceEchoRequest:
+    """Immutable raw-ingress facts needed for one visible voice echo."""
+
+    source_event_id: str
+    target: MessageTarget
+    requester_user_id: str
+    raw_source: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _VisibleVoiceEchoHandle:
+    """One enabled visible-echo lifecycle and its optional placeholder send."""
+
+    request: VisibleVoiceEchoRequest
+    placeholder_task: asyncio.Task[str | None] | None
+
+
+@dataclass(frozen=True)
+class VisibleVoiceEchoDeps:
+    """Collaborators needed for visible voice delivery and durable deduplication."""
+
+    runtime: BotRuntimeView
+    logger: structlog.stdlib.BoundLogger
+    agent_name: str
+    delivery_gateway: DeliveryGateway
+    turn_store: TurnStore
+    ingress: IngressValidator
+
+
+@dataclass
+class VisibleVoiceEchoLifecycle:
+    """Post one early router placeholder and settle it exactly once."""
+
+    deps: VisibleVoiceEchoDeps
+    _placeholder_tasks: dict[str, asyncio.Task[str | None]] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
+
+    def start(self, request: VisibleVoiceEchoRequest) -> _VisibleVoiceEchoHandle | None:
+        """Start the earliest truthful visible state for one raw voice event."""
+        config = self.deps.runtime.config.voice
+        if self.deps.agent_name != ROUTER_AGENT_NAME or not config.visible_router_echo:
+            return None
+        placeholder_task = self._start_placeholder(request) if config.enabled else None
+        return _VisibleVoiceEchoHandle(request=request, placeholder_task=placeholder_task)
+
+    async def finish(
+        self,
+        handle: _VisibleVoiceEchoHandle | None,
+        normalized_event: PreparedTextEvent,
+    ) -> None:
+        """Best-effort settle one started lifecycle without blocking canonical dispatch."""
+        if handle is None:
+            return
+        task = create_background_task(
+            self._settle(handle, normalized_event),
+            name=(f"voice_placeholder_finish:{handle.request.target.room_id}:{handle.request.source_event_id}"),
+            owner=self.deps.runtime,
+        )
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self.deps.logger.warning(
+                "Visible voice echo failed; continuing canonical voice dispatch",
+                event_id=handle.request.source_event_id,
+                room_id=handle.request.target.room_id,
+                exception_type=exc.__class__.__name__,
+                error=str(exc),
+            )
+
+    def finish_after_cancellation(
+        self,
+        handle: _VisibleVoiceEchoHandle | None,
+        fallback_event: PreparedTextEvent,
+    ) -> None:
+        """Schedule terminal fallback cleanup without swallowing caller cancellation."""
+        if handle is None:
+            return
+        create_background_task(
+            self._settle(handle, fallback_event),
+            name=(f"voice_placeholder_cancel_finish:{handle.request.target.room_id}:{handle.request.source_event_id}"),
+            owner=self.deps.runtime,
+        )
+
+    def _start_placeholder(self, request: VisibleVoiceEchoRequest) -> asyncio.Task[str | None]:
+        existing_task = self._placeholder_tasks.get(request.source_event_id)
+        if existing_task is not None:
+            return existing_task
+        task = create_background_task(
+            self._send_placeholder(request),
+            name=f"voice_placeholder:{request.target.room_id}:{request.source_event_id}",
+            owner=self.deps.runtime,
+        )
+        self._placeholder_tasks[request.source_event_id] = task
+        task.add_done_callback(
+            lambda completed_task: self._clear_placeholder_task(
+                request.source_event_id,
+                completed_task,
+            ),
+        )
+        return task
+
+    def _clear_placeholder_task(
+        self,
+        source_event_id: str,
+        completed_task: asyncio.Task[str | None],
+    ) -> None:
+        if self._placeholder_tasks.get(source_event_id) is completed_task:
+            self._placeholder_tasks.pop(source_event_id)
+
+    async def _send_placeholder(self, request: VisibleVoiceEchoRequest) -> str | None:
+        async with _serialize_update(self._update_key(request)):
+            existing_event_id = self.deps.turn_store.visible_echo_for_source(request.source_event_id)
+            if existing_event_id is not None:
+                return existing_event_id
+            event_id = await self.deps.delivery_gateway.send_text(
+                SendTextRequest(
+                    target=request.target,
+                    response_text=_VOICE_TRANSCRIPTION_PLACEHOLDER,
+                    skip_mentions=True,
+                    extra_content=self._extra_content(
+                        requester_user_id=request.requester_user_id,
+                        normalized_source=request.raw_source,
+                    ),
+                ),
+            )
+            if event_id is not None:
+                self.deps.turn_store.record_visible_echo(request.source_event_id, event_id)
+            return event_id
+
+    async def _settle(
+        self,
+        handle: _VisibleVoiceEchoHandle,
+        normalized_event: PreparedTextEvent,
+    ) -> str | None:
+        request = handle.request
+        is_fallback = _is_raw_audio_fallback(normalized_event)
+        placeholder_event_id = (
+            await asyncio.shield(handle.placeholder_task) if handle.placeholder_task is not None else None
+        )
+        async with _serialize_update(self._update_key(request)):
+            finalized = self.deps.turn_store.finalized_visible_echo(request.source_event_id)
+            if finalized is not None and (not finalized.is_fallback or is_fallback):
+                return finalized.event_id
+
+            event_id = placeholder_event_id or self.deps.turn_store.visible_echo_for_source(
+                request.source_event_id,
+            )
+            extra_content = self._extra_content(
+                requester_user_id=request.requester_user_id,
+                normalized_source=normalized_event.source,
+            )
+            if event_id is None:
+                event_id = await self.deps.delivery_gateway.send_text(
+                    SendTextRequest(
+                        target=request.target,
+                        response_text=normalized_event.body,
+                        skip_mentions=True,
+                        extra_content=extra_content,
+                    ),
+                )
+                if event_id is None:
+                    return None
+                self.deps.turn_store.record_visible_echo(request.source_event_id, event_id)
+            else:
+                edited = await self.deps.delivery_gateway.edit_text(
+                    EditTextRequest(
+                        target=request.target,
+                        event_id=event_id,
+                        new_text=normalized_event.body,
+                        extra_content=extra_content,
+                        retry_sync_recovery=True,
+                    ),
+                )
+                if not edited:
+                    return None
+
+            self.deps.turn_store.record_finalized_visible_echo(
+                request.source_event_id,
+                event_id,
+                is_fallback=is_fallback,
+            )
+            return event_id
+
+    def _update_key(self, request: VisibleVoiceEchoRequest) -> tuple[str, str, str]:
+        return (self.deps.agent_name, request.target.room_id, request.source_event_id)
+
+    def _extra_content(
+        self,
+        *,
+        requester_user_id: str,
+        normalized_source: dict[str, Any],
+    ) -> dict[str, Any]:
+        payload_metadata = payload_metadata_from_source(normalized_source, trust_internal_metadata=True)
+        inherited_original_sender = payload_metadata.original_sender
+        relay_original_sender = original_sender_for_router_relay(
+            requester_id=requester_user_id,
+            requester_entity_name=self.deps.ingress.managed_entity_name_for_sender(requester_user_id),
+            inherited_original_sender=inherited_original_sender,
+            inherited_original_sender_entity_name=(
+                self.deps.ingress.managed_entity_name_for_sender(inherited_original_sender)
+                if inherited_original_sender is not None
+                else None
+            ),
+        )
+        extra_content: dict[str, Any] = {
+            SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+            VISIBLE_ROUTER_VOICE_ECHO_KEY: True,
+        }
+        if relay_original_sender is not None:
+            extra_content[ORIGINAL_SENDER_KEY] = relay_original_sender
+        if payload_metadata.attachment_ids:
+            extra_content[ATTACHMENT_IDS_KEY] = list(payload_metadata.attachment_ids)
+        if payload_metadata.raw_audio_fallback:
+            extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] = True
+        if payload_metadata.voice_transcript:
+            extra_content[VOICE_TRANSCRIPT_KEY] = True
+        return extra_content
+
+
+def _is_raw_audio_fallback(event: PreparedTextEvent) -> bool:
+    content = event.source.get("content")
+    return isinstance(content, dict) and content.get(VOICE_RAW_AUDIO_FALLBACK_KEY) is True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -91,6 +91,7 @@ from mindroom.turn_controller import TurnController, _DispatchPreparation, _Repl
 from mindroom.turn_origin import TurnOrigin, classify_turn_origin
 from mindroom.turn_policy import PreparedDispatch, TurnPolicy
 from mindroom.turn_store import TurnStore
+from mindroom.visible_voice_echo import VisibleVoiceEchoLifecycle
 from tests.identity_helpers import persist_entity_accounts
 
 if TYPE_CHECKING:
@@ -1179,6 +1180,7 @@ def wrap_extracted_collaborators(bot: RuntimeBot, *names: str) -> RuntimeBot:
         "_delivery_gateway",
         "_response_runner",
         "_turn_store",
+        "_visible_voice_echo",
         "_edit_regenerator",
         "_inbound_turn_normalizer",
         "_conversation_resolver",
@@ -1364,6 +1366,20 @@ def replace_turn_controller_deps(bot: RuntimeBot, **changes: object) -> TurnCont
             ),
         )
     bot._ingress_validator = rebuilt_changes["ingress"]
+    visible_voice_echo = unwrap_extracted_collaborator(bot._visible_voice_echo)
+    bot._visible_voice_echo = VisibleVoiceEchoLifecycle(
+        replace(
+            visible_voice_echo.deps,
+            runtime=rebuilt_changes.get("runtime", controller.deps.runtime),
+            logger=rebuilt_changes.get("logger", controller.deps.logger),
+            agent_name=rebuilt_changes.get("agent_name", controller.deps.agent_name),
+            delivery_gateway=rebuilt_changes["delivery_gateway"],
+            turn_store=rebuilt_changes["turn_store"],
+            ingress=rebuilt_changes["ingress"],
+        ),
+    )
+    wrap_extracted_collaborators(bot, "_visible_voice_echo")
+    rebuilt_changes["visible_voice_echo"] = bot._visible_voice_echo
     rebuilt = TurnController(replace(controller.deps, **rebuilt_changes))
     bot._turn_controller = rebuilt
     edit_changes = {

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -110,7 +110,6 @@ def _sync_turn_policy_runtime(bot: AgentBot) -> None:
     install_runtime_cache_support(bot)
     turn_store = unwrap_extracted_collaborator(bot._turn_store)
     turn_store.is_handled = MagicMock(return_value=False)
-    turn_store.visible_echo_for_sources = MagicMock(return_value=None)
     turn_store.record_turn = MagicMock()
     _replace_turn_policy_deps(bot, logger=bot.logger)
     replace_turn_controller_deps(bot, logger=bot.logger)

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -61,6 +61,7 @@ from mindroom.turn_controller import TurnController, TurnControllerDeps
 from mindroom.turn_origin import TurnIntent
 from mindroom.turn_policy import IngressHookRunner, TurnPolicy, TurnPolicyDeps
 from mindroom.turn_store import TurnStore, TurnStoreDeps
+from mindroom.visible_voice_echo import VisibleVoiceEchoDeps, VisibleVoiceEchoLifecycle
 from tests.conftest import (
     bind_runtime_paths,
     make_conversation_cache_mock,
@@ -399,6 +400,16 @@ def _build_harness(
             edit_regenerator=_UnusedEditRegenerator(),
             ingress=ingress_validator,
             interrupted_turn_rooms=interrupted_turn_rooms,
+            visible_voice_echo=VisibleVoiceEchoLifecycle(
+                VisibleVoiceEchoDeps(
+                    runtime=runtime,
+                    logger=logger,
+                    agent_name=agent_name,
+                    delivery_gateway=cast("DeliveryGateway", gateway),
+                    turn_store=turn_store,
+                    ingress=ingress_validator,
+                ),
+            ),
         ),
     )
     controller_ref.append(controller)

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -1612,7 +1612,6 @@ class TestAgentBot(AgentBotTestBase):
                     ),
                 ),
             ),
-            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()) as mock_echo,
             patch.object(
                 bot._response_runner,
                 "active_thread_ids_for_room",
@@ -1645,7 +1644,6 @@ class TestAgentBot(AgentBotTestBase):
             ready_event = mock_admit.await_args.kwargs["ready_result"]
 
         assert isinstance(ready_event, ReadyPendingEvent)
-        mock_echo.assert_awaited_once()
         mock_reserve_waiting_human_message.assert_called_once()
         reserved_target = mock_reserve_waiting_human_message.call_args.kwargs["target"]
         assert reserved_target.resolved_thread_id == "$thread_root"

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -816,12 +816,10 @@ class TestAgentBot(AgentBotTestBase):
         _wrap_extracted_collaborators(bot)
         bot.client = _make_matrix_client_mock()
         tracker = _set_turn_store_tracker(bot, MagicMock())
-        tracker.visible_echo_event_id_for_sources.side_effect = lambda source_event_ids: (
-            "$voice_echo" if tuple(source_event_ids) == ("$voice", "$text") else None
-        )
         tracker.get_turn_record.side_effect = lambda source_event_id: (
             TurnRecord.create(
                 ["$voice", "$text"],
+                response_event_id="$voice_echo",
                 completed=False,
                 visible_echo_event_id="$voice_echo",
             )

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -822,6 +822,7 @@ class TestAgentBot(AgentBotTestBase):
                 response_event_id="$voice_echo",
                 completed=False,
                 visible_echo_event_id="$voice_echo",
+                visible_echo_is_fallback=False,
             )
             if source_event_id in {"$voice", "$text"}
             else None
@@ -884,6 +885,7 @@ class TestAgentBot(AgentBotTestBase):
                     response_event_id="$voice_echo",
                     source_event_prompts={"$voice": "voice prompt", "$text": "text prompt"},
                     visible_echo_event_id="$voice_echo",
+                    visible_echo_is_fallback=False,
                     requester_id="@user:localhost",
                     correlation_id="corr-visible-echo",
                 ),

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -1524,6 +1524,15 @@ def test_visible_echo_is_finalized_only_after_replacement_acknowledgement(tmp_pa
     assert store.finalized_visible_echo_for_sources(("$event",)) == "$echo"
 
 
+def test_visible_echo_finalization_requires_tracked_placeholder(tmp_path: Path) -> None:
+    """An acknowledgement alone must not create a finalized visible echo."""
+    store = _store(tmp_path)
+
+    store.record_finalized_visible_echo("$event", "$echo")
+
+    assert store.get_turn_record("$event") is None
+
+
 def test_visible_echo_finalization_cannot_overwrite_terminal_outcome(tmp_path: Path) -> None:
     """A late edit acknowledgement should preserve a concurrently completed turn."""
     store = _store(tmp_path)

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -1515,20 +1515,24 @@ def test_visible_echo_is_finalized_only_after_replacement_acknowledgement(tmp_pa
 
     assert store.finalized_visible_echo_for_sources(("$event",)) is None
 
-    store.record_finalized_visible_echo("$event", "$echo")
+    store.record_finalized_visible_echo("$event", "$echo", is_fallback=False)
 
     record = store.get_turn_record("$event")
     assert record is not None
     assert not record.completed
     assert record.response_event_id == "$echo"
     assert store.finalized_visible_echo_for_sources(("$event",)) == "$echo"
+    finalized = store.finalized_visible_echo("$event")
+    assert finalized is not None
+    assert finalized.event_id == "$echo"
+    assert finalized.is_fallback is False
 
 
 def test_visible_echo_finalization_requires_tracked_placeholder(tmp_path: Path) -> None:
     """An acknowledgement alone must not create a finalized visible echo."""
     store = _store(tmp_path)
 
-    store.record_finalized_visible_echo("$event", "$echo")
+    store.record_finalized_visible_echo("$event", "$echo", is_fallback=False)
 
     assert store.get_turn_record("$event") is None
 
@@ -1539,12 +1543,39 @@ def test_visible_echo_finalization_cannot_overwrite_terminal_outcome(tmp_path: P
     store.record_visible_echo("$event", "$echo")
     store.record_turn(TurnRecord.create(["$event"], response_event_id="$response"))
 
-    store.record_finalized_visible_echo("$event", "$echo")
+    store.record_finalized_visible_echo("$event", "$echo", is_fallback=False)
 
     record = store.get_turn_record("$event")
     assert record is not None
     assert record.completed
     assert record.response_event_id == "$response"
+    finalized = store.finalized_visible_echo("$event")
+    assert finalized is not None
+    assert finalized.event_id == "$echo"
+    assert finalized.is_fallback is False
+
+
+def test_finalized_visible_echo_keeps_transcript_over_fallback(tmp_path: Path) -> None:
+    """Transcript replacement should upgrade fallback and reject later downgrade."""
+    store = _store(tmp_path)
+    store.record_visible_echo("$event", "$echo")
+
+    store.record_finalized_visible_echo("$event", "$echo", is_fallback=True)
+    fallback = store.finalized_visible_echo("$event")
+    assert fallback is not None
+    assert fallback.is_fallback is True
+
+    store.record_finalized_visible_echo("$event", "$echo", is_fallback=False)
+    transcript = store.finalized_visible_echo("$event")
+    assert transcript is not None
+    assert transcript.is_fallback is False
+
+    store.record_finalized_visible_echo("$event", "$echo", is_fallback=True)
+    assert store.finalized_visible_echo("$event") == transcript
+
+    store._ledger.flush()
+    _reset_handled_turn_ledger_runtime()
+    assert _store(tmp_path).finalized_visible_echo("$event") == transcript
 
 
 def test_terminal_turn_rejects_conflicting_completed_canonical_source(tmp_path: Path) -> None:

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -1508,6 +1508,36 @@ def test_terminal_turn_can_replace_a_provisional_source_identity(tmp_path: Path)
     assert first_record.visible_echo_event_id == "$echo"
 
 
+def test_visible_echo_is_finalized_only_after_replacement_acknowledgement(tmp_path: Path) -> None:
+    """A posted placeholder should not become a terminal router outcome before its edit succeeds."""
+    store = _store(tmp_path)
+    store.record_visible_echo("$event", "$echo")
+
+    assert store.finalized_visible_echo_for_sources(("$event",)) is None
+
+    store.record_finalized_visible_echo("$event", "$echo")
+
+    record = store.get_turn_record("$event")
+    assert record is not None
+    assert not record.completed
+    assert record.response_event_id == "$echo"
+    assert store.finalized_visible_echo_for_sources(("$event",)) == "$echo"
+
+
+def test_visible_echo_finalization_cannot_overwrite_terminal_outcome(tmp_path: Path) -> None:
+    """A late edit acknowledgement should preserve a concurrently completed turn."""
+    store = _store(tmp_path)
+    store.record_visible_echo("$event", "$echo")
+    store.record_turn(TurnRecord.create(["$event"], response_event_id="$response"))
+
+    store.record_finalized_visible_echo("$event", "$echo")
+
+    record = store.get_turn_record("$event")
+    assert record is not None
+    assert record.completed
+    assert record.response_event_id == "$response"
+
+
 def test_terminal_turn_rejects_conflicting_completed_canonical_source(tmp_path: Path) -> None:
     """A completed source cannot be reassigned into a different canonical turn."""
     store = _store(tmp_path)

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -690,17 +690,16 @@ async def test_voice_message_clears_active_turn_signal_when_post_stt_echo_fails(
 
 
 @pytest.mark.parametrize(
-    ("echo_side_effect", "echo_return"),
+    "echo_side_effect",
     [
-        pytest.param(RuntimeError("echo failed"), None, id="failed"),
-        pytest.param(None, None, id="disabled"),
+        pytest.param(RuntimeError("echo failed"), id="failed"),
+        pytest.param(None, id="disabled"),
     ],
 )
 @pytest.mark.asyncio
 async def test_failed_or_disabled_visible_echo_does_not_affect_canonical_voice_dispatch(
     mock_home_bot: AgentBot,
     echo_side_effect: BaseException | None,
-    echo_return: str | None,
 ) -> None:
     """Visible echo failures or disabled echo should not block canonical voice dispatch."""
     bot = mock_home_bot
@@ -738,7 +737,7 @@ async def test_failed_or_disabled_visible_echo_does_not_affect_canonical_voice_d
         patch.object(
             bot._turn_controller,
             "_send_visible_voice_transcription_placeholder",
-            new=AsyncMock(side_effect=echo_side_effect, return_value=echo_return),
+            new=AsyncMock(side_effect=echo_side_effect),
         ),
         patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
         patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -689,19 +689,12 @@ async def test_voice_message_clears_active_turn_signal_when_post_stt_echo_fails(
     assert not queued_signal.is_set()
 
 
-@pytest.mark.parametrize(
-    "echo_side_effect",
-    [
-        pytest.param(RuntimeError("echo failed"), id="failed"),
-        pytest.param(None, id="disabled"),
-    ],
-)
 @pytest.mark.asyncio
-async def test_failed_or_disabled_visible_echo_does_not_affect_canonical_voice_dispatch(
+async def test_non_router_skips_visible_echo_and_dispatches_canonical_voice(
     mock_home_bot: AgentBot,
-    echo_side_effect: BaseException | None,
+    generate_response_mock: AsyncMock,
 ) -> None:
-    """Visible echo failures or disabled echo should not block canonical voice dispatch."""
+    """A non-router should dispatch canonical voice without posting a visible echo."""
     bot = mock_home_bot
     room = _threaded_room()
     _install_test_coalescing_gate(bot, debounce_seconds=0.0)
@@ -711,17 +704,19 @@ async def test_failed_or_disabled_visible_echo_does_not_affect_canonical_voice_d
         text="canonical voice transcript",
         thread_id="$thread_root",
     )
-    dispatches: list[tuple[list[str], str]] = []
-
-    async def record_dispatch(
-        _room: nio.MatrixRoom,
-        dispatched_event: PreparedTextEvent | nio.RoomMessageText,
-        _requester_user_id: str,
-        *,
-        handled_turn: TurnRecord | None = None,
-        **_metadata: object,
-    ) -> None:
-        dispatches.append((_handled_source_event_ids(handled_turn), dispatched_event.body))
+    bot._conversation_resolver.extract_dispatch_context = AsyncMock(
+        return_value=dispatch_context_result(
+            MessageContext(
+                am_i_mentioned=True,
+                is_thread=True,
+                thread_id="$thread_root",
+                thread_history=[],
+                mentioned_agents=[bot.matrix_id],
+                has_non_agent_mentions=False,
+                requires_model_history_refresh=False,
+            ),
+        ),
+    )
 
     with (
         patch.object(
@@ -729,23 +724,14 @@ async def test_failed_or_disabled_visible_echo_does_not_affect_canonical_voice_d
             "prepare_voice_event",
             new=AsyncMock(return_value=normalized_voice),
         ),
-        patch.object(
-            bot._turn_controller,
-            "_visible_router_voice_echo_enabled",
-            return_value=echo_side_effect is not None,
-        ),
-        patch.object(
-            bot._turn_controller,
-            "_send_visible_voice_transcription_placeholder",
-            new=AsyncMock(side_effect=echo_side_effect),
-        ),
-        patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
         patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
     ):
         await bot._on_media_message(room, voice_event)
         await drain_coalescing(bot)
 
-    assert dispatches == [(["$voice-visible-echo"], "canonical voice transcript")]
+    generate_response_mock.assert_called_once()
+    assert generate_response_mock.call_args.kwargs["prompt"].startswith("canonical voice transcript")
+    assert bot._turn_store.visible_echo_for_source(voice_event.event_id) is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -22,6 +22,7 @@ from mindroom.config.main import Config
 from mindroom.constants import (
     ATTACHMENT_IDS_KEY,
     ORIGINAL_SENDER_KEY,
+    ROUTER_AGENT_NAME,
     SOURCE_KIND_KEY,
     VISIBLE_ROUTER_VOICE_ECHO_KEY,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
@@ -37,8 +38,10 @@ from tests.conftest import (
     bind_runtime_paths,
     dispatch_context_result,
     drain_coalescing,
+    install_edit_message_mock,
     install_generate_response_mock,
     install_runtime_cache_support,
+    install_send_response_mock,
     replace_turn_controller_deps,
     runtime_paths_for,
     sync_bot_runtime_state,
@@ -660,6 +663,9 @@ async def test_voice_message_clears_active_turn_signal_when_post_stt_echo_fails(
         assert queued_signal.pending_human_messages == 1
         raise echo_error
 
+    replace_turn_controller_deps(bot, agent_name=ROUTER_AGENT_NAME)
+    install_send_response_mock(bot, AsyncMock(return_value="$voice-placeholder"))
+    install_edit_message_mock(bot, AsyncMock(side_effect=fail_visible_echo))
     turn_active = True
     queued_signal.begin_response_turn()
     try:
@@ -668,21 +674,6 @@ async def test_voice_message_clears_active_turn_signal_when_post_stt_echo_fails(
                 bot._turn_controller.deps.normalizer,
                 "prepare_voice_event",
                 new=AsyncMock(return_value=normalized_voice),
-            ),
-            patch.object(
-                bot._turn_controller,
-                "_visible_router_voice_echo_enabled",
-                return_value=True,
-            ),
-            patch.object(
-                bot._turn_controller,
-                "_send_visible_voice_transcription_placeholder",
-                new=AsyncMock(return_value="$voice-placeholder"),
-            ),
-            patch.object(
-                bot._turn_controller,
-                "_finish_visible_voice_echo",
-                new=AsyncMock(side_effect=fail_visible_echo),
             ),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
         ):

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -671,7 +671,17 @@ async def test_voice_message_clears_active_turn_signal_when_post_stt_echo_fails(
             ),
             patch.object(
                 bot._turn_controller,
-                "_maybe_send_visible_voice_echo",
+                "_visible_router_voice_echo_enabled",
+                return_value=True,
+            ),
+            patch.object(
+                bot._turn_controller,
+                "_send_visible_voice_transcription_placeholder",
+                new=AsyncMock(return_value="$voice-placeholder"),
+            ),
+            patch.object(
+                bot._turn_controller,
+                "_finish_visible_voice_echo",
                 new=AsyncMock(side_effect=fail_visible_echo),
             ),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
@@ -731,7 +741,12 @@ async def test_failed_or_disabled_visible_echo_does_not_affect_canonical_voice_d
         ),
         patch.object(
             bot._turn_controller,
-            "_maybe_send_visible_voice_echo",
+            "_visible_router_voice_echo_enabled",
+            return_value=echo_side_effect is not None,
+        ),
+        patch.object(
+            bot._turn_controller,
+            "_send_visible_voice_transcription_placeholder",
             new=AsyncMock(side_effect=echo_side_effect, return_value=echo_return),
         ),
         patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
@@ -816,7 +831,6 @@ async def test_voice_message_uses_canonical_target_for_queued_notice_before_stt(
                 "prepare_voice_event",
                 new=AsyncMock(return_value=normalized_voice),
             ),
-            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
             patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=capture_dispatch)),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
         ):
@@ -908,7 +922,6 @@ async def test_room_mode_voice_notice_survives_until_queued_dispatch_owns_it(
                 "prepare_voice_event",
                 new=AsyncMock(side_effect=prepare_voice_event),
             ),
-            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
             patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=capture_dispatch)),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
         ):
@@ -1005,7 +1018,6 @@ async def test_voice_and_text_followups_during_streaming_coalesce_in_receive_ord
                 "resolve_text_event",
                 new=AsyncMock(side_effect=resolve_text_event),
             ),
-            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
             patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
             patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
@@ -1111,7 +1123,6 @@ async def test_voice_first_text_second_uses_receive_order_when_stt_finishes_late
                 "resolve_text_event",
                 new=AsyncMock(side_effect=resolve_text_event),
             ),
-            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
             patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
             patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
@@ -1207,7 +1218,6 @@ async def test_voice_first_text_second_waits_for_slow_thread_resolution(
                 "resolve_text_event",
                 new=AsyncMock(side_effect=resolve_text_event),
             ),
-            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
             patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
             patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
@@ -1312,7 +1322,6 @@ async def test_root_voice_and_root_text_share_room_scope_while_stt_pending(
                 "resolve_text_event",
                 new=AsyncMock(side_effect=resolve_text_event),
             ),
-            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
             patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
             patch("mindroom.turn_controller.interactive.handle_text_response", new=AsyncMock(return_value=None)),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
@@ -1389,7 +1398,6 @@ async def test_room_mode_voice_burst_dispatches_as_one_turn(mock_home_bot: Agent
                 "prepare_voice_event",
                 new=AsyncMock(side_effect=prepare_voice_event),
             ),
-            patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
             patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
         ):
@@ -1520,7 +1528,6 @@ async def test_raw_voice_normalization_exception_dispatches_audio_fallback(mock_
             new=AsyncMock(side_effect=RuntimeError("stt failed")),
         ),
         patch("mindroom.voice_handler.download_media_bytes", new=AsyncMock(return_value=b"raw audio bytes")),
-        patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
         patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
         patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
     ):
@@ -1561,7 +1568,6 @@ async def test_raw_voice_download_failure_dispatches_text_only_fallback(mock_hom
 
     with (
         patch("mindroom.voice_handler.download_media_bytes", new=AsyncMock(return_value=None)),
-        patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
         patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
         patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
     ):
@@ -1603,7 +1609,6 @@ async def test_raw_voice_thread_resolution_exception_does_not_dispatch_guessed_f
             new=AsyncMock(side_effect=RuntimeError("thread lookup failed")),
         ),
         patch.object(bot._turn_controller.deps.normalizer, "prepare_voice_event", new=AsyncMock()),
-        patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
         patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
         patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
     ):
@@ -1664,7 +1669,6 @@ async def test_raw_voice_root_target_failures_do_not_dispatch_guessed_fallbacks(
         ),
         patch("mindroom.voice_handler.download_media_bytes", new=AsyncMock(return_value=None)),
         patch.object(bot._turn_controller.deps.normalizer, "prepare_voice_event", new=AsyncMock()),
-        patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
         patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
         patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
     ):
@@ -1703,7 +1707,6 @@ async def test_raw_voice_cache_append_exception_does_not_dispatch_guessed_fallba
             new=AsyncMock(side_effect=RuntimeError("cache append failed")),
         ),
         patch.object(bot._turn_controller.deps.normalizer, "prepare_voice_event", new=prepare_voice_event),
-        patch.object(bot._turn_controller, "_maybe_send_visible_voice_echo", new=AsyncMock()),
         patch.object(bot._turn_controller, "_dispatch_text_message", new=AsyncMock(side_effect=record_dispatch)),
         patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
     ):

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -1157,8 +1157,8 @@ async def test_voice_echo_finishes_after_config_is_disabled_mid_transcription(tm
 
 
 @pytest.mark.asyncio
-async def test_voice_echo_edit_failure_does_not_post_second_message(tmp_path) -> None:  # noqa: ANN001
-    """A failed replacement should not orphan the placeholder beside a second echo."""
+async def test_voice_echo_edit_failure_retries_existing_placeholder(tmp_path) -> None:  # noqa: ANN001
+    """A failed replacement should retry the same placeholder on redelivery."""
     bot, room, event = _make_visible_router_echo_scenario(tmp_path)
     bot._delivery_gateway.edit_text.side_effect = None
     bot._delivery_gateway.edit_text.return_value = False
@@ -1172,9 +1172,15 @@ async def test_voice_echo_edit_failure_does_not_post_second_message(tmp_path) ->
         mock_voice.return_value = f"{VOICE_PREFIX}@home turn on the lights"
         await bot._turn_controller.handle_media_event(room, event)
         await drain_coalescing(bot)
+        assert not bot._turn_store.is_handled(event.event_id)
+
+        bot._delivery_gateway.edit_text.return_value = True
+        await bot._turn_controller.handle_media_event(room, event)
+        await drain_coalescing(bot)
 
     bot._delivery_gateway.send_text.assert_awaited_once()
-    bot._delivery_gateway.edit_text.assert_awaited_once()
+    assert bot._delivery_gateway.edit_text.await_count == 2
+    assert bot._turn_store.is_handled(event.event_id)
     assert bot._turn_store.visible_echo_for_source(event.event_id) == "$voice_echo"
 
 

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import replace
 from typing import TYPE_CHECKING
@@ -12,6 +13,7 @@ import pytest
 from agno.media import Audio
 
 from mindroom.attachments import _attachment_id_for_event, load_attachment
+from mindroom.background_tasks import wait_for_background_tasks
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
@@ -25,6 +27,7 @@ from mindroom.constants import (
     VOICE_RAW_AUDIO_FALLBACK_KEY,
     VOICE_TRANSCRIPT_KEY,
 )
+from mindroom.dispatch_handoff import PreparedTextEvent
 from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND, VOICE_SOURCE_KIND
 from mindroom.handled_turns import TurnRecord
 from mindroom.history.types import HistoryScope
@@ -35,6 +38,7 @@ from mindroom.voice_handler import prepare_voice_message
 from tests.conftest import (
     bind_runtime_paths,
     drain_coalescing,
+    install_edit_message_mock,
     install_generate_response_mock,
     install_runtime_cache_support,
     install_send_response_mock,
@@ -168,6 +172,7 @@ def _make_visible_router_echo_scenario(
     else:
         send_response.return_value = send_response_return
     install_send_response_mock(bot, send_response)
+    install_edit_message_mock(bot, AsyncMock(return_value=True))
 
     room_user_ids = [
         "@mindroom_router:localhost",
@@ -982,16 +987,270 @@ async def test_router_posts_visible_voice_echo_when_enabled(tmp_path) -> None:  
         await drain_coalescing(bot)
 
     bot._delivery_gateway.send_text.assert_called_once()
-    request = bot._delivery_gateway.send_text.call_args.args[0]
-    assert request.target.reply_to_event_id == "$voice_event"
-    assert request.response_text == f"{VOICE_PREFIX}@home turn on the lights"
-    assert request.target.resolved_thread_id == "$voice_event"
-    assert request.skip_mentions is True
-    assert request.extra_content is not None
-    assert request.extra_content[ORIGINAL_SENDER_KEY] == "@alice:example.com"
-    assert request.extra_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
-    assert request.extra_content[ATTACHMENT_IDS_KEY] == [_attachment_id_for_event("$voice_event")]
-    assert VOICE_RAW_AUDIO_FALLBACK_KEY not in request.extra_content
+    placeholder_request = bot._delivery_gateway.send_text.call_args.args[0]
+    assert placeholder_request.target.reply_to_event_id == "$voice_event"
+    assert placeholder_request.response_text == "Router agent is transcribing…"
+    assert placeholder_request.target.resolved_thread_id == "$voice_event"
+    assert placeholder_request.skip_mentions is True
+
+    bot._delivery_gateway.edit_text.assert_awaited_once()
+    edit_request = bot._delivery_gateway.edit_text.await_args.args[0]
+    assert edit_request.event_id == "$voice_echo"
+    assert edit_request.new_text == f"{VOICE_PREFIX}@home turn on the lights"
+    assert edit_request.extra_content is not None
+    assert edit_request.extra_content[ORIGINAL_SENDER_KEY] == "@alice:example.com"
+    assert edit_request.extra_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+    assert edit_request.extra_content[ATTACHMENT_IDS_KEY] == [_attachment_id_for_event("$voice_event")]
+    assert VOICE_RAW_AUDIO_FALLBACK_KEY not in edit_request.extra_content
+
+
+@pytest.mark.asyncio
+async def test_router_posts_transcription_placeholder_before_voice_is_ready(tmp_path) -> None:  # noqa: ANN001
+    """Router should show immediate progress, then replace it with the normalized voice text."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    allow_placeholder_send = asyncio.Event()
+    placeholder_send_finished = asyncio.Event()
+    placeholder_send_started = asyncio.Event()
+    transcription_started = asyncio.Event()
+    release_transcription = asyncio.Event()
+
+    async def transcribe_voice(*_args: object, **_kwargs: object) -> str:
+        transcription_started.set()
+        await release_transcription.wait()
+        return f"{VOICE_PREFIX}@home turn on the lights"
+
+    async def send_visible_echo(_request: object) -> str:
+        placeholder_send_started.set()
+        await allow_placeholder_send.wait()
+        placeholder_send_finished.set()
+        return "$voice_echo"
+
+    with (
+        patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
+        patch("mindroom.voice_handler._handle_voice_message", side_effect=transcribe_voice),
+        patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+    ):
+        mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
+        bot._delivery_gateway.send_text.side_effect = send_visible_echo
+        await bot._turn_controller.handle_media_event(room, event)
+        try:
+            await asyncio.wait_for(placeholder_send_started.wait(), timeout=1)
+            await asyncio.wait_for(transcription_started.wait(), timeout=1)
+            assert not placeholder_send_finished.is_set()
+            allow_placeholder_send.set()
+            await asyncio.wait_for(placeholder_send_finished.wait(), timeout=1)
+            placeholder_request = bot._delivery_gateway.send_text.await_args.args[0]
+            assert placeholder_request.response_text == "Router agent is transcribing…"
+            bot._delivery_gateway.edit_text.assert_not_awaited()
+        finally:
+            allow_placeholder_send.set()
+            release_transcription.set()
+            await drain_coalescing(bot)
+
+    bot._delivery_gateway.send_text.assert_awaited_once()
+    bot._delivery_gateway.edit_text.assert_awaited_once()
+    edit_request = bot._delivery_gateway.edit_text.await_args.args[0]
+    assert edit_request.event_id == "$voice_echo"
+    assert edit_request.new_text == f"{VOICE_PREFIX}@home turn on the lights"
+    assert edit_request.extra_content is not None
+    assert edit_request.extra_content[ORIGINAL_SENDER_KEY] == "@alice:example.com"
+    assert edit_request.extra_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+    assert edit_request.extra_content[ATTACHMENT_IDS_KEY] == [_attachment_id_for_event("$voice_event")]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_voice_redelivery_shares_visible_echo_lifecycle(tmp_path) -> None:  # noqa: ANN001
+    """Concurrent delivery of one audio event should send and finish one visible echo."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    allow_normalization = asyncio.Event()
+    allow_placeholder_send = asyncio.Event()
+    both_normalizations_started = asyncio.Event()
+    placeholder_send_started = asyncio.Event()
+    normalization_count = 0
+    normalized_event = PreparedTextEvent(
+        sender=event.sender,
+        event_id=event.event_id,
+        body=f"{VOICE_PREFIX}@home turn on the lights",
+        source={
+            "content": {
+                "body": f"{VOICE_PREFIX}@home turn on the lights",
+                ORIGINAL_SENDER_KEY: event.sender,
+                SOURCE_KIND_KEY: VOICE_SOURCE_KIND,
+                VOICE_TRANSCRIPT_KEY: True,
+            },
+        },
+        server_timestamp=event.server_timestamp,
+        source_kind_override=VOICE_SOURCE_KIND,
+    )
+
+    async def normalize_voice(*_args: object, **_kwargs: object) -> tuple[PreparedTextEvent, str]:
+        nonlocal normalization_count
+        normalization_count += 1
+        if normalization_count == 2:
+            both_normalizations_started.set()
+        await allow_normalization.wait()
+        return normalized_event, event.event_id
+
+    async def send_placeholder(_request: object) -> str:
+        placeholder_send_started.set()
+        await allow_placeholder_send.wait()
+        return "$voice_echo"
+
+    with (
+        patch.object(
+            bot._turn_controller,
+            "_normalize_voice_event_or_fallback",
+            new=AsyncMock(side_effect=normalize_voice),
+        ),
+        patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+    ):
+        bot._delivery_gateway.send_text.side_effect = send_placeholder
+        await bot._turn_controller.handle_media_event(room, event)
+        await bot._turn_controller.handle_media_event(room, event)
+        try:
+            await asyncio.wait_for(both_normalizations_started.wait(), timeout=1)
+            await asyncio.wait_for(placeholder_send_started.wait(), timeout=1)
+            await asyncio.sleep(0)
+            assert bot._delivery_gateway.send_text.await_count == 1
+        finally:
+            allow_normalization.set()
+            allow_placeholder_send.set()
+            await drain_coalescing(bot)
+
+    bot._delivery_gateway.send_text.assert_awaited_once()
+    bot._delivery_gateway.edit_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_voice_echo_finishes_after_config_is_disabled_mid_transcription(tmp_path) -> None:  # noqa: ANN001
+    """A started placeholder lifecycle should finish despite a live config toggle."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    placeholder_sent = asyncio.Event()
+    release_transcription = asyncio.Event()
+    transcription_started = asyncio.Event()
+
+    async def transcribe_voice(*_args: object, **_kwargs: object) -> str:
+        transcription_started.set()
+        await release_transcription.wait()
+        return f"{VOICE_PREFIX}@home turn on the lights"
+
+    async def send_placeholder(_request: object) -> str:
+        placeholder_sent.set()
+        return "$voice_echo"
+
+    with (
+        patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
+        patch("mindroom.voice_handler._handle_voice_message", side_effect=transcribe_voice),
+        patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+    ):
+        mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
+        bot._delivery_gateway.send_text.side_effect = send_placeholder
+        await bot._turn_controller.handle_media_event(room, event)
+        await asyncio.wait_for(placeholder_sent.wait(), timeout=1)
+        await asyncio.wait_for(transcription_started.wait(), timeout=1)
+        bot.config.voice.visible_router_echo = False
+        release_transcription.set()
+        await drain_coalescing(bot)
+
+    bot._delivery_gateway.send_text.assert_awaited_once()
+    bot._delivery_gateway.edit_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_voice_echo_edit_failure_does_not_post_second_message(tmp_path) -> None:  # noqa: ANN001
+    """A failed replacement should not orphan the placeholder beside a second echo."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    bot._delivery_gateway.edit_text.side_effect = None
+    bot._delivery_gateway.edit_text.return_value = False
+
+    with (
+        patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
+        patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
+        patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+    ):
+        mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
+        mock_voice.return_value = f"{VOICE_PREFIX}@home turn on the lights"
+        await bot._turn_controller.handle_media_event(room, event)
+        await drain_coalescing(bot)
+
+    bot._delivery_gateway.send_text.assert_awaited_once()
+    bot._delivery_gateway.edit_text.assert_awaited_once()
+    assert bot._turn_store.visible_echo_for_source(event.event_id) == "$voice_echo"
+
+
+@pytest.mark.asyncio
+async def test_voice_placeholder_is_owned_by_runtime_shutdown(tmp_path) -> None:  # noqa: ANN001
+    """Runtime shutdown should find and cancel a blocked voice-placeholder send."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    placeholder_send_started = asyncio.Event()
+    placeholder_send_stopped = asyncio.Event()
+    release_placeholder_send = asyncio.Event()
+    release_transcription = asyncio.Event()
+
+    async def transcribe_voice(*_args: object, **_kwargs: object) -> str:
+        await release_transcription.wait()
+        return f"{VOICE_PREFIX}@home turn on the lights"
+
+    async def send_placeholder(_request: object) -> str:
+        placeholder_send_started.set()
+        try:
+            await release_placeholder_send.wait()
+        finally:
+            placeholder_send_stopped.set()
+        return "$voice_echo"
+
+    with (
+        patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
+        patch("mindroom.voice_handler._handle_voice_message", side_effect=transcribe_voice),
+        patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+    ):
+        mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
+        bot._delivery_gateway.send_text.side_effect = send_placeholder
+        await bot._turn_controller.handle_media_event(room, event)
+        await asyncio.wait_for(placeholder_send_started.wait(), timeout=1)
+        try:
+            completed = await wait_for_background_tasks(timeout=0.0, owner=bot._runtime_view)
+            assert completed is False
+            await asyncio.wait_for(placeholder_send_stopped.wait(), timeout=1)
+        finally:
+            release_placeholder_send.set()
+            release_transcription.set()
+            await drain_coalescing(bot)
+
+
+@pytest.mark.asyncio
+async def test_voice_placeholder_finish_is_owned_by_runtime_shutdown(tmp_path) -> None:  # noqa: ANN001
+    """Runtime shutdown should find and cancel a blocked placeholder replacement."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    edit_started = asyncio.Event()
+    edit_stopped = asyncio.Event()
+    release_edit = asyncio.Event()
+
+    async def edit_placeholder(_request: object) -> bool:
+        edit_started.set()
+        try:
+            await release_edit.wait()
+        finally:
+            edit_stopped.set()
+        return True
+
+    with (
+        patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
+        patch("mindroom.voice_handler._handle_voice_message", new_callable=AsyncMock) as mock_voice,
+        patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+    ):
+        mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
+        mock_voice.return_value = f"{VOICE_PREFIX}@home turn on the lights"
+        bot._delivery_gateway.edit_text.side_effect = edit_placeholder
+        await bot._turn_controller.handle_media_event(room, event)
+        await asyncio.wait_for(edit_started.wait(), timeout=1)
+        try:
+            completed = await wait_for_background_tasks(timeout=0.0, owner=bot._runtime_view)
+            assert completed is False
+            await asyncio.wait_for(edit_stopped.wait(), timeout=1)
+        finally:
+            release_edit.set()
+            await drain_coalescing(bot)
 
 
 @pytest.mark.asyncio
@@ -1011,6 +1270,7 @@ async def test_router_visible_voice_echo_is_deduplicated_on_redelivery(tmp_path)
         await drain_coalescing(bot)
 
     bot._delivery_gateway.send_text.assert_called_once()
+    bot._delivery_gateway.edit_text.assert_awaited_once()
     assert mock_download_audio.await_count == 1
     assert mock_voice.await_count == 1
     assert bot._turn_store.is_handled(event.event_id)
@@ -1073,13 +1333,17 @@ async def test_router_visible_voice_echo_keeps_multi_agent_handoff(tmp_path) -> 
     echo_request = bot._delivery_gateway.send_text.call_args_list[0].args[0]
     handoff_request = bot._delivery_gateway.send_text.call_args_list[1].args[0]
     assert echo_request.target.reply_to_event_id == "$voice_event"
-    assert echo_request.response_text == f"{VOICE_PREFIX}summarize this audio"
+    assert echo_request.response_text == "Router agent is transcribing…"
     assert echo_request.skip_mentions is True
-    assert echo_request.extra_content is not None
-    assert echo_request.extra_content[ORIGINAL_SENDER_KEY] == "@alice:example.com"
-    assert echo_request.extra_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
-    assert echo_request.extra_content[ATTACHMENT_IDS_KEY] == [_attachment_id_for_event("$voice_event")]
-    assert VOICE_RAW_AUDIO_FALLBACK_KEY not in echo_request.extra_content
+    bot._delivery_gateway.edit_text.assert_awaited_once()
+    edit_request = bot._delivery_gateway.edit_text.await_args.args[0]
+    assert edit_request.event_id == "$voice_echo"
+    assert edit_request.new_text == f"{VOICE_PREFIX}summarize this audio"
+    assert edit_request.extra_content is not None
+    assert edit_request.extra_content[ORIGINAL_SENDER_KEY] == "@alice:example.com"
+    assert edit_request.extra_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+    assert edit_request.extra_content[ATTACHMENT_IDS_KEY] == [_attachment_id_for_event("$voice_event")]
+    assert VOICE_RAW_AUDIO_FALLBACK_KEY not in edit_request.extra_content
     assert handoff_request.target.reply_to_event_id == "$voice_event"
     assert handoff_request.response_text == "@home could you help with this?"
     assert handoff_request.extra_content == {
@@ -1104,13 +1368,17 @@ async def test_router_visible_voice_echo_marks_raw_audio_fallback(tmp_path) -> N
         await drain_coalescing(bot)
 
     bot._delivery_gateway.send_text.assert_called_once()
-    request = bot._delivery_gateway.send_text.call_args.args[0]
-    assert request.response_text == f"{VOICE_PREFIX}[Attached voice message]"
-    assert request.extra_content is not None
-    assert request.extra_content[ORIGINAL_SENDER_KEY] == "@alice:example.com"
-    assert request.extra_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
-    assert request.extra_content[ATTACHMENT_IDS_KEY] == [_attachment_id_for_event("$voice_event")]
-    assert request.extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] is True
+    placeholder_request = bot._delivery_gateway.send_text.call_args.args[0]
+    assert placeholder_request.response_text == "Router agent is transcribing…"
+
+    bot._delivery_gateway.edit_text.assert_awaited_once()
+    edit_request = bot._delivery_gateway.edit_text.await_args.args[0]
+    assert edit_request.new_text == f"{VOICE_PREFIX}[Attached voice message]"
+    assert edit_request.extra_content is not None
+    assert edit_request.extra_content[ORIGINAL_SENDER_KEY] == "@alice:example.com"
+    assert edit_request.extra_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+    assert edit_request.extra_content[ATTACHMENT_IDS_KEY] == [_attachment_id_for_event("$voice_event")]
+    assert edit_request.extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] is True
 
 
 @pytest.mark.asyncio
@@ -1144,10 +1412,11 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries(
 
     response_texts = [call.args[0].response_text for call in bot._delivery_gateway.send_text.call_args_list]
     assert response_texts == [
-        f"{VOICE_PREFIX}summarize this audio",
+        "Router agent is transcribing…",
         "@home could you help with this?",
         "@home could you help with this?",
     ]
+    assert bot._delivery_gateway.edit_text.await_count == 2
     assert bot._turn_store.is_handled(event.event_id)
     assert bot._turn_store.visible_echo_for_source(event.event_id) == "$voice_echo"
 

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -1179,6 +1179,86 @@ async def test_voice_echo_edit_failure_does_not_post_second_message(tmp_path) ->
 
 
 @pytest.mark.asyncio
+async def test_voice_readiness_failure_replaces_placeholder_with_fallback(tmp_path) -> None:  # noqa: ANN001
+    """A readiness failure after placeholder delivery should leave terminal fallback text."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+
+    with (
+        patch.object(
+            bot._turn_controller.deps.resolver,
+            "build_ingress_envelope",
+            side_effect=RuntimeError("readiness failed"),
+        ),
+        patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+    ):
+        await bot._turn_controller.handle_media_event(room, event)
+        await drain_coalescing(bot)
+
+    bot._delivery_gateway.send_text.assert_awaited_once()
+    bot._delivery_gateway.edit_text.assert_awaited_once()
+    edit_request = bot._delivery_gateway.edit_text.await_args.args[0]
+    assert edit_request.event_id == "$voice_echo"
+    assert edit_request.new_text == f"{VOICE_PREFIX}[Attached voice message]"
+    assert edit_request.extra_content is not None
+    assert edit_request.extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] is True
+
+
+@pytest.mark.asyncio
+async def test_voice_readiness_cancellation_schedules_terminal_placeholder_fallback(tmp_path) -> None:  # noqa: ANN001
+    """Cancelling readiness should schedule terminal fallback replacement before escaping."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    normalization_started = asyncio.Event()
+    placeholder_sent = asyncio.Event()
+
+    async def wait_for_cancellation(*_args: object, **_kwargs: object) -> None:
+        normalization_started.set()
+        await asyncio.Event().wait()
+
+    async def send_placeholder(_request: object) -> str:
+        placeholder_sent.set()
+        return "$voice_echo"
+
+    bot._delivery_gateway.send_text.side_effect = send_placeholder
+    with (
+        patch.object(
+            bot._turn_controller.deps.normalizer,
+            "prepare_voice_event",
+            side_effect=wait_for_cancellation,
+        ),
+        patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+    ):
+        prechecked_event = bot._turn_controller._precheck_dispatch_event(room, event)
+        assert prechecked_event is not None
+        voice_target = bot._turn_controller.deps.resolver.build_message_target(
+            room_id=room.room_id,
+            thread_id=event.event_id,
+            reply_to_event_id=event.event_id,
+            event_source=event.source,
+        )
+        ready_task = asyncio.create_task(
+            bot._turn_controller._ready_voice_event(
+                room=room,
+                prechecked_event=prechecked_event,
+                voice_target=voice_target,
+                dispatch_timing=None,
+            ),
+        )
+        await asyncio.wait_for(normalization_started.wait(), timeout=1)
+        await asyncio.wait_for(placeholder_sent.wait(), timeout=1)
+        ready_task.cancel()
+        result = await asyncio.gather(ready_task, return_exceptions=True)
+
+    assert isinstance(result[0], asyncio.CancelledError)
+    assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view) is True
+    bot._delivery_gateway.edit_text.assert_awaited_once()
+    edit_request = bot._delivery_gateway.edit_text.await_args.args[0]
+    assert edit_request.event_id == "$voice_echo"
+    assert edit_request.new_text == f"{VOICE_PREFIX}[Attached voice message]"
+    assert edit_request.extra_content is not None
+    assert edit_request.extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] is True
+
+
+@pytest.mark.asyncio
 async def test_voice_placeholder_is_owned_by_runtime_shutdown(tmp_path) -> None:  # noqa: ANN001
     """Runtime shutdown should find and cancel a blocked voice-placeholder send."""
     bot, room, event = _make_visible_router_echo_scenario(tmp_path)

--- a/tests/test_voice_command_processing.py
+++ b/tests/test_voice_command_processing.py
@@ -34,6 +34,7 @@ from mindroom.history.types import HistoryScope
 from mindroom.matrix.cache.thread_history_result import thread_history_result
 from mindroom.matrix.identity import MatrixID
 from mindroom.message_target import MessageTarget
+from mindroom.visible_voice_echo import VisibleVoiceEchoRequest
 from mindroom.voice_handler import prepare_voice_message
 from tests.conftest import (
     bind_runtime_paths,
@@ -51,6 +52,8 @@ from tests.conftest import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from mindroom.delivery_gateway import EditTextRequest
 
 
 def _attach_runtime_paths(config: Config, tmp_path: Path) -> Config:
@@ -136,6 +139,7 @@ def _make_visible_router_echo_scenario(
     *,
     agents: dict | None = None,
     authorization: dict | None = None,
+    voice_enabled: bool = True,
     send_response_return: str | None = "$voice_echo",
     send_response_side_effect: list[str] | None = None,
 ) -> tuple[AgentBot, nio.MatrixRoom, nio.RoomMessageAudio]:
@@ -150,7 +154,7 @@ def _make_visible_router_echo_scenario(
         Config(
             agents=configured_agents,
             authorization=authorization or {"default_room_access": True},
-            voice={"enabled": True, "visible_router_echo": True},
+            voice={"enabled": voice_enabled, "visible_router_echo": True},
         ),
         tmp_path,
     )
@@ -1005,6 +1009,27 @@ async def test_router_posts_visible_voice_echo_when_enabled(tmp_path) -> None:  
 
 
 @pytest.mark.asyncio
+async def test_router_voice_echo_skips_transcription_placeholder_when_voice_is_disabled(tmp_path) -> None:  # noqa: ANN001
+    """Disabled STT should post only truthful attached-voice fallback text."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path, voice_enabled=False)
+
+    with (
+        patch("mindroom.voice_handler._download_audio", new_callable=AsyncMock) as mock_download_audio,
+        patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+    ):
+        mock_download_audio.return_value = Audio(content=b"voice-bytes", mime_type="audio/ogg")
+        await bot._on_media_message(room, event)
+        await drain_coalescing(bot)
+
+    bot._delivery_gateway.send_text.assert_awaited_once()
+    request = bot._delivery_gateway.send_text.await_args.args[0]
+    assert request.response_text == f"{VOICE_PREFIX}[Attached voice message]"
+    assert request.extra_content is not None
+    assert request.extra_content[VOICE_RAW_AUDIO_FALLBACK_KEY] is True
+    bot._delivery_gateway.edit_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_router_posts_transcription_placeholder_before_voice_is_ready(tmp_path) -> None:  # noqa: ANN001
     """Router should show immediate progress, then replace it with the normalized voice text."""
     bot, room, event = _make_visible_router_echo_scenario(tmp_path)
@@ -1185,6 +1210,172 @@ async def test_voice_echo_edit_failure_retries_existing_placeholder(tmp_path) ->
 
 
 @pytest.mark.asyncio
+async def test_finalized_voice_transcript_is_not_replaced_by_late_fallback(tmp_path) -> None:  # noqa: ANN001
+    """A late fallback must not downgrade a successfully delivered transcript."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    voice_target = bot._turn_controller.deps.resolver.build_message_target(
+        room_id=room.room_id,
+        thread_id=event.event_id,
+        reply_to_event_id=event.event_id,
+        event_source=event.source,
+    )
+    bot._turn_store.record_visible_echo(event.event_id, "$voice_echo")
+    bot._turn_store.record_finalized_visible_echo(
+        event.event_id,
+        "$voice_echo",
+        is_fallback=False,
+    )
+    handle = bot._visible_voice_echo.start(
+        VisibleVoiceEchoRequest(
+            source_event_id=event.event_id,
+            target=voice_target,
+            requester_user_id=event.sender,
+            raw_source=event.source,
+        ),
+    )
+
+    await bot._visible_voice_echo.finish(
+        handle,
+        PreparedTextEvent(
+            sender=event.sender,
+            event_id=event.event_id,
+            body=f"{VOICE_PREFIX}[Attached voice message]",
+            source={
+                "content": {
+                    "body": f"{VOICE_PREFIX}[Attached voice message]",
+                    ORIGINAL_SENDER_KEY: event.sender,
+                    SOURCE_KIND_KEY: VOICE_SOURCE_KIND,
+                    VOICE_RAW_AUDIO_FALLBACK_KEY: True,
+                },
+            },
+            server_timestamp=event.server_timestamp,
+            source_kind_override=VOICE_SOURCE_KIND,
+        ),
+    )
+
+    bot._delivery_gateway.edit_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_voice_finish_does_not_replace_finalized_transcript(tmp_path) -> None:  # noqa: ANN001
+    """Cancellation cleanup must not downgrade a successfully delivered transcript."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    voice_target = bot._turn_controller.deps.resolver.build_message_target(
+        room_id=room.room_id,
+        thread_id=event.event_id,
+        reply_to_event_id=event.event_id,
+        event_source=event.source,
+    )
+    bot._turn_store.record_visible_echo(event.event_id, "$voice_echo")
+    bot._turn_store.record_finalized_visible_echo(
+        event.event_id,
+        "$voice_echo",
+        is_fallback=False,
+    )
+    handle = bot._visible_voice_echo.start(
+        VisibleVoiceEchoRequest(
+            source_event_id=event.event_id,
+            target=voice_target,
+            requester_user_id=event.sender,
+            raw_source=event.source,
+        ),
+    )
+    fallback_event = PreparedTextEvent(
+        sender=event.sender,
+        event_id=event.event_id,
+        body=f"{VOICE_PREFIX}[Attached voice message]",
+        source={
+            "content": {
+                "body": f"{VOICE_PREFIX}[Attached voice message]",
+                ORIGINAL_SENDER_KEY: event.sender,
+                SOURCE_KIND_KEY: VOICE_SOURCE_KIND,
+                VOICE_RAW_AUDIO_FALLBACK_KEY: True,
+            },
+        },
+        server_timestamp=event.server_timestamp,
+        source_kind_override=VOICE_SOURCE_KIND,
+    )
+
+    bot._visible_voice_echo.finish_after_cancellation(handle, fallback_event)
+
+    assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view) is True
+    bot._delivery_gateway.edit_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_transcript_wins_when_fallback_edit_is_in_flight(tmp_path) -> None:  # noqa: ANN001
+    """A transcript arriving during fallback delivery should become final visible text."""
+    bot, room, event = _make_visible_router_echo_scenario(tmp_path)
+    voice_target = bot._turn_controller.deps.resolver.build_message_target(
+        room_id=room.room_id,
+        thread_id=event.event_id,
+        reply_to_event_id=event.event_id,
+        event_source=event.source,
+    )
+    handle = bot._visible_voice_echo.start(
+        VisibleVoiceEchoRequest(
+            source_event_id=event.event_id,
+            target=voice_target,
+            requester_user_id=event.sender,
+            raw_source=event.source,
+        ),
+    )
+    assert handle is not None
+    assert handle.placeholder_task is not None
+    assert await handle.placeholder_task == "$voice_echo"
+
+    edit_started = asyncio.Event()
+    release_fallback_edit = asyncio.Event()
+    edited_texts: list[str] = []
+
+    async def edit_text(request: EditTextRequest) -> bool:
+        new_text = request.new_text
+        edited_texts.append(new_text)
+        if len(edited_texts) == 1:
+            edit_started.set()
+            await release_fallback_edit.wait()
+        return True
+
+    bot._delivery_gateway.edit_text.side_effect = edit_text
+    fallback_event = PreparedTextEvent(
+        sender=event.sender,
+        event_id=event.event_id,
+        body=f"{VOICE_PREFIX}[Attached voice message]",
+        source={
+            "content": {
+                "body": f"{VOICE_PREFIX}[Attached voice message]",
+                VOICE_RAW_AUDIO_FALLBACK_KEY: True,
+            },
+        },
+    )
+    transcript_event = PreparedTextEvent(
+        sender=event.sender,
+        event_id=event.event_id,
+        body=f"{VOICE_PREFIX}summarize this audio",
+        source={
+            "content": {
+                "body": f"{VOICE_PREFIX}summarize this audio",
+                VOICE_TRANSCRIPT_KEY: True,
+            },
+        },
+    )
+
+    fallback_task = asyncio.create_task(bot._visible_voice_echo.finish(handle, fallback_event))
+    await asyncio.wait_for(edit_started.wait(), timeout=1)
+    transcript_task = asyncio.create_task(bot._visible_voice_echo.finish(handle, transcript_event))
+    release_fallback_edit.set()
+    await asyncio.gather(fallback_task, transcript_task)
+
+    assert edited_texts == [
+        f"{VOICE_PREFIX}[Attached voice message]",
+        f"{VOICE_PREFIX}summarize this audio",
+    ]
+    finalized = bot._turn_store.finalized_visible_echo(event.event_id)
+    assert finalized is not None
+    assert finalized.is_fallback is False
+
+
+@pytest.mark.asyncio
 async def test_voice_readiness_failure_replaces_placeholder_with_fallback(tmp_path) -> None:  # noqa: ANN001
     """A readiness failure after placeholder delivery should leave terminal fallback text."""
     bot, room, event = _make_visible_router_echo_scenario(tmp_path)
@@ -1233,28 +1424,12 @@ async def test_voice_readiness_cancellation_schedules_terminal_placeholder_fallb
         ),
         patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
     ):
-        prechecked_event = bot._turn_controller._precheck_dispatch_event(room, event)
-        assert prechecked_event is not None
-        voice_target = bot._turn_controller.deps.resolver.build_message_target(
-            room_id=room.room_id,
-            thread_id=event.event_id,
-            reply_to_event_id=event.event_id,
-            event_source=event.source,
-        )
-        ready_task = asyncio.create_task(
-            bot._turn_controller._ready_voice_event(
-                room=room,
-                prechecked_event=prechecked_event,
-                voice_target=voice_target,
-                dispatch_timing=None,
-            ),
-        )
+        await bot._turn_controller.handle_media_event(room, event)
         await asyncio.wait_for(normalization_started.wait(), timeout=1)
         await asyncio.wait_for(placeholder_sent.wait(), timeout=1)
-        ready_task.cancel()
-        result = await asyncio.gather(ready_task, return_exceptions=True)
+        drain_result = await bot._coalescing_gate.drain_all(ready_timeout_seconds=0.0)
 
-    assert isinstance(result[0], asyncio.CancelledError)
+    assert drain_result.cancelled_unready_count == 1
     assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view) is True
     bot._delivery_gateway.edit_text.assert_awaited_once()
     edit_request = bot._delivery_gateway.edit_text.await_args.args[0]
@@ -1438,6 +1613,10 @@ async def test_router_visible_voice_echo_keeps_multi_agent_handoff(tmp_path) -> 
         ATTACHMENT_IDS_KEY: [_attachment_id_for_event("$voice_event")],
         VOICE_TRANSCRIPT_KEY: True,
     }
+    finalized_echo = bot._turn_store.finalized_visible_echo(event.event_id)
+    assert finalized_echo is not None
+    assert finalized_echo.event_id == "$voice_echo"
+    assert finalized_echo.is_fallback is False
 
 
 @pytest.mark.asyncio
@@ -1502,7 +1681,7 @@ async def test_router_visible_voice_echo_is_not_duplicated_when_handoff_retries(
         "@home could you help with this?",
         "@home could you help with this?",
     ]
-    assert bot._delivery_gateway.edit_text.await_count == 2
+    bot._delivery_gateway.edit_text.assert_awaited_once()
     assert bot._turn_store.is_handled(event.event_id)
     assert bot._turn_store.visible_echo_for_source(event.event_id) == "$voice_echo"
 


### PR DESCRIPTION
## Summary
- post `Router agent is transcribing…` as soon as voice ingress has a target, while speech-to-text starts concurrently
- replace that same Matrix event with the transcript or raw-audio fallback while preserving relay metadata and deduplication
- share and runtime-own the placeholder lifecycle across redelivery and shutdown

## Testing
- `uv run pytest -q`
- `uv run pre-commit run --all-files`
- exact-head independent review: APPROVE

## Summary by Sourcery

Show an immediate router transcription placeholder for voice messages and replace it with the final transcript or raw‑audio fallback while keeping routing metadata intact.

New Features:
- Introduce a dedicated router transcription placeholder message for visible voice echo flows.
- Track per-voice-event placeholder and replacement tasks so the router owns the full visible transcription lifecycle, including redelivery and shutdown.

Enhancements:
- Gate visible voice echo behavior behind a helper that checks router ownership and configuration.
- Reuse the same Matrix event by editing the placeholder into the final transcript or fallback text rather than posting a second echo.

Documentation:
- Revise voice and router documentation, configuration references, and agent configuration examples to describe the new transcription placeholder flow and updated `voice.visible_router_echo` semantics.

Tests:
- Add extensive async tests covering placeholder timing, sharing across concurrent redelivery, behavior when config toggles mid-transcription, edit failures, and runtime shutdown ownership of placeholder tasks.
- Update existing voice routing, handoff, threading, and preview tests to assert the new placeholder-first, edit-later behavior and visible echo deduplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When `voice.visible_router_echo` is enabled, router-facing voice messages now show an immediate “transcribing…” placeholder, then replace it with the normalized transcript (or fallback).
  * Concurrent deliveries deduplicate to a shared placeholder lifecycle; placeholder edits are lifecycle-driven and race-safe.

* **Bug Fixes**
  * Visible-echo finalization is now durable and monotonic, preventing late acknowledgements from overwriting already-completed outcomes.

* **Documentation**
  * Updated voice/router configuration and behavior docs to match the placeholder-then-replace flow and responder guidance.

* **Tests**
  * Expanded regression and async coverage for deduplication, retries, fallback, cancellations, shutdown, and finalization rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->