### PR TITLE
Fix red main: move the unparseable-URL Git test to the file holding its helper

### DIFF
--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -882,3 +882,34 @@ async def test_run_git_cancellation_kills_subprocess(
 
     assert process.kill_called is True
     assert process.wait_called is True
+
+
+@pytest.mark.asyncio
+async def test_run_git_reports_the_git_failure_when_stderr_holds_an_unparseable_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed URLs in Git output must not replace the failure with a parse error.
+
+    Redaction runs on whatever a remote or a local ``git`` chose to print, and an
+    unterminated IPv6 literal makes ``urlparse`` raise. Raising there would
+    destroy the diagnostic exactly when something has already gone wrong.
+    """
+    manager = _git_manager(tmp_path)
+
+    class _FailingProcess:
+        returncode = 128
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b"fatal: unable to access 'http://[': bad address"
+
+    async def _fake_create_subprocess_exec(*args: object, **kwargs: object) -> _FailingProcess:
+        _ = args, kwargs
+        return _FailingProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+
+    with pytest.raises(RuntimeError, match="Git command failed with exit code 128") as exc_info:
+        await manager.git_source._run_git(["fetch", "origin", "main"])
+
+    assert "bad address" in str(exc_info.value)

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -8117,37 +8117,6 @@ def test_long_credential_free_urls_keep_their_diagnostic(length: int) -> None:
     assert redact_credentials_in_text(text) == text
 
 
-@pytest.mark.asyncio
-async def test_run_git_reports_the_git_failure_when_stderr_holds_an_unparseable_url(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Malformed URLs in Git output must not replace the failure with a parse error.
-
-    Redaction runs on whatever a remote or a local ``git`` chose to print, and an
-    unterminated IPv6 literal makes ``urlparse`` raise. Raising there would
-    destroy the diagnostic exactly when something has already gone wrong.
-    """
-    manager = _git_manager(tmp_path)
-
-    class _FailingProcess:
-        returncode = 128
-
-        async def communicate(self) -> tuple[bytes, bytes]:
-            return b"", b"fatal: unable to access 'http://[': bad address"
-
-    async def _fake_create_subprocess_exec(*args: object, **kwargs: object) -> _FailingProcess:
-        _ = args, kwargs
-        return _FailingProcess()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
-
-    with pytest.raises(RuntimeError, match="Git command failed with exit code 128") as exc_info:
-        await manager.git_source._run_git(["fetch", "origin", "main"])
-
-    assert "bad address" in str(exc_info.value)
-
-
 def test_redacting_a_non_ascii_basic_token_does_not_raise() -> None:
     """A Basic token that is not decodable must still redact, not blow up.
 


### PR DESCRIPTION
`pytest` is red on `main` at `3697e6a0d`:

```
FAILED tests/test_knowledge_manager.py::test_run_git_reports_the_git_failure_when_stderr_holds_an_unparseable_url
  NameError: name '_git_manager' is not defined
```

`ruff check` flags the same line as `F821`.

## Cause

A semantic conflict between two PRs that merged in sequence, neither of which conflicted textually.

- #1724 moved the `_git_manager` helper out of `tests/test_knowledge_manager.py` into `tests/test_knowledge_git_source.py`.
- #1719 independently added `test_run_git_reports_the_git_failure_when_stderr_holds_an_unparseable_url` to `tests/test_knowledge_manager.py`, calling that helper.

Each was green against its own base. The two edits sit roughly 2000 lines apart, so Git reported no conflict and neither PR's CI could observe the break — it exists only in the merged tree.

## Fix

Move the one test into `tests/test_knowledge_git_source.py`, which already defines the helper. The test's subject is `git_source._run_git`, so that is where it belonged regardless; #1724 would have moved it had it existed at the time.

The test body is unchanged. `asyncio`, `pytest` and `Path` are already imported in the destination file, so no import changes were needed.

## Verification

- Moved test passes in its new home.
- Collection across the two files is unchanged at **274**: `257 + 17` becomes `256 + 18`.
- The only remaining `_git_manager` match in the manager file is an unrelated test *name*, `test_git_manager_construction_does_not_probe_checkout_on_event_loop`.
- `ruff check` clean on both files; full pre-commit clean.

## Summary by Sourcery

Tests:
- Relocate the unparseable-URL git failure test from the knowledge manager tests to the git source tests so it can use the shared _git_manager helper and pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when Git reports failures containing malformed URLs, preserving the original Git error details.
  * Ensured credential redaction safely handles non-ASCII Basic authorization tokens.

* **Tests**
  * Added coverage for malformed Git error URLs and non-ASCII authorization headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->