### PR TITLE
Pin manual thread summaries against automatic overwrite

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -446,7 +446,9 @@ Sandbox-proxied execution is stricter than direct local execution: ordinary runt
 # while keeping the rest of defaults.tools for that agent.
 # See agents.md for the full per-agent tool configuration syntax.
 # These thresholds only affect automatic thread summaries; manual `set_thread_summary`
-# tool calls write immediately and reset the automatic baseline from the new message count.
+# tool calls write immediately and pin the thread by default, which stops automatic
+# summaries entirely until a `pin=False` call releases it.
+# Automatic summaries are also skipped on threads tagged `resolved`.
 
 # Memory system configuration (optional)
 memory:

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -261,7 +261,8 @@ set_thread_summary(
 - `summary` must be a non-empty string up to 300 characters after whitespace normalization.
 - The tool writes a normal Matrix notice event, so the updated summary remains visible in the thread timeline.
 - Automatic thread summaries still exist, but this tool gives an agent an explicit override path when a human asks for a manual summary refresh.
-- Pin state lives in the summary notice's `io.mindroom.thread_summary` metadata, so it survives restarts and is shared across replicas.
+- Pin state lives in the summary notice's `io.mindroom.thread_summary` metadata, so it survives restarts and every runtime reads the same decision.
+- Pinning stops the whole automatic pass, not just the title. A thread pinned before its automatic topic tags are inferred will not receive them; tag it explicitly with `thread_tags` instead.
 - Automatic summaries are also skipped on threads carrying the `resolved` tag.
 
 ## [`thread_model`]

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -225,11 +225,12 @@ reopen_thread()
 
 ### What It Does
 
-`thread_summary` exposes `set_thread_summary(summary, thread_id=None, room_id=None)`.
+`thread_summary` exposes `set_thread_summary(summary, thread_id=None, room_id=None, pin=True)`.
 The tool defaults to the active room and current resolved thread from `ToolRuntimeContext`.
 When there is no active resolved thread context, pass `thread_id` explicitly.
 The tool normalizes the target to the canonical thread root before sending a new `m.notice` summary event with `io.mindroom.thread_summary` metadata.
-Manual summaries are marked with `model_name="manual"` and update the cached last-summary count so later automatic summaries continue from the new baseline.
+Manual summaries are marked with `model_name="manual"` and pin the thread by default, which stops automatic summaries from overwriting the title.
+Pass `pin=False` to write a summary that later automatic summaries may replace; that also releases a thread pinned by an earlier call.
 A per-thread async lock prevents concurrent duplicate manual summaries from racing each other.
 
 ### Configuration
@@ -247,6 +248,7 @@ agents:
 
 ```python
 set_thread_summary("Decision: ship the current plan and revisit logs tomorrow.")
+set_thread_summary("Routine status update.", pin=False)
 set_thread_summary(
     "Summary for the import thread.",
     thread_id="$threadRoot",
@@ -259,6 +261,8 @@ set_thread_summary(
 - `summary` must be a non-empty string up to 300 characters after whitespace normalization.
 - The tool writes a normal Matrix notice event, so the updated summary remains visible in the thread timeline.
 - Automatic thread summaries still exist, but this tool gives an agent an explicit override path when a human asks for a manual summary refresh.
+- Pin state lives in the summary notice's `io.mindroom.thread_summary` metadata, so it survives restarts and is shared across replicas.
+- Automatic summaries are also skipped on threads carrying the `resolved` tag.
 
 ## [`thread_model`]
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1304,7 +1304,9 @@ Sandbox-proxied execution is stricter than direct local execution: ordinary runt
 # while keeping the rest of defaults.tools for that agent.
 # See agents.md for the full per-agent tool configuration syntax.
 # These thresholds only affect automatic thread summaries; manual `set_thread_summary`
-# tool calls write immediately and reset the automatic baseline from the new message count.
+# tool calls write immediately and pin the thread by default, which stops automatic
+# summaries entirely until a `pin=False` call releases it.
+# Automatic summaries are also skipped on threads tagged `resolved`.
 
 # Memory system configuration (optional)
 memory:
@@ -7234,11 +7236,12 @@ reopen_thread()
 
 ### What It Does
 
-`thread_summary` exposes `set_thread_summary(summary, thread_id=None, room_id=None)`.
+`thread_summary` exposes `set_thread_summary(summary, thread_id=None, room_id=None, pin=True)`.
 The tool defaults to the active room and current resolved thread from `ToolRuntimeContext`.
 When there is no active resolved thread context, pass `thread_id` explicitly.
 The tool normalizes the target to the canonical thread root before sending a new `m.notice` summary event with `io.mindroom.thread_summary` metadata.
-Manual summaries are marked with `model_name="manual"` and update the cached last-summary count so later automatic summaries continue from the new baseline.
+Manual summaries are marked with `model_name="manual"` and pin the thread by default, which stops automatic summaries from overwriting the title.
+Pass `pin=False` to write a summary that later automatic summaries may replace; that also releases a thread pinned by an earlier call.
 A per-thread async lock prevents concurrent duplicate manual summaries from racing each other.
 
 ### Configuration
@@ -7256,6 +7259,7 @@ agents:
 
 ```python
 set_thread_summary("Decision: ship the current plan and revisit logs tomorrow.")
+set_thread_summary("Routine status update.", pin=False)
 set_thread_summary(
     "Summary for the import thread.",
     thread_id="$threadRoot",
@@ -7268,6 +7272,8 @@ set_thread_summary(
 - `summary` must be a non-empty string up to 300 characters after whitespace normalization.
 - The tool writes a normal Matrix notice event, so the updated summary remains visible in the thread timeline.
 - Automatic thread summaries still exist, but this tool gives an agent an explicit override path when a human asks for a manual summary refresh.
+- Pin state lives in the summary notice's `io.mindroom.thread_summary` metadata, so it survives restarts and is shared across replicas.
+- Automatic summaries are also skipped on threads carrying the `resolved` tag.
 
 ## [`thread_model`]
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7272,7 +7272,8 @@ set_thread_summary(
 - `summary` must be a non-empty string up to 300 characters after whitespace normalization.
 - The tool writes a normal Matrix notice event, so the updated summary remains visible in the thread timeline.
 - Automatic thread summaries still exist, but this tool gives an agent an explicit override path when a human asks for a manual summary refresh.
-- Pin state lives in the summary notice's `io.mindroom.thread_summary` metadata, so it survives restarts and is shared across replicas.
+- Pin state lives in the summary notice's `io.mindroom.thread_summary` metadata, so it survives restarts and every runtime reads the same decision.
+- Pinning stops the whole automatic pass, not just the title. A thread pinned before its automatic topic tags are inferred will not receive them; tag it explicitly with `thread_tags` instead.
 - Automatic summaries are also skipped on threads carrying the `resolved` tag.
 
 ## [`thread_model`]

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -442,7 +442,9 @@ Sandbox-proxied execution is stricter than direct local execution: ordinary runt
 # while keeping the rest of defaults.tools for that agent.
 # See agents.md for the full per-agent tool configuration syntax.
 # These thresholds only affect automatic thread summaries; manual `set_thread_summary`
-# tool calls write immediately and reset the automatic baseline from the new message count.
+# tool calls write immediately and pin the thread by default, which stops automatic
+# summaries entirely until a `pin=False` call releases it.
+# Automatic summaries are also skipped on threads tagged `resolved`.
 
 # Memory system configuration (optional)
 memory:

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -257,7 +257,8 @@ set_thread_summary(
 - `summary` must be a non-empty string up to 300 characters after whitespace normalization.
 - The tool writes a normal Matrix notice event, so the updated summary remains visible in the thread timeline.
 - Automatic thread summaries still exist, but this tool gives an agent an explicit override path when a human asks for a manual summary refresh.
-- Pin state lives in the summary notice's `io.mindroom.thread_summary` metadata, so it survives restarts and is shared across replicas.
+- Pin state lives in the summary notice's `io.mindroom.thread_summary` metadata, so it survives restarts and every runtime reads the same decision.
+- Pinning stops the whole automatic pass, not just the title. A thread pinned before its automatic topic tags are inferred will not receive them; tag it explicitly with `thread_tags` instead.
 - Automatic summaries are also skipped on threads carrying the `resolved` tag.
 
 ## [`thread_model`]

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -221,11 +221,12 @@ reopen_thread()
 
 ### What It Does
 
-`thread_summary` exposes `set_thread_summary(summary, thread_id=None, room_id=None)`.
+`thread_summary` exposes `set_thread_summary(summary, thread_id=None, room_id=None, pin=True)`.
 The tool defaults to the active room and current resolved thread from `ToolRuntimeContext`.
 When there is no active resolved thread context, pass `thread_id` explicitly.
 The tool normalizes the target to the canonical thread root before sending a new `m.notice` summary event with `io.mindroom.thread_summary` metadata.
-Manual summaries are marked with `model_name="manual"` and update the cached last-summary count so later automatic summaries continue from the new baseline.
+Manual summaries are marked with `model_name="manual"` and pin the thread by default, which stops automatic summaries from overwriting the title.
+Pass `pin=False` to write a summary that later automatic summaries may replace; that also releases a thread pinned by an earlier call.
 A per-thread async lock prevents concurrent duplicate manual summaries from racing each other.
 
 ### Configuration
@@ -243,6 +244,7 @@ agents:
 
 ```python
 set_thread_summary("Decision: ship the current plan and revisit logs tomorrow.")
+set_thread_summary("Routine status update.", pin=False)
 set_thread_summary(
     "Summary for the import thread.",
     thread_id="$threadRoot",
@@ -255,6 +257,8 @@ set_thread_summary(
 - `summary` must be a non-empty string up to 300 characters after whitespace normalization.
 - The tool writes a normal Matrix notice event, so the updated summary remains visible in the thread timeline.
 - Automatic thread summaries still exist, but this tool gives an agent an explicit override path when a human asks for a manual summary refresh.
+- Pin state lives in the summary notice's `io.mindroom.thread_summary` metadata, so it survives restarts and is shared across replicas.
+- Automatic summaries are also skipped on threads carrying the `resolved` tag.
 
 ## [`thread_model`]
 

--- a/src/mindroom/custom_tools/thread_summary.py
+++ b/src/mindroom/custom_tools/thread_summary.py
@@ -41,10 +41,14 @@ class ThreadSummaryTools(Toolkit):
         summary: str,
         thread_id: str | None = None,
         room_id: str | None = None,
+        pin: bool = True,
     ) -> str:
         """Write a plain-text summary notice into the current or specified Matrix thread.
 
         Summary must be plain text (no markdown), maximum 300 characters.
+        Pinning stops automatic re-summarization from overwriting the title, and
+        is the default. Pass pin=False for a routine update that later automatic
+        summaries may replace; that also releases an earlier pin.
         """
         context = get_tool_runtime_context()
         if context is None:
@@ -108,6 +112,7 @@ class ThreadSummaryTools(Toolkit):
                 config=context.config,
                 runtime_paths=context.runtime_paths,
                 conversation_cache=conversation_cache,
+                pin=pin,
             )
         except ThreadSummaryWriteError as exc:
             return self._payload(
@@ -126,4 +131,5 @@ class ThreadSummaryTools(Toolkit):
             event_id=result.event_id,
             message_count=result.message_count,
             summary=result.summary,
+            pinned=pin,
         )

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -506,14 +506,47 @@ async def _thread_is_resolved(
     try:
         tags_state = await get_thread_tags(client, room_id, thread_id)
     except Exception as exc:
-        logger.warning(
+        # Keep the type and traceback: this catch is broad, and intermittent
+        # Matrix failures are otherwise indistinguishable from each other.
+        logger.exception(
             "Thread tag read failed; continuing with automatic summary",
             room_id=room_id,
             thread_id=thread_id,
-            error=str(exc),
+            error_type=type(exc).__name__,
         )
         return False
     return tags_state is not None and RESOLVED_THREAD_TAG in tags_state.tags
+
+
+async def _pinned_since_generation_started(
+    conversation_cache: ConversationCacheProtocol,
+    room_id: str,
+    thread_id: str,
+    *,
+    trusted_sender_ids: Collection[str],
+) -> bool:
+    """Return whether a pin landed while this pass was generating a summary.
+
+    The gate before generation cannot cover the generation window itself. The
+    per-thread lock is process-local, so another runtime can write a manual pin
+    while this process is waiting on the model, and the finished automatic
+    summary would then land on top of a title the user just fixed.
+
+    Fails open, like the other background reads here: if the re-read fails the
+    pass delivers, which is the same exposure the pre-generation gate already
+    has. An automatic summary carries no ``pinned`` key, so the worst case is a
+    single superseded title and the next pass bails at the gate.
+    """
+    try:
+        thread_history = await _load_thread_history(conversation_cache, room_id, thread_id)
+    except Exception:
+        logger.exception(
+            "Pin re-check before summary delivery failed; delivering anyway",
+            room_id=room_id,
+            thread_id=thread_id,
+        )
+        return False
+    return _recover_pin_state(thread_history, trusted_sender_ids=trusted_sender_ids)
 
 
 @timed("maybe_generate_thread_summary")
@@ -625,8 +658,31 @@ async def _deliver_generated_summary(
     message_count: int,
     model_name: str,
     conversation_cache: ConversationCacheProtocol,
+    *,
+    trusted_sender_ids: Collection[str],
 ) -> None:
-    """Apply initial tags, then independently deliver the generated summary."""
+    """Apply initial tags, then independently deliver the generated summary.
+
+    Re-reads pin state first. The gate before generation cannot cover the
+    generation window, and the per-thread lock is process-local, so another
+    runtime can write a manual pin while this process waits on the model. That
+    check belongs here rather than in the caller because it is a delivery-time
+    question: a superseded summary should apply neither its tags nor its title.
+    """
+    if await _pinned_since_generation_started(
+        conversation_cache,
+        room_id,
+        thread_id,
+        trusted_sender_ids=trusted_sender_ids,
+    ):
+        logger.info(
+            "Discarding an automatic thread summary that a pin superseded during generation",
+            room_id=room_id,
+            thread_id=thread_id,
+            message_count=message_count,
+        )
+        return
+
     initial_enrichment_complete: bool | None = None
     if isinstance(generated, _ThreadEnrichment):
         initial_enrichment_complete = await _apply_initial_tags(
@@ -934,6 +990,7 @@ async def maybe_generate_thread_summary(  # noqa: PLR0911
             message_count,
             model_name,
             conversation_cache,
+            trusted_sender_ids=trusted_sender_ids,
         )
         # Record after the delivery attempt so cancellation cannot leave a
         # partially delivered initial enrichment marked complete.

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -532,13 +532,25 @@ async def _pinned_since_generation_started(
     while this process is waiting on the model, and the finished automatic
     summary would then land on top of a title the user just fixed.
 
+    Reads from source rather than through ``get_strict_thread_history``. That
+    read is strict about staleness but still accepts a valid local cache hit, so
+    it cannot observe a pin another runtime just wrote — which is the only case
+    this guard exists for. Costs one homeserver read per generated summary, so
+    once per interval rather than per turn.
+
     Fails open, like the other background reads here: if the re-read fails the
     pass delivers, which is the same exposure the pre-generation gate already
     has. An automatic summary carries no ``pinned`` key, so the worst case is a
     single superseded title and the next pass bails at the gate.
     """
     try:
-        thread_history = await _load_thread_history(conversation_cache, room_id, thread_id)
+        thread_history = list(
+            await conversation_cache.refresh_strict_thread_history_from_source(
+                room_id,
+                thread_id,
+                caller_label="thread_summary_pin_recheck",
+            ),
+        )
     except Exception:
         logger.exception(
             "Pin re-check before summary delivery failed; delivering anyway",

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -632,7 +632,7 @@ async def send_thread_summary_event(
     conversation_cache: ConversationCacheProtocol,
     *,
     initial_enrichment_complete: bool | None = None,
-    pinned: bool = False,
+    pinned: bool | None = None,
     known_latest_thread_event_id: str | None = None,
 ) -> str | None:
     """Send a thread summary as a standard Matrix notice event.
@@ -642,9 +642,12 @@ async def send_thread_summary_event(
     directly, skipping the history read that would otherwise scan the homeserver
     for a thread with no cache snapshot yet.
 
-    ``pinned`` records whether this summary should stop automatic
-    re-summarization. It defaults to ``False`` so that callers writing summaries
-    directly, such as the subagent spawn path, never pin a thread implicitly.
+    ``pinned`` records an explicit decision about whether this summary should
+    stop automatic re-summarization. It defaults to ``None``, which omits the
+    key entirely and leaves any existing pin decision untouched. Only callers
+    acting on a user's intent should pass a boolean: writers that summarize as a
+    side effect, such as the subagent spawn path, must not disturb pin state on
+    a thread the user already pinned.
     """
     normalized_summary = normalize_thread_summary_text(summary)
     if not normalized_summary:
@@ -683,12 +686,11 @@ async def send_thread_summary_event(
         "message_count": message_count,
         "generated_at": datetime.now(UTC).isoformat(),
         "model": model_name,
-        # Always recorded, including False: pin recovery is last-wins, so an
-        # explicit release has to be representable in the metadata.
-        "pinned": pinned,
     }
     if initial_enrichment_complete is not None:
         summary_metadata["initial_enrichment_complete"] = initial_enrichment_complete
+    if pinned is not None:
+        summary_metadata["pinned"] = pinned
 
     content = build_message_content(
         truncated_summary,

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -27,7 +27,14 @@ from mindroom.thread_tag_vocabulary import (
     load_tag_vocabulary_snapshot,
     maybe_rebuild_tag_vocabulary,
 )
-from mindroom.thread_tags import AUTOMATIC_THREAD_TAG_EXCLUSIONS, coerce_tag_name, set_thread_tags_if_empty
+from mindroom.thread_tags import (
+    AUTOMATIC_THREAD_TAG_EXCLUSIONS,
+    RESOLVED_THREAD_TAG,
+    ThreadTagsError,
+    coerce_tag_name,
+    get_thread_tags,
+    set_thread_tags_if_empty,
+)
 from mindroom.timing import timed
 
 if TYPE_CHECKING:
@@ -288,6 +295,29 @@ def _recover_last_summary_count(
     return best_count
 
 
+def _recover_pin_state(
+    thread_history: Sequence[ResolvedVisibleMessage],
+    *,
+    trusted_sender_ids: Collection[str],
+) -> bool:
+    """Return the latest durable pin decision recorded in summary metadata.
+
+    Unlike the enrichment flag this is last-wins, so a later ``pinned: false``
+    summary releases a thread that an earlier summary pinned. Values that are
+    absent or not booleans leave the running decision untouched rather than
+    silently unpinning.
+    """
+    pinned = False
+    for message in thread_history:
+        metadata = _thread_summary_metadata(message, trusted_sender_ids=trusted_sender_ids)
+        if metadata is None:
+            continue
+        recorded = metadata.get("pinned")
+        if isinstance(recorded, bool):
+            pinned = recorded
+    return pinned
+
+
 def _recover_initial_enrichment_complete(
     thread_history: Sequence[ResolvedVisibleMessage],
     *,
@@ -432,6 +462,29 @@ async def _generate_summary(
     if isinstance(content, _ThreadSummary):
         return content.summary
     return None
+
+
+async def _thread_is_resolved(
+    client: nio.AsyncClient,
+    room_id: str,
+    thread_id: str,
+) -> bool:
+    """Return whether a thread carries the resolved lifecycle tag.
+
+    Fails open: a transient room-state read error must not suppress summaries
+    room-wide, and the cost of being wrong is one summary on a resolved thread.
+    """
+    try:
+        tags_state = await get_thread_tags(client, room_id, thread_id)
+    except ThreadTagsError as exc:
+        logger.warning(
+            "Thread tag read failed; continuing with automatic summary",
+            room_id=room_id,
+            thread_id=thread_id,
+            error=str(exc),
+        )
+        return False
+    return tags_state is not None and RESOLVED_THREAD_TAG in tags_state.tags
 
 
 @timed("maybe_generate_thread_summary")
@@ -579,6 +632,7 @@ async def send_thread_summary_event(
     conversation_cache: ConversationCacheProtocol,
     *,
     initial_enrichment_complete: bool | None = None,
+    pinned: bool = False,
     known_latest_thread_event_id: str | None = None,
 ) -> str | None:
     """Send a thread summary as a standard Matrix notice event.
@@ -587,6 +641,10 @@ async def send_thread_summary_event(
     event in the thread (for example the creator of a brand-new thread) supply it
     directly, skipping the history read that would otherwise scan the homeserver
     for a thread with no cache snapshot yet.
+
+    ``pinned`` records whether this summary should stop automatic
+    re-summarization. It defaults to ``False`` so that callers writing summaries
+    directly, such as the subagent spawn path, never pin a thread implicitly.
     """
     normalized_summary = normalize_thread_summary_text(summary)
     if not normalized_summary:
@@ -625,6 +683,9 @@ async def send_thread_summary_event(
         "message_count": message_count,
         "generated_at": datetime.now(UTC).isoformat(),
         "model": model_name,
+        # Always recorded, including False: pin recovery is last-wins, so an
+        # explicit release has to be representable in the metadata.
+        "pinned": pinned,
     }
     if initial_enrichment_complete is not None:
         summary_metadata["initial_enrichment_complete"] = initial_enrichment_complete
@@ -665,8 +726,14 @@ async def set_manual_thread_summary(
     config: Config,
     runtime_paths: RuntimePaths,
     conversation_cache: ConversationCacheProtocol,
+    pin: bool = True,
 ) -> _ThreadSummaryWriteResult:
-    """Write one validated manual summary for a canonical thread root."""
+    """Write one validated manual summary for a canonical thread root.
+
+    Pins the thread by default so the written title survives automatic
+    re-summarization. ``pin=False`` writes the summary and releases any pin an
+    earlier manual write established.
+    """
     if not isinstance(summary, str) or not summary.strip():
         msg = "summary must be a non-empty string."
         raise ThreadSummaryWriteError(msg)
@@ -703,6 +770,7 @@ async def set_manual_thread_summary(
                 message_count,
                 "manual",
                 conversation_cache,
+                pinned=pin,
             )
         except Exception as exc:
             msg = "Failed to send thread summary event."
@@ -719,7 +787,7 @@ async def set_manual_thread_summary(
         )
 
 
-async def maybe_generate_thread_summary(
+async def maybe_generate_thread_summary(  # noqa: PLR0911
     client: nio.AsyncClient,
     room_id: str,
     thread_id: str,
@@ -756,7 +824,27 @@ async def maybe_generate_thread_summary(
             thread_history,
             trusted_sender_ids=trusted_sender_ids,
         )
+        if _recover_pin_state(thread_history, trusted_sender_ids=trusted_sender_ids):
+            logger.debug(
+                "Skipping automatic thread summary for a pinned thread",
+                room_id=room_id,
+                thread_id=thread_id,
+                message_count=message_count,
+            )
+            # Advance the baseline so the cheap pre-check stops firing, and
+            # therefore stops spawning a history-loading pass, on every turn.
+            update_last_summary_count(room_id, thread_id, message_count)
+            return
         if message_count < threshold:
+            return
+        if await _thread_is_resolved(client, room_id, thread_id):
+            logger.debug(
+                "Skipping automatic thread summary for a resolved thread",
+                room_id=room_id,
+                thread_id=thread_id,
+                message_count=message_count,
+            )
+            update_last_summary_count(room_id, thread_id, message_count)
             return
 
         initial_enrichment = recovered_summary_count > 0 and not _recover_initial_enrichment_complete(

--- a/src/mindroom/thread_summary.py
+++ b/src/mindroom/thread_summary.py
@@ -30,7 +30,6 @@ from mindroom.thread_tag_vocabulary import (
 from mindroom.thread_tags import (
     AUTOMATIC_THREAD_TAG_EXCLUSIONS,
     RESOLVED_THREAD_TAG,
-    ThreadTagsError,
     coerce_tag_name,
     get_thread_tags,
     set_thread_tags_if_empty,
@@ -295,25 +294,51 @@ def _recover_last_summary_count(
     return best_count
 
 
+def _parse_summary_generated_at(metadata: dict[str, object]) -> datetime | None:
+    """Return the ISO-8601 ``generated_at`` recorded on one summary, when usable."""
+    raw = metadata.get("generated_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
 def _recover_pin_state(
     thread_history: Sequence[ResolvedVisibleMessage],
     *,
     trusted_sender_ids: Collection[str],
 ) -> bool:
-    """Return the latest durable pin decision recorded in summary metadata.
+    """Return the newest durable pin decision recorded in summary metadata.
 
-    Unlike the enrichment flag this is last-wins, so a later ``pinned: false``
-    summary releases a thread that an earlier summary pinned. Values that are
-    absent or not booleans leave the running decision untouched rather than
-    silently unpinning.
+    A later ``pinned: false`` summary releases a thread that an earlier summary
+    pinned, so the newest decision has to win. Summaries that omit the key state
+    no intent and are ignored entirely.
+
+    Ordering comes from ``generated_at`` rather than the position of the message
+    in the history, because history position does not always reflect Matrix
+    order: ``_sort_thread_items_root_first`` breaks equal ``origin_server_ts``
+    ties with backward-scan input order, which is newest-first. ``generated_at``
+    is also what the client uses to choose the summary it displays, so the pin
+    decision and the visible title are resolved by the same clock.
     """
+    newest_decision: tuple[datetime, int] | None = None
     pinned = False
-    for message in thread_history:
+    for position, message in enumerate(thread_history):
         metadata = _thread_summary_metadata(message, trusted_sender_ids=trusted_sender_ids)
         if metadata is None:
             continue
         recorded = metadata.get("pinned")
-        if isinstance(recorded, bool):
+        if not isinstance(recorded, bool):
+            continue
+        generated_at = _parse_summary_generated_at(metadata)
+        if generated_at is None:
+            continue
+        decision = (generated_at, position)
+        if newest_decision is None or decision > newest_decision:
+            newest_decision = decision
             pinned = recorded
     return pinned
 
@@ -471,12 +496,16 @@ async def _thread_is_resolved(
 ) -> bool:
     """Return whether a thread carries the resolved lifecycle tag.
 
-    Fails open: a transient room-state read error must not suppress summaries
-    room-wide, and the cost of being wrong is one summary on a resolved thread.
+    Fails open, matching ``_refresh_tag_vocabulary`` and the history load in this
+    module: this is a best-effort background read, and the cost of being wrong is
+    one summary on a resolved thread. Letting a transport error escape instead
+    would abort the pass before it advances the baseline, so a persistently
+    failing room-state read would re-run the full state and history reads on
+    every turn.
     """
     try:
         tags_state = await get_thread_tags(client, room_id, thread_id)
-    except ThreadTagsError as exc:
+    except Exception as exc:
         logger.warning(
             "Thread tag read failed; continuing with automatic summary",
             room_id=room_id,

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -35,6 +35,7 @@ from mindroom.thread_summary import (
     _next_threshold,
     _recover_initial_enrichment_complete,
     _recover_last_summary_count,
+    _recover_pin_state,
     _resolve_thread_summary_model_name,
     _thread_locks,
     _thread_summary_cache_key,
@@ -49,7 +50,12 @@ from mindroom.thread_summary import (
     update_last_summary_count,
 )
 from mindroom.thread_tag_vocabulary import _TagUsage, _TagVocabularySnapshot
-from mindroom.thread_tags import SetThreadTagsIfEmptyResult, ThreadTagsError
+from mindroom.thread_tags import (
+    SetThreadTagsIfEmptyResult,
+    ThreadTagRecord,
+    ThreadTagsError,
+    ThreadTagsState,
+)
 from tests.conftest import make_matrix_client_mock
 
 if TYPE_CHECKING:
@@ -85,6 +91,7 @@ def _make_summary_notice_message(
     initial_enrichment_complete: bool | None = True,
     model: str = "manual",
     sender: str = "@mindroom:localhost",
+    pinned: bool | None = None,
 ) -> ResolvedVisibleMessage:
     """Build a synthetic thread summary notice for history-counting regressions."""
     summary = "🧵 Existing thread summary"
@@ -96,6 +103,8 @@ def _make_summary_notice_message(
     }
     if initial_enrichment_complete is not None:
         summary_metadata["initial_enrichment_complete"] = initial_enrichment_complete
+    if pinned is not None:
+        summary_metadata["pinned"] = pinned
     return ResolvedVisibleMessage.synthetic(
         sender=sender,
         body=summary,
@@ -654,9 +663,15 @@ class TestMaybeGenerateThreadSummary:
         self.conversation_cache = MagicMock()
         self.conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value="$thread1")
         self.conversation_cache.notify_outbound_message = Mock()
-        with patch(
-            "mindroom.thread_summary.maybe_rebuild_tag_vocabulary",
-            new=AsyncMock(return_value=None),
+        with (
+            patch(
+                "mindroom.thread_summary.maybe_rebuild_tag_vocabulary",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "mindroom.thread_summary.get_thread_tags",
+                new=AsyncMock(return_value=None),
+            ),
         ):
             yield
 
@@ -675,6 +690,173 @@ class TestMaybeGenerateThreadSummary:
             rp,
             conversation_cache=self.conversation_cache,
         )
+
+    async def test_pinned_thread_skips_generation(self) -> None:
+        """A pinned thread past the threshold must not call the LLM."""
+        client = _mock_client()
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+        history = [
+            *_make_thread_history(12),
+            _make_summary_notice_message("$thread1", message_count=2, pinned=True),
+        ]
+
+        with (
+            patch(
+                "mindroom.thread_summary.current_internal_sender_ids",
+                return_value=_TRUSTED_SUMMARY_SENDERS,
+            ),
+            patch("mindroom.thread_summary._load_thread_history", return_value=history),
+            patch("mindroom.thread_summary._generate_summary") as mock_gen,
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        mock_gen.assert_not_awaited()
+
+    async def test_pinned_bail_advances_baseline(self) -> None:
+        """Bailing must advance the baseline so the pre-check stops firing every turn."""
+        client = _mock_client()
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+        history = [
+            *_make_thread_history(12),
+            _make_summary_notice_message("$thread1", message_count=2, pinned=True),
+        ]
+
+        with (
+            patch(
+                "mindroom.thread_summary.current_internal_sender_ids",
+                return_value=_TRUSTED_SUMMARY_SENDERS,
+            ),
+            patch("mindroom.thread_summary._load_thread_history", return_value=history),
+            patch("mindroom.thread_summary._generate_summary"),
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        assert _last_summary_counts[_thread_summary_cache_key("!room:x", "$thread1")] == 12
+        with patch("mindroom.thread_summary.claim_vocabulary_check", return_value=False):
+            assert not should_queue_thread_summary(
+                "!room:x",
+                "$thread1",
+                config,
+                rp,
+                message_count_hint=12,
+            )
+
+    async def test_released_thread_resumes_generation(self) -> None:
+        """A later pinned=False summary lets automatic generation resume."""
+        client = _mock_client()
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+        # 15 messages clears the threshold that the recovered baseline of 3
+        # pushes to 13, so only the pin state decides whether generation runs.
+        history = [
+            *_make_thread_history(15),
+            _make_summary_notice_message("$thread1", message_count=2, event_id="$s1", pinned=True),
+            _make_summary_notice_message("$thread1", message_count=3, event_id="$s2", pinned=False),
+        ]
+
+        with (
+            patch(
+                "mindroom.thread_summary.current_internal_sender_ids",
+                return_value=_TRUSTED_SUMMARY_SENDERS,
+            ),
+            patch("mindroom.thread_summary._load_thread_history", return_value=history),
+            patch(
+                "mindroom.thread_summary._generate_summary",
+                return_value="Fresh summary",
+            ) as mock_gen,
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        mock_gen.assert_awaited_once()
+
+    async def test_resolved_thread_skips_generation(self) -> None:
+        """A resolved thread should stop burning LLM calls on re-titling."""
+        client = _mock_client()
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+        tags_state = ThreadTagsState(
+            room_id="!room:x",
+            thread_root_id="$thread1",
+            tags={
+                "resolved": ThreadTagRecord(
+                    set_by="@user:localhost",
+                    set_at=datetime.now(UTC),
+                ),
+            },
+        )
+
+        with (
+            patch(
+                "mindroom.thread_summary.current_internal_sender_ids",
+                return_value=_TRUSTED_SUMMARY_SENDERS,
+            ),
+            patch(
+                "mindroom.thread_summary._load_thread_history",
+                return_value=_make_thread_history(12),
+            ),
+            patch(
+                "mindroom.thread_summary.get_thread_tags",
+                new=AsyncMock(return_value=tags_state),
+            ),
+            patch("mindroom.thread_summary._generate_summary") as mock_gen,
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        mock_gen.assert_not_awaited()
+        assert _last_summary_counts[_thread_summary_cache_key("!room:x", "$thread1")] == 12
+
+    async def test_tag_read_failure_still_generates(self) -> None:
+        """The tag read fails open; a state blip must not suppress summaries."""
+        client = _mock_client()
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+
+        with (
+            patch(
+                "mindroom.thread_summary.current_internal_sender_ids",
+                return_value=_TRUSTED_SUMMARY_SENDERS,
+            ),
+            patch(
+                "mindroom.thread_summary._load_thread_history",
+                return_value=_make_thread_history(12),
+            ),
+            patch(
+                "mindroom.thread_summary.get_thread_tags",
+                new=AsyncMock(side_effect=ThreadTagsError("state fetch failed")),
+            ),
+            patch(
+                "mindroom.thread_summary._generate_summary",
+                return_value="Fresh summary",
+            ) as mock_gen,
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        mock_gen.assert_awaited_once()
+
+    async def test_below_threshold_does_not_read_tags(self) -> None:
+        """The tag read must sit behind the threshold test to stay cheap."""
+        client = _mock_client()
+        config = _mock_config()
+        rp = _mock_runtime_paths()
+        get_tags = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "mindroom.thread_summary.current_internal_sender_ids",
+                return_value=_TRUSTED_SUMMARY_SENDERS,
+            ),
+            patch(
+                "mindroom.thread_summary._load_thread_history",
+                return_value=_make_thread_history(3),
+            ),
+            patch("mindroom.thread_summary.get_thread_tags", new=get_tags),
+            patch("mindroom.thread_summary._generate_summary"),
+        ):
+            await self._maybe_generate(client, config, rp)
+
+        get_tags.assert_not_awaited()
 
     async def test_below_threshold_skips(self) -> None:
         """No LLM call when message count is below the first threshold."""
@@ -2063,6 +2245,7 @@ class TestSetManualThreadSummary:
             4,
             "manual",
             conversation_cache,
+            pinned=True,
         )
         assert _last_summary_counts[_thread_summary_cache_key("!room:x", "$root1")] == 4
 
@@ -2560,5 +2743,57 @@ class TestSummaryNoticeFiltering:
         assert "Existing thread summary" in text
         assert not _is_thread_summary_message(
             forged,
+            trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS,
+        )
+
+
+class TestRecoverPinState:
+    """Pin recovery from durable summary metadata."""
+
+    def test_absent_pinned_key_is_not_pinned(self) -> None:
+        """Summaries written before pinning existed must not pin retroactively."""
+        history = [_make_summary_notice_message("$thread1", message_count=2)]
+        assert _recover_pin_state(history, trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS) is False
+
+    def test_latest_pin_wins_over_earlier_release(self) -> None:
+        """A later pin overrides an earlier release."""
+        history = [
+            _make_summary_notice_message("$thread1", message_count=2, event_id="$s1", pinned=False),
+            _make_summary_notice_message("$thread1", message_count=4, event_id="$s2", pinned=True),
+        ]
+        assert _recover_pin_state(history, trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS)
+
+    def test_latest_release_wins_over_earlier_pin(self) -> None:
+        """Release must be possible; any-wins recovery would make it impossible."""
+        history = [
+            _make_summary_notice_message("$thread1", message_count=2, event_id="$s1", pinned=True),
+            _make_summary_notice_message("$thread1", message_count=4, event_id="$s2", pinned=False),
+        ]
+        assert _recover_pin_state(history, trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS) is False
+
+    def test_untrusted_sender_cannot_pin(self) -> None:
+        """Only runtime-owned senders may set pin state."""
+        history = [
+            _make_summary_notice_message(
+                "$thread1",
+                message_count=2,
+                pinned=True,
+                sender="@stranger:elsewhere",
+            ),
+        ]
+        assert _recover_pin_state(history, trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS) is False
+
+    def test_non_bool_pinned_value_does_not_change_state(self) -> None:
+        """A malformed value must not silently unpin."""
+        pinned_message = _make_summary_notice_message(
+            "$thread1",
+            message_count=2,
+            event_id="$s1",
+            pinned=True,
+        )
+        malformed = _make_summary_notice_message("$thread1", message_count=4, event_id="$s2")
+        malformed.content["io.mindroom.thread_summary"]["pinned"] = "yes"
+        assert _recover_pin_state(
+            [pinned_message, malformed],
             trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS,
         )

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -666,6 +666,8 @@ class TestMaybeGenerateThreadSummary:
         self.conversation_cache = MagicMock()
         self.conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value="$thread1")
         self.conversation_cache.notify_outbound_message = Mock()
+        # The pre-delivery pin guard reads from source; default it to "no pin".
+        self.conversation_cache.refresh_strict_thread_history_from_source = AsyncMock(return_value=[])
         with (
             patch(
                 "mindroom.thread_summary.maybe_rebuild_tag_vocabulary",
@@ -943,10 +945,7 @@ class TestMaybeGenerateThreadSummary:
         ):
             await self._maybe_generate(client, config, rp)
 
-        # Two reads per generated summary: the pre-generation gate, then the
-        # pin re-check immediately before delivery.
-        assert load.await_count == 2
-        load.assert_awaited_with(self.conversation_cache, "!room:x", "$thread1")
+        load.assert_awaited_once_with(self.conversation_cache, "!room:x", "$thread1")
         generate.assert_awaited_once_with(
             thread_history,
             config,
@@ -2048,10 +2047,7 @@ class TestMaybeGenerateThreadSummary:
             release_fetch.set()
             await asyncio.gather(first, second)
 
-        # Three reads: both passes gate, then only the first reaches generation
-        # and re-checks the pin before delivery. The second sees the baseline
-        # the first advanced and returns at the threshold.
-        assert fetch_calls == 3
+        assert fetch_calls == 2
         mock_send.assert_awaited_once()
 
 
@@ -3013,10 +3009,15 @@ async def test_pin_decision_survives_a_real_write_and_read_round_trip(pinned: bo
 class TestPinLandingDuringGeneration:
     """A pin written while the model runs must supersede the in-flight summary."""
 
-    def _cache(self) -> MagicMock:
+    def _cache(self, source_history: list | None = None) -> MagicMock:
         conversation_cache = MagicMock()
         conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value="$thread1")
         conversation_cache.notify_outbound_message = Mock()
+        # The guard must read from source, not through the cache: a pin written
+        # by another runtime is not in this runtime's cache yet.
+        conversation_cache.refresh_strict_thread_history_from_source = AsyncMock(
+            return_value=source_history if source_history is not None else [],
+        )
         return conversation_cache
 
     async def _run(self, conversation_cache: MagicMock, histories: list) -> AsyncMock:
@@ -3048,31 +3049,43 @@ class TestPinLandingDuringGeneration:
             )
         return deliver
 
-    async def test_pin_during_generation_discards_the_summary(self) -> None:
-        """The pre-generation gate cannot see a pin that lands mid-generation."""
+    async def test_pin_visible_only_at_source_discards_the_summary(self) -> None:
+        """A pin another runtime wrote is not in this runtime's cache yet.
+
+        get_strict_thread_history is strict about staleness but still accepts a
+        valid local cache hit, so reading through it would miss the pin and
+        deliver the stale title anyway.
+        """
         unpinned = _make_thread_history(12)
-        pinned_later = [
+        pinned_at_source = [
             *_make_thread_history(12),
             _make_summary_notice_message("$thread1", message_count=12, pinned=True),
         ]
+        conversation_cache = self._cache(source_history=pinned_at_source)
 
-        deliver = await self._run(self._cache(), [unpinned, pinned_later])
+        # Cache reads stay unpinned for the whole pass.
+        deliver = await self._run(conversation_cache, [unpinned, unpinned])
 
         deliver.assert_not_awaited()
+        conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once()
         assert _last_summary_counts[_thread_summary_cache_key("!room:x", "$thread1")] == 12
 
     async def test_still_delivers_when_no_pin_landed(self) -> None:
         """The re-check must not suppress ordinary summaries."""
         unpinned = _make_thread_history(12)
 
-        deliver = await self._run(self._cache(), [unpinned, list(unpinned)])
+        deliver = await self._run(self._cache(source_history=list(unpinned)), [unpinned, unpinned])
 
         deliver.assert_awaited_once()
 
     async def test_recheck_failure_still_delivers(self) -> None:
-        """A failed re-read falls back to the pre-generation decision."""
+        """A failed source re-read falls back to the pre-generation decision."""
         unpinned = _make_thread_history(12)
+        conversation_cache = self._cache()
+        conversation_cache.refresh_strict_thread_history_from_source = AsyncMock(
+            side_effect=RuntimeError("source read failed"),
+        )
 
-        deliver = await self._run(self._cache(), [unpinned, RuntimeError("history read failed")])
+        deliver = await self._run(conversation_cache, [unpinned, unpinned])
 
         deliver.assert_awaited_once()

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -37,6 +37,7 @@ from mindroom.thread_summary import (
     _recover_last_summary_count,
     _recover_pin_state,
     _resolve_thread_summary_model_name,
+    _thread_is_resolved,
     _thread_locks,
     _thread_summary_cache_key,
     _ThreadEnrichment,
@@ -92,6 +93,7 @@ def _make_summary_notice_message(
     model: str = "manual",
     sender: str = "@mindroom:localhost",
     pinned: bool | None = None,
+    generated_at: str = "2026-01-01T00:00:00+00:00",
 ) -> ResolvedVisibleMessage:
     """Build a synthetic thread summary notice for history-counting regressions."""
     summary = "🧵 Existing thread summary"
@@ -100,6 +102,7 @@ def _make_summary_notice_message(
         "summary": summary,
         "message_count": message_count,
         "model": model,
+        "generated_at": generated_at,
     }
     if initial_enrichment_complete is not None:
         summary_metadata["initial_enrichment_complete"] = initial_enrichment_complete
@@ -2758,18 +2761,103 @@ class TestRecoverPinState:
     def test_latest_pin_wins_over_earlier_release(self) -> None:
         """A later pin overrides an earlier release."""
         history = [
-            _make_summary_notice_message("$thread1", message_count=2, event_id="$s1", pinned=False),
-            _make_summary_notice_message("$thread1", message_count=4, event_id="$s2", pinned=True),
+            _make_summary_notice_message(
+                "$thread1",
+                message_count=2,
+                event_id="$s1",
+                pinned=False,
+                generated_at="2026-01-01T00:00:00+00:00",
+            ),
+            _make_summary_notice_message(
+                "$thread1",
+                message_count=4,
+                event_id="$s2",
+                pinned=True,
+                generated_at="2026-01-01T00:05:00+00:00",
+            ),
         ]
         assert _recover_pin_state(history, trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS)
 
     def test_latest_release_wins_over_earlier_pin(self) -> None:
         """Release must be possible; any-wins recovery would make it impossible."""
         history = [
-            _make_summary_notice_message("$thread1", message_count=2, event_id="$s1", pinned=True),
-            _make_summary_notice_message("$thread1", message_count=4, event_id="$s2", pinned=False),
+            _make_summary_notice_message(
+                "$thread1",
+                message_count=2,
+                event_id="$s1",
+                pinned=True,
+                generated_at="2026-01-01T00:00:00+00:00",
+            ),
+            _make_summary_notice_message(
+                "$thread1",
+                message_count=4,
+                event_id="$s2",
+                pinned=False,
+                generated_at="2026-01-01T00:05:00+00:00",
+            ),
         ]
         assert _recover_pin_state(history, trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS) is False
+
+    def test_newest_decision_wins_when_history_order_is_reversed(self) -> None:
+        """History position must not decide the pin.
+
+        _sort_thread_items_root_first breaks equal origin_server_ts ties with
+        backward-scan input order, which is newest-first, so a release written
+        after a pin in the same millisecond can appear before it in history.
+        """
+        release = _make_summary_notice_message(
+            "$thread1",
+            message_count=4,
+            event_id="$release",
+            pinned=False,
+            generated_at="2026-01-01T00:05:00+00:00",
+        )
+        pin = _make_summary_notice_message(
+            "$thread1",
+            message_count=2,
+            event_id="$pin",
+            pinned=True,
+            generated_at="2026-01-01T00:00:00+00:00",
+        )
+        assert _recover_pin_state([release, pin], trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS) is False
+
+    def test_falls_back_to_position_when_timestamps_are_identical(self) -> None:
+        """Identical generated_at values still resolve deterministically."""
+        history = [
+            _make_summary_notice_message(
+                "$thread1",
+                message_count=2,
+                event_id="$s1",
+                pinned=True,
+                generated_at="2026-01-01T00:00:00+00:00",
+            ),
+            _make_summary_notice_message(
+                "$thread1",
+                message_count=4,
+                event_id="$s2",
+                pinned=False,
+                generated_at="2026-01-01T00:00:00+00:00",
+            ),
+        ]
+        assert _recover_pin_state(history, trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS) is False
+
+    def test_decision_without_usable_timestamp_is_ignored(self) -> None:
+        """A malformed generated_at must not silently flip the decision."""
+        pin = _make_summary_notice_message(
+            "$thread1",
+            message_count=2,
+            event_id="$s1",
+            pinned=True,
+            generated_at="2026-01-01T00:00:00+00:00",
+        )
+        malformed = _make_summary_notice_message(
+            "$thread1",
+            message_count=4,
+            event_id="$s2",
+            pinned=False,
+            generated_at="not-a-timestamp",
+        )
+        assert _recover_pin_state([pin, malformed], trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS)
 
     def test_untrusted_sender_cannot_pin(self) -> None:
         """Only runtime-owned senders may set pin state."""
@@ -2837,3 +2925,20 @@ class TestSummaryWritersLeavePinStateAlone:
             [pin, side_effect_write],
             trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS,
         )
+
+
+@pytest.mark.asyncio
+async def test_resolved_tag_transport_error_fails_open() -> None:
+    """A raw transport error from the tag read must not abort the summary pass.
+
+    get_thread_tags awaits client.room_get_state directly, so a timeout is not
+    wrapped in ThreadTagsError. Letting it escape would skip the baseline
+    advance and re-run the full state and history reads on every turn.
+    """
+    client = _mock_client()
+
+    with patch(
+        "mindroom.thread_summary.get_thread_tags",
+        new=AsyncMock(side_effect=TimeoutError("state timeout")),
+    ):
+        assert await _thread_is_resolved(client, "!room:x", "$thread1") is False

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -943,7 +943,10 @@ class TestMaybeGenerateThreadSummary:
         ):
             await self._maybe_generate(client, config, rp)
 
-        load.assert_awaited_once_with(self.conversation_cache, "!room:x", "$thread1")
+        # Two reads per generated summary: the pre-generation gate, then the
+        # pin re-check immediately before delivery.
+        assert load.await_count == 2
+        load.assert_awaited_with(self.conversation_cache, "!room:x", "$thread1")
         generate.assert_awaited_once_with(
             thread_history,
             config,
@@ -2045,7 +2048,10 @@ class TestMaybeGenerateThreadSummary:
             release_fetch.set()
             await asyncio.gather(first, second)
 
-        assert fetch_calls == 2
+        # Three reads: both passes gate, then only the first reaches generation
+        # and re-checks the pin before delivery. The second sees the baseline
+        # the first advanced and returns at the threshold.
+        assert fetch_calls == 3
         mock_send.assert_awaited_once()
 
 
@@ -3001,3 +3007,72 @@ async def test_pin_decision_survives_a_real_write_and_read_round_trip(pinned: bo
     )
 
     assert _recover_pin_state([delivered], trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS) is pinned
+
+
+@pytest.mark.asyncio
+class TestPinLandingDuringGeneration:
+    """A pin written while the model runs must supersede the in-flight summary."""
+
+    def _cache(self) -> MagicMock:
+        conversation_cache = MagicMock()
+        conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value="$thread1")
+        conversation_cache.notify_outbound_message = Mock()
+        return conversation_cache
+
+    async def _run(self, conversation_cache: MagicMock, histories: list) -> AsyncMock:
+        client = _mock_client()
+        with (
+            patch("mindroom.thread_summary.maybe_rebuild_tag_vocabulary", new=AsyncMock(return_value=None)),
+            patch("mindroom.thread_summary.get_thread_tags", new=AsyncMock(return_value=None)),
+            patch(
+                "mindroom.thread_summary.current_internal_sender_ids",
+                return_value=_TRUSTED_SUMMARY_SENDERS,
+            ),
+            patch("mindroom.thread_summary._load_thread_history", side_effect=histories),
+            patch(
+                "mindroom.thread_summary._generate_summary",
+                return_value="Freshly generated title",
+            ),
+            patch(
+                "mindroom.thread_summary.send_thread_summary_event",
+                new=AsyncMock(return_value="$summary1"),
+            ) as deliver,
+        ):
+            await maybe_generate_thread_summary(
+                client,
+                "!room:x",
+                "$thread1",
+                _mock_config(),
+                _mock_runtime_paths(),
+                conversation_cache=conversation_cache,
+            )
+        return deliver
+
+    async def test_pin_during_generation_discards_the_summary(self) -> None:
+        """The pre-generation gate cannot see a pin that lands mid-generation."""
+        unpinned = _make_thread_history(12)
+        pinned_later = [
+            *_make_thread_history(12),
+            _make_summary_notice_message("$thread1", message_count=12, pinned=True),
+        ]
+
+        deliver = await self._run(self._cache(), [unpinned, pinned_later])
+
+        deliver.assert_not_awaited()
+        assert _last_summary_counts[_thread_summary_cache_key("!room:x", "$thread1")] == 12
+
+    async def test_still_delivers_when_no_pin_landed(self) -> None:
+        """The re-check must not suppress ordinary summaries."""
+        unpinned = _make_thread_history(12)
+
+        deliver = await self._run(self._cache(), [unpinned, list(unpinned)])
+
+        deliver.assert_awaited_once()
+
+    async def test_recheck_failure_still_delivers(self) -> None:
+        """A failed re-read falls back to the pre-generation decision."""
+        unpinned = _make_thread_history(12)
+
+        deliver = await self._run(self._cache(), [unpinned, RuntimeError("history read failed")])
+
+        deliver.assert_awaited_once()

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -2797,3 +2797,43 @@ class TestRecoverPinState:
             [pinned_message, malformed],
             trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS,
         )
+
+
+@pytest.mark.asyncio
+class TestSummaryWritersLeavePinStateAlone:
+    """Writers that summarize as a side effect must not disturb a user's pin."""
+
+    async def test_default_write_omits_pinned_key(self) -> None:
+        """send_thread_summary_event must not record a pin decision unless asked.
+
+        The subagent spawn path reuses an existing thread by label and writes a
+        summary outside the per-thread summary lock. Recording pinned=False by
+        default there would silently release a pin the user had set.
+        """
+        client = _mock_client()
+        conversation_cache = MagicMock()
+        conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value="$thread1")
+        conversation_cache.notify_outbound_message = Mock()
+
+        await send_thread_summary_event(
+            client,
+            "!room:x",
+            "$thread1",
+            "Spawned session summary",
+            1,
+            "manual",
+            conversation_cache,
+        )
+
+        sent_content = client.room_send.await_args.kwargs["content"]
+        assert "pinned" not in sent_content["io.mindroom.thread_summary"]
+
+    async def test_unpinned_side_effect_write_does_not_release_a_pin(self) -> None:
+        """A pinned thread stays pinned after a summary written without intent."""
+        pin = _make_summary_notice_message("$thread1", message_count=2, event_id="$s1", pinned=True)
+        side_effect_write = _make_summary_notice_message("$thread1", message_count=3, event_id="$s2")
+
+        assert _recover_pin_state(
+            [pin, side_effect_write],
+            trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS,
+        )

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -2964,3 +2964,40 @@ async def test_resolved_tag_transport_error_fails_open() -> None:
         new=AsyncMock(side_effect=TimeoutError("state timeout")),
     ):
         assert await _thread_is_resolved(client, "!room:x", "$thread1") is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pinned", [True, False])
+async def test_pin_decision_survives_a_real_write_and_read_round_trip(pinned: bool) -> None:
+    """Bind the writer to the reader.
+
+    Every other pin test feeds _recover_pin_state a hand-built fixture, so the
+    key name and the generated_at format are asserted only against themselves.
+    This drives the real send path, then recovers from exactly what was sent.
+    """
+    client = _mock_client()
+    conversation_cache = MagicMock()
+    conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value="$thread1")
+    conversation_cache.notify_outbound_message = Mock()
+
+    await send_thread_summary_event(
+        client,
+        "!room:x",
+        "$thread1",
+        "A deliberate title",
+        4,
+        "manual",
+        conversation_cache,
+        pinned=pinned,
+    )
+
+    sent_content = client.room_send.await_args.kwargs["content"]
+    delivered = ResolvedVisibleMessage.synthetic(
+        sender="@mindroom:localhost",
+        body=sent_content["body"],
+        event_id="$delivered",
+        content=sent_content,
+        thread_id="$thread1",
+    )
+
+    assert _recover_pin_state([delivered], trusted_sender_ids=_TRUSTED_SUMMARY_SENDERS) is pinned

--- a/tests/test_thread_summary.py
+++ b/tests/test_thread_summary.py
@@ -2916,6 +2916,28 @@ class TestSummaryWritersLeavePinStateAlone:
         sent_content = client.room_send.await_args.kwargs["content"]
         assert "pinned" not in sent_content["io.mindroom.thread_summary"]
 
+    @pytest.mark.parametrize("pinned", [True, False])
+    async def test_explicit_decision_lands_in_sent_metadata(self, pinned: bool) -> None:
+        """An explicit pin decision must reach the Matrix event, not just the call."""
+        client = _mock_client()
+        conversation_cache = MagicMock()
+        conversation_cache.get_latest_thread_event_id_if_needed = AsyncMock(return_value="$thread1")
+        conversation_cache.notify_outbound_message = Mock()
+
+        await send_thread_summary_event(
+            client,
+            "!room:x",
+            "$thread1",
+            "A deliberate title",
+            1,
+            "manual",
+            conversation_cache,
+            pinned=pinned,
+        )
+
+        sent_content = client.room_send.await_args.kwargs["content"]
+        assert sent_content["io.mindroom.thread_summary"]["pinned"] is pinned
+
     async def test_unpinned_side_effect_write_does_not_release_a_pin(self) -> None:
         """A pinned thread stays pinned after a summary written without intent."""
         pin = _make_summary_notice_message("$thread1", message_count=2, event_id="$s1", pinned=True)

--- a/tests/test_thread_summary_tool.py
+++ b/tests/test_thread_summary_tool.py
@@ -116,6 +116,7 @@ async def test_set_thread_summary_defaults_to_context_room_and_thread() -> None:
         "action": "set",
         "event_id": "$summary-event:localhost",
         "message_count": 3,
+        "pinned": True,
         "room_id": "!room:localhost",
         "status": "ok",
         "summary": "🧵 Ready for review",
@@ -136,6 +137,7 @@ async def test_set_thread_summary_defaults_to_context_room_and_thread() -> None:
         config=context.config,
         runtime_paths=context.runtime_paths,
         conversation_cache=context.conversation_cache,
+        pin=True,
     )
 
 
@@ -168,6 +170,7 @@ async def test_set_thread_summary_returns_helper_summary() -> None:
         config=context.config,
         runtime_paths=context.runtime_paths,
         conversation_cache=context.conversation_cache,
+        pin=True,
     )
 
 
@@ -220,6 +223,7 @@ async def test_set_thread_summary_normalizes_explicit_thread_id() -> None:
         config=context.config,
         runtime_paths=context.runtime_paths,
         conversation_cache=context.conversation_cache,
+        pin=True,
     )
 
 
@@ -425,3 +429,51 @@ async def test_set_thread_summary_returns_error_when_send_raises() -> None:
     assert payload["status"] == "error"
     assert payload["thread_id"] == "$ctx-thread:localhost"
     assert payload["message"] == "Failed to send thread summary event."
+
+
+@pytest.mark.asyncio
+async def test_set_thread_summary_pins_by_default() -> None:
+    """Asking an agent to set a title should make it survive automatic re-summarization."""
+    tool = ThreadSummaryTools()
+    context = _make_context(thread_id="$ctx-thread:localhost")
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
+            new=AsyncMock(return_value="$ctx-thread:localhost"),
+        ),
+        patch(
+            "mindroom.custom_tools.thread_summary.set_manual_thread_summary",
+            new=AsyncMock(return_value=_write_result(summary="A fixed title")),
+        ) as mock_set,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await tool.set_thread_summary("A fixed title"))
+
+    assert payload["status"] == "ok"
+    assert payload["pinned"] is True
+    assert mock_set.await_args.kwargs["pin"] is True
+
+
+@pytest.mark.asyncio
+async def test_set_thread_summary_forwards_pin_false() -> None:
+    """pin=False writes a summary and releases the thread for automatic summaries."""
+    tool = ThreadSummaryTools()
+    context = _make_context(thread_id="$ctx-thread:localhost")
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_summary.resolve_thread_root_event_id_for_client",
+            new=AsyncMock(return_value="$ctx-thread:localhost"),
+        ),
+        patch(
+            "mindroom.custom_tools.thread_summary.set_manual_thread_summary",
+            new=AsyncMock(return_value=_write_result(summary="A routine title")),
+        ) as mock_set,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await tool.set_thread_summary("A routine title", pin=False))
+
+    assert payload["status"] == "ok"
+    assert payload["pinned"] is False
+    assert mock_set.await_args.kwargs["pin"] is False


### PR DESCRIPTION
## Problem

A manually written thread summary does not hold.

`set_thread_summary` writes the notice and then calls `update_last_summary_count`, which only moves the automatic baseline forward. The next automatic summary fires `defaults.thread_summary_subsequent_interval` messages later (default 10) and replaces the title the user chose. On a long-running thread this repeats indefinitely.

There was no way to stop it. The only related knobs — `thread_summary_first_threshold`, `thread_summary_subsequent_interval`, `thread_summary_model`, `room_thread_summary_models` — choose *when* and *which model*, never *whether*.

A client-side fix is not possible: the winning title is chosen by newest `generated_at` with `message_count` as a tiebreak, so the backend has to stop emitting.

## Approach

Record a `pinned` boolean in the existing `io.mindroom.thread_summary` notice metadata. `maybe_generate_thread_summary` already recovers durable per-thread state from that metadata on every pass, so the stored decision needs no new store and survives restarts, and every runtime reads the same decision.

The gate before generation cannot cover the generation window itself, and the per-thread lock is process-local, so `_deliver_generated_summary` re-reads pin state immediately before delivery and discards a superseded summary — its tags as well as its title. That re-read uses `refresh_strict_thread_history_from_source` rather than `get_strict_thread_history`: the latter is strict about staleness but still accepts a valid local cache hit, so it could not observe a pin another runtime had just written, which is the only case the guard exists for.

This does add I/O, in two places. The `resolved` check performs a full uncached `client.room_get_state`, and the pre-delivery guard performs a source read. Both sit behind the message-count threshold, so they cost once per interval on threads that were about to generate anyway, not once per turn.

`set_thread_summary(summary, thread_id=None, room_id=None, pin=True)` pins by default; `pin=False` writes a summary and releases an earlier pin.

Threads carrying the `resolved` tag are skipped too — a finished thread re-titling itself every 10 messages is the same annoyance plus wasted LLM calls.

## Details worth reviewing

**Recovery is last-wins**, unlike the neighbouring `_recover_initial_enrichment_complete`, which is any-wins. Any-wins would make release impossible, because the earlier `pinned: true` event stays in history forever. Values that are absent or not booleans leave the running decision untouched rather than silently unpinning.

**`send_thread_summary_event`'s `pinned` parameter is `bool | None`, defaulting to `None`,** which omits the key entirely and leaves any existing decision untouched. Only callers acting on a user's intent pass a boolean. This matters because `_maybe_reuse_spawned_session` in `custom_tools/subagents.py` resolves a *pre-existing* thread by label and writes a summary into it outside the per-thread lock: recording `pinned: false` there would silently release a pin the user had set. Keying the pin off `model == "manual"` would have been worse still, since that path uses the same label. `tests/test_subagents.py` is in the verified set for that reason.

**Gate ordering is load-bearing for cost.** The pin check is free — it reads history the pass already loaded — and runs before the threshold test, so pinned threads never pay for a tag read. The `resolved` check needs `get_thread_tags`, which is a full uncached `client.room_get_state`, so it sits *after* the threshold test and only runs when an LLM call was about to fire anyway. A test asserts the tag read does not happen below threshold.

**Every bail advances the baseline.** Without that the threshold freezes while the message count grows, so `should_queue_thread_summary` turns permanently true and every turn spawns a background pass that loads full thread history before bailing — worst on exactly the long threads this targets.

**The tag read fails open.** A transient room-state error yields at most one summary on a resolved thread; failing closed would silently suppress summaries room-wide.

## Accepted limitations

- Redacting the pinned summary event reverts pin state to whatever the preceding summary recorded.
- Pin recovery only trusts senders in `current_internal_sender_ids`, so rotating bot user IDs loses the pin — the existing limitation of baseline recovery, not a new one.
- No way to unpin without supplying a title. Pass the current one.

A thread-rename affordance in the client is the real product answer; it would write the same `pinned: true` metadata and need no further backend change.

## Verification

- `tests/test_thread_summary.py`, `tests/test_thread_summary_tool.py`, `tests/test_subagents.py`, `tests/test_thread_tags.py`, `tests/test_thread_tags_tool.py` — all pass.
- `uv run pre-commit run --all-files` — clean.
- `tests/test_import_graph.py` and `uv run tach check --dependencies --interfaces` — pass; no new module boundary is crossed, `thread_summary` already imported from `thread_tags`.

Docs updated in `docs/tools/matrix-and-attachments.md` and `docs/configuration/index.md`, both of which claimed manual summaries merely reset the baseline.

## Summary by Sourcery

Pin manually set thread summaries to prevent automatic re-summarization from overwriting them, and skip automatic summaries on resolved threads while preserving durability and performance characteristics.

New Features:
- Allow manual thread summaries to be pinned or explicitly unpinned via a new pin parameter on set_thread_summary and the thread_summary tool, with pin state stored durably in summary metadata.

Bug Fixes:
- Prevent automatic thread summaries from repeatedly overwriting manually set thread titles on long-running threads.
- Ensure automatic summaries do not continue running on threads marked as resolved, avoiding unnecessary LLM usage.

Enhancements:
- Introduce pin-state recovery from existing summary metadata using a last-wins strategy constrained to trusted senders.
- Advance the last-summary baseline on all early exits, including pinned and resolved threads, so pre-checks stop triggering unnecessary background passes.
- Make tag-based resolution checks fail open and run only after threshold checks to limit cost and avoid room-wide suppression on transient errors.

Documentation:
- Document the new pin argument and default behavior for manual thread summaries, including how pinning interacts with automatic summaries and resolved threads in the tools and configuration guides.

Tests:
- Add coverage for pin-state recovery semantics, pinned and released thread behavior, skipping generation for resolved threads, tag-read failure behavior, below-threshold tag access, and the thread_summary tool’s pin parameter propagation.

