### PR TITLE
Fix no-op MCP catalog admission drains

### DIFF
--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -77,29 +77,35 @@ main() entry
 - **Sync loops**: Each bot runs `sync_forever_with_restart()` with automatic retry; the default `matrix_sync.mode: classic` uses classic `/v3/sync` and `matrix_sync.mode: sliding` opts into MSC4186 Simplified Sliding Sync
 - **Internal user identity**: `mindroom_user.username` is the account-creation request; runtime authorization uses the persisted actual Matrix ID
 
-## Hot Reload
+## Runtime Replacement Admission
 
-Config changes are detected via polling (`watch_paths()` checks watched source-file mtimes every second and fires after one quiet scan):
+Config changes are detected via polling (`watch_paths()` checks watched source-file mtimes every second and fires after one quiet scan).
+MCP catalog changes use the same replacement admission path when the changed server has dependent agents or teams.
+The MCP manager callback schedules an orchestrator-owned background task so the triggering tool call can return and release its admission slot before replacement draining begins.
 
-1. On change, `ConfigReloadLifecycle.request_reload()` queues a debounced reload that waits until no responses are in flight, logging periodic warnings while it waits
-2. Sampling the in-flight count and closing the shared `ResponseAdmissionGate` happen atomically, so a new response cannot race the decision to apply.
+1. On a config change, `ConfigReloadLifecycle.request_reload()` queues a debounced reload.
+2. On an MCP catalog change, the orchestrator returns immediately when no configured entity references that server, while still clearing the worker validation snapshot cache.
+   The dependent-entity check runs again under the config update lock immediately before replacement.
+3. `ConfigReloadLifecycle.apply_with_response_admission()` serializes config reloads and MCP catalog replacements behind one global admission owner.
+4. Sampling the in-flight count and closing the shared `ResponseAdmissionGate` happen atomically, so a new response cannot race the decision to apply.
    The gate covers Matrix-driven response lifecycles only.
-   Direct agent-run entry points that bypass the response lifecycle (`mindroom.api.openai_compat` and cascaded voice in `mindroom.matrix_rtc.call_tools`) are not admitted through it, so a reload can still land underneath one of those runs.
+   Direct agent-run entry points that bypass the response lifecycle (`mindroom.api.openai_compat` and cascaded voice in `mindroom.matrix_rtc.call_tools`) are not admitted through it, so a replacement can still land underneath one of those runs.
    The gate stays closed, but is not held, across config loading and plan application.
-   Holding it would stall the apply against itself: applying the plan stops bots, and stopping a bot drains its detached responses
-3. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
+   Holding it would stall the apply against itself: applying the plan stops bots, and stopping a bot drains its detached responses.
+5. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
    The gate is global and covers the whole apply window regardless of how narrow the plan turns out to be.
    When the apply finishes, responses owned by unchanged or replacement runtimes compete for admission normally.
-4. A runtime being replaced wakes its pre-admission waiters with `ResponseAdmissionRefusedError`.
+6. A runtime being replaced wakes its pre-admission waiters with `ResponseAdmissionRefusedError`.
    This is deliberately not an `asyncio.CancelledError`, because the Matrix callback must fail and invalidate the old sync checkpoint so the replacement runtime replays the source event.
    The refusal path performs no Matrix I/O, so replacement shutdown cannot stall on an untimed send.
-   Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped
-5. If responses never drain, the reload stops deferring after ten minutes and closes the gate over the still-running responses, so a config change cannot be starved forever on a busy install
-6. `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`
-7. The orchestrator applies the resulting plan: affected entities are stopped, recreated, and restarted
-8. Removed entities run `cleanup()` (leave rooms, stop bot)
-9. New/restarted bots go through room setup
-10. The gate reopens once the apply finishes, whether it succeeded or failed, and deferred responses may then start
+   Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped.
+7. If responses never drain, either replacement flow stops deferring after 600 seconds and closes the gate over still-running responses.
+   This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
+8. For config reloads, `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`.
+9. The orchestrator applies the resulting plan: affected entities are stopped, recreated, and restarted.
+10. Removed entities run `cleanup()` to leave rooms and stop the bot.
+11. New and restarted bots go through room setup.
+12. The gate reopens once the apply finishes, whether it succeeded, failed, or was cancelled, and deferred responses may then start.
 
 Skills are watched separately via `_watch_skills_task()` with cache invalidation.
 
@@ -108,7 +114,7 @@ Skills are watched separately via `_watch_skills_task()` with cache invalidation
 The `src/mindroom/orchestration/` subpackage contains helpers extracted from the monolithic orchestrator:
 
 - **`runtime.py`** — Sync loop helpers: `sync_forever_with_restart()` with linear backoff (capped at 60s), `cancel_task()`, and `create_logged_task()` for safe asyncio task creation.
-- **`config_lifecycle.py`** — Debounced config-reload lifecycle: `ConfigReloadLifecycle` owns reload queueing, response draining, and the load → diff → plan sequencing, dispatching the plan back to the orchestrator to apply.
+- **`config_lifecycle.py`** — Debounced config-reload and shared replacement-admission lifecycle: `ConfigReloadLifecycle` owns reload queueing, serialized global response draining for config and MCP replacements, and the load → diff → plan sequencing that dispatches config plans back to the orchestrator.
 - **`config_updates.py`** — Config diffing and reload planning: `build_config_update_plan()` computes a `ConfigUpdatePlan` by calling `_identify_entities_to_restart()`, which diffs old and new configs using `model_dump(exclude_none=True)`.
 - **`plugin_watch.py`** — Plugin hot-reload watcher: `watch_plugins_task()` polls configured plugin roots, with `PluginWatchState` owning the watcher baselines and dirty-state revision.
 - **`rooms.py`** — Room invitation helpers: `get_authorized_user_ids_to_invite()` and `get_root_space_user_ids_to_invite()` compute which users should be invited to managed rooms and the root Matrix space.
@@ -174,10 +180,11 @@ On `orchestrator.stop()`:
 
 1. Set `self.running = False`
 2. Cancel config reload task
-3. Stop memory auto-flush worker
-4. Shut down the per-binding knowledge refresh scheduler
-5. Cancel pending bot start tasks
-6. Stop the MCP manager
-7. Cancel all sync tasks
-8. Signal all bots to stop (`bot.running = False`)
-9. Call `bot.stop()` for each bot concurrently (waits 5s for background tasks, cancels scheduled tasks, closes Matrix client)
+3. Drain orchestrator-owned MCP catalog replacement tasks for up to 5 seconds before MCP or entity teardown
+4. Stop memory auto-flush worker
+5. Shut down the per-binding knowledge refresh scheduler
+6. Cancel pending bot start tasks
+7. Stop the MCP manager
+8. Cancel all sync tasks
+9. Signal all bots to stop (`bot.running = False`)
+10. Call `bot.stop()` for each bot concurrently (waits 5s for background tasks, cancels scheduled tasks, closes Matrix client)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -426,6 +426,10 @@ If reconnect also fails, the error is surfaced to the caller.
 
 If an MCP server sends a `tools/list_changed` notification, MindRoom refreshes that server's catalog.
 If the catalog changed, MindRoom restarts the agents and teams that reference that server so they pick up the updated tool list.
+The catalog-change callback schedules this replacement asynchronously so the triggering MCP tool call can finish before response draining starts.
+Configured servers with no dependent entity return before admission draining while still invalidating the worker validation snapshot cache.
+Referenced-entity replacement shares one serialized global response-admission owner with config reload.
+It waits up to 600 seconds for active Matrix responses to drain, then force-applies while keeping admission closed over the replacement window.
 
 ## Limitations
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -11118,6 +11118,10 @@ If reconnect also fails, the error is surfaced to the caller.
 
 If an MCP server sends a `tools/list_changed` notification, MindRoom refreshes that server's catalog.
 If the catalog changed, MindRoom restarts the agents and teams that reference that server so they pick up the updated tool list.
+The catalog-change callback schedules this replacement asynchronously so the triggering MCP tool call can finish before response draining starts.
+Configured servers with no dependent entity return before admission draining while still invalidating the worker validation snapshot cache.
+Referenced-entity replacement shares one serialized global response-admission owner with config reload.
+It waits up to 600 seconds for active Matrix responses to drain, then force-applies while keeping admission closed over the replacement window.
 
 ## Limitations
 
@@ -16412,29 +16416,35 @@ main() entry
 - **Sync loops**: Each bot runs `sync_forever_with_restart()` with automatic retry; the default `matrix_sync.mode: classic` uses classic `/v3/sync` and `matrix_sync.mode: sliding` opts into MSC4186 Simplified Sliding Sync
 - **Internal user identity**: `mindroom_user.username` is the account-creation request; runtime authorization uses the persisted actual Matrix ID
 
-## Hot Reload
+## Runtime Replacement Admission
 
-Config changes are detected via polling (`watch_paths()` checks watched source-file mtimes every second and fires after one quiet scan):
+Config changes are detected via polling (`watch_paths()` checks watched source-file mtimes every second and fires after one quiet scan).
+MCP catalog changes use the same replacement admission path when the changed server has dependent agents or teams.
+The MCP manager callback schedules an orchestrator-owned background task so the triggering tool call can return and release its admission slot before replacement draining begins.
 
-1. On change, `ConfigReloadLifecycle.request_reload()` queues a debounced reload that waits until no responses are in flight, logging periodic warnings while it waits
-2. Sampling the in-flight count and closing the shared `ResponseAdmissionGate` happen atomically, so a new response cannot race the decision to apply.
+1. On a config change, `ConfigReloadLifecycle.request_reload()` queues a debounced reload.
+2. On an MCP catalog change, the orchestrator returns immediately when no configured entity references that server, while still clearing the worker validation snapshot cache.
+   The dependent-entity check runs again under the config update lock immediately before replacement.
+3. `ConfigReloadLifecycle.apply_with_response_admission()` serializes config reloads and MCP catalog replacements behind one global admission owner.
+4. Sampling the in-flight count and closing the shared `ResponseAdmissionGate` happen atomically, so a new response cannot race the decision to apply.
    The gate covers Matrix-driven response lifecycles only.
-   Direct agent-run entry points that bypass the response lifecycle (`mindroom.api.openai_compat` and cascaded voice in `mindroom.matrix_rtc.call_tools`) are not admitted through it, so a reload can still land underneath one of those runs.
+   Direct agent-run entry points that bypass the response lifecycle (`mindroom.api.openai_compat` and cascaded voice in `mindroom.matrix_rtc.call_tools`) are not admitted through it, so a replacement can still land underneath one of those runs.
    The gate stays closed, but is not held, across config loading and plan application.
-   Holding it would stall the apply against itself: applying the plan stops bots, and stopping a bot drains its detached responses
-3. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
+   Holding it would stall the apply against itself: applying the plan stops bots, and stopping a bot drains its detached responses.
+5. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
    The gate is global and covers the whole apply window regardless of how narrow the plan turns out to be.
    When the apply finishes, responses owned by unchanged or replacement runtimes compete for admission normally.
-4. A runtime being replaced wakes its pre-admission waiters with `ResponseAdmissionRefusedError`.
+6. A runtime being replaced wakes its pre-admission waiters with `ResponseAdmissionRefusedError`.
    This is deliberately not an `asyncio.CancelledError`, because the Matrix callback must fail and invalidate the old sync checkpoint so the replacement runtime replays the source event.
    The refusal path performs no Matrix I/O, so replacement shutdown cannot stall on an untimed send.
-   Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped
-5. If responses never drain, the reload stops deferring after ten minutes and closes the gate over the still-running responses, so a config change cannot be starved forever on a busy install
-6. `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`
-7. The orchestrator applies the resulting plan: affected entities are stopped, recreated, and restarted
-8. Removed entities run `cleanup()` (leave rooms, stop bot)
-9. New/restarted bots go through room setup
-10. The gate reopens once the apply finishes, whether it succeeded or failed, and deferred responses may then start
+   Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped.
+7. If responses never drain, either replacement flow stops deferring after 600 seconds and closes the gate over still-running responses.
+   This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
+8. For config reloads, `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`.
+9. The orchestrator applies the resulting plan: affected entities are stopped, recreated, and restarted.
+10. Removed entities run `cleanup()` to leave rooms and stop the bot.
+11. New and restarted bots go through room setup.
+12. The gate reopens once the apply finishes, whether it succeeded, failed, or was cancelled, and deferred responses may then start.
 
 Skills are watched separately via `_watch_skills_task()` with cache invalidation.
 
@@ -16443,7 +16453,7 @@ Skills are watched separately via `_watch_skills_task()` with cache invalidation
 The `src/mindroom/orchestration/` subpackage contains helpers extracted from the monolithic orchestrator:
 
 - **`runtime.py`** — Sync loop helpers: `sync_forever_with_restart()` with linear backoff (capped at 60s), `cancel_task()`, and `create_logged_task()` for safe asyncio task creation.
-- **`config_lifecycle.py`** — Debounced config-reload lifecycle: `ConfigReloadLifecycle` owns reload queueing, response draining, and the load → diff → plan sequencing, dispatching the plan back to the orchestrator to apply.
+- **`config_lifecycle.py`** — Debounced config-reload and shared replacement-admission lifecycle: `ConfigReloadLifecycle` owns reload queueing, serialized global response draining for config and MCP replacements, and the load → diff → plan sequencing that dispatches config plans back to the orchestrator.
 - **`config_updates.py`** — Config diffing and reload planning: `build_config_update_plan()` computes a `ConfigUpdatePlan` by calling `_identify_entities_to_restart()`, which diffs old and new configs using `model_dump(exclude_none=True)`.
 - **`plugin_watch.py`** — Plugin hot-reload watcher: `watch_plugins_task()` polls configured plugin roots, with `PluginWatchState` owning the watcher baselines and dirty-state revision.
 - **`rooms.py`** — Room invitation helpers: `get_authorized_user_ids_to_invite()` and `get_root_space_user_ids_to_invite()` compute which users should be invited to managed rooms and the root Matrix space.
@@ -16509,13 +16519,14 @@ On `orchestrator.stop()`:
 
 1. Set `self.running = False`
 2. Cancel config reload task
-3. Stop memory auto-flush worker
-4. Shut down the per-binding knowledge refresh scheduler
-5. Cancel pending bot start tasks
-6. Stop the MCP manager
-7. Cancel all sync tasks
-8. Signal all bots to stop (`bot.running = False`)
-9. Call `bot.stop()` for each bot concurrently (waits 5s for background tasks, cancels scheduled tasks, closes Matrix client)
+3. Drain orchestrator-owned MCP catalog replacement tasks for up to 5 seconds before MCP or entity teardown
+4. Stop memory auto-flush worker
+5. Shut down the per-binding knowledge refresh scheduler
+6. Cancel pending bot start tasks
+7. Stop the MCP manager
+8. Cancel all sync tasks
+9. Signal all bots to stop (`bot.running = False`)
+10. Call `bot.stop()` for each bot concurrently (waits 5s for background tasks, cancels scheduled tasks, closes Matrix client)
 
 # Deployment
 

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -73,29 +73,35 @@ main() entry
 - **Sync loops**: Each bot runs `sync_forever_with_restart()` with automatic retry; the default `matrix_sync.mode: classic` uses classic `/v3/sync` and `matrix_sync.mode: sliding` opts into MSC4186 Simplified Sliding Sync
 - **Internal user identity**: `mindroom_user.username` is the account-creation request; runtime authorization uses the persisted actual Matrix ID
 
-## Hot Reload
+## Runtime Replacement Admission
 
-Config changes are detected via polling (`watch_paths()` checks watched source-file mtimes every second and fires after one quiet scan):
+Config changes are detected via polling (`watch_paths()` checks watched source-file mtimes every second and fires after one quiet scan).
+MCP catalog changes use the same replacement admission path when the changed server has dependent agents or teams.
+The MCP manager callback schedules an orchestrator-owned background task so the triggering tool call can return and release its admission slot before replacement draining begins.
 
-1. On change, `ConfigReloadLifecycle.request_reload()` queues a debounced reload that waits until no responses are in flight, logging periodic warnings while it waits
-2. Sampling the in-flight count and closing the shared `ResponseAdmissionGate` happen atomically, so a new response cannot race the decision to apply.
+1. On a config change, `ConfigReloadLifecycle.request_reload()` queues a debounced reload.
+2. On an MCP catalog change, the orchestrator returns immediately when no configured entity references that server, while still clearing the worker validation snapshot cache.
+   The dependent-entity check runs again under the config update lock immediately before replacement.
+3. `ConfigReloadLifecycle.apply_with_response_admission()` serializes config reloads and MCP catalog replacements behind one global admission owner.
+4. Sampling the in-flight count and closing the shared `ResponseAdmissionGate` happen atomically, so a new response cannot race the decision to apply.
    The gate covers Matrix-driven response lifecycles only.
-   Direct agent-run entry points that bypass the response lifecycle (`mindroom.api.openai_compat` and cascaded voice in `mindroom.matrix_rtc.call_tools`) are not admitted through it, so a reload can still land underneath one of those runs.
+   Direct agent-run entry points that bypass the response lifecycle (`mindroom.api.openai_compat` and cascaded voice in `mindroom.matrix_rtc.call_tools`) are not admitted through it, so a replacement can still land underneath one of those runs.
    The gate stays closed, but is not held, across config loading and plan application.
-   Holding it would stall the apply against itself: applying the plan stops bots, and stopping a bot drains its detached responses
-3. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
+   Holding it would stall the apply against itself: applying the plan stops bots, and stopping a bot drains its detached responses.
+5. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
    The gate is global and covers the whole apply window regardless of how narrow the plan turns out to be.
    When the apply finishes, responses owned by unchanged or replacement runtimes compete for admission normally.
-4. A runtime being replaced wakes its pre-admission waiters with `ResponseAdmissionRefusedError`.
+6. A runtime being replaced wakes its pre-admission waiters with `ResponseAdmissionRefusedError`.
    This is deliberately not an `asyncio.CancelledError`, because the Matrix callback must fail and invalidate the old sync checkpoint so the replacement runtime replays the source event.
    The refusal path performs no Matrix I/O, so replacement shutdown cannot stall on an untimed send.
-   Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped
-5. If responses never drain, the reload stops deferring after ten minutes and closes the gate over the still-running responses, so a config change cannot be starved forever on a busy install
-6. `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`
-7. The orchestrator applies the resulting plan: affected entities are stopped, recreated, and restarted
-8. Removed entities run `cleanup()` (leave rooms, stop bot)
-9. New/restarted bots go through room setup
-10. The gate reopens once the apply finishes, whether it succeeded or failed, and deferred responses may then start
+   Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped.
+7. If responses never drain, either replacement flow stops deferring after 600 seconds and closes the gate over still-running responses.
+   This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
+8. For config reloads, `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`.
+9. The orchestrator applies the resulting plan: affected entities are stopped, recreated, and restarted.
+10. Removed entities run `cleanup()` to leave rooms and stop the bot.
+11. New and restarted bots go through room setup.
+12. The gate reopens once the apply finishes, whether it succeeded, failed, or was cancelled, and deferred responses may then start.
 
 Skills are watched separately via `_watch_skills_task()` with cache invalidation.
 
@@ -104,7 +110,7 @@ Skills are watched separately via `_watch_skills_task()` with cache invalidation
 The `src/mindroom/orchestration/` subpackage contains helpers extracted from the monolithic orchestrator:
 
 - **`runtime.py`** — Sync loop helpers: `sync_forever_with_restart()` with linear backoff (capped at 60s), `cancel_task()`, and `create_logged_task()` for safe asyncio task creation.
-- **`config_lifecycle.py`** — Debounced config-reload lifecycle: `ConfigReloadLifecycle` owns reload queueing, response draining, and the load → diff → plan sequencing, dispatching the plan back to the orchestrator to apply.
+- **`config_lifecycle.py`** — Debounced config-reload and shared replacement-admission lifecycle: `ConfigReloadLifecycle` owns reload queueing, serialized global response draining for config and MCP replacements, and the load → diff → plan sequencing that dispatches config plans back to the orchestrator.
 - **`config_updates.py`** — Config diffing and reload planning: `build_config_update_plan()` computes a `ConfigUpdatePlan` by calling `_identify_entities_to_restart()`, which diffs old and new configs using `model_dump(exclude_none=True)`.
 - **`plugin_watch.py`** — Plugin hot-reload watcher: `watch_plugins_task()` polls configured plugin roots, with `PluginWatchState` owning the watcher baselines and dirty-state revision.
 - **`rooms.py`** — Room invitation helpers: `get_authorized_user_ids_to_invite()` and `get_root_space_user_ids_to_invite()` compute which users should be invited to managed rooms and the root Matrix space.
@@ -170,10 +176,11 @@ On `orchestrator.stop()`:
 
 1. Set `self.running = False`
 2. Cancel config reload task
-3. Stop memory auto-flush worker
-4. Shut down the per-binding knowledge refresh scheduler
-5. Cancel pending bot start tasks
-6. Stop the MCP manager
-7. Cancel all sync tasks
-8. Signal all bots to stop (`bot.running = False`)
-9. Call `bot.stop()` for each bot concurrently (waits 5s for background tasks, cancels scheduled tasks, closes Matrix client)
+3. Drain orchestrator-owned MCP catalog replacement tasks for up to 5 seconds before MCP or entity teardown
+4. Stop memory auto-flush worker
+5. Shut down the per-binding knowledge refresh scheduler
+6. Cancel pending bot start tasks
+7. Stop the MCP manager
+8. Cancel all sync tasks
+9. Signal all bots to stop (`bot.running = False`)
+10. Call `bot.stop()` for each bot concurrently (waits 5s for background tasks, cancels scheduled tasks, closes Matrix client)

--- a/skills/mindroom-docs/references/page__mcp__index.md
+++ b/skills/mindroom-docs/references/page__mcp__index.md
@@ -422,6 +422,10 @@ If reconnect also fails, the error is surfaced to the caller.
 
 If an MCP server sends a `tools/list_changed` notification, MindRoom refreshes that server's catalog.
 If the catalog changed, MindRoom restarts the agents and teams that reference that server so they pick up the updated tool list.
+The catalog-change callback schedules this replacement asynchronously so the triggering MCP tool call can finish before response draining starts.
+Configured servers with no dependent entity return before admission draining while still invalidating the worker validation snapshot cache.
+Referenced-entity replacement shares one serialized global response-admission owner with config reload.
+It waits up to 600 seconds for active Matrix responses to drain, then force-applies while keeping admission closed over the replacement window.
 
 ## Limitations
 

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -1,4 +1,4 @@
-"""Debounced config-reload lifecycle for the orchestrator."""
+"""Debounced config reload and shared response-admission replacement lifecycle."""
 
 from __future__ import annotations
 
@@ -30,18 +30,18 @@ logger = get_logger(__name__)
 
 
 _CONFIG_RELOAD_DEBOUNCE_SECONDS = 2.0
-_CONFIG_RELOAD_IDLE_POLL_SECONDS = 0.5
-_CONFIG_RELOAD_DRAIN_WARNING_AFTER_SECONDS = 30.0
-_CONFIG_RELOAD_DRAIN_WARNING_INTERVAL_SECONDS = 30.0
+_REPLACEMENT_DRAIN_IDLE_POLL_SECONDS = 0.5
+_REPLACEMENT_DRAIN_WARNING_AFTER_SECONDS = 30.0
+_REPLACEMENT_DRAIN_WARNING_INTERVAL_SECONDS = 30.0
 # The in-flight count includes responses still queued behind a conversation lock,
 # so a busy install may never observe a fully idle moment. Bound the wait rather
-# than letting a config change be deferred forever.
-_CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS = 600.0
+# than letting a replacement be deferred forever.
+_REPLACEMENT_DRAIN_FORCE_AFTER_SECONDS = 600.0
 
 
 @dataclass
-class _ConfigReloadDrainState:
-    """Track response-drain state for a queued config reload."""
+class _ReplacementDrainState:
+    """Track response-drain state for one replacement apply."""
 
     waiting_for_idle: bool = False
     wait_started_at: float | None = None
@@ -77,18 +77,19 @@ class _ConfigReloadDrainState:
         """Record the time a drain warning was logged."""
         self.last_warning_at = now
 
-    def should_force_reload(self, *, now: float, force_after_seconds: float) -> bool:
+    def should_force_apply(self, *, now: float, force_after_seconds: float) -> bool:
         """Return whether the drain has waited long enough to stop deferring."""
         return self.wait_started_at is not None and self.wait_seconds(now) >= force_after_seconds
 
 
 @dataclass
 class ConfigReloadLifecycle:
-    """Own debounced config reloads: queueing, response drain, and plan dispatch.
+    """Own debounced config reloads and serialized replacement admission.
 
     The orchestrator stays the owner of applying a plan (restarting bots,
-    reconciling accounts and rooms); this collaborator owns when a reload
-    runs and how the new config is diffed into a plan.
+    reconciling accounts and rooms). This collaborator owns when a config
+    reload runs, how it is diffed into a plan, and the global admission window
+    shared by config reloads and asynchronous MCP catalog replacements.
     """
 
     runtime_paths: RuntimePaths
@@ -165,52 +166,54 @@ class ConfigReloadLifecycle:
         if delay_seconds > 0:
             await asyncio.sleep(delay_seconds)
 
-    async def _should_defer_reload_for_active_responses(
+    async def _should_defer_replacement_for_active_responses(
         self,
         *,
-        drain_state: _ConfigReloadDrainState,
+        drain_state: _ReplacementDrainState,
         active_response_count: int,
         loop: asyncio.AbstractEventLoop,
-        operation_name: str = "configuration reload",
+        operation_name: str,
     ) -> bool:
         """Return whether one replacement apply should keep waiting for responses.
 
         Only called with responses actually in flight: the caller applies
         immediately when ``close_if_idle()`` succeeds.
         """
-        titled_operation_name = operation_name[0].upper() + operation_name[1:]
         now = loop.time()
         if not drain_state.waiting_for_idle:
             logger.info(
-                f"Deferring {operation_name} until active responses finish",
+                "Deferring replacement until active responses finish",
+                operation=operation_name,
                 active_response_count=active_response_count,
             )
             drain_state.begin_wait(now=now)
         elif drain_state.should_warn(
             now=now,
-            warning_after_seconds=_CONFIG_RELOAD_DRAIN_WARNING_AFTER_SECONDS,
-            warning_interval_seconds=_CONFIG_RELOAD_DRAIN_WARNING_INTERVAL_SECONDS,
+            warning_after_seconds=_REPLACEMENT_DRAIN_WARNING_AFTER_SECONDS,
+            warning_interval_seconds=_REPLACEMENT_DRAIN_WARNING_INTERVAL_SECONDS,
         ):
             logger.warning(
-                f"{titled_operation_name} still waiting for active responses to finish",
+                "Replacement still waiting for active responses to finish",
+                operation=operation_name,
                 active_response_count=active_response_count,
                 drain_wait_seconds=round(drain_state.wait_seconds(now), 1),
             )
             drain_state.mark_warning(now)
 
-        if drain_state.should_force_reload(
+        if drain_state.should_force_apply(
             now=now,
-            force_after_seconds=_CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS,
+            force_after_seconds=_REPLACEMENT_DRAIN_FORCE_AFTER_SECONDS,
         ):
             logger.error(
-                f"Applying {operation_name} while responses are still active",
+                "Applying replacement while responses are still active",
+                operation=operation_name,
                 active_response_count=active_response_count,
                 drain_wait_seconds=round(drain_state.wait_seconds(now), 1),
-                timeout_seconds=_CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS,
+                timeout_seconds=_REPLACEMENT_DRAIN_FORCE_AFTER_SECONDS,
             )
             return False
 
-        await asyncio.sleep(_CONFIG_RELOAD_IDLE_POLL_SECONDS)
+        await asyncio.sleep(_REPLACEMENT_DRAIN_IDLE_POLL_SECONDS)
         return True
 
     async def _apply_with_closed_admission(
@@ -238,19 +241,27 @@ class ConfigReloadLifecycle:
         operation: Callable[[], Awaitable[None]],
         *,
         operation_name: str,
-        request_is_current: Callable[[], bool] | None = None,
-    ) -> bool:
-        """Drain responses, own admission, then run one serialized replacement apply."""
-        is_current = request_is_current or (lambda: True)
+        request_is_current: Callable[[], bool],
+    ) -> None:
+        """Run one global serialized replacement after a bounded response drain.
+
+        Config reloads call this from their debounced task. MCP catalog changes
+        call it from an orchestrator-owned background task so an admitted tool
+        call cannot wait on its own slot. The drain defers for at most 600
+        seconds before closing admission over a forced apply.
+        """
         loop = asyncio.get_running_loop()
-        drain_state = _ConfigReloadDrainState()
+        drain_state = _ReplacementDrainState()
         async with self._response_admission_apply_lock:
-            while is_current():
+            while request_is_current():
                 if self.response_admission_gate.close_if_idle():
                     if drain_state.waiting_for_idle:
-                        logger.info(f"Active responses finished; applying {operation_name}")
+                        logger.info(
+                            "Active responses finished; applying replacement",
+                            operation=operation_name,
+                        )
                     break
-                if await self._should_defer_reload_for_active_responses(
+                if await self._should_defer_replacement_for_active_responses(
                     drain_state=drain_state,
                     active_response_count=self.response_admission_gate.in_flight_response_count,
                     loop=loop,
@@ -260,10 +271,9 @@ class ConfigReloadLifecycle:
                 self.response_admission_gate.close()
                 break
             else:
-                return False
+                return
 
             await self._apply_with_closed_admission(operation)
-        return True
 
     async def _apply_queued_config_reload(self) -> None:
         """Apply one queued config reload attempt and log the result."""

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1388,7 +1388,11 @@ class _MultiAgentOrchestrator:
 
     async def _handle_mcp_catalog_change(self, server_id: str) -> None:
         """Restart entities that reference one changed MCP catalog."""
-        if not self.running or self.config is None:
+        config = self.config
+        if not self.running or config is None:
+            return
+        if not config.get_entities_referencing_tools({mcp_tool_name(server_id)}):
+            clear_worker_validation_snapshot_cache()
             return
         await self.config_reload.apply_with_response_admission(
             partial(self._apply_mcp_catalog_change, server_id),

--- a/src/mindroom/response_admission.py
+++ b/src/mindroom/response_admission.py
@@ -42,7 +42,7 @@ class ResponseAdmissionRefusedError(Exception):
     """
 
     def __init__(self) -> None:
-        super().__init__("Configuration reload is restarting this entity")
+        super().__init__("Runtime replacement is restarting this entity")
 
 
 @dataclass
@@ -98,5 +98,5 @@ class ResponseAdmissionGate:
         self._open_event.set()
 
     async def wait_until_open(self) -> None:
-        """Wait until config application reopens response admission."""
+        """Wait until runtime replacement reopens response admission."""
         await self._open_event.wait()

--- a/src/mindroom/response_admission.py
+++ b/src/mindroom/response_admission.py
@@ -1,24 +1,30 @@
-"""Shared gate deciding when responses may be admitted during a config apply.
+"""Shared global gate deciding when responses may enter a runtime replacement.
 
-A config reload must not hand new responses to entities it is about to stop and
-recreate. The gate closes admission for exactly that window, but the applier
-never holds it while running the plan: applying stops bots, and stopping a bot
-drains its detached responses, which would otherwise wait on the very gate the
+Config reloads and MCP catalog replacements must not hand new responses to
+entities they are about to stop and recreate. ``ConfigReloadLifecycle``
+serializes those flows behind one admission owner, waits up to 600 seconds for
+active responses to drain, and then force-applies if the runtime never becomes
+idle. MCP notifications schedule their replacement asynchronously so the
+triggering admitted tool call can release its own slot first.
+
+The gate closes admission for exactly the apply window, but the applier never
+holds it while running the plan. Applying stops bots, and stopping a bot drains
+its detached responses, which would otherwise wait on the very gate the
 applier holds.
 
 Scope: the gate covers Matrix-driven response lifecycles, which is where a
-config reload can stop an entity mid-turn. Direct agent-run entry points that
+replacement can stop an entity mid-turn. Direct agent-run entry points that
 bypass the response lifecycle (the OpenAI-compatible API in
 ``mindroom.api.openai_compat`` and cascaded voice in
-``mindroom.matrix_rtc.call_tools``) are not admitted through it, so a reload can
-still land underneath one of those runs.
+``mindroom.matrix_rtc.call_tools``) are not admitted through it, so a
+replacement can still land underneath one of those runs.
 
 Every state transition is deliberately synchronous. No critical section here
 contains an ``await``, so the single-threaded event loop cannot interleave one
 transition against another and a lock would add nothing. ``wait_until_open``
 only observes the event published by those transitions. Keeping ``release``
 synchronous matters on cancellation, where an ``await`` could itself be
-interrupted and permanently leak a slot, wedging config reload.
+interrupted and permanently leak a slot, wedging replacement admission.
 """
 
 from __future__ import annotations
@@ -28,7 +34,7 @@ from dataclasses import dataclass, field
 
 
 class ResponseAdmissionRefusedError(Exception):
-    """Raised when a response waiting through config apply loses its runtime.
+    """Raised when a response waiting through replacement loses its runtime.
 
     Deliberately not an ``asyncio.CancelledError``. The response never entered
     its lifecycle, so replacement-runtime replay must see a failed callback
@@ -41,7 +47,7 @@ class ResponseAdmissionRefusedError(Exception):
 
 @dataclass
 class ResponseAdmissionGate:
-    """Track in-flight responses and close admission while a config apply runs."""
+    """Track in-flight responses and close admission while a replacement runs."""
 
     _in_flight_response_count: int = field(default=0, init=False)
     _closed: bool = field(default=False, init=False)
@@ -58,11 +64,11 @@ class ResponseAdmissionGate:
 
     @property
     def closed(self) -> bool:
-        """Return whether admission is currently closed for a config apply."""
+        """Return whether admission is currently closed for a replacement."""
         return self._closed
 
     def admit(self) -> bool:
-        """Reserve one response slot, or return False while a config apply owns the runtime."""
+        """Reserve one response slot, or return False during replacement."""
         if self._closed:
             return False
         self._in_flight_response_count += 1
@@ -87,7 +93,7 @@ class ResponseAdmissionGate:
         self._open_event.clear()
 
     def reopen(self) -> None:
-        """Reopen admission after a config apply finishes."""
+        """Reopen admission after a replacement finishes."""
         self._closed = False
         self._open_event.set()
 

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -830,7 +830,7 @@ class ResponseRunner:
             if not admission_deferred:
                 admission_deferred = True
                 self.deps.logger.info(
-                    "response_deferred_during_config_apply",
+                    "response_deferred_during_replacement",
                     response_kind=response_kind,
                     **request.response_envelope.target.log_context,
                 )

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -12,7 +12,7 @@ import pytest
 import mindroom.orchestration.config_lifecycle as lifecycle_module
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
-from mindroom.orchestration.config_lifecycle import ConfigReloadLifecycle, _ConfigReloadDrainState
+from mindroom.orchestration.config_lifecycle import ConfigReloadLifecycle, _ReplacementDrainState
 from mindroom.orchestration.config_updates import ConfigUpdatePlan
 from mindroom.orchestration.runtime import create_logged_task
 from mindroom.response_admission import ResponseAdmissionGate
@@ -46,9 +46,9 @@ def _make_lifecycle(
     )
 
 
-def test_drain_state_tracks_wait_warning_and_force() -> None:
-    """Drain-state helpers should model wait, warning, and force transitions."""
-    state = _ConfigReloadDrainState()
+def test_replacement_drain_state_tracks_wait_warning_and_force() -> None:
+    """Replacement-drain helpers should model wait, warning, and force transitions."""
+    state = _ReplacementDrainState()
 
     assert state.waiting_for_idle is False
 
@@ -90,8 +90,8 @@ def test_drain_state_tracks_wait_warning_and_force() -> None:
         )
         is True
     )
-    assert state.should_force_reload(now=11.9, force_after_seconds=2.0) is False
-    assert state.should_force_reload(now=12.0, force_after_seconds=2.0) is True
+    assert state.should_force_apply(now=11.9, force_after_seconds=2.0) is False
+    assert state.should_force_apply(now=12.0, force_after_seconds=2.0) is True
 
 
 @pytest.mark.asyncio
@@ -121,7 +121,7 @@ async def test_rapid_requests_coalesce_into_one_reload(
 ) -> None:
     """Multiple quick reload requests should extend the debounce and apply once."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.05)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0.01)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
     lifecycle = _make_lifecycle(tmp_path)
     lifecycle.update_config = AsyncMock(return_value=True)
 
@@ -144,7 +144,7 @@ async def test_reload_drains_active_responses_before_applying(
 ) -> None:
     """A queued reload should wait until in-flight responses finish."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.01)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0.01)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
     gate = ResponseAdmissionGate()
     assert gate.admit()
     lifecycle = _make_lifecycle(tmp_path, response_admission_gate=gate)
@@ -180,11 +180,19 @@ async def test_replacement_admission_serializes_config_and_mcp_owners(tmp_path: 
         await asyncio.Future()
 
     mcp_task = asyncio.create_task(
-        lifecycle.apply_with_response_admission(apply_mcp_restart, operation_name="MCP catalog restart"),
+        lifecycle.apply_with_response_admission(
+            apply_mcp_restart,
+            operation_name="MCP catalog restart",
+            request_is_current=lambda: True,
+        ),
     )
     await mcp_started.wait()
     config_task = asyncio.create_task(
-        lifecycle.apply_with_response_admission(apply_config_reload, operation_name="configuration reload"),
+        lifecycle.apply_with_response_admission(
+            apply_config_reload,
+            operation_name="configuration reload",
+            request_is_current=lambda: True,
+        ),
     )
     await asyncio.sleep(0)
     assert gate.closed
@@ -207,52 +215,67 @@ async def test_stuck_drain_warns_then_stops_deferring(
     warning_after_seconds = 0.5
     force_after_seconds = 1_000.0
     wait_started_at = 10.0
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0)
     monkeypatch.setattr(
-        "mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_WARNING_AFTER_SECONDS",
+        "mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_WARNING_AFTER_SECONDS",
         warning_after_seconds,
     )
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_WARNING_INTERVAL_SECONDS", 1.0)
     monkeypatch.setattr(
-        "mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS",
+        "mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_WARNING_INTERVAL_SECONDS",
+        1.0,
+    )
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_FORCE_AFTER_SECONDS",
         force_after_seconds,
     )
     logger_mock = MagicMock()
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle.logger", logger_mock)
     lifecycle = _make_lifecycle(tmp_path)
-    drain_state = _ConfigReloadDrainState()
+    drain_state = _ReplacementDrainState()
     loop = MagicMock(spec=asyncio.AbstractEventLoop)
     loop.time.side_effect = [wait_started_at, wait_started_at + 1.0, wait_started_at + force_after_seconds]
 
-    should_defer = await lifecycle._should_defer_reload_for_active_responses(
+    should_defer = await lifecycle._should_defer_replacement_for_active_responses(
         drain_state=drain_state,
         active_response_count=1,
         loop=loop,
+        operation_name="configuration reload",
     )
     assert should_defer is True
+    logger_mock.info.assert_any_call(
+        "Deferring replacement until active responses finish",
+        operation="configuration reload",
+        active_response_count=1,
+    )
 
     # Past the warning threshold but still inside the bound: warn and keep waiting.
-    should_defer = await lifecycle._should_defer_reload_for_active_responses(
+    should_defer = await lifecycle._should_defer_replacement_for_active_responses(
         drain_state=drain_state,
         active_response_count=1,
         loop=loop,
+        operation_name="configuration reload",
     )
     assert should_defer is True
     assert any(
-        call.args and call.args[0] == "Configuration reload still waiting for active responses to finish"
+        call.args
+        and call.args[0] == "Replacement still waiting for active responses to finish"
+        and call.kwargs["operation"] == "configuration reload"
         for call in logger_mock.warning.call_args_list
     )
     logger_mock.error.assert_not_called()
 
     # At the bound: stop deferring so the change cannot be starved forever.
-    should_defer = await lifecycle._should_defer_reload_for_active_responses(
+    should_defer = await lifecycle._should_defer_replacement_for_active_responses(
         drain_state=drain_state,
         active_response_count=1,
         loop=loop,
+        operation_name="configuration reload",
     )
     assert should_defer is False
     assert any(
-        call.args and call.args[0] == "Applying configuration reload while responses are still active"
+        call.args
+        and call.args[0] == "Applying replacement while responses are still active"
+        and call.kwargs["operation"] == "configuration reload"
         for call in logger_mock.error.call_args_list
     )
 
@@ -264,7 +287,7 @@ async def test_new_request_during_drain_keeps_waiting_for_idle(
 ) -> None:
     """A newer config change should not make an active response reload early."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.01)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0.005)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.005)
     gate = ResponseAdmissionGate()
     assert gate.admit()
     lifecycle = _make_lifecycle(tmp_path, response_admission_gate=gate)
@@ -293,7 +316,7 @@ async def test_failed_update_does_not_strand_queued_reload(
 ) -> None:
     """A failed update must not prevent a subsequently queued reload from running."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.01)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0.01)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
     lifecycle = _make_lifecycle(tmp_path)
 
     call_count = 0
@@ -325,7 +348,7 @@ async def test_config_change_during_update_triggers_second_reload(
 ) -> None:
     """A config change arriving while an update runs should cause a second reload."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.01)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0.01)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
     lifecycle = _make_lifecycle(tmp_path)
 
     call_count = 0
@@ -392,7 +415,7 @@ async def test_cancel_clears_queued_reload(
 ) -> None:
     """Cancelling should stop the queued reload before it applies."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.01)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0.01)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
     busy_gate = ResponseAdmissionGate()
     assert busy_gate.admit()
     lifecycle = _make_lifecycle(tmp_path, response_admission_gate=busy_gate)
@@ -514,8 +537,8 @@ async def test_drain_applies_reload_after_force_timeout(
 ) -> None:
     """A never-idle install must still get its config change applied eventually."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DRAIN_FORCE_AFTER_SECONDS", 0.05)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_FORCE_AFTER_SECONDS", 0.05)
     gate = ResponseAdmissionGate()
     # A response that never finishes, so the gate is never idle.
     assert gate.admit()

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -1485,7 +1485,13 @@ async def test_config_update_serializes_manual_plugin_reload_and_mcp_catalog_cha
     tmp_path: Path,
 ) -> None:
     """Manual plugin reloads and MCP restarts must wait for config application."""
-    config = _runtime_bound_config(Config(), tmp_path)
+    config = _runtime_bound_config(
+        Config(
+            agents={"agent1": AgentConfig(display_name="Agent 1", tools=["mcp_demo"])},
+            mcp_servers={"demo": {"transport": "stdio", "command": "npx"}},
+        ),
+        tmp_path,
+    )
     orchestrator = _MultiAgentOrchestrator(runtime_paths_for(config))
     orchestrator.config = config
     orchestrator.running = True
@@ -1517,12 +1523,15 @@ async def test_config_update_serializes_manual_plugin_reload_and_mcp_catalog_cha
         assert not mcp_task.done()
         reload_plugins_mock.assert_not_called()
 
+        # The authoritative under-lock recheck must observe the config current
+        # when the queued MCP replacement finally applies.
+        orchestrator.config = _runtime_bound_config(Config(), tmp_path)
         finish_apply.set()
         assert await config_task is False
         assert await plugin_task is reload_result
         await mcp_task
 
-    reload_plugins_mock.assert_called_once_with(config, orchestrator.runtime_paths)
+    reload_plugins_mock.assert_called_once_with(orchestrator.config, orchestrator.runtime_paths)
 
 
 @pytest.mark.asyncio
@@ -1533,7 +1542,7 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
 ) -> None:
     """Queued reloads should wait for tracked responses even without a Matrix event ID."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.01)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0.01)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
 
     config = _runtime_bound_config(
         Config(
@@ -3096,7 +3105,7 @@ async def test_shutdown_during_active_drain_cancels_reload(
 ) -> None:
     """Calling stop() during an active drain must cancel the reload without applying it."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.01)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_IDLE_POLL_SECONDS", 0.01)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
 
     orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
     orchestrator.running = True

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -3029,10 +3029,11 @@ async def test_replaced_runtime_refuses_deferred_response_without_matrix_io(
         assert task.done()
         assert not task.cancelled()
         assert isinstance(task.exception(), ResponseAdmissionRefusedError)
+        assert str(task.exception()) == "Runtime replacement is restarting this entity"
         assert bot.in_flight_response_count == 0
         send_response.assert_not_awaited()
         assert any(
-            call.args and call.args[0] == "response_deferred_during_config_apply"
+            call.args and call.args[0] == "response_deferred_during_replacement"
             for call in refusal_logger.info.call_args_list
         )
         assert any(

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -1525,13 +1525,14 @@ async def test_config_update_serializes_manual_plugin_reload_and_mcp_catalog_cha
 
         # The authoritative under-lock recheck must observe the config current
         # when the queued MCP replacement finally applies.
-        orchestrator.config = _runtime_bound_config(Config(), tmp_path)
+        replacement_config = _runtime_bound_config(Config(), tmp_path)
+        orchestrator.config = replacement_config
         finish_apply.set()
         assert await config_task is False
         assert await plugin_task is reload_result
         await mcp_task
 
-    reload_plugins_mock.assert_called_once_with(orchestrator.config, orchestrator.runtime_paths)
+    reload_plugins_mock.assert_called_once_with(replacement_config, orchestrator.runtime_paths)
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -584,6 +584,41 @@ async def test_handle_mcp_catalog_change_restarts_dependent_entities(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_unreferenced_mcp_catalog_change_skips_response_drain(tmp_path: Path) -> None:
+    """A configured server with no dependents should not wait for unrelated responses."""
+    runtime_paths = _runtime_paths(tmp_path)
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    orchestrator.config = Config.validate_with_runtime(
+        {
+            "mcp_servers": {
+                "demo": {
+                    "transport": "stdio",
+                    "command": "npx",
+                },
+            },
+            "agents": {
+                "plain": {
+                    "display_name": "Plain",
+                    "role": "No MCP",
+                },
+            },
+        },
+        runtime_paths,
+    )
+    orchestrator.running = True
+    assert orchestrator._response_admission_gate.admit()
+
+    try:
+        with patch("mindroom.orchestrator.clear_worker_validation_snapshot_cache") as mock_clear_snapshot_cache:
+            await asyncio.wait_for(orchestrator._handle_mcp_catalog_change("demo"), timeout=0.1)
+    finally:
+        orchestrator._response_admission_gate.release()
+
+    mock_clear_snapshot_cache.assert_called_once_with()
+    assert orchestrator._response_admission_gate.closed is False
+
+
+@pytest.mark.asyncio
 async def test_handle_mcp_catalog_change_sets_up_rooms_before_trigger_runtime_rebind(tmp_path: Path) -> None:
     """MCP restarts refresh rooms before publishing trigger runtime."""
     runtime_paths = _runtime_paths(tmp_path)

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -152,12 +152,23 @@ def setup_test_bot(
     return install_runtime_cache_support(bot)
 
 
-def _router_readiness_runtime(tmp_path: Path) -> tuple[AgentBot, AgentBot, _MultiAgentOrchestrator, nio.MatrixRoom]:
+def _router_readiness_runtime(
+    tmp_path: Path,
+    *,
+    with_mcp_server: bool = False,
+) -> tuple[AgentBot, AgentBot, _MultiAgentOrchestrator, nio.MatrixRoom]:
     """Return a live router and one running target that has not completed first sync."""
     room_id = "!router-readiness:localhost"
     config = _runtime_bound_config(
         Config(
-            agents={"general": AgentConfig(display_name="General", rooms=[room_id])},
+            agents={
+                "general": AgentConfig(
+                    display_name="General",
+                    rooms=[room_id],
+                    tools=["mcp_demo"] if with_mcp_server else [],
+                ),
+            },
+            mcp_servers={"demo": {"transport": "stdio", "command": "npx"}} if with_mcp_server else {},
             authorization={"default_room_access": True},
         ),
         tmp_path,
@@ -505,21 +516,11 @@ class TestRoutingRegression:
         tmp_path: Path,
     ) -> None:
         """MCP replacement must not stop the selected target during relay delivery."""
-        router_bot, target_bot, orchestrator, room = _router_readiness_runtime(tmp_path)
-        orchestrator.config = _runtime_bound_config(
-            Config(
-                agents={
-                    "general": AgentConfig(
-                        display_name="General",
-                        rooms=[room.room_id],
-                        tools=["mcp_demo"],
-                    ),
-                },
-                mcp_servers={"demo": {"transport": "stdio", "command": "npx"}},
-                authorization={"default_room_access": True},
-            ),
+        router_bot, target_bot, orchestrator, room = _router_readiness_runtime(
             tmp_path,
+            with_mcp_server=True,
         )
+        assert router_bot.config is orchestrator.config
         monkeypatch.setattr(
             "mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS",
             0,

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -157,8 +157,7 @@ def _router_readiness_runtime(tmp_path: Path) -> tuple[AgentBot, AgentBot, _Mult
     room_id = "!router-readiness:localhost"
     config = _runtime_bound_config(
         Config(
-            agents={"general": AgentConfig(display_name="General", rooms=[room_id], tools=["mcp_demo"])},
-            mcp_servers={"demo": {"transport": "stdio", "command": "npx"}},
+            agents={"general": AgentConfig(display_name="General", rooms=[room_id])},
             authorization={"default_room_access": True},
         ),
         tmp_path,
@@ -500,9 +499,31 @@ class TestRoutingRegression:
         assert router_bot._sync_cache_trust.checkpoint is None
 
     @pytest.mark.asyncio
-    async def test_mcp_catalog_restart_waits_for_admitted_router_relay_delivery(self, tmp_path: Path) -> None:
+    async def test_mcp_catalog_restart_waits_for_admitted_router_relay_delivery(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
         """MCP replacement must not stop the selected target during relay delivery."""
         router_bot, target_bot, orchestrator, room = _router_readiness_runtime(tmp_path)
+        orchestrator.config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": AgentConfig(
+                        display_name="General",
+                        rooms=[room.room_id],
+                        tools=["mcp_demo"],
+                    ),
+                },
+                mcp_servers={"demo": {"transport": "stdio", "command": "npx"}},
+                authorization={"default_room_access": True},
+            ),
+            tmp_path,
+        )
+        monkeypatch.setattr(
+            "mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS",
+            0,
+        )
         router_bot._first_sync_done = target_bot._first_sync_done = True
         router_bot.admission_gate = target_bot.admission_gate = orchestrator._response_admission_gate
         orchestrator.running = True

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -2134,9 +2134,17 @@ async def test_new_agent_not_started_twice(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_orchestrator_stop_cancels_all_tasks(tmp_path: Path) -> None:
     """Test that stop() cancels all sync tasks."""
+    shutdown_order: list[str] = []
+
+    async def track_catalog_drain(*_args: object, **_kwargs: object) -> None:
+        shutdown_order.append("catalog_drain")
+
     with (
         patch("mindroom.orchestrator.cancel_sync_task") as mock_cancel,
-        patch("mindroom.orchestrator.wait_for_background_tasks", new=AsyncMock()) as mock_wait,
+        patch(
+            "mindroom.orchestrator.wait_for_background_tasks",
+            new=AsyncMock(side_effect=track_catalog_drain),
+        ) as mock_wait,
     ):
         orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
 
@@ -2157,18 +2165,25 @@ async def test_orchestrator_stop_cancels_all_tasks(tmp_path: Path) -> None:
         # Create mock bots
         mock_bot1 = AsyncMock()
         mock_bot1.running = True
-        mock_bot1.stop = AsyncMock()
         mock_bot2 = AsyncMock()
         mock_bot2.running = True
-        mock_bot2.stop = AsyncMock()
+
+        async def track_entity_stop(*_args: object, **_kwargs: object) -> None:
+            shutdown_order.append("entity_teardown")
+
+        mock_bot1.stop = AsyncMock(side_effect=track_entity_stop)
+        mock_bot2.stop = AsyncMock(side_effect=track_entity_stop)
 
         orchestrator.agent_bots = {
             "agent1": mock_bot1,
             "router": mock_bot2,
         }
 
-        # Stop orchestrator
-        await orchestrator.stop()
+        async def track_mcp_stop() -> None:
+            shutdown_order.append("mcp_teardown")
+
+        with patch.object(orchestrator, "_stop_mcp_manager", new=AsyncMock(side_effect=track_mcp_stop)):
+            await orchestrator.stop()
 
         # Verify all tasks were cancelled
         assert set(cancelled) == {"agent1", "router"}
@@ -2181,6 +2196,8 @@ async def test_orchestrator_stop_cancels_all_tasks(tmp_path: Path) -> None:
         mock_bot2.stop.assert_awaited_once_with(shutdown_intent=ORDERLY_SHUTDOWN)
         owner = orchestrator._mcp_catalog_change_task_owner
         mock_wait.assert_awaited_once_with(5.0, owner=owner, shutdown_intent=ORDERLY_SHUTDOWN)
+        assert shutdown_order.index("catalog_drain") < shutdown_order.index("mcp_teardown")
+        assert shutdown_order.index("catalog_drain") < shutdown_order.index("entity_teardown")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Skip the global response-admission drain when a changed MCP server has no configured dependents while still clearing the worker validation snapshot cache.
- Keep the authoritative dependency recheck under the config lock and make the shared admission API, naming, logs, and docs explicit for both config and MCP replacement flows.
- Strengthen shutdown ordering and MCP admission regression coverage, localizing MCP configuration to the tests that require it.

## Validation

- `uv run pytest -q -n 0 --no-cov tests/test_config_lifecycle.py tests/test_mcp_manager.py tests/test_mcp_orchestrator.py tests/test_routing_regression.py tests/test_config_reload.py tests/test_dynamic_config_update.py tests/test_sync_task_cancellation.py::test_orchestrator_stop_cancels_all_tasks`
- `uv run pre-commit run --all-files`

Follow-up to #1739.

## Summary by Sourcery

Unify config reloads and MCP catalog replacements behind a shared response-admission lifecycle while tightening MCP replacement behavior and shutdown ordering.

Bug Fixes:
- Skip response-admission draining for MCP catalog changes when the changed server has no configured dependent entities, while still clearing the worker validation snapshot cache.
- Prevent MCP catalog replacement from starving or racing active Matrix responses by bounding the drain and rechecking dependents under the config lock.
- Ensure orchestrator shutdown drains MCP catalog replacement tasks before tearing down MCP infrastructure and entities.

Enhancements:
- Generalize the config reload drain into a global replacement admission window shared by config reloads and asynchronous MCP catalog replacements.
- Clarify and rename response-admission drain state and logging to be operation-aware, including a bounded forced-apply path when responses never fully drain.
- Serialize config reloads and MCP catalog replacements through a single admission owner to avoid concurrent replacements.
- Improve shutdown ordering by explicitly draining orchestrator-owned MCP catalog replacement tasks and asserting the order in tests.

Documentation:
- Document the shared runtime replacement admission model for config reloads and MCP catalog changes, including bounded draining and refusal semantics, in orchestration and MCP docs and mirrored skill references.

Tests:
- Extend and adjust config lifecycle, MCP orchestrator, routing regression, sync-task cancellation, and config reload tests to cover the shared replacement admission flow, no-op MCP catalog changes, and shutdown ordering around MCP catalog drains.