### PR TITLE
Reject hidden SSH credentials before Git persistence

### DIFF
--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -195,11 +195,21 @@ def _parsed_remote_url(clean_url: str, base_id: str) -> str:
     if parsed.netloc.count("@") > 1:
         raise _unwritable_remote(base_id, "the URL has an ambiguous authority")
 
-    # No check for a password in the authority: ``credential_free_repo_url`` has
-    # already stripped one, and the bare ``user@host`` it deliberately keeps for
-    # SSH has no colon. A 400k-case fuzz reached this point with a password zero
-    # times, so a branch here would be untested code guarding nothing.
     return clean_url
+
+
+def _refuse_decoded_ssh_password(decoded_url: str, base_id: str) -> None:
+    """Refuse an SSH password separator hidden from the sanitizing parse."""
+    if not decoded_url.lower().startswith("ssh://"):
+        return
+
+    try:
+        parsed = urlparse(decoded_url)
+    except ValueError:
+        raise _unwritable_remote(base_id, "the decoded URL cannot be parsed") from None
+
+    if parsed.scheme == "ssh" and parsed.netloc and parsed.password is not None:
+        raise _unwritable_remote(base_id, "an encoded separator hides authentication credentials")
 
 
 def _persistable_remote_url(repo_url: str, base_id: str) -> str:
@@ -240,8 +250,11 @@ def _persistable_remote_url(repo_url: str, base_id: str) -> str:
         # repository URL is never this long, so refusing costs nothing real.
         raise _unwritable_remote(base_id, "the URL is implausibly long")
 
-    if fully_unquoted(clean_url).count("@") != clean_url.count("@"):
+    decoded_url = fully_unquoted(clean_url)
+    if decoded_url.count("@") != clean_url.count("@"):
         raise _unwritable_remote(base_id, "a percent-encoded separator hides part of the URL")
+
+    _refuse_decoded_ssh_password(decoded_url, base_id)
 
     if clean_url.count("://") > 1:
         # A second URL nested in the path carries its own userinfo, which the

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 
+import mindroom.knowledge.git_source as knowledge_git_source_module
 from mindroom.config.knowledge import KnowledgeGitConfig
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.knowledge.git_source import GitKnowledgeSource, GitSyncResult
@@ -59,6 +60,34 @@ def _git_manager(
     if include_extensions is not None:
         config.knowledge_bases["docs"].include_extensions = include_extensions
     return KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
+
+
+@pytest.mark.parametrize(
+    "repo_url",
+    [
+        pytest.param("ssh://git%3AS3CR3T-CANARY@example.com/org/repo.git", id="encoded-colon"),
+        pytest.param("ssh://git%253AS3CR3T-CANARY@example.com/org/repo.git", id="double-encoded-colon"),
+        pytest.param("ssh://git\uff1aS3CR3T-CANARY@example.com/org/repo.git", id="nfkc-colon"),
+    ],
+)
+def test_hidden_ssh_password_separator_is_refused_before_persistence(repo_url: str) -> None:
+    """Hidden SSH credentials must never reach the checkout's Git config."""
+    with pytest.raises(RuntimeError, match="Refusing to write an unsafe remote URL") as exc_info:
+        knowledge_git_source_module._persistable_remote_url(repo_url, "docs")
+
+    assert "S3CR3T-CANARY" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "repo_url",
+    [
+        "ssh://git@example.com/org/repo.git",
+        "ssh://git@example.com:2222/org:repo.git",
+    ],
+)
+def test_passwordless_ssh_authority_forms_remain_persistable(repo_url: str) -> None:
+    """Usernames, ports, and colons outside userinfo remain supported."""
+    assert knowledge_git_source_module._persistable_remote_url(repo_url, "docs") == repo_url
 
 
 @pytest.mark.asyncio
@@ -743,6 +772,37 @@ async def test_run_git_redacts_credentials_in_error_message(
     message = str(exc_info.value)
     assert "secret-token" not in message
     assert "https://***@github.com/example/private.git" in message
+
+
+@pytest.mark.asyncio
+async def test_run_git_reports_the_git_failure_when_stderr_holds_an_unparseable_url(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed URLs in Git output must not replace the failure with a parse error.
+
+    Redaction runs on whatever a remote or a local ``git`` chose to print, and an
+    unterminated IPv6 literal makes ``urlparse`` raise. Raising there would
+    destroy the diagnostic exactly when something has already gone wrong.
+    """
+    manager = _git_manager(tmp_path)
+
+    class _FailingProcess:
+        returncode = 128
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b"fatal: unable to access 'http://[': bad address"
+
+    async def _fake_create_subprocess_exec(*args: object, **kwargs: object) -> _FailingProcess:
+        _ = args, kwargs
+        return _FailingProcess()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+
+    with pytest.raises(RuntimeError, match="Git command failed with exit code 128") as exc_info:
+        await manager.git_source._run_git(["fetch", "origin", "main"])
+
+    assert "bad address" in str(exc_info.value)
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -775,37 +775,6 @@ async def test_run_git_redacts_credentials_in_error_message(
 
 
 @pytest.mark.asyncio
-async def test_run_git_reports_the_git_failure_when_stderr_holds_an_unparseable_url(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Malformed URLs in Git output must not replace the failure with a parse error.
-
-    Redaction runs on whatever a remote or a local ``git`` chose to print, and an
-    unterminated IPv6 literal makes ``urlparse`` raise. Raising there would
-    destroy the diagnostic exactly when something has already gone wrong.
-    """
-    manager = _git_manager(tmp_path)
-
-    class _FailingProcess:
-        returncode = 128
-
-        async def communicate(self) -> tuple[bytes, bytes]:
-            return b"", b"fatal: unable to access 'http://[': bad address"
-
-    async def _fake_create_subprocess_exec(*args: object, **kwargs: object) -> _FailingProcess:
-        _ = args, kwargs
-        return _FailingProcess()
-
-    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
-
-    with pytest.raises(RuntimeError, match="Git command failed with exit code 128") as exc_info:
-        await manager.git_source._run_git(["fetch", "origin", "main"])
-
-    assert "bad address" in str(exc_info.value)
-
-
-@pytest.mark.asyncio
 async def test_run_git_timeout_kills_subprocess_and_raises_runtime_error(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -7977,10 +7977,6 @@ async def test_valid_json_does_not_hide_downstream_json_decode_error(
     assert all(entry["event"] != "Malformed JSON knowledge file; indexing as text" for entry in logs)
 
 
-#: fixed; ``ambiguous-authority`` was already redacted by luck, because its last
-#: ``@`` happens to fall after the secret, and is pinned so it stays that way.
-
-
 #: Repository URLs that must never be written to ``.git/config``. The first four
 #: are documented provider credential forms with the scheme mistyped or dropped;
 #: ``urlparse`` reports the username as a scheme and finds no authority, so a


### PR DESCRIPTION
## Summary

- refuse percent-encoded, repeatedly encoded, and NFKC-equivalent SSH password separators before a remote reaches .git/config
- preserve passwordless SSH usernames, ports, and path colons
- remove the orphaned test comment left by the earlier redaction follow-up

Follow-up to #1719. Rebasing onto #1728 keeps its Git-source test move as the single source of truth.

## Testing

- uv run pytest -n 8: 12,175 passed, 54 skipped
- uv run pre-commit run --all-files
- uv run tach check --dependencies --interfaces
- focused Git URL persistence tests: 6 passed

## Summary by Sourcery

Reject unsafe SSH remote URLs with hidden password separators before persisting Git configuration.

Bug Fixes:
- Prevent SSH URLs with percent-encoded, repeatedly encoded, or NFKC-equivalent password separators from being written to .git/config.
- Ensure error messages for rejected SSH URLs do not leak credential-like substrings.

Enhancements:
- Preserve support for passwordless SSH usernames, ports, and path colons in persistable remote URLs.

Tests:
- Add regression tests covering rejection of SSH URLs with hidden password separators and acceptance of safe SSH authority forms.
- Remove an obsolete comment related to previously fixed ambiguous authority redaction tests.