### PR TITLE
Move process-wide refresh lock state into its own module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,8 @@ Matrix sync callback
 | `knowledge/file_listing.py` | Which files belong to a knowledge base: include patterns, traversal, symlink-safe inclusion rules |
 | `knowledge/collections.py` | Chroma collection lifecycle for one knowledge base: naming, opening, probing, deleting, reclaiming |
 | `knowledge/git_source.py` | The Git checkout a knowledge base indexes: clone, fetch, force-align, LFS hydration, credential injection |
+| `knowledge/refresh_runner.py` | Dispatches one knowledge refresh: subprocess spawn, cancellation cleanup, publish and reconcile decisions |
+| `knowledge/refresh_locks.py` | Process-wide refresh serialization (in-loop and cross-process source-root locks) and active-refresh bookkeeping |
 | `tool_system/skills.py` | Skill integration system (OpenClaw-compatible) |
 | `tool_system/plugins.py` | Plugin loading and tool/skill extension |
 | `scheduling.py` | Cron and natural-language task scheduling |

--- a/src/mindroom/api/knowledge.py
+++ b/src/mindroom/api/knowledge.py
@@ -18,8 +18,8 @@ from mindroom.knowledge.file_listing import git_checkout_present, include_knowle
 from mindroom.knowledge.file_listing import list_git_tracked_knowledge_files as list_git_tracked_managed_knowledge_files
 from mindroom.knowledge.file_listing import list_knowledge_files as list_managed_knowledge_files
 from mindroom.knowledge.redaction import redact_credentials_in_text, redact_url_credentials
+from mindroom.knowledge.refresh_locks import is_refresh_active_for_binding
 from mindroom.knowledge.refresh_runner import (
-    is_refresh_active_for_binding,
     knowledge_binding_mutation_lock,
     publish_file_mode_source_metadata_for_base,
     refresh_knowledge_binding,

--- a/src/mindroom/knowledge/refresh_locks.py
+++ b/src/mindroom/knowledge/refresh_locks.py
@@ -30,9 +30,10 @@ if TYPE_CHECKING:
 
 
 _refresh_locks_guard = Lock()
-# Deliberately uncapped, unlike the lock and cooldown tables below: entries are
-# refcounts that clear when a refresh finishes, so evicting a live one would
-# report an in-flight refresh as idle and mask the leak a crashed refresh means.
+# Deliberately uncapped, unlike the lock table below and the refresh cooldowns in
+# knowledge/utils.py: entries are refcounts that clear when a refresh finishes, so
+# evicting a live one would report an in-flight refresh as idle and mask the leak a
+# crashed refresh means.
 _active_refresh_counts: dict[KnowledgeRefreshTarget, int] = {}
 _active_refresh_counts_guard = Lock()
 _MAX_REFRESH_LOCKS = 512

--- a/src/mindroom/knowledge/refresh_locks.py
+++ b/src/mindroom/knowledge/refresh_locks.py
@@ -1,0 +1,152 @@
+"""Process-wide serialization and activity bookkeeping for knowledge refreshes.
+
+Refresh work for one source root must not overlap, neither inside this event loop
+(``acquire_refresh_lock``) nor across the refresh subprocesses that share the same
+checkout (``acquire_refresh_file_lock``). Callers acquire the pair; this module owns
+the tables behind them, which are process-wide singletons.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import tempfile
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from pathlib import Path
+from threading import Lock
+from typing import TYPE_CHECKING
+
+from mindroom.file_locks import async_exclusive_file_lock
+from mindroom.knowledge.registry import resolve_refresh_target
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from mindroom.config.main import Config
+    from mindroom.constants import RuntimePaths
+    from mindroom.knowledge.registry import KnowledgeRefreshTarget, KnowledgeSourceRoot
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+
+
+_refresh_locks_guard = Lock()
+# Deliberately uncapped, unlike the lock and cooldown tables below: entries are
+# refcounts that clear when a refresh finishes, so evicting a live one would
+# report an in-flight refresh as idle and mask the leak a crashed refresh means.
+_active_refresh_counts: dict[KnowledgeRefreshTarget, int] = {}
+_active_refresh_counts_guard = Lock()
+_MAX_REFRESH_LOCKS = 512
+_REFRESH_FILE_LOCK_POLL_SECONDS = 0.1
+
+
+@dataclass
+class _RefreshLockEntry:
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    borrowers: int = 0
+
+
+_refresh_locks: dict[KnowledgeSourceRoot, _RefreshLockEntry] = {}
+
+
+def _borrow_refresh_lock_for_key(key: KnowledgeSourceRoot) -> _RefreshLockEntry:
+    with _refresh_locks_guard:
+        entry = _refresh_locks.get(key)
+        if entry is None:
+            _prune_refresh_locks_locked(reserve_slots=1)
+            entry = _RefreshLockEntry()
+            _refresh_locks[key] = entry
+        entry.borrowers += 1
+        return entry
+
+
+def _release_refresh_lock_for_key(key: KnowledgeSourceRoot, entry: _RefreshLockEntry) -> None:
+    with _refresh_locks_guard:
+        if entry.borrowers <= 0:
+            return
+        entry.borrowers -= 1
+        if _refresh_locks.get(key) is entry:
+            _prune_refresh_locks_locked()
+
+
+def _prune_refresh_locks_locked(*, reserve_slots: int = 0) -> None:
+    target_size = max(_MAX_REFRESH_LOCKS - reserve_slots, 0)
+    if len(_refresh_locks) <= target_size:
+        return
+    excess = len(_refresh_locks) - target_size
+    for key, entry in tuple(_refresh_locks.items()):
+        if excess <= 0:
+            break
+        if entry.borrowers > 0 or entry.lock.locked():
+            continue
+        _refresh_locks.pop(key, None)
+        excess -= 1
+
+
+@asynccontextmanager
+async def acquire_refresh_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
+    """Serialize source-root refresh and mutation work in this runtime event loop."""
+    entry = _borrow_refresh_lock_for_key(key)
+    acquired = False
+    try:
+        await entry.lock.acquire()
+        acquired = True
+        yield
+    finally:
+        if acquired:
+            entry.lock.release()
+        _release_refresh_lock_for_key(key, entry)
+
+
+def _refresh_file_lock_path(key: KnowledgeSourceRoot) -> Path:
+    digest = hashlib.sha256(f"{key.storage_root}\0{key.knowledge_path}".encode()).hexdigest()
+    return Path(tempfile.gettempdir()) / "mindroom" / "knowledge_refresh_locks" / f"{digest}.lock"
+
+
+@asynccontextmanager
+async def acquire_refresh_file_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
+    """Serialize source-root refresh and mutation work across processes."""
+    async with async_exclusive_file_lock(_refresh_file_lock_path(key), poll_seconds=_REFRESH_FILE_LOCK_POLL_SECONDS):
+        yield
+
+
+def mark_refresh_active(key: KnowledgeRefreshTarget) -> None:
+    """Record scheduler-level refresh activity before a task reaches the runner."""
+    with _active_refresh_counts_guard:
+        _active_refresh_counts[key] = _active_refresh_counts.get(key, 0) + 1
+
+
+def mark_refresh_inactive(key: KnowledgeRefreshTarget) -> None:
+    """Clear scheduler-level refresh activity after a scheduled task finishes."""
+    with _active_refresh_counts_guard:
+        count = _active_refresh_counts.get(key, 0)
+        if count <= 1:
+            _active_refresh_counts.pop(key, None)
+        else:
+            _active_refresh_counts[key] = count - 1
+
+
+def is_refresh_active(key: KnowledgeRefreshTarget) -> bool:
+    """Return whether a refresh is active for one resolved physical binding."""
+    with _active_refresh_counts_guard:
+        return _active_refresh_counts.get(key, 0) > 0
+
+
+def is_refresh_active_for_binding(
+    base_id: str,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> bool:
+    """Resolve a binding and return whether it has an active refresh."""
+    try:
+        key = resolve_refresh_target(
+            base_id,
+            config=config,
+            runtime_paths=runtime_paths,
+            execution_identity=execution_identity,
+            create=False,
+        )
+    except ValueError:
+        return False
+    return is_refresh_active(key)

--- a/src/mindroom/knowledge/refresh_locks.py
+++ b/src/mindroom/knowledge/refresh_locks.py
@@ -1,9 +1,9 @@
 """Process-wide serialization and activity bookkeeping for knowledge refreshes.
 
-Refresh work for one source root must not overlap, neither inside this event loop
-(``acquire_refresh_lock``) nor across the refresh subprocesses that share the same
-checkout (``acquire_refresh_file_lock``). Callers acquire the pair; this module owns
-the tables behind them, which are process-wide singletons.
+Refresh work for one source root must not overlap, neither inside this event loop nor
+across the refresh subprocesses that share the same checkout. Both exclusions are
+required, so ``refresh_source_root_lock`` is the only way to take either one, and this
+module owns the tables behind them, which are process-wide singletons.
 """
 
 from __future__ import annotations
@@ -84,7 +84,7 @@ def _prune_refresh_locks_locked(*, reserve_slots: int = 0) -> None:
 
 
 @asynccontextmanager
-async def acquire_refresh_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
+async def _acquire_refresh_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
     """Serialize source-root refresh and mutation work in this runtime event loop."""
     entry = _borrow_refresh_lock_for_key(key)
     acquired = False
@@ -104,9 +104,31 @@ def _refresh_file_lock_path(key: KnowledgeSourceRoot) -> Path:
 
 
 @asynccontextmanager
-async def acquire_refresh_file_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
+async def _acquire_refresh_file_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
     """Serialize source-root refresh and mutation work across processes."""
     async with async_exclusive_file_lock(_refresh_file_lock_path(key), poll_seconds=_REFRESH_FILE_LOCK_POLL_SECONDS):
+        yield
+
+
+@asynccontextmanager
+async def refresh_source_root_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
+    """Hold every exclusion one source root's refresh and mutation work needs.
+
+    The two halves cover different concurrency domains and neither substitutes for the
+    other, so taking them as one unit is what makes the pairing checkable instead of a
+    convention every new call site has to remember.
+
+    Dropping the cross-process half corrupts data: a scheduled refresh runs in a child
+    interpreter, where the parent's ``asyncio.Lock`` is invisible, so nothing would stop
+    it from indexing a source tree while an API upload or delete rewrites it and then
+    publishing that half-written corpus as the last-good index.
+
+    Dropping the in-loop half degrades instead: tasks in one event loop would contend on
+    ``flock`` alone, polling every ``_REFRESH_FILE_LOCK_POLL_SECONDS`` in arrival-blind
+    order rather than queueing, and the borrow counts that keep the lock table from
+    evicting a live entry would never be recorded.
+    """
+    async with _acquire_refresh_lock(key), _acquire_refresh_file_lock(key):
         yield
 
 

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -22,10 +22,9 @@ from mindroom.knowledge.index_metadata import state_for_publication
 from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.redaction import redact_credentials_in_text
 from mindroom.knowledge.refresh_locks import (
-    acquire_refresh_file_lock,
-    acquire_refresh_lock,
     mark_refresh_active,
     mark_refresh_inactive,
+    refresh_source_root_lock,
 )
 from mindroom.knowledge.registry import (
     PublishedIndexKey,
@@ -246,7 +245,7 @@ async def _cleanup_cancelled_refresh_subprocess(
     try:
         await _terminate_refresh_subprocess(process)
         source_root = source_root_for_published_index_key(key)
-        async with acquire_refresh_lock(source_root), acquire_refresh_file_lock(source_root):
+        async with refresh_source_root_lock(source_root):
             await _reconcile_cancelled_refresh(
                 key,
                 initial_state=initial_state,
@@ -265,7 +264,7 @@ async def _reconcile_failed_refresh_subprocess(
 ) -> None:
     try:
         source_root = source_root_for_published_index_key(key)
-        async with acquire_refresh_lock(source_root), acquire_refresh_file_lock(source_root):
+        async with refresh_source_root_lock(source_root):
             state = await asyncio.to_thread(load_published_index_state, published_index_metadata_path(key))
             if not _failed_subprocess_state_can_be_reconciled(key, state, initial_state):
                 return
@@ -292,7 +291,7 @@ async def knowledge_binding_mutation_lock(
         create=create,
     )
     source_root = source_root_for_refresh_target(key)
-    async with acquire_refresh_lock(source_root), acquire_refresh_file_lock(source_root):
+    async with refresh_source_root_lock(source_root):
         yield
 
 
@@ -333,7 +332,7 @@ async def _refresh_resolved_knowledge_binding(
     source_root = source_root_for_published_index_key(key)
     mark_refresh_active(refresh_target)
     try:
-        async with acquire_refresh_lock(source_root), acquire_refresh_file_lock(source_root):
+        async with refresh_source_root_lock(source_root):
             initial_state = await asyncio.to_thread(
                 load_published_index_state,
                 published_index_metadata_path(key),

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -4,30 +4,30 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import hashlib
 import json
 import os
 import signal
 import sys
-import tempfile
 from contextlib import asynccontextmanager, suppress
-from dataclasses import asdict, dataclass, field, replace
+from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from threading import Lock
 from typing import TYPE_CHECKING, TypedDict, cast
 
 from mindroom.config.knowledge import KnowledgeBaseConfig
 from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths, runtime_env_values
-from mindroom.file_locks import async_exclusive_file_lock
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.index_metadata import state_for_publication
 from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.redaction import redact_credentials_in_text
+from mindroom.knowledge.refresh_locks import (
+    acquire_refresh_file_lock,
+    acquire_refresh_lock,
+    mark_refresh_active,
+    mark_refresh_inactive,
+)
 from mindroom.knowledge.registry import (
-    KnowledgeRefreshTarget,
-    KnowledgeSourceRoot,
     PublishedIndexKey,
     PublishedIndexState,
     load_published_index_state,
@@ -91,14 +91,6 @@ class _SubprocessSessionKwargs(TypedDict, total=False):
     start_new_session: bool
 
 
-_refresh_locks_guard = Lock()
-# Deliberately uncapped, unlike the lock and cooldown tables below: entries are
-# refcounts that clear when a refresh finishes, so evicting a live one would
-# report an in-flight refresh as idle and mask the leak a crashed refresh means.
-_active_refresh_counts: dict[KnowledgeRefreshTarget, int] = {}
-_active_refresh_counts_guard = Lock()
-_MAX_REFRESH_LOCKS = 512
-_REFRESH_FILE_LOCK_POLL_SECONDS = 0.1
 _REFRESH_SUBPROCESS_THREAD_ENV = {
     "OMP_NUM_THREADS": "1",
     "OPENBLAS_NUM_THREADS": "1",
@@ -107,106 +99,6 @@ _REFRESH_SUBPROCESS_THREAD_ENV = {
     "VECLIB_MAXIMUM_THREADS": "1",
     "TOKENIZERS_PARALLELISM": "false",
 }
-
-
-@dataclass
-class _RefreshLockEntry:
-    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-    borrowers: int = 0
-
-
-_refresh_locks: dict[KnowledgeSourceRoot, _RefreshLockEntry] = {}
-
-
-def _borrow_refresh_lock_for_key(key: KnowledgeSourceRoot) -> _RefreshLockEntry:
-    with _refresh_locks_guard:
-        entry = _refresh_locks.get(key)
-        if entry is None:
-            _prune_refresh_locks_locked(reserve_slots=1)
-            entry = _RefreshLockEntry()
-            _refresh_locks[key] = entry
-        entry.borrowers += 1
-        return entry
-
-
-def _release_refresh_lock_for_key(key: KnowledgeSourceRoot, entry: _RefreshLockEntry) -> None:
-    with _refresh_locks_guard:
-        if entry.borrowers <= 0:
-            return
-        entry.borrowers -= 1
-        if _refresh_locks.get(key) is entry:
-            _prune_refresh_locks_locked()
-
-
-def _prune_refresh_locks_locked(*, reserve_slots: int = 0) -> None:
-    target_size = max(_MAX_REFRESH_LOCKS - reserve_slots, 0)
-    if len(_refresh_locks) <= target_size:
-        return
-    excess = len(_refresh_locks) - target_size
-    for key, entry in tuple(_refresh_locks.items()):
-        if excess <= 0:
-            break
-        if entry.borrowers > 0 or entry.lock.locked():
-            continue
-        _refresh_locks.pop(key, None)
-        excess -= 1
-
-
-@asynccontextmanager
-async def _acquire_refresh_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
-    entry = _borrow_refresh_lock_for_key(key)
-    acquired = False
-    try:
-        await entry.lock.acquire()
-        acquired = True
-        yield
-    finally:
-        if acquired:
-            entry.lock.release()
-        _release_refresh_lock_for_key(key, entry)
-
-
-def mark_refresh_active(key: KnowledgeRefreshTarget) -> None:
-    """Record scheduler-level refresh activity before a task reaches the runner."""
-    with _active_refresh_counts_guard:
-        _active_refresh_counts[key] = _active_refresh_counts.get(key, 0) + 1
-
-
-def mark_refresh_inactive(key: KnowledgeRefreshTarget) -> None:
-    """Clear scheduler-level refresh activity after a scheduled task finishes."""
-    with _active_refresh_counts_guard:
-        count = _active_refresh_counts.get(key, 0)
-        if count <= 1:
-            _active_refresh_counts.pop(key, None)
-        else:
-            _active_refresh_counts[key] = count - 1
-
-
-def is_refresh_active(key: KnowledgeRefreshTarget) -> bool:
-    """Return whether a refresh is active for one resolved physical binding."""
-    with _active_refresh_counts_guard:
-        return _active_refresh_counts.get(key, 0) > 0
-
-
-def is_refresh_active_for_binding(
-    base_id: str,
-    *,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-) -> bool:
-    """Resolve a binding and return whether it has an active refresh."""
-    try:
-        key = resolve_refresh_target(
-            base_id,
-            config=config,
-            runtime_paths=runtime_paths,
-            execution_identity=execution_identity,
-            create=False,
-        )
-    except ValueError:
-        return False
-    return is_refresh_active(key)
 
 
 async def refresh_knowledge_binding_in_subprocess(
@@ -318,18 +210,6 @@ async def _send_subprocess_refresh_request(
         await process.stdin.wait_closed()
 
 
-def _refresh_file_lock_path(key: KnowledgeSourceRoot) -> Path:
-    digest = hashlib.sha256(f"{key.storage_root}\0{key.knowledge_path}".encode()).hexdigest()
-    return Path(tempfile.gettempdir()) / "mindroom" / "knowledge_refresh_locks" / f"{digest}.lock"
-
-
-@asynccontextmanager
-async def _acquire_refresh_file_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
-    """Serialize source-root refresh and mutation work across processes."""
-    async with async_exclusive_file_lock(_refresh_file_lock_path(key), poll_seconds=_REFRESH_FILE_LOCK_POLL_SECONDS):
-        yield
-
-
 def _subprocess_session_kwargs() -> _SubprocessSessionKwargs:
     if os.name == "nt":
         return {}
@@ -366,7 +246,7 @@ async def _cleanup_cancelled_refresh_subprocess(
     try:
         await _terminate_refresh_subprocess(process)
         source_root = source_root_for_published_index_key(key)
-        async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
+        async with acquire_refresh_lock(source_root), acquire_refresh_file_lock(source_root):
             await _reconcile_cancelled_refresh(
                 key,
                 initial_state=initial_state,
@@ -385,7 +265,7 @@ async def _reconcile_failed_refresh_subprocess(
 ) -> None:
     try:
         source_root = source_root_for_published_index_key(key)
-        async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
+        async with acquire_refresh_lock(source_root), acquire_refresh_file_lock(source_root):
             state = await asyncio.to_thread(load_published_index_state, published_index_metadata_path(key))
             if not _failed_subprocess_state_can_be_reconciled(key, state, initial_state):
                 return
@@ -412,7 +292,7 @@ async def knowledge_binding_mutation_lock(
         create=create,
     )
     source_root = source_root_for_refresh_target(key)
-    async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
+    async with acquire_refresh_lock(source_root), acquire_refresh_file_lock(source_root):
         yield
 
 
@@ -453,7 +333,7 @@ async def _refresh_resolved_knowledge_binding(
     source_root = source_root_for_published_index_key(key)
     mark_refresh_active(refresh_target)
     try:
-        async with _acquire_refresh_lock(source_root), _acquire_refresh_file_lock(source_root):
+        async with acquire_refresh_lock(source_root), acquire_refresh_file_lock(source_root):
             initial_state = await asyncio.to_thread(
                 load_published_index_state,
                 published_index_metadata_path(key),

--- a/src/mindroom/knowledge/refresh_scheduler.py
+++ b/src/mindroom/knowledge/refresh_scheduler.py
@@ -17,10 +17,12 @@ from mindroom.embedder_health import (
     get_embedder_failure,
 )
 from mindroom.embedding_errors import extract_classified_embedder_detail
-from mindroom.knowledge.refresh_runner import (
+from mindroom.knowledge.refresh_locks import (
     is_refresh_active,
     mark_refresh_active,
     mark_refresh_inactive,
+)
+from mindroom.knowledge.refresh_runner import (
     refresh_knowledge_binding,
     refresh_knowledge_binding_in_subprocess,
 )

--- a/tach.toml
+++ b/tach.toml
@@ -569,6 +569,7 @@ depends_on = [
     "mindroom.knowledge.availability",
     "mindroom.knowledge.file_listing",
     "mindroom.knowledge.redaction",
+    "mindroom.knowledge.refresh_locks",
     "mindroom.knowledge.refresh_runner",
     "mindroom.knowledge.status",
 ]
@@ -3596,9 +3597,19 @@ path = "mindroom.knowledge.refresh_scheduler"
 depends_on = [
     "mindroom.embedder_health",
     "mindroom.embedding_errors",
+    "mindroom.knowledge.refresh_locks",
     "mindroom.knowledge.refresh_runner",
     "mindroom.knowledge.registry",
     "mindroom.logging_config",
+]
+
+[[modules]]
+path = "mindroom.knowledge.refresh_locks"
+depends_on = ["mindroom.knowledge.registry"]
+visibility = [
+    "mindroom.api.knowledge",
+    "mindroom.knowledge.refresh_runner",
+    "mindroom.knowledge.refresh_scheduler",
 ]
 
 [[modules]]
@@ -3610,6 +3621,7 @@ depends_on = [
     "mindroom.knowledge.index_metadata",
     "mindroom.knowledge.manager",
     "mindroom.knowledge.redaction",
+    "mindroom.knowledge.refresh_locks",
     "mindroom.knowledge.registry",
     "mindroom.runtime_resolution",
     "mindroom.tool_system.worker_routing",

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -30,6 +30,7 @@ from watchfiles import Change
 import mindroom.knowledge.file_listing as knowledge_file_listing_module
 import mindroom.knowledge.git_source as knowledge_git_source_module
 import mindroom.knowledge.manager as knowledge_manager_module
+import mindroom.knowledge.refresh_locks as knowledge_refresh_locks
 import mindroom.knowledge.refresh_runner as knowledge_refresh_runner
 import mindroom.knowledge.refresh_scheduler as knowledge_refresh_scheduler
 import mindroom.knowledge.registry as knowledge_registry
@@ -317,13 +318,13 @@ def patch_vector_store(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     monkeypatch.setattr("mindroom.knowledge.registry.create_configured_embedder", lambda *_args, **_kwargs: object())
     knowledge_registry._published_indexes.clear()
     knowledge_utils._refresh_scheduled_at.clear()
-    knowledge_refresh_runner._refresh_locks.clear()
-    knowledge_refresh_runner._active_refresh_counts.clear()
+    knowledge_refresh_locks._refresh_locks.clear()
+    knowledge_refresh_locks._active_refresh_counts.clear()
     yield
     knowledge_registry._published_indexes.clear()
     knowledge_utils._refresh_scheduled_at.clear()
-    knowledge_refresh_runner._refresh_locks.clear()
-    knowledge_refresh_runner._active_refresh_counts.clear()
+    knowledge_refresh_locks._refresh_locks.clear()
+    knowledge_refresh_locks._active_refresh_counts.clear()
     _VectorDb.collections = {}
 
 
@@ -332,7 +333,7 @@ async def _wait_for_refresh_lock_borrowers(
     expected: int,
 ) -> None:
     for _ in range(50):
-        entry = knowledge_refresh_runner._refresh_locks.get(key)
+        entry = knowledge_refresh_locks._refresh_locks.get(key)
         if entry is not None and entry.borrowers == expected:
             return
         await asyncio.sleep(0)
@@ -340,8 +341,8 @@ async def _wait_for_refresh_lock_borrowers(
 
 
 def _create_idle_refresh_lock(key: knowledge_registry.KnowledgeSourceRoot) -> None:
-    entry = knowledge_refresh_runner._borrow_refresh_lock_for_key(key)
-    knowledge_refresh_runner._release_refresh_lock_for_key(key, entry)
+    entry = knowledge_refresh_locks._borrow_refresh_lock_for_key(key)
+    knowledge_refresh_locks._release_refresh_lock_for_key(key, entry)
 
 
 def _base_storage_path(config: Config, runtime_paths: RuntimePaths, base_id: str = "docs") -> Path:
@@ -614,7 +615,7 @@ def test_real_refresh_scheduler_without_running_loop_does_not_mark_active(tmp_pa
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     refresh_target = knowledge_registry.resolve_refresh_target("docs", config=config, runtime_paths=runtime_paths)
 
-    assert knowledge_refresh_runner.is_refresh_active(refresh_target) is False
+    assert knowledge_refresh_locks.is_refresh_active(refresh_target) is False
     assert scheduler.is_refreshing("docs", config=config, runtime_paths=runtime_paths) is False
 
 
@@ -2023,7 +2024,7 @@ async def test_refreshing_state_cancellation_clears_active_refresh_count(
         await refresh_task
 
     refresh_target = knowledge_registry.resolve_refresh_target("docs", config=config, runtime_paths=runtime_paths)
-    assert knowledge_refresh_runner.is_refresh_active(refresh_target) is False
+    assert knowledge_refresh_locks.is_refresh_active(refresh_target) is False
 
 
 @pytest.mark.asyncio
@@ -2179,7 +2180,7 @@ async def test_refresh_lock_pruning_keeps_queued_waiter_entry(
     holder_entered = asyncio.Event()
     release_holder = asyncio.Event()
     waiter_entered = asyncio.Event()
-    monkeypatch.setattr(knowledge_refresh_runner, "_MAX_REFRESH_LOCKS", 1)
+    monkeypatch.setattr(knowledge_refresh_locks, "_MAX_REFRESH_LOCKS", 1)
 
     async def _hold_lock() -> None:
         async with knowledge_binding_mutation_lock("docs", config=config, runtime_paths=runtime_paths):
@@ -2194,7 +2195,7 @@ async def test_refresh_lock_pruning_keeps_queued_waiter_entry(
     await holder_entered.wait()
     waiter_task = asyncio.create_task(_queued_waiter())
     await _wait_for_refresh_lock_borrowers(source_root, 2)
-    original_entry = knowledge_refresh_runner._refresh_locks[source_root]
+    original_entry = knowledge_refresh_locks._refresh_locks[source_root]
 
     for index in range(5):
         _create_idle_refresh_lock(
@@ -2204,7 +2205,7 @@ async def test_refresh_lock_pruning_keeps_queued_waiter_entry(
             ),
         )
 
-    assert knowledge_refresh_runner._refresh_locks.get(source_root) is original_entry
+    assert knowledge_refresh_locks._refresh_locks.get(source_root) is original_entry
 
     release_holder.set()
     async with asyncio.timeout(1):
@@ -3731,7 +3732,7 @@ async def test_refresh_uses_cross_process_source_lock(
         locked_roots.append(source_root)
         yield
 
-    monkeypatch.setattr(knowledge_refresh_runner, "_acquire_refresh_file_lock", _record_file_lock)
+    monkeypatch.setattr(knowledge_refresh_runner, "acquire_refresh_file_lock", _record_file_lock)
 
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
@@ -3757,7 +3758,7 @@ async def test_mutation_lock_uses_cross_process_source_lock(
         locked_roots.append(source_root)
         yield
 
-    monkeypatch.setattr(knowledge_refresh_runner, "_acquire_refresh_file_lock", _record_file_lock)
+    monkeypatch.setattr(knowledge_refresh_runner, "acquire_refresh_file_lock", _record_file_lock)
 
     async with knowledge_binding_mutation_lock("docs", config=config, runtime_paths=runtime_paths):
         pass
@@ -6573,7 +6574,7 @@ def test_private_agent_knowledge_bookkeeping_is_bounded(tmp_path: Path) -> None:
     max_entries = max(
         knowledge_registry._MAX_PRIVATE_PUBLISHED_INDEXES,
         knowledge_utils._MAX_REFRESH_SCHEDULED_COOLDOWNS,
-        knowledge_refresh_runner._MAX_REFRESH_LOCKS,
+        knowledge_refresh_locks._MAX_REFRESH_LOCKS,
     )
     scheduler = MagicMock()
     scheduler.is_refreshing = MagicMock(return_value=False)
@@ -6624,7 +6625,7 @@ def test_private_agent_knowledge_bookkeeping_is_bounded(tmp_path: Path) -> None:
     )
     assert private_index_count <= knowledge_registry._MAX_PRIVATE_PUBLISHED_INDEXES
     assert len(knowledge_utils._refresh_scheduled_at) <= knowledge_utils._MAX_REFRESH_SCHEDULED_COOLDOWNS
-    assert len(knowledge_refresh_runner._refresh_locks) <= knowledge_refresh_runner._MAX_REFRESH_LOCKS
+    assert len(knowledge_refresh_locks._refresh_locks) <= knowledge_refresh_locks._MAX_REFRESH_LOCKS
 
 
 def test_private_index_read_path_cache_insertion_is_bounded(tmp_path: Path) -> None:

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -89,7 +89,8 @@ from tests.knowledge_test_support import (
 pytestmark = pytest.mark.usefixtures("patch_vector_store")
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Coroutine, Iterable
+    from collections.abc import AsyncIterator, Callable, Coroutine, Iterable
+    from contextlib import AbstractAsyncContextManager
     from types import ModuleType
 
     from agno.knowledge.reader.base import Reader
@@ -1957,6 +1958,78 @@ async def test_refresh_lock_pruning_keeps_queued_waiter_entry(
     assert waiter_entered.is_set()
 
 
+@pytest.mark.asyncio
+async def test_source_root_lock_takes_the_in_loop_half_before_the_cross_process_half(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The in-loop half must nest outside the file lock, so the two unwind in reverse."""
+    source_root = knowledge_registry.KnowledgeSourceRoot(
+        storage_root=str(tmp_path),
+        knowledge_path=str(tmp_path / "docs"),
+    )
+    events: list[str] = []
+
+    def _recorder(half: str) -> Callable[[knowledge_registry.KnowledgeSourceRoot], AbstractAsyncContextManager[None]]:
+        @asynccontextmanager
+        async def _record(key: knowledge_registry.KnowledgeSourceRoot) -> AsyncIterator[None]:
+            assert key == source_root
+            events.append(f"acquire {half}")
+            try:
+                yield
+            finally:
+                events.append(f"release {half}")
+
+        return _record
+
+    monkeypatch.setattr(knowledge_refresh_locks, "_acquire_refresh_lock", _recorder("in_loop"))
+    monkeypatch.setattr(knowledge_refresh_locks, "_acquire_refresh_file_lock", _recorder("file"))
+
+    async with knowledge_refresh_locks.refresh_source_root_lock(source_root):
+        events.append("body")
+
+    assert events == ["acquire in_loop", "acquire file", "body", "release file", "release in_loop"]
+
+
+@pytest.mark.asyncio
+async def test_cancelling_while_the_cross_process_half_is_pending_frees_the_in_loop_half(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Taking the pair in two stages must not strand the first half when the second is cancelled."""
+    source_root = knowledge_registry.KnowledgeSourceRoot(
+        storage_root=str(tmp_path),
+        knowledge_path=str(tmp_path / "docs"),
+    )
+    file_lock_reached = asyncio.Event()
+    release_file_lock = asyncio.Event()
+
+    @asynccontextmanager
+    async def _blocked_file_lock(_key: knowledge_registry.KnowledgeSourceRoot) -> AsyncIterator[None]:
+        file_lock_reached.set()
+        await release_file_lock.wait()
+        yield
+
+    monkeypatch.setattr(knowledge_refresh_locks, "_acquire_refresh_file_lock", _blocked_file_lock)
+
+    async def _take_the_pair() -> None:
+        async with knowledge_refresh_locks.refresh_source_root_lock(source_root):
+            pass
+
+    blocked_task = asyncio.create_task(_take_the_pair())
+    await file_lock_reached.wait()
+    await _wait_for_refresh_lock_borrowers(source_root, 1)
+    entry = knowledge_refresh_locks._refresh_locks[source_root]
+    assert entry.lock.locked()
+
+    blocked_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await blocked_task
+
+    assert not entry.lock.locked()
+    assert entry.borrowers == 0
+
+
 def test_source_changed_updates_refresh_state_without_changing_index(tmp_path: Path) -> None:
     """Source mutation records source changes without mutating published index data."""
     docs_path = tmp_path / "docs"
@@ -3437,7 +3510,7 @@ async def test_refresh_uses_cross_process_source_lock(
         locked_roots.append(source_root)
         yield
 
-    monkeypatch.setattr(knowledge_refresh_runner, "acquire_refresh_file_lock", _record_file_lock)
+    monkeypatch.setattr(knowledge_refresh_locks, "_acquire_refresh_file_lock", _record_file_lock)
 
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
@@ -3463,7 +3536,7 @@ async def test_mutation_lock_uses_cross_process_source_lock(
         locked_roots.append(source_root)
         yield
 
-    monkeypatch.setattr(knowledge_refresh_runner, "acquire_refresh_file_lock", _record_file_lock)
+    monkeypatch.setattr(knowledge_refresh_locks, "_acquire_refresh_file_lock", _record_file_lock)
 
     async with knowledge_binding_mutation_lock("docs", config=config, runtime_paths=runtime_paths):
         pass


### PR DESCRIPTION
## What this does

`src/mindroom/knowledge/refresh_runner.py` did two unrelated things: dispatch a knowledge refresh (subprocess spawn, cancellation cleanup, publish/reconcile decisions) and maintain the process-wide tables that serialize refresh work and count active refreshes.

Two commits, separately reviewable:

1. `a02630243` — move the serialization concern into `src/mindroom/knowledge/refresh_locks.py`, unchanged.
2. `dee3e90bf` — collapse the four duplicated paired acquisitions into one helper and make the halves private.

### 1. The move

| Moved | Note |
| --- | --- |
| `_refresh_locks`, `_refresh_locks_guard`, `_MAX_REFRESH_LOCKS` | in-loop lock table + cap |
| `_active_refresh_counts`, `_active_refresh_counts_guard` | activity refcounts |
| `_RefreshLockEntry` | internal to the new module |
| `_borrow_refresh_lock_for_key`, `_release_refresh_lock_for_key`, `_prune_refresh_locks_locked` | table bookkeeping |
| `_acquire_refresh_lock` | in-loop half |
| `_REFRESH_FILE_LOCK_POLL_SECONDS`, `_refresh_file_lock_path`, `_acquire_refresh_file_lock` | cross-process half |
| `mark_refresh_active`, `mark_refresh_inactive`, `is_refresh_active`, `is_refresh_active_for_binding` | public API, unchanged |

The cross-process file lock came along because the poll constant is read only there, and because it is itself a refresh lock — leaving it behind would have kept half of one concern in `refresh_runner`.

An AST comparison of every definition and module-level assignment in that commit against `origin/main` reports each one identical, modulo one added docstring (ruff `D103`).

### 2. The pair is now inseparable

Four sites repeated `async with acquire_refresh_lock(root), acquire_refresh_file_lock(root)`. They are now `async with refresh_source_root_lock(root)`, and both halves are private, so a future call site cannot take one without the other. This is the part that removes active duplication, and it converts a convention into a checked property.

The two halves are not independently useful, and the failure modes differ:

- **Without the cross-process half, data corrupts.** A scheduled refresh runs in a child interpreter (`refresh_knowledge_binding_in_subprocess`), where the parent's `asyncio.Lock` is invisible. Nothing would stop it from indexing a source tree while an API upload or delete (`api/knowledge.py:676,728`) rewrites it, and it would then publish that half-written corpus as the last-good index. This is why the file lock was added in the first place, in #765, the PR that moved refreshes into subprocesses.
- **Without the in-loop half, throughput degrades.** Tasks in one event loop would contend on `flock` alone, polling every 100 ms in arrival-blind order instead of queueing, and the borrow counts that stop the lock table from evicting a live entry would never be recorded.

Because byte-identity no longer applies to the four call sites, equivalence is shown behaviourally instead:

- **Order** — in-loop acquired first, released last. Pinned by `test_source_root_lock_takes_the_in_loop_half_before_the_cross_process_half`, which asserts the full five-event sequence. Swapping the two lines in the helper fails it, and fails the cancellation test too.
- **Count** — one acquisition of each half per paired entry, and zero borrowers left behind, confirmed by instrumenting both halves around a real acquisition. `test_refresh_uses_cross_process_source_lock` and `test_mutation_lock_uses_cross_process_source_lock` already assert exactly one file-lock acquisition per refresh and per mutation, and still pass.
- **Cancellation** — `test_cancelling_while_the_cross_process_half_is_pending_frees_the_in_loop_half` covers the hazard the two-stage acquisition introduces: cancel a task that holds the in-loop half and is still waiting on the file lock, and the in-loop lock must be released with the borrow count returned to zero. The pre-existing `test_cancelled_source_lock_waiter_does_not_wedge_later_mutation` continues to cover cancellation of a queued waiter through the pair.
- **No guard held across an await** — an AST walk over `refresh_locks.py` confirms no `with _refresh_locks_guard`/`with _active_refresh_counts_guard` block contains an `await`, `async with`, or `async for`.

## Single copy of the state

The lock and count tables are process-wide singletons. Every importer points at the owning module:

- `refresh_scheduler.py` — `is_refresh_active`, `mark_refresh_active`, `mark_refresh_inactive`.
- `api/knowledge.py` — `is_refresh_active_for_binding`.
- `tests/test_knowledge_manager.py` — 15 references via a `knowledge_refresh_locks` alias.
- `tests/knowledge_test_support.py:14,298-304` — the shared `patch_vector_store` fixture #1724 relocated clears both tables; those four clears now point at `refresh_locks`.

**No re-export was left behind.** Exactly three moved names remain bound in `refresh_runner.__dict__` — `refresh_source_root_lock`, `mark_refresh_active`, `mark_refresh_inactive` — and all three are called there. `refresh_locks`'s entire public surface is those three plus `is_refresh_active` and `is_refresh_active_for_binding`.

That is also what makes the silent-patch surface of this PR **zero**, and an earlier version of this description got the reasoning wrong, so to be explicit: a patch aimed at a moved name on the old module path does not go quietly inert, it raises. `monkeypatch.setattr` defaults to `raising=True`, and every moved name except those three is absent from `refresh_runner`, so `monkeypatch.setattr(refresh_runner, "_MAX_REFRESH_LOCKS", 1)` raises `AttributeError`. A silently inert patch would have required leaving a re-export in place, which would rebind only `refresh_runner`'s copy while the pruner kept reading the real one. There is no such re-export.

The `_MAX_REFRESH_LOCKS` patch in `test_refresh_lock_pruning_keeps_queued_waiter_entry` still reaches the live read site, verified rather than assumed: set the attribute on `refresh_locks` to 1, borrow and release five distinct keys, and the table prunes to one entry.

Conversely, the two tests that observe the cross-process lock had to follow the composition point. Before, `from ... import acquire_refresh_file_lock` bound the object into `refresh_runner.__dict__`, so patching it on `refresh_locks` would not have intercepted `refresh_runner`'s call sites — the patch had to target `refresh_runner`. Now that the pairing happens inside `refresh_locks`, the patch targets `refresh_locks._acquire_refresh_file_lock`, which is both the owning seam and the only binding the call path reads.

Tach: new module entry with `depends_on = ["mindroom.knowledge.registry"]` and `visibility` limited to its three importers. `uv run tach check --dependencies --interfaces` and the module-privacy hook both pass.

## Was it worth doing (Refactor Policy)

- **Removes active duplication:** yes, in the second commit — four copies of a two-lock acquisition that must agree, replaced by one helper. The move alone did not, which is the criterion an earlier revision of this PR failed.
- **Source of truth without an unnecessary abstraction layer:** yes. One module owns the tables and the pairing; no class, no options parameter, no configurable ordering.
- **Reduces net complexity:** yes. Four multi-lock call sites become single-lock, and the invariant is enforced by the module boundary rather than by reviewer attention.
- **Covered by tests in the same PR:** yes. Existing tests carried and re-pointed; two added for exactly what the helper newly owns, both shown to fail under a mutated acquisition order.

## Tests

`tests/test_knowledge_manager.py`, `tests/test_knowledge_git_source.py`, `tests/api/test_knowledge_api.py`, `tests/test_knowledge_resumable_refresh.py` all pass, with one exception inherited from `main`:

```
FAILED tests/test_knowledge_manager.py::test_run_git_reports_the_git_failure_when_stderr_holds_an_unparseable_url
  NameError: name '_git_manager' is not defined
```

`pytest` on `main` @ `3697e6a0d` fails the same way, and `ruff` reports it as `F821`. #1724 moved the `_git_manager` helper into `tests/test_knowledge_git_source.py` while #1719 independently added a test to the old file that calls it — no textual conflict, both green against their own bases. #1728 fixes it; this branch goes green when that lands. `ruff`, `ruff format`, `ty`, `tach`, and `privata` are otherwise clean.
