### PR TITLE
Fix checkpoint discard diagnostics

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1757,7 +1757,7 @@ class AgentBot:
         ):
             self._sync_cache_trust.discard()
             self.logger.warning(
-                "sync_checkpoint_not_saved_after_incomplete_coalescing_drain",
+                "sync_checkpoint_not_saved_after_incomplete_shutdown",
                 agent_name=self.agent_name,
                 callback_failure_count=callback_failure_count,
                 background_tasks_completed=background_tasks_completed,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1757,7 +1757,7 @@ class AgentBot:
         ):
             self._sync_cache_trust.discard()
             self.logger.warning(
-                "sync_checkpoint_not_saved_after_incomplete_shutdown",
+                "sync_checkpoint_discarded",
                 agent_name=self.agent_name,
                 callback_failure_count=callback_failure_count,
                 background_tasks_completed=background_tasks_completed,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1409,20 +1409,15 @@ def patch_response_runner_module(**changes: object) -> Generator[None, None, Non
 def install_shutdown_drain_mocks(
     bot: RuntimeBot,
     *,
-    coalescing_drain_completed: bool,
+    coalescing_drain_result: CoalescingDrainResult,
     responses_drained: bool,
-) -> CoalescingDrainResult:
+) -> None:
     """Install exact shutdown drain outcomes through stable collaborator seams."""
     wrap_extracted_collaborators(bot, "_coalescing_gate", "_response_runner")
-    drain_result = CoalescingDrainResult(
-        completed=coalescing_drain_completed,
-        cancelled_unready_count=int(not coalescing_drain_completed),
-    )
     bot._coalescing_gate.drain_all = AsyncMock(
-        return_value=drain_result,
+        return_value=coalescing_drain_result,
     )
     bot._response_runner.drain_inbox_responses = AsyncMock(return_value=responses_drained)
-    return drain_result
 
 
 def install_send_response_mock(bot: RuntimeBot, send_response: AsyncMock) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1411,13 +1411,18 @@ def install_shutdown_drain_mocks(
     *,
     coalescing_drain_completed: bool,
     responses_drained: bool,
-) -> None:
+) -> CoalescingDrainResult:
     """Install exact shutdown drain outcomes through stable collaborator seams."""
     wrap_extracted_collaborators(bot, "_coalescing_gate", "_response_runner")
+    drain_result = CoalescingDrainResult(
+        completed=coalescing_drain_completed,
+        cancelled_unready_count=int(not coalescing_drain_completed),
+    )
     bot._coalescing_gate.drain_all = AsyncMock(
-        return_value=CoalescingDrainResult(completed=coalescing_drain_completed),
+        return_value=drain_result,
     )
     bot._response_runner.drain_inbox_responses = AsyncMock(return_value=responses_drained)
+    return drain_result
 
 
 def install_send_response_mock(bot: RuntimeBot, send_response: AsyncMock) -> None:

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -1040,35 +1040,34 @@ async def test_shutdown_timeout_does_not_save_checkpoint_for_cancelled_ingress(t
 
 
 @pytest.mark.parametrize(
-    ("coalescing_drain_completed", "responses_drained"),
+    ("coalescing_drain_result", "responses_drained"),
     [
-        (True, False),
-        (False, True),
+        (CoalescingDrainResult(completed=True), False),
+        (CoalescingDrainResult(completed=False, cancelled_unready_count=1), True),
     ],
 )
 @pytest.mark.asyncio
 async def test_shutdown_discard_warning_logs_exact_drain_predicates(
     tmp_path: Path,
-    coalescing_drain_completed: bool,
+    coalescing_drain_result: CoalescingDrainResult,
     responses_drained: bool,
 ) -> None:
     """Checkpoint-discard logs should identify which content-free drain predicate failed."""
     bot = _agent_bot(tmp_path)
-    drain_result = install_shutdown_drain_mocks(
+    install_shutdown_drain_mocks(
         bot,
-        coalescing_drain_completed=coalescing_drain_completed,
+        coalescing_drain_result=coalescing_drain_result,
         responses_drained=responses_drained,
     )
-    assert drain_result.completed is coalescing_drain_completed
-    assert bool(drain_result.cancelled_unready_count) is not coalescing_drain_completed
 
     with capture_logs() as logs:
         await bot.prepare_for_sync_shutdown()
 
     warnings = [entry for entry in logs if entry["event"] == "sync_checkpoint_not_saved_after_incomplete_shutdown"]
     assert len(warnings) == 1
-    assert warnings[0]["coalescing_drain_completed"] is coalescing_drain_completed
-    assert warnings[0]["cancelled_unready_count"] == int(not coalescing_drain_completed)
+    assert warnings[0]["coalescing_drain_completed"] is coalescing_drain_result.completed
+    assert warnings[0]["cancelled_unready_count"] == coalescing_drain_result.cancelled_unready_count
+    assert warnings[0]["coalescing_drain_completed"] is (warnings[0]["cancelled_unready_count"] == 0)
     assert warnings[0]["responses_drained"] is responses_drained
     assert not {"body", "content", "formatted_body", "message_content"} & warnings[0].keys()
 

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -1063,7 +1063,7 @@ async def test_shutdown_discard_warning_logs_exact_drain_predicates(
     with capture_logs() as logs:
         await bot.prepare_for_sync_shutdown()
 
-    warnings = [entry for entry in logs if entry["event"] == "sync_checkpoint_not_saved_after_incomplete_shutdown"]
+    warnings = [entry for entry in logs if entry["event"] == "sync_checkpoint_discarded"]
     assert len(warnings) == 1
     assert warnings[0]["coalescing_drain_completed"] is coalescing_drain_result.completed
     assert warnings[0]["cancelled_unready_count"] == coalescing_drain_result.cancelled_unready_count
@@ -1106,8 +1106,8 @@ async def test_shutdown_timeout_does_not_save_checkpoint_for_post_drain_backgrou
 
 
 @pytest.mark.asyncio
-async def test_callback_failure_prevents_certified_shutdown_checkpoint(tmp_path: Path) -> None:
-    """A Matrix callback exception must make the certified sync token unsafe."""
+async def test_callback_failure_discards_checkpoint_with_generic_event(tmp_path: Path) -> None:
+    """A callback-only discard must not blame an incomplete shutdown."""
     bot = _agent_bot(tmp_path)
     bot._sync_cache_trust.state = SyncTrustState.CERTIFIED
     bot._sync_cache_trust.checkpoint = SyncCheckpoint("s_after_bad_callback")
@@ -1121,11 +1121,19 @@ async def test_callback_failure_prevents_certified_shutdown_checkpoint(tmp_path:
     await callback()
     await wait_for_background_tasks(timeout=0.5, owner=bot._runtime_view)
 
-    await bot.prepare_for_sync_shutdown()
+    with capture_logs() as logs:
+        await bot.prepare_for_sync_shutdown()
 
     assert bot._sync_cache_trust.state is SyncTrustState.UNCERTAIN
     assert bot._sync_cache_trust.checkpoint is None
     assert _load_sync_token_value(tmp_path, bot.agent_name) is None
+    warnings = [entry for entry in logs if entry["event"] == "sync_checkpoint_discarded"]
+    assert len(warnings) == 1
+    assert warnings[0]["callback_failure_count"] == 1
+    assert warnings[0]["background_tasks_completed"] is True
+    assert warnings[0]["coalescing_drain_completed"] is True
+    assert warnings[0]["responses_drained"] is True
+    assert warnings[0]["post_drain_background_tasks_completed"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -1054,18 +1054,18 @@ async def test_shutdown_discard_warning_logs_exact_drain_predicates(
 ) -> None:
     """Checkpoint-discard logs should identify which content-free drain predicate failed."""
     bot = _agent_bot(tmp_path)
-    install_shutdown_drain_mocks(
+    drain_result = install_shutdown_drain_mocks(
         bot,
         coalescing_drain_completed=coalescing_drain_completed,
         responses_drained=responses_drained,
     )
+    assert drain_result.completed is coalescing_drain_completed
+    assert bool(drain_result.cancelled_unready_count) is not coalescing_drain_completed
 
     with capture_logs() as logs:
         await bot.prepare_for_sync_shutdown()
 
-    warnings = [
-        entry for entry in logs if entry["event"] == "sync_checkpoint_not_saved_after_incomplete_coalescing_drain"
-    ]
+    warnings = [entry for entry in logs if entry["event"] == "sync_checkpoint_not_saved_after_incomplete_shutdown"]
     assert len(warnings) == 1
     assert warnings[0]["coalescing_drain_completed"] is coalescing_drain_completed
     assert warnings[0]["responses_drained"] is responses_drained

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -1067,7 +1067,6 @@ async def test_shutdown_discard_warning_logs_exact_drain_predicates(
     assert len(warnings) == 1
     assert warnings[0]["coalescing_drain_completed"] is coalescing_drain_result.completed
     assert warnings[0]["cancelled_unready_count"] == coalescing_drain_result.cancelled_unready_count
-    assert warnings[0]["coalescing_drain_completed"] is (warnings[0]["cancelled_unready_count"] == 0)
     assert warnings[0]["responses_drained"] is responses_drained
     assert not {"body", "content", "formatted_body", "message_content"} & warnings[0].keys()
 

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -1068,6 +1068,7 @@ async def test_shutdown_discard_warning_logs_exact_drain_predicates(
     warnings = [entry for entry in logs if entry["event"] == "sync_checkpoint_not_saved_after_incomplete_shutdown"]
     assert len(warnings) == 1
     assert warnings[0]["coalescing_drain_completed"] is coalescing_drain_completed
+    assert warnings[0]["cancelled_unready_count"] == int(not coalescing_drain_completed)
     assert warnings[0]["responses_drained"] is responses_drained
     assert not {"body", "content", "formatted_body", "message_content"} & warnings[0].keys()
 


### PR DESCRIPTION
## Summary
- Use generic checkpoint-discard event; structured fields identify cause.
- Cover callback-only discard with settled shutdown drains.
- Keep shutdown drain fixtures invariant-valid; remove false single-counter assertion.

## Verification
- `uv run pytest -q tests/test_matrix_sync_tokens.py -k "shutdown_discard_warning or callback_failure_discards_checkpoint_with_generic_event" --no-cov -n 0`
- `uv run pytest -q tests/test_coalescing.py --no-cov -n 0`
- `uv run pre-commit run --files src/mindroom/bot.py tests/test_matrix_sync_tokens.py`