### PR TITLE
Fix auto-resume freshness actor selection

### DIFF
--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -255,6 +255,7 @@ async def recover_stale_streaming_messages(
             cleaned_count += room_cleaned_count
             if resume_client is None or not config.defaults.auto_resume_after_restart or not interrupted_threads:
                 continue
+            retryable_room_ids: set[str] = set()
             resumed_count += await _auto_resume_interrupted_threads(
                 resume_client,
                 interrupted_threads,
@@ -263,7 +264,9 @@ async def recover_stale_streaming_messages(
                 conversation_cache=resume_conversation_cache,
                 owner_actors=joined_actors,
                 delay_before_first=resumed_count > 0,
+                retryable_room_ids=retryable_room_ids,
             )
+            scanned_room_ids.difference_update(retryable_room_ids)
     finally:
         for task in tasks:
             if not task.done():
@@ -317,6 +320,7 @@ async def _auto_resume_interrupted_threads(
     owner_actors: Mapping[str, StaleStreamCleanupActor],
     delay: float = 2.0,
     delay_before_first: bool = False,
+    retryable_room_ids: set[str] | None = None,
 ) -> int:
     """Send resume prompts for interrupted threaded conversations."""
     if not interrupted:
@@ -341,6 +345,10 @@ async def _auto_resume_interrupted_threads(
         )
         owner_actor = owner_actors.get(owner_user_id) if owner_user_id is not None else None
         if owner_actor is None or owner_actor.conversation_cache is None:
+            _mark_auto_resume_room_retryable(
+                retryable_room_ids,
+                room_id=interrupted_thread.room_id,
+            )
             logger.warning(
                 "Skipping auto-resume because owning actor is unavailable or not joined",
                 room_id=interrupted_thread.room_id,
@@ -358,6 +366,8 @@ async def _auto_resume_interrupted_threads(
             conversation_cache=owner_actor.conversation_cache,
         ):
             continue
+        send_attempted = False
+        delivered = None
         try:
             content = _build_auto_resume_content(
                 interrupted_thread,
@@ -365,6 +375,7 @@ async def _auto_resume_interrupted_threads(
                 runtime_paths=runtime_paths,
             )
             delay_due = True
+            send_attempted = True
             delivered = await send_message_result(client, interrupted_thread.room_id, content)
             if delivered is not None:
                 if conversation_cache is not None:
@@ -396,8 +407,37 @@ async def _auto_resume_interrupted_threads(
                 target_event_id=interrupted_thread.target_event_id,
                 error=str(exc),
             )
+        finally:
+            _mark_failed_auto_resume_delivery_retryable(
+                retryable_room_ids,
+                room_id=interrupted_thread.room_id,
+                send_attempted=send_attempted,
+                delivered=delivered,
+            )
 
     return resumed_count
+
+
+def _mark_auto_resume_room_retryable(
+    retryable_room_ids: set[str] | None,
+    *,
+    room_id: str,
+) -> None:
+    """Release a room so a later joined-membership wave can retry it."""
+    if retryable_room_ids is not None:
+        retryable_room_ids.add(room_id)
+
+
+def _mark_failed_auto_resume_delivery_retryable(
+    retryable_room_ids: set[str] | None,
+    *,
+    room_id: str,
+    send_attempted: bool,
+    delivered: object | None,
+) -> None:
+    """Release rooms whose router delivery attempt produced no Matrix event."""
+    if send_attempted and delivered is None:
+        _mark_auto_resume_room_retryable(retryable_room_ids, room_id=room_id)
 
 
 async def _interrupted_target_remains_latest_human_work(

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -220,10 +220,11 @@ async def recover_stale_streaming_messages(
     async def recover_room(
         room_id: str,
         joined_actors: dict[str, StaleStreamCleanupActor],
-    ) -> tuple[int, list[_InterruptedThread], dict[str, StaleStreamCleanupActor]]:
+    ) -> tuple[int, list[_InterruptedThread], dict[str, StaleStreamCleanupActor], set[str]]:
         scan_actor = joined_actors.get(resume_user_id) if isinstance(resume_user_id, str) else None
         if scan_actor is None:
             scan_actor = joined_actors[min(joined_actors)]
+        retryable_room_ids: set[str] = set()
         async with semaphore:
             try:
                 cleaned_count, interrupted_threads = await _cleanup_stale_streaming_room(
@@ -235,13 +236,14 @@ async def recover_stale_streaming_messages(
                     runtime_paths=runtime_paths,
                     startup_cutoff_ms=startup_cutoff_ms,
                     terminal_interrupted_only=target_room_ids is not None,
+                    retryable_room_ids=retryable_room_ids,
                 )
             except Exception:
                 scanned_room_ids.discard(room_id)
                 logger.warning("Failed stale stream recovery for room", room_id=room_id, exc_info=True)
-                return 0, [], joined_actors
+                return 0, [], joined_actors, set()
             else:
-                return cleaned_count, interrupted_threads, joined_actors
+                return cleaned_count, interrupted_threads, joined_actors, retryable_room_ids
 
     tasks = [
         asyncio.create_task(recover_room(room_id, joined_actors), name=f"stale_stream_recovery:{room_id}")
@@ -251,11 +253,11 @@ async def recover_stale_streaming_messages(
     resumed_count = 0
     try:
         for completed in asyncio.as_completed(tasks):
-            room_cleaned_count, interrupted_threads, joined_actors = await completed
+            room_cleaned_count, interrupted_threads, joined_actors, retryable_room_ids = await completed
             cleaned_count += room_cleaned_count
+            scanned_room_ids.difference_update(retryable_room_ids)
             if resume_client is None or not config.defaults.auto_resume_after_restart or not interrupted_threads:
                 continue
-            retryable_room_ids: set[str] = set()
             resumed_count += await _auto_resume_interrupted_threads(
                 resume_client,
                 interrupted_threads,
@@ -545,6 +547,7 @@ async def _cleanup_stale_streaming_room(
     runtime_paths: RuntimePaths,
     startup_cutoff_ms: int | None = None,
     terminal_interrupted_only: bool = False,
+    retryable_room_ids: set[str] | None = None,
 ) -> tuple[int, list[_InterruptedThread]]:
     """Scan one room once and let each bot account repair its own messages."""
     if not actors:
@@ -558,7 +561,7 @@ async def _cleanup_stale_streaming_room(
     scanned_state = await _scan_room_message_states(
         scan_client,
         room_id=room_id,
-        cleanup_bot_user_ids=set(actors),
+        cleanup_bot_user_ids=bot_user_ids,
         bot_user_ids=bot_user_ids,
         config=config,
         runtime_paths=runtime_paths,
@@ -580,8 +583,20 @@ async def _cleanup_stale_streaming_room(
     for target_event_id, state in candidate_items:
         assert state.latest_body is not None  # guaranteed by filter above
         bot_user_id = state.bot_user_id
-        actor = actors.get(bot_user_id) if bot_user_id is not None else None
-        if bot_user_id is None or actor is None:
+        if bot_user_id is None:
+            continue
+        actor = actors.get(bot_user_id)
+        if actor is None:
+            _mark_unavailable_cleanup_actor_retryable(
+                retryable_room_ids,
+                room_id=room_id,
+                bot_user_id=bot_user_id,
+                state=state,
+                config=config,
+                runtime_paths=runtime_paths,
+                current_time_ms=current_time_ms,
+                scan_policy=scan_policy,
+            )
             continue
         edited, interrupted = await _process_stale_room_candidate(
             actor,
@@ -606,6 +621,32 @@ async def _cleanup_stale_streaming_room(
     return cleaned_count, interrupted_threads
 
 
+def _mark_unavailable_cleanup_actor_retryable(
+    retryable_room_ids: set[str] | None,
+    *,
+    room_id: str,
+    bot_user_id: str,
+    state: _MessageState,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    current_time_ms: int,
+    scan_policy: _CleanupScanPolicy,
+) -> None:
+    """Release a room when its recoverable message owner is not joined yet."""
+    if (
+        _cleanup_candidate_agent_name(
+            bot_user_id,
+            state=state,
+            config=config,
+            runtime_paths=runtime_paths,
+            current_time_ms=current_time_ms,
+            scan_policy=scan_policy,
+        )
+        is not None
+    ):
+        _mark_auto_resume_room_retryable(retryable_room_ids, room_id=room_id)
+
+
 async def _process_stale_room_candidate(
     actor: StaleStreamCleanupActor,
     *,
@@ -623,14 +664,15 @@ async def _process_stale_room_candidate(
 ) -> tuple[bool, _InterruptedThread | None]:
     """Repair or classify one bot-owned candidate from a shared room scan."""
     assert state.latest_body is not None
-    agent_name = _agent_name_for_bot_user_id(bot_user_id, config, runtime_paths)
-    if agent_name is None or _should_skip_for_startup_cleanup_window(
-        state,
-        now_ms=current_time_ms,
+    agent_name = _cleanup_candidate_agent_name(
+        bot_user_id,
+        state=state,
+        config=config,
+        runtime_paths=runtime_paths,
+        current_time_ms=current_time_ms,
         scan_policy=scan_policy,
-    ):
-        return False, None
-    if scan_policy.terminal_interrupted_only and not _has_resumable_interrupted_note(state):
+    )
+    if agent_name is None:
         return False, None
     if _is_cleanup_candidate(state):
         return await _cleanup_candidate_message(
@@ -661,6 +703,32 @@ async def _process_stale_room_candidate(
         agent_name=agent_name,
         prior_edit_succeeded=prior_edit_succeeded,
     )
+
+
+def _cleanup_candidate_agent_name(
+    bot_user_id: str,
+    *,
+    state: _MessageState,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    current_time_ms: int,
+    scan_policy: _CleanupScanPolicy,
+) -> str | None:
+    """Return the owner name when one message belongs in this cleanup pass."""
+    assert state.latest_body is not None
+    agent_name = _agent_name_for_bot_user_id(bot_user_id, config, runtime_paths)
+    if agent_name is None or _should_skip_for_startup_cleanup_window(
+        state,
+        now_ms=current_time_ms,
+        scan_policy=scan_policy,
+    ):
+        return None
+    if scan_policy.terminal_interrupted_only and not _has_resumable_interrupted_note(state):
+        return None
+    has_interrupted_note = _has_restart_interrupted_note(state.latest_body) or _has_resumable_interrupted_note(state)
+    if _is_cleanup_candidate(state) or has_interrupted_note:
+        return agent_name
+    return None
 
 
 async def _handle_interrupted_message(

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -120,6 +120,7 @@ class StaleStreamRecoveryState:
 
     scanned_room_ids: set[str] = field(default_factory=set)
     retry_target_event_ids: set[str] = field(default_factory=set)
+    known_actor_user_ids: set[str] = field(default_factory=set)
 
 
 @dataclass(frozen=True)
@@ -230,6 +231,18 @@ def _requester_resolution_message(
     )
 
 
+def _reopen_rooms_for_new_actors(
+    actors: dict[str, StaleStreamCleanupActor],
+    recovery_state: StaleStreamRecoveryState,
+) -> None:
+    """Reopen expected rooms when an actor first joins this recovery generation."""
+    new_actor_user_ids = set(actors).difference(recovery_state.known_actor_user_ids)
+    recovery_state.scanned_room_ids.difference_update(
+        room_id for bot_user_id in new_actor_user_ids for room_id in actors[bot_user_id].expected_room_ids
+    )
+    recovery_state.known_actor_user_ids.update(new_actor_user_ids)
+
+
 async def recover_stale_streaming_messages(
     actors: dict[str, StaleStreamCleanupActor],
     *,
@@ -243,6 +256,8 @@ async def recover_stale_streaming_messages(
     room_concurrency: int = _RECOVERY_ROOM_CONCURRENCY,
 ) -> _StaleStreamRecoveryResult:
     """Recover stale streams through one concurrent Matrix-history path."""
+    _reopen_rooms_for_new_actors(actors, recovery_state)
+
     room_actors = {
         room_id: joined_actors
         for room_id, joined_actors in (await _joined_room_actors(actors)).items()
@@ -290,6 +305,7 @@ async def recover_stale_streaming_messages(
     ]
     cleaned_count = 0
     resumed_count = 0
+    processed_room_ids: set[str] = set()
     try:
         for completed in asyncio.as_completed(tasks):
             room_result = await completed
@@ -301,6 +317,7 @@ async def recover_stale_streaming_messages(
                 or not config.defaults.auto_resume_after_restart
                 or not room_result.interrupted_threads
             ):
+                processed_room_ids.add(room_result.room_id)
                 continue
             recovery_state.retry_target_event_ids.update(
                 interrupted_thread.target_event_id for interrupted_thread in room_result.interrupted_threads
@@ -319,7 +336,9 @@ async def recover_stale_streaming_messages(
                 auto_resume_result.settled_target_event_ids,
             )
             recovery_state.retry_target_event_ids.update(auto_resume_result.retry_target_event_ids)
+            processed_room_ids.add(room_result.room_id)
     finally:
+        recovery_state.scanned_room_ids.difference_update(set(room_actors).difference(processed_room_ids))
         for task in tasks:
             if not task.done():
                 task.cancel()

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -13,6 +13,7 @@ from nio.api import RelationshipType
 from mindroom.authorization import get_effective_sender_id_for_reply_permissions
 from mindroom.constants import (
     ORIGINAL_SENDER_KEY,
+    ROUTER_AGENT_NAME,
     SOURCE_KIND_KEY,
     STREAM_STATUS_CANCELLED,
     STREAM_STATUS_COMPLETED,
@@ -1920,7 +1921,11 @@ def _build_auto_resume_content(
     runtime_paths: RuntimePaths,
 ) -> dict[str, object]:
     """Build the router-authored visible resume relay for one interrupted agent."""
-    target_user_id = _current_configured_entity_user_id(interrupted_thread.agent_name, config, runtime_paths)
+    target_user_id = (
+        None
+        if interrupted_thread.agent_name == ROUTER_AGENT_NAME
+        else _current_configured_entity_user_id(interrupted_thread.agent_name, config, runtime_paths)
+    )
     display_name = _entity_display_name(interrupted_thread.agent_name, config)
 
     body = AUTO_RESUME_MESSAGE
@@ -1956,7 +1961,7 @@ def _current_configured_entity_user_id(
     runtime_paths: RuntimePaths,
 ) -> str | None:
     """Return one configured entity user ID without resolving unrelated entities."""
-    if entity_name not in config.agents and entity_name not in config.teams:
+    if entity_name != ROUTER_AGENT_NAME and entity_name not in config.agents and entity_name not in config.teams:
         return None
     try:
         return current_entity_id(entity_name, runtime_paths).full_id

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -302,6 +302,9 @@ async def recover_stale_streaming_messages(
                 or not room_result.interrupted_threads
             ):
                 continue
+            recovery_state.retry_target_event_ids.update(
+                interrupted_thread.target_event_id for interrupted_thread in room_result.interrupted_threads
+            )
             auto_resume_result = await _auto_resume_interrupted_threads(
                 resume_client,
                 room_result.interrupted_threads,

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -127,6 +127,7 @@ class _MessageState:
 
     latest_body: str | None = None
     latest_timestamp: int = 0
+    original_timestamp: int | None = None
     latest_event_id: str = ""
     latest_content: dict[str, Any] | None = None
     thread_id: str | None = None
@@ -1081,6 +1082,7 @@ def _merge_resolved_message_state(
     normalized_latest_content = {key: value for key, value in message.content.items() if isinstance(key, str)}
     state = message_states.setdefault(target_event_id, _MessageState())
     state.latest_body = message.body
+    state.original_timestamp = message.timestamp
     # The last time this message changed, not when it was created. ``timestamp`` deliberately
     # stays the original event's so an edit cannot reorder a thread, which means it is the
     # wrong clock for "is this stream still active": a placeholder posted eight hours ago and
@@ -1858,17 +1860,24 @@ def _should_skip_for_startup_cleanup_window(
 ) -> bool:
     """Return whether startup cleanup should ignore one candidate by age."""
     timestamp_ms = state.latest_timestamp
-    if _is_at_or_after_startup_cutoff(timestamp_ms, startup_cutoff_ms=scan_policy.startup_cutoff_ms):
+    is_resumable_interruption = scan_policy.collect_terminal_interrupted_for_resume and _has_resumable_interrupted_note(
+        state,
+    )
+    cutoff_timestamp_ms = (
+        state.original_timestamp if is_resumable_interruption and state.original_timestamp is not None else timestamp_ms
+    )
+    if _is_at_or_after_startup_cutoff(
+        cutoff_timestamp_ms,
+        startup_cutoff_ms=scan_policy.startup_cutoff_ms,
+    ):
         return True
     # A terminal interruption cannot still be receiving chunks. Targeted
     # replacement recovery passes no cutoff because local and Matrix clocks
     # are not comparable.
-    if _is_recent_timestamp(timestamp_ms, now_ms=now_ms) and not (
-        scan_policy.collect_terminal_interrupted_for_resume and _has_resumable_interrupted_note(state)
-    ):
+    if _is_recent_timestamp(timestamp_ms, now_ms=now_ms) and not is_resumable_interruption:
         return True
     if _is_older_than_cleanup_window(timestamp_ms, now_ms=now_ms):
-        return not (scan_policy.collect_terminal_interrupted_for_resume and _has_resumable_interrupted_note(state))
+        return not is_resumable_interruption
     return False
 
 

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -324,7 +324,7 @@ async def _auto_resume_interrupted_threads(
     owner_actors: Mapping[str, StaleStreamCleanupActor],
     delay: float = 2.0,
     delay_before_first: bool = False,
-    retryable_room_ids: set[str] | None = None,
+    retryable_room_ids: set[str],
 ) -> int:
     """Send resume prompts for interrupted threaded conversations."""
     if not interrupted:
@@ -349,10 +349,7 @@ async def _auto_resume_interrupted_threads(
         )
         owner_actor = owner_actors.get(owner_user_id) if owner_user_id is not None else None
         if owner_actor is None or owner_actor.conversation_cache is None:
-            _mark_auto_resume_room_retryable(
-                retryable_room_ids,
-                room_id=interrupted_thread.room_id,
-            )
+            retryable_room_ids.add(interrupted_thread.room_id)
             logger.warning(
                 "Skipping auto-resume because owning actor is unavailable or not joined",
                 room_id=interrupted_thread.room_id,
@@ -422,26 +419,16 @@ async def _auto_resume_interrupted_threads(
     return resumed_count
 
 
-def _mark_auto_resume_room_retryable(
-    retryable_room_ids: set[str] | None,
-    *,
-    room_id: str,
-) -> None:
-    """Release a room so a later joined-membership wave can retry it."""
-    if retryable_room_ids is not None:
-        retryable_room_ids.add(room_id)
-
-
 def _mark_failed_auto_resume_delivery_retryable(
-    retryable_room_ids: set[str] | None,
+    retryable_room_ids: set[str],
     *,
     room_id: str,
     send_attempted: bool,
     delivered: object | None,
 ) -> None:
-    """Release rooms whose router delivery attempt produced no Matrix event."""
+    """Release a room when router delivery produced no Matrix event."""
     if send_attempted and delivered is None:
-        _mark_auto_resume_room_retryable(retryable_room_ids, room_id=room_id)
+        retryable_room_ids.add(room_id)
 
 
 async def _interrupted_target_remains_latest_human_work(
@@ -549,7 +536,7 @@ async def _cleanup_stale_streaming_room(
     runtime_paths: RuntimePaths,
     startup_cutoff_ms: int | None = None,
     terminal_interrupted_only: bool = False,
-    retryable_room_ids: set[str] | None = None,
+    retryable_room_ids: set[str],
 ) -> tuple[int, list[_InterruptedThread]]:
     """Scan one room once and let each bot account repair its own messages."""
     if not actors:
@@ -624,7 +611,7 @@ async def _cleanup_stale_streaming_room(
 
 
 def _mark_unavailable_cleanup_actor_retryable(
-    retryable_room_ids: set[str] | None,
+    retryable_room_ids: set[str],
     *,
     room_id: str,
     bot_user_id: str,
@@ -646,7 +633,7 @@ def _mark_unavailable_cleanup_actor_retryable(
         )
         is not None
     ):
-        _mark_auto_resume_room_retryable(retryable_room_ids, room_id=room_id)
+        retryable_room_ids.add(room_id)
 
 
 async def _process_stale_room_candidate(

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -60,7 +60,7 @@ from mindroom.streaming import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterable, Sequence
+    from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -220,13 +220,13 @@ async def recover_stale_streaming_messages(
     async def recover_room(
         room_id: str,
         joined_actors: dict[str, StaleStreamCleanupActor],
-    ) -> tuple[int, list[_InterruptedThread]]:
+    ) -> tuple[int, list[_InterruptedThread], dict[str, StaleStreamCleanupActor]]:
         scan_actor = joined_actors.get(resume_user_id) if isinstance(resume_user_id, str) else None
         if scan_actor is None:
             scan_actor = joined_actors[min(joined_actors)]
         async with semaphore:
             try:
-                return await _cleanup_stale_streaming_room(
+                cleaned_count, interrupted_threads = await _cleanup_stale_streaming_room(
                     scan_actor.client,
                     room_id=room_id,
                     actors=joined_actors,
@@ -239,7 +239,9 @@ async def recover_stale_streaming_messages(
             except Exception:
                 scanned_room_ids.discard(room_id)
                 logger.warning("Failed stale stream recovery for room", room_id=room_id, exc_info=True)
-                return 0, []
+                return 0, [], joined_actors
+            else:
+                return cleaned_count, interrupted_threads, joined_actors
 
     tasks = [
         asyncio.create_task(recover_room(room_id, joined_actors), name=f"stale_stream_recovery:{room_id}")
@@ -249,7 +251,7 @@ async def recover_stale_streaming_messages(
     resumed_count = 0
     try:
         for completed in asyncio.as_completed(tasks):
-            room_cleaned_count, interrupted_threads = await completed
+            room_cleaned_count, interrupted_threads, joined_actors = await completed
             cleaned_count += room_cleaned_count
             if resume_client is None or not config.defaults.auto_resume_after_restart or not interrupted_threads:
                 continue
@@ -259,6 +261,7 @@ async def recover_stale_streaming_messages(
                 config=config,
                 runtime_paths=runtime_paths,
                 conversation_cache=resume_conversation_cache,
+                owner_actors=joined_actors,
                 delay_before_first=resumed_count > 0,
             )
     finally:
@@ -311,6 +314,7 @@ async def _auto_resume_interrupted_threads(
     config: Config,
     runtime_paths: RuntimePaths,
     conversation_cache: ConversationCacheProtocol | None = None,
+    owner_actors: Mapping[str, StaleStreamCleanupActor],
     delay: float = 2.0,
     delay_before_first: bool = False,
 ) -> int:
@@ -330,6 +334,20 @@ async def _auto_resume_interrupted_threads(
                 target_event_id=interrupted_thread.target_event_id,
             )
             continue
+        owner_user_id = _current_configured_entity_user_id(
+            interrupted_thread.agent_name,
+            config,
+            runtime_paths,
+        )
+        owner_actor = owner_actors.get(owner_user_id) if owner_user_id is not None else None
+        if owner_actor is None or owner_actor.conversation_cache is None:
+            logger.warning(
+                "Skipping auto-resume because owning actor is unavailable or not joined",
+                room_id=interrupted_thread.room_id,
+                agent_name=interrupted_thread.agent_name,
+                target_event_id=interrupted_thread.target_event_id,
+            )
+            continue
         if delay_due:
             await asyncio.sleep(delay)
             delay_due = False
@@ -337,7 +355,7 @@ async def _auto_resume_interrupted_threads(
             interrupted_thread,
             config=config,
             runtime_paths=runtime_paths,
-            conversation_cache=conversation_cache,
+            conversation_cache=owner_actor.conversation_cache,
         ):
             continue
         try:

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
 
 import nio
@@ -13,7 +14,6 @@ from nio.api import RelationshipType
 from mindroom.authorization import get_effective_sender_id_for_reply_permissions
 from mindroom.constants import (
     ORIGINAL_SENDER_KEY,
-    ROUTER_AGENT_NAME,
     SOURCE_KIND_KEY,
     STREAM_STATUS_CANCELLED,
     STREAM_STATUS_COMPLETED,
@@ -31,8 +31,6 @@ from mindroom.dispatch_source import (
     is_auto_resume_relay_body,
 )
 from mindroom.entity_resolution import (
-    MissingManagedEntityAccountError,
-    current_entity_id,
     current_internal_sender_ids,
     entity_identity_registry,
 )
@@ -61,7 +59,7 @@ from mindroom.streaming import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Iterable, Mapping, Sequence
+    from collections.abc import AsyncIterator, Iterable, Sequence
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -92,24 +90,36 @@ _TERMINAL_STREAM_STATUSES = frozenset(
 
 
 @dataclass(frozen=True)
+class StaleStreamCleanupActor:
+    """One bot account that may repair its own stale messages."""
+
+    client: nio.AsyncClient
+    conversation_cache: ConversationCacheProtocol
+    first_sync_complete: bool
+    expected_room_ids: frozenset[str]
+
+
+@dataclass(frozen=True)
 class _InterruptedThread:
-    """One interrupted thread that can be resumed after restart."""
+    """One exact-owner interrupted thread that can be resumed after restart."""
 
     room_id: str
     thread_id: str | None
     target_event_id: str
     partial_text: str
     agent_name: str
+    bot_user_id: str
+    owner_actor: StaleStreamCleanupActor = field(compare=False, repr=False)
     original_sender_id: str | None = None
     timestamp_ms: int = field(default=0, compare=False)
 
 
-@dataclass(frozen=True)
-class StaleStreamCleanupActor:
-    """One bot account that may repair its own stale messages."""
+@dataclass
+class StaleStreamRecoveryState:
+    """Narrow cross-pass state for one startup recovery generation."""
 
-    client: nio.AsyncClient
-    conversation_cache: ConversationCacheProtocol | None
+    scanned_room_ids: set[str] = field(default_factory=set)
+    retry_target_event_ids: set[str] = field(default_factory=set)
 
 
 @dataclass(frozen=True)
@@ -121,13 +131,40 @@ class _StaleStreamRecoveryResult:
     resumed_count: int
 
 
+@dataclass(frozen=True)
+class _RoomCleanupResult:
+    """Typed outcome from one room history scan."""
+
+    room_id: str
+    cleaned_count: int
+    interrupted_threads: tuple[_InterruptedThread, ...]
+    retry_room: bool = False
+
+
+@dataclass(frozen=True)
+class _AutoResumeResult:
+    """Typed delivery outcome for one group of exact-owner candidates."""
+
+    resumed_count: int
+    retry_room_ids: frozenset[str]
+    retry_target_event_ids: frozenset[str]
+    settled_target_event_ids: frozenset[str]
+
+
+class _FreshnessOutcome(Enum):
+    """Authoritative startup auto-resume freshness classification."""
+
+    CURRENT = auto()
+    NEWER_HUMAN = auto()
+    RETRY = auto()
+
+
 @dataclass
 class _MessageState:
     """Latest visible state for one original Matrix message."""
 
     latest_body: str | None = None
     latest_timestamp: int = 0
-    original_timestamp: int | None = None
     latest_event_id: str = ""
     latest_content: dict[str, Any] | None = None
     thread_id: str | None = None
@@ -201,7 +238,7 @@ async def recover_stale_streaming_messages(
     config: Config,
     runtime_paths: RuntimePaths,
     startup_cutoff_ms: int | None,
-    scanned_room_ids: set[str],
+    recovery_state: StaleStreamRecoveryState,
     target_room_ids: set[str] | None = None,
     room_concurrency: int = _RECOVERY_ROOM_CONCURRENCY,
 ) -> _StaleStreamRecoveryResult:
@@ -209,43 +246,43 @@ async def recover_stale_streaming_messages(
     room_actors = {
         room_id: joined_actors
         for room_id, joined_actors in (await _joined_room_actors(actors)).items()
-        if room_id not in scanned_room_ids and (target_room_ids is None or room_id in target_room_ids)
+        if room_id not in recovery_state.scanned_room_ids and (target_room_ids is None or room_id in target_room_ids)
     }
-    scanned_room_ids.update(room_actors)
+    recovery_state.scanned_room_ids.update(room_actors)
     if not room_actors:
         return _StaleStreamRecoveryResult(room_count=0, cleaned_count=0, resumed_count=0)
 
     semaphore = asyncio.Semaphore(max(1, room_concurrency))
-    all_bot_user_ids = set(actors)
     resume_user_id = resume_client.user_id if resume_client is not None else None
 
     async def recover_room(
         room_id: str,
         joined_actors: dict[str, StaleStreamCleanupActor],
-    ) -> tuple[int, list[_InterruptedThread], dict[str, StaleStreamCleanupActor], set[str]]:
+    ) -> _RoomCleanupResult:
         scan_actor = joined_actors.get(resume_user_id) if isinstance(resume_user_id, str) else None
         if scan_actor is None:
             scan_actor = joined_actors[min(joined_actors)]
-        retryable_room_ids: set[str] = set()
         async with semaphore:
             try:
-                cleaned_count, interrupted_threads = await _cleanup_stale_streaming_room(
+                return await _cleanup_stale_streaming_room(
                     scan_actor.client,
                     room_id=room_id,
-                    actors=joined_actors,
-                    bot_user_ids=all_bot_user_ids,
+                    actors=actors,
+                    joined_bot_user_ids=frozenset(joined_actors),
                     config=config,
                     runtime_paths=runtime_paths,
                     startup_cutoff_ms=startup_cutoff_ms,
                     terminal_interrupted_only=target_room_ids is not None,
-                    retryable_room_ids=retryable_room_ids,
+                    retry_target_event_ids=frozenset(recovery_state.retry_target_event_ids),
                 )
             except Exception:
-                scanned_room_ids.discard(room_id)
                 logger.warning("Failed stale stream recovery for room", room_id=room_id, exc_info=True)
-                return 0, [], joined_actors, set()
-            else:
-                return cleaned_count, interrupted_threads, joined_actors, retryable_room_ids
+                return _RoomCleanupResult(
+                    room_id=room_id,
+                    cleaned_count=0,
+                    interrupted_threads=(),
+                    retry_room=True,
+                )
 
     tasks = [
         asyncio.create_task(recover_room(room_id, joined_actors), name=f"stale_stream_recovery:{room_id}")
@@ -255,22 +292,30 @@ async def recover_stale_streaming_messages(
     resumed_count = 0
     try:
         for completed in asyncio.as_completed(tasks):
-            room_cleaned_count, interrupted_threads, joined_actors, retryable_room_ids = await completed
-            cleaned_count += room_cleaned_count
-            scanned_room_ids.difference_update(retryable_room_ids)
-            if resume_client is None or not config.defaults.auto_resume_after_restart or not interrupted_threads:
+            room_result = await completed
+            cleaned_count += room_result.cleaned_count
+            if room_result.retry_room:
+                recovery_state.scanned_room_ids.discard(room_result.room_id)
+            if (
+                resume_client is None
+                or not config.defaults.auto_resume_after_restart
+                or not room_result.interrupted_threads
+            ):
                 continue
-            resumed_count += await _auto_resume_interrupted_threads(
+            auto_resume_result = await _auto_resume_interrupted_threads(
                 resume_client,
-                interrupted_threads,
+                room_result.interrupted_threads,
                 config=config,
                 runtime_paths=runtime_paths,
                 conversation_cache=resume_conversation_cache,
-                owner_actors=joined_actors,
                 delay_before_first=resumed_count > 0,
-                retryable_room_ids=retryable_room_ids,
             )
-            scanned_room_ids.difference_update(retryable_room_ids)
+            resumed_count += auto_resume_result.resumed_count
+            recovery_state.scanned_room_ids.difference_update(auto_resume_result.retry_room_ids)
+            recovery_state.retry_target_event_ids.difference_update(
+                auto_resume_result.settled_target_event_ids,
+            )
+            recovery_state.retry_target_event_ids.update(auto_resume_result.retry_target_event_ids)
     finally:
         for task in tasks:
             if not task.done():
@@ -316,22 +361,20 @@ async def _joined_room_actors(
 
 async def _auto_resume_interrupted_threads(
     client: nio.AsyncClient,
-    interrupted: list[_InterruptedThread],
+    interrupted: Sequence[_InterruptedThread],
     *,
     config: Config,
     runtime_paths: RuntimePaths,
     conversation_cache: ConversationCacheProtocol | None = None,
-    owner_actors: Mapping[str, StaleStreamCleanupActor],
     delay: float = 2.0,
     delay_before_first: bool = False,
-    retryable_room_ids: set[str],
-) -> int:
+) -> _AutoResumeResult:
     """Send resume prompts for interrupted threaded conversations."""
-    if not interrupted:
-        return 0
-
     candidate_threads = _ordered_auto_resume_candidates(interrupted)
     resumed_count = 0
+    retry_room_ids: set[str] = set()
+    retry_target_event_ids: set[str] = set()
+    settled_target_event_ids: set[str] = set()
     delay_due = delay_before_first
     for interrupted_thread in candidate_threads:
         if interrupted_thread.original_sender_id is None:
@@ -341,65 +384,31 @@ async def _auto_resume_interrupted_threads(
                 thread_id=interrupted_thread.thread_id,
                 target_event_id=interrupted_thread.target_event_id,
             )
-            continue
-        owner_user_id = _current_configured_entity_user_id(
-            interrupted_thread.agent_name,
-            config,
-            runtime_paths,
-        )
-        owner_actor = owner_actors.get(owner_user_id) if owner_user_id is not None else None
-        if owner_actor is None or owner_actor.conversation_cache is None:
-            retryable_room_ids.add(interrupted_thread.room_id)
-            logger.warning(
-                "Skipping auto-resume because owning actor is unavailable or not joined",
-                room_id=interrupted_thread.room_id,
-                agent_name=interrupted_thread.agent_name,
-                target_event_id=interrupted_thread.target_event_id,
-            )
+            settled_target_event_ids.add(interrupted_thread.target_event_id)
             continue
         if delay_due:
             await asyncio.sleep(delay)
             delay_due = False
-        if not await _interrupted_target_remains_latest_human_work(
+        freshness = await _interrupted_target_freshness(
             interrupted_thread,
             config=config,
             runtime_paths=runtime_paths,
-            conversation_cache=owner_actor.conversation_cache,
-        ):
+        )
+        if freshness is _FreshnessOutcome.RETRY:
+            retry_room_ids.add(interrupted_thread.room_id)
+            retry_target_event_ids.add(interrupted_thread.target_event_id)
             continue
-        send_attempted = False
-        delivered = None
+        settled_target_event_ids.add(interrupted_thread.target_event_id)
+        if freshness is _FreshnessOutcome.NEWER_HUMAN:
+            continue
         try:
             content = _build_auto_resume_content(
                 interrupted_thread,
+                sender_is_owner=interrupted_thread.owner_actor.client is client,
                 config=config,
-                runtime_paths=runtime_paths,
             )
             delay_due = True
-            send_attempted = True
             delivered = await send_message_result(client, interrupted_thread.room_id, content)
-            if delivered is not None:
-                if conversation_cache is not None:
-                    conversation_cache.notify_outbound_message(
-                        interrupted_thread.room_id,
-                        delivered.event_id,
-                        delivered.content_sent,
-                    )
-                logger.info(
-                    "Queued auto-resume after restart",
-                    room_id=interrupted_thread.room_id,
-                    thread_id=interrupted_thread.thread_id,
-                    target_event_id=interrupted_thread.target_event_id,
-                    event_id=delivered.event_id,
-                )
-                resumed_count += 1
-            else:
-                logger.warning(
-                    "Failed to queue auto-resume after restart",
-                    room_id=interrupted_thread.room_id,
-                    thread_id=interrupted_thread.thread_id,
-                    target_event_id=interrupted_thread.target_event_id,
-                )
         except Exception as exc:
             logger.warning(
                 "Failed to send auto-resume message",
@@ -408,42 +417,64 @@ async def _auto_resume_interrupted_threads(
                 target_event_id=interrupted_thread.target_event_id,
                 error=str(exc),
             )
-        finally:
-            _mark_failed_auto_resume_delivery_retryable(
-                retryable_room_ids,
+            retry_room_ids.add(interrupted_thread.room_id)
+            retry_target_event_ids.add(interrupted_thread.target_event_id)
+            settled_target_event_ids.discard(interrupted_thread.target_event_id)
+            continue
+        if delivered is None:
+            logger.warning(
+                "Failed to queue auto-resume after restart",
                 room_id=interrupted_thread.room_id,
-                send_attempted=send_attempted,
-                delivered=delivered,
+                thread_id=interrupted_thread.thread_id,
+                target_event_id=interrupted_thread.target_event_id,
             )
+            retry_room_ids.add(interrupted_thread.room_id)
+            retry_target_event_ids.add(interrupted_thread.target_event_id)
+            settled_target_event_ids.discard(interrupted_thread.target_event_id)
+            continue
+        if conversation_cache is not None:
+            try:
+                conversation_cache.notify_outbound_message(
+                    interrupted_thread.room_id,
+                    delivered.event_id,
+                    delivered.content_sent,
+                )
+            except Exception:
+                logger.warning(
+                    "Failed to record queued auto-resume message",
+                    room_id=interrupted_thread.room_id,
+                    event_id=delivered.event_id,
+                    exc_info=True,
+                )
+        logger.info(
+            "Queued auto-resume after restart",
+            room_id=interrupted_thread.room_id,
+            thread_id=interrupted_thread.thread_id,
+            target_event_id=interrupted_thread.target_event_id,
+            event_id=delivered.event_id,
+        )
+        resumed_count += 1
 
-    return resumed_count
+    return _AutoResumeResult(
+        resumed_count=resumed_count,
+        retry_room_ids=frozenset(retry_room_ids),
+        retry_target_event_ids=frozenset(retry_target_event_ids),
+        settled_target_event_ids=frozenset(settled_target_event_ids),
+    )
 
 
-def _mark_failed_auto_resume_delivery_retryable(
-    retryable_room_ids: set[str],
-    *,
-    room_id: str,
-    send_attempted: bool,
-    delivered: object | None,
-) -> None:
-    """Release a room when router delivery produced no Matrix event."""
-    if send_attempted and delivered is None:
-        retryable_room_ids.add(room_id)
-
-
-async def _interrupted_target_remains_latest_human_work(
+async def _interrupted_target_freshness(
     interrupted_thread: _InterruptedThread,
     *,
     config: Config,
     runtime_paths: RuntimePaths,
-    conversation_cache: ConversationCacheProtocol | None,
-) -> bool:
-    """Return whether authoritative history has no newer effective human activity."""
-    if conversation_cache is None or interrupted_thread.thread_id is None:
-        return False
+) -> _FreshnessOutcome:
+    """Classify an interrupted target using its exact owner's authoritative history."""
+    if interrupted_thread.thread_id is None:
+        return _FreshnessOutcome.RETRY
 
     try:
-        history = await conversation_cache.refresh_strict_thread_history_from_source(
+        history = await interrupted_thread.owner_actor.conversation_cache.refresh_strict_thread_history_from_source(
             interrupted_thread.room_id,
             interrupted_thread.thread_id,
             caller_label="startup_auto_resume_freshness",
@@ -452,7 +483,7 @@ async def _interrupted_target_remains_latest_human_work(
             history,
             target_event_id=interrupted_thread.target_event_id,
         )
-        remains_latest = _later_thread_activity_is_internal(
+        remains_current = _later_thread_activity_is_internal(
             later_messages,
             config=config,
             runtime_paths=runtime_paths,
@@ -463,14 +494,15 @@ async def _interrupted_target_remains_latest_human_work(
             target_event_id=interrupted_thread.target_event_id,
             error=str(exc),
         )
-        return False
+        return _FreshnessOutcome.RETRY
 
-    if not remains_latest:
+    if not remains_current:
         logger.info(
             "Skipping stale auto-resume after newer human activity",
             target_event_id=interrupted_thread.target_event_id,
         )
-    return remains_latest
+        return _FreshnessOutcome.NEWER_HUMAN
+    return _FreshnessOutcome.CURRENT
 
 
 def _authoritative_history_after_target(
@@ -531,17 +563,18 @@ async def _cleanup_stale_streaming_room(
     *,
     room_id: str,
     actors: dict[str, StaleStreamCleanupActor],
-    bot_user_ids: set[str],
+    joined_bot_user_ids: frozenset[str],
     config: Config,
     runtime_paths: RuntimePaths,
     startup_cutoff_ms: int | None = None,
     terminal_interrupted_only: bool = False,
-    retryable_room_ids: set[str],
-) -> tuple[int, list[_InterruptedThread]]:
+    retry_target_event_ids: frozenset[str] = frozenset(),
+) -> _RoomCleanupResult:
     """Scan one room once and let each bot account repair its own messages."""
     if not actors:
-        return 0, []
+        return _RoomCleanupResult(room_id, 0, ())
     current_time_ms = int(time.time() * 1000)
+    bot_user_ids = set(actors)
     scan_policy = _cleanup_scan_policy(
         config,
         startup_cutoff_ms=startup_cutoff_ms,
@@ -550,7 +583,6 @@ async def _cleanup_stale_streaming_room(
     scanned_state = await _scan_room_message_states(
         scan_client,
         room_id=room_id,
-        cleanup_bot_user_ids=bot_user_ids,
         bot_user_ids=bot_user_ids,
         config=config,
         runtime_paths=runtime_paths,
@@ -559,9 +591,10 @@ async def _cleanup_stale_streaming_room(
     )
     message_states = scanned_state.message_states
     if not message_states:
-        return 0, []
+        return _RoomCleanupResult(room_id, 0, ())
 
     cleaned_count = 0
+    retry_room = False
     prior_edit_succeeded_by_bot: set[str] = set()
     interrupted_threads: list[_InterruptedThread] = []
     candidate_items = sorted(
@@ -574,18 +607,25 @@ async def _cleanup_stale_streaming_room(
         bot_user_id = state.bot_user_id
         if bot_user_id is None:
             continue
-        actor = actors.get(bot_user_id)
-        if actor is None:
-            _mark_unavailable_cleanup_actor_retryable(
-                retryable_room_ids,
-                room_id=room_id,
-                bot_user_id=bot_user_id,
+        actor = actors[bot_user_id]
+        allow_post_cutoff = target_event_id in retry_target_event_ids
+        if bot_user_id not in joined_bot_user_ids or not actor.first_sync_complete:
+            agent_name = _cleanup_candidate_agent_name(
+                bot_user_id,
                 state=state,
                 config=config,
                 runtime_paths=runtime_paths,
                 current_time_ms=current_time_ms,
                 scan_policy=scan_policy,
+                allow_post_cutoff=allow_post_cutoff,
             )
+            has_pending_work = (
+                agent_name is not None
+                and room_id in actor.expected_room_ids
+                and target_event_id not in scanned_state.auto_resume_target_event_ids
+                and not _is_older_than_cleanup_window(state.latest_timestamp, now_ms=current_time_ms)
+            )
+            retry_room = retry_room or has_pending_work
             continue
         edited, interrupted = await _process_stale_room_candidate(
             actor,
@@ -599,6 +639,7 @@ async def _cleanup_stale_streaming_room(
             runtime_paths=runtime_paths,
             current_time_ms=current_time_ms,
             scan_policy=scan_policy,
+            allow_post_cutoff=allow_post_cutoff,
             prior_edit_succeeded=bot_user_id in prior_edit_succeeded_by_bot,
         )
         if edited:
@@ -607,33 +648,12 @@ async def _cleanup_stale_streaming_room(
         if interrupted is not None:
             interrupted_threads.append(interrupted)
 
-    return cleaned_count, interrupted_threads
-
-
-def _mark_unavailable_cleanup_actor_retryable(
-    retryable_room_ids: set[str],
-    *,
-    room_id: str,
-    bot_user_id: str,
-    state: _MessageState,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    current_time_ms: int,
-    scan_policy: _CleanupScanPolicy,
-) -> None:
-    """Release a room when its recoverable message owner is not joined yet."""
-    if (
-        _cleanup_candidate_agent_name(
-            bot_user_id,
-            state=state,
-            config=config,
-            runtime_paths=runtime_paths,
-            current_time_ms=current_time_ms,
-            scan_policy=scan_policy,
-        )
-        is not None
-    ):
-        retryable_room_ids.add(room_id)
+    return _RoomCleanupResult(
+        room_id=room_id,
+        cleaned_count=cleaned_count,
+        interrupted_threads=tuple(interrupted_threads),
+        retry_room=retry_room,
+    )
 
 
 async def _process_stale_room_candidate(
@@ -649,6 +669,7 @@ async def _process_stale_room_candidate(
     runtime_paths: RuntimePaths,
     current_time_ms: int,
     scan_policy: _CleanupScanPolicy,
+    allow_post_cutoff: bool,
     prior_edit_succeeded: bool,
 ) -> tuple[bool, _InterruptedThread | None]:
     """Repair or classify one bot-owned candidate from a shared room scan."""
@@ -660,6 +681,7 @@ async def _process_stale_room_candidate(
         runtime_paths=runtime_paths,
         current_time_ms=current_time_ms,
         scan_policy=scan_policy,
+        allow_post_cutoff=allow_post_cutoff,
     )
     if agent_name is None:
         return False, None
@@ -674,10 +696,10 @@ async def _process_stale_room_candidate(
             runtime_paths=runtime_paths,
             conversation_cache=actor.conversation_cache,
             agent_name=agent_name,
+            bot_user_id=bot_user_id,
+            owner_actor=actor,
             prior_edit_succeeded=prior_edit_succeeded,
         )
-    if not (_has_restart_interrupted_note(state.latest_body) or _has_resumable_interrupted_note(state)):
-        return False, None
     return await _handle_interrupted_message(
         actor.client,
         room_id=room_id,
@@ -690,6 +712,8 @@ async def _process_stale_room_candidate(
         runtime_paths=runtime_paths,
         conversation_cache=actor.conversation_cache,
         agent_name=agent_name,
+        bot_user_id=bot_user_id,
+        owner_actor=actor,
         prior_edit_succeeded=prior_edit_succeeded,
     )
 
@@ -702,6 +726,7 @@ def _cleanup_candidate_agent_name(
     runtime_paths: RuntimePaths,
     current_time_ms: int,
     scan_policy: _CleanupScanPolicy,
+    allow_post_cutoff: bool,
 ) -> str | None:
     """Return the owner name when one message belongs in this cleanup pass."""
     assert state.latest_body is not None
@@ -710,6 +735,7 @@ def _cleanup_candidate_agent_name(
         state,
         now_ms=current_time_ms,
         scan_policy=scan_policy,
+        allow_post_cutoff=allow_post_cutoff,
     ):
         return None
     if scan_policy.terminal_interrupted_only and not _has_resumable_interrupted_note(state):
@@ -733,6 +759,8 @@ async def _handle_interrupted_message(
     runtime_paths: RuntimePaths,
     conversation_cache: ConversationCacheProtocol | None = None,
     agent_name: str,
+    bot_user_id: str,
+    owner_actor: StaleStreamCleanupActor,
     prior_edit_succeeded: bool,
 ) -> tuple[bool, _InterruptedThread | None]:
     """Handle an interrupted response or restart marker seen during startup cleanup."""
@@ -743,6 +771,8 @@ async def _handle_interrupted_message(
             target_event_id=target_event_id,
             state=state,
             agent_name=agent_name,
+            bot_user_id=bot_user_id,
+            owner_actor=owner_actor,
         )
     repaired = await _repair_restart_marked_message_metadata(
         client,
@@ -814,6 +844,8 @@ async def _cleanup_one_stale_message(
     runtime_paths: RuntimePaths,
     conversation_cache: ConversationCacheProtocol | None = None,
     agent_name: str,
+    bot_user_id: str,
+    owner_actor: StaleStreamCleanupActor,
 ) -> tuple[bool, _InterruptedThread | None]:
     """Edit one stale message, redact stop reactions, return interrupted thread info."""
     assert state.latest_body is not None
@@ -838,6 +870,8 @@ async def _cleanup_one_stale_message(
             target_event_id=target_event_id,
             partial_text=_truncate_partial_text(clean_partial_reply_text(state.latest_body)),
             agent_name=agent_name,
+            bot_user_id=bot_user_id,
+            owner_actor=owner_actor,
             original_sender_id=state.requester_user_id,
             timestamp_ms=state.latest_timestamp,
         )
@@ -862,6 +896,8 @@ async def _cleanup_candidate_message(
     runtime_paths: RuntimePaths,
     conversation_cache: ConversationCacheProtocol | None = None,
     agent_name: str,
+    bot_user_id: str,
+    owner_actor: StaleStreamCleanupActor,
     prior_edit_succeeded: bool,
 ) -> tuple[bool, _InterruptedThread | None]:
     """Best-effort cleanup of one stale candidate message."""
@@ -878,6 +914,8 @@ async def _cleanup_candidate_message(
             runtime_paths=runtime_paths,
             conversation_cache=conversation_cache,
             agent_name=agent_name,
+            bot_user_id=bot_user_id,
+            owner_actor=owner_actor,
         )
     except Exception as exc:
         logger.warning(
@@ -893,7 +931,6 @@ async def _scan_room_message_states(
     client: nio.AsyncClient,
     *,
     room_id: str,
-    cleanup_bot_user_ids: set[str],
     bot_user_ids: set[str],
     config: Config,
     runtime_paths: RuntimePaths,
@@ -904,7 +941,7 @@ async def _scan_room_message_states(
     message_states, message_events = await _collect_room_history_events(
         client,
         room_id=room_id,
-        cleanup_bot_user_ids=cleanup_bot_user_ids,
+        cleanup_bot_user_ids=bot_user_ids,
         now_ms=now_ms,
         scan_policy=scan_policy,
     )
@@ -914,14 +951,14 @@ async def _scan_room_message_states(
         config=config,
         runtime_paths=runtime_paths,
     )
-    bot_message_events = [event for event in message_events if event.sender in cleanup_bot_user_ids]
+    bot_message_events = [event for event in message_events if event.sender in bot_user_ids]
     resolved_messages = await resolve_latest_visible_messages(
         bot_message_events,
         client,
         trusted_sender_ids=trusted_sender_ids,
     )
     bot_resolved_messages = {
-        event_id: message for event_id, message in resolved_messages.items() if message.sender in cleanup_bot_user_ids
+        event_id: message for event_id, message in resolved_messages.items() if message.sender in bot_user_ids
     }
     scanned_message_data_by_event_id = await _scanned_message_data_by_event_id(message_events)
     auto_resume_target_event_ids = _auto_resume_target_event_ids(
@@ -933,14 +970,14 @@ async def _scan_room_message_states(
         resolved_messages=bot_resolved_messages,
         scanned_message_data_by_event_id=scanned_message_data_by_event_id,
         room_id=room_id,
-        bot_user_ids=cleanup_bot_user_ids,
+        bot_user_ids=bot_user_ids,
         config=config,
         runtime_paths=runtime_paths,
     )
     _merge_bot_resolved_message_states(
         message_states,
         bot_resolved_messages,
-        bot_user_ids=cleanup_bot_user_ids,
+        bot_user_ids=bot_user_ids,
         requester_ids_by_event_id=requester_ids_by_event_id,
         scanned_message_data_by_event_id=scanned_message_data_by_event_id,
     )
@@ -1069,7 +1106,6 @@ def _merge_resolved_message_state(
     normalized_latest_content = {key: value for key, value in message.content.items() if isinstance(key, str)}
     state = message_states.setdefault(target_event_id, _MessageState())
     state.latest_body = message.body
-    state.original_timestamp = message.timestamp
     # The last time this message changed, not when it was created. ``timestamp`` deliberately
     # stays the original event's so an edit cannot reorder a thread, which means it is the
     # wrong clock for "is this stream still active": a placeholder posted eight hours ago and
@@ -1762,7 +1798,7 @@ def _truncate_partial_text(text: str, *, limit: int = _INTERRUPTED_PARTIAL_TEXT_
 
 
 def _ordered_auto_resume_candidates(
-    interrupted: list[_InterruptedThread],
+    interrupted: Sequence[_InterruptedThread],
 ) -> list[_InterruptedThread]:
     """Return each unique interrupted thread once in timestamp order."""
     latest_by_key: dict[tuple[str, str, str], _InterruptedThread] = {}
@@ -1770,7 +1806,7 @@ def _ordered_auto_resume_candidates(
     for interrupted_thread in interrupted:
         if interrupted_thread.thread_id is None:
             continue
-        key = (interrupted_thread.room_id, interrupted_thread.thread_id, interrupted_thread.agent_name)
+        key = (interrupted_thread.room_id, interrupted_thread.thread_id, interrupted_thread.bot_user_id)
         existing = latest_by_key.get(key)
         if existing is None or interrupted_thread.timestamp_ms >= existing.timestamp_ms:
             latest_by_key[key] = interrupted_thread
@@ -1813,6 +1849,8 @@ def _interrupted_thread_from_terminal_state(
     target_event_id: str,
     state: _MessageState,
     agent_name: str,
+    bot_user_id: str,
+    owner_actor: StaleStreamCleanupActor,
 ) -> _InterruptedThread | None:
     """Build an auto-resume record for an already-terminal interrupted response."""
     assert state.latest_body is not None
@@ -1824,6 +1862,8 @@ def _interrupted_thread_from_terminal_state(
         target_event_id=target_event_id,
         partial_text=_truncate_partial_text(clean_partial_reply_text(state.latest_body)),
         agent_name=agent_name,
+        bot_user_id=bot_user_id,
+        owner_actor=owner_actor,
         original_sender_id=state.requester_user_id,
         timestamp_ms=state.latest_timestamp,
     )
@@ -1844,17 +1884,15 @@ def _should_skip_for_startup_cleanup_window(
     *,
     now_ms: int,
     scan_policy: _CleanupScanPolicy,
+    allow_post_cutoff: bool,
 ) -> bool:
     """Return whether startup cleanup should ignore one candidate by age."""
     timestamp_ms = state.latest_timestamp
     is_resumable_interruption = scan_policy.collect_terminal_interrupted_for_resume and _has_resumable_interrupted_note(
         state,
     )
-    cutoff_timestamp_ms = (
-        state.original_timestamp if is_resumable_interruption and state.original_timestamp is not None else timestamp_ms
-    )
-    if _is_at_or_after_startup_cutoff(
-        cutoff_timestamp_ms,
+    if not allow_post_cutoff and _is_at_or_after_startup_cutoff(
+        timestamp_ms,
         startup_cutoff_ms=scan_policy.startup_cutoff_ms,
     ):
         return True
@@ -1913,15 +1951,11 @@ def _lookback_scan_state(
 def _build_auto_resume_content(
     interrupted_thread: _InterruptedThread,
     *,
+    sender_is_owner: bool,
     config: Config,
-    runtime_paths: RuntimePaths,
 ) -> dict[str, object]:
     """Build the router-authored visible resume relay for one interrupted agent."""
-    target_user_id = (
-        None
-        if interrupted_thread.agent_name == ROUTER_AGENT_NAME
-        else _current_configured_entity_user_id(interrupted_thread.agent_name, config, runtime_paths)
-    )
+    target_user_id = None if sender_is_owner else interrupted_thread.bot_user_id
     display_name = _entity_display_name(interrupted_thread.agent_name, config)
 
     body = AUTO_RESUME_MESSAGE
@@ -1949,21 +1983,6 @@ def _build_auto_resume_content(
         latest_thread_event_id=interrupted_thread.target_event_id,
         extra_content=extra_content,
     )
-
-
-def _current_configured_entity_user_id(
-    entity_name: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> str | None:
-    """Return one configured entity user ID without resolving unrelated entities."""
-    if entity_name != ROUTER_AGENT_NAME and entity_name not in config.agents and entity_name not in config.teams:
-        return None
-    try:
-        return current_entity_id(entity_name, runtime_paths).full_id
-    except MissingManagedEntityAccountError:
-        logger.debug("auto_resume_target_entity_account_unavailable", entity_name=entity_name)
-        return None
 
 
 def _entity_display_name(agent_name: str, config: Config) -> str:

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1184,6 +1184,18 @@ class _MultiAgentOrchestrator:
     async def handle_bot_ready(self, bot: AgentBot | TeamBot) -> None:
         """Handle bot-ready notifications through the public runtime protocol."""
         await self._approval_transport.handle_bot_ready(bot)
+        if (
+            self.agent_bots.get(bot.agent_name) is not bot
+            or self.config is None
+            or self._startup_maintenance.startup_cutoff_ms is None
+        ):
+            return
+        self._startup_maintenance.schedule_ready_recovery(
+            partial(self._recover_restart_work_after_bot_ready, bot),
+        )
+
+    async def _recover_restart_work_after_bot_ready(self, bot: AgentBot | TeamBot) -> None:
+        """Recover startup and replacement work for the exact ready generation."""
         if self.agent_bots.get(bot.agent_name) is not bot or self.config is None:
             return
         startup_cutoff_ms = self._startup_maintenance.startup_cutoff_ms

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -47,6 +47,7 @@ from mindroom.matrix.identity import managed_account_user_id
 from mindroom.matrix.rooms import ensure_all_rooms_exist, ensure_root_space, ensure_user_in_rooms
 from mindroom.matrix.stale_stream_cleanup import (
     StaleStreamCleanupActor,
+    StaleStreamRecoveryState,
     recover_stale_streaming_messages,
 )
 from mindroom.matrix.state import load_rooms, resolve_room_aliases
@@ -296,12 +297,12 @@ class _MultiAgentOrchestrator:
             event_cache_provider=self._approval_event_cache,
         )
         self._startup_maintenance = StartupMaintenanceController(
-            recover_stale_streams=lambda bots, config, startup_cutoff_ms, scanned_room_ids: (
+            recover_stale_streams=lambda bots, config, startup_cutoff_ms, recovery_state: (
                 self._recover_stale_streams_after_restart(
                     bots,
                     config,
                     startup_cutoff_ms,
-                    scanned_room_ids,
+                    recovery_state,
                 )
             ),
             setup_rooms_and_memberships=self._setup_startup_rooms_and_memberships,
@@ -1056,7 +1057,7 @@ class _MultiAgentOrchestrator:
         bots: list[AgentBot | TeamBot],
         config: Config,
         startup_cutoff_ms: int | None,
-        scanned_room_ids: set[str],
+        recovery_state: StaleStreamRecoveryState,
         *,
         target_room_ids: set[str] | None = None,
     ) -> None:
@@ -1068,6 +1069,16 @@ class _MultiAgentOrchestrator:
             actors[bot.agent_user.user_id] = StaleStreamCleanupActor(
                 client=bot.client,
                 conversation_cache=bot._conversation_cache,
+                first_sync_complete=(
+                    self.agent_bots.get(bot.agent_name) is bot
+                    and self.entity_first_sync_complete(bot.agent_name) is True
+                ),
+                expected_room_ids=frozenset(
+                    resolve_room_aliases(
+                        get_rooms_for_entity(bot.agent_name, config),
+                        runtime_paths=self.runtime_paths,
+                    ),
+                ),
             )
         if not actors:
             return
@@ -1080,7 +1091,7 @@ class _MultiAgentOrchestrator:
             config=config,
             runtime_paths=self.runtime_paths,
             startup_cutoff_ms=startup_cutoff_ms,
-            scanned_room_ids=scanned_room_ids,
+            recovery_state=recovery_state,
             target_room_ids=target_room_ids,
         )
         logger.info(
@@ -1146,19 +1157,22 @@ class _MultiAgentOrchestrator:
             pending_room_ids.difference_update(room_ids)
             if not pending_room_ids:
                 del self._pending_replacement_recovery_room_ids[entity_name]
-        scanned_room_ids: set[str] = set()
+        recovery_state = StaleStreamRecoveryState()
         try:
             await self._recover_stale_streams_after_restart(
                 recovery_bots,
                 config,
                 None,
-                scanned_room_ids,
+                recovery_state,
                 target_room_ids=set().union(*claimed_room_ids.values()),
             )
         except BaseException:
             self._restore_pending_replacement_rooms(claimed_room_ids, set())
             raise
-        self._restore_pending_replacement_rooms(claimed_room_ids, scanned_room_ids)
+        self._restore_pending_replacement_rooms(
+            claimed_room_ids,
+            recovery_state.scanned_room_ids,
+        )
 
     def _resolve_bot_room_aliases(self, bots: list[AgentBot | TeamBot], config: Config) -> None:
         """Resolve currently known room aliases into each bot's configured room IDs."""

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1184,6 +1184,17 @@ class _MultiAgentOrchestrator:
     async def handle_bot_ready(self, bot: AgentBot | TeamBot) -> None:
         """Handle bot-ready notifications through the public runtime protocol."""
         await self._approval_transport.handle_bot_ready(bot)
+        if self.agent_bots.get(bot.agent_name) is not bot or self.config is None:
+            return
+        startup_cutoff_ms = self._startup_maintenance.startup_cutoff_ms
+        if startup_cutoff_ms is not None:
+            await self._recover_stale_streams_after_restart(
+                self._running_startup_maintenance_bots(),
+                self.config,
+                startup_cutoff_ms,
+                self._startup_maintenance.recovery_state,
+            )
+        await self._recover_pending_replacement_rooms(self.config)
 
     async def _start_runtime(self) -> None:
         """Run the startup sequence before handing off to the sync loops."""

--- a/src/mindroom/startup_maintenance.py
+++ b/src/mindroom/startup_maintenance.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from mindroom.logging_config import get_logger
+from mindroom.matrix.stale_stream_cleanup import StaleStreamRecoveryState
 from mindroom.orchestration.runtime import (
     cancel_logged_task,
     create_logged_task,
@@ -23,7 +24,10 @@ logger = get_logger(__name__)
 
 type _StartupBot = AgentBot | TeamBot
 type _SetupRooms = Callable[[list[_StartupBot]], Awaitable[None]]
-type _RecoverStaleStreams = Callable[[list[_StartupBot], Config, int, set[str]], Awaitable[None]]
+type _RecoverStaleStreams = Callable[
+    [list[_StartupBot], Config, int, StaleStreamRecoveryState],
+    Awaitable[None],
+]
 type _SyncRuntimeSupport = Callable[[Config], Awaitable[None]]
 type _MarkRuntimeSupportReady = Callable[[], Awaitable[None]]
 type _RunningBots = Callable[[], list[_StartupBot]]
@@ -72,7 +76,7 @@ class StartupMaintenanceController:
         self.start(bots, config, startup_cutoff_ms=self.startup_cutoff_ms)
 
     async def _run(self, bots: list[_StartupBot], config: Config, startup_cutoff_ms: int) -> None:
-        scanned_room_ids: set[str] = set()
+        recovery_state = StaleStreamRecoveryState()
         room_setup_task = asyncio.create_task(
             self._run_phase(
                 "startup_maintenance.rooms_and_memberships",
@@ -88,7 +92,7 @@ class StartupMaintenanceController:
                     bots,
                     config,
                     startup_cutoff_ms,
-                    scanned_room_ids,
+                    recovery_state,
                 ),
                 failure_message="Initial startup stale stream recovery failed",
             )
@@ -99,7 +103,7 @@ class StartupMaintenanceController:
                     bots,
                     config,
                     startup_cutoff_ms,
-                    scanned_room_ids,
+                    recovery_state,
                 ),
                 failure_message="Joined-room delta stale stream recovery failed",
             )

--- a/src/mindroom/startup_maintenance.py
+++ b/src/mindroom/startup_maintenance.py
@@ -43,10 +43,19 @@ class StartupMaintenanceController:
     mark_runtime_support_ready: _MarkRuntimeSupportReady
     task: asyncio.Task[None] | None = field(default=None, init=False)
     startup_cutoff_ms: int | None = field(default=None, init=False)
+    recovery_state: StaleStreamRecoveryState = field(
+        default_factory=StaleStreamRecoveryState,
+        init=False,
+    )
 
     def start(self, bots: list[_StartupBot], config: Config, *, startup_cutoff_ms: int) -> None:
         """Schedule detached startup maintenance for one startup generation."""
         self.startup_cutoff_ms = startup_cutoff_ms
+        self.recovery_state = StaleStreamRecoveryState()
+        self._schedule(bots, config, startup_cutoff_ms)
+
+    def _schedule(self, bots: list[_StartupBot], config: Config, startup_cutoff_ms: int) -> None:
+        """Schedule maintenance while preserving the current generation state."""
         self.task = create_logged_task(
             self._run(bots, config, startup_cutoff_ms),
             name="startup_maintenance",
@@ -73,10 +82,9 @@ class StartupMaintenanceController:
         bots = running_bots()
         if not bots:
             return
-        self.start(bots, config, startup_cutoff_ms=self.startup_cutoff_ms)
+        self._schedule(bots, config, self.startup_cutoff_ms)
 
     async def _run(self, bots: list[_StartupBot], config: Config, startup_cutoff_ms: int) -> None:
-        recovery_state = StaleStreamRecoveryState()
         room_setup_task = asyncio.create_task(
             self._run_phase(
                 "startup_maintenance.rooms_and_memberships",
@@ -92,7 +100,7 @@ class StartupMaintenanceController:
                     bots,
                     config,
                     startup_cutoff_ms,
-                    recovery_state,
+                    self.recovery_state,
                 ),
                 failure_message="Initial startup stale stream recovery failed",
             )
@@ -103,7 +111,7 @@ class StartupMaintenanceController:
                     bots,
                     config,
                     startup_cutoff_ms,
-                    recovery_state,
+                    self.recovery_state,
                 ),
                 failure_message="Joined-room delta stale stream recovery failed",
             )

--- a/src/mindroom/startup_maintenance.py
+++ b/src/mindroom/startup_maintenance.py
@@ -43,6 +43,7 @@ class StartupMaintenanceController:
     sync_runtime_support: _SyncRuntimeSupport
     mark_runtime_support_ready: _MarkRuntimeSupportReady
     task: asyncio.Task[None] | None = field(default=None, init=False)
+    _tasks: set[asyncio.Task[None]] = field(default_factory=set, init=False, repr=False)
     startup_cutoff_ms: int | None = field(default=None, init=False)
     recovery_state: StaleStreamRecoveryState = field(
         default_factory=StaleStreamRecoveryState,
@@ -57,19 +58,29 @@ class StartupMaintenanceController:
 
     def _schedule(self, bots: list[_StartupBot], config: Config, startup_cutoff_ms: int) -> None:
         """Schedule maintenance while preserving the current generation state."""
-        self.task = create_logged_task(
-            self._run(bots, config, startup_cutoff_ms),
-            name="startup_maintenance",
-            failure_message="Startup maintenance task failed",
+        self._track_task(
+            create_logged_task(
+                self._run(bots, config, startup_cutoff_ms),
+                name="startup_maintenance",
+                failure_message="Startup maintenance task failed",
+            ),
         )
+
+    def _track_task(self, task: asyncio.Task[None]) -> None:
+        """Track every task represented by the serialized maintenance chain."""
+        self.task = task
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
 
     def schedule_ready_recovery(self, recovery: _ReadyRecovery) -> None:
         """Queue one bot-ready recovery after current startup maintenance."""
         previous_task = self.task
-        self.task = create_logged_task(
-            self._run_ready_recovery(previous_task, recovery),
-            name="startup_ready_recovery",
-            failure_message="Bot-ready restart recovery task failed",
+        self._track_task(
+            create_logged_task(
+                self._run_ready_recovery(previous_task, recovery),
+                name="startup_ready_recovery",
+                failure_message="Bot-ready restart recovery task failed",
+            ),
         )
 
     async def _run_ready_recovery(
@@ -87,11 +98,14 @@ class StartupMaintenanceController:
         )
 
     async def cancel(self) -> bool:
-        """Cancel detached startup maintenance and report whether unfinished work was interrupted."""
-        task = self.task
+        """Cancel all detached maintenance and report whether unfinished work was interrupted."""
+        tasks = set(self._tasks)
+        if self.task is not None:
+            tasks.add(self.task)
         self.task = None
-        should_replay = task is not None and not task.done()
-        await cancel_logged_task(task)
+        should_replay = any(not task.done() for task in tasks)
+        await asyncio.gather(*(cancel_logged_task(task) for task in tasks))
+        self._tasks.difference_update(tasks)
         return should_replay
 
     def restart_after_config_reload(

--- a/src/mindroom/startup_maintenance.py
+++ b/src/mindroom/startup_maintenance.py
@@ -31,6 +31,7 @@ type _RecoverStaleStreams = Callable[
 type _SyncRuntimeSupport = Callable[[Config], Awaitable[None]]
 type _MarkRuntimeSupportReady = Callable[[], Awaitable[None]]
 type _RunningBots = Callable[[], list[_StartupBot]]
+type _ReadyRecovery = Callable[[], Awaitable[None]]
 
 
 @dataclass
@@ -60,6 +61,29 @@ class StartupMaintenanceController:
             self._run(bots, config, startup_cutoff_ms),
             name="startup_maintenance",
             failure_message="Startup maintenance task failed",
+        )
+
+    def schedule_ready_recovery(self, recovery: _ReadyRecovery) -> None:
+        """Queue one bot-ready recovery after current startup maintenance."""
+        previous_task = self.task
+        self.task = create_logged_task(
+            self._run_ready_recovery(previous_task, recovery),
+            name="startup_ready_recovery",
+            failure_message="Bot-ready restart recovery task failed",
+        )
+
+    async def _run_ready_recovery(
+        self,
+        previous_task: asyncio.Task[None] | None,
+        recovery: _ReadyRecovery,
+    ) -> None:
+        """Serialize a bot-ready recovery behind prior maintenance work."""
+        if previous_task is not None:
+            await previous_task
+        await self._run_phase(
+            "startup_maintenance.stale_stream_recovery.bot_ready",
+            recovery,
+            failure_message="Bot-ready stale stream recovery failed",
         )
 
     async def cancel(self) -> bool:

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -8,7 +8,12 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from mindroom.authorization import is_sender_allowed_for_agent_reply, responder_candidate_entities_for_room
 from mindroom.constants import MATRIX_MESSAGE_TARGET_ENRICHMENT_KEY, ROUTER_AGENT_NAME, RuntimePaths
-from mindroom.dispatch_source import ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND, ScheduledHistoryBudget
+from mindroom.dispatch_source import (
+    ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+    TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+    ScheduledHistoryBudget,
+    is_auto_resume_relay_body,
+)
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.hooks import (
     EVENT_MESSAGE_ENRICH,
@@ -592,7 +597,17 @@ class TurnPolicy:
         context = dispatch.context
         planning_thread_history = context.planning_thread_history
         requester_user_id = dispatch.requester_user_id
-        if is_router_only_agent_mention(
+        if (
+            dispatch.envelope.source_kind == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+            and is_auto_resume_relay_body(dispatch.envelope.body)
+            and not context.mentioned_agents
+            and not context.has_non_agent_mentions
+        ):
+            plan = _DispatchPlan(
+                kind="respond",
+                response_action=ResponseAction(kind="individual"),
+            )
+        elif is_router_only_agent_mention(
             context.mentioned_agents,
             has_non_agent_mentions=context.has_non_agent_mentions,
             config=self.deps.runtime.config,

--- a/tests/test_ingress_validation.py
+++ b/tests/test_ingress_validation.py
@@ -55,6 +55,12 @@ def test_trusted_relay_resolves_requester_and_allows_self_authored_ingress(tmp_p
         ),
     )
     human_sender = "@human:localhost"
+    owner_actor = stale_stream_cleanup.StaleStreamCleanupActor(
+        client=MagicMock(spec=nio.AsyncClient),
+        conversation_cache=MagicMock(),
+        first_sync_complete=True,
+        expected_room_ids=frozenset(),
+    )
     content = stale_stream_cleanup._build_auto_resume_content(
         stale_stream_cleanup._InterruptedThread(
             room_id="!room:localhost",
@@ -62,10 +68,12 @@ def test_trusted_relay_resolves_requester_and_allows_self_authored_ingress(tmp_p
             target_event_id="$target",
             partial_text="partial",
             agent_name="test_agent",
+            bot_user_id=ids["test_agent"].full_id,
+            owner_actor=owner_actor,
             original_sender_id=human_sender,
         ),
+        sender_is_owner=False,
         config=config,
-        runtime_paths=runtime_paths,
     )
 
     assert content[ORIGINAL_SENDER_KEY] == human_sender

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mindroom.constants import RuntimePaths
+    from mindroom.matrix.stale_stream_cleanup import StaleStreamRecoveryState
 
 
 def _runtime_paths(tmp_path: Path) -> RuntimePaths:
@@ -852,11 +853,11 @@ async def test_entity_replacement_recovers_rooms_after_old_bot_is_removed(
         _bots: object,
         _config: object,
         _cutoff: object,
-        scanned_room_ids: set[str],
+        recovery_state: StaleStreamRecoveryState,
         *,
         target_room_ids: set[str],
     ) -> None:
-        scanned_room_ids.update(target_room_ids)
+        recovery_state.scanned_room_ids.update(target_room_ids)
 
     with (
         patch(
@@ -883,7 +884,7 @@ async def test_entity_replacement_recovers_rooms_after_old_bot_is_removed(
     assert mock_recover.await_args.args[0] == [new_bot]
     assert mock_recover.await_args.args[1] is config
     assert mock_recover.await_args.args[2] is None
-    assert mock_recover.await_args.args[3] == {"!interrupted:example.org"}
+    assert mock_recover.await_args.args[3].scanned_room_ids == {"!interrupted:example.org"}
     assert mock_recover.await_args.kwargs["target_room_ids"] == {"!interrupted:example.org"}
     assert orchestrator._pending_replacement_recovery_room_ids == {}
 
@@ -938,11 +939,11 @@ async def test_mcp_prestop_captures_rooms_before_old_bot_is_removed(tmp_path: Pa
         _bots: object,
         _config: object,
         _cutoff: object,
-        scanned_room_ids: set[str],
+        recovery_state: StaleStreamRecoveryState,
         *,
         target_room_ids: set[str],
     ) -> None:
-        scanned_room_ids.update(target_room_ids)
+        recovery_state.scanned_room_ids.update(target_room_ids)
 
     with (
         patch(
@@ -1032,14 +1033,14 @@ async def test_pending_replacement_recovery_claims_once_and_requeues_failed_room
         _bots: object,
         _config: object,
         _cutoff: object,
-        scanned_room_ids: set[str],
+        recovery_state: StaleStreamRecoveryState,
         *,
         target_room_ids: set[str],
     ) -> None:
         assert target_room_ids == {"!scanned:example.org", "!failed:example.org"}
         assert orchestrator._pending_replacement_recovery_room_ids == {}
         await orchestrator._recover_pending_replacement_rooms(config)
-        scanned_room_ids.add("!scanned:example.org")
+        recovery_state.scanned_room_ids.add("!scanned:example.org")
 
     with patch.object(
         orchestrator,

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -1057,7 +1057,7 @@ async def test_pending_replacement_recovery_claims_once_and_requeues_failed_room
 
 @pytest.mark.asyncio
 async def test_current_bot_ready_retries_startup_and_replacement_recovery(tmp_path: Path) -> None:
-    """First-sync completion retries rooms deferred for the exact current generation."""
+    """First-sync completion schedules serialized recovery outside the sync callback."""
     orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
     config = _config_with_code_agent(tmp_path)
     config.defaults.auto_resume_after_restart = True
@@ -1071,6 +1071,12 @@ async def test_current_bot_ready_retries_startup_and_replacement_recovery(tmp_pa
     orchestrator.agent_bots = {ROUTER_AGENT_NAME: router_bot, "code": code_bot}
     orchestrator._startup_maintenance.startup_cutoff_ms = 123456
     startup_recovery_state = orchestrator._startup_maintenance.recovery_state
+    recovery_started = asyncio.Event()
+    release_recovery = asyncio.Event()
+
+    async def recover_startup(*_args: object, **_kwargs: object) -> None:
+        recovery_started.set()
+        await release_recovery.wait()
 
     with (
         patch.object(
@@ -1081,7 +1087,7 @@ async def test_current_bot_ready_retries_startup_and_replacement_recovery(tmp_pa
         patch.object(
             orchestrator,
             "_recover_stale_streams_after_restart",
-            new=AsyncMock(),
+            new=AsyncMock(side_effect=recover_startup),
         ) as recover_startup,
         patch.object(
             orchestrator,
@@ -1089,7 +1095,16 @@ async def test_current_bot_ready_retries_startup_and_replacement_recovery(tmp_pa
             new=AsyncMock(),
         ) as recover_replacement,
     ):
-        await orchestrator.handle_bot_ready(code_bot)
+        ready_call = asyncio.create_task(orchestrator.handle_bot_ready(code_bot))
+        try:
+            await asyncio.wait_for(recovery_started.wait(), timeout=1.0)
+            await asyncio.sleep(0)
+            assert ready_call.done()
+        finally:
+            release_recovery.set()
+            await ready_call
+        assert orchestrator._startup_maintenance.task is not None
+        await orchestrator._startup_maintenance.task
 
     recover_startup.assert_awaited_once_with(
         [router_bot, code_bot],

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -1056,6 +1056,51 @@ async def test_pending_replacement_recovery_claims_once_and_requeues_failed_room
 
 
 @pytest.mark.asyncio
+async def test_current_bot_ready_retries_startup_and_replacement_recovery(tmp_path: Path) -> None:
+    """First-sync completion retries rooms deferred for the exact current generation."""
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))
+    config = _config_with_code_agent(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    orchestrator.config = config
+    router_bot = MagicMock(spec=AgentBot)
+    router_bot.agent_name = ROUTER_AGENT_NAME
+    router_bot.running = True
+    code_bot = MagicMock(spec=AgentBot)
+    code_bot.agent_name = "code"
+    code_bot.running = True
+    orchestrator.agent_bots = {ROUTER_AGENT_NAME: router_bot, "code": code_bot}
+    orchestrator._startup_maintenance.startup_cutoff_ms = 123456
+    startup_recovery_state = orchestrator._startup_maintenance.recovery_state
+
+    with (
+        patch.object(
+            orchestrator._approval_transport,
+            "handle_bot_ready",
+            new=AsyncMock(),
+        ),
+        patch.object(
+            orchestrator,
+            "_recover_stale_streams_after_restart",
+            new=AsyncMock(),
+        ) as recover_startup,
+        patch.object(
+            orchestrator,
+            "_recover_pending_replacement_rooms",
+            new=AsyncMock(),
+        ) as recover_replacement,
+    ):
+        await orchestrator.handle_bot_ready(code_bot)
+
+    recover_startup.assert_awaited_once_with(
+        [router_bot, code_bot],
+        config,
+        123456,
+        startup_recovery_state,
+    )
+    recover_replacement.assert_awaited_once_with(config)
+
+
+@pytest.mark.asyncio
 async def test_delayed_replacement_start_retries_pending_room_recovery(tmp_path: Path) -> None:
     """A transient replacement startup failure must not discard its interrupted-room handoff."""
     orchestrator = _MultiAgentOrchestrator(runtime_paths=_runtime_paths(tmp_path))

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -638,6 +638,41 @@ async def test_cleanup_skips_streaming_messages_at_or_after_startup_cutoff(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_cleanup_skips_restart_interrupted_message_created_after_startup_cutoff(tmp_path: Path) -> None:
+    """Auto-resume must not claim a terminal message created by this process."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    client = _make_client()
+    startup_cutoff_ms = NOW_MS - 120_000
+    client.room_messages.return_value = _room_messages_response(
+        _make_message_event(
+            event_id="$thread-root",
+            body="Question",
+            sender=USER_ID,
+            timestamp_ms=startup_cutoff_ms - 1,
+        ),
+        _make_message_event(
+            event_id="$current-process-interruption",
+            body=build_restart_interrupted_body("Partial"),
+            timestamp_ms=startup_cutoff_ms + 1,
+            relates_to=_thread_reply_relation("$thread-root", "$thread-root"),
+            extra_content={STREAM_STATUS_KEY: "error"},
+        ),
+    )
+    client.room_get_event_relations = MagicMock(return_value=_aiter())
+
+    cleaned, interrupted = await _run_cleanup(
+        client,
+        config,
+        joined_rooms=[ROOM_ID],
+        startup_cutoff_ms=startup_cutoff_ms,
+    )
+
+    assert cleaned == 0
+    assert interrupted == []
+
+
+@pytest.mark.asyncio
 async def test_cleanup_returns_interrupted_thread_per_cleaned_threaded_message(tmp_path: Path) -> None:
     """Cleanup should return one interrupted-thread record per cleaned threaded message."""
     config = _make_config(tmp_path)
@@ -3113,7 +3148,7 @@ async def test_recovery_selects_joined_owner_for_freshness_and_router_for_relay(
 
 @pytest.mark.asyncio
 async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(tmp_path: Path) -> None:
-    """A failed router relay should let the joined-room delta retry after router membership."""
+    """A failed relay after cleanup should remain retryable after router membership."""
     config = _make_config(tmp_path)
     config.defaults.auto_resume_after_restart = True
     router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
@@ -3133,6 +3168,40 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
         BOT_USER_ID: StaleStreamCleanupActor(owner_client, owner_cache),
     }
     router_joined = False
+    startup_cutoff_ms = int(stale_stream_cleanup_module.time.time() * 1000)
+    restart_body = build_restart_interrupted_body("Partial")
+    original_history = _room_messages_response(
+        _make_message_event(
+            event_id="$thread",
+            body="Question",
+            sender=USER_ID,
+            timestamp_ms=startup_cutoff_ms - (STALE_AGE_MS + 20_000),
+        ),
+        _make_message_event(
+            event_id="$target",
+            body="Partial",
+            timestamp_ms=startup_cutoff_ms - STALE_AGE_MS,
+            relates_to=_thread_reply_relation("$thread", "$thread"),
+            extra_content={STREAM_STATUS_KEY: "streaming"},
+        ),
+    )
+    edited_history = _room_messages_response(
+        *original_history.chunk,
+        _make_message_event(
+            event_id="$cleanup-edit",
+            body=f"* {restart_body}",
+            timestamp_ms=startup_cutoff_ms + 1,
+            relates_to={"rel_type": "m.replace", "event_id": "$target"},
+            new_content={
+                "body": restart_body,
+                "msgtype": "m.text",
+                STREAM_STATUS_KEY: "error",
+            },
+        ),
+    )
+    owner_client.room_messages.return_value = original_history
+    owner_client.room_get_event_relations = MagicMock(return_value=_aiter())
+    router_client.room_get_event_relations = MagicMock(return_value=_aiter())
 
     async def joined_rooms(client: object) -> list[str]:
         if client is router_client:
@@ -3140,16 +3209,20 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
         assert client is owner_client
         return [ROOM_ID]
 
+    async def cleanup_edit(*_: object, **__: object) -> object:
+        router_client.room_messages.return_value = edited_history
+        return delivered_matrix_event("$cleanup-edit")
+
     with (
         patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(0, [interrupted])),
-        ),
         patch(
             "mindroom.matrix.stale_stream_cleanup.send_message_result",
             new=AsyncMock(side_effect=[None, delivered_matrix_event("$resume")]),
         ) as mock_send,
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.edit_message_result",
+            new=AsyncMock(side_effect=cleanup_edit),
+        ) as mock_edit,
     ):
         scanned_room_ids: set[str] = set()
         failed_result = await recover_stale_streaming_messages(
@@ -3158,10 +3231,10 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
             resume_conversation_cache=router_cache,
             config=config,
             runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=NOW_MS,
+            startup_cutoff_ms=startup_cutoff_ms,
             scanned_room_ids=scanned_room_ids,
         )
-        assert failed_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=0)
+        assert failed_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)
         assert scanned_room_ids == set()
 
         router_joined = True
@@ -3171,7 +3244,7 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
             resume_conversation_cache=router_cache,
             config=config,
             runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=NOW_MS,
+            startup_cutoff_ms=startup_cutoff_ms,
             scanned_room_ids=scanned_room_ids,
         )
 
@@ -3179,6 +3252,7 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
     assert scanned_room_ids == {ROOM_ID}
     assert owner_cache.refresh_strict_thread_history_from_source.await_count == 2
     router_cache.refresh_strict_thread_history_from_source.assert_not_awaited()
+    mock_edit.assert_awaited_once()
     assert mock_send.await_count == 2
     assert all(call.args[0] is router_client for call in mock_send.await_args_list)
 

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -3051,7 +3051,6 @@ async def test_recovery_selects_joined_owner_for_freshness_and_router_for_relay(
             "mindroom.matrix.stale_stream_cleanup.send_message_result",
             new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
         ) as mock_send,
-        patch.object(stale_stream_cleanup_module.logger, "warning") as mock_warning,
     ):
         result = await recover_stale_streaming_messages(
             actors,
@@ -3069,14 +3068,6 @@ async def test_recovery_selects_joined_owner_for_freshness_and_router_for_relay(
     assert mock_send.await_count == expected_resumed
     if expected_resumed:
         assert mock_send.await_args.args[0] is router_client
-        mock_warning.assert_not_called()
-    else:
-        mock_warning.assert_called_once_with(
-            "Skipping auto-resume because owning actor is unavailable or not joined",
-            room_id=ROOM_ID,
-            agent_name="test_agent",
-            target_event_id="$target",
-        )
 
 
 @pytest.mark.asyncio

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -312,6 +312,18 @@ def _auto_resume_conversation_cache(interrupted: list[InterruptedThread]) -> Asy
     return conversation_cache
 
 
+def _auto_resume_owner_actors(
+    conversation_cache: AsyncMock | None,
+) -> dict[str, StaleStreamCleanupActor]:
+    return {
+        BOT_USER_ID: StaleStreamCleanupActor(_make_client(), conversation_cache),
+        OTHER_BOT_USER_ID: StaleStreamCleanupActor(
+            make_matrix_client_mock(user_id=OTHER_BOT_USER_ID),
+            conversation_cache,
+        ),
+    }
+
+
 def _assert_preserved_edit_payload(content: dict[str, object], expected_keys: dict[str, object]) -> None:
     """Assert io.mindroom.* keys are present in both edit payload layers."""
     new_content = cast("dict[str, object]", content["m.new_content"])
@@ -759,6 +771,9 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
+            owner_actors=_auto_resume_owner_actors(
+                _auto_resume_conversation_cache(interrupted),
+            ),
         )
 
     assert resumed_count == 2
@@ -797,6 +812,9 @@ async def test_auto_resume_skips_interruption_without_resolved_requester(tmp_pat
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
+            owner_actors=_auto_resume_owner_actors(
+                _auto_resume_conversation_cache(interrupted),
+            ),
         )
 
     assert resumed_count == 0
@@ -856,6 +874,7 @@ async def test_auto_resume_classifies_later_activity_by_effective_sender_and_his
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
+            owner_actors=_auto_resume_owner_actors(conversation_cache),
         )
 
     assert resumed_count == expected_resumes
@@ -902,6 +921,7 @@ async def test_prior_auto_resume_relay_does_not_suppress_sibling_resume(tmp_path
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
+            owner_actors=_auto_resume_owner_actors(conversation_cache),
         )
 
     assert resumed_count == 1
@@ -973,6 +993,7 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
+            owner_actors=_auto_resume_owner_actors(conversation_cache),
         )
 
     assert resumed_count == 0
@@ -1013,6 +1034,7 @@ async def test_auto_resume_propagates_cancelled_source_refresh(tmp_path: Path) -
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
+            owner_actors=_auto_resume_owner_actors(conversation_cache),
         )
 
     mock_send.assert_not_awaited()
@@ -1048,6 +1070,7 @@ async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
+            owner_actors=_auto_resume_owner_actors(conversation_cache),
         )
 
     assert resumed_count == 0
@@ -1113,6 +1136,7 @@ async def test_auto_resume_checks_freshness_after_delay_before_each_delivery(tmp
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
+            owner_actors=_auto_resume_owner_actors(conversation_cache),
         )
 
     assert resumed_count == 3
@@ -1164,6 +1188,9 @@ async def test_auto_resume_target_mention_ignores_unprepared_unrelated_entity(tm
             config=config,
             runtime_paths=runtime_paths,
             conversation_cache=_auto_resume_conversation_cache(interrupted),
+            owner_actors=_auto_resume_owner_actors(
+                _auto_resume_conversation_cache(interrupted),
+            ),
         )
 
     assert resumed_count == 1
@@ -1259,6 +1286,9 @@ async def test_auto_resume_skips_thread_id_none(tmp_path: Path) -> None:
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
+            owner_actors=_auto_resume_owner_actors(
+                _auto_resume_conversation_cache(interrupted),
+            ),
         )
 
     assert resumed_count == 1
@@ -1294,6 +1324,7 @@ async def test_auto_resume_records_outbound_message_when_send_succeeds(tmp_path:
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
+            owner_actors=_auto_resume_owner_actors(conversation_cache),
         )
 
     assert resumed_count == 1
@@ -1997,6 +2028,7 @@ async def test_recent_mid_tool_shutdown_marker_resumes_only_without_newer_human_
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
+            owner_actors=_auto_resume_owner_actors(conversation_cache),
             delay=0,
         )
 
@@ -2841,6 +2873,9 @@ async def test_auto_resume_dedupes_same_agent_and_thread_using_newest_target(tmp
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
+            owner_actors=_auto_resume_owner_actors(
+                _auto_resume_conversation_cache(interrupted),
+            ),
         )
 
     assert resumed_count == 1
@@ -2905,6 +2940,9 @@ async def test_auto_resume_sends_all_unique_threads_after_replacing_older_target
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
+            owner_actors=_auto_resume_owner_actors(
+                _auto_resume_conversation_cache(interrupted),
+            ),
         )
 
     assert resumed_count == 3
@@ -2954,6 +2992,9 @@ async def test_auto_resume_sends_threads_from_every_room(tmp_path: Path) -> None
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
+            owner_actors=_auto_resume_owner_actors(
+                _auto_resume_conversation_cache(interrupted),
+            ),
         )
 
     assert resumed_count == 2
@@ -2961,6 +3002,142 @@ async def test_auto_resume_sends_threads_from_every_room(tmp_path: Path) -> None
         "$thread-old",
         "$thread-new",
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("router_joined", "owner_joined", "expected_resumed"),
+    [
+        (False, True, 1),
+        (True, True, 1),
+        (True, False, 0),
+    ],
+    ids=["router-not-joined", "router-joined-late", "owner-not-joined"],
+)
+async def test_recovery_selects_joined_owner_for_freshness_and_router_for_relay(
+    tmp_path: Path,
+    router_joined: bool,
+    owner_joined: bool,
+    expected_resumed: int,
+) -> None:
+    """Strict freshness needs the joined owner; successful delivery stays router-authored."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    owner_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    interrupted = InterruptedThread(ROOM_ID, "$thread", "$target", "Partial", "test_agent", original_sender_id=USER_ID)
+    router_cache = _auto_resume_conversation_cache([interrupted])
+    router_cache.refresh_strict_thread_history_from_source.side_effect = None
+    router_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history()
+    owner_cache = _auto_resume_conversation_cache([interrupted])
+    actors = {
+        "@actual_router:localhost": StaleStreamCleanupActor(router_client, router_cache),
+        BOT_USER_ID: StaleStreamCleanupActor(owner_client, owner_cache),
+    }
+
+    async def joined_rooms(client: object) -> list[str]:
+        if client is router_client:
+            return [ROOM_ID] if router_joined else []
+        assert client is owner_client
+        return [ROOM_ID] if owner_joined else []
+
+    with (
+        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
+            new=AsyncMock(return_value=(0, [interrupted])),
+        ),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.send_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
+        ) as mock_send,
+        patch.object(stale_stream_cleanup_module.logger, "warning") as mock_warning,
+    ):
+        result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=router_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=set(),
+        )
+
+    assert result.resumed_count == expected_resumed
+    assert owner_cache.refresh_strict_thread_history_from_source.await_count == expected_resumed
+    router_cache.refresh_strict_thread_history_from_source.assert_not_awaited()
+    assert mock_send.await_count == expected_resumed
+    if expected_resumed:
+        assert mock_send.await_args.args[0] is router_client
+        mock_warning.assert_not_called()
+    else:
+        mock_warning.assert_called_once_with(
+            "Skipping auto-resume because owning actor is unavailable or not joined",
+            room_id=ROOM_ID,
+            agent_name="test_agent",
+            target_event_id="$target",
+        )
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_uses_each_interrupted_owner_cache(tmp_path: Path) -> None:
+    """Interrupted threads from different agents should refresh through their own caches."""
+    config = _make_config(tmp_path)
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    first_interrupted = InterruptedThread(
+        ROOM_ID,
+        "$first-thread",
+        "$first-target",
+        "First",
+        "test_agent",
+        original_sender_id=USER_ID,
+    )
+    second_interrupted = InterruptedThread(
+        ROOM_ID,
+        "$second-thread",
+        "$second-target",
+        "Second",
+        "other",
+        original_sender_id=USER_ID,
+    )
+    router_cache = _auto_resume_conversation_cache([])
+    first_cache = _auto_resume_conversation_cache([first_interrupted])
+    second_cache = _auto_resume_conversation_cache([second_interrupted])
+    owner_actors = {
+        BOT_USER_ID: StaleStreamCleanupActor(_make_client(), first_cache),
+        OTHER_BOT_USER_ID: StaleStreamCleanupActor(
+            make_matrix_client_mock(user_id=OTHER_BOT_USER_ID),
+            second_cache,
+        ),
+    }
+
+    with (
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.send_message_result",
+            new=AsyncMock(
+                side_effect=[
+                    delivered_matrix_event("$first-resume"),
+                    delivered_matrix_event("$second-resume"),
+                ],
+            ),
+        ) as mock_send,
+        patch("mindroom.matrix.stale_stream_cleanup.asyncio.sleep", new=AsyncMock()),
+    ):
+        resumed_count = await auto_resume_interrupted_threads(
+            router_client,
+            [first_interrupted, second_interrupted],
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=router_cache,
+            owner_actors=owner_actors,
+        )
+
+    assert resumed_count == 2
+    first_cache.refresh_strict_thread_history_from_source.assert_awaited_once()
+    second_cache.refresh_strict_thread_history_from_source.assert_awaited_once()
+    router_cache.refresh_strict_thread_history_from_source.assert_not_awaited()
+    assert mock_send.await_count == 2
+    assert all(item.args[0] is router_client for item in mock_send.await_args_list)
 
 
 @pytest.mark.asyncio
@@ -3443,6 +3620,9 @@ async def test_auto_resume_continues_after_send_exception(tmp_path: Path) -> Non
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
+            owner_actors=_auto_resume_owner_actors(
+                _auto_resume_conversation_cache(interrupted),
+            ),
         )
 
     assert resumed_count == 2

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -797,6 +797,47 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
 
 
 @pytest.mark.asyncio
+async def test_auto_resume_router_interruption_uses_router_cache_without_self_mention(tmp_path: Path) -> None:
+    """A router-owned stream should refresh through the router and keep its generic relay."""
+    config = _make_config(tmp_path)
+    router_user_id = entity_ids(config, runtime_paths_for(config))[ROUTER_AGENT_NAME].full_id
+    router_client = make_matrix_client_mock(user_id=router_user_id)
+    interrupted = [
+        InterruptedThread(
+            room_id=ROOM_ID,
+            thread_id="$thread",
+            target_event_id="$target",
+            partial_text="Partial",
+            agent_name=ROUTER_AGENT_NAME,
+            original_sender_id=USER_ID,
+        ),
+    ]
+    router_cache = _auto_resume_conversation_cache(interrupted)
+
+    with patch(
+        "mindroom.matrix.stale_stream_cleanup.send_message_result",
+        new=AsyncMock(return_value=delivered_matrix_event("$resume")),
+    ) as mock_send:
+        resumed_count = await auto_resume_interrupted_threads(
+            router_client,
+            interrupted,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=router_cache,
+            owner_actors={
+                router_user_id: StaleStreamCleanupActor(router_client, router_cache),
+            },
+        )
+
+    assert resumed_count == 1
+    router_cache.refresh_strict_thread_history_from_source.assert_awaited_once()
+    mock_send.assert_awaited_once()
+    content = mock_send.await_args.args[2]
+    assert content["body"] == AUTO_RESUME_MESSAGE
+    assert "m.mentions" not in content
+
+
+@pytest.mark.asyncio
 async def test_auto_resume_skips_interruption_without_resolved_requester(tmp_path: Path) -> None:
     """Auto-resume should fail closed when restart recovery cannot resolve requester identity."""
     config = _make_config(tmp_path)

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -265,6 +265,7 @@ async def _run_cleanup(
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=startup_cutoff_ms,
             terminal_interrupted_only=terminal_interrupted_only,
+            retryable_room_ids=set(),
         )
 
 
@@ -809,6 +810,7 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
             owner_actors=_auto_resume_owner_actors(
                 _auto_resume_conversation_cache(interrupted),
             ),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 2
@@ -862,6 +864,7 @@ async def test_auto_resume_router_interruption_uses_router_cache_without_self_me
             owner_actors={
                 router_user_id: StaleStreamCleanupActor(router_client, router_cache),
             },
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 1
@@ -891,6 +894,7 @@ async def test_auto_resume_skips_interruption_without_resolved_requester(tmp_pat
             owner_actors=_auto_resume_owner_actors(
                 _auto_resume_conversation_cache(interrupted),
             ),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 0
@@ -951,6 +955,7 @@ async def test_auto_resume_classifies_later_activity_by_effective_sender_and_his
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
             owner_actors=_auto_resume_owner_actors(conversation_cache),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == expected_resumes
@@ -998,6 +1003,7 @@ async def test_prior_auto_resume_relay_does_not_suppress_sibling_resume(tmp_path
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
             owner_actors=_auto_resume_owner_actors(conversation_cache),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 1
@@ -1070,6 +1076,7 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
             owner_actors=_auto_resume_owner_actors(conversation_cache),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 0
@@ -1111,6 +1118,7 @@ async def test_auto_resume_propagates_cancelled_source_refresh(tmp_path: Path) -
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
             owner_actors=_auto_resume_owner_actors(conversation_cache),
+            retryable_room_ids=set(),
         )
 
     mock_send.assert_not_awaited()
@@ -1147,6 +1155,7 @@ async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
             owner_actors=_auto_resume_owner_actors(conversation_cache),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 0
@@ -1213,6 +1222,7 @@ async def test_auto_resume_checks_freshness_after_delay_before_each_delivery(tmp
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
             owner_actors=_auto_resume_owner_actors(conversation_cache),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 3
@@ -1267,6 +1277,7 @@ async def test_auto_resume_target_mention_ignores_unprepared_unrelated_entity(tm
             owner_actors=_auto_resume_owner_actors(
                 _auto_resume_conversation_cache(interrupted),
             ),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 1
@@ -1365,6 +1376,7 @@ async def test_auto_resume_skips_thread_id_none(tmp_path: Path) -> None:
             owner_actors=_auto_resume_owner_actors(
                 _auto_resume_conversation_cache(interrupted),
             ),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 1
@@ -1401,6 +1413,7 @@ async def test_auto_resume_records_outbound_message_when_send_succeeds(tmp_path:
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
             owner_actors=_auto_resume_owner_actors(conversation_cache),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 1
@@ -2105,6 +2118,7 @@ async def test_recent_mid_tool_shutdown_marker_resumes_only_without_newer_human_
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
             owner_actors=_auto_resume_owner_actors(conversation_cache),
+            retryable_room_ids=set(),
             delay=0,
         )
 
@@ -2952,6 +2966,7 @@ async def test_auto_resume_dedupes_same_agent_and_thread_using_newest_target(tmp
             owner_actors=_auto_resume_owner_actors(
                 _auto_resume_conversation_cache(interrupted),
             ),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 1
@@ -3019,6 +3034,7 @@ async def test_auto_resume_sends_all_unique_threads_after_replacing_older_target
             owner_actors=_auto_resume_owner_actors(
                 _auto_resume_conversation_cache(interrupted),
             ),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 3
@@ -3071,6 +3087,7 @@ async def test_auto_resume_sends_threads_from_every_room(tmp_path: Path) -> None
             owner_actors=_auto_resume_owner_actors(
                 _auto_resume_conversation_cache(interrupted),
             ),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 2
@@ -3393,6 +3410,7 @@ async def test_auto_resume_uses_each_interrupted_owner_cache(tmp_path: Path) -> 
             runtime_paths=runtime_paths_for(config),
             conversation_cache=router_cache,
             owner_actors=owner_actors,
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 2
@@ -3662,6 +3680,7 @@ async def test_shared_room_cleanup_routes_edits_through_each_message_owner(tmp_p
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=NOW_MS,
+            retryable_room_ids=set(),
         )
 
     assert cleaned_count == 2
@@ -3886,6 +3905,7 @@ async def test_auto_resume_continues_after_send_exception(tmp_path: Path) -> Non
             owner_actors=_auto_resume_owner_actors(
                 _auto_resume_conversation_cache(interrupted),
             ),
+            retryable_room_ids=set(),
         )
 
     assert resumed_count == 2

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -6,6 +6,7 @@ import asyncio
 import importlib
 import json
 from contextlib import suppress
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
@@ -30,16 +31,23 @@ from mindroom.matrix.client_thread_history import OpaqueEncryptedThreadHistoryEr
 from mindroom.matrix.identity import managed_account_key
 from mindroom.matrix.stale_stream_cleanup import (
     StaleStreamCleanupActor,
+    StaleStreamRecoveryState,
     recover_stale_streaming_messages,
 )
 from mindroom.matrix.stale_stream_cleanup import (
-    _auto_resume_interrupted_threads as auto_resume_interrupted_threads,
+    _auto_resume_interrupted_threads as auto_resume_interrupted_threads_result,
+)
+from mindroom.matrix.stale_stream_cleanup import (
+    _AutoResumeResult as AutoResumeResult,
 )
 from mindroom.matrix.stale_stream_cleanup import (
     _cleanup_stale_streaming_room as cleanup_stale_streaming_room,
 )
 from mindroom.matrix.stale_stream_cleanup import (
-    _InterruptedThread as InterruptedThread,
+    _InterruptedThread as InterruptedThreadRecord,
+)
+from mindroom.matrix.stale_stream_cleanup import (
+    _RoomCleanupResult as RoomCleanupResult,
 )
 from mindroom.matrix.stale_stream_cleanup import (
     _StaleStreamRecoveryResult as StaleStreamRecoveryResult,
@@ -61,6 +69,10 @@ from tests.identity_helpers import entity_ids, persist_entity_accounts
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
+    from mindroom.config.main import Config as ConfigType
+    from mindroom.constants import RuntimePaths
+    from mindroom.matrix.conversation_cache import ConversationCacheProtocol
+
 BOT_USER_ID = "@actual_test_agent:localhost"
 OTHER_BOT_USER_ID = "@actual_other:localhost"
 ROOM_ID = "!room:example.com"
@@ -69,6 +81,84 @@ STALE_AGE_MS = stale_stream_cleanup_module._STALE_STREAM_RECENCY_GUARD_MS + 60_0
 OLD_STALE_AGE_MS = stale_stream_cleanup_module._STALE_STREAM_LOOKBACK_MS + 60_000
 USER_ID = "@user:example.com"
 OTHER_USER_ID = "@other-user:example.com"
+
+
+def InterruptedThread(  # noqa: N802
+    room_id: str,
+    thread_id: str | None,
+    target_event_id: str,
+    partial_text: str,
+    agent_name: str,
+    *,
+    original_sender_id: str | None = None,
+    timestamp_ms: int = 0,
+    bot_user_id: str | None = None,
+    owner_actor: StaleStreamCleanupActor | None = None,
+) -> InterruptedThreadRecord:
+    """Build an exact-owner auto-resume candidate for tests."""
+    resolved_bot_user_id = bot_user_id
+    if resolved_bot_user_id is None:
+        if agent_name == ROUTER_AGENT_NAME:
+            resolved_bot_user_id = "@actual_router:localhost"
+        elif agent_name == "other":
+            resolved_bot_user_id = OTHER_BOT_USER_ID
+        else:
+            resolved_bot_user_id = BOT_USER_ID
+    if owner_actor is None:
+        owner_cache = AsyncMock()
+        owner_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+            _history_message(target_event_id),
+        )
+        owner_cache.notify_outbound_message = Mock()
+        owner_actor = _cleanup_actor(
+            make_matrix_client_mock(user_id=resolved_bot_user_id),
+            owner_cache,
+        )
+    return InterruptedThreadRecord(
+        room_id=room_id,
+        thread_id=thread_id,
+        target_event_id=target_event_id,
+        partial_text=partial_text,
+        agent_name=agent_name,
+        bot_user_id=resolved_bot_user_id,
+        owner_actor=owner_actor,
+        original_sender_id=original_sender_id,
+        timestamp_ms=timestamp_ms,
+    )
+
+
+async def auto_resume_interrupted_threads(
+    client: nio.AsyncClient,
+    interrupted: list[InterruptedThreadRecord],
+    *,
+    config: ConfigType,
+    runtime_paths: RuntimePaths,
+    conversation_cache: ConversationCacheProtocol | None = None,
+    owner_actors: dict[str, StaleStreamCleanupActor] | None = None,
+    delay: float = 2.0,
+    delay_before_first: bool = False,
+    retryable_room_ids: set[str] | None = None,
+) -> int:
+    """Return count while binding legacy test fixtures onto exact candidates."""
+    candidates = [
+        replace(
+            candidate,
+            owner_actor=(owner_actors[candidate.bot_user_id] if owner_actors is not None else candidate.owner_actor),
+        )
+        for candidate in interrupted
+    ]
+    result = await auto_resume_interrupted_threads_result(
+        client,
+        candidates,
+        config=config,
+        runtime_paths=runtime_paths,
+        conversation_cache=conversation_cache,
+        delay=delay,
+        delay_before_first=delay_before_first,
+    )
+    if retryable_room_ids is not None:
+        retryable_room_ids.update(result.retry_room_ids)
+    return result.resumed_count
 
 
 def _make_config(tmp_path: Path) -> Config:
@@ -209,6 +299,22 @@ def _make_client() -> AsyncMock:
     return make_matrix_client_mock(user_id=BOT_USER_ID)
 
 
+def _cleanup_actor(
+    client: AsyncMock,
+    conversation_cache: ConversationCacheProtocol | None = None,
+    *,
+    first_sync_complete: bool = True,
+    expected_room_ids: frozenset[str] = frozenset({ROOM_ID}),
+) -> StaleStreamCleanupActor:
+    """Return one exact cleanup actor generation."""
+    return StaleStreamCleanupActor(
+        client=client,
+        conversation_cache=conversation_cache if conversation_cache is not None else MagicMock(),
+        first_sync_complete=first_sync_complete,
+        expected_room_ids=expected_room_ids,
+    )
+
+
 def _room_messages_response(*events: object, end: str | None = None) -> nio.RoomMessagesResponse:
     response = MagicMock()
     response.__class__ = nio.RoomMessagesResponse
@@ -248,25 +354,24 @@ async def _run_cleanup(
     config: Config,
     *,
     joined_rooms: list[str],
-    bot_user_ids: set[str] | None = None,
     now_ms: int = NOW_MS,
     startup_cutoff_ms: int | None = None,
     terminal_interrupted_only: bool = False,
-) -> tuple[int, list[InterruptedThread]]:
+) -> tuple[int, list[InterruptedThreadRecord]]:
     client.user_id = BOT_USER_ID
     assert joined_rooms == [ROOM_ID]
     with patch("mindroom.matrix.stale_stream_cleanup.time.time", return_value=now_ms / 1000):
-        return await cleanup_stale_streaming_room(
+        result = await cleanup_stale_streaming_room(
             client,
             room_id=ROOM_ID,
-            actors={BOT_USER_ID: StaleStreamCleanupActor(client, None)},
-            bot_user_ids={BOT_USER_ID} if bot_user_ids is None else bot_user_ids,
+            actors={BOT_USER_ID: _cleanup_actor(client)},
+            joined_bot_user_ids=frozenset({BOT_USER_ID}),
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=startup_cutoff_ms,
             terminal_interrupted_only=terminal_interrupted_only,
-            retryable_room_ids=set(),
         )
+    return result.cleaned_count, list(result.interrupted_threads)
 
 
 def _history_message(
@@ -294,7 +399,7 @@ def _authoritative_history(*messages: ResolvedVisibleMessage) -> ThreadHistoryRe
     )
 
 
-def _auto_resume_conversation_cache(interrupted: list[InterruptedThread]) -> AsyncMock:
+def _auto_resume_conversation_cache(interrupted: list[InterruptedThreadRecord]) -> AsyncMock:
     conversation_cache = AsyncMock()
 
     def history_for_thread(room_id: str, thread_id: str, **_: object) -> ThreadHistoryResult:
@@ -317,8 +422,8 @@ def _auto_resume_owner_actors(
     conversation_cache: AsyncMock | None,
 ) -> dict[str, StaleStreamCleanupActor]:
     return {
-        BOT_USER_ID: StaleStreamCleanupActor(_make_client(), conversation_cache),
-        OTHER_BOT_USER_ID: StaleStreamCleanupActor(
+        BOT_USER_ID: _cleanup_actor(_make_client(), conversation_cache),
+        OTHER_BOT_USER_ID: _cleanup_actor(
             make_matrix_client_mock(user_id=OTHER_BOT_USER_ID),
             conversation_cache,
         ),
@@ -384,7 +489,6 @@ async def test_relations_api_filters_reactions_and_unions_history_ids(tmp_path: 
             client,
             config,
             joined_rooms=[ROOM_ID],
-            bot_user_ids={BOT_USER_ID},
         )
 
     assert cleaned == 1
@@ -674,6 +778,53 @@ async def test_cleanup_skips_restart_interrupted_message_created_after_startup_c
 
 
 @pytest.mark.asyncio
+async def test_cleanup_skips_external_restart_interruption_edited_after_startup_cutoff(tmp_path: Path) -> None:
+    """Latest edit time keeps externally authored terminal interruptions behind the startup fence."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    client = _make_client()
+    startup_cutoff_ms = NOW_MS - 120_000
+    restart_body = build_restart_interrupted_body("Partial")
+    client.room_messages.return_value = _room_messages_response(
+        _make_message_event(
+            event_id="$thread-root",
+            body="Question",
+            sender=USER_ID,
+            timestamp_ms=startup_cutoff_ms - 2_000,
+        ),
+        _make_message_event(
+            event_id="$external-interruption",
+            body="Partial",
+            timestamp_ms=startup_cutoff_ms - 1_000,
+            relates_to=_thread_reply_relation("$thread-root", "$thread-root"),
+            extra_content={STREAM_STATUS_KEY: "streaming"},
+        ),
+        _make_message_event(
+            event_id="$post-cutoff-edit",
+            body=f"* {restart_body}",
+            timestamp_ms=startup_cutoff_ms + 1,
+            relates_to={"rel_type": "m.replace", "event_id": "$external-interruption"},
+            new_content={
+                "body": restart_body,
+                "msgtype": "m.text",
+                STREAM_STATUS_KEY: "error",
+            },
+        ),
+    )
+    client.room_get_event_relations = MagicMock(return_value=_aiter())
+
+    cleaned, interrupted = await _run_cleanup(
+        client,
+        config,
+        joined_rooms=[ROOM_ID],
+        startup_cutoff_ms=startup_cutoff_ms,
+    )
+
+    assert cleaned == 0
+    assert interrupted == []
+
+
+@pytest.mark.asyncio
 async def test_cleanup_returns_interrupted_thread_per_cleaned_threaded_message(tmp_path: Path) -> None:
     """Cleanup should return one interrupted-thread record per cleaned threaded message."""
     config = _make_config(tmp_path)
@@ -698,7 +849,12 @@ async def test_cleanup_returns_interrupted_thread_per_cleaned_threaded_message(t
 
     with patch(
         "mindroom.matrix.stale_stream_cleanup.edit_message_result",
-        new=AsyncMock(side_effect=["$edit1", "$edit2"]),
+        new=AsyncMock(
+            side_effect=[
+                delivered_matrix_event("$edit1"),
+                delivered_matrix_event("$edit2"),
+            ],
+        ),
     ):
         cleaned, interrupted = await _run_cleanup(client, config, joined_rooms=[ROOM_ID])
 
@@ -721,6 +877,8 @@ async def test_cleanup_returns_interrupted_thread_per_cleaned_threaded_message(t
             original_sender_id=None,
         ),
     ]
+    assert {item.bot_user_id for item in interrupted} == {BOT_USER_ID}
+    assert all(item.owner_actor.client is client for item in interrupted)
 
 
 @pytest.mark.asyncio
@@ -788,6 +946,10 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
             original_sender_id=USER_ID,
         ),
     ]
+    owner_cache = _auto_resume_conversation_cache(interrupted)
+    owner_actor = _cleanup_actor(_make_client(), owner_cache)
+    interrupted = [replace(item, owner_actor=owner_actor) for item in interrupted]
+    router_cache = _auto_resume_conversation_cache([])
 
     with (
         patch(
@@ -806,11 +968,7 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
             interrupted,
             config=config,
             runtime_paths=runtime_paths_for(config),
-            conversation_cache=_auto_resume_conversation_cache(interrupted),
-            owner_actors=_auto_resume_owner_actors(
-                _auto_resume_conversation_cache(interrupted),
-            ),
-            retryable_room_ids=set(),
+            conversation_cache=router_cache,
         )
 
     assert resumed_count == 2
@@ -862,7 +1020,7 @@ async def test_auto_resume_router_interruption_uses_router_cache_without_self_me
             runtime_paths=runtime_paths_for(config),
             conversation_cache=router_cache,
             owner_actors={
-                router_user_id: StaleStreamCleanupActor(router_client, router_cache),
+                router_user_id: _cleanup_actor(router_client, router_cache),
             },
             retryable_room_ids=set(),
         )
@@ -1421,6 +1579,46 @@ async def test_auto_resume_records_outbound_message_when_send_succeeds(tmp_path:
     record_args = conversation_cache.notify_outbound_message.call_args.args
     assert record_args[:2] == (ROOM_ID, "$resume")
     assert record_args[2]["m.relates_to"]["event_id"] == "$threaded"
+
+
+@pytest.mark.asyncio
+async def test_auto_resume_does_not_retry_after_delivery_bookkeeping_failure(tmp_path: Path) -> None:
+    """A delivered relay is settled even when router cache bookkeeping fails."""
+    config = _make_config(tmp_path)
+    client = AsyncMock(spec=nio.AsyncClient)
+    interrupted = [
+        InterruptedThread(
+            room_id=ROOM_ID,
+            thread_id="$threaded",
+            target_event_id="$target",
+            partial_text="Threaded",
+            agent_name="test_agent",
+            original_sender_id=USER_ID,
+        ),
+    ]
+    conversation_cache = _auto_resume_conversation_cache(interrupted)
+    conversation_cache.notify_outbound_message.side_effect = RuntimeError("cache unavailable")
+
+    with patch(
+        "mindroom.matrix.stale_stream_cleanup.send_message_result",
+        new=AsyncMock(return_value=delivered_matrix_event("$resume")),
+    ) as mock_send:
+        result = await auto_resume_interrupted_threads_result(
+            client,
+            [
+                replace(
+                    interrupted[0],
+                    owner_actor=_cleanup_actor(_make_client(), conversation_cache),
+                ),
+            ],
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            conversation_cache=conversation_cache,
+        )
+
+    assert result.resumed_count == 1
+    assert result.retry_room_ids == frozenset()
+    mock_send.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -2131,7 +2329,7 @@ async def test_targeted_recovery_scans_only_handoff_rooms_without_a_clock_cutoff
     """Replacement recovery must exclude unrelated rooms and preserve the Matrix clock domain."""
     config = _make_config(tmp_path)
     client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    actors = {BOT_USER_ID: StaleStreamCleanupActor(client, MagicMock())}
+    actors = {BOT_USER_ID: _cleanup_actor(client)}
 
     with (
         patch(
@@ -2140,7 +2338,7 @@ async def test_targeted_recovery_scans_only_handoff_rooms_without_a_clock_cutoff
         ),
         patch(
             "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(0, [])),
+            new=AsyncMock(return_value=RoomCleanupResult(ROOM_ID, 0, ())),
         ) as cleanup_room,
     ):
         scanned_room_ids: set[str] = set()
@@ -2151,7 +2349,7 @@ async def test_targeted_recovery_scans_only_handoff_rooms_without_a_clock_cutoff
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=None,
-            scanned_room_ids=scanned_room_ids,
+            recovery_state=StaleStreamRecoveryState(scanned_room_ids),
             target_room_ids={ROOM_ID},
         )
 
@@ -2203,7 +2401,7 @@ async def test_failed_targeted_room_scan_remains_unscanned_for_retry(tmp_path: P
     """A transient room-history failure must leave the claimed handoff retryable."""
     config = _make_config(tmp_path)
     client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    actors = {BOT_USER_ID: StaleStreamCleanupActor(client, MagicMock())}
+    actors = {BOT_USER_ID: _cleanup_actor(client)}
 
     with (
         patch(
@@ -2223,7 +2421,7 @@ async def test_failed_targeted_room_scan_remains_unscanned_for_retry(tmp_path: P
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=None,
-            scanned_room_ids=scanned_room_ids,
+            recovery_state=StaleStreamRecoveryState(scanned_room_ids),
             target_room_ids={ROOM_ID},
         )
 
@@ -3099,19 +3297,13 @@ async def test_auto_resume_sends_threads_from_every_room(tmp_path: Path) -> None
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("router_joined", "owner_joined", "expected_resumed"),
-    [
-        (False, True, 1),
-        (True, True, 1),
-        (True, False, 0),
-    ],
-    ids=["router-not-joined", "router-joined-late", "owner-not-joined"],
+    "router_joined",
+    [False, True],
+    ids=["router-not-joined", "router-joined"],
 )
 async def test_recovery_selects_joined_owner_for_freshness_and_router_for_relay(
     tmp_path: Path,
     router_joined: bool,
-    owner_joined: bool,
-    expected_resumed: int,
 ) -> None:
     """Strict freshness needs the joined owner; successful delivery stays router-authored."""
     config = _make_config(tmp_path)
@@ -3124,21 +3316,22 @@ async def test_recovery_selects_joined_owner_for_freshness_and_router_for_relay(
     router_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history()
     owner_cache = _auto_resume_conversation_cache([interrupted])
     actors = {
-        "@actual_router:localhost": StaleStreamCleanupActor(router_client, router_cache),
-        BOT_USER_ID: StaleStreamCleanupActor(owner_client, owner_cache),
+        "@actual_router:localhost": _cleanup_actor(router_client, router_cache),
+        BOT_USER_ID: _cleanup_actor(owner_client, owner_cache),
     }
+    interrupted = replace(interrupted, owner_actor=actors[BOT_USER_ID])
 
     async def joined_rooms(client: object) -> list[str]:
         if client is router_client:
             return [ROOM_ID] if router_joined else []
         assert client is owner_client
-        return [ROOM_ID] if owner_joined else []
+        return [ROOM_ID]
 
     with (
         patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
         patch(
             "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(0, [interrupted])),
+            new=AsyncMock(return_value=RoomCleanupResult(ROOM_ID, 0, (interrupted,))),
         ),
         patch(
             "mindroom.matrix.stale_stream_cleanup.send_message_result",
@@ -3152,15 +3345,14 @@ async def test_recovery_selects_joined_owner_for_freshness_and_router_for_relay(
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=set(),
+            recovery_state=StaleStreamRecoveryState(),
         )
 
-    assert result.resumed_count == expected_resumed
-    assert owner_cache.refresh_strict_thread_history_from_source.await_count == expected_resumed
+    assert result.resumed_count == 1
+    assert owner_cache.refresh_strict_thread_history_from_source.await_count == 1
     router_cache.refresh_strict_thread_history_from_source.assert_not_awaited()
-    assert mock_send.await_count == expected_resumed
-    if expected_resumed:
-        assert mock_send.await_args.args[0] is router_client
+    mock_send.assert_awaited_once()
+    assert mock_send.await_args.args[0] is router_client
 
 
 @pytest.mark.asyncio
@@ -3181,8 +3373,8 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
     router_cache = _auto_resume_conversation_cache([])
     owner_cache = _auto_resume_conversation_cache([interrupted])
     actors = {
-        "@actual_router:localhost": StaleStreamCleanupActor(router_client, router_cache),
-        BOT_USER_ID: StaleStreamCleanupActor(owner_client, owner_cache),
+        "@actual_router:localhost": _cleanup_actor(router_client, router_cache),
+        BOT_USER_ID: _cleanup_actor(owner_client, owner_cache),
     }
     router_joined = False
     startup_cutoff_ms = int(stale_stream_cleanup_module.time.time() * 1000)
@@ -3241,7 +3433,8 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
             new=AsyncMock(side_effect=cleanup_edit),
         ) as mock_edit,
     ):
-        scanned_room_ids: set[str] = set()
+        recovery_state = StaleStreamRecoveryState()
+        scanned_room_ids = recovery_state.scanned_room_ids
         failed_result = await recover_stale_streaming_messages(
             actors,
             resume_client=router_client,
@@ -3249,7 +3442,7 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=startup_cutoff_ms,
-            scanned_room_ids=scanned_room_ids,
+            recovery_state=recovery_state,
         )
         assert failed_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)
         assert scanned_room_ids == set()
@@ -3262,7 +3455,7 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=startup_cutoff_ms,
-            scanned_room_ids=scanned_room_ids,
+            recovery_state=recovery_state,
         )
 
     assert recovered_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=1)
@@ -3279,6 +3472,7 @@ async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_pat
     """Real cleanup should let the membership wave retry after a message owner joins."""
     config = _make_config(tmp_path)
     config.defaults.auto_resume_after_restart = True
+    now_ms = int(stale_stream_cleanup_module.time.time() * 1000)
     router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
     owner_client = make_matrix_client_mock(user_id=BOT_USER_ID)
     interrupted = InterruptedThread(
@@ -3292,8 +3486,8 @@ async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_pat
     router_cache = _auto_resume_conversation_cache([])
     owner_cache = _auto_resume_conversation_cache([interrupted])
     actors = {
-        "@actual_router:localhost": StaleStreamCleanupActor(router_client, router_cache),
-        BOT_USER_ID: StaleStreamCleanupActor(owner_client, owner_cache),
+        "@actual_router:localhost": _cleanup_actor(router_client, router_cache),
+        BOT_USER_ID: _cleanup_actor(owner_client, owner_cache),
     }
     owner_joined = False
     router_client.room_messages.return_value = _room_messages_response(
@@ -3301,12 +3495,12 @@ async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_pat
             event_id="$thread",
             body="Question",
             sender=USER_ID,
-            timestamp_ms=NOW_MS - (STALE_AGE_MS + 20_000),
+            timestamp_ms=now_ms - (STALE_AGE_MS + 20_000),
         ),
         _make_message_event(
             event_id="$target",
             body=build_restart_interrupted_body("Partial"),
-            timestamp_ms=NOW_MS - STALE_AGE_MS,
+            timestamp_ms=now_ms - STALE_AGE_MS,
             relates_to=_thread_reply_relation("$thread", "$thread"),
             extra_content={STREAM_STATUS_KEY: "error"},
         ),
@@ -3327,15 +3521,16 @@ async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_pat
             new=AsyncMock(return_value=delivered_matrix_event("$resume")),
         ) as mock_send,
     ):
-        scanned_room_ids: set[str] = set()
+        recovery_state = StaleStreamRecoveryState()
+        scanned_room_ids = recovery_state.scanned_room_ids
         missing_owner_result = await recover_stale_streaming_messages(
             actors,
             resume_client=router_client,
             resume_conversation_cache=router_cache,
             config=config,
             runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=scanned_room_ids,
+            startup_cutoff_ms=now_ms,
+            recovery_state=recovery_state,
         )
         assert missing_owner_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=0)
         assert scanned_room_ids == set()
@@ -3347,8 +3542,8 @@ async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_pat
             resume_conversation_cache=router_cache,
             config=config,
             runtime_paths=runtime_paths_for(config),
-            startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=scanned_room_ids,
+            startup_cutoff_ms=now_ms,
+            recovery_state=recovery_state,
         )
 
     assert recovered_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=1)
@@ -3357,6 +3552,290 @@ async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_pat
     router_cache.refresh_strict_thread_history_from_source.assert_not_awaited()
     mock_send.assert_awaited_once()
     assert mock_send.await_args.args[0] is router_client
+
+
+@pytest.mark.asyncio
+async def test_transient_freshness_failure_retries_then_sends_once(tmp_path: Path) -> None:
+    """Uncertain source history releases the room; authoritative retry sends once."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    owner_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    now_ms = int(stale_stream_cleanup_module.time.time() * 1000)
+    router_cache = _auto_resume_conversation_cache([])
+    owner_cache = _auto_resume_conversation_cache([])
+    owner_cache.refresh_strict_thread_history_from_source.side_effect = [
+        TimeoutError("transient source failure"),
+        _authoritative_history(_history_message("$target")),
+    ]
+    actors = {
+        "@actual_router:localhost": _cleanup_actor(router_client, router_cache),
+        BOT_USER_ID: _cleanup_actor(owner_client, owner_cache),
+    }
+    router_client.room_messages.return_value = _room_messages_response(
+        _make_message_event(
+            event_id="$thread",
+            body="Question",
+            sender=USER_ID,
+            timestamp_ms=now_ms - (STALE_AGE_MS + 20_000),
+        ),
+        _make_message_event(
+            event_id="$target",
+            body=build_restart_interrupted_body("Partial"),
+            timestamp_ms=now_ms - STALE_AGE_MS,
+            relates_to=_thread_reply_relation("$thread", "$thread"),
+            extra_content={STREAM_STATUS_KEY: "error"},
+        ),
+    )
+    router_client.room_get_event_relations = MagicMock(return_value=_aiter())
+
+    async def joined_rooms(client: object) -> list[str]:
+        assert client in {router_client, owner_client}
+        return [ROOM_ID]
+
+    with (
+        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.send_message_result",
+            new=AsyncMock(return_value=delivered_matrix_event("$resume")),
+        ) as mock_send,
+    ):
+        recovery_state = StaleStreamRecoveryState()
+        scanned_room_ids = recovery_state.scanned_room_ids
+        first = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=router_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=now_ms + 1,
+            recovery_state=recovery_state,
+        )
+        assert first.resumed_count == 0
+        assert scanned_room_ids == set()
+
+        second = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=router_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=now_ms + 1,
+            recovery_state=recovery_state,
+        )
+
+    assert second.resumed_count == 1
+    assert scanned_room_ids == {ROOM_ID}
+    assert owner_cache.refresh_strict_thread_history_from_source.await_count == 2
+    mock_send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unready_owner_generation_retries_until_exact_replacement_is_ready(tmp_path: Path) -> None:
+    """Joined membership is insufficient; only the ready owner generation may refresh and relay."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    owner_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    now_ms = int(stale_stream_cleanup_module.time.time() * 1000)
+    router_cache = _auto_resume_conversation_cache([])
+    unready_cache = _auto_resume_conversation_cache([])
+    ready_cache = _auto_resume_conversation_cache([])
+    ready_cache.refresh_strict_thread_history_from_source.side_effect = None
+    ready_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+        _history_message("$target"),
+    )
+    actors = {
+        "@actual_router:localhost": _cleanup_actor(router_client, router_cache),
+        BOT_USER_ID: _cleanup_actor(
+            owner_client,
+            unready_cache,
+            first_sync_complete=False,
+        ),
+    }
+    router_client.room_messages.return_value = _room_messages_response(
+        _make_message_event(
+            event_id="$thread",
+            body="Question",
+            sender=USER_ID,
+            timestamp_ms=now_ms - (STALE_AGE_MS + 20_000),
+        ),
+        _make_message_event(
+            event_id="$target",
+            body=build_restart_interrupted_body("Partial"),
+            timestamp_ms=now_ms - STALE_AGE_MS,
+            relates_to=_thread_reply_relation("$thread", "$thread"),
+            extra_content={STREAM_STATUS_KEY: "error"},
+        ),
+    )
+    router_client.room_get_event_relations = MagicMock(return_value=_aiter())
+
+    async def joined_rooms(client: object) -> list[str]:
+        assert client in {router_client, owner_client}
+        return [ROOM_ID]
+
+    with (
+        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.send_message_result",
+            new=AsyncMock(return_value=delivered_matrix_event("$resume")),
+        ) as mock_send,
+    ):
+        recovery_state = StaleStreamRecoveryState()
+        scanned_room_ids = recovery_state.scanned_room_ids
+        unready = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=router_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=now_ms + 1,
+            recovery_state=recovery_state,
+        )
+        assert unready.resumed_count == 0
+        assert scanned_room_ids == set()
+
+        actors[BOT_USER_ID] = _cleanup_actor(owner_client, ready_cache)
+        ready = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=router_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=now_ms + 1,
+            recovery_state=recovery_state,
+        )
+
+    assert ready.resumed_count == 1
+    unready_cache.refresh_strict_thread_history_from_source.assert_not_awaited()
+    ready_cache.refresh_strict_thread_history_from_source.assert_awaited_once()
+    mock_send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_removed_owner_does_not_release_room_across_three_passes(tmp_path: Path) -> None:
+    """Configured-but-removed owners leave no pending room recovery work."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    owner_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    now_ms = int(stale_stream_cleanup_module.time.time() * 1000)
+    actors = {
+        "@actual_router:localhost": _cleanup_actor(router_client),
+        BOT_USER_ID: _cleanup_actor(
+            owner_client,
+            expected_room_ids=frozenset(),
+        ),
+    }
+    router_client.room_messages.return_value = _room_messages_response(
+        _make_message_event(
+            event_id="$thread",
+            body="Question",
+            sender=USER_ID,
+            timestamp_ms=now_ms - (STALE_AGE_MS + 20_000),
+        ),
+        _make_message_event(
+            event_id="$target",
+            body=build_restart_interrupted_body("Partial"),
+            timestamp_ms=now_ms - STALE_AGE_MS,
+            relates_to=_thread_reply_relation("$thread", "$thread"),
+            extra_content={STREAM_STATUS_KEY: "error"},
+        ),
+    )
+    router_client.room_get_event_relations = MagicMock(return_value=_aiter())
+
+    async def joined_rooms(client: object) -> list[str]:
+        return [ROOM_ID] if client is router_client else []
+
+    with patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms):
+        recovery_state = StaleStreamRecoveryState()
+        scanned_room_ids = recovery_state.scanned_room_ids
+        results = [
+            await recover_stale_streaming_messages(
+                actors,
+                resume_client=router_client,
+                resume_conversation_cache=actors["@actual_router:localhost"].conversation_cache,
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                startup_cutoff_ms=now_ms + 1,
+                recovery_state=recovery_state,
+            )
+            for _ in range(3)
+        ]
+
+    assert [result.room_count for result in results] == [1, 0, 0]
+    assert scanned_room_ids == {ROOM_ID}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "absent_owner_state",
+    ["completed", "relayed", "expired"],
+)
+async def test_absent_owner_without_pending_work_keeps_room_scanned(
+    tmp_path: Path,
+    absent_owner_state: str,
+) -> None:
+    """Only a current unrelayed candidate may release an absent owner's room."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_user_id = "@actual_router:localhost"
+    router_client = make_matrix_client_mock(user_id=router_user_id)
+    owner_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    now_ms = int(stale_stream_cleanup_module.time.time() * 1000)
+    target_timestamp_ms = now_ms - OLD_STALE_AGE_MS if absent_owner_state == "expired" else now_ms - STALE_AGE_MS
+    target_body = "Completed" if absent_owner_state == "completed" else build_restart_interrupted_body("Partial")
+    target_status = "completed" if absent_owner_state == "completed" else "error"
+    events = [
+        _make_message_event(
+            event_id="$thread",
+            body="Question",
+            sender=USER_ID,
+            timestamp_ms=target_timestamp_ms - 20_000,
+        ),
+        _make_message_event(
+            event_id="$target",
+            body=target_body,
+            timestamp_ms=target_timestamp_ms,
+            relates_to=_thread_reply_relation("$thread", "$thread"),
+            extra_content={STREAM_STATUS_KEY: target_status},
+        ),
+    ]
+    if absent_owner_state == "relayed":
+        events.append(
+            _make_message_event(
+                event_id="$resume",
+                body=f"@Test Agent {AUTO_RESUME_MESSAGE}",
+                sender=router_user_id,
+                timestamp_ms=target_timestamp_ms + 1,
+                relates_to=_thread_reply_relation("$thread", "$target"),
+            ),
+        )
+    router_client.room_messages.return_value = _room_messages_response(*events)
+    router_client.room_get_event_relations = MagicMock(return_value=_aiter())
+    actors = {
+        router_user_id: _cleanup_actor(router_client),
+        BOT_USER_ID: _cleanup_actor(owner_client),
+    }
+
+    async def joined_rooms(client: object) -> list[str]:
+        return [ROOM_ID] if client is router_client else []
+
+    with patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms):
+        recovery_state = StaleStreamRecoveryState()
+        scanned_room_ids = recovery_state.scanned_room_ids
+        result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=actors[router_user_id].conversation_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=now_ms + 1,
+            recovery_state=recovery_state,
+        )
+
+    assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=0)
+    assert scanned_room_ids == {ROOM_ID}
 
 
 @pytest.mark.asyncio
@@ -3384,8 +3863,8 @@ async def test_auto_resume_uses_each_interrupted_owner_cache(tmp_path: Path) -> 
     first_cache = _auto_resume_conversation_cache([first_interrupted])
     second_cache = _auto_resume_conversation_cache([second_interrupted])
     owner_actors = {
-        BOT_USER_ID: StaleStreamCleanupActor(_make_client(), first_cache),
-        OTHER_BOT_USER_ID: StaleStreamCleanupActor(
+        BOT_USER_ID: _cleanup_actor(_make_client(), first_cache),
+        OTHER_BOT_USER_ID: _cleanup_actor(
             make_matrix_client_mock(user_id=OTHER_BOT_USER_ID),
             second_cache,
         ),
@@ -3430,14 +3909,15 @@ async def test_recovery_scans_unique_rooms_and_resumes_before_slow_rooms_finish(
     router_client = make_matrix_client_mock(user_id=router_user_id)
     agent_client = make_matrix_client_mock(user_id=BOT_USER_ID)
     actors = {
-        router_user_id: StaleStreamCleanupActor(router_client, MagicMock()),
-        BOT_USER_ID: StaleStreamCleanupActor(agent_client, MagicMock()),
+        router_user_id: _cleanup_actor(router_client),
+        BOT_USER_ID: _cleanup_actor(agent_client),
     }
     slow_room_started = asyncio.Event()
     release_slow_room = asyncio.Event()
     resume_sent = asyncio.Event()
     scanned_rooms: dict[str, tuple[object, set[str]]] = {}
-    scanned_room_ids: set[str] = set()
+    recovery_state = StaleStreamRecoveryState()
+    scanned_room_ids = recovery_state.scanned_room_ids
     include_new_room = False
 
     async def joined_rooms(client: object) -> list[str]:
@@ -3449,29 +3929,33 @@ async def test_recovery_scans_unique_rooms_and_resumes_before_slow_rooms_finish(
         assert client is agent_client
         return ["!shared:example.com", "!slow:example.com"]
 
-    async def cleanup_room(scan_client: object, **kwargs: object) -> tuple[int, list[InterruptedThread]]:
+    async def cleanup_room(scan_client: object, **kwargs: object) -> RoomCleanupResult:
         room_id = cast("str", kwargs["room_id"])
-        room_actors = cast("dict[str, StaleStreamCleanupActor]", kwargs["actors"])
-        scanned_rooms[room_id] = (scan_client, set(room_actors))
+        joined_bot_user_ids = cast("frozenset[str]", kwargs["joined_bot_user_ids"])
+        scanned_rooms[room_id] = (scan_client, set(joined_bot_user_ids))
         if room_id == "!slow:example.com":
             slow_room_started.set()
             await release_slow_room.wait()
-            return 0, []
+            return RoomCleanupResult(room_id, 0, ())
         if room_id == "!fast:example.com":
-            return 1, [
-                InterruptedThread(
-                    room_id=room_id,
-                    thread_id="$thread",
-                    target_event_id="$target",
-                    partial_text="Partial",
-                    agent_name="test_agent",
+            return RoomCleanupResult(
+                room_id,
+                1,
+                (
+                    InterruptedThread(
+                        room_id=room_id,
+                        thread_id="$thread",
+                        target_event_id="$target",
+                        partial_text="Partial",
+                        agent_name="test_agent",
+                    ),
                 ),
-            ]
-        return 0, []
+            )
+        return RoomCleanupResult(room_id, 0, ())
 
-    async def auto_resume(*_args: object, **_kwargs: object) -> int:
+    async def auto_resume(*_args: object, **_kwargs: object) -> AutoResumeResult:
         resume_sent.set()
-        return 1
+        return AutoResumeResult(1, frozenset(), frozenset(), frozenset())
 
     with (
         patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
@@ -3486,7 +3970,7 @@ async def test_recovery_scans_unique_rooms_and_resumes_before_slow_rooms_finish(
                 config=config,
                 runtime_paths=runtime_paths_for(config),
                 startup_cutoff_ms=NOW_MS,
-                scanned_room_ids=scanned_room_ids,
+                recovery_state=recovery_state,
             ),
         )
         await asyncio.wait_for(slow_room_started.wait(), timeout=1.0)
@@ -3502,7 +3986,7 @@ async def test_recovery_scans_unique_rooms_and_resumes_before_slow_rooms_finish(
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=scanned_room_ids,
+            recovery_state=recovery_state,
         )
 
     assert result == StaleStreamRecoveryResult(room_count=3, cleaned_count=1, resumed_count=1)
@@ -3527,7 +4011,7 @@ async def test_recovery_resumes_all_51_rooms_even_when_newest_room_finishes_last
     config.defaults.auto_resume_after_restart = True
     router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
     actors = {
-        "@actual_router:localhost": StaleStreamCleanupActor(router_client, MagicMock()),
+        "@actual_router:localhost": _cleanup_actor(router_client),
     }
     room_ids = [f"!room-{index}:example.com" for index in range(51)]
     slow_room_id = room_ids[-1]
@@ -3535,30 +4019,39 @@ async def test_recovery_resumes_all_51_rooms_even_when_newest_room_finishes_last
     release_slow_room = asyncio.Event()
     fast_rooms_resumed = asyncio.Event()
     resumed_room_ids: list[str] = []
-    scanned_room_ids: set[str] = set()
+    recovery_state = StaleStreamRecoveryState()
+    scanned_room_ids = recovery_state.scanned_room_ids
 
-    async def cleanup_room(_: object, **kwargs: object) -> tuple[int, list[InterruptedThread]]:
+    async def cleanup_room(_: object, **kwargs: object) -> RoomCleanupResult:
         room_id = cast("str", kwargs["room_id"])
         room_index = room_ids.index(room_id)
         if room_id == slow_room_id:
             slow_room_started.set()
             await release_slow_room.wait()
-        return 0, [
-            InterruptedThread(
-                room_id=room_id,
-                thread_id=f"$thread-{room_index}",
-                target_event_id=f"$target-{room_index}",
-                partial_text="Partial",
-                agent_name="test_agent",
-                timestamp_ms=room_index,
+        return RoomCleanupResult(
+            room_id,
+            0,
+            (
+                InterruptedThread(
+                    room_id=room_id,
+                    thread_id=f"$thread-{room_index}",
+                    target_event_id=f"$target-{room_index}",
+                    partial_text="Partial",
+                    agent_name="test_agent",
+                    timestamp_ms=room_index,
+                ),
             ),
-        ]
+        )
 
-    async def auto_resume(_: object, interrupted: list[InterruptedThread], **__: object) -> int:
+    async def auto_resume(
+        _: object,
+        interrupted: list[InterruptedThreadRecord],
+        **__: object,
+    ) -> AutoResumeResult:
         resumed_room_ids.extend(item.room_id for item in interrupted)
         if len(resumed_room_ids) == 50:
             fast_rooms_resumed.set()
-        return len(interrupted)
+        return AutoResumeResult(len(interrupted), frozenset(), frozenset(), frozenset())
 
     with (
         patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", new=AsyncMock(return_value=room_ids)),
@@ -3573,7 +4066,7 @@ async def test_recovery_resumes_all_51_rooms_even_when_newest_room_finishes_last
                 config=config,
                 runtime_paths=runtime_paths_for(config),
                 startup_cutoff_ms=NOW_MS,
-                scanned_room_ids=scanned_room_ids,
+                recovery_state=recovery_state,
                 room_concurrency=51,
             ),
         )
@@ -3595,7 +4088,7 @@ async def test_recovery_without_resume_client_still_cleans_rooms(tmp_path: Path)
     config = _make_config(tmp_path)
     config.defaults.auto_resume_after_restart = True
     client = make_matrix_client_mock(user_id=BOT_USER_ID)
-    actors = {BOT_USER_ID: StaleStreamCleanupActor(client, MagicMock())}
+    actors = {BOT_USER_ID: _cleanup_actor(client)}
     interrupted = InterruptedThread(
         room_id=ROOM_ID,
         thread_id="$thread",
@@ -3608,14 +4101,15 @@ async def test_recovery_without_resume_client_still_cleans_rooms(tmp_path: Path)
         patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", new=AsyncMock(return_value=[ROOM_ID])),
         patch(
             "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(1, [interrupted])),
+            new=AsyncMock(return_value=RoomCleanupResult(ROOM_ID, 1, (interrupted,))),
         ),
         patch(
             "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
             new=AsyncMock(),
         ) as auto_resume,
     ):
-        scanned_room_ids: set[str] = set()
+        recovery_state = StaleStreamRecoveryState()
+        scanned_room_ids = recovery_state.scanned_room_ids
         result = await recover_stale_streaming_messages(
             actors,
             resume_client=None,
@@ -3623,7 +4117,7 @@ async def test_recovery_without_resume_client_still_cleans_rooms(tmp_path: Path)
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=NOW_MS,
-            scanned_room_ids=scanned_room_ids,
+            recovery_state=recovery_state,
         )
 
     assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)
@@ -3638,8 +4132,8 @@ async def test_shared_room_cleanup_routes_edits_through_each_message_owner(tmp_p
     first_client = make_matrix_client_mock(user_id=BOT_USER_ID)
     second_client = make_matrix_client_mock(user_id=OTHER_BOT_USER_ID)
     actors = {
-        BOT_USER_ID: StaleStreamCleanupActor(first_client, MagicMock()),
-        OTHER_BOT_USER_ID: StaleStreamCleanupActor(second_client, MagicMock()),
+        BOT_USER_ID: _cleanup_actor(first_client),
+        OTHER_BOT_USER_ID: _cleanup_actor(second_client),
     }
     scanned_state = stale_stream_cleanup_module._ScannedRoomMessageStates(
         message_states={
@@ -3672,19 +4166,18 @@ async def test_shared_room_cleanup_routes_edits_through_each_message_owner(tmp_p
             new=AsyncMock(return_value=(True, None)),
         ) as cleanup_candidate,
     ):
-        cleaned_count, interrupted = await cleanup_stale_streaming_room(
+        cleanup_result = await cleanup_stale_streaming_room(
             first_client,
             room_id=ROOM_ID,
             actors=actors,
-            bot_user_ids=set(actors),
+            joined_bot_user_ids=frozenset(actors),
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=NOW_MS,
-            retryable_room_ids=set(),
         )
 
-    assert cleaned_count == 2
-    assert interrupted == []
+    assert cleanup_result.cleaned_count == 2
+    assert cleanup_result.interrupted_threads == ()
     assert [call.args[0] for call in cleanup_candidate.await_args_list] == [first_client, second_client]
 
 
@@ -3718,14 +4211,14 @@ async def test_orchestrator_runs_two_recovery_waves_around_room_setup(tmp_path: 
         _: list[object],
         __: Config,
         startup_cutoff_ms: int,
-        scanned_room_ids: set[str],
+        recovery_state: StaleStreamRecoveryState,
     ) -> None:
         assert startup_cutoff_ms > 0
         call_order.append("recover")
-        if scanned_room_ids:
+        if recovery_state.scanned_room_ids:
             recovery_finished.set()
         else:
-            scanned_room_ids.add(ROOM_ID)
+            recovery_state.scanned_room_ids.add(ROOM_ID)
 
     ready = asyncio.Event()
 
@@ -3746,7 +4239,7 @@ async def test_orchestrator_runs_two_recovery_waves_around_room_setup(tmp_path: 
         runtime_task = asyncio.create_task(orchestrator.start())
         try:
             await asyncio.wait_for(ready.wait(), timeout=1.0)
-            await asyncio.wait_for(recovery_finished.wait(), timeout=1.0)
+            await asyncio.wait_for(recovery_finished.wait(), timeout=3.0)
             await orchestrator.stop()
             await asyncio.wait_for(runtime_task, timeout=1.0)
         finally:
@@ -3772,36 +4265,76 @@ async def test_orchestrator_recovery_uses_router_for_resume_and_all_started_bots
     router_bot.client = router_client
     router_bot.agent_user = MagicMock(user_id="@mindroom_router:example.com")
     router_bot._conversation_cache = MagicMock()
+    router_bot.first_sync_complete = True
+    router_bot.rooms = [ROOM_ID]
     agent_client = AsyncMock(spec=nio.AsyncClient)
     agent_bot = MagicMock()
     agent_bot.agent_name = "test_agent"
     agent_bot.client = agent_client
     agent_bot.agent_user = MagicMock(user_id=BOT_USER_ID)
     agent_bot._conversation_cache = MagicMock()
+    agent_bot.first_sync_complete = False
+    agent_bot.rooms = [ROOM_ID]
     orchestrator.agent_bots = {ROUTER_AGENT_NAME: router_bot, "test_agent": agent_bot}
 
     with patch(
         "mindroom.orchestrator.recover_stale_streaming_messages",
         new=AsyncMock(return_value=StaleStreamRecoveryResult(room_count=2, cleaned_count=1, resumed_count=1)),
     ) as mock_recover:
-        scanned_room_ids: set[str] = set()
+        recovery_state = StaleStreamRecoveryState()
         await orchestrator._recover_stale_streams_after_restart(
             [router_bot, agent_bot],
             config,
             NOW_MS,
-            scanned_room_ids,
+            recovery_state,
         )
 
     mock_recover.assert_awaited_once()
     actors = mock_recover.await_args.args[0]
     assert set(actors) == {"@mindroom_router:example.com", BOT_USER_ID}
     assert actors[BOT_USER_ID].client is agent_client
+    assert actors[BOT_USER_ID].first_sync_complete is False
+    assert actors[BOT_USER_ID].expected_room_ids == frozenset({ROOM_ID})
     assert mock_recover.await_args.kwargs["resume_client"] is router_client
     assert mock_recover.await_args.kwargs["resume_conversation_cache"] is router_bot._conversation_cache
     assert mock_recover.await_args.kwargs["config"] == config
     assert mock_recover.await_args.kwargs["runtime_paths"] == runtime_paths_for(config)
     assert mock_recover.await_args.kwargs["startup_cutoff_ms"] == NOW_MS
-    assert mock_recover.await_args.kwargs["scanned_room_ids"] is scanned_room_ids
+    assert mock_recover.await_args.kwargs["recovery_state"] is recovery_state
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_marks_replaced_actor_generation_unready(tmp_path: Path) -> None:
+    """A stale bot object must not inherit first-sync readiness from its replacement."""
+    config = _make_config(tmp_path)
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
+    orchestrator.config = config
+
+    current_bot = MagicMock()
+    current_bot.agent_name = "test_agent"
+    current_bot.running = True
+    current_bot.first_sync_complete = True
+    orchestrator.agent_bots = {"test_agent": current_bot}
+
+    replaced_bot = MagicMock()
+    replaced_bot.agent_name = "test_agent"
+    replaced_bot.client = AsyncMock(spec=nio.AsyncClient)
+    replaced_bot.agent_user = MagicMock(user_id=BOT_USER_ID)
+    replaced_bot._conversation_cache = MagicMock()
+
+    with patch(
+        "mindroom.orchestrator.recover_stale_streaming_messages",
+        new=AsyncMock(return_value=StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=0)),
+    ) as mock_recover:
+        await orchestrator._recover_stale_streams_after_restart(
+            [replaced_bot],
+            config,
+            NOW_MS,
+            StaleStreamRecoveryState(),
+        )
+
+    actors = mock_recover.await_args.args[0]
+    assert actors[BOT_USER_ID].first_sync_complete is False
 
 
 @pytest.mark.asyncio
@@ -3817,13 +4350,19 @@ async def test_orchestrator_recovery_still_cleans_when_router_is_unavailable(tmp
     agent_bot.client = agent_client
     agent_bot.agent_user = MagicMock(user_id=BOT_USER_ID)
     agent_bot._conversation_cache = MagicMock()
+    agent_bot.first_sync_complete = True
     orchestrator.agent_bots = {"test_agent": agent_bot}
 
     with patch(
         "mindroom.orchestrator.recover_stale_streaming_messages",
         new=AsyncMock(return_value=StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)),
     ) as mock_recover:
-        await orchestrator._recover_stale_streams_after_restart([agent_bot], config, NOW_MS, set())
+        await orchestrator._recover_stale_streams_after_restart(
+            [agent_bot],
+            config,
+            NOW_MS,
+            StaleStreamRecoveryState(),
+        )
 
     mock_recover.assert_awaited_once()
     assert mock_recover.await_args.kwargs["resume_client"] is None

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -3955,12 +3955,21 @@ async def test_recovery_scans_unique_rooms_and_resumes_before_slow_rooms_finish(
 
 @pytest.mark.asyncio
 async def test_cancelled_auto_resume_preserves_exact_target_for_replay(tmp_path: Path) -> None:
-    """Cancellation after cleanup keeps the exact post-cutoff target retryable."""
+    """Cancellation after cleanup keeps the room and exact target retryable."""
     config = _make_config(tmp_path)
     config.defaults.auto_resume_after_restart = True
     router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    owner_cache = AsyncMock()
+    owner_cache.refresh_startup_thread_history_from_source = AsyncMock(
+        side_effect=[
+            asyncio.CancelledError(),
+            _authoritative_history(_history_message("$target")),
+        ],
+    )
+    owner_cache.notify_outbound_message = Mock()
+    router_actor = _cleanup_actor(router_client, owner_cache)
     actors = {
-        "@actual_router:localhost": _cleanup_actor(router_client),
+        "@actual_router:localhost": router_actor,
     }
     interrupted = InterruptedThread(
         room_id=ROOM_ID,
@@ -3969,6 +3978,7 @@ async def test_cancelled_auto_resume_preserves_exact_target_for_replay(tmp_path:
         partial_text="Partial",
         agent_name=ROUTER_AGENT_NAME,
         original_sender_id=USER_ID,
+        owner_actor=router_actor,
     )
     recovery_state = StaleStreamRecoveryState()
 
@@ -3980,24 +3990,89 @@ async def test_cancelled_auto_resume_preserves_exact_target_for_replay(tmp_path:
         patch(
             "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
             new=AsyncMock(return_value=RoomCleanupResult(ROOM_ID, 1, (interrupted,))),
-        ),
+        ) as mock_cleanup,
         patch(
-            "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
-            new=AsyncMock(side_effect=asyncio.CancelledError),
-        ),
-        pytest.raises(asyncio.CancelledError),
+            "mindroom.matrix.stale_stream_cleanup.send_message_result",
+            new=AsyncMock(return_value=delivered_matrix_event("$resume")),
+        ) as mock_send,
     ):
-        await recover_stale_streaming_messages(
+        with pytest.raises(asyncio.CancelledError):
+            await recover_stale_streaming_messages(
+                actors,
+                resume_client=router_client,
+                resume_conversation_cache=owner_cache,
+                config=config,
+                runtime_paths=runtime_paths_for(config),
+                startup_cutoff_ms=NOW_MS,
+                recovery_state=recovery_state,
+            )
+
+        assert recovery_state.retry_target_event_ids == {"$target"}
+        assert recovery_state.scanned_room_ids == set()
+        mock_send.assert_not_awaited()
+
+        replay_result = await recover_stale_streaming_messages(
             actors,
             resume_client=router_client,
-            resume_conversation_cache=actors["@actual_router:localhost"].conversation_cache,
+            resume_conversation_cache=owner_cache,
             config=config,
             runtime_paths=runtime_paths_for(config),
             startup_cutoff_ms=NOW_MS,
             recovery_state=recovery_state,
         )
 
-    assert recovery_state.retry_target_event_ids == {"$target"}
+    assert replay_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=1)
+    assert recovery_state.retry_target_event_ids == set()
+    assert recovery_state.scanned_room_ids == {ROOM_ID}
+    assert mock_cleanup.await_count == 2
+    mock_send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recovery_rescans_expected_rooms_when_owner_actor_appears(tmp_path: Path) -> None:
+    """A later-starting owner must reopen rooms scanned before its actor existed."""
+    config = _make_config(tmp_path)
+    router_user_id = "@actual_router:localhost"
+    router_client = make_matrix_client_mock(user_id=router_user_id)
+    owner_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    actors = {
+        router_user_id: _cleanup_actor(router_client),
+    }
+    recovery_state = StaleStreamRecoveryState()
+
+    with (
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.get_joined_rooms",
+            new=AsyncMock(return_value=[ROOM_ID]),
+        ),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
+            new=AsyncMock(return_value=RoomCleanupResult(ROOM_ID, 0, ())),
+        ) as mock_cleanup,
+    ):
+        initial_result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=actors[router_user_id].conversation_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            recovery_state=recovery_state,
+        )
+        actors[BOT_USER_ID] = _cleanup_actor(owner_client)
+        owner_ready_result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=actors[router_user_id].conversation_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            recovery_state=recovery_state,
+        )
+
+    assert initial_result.room_count == 1
+    assert owner_ready_result.room_count == 1
+    assert mock_cleanup.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -3071,6 +3071,150 @@ async def test_recovery_selects_joined_owner_for_freshness_and_router_for_relay(
 
 
 @pytest.mark.asyncio
+async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(tmp_path: Path) -> None:
+    """A failed router relay should let the joined-room delta retry after router membership."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    owner_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    interrupted = InterruptedThread(
+        ROOM_ID,
+        "$thread",
+        "$target",
+        "Partial",
+        "test_agent",
+        original_sender_id=USER_ID,
+    )
+    router_cache = _auto_resume_conversation_cache([])
+    owner_cache = _auto_resume_conversation_cache([interrupted])
+    actors = {
+        "@actual_router:localhost": StaleStreamCleanupActor(router_client, router_cache),
+        BOT_USER_ID: StaleStreamCleanupActor(owner_client, owner_cache),
+    }
+    router_joined = False
+
+    async def joined_rooms(client: object) -> list[str]:
+        if client is router_client:
+            return [ROOM_ID] if router_joined else []
+        assert client is owner_client
+        return [ROOM_ID]
+
+    with (
+        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
+            new=AsyncMock(return_value=(0, [interrupted])),
+        ),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.send_message_result",
+            new=AsyncMock(side_effect=[None, delivered_matrix_event("$resume")]),
+        ) as mock_send,
+    ):
+        scanned_room_ids: set[str] = set()
+        failed_result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=router_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=scanned_room_ids,
+        )
+        assert failed_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=0)
+        assert scanned_room_ids == set()
+
+        router_joined = True
+        recovered_result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=router_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=scanned_room_ids,
+        )
+
+    assert recovered_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=1)
+    assert scanned_room_ids == {ROOM_ID}
+    assert owner_cache.refresh_strict_thread_history_from_source.await_count == 2
+    router_cache.refresh_strict_thread_history_from_source.assert_not_awaited()
+    assert mock_send.await_count == 2
+    assert all(call.args[0] is router_client for call in mock_send.await_args_list)
+
+
+@pytest.mark.asyncio
+async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_path: Path) -> None:
+    """A missing owner should let the membership wave retry after that owner joins."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    owner_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    interrupted = InterruptedThread(
+        ROOM_ID,
+        "$thread",
+        "$target",
+        "Partial",
+        "test_agent",
+        original_sender_id=USER_ID,
+    )
+    router_cache = _auto_resume_conversation_cache([])
+    owner_cache = _auto_resume_conversation_cache([interrupted])
+    actors = {
+        "@actual_router:localhost": StaleStreamCleanupActor(router_client, router_cache),
+        BOT_USER_ID: StaleStreamCleanupActor(owner_client, owner_cache),
+    }
+    owner_joined = False
+
+    async def joined_rooms(client: object) -> list[str]:
+        if client is router_client:
+            return [ROOM_ID]
+        assert client is owner_client
+        return [ROOM_ID] if owner_joined else []
+
+    with (
+        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
+            new=AsyncMock(return_value=(0, [interrupted])),
+        ),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.send_message_result",
+            new=AsyncMock(return_value=delivered_matrix_event("$resume")),
+        ) as mock_send,
+    ):
+        scanned_room_ids: set[str] = set()
+        missing_owner_result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=router_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=scanned_room_ids,
+        )
+        assert missing_owner_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=0)
+        assert scanned_room_ids == set()
+
+        owner_joined = True
+        recovered_result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=router_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=scanned_room_ids,
+        )
+
+    assert recovered_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=1)
+    assert scanned_room_ids == {ROOM_ID}
+    owner_cache.refresh_strict_thread_history_from_source.assert_awaited_once()
+    router_cache.refresh_strict_thread_history_from_source.assert_not_awaited()
+    mock_send.assert_awaited_once()
+    assert mock_send.await_args.args[0] is router_client
+
+
+@pytest.mark.asyncio
 async def test_auto_resume_uses_each_interrupted_owner_cache(tmp_path: Path) -> None:
     """Interrupted threads from different agents should refresh through their own caches."""
     config = _make_config(tmp_path)

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -35,7 +35,7 @@ from mindroom.matrix.stale_stream_cleanup import (
     recover_stale_streaming_messages,
 )
 from mindroom.matrix.stale_stream_cleanup import (
-    _auto_resume_interrupted_threads as auto_resume_interrupted_threads_result,
+    _auto_resume_interrupted_threads as auto_resume_interrupted_threads,
 )
 from mindroom.matrix.stale_stream_cleanup import (
     _AutoResumeResult as AutoResumeResult,
@@ -69,8 +69,6 @@ from tests.identity_helpers import entity_ids, persist_entity_accounts
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
-    from mindroom.config.main import Config as ConfigType
-    from mindroom.constants import RuntimePaths
     from mindroom.matrix.conversation_cache import ConversationCacheProtocol
 
 BOT_USER_ID = "@actual_test_agent:localhost"
@@ -125,40 +123,6 @@ def InterruptedThread(  # noqa: N802
         original_sender_id=original_sender_id,
         timestamp_ms=timestamp_ms,
     )
-
-
-async def auto_resume_interrupted_threads(
-    client: nio.AsyncClient,
-    interrupted: list[InterruptedThreadRecord],
-    *,
-    config: ConfigType,
-    runtime_paths: RuntimePaths,
-    conversation_cache: ConversationCacheProtocol | None = None,
-    owner_actors: dict[str, StaleStreamCleanupActor] | None = None,
-    delay: float = 2.0,
-    delay_before_first: bool = False,
-    retryable_room_ids: set[str] | None = None,
-) -> int:
-    """Return count while binding legacy test fixtures onto exact candidates."""
-    candidates = [
-        replace(
-            candidate,
-            owner_actor=(owner_actors[candidate.bot_user_id] if owner_actors is not None else candidate.owner_actor),
-        )
-        for candidate in interrupted
-    ]
-    result = await auto_resume_interrupted_threads_result(
-        client,
-        candidates,
-        config=config,
-        runtime_paths=runtime_paths,
-        conversation_cache=conversation_cache,
-        delay=delay,
-        delay_before_first=delay_before_first,
-    )
-    if retryable_room_ids is not None:
-        retryable_room_ids.update(result.retry_room_ids)
-    return result.resumed_count
 
 
 def _make_config(tmp_path: Path) -> Config:
@@ -418,16 +382,23 @@ def _auto_resume_conversation_cache(interrupted: list[InterruptedThreadRecord]) 
     return conversation_cache
 
 
-def _auto_resume_owner_actors(
+def _with_owner_cache(
+    interrupted: list[InterruptedThreadRecord],
     conversation_cache: AsyncMock | None,
-) -> dict[str, StaleStreamCleanupActor]:
-    return {
-        BOT_USER_ID: _cleanup_actor(_make_client(), conversation_cache),
-        OTHER_BOT_USER_ID: _cleanup_actor(
-            make_matrix_client_mock(user_id=OTHER_BOT_USER_ID),
-            conversation_cache,
-        ),
-    }
+    *,
+    client: AsyncMock | None = None,
+) -> list[InterruptedThreadRecord]:
+    """Bind each test candidate to an explicit exact-owner actor."""
+    return [
+        replace(
+            candidate,
+            owner_actor=_cleanup_actor(
+                client or make_matrix_client_mock(user_id=candidate.bot_user_id),
+                conversation_cache,
+            ),
+        )
+        for candidate in interrupted
+    ]
 
 
 def _assert_preserved_edit_payload(content: dict[str, object], expected_keys: dict[str, object]) -> None:
@@ -963,7 +934,7 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
         ) as mock_send,
         patch("mindroom.matrix.stale_stream_cleanup.asyncio.sleep", new=AsyncMock()) as mock_sleep,
     ):
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
             interrupted,
             config=config,
@@ -971,7 +942,7 @@ async def test_auto_resume_sends_correctly_threaded_messages(tmp_path: Path) -> 
             conversation_cache=router_cache,
         )
 
-    assert resumed_count == 2
+    assert result.resumed_count == 2
     assert mock_send.await_count == 2
     first_content = mock_send.await_args_list[0].args[2]
     second_content = mock_send.await_args_list[1].args[2]
@@ -1013,19 +984,15 @@ async def test_auto_resume_router_interruption_uses_router_cache_without_self_me
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
         new=AsyncMock(return_value=delivered_matrix_event("$resume")),
     ) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             router_client,
-            interrupted,
+            _with_owner_cache(interrupted, router_cache, client=router_client),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=router_cache,
-            owner_actors={
-                router_user_id: _cleanup_actor(router_client, router_cache),
-            },
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 1
+    assert result.resumed_count == 1
     router_cache.refresh_startup_thread_history_from_source.assert_awaited_once()
     mock_send.assert_awaited_once()
     content = mock_send.await_args.args[2]
@@ -1043,19 +1010,18 @@ async def test_auto_resume_skips_interruption_without_resolved_requester(tmp_pat
     ]
 
     with patch("mindroom.matrix.stale_stream_cleanup.send_message_result", new=AsyncMock()) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(
+                interrupted,
+                _auto_resume_conversation_cache(interrupted),
+            ),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
-            owner_actors=_auto_resume_owner_actors(
-                _auto_resume_conversation_cache(interrupted),
-            ),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 0
+    assert result.resumed_count == 0
     mock_send.assert_not_awaited()
 
 
@@ -1106,17 +1072,15 @@ async def test_auto_resume_classifies_later_activity_by_effective_sender_and_his
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
     ) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(interrupted, conversation_cache),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
-            owner_actors=_auto_resume_owner_actors(conversation_cache),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == expected_resumes
+    assert result.resumed_count == expected_resumes
     assert mock_send.await_count == expected_resumes
 
 
@@ -1154,17 +1118,15 @@ async def test_prior_auto_resume_relay_does_not_suppress_sibling_resume(tmp_path
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
     ) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(interrupted, conversation_cache),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
-            owner_actors=_auto_resume_owner_actors(conversation_cache),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 1
+    assert result.resumed_count == 1
     mock_send.assert_awaited_once()
 
 
@@ -1227,17 +1189,15 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
         )
 
     with patch("mindroom.matrix.stale_stream_cleanup.send_message_result", new=AsyncMock()) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(interrupted, conversation_cache),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
-            owner_actors=_auto_resume_owner_actors(conversation_cache),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 0
+    assert result.resumed_count == 0
     mock_send.assert_not_awaited()
     if conversation_cache is not None:
         conversation_cache.refresh_startup_thread_history_from_source.assert_awaited_once_with(
@@ -1271,12 +1231,10 @@ async def test_auto_resume_propagates_cancelled_source_refresh(tmp_path: Path) -
     ):
         await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(interrupted, conversation_cache),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
-            owner_actors=_auto_resume_owner_actors(conversation_cache),
-            retryable_room_ids=set(),
         )
 
     mock_send.assert_not_awaited()
@@ -1306,17 +1264,15 @@ async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_
     )
 
     with patch("mindroom.matrix.stale_stream_cleanup.send_message_result", new=AsyncMock()) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(interrupted, conversation_cache),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
-            owner_actors=_auto_resume_owner_actors(conversation_cache),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 0
+    assert result.resumed_count == 0
     conversation_cache.refresh_startup_thread_history_from_source.assert_awaited_once_with(
         ROOM_ID,
         "$thread",
@@ -1373,17 +1329,15 @@ async def test_auto_resume_checks_freshness_after_delay_before_each_delivery(tmp
             new=AsyncMock(side_effect=sleep_with_activity),
         ) as mock_sleep,
     ):
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(interrupted, conversation_cache),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
-            owner_actors=_auto_resume_owner_actors(conversation_cache),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 3
+    assert result.resumed_count == 3
     assert [call.args[2]["m.relates_to"]["event_id"] for call in mock_send.await_args_list] == [
         "$thread-0",
         "$thread-1",
@@ -1426,19 +1380,18 @@ async def test_auto_resume_target_mention_ignores_unprepared_unrelated_entity(tm
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
         new=AsyncMock(return_value=delivered_matrix_event("$resume1")),
     ) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(
+                interrupted,
+                _auto_resume_conversation_cache(interrupted),
+            ),
             config=config,
             runtime_paths=runtime_paths,
             conversation_cache=_auto_resume_conversation_cache(interrupted),
-            owner_actors=_auto_resume_owner_actors(
-                _auto_resume_conversation_cache(interrupted),
-            ),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 1
+    assert result.resumed_count == 1
     content = mock_send.await_args.args[2]
     assert content["body"] == f"@Test Agent {AUTO_RESUME_MESSAGE}"
     assert content["m.mentions"] == {"user_ids": [BOT_USER_ID]}
@@ -1525,19 +1478,18 @@ async def test_auto_resume_skips_thread_id_none(tmp_path: Path) -> None:
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
     ) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(
+                interrupted,
+                _auto_resume_conversation_cache(interrupted),
+            ),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
-            owner_actors=_auto_resume_owner_actors(
-                _auto_resume_conversation_cache(interrupted),
-            ),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 1
+    assert result.resumed_count == 1
     mock_send.assert_awaited_once()
     assert mock_send.await_args.args[1] == ROOM_ID
     assert mock_send.await_args.args[2]["m.relates_to"]["event_id"] == "$threaded"
@@ -1564,17 +1516,15 @@ async def test_auto_resume_records_outbound_message_when_send_succeeds(tmp_path:
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
     ):
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(interrupted, conversation_cache),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
-            owner_actors=_auto_resume_owner_actors(conversation_cache),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 1
+    assert result.resumed_count == 1
     conversation_cache.notify_outbound_message.assert_called_once()
     record_args = conversation_cache.notify_outbound_message.call_args.args
     assert record_args[:2] == (ROOM_ID, "$resume")
@@ -1603,7 +1553,7 @@ async def test_auto_resume_does_not_retry_after_delivery_bookkeeping_failure(tmp
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
         new=AsyncMock(return_value=delivered_matrix_event("$resume")),
     ) as mock_send:
-        result = await auto_resume_interrupted_threads_result(
+        result = await auto_resume_interrupted_threads(
             client,
             [
                 replace(
@@ -2309,19 +2259,17 @@ async def test_recent_mid_tool_shutdown_marker_resumes_only_without_newer_human_
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$auto-resume")),
     ) as send_resume:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(interrupted, conversation_cache),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=conversation_cache,
-            owner_actors=_auto_resume_owner_actors(conversation_cache),
-            retryable_room_ids=set(),
             delay=0,
         )
 
-    assert resumed_count == (0 if newer_human_activity else 1)
-    assert send_resume.await_count == resumed_count
+    assert result.resumed_count == (0 if newer_human_activity else 1)
+    assert send_resume.await_count == result.resumed_count
 
 
 @pytest.mark.asyncio
@@ -3155,19 +3103,18 @@ async def test_auto_resume_dedupes_same_agent_and_thread_using_newest_target(tmp
         "mindroom.matrix.stale_stream_cleanup.send_message_result",
         new=AsyncMock(side_effect=delivered_matrix_side_effect("$resume")),
     ) as mock_send:
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(
+                interrupted,
+                _auto_resume_conversation_cache(interrupted),
+            ),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
-            owner_actors=_auto_resume_owner_actors(
-                _auto_resume_conversation_cache(interrupted),
-            ),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 1
+    assert result.resumed_count == 1
     mock_send.assert_awaited_once()
     assert mock_send.await_args.args[2]["m.relates_to"]["m.in_reply_to"] == {"event_id": "$newer"}
 
@@ -3223,19 +3170,18 @@ async def test_auto_resume_sends_all_unique_threads_after_replacing_older_target
         ) as mock_send,
         patch("mindroom.matrix.stale_stream_cleanup.asyncio.sleep", new=AsyncMock()),
     ):
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(
+                interrupted,
+                _auto_resume_conversation_cache(interrupted),
+            ),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
-            owner_actors=_auto_resume_owner_actors(
-                _auto_resume_conversation_cache(interrupted),
-            ),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 3
+    assert result.resumed_count == 3
     assert [call.args[2]["m.relates_to"]["m.in_reply_to"] for call in mock_send.await_args_list] == [
         {"event_id": "$thread-two-target"},
         {"event_id": "$thread-three-target"},
@@ -3276,19 +3222,18 @@ async def test_auto_resume_sends_threads_from_every_room(tmp_path: Path) -> None
         ) as mock_send,
         patch("mindroom.matrix.stale_stream_cleanup.asyncio.sleep", new=AsyncMock()),
     ):
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(
+                interrupted,
+                _auto_resume_conversation_cache(interrupted),
+            ),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
-            owner_actors=_auto_resume_owner_actors(
-                _auto_resume_conversation_cache(interrupted),
-            ),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 2
+    assert result.resumed_count == 2
     assert [call.args[2]["m.relates_to"]["event_id"] for call in mock_send.await_args_list] == [
         "$thread-old",
         "$thread-new",
@@ -3882,17 +3827,21 @@ async def test_auto_resume_uses_each_interrupted_owner_cache(tmp_path: Path) -> 
         ) as mock_send,
         patch("mindroom.matrix.stale_stream_cleanup.asyncio.sleep", new=AsyncMock()),
     ):
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             router_client,
-            [first_interrupted, second_interrupted],
+            [
+                replace(
+                    candidate,
+                    owner_actor=owner_actors[candidate.bot_user_id],
+                )
+                for candidate in (first_interrupted, second_interrupted)
+            ],
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=router_cache,
-            owner_actors=owner_actors,
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 2
+    assert result.resumed_count == 2
     first_cache.refresh_startup_thread_history_from_source.assert_awaited_once()
     second_cache.refresh_startup_thread_history_from_source.assert_awaited_once()
     router_cache.refresh_startup_thread_history_from_source.assert_not_awaited()
@@ -4002,6 +3951,53 @@ async def test_recovery_scans_unique_rooms_and_resumes_before_slow_rooms_finish(
     assert scanned_rooms["!slow:example.com"] == (agent_client, {BOT_USER_ID})
     assert scanned_rooms["!new:example.com"] == (router_client, {router_user_id})
     assert scanned_room_ids == set(scanned_rooms)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_auto_resume_preserves_exact_target_for_replay(tmp_path: Path) -> None:
+    """Cancellation after cleanup keeps the exact post-cutoff target retryable."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    actors = {
+        "@actual_router:localhost": _cleanup_actor(router_client),
+    }
+    interrupted = InterruptedThread(
+        room_id=ROOM_ID,
+        thread_id="$thread",
+        target_event_id="$target",
+        partial_text="Partial",
+        agent_name=ROUTER_AGENT_NAME,
+        original_sender_id=USER_ID,
+    )
+    recovery_state = StaleStreamRecoveryState()
+
+    with (
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.get_joined_rooms",
+            new=AsyncMock(return_value=[ROOM_ID]),
+        ),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
+            new=AsyncMock(return_value=RoomCleanupResult(ROOM_ID, 1, (interrupted,))),
+        ),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
+            new=AsyncMock(side_effect=asyncio.CancelledError),
+        ),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            resume_conversation_cache=actors["@actual_router:localhost"].conversation_cache,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            recovery_state=recovery_state,
+        )
+
+    assert recovery_state.retry_target_event_ids == {"$target"}
 
 
 @pytest.mark.asyncio
@@ -4435,19 +4431,18 @@ async def test_auto_resume_continues_after_send_exception(tmp_path: Path) -> Non
         ) as mock_send,
         patch("mindroom.matrix.stale_stream_cleanup.asyncio.sleep", new=AsyncMock()),
     ):
-        resumed_count = await auto_resume_interrupted_threads(
+        result = await auto_resume_interrupted_threads(
             client,
-            interrupted,
+            _with_owner_cache(
+                interrupted,
+                _auto_resume_conversation_cache(interrupted),
+            ),
             config=config,
             runtime_paths=runtime_paths_for(config),
             conversation_cache=_auto_resume_conversation_cache(interrupted),
-            owner_actors=_auto_resume_owner_actors(
-                _auto_resume_conversation_cache(interrupted),
-            ),
-            retryable_room_ids=set(),
         )
 
-    assert resumed_count == 2
+    assert result.resumed_count == 2
     assert mock_send.await_count == 3
 
 

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -3144,7 +3144,7 @@ async def test_failed_router_relay_keeps_room_retryable_for_post_join_recovery(t
 
 @pytest.mark.asyncio
 async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_path: Path) -> None:
-    """A missing owner should let the membership wave retry after that owner joins."""
+    """Real cleanup should let the membership wave retry after a message owner joins."""
     config = _make_config(tmp_path)
     config.defaults.auto_resume_after_restart = True
     router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
@@ -3164,6 +3164,23 @@ async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_pat
         BOT_USER_ID: StaleStreamCleanupActor(owner_client, owner_cache),
     }
     owner_joined = False
+    router_client.room_messages.return_value = _room_messages_response(
+        _make_message_event(
+            event_id="$thread",
+            body="Question",
+            sender=USER_ID,
+            timestamp_ms=NOW_MS - (STALE_AGE_MS + 20_000),
+        ),
+        _make_message_event(
+            event_id="$target",
+            body=build_restart_interrupted_body("Partial"),
+            timestamp_ms=NOW_MS - STALE_AGE_MS,
+            relates_to=_thread_reply_relation("$thread", "$thread"),
+            extra_content={STREAM_STATUS_KEY: "error"},
+        ),
+    )
+    router_client.room_get_event_relations = MagicMock(return_value=_aiter())
+    owner_client.room_get_event_relations = MagicMock(return_value=_aiter())
 
     async def joined_rooms(client: object) -> list[str]:
         if client is router_client:
@@ -3173,10 +3190,6 @@ async def test_missing_owner_keeps_room_retryable_for_post_join_recovery(tmp_pat
 
     with (
         patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
-        patch(
-            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
-            new=AsyncMock(return_value=(0, [interrupted])),
-        ),
         patch(
             "mindroom.matrix.stale_stream_cleanup.send_message_result",
             new=AsyncMock(return_value=delivered_matrix_event("$resume")),

--- a/tests/test_startup_maintenance.py
+++ b/tests/test_startup_maintenance.py
@@ -115,16 +115,17 @@ async def test_startup_maintenance_continues_after_failed_recovery_and_room_setu
 
 @pytest.mark.asyncio
 async def test_startup_maintenance_cancel_reports_unfinished_and_replays_with_running_bots() -> None:
-    """Canceling unfinished maintenance reports replay and reuses fresh running bots."""
+    """Canceled replay keeps exact retry targets and reuses fresh running bots."""
     started = asyncio.Event()
     release = asyncio.Event()
+    recover_stale = AsyncMock()
 
     async def setup_rooms(_: list[object]) -> None:
         started.set()
         await release.wait()
 
     controller = StartupMaintenanceController(
-        recover_stale_streams=AsyncMock(),
+        recover_stale_streams=recover_stale,
         setup_rooms_and_memberships=setup_rooms,
         sync_runtime_support=AsyncMock(),
         mark_runtime_support_ready=AsyncMock(),
@@ -132,6 +133,8 @@ async def test_startup_maintenance_cancel_reports_unfinished_and_replays_with_ru
 
     controller.start([MagicMock()], MagicMock(), startup_cutoff_ms=123456)
     await asyncio.wait_for(started.wait(), timeout=1.0)
+    recovery_state = controller.recovery_state
+    recovery_state.retry_target_event_ids.add("$retry")
 
     should_replay = await controller.cancel()
 
@@ -142,15 +145,17 @@ async def test_startup_maintenance_cancel_reports_unfinished_and_replays_with_ru
     def running_bots() -> list[object]:
         return [running_bot]
 
-    replay_config = MagicMock()
-    with patch.object(controller, "start") as start:
-        controller.restart_after_config_reload(
-            config=replay_config,
-            running_bots=running_bots,
-        )
-
-    start.assert_called_once_with([running_bot], replay_config, startup_cutoff_ms=123456)
     release.set()
+    replay_config = MagicMock()
+    controller.restart_after_config_reload(
+        config=replay_config,
+        running_bots=running_bots,
+    )
+    await _wait_for_controller(controller)
+
+    assert controller.recovery_state is recovery_state
+    assert controller.recovery_state.retry_target_event_ids == {"$retry"}
+    assert recover_stale.await_args_list[-1].args[:3] == ([running_bot], replay_config, 123456)
 
 
 @pytest.mark.asyncio

--- a/tests/test_startup_maintenance.py
+++ b/tests/test_startup_maintenance.py
@@ -159,6 +159,40 @@ async def test_startup_maintenance_cancel_reports_unfinished_and_replays_with_ru
 
 
 @pytest.mark.asyncio
+async def test_ready_recovery_is_detached_and_serialized() -> None:
+    """Ready callbacks enqueue recovery without overlapping maintenance sweeps."""
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+
+    async def first_recovery() -> None:
+        first_started.set()
+        await release_first.wait()
+
+    async def second_recovery() -> None:
+        second_started.set()
+
+    controller = StartupMaintenanceController(
+        recover_stale_streams=AsyncMock(),
+        setup_rooms_and_memberships=AsyncMock(),
+        sync_runtime_support=AsyncMock(),
+        mark_runtime_support_ready=AsyncMock(),
+    )
+
+    controller.schedule_ready_recovery(first_recovery)
+    controller.schedule_ready_recovery(second_recovery)
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    await asyncio.sleep(0)
+    assert not second_started.is_set()
+
+    release_first.set()
+    assert controller.task is not None
+    await asyncio.wait_for(controller.task, timeout=1.0)
+
+    assert second_started.is_set()
+
+
+@pytest.mark.asyncio
 async def test_startup_maintenance_cancel_completed_task_returns_false() -> None:
     """Canceling completed maintenance does not request replay."""
     controller = StartupMaintenanceController(

--- a/tests/test_startup_maintenance.py
+++ b/tests/test_startup_maintenance.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from mindroom.matrix.stale_stream_cleanup import StaleStreamRecoveryState
 from mindroom.startup_maintenance import StartupMaintenanceController
 
 
@@ -29,13 +30,13 @@ async def test_startup_maintenance_scans_rooms_joined_during_concurrent_setup() 
         started_bots: list[object],
         recovery_config: object,
         startup_cutoff_ms: int,
-        scanned_room_ids: set[str],
+        recovery_state: StaleStreamRecoveryState,
     ) -> None:
         assert started_bots == bots
         assert recovery_config is config
         assert startup_cutoff_ms == 123456
-        newly_joined_room_ids = joined_room_ids - scanned_room_ids
-        scanned_room_ids.update(newly_joined_room_ids)
+        newly_joined_room_ids = joined_room_ids - recovery_state.scanned_room_ids
+        recovery_state.scanned_room_ids.update(newly_joined_room_ids)
         recovery_waves.append(newly_joined_room_ids)
         call_order.append(f"recover-{len(recovery_waves)}")
         if len(recovery_waves) == 1:
@@ -78,7 +79,12 @@ async def test_startup_maintenance_continues_after_failed_recovery_and_room_setu
     """Later phases still run after stale recovery and room setup fail."""
     call_order: list[str] = []
 
-    async def recover_stale(_: list[object], __: object, ___: int, ____: set[str]) -> None:
+    async def recover_stale(
+        _: list[object],
+        __: object,
+        ___: int,
+        ____: StaleStreamRecoveryState,
+    ) -> None:
         call_order.append("recover")
         msg = "recovery failed"
         raise RuntimeError(msg)

--- a/tests/test_startup_maintenance.py
+++ b/tests/test_startup_maintenance.py
@@ -193,6 +193,45 @@ async def test_ready_recovery_is_detached_and_serialized() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cancel_stops_current_recovery_when_queued_recovery_has_not_started() -> None:
+    """Canceling the queue must stop work hidden behind its newest task."""
+    first_started = asyncio.Event()
+    first_cancelled = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def first_recovery() -> None:
+        first_started.set()
+        try:
+            await release_first.wait()
+        finally:
+            first_cancelled.set()
+
+    controller = StartupMaintenanceController(
+        recover_stale_streams=AsyncMock(),
+        setup_rooms_and_memberships=AsyncMock(),
+        sync_runtime_support=AsyncMock(),
+        mark_runtime_support_ready=AsyncMock(),
+    )
+
+    controller.schedule_ready_recovery(first_recovery)
+    first_task = controller.task
+    assert first_task is not None
+    await asyncio.wait_for(first_started.wait(), timeout=1.0)
+    controller.schedule_ready_recovery(AsyncMock())
+
+    try:
+        should_replay = await controller.cancel()
+        assert should_replay is True
+        assert first_cancelled.is_set()
+        assert first_task.done()
+    finally:
+        release_first.set()
+        if not first_task.done():
+            first_task.cancel()
+        await asyncio.gather(first_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
 async def test_startup_maintenance_cancel_completed_task_returns_false() -> None:
     """Canceling completed maintenance does not request replay."""
     controller = StartupMaintenanceController(

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1875,7 +1875,7 @@ async def test_update_config_replays_cancelled_startup_maintenance_and_runs_appr
         orchestrator._startup_maintenance.task = old_maintenance_task
         await asyncio.wait_for(maintenance_started.wait(), timeout=1.0)
 
-        def replay_startup_maintenance(bots: list[object], config: object, *, startup_cutoff_ms: int) -> None:
+        def replay_startup_maintenance(bots: list[object], config: object, startup_cutoff_ms: int) -> None:
             replayed.append((bots, config, startup_cutoff_ms))
 
         with (
@@ -1887,7 +1887,7 @@ async def test_update_config_replays_cancelled_startup_maintenance_and_runs_appr
             patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
             patch.object(orchestrator, "_update_unchanged_bots", new=AsyncMock()),
             patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
-            patch.object(orchestrator._startup_maintenance, "start", side_effect=replay_startup_maintenance),
+            patch.object(orchestrator._startup_maintenance, "_schedule", side_effect=replay_startup_maintenance),
             patch.object(
                 orchestrator._approval_transport,
                 "mark_startup_runtime_support_ready",

--- a/tests/test_turn_policy.py
+++ b/tests/test_turn_policy.py
@@ -18,6 +18,7 @@ from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.conversation_resolver import MessageContext
+from mindroom.dispatch_source import AUTO_RESUME_MESSAGE, TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.logging_config import get_logger
 from mindroom.matrix.cache.thread_history_result import thread_history_result
@@ -113,16 +114,23 @@ def _context(
     )
 
 
-def _dispatch(context: MessageContext, *, agent_name: str) -> PreparedDispatch:
+def _dispatch(
+    context: MessageContext,
+    *,
+    agent_name: str,
+    prompt: str = "hello agents",
+    source_kind: str = "message",
+) -> PreparedDispatch:
     target = MessageTarget.resolve(_ROOM_ID, context.thread_id, _EVENT_ID)
     envelope = request_envelope(
         room_id=_ROOM_ID,
         reply_to_event_id=_EVENT_ID,
         thread_id=context.thread_id,
-        prompt="hello agents",
+        prompt=prompt,
         user_id=_SENDER,
         target=target,
         agent_name=agent_name,
+        source_kind=source_kind,
     )
     return PreparedDispatch(
         requester_user_id=_SENDER,
@@ -496,6 +504,35 @@ async def test_router_ignores_thread_with_unavailable_policy_history(config: Con
 
     assert plan.kind == "ignore"
     assert plan.ignore_reason == "router"
+
+
+@pytest.mark.asyncio
+async def test_router_responds_to_trusted_auto_resume_with_unavailable_history(config: Config) -> None:
+    """A router-owned interrupted turn resumes despite deferred thread hydration."""
+    policy = _policy_for(config, ROUTER_AGENT_NAME)
+    room = _room_with_members(
+        _SENDER,
+        _entity_id(config, ROUTER_AGENT_NAME).full_id,
+        _entity_id(config, "general").full_id,
+        _entity_id(config, "research").full_id,
+    )
+    context = _context(
+        thread_id="$thread:localhost",
+        thread_history=[make_visible_message(sender=_SENDER, body="earlier")],
+        full_history=False,
+    )
+    dispatch = _dispatch(
+        context,
+        agent_name=ROUTER_AGENT_NAME,
+        prompt=AUTO_RESUME_MESSAGE,
+        source_kind=TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+    )
+
+    plan = await _plan(policy, room, dispatch)
+
+    assert plan.kind == "respond"
+    assert plan.response_action is not None
+    assert plan.response_action.kind == "individual"
 
 
 def test_prepared_dispatch_rejects_mismatched_envelope_target() -> None:


### PR DESCRIPTION
## Status: CHANGES REQUIRED

Three fresh exact-head review rounds exposed new lifecycle and state-accounting bug classes after each repair.
Per repository policy, patching stopped for architecture reconsideration.
Do not merge this head.

Current blockers:

- same-owner/thread deduplication leaves superseded target IDs retryable and can send an older second resume
- persisted accepted-invite rooms are absent from owner expected-room state
- config-reload cancellation can miss a concurrently queued recovery task
- a final transient freshness or send failure has no autonomous retry trigger

Recommended replacement: close this PR and open a fresh normal PR from current `main` with one orchestrator-owned `RestartRecoveryCoordinator` worker, semantic per-owner room jobs, a latest-target watermark per owner/room/thread, exact generation fencing, config pause/resume, and capped exponential retries.
`StartupMaintenanceController` should return to one-shot room setup and runtime-support work.

## Implemented direction

- carry each interrupted candidate with its exact `bot_user_id` and current actor generation, including the actor client and conversation cache
- require current-generation first-sync readiness before owner cleanup or freshness reads; joined membership alone is not readiness
- queue bot-ready recovery behind startup maintenance so long resume sweeps never block the Matrix sync callback or watchdog
- track and cancel queued/current recovery tasks
- reopen expected rooms when a previously absent owner actor starts
- keep the router as the visible relay sender and outbound-cache bookkeeper while freshness uses the exact owner cache
- let the router execute its own trusted unmentioned auto-resume relay even when planning history is intentionally unavailable
- classify freshness as `CURRENT`, `NEWER_HUMAN`, or `RETRY`
- preserve the latest-edit startup cutoff and exact retry target IDs across config-reload cancellation
- unmark unfinished rooms on cancellation or failure

## Verification

- `PYTHONPATH=src uv run pytest tests/test_stale_stream_cleanup.py tests/test_startup_maintenance.py tests/test_mcp_orchestrator.py tests/test_sync_task_cancellation.py tests/test_turn_policy.py tests/test_ingress_validation.py tests/test_orchestrator_runtime.py tests/test_bot_ready_hook.py -n 0 --no-cov -q`
- `PYTHONPATH=src uv run pytest` (12,260 passed, 54 skipped)
- `uv run pre-commit run --all-files`
- GitHub CI passed
- Qodo on the exact head reported 0 bugs and 0 rule violations, but the independent exact-head reviewers reproduced the blockers above
