### PR TITLE
Gate router handoffs on target first-sync readiness

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -643,6 +643,11 @@ class AgentBot:
         self._runtime_view.client = value
 
     @property
+    def first_sync_complete(self) -> bool:
+        """Return whether this bot generation completed its first sync."""
+        return self._first_sync_done
+
+    @property
     def config(self) -> Config:
         """Return the canonical live config."""
         return self._runtime_view.config

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -314,6 +314,13 @@ class _MultiAgentOrchestrator:
         """Return the orchestrator-owned background knowledge refresh scheduler."""
         return self._knowledge_refresh_scheduler
 
+    def entity_first_sync_complete(self, entity_name: str) -> bool | None:
+        """Return first-sync readiness for the current entity generation."""
+        bot = self.agent_bots.get(entity_name)
+        if bot is None:
+            return None
+        return bot.running and bot.first_sync_complete
+
     async def _stop_memory_auto_flush_worker(self) -> None:
         """Stop the background memory auto-flush worker if running."""
         worker = self._memory_auto_flush_worker

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -6,7 +6,7 @@ import asyncio
 import signal
 import time
 from collections.abc import Awaitable, Callable
-from contextlib import suppress
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field, replace
 from functools import partial
 from typing import TYPE_CHECKING, NoReturn, cast, overload
@@ -124,7 +124,7 @@ from .runtime_support import (
 
 if TYPE_CHECKING:
     import socket
-    from collections.abc import Awaitable, Callable, Iterable
+    from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
     from pathlib import Path
     from types import FrameType
 
@@ -320,6 +320,12 @@ class _MultiAgentOrchestrator:
         if bot is None:
             return None
         return bot.running and bot.first_sync_complete
+
+    @asynccontextmanager
+    async def entity_first_sync_readiness_guard(self, entity_name: str) -> AsyncIterator[bool | None]:
+        """Keep the sampled entity generation current through one guarded delivery."""
+        async with self._config_update_lock:
+            yield self.entity_first_sync_complete(entity_name)
 
     async def _stop_memory_auto_flush_worker(self) -> None:
         """Stop the background memory auto-flush worker if running."""

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -6,7 +6,7 @@ import asyncio
 import signal
 import time
 from collections.abc import Awaitable, Callable
-from contextlib import asynccontextmanager, suppress
+from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from functools import partial
 from typing import TYPE_CHECKING, NoReturn, cast, overload
@@ -124,7 +124,7 @@ from .runtime_support import (
 
 if TYPE_CHECKING:
     import socket
-    from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
+    from collections.abc import Awaitable, Callable, Iterable
     from pathlib import Path
     from types import FrameType
 
@@ -320,12 +320,6 @@ class _MultiAgentOrchestrator:
         if bot is None:
             return None
         return bot.running and bot.first_sync_complete
-
-    @asynccontextmanager
-    async def entity_first_sync_readiness_guard(self, entity_name: str) -> AsyncIterator[bool | None]:
-        """Keep the sampled entity generation current through one guarded delivery."""
-        async with self._config_update_lock:
-            yield self.entity_first_sync_complete(entity_name)
 
     async def _stop_memory_auto_flush_worker(self) -> None:
         """Stop the background memory auto-flush worker if running."""

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -586,7 +586,7 @@ class ResponseRunner:
         """Wake pre-admission responses whose owning runtime is shutting down."""
         self._admission_shutdown_requested.set()
 
-    async def _wait_for_admission_or_shutdown(self) -> bool:
+    async def wait_for_admission_or_shutdown(self) -> bool:
         """Return whether admission reopened before this runtime started shutdown."""
         if self._admission_shutdown_requested.is_set():
             return False
@@ -834,7 +834,7 @@ class ResponseRunner:
                     response_kind=response_kind,
                     **request.response_envelope.target.log_context,
                 )
-            if not await self._wait_for_admission_or_shutdown():
+            if not await self.wait_for_admission_or_shutdown():
                 self.deps.logger.warning(
                     "response_refused_after_runtime_replacement",
                     response_kind=response_kind,

--- a/src/mindroom/runtime_protocols.py
+++ b/src/mindroom/runtime_protocols.py
@@ -61,6 +61,10 @@ class OrchestratorRuntime(Protocol):
         """Validate persisted managed Matrix identities for the live config."""
         ...
 
+    def entity_first_sync_complete(self, entity_name: str) -> bool | None:
+        """Return first-sync readiness for the current entity generation."""
+        ...
+
     def handle_bot_ready(self, bot: AgentBot | TeamBot) -> Awaitable[None]:
         """Handle a managed bot completing its first sync."""
         ...

--- a/src/mindroom/runtime_protocols.py
+++ b/src/mindroom/runtime_protocols.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
-    from contextlib import AbstractAsyncContextManager
 
     import nio
 
@@ -64,13 +63,6 @@ class OrchestratorRuntime(Protocol):
 
     def entity_first_sync_complete(self, entity_name: str) -> bool | None:
         """Return first-sync readiness for the current entity generation."""
-        ...
-
-    def entity_first_sync_readiness_guard(
-        self,
-        entity_name: str,
-    ) -> AbstractAsyncContextManager[bool | None]:
-        """Keep the sampled entity generation current through one guarded delivery."""
         ...
 
     def handle_bot_ready(self, bot: AgentBot | TeamBot) -> Awaitable[None]:

--- a/src/mindroom/runtime_protocols.py
+++ b/src/mindroom/runtime_protocols.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable
+    from contextlib import AbstractAsyncContextManager
 
     import nio
 
@@ -63,6 +64,13 @@ class OrchestratorRuntime(Protocol):
 
     def entity_first_sync_complete(self, entity_name: str) -> bool | None:
         """Return first-sync readiness for the current entity generation."""
+        ...
+
+    def entity_first_sync_readiness_guard(
+        self,
+        entity_name: str,
+    ) -> AbstractAsyncContextManager[bool | None]:
+        """Keep the sampled entity generation current through one guarded delivery."""
         ...
 
     def handle_bot_ready(self, bot: AgentBot | TeamBot) -> Awaitable[None]:

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -30,6 +30,7 @@ from mindroom.handled_turns import TurnRecord
 from mindroom.inbound_turn_normalizer import TextNormalizationRequest
 from mindroom.matrix.media import is_audio_message_event, is_matrix_media_dispatch_event
 from mindroom.matrix.rooms import is_dm_room
+from mindroom.response_admission import ResponseAdmissionRefusedError
 from mindroom.response_payload_preparation import DispatchPayloadInputs
 from mindroom.timing import (
     DispatchPipelineTiming,
@@ -492,6 +493,20 @@ async def _run_claimed_response(
         controller.deps.turn_store.release_pending_turn_claim(turn_claim)
 
 
+async def _run_admitted_router_relay(
+    controller: TurnController,
+    relay: Callable[[], Awaitable[None]],
+) -> None:
+    """Keep config application outside one router selection and relay delivery."""
+    admission_gate = controller.deps.runtime.response_admission_gate
+    if not admission_gate.admit():
+        raise ResponseAdmissionRefusedError
+    try:
+        await relay()
+    finally:
+        admission_gate.release()
+
+
 async def _execute_route_plan(
     controller: TurnController,
     room: nio.MatrixRoom,
@@ -526,12 +541,15 @@ async def _execute_route_plan(
         )
     if prepared.dispatch.scheduled_history_budget is not None:
         routing_kwargs["scheduled_prompt"] = prepared.event.body
-    await controller._execute_router_relay(
-        room,
-        route_event,
-        prepared.dispatch.context.thread_history,
-        prepared.dispatch.target.resolved_thread_id,
-        **routing_kwargs,
+    await _run_admitted_router_relay(
+        controller,
+        lambda: controller._execute_router_relay(
+            room,
+            route_event,
+            prepared.dispatch.context.thread_history,
+            prepared.dispatch.target.resolved_thread_id,
+            **routing_kwargs,
+        ),
     )
 
 

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -499,8 +499,10 @@ async def _run_admitted_router_relay(
 ) -> None:
     """Keep config application outside one router selection and relay delivery."""
     admission_gate = controller.deps.runtime.response_admission_gate
-    if not admission_gate.admit():
-        raise ResponseAdmissionRefusedError
+    while not admission_gate.admit():
+        if not await controller.deps.response_runner.wait_for_admission_or_shutdown():
+            controller.deps.runtime.mark_callback_failed()
+            raise ResponseAdmissionRefusedError
     try:
         await relay()
     finally:

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -162,7 +162,7 @@ def _gate_router_target_readiness(
     return (suggested_entity if first_sync_complete is True else None, first_sync_complete is False)
 
 
-async def _send_router_relay_with_readiness_guard(
+async def _send_router_relay_after_readiness_recheck(
     *,
     orchestrator: OrchestratorRuntime | None,
     delivery_gateway: DeliveryGateway,
@@ -170,23 +170,21 @@ async def _send_router_relay_with_readiness_guard(
     suggested_entity: str | None,
     delivery_request: SendTextRequest,
 ) -> tuple[str | None, str | None]:
-    """Send one relay while preventing its sampled target generation from changing."""
+    """Recheck one sampled target immediately before sending its relay."""
     if selected_entity is None or orchestrator is None:
         return await delivery_gateway.send_text(delivery_request), suggested_entity
-    async with orchestrator.entity_first_sync_readiness_guard(selected_entity) as final_readiness:
-        if final_readiness is True:
-            return await delivery_gateway.send_text(delivery_request), suggested_entity
-        fallback_extra_content = dict(delivery_request.extra_content or {})
-        fallback_extra_content.pop(ORIGINAL_SENDER_KEY, None)
-        fallback_extra_content.pop(SOURCE_KIND_KEY, None)
-        fallback_request = replace(
-            delivery_request,
-            response_text=(
-                _ROUTER_TARGET_STARTING_TEXT if final_readiness is False else _ROUTER_TARGET_UNAVAILABLE_TEXT
-            ),
-            extra_content=fallback_extra_content or None,
-        )
-        return await delivery_gateway.send_text(fallback_request), None
+    final_readiness = orchestrator.entity_first_sync_complete(selected_entity)
+    if final_readiness is True:
+        return await delivery_gateway.send_text(delivery_request), suggested_entity
+    fallback_extra_content = dict(delivery_request.extra_content or {})
+    fallback_extra_content.pop(ORIGINAL_SENDER_KEY, None)
+    fallback_extra_content.pop(SOURCE_KIND_KEY, None)
+    fallback_request = replace(
+        delivery_request,
+        response_text=_ROUTER_TARGET_STARTING_TEXT if final_readiness is False else _ROUTER_TARGET_UNAVAILABLE_TEXT,
+        extra_content=fallback_extra_content or None,
+    )
+    return await delivery_gateway.send_text(fallback_request), None
 
 
 def _room_level_context_event(event: TextDispatchEvent) -> TextDispatchEvent:
@@ -1587,7 +1585,7 @@ class TurnController:
             response_text=response_text,
             extra_content=routed_extra_content or None,
         )
-        event_id, suggested_entity = await _send_router_relay_with_readiness_guard(
+        event_id, suggested_entity = await _send_router_relay_after_readiness_recheck(
             orchestrator=self.deps.runtime.orchestrator,
             delivery_gateway=self.deps.delivery_gateway,
             selected_entity=selected_entity,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -135,6 +135,7 @@ if TYPE_CHECKING:
     from mindroom.message_target import MessageTarget
     from mindroom.response_lifecycle import QueuedHumanNoticeReservation
     from mindroom.response_runner import ResponseRunner
+    from mindroom.runtime_protocols import OrchestratorRuntime
     from mindroom.sync_restart_retry import InterruptedTurnRooms
     from mindroom.tool_system.runtime_context import ToolRuntimeSupport
     from mindroom.turn_store import TurnStore
@@ -143,6 +144,17 @@ if TYPE_CHECKING:
 
 _QUEUED_NOTICE_METADATA_KIND = "queued_notice_reservation"
 _PENDING_TURN_CLAIM_METADATA_KIND = "pending_turn_claim"
+
+
+def _gate_router_target_readiness(
+    orchestrator: OrchestratorRuntime | None,
+    suggested_entity: str | None,
+) -> tuple[str | None, bool]:
+    """Drop a known unready or stale router selection before relay delivery."""
+    if suggested_entity is None or orchestrator is None:
+        return suggested_entity, False
+    first_sync_complete = orchestrator.entity_first_sync_complete(suggested_entity)
+    return (suggested_entity if first_sync_complete is True else None, first_sync_complete is False)
 
 
 def _room_level_context_event(event: TextDispatchEvent) -> TextDispatchEvent:
@@ -1469,7 +1481,14 @@ class TurnController:
                     thread_history,
                 )
 
-        if not suggested_entity:
+        suggested_entity, target_starting = _gate_router_target_readiness(
+            self.deps.runtime.orchestrator,
+            suggested_entity,
+        )
+
+        if target_starting:
+            response_text = "That agent is still starting. Please try again shortly."
+        elif not suggested_entity:
             response_text = (
                 "⚠️ I couldn't determine which agent or team should help with this. "
                 "Please try mentioning an agent or team directly with @ or rephrase your request."

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -144,6 +144,11 @@ if TYPE_CHECKING:
 
 _QUEUED_NOTICE_METADATA_KIND = "queued_notice_reservation"
 _PENDING_TURN_CLAIM_METADATA_KIND = "pending_turn_claim"
+_ROUTER_TARGET_STARTING_TEXT = "That agent is still starting. Please try again shortly."
+_ROUTER_TARGET_UNAVAILABLE_TEXT = (
+    "⚠️ I couldn't determine which agent or team should help with this. "
+    "Please try mentioning an agent or team directly with @ or rephrase your request."
+)
 
 
 def _gate_router_target_readiness(
@@ -155,6 +160,33 @@ def _gate_router_target_readiness(
         return suggested_entity, False
     first_sync_complete = orchestrator.entity_first_sync_complete(suggested_entity)
     return (suggested_entity if first_sync_complete is True else None, first_sync_complete is False)
+
+
+async def _send_router_relay_with_readiness_guard(
+    *,
+    orchestrator: OrchestratorRuntime | None,
+    delivery_gateway: DeliveryGateway,
+    selected_entity: str | None,
+    suggested_entity: str | None,
+    delivery_request: SendTextRequest,
+) -> tuple[str | None, str | None]:
+    """Send one relay while preventing its sampled target generation from changing."""
+    if selected_entity is None or orchestrator is None:
+        return await delivery_gateway.send_text(delivery_request), suggested_entity
+    async with orchestrator.entity_first_sync_readiness_guard(selected_entity) as final_readiness:
+        if final_readiness is True:
+            return await delivery_gateway.send_text(delivery_request), suggested_entity
+        fallback_extra_content = dict(delivery_request.extra_content or {})
+        fallback_extra_content.pop(ORIGINAL_SENDER_KEY, None)
+        fallback_extra_content.pop(SOURCE_KIND_KEY, None)
+        fallback_request = replace(
+            delivery_request,
+            response_text=(
+                _ROUTER_TARGET_STARTING_TEXT if final_readiness is False else _ROUTER_TARGET_UNAVAILABLE_TEXT
+            ),
+            extra_content=fallback_extra_content or None,
+        )
+        return await delivery_gateway.send_text(fallback_request), None
 
 
 def _room_level_context_event(event: TextDispatchEvent) -> TextDispatchEvent:
@@ -1481,18 +1513,16 @@ class TurnController:
                     thread_history,
                 )
 
+        selected_entity = suggested_entity
         suggested_entity, target_starting = _gate_router_target_readiness(
             self.deps.runtime.orchestrator,
             suggested_entity,
         )
 
         if target_starting:
-            response_text = "That agent is still starting. Please try again shortly."
+            response_text = _ROUTER_TARGET_STARTING_TEXT
         elif not suggested_entity:
-            response_text = (
-                "⚠️ I couldn't determine which agent or team should help with this. "
-                "Please try mentioning an agent or team directly with @ or rephrase your request."
-            )
+            response_text = _ROUTER_TARGET_UNAVAILABLE_TEXT
             with bound_log_context(room_id=room.room_id, thread_id=thread_id):
                 self.deps.logger.warning("Router failed to determine entity")
         else:
@@ -1552,12 +1582,17 @@ class TurnController:
             else:
                 routed_extra_content.pop(ATTACHMENT_IDS_KEY, None)
 
-        event_id = await self.deps.delivery_gateway.send_text(
-            SendTextRequest(
-                target=resolved_target,
-                response_text=response_text,
-                extra_content=routed_extra_content or None,
-            ),
+        delivery_request = SendTextRequest(
+            target=resolved_target,
+            response_text=response_text,
+            extra_content=routed_extra_content or None,
+        )
+        event_id, suggested_entity = await _send_router_relay_with_readiness_guard(
+            orchestrator=self.deps.runtime.orchestrator,
+            delivery_gateway=self.deps.delivery_gateway,
+            selected_entity=selected_entity,
+            suggested_entity=suggested_entity,
+            delivery_request=delivery_request,
         )
         tracked_handled_turn = handled_turn or TurnRecord.create([event.event_id])
         tracked_handled_turn = replace(

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -843,6 +843,25 @@ class TestMultiAgentOrchestrator:
         assert orchestrator.agent_bots == {}
         assert not orchestrator.running
 
+    def test_entity_first_sync_complete_tracks_current_generation(self, tmp_path: Path) -> None:
+        """Readiness must follow the bot currently registered for an entity."""
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        ready_bot = MagicMock(spec=AgentBot)
+        ready_bot.running = True
+        ready_bot.first_sync_complete = True
+        replacement_bot = MagicMock(spec=AgentBot)
+        replacement_bot.running = True
+        replacement_bot.first_sync_complete = False
+
+        orchestrator.agent_bots["general"] = ready_bot
+        assert orchestrator.entity_first_sync_complete("general") is True
+
+        orchestrator.agent_bots["general"] = replacement_bot
+        assert orchestrator.entity_first_sync_complete("general") is False
+
+        del orchestrator.agent_bots["general"]
+        assert orchestrator.entity_first_sync_complete("general") is None
+
     @pytest.mark.asyncio
     async def test_ensure_room_invitations_invites_authorized_users(self, tmp_path: Path) -> None:
         """Global users and room-permitted users should be invited to managed rooms."""

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -843,25 +843,6 @@ class TestMultiAgentOrchestrator:
         assert orchestrator.agent_bots == {}
         assert not orchestrator.running
 
-    def test_entity_first_sync_complete_tracks_current_generation(self, tmp_path: Path) -> None:
-        """Readiness must follow the bot currently registered for an entity."""
-        orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
-        ready_bot = MagicMock(spec=AgentBot)
-        ready_bot.running = True
-        ready_bot.first_sync_complete = True
-        replacement_bot = MagicMock(spec=AgentBot)
-        replacement_bot.running = True
-        replacement_bot.first_sync_complete = False
-
-        orchestrator.agent_bots["general"] = ready_bot
-        assert orchestrator.entity_first_sync_complete("general") is True
-
-        orchestrator.agent_bots["general"] = replacement_bot
-        assert orchestrator.entity_first_sync_complete("general") is False
-
-        del orchestrator.agent_bots["general"]
-        assert orchestrator.entity_first_sync_complete("general") is None
-
     @pytest.mark.asyncio
     async def test_ensure_room_invitations_invites_authorized_users(self, tmp_path: Path) -> None:
         """Global users and room-permitted users should be invited to managed rooms."""

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -28,6 +28,7 @@ from mindroom.matrix.identity import MatrixID, managed_account_key
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
+from mindroom.orchestrator import _MultiAgentOrchestrator
 from mindroom.routing import suggest_responder_for_message
 from mindroom.teams import TeamOutcome, TeamResolution
 from mindroom.thread_utils import AgentResponseDecision
@@ -141,6 +142,71 @@ def setup_test_bot(
     )
     bot.client = make_matrix_client_mock(user_id=agent.user_id)
     return install_runtime_cache_support(bot)
+
+
+def _router_readiness_runtime(
+    tmp_path: Path,
+) -> tuple[AgentBot, AgentBot, _MultiAgentOrchestrator, nio.MatrixRoom]:
+    """Return a live router and one running target that has not completed first sync."""
+    room_id = "!router-readiness:localhost"
+    config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General", rooms=[room_id])},
+            authorization={"default_room_access": True},
+        ),
+        tmp_path,
+    )
+    runtime_paths = runtime_paths_for(config)
+    ids = entity_ids(config, runtime_paths)
+    router_bot = setup_test_bot(
+        AgentMatrixUser(
+            agent_name="router",
+            password=TEST_PASSWORD,
+            display_name="Router",
+            user_id=ids["router"].full_id,
+        ),
+        tmp_path,
+        room_id,
+        config=config,
+    )
+    target_bot = setup_test_bot(
+        AgentMatrixUser(
+            agent_name="general",
+            password=TEST_PASSWORD,
+            display_name="General",
+            user_id=ids["general"].full_id,
+        ),
+        tmp_path,
+        room_id,
+        config=config,
+    )
+    orchestrator = _MultiAgentOrchestrator(runtime_paths)
+    orchestrator.config = config
+    orchestrator.agent_bots = {"router": router_bot, "general": target_bot}
+    router_bot.orchestrator = orchestrator
+    router_bot.running = target_bot.running = True
+    router_bot.client.room_send.return_value = nio.RoomSendResponse.from_dict(
+        {"event_id": "$router-response"},
+        room_id=room_id,
+    )
+    room = nio.MatrixRoom(room_id=room_id, own_user_id=ids["router"].full_id)
+    room.users = {
+        ids["router"].full_id: MagicMock(),
+        ids["general"].full_id: MagicMock(),
+        "@user:localhost": MagicMock(),
+    }
+    return router_bot, target_bot, orchestrator, room
+
+
+def _router_readiness_event(event_id: str) -> nio.RoomMessageText:
+    return nio.RoomMessageText.from_dict(
+        {
+            "event_id": event_id,
+            "sender": "@user:localhost",
+            "origin_server_ts": 1_000,
+            "content": {"msgtype": "m.text", "body": "Please route this"},
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -344,6 +410,77 @@ def mock_news_agent() -> AgentMatrixUser:
 
 class TestRoutingRegression:
     """Regression tests for routing behavior."""
+
+    @pytest.mark.asyncio
+    async def test_router_relay_waits_for_target_first_sync(self, tmp_path: Path) -> None:
+        """An unavailable target gets a visible status, then one relay after readiness."""
+        router_bot, target_bot, _, room = _router_readiness_runtime(tmp_path)
+
+        await router_bot._turn_controller._execute_router_relay(
+            room,
+            _router_readiness_event("$before-ready"),
+            [],
+            requester_user_id="@user:localhost",
+        )
+        target_bot._first_sync_done = True
+        await router_bot._turn_controller._execute_router_relay(
+            room,
+            _router_readiness_event("$after-ready"),
+            [],
+            requester_user_id="@user:localhost",
+        )
+
+        sent_contents = [call.kwargs["content"] for call in router_bot.client.room_send.await_args_list]
+        assert sent_contents[0]["body"] == "That agent is still starting. Please try again shortly."
+        assert ORIGINAL_SENDER_KEY not in sent_contents[0]
+        assert SOURCE_KIND_KEY not in sent_contents[0]
+        relay_contents = [
+            content for content in sent_contents if content.get(SOURCE_KIND_KEY) == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+        ]
+        assert len(relay_contents) == 1
+        assert relay_contents[0]["body"] == "@mindroom_general:localhost could you help with this?"
+        assert relay_contents[0][ORIGINAL_SENDER_KEY] == "@user:localhost"
+
+    @pytest.mark.asyncio
+    async def test_router_target_replacement_resets_first_sync_readiness(self, tmp_path: Path) -> None:
+        """A newly registered bot generation must not inherit readiness."""
+        router_bot, target_bot, orchestrator, room = _router_readiness_runtime(tmp_path)
+        target_bot._first_sync_done = True
+        replacement = setup_test_bot(
+            target_bot.agent_user,
+            tmp_path,
+            room.room_id,
+            config=target_bot.config,
+        )
+        replacement.running = True
+        replacement.orchestrator = orchestrator
+        orchestrator.agent_bots["general"] = replacement
+
+        await router_bot._turn_controller._execute_router_relay(
+            room,
+            _router_readiness_event("$replacement-starting"),
+            [],
+            requester_user_id="@user:localhost",
+        )
+
+        content = router_bot.client.room_send.await_args.kwargs["content"]
+        assert content["body"] == "That agent is still starting. Please try again shortly."
+        assert SOURCE_KIND_KEY not in content
+
+    @pytest.mark.asyncio
+    async def test_router_removed_target_keeps_existing_no_responder_behavior(self, tmp_path: Path) -> None:
+        """A removed target stays unavailable instead of gaining a false-ready path."""
+        router_bot, _, orchestrator, room = _router_readiness_runtime(tmp_path)
+        del orchestrator.agent_bots["general"]
+
+        await router_bot._turn_controller._execute_router_relay(
+            room,
+            _router_readiness_event("$removed"),
+            [],
+            requester_user_id="@user:localhost",
+        )
+
+        router_bot.client.room_send.assert_not_awaited()
 
     @pytest.mark.asyncio
     @patch("mindroom.response_attempt.is_user_online")
@@ -886,15 +1023,16 @@ class TestRoutingRegression:
             user_id=ids["router"].full_id,
         )
         router_bot = setup_test_bot(router_agent, tmp_path, test_room_id, config=test_config)
-        router_bot.orchestrator = SimpleNamespace(
-            agent_bots={
-                "alpha": SimpleNamespace(running=True),
-                "beta": SimpleNamespace(running=False),
-                "writer": SimpleNamespace(running=True),
-                "ops": SimpleNamespace(running=True),
-                "router": SimpleNamespace(running=True),
-            },
-        )
+        orchestrator = MagicMock(spec=_MultiAgentOrchestrator)
+        orchestrator.agent_bots = {
+            "alpha": SimpleNamespace(running=True),
+            "beta": SimpleNamespace(running=False),
+            "writer": SimpleNamespace(running=True),
+            "ops": SimpleNamespace(running=True),
+            "router": SimpleNamespace(running=True),
+        }
+        orchestrator.entity_first_sync_complete.return_value = True
+        router_bot.orchestrator = orchestrator
 
         mock_suggest_responder.side_effect = AssertionError("AI router should not see unavailable candidates")
         mock_send_response = MagicMock()

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -17,6 +17,8 @@ import pytest
 from agno.models.ollama import Ollama
 
 from mindroom.bot import AgentBot, TeamBot
+from mindroom.coalescing import CoalescingGate, ReadyPendingEvent
+from mindroom.coalescing_batch import CoalescingKey, PendingEvent
 from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
@@ -27,10 +29,10 @@ from mindroom.hooks import MessageEnvelope
 from mindroom.knowledge.utils import _KnowledgeResolution
 from mindroom.matrix.identity import MatrixID, managed_account_key
 from mindroom.matrix.state import MatrixState
+from mindroom.matrix.sync_certification import SyncCheckpoint, SyncTrustState
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestrator import _MultiAgentOrchestrator
-from mindroom.response_admission import ResponseAdmissionRefusedError
 from mindroom.routing import suggest_responder_for_message
 from mindroom.teams import TeamOutcome, TeamResolution
 from mindroom.text_ingress_dispatch import _run_admitted_router_relay
@@ -148,9 +150,7 @@ def setup_test_bot(
     return install_runtime_cache_support(bot)
 
 
-def _router_readiness_runtime(
-    tmp_path: Path,
-) -> tuple[AgentBot, AgentBot, _MultiAgentOrchestrator, nio.MatrixRoom]:
+def _router_readiness_runtime(tmp_path: Path) -> tuple[AgentBot, AgentBot, _MultiAgentOrchestrator, nio.MatrixRoom]:
     """Return a live router and one running target that has not completed first sync."""
     room_id = "!router-readiness:localhost"
     config = _runtime_bound_config(
@@ -179,9 +179,7 @@ def _router_readiness_runtime(
         room_id=room_id,
     )
     room = nio.MatrixRoom(room_id=room_id, own_user_id=ids["router"].full_id)
-    room.users = {
-        user_id: MagicMock() for user_id in (*[identity.full_id for identity in ids.values()], "@user:localhost")
-    }
+    room.users = {ids["general"].full_id: MagicMock(), "@user:localhost": MagicMock()}
     return router_bot, target_bot, orchestrator, room
 
 
@@ -193,6 +191,15 @@ def _router_readiness_event(event_id: str) -> nio.RoomMessageText:
             "origin_server_ts": 1_000,
             "content": {"msgtype": "m.text", "body": "Please route this"},
         },
+    )
+
+
+def _router_relay(router_bot: AgentBot, room: nio.MatrixRoom, event_id: str) -> Awaitable[None]:
+    return router_bot._turn_controller._execute_router_relay(
+        room,
+        _router_readiness_event(event_id),
+        [],
+        requester_user_id="@user:localhost",
     )
 
 
@@ -402,49 +409,31 @@ class TestRoutingRegression:
     async def test_router_relay_waits_for_target_first_sync(self, tmp_path: Path) -> None:
         """An unavailable target gets a visible status, then one relay after readiness."""
         router_bot, target_bot, _, room = _router_readiness_runtime(tmp_path)
-
-        await router_bot._turn_controller._execute_router_relay(
-            room,
-            _router_readiness_event("$before-ready"),
-            [],
-            requester_user_id="@user:localhost",
-        )
+        await _router_relay(router_bot, room, "$before-ready")
         target_bot._first_sync_done = True
-        await router_bot._turn_controller._execute_router_relay(
-            room,
-            _router_readiness_event("$after-ready"),
-            [],
-            requester_user_id="@user:localhost",
-        )
-
+        await _router_relay(router_bot, room, "$after-ready")
         sent_contents = [call.kwargs["content"] for call in router_bot.client.room_send.await_args_list]
         assert sent_contents[0]["body"] == "That agent is still starting. Please try again shortly."
         assert ORIGINAL_SENDER_KEY not in sent_contents[0]
         assert SOURCE_KIND_KEY not in sent_contents[0]
-        relay_contents = [
-            content for content in sent_contents if content.get(SOURCE_KIND_KEY) == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
-        ]
-        assert len(relay_contents) == 1
-        assert relay_contents[0]["body"] == "@mindroom_general:localhost could you help with this?"
-        assert relay_contents[0][ORIGINAL_SENDER_KEY] == "@user:localhost"
+        assert sent_contents[1][SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+        assert sent_contents[1]["body"] == "@mindroom_general:localhost could you help with this?"
+        assert sent_contents[1][ORIGINAL_SENDER_KEY] == "@user:localhost"
 
     @pytest.mark.asyncio
     async def test_router_relay_keeps_ready_generation_current_through_delivery(self, tmp_path: Path) -> None:
         """Config apply waits for relay delivery, and replacement readiness starts fresh."""
         router_bot, target_bot, orchestrator, room = _router_readiness_runtime(tmp_path)
-        target_bot._first_sync_done = True
-        replacement = MagicMock(spec=AgentBot)
-        replacement.running = True
-        replacement.first_sync_complete = False
+        router_bot._first_sync_done = target_bot._first_sync_done = True
+        replacement = MagicMock(spec=AgentBot, running=True, first_sync_complete=False)
+        fresh_replacement = MagicMock(spec=AgentBot, running=True, first_sync_complete=False)
         send_started = asyncio.Event()
         release_send = asyncio.Event()
 
-        def relay(event_id: str) -> Awaitable[None]:
-            return router_bot._turn_controller._execute_router_relay(
-                room,
-                _router_readiness_event(event_id),
-                [],
-                requester_user_id="@user:localhost",
+        def admitted_relay(event_id: str) -> Awaitable[None]:
+            return _run_admitted_router_relay(
+                router_bot._turn_controller,
+                lambda: _router_relay(router_bot, room, event_id),
             )
 
         async def blocking_room_send(**_: object) -> nio.RoomSendResponse:
@@ -455,51 +444,64 @@ class TestRoutingRegression:
         async def replace_target(relay_task: asyncio.Task[None]) -> None:
             await relay_task
             assert router_bot.admission_gate.close_if_idle()
-            try:
-                async with orchestrator._config_update_lock:
-                    orchestrator.agent_bots["general"] = replacement
-            finally:
-                router_bot.admission_gate.reopen()
+            async with orchestrator._config_update_lock:
+                orchestrator.agent_bots["general"] = fresh_replacement
+            router_bot.admission_gate.reopen()
+
+        router_bot.admission_gate.close()
+        target_reload_task = asyncio.create_task(admitted_relay("$target-reload"))
+        await asyncio.sleep(0)
+        assert not target_reload_task.done()
+        orchestrator.agent_bots["general"] = replacement
+        router_bot.admission_gate.reopen()
+        await target_reload_task
+        assert router_bot.client.room_send.await_count == 1
+        replacement.first_sync_complete = True
 
         router_bot.client.room_send.side_effect = blocking_room_send
-        router_bot.admission_gate.close()
-        with pytest.raises(ResponseAdmissionRefusedError):
-            await _run_admitted_router_relay(
-                router_bot._turn_controller,
-                lambda: relay("$config-already-applying"),
-            )
-        router_bot.admission_gate.reopen()
-        relay_task = asyncio.create_task(
-            _run_admitted_router_relay(
-                router_bot._turn_controller,
-                lambda: relay("$replacement-during-send"),
-            ),
-        )
+        relay_task = asyncio.create_task(admitted_relay("$replacement-during-send"))
         await send_started.wait()
         assert not router_bot.admission_gate.close_if_idle()
         replacement_task = asyncio.create_task(replace_target(relay_task))
         release_send.set()
         await asyncio.gather(relay_task, replacement_task)
 
-        assert orchestrator.agent_bots["general"] is replacement
-        await _run_admitted_router_relay(router_bot._turn_controller, lambda: relay("$replacement-starting"))
+        assert orchestrator.agent_bots["general"] is fresh_replacement
+        await admitted_relay("$replacement-starting")
         content = router_bot.client.room_send.await_args.kwargs["content"]
         assert content["body"] == "That agent is still starting. Please try again shortly."
         assert SOURCE_KIND_KEY not in content
+
+        coalescing_gate = CoalescingGate(
+            dispatch_batch=lambda _: admitted_relay("$router-shutdown"),
+            debounce_seconds=lambda: 0,
+            is_shutting_down=lambda: False,
+        )
+        router_bot.admission_gate.close()
+        router_bot._response_runner.refuse_pending_admissions()
+        await coalescing_gate.admit(
+            CoalescingKey(room.room_id, None, "@user:localhost"),
+            ready_result=ReadyPendingEvent(
+                pending_event=PendingEvent(
+                    event=_router_readiness_event("$router-shutdown"),
+                    room=room,
+                    source_kind="message",
+                ),
+            ),
+        )
+        await coalescing_gate.drain_all()
+        assert router_bot._runtime_view.callback_failure_count == 1
+        router_bot._sync_cache_trust.state = SyncTrustState.CERTIFIED
+        router_bot._sync_cache_trust.checkpoint = SyncCheckpoint("s_before_router_shutdown")
+        await router_bot.prepare_for_sync_shutdown()
+        assert router_bot._sync_cache_trust.checkpoint is None
 
     @pytest.mark.asyncio
     async def test_router_removed_target_keeps_existing_no_responder_behavior(self, tmp_path: Path) -> None:
         """A removed target stays unavailable instead of gaining a false-ready path."""
         router_bot, _, orchestrator, room = _router_readiness_runtime(tmp_path)
         del orchestrator.agent_bots["general"]
-
-        await router_bot._turn_controller._execute_router_relay(
-            room,
-            _router_readiness_event("$removed"),
-            [],
-            requester_user_id="@user:localhost",
-        )
-
+        await _router_relay(router_bot, room, "$removed")
         router_bot.client.room_send.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -30,8 +30,10 @@ from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
 from mindroom.orchestrator import _MultiAgentOrchestrator
+from mindroom.response_admission import ResponseAdmissionRefusedError
 from mindroom.routing import suggest_responder_for_message
 from mindroom.teams import TeamOutcome, TeamResolution
+from mindroom.text_ingress_dispatch import _run_admitted_router_relay
 from mindroom.thread_utils import AgentResponseDecision
 from mindroom.turn_policy import PreparedDispatch, TurnPolicy, TurnPolicyDeps, _ResponderAvailability
 from tests.conftest import (
@@ -48,6 +50,7 @@ from tests.conftest import (
 from tests.identity_helpers import actual_entity_usernames, entity_ids, entity_name_for_id, persist_entity_accounts
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable
     from pathlib import Path
 
     from mindroom.turn_origin import TurnOrigin
@@ -426,64 +429,63 @@ class TestRoutingRegression:
         assert relay_contents[0][ORIGINAL_SENDER_KEY] == "@user:localhost"
 
     @pytest.mark.asyncio
-    async def test_router_target_replacement_resets_first_sync_readiness(self, tmp_path: Path) -> None:
-        """A newly registered bot generation must not inherit readiness."""
+    async def test_router_relay_keeps_ready_generation_current_through_delivery(self, tmp_path: Path) -> None:
+        """Config apply waits for relay delivery, and replacement readiness starts fresh."""
         router_bot, target_bot, orchestrator, room = _router_readiness_runtime(tmp_path)
         target_bot._first_sync_done = True
         replacement = MagicMock(spec=AgentBot)
         replacement.running = True
         replacement.first_sync_complete = False
-        orchestrator.agent_bots["general"] = replacement
-
-        await router_bot._turn_controller._execute_router_relay(
-            room,
-            _router_readiness_event("$replacement-starting"),
-            [],
-            requester_user_id="@user:localhost",
-        )
-
-        content = router_bot.client.room_send.await_args.kwargs["content"]
-        assert content["body"] == "That agent is still starting. Please try again shortly."
-        assert SOURCE_KIND_KEY not in content
-
-    @pytest.mark.asyncio
-    async def test_router_relay_keeps_ready_generation_current_through_delivery(self, tmp_path: Path) -> None:
-        """A replacement cannot become current while its predecessor's relay is sending."""
-        router_bot, target_bot, orchestrator, room = _router_readiness_runtime(tmp_path)
-        target_bot._first_sync_done = True
-        replacement = MagicMock(spec=AgentBot)
         send_started = asyncio.Event()
         release_send = asyncio.Event()
+
+        def relay(event_id: str) -> Awaitable[None]:
+            return router_bot._turn_controller._execute_router_relay(
+                room,
+                _router_readiness_event(event_id),
+                [],
+                requester_user_id="@user:localhost",
+            )
 
         async def blocking_room_send(**_: object) -> nio.RoomSendResponse:
             send_started.set()
             await release_send.wait()
             return nio.RoomSendResponse.from_dict({"event_id": "$router-response"}, room_id=room.room_id)
 
-        async def replace_target() -> None:
-            async with orchestrator._config_update_lock:
-                orchestrator.agent_bots["general"] = replacement
+        async def replace_target(relay_task: asyncio.Task[None]) -> None:
+            await relay_task
+            assert router_bot.admission_gate.close_if_idle()
+            try:
+                async with orchestrator._config_update_lock:
+                    orchestrator.agent_bots["general"] = replacement
+            finally:
+                router_bot.admission_gate.reopen()
 
         router_bot.client.room_send.side_effect = blocking_room_send
+        router_bot.admission_gate.close()
+        with pytest.raises(ResponseAdmissionRefusedError):
+            await _run_admitted_router_relay(
+                router_bot._turn_controller,
+                lambda: relay("$config-already-applying"),
+            )
+        router_bot.admission_gate.reopen()
         relay_task = asyncio.create_task(
-            router_bot._turn_controller._execute_router_relay(
-                room,
-                _router_readiness_event("$replacement-during-send"),
-                [],
-                requester_user_id="@user:localhost",
+            _run_admitted_router_relay(
+                router_bot._turn_controller,
+                lambda: relay("$replacement-during-send"),
             ),
         )
         await send_started.wait()
-        replacement_task = asyncio.create_task(replace_target())
-        try:
-            await asyncio.sleep(0)
-            assert orchestrator.agent_bots["general"] is target_bot
-        finally:
-            release_send.set()
-            await relay_task
-            await replacement_task
+        assert not router_bot.admission_gate.close_if_idle()
+        replacement_task = asyncio.create_task(replace_target(relay_task))
+        release_send.set()
+        await asyncio.gather(relay_task, replacement_task)
 
         assert orchestrator.agent_bots["general"] is replacement
+        await _run_admitted_router_relay(router_bot._turn_controller, lambda: relay("$replacement-starting"))
+        content = router_bot.client.room_send.await_args.kwargs["content"]
+        assert content["body"] == "That agent is still starting. Please try again shortly."
+        assert SOURCE_KIND_KEY not in content
 
     @pytest.mark.asyncio
     async def test_router_removed_target_keeps_existing_no_responder_behavior(self, tmp_path: Path) -> None:

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -1041,16 +1041,15 @@ class TestRoutingRegression:
             user_id=ids["router"].full_id,
         )
         router_bot = setup_test_bot(router_agent, tmp_path, test_room_id, config=test_config)
-        orchestrator = MagicMock(spec=_MultiAgentOrchestrator)
+        orchestrator = _MultiAgentOrchestrator(runtime_paths)
+        orchestrator.config = test_config
         orchestrator.agent_bots = {
-            "alpha": SimpleNamespace(running=True),
-            "beta": SimpleNamespace(running=False),
-            "writer": SimpleNamespace(running=True),
-            "ops": SimpleNamespace(running=True),
-            "router": SimpleNamespace(running=True),
+            "alpha": MagicMock(spec=AgentBot, running=True, first_sync_complete=True),
+            "beta": MagicMock(spec=AgentBot, running=False, first_sync_complete=False),
+            "writer": MagicMock(spec=AgentBot, running=True, first_sync_complete=True),
+            "ops": MagicMock(spec=TeamBot, running=True, first_sync_complete=True),
+            "router": MagicMock(spec=AgentBot, running=True, first_sync_complete=True),
         }
-        orchestrator.entity_first_sync_complete.return_value = True
-        orchestrator.entity_first_sync_readiness_guard.return_value.__aenter__.return_value = True
         router_bot.orchestrator = orchestrator
 
         mock_suggest_responder.side_effect = AssertionError("AI router should not see unavailable candidates")

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -7,6 +7,7 @@ These tests ensure that fixed bugs don't resurface, particularly:
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -158,28 +159,13 @@ def _router_readiness_runtime(
     )
     runtime_paths = runtime_paths_for(config)
     ids = entity_ids(config, runtime_paths)
-    router_bot = setup_test_bot(
-        AgentMatrixUser(
-            agent_name="router",
-            password=TEST_PASSWORD,
-            display_name="Router",
-            user_id=ids["router"].full_id,
-        ),
-        tmp_path,
-        room_id,
-        config=config,
-    )
-    target_bot = setup_test_bot(
-        AgentMatrixUser(
-            agent_name="general",
-            password=TEST_PASSWORD,
-            display_name="General",
-            user_id=ids["general"].full_id,
-        ),
-        tmp_path,
-        room_id,
-        config=config,
-    )
+
+    def make_bot(entity_name: str) -> AgentBot:
+        user = AgentMatrixUser(entity_name, ids[entity_name].full_id, entity_name.title(), TEST_PASSWORD)
+        return setup_test_bot(user, tmp_path, room_id, config=config)
+
+    router_bot = make_bot("router")
+    target_bot = make_bot("general")
     orchestrator = _MultiAgentOrchestrator(runtime_paths)
     orchestrator.config = config
     orchestrator.agent_bots = {"router": router_bot, "general": target_bot}
@@ -191,9 +177,7 @@ def _router_readiness_runtime(
     )
     room = nio.MatrixRoom(room_id=room_id, own_user_id=ids["router"].full_id)
     room.users = {
-        ids["router"].full_id: MagicMock(),
-        ids["general"].full_id: MagicMock(),
-        "@user:localhost": MagicMock(),
+        user_id: MagicMock() for user_id in (*[identity.full_id for identity in ids.values()], "@user:localhost")
     }
     return router_bot, target_bot, orchestrator, room
 
@@ -446,14 +430,9 @@ class TestRoutingRegression:
         """A newly registered bot generation must not inherit readiness."""
         router_bot, target_bot, orchestrator, room = _router_readiness_runtime(tmp_path)
         target_bot._first_sync_done = True
-        replacement = setup_test_bot(
-            target_bot.agent_user,
-            tmp_path,
-            room.room_id,
-            config=target_bot.config,
-        )
+        replacement = MagicMock(spec=AgentBot)
         replacement.running = True
-        replacement.orchestrator = orchestrator
+        replacement.first_sync_complete = False
         orchestrator.agent_bots["general"] = replacement
 
         await router_bot._turn_controller._execute_router_relay(
@@ -466,6 +445,45 @@ class TestRoutingRegression:
         content = router_bot.client.room_send.await_args.kwargs["content"]
         assert content["body"] == "That agent is still starting. Please try again shortly."
         assert SOURCE_KIND_KEY not in content
+
+    @pytest.mark.asyncio
+    async def test_router_relay_keeps_ready_generation_current_through_delivery(self, tmp_path: Path) -> None:
+        """A replacement cannot become current while its predecessor's relay is sending."""
+        router_bot, target_bot, orchestrator, room = _router_readiness_runtime(tmp_path)
+        target_bot._first_sync_done = True
+        replacement = MagicMock(spec=AgentBot)
+        send_started = asyncio.Event()
+        release_send = asyncio.Event()
+
+        async def blocking_room_send(**_: object) -> nio.RoomSendResponse:
+            send_started.set()
+            await release_send.wait()
+            return nio.RoomSendResponse.from_dict({"event_id": "$router-response"}, room_id=room.room_id)
+
+        async def replace_target() -> None:
+            async with orchestrator._config_update_lock:
+                orchestrator.agent_bots["general"] = replacement
+
+        router_bot.client.room_send.side_effect = blocking_room_send
+        relay_task = asyncio.create_task(
+            router_bot._turn_controller._execute_router_relay(
+                room,
+                _router_readiness_event("$replacement-during-send"),
+                [],
+                requester_user_id="@user:localhost",
+            ),
+        )
+        await send_started.wait()
+        replacement_task = asyncio.create_task(replace_target())
+        try:
+            await asyncio.sleep(0)
+            assert orchestrator.agent_bots["general"] is target_bot
+        finally:
+            release_send.set()
+            await relay_task
+            await replacement_task
+
+        assert orchestrator.agent_bots["general"] is replacement
 
     @pytest.mark.asyncio
     async def test_router_removed_target_keeps_existing_no_responder_behavior(self, tmp_path: Path) -> None:
@@ -1032,6 +1050,7 @@ class TestRoutingRegression:
             "router": SimpleNamespace(running=True),
         }
         orchestrator.entity_first_sync_complete.return_value = True
+        orchestrator.entity_first_sync_readiness_guard.return_value.__aenter__.return_value = True
         router_bot.orchestrator = orchestrator
 
         mock_suggest_responder.side_effect = AssertionError("AI router should not see unavailable candidates")


### PR DESCRIPTION
## Summary

- expose first-sync completion for the current orchestrator-managed bot generation
- stop router handoffs to a selected agent or team that is still starting
- keep target-only config reloads outside router selection and Matrix delivery without dropping the waiting relay
- wake router-shutdown waiters, poison sync continuity before coalescing containment, and replay from the prior checkpoint
- return `That agent is still starting. Please try again shortly.` without target relay metadata
- preserve ready-target routing and removed-target behavior

## Testing

- routing regression suite (21 passed)
- focused admission/config lifecycle suite (3 passed)
- focused router and route-dispatch suite (18 passed)
- changed-file Ruff, Ruff format, Ty, Tach, and import-graph checks
- complete repository suite passed as a bounded composite: the PostgreSQL 45-thread fanout passed alone in 41.09s and the entire remainder passed with 4 workers
- one unrelated starting-base test was deselected because that base references undefined `_git_manager`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added readiness tracking for initial synchronization.
  * Router relays now wait for targets to become ready before delivery.
  * Users receive clear “still starting” or unavailable notices when a target cannot respond.
  * Relay metadata is protected when readiness checks fail.

* **Bug Fixes**
  * Prevented stale or removed targets from receiving routed messages.
  * Added admission checks to ensure relays run only when runtime capacity is available.
  * Preserved delivery consistency when targets are replaced during an active relay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->