### PR TITLE
Fence MCP catalog restarts with response admission

### DIFF
--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -47,12 +47,6 @@ class _ConfigReloadDrainState:
     wait_started_at: float | None = None
     last_warning_at: float | None = None
 
-    def reset(self) -> None:
-        """Clear all drain tracking state."""
-        self.waiting_for_idle = False
-        self.wait_started_at = None
-        self.last_warning_at = None
-
     def begin_wait(self, *, now: float) -> None:
         """Start a fresh response-drain window."""
         self.waiting_for_idle = True

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -46,25 +46,18 @@ class _ConfigReloadDrainState:
     waiting_for_idle: bool = False
     wait_started_at: float | None = None
     last_warning_at: float | None = None
-    request_started_at: float | None = None
 
     def reset(self) -> None:
         """Clear all drain tracking state."""
         self.waiting_for_idle = False
         self.wait_started_at = None
         self.last_warning_at = None
-        self.request_started_at = None
 
-    def begin_wait(self, *, now: float, requested_at: float) -> None:
-        """Start a fresh drain window for the current reload request."""
+    def begin_wait(self, *, now: float) -> None:
+        """Start a fresh response-drain window."""
         self.waiting_for_idle = True
         self.wait_started_at = now
         self.last_warning_at = None
-        self.request_started_at = requested_at
-
-    def should_reset_for_request(self, requested_at: float) -> bool:
-        """Return whether a newer request should restart the drain window."""
-        return self.waiting_for_idle and self.request_started_at != requested_at
 
     def wait_seconds(self, now: float) -> float:
         """Return how long the current drain window has been waiting."""
@@ -114,6 +107,7 @@ class ConfigReloadLifecycle:
     # Shared with manual plugin reloads and MCP catalog-change handling so no
     # two publication flows can interleave their read-plan-apply sequences.
     config_update_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _response_admission_apply_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
     _reload_task: asyncio.Task | None = field(default=None, init=False)
     _requested_at: float | None = field(default=None, init=False)
     # Source files of the last reload attempt that failed to load, so the
@@ -181,29 +175,30 @@ class ConfigReloadLifecycle:
         self,
         *,
         drain_state: _ConfigReloadDrainState,
-        requested_at: float,
         active_response_count: int,
         loop: asyncio.AbstractEventLoop,
+        operation_name: str = "configuration reload",
     ) -> bool:
-        """Return whether a queued reload should keep waiting for responses to finish.
+        """Return whether one replacement apply should keep waiting for responses.
 
         Only called with responses actually in flight: the caller applies
         immediately when ``close_if_idle()`` succeeds.
         """
+        titled_operation_name = operation_name[0].upper() + operation_name[1:]
         now = loop.time()
         if not drain_state.waiting_for_idle:
             logger.info(
-                "Deferring configuration reload until active responses finish",
+                f"Deferring {operation_name} until active responses finish",
                 active_response_count=active_response_count,
             )
-            drain_state.begin_wait(now=now, requested_at=requested_at)
+            drain_state.begin_wait(now=now)
         elif drain_state.should_warn(
             now=now,
             warning_after_seconds=_CONFIG_RELOAD_DRAIN_WARNING_AFTER_SECONDS,
             warning_interval_seconds=_CONFIG_RELOAD_DRAIN_WARNING_INTERVAL_SECONDS,
         ):
             logger.warning(
-                "Configuration reload still waiting for active responses to finish",
+                f"{titled_operation_name} still waiting for active responses to finish",
                 active_response_count=active_response_count,
                 drain_wait_seconds=round(drain_state.wait_seconds(now), 1),
             )
@@ -214,7 +209,7 @@ class ConfigReloadLifecycle:
             force_after_seconds=_CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS,
         ):
             logger.error(
-                "Applying configuration reload while responses are still active",
+                f"Applying {operation_name} while responses are still active",
                 active_response_count=active_response_count,
                 drain_wait_seconds=round(drain_state.wait_seconds(now), 1),
                 timeout_seconds=_CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS,
@@ -224,8 +219,11 @@ class ConfigReloadLifecycle:
         await asyncio.sleep(_CONFIG_RELOAD_IDLE_POLL_SECONDS)
         return True
 
-    async def _apply_with_closed_admission(self) -> None:
-        """Apply one queued reload with admission already closed, then always reopen it.
+    async def _apply_with_closed_admission(
+        self,
+        operation: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Apply one replacement with admission already closed, then always reopen it.
 
         Callers must close the gate immediately before calling, with no await in
         between, so nothing can be admitted into the window.
@@ -237,9 +235,41 @@ class ConfigReloadLifecycle:
         """
         assert self.response_admission_gate.closed, "admission must be closed before applying"
         try:
-            await self._apply_queued_config_reload()
+            await operation()
         finally:
             self.response_admission_gate.reopen()
+
+    async def apply_with_response_admission(
+        self,
+        operation: Callable[[], Awaitable[None]],
+        *,
+        operation_name: str,
+        request_is_current: Callable[[], bool] | None = None,
+    ) -> bool:
+        """Drain responses, own admission, then run one serialized replacement apply."""
+        is_current = request_is_current or (lambda: True)
+        loop = asyncio.get_running_loop()
+        drain_state = _ConfigReloadDrainState()
+        async with self._response_admission_apply_lock:
+            while is_current():
+                if self.response_admission_gate.close_if_idle():
+                    if drain_state.waiting_for_idle:
+                        logger.info(f"Active responses finished; applying {operation_name}")
+                    break
+                if await self._should_defer_reload_for_active_responses(
+                    drain_state=drain_state,
+                    active_response_count=self.response_admission_gate.in_flight_response_count,
+                    loop=loop,
+                    operation_name=operation_name,
+                ):
+                    continue
+                self.response_admission_gate.close()
+                break
+            else:
+                return False
+
+            await self._apply_with_closed_admission(operation)
+        return True
 
     async def _apply_queued_config_reload(self) -> None:
         """Apply one queued config reload attempt and log the result."""
@@ -266,7 +296,6 @@ class ConfigReloadLifecycle:
         """Apply queued config reloads after debounce and response drain."""
         current_task = asyncio.current_task()
         loop = asyncio.get_running_loop()
-        drain_state = _ConfigReloadDrainState()
 
         try:
             while self.is_running() and self._requested_at is not None:
@@ -274,38 +303,13 @@ class ConfigReloadLifecycle:
                 await self._wait_for_reload_debounce(requested_at, loop)
                 if self._requested_at != requested_at:
                     # A newer config change superseded the current one.
-                    # Reset drain state so the new change gets a full drain window.
-                    drain_state.reset()
                     continue
 
-                if drain_state.should_reset_for_request(requested_at):
-                    # A newer config change arrived while we were already waiting
-                    # for responses to drain, so restart the drain window.
-                    drain_state.reset()
-                    continue
-
-                # Closing the gate is atomic with the final idle sample, so a response
-                # cannot slip in between.
-                if self.response_admission_gate.close_if_idle():
-                    if drain_state.waiting_for_idle:
-                        logger.info("Active responses finished; applying queued configuration reload")
-                        drain_state.reset()
-                    await self._apply_with_closed_admission()
-                    continue
-
-                if await self._should_defer_reload_for_active_responses(
-                    drain_state=drain_state,
-                    requested_at=requested_at,
-                    active_response_count=self.response_admission_gate.in_flight_response_count,
-                    loop=loop,
-                ):
-                    continue
-
-                # The drain timed out. Close admission over the still-running
-                # responses so the apply is not racing fresh ones, then apply.
-                drain_state.reset()
-                self.response_admission_gate.close()
-                await self._apply_with_closed_admission()
+                await self.apply_with_response_admission(
+                    self._apply_queued_config_reload,
+                    operation_name="configuration reload",
+                    request_is_current=lambda requested_at=requested_at: self._requested_at == requested_at,
+                )
         finally:
             if self._reload_task is current_task:
                 self._reload_task = None

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1854,7 +1854,8 @@ class _MultiAgentOrchestrator:
         self._external_trigger_runtime.unbind()
         await shutdown_approval_runtime()
         await self.config_reload.cancel()
-        await wait_for_background_tasks(owner=self._mcp_catalog_change_task_owner)
+        owner = self._mcp_catalog_change_task_owner
+        await wait_for_background_tasks(5.0, owner=owner, shutdown_intent=ORDERLY_SHUTDOWN)
         await self._startup_maintenance.cancel()
         await self._todo_poke_runtime.stop()
         await self._stop_memory_auto_flush_worker()

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -18,7 +18,7 @@ from mindroom import constants
 from mindroom.agents import ensure_default_agent_workspaces
 from mindroom.approval_transport import ApprovalMatrixTransport
 from mindroom.authorization import is_authorized_sender
-from mindroom.background_tasks import create_background_task
+from mindroom.background_tasks import create_background_task, wait_for_background_tasks
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.embedder_health import check_embedder_health, handle_embedder_config_reload
 from mindroom.entity_resolution import (
@@ -246,6 +246,7 @@ class _MultiAgentOrchestrator:
     _mcp_manager: MCPServerManager | None = field(default=None, init=False)
     _config_update_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _response_admission_gate: ResponseAdmissionGate = field(default_factory=ResponseAdmissionGate, init=False)
+    _mcp_catalog_change_task_owner: object = field(default_factory=object, init=False, repr=False)
     _pending_replacement_recovery_room_ids: dict[str, set[str]] = field(default_factory=dict, init=False)
     _runtime_support: OwnedRuntimeSupport = field(init=False)
     _event_cache_write_task_owner: object = field(default_factory=object, init=False)
@@ -647,7 +648,7 @@ class _MultiAgentOrchestrator:
         if manager is None:
             manager = MCPServerManager(
                 self.runtime_paths,
-                on_catalog_change=self._handle_mcp_catalog_change,
+                on_catalog_change=self._notify_mcp_catalog_change,
             )
             self._mcp_manager = manager
         bind_mcp_server_manager(manager)
@@ -1387,6 +1388,26 @@ class _MultiAgentOrchestrator:
 
     async def _handle_mcp_catalog_change(self, server_id: str) -> None:
         """Restart entities that reference one changed MCP catalog."""
+        if not self.running or self.config is None:
+            return
+        await self.config_reload.apply_with_response_admission(
+            partial(self._apply_mcp_catalog_change, server_id),
+            operation_name="MCP catalog restart",
+            request_is_current=lambda: self.running and self.config is not None,
+        )
+
+    async def _notify_mcp_catalog_change(self, server_id: str) -> None:
+        """Schedule a catalog restart so an admitted MCP call can release first."""
+        if not self.running:
+            return
+        create_background_task(
+            self._handle_mcp_catalog_change(server_id),
+            name=f"mcp_catalog_change:{server_id}",
+            owner=self._mcp_catalog_change_task_owner,
+        )
+
+    async def _apply_mcp_catalog_change(self, server_id: str) -> None:
+        """Apply one MCP catalog-triggered entity replacement."""
         async with self._config_update_lock:
             if not self.running or self.config is None:
                 return
@@ -1833,6 +1854,7 @@ class _MultiAgentOrchestrator:
         self._external_trigger_runtime.unbind()
         await shutdown_approval_runtime()
         await self.config_reload.cancel()
+        await wait_for_background_tasks(owner=self._mcp_catalog_change_task_owner)
         await self._startup_maintenance.cancel()
         await self._todo_poke_runtime.stop()
         await self._stop_memory_auto_flush_worker()

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -46,8 +46,8 @@ def _make_lifecycle(
     )
 
 
-def test_drain_state_tracks_wait_warning_force_and_reset() -> None:
-    """Drain-state helpers should model wait, warning, force, and reset transitions."""
+def test_drain_state_tracks_wait_warning_and_force() -> None:
+    """Drain-state helpers should model wait, warning, and force transitions."""
     state = _ConfigReloadDrainState()
 
     assert state.waiting_for_idle is False
@@ -92,11 +92,6 @@ def test_drain_state_tracks_wait_warning_force_and_reset() -> None:
     )
     assert state.should_force_reload(now=11.9, force_after_seconds=2.0) is False
     assert state.should_force_reload(now=12.0, force_after_seconds=2.0) is True
-
-    state.reset()
-
-    assert state.waiting_for_idle is False
-    assert state.should_force_reload(now=1e9, force_after_seconds=2.0) is False
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -51,13 +51,10 @@ def test_drain_state_tracks_wait_warning_force_and_reset() -> None:
     state = _ConfigReloadDrainState()
 
     assert state.waiting_for_idle is False
-    assert state.should_reset_for_request(1.0) is False
 
-    state.begin_wait(now=10.0, requested_at=1.0)
+    state.begin_wait(now=10.0)
 
     assert state.waiting_for_idle is True
-    assert state.should_reset_for_request(1.0) is False
-    assert state.should_reset_for_request(2.0) is True
     assert (
         state.should_warn(
             now=10.5,
@@ -99,7 +96,6 @@ def test_drain_state_tracks_wait_warning_force_and_reset() -> None:
     state.reset()
 
     assert state.waiting_for_idle is False
-    assert state.should_reset_for_request(2.0) is False
     assert state.should_force_reload(now=1e9, force_after_seconds=2.0) is False
 
 
@@ -173,6 +169,41 @@ async def test_reload_drains_active_responses_before_applying(
 
 
 @pytest.mark.asyncio
+async def test_replacement_admission_serializes_config_and_mcp_owners(tmp_path: Path) -> None:
+    """Concurrent replacement flows must never share or prematurely reopen gate ownership."""
+    gate = ResponseAdmissionGate()
+    lifecycle = _make_lifecycle(tmp_path, response_admission_gate=gate)
+    mcp_started = asyncio.Event()
+    config_started = asyncio.Event()
+
+    async def apply_mcp_restart() -> None:
+        mcp_started.set()
+        await asyncio.Future()
+
+    async def apply_config_reload() -> None:
+        config_started.set()
+        await asyncio.Future()
+
+    mcp_task = asyncio.create_task(
+        lifecycle.apply_with_response_admission(apply_mcp_restart, operation_name="MCP catalog restart"),
+    )
+    await mcp_started.wait()
+    config_task = asyncio.create_task(
+        lifecycle.apply_with_response_admission(apply_config_reload, operation_name="configuration reload"),
+    )
+    await asyncio.sleep(0)
+    assert gate.closed
+    assert not config_started.is_set()
+    mcp_task.cancel()
+    await asyncio.gather(mcp_task, return_exceptions=True)
+    await asyncio.wait_for(config_started.wait(), timeout=1)
+    assert gate.closed
+    config_task.cancel()
+    await asyncio.gather(config_task, return_exceptions=True)
+    assert gate.closed is False
+
+
+@pytest.mark.asyncio
 async def test_stuck_drain_warns_then_stops_deferring(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -180,7 +211,6 @@ async def test_stuck_drain_warns_then_stops_deferring(
     """A wedged drain should warn, keep waiting, and only stop deferring at the bound."""
     warning_after_seconds = 0.5
     force_after_seconds = 1_000.0
-    requested_at = 1.0
     wait_started_at = 10.0
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0)
     monkeypatch.setattr(
@@ -201,7 +231,6 @@ async def test_stuck_drain_warns_then_stops_deferring(
 
     should_defer = await lifecycle._should_defer_reload_for_active_responses(
         drain_state=drain_state,
-        requested_at=requested_at,
         active_response_count=1,
         loop=loop,
     )
@@ -210,7 +239,6 @@ async def test_stuck_drain_warns_then_stops_deferring(
     # Past the warning threshold but still inside the bound: warn and keep waiting.
     should_defer = await lifecycle._should_defer_reload_for_active_responses(
         drain_state=drain_state,
-        requested_at=requested_at,
         active_response_count=1,
         loop=loop,
     )
@@ -224,7 +252,6 @@ async def test_stuck_drain_warns_then_stops_deferring(
     # At the bound: stop deferring so the change cannot be starved forever.
     should_defer = await lifecycle._should_defer_reload_for_active_responses(
         drain_state=drain_state,
-        requested_at=requested_at,
         active_response_count=1,
         loop=loop,
     )

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -514,9 +514,6 @@ class TestRoutingRegression:
             await release_send.wait()
             return nio.RoomSendResponse.from_dict({"event_id": "$router-response"}, room_id=room.room_id)
 
-        async def stop_after_relay(*_: object, **__: object) -> None:
-            assert router_bot.admission_gate.in_flight_response_count == 0
-
         router_bot.client.room_send.side_effect = blocking_room_send
         relay_task = asyncio.create_task(
             _run_admitted_router_relay(
@@ -528,12 +525,12 @@ class TestRoutingRegression:
         assert router_bot.admission_gate.in_flight_response_count == 1
 
         with (
-            patch("mindroom.orchestrator.stop_entities", new=AsyncMock(side_effect=stop_after_relay)) as mock_stop,
+            patch("mindroom.orchestrator.stop_entities", new_callable=AsyncMock) as mock_stop,
             patch.object(
                 orchestrator,
                 "_create_and_start_entities",
                 new=AsyncMock(return_value=EntityStartResults()),
-            ) as mock_create,
+            ),
         ):
             await orchestrator._notify_mcp_catalog_change("demo")
             try:
@@ -548,9 +545,6 @@ class TestRoutingRegression:
                 )
 
         mock_stop.assert_awaited_once()
-        mock_create.assert_awaited_once()
-        assert router_bot.client.room_send.await_count == 1
-        assert router_bot.admission_gate.in_flight_response_count == 0
         assert router_bot.admission_gate.closed is False
 
     @pytest.mark.asyncio

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -529,7 +529,6 @@ class TestRoutingRegression:
 
         with (
             patch("mindroom.orchestrator.stop_entities", new=AsyncMock(side_effect=stop_after_relay)) as mock_stop,
-            patch.object(orchestrator, "_cancel_bot_start_task", new=AsyncMock()),
             patch.object(
                 orchestrator,
                 "_create_and_start_entities",

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -16,6 +16,7 @@ import nio
 import pytest
 from agno.models.ollama import Ollama
 
+from mindroom.background_tasks import wait_for_background_tasks
 from mindroom.bot import AgentBot, TeamBot
 from mindroom.coalescing import CoalescingGate, ReadyPendingEvent
 from mindroom.coalescing_batch import CoalescingKey, PendingEvent
@@ -32,6 +33,7 @@ from mindroom.matrix.state import MatrixState
 from mindroom.matrix.sync_certification import SyncCheckpoint, SyncTrustState
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.message_target import MessageTarget
+from mindroom.orchestration.runtime import EntityStartResults
 from mindroom.orchestrator import _MultiAgentOrchestrator
 from mindroom.routing import suggest_responder_for_message
 from mindroom.teams import TeamOutcome, TeamResolution
@@ -155,7 +157,8 @@ def _router_readiness_runtime(tmp_path: Path) -> tuple[AgentBot, AgentBot, _Mult
     room_id = "!router-readiness:localhost"
     config = _runtime_bound_config(
         Config(
-            agents={"general": AgentConfig(display_name="General", rooms=[room_id])},
+            agents={"general": AgentConfig(display_name="General", rooms=[room_id], tools=["mcp_demo"])},
+            mcp_servers={"demo": {"transport": "stdio", "command": "npx"}},
             authorization={"default_room_access": True},
         ),
         tmp_path,
@@ -495,6 +498,61 @@ class TestRoutingRegression:
         router_bot._sync_cache_trust.checkpoint = SyncCheckpoint("s_before_router_shutdown")
         await router_bot.prepare_for_sync_shutdown()
         assert router_bot._sync_cache_trust.checkpoint is None
+
+    @pytest.mark.asyncio
+    async def test_mcp_catalog_restart_waits_for_admitted_router_relay_delivery(self, tmp_path: Path) -> None:
+        """MCP replacement must not stop the selected target during relay delivery."""
+        router_bot, target_bot, orchestrator, room = _router_readiness_runtime(tmp_path)
+        router_bot._first_sync_done = target_bot._first_sync_done = True
+        router_bot.admission_gate = target_bot.admission_gate = orchestrator._response_admission_gate
+        orchestrator.running = True
+        send_started = asyncio.Event()
+        release_send = asyncio.Event()
+
+        async def blocking_room_send(**_: object) -> nio.RoomSendResponse:
+            send_started.set()
+            await release_send.wait()
+            return nio.RoomSendResponse.from_dict({"event_id": "$router-response"}, room_id=room.room_id)
+
+        async def stop_after_relay(*_: object, **__: object) -> None:
+            assert router_bot.admission_gate.in_flight_response_count == 0
+
+        router_bot.client.room_send.side_effect = blocking_room_send
+        relay_task = asyncio.create_task(
+            _run_admitted_router_relay(
+                router_bot._turn_controller,
+                lambda: _router_relay(router_bot, room, "$mcp-restart"),
+            ),
+        )
+        await send_started.wait()
+        assert router_bot.admission_gate.in_flight_response_count == 1
+
+        with (
+            patch("mindroom.orchestrator.stop_entities", new=AsyncMock(side_effect=stop_after_relay)) as mock_stop,
+            patch.object(orchestrator, "_cancel_bot_start_task", new=AsyncMock()),
+            patch.object(
+                orchestrator,
+                "_create_and_start_entities",
+                new=AsyncMock(return_value=EntityStartResults()),
+            ) as mock_create,
+        ):
+            await orchestrator._notify_mcp_catalog_change("demo")
+            try:
+                await asyncio.sleep(0)
+                assert mock_stop.await_count == 0
+            finally:
+                release_send.set()
+                await relay_task
+                assert await wait_for_background_tasks(
+                    timeout=1,
+                    owner=orchestrator._mcp_catalog_change_task_owner,
+                )
+
+        mock_stop.assert_awaited_once()
+        mock_create.assert_awaited_once()
+        assert router_bot.client.room_send.await_count == 1
+        assert router_bot.admission_gate.in_flight_response_count == 0
+        assert router_bot.admission_gate.closed is False
 
     @pytest.mark.asyncio
     async def test_router_removed_target_keeps_existing_no_responder_behavior(self, tmp_path: Path) -> None:

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -2134,7 +2134,10 @@ async def test_new_agent_not_started_twice(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_orchestrator_stop_cancels_all_tasks(tmp_path: Path) -> None:
     """Test that stop() cancels all sync tasks."""
-    with patch("mindroom.orchestrator.cancel_sync_task") as mock_cancel:
+    with (
+        patch("mindroom.orchestrator.cancel_sync_task") as mock_cancel,
+        patch("mindroom.orchestrator.wait_for_background_tasks", new=AsyncMock()) as mock_wait,
+    ):
         orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
 
         # Track which tasks are cancelled
@@ -2176,6 +2179,8 @@ async def test_orchestrator_stop_cancels_all_tasks(tmp_path: Path) -> None:
         # Verify bots were stopped with public shutdown metadata and no restart cancellation source.
         mock_bot1.stop.assert_awaited_once_with(shutdown_intent=ORDERLY_SHUTDOWN)
         mock_bot2.stop.assert_awaited_once_with(shutdown_intent=ORDERLY_SHUTDOWN)
+        owner = orchestrator._mcp_catalog_change_task_owner
+        mock_wait.assert_awaited_once_with(5.0, owner=owner, shutdown_intent=ORDERLY_SHUTDOWN)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- route MCP catalog-triggered replacements through the shared response-admission drain and forced-apply policy
- schedule catalog callbacks as owned background work so an admitted MCP tool call cannot wait on its own response slot
- wait for in-progress catalog replacement work during shutdown to avoid partial entity replacement
- serialize config and MCP admission ownership and cover the router relay delivery race

## Validation
- `uv run pre-commit run --all-files`
- `.venv/bin/python -m pytest -q -n 0 tests/test_config_lifecycle.py tests/test_mcp_manager.py tests/test_mcp_orchestrator.py tests/test_routing_regression.py tests/test_config_reload.py tests/test_dynamic_config_update.py` (188 passed, 1 skipped)

## Value gate
The exact diff leaves current `main` better: it closes a deterministic generation-replacement race and admitted-tool self-wait through one existing lifecycle policy, without a second queue, schema, dedup layer, or replacement state machine.

## Summary by Sourcery

Route MCP catalog-triggered entity restarts through the shared response-admission lifecycle and ensure they complete safely alongside config reloads and router responses.

Bug Fixes:
- Ensure MCP catalog-triggered entity restarts wait for in-flight router responses to complete and do not interrupt relay delivery.
- Guarantee MCP catalog restart background work is owned and drained correctly on shutdown to avoid partial entity replacement or hanging tasks.
- Prevent concurrent replacement flows from prematurely reopening the response admission gate or overlapping their apply phases.

Enhancements:
- Generalize the response-admission drain/apply logic so multiple replacement flows (config reloads and MCP catalog restarts) share a serialized gate ownership policy.
- Refine logging and drain state handling to remove request-based reset logic while preserving warning and force-apply behavior for long-running drains.

Tests:
- Add regression tests to verify MCP catalog restarts do not stop selected router targets during response relay delivery.
- Add tests to ensure config and MCP replacement flows serialize gate ownership and that stuck drains maintain the intended warn-then-force semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration reload handling during active responses.
  * Prevented concurrent MCP catalog replacements from interrupting in-flight message delivery.
  * Ensured superseded reload requests are skipped safely.
  * Improved shutdown reliability by waiting for background catalog-change tasks to finish.

* **Tests**
  * Added coverage for concurrent reloads, MCP replacement sequences, and orderly shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->