### PR TITLE
Keep startup auto-resume refresh off the live cache lane

### DIFF
--- a/src/mindroom/matrix/conversation_cache.py
+++ b/src/mindroom/matrix/conversation_cache.py
@@ -190,6 +190,15 @@ class ConversationCacheProtocol(Protocol):
     ) -> ThreadReadResult:
         """Refresh strict full history directly from Matrix."""
 
+    async def refresh_startup_thread_history_from_source(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        caller_label: str = "unknown",
+    ) -> ThreadReadResult:
+        """Refresh startup-only strict history without entering live cache coordination."""
+
     async def get_thread_id_for_event(self, room_id: str, event_id: str) -> str | None:
         """Resolve the cached thread root for one event when known."""
 
@@ -1020,6 +1029,25 @@ class MatrixConversationCache(ConversationCacheProtocol):
             room_id,
             thread_id,
             mode=ThreadReadMode.STRICT_SOURCE_REFRESH,
+            caller_label=caller_label,
+        )
+
+    async def refresh_startup_thread_history_from_source(
+        self,
+        room_id: str,
+        thread_id: str,
+        *,
+        caller_label: str = "unknown",
+    ) -> ThreadReadResult:
+        """Refresh startup-only strict history without entering live cache coordination."""
+        return await refresh_thread_history_from_source(
+            self._require_client(),
+            room_id,
+            thread_id,
+            self.runtime.event_cache,
+            hydrate_sidecars=True,
+            allow_stale_fallback=False,
+            trusted_sender_ids=self._trusted_sender_ids(),
             caller_label=caller_label,
         )
 

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -394,7 +394,7 @@ async def _interrupted_target_remains_latest_human_work(
         return False
 
     try:
-        history = await conversation_cache.refresh_strict_thread_history_from_source(
+        history = await conversation_cache.refresh_startup_thread_history_from_source(
             interrupted_thread.room_id,
             interrupted_thread.thread_id,
             caller_label="startup_auto_resume_freshness",

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -837,6 +837,140 @@ async def test_strict_source_refresh_bypasses_usable_cache(
 
 
 @pytest.mark.asyncio
+async def test_startup_source_refresh_does_not_join_foreground_refill(
+    tmp_path: Path,
+) -> None:
+    """Startup refresh should finish without joining a blocked foreground refill."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    client = object()
+    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=client)
+    coordinator = EventCacheWriteCoordinator(logger=conversation_cache.logger)
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    first_source_call_started = asyncio.Event()
+    release_first_source_call = asyncio.Event()
+    second_source_call_started = asyncio.Event()
+    source_call_count = 0
+    foreground_refill: asyncio.Task[ThreadHistoryResult] | None = None
+    startup_refresh: asyncio.Task[ThreadHistoryResult] | None = None
+    foreground_history = thread_history_result(
+        [ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Foreground", event_id="$foreground")],
+        is_full_history=True,
+    )
+    startup_history = thread_history_result(
+        [ResolvedVisibleMessage.synthetic(sender="@bot:localhost", body="Startup", event_id="$startup")],
+        is_full_history=True,
+        diagnostics={"thread_read_source": "homeserver"},
+    )
+
+    async def source_refresh(*_args: object, **kwargs: object) -> ThreadHistoryResult:
+        nonlocal source_call_count
+        source_call_count += 1
+        if source_call_count == 1:
+            first_source_call_started.set()
+            await release_first_source_call.wait()
+            return foreground_history
+        assert kwargs["hydrate_sidecars"] is True
+        assert kwargs["allow_stale_fallback"] is False
+        assert kwargs["caller_label"] == "startup_auto_resume_freshness"
+        second_source_call_started.set()
+        return startup_history
+
+    try:
+        with patch(
+            "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+            AsyncMock(side_effect=source_refresh),
+        ):
+            foreground_refill = asyncio.create_task(
+                conversation_cache._refill_thread_from_client(
+                    "!room:localhost",
+                    "$thread:localhost",
+                    cache_reject_diagnostics=None,
+                    wants_full_history=True,
+                    allows_stale_fallback=False,
+                ),
+            )
+            await asyncio.wait_for(first_source_call_started.wait(), timeout=1.0)
+            foreground_single_flight = dict(conversation_cache._refill_single_flight._in_flight)
+            assert len(foreground_single_flight) == 1
+
+            startup_refresh = asyncio.create_task(
+                conversation_cache.refresh_startup_thread_history_from_source(
+                    "!room:localhost",
+                    "$thread:localhost",
+                    caller_label="startup_auto_resume_freshness",
+                ),
+            )
+            await asyncio.wait_for(second_source_call_started.wait(), timeout=1.0)
+            startup_result = await asyncio.wait_for(startup_refresh, timeout=1.0)
+
+            assert [message.event_id for message in startup_result] == ["$startup"]
+            assert startup_result.is_full_history is True
+            assert foreground_refill.done() is False
+            assert conversation_cache._refill_single_flight._in_flight == foreground_single_flight
+
+            release_first_source_call.set()
+            foreground_result = await asyncio.wait_for(foreground_refill, timeout=1.0)
+            assert [message.event_id for message in foreground_result] == ["$foreground"]
+    finally:
+        release_first_source_call.set()
+        await asyncio.gather(
+            *(task for task in (foreground_refill, startup_refresh) if task is not None),
+            return_exceptions=True,
+        )
+        await coordinator.close()
+        await event_cache.close()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_startup_source_refresh_leaves_no_shared_refill_state(
+    tmp_path: Path,
+) -> None:
+    """Cancelling startup refresh should not retain coordinator or singleflight state."""
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=object())
+    coordinator = EventCacheWriteCoordinator(logger=conversation_cache.logger)
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    source_call_started = asyncio.Event()
+    release_source_call = asyncio.Event()
+    startup_refresh: asyncio.Task[ThreadHistoryResult] | None = None
+
+    async def blocking_source_refresh(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
+        source_call_started.set()
+        await release_source_call.wait()
+        return thread_history_result([], is_full_history=True)
+
+    try:
+        with patch(
+            "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+            AsyncMock(side_effect=blocking_source_refresh),
+        ):
+            startup_refresh = asyncio.create_task(
+                conversation_cache.refresh_startup_thread_history_from_source(
+                    "!room:localhost",
+                    "$thread:localhost",
+                    caller_label="startup_auto_resume_freshness",
+                ),
+            )
+            await asyncio.wait_for(source_call_started.wait(), timeout=1.0)
+            startup_refresh.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await asyncio.wait_for(startup_refresh, timeout=1.0)
+
+            assert conversation_cache._refill_single_flight._in_flight == {}
+            assert coordinator._room_states == {}
+    finally:
+        release_source_call.set()
+        await asyncio.gather(
+            *(task for task in (startup_refresh,) if task is not None),
+            return_exceptions=True,
+        )
+        await coordinator.close()
+        await event_cache.close()
+
+
+@pytest.mark.asyncio
 async def test_strict_thread_history_propagates_cache_coordinator_timeout(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -305,7 +305,7 @@ def _auto_resume_conversation_cache(interrupted: list[InterruptedThread]) -> Asy
             ],
         )
 
-    conversation_cache.refresh_strict_thread_history_from_source = AsyncMock(
+    conversation_cache.refresh_startup_thread_history_from_source = AsyncMock(
         side_effect=history_for_thread,
     )
     conversation_cache.notify_outbound_message = Mock()
@@ -840,8 +840,8 @@ async def test_auto_resume_classifies_later_activity_by_effective_sender_and_his
         ),
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
-    conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
-    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+    conversation_cache.refresh_startup_thread_history_from_source.side_effect = None
+    conversation_cache.refresh_startup_thread_history_from_source.return_value = _authoritative_history(
         _history_message("$target", timestamp=100),
         _history_message("$newer", sender=newer_sender, timestamp=100, content=newer_content),
     )
@@ -878,8 +878,8 @@ async def test_prior_auto_resume_relay_does_not_suppress_sibling_resume(tmp_path
         ),
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
-    conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
-    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+    conversation_cache.refresh_startup_thread_history_from_source.side_effect = None
+    conversation_cache.refresh_startup_thread_history_from_source.return_value = _authoritative_history(
         _history_message("$target"),
         _history_message(
             "$prior-resume",
@@ -932,36 +932,36 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
     ]
     conversation_cache = None if history_case == "missing" else _auto_resume_conversation_cache(interrupted)
     if conversation_cache is not None and history_case == "failed":
-        conversation_cache.refresh_strict_thread_history_from_source.side_effect = RuntimeError("history failed")
+        conversation_cache.refresh_startup_thread_history_from_source.side_effect = RuntimeError("history failed")
     elif conversation_cache is not None and history_case == "incomplete":
-        conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
-        conversation_cache.refresh_strict_thread_history_from_source.return_value = thread_history_result(
+        conversation_cache.refresh_startup_thread_history_from_source.side_effect = None
+        conversation_cache.refresh_startup_thread_history_from_source.return_value = thread_history_result(
             [_history_message("$target")],
             is_full_history=False,
             diagnostics={"thread_read_source": "homeserver"},
         )
     elif conversation_cache is not None and history_case == "degraded":
-        conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
-        conversation_cache.refresh_strict_thread_history_from_source.return_value = thread_history_result(
+        conversation_cache.refresh_startup_thread_history_from_source.side_effect = None
+        conversation_cache.refresh_startup_thread_history_from_source.return_value = thread_history_result(
             [_history_message("$target")],
             is_full_history=True,
             diagnostics={"thread_read_source": "homeserver", "thread_read_degraded": True},
         )
     elif conversation_cache is not None and history_case == "opaque":
-        conversation_cache.refresh_strict_thread_history_from_source.side_effect = OpaqueEncryptedThreadHistoryError(
+        conversation_cache.refresh_startup_thread_history_from_source.side_effect = OpaqueEncryptedThreadHistoryError(
             "opaque history",
         )
     elif conversation_cache is not None and history_case == "missing_target":
-        conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
-        conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+        conversation_cache.refresh_startup_thread_history_from_source.side_effect = None
+        conversation_cache.refresh_startup_thread_history_from_source.return_value = _authoritative_history(
             _history_message("$other"),
         )
     elif conversation_cache is not None and history_case == "untrusted_sender":
         state = MatrixState.load(runtime_paths_for(config))
         state.accounts.pop(managed_account_key("other"))
         state.save(runtime_paths_for(config))
-        conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
-        conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+        conversation_cache.refresh_startup_thread_history_from_source.side_effect = None
+        conversation_cache.refresh_startup_thread_history_from_source.return_value = _authoritative_history(
             _history_message("$target"),
             _history_message("$later", sender=OTHER_BOT_USER_ID),
         )
@@ -978,7 +978,7 @@ async def test_auto_resume_fails_closed_without_authoritative_target_history(
     assert resumed_count == 0
     mock_send.assert_not_awaited()
     if conversation_cache is not None:
-        conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once_with(
+        conversation_cache.refresh_startup_thread_history_from_source.assert_awaited_once_with(
             ROOM_ID,
             "$thread",
             caller_label="startup_auto_resume_freshness",
@@ -1001,7 +1001,7 @@ async def test_auto_resume_propagates_cancelled_source_refresh(tmp_path: Path) -
         ),
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
-    conversation_cache.refresh_strict_thread_history_from_source.side_effect = asyncio.CancelledError
+    conversation_cache.refresh_startup_thread_history_from_source.side_effect = asyncio.CancelledError
 
     with (
         patch("mindroom.matrix.stale_stream_cleanup.send_message_result", new=AsyncMock()) as mock_send,
@@ -1016,7 +1016,7 @@ async def test_auto_resume_propagates_cancelled_source_refresh(tmp_path: Path) -
         )
 
     mock_send.assert_not_awaited()
-    conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once()
+    conversation_cache.refresh_startup_thread_history_from_source.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -1035,8 +1035,8 @@ async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_
         ),
     ]
     conversation_cache = _auto_resume_conversation_cache(interrupted)
-    conversation_cache.refresh_strict_thread_history_from_source.side_effect = None
-    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+    conversation_cache.refresh_startup_thread_history_from_source.side_effect = None
+    conversation_cache.refresh_startup_thread_history_from_source.return_value = _authoritative_history(
         _history_message("$target"),
         _history_message("$newer-human", sender=USER_ID),
     )
@@ -1051,7 +1051,7 @@ async def test_auto_resume_source_refresh_sees_newer_human_missing_from_startup_
         )
 
     assert resumed_count == 0
-    conversation_cache.refresh_strict_thread_history_from_source.assert_awaited_once_with(
+    conversation_cache.refresh_startup_thread_history_from_source.assert_awaited_once_with(
         ROOM_ID,
         "$thread",
         caller_label="startup_auto_resume_freshness",
@@ -1095,7 +1095,7 @@ async def test_auto_resume_checks_freshness_after_delay_before_each_delivery(tmp
             messages.append(_history_message("$human-later", sender=USER_ID))
         return _authoritative_history(*messages)
 
-    conversation_cache.refresh_strict_thread_history_from_source.side_effect = history_for_call
+    conversation_cache.refresh_startup_thread_history_from_source.side_effect = history_for_call
 
     with (
         patch(
@@ -1982,7 +1982,7 @@ async def test_recent_mid_tool_shutdown_marker_resumes_only_without_newer_human_
             ),
         )
     conversation_cache = AsyncMock()
-    conversation_cache.refresh_strict_thread_history_from_source.return_value = _authoritative_history(
+    conversation_cache.refresh_startup_thread_history_from_source.return_value = _authoritative_history(
         *history_messages,
     )
     conversation_cache.notify_outbound_message = Mock()

--- a/tests/test_thread_read_guards.py
+++ b/tests/test_thread_read_guards.py
@@ -357,6 +357,94 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         assert client.room_messages.await_count == 1
 
     @pytest.mark.asyncio
+    async def test_startup_source_refresh_preserves_concurrent_live_append(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An older startup scan should not overwrite a live append that finishes mid-scan."""
+        room_id = "!test:localhost"
+        thread_id = "$thread:localhost"
+        event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+        await event_cache.initialize()
+        coordinator = _runtime_write_coordinator()
+        root_event = _text_event(
+            event_id=thread_id,
+            body="Root",
+            sender="@user:localhost",
+            server_timestamp=1000,
+            room_id=room_id,
+        )
+        live_event = _text_event(
+            event_id="$live:localhost",
+            body="Live",
+            sender="@agent:localhost",
+            server_timestamp=2000,
+            room_id=room_id,
+            thread_id=thread_id,
+        )
+        await _replace_thread(event_cache, room_id, thread_id, [root_event.source])
+        client = _relations_client(
+            root_event=root_event,
+            thread_events=[],
+            next_batch="s_initial",
+        )
+        room_messages_response = client.room_messages.return_value
+        source_scan_started = asyncio.Event()
+        release_source_scan = asyncio.Event()
+        startup_refresh: asyncio.Task[ThreadHistoryResult] | None = None
+        live_append: asyncio.Task[None] | None = None
+
+        async def blocking_room_messages(*_args: object, **_kwargs: object) -> nio.RoomMessagesResponse:
+            source_scan_started.set()
+            await release_source_scan.wait()
+            return room_messages_response
+
+        client.room_messages = AsyncMock(side_effect=blocking_room_messages)
+        access = MatrixConversationCache(
+            logger=MagicMock(),
+            runtime=_conversation_runtime(
+                client=client,
+                event_cache=event_cache,
+                coordinator=coordinator,
+            ),
+        )
+
+        try:
+            startup_refresh = asyncio.create_task(
+                access.refresh_startup_thread_history_from_source(
+                    room_id,
+                    thread_id,
+                    caller_label="startup_auto_resume_freshness",
+                ),
+            )
+            await asyncio.wait_for(source_scan_started.wait(), timeout=1.0)
+
+            live_append = asyncio.create_task(
+                access.append_live_event(
+                    room_id,
+                    live_event,
+                    event_info=EventInfo.from_event(live_event.source),
+                ),
+            )
+            await asyncio.wait_for(live_append, timeout=1.0)
+
+            release_source_scan.set()
+            startup_result = await asyncio.wait_for(startup_refresh, timeout=1.0)
+            cached = await event_cache.get_thread_events(room_id, thread_id)
+        finally:
+            release_source_scan.set()
+            await asyncio.gather(
+                *(task for task in (startup_refresh, live_append) if task is not None),
+                return_exceptions=True,
+            )
+            await coordinator.close()
+            await event_cache.close()
+
+        assert startup_result.is_full_history is True
+        assert cached is not None
+        assert [event["event_id"] for event in cached] == [thread_id, "$live:localhost"]
+
+    @pytest.mark.asyncio
     async def test_live_redaction_resolution_does_not_block_same_room_read(self) -> None:
         """A same-room read must not wait on live redaction resolution before the queued cache write starts."""
         coordinator = _runtime_write_coordinator()


### PR DESCRIPTION
## Summary
- add a startup-only authoritative thread refresh outside the live cache coordinator and refill singleflight
- keep all non-startup strict reads on the existing coordinated path
- rely on the existing membership-epoch and fetch-start guards so concurrent live mutations win

## Why
Startup auto-resume shared the live cache lane. A slow startup scan could delay live reads until their degraded fallback timeout. This replaces #1737's scheduler approach with one narrow caller boundary.

## Verification
- RED-to-GREEN starvation, cancellation-state, and concurrent-live-mutation regressions
- 363 owning-seam tests passed
- final focused rerun: 84 passed
- pre-commit: all hooks passed
- independent task and whole-branch reviews: approved

A later redundant owning-suite rerun hit local PostgreSQL disk exhaustion; the preceding exact owning pass and final focused rerun were green. GitHub CI provides fresh verification.

## Summary by Sourcery

Introduce a dedicated startup-only thread history refresh path that bypasses live cache coordination to avoid contention with foreground refills and live mutations.

New Features:
- Add a startup-only thread history refresh API that fetches strict history without using the coordinated live cache lane.

Enhancements:
- Update auto-resume and stale stream cleanup logic to use the new startup refresh path instead of the strict coordinated refresh.
- Strengthen thread read guard and event cache tests to verify startup refresh does not interfere with foreground refills or live appends and leaves no shared state on cancellation.

Tests:
- Add tests ensuring startup source refresh runs independently of foreground refills, does not corrupt singleflight or coordinator state on cancellation, and preserves concurrent live appends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread history refresh during startup to use authoritative server data.
  * Improved automatic conversation resumption by more accurately detecting recent human activity.
  * Prevented concurrent live updates from being lost while startup history is refreshed.
  * Ensured cancelled or interrupted refreshes leave no lingering state that could affect later operations.

* **Reliability**
  * Added safeguards and coverage for concurrent refreshes, cancellations, and unavailable history scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->