### PR TITLE
Bound voice normalization so hung STT work cannot wedge ingress lanes

### DIFF
--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -81,6 +81,13 @@ class _NormalizedVoiceMessage:
 
 
 _VOICE_NORMALIZATION_CACHE_MAX_ENTRIES = 128
+# Ingress lanes serialize per-sender delivery behind voice readiness, so a hung
+# normalization (download, STT, or the normalizer LLM call) wedges every later
+# message from that sender. Both timeouts exist to bound that failure mode: the
+# LLM cleanup call fails open to the raw transcription, and the shared
+# normalization task fails into the raw-audio fallback path.
+_VOICE_NORMALIZER_LLM_TIMEOUT_SECONDS = 45.0
+_VOICE_NORMALIZATION_TOTAL_TIMEOUT_SECONDS = 300.0
 _voice_normalization_cache: OrderedDict[tuple[str, str, str, str], _NormalizedVoiceMessage] = OrderedDict()
 _voice_normalization_tasks: dict[tuple[str, str, str, str], asyncio.Task[_NormalizedVoiceMessage | None]] = {}
 
@@ -199,17 +206,22 @@ async def _normalize_voice_message(
 
     task = _voice_normalization_tasks.get(cache_key)
     if task is None:
-        task = asyncio.create_task(
-            _compute_normalized_voice_message(
-                client,
-                storage_path,
-                room,
-                event,
-                config,
-                runtime_paths,
-                thread_id=thread_id,
-            ),
-        )
+
+        async def _compute_bounded() -> _NormalizedVoiceMessage | None:
+            # Hard deadline so a hung download/STT/normalizer fails this shared
+            # task instead of wedging every waiter (and their ingress lanes).
+            async with asyncio.timeout(_VOICE_NORMALIZATION_TOTAL_TIMEOUT_SECONDS):
+                return await _compute_normalized_voice_message(
+                    client,
+                    storage_path,
+                    room,
+                    event,
+                    config,
+                    runtime_paths,
+                    thread_id=thread_id,
+                )
+
+        task = asyncio.create_task(_compute_bounded())
         _voice_normalization_tasks[cache_key] = task
         task.add_done_callback(lambda done_task: _finalize_inflight_voice_normalization_task(cache_key, done_task))
 
@@ -581,9 +593,19 @@ async def _process_transcription(
             telemetry=False,
         )
 
-        # Process the transcription with the agent
+        # Process the transcription with the agent. The transcription is already
+        # usable, so a slow or hung normalizer model fails open to it instead of
+        # blocking voice readiness (and the ingress lane serialized behind it).
         session_id = f"voice_process_{uuid.uuid4()}"
-        response = await agent.arun(prompt, session_id=session_id)
+        try:
+            async with asyncio.timeout(_VOICE_NORMALIZER_LLM_TIMEOUT_SECONDS):
+                response = await agent.arun(prompt, session_id=session_id)
+        except TimeoutError:
+            logger.warning(
+                "voice_transcription_normalizer_timeout",
+                timeout_seconds=_VOICE_NORMALIZER_LLM_TIMEOUT_SECONDS,
+            )
+            return transcription
 
         # Extract the content from the response
         if response and response.content:

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -278,23 +278,30 @@ async def prepare_raw_voice_fallback_message(
     thread_id: str | None,
 ) -> _PreparedVoiceMessage:
     """Download/register audio and build a fallback text event without STT."""
-    audio = await _download_audio(client, event)
     attachment_id = None
-    if audio is None or audio.content is None:
-        logger.error("Failed to download audio file for raw voice fallback")
-    else:
-        attachment_record = await register_audio_attachment(
-            storage_path,
-            event_id=event.event_id,
-            audio_bytes=audio.content,
-            mime_type=audio.mime_type,
-            room_id=room.room_id,
-            thread_id=thread_id,
-            sender=event.sender,
-            event_timestamp=event.server_timestamp,
-            filename=event.body if isinstance(event.body, str) else None,
+    try:
+        async with asyncio.timeout(_VOICE_NORMALIZATION_TOTAL_TIMEOUT_SECONDS):
+            audio = await _download_audio(client, event)
+            if audio is None or audio.content is None:
+                logger.error("Failed to download audio file for raw voice fallback")
+            else:
+                attachment_record = await register_audio_attachment(
+                    storage_path,
+                    event_id=event.event_id,
+                    audio_bytes=audio.content,
+                    mime_type=audio.mime_type,
+                    room_id=room.room_id,
+                    thread_id=thread_id,
+                    sender=event.sender,
+                    event_timestamp=event.server_timestamp,
+                    filename=event.body if isinstance(event.body, str) else None,
+                )
+                attachment_id = attachment_record.attachment_id if attachment_record is not None else None
+    except TimeoutError:
+        logger.warning(
+            "voice_raw_fallback_timeout",
+            timeout_seconds=_VOICE_NORMALIZATION_TOTAL_TIMEOUT_SECONDS,
         )
-        attachment_id = attachment_record.attachment_id if attachment_record is not None else None
 
     return _build_prepared_voice_message(
         event,

--- a/tests/test_ingress_lanes.py
+++ b/tests/test_ingress_lanes.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 
-from mindroom import inbound_turn_normalizer, interactive
+from mindroom import inbound_turn_normalizer, interactive, voice_handler
 from mindroom.cancellation import SYNC_RESTART_CANCEL_MSG
 from mindroom.coalescing import CoalescingGate, IngressAdmissionClosedError, ReadyPendingEvent
 from mindroom.coalescing_batch import CoalescingKey, PendingEvent
@@ -41,6 +41,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mindroom.coalescing_batch import CoalescedBatch
+    from mindroom.handled_turns import TurnRecord
 
 
 def _room(room_id: str = "!room:localhost") -> nio.MatrixRoom:
@@ -646,6 +647,54 @@ def _router_voice_echo_event(
             },
         ),
     )
+
+
+@pytest.mark.asyncio
+async def test_hung_voice_download_fallback_releases_later_sender_slot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A timed-out fallback must settle voice readiness and release later sender work."""
+    bot = _make_bot(tmp_path, debounce_ms=0)
+    bot.config.voice.enabled = True
+    bot.config.voice.visible_router_echo = False
+    room = _make_room()
+    voice_note = _audio_event(event_id="$voice", thread_id="$voice-thread")
+    later_text = _text_event(event_id="$later", body="later", thread_id="$other-thread")
+    dispatched_source_ids: list[str] = []
+
+    async def record_dispatch(
+        _room: nio.MatrixRoom,
+        _event: nio.RoomMessageText,
+        _requester_user_id: str,
+        *,
+        handled_turn: TurnRecord | None = None,
+        **_metadata: object,
+    ) -> None:
+        if handled_turn is not None:
+            dispatched_source_ids.extend(handled_turn.source_event_ids)
+
+    async def hung_download(*_args: object, **_kwargs: object) -> None:
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(voice_handler, "_VOICE_NORMALIZATION_TOTAL_TIMEOUT_SECONDS", 0.05)
+    try:
+        with (
+            patch("mindroom.voice_handler._download_audio", side_effect=hung_download),
+            patch.object(
+                bot._turn_controller,
+                "_dispatch_text_message",
+                new=AsyncMock(side_effect=record_dispatch),
+            ),
+        ):
+            await bot._turn_controller.handle_media_event(room, voice_note)
+            await bot._turn_controller.handle_text_event(room, later_text)
+            await _wait_for(lambda: "$later" in dispatched_source_ids, deadline_seconds=1.0)
+
+        assert "$voice" in dispatched_source_ids
+        assert bot._coalescing_gate.lanes.all_settled()
+    finally:
+        await bot._coalescing_gate.drain_all(ready_timeout_seconds=0.1)
 
 
 @pytest.mark.asyncio

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -637,3 +637,83 @@ class TestVoiceHandler:
         assert compute_calls == 1
         assert cache_key in voice_handler._voice_normalization_cache
         assert cache_key not in voice_handler._voice_normalization_tasks
+
+    @pytest.mark.asyncio
+    async def test_process_transcription_returns_raw_transcription_when_normalizer_llm_hangs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A hung normalizer LLM call must fail open to the raw transcription."""
+        config = _runtime_bound_config(
+            Config(
+                voice=VoiceConfig(enabled=True),
+                agents={"code": AgentConfig(display_name="CodeAgent", role="Code agent")},
+            ),
+        )
+        monkeypatch.setattr(voice_handler, "_VOICE_NORMALIZER_LLM_TIMEOUT_SECONDS", 0.05, raising=False)
+        arun_started = asyncio.Event()
+
+        class HungAgent:
+            def __init__(self, *_args: object, **_kwargs: object) -> None:
+                pass
+
+            async def arun(self, *_args: object, **_kwargs: object) -> None:
+                arun_started.set()
+                await asyncio.Event().wait()
+
+        with (
+            patch("mindroom.voice_handler.model_loading.get_model_instance", return_value=MagicMock()),
+            patch("mindroom.voice_handler.Agent", HungAgent),
+        ):
+            result = await asyncio.wait_for(
+                _process_transcription("turn on the lights", config),
+                timeout=2.0,
+            )
+
+        assert arun_started.is_set()
+        assert result == "turn on the lights"
+
+    @pytest.mark.asyncio
+    async def test_normalize_voice_message_fails_when_normalization_hangs(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A hung download must fail the shared normalization task instead of wedging waiters."""
+        config = _runtime_bound_config(Config(voice=VoiceConfig(enabled=True)))
+        monkeypatch.setattr(voice_handler, "_VOICE_NORMALIZATION_TOTAL_TIMEOUT_SECONDS", 0.05, raising=False)
+        client = AsyncMock()
+        room = _matrix_room("!test:server", members=("@alice:example.com",))
+        event = MagicMock(spec=nio.RoomMessageAudio)
+        event.event_id = "$hung_voice"
+        event.sender = "@alice:example.com"
+        event.body = "voice.ogg"
+        event.source = {"content": {"body": "voice.ogg"}}
+
+        voice_handler._voice_normalization_cache.clear()
+        voice_handler._voice_normalization_tasks.clear()
+
+        async def hung_download(*_args: object, **_kwargs: object) -> None:
+            await asyncio.Event().wait()
+
+        try:
+            with patch("mindroom.voice_handler._download_audio", side_effect=hung_download):
+                with pytest.raises(TimeoutError):
+                    await asyncio.wait_for(
+                        voice_handler._normalize_voice_message(
+                            client,
+                            tmp_path,
+                            room,
+                            event,
+                            config,
+                            runtime_paths_for(config),
+                            thread_id=None,
+                        ),
+                        timeout=2.0,
+                    )
+                await asyncio.sleep(0.01)
+                assert voice_handler._voice_normalization_tasks == {}
+        finally:
+            for task in voice_handler._voice_normalization_tasks.values():
+                task.cancel()
+            voice_handler._voice_normalization_tasks.clear()

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -17,7 +17,7 @@ from mindroom import voice_handler
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.voice import VoiceConfig, VoiceSTTConfig, _VoiceLLMConfig
-from mindroom.constants import ATTACHMENT_IDS_KEY
+from mindroom.constants import ATTACHMENT_IDS_KEY, VOICE_RAW_AUDIO_FALLBACK_KEY
 from mindroom.model_defaults import LOCAL_OPENAI_API_KEY_DEFAULT
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 from tests.identity_helpers import persist_actual_entity_accounts
@@ -717,3 +717,44 @@ class TestVoiceHandler:
             for task in voice_handler._voice_normalization_tasks.values():
                 task.cancel()
             voice_handler._voice_normalization_tasks.clear()
+
+    @pytest.mark.asyncio
+    async def test_prepare_raw_voice_fallback_message_times_out_hung_download(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        """A hung fallback download must degrade to text instead of wedging the ingress lane."""
+        config = _runtime_bound_config(Config(voice=VoiceConfig(enabled=True)))
+        monkeypatch.setattr(voice_handler, "_VOICE_NORMALIZATION_TOTAL_TIMEOUT_SECONDS", 0.05, raising=False)
+        client = AsyncMock()
+        room = _matrix_room("!test:server", members=("@alice:example.com",))
+        event = MagicMock(spec=nio.RoomMessageAudio)
+        event.event_id = "$hung_fallback"
+        event.sender = "@alice:example.com"
+        event.body = "voice.ogg"
+        event.server_timestamp = 1_000
+        event.source = {"content": {"body": "voice.ogg", "msgtype": "m.audio"}}
+        download_started = asyncio.Event()
+
+        async def hung_download(*_args: object, **_kwargs: object) -> None:
+            download_started.set()
+            await asyncio.Event().wait()
+
+        with patch("mindroom.voice_handler._download_audio", side_effect=hung_download):
+            prepared = await asyncio.wait_for(
+                voice_handler.prepare_raw_voice_fallback_message(
+                    client,
+                    tmp_path,
+                    room,
+                    event,
+                    config,
+                    runtime_paths=runtime_paths_for(config),
+                    thread_id=None,
+                ),
+                timeout=2.0,
+            )
+
+        assert download_started.is_set()
+        assert prepared.source["content"][VOICE_RAW_AUDIO_FALLBACK_KEY] is True
+        assert ATTACHMENT_IDS_KEY not in prepared.source["content"]


### PR DESCRIPTION
## Problem

Production incident 2026-07-29 (~23:25-00:05 UTC): the Mind agent stopped responding while the
service stayed `active (running)`.

A voice message's post-transcription normalizer LLM call hung waiting for response headers on a
dead TLS connection. The only bound on that call is the 3600s client timeout from
`model_loading._CLAUDE_REQUEST_TIMEOUT_SECONDS`. Voice normalization is a shared single-flight
task (`_voice_normalization_tasks`), awaited via `asyncio.shield` by both the router and the
responding agent, and ingress lanes serialize per-sender delivery behind voice readiness - so the
head slot never settled and every later message from that sender in the room queued forever
(`ingress_lanes.py`'s own comment: "a head slot that never settles poisons its sender's lane").

## Fix

Two bounds, both failing open:

- **Normalizer LLM call: 45s** (`_VOICE_NORMALIZER_LLM_TIMEOUT_SECONDS`). On expiry, log
  `voice_transcription_normalizer_timeout` and return the raw transcription, which is already
  usable at that point.
- **Shared normalization task: 300s overall** (`_VOICE_NORMALIZATION_TOTAL_TIMEOUT_SECONDS`),
  covering download, STT, and normalization. On expiry the single-flight task fails with
  `TimeoutError`, which the existing `_normalize_voice_event_or_fallback` machinery converts into
  the raw-audio fallback dispatch, settling the lane. Failed tasks were already excluded from the
  result cache and removed from the in-flight map.

## Tests (TDD - both watched failing first)

- `test_process_transcription_returns_raw_transcription_when_normalizer_llm_hangs`: hung
  `agent.arun` returns the raw transcription within the deadline.
- `test_normalize_voice_message_fails_when_normalization_hangs`: hung download fails the shared
  task with `TimeoutError` and clears `_voice_normalization_tasks` instead of wedging waiters.

Full `test_voice_handler.py` (28) plus `test_voice_command_processing.py`,
`test_voice_handler_thread.py`, `test_matrix_voice_message.py`, `test_voice_bot_threading.py`
(87 total) pass; ruff check/format clean.

## Incident recovery note

The live wedge was cleared without a restart by cancelling the stuck
`_compute_normalized_voice_message` task via `sys.remote_exec`; the lane drained through the
existing `ingress_lane_ready_task_cancelled` path, which is the same recovery this change automates.

## Summary by Sourcery

Bound voice transcription normalization so hung STT/normalizer calls cannot wedge per-sender ingress lanes, failing open to existing raw transcription/audio fallback paths.

Enhancements:
- Add configurable timeouts for the normalizer LLM call and the overall shared voice normalization task to bound long-running operations and keep ingress lanes flowing.

Tests:
- Add tests verifying that a hung normalizer LLM call returns the raw transcription within a deadline and that a hung normalization/download fails the shared task with TimeoutError and clears in-flight tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards to prevent voice-processing delays from blocking subsequent messages.
  * Voice transcription now falls back to the original text if normalization takes too long.
  * Timed-out audio processing is properly stopped and cleaned up.

* **Tests**
  * Added coverage for transcription and audio-processing timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->