### PR TITLE
Fence historical dispatch during cold Matrix sync

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import math
 import time
 from dataclasses import dataclass, replace
 from functools import cached_property
@@ -22,6 +21,7 @@ from mindroom.bot_room_lifecycle import BotRoomLifecycle, BotRoomLifecycleDeps
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.desktop.pairing_receiver import register_desktop_pairing_receiver
 from mindroom.entity_resolution import entity_identity_registry
+from mindroom.historical_dispatch_fence import HistoricalDispatchFence
 from mindroom.hooks import (
     EVENT_AGENT_STARTED,
     EVENT_AGENT_STOPPED,
@@ -287,8 +287,7 @@ class AgentBot:
     _last_sync_monotonic: float | None
     _first_sync_done: bool
     _sync_shutting_down: bool
-    _startup_cutoff_ms: int
-    _historical_dispatch_fence_armed: bool
+    _historical_dispatch_fence: HistoricalDispatchFence
 
     # Shared runtime state and extracted collaborators
     _hook_registry_state: HookRegistryState
@@ -346,8 +345,9 @@ class AgentBot:
         self._last_sync_monotonic = None
         self._first_sync_done = False
         self._sync_shutting_down = False
-        self._startup_cutoff_ms = int(time.time() * 1000)
-        self._historical_dispatch_fence_armed = False
+        self._historical_dispatch_fence = HistoricalDispatchFence(
+            startup_cutoff_ms=int(time.time() * 1000),
+        )
         self._hook_registry_state = HookRegistryState(HookRegistry.empty())
         self._room_member_callback_registered = False
         self._room_member_join_hooks_armed = False
@@ -1082,10 +1082,13 @@ class AgentBot:
 
     def _set_historical_dispatch_fence(self, *, armed: bool) -> None:
         """Set tokenless-window admission and its matching decrypt-notice floor."""
-        self._historical_dispatch_fence_armed = armed
+        self._historical_dispatch_fence.set_armed(armed=armed)
         client = self.client
         if armed and client is not None and client.user_id:
-            raise_notice_floor(client.user_id, floor_timestamp_ms=self._startup_cutoff_ms)
+            raise_notice_floor(
+                client.user_id,
+                floor_timestamp_ms=self._historical_dispatch_fence.startup_cutoff_ms,
+            )
 
     def _certify_sync_response(
         self,
@@ -1162,45 +1165,23 @@ class AgentBot:
         )
 
         async def wrapper(room: nio.MatrixRoom, event: nio.Event) -> None:
-            if not self._initial_sync_event_is_dispatchable(room, event, callback_name=callback_name):
+            decision = self._historical_dispatch_fence.classify(event.source)
+            if not decision.dispatchable:
+                assert decision.reason is not None
+                assert decision.log_level is not None
+                log_fenced_event = self.logger.debug if decision.log_level == "debug" else self.logger.info
+                log_fenced_event(
+                    "matrix_initial_sync_dispatch_fenced",
+                    callback=callback_name,
+                    event_id=event.event_id,
+                    room_id=room.room_id,
+                    agent_name=self.agent_name,
+                    reason=decision.reason,
+                )
                 return
             await task_wrapper(room, event)
 
         return wrapper
-
-    def _initial_sync_event_is_dispatchable(
-        self,
-        room: nio.MatrixRoom,
-        event: nio.Event,
-        *,
-        callback_name: str,
-    ) -> bool:
-        """Return whether one callback may enter user-visible dispatch."""
-        if not self._historical_dispatch_fence_armed:
-            return True
-
-        origin_server_ts = origin_server_ts_from_event_source(event.source)
-        timestamp_is_finite = isinstance(origin_server_ts, int) or (
-            isinstance(origin_server_ts, float) and math.isfinite(origin_server_ts)
-        )
-        if timestamp_is_finite:
-            assert origin_server_ts is not None
-            if origin_server_ts >= self._startup_cutoff_ms:
-                return True
-            reason = "predates_startup_cutoff"
-        else:
-            reason = "missing_origin_server_ts" if origin_server_ts is None else "invalid_origin_server_ts"
-
-        log_fenced_event = self.logger.debug if reason == "predates_startup_cutoff" else self.logger.info
-        log_fenced_event(
-            "matrix_initial_sync_dispatch_fenced",
-            callback=callback_name,
-            event_id=event.event_id,
-            room_id=room.room_id,
-            agent_name=self.agent_name,
-            reason=reason,
-        )
-        return False
 
     def _room_member_join_sync_hook_plan(
         self,
@@ -1839,6 +1820,8 @@ class AgentBot:
     async def sync_forever(self) -> None:
         """Run the sync loop for this agent."""
         assert self.client is not None
+        if self.config.matrix_sync.mode == "sliding":
+            self._set_historical_dispatch_fence(armed=True)
         await run_matrix_sync_forever(
             self.client,
             config=self.config,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1916,6 +1916,8 @@ class AgentBot:
             return
         retry_token = self._sync_cache_trust.retry_token()
         cast("Any", client).next_batch = retry_token
+        if retry_token is None:
+            self._set_historical_dispatch_fence(armed=True)
         self.logger.warning(
             "matrix_redaction_callback_failed_replaying_sync",
             has_retry_token=retry_token is not None,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import time
 from dataclasses import dataclass, replace
 from functools import cached_property
@@ -286,6 +287,8 @@ class AgentBot:
     _last_sync_monotonic: float | None
     _first_sync_done: bool
     _sync_shutting_down: bool
+    _startup_cutoff_ms: int
+    _historical_dispatch_fence_armed: bool
 
     # Shared runtime state and extracted collaborators
     _hook_registry_state: HookRegistryState
@@ -343,6 +346,8 @@ class AgentBot:
         self._last_sync_monotonic = None
         self._first_sync_done = False
         self._sync_shutting_down = False
+        self._startup_cutoff_ms = int(time.time() * 1000)
+        self._historical_dispatch_fence_armed = False
         self._hook_registry_state = HookRegistryState(HookRegistry.empty())
         self._room_member_callback_registered = False
         self._room_member_join_hooks_armed = False
@@ -1072,9 +1077,15 @@ class AgentBot:
         assert client is not None
         sync_token = await self._sync_cache_trust.prepare_startup()
         cast("Any", client).next_batch = sync_token
-        if sync_token is None and client.user_id:
-            # A cold sync replays history handled by an older device.
-            raise_notice_floor(client.user_id)
+        starts_without_continuity = self.config.matrix_sync.mode == "sliding" or sync_token is None
+        self._set_historical_dispatch_fence(armed=starts_without_continuity)
+
+    def _set_historical_dispatch_fence(self, *, armed: bool) -> None:
+        """Set tokenless-window admission and its matching decrypt-notice floor."""
+        self._historical_dispatch_fence_armed = armed
+        client = self.client
+        if armed and client is not None and client.user_id:
+            raise_notice_floor(client.user_id, floor_timestamp_ms=self._startup_cutoff_ms)
 
     def _certify_sync_response(
         self,
@@ -1088,6 +1099,9 @@ class AgentBot:
             next_batch=next_batch,
             cache_result=cache_result,
             first_sync=first_sync,
+        )
+        self._set_historical_dispatch_fence(
+            armed=decision.reset_client_token or decision.reason == "missing_next_batch",
         )
         if decision.reset_client_token and self.client is not None:
             cast("Any", self.client).next_batch = None
@@ -1133,6 +1147,59 @@ class AgentBot:
             create_background_task(error_handler(), owner=self._runtime_view)
 
         return wrapper
+
+    def _create_dispatch_task_wrapper(
+        self,
+        callback: Callable[..., Awaitable[None]],
+        *,
+        callback_name: str,
+    ) -> Callable[..., Awaitable[None]]:
+        """Fence cold-sync history before dispatch work becomes a background task."""
+        task_wrapper = _create_task_wrapper(
+            callback,
+            owner=self._runtime_view,
+            on_error=self._sync_cache_trust.mark_callback_failed,
+        )
+
+        async def wrapper(room: nio.MatrixRoom, event: nio.Event) -> None:
+            if not self._initial_sync_event_is_dispatchable(room, event, callback_name=callback_name):
+                return
+            await task_wrapper(room, event)
+
+        return wrapper
+
+    def _initial_sync_event_is_dispatchable(
+        self,
+        room: nio.MatrixRoom,
+        event: nio.Event,
+        *,
+        callback_name: str,
+    ) -> bool:
+        """Return whether one callback may enter user-visible dispatch."""
+        if not self._historical_dispatch_fence_armed:
+            return True
+
+        origin_server_ts = origin_server_ts_from_event_source(event.source)
+        timestamp_is_finite = isinstance(origin_server_ts, int) or (
+            isinstance(origin_server_ts, float) and math.isfinite(origin_server_ts)
+        )
+        if timestamp_is_finite:
+            assert origin_server_ts is not None
+            if origin_server_ts >= self._startup_cutoff_ms:
+                return True
+            reason = "predates_startup_cutoff"
+        else:
+            reason = "missing_origin_server_ts" if origin_server_ts is None else "invalid_origin_server_ts"
+
+        self.logger.info(
+            "matrix_initial_sync_dispatch_fenced",
+            callback=callback_name,
+            event_id=event.event_id,
+            room_id=room.room_id,
+            agent_name=self.agent_name,
+            reason=reason,
+        )
+        return False
 
     def _room_member_join_sync_hook_plan(
         self,
@@ -1226,6 +1293,7 @@ class AgentBot:
             # Sliding sync never certifies the classic checkpoint, but the
             # account's own kicks and bans still must fence and purge rooms.
             await self._apply_own_room_membership_from_sliding_sync(_response)
+            self._set_historical_dispatch_fence(armed=False)
         self._first_sync_done = True
         self._room_member_join_hooks_armed = room_member_join_hook_plan.arm_after_response
 
@@ -1259,12 +1327,16 @@ class AgentBot:
             # nio restarts expired sliding connections (M_UNKNOWN_POS)
             # transparently, and sliding errors say nothing about the classic
             # sync checkpoint, so classic token rejection must not run here.
+            if _response.status_code == "M_UNKNOWN_POS":
+                self._set_historical_dispatch_fence(armed=True)
             self._warn_if_sliding_sync_never_succeeded(_response)
             return
         if _response.status_code == "M_UNKNOWN_POS":
             decision = self._sync_cache_trust.reject_unknown_pos()
-            if decision.reset_client_token and self.client is not None:
-                cast("Any", self.client).next_batch = None
+            if decision.reset_client_token:
+                self._set_historical_dispatch_fence(armed=True)
+                if self.client is not None:
+                    cast("Any", self.client).next_batch = None
             self._room_member_join_hooks_armed = False
             self.logger.warning(
                 "matrix_sync_token_rejected",
@@ -1466,7 +1538,7 @@ class AgentBot:
                 nio.InviteEvent,  # ty: ignore[invalid-argument-type]  # InviteEvent doesn't inherit Event
             )
             client.add_event_callback(
-                _create_task_wrapper(self._on_message, owner=self._runtime_view, on_error=callback_failed),
+                self._create_dispatch_task_wrapper(self._on_message, callback_name="message"),
                 nio.RoomMessageText,
             )
             client.add_event_callback(
@@ -1474,23 +1546,21 @@ class AgentBot:
                 nio.RedactionEvent,
             )
             client.add_event_callback(
-                _create_task_wrapper(self._on_reaction, owner=self._runtime_view, on_error=callback_failed),
+                self._create_dispatch_task_wrapper(self._on_reaction, callback_name="reaction"),
                 nio.ReactionEvent,
             )
 
             # Register media callbacks on all agents (each agent handles its own routing)
-            media_callback = _create_task_wrapper(
+            media_callback = self._create_dispatch_task_wrapper(
                 self._on_media_message,
-                owner=self._runtime_view,
-                on_error=callback_failed,
+                callback_name="media",
             )
             for event_type in MATRIX_MEDIA_EVENT_TYPES:
                 client.add_event_callback(media_callback, event_type)
             client.add_event_callback(
-                _create_task_wrapper(
+                self._create_dispatch_task_wrapper(
                     self._on_unknown_event,
-                    owner=self._runtime_view,
-                    on_error=callback_failed,
+                    callback_name="approval",
                 ),
                 nio.UnknownEvent,
             )

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -163,6 +163,7 @@ class _RoomMemberJoinSyncHookPlan:
     arm_after_response: bool = True
     emit_state: bool = False
     emit_timeline: bool = False
+    emit_fenced_timeline: bool = False
     record_state_seen: bool = False
 
 
@@ -1083,8 +1084,6 @@ class AgentBot:
     def _set_historical_dispatch_fence(self, *, armed: bool) -> None:
         """Set tokenless-window admission and its matching decrypt-notice floor."""
         self._historical_dispatch_fence.set_armed(armed=armed)
-        if armed:
-            self._room_member_join_hooks_armed = False
         client = self.client
         if armed and client is not None and client.user_id:
             raise_notice_floor(
@@ -1105,9 +1104,8 @@ class AgentBot:
             cache_result=cache_result,
             first_sync=first_sync,
         )
-        self._set_historical_dispatch_fence(
-            armed=decision.reset_client_token or decision.reason == "missing_next_batch",
-        )
+        if decision.reset_client_token or decision.reason == "missing_next_batch":
+            self._set_historical_dispatch_fence(armed=True)
         if decision.reset_client_token and self.client is not None:
             cast("Any", self.client).next_batch = None
         return decision
@@ -1134,7 +1132,10 @@ class AgentBot:
         async def wrapper(room: nio.MatrixRoom, event: nio.Event) -> None:
             if not isinstance(event, nio.RoomMemberEvent):
                 return
-            hooks_armed_at_delivery = self._first_sync_done and self._room_member_join_hooks_armed
+            fence_armed = self._historical_dispatch_fence.armed
+            if fence_armed and not self._historical_dispatch_fence.classify(event.source).dispatchable:
+                return
+            hooks_armed_at_delivery = self._first_sync_done and (fence_armed or self._room_member_join_hooks_armed)
 
             async def error_handler() -> None:
                 try:
@@ -1168,7 +1169,7 @@ class AgentBot:
 
         async def wrapper(room: nio.MatrixRoom, event: nio.Event) -> None:
             decision = self._historical_dispatch_fence.classify(event.source)
-            if not decision.dispatchable:
+            if not decision.dispatchable and not self._turn_store.has_pending_turn(event.event_id):
                 assert decision.reason is not None
                 assert decision.log_level is not None
                 log_fenced_event = self.logger.debug if decision.log_level == "debug" else self.logger.info
@@ -1194,17 +1195,22 @@ class AgentBot:
         decision: SyncCertificationDecision,
     ) -> _RoomMemberJoinSyncHookPlan:
         """Return room-member join hook actions for one certified sync response."""
-        if decision.reset_client_token or self._historical_dispatch_fence.armed:
+        if decision.reset_client_token or decision.reason == "missing_next_batch":
             return _RoomMemberJoinSyncHookPlan(arm_after_response=False)
+        emit_fenced_timeline = self._historical_dispatch_fence.armed and decision.state is SyncTrustState.CERTIFIED
         # The first restored-token sync is requested with full_state=True, so its
         # state block is a current snapshot. Only the timeline is a catch-up stream.
         emit_certified_state = (
-            decision.state is SyncTrustState.CERTIFIED and not first_sync_response and hooks_were_armed
+            decision.state is SyncTrustState.CERTIFIED
+            and not first_sync_response
+            and hooks_were_armed
+            and not emit_fenced_timeline
         )
         return _RoomMemberJoinSyncHookPlan(
             arm_after_response=True,
             emit_state=emit_certified_state,
             emit_timeline=restored_token_first_sync_response,
+            emit_fenced_timeline=emit_fenced_timeline,
             record_state_seen=decision.state is SyncTrustState.CERTIFIED and not emit_certified_state,
         )
 
@@ -1218,6 +1224,8 @@ class AgentBot:
         """Run sync-response side effects that must poison certification on failure."""
         # The emit flags are only set by the classic-sync certification path.
         if isinstance(response, nio.SyncResponse):
+            if room_member_join_hook_plan.emit_fenced_timeline:
+                await self._emit_room_member_joined_sync_timeline_hooks(response, apply_historical_fence=True)
             if room_member_join_hook_plan.record_state_seen:
                 await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
             if room_member_join_hook_plan.emit_timeline:
@@ -1241,6 +1249,7 @@ class AgentBot:
         first_sync_response = not self._first_sync_done
         room_member_join_hooks_were_armed = self._room_member_join_hooks_armed
         room_member_join_hook_plan = _RoomMemberJoinSyncHookPlan()
+        certification_decision: SyncCertificationDecision | None = None
         self.last_sync_time = mark_matrix_sync_success(self.agent_name)
         self._last_sync_monotonic = time.monotonic()
 
@@ -1262,7 +1271,7 @@ class AgentBot:
                     first_sync=first_sync_response,
                 )
                 raise
-            decision = self._certify_sync_response(
+            certification_decision = self._certify_sync_response(
                 next_batch=_response.next_batch,
                 cache_result=cache_result,
                 first_sync=first_sync_response,
@@ -1271,13 +1280,12 @@ class AgentBot:
                 first_sync_response=first_sync_response,
                 restored_token_first_sync_response=restored_token_first_sync_response,
                 hooks_were_armed=room_member_join_hooks_were_armed,
-                decision=decision,
+                decision=certification_decision,
             )
         elif isinstance(_response, nio.SlidingSyncResponse):
             # Sliding sync never certifies the classic checkpoint, but the
             # account's own kicks and bans still must fence and purge rooms.
             await self._apply_own_room_membership_from_sliding_sync(_response)
-            self._set_historical_dispatch_fence(armed=False)
         self._first_sync_done = True
         self._room_member_join_hooks_armed = room_member_join_hook_plan.arm_after_response
 
@@ -1293,6 +1301,12 @@ class AgentBot:
         except Exception:
             self._sync_cache_trust.mark_callback_failed()
             raise
+        if isinstance(_response, nio.SlidingSyncResponse) or (
+            certification_decision is not None
+            and not certification_decision.reset_client_token
+            and certification_decision.reason != "missing_next_batch"
+        ):
+            self._set_historical_dispatch_fence(armed=False)
         if self._calls_reconcile_pending:
             self._calls_reconcile_pending = False
             call_manager = self._call_manager
@@ -1982,7 +1996,12 @@ class AgentBot:
         ):
             await self._emit_room_member_joined_hooks(join)
 
-    async def _emit_room_member_joined_sync_timeline_hooks(self, response: nio.SyncResponse) -> None:
+    async def _emit_room_member_joined_sync_timeline_hooks(
+        self,
+        response: nio.SyncResponse,
+        *,
+        apply_historical_fence: bool = False,
+    ) -> None:
         """Expose human joins from a restored-token catch-up sync timeline."""
         if self.agent_name != ROUTER_AGENT_NAME or not self._first_sync_done or not self._room_member_join_hooks_armed:
             return
@@ -1998,6 +2017,11 @@ class AgentBot:
             config=self.config,
             runtime_paths=self.runtime_paths,
             storage_root=self.runtime_paths.storage_root,
+            event_admitted=(
+                (lambda event: self._historical_dispatch_fence.classify(event.source).dispatchable)
+                if apply_historical_fence
+                else None
+            ),
         ):
             await self._emit_room_member_joined_hooks(join)
 

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1083,6 +1083,8 @@ class AgentBot:
     def _set_historical_dispatch_fence(self, *, armed: bool) -> None:
         """Set tokenless-window admission and its matching decrypt-notice floor."""
         self._historical_dispatch_fence.set_armed(armed=armed)
+        if armed:
+            self._room_member_join_hooks_armed = False
         client = self.client
         if armed and client is not None and client.user_id:
             raise_notice_floor(
@@ -1192,7 +1194,7 @@ class AgentBot:
         decision: SyncCertificationDecision,
     ) -> _RoomMemberJoinSyncHookPlan:
         """Return room-member join hook actions for one certified sync response."""
-        if decision.reset_client_token:
+        if decision.reset_client_token or self._historical_dispatch_fence.armed:
             return _RoomMemberJoinSyncHookPlan(arm_after_response=False)
         # The first restored-token sync is requested with full_state=True, so its
         # state block is a current snapshot. Only the timeline is a catch-up stream.
@@ -1319,7 +1321,6 @@ class AgentBot:
                 self._set_historical_dispatch_fence(armed=True)
                 if self.client is not None:
                     cast("Any", self.client).next_batch = None
-            self._room_member_join_hooks_armed = False
             self.logger.warning(
                 "matrix_sync_token_rejected",
                 status_code=_response.status_code,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1191,7 +1191,8 @@ class AgentBot:
         else:
             reason = "missing_origin_server_ts" if origin_server_ts is None else "invalid_origin_server_ts"
 
-        self.logger.info(
+        log_fenced_event = self.logger.debug if reason == "predates_startup_cutoff" else self.logger.info
+        log_fenced_event(
             "matrix_initial_sync_dispatch_fenced",
             callback=callback_name,
             event_id=event.event_id,

--- a/src/mindroom/historical_dispatch_fence.py
+++ b/src/mindroom/historical_dispatch_fence.py
@@ -1,0 +1,63 @@
+"""Admission policy for historical Matrix callbacks."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Literal
+
+from mindroom.matrix.event_info import origin_server_ts_from_event_source
+
+type _HistoricalDispatchFenceReason = Literal[
+    "predates_startup_cutoff",
+    "missing_origin_server_ts",
+    "invalid_origin_server_ts",
+]
+type _HistoricalDispatchLogLevel = Literal["debug", "info"]
+
+
+@dataclass(frozen=True, slots=True)
+class _HistoricalDispatchDecision:
+    """Describe whether one Matrix callback may enter user-visible dispatch."""
+
+    dispatchable: bool
+    reason: _HistoricalDispatchFenceReason | None = None
+    log_level: _HistoricalDispatchLogLevel | None = None
+
+
+@dataclass(slots=True)
+class HistoricalDispatchFence:
+    """Fence historical callbacks against one fixed construction-time cutoff."""
+
+    startup_cutoff_ms: int
+    armed: bool = False
+
+    def set_armed(self, *, armed: bool) -> None:
+        """Set whether timestamp admission is enforced."""
+        self.armed = armed
+
+    def classify(self, event_source: object) -> _HistoricalDispatchDecision:
+        """Classify one raw Matrix event source for dispatch."""
+        if not self.armed:
+            return _HistoricalDispatchDecision(dispatchable=True)
+
+        origin_server_ts = origin_server_ts_from_event_source(event_source)
+        if isinstance(origin_server_ts, int) or (
+            isinstance(origin_server_ts, float) and math.isfinite(origin_server_ts)
+        ):
+            if origin_server_ts >= self.startup_cutoff_ms:
+                return _HistoricalDispatchDecision(dispatchable=True)
+            return _HistoricalDispatchDecision(
+                dispatchable=False,
+                reason="predates_startup_cutoff",
+                log_level="debug",
+            )
+
+        reason: _HistoricalDispatchFenceReason = (
+            "missing_origin_server_ts" if origin_server_ts is None else "invalid_origin_server_ts"
+        )
+        return _HistoricalDispatchDecision(
+            dispatchable=False,
+            reason=reason,
+            log_level="info",
+        )

--- a/src/mindroom/matrix/decrypt_failure.py
+++ b/src/mindroom/matrix/decrypt_failure.py
@@ -84,15 +84,24 @@ def e2ee_stats() -> E2EEStats:
 _notice_floors: dict[tuple[str, str | None], int] = {}
 
 
-def raise_notice_floor(user_id: str, room_id: str | None = None) -> None:
-    """Suppress visible decrypt-failure notices for events older than now.
+def raise_notice_floor(
+    user_id: str,
+    room_id: str | None = None,
+    *,
+    floor_timestamp_ms: int | None = None,
+) -> None:
+    """Suppress visible decrypt-failure notices for events older than a floor.
 
     Bots call this when they join a room mid-flight (pre-join encrypted
     history is expected to be undecryptable) and when they start without sync
     continuity (a tokenless initial sync replays events an earlier device may
     already have handled). ``room_id=None`` applies to every room for the bot.
+    The current wall clock is used unless the caller preserves an earlier
+    startup cutoff across continuity retries.
     """
-    _notice_floors[(user_id, room_id)] = int(time.time() * 1000)
+    floor = int(time.time() * 1000) if floor_timestamp_ms is None else floor_timestamp_ms
+    key = (user_id, room_id)
+    _notice_floors[key] = max(_notice_floors.get(key, 0), floor)
 
 
 def _below_notice_floor(user_id: str | None, room_id: str, server_timestamp: int) -> bool:

--- a/src/mindroom/matrix/room_member_joins.py
+++ b/src/mindroom/matrix/room_member_joins.py
@@ -16,7 +16,7 @@ from mindroom.entity_resolution import entity_identity_registry, mindroom_user_i
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator, Mapping
+    from collections.abc import Callable, Iterator, Mapping
     from pathlib import Path
 
     from mindroom.config.main import Config
@@ -255,6 +255,7 @@ def room_member_joins_from_sync_timeline(
     config: Config,
     runtime_paths: RuntimePaths,
     storage_root: Path,
+    event_admitted: Callable[[nio.RoomMemberEvent], bool] | None = None,
 ) -> tuple[RoomMemberJoin, ...]:
     """Return hook payloads for human joins delivered through sync timeline events."""
     joins: list[RoomMemberJoin] = []
@@ -264,6 +265,8 @@ def room_member_joins_from_sync_timeline(
             continue
         for event in join_info.timeline.events:
             if not isinstance(event, nio.RoomMemberEvent):
+                continue
+            if event_admitted is not None and not event_admitted(event):
                 continue
             join = room_member_join_from_event(
                 room,

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -135,6 +135,11 @@ class TurnStore:
         """Return whether one source event already has a terminal outcome."""
         return self._ledger.has_responded(event_id)
 
+    def has_pending_turn(self, event_id: str) -> bool:
+        """Return whether one exact event belongs to a durable incomplete turn."""
+        turn_record = self.get_turn_record(event_id)
+        return turn_record is not None and not turn_record.completed
+
     def visible_echo_for_source(self, source_event_id: str) -> str | None:
         """Return the tracked visible echo for one source event."""
         return self._ledger.get_visible_echo_event_id(source_event_id)

--- a/tach.toml
+++ b/tach.toml
@@ -2371,6 +2371,11 @@ path = "mindroom.matrix.event_info"
 depends_on = []
 
 [[modules]]
+path = "mindroom.historical_dispatch_fence"
+depends_on = ["mindroom.matrix.event_info"]
+visibility = ["mindroom.bot"]
+
+[[modules]]
 path = "mindroom.matrix.visible_body"
 depends_on = [
     "mindroom.constants",
@@ -2714,6 +2719,7 @@ depends_on = [
     "mindroom.edit_regenerator",
     "mindroom.entity_resolution",
     "mindroom.hooks",
+    "mindroom.historical_dispatch_fence",
     "mindroom.inbound_turn_normalizer",
     "mindroom.knowledge",
     "mindroom.matrix.client_room_admin",

--- a/tests/test_decrypt_failure.py
+++ b/tests/test_decrypt_failure.py
@@ -289,6 +289,32 @@ async def test_global_floor_suppresses_notices_in_every_room(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_explicit_notice_floor_preserves_post_start_failures(tmp_path: Path) -> None:
+    """A continuity reset reuses the startup cutoff instead of hiding newer failures."""
+    client = _mock_client()
+    raise_notice_floor(client.user_id, floor_timestamp_ms=2_000)
+    notice = AsyncMock(return_value=True)
+
+    with patch.object(decrypt_failure, "_send_decrypt_failure_notice", new=notice):
+        await handle_decrypt_failure(
+            client,
+            _mock_room(),
+            _megolm_event(session_id="historical", server_timestamp=1_999),
+            agent_name="assistant",
+            runtime_paths=_runtime_paths(tmp_path),
+        )
+        await handle_decrypt_failure(
+            client,
+            _mock_room(),
+            _megolm_event(session_id="post-start", server_timestamp=2_000),
+            agent_name="assistant",
+            runtime_paths=_runtime_paths(tmp_path),
+        )
+
+    notice.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_event_newer_than_floor_still_notifies(tmp_path: Path) -> None:
     """Fresh messages arriving after a floor was raised must still notify."""
     client = _mock_client()

--- a/tests/test_historical_dispatch_fence.py
+++ b/tests/test_historical_dispatch_fence.py
@@ -1,0 +1,69 @@
+"""Tests for historical Matrix callback admission."""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from mindroom.historical_dispatch_fence import HistoricalDispatchFence
+
+
+def test_unarmed_fence_allows_events_without_timestamps() -> None:
+    """An inactive fence leaves normal callback admission unchanged."""
+    fence = HistoricalDispatchFence(startup_cutoff_ms=2_000)
+
+    assert fence.classify({}).dispatchable
+
+
+@pytest.mark.parametrize("origin_server_ts", [2_000, 2_001])
+def test_armed_fence_allows_events_at_or_after_cutoff(origin_server_ts: int) -> None:
+    """The startup cutoff remains inclusive."""
+    fence = HistoricalDispatchFence(startup_cutoff_ms=2_000, armed=True)
+
+    assert fence.classify({"origin_server_ts": origin_server_ts}).dispatchable
+
+
+def test_armed_fence_debug_fences_events_before_cutoff() -> None:
+    """Ordinary historical events are rejected at debug severity."""
+    fence = HistoricalDispatchFence(startup_cutoff_ms=2_000, armed=True)
+
+    decision = fence.classify({"origin_server_ts": 1_999})
+
+    assert not decision.dispatchable
+    assert decision.reason == "predates_startup_cutoff"
+    assert decision.log_level == "debug"
+
+
+def test_armed_fence_info_fences_events_without_timestamps() -> None:
+    """Missing timestamps fail closed and remain observable."""
+    fence = HistoricalDispatchFence(startup_cutoff_ms=2_000, armed=True)
+
+    decision = fence.classify({})
+
+    assert not decision.dispatchable
+    assert decision.reason == "missing_origin_server_ts"
+    assert decision.log_level == "info"
+
+
+@pytest.mark.parametrize("origin_server_ts", [math.nan, math.inf, -math.inf])
+def test_armed_fence_info_fences_nonfinite_timestamps(origin_server_ts: float) -> None:
+    """Nonfinite timestamps fail closed and remain observable."""
+    fence = HistoricalDispatchFence(startup_cutoff_ms=2_000, armed=True)
+
+    decision = fence.classify({"origin_server_ts": origin_server_ts})
+
+    assert not decision.dispatchable
+    assert decision.reason == "invalid_origin_server_ts"
+    assert decision.log_level == "info"
+
+
+def test_rearming_preserves_construction_time_cutoff() -> None:
+    """Receive-loop restarts reuse the original construction-time cutoff."""
+    fence = HistoricalDispatchFence(startup_cutoff_ms=2_000, armed=True)
+
+    fence.set_armed(armed=False)
+    fence.set_armed(armed=True)
+
+    assert fence.startup_cutoff_ms == 2_000
+    assert not fence.classify({"origin_server_ts": 1_999}).dispatchable

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -411,7 +411,10 @@ async def test_sliding_initial_sync_raises_decrypt_notice_floor_despite_classic_
     with patch("mindroom.bot.raise_notice_floor") as notice_floor:
         await _start_bot_with_client(bot, client)
 
-    notice_floor.assert_called_once_with(client.user_id, floor_timestamp_ms=bot._startup_cutoff_ms)
+    notice_floor.assert_called_once_with(
+        client.user_id,
+        floor_timestamp_ms=bot._historical_dispatch_fence.startup_cutoff_ms,
+    )
 
 
 @pytest.mark.asyncio
@@ -435,7 +438,7 @@ async def test_missing_next_batch_keeps_historical_dispatch_fence_armed(tmp_path
     ):
         await bot._on_sync_response(response)
 
-    assert bot._historical_dispatch_fence_armed is True
+    assert bot._historical_dispatch_fence.armed is True
 
 
 @pytest.mark.asyncio
@@ -461,7 +464,10 @@ async def test_post_start_unknown_pos_rearms_historical_dispatch_fence(tmp_path:
         sync_error.status_code = "M_UNKNOWN_POS"
         await bot._on_sync_error(sync_error)
 
-    notice_floor.assert_called_once_with(client.user_id, floor_timestamp_ms=bot._startup_cutoff_ms)
+    notice_floor.assert_called_once_with(
+        client.user_id,
+        floor_timestamp_ms=bot._historical_dispatch_fence.startup_cutoff_ms,
+    )
 
     callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
     handle_text_event = AsyncMock()
@@ -637,6 +643,31 @@ async def test_tokenless_initial_sync_retry_reuses_original_cutoff(tmp_path: Pat
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
     assert [call.args[1].event_id for call in handle_text_event.await_args_list] == ["$post-start"]
+
+
+@pytest.mark.asyncio
+async def test_sliding_receive_loop_restart_fences_history_after_success(tmp_path: Path) -> None:
+    """A fresh positionless Sliding Sync loop must fence history after an earlier success."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    bot.config.matrix_sync.mode = "sliding"
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    event = _text_event("$historical-after-sliding-restart", "historical", 1_500)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    await _start_bot_with_client(bot, client)
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    handle_text_event = AsyncMock()
+    with (
+        patch.object(bot, "_run_sync_response_side_effects", AsyncMock()),
+        patch.object(bot._turn_controller, "handle_text_event", handle_text_event),
+    ):
+        await bot._on_sync_response(nio.SlidingSyncResponse("pos"))
+        await bot.sync_forever()
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_text_event.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -425,6 +425,10 @@ async def test_missing_next_batch_keeps_historical_dispatch_fence_armed(tmp_path
     client.next_batch = None
 
     await _start_bot_with_client(bot, client)
+    bot._first_sync_done = True
+    bot._room_member_join_hooks_armed = True
+    bot._sync_cache_trust.state = SyncTrustState.CERTIFIED
+    bot._sync_cache_trust.checkpoint = SyncCheckpoint("s_before_missing_token")
     response = MagicMock(spec=nio.SyncResponse)
     response.next_batch = None
     response.rooms = MagicMock(join={}, leave={})
@@ -439,6 +443,7 @@ async def test_missing_next_batch_keeps_historical_dispatch_fence_armed(tmp_path
         await bot._on_sync_response(response)
 
     assert bot._historical_dispatch_fence.armed is True
+    assert bot._room_member_join_hooks_armed is False
 
 
 @pytest.mark.asyncio
@@ -524,12 +529,14 @@ def test_redaction_rewind_without_retry_token_rearms_historical_dispatch_fence(t
     client.next_batch = "s_uncertified"
     bot.client = client
     assert not bot._historical_dispatch_fence.armed
+    bot._room_member_join_hooks_armed = True
 
     with patch("mindroom.bot.raise_notice_floor") as notice_floor:
         bot._rewind_sync_after_redaction_failure()
 
     assert client.next_batch is None
     assert bot._historical_dispatch_fence.armed
+    assert not bot._room_member_join_hooks_armed
     notice_floor.assert_called_once_with(
         client.user_id,
         floor_timestamp_ms=bot._historical_dispatch_fence.startup_cutoff_ms,
@@ -684,6 +691,34 @@ async def test_sliding_receive_loop_restart_fences_history_after_success(tmp_pat
     ):
         await bot._on_sync_response(nio.SlidingSyncResponse("pos"))
         await bot.sync_forever()
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_text_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sliding_unknown_pos_fences_history_before_next_response(tmp_path: Path) -> None:
+    """An expired Sliding position must immediately restore historical callback fencing."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    bot.config.matrix_sync.mode = "sliding"
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    event = _text_event("$history-after-unknown-pos", "historical", 1_500)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    await _start_bot_with_client(bot, client)
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    with patch.object(bot, "_run_sync_response_side_effects", AsyncMock()):
+        await bot._on_sync_response(nio.SlidingSyncResponse("pos"))
+    assert not bot._historical_dispatch_fence.armed
+
+    await bot._on_sync_error(nio.SlidingSyncError("connection expired", "M_UNKNOWN_POS"))
+    assert bot._historical_dispatch_fence.armed
+    assert not bot._room_member_join_hooks_armed
+
+    handle_text_event = AsyncMock()
+    with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
         await callback(room, event)
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -23,6 +23,7 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.dispatch_handoff import PendingDispatchMetadata
 from mindroom.dispatch_source import VOICE_SOURCE_KIND
+from mindroom.handled_turns import TurnRecord
 from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.postgres_event_cache import PostgresEventCache
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
@@ -293,6 +294,59 @@ async def test_tokenless_initial_sync_caches_old_text_without_dispatch(tmp_path:
 
 
 @pytest.mark.asyncio
+async def test_tokenless_sync_replays_only_exact_durable_pending_events(tmp_path: Path) -> None:
+    """Cold history may resume an exact pending turn without reopening unrelated events."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+    pending_text = _text_event("$pending-text", "resume me", 1_500)
+    unrelated_text = _text_event("$unrelated-text", "ignore me", 1_500)
+    pending_reaction = nio.Event.parse_event(
+        {
+            "type": "m.reaction",
+            "event_id": "$pending-reaction",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1_500,
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": "$question",
+                    "key": "1",
+                },
+            },
+        },
+    )
+    assert isinstance(pending_reaction, nio.ReactionEvent)
+    bot._turn_store.record_pending_turn(TurnRecord.create([pending_text.event_id], completed=False))
+    bot._turn_store.record_pending_turn(
+        TurnRecord.create(
+            ["$question"],
+            discovery_event_ids=(pending_reaction.event_id,),
+            completed=False,
+        ),
+    )
+
+    await _start_bot_with_client(bot, client)
+    text_callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    reaction_callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.ReactionEvent))
+    handle_text_event = AsyncMock()
+    handle_reaction_inner = AsyncMock()
+    with (
+        patch.object(bot._turn_controller, "handle_text_event", handle_text_event),
+        patch.object(bot, "_handle_reaction_inner", handle_reaction_inner),
+    ):
+        await text_callback(room, pending_text)
+        await text_callback(room, unrelated_text)
+        await reaction_callback(room, pending_reaction)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    assert [call.args[1].event_id for call in handle_text_event.await_args_list] == [pending_text.event_id]
+    handle_reaction_inner.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_tokenless_initial_sync_drops_old_media_before_processing(tmp_path: Path) -> None:
     """Cold-sync media must not enter attachment, transcription, or routing work."""
     with patch("mindroom.bot.time.time", return_value=2.0):
@@ -443,7 +497,6 @@ async def test_missing_next_batch_keeps_historical_dispatch_fence_armed(tmp_path
         await bot._on_sync_response(response)
 
     assert bot._historical_dispatch_fence.armed is True
-    assert bot._room_member_join_hooks_armed is False
 
 
 @pytest.mark.asyncio
@@ -536,7 +589,6 @@ def test_redaction_rewind_without_retry_token_rearms_historical_dispatch_fence(t
 
     assert client.next_batch is None
     assert bot._historical_dispatch_fence.armed
-    assert not bot._room_member_join_hooks_armed
     notice_floor.assert_called_once_with(
         client.user_id,
         floor_timestamp_ms=bot._historical_dispatch_fence.startup_cutoff_ms,
@@ -715,7 +767,6 @@ async def test_sliding_unknown_pos_fences_history_before_next_response(tmp_path:
 
     await bot._on_sync_error(nio.SlidingSyncError("connection expired", "M_UNKNOWN_POS"))
     assert bot._historical_dispatch_fence.armed
-    assert not bot._room_member_join_hooks_armed
 
     handle_text_event = AsyncMock()
     with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -417,12 +417,9 @@ async def test_sliding_initial_sync_raises_decrypt_notice_floor_despite_classic_
 @pytest.mark.asyncio
 async def test_missing_next_batch_keeps_historical_dispatch_fence_armed(tmp_path: Path) -> None:
     """A successful response without a continuation token leaves the next request tokenless."""
-    with patch("mindroom.bot.time.time", return_value=2.0):
-        bot = _agent_bot(tmp_path)
+    bot = _agent_bot(tmp_path)
     client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     client.next_batch = None
-    event = _text_event("$missing-token-history", "historical", 1_999)
-    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
 
     await _start_bot_with_client(bot, client)
     response = MagicMock(spec=nio.SyncResponse)
@@ -438,13 +435,7 @@ async def test_missing_next_batch_keeps_historical_dispatch_fence_armed(tmp_path
     ):
         await bot._on_sync_response(response)
 
-    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
-    handle_text_event = AsyncMock()
-    with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
-        await callback(room, event)
-        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
-
-    handle_text_event.assert_not_awaited()
+    assert bot._historical_dispatch_fence_armed is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -26,7 +26,7 @@ from mindroom.dispatch_source import VOICE_SOURCE_KIND
 from mindroom.matrix.cache.event_cache import EventCacheBackendUnavailableError
 from mindroom.matrix.cache.postgres_event_cache import PostgresEventCache
 from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
-from mindroom.matrix.sync_certification import SyncCheckpoint, SyncTrustState
+from mindroom.matrix.sync_certification import SyncCacheWriteResult, SyncCheckpoint, SyncTrustState
 from mindroom.matrix.sync_tokens import clear_sync_token, load_sync_checkpoint, save_sync_token
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.response_admission import ResponseAdmissionGate
@@ -47,6 +47,7 @@ from tests.conftest import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
     from pathlib import Path
 
     from mindroom.coalescing import LaneSlot, _GateEntry
@@ -105,6 +106,48 @@ def _text_event(event_id: str, body: str, origin_server_ts: int) -> nio.RoomMess
             "type": "m.room.message",
         },
     )
+
+
+def _image_event(event_id: str, origin_server_ts: int) -> nio.RoomMessageImage:
+    event = nio.RoomMessage.parse_event(
+        {
+            "content": {"body": "image.png", "msgtype": "m.image", "url": "mxc://localhost/image"},
+            "event_id": event_id,
+            "sender": "@user:localhost",
+            "origin_server_ts": origin_server_ts,
+            "room_id": "!room:localhost",
+            "type": "m.room.message",
+        },
+    )
+    assert isinstance(event, nio.RoomMessageImage)
+    return event
+
+
+def _sync_response_with_event(event: nio.Event, *, next_batch: str = "s_after_cold_sync") -> nio.SyncResponse:
+    response = MagicMock(spec=nio.SyncResponse)
+    response.next_batch = next_batch
+    response.rooms = MagicMock(
+        join={
+            "!room:localhost": MagicMock(
+                timeline=MagicMock(events=[event], limited=False),
+            ),
+        },
+        leave={},
+    )
+    return response
+
+
+async def _start_bot_with_client(bot: AgentBot, client: AsyncMock) -> None:
+    with (
+        patch("mindroom.bot.login_agent_user", AsyncMock(return_value=client)),
+        patch.object(bot, "_set_presence_with_model_info", AsyncMock()),
+        patch("mindroom.bot.interactive.init_persistence"),
+    ):
+        await bot.start()
+
+
+def _registered_event_callback(client: AsyncMock, event_type: type[nio.Event]) -> object:
+    return next(call.args[0] for call in client.add_event_callback.call_args_list if call.args[1] is event_type)
 
 
 def _room_member_event(event_id: str = "$member-join") -> nio.RoomMemberEvent:
@@ -215,6 +258,383 @@ async def test_bot_start_restores_saved_sync_token(tmp_path: Path) -> None:
         await bot.start()
 
     assert client.next_batch == "s_saved"
+
+
+@pytest.mark.asyncio
+async def test_tokenless_initial_sync_caches_old_text_without_dispatch(tmp_path: Path) -> None:
+    """Cold-sync history must reach cache certification without becoming a new turn."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    cache_root = SqliteEventCache(tmp_path / "cold-sync-event-cache.db")
+    bot.event_cache = cache_root.for_principal(bot.agent_user.user_id or "@mindroom_code:localhost")
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    event = _text_event("$historical-text", "historical", 1_999)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    try:
+        await _start_bot_with_client(bot, client)
+        bot.config.agents["code"].startup_thread_prewarm = False
+        callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+        handle_text_event = AsyncMock()
+        with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
+            await callback(room, event)
+            await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+        await bot._on_sync_response(_sync_response_with_event(event))
+        cached_event = await bot.event_cache.get_event(room.room_id, event.event_id)
+    finally:
+        await cache_root.close()
+
+    assert cached_event is not None
+    assert cached_event["event_id"] == "$historical-text"
+    assert _load_sync_token_value(tmp_path, bot.agent_name) == "s_after_cold_sync"
+    handle_text_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tokenless_initial_sync_drops_old_media_before_processing(tmp_path: Path) -> None:
+    """Cold-sync media must not enter attachment, transcription, or routing work."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    event = _image_event("$historical-media", 1_999)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    await _start_bot_with_client(bot, client)
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageImage))
+    handle_media_event = AsyncMock()
+    with patch.object(bot._turn_controller, "handle_media_event", handle_media_event):
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_media_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tokenless_initial_sync_dispatches_event_at_startup_cutoff_once(tmp_path: Path) -> None:
+    """An event sent while startup begins remains eligible on the inclusive cutoff."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    event = _text_event("$startup-live", "live", 2_000)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    await _start_bot_with_client(bot, client)
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    handle_text_event = AsyncMock()
+    with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_text_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_restored_checkpoint_keeps_incremental_dispatch_unchanged(tmp_path: Path) -> None:
+    """Restored-token catch-up events must retain existing dispatch behavior."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    save_sync_token(
+        tmp_path,
+        bot.agent_name,
+        "s_restored",
+        cache_generation=bot.event_cache.cache_generation,
+    )
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    event = _text_event("$incremental", "incremental", 1_000)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    await _start_bot_with_client(bot, client)
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    handle_text_event = AsyncMock()
+    with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_text_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sliding_initial_sync_fences_history_despite_classic_checkpoint(tmp_path: Path) -> None:
+    """Sliding Sync starts without a reusable position even if a classic checkpoint exists."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    bot.config.matrix_sync.mode = "sliding"
+    save_sync_token(
+        tmp_path,
+        bot.agent_name,
+        "s_classic",
+        cache_generation=bot.event_cache.cache_generation,
+    )
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    event = _text_event("$sliding-history", "historical", 1_999)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    await _start_bot_with_client(bot, client)
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    handle_text_event = AsyncMock()
+    with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_text_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sliding_initial_sync_raises_decrypt_notice_floor_despite_classic_checkpoint(tmp_path: Path) -> None:
+    """Sliding history needs the existing decrypt-notice floor because no position is reusable."""
+    bot = _agent_bot(tmp_path)
+    bot.config.matrix_sync.mode = "sliding"
+    save_sync_token(
+        tmp_path,
+        bot.agent_name,
+        "s_classic",
+        cache_generation=bot.event_cache.cache_generation,
+    )
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+
+    with patch("mindroom.bot.raise_notice_floor") as notice_floor:
+        await _start_bot_with_client(bot, client)
+
+    notice_floor.assert_called_once_with(client.user_id, floor_timestamp_ms=bot._startup_cutoff_ms)
+
+
+@pytest.mark.asyncio
+async def test_missing_next_batch_keeps_historical_dispatch_fence_armed(tmp_path: Path) -> None:
+    """A successful response without a continuation token leaves the next request tokenless."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    event = _text_event("$missing-token-history", "historical", 1_999)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    await _start_bot_with_client(bot, client)
+    response = MagicMock(spec=nio.SyncResponse)
+    response.next_batch = None
+    response.rooms = MagicMock(join={}, leave={})
+    with (
+        patch.object(
+            bot._conversation_cache,
+            "cache_sync_timeline_for_certification",
+            AsyncMock(return_value=SyncCacheWriteResult(complete=True)),
+        ),
+        patch.object(bot, "_run_sync_response_side_effects", AsyncMock()),
+    ):
+        await bot._on_sync_response(response)
+
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    handle_text_event = AsyncMock()
+    with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_text_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_start_unknown_pos_rearms_historical_dispatch_fence(tmp_path: Path) -> None:
+    """A rejected live checkpoint makes the next classic request tokenless again."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    save_sync_token(
+        tmp_path,
+        bot.agent_name,
+        "s_restored",
+        cache_generation=bot.event_cache.cache_generation,
+    )
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    event = _text_event("$unknown-pos-history", "historical", 1_999)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    with patch("mindroom.bot.raise_notice_floor") as notice_floor:
+        await _start_bot_with_client(bot, client)
+        bot._first_sync_done = True
+        sync_error = MagicMock(spec=nio.SyncError)
+        sync_error.status_code = "M_UNKNOWN_POS"
+        await bot._on_sync_error(sync_error)
+
+    notice_floor.assert_called_once_with(client.user_id, floor_timestamp_ms=bot._startup_cutoff_ms)
+
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    handle_text_event = AsyncMock()
+    with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_text_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_post_start_certification_reset_rearms_historical_dispatch_fence(tmp_path: Path) -> None:
+    """A certification rewind makes the following classic request tokenless."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    save_sync_token(
+        tmp_path,
+        bot.agent_name,
+        "s_restored",
+        cache_generation=bot.event_cache.cache_generation,
+    )
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    event = _text_event("$rewind-history", "historical", 1_999)
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    await _start_bot_with_client(bot, client)
+    bot._first_sync_done = True
+    response = MagicMock(spec=nio.SyncResponse)
+    response.next_batch = "s_limited"
+    response.rooms = MagicMock(join={}, leave={})
+    with patch.object(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(return_value=SyncCacheWriteResult(complete=True, limited_room_ids=(room.room_id,))),
+    ):
+        await bot._on_sync_response(response)
+    assert client.next_batch is None
+
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    handle_text_event = AsyncMock()
+    with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_text_event.assert_not_awaited()
+
+
+@pytest.mark.parametrize(
+    ("origin_server_ts", "expected_reason"),
+    [
+        pytest.param(None, "missing_origin_server_ts", id="missing"),
+        pytest.param(float("inf"), "invalid_origin_server_ts", id="non-finite"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_tokenless_initial_sync_unusable_timestamp_fails_closed(
+    tmp_path: Path,
+    origin_server_ts: float | None,
+    expected_reason: str,
+) -> None:
+    """An untrusted timestamp must not license user-visible cold-sync dispatch."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    event = MagicMock(spec=nio.RoomMessageText)
+    event.event_id = "$missing-timestamp"
+    event.sender = "@user:localhost"
+    event.source = {
+        "content": {"body": "missing timestamp", "msgtype": "m.text"},
+        "event_id": event.event_id,
+        "sender": event.sender,
+        "type": "m.room.message",
+    }
+    if origin_server_ts is not None:
+        event.source["origin_server_ts"] = origin_server_ts
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+
+    await _start_bot_with_client(bot, client)
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    handle_text_event = AsyncMock()
+    with (
+        patch.object(bot._turn_controller, "handle_text_event", handle_text_event),
+        capture_logs() as logs,
+    ):
+        await callback(room, event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    handle_text_event.assert_not_awaited()
+    assert any(
+        entry.get("event") == "matrix_initial_sync_dispatch_fenced" and entry.get("reason") == expected_reason
+        for entry in logs
+    )
+
+
+@pytest.mark.asyncio
+async def test_tokenless_initial_sync_fences_old_reaction_and_approval_action(tmp_path: Path) -> None:
+    """Replayed reactions and custom approval responses must have no action side effects."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+    reaction = nio.Event.parse_event(
+        {
+            "type": "m.reaction",
+            "event_id": "$historical-reaction",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1_999,
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": "$approval-card",
+                    "key": "✅",
+                },
+            },
+        },
+    )
+    approval_response = nio.Event.parse_event(
+        {
+            "type": "io.mindroom.tool_approval_response",
+            "event_id": "$historical-approval",
+            "sender": "@user:localhost",
+            "origin_server_ts": 1_999,
+            "content": {"approval_id": "approval-1", "status": "approved"},
+        },
+    )
+    assert isinstance(reaction, nio.ReactionEvent)
+    assert isinstance(approval_response, nio.UnknownEvent)
+
+    await _start_bot_with_client(bot, client)
+    reaction_callback = cast(
+        "Callable[..., Awaitable[None]]",
+        _registered_event_callback(client, nio.ReactionEvent),
+    )
+    approval_callback = cast(
+        "Callable[..., Awaitable[None]]",
+        _registered_event_callback(client, nio.UnknownEvent),
+    )
+    approval_action = AsyncMock(return_value=True)
+    with patch("mindroom.bot.handle_tool_approval_action", approval_action):
+        await reaction_callback(room, reaction)
+        await approval_callback(room, approval_response)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    approval_action.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tokenless_initial_sync_retry_reuses_original_cutoff(tmp_path: Path) -> None:
+    """Watchdog retry must keep post-start events eligible and old history fenced."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = None
+    room = nio.MatrixRoom("!room:localhost", bot.agent_user.user_id)
+    post_start_event = _text_event("$post-start", "post-start", 2_500)
+    historical_event = _text_event("$historical-after-retry", "historical", 1_500)
+
+    await _start_bot_with_client(bot, client)
+    callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageText))
+    with patch("mindroom.bot.time.time", return_value=2.5):
+        await bot.sync_forever()
+    with patch("mindroom.bot.time.time", return_value=3.0):
+        await bot.sync_forever()
+    handle_text_event = AsyncMock()
+    with patch.object(bot._turn_controller, "handle_text_event", handle_text_event):
+        await callback(room, post_start_event)
+        await callback(room, historical_event)
+        await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    assert [call.args[1].event_id for call in handle_text_event.await_args_list] == ["$post-start"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -516,6 +516,26 @@ async def test_post_start_certification_reset_rearms_historical_dispatch_fence(t
     handle_text_event.assert_not_awaited()
 
 
+def test_redaction_rewind_without_retry_token_rearms_historical_dispatch_fence(tmp_path: Path) -> None:
+    """A failed critical callback without a checkpoint makes the retry tokenless."""
+    with patch("mindroom.bot.time.time", return_value=2.0):
+        bot = _agent_bot(tmp_path)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.next_batch = "s_uncertified"
+    bot.client = client
+    assert not bot._historical_dispatch_fence.armed
+
+    with patch("mindroom.bot.raise_notice_floor") as notice_floor:
+        bot._rewind_sync_after_redaction_failure()
+
+    assert client.next_batch is None
+    assert bot._historical_dispatch_fence.armed
+    notice_floor.assert_called_once_with(
+        client.user_id,
+        floor_timestamp_ms=bot._historical_dispatch_fence.startup_cutoff_ms,
+    )
+
+
 @pytest.mark.parametrize(
     ("origin_server_ts", "expected_reason"),
     [

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -305,11 +305,20 @@ async def test_tokenless_initial_sync_drops_old_media_before_processing(tmp_path
     await _start_bot_with_client(bot, client)
     callback = cast("Callable[..., Awaitable[None]]", _registered_event_callback(client, nio.RoomMessageImage))
     handle_media_event = AsyncMock()
-    with patch.object(bot._turn_controller, "handle_media_event", handle_media_event):
+    with (
+        patch.object(bot._turn_controller, "handle_media_event", handle_media_event),
+        capture_logs() as logs,
+    ):
         await callback(room, event)
         await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
     handle_media_event.assert_not_awaited()
+    assert any(
+        entry.get("event") == "matrix_initial_sync_dispatch_fenced"
+        and entry.get("reason") == "predates_startup_cutoff"
+        and entry.get("log_level") == "debug"
+        for entry in logs
+    )
 
 
 @pytest.mark.asyncio
@@ -553,7 +562,9 @@ async def test_tokenless_initial_sync_unusable_timestamp_fails_closed(
 
     handle_text_event.assert_not_awaited()
     assert any(
-        entry.get("event") == "matrix_initial_sync_dispatch_fenced" and entry.get("reason") == expected_reason
+        entry.get("event") == "matrix_initial_sync_dispatch_fenced"
+        and entry.get("reason") == expected_reason
+        and entry.get("log_level") == "info"
         for entry in logs
     )
 

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -58,6 +58,7 @@ def _room_member_event(
     event_id: str = "$join",
     user_id: str = "@alice:localhost",
     sender: str | None = None,
+    origin_server_ts: int = 1,
     membership: str = "join",
     prev_membership: str | None = "leave",
     display_name: str | None = "Alice",
@@ -73,7 +74,7 @@ def _room_member_event(
         "event_id": event_id,
         "sender": sender or user_id,
         "state_key": user_id,
-        "origin_server_ts": 1,
+        "origin_server_ts": origin_server_ts,
         "content": content,
     }
     if prev_membership is not None:
@@ -133,6 +134,17 @@ def _agent_bot(tmp_path: Path) -> AgentBot:
         password=TEST_PASSWORD,
     )
     return install_runtime_cache_support(AgentBot(agent_user, tmp_path, config=config, runtime_paths=runtime_paths))
+
+
+def _record_join_event_ids(bot: AgentBot) -> list[str]:
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    return seen
 
 
 def test_room_member_joined_is_a_builtin_hook_event() -> None:
@@ -475,6 +487,8 @@ async def test_unknown_pos_resync_does_not_emit_room_member_joined_snapshot(
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_rejected"
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    bot._register_room_member_callback_after_initial_sync()
+    room_member_callback = bot.client.add_event_callback.call_args.args[0]
     monkeypatch.setattr(
         bot._conversation_cache,
         "cache_sync_timeline_for_certification",
@@ -484,13 +498,14 @@ async def test_unknown_pos_resync_does_not_emit_room_member_joined_snapshot(
     sync_error.status_code = "M_UNKNOWN_POS"
 
     await bot._on_sync_error(sync_error)
-    await bot._on_room_member(room, _room_member_event(event_id="$timeline-snapshot"))
+    await room_member_callback(room, _room_member_event(event_id="$timeline-snapshot"))
     await bot._on_sync_response(
         _sync_response_with_state(
             room.room_id,
             [_room_member_event(event_id="$state-snapshot")],
         ),
     )
+    await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
     assert seen == []
 
@@ -537,6 +552,83 @@ async def test_registered_room_member_callback_uses_delivery_time_arming_state(
     await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
     assert seen == ["$live"]
+
+
+@pytest.mark.asyncio
+async def test_classic_recovery_emits_only_post_cutoff_timeline_join_before_state_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A recovery timeline must expose its fresh join before state records the user seen."""
+    bot = _router_bot(tmp_path)
+    seen = _record_join_event_ids(bot)
+    room = _room()
+    bot.client.rooms = {room.room_id: room}
+    bot._historical_dispatch_fence.startup_cutoff_ms = 2_000
+    bot._set_historical_dispatch_fence(armed=True)
+    monkeypatch.setattr(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(return_value=SyncCacheWriteResult(complete=True)),
+    )
+    historical_join = _room_member_event(
+        event_id="$historical-join",
+        origin_server_ts=1_500,
+    )
+    fresh_join = _room_member_event(
+        event_id="$fresh-join",
+        user_id="@bob:localhost",
+        origin_server_ts=2_500,
+    )
+    fresh_state = _room_member_event(
+        event_id="$fresh-state",
+        user_id="@bob:localhost",
+        origin_server_ts=2_500,
+        prev_membership=None,
+    )
+
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [fresh_state],
+            timeline_events=[historical_join, fresh_join],
+        ),
+    )
+
+    assert seen == ["$fresh-join"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sync_mode", ["classic", "sliding"])
+async def test_restarted_sync_member_callback_filters_history_but_keeps_fresh_join(
+    tmp_path: Path,
+    sync_mode: str,
+) -> None:
+    """A positionless retry must filter members by timestamp, not disable hooks."""
+    bot = _router_bot(tmp_path)
+    seen = _record_join_event_ids(bot)
+    bot.config.matrix_sync.mode = sync_mode
+    room = _room()
+    bot._register_room_member_callback_after_initial_sync()
+    room_member_callback = bot.client.add_event_callback.call_args.args[0]
+    bot._historical_dispatch_fence.startup_cutoff_ms = 2_000
+    if sync_mode == "sliding":
+        await bot._on_sync_error(nio.SlidingSyncError("connection expired", "M_UNKNOWN_POS"))
+    else:
+        bot._set_historical_dispatch_fence(armed=True)
+
+    await room_member_callback(room, _room_member_event(event_id="$historical", origin_server_ts=1_500))
+    await room_member_callback(
+        room,
+        _room_member_event(
+            event_id="$fresh",
+            user_id="@bob:localhost",
+            origin_server_ts=2_500,
+        ),
+    )
+    await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
+    assert seen == ["$fresh"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Fence historical text, edit, media, reaction, and approval callbacks whenever Matrix sync starts without reusable continuity.
- Keep events at or after one fixed runtime-start cutoff eligible while preserving cache certification, state callbacks, and explicit interrupted-turn recovery.
- Apply the same fixed cutoff to decrypt-failure notices so replayed encrypted history stays silent without hiding new failures.

## Tests

- Added callback-level regression coverage for classic and Sliding Sync cold windows, restored checkpoints, retries, token resets, missing timestamps, missing continuation tokens, and decrypt-notice floors.
- Ran 146 focused sync, cache, decrypt, retry, auto-resume, startup, and import-boundary tests.
- Ran the full suite: 12,188 passed and 54 skipped.
- Ran all pre-commit hooks.

## Summary by Sourcery

Fence Matrix cold-sync historical events from user-visible dispatch while preserving cache certification and decrypt-failure notice behavior around a fixed startup cutoff.

New Features:
- Add a startup-based historical-dispatch fence that blocks cold-sync replayed events from entering normal message, reaction, media, and approval handling during tokenless windows.

Enhancements:
- Track a fixed startup cutoff timestamp and reuse it across continuity retries and sync-token resets to distinguish historical from live events.
- Tie historical-dispatch fencing into sync certification, sliding-sync startup, and unknown-position errors so fencing automatically arms or disarms with continuity state.
- Extend decrypt-failure notice flooring to accept an explicit timestamp and enforce a monotonic per-user/room floor to keep replayed encrypted history silent without hiding new failures.

Tests:
- Add comprehensive regression tests around tokenless and sliding Matrix sync windows, restored checkpoints, missing continuation tokens, certification resets, timestamp edge cases, and reaction/approval side effects.
- Add tests ensuring decrypt-failure notice floors interact correctly with the startup cutoff so post-start failures still surface while older failures remain suppressed.