### PR TITLE
Log exact checkpoint discard predicates

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1756,6 +1756,8 @@ class AgentBot:
                 agent_name=self.agent_name,
                 callback_failure_count=callback_failure_count,
                 background_tasks_completed=background_tasks_completed,
+                coalescing_drain_completed=drain_result.completed,
+                responses_drained=responses_drained,
                 post_drain_background_tasks_completed=post_drain_background_tasks_completed,
                 released_reservation_count=drain_result.released_reservation_count,
                 cancelled_unready_count=drain_result.cancelled_unready_count,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ import mindroom.bot  # noqa: F401
 from mindroom.agent_storage import get_agent_session, get_team_session
 from mindroom.ai import ResponseTurnContext
 from mindroom.bot import AgentBot, TeamBot
+from mindroom.coalescing import CoalescingDrainResult
 from mindroom.config.main import Config, load_config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths, safe_replace
 from mindroom.conversation_resolver import DispatchContextResult, MessageContext
@@ -169,6 +170,7 @@ __all__ = [
     "install_generate_response_mock",
     "install_runtime_cache_support",
     "install_send_response_mock",
+    "install_shutdown_drain_mocks",
     "load_config_yaml",
     "make_conversation_cache_mock",
     "make_event_cache_mock",
@@ -1402,6 +1404,20 @@ def patch_response_runner_module(**changes: object) -> Generator[None, None, Non
             )
             stack.enter_context(patch(f"{module_name}.{name}", new=replacement))
         yield
+
+
+def install_shutdown_drain_mocks(
+    bot: RuntimeBot,
+    *,
+    coalescing_drain_completed: bool,
+    responses_drained: bool,
+) -> None:
+    """Install exact shutdown drain outcomes through stable collaborator seams."""
+    wrap_extracted_collaborators(bot, "_coalescing_gate", "_response_runner")
+    bot._coalescing_gate.drain_all = AsyncMock(
+        return_value=CoalescingDrainResult(completed=coalescing_drain_completed),
+    )
+    bot._response_runner.drain_inbox_responses = AsyncMock(return_value=responses_drained)
 
 
 def install_send_response_mock(bot: RuntimeBot, send_response: AsyncMock) -> None:

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -1038,6 +1038,38 @@ async def test_shutdown_timeout_does_not_save_checkpoint_for_cancelled_ingress(t
     assert _load_sync_token_value(tmp_path, bot.agent_name) is None
 
 
+@pytest.mark.parametrize(
+    ("coalescing_drain_completed", "responses_drained"),
+    [
+        (True, False),
+        (False, True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_shutdown_discard_warning_logs_exact_drain_predicates(
+    tmp_path: Path,
+    coalescing_drain_completed: bool,
+    responses_drained: bool,
+) -> None:
+    """Checkpoint-discard logs should identify which content-free drain predicate failed."""
+    bot = _agent_bot(tmp_path)
+    bot._coalescing_gate.drain_all = AsyncMock(
+        return_value=CoalescingDrainResult(completed=coalescing_drain_completed),
+    )
+    bot._response_runner.drain_inbox_responses = AsyncMock(return_value=responses_drained)
+
+    with capture_logs() as logs:
+        await bot.prepare_for_sync_shutdown()
+
+    warnings = [
+        entry for entry in logs if entry["event"] == "sync_checkpoint_not_saved_after_incomplete_coalescing_drain"
+    ]
+    assert len(warnings) == 1
+    assert warnings[0]["coalescing_drain_completed"] is coalescing_drain_completed
+    assert warnings[0]["responses_drained"] is responses_drained
+    assert not {"body", "content", "formatted_body", "message_content"} & warnings[0].keys()
+
+
 @pytest.mark.asyncio
 async def test_shutdown_timeout_does_not_save_checkpoint_for_unsettled_callbacks(tmp_path: Path) -> None:
     """Shutdown must not checkpoint if callback tasks timed out before the gate drain."""

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -41,6 +41,7 @@ from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
     install_runtime_cache_support,
+    install_shutdown_drain_mocks,
     make_matrix_client_mock,
     runtime_paths_for,
     test_runtime_paths,
@@ -1053,10 +1054,11 @@ async def test_shutdown_discard_warning_logs_exact_drain_predicates(
 ) -> None:
     """Checkpoint-discard logs should identify which content-free drain predicate failed."""
     bot = _agent_bot(tmp_path)
-    bot._coalescing_gate.drain_all = AsyncMock(
-        return_value=CoalescingDrainResult(completed=coalescing_drain_completed),
+    install_shutdown_drain_mocks(
+        bot,
+        coalescing_drain_completed=coalescing_drain_completed,
+        responses_drained=responses_drained,
     )
-    bot._response_runner.drain_inbox_responses = AsyncMock(return_value=responses_drained)
 
     with capture_logs() as logs:
         await bot.prepare_for_sync_shutdown()


### PR DESCRIPTION
## Summary

- Add `coalescing_drain_completed` and `responses_drained` to the existing content-free checkpoint-discard warning.
- Cover response-only and coalescing-only drain failures with structured-log assertions.
- Preserve shutdown and checkpoint behavior unchanged.

## Validation

- `pytest tests/test_matrix_sync_tokens.py -x --lf --cache-clear -n 0 --no-cov -q` (58 passed)
- Changed-file Ruff, formatting, and ty checks passed.
- Full pytest reached 5,536 passed and 32 skipped before stopping on the existing undefined `_git_manager` helper in `tests/test_knowledge_manager.py:8131`.
- `pre-commit run --all-files` passed all hooks except Ruff and ty on that same existing undefined helper.

## Summary by Sourcery

Log detailed predicates for incomplete coalescing drain during sync shutdown and verify them via tests.

New Features:
- Include coalescing and response drain completion flags in the sync checkpoint discard warning log.

Tests:
- Add parametrized async test to assert that checkpoint-discard warnings log the exact drain predicate values without leaking message content.