### PR TITLE
Unify sync cache-write progress for watchdog and health

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -207,8 +207,13 @@ Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 | `MINDROOM_DASHBOARD_CORS_ALLOW_ALL_ORIGINS` | Set to `true` to allow every dashboard API origin while disabling credentialed CORS responses | _(unset)_ |
 | `MINDROOM_NO_AUTO_INSTALL_TOOLS` | Set to `1`/`true`/`yes` to disable automatic tool dependency installation | _(unset — auto-install enabled)_ |
 | `MINDROOM_MATRIX_HOMESERVER_STARTUP_TIMEOUT_SECONDS` | Seconds to wait for homeserver to become reachable at startup (0 = skip). MindRoom polls the homeserver's `/_matrix/client/versions` endpoint with exponential backoff retry, detecting permanent errors (e.g., wrong URL) vs transient failures | _(wait indefinitely)_ |
+| `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` | Finite positive seconds the sync watchdog and `/api/health` may wait for one active durable sync-cache phase before treating it as wedged | `600` |
 | `MINDROOM_DISPATCH_THREAD_READ_TIMEOUT_SECONDS` | Wall-clock seconds allowed for live dispatch-safe Matrix thread reads before dispatch proceeds with degraded thread evidence | `1.0` |
 | `MINDROOM_WORKER_BACKEND` | Worker backend for tool execution (`static_runner`, `docker`, or `kubernetes`) | `static_runner` |
+
+The sync cache-write grace is a hang backstop, not the ordinary Matrix transport timeout.
+Set it above the observed healthy cache-write p99 for the deployment.
+Raising it delays both watchdog cancellation and liveness failure only while a sync callback is actively completing its sequential durable cache phase.
 
 ### OpenAI-Compatible API
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -292,7 +292,12 @@ MindRoom tracks runtime phases internally:
 | `failed` | Startup or runtime failure (detail message available) |
 
 When the semantic-search embedder is failing, the health payload additionally carries `"embedder": {"status": "failing", "detail": ...}` with the classified cause; this block is diagnostic only and never flips liveness.
-Use `/api/health` for liveness probes and `/api/ready` for readiness probes in container orchestrators. Note: `/api/health` returns `503` when Matrix sync is stale (>180s without successful sync, after the 120s watchdog timeout has attempted recovery). Configure liveness probe `failureThreshold` to allow sufficient time for watchdog self-healing.
+Use `/api/health` for liveness probes and `/api/ready` for readiness probes in container orchestrators.
+Ordinary Matrix transport silence still reaches the watchdog after 120 seconds and makes `/api/health` return `503` after 180 seconds without a successful sync.
+While a sync callback is actively completing its sequential durable cache phase, the watchdog and `/api/health` consume the same monotonic progress snapshot and defer for `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` (default 600).
+Both stop deferring when that grace expires.
+Successful cache-phase completion refreshes both liveness clocks, so a long healthy write does not immediately return `503`.
+Configure liveness probe `failureThreshold` to allow sufficient time for watchdog self-healing.
 
 ### Tools & Matrix
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -847,7 +847,12 @@ MindRoom tracks runtime phases internally:
 | `failed` | Startup or runtime failure (detail message available) |
 
 When the semantic-search embedder is failing, the health payload additionally carries `"embedder": {"status": "failing", "detail": ...}` with the classified cause; this block is diagnostic only and never flips liveness.
-Use `/api/health` for liveness probes and `/api/ready` for readiness probes in container orchestrators. Note: `/api/health` returns `503` when Matrix sync is stale (>180s without successful sync, after the 120s watchdog timeout has attempted recovery). Configure liveness probe `failureThreshold` to allow sufficient time for watchdog self-healing.
+Use `/api/health` for liveness probes and `/api/ready` for readiness probes in container orchestrators.
+Ordinary Matrix transport silence still reaches the watchdog after 120 seconds and makes `/api/health` return `503` after 180 seconds without a successful sync.
+While a sync callback is actively completing its sequential durable cache phase, the watchdog and `/api/health` consume the same monotonic progress snapshot and defer for `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` (default 600).
+Both stop deferring when that grace expires.
+Successful cache-phase completion refreshes both liveness clocks, so a long healthy write does not immediately return `503`.
+Configure liveness probe `failureThreshold` to allow sufficient time for watchdog self-healing.
 
 ### Tools & Matrix
 
@@ -1065,8 +1070,13 @@ Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 | `MINDROOM_DASHBOARD_CORS_ALLOW_ALL_ORIGINS` | Set to `true` to allow every dashboard API origin while disabling credentialed CORS responses | _(unset)_ |
 | `MINDROOM_NO_AUTO_INSTALL_TOOLS` | Set to `1`/`true`/`yes` to disable automatic tool dependency installation | _(unset — auto-install enabled)_ |
 | `MINDROOM_MATRIX_HOMESERVER_STARTUP_TIMEOUT_SECONDS` | Seconds to wait for homeserver to become reachable at startup (0 = skip). MindRoom polls the homeserver's `/_matrix/client/versions` endpoint with exponential backoff retry, detecting permanent errors (e.g., wrong URL) vs transient failures | _(wait indefinitely)_ |
+| `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` | Finite positive seconds the sync watchdog and `/api/health` may wait for one active durable sync-cache phase before treating it as wedged | `600` |
 | `MINDROOM_DISPATCH_THREAD_READ_TIMEOUT_SECONDS` | Wall-clock seconds allowed for live dispatch-safe Matrix thread reads before dispatch proceeds with degraded thread evidence | `1.0` |
 | `MINDROOM_WORKER_BACKEND` | Worker backend for tool execution (`static_runner`, `docker`, or `kubernetes`) | `static_runner` |
+
+The sync cache-write grace is a hang backstop, not the ordinary Matrix transport timeout.
+Set it above the observed healthy cache-write p99 for the deployment.
+Raising it delays both watchdog cancellation and liveness failure only while a sync callback is actively completing its sequential durable cache phase.
 
 ### OpenAI-Compatible API
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -203,8 +203,13 @@ Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 | `MINDROOM_DASHBOARD_CORS_ALLOW_ALL_ORIGINS` | Set to `true` to allow every dashboard API origin while disabling credentialed CORS responses | _(unset)_ |
 | `MINDROOM_NO_AUTO_INSTALL_TOOLS` | Set to `1`/`true`/`yes` to disable automatic tool dependency installation | _(unset — auto-install enabled)_ |
 | `MINDROOM_MATRIX_HOMESERVER_STARTUP_TIMEOUT_SECONDS` | Seconds to wait for homeserver to become reachable at startup (0 = skip). MindRoom polls the homeserver's `/_matrix/client/versions` endpoint with exponential backoff retry, detecting permanent errors (e.g., wrong URL) vs transient failures | _(wait indefinitely)_ |
+| `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` | Finite positive seconds the sync watchdog and `/api/health` may wait for one active durable sync-cache phase before treating it as wedged | `600` |
 | `MINDROOM_DISPATCH_THREAD_READ_TIMEOUT_SECONDS` | Wall-clock seconds allowed for live dispatch-safe Matrix thread reads before dispatch proceeds with degraded thread evidence | `1.0` |
 | `MINDROOM_WORKER_BACKEND` | Worker backend for tool execution (`static_runner`, `docker`, or `kubernetes`) | `static_runner` |
+
+The sync cache-write grace is a hang backstop, not the ordinary Matrix transport timeout.
+Set it above the observed healthy cache-write p99 for the deployment.
+Raising it delays both watchdog cancellation and liveness failure only while a sync callback is actively completing its sequential durable cache phase.
 
 ### OpenAI-Compatible API
 

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -288,7 +288,12 @@ MindRoom tracks runtime phases internally:
 | `failed` | Startup or runtime failure (detail message available) |
 
 When the semantic-search embedder is failing, the health payload additionally carries `"embedder": {"status": "failing", "detail": ...}` with the classified cause; this block is diagnostic only and never flips liveness.
-Use `/api/health` for liveness probes and `/api/ready` for readiness probes in container orchestrators. Note: `/api/health` returns `503` when Matrix sync is stale (>180s without successful sync, after the 120s watchdog timeout has attempted recovery). Configure liveness probe `failureThreshold` to allow sufficient time for watchdog self-healing.
+Use `/api/health` for liveness probes and `/api/ready` for readiness probes in container orchestrators.
+Ordinary Matrix transport silence still reaches the watchdog after 120 seconds and makes `/api/health` return `503` after 180 seconds without a successful sync.
+While a sync callback is actively completing its sequential durable cache phase, the watchdog and `/api/health` consume the same monotonic progress snapshot and defer for `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` (default 600).
+Both stop deferring when that grace expires.
+Successful cache-phase completion refreshes both liveness clocks, so a long healthy write does not immediately return `503`.
+Configure liveness probe `failureThreshold` to allow sufficient time for watchdog self-healing.
 
 ### Tools & Matrix
 

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -43,7 +43,7 @@ from mindroom.knowledge.watch import KnowledgeSourceWatcher
 from mindroom.logging_config import get_logger
 from mindroom.matrix.decrypt_failure import e2ee_stats
 from mindroom.matrix.health import get_matrix_sync_health_snapshot
-from mindroom.orchestration.runtime import matrix_sync_startup_timeout_seconds
+from mindroom.orchestration.runtime import matrix_sync_cache_write_grace_seconds, matrix_sync_startup_timeout_seconds
 from mindroom.runtime_state import get_runtime_state
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
 from mindroom.workers.backend import maintain_workers
@@ -717,6 +717,7 @@ async def health_check(request: Request) -> JSONResponse:
     runtime_paths = _api_runtime_paths(request)
     sync_health = get_matrix_sync_health_snapshot(
         startup_grace_seconds=matrix_sync_startup_timeout_seconds(runtime_paths),
+        cache_write_grace_seconds=matrix_sync_cache_write_grace_seconds(runtime_paths),
     )
 
     response: dict[str, object] = {

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -39,7 +39,14 @@ from mindroom.hooks import (
 from mindroom.matrix.conversation_cache import MatrixConversationCache
 from mindroom.matrix.decrypt_failure import handle_decrypt_failure, raise_notice_floor
 from mindroom.matrix.event_info import EventInfo, origin_server_ts_from_event_source
-from mindroom.matrix.health import clear_matrix_sync_state, mark_matrix_sync_loop_started, mark_matrix_sync_success
+from mindroom.matrix.health import (
+    SyncCacheWriteProgress,
+    clear_matrix_sync_state,
+    get_matrix_sync_cache_write_progress,
+    mark_matrix_sync_loop_started,
+    mark_matrix_sync_success,
+    track_matrix_sync_cache_write,
+)
 from mindroom.matrix.media import MATRIX_MEDIA_EVENT_TYPES
 from mindroom.matrix.presence import build_agent_status_message, set_presence_status
 from mindroom.matrix.room_cleanup import cleanup_all_orphaned_bots
@@ -1104,6 +1111,15 @@ class AgentBot:
             return None
         return time.monotonic() - self._last_sync_monotonic
 
+    def sync_cache_write_progress(self) -> SyncCacheWriteProgress | None:
+        """Return the durable sync-cache phase shared by watchdog and health."""
+        return get_matrix_sync_cache_write_progress(self.agent_name)
+
+    def _mark_sync_progress(self) -> None:
+        """Advance watchdog and health freshness from one sync progress event."""
+        self.last_sync_time = mark_matrix_sync_success(self.agent_name)
+        self._last_sync_monotonic = time.monotonic()
+
     def _register_room_member_callback_after_initial_sync(self) -> None:
         """Start listening for live member joins after startup history is drained."""
         if self.agent_name != ROUTER_AGENT_NAME or self._room_member_callback_registered:
@@ -1195,42 +1211,45 @@ class AgentBot:
         first_sync_response = not self._first_sync_done
         room_member_join_hooks_were_armed = self._room_member_join_hooks_armed
         room_member_join_hook_plan = _RoomMemberJoinSyncHookPlan()
-        self.last_sync_time = mark_matrix_sync_success(self.agent_name)
-        self._last_sync_monotonic = time.monotonic()
+        self._mark_sync_progress()
 
         if self._sync_shutting_down:
             return
 
         if isinstance(_response, nio.SyncResponse):
-            await self._apply_own_room_membership_from_sync(_response)
-            restored_token_first_sync_response = (
-                first_sync_response and self._sync_cache_trust.state is SyncTrustState.PENDING
-            )
-            try:
-                cache_result = await self._conversation_cache.cache_sync_timeline_for_certification(_response)
-            except asyncio.CancelledError as exc:
-                cache_result = SyncCacheWriteResult(complete=False, errors=(exc,))
-                self._certify_sync_response(
+            with track_matrix_sync_cache_write(self.agent_name):
+                await self._apply_own_room_membership_from_sync(_response)
+                restored_token_first_sync_response = (
+                    first_sync_response and self._sync_cache_trust.state is SyncTrustState.PENDING
+                )
+                try:
+                    cache_result = await self._conversation_cache.cache_sync_timeline_for_certification(_response)
+                except asyncio.CancelledError as exc:
+                    cache_result = SyncCacheWriteResult(complete=False, errors=(exc,))
+                    self._certify_sync_response(
+                        next_batch=_response.next_batch,
+                        cache_result=cache_result,
+                        first_sync=first_sync_response,
+                    )
+                    raise
+                decision = self._certify_sync_response(
                     next_batch=_response.next_batch,
                     cache_result=cache_result,
                     first_sync=first_sync_response,
                 )
-                raise
-            decision = self._certify_sync_response(
-                next_batch=_response.next_batch,
-                cache_result=cache_result,
-                first_sync=first_sync_response,
-            )
-            room_member_join_hook_plan = self._room_member_join_sync_hook_plan(
-                first_sync_response=first_sync_response,
-                restored_token_first_sync_response=restored_token_first_sync_response,
-                hooks_were_armed=room_member_join_hooks_were_armed,
-                decision=decision,
-            )
+                room_member_join_hook_plan = self._room_member_join_sync_hook_plan(
+                    first_sync_response=first_sync_response,
+                    restored_token_first_sync_response=restored_token_first_sync_response,
+                    hooks_were_armed=room_member_join_hooks_were_armed,
+                    decision=decision,
+                )
+            self._mark_sync_progress()
         elif isinstance(_response, nio.SlidingSyncResponse):
             # Sliding sync never certifies the classic checkpoint, but the
             # account's own kicks and bans still must fence and purge rooms.
-            await self._apply_own_room_membership_from_sliding_sync(_response)
+            with track_matrix_sync_cache_write(self.agent_name):
+                await self._apply_own_room_membership_from_sliding_sync(_response)
+            self._mark_sync_progress()
         self._first_sync_done = True
         self._room_member_join_hooks_armed = room_member_join_hook_plan.arm_after_response
 

--- a/src/mindroom/matrix/health.py
+++ b/src/mindroom/matrix/health.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import time
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from threading import Lock
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     import httpx
 
 _MATRIX_VERSIONS_PATH = "/_matrix/client/versions"
@@ -15,6 +19,7 @@ MSC4186_UNSTABLE_FEATURE = "org.matrix.simplified_msc3575"
 _MATRIX_SYNC_HEALTH_STALE_SECONDS = 180.0
 MATRIX_SYNC_STARTUP_GRACE_SECONDS = 600.0
 MATRIX_SYNC_WATCHDOG_TIMEOUT_SECONDS = 120.0
+MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS = 600.0
 
 
 @dataclass(slots=True)
@@ -24,6 +29,18 @@ class _MatrixSyncState:
     running: bool = False
     loop_started_time: datetime | None = None
     last_sync_time: datetime | None = None
+    cache_write_started_monotonic: float | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class SyncCacheWriteProgress:
+    """Immutable view of one active durable sync-cache phase."""
+
+    started_monotonic: float
+
+    def seconds_in_flight(self, now_monotonic: float) -> float:
+        """Return elapsed phase time without allowing a negative clock delta."""
+        return max(0.0, now_monotonic - self.started_monotonic)
 
 
 @dataclass(frozen=True, slots=True)
@@ -96,6 +113,32 @@ def mark_matrix_sync_success(entity_name: str, sync_time: datetime | None = None
     return resolved_sync_time
 
 
+@contextmanager
+def track_matrix_sync_cache_write(entity_name: str) -> Iterator[None]:
+    """Publish one entity's complete sequential durable cache phase."""
+    started_monotonic = time.monotonic()
+    with _matrix_sync_lock:
+        state = _matrix_sync_state.setdefault(entity_name, _MatrixSyncState())
+        state.cache_write_started_monotonic = started_monotonic
+    try:
+        yield
+    finally:
+        with _matrix_sync_lock:
+            state = _matrix_sync_state.get(entity_name)
+            if state is not None and state.cache_write_started_monotonic == started_monotonic:
+                state.cache_write_started_monotonic = None
+
+
+def get_matrix_sync_cache_write_progress(entity_name: str) -> SyncCacheWriteProgress | None:
+    """Return the sole cache-write progress snapshot for one entity."""
+    with _matrix_sync_lock:
+        state = _matrix_sync_state.get(entity_name)
+        started_monotonic = state.cache_write_started_monotonic if state is not None else None
+    if started_monotonic is None:
+        return None
+    return SyncCacheWriteProgress(started_monotonic=started_monotonic)
+
+
 def clear_matrix_sync_state(entity_name: str) -> None:
     """Remove one entity from the shared Matrix sync-health registry."""
     with _matrix_sync_lock:
@@ -106,7 +149,9 @@ def get_matrix_sync_health_snapshot(
     *,
     stale_after_seconds: float = _MATRIX_SYNC_HEALTH_STALE_SECONDS,
     startup_grace_seconds: float = MATRIX_SYNC_STARTUP_GRACE_SECONDS,
+    cache_write_grace_seconds: float = MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS,
     now: datetime | None = None,
+    now_monotonic: float | None = None,
 ) -> _MatrixSyncHealthSnapshot:
     """Return the current Matrix sync-health snapshot.
 
@@ -114,11 +159,21 @@ def get_matrix_sync_health_snapshot(
     entities, because any stale entity should surface as unhealthy.
     """
     current_time = _normalize_sync_time(now or datetime.now(UTC))
+    current_monotonic = time.monotonic() if now_monotonic is None else now_monotonic
     with _matrix_sync_lock:
         active_states = tuple(
             sorted(
                 (
-                    (entity_name, state.last_sync_time, state.loop_started_time)
+                    (
+                        entity_name,
+                        state.last_sync_time,
+                        state.loop_started_time,
+                        (
+                            SyncCacheWriteProgress(state.cache_write_started_monotonic)
+                            if state.cache_write_started_monotonic is not None
+                            else None
+                        ),
+                    )
                     for entity_name, state in _matrix_sync_state.items()
                     if state.running
                 ),
@@ -133,24 +188,36 @@ def get_matrix_sync_health_snapshot(
             last_sync_time=None,
         )
 
-    active_entities = tuple(entity_name for entity_name, _, _ in active_states)
+    active_entities = tuple(entity_name for entity_name, _, _, _ in active_states)
     stale_entities = tuple(
         entity_name
-        for entity_name, last_sync_time, loop_started_time in active_states
+        for entity_name, last_sync_time, loop_started_time, cache_write_progress in active_states
         if (
-            (last_sync_time is not None and (current_time - last_sync_time).total_seconds() > stale_after_seconds)
+            (
+                cache_write_progress is not None
+                and cache_write_progress.seconds_in_flight(current_monotonic) > cache_write_grace_seconds
+            )
             or (
-                last_sync_time is None
-                and loop_started_time is not None
-                and (current_time - loop_started_time).total_seconds() > startup_grace_seconds
+                cache_write_progress is None
+                and (
+                    (
+                        last_sync_time is not None
+                        and (current_time - last_sync_time).total_seconds() > stale_after_seconds
+                    )
+                    or (
+                        last_sync_time is None
+                        and loop_started_time is not None
+                        and (current_time - loop_started_time).total_seconds() > startup_grace_seconds
+                    )
+                )
             )
         )
     )
-    if any(last_sync_time is None for _, last_sync_time, _ in active_states):
+    if any(last_sync_time is None for _, last_sync_time, _, _ in active_states):
         oldest_last_sync_time = None
     else:
         oldest_last_sync_time = min(
-            last_sync_time for _, last_sync_time, _ in active_states if last_sync_time is not None
+            last_sync_time for _, last_sync_time, _, _ in active_states if last_sync_time is not None
         )
     return _MatrixSyncHealthSnapshot(
         active_entities=active_entities,

--- a/src/mindroom/matrix/health.py
+++ b/src/mindroom/matrix/health.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import time
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -158,6 +159,9 @@ def get_matrix_sync_health_snapshot(
     The reported `last_sync_time` is the oldest successful sync among active
     entities, because any stale entity should surface as unhealthy.
     """
+    if not math.isfinite(cache_write_grace_seconds) or cache_write_grace_seconds <= 0:
+        msg = "cache_write_grace_seconds must be a finite positive number"
+        raise ValueError(msg)
     current_time = _normalize_sync_time(now or datetime.now(UTC))
     current_monotonic = time.monotonic() if now_monotonic is None else now_monotonic
     with _matrix_sync_lock:

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import random
 import time
 from contextlib import suppress
@@ -25,6 +26,7 @@ from mindroom.cancellation import (
 from mindroom.constants import RuntimePaths, runtime_matrix_ssl_verify
 from mindroom.logging_config import get_logger
 from mindroom.matrix.health import (
+    MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS,
     MATRIX_SYNC_STARTUP_GRACE_SECONDS,
     MATRIX_SYNC_WATCHDOG_TIMEOUT_SECONDS,
     matrix_versions_url,
@@ -59,6 +61,7 @@ STARTUP_RETRY_MAX_DELAY_SECONDS = 60.0
 _CANCELLING_LOGGED_TASKS: set[asyncio.Task[Any]] = set()
 _MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS = 5.0
 _MATRIX_SYNC_STARTUP_TIMEOUT_ENV = "MINDROOM_MATRIX_SYNC_STARTUP_TIMEOUT_SECONDS"
+_MATRIX_SYNC_CACHE_WRITE_GRACE_ENV = "MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS"
 _STALLED_RESTART_MAX_JITTER_SECONDS = 10.0
 
 
@@ -92,6 +95,7 @@ __all__ = [
     "log_cancelled_response_source",
     "log_startup_phase_finished",
     "log_startup_phase_started",
+    "matrix_sync_cache_write_grace_seconds",
     "matrix_sync_startup_timeout_seconds",
     "request_task_cancel",
     "retry_delay_seconds",
@@ -158,6 +162,18 @@ def matrix_sync_startup_timeout_seconds(runtime_paths: RuntimePaths) -> float:
     value = float(raw)
     if value <= 0:
         msg = f"{_MATRIX_SYNC_STARTUP_TIMEOUT_ENV} must be a positive number"
+        raise ValueError(msg)
+    return value
+
+
+def matrix_sync_cache_write_grace_seconds(runtime_paths: RuntimePaths) -> float:
+    """Return the finite grace for one active durable sync-cache phase."""
+    raw = (runtime_paths.env_value(_MATRIX_SYNC_CACHE_WRITE_GRACE_ENV) or "").strip()
+    if not raw:
+        return MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS
+    value = float(raw)
+    if not math.isfinite(value) or value <= 0:
+        msg = f"{_MATRIX_SYNC_CACHE_WRITE_GRACE_ENV} must be a finite positive number"
         raise ValueError(msg)
     return value
 
@@ -248,6 +264,7 @@ class _SyncIteration:
         against a first sync that never completes.
         """
         startup_timeout_seconds = matrix_sync_startup_timeout_seconds(bot.runtime_paths)
+        cache_write_grace_seconds = matrix_sync_cache_write_grace_seconds(bot.runtime_paths)
         startup_monotonic = time.monotonic()
         while bot.running and not sync_task.done():
             await asyncio.sleep(_MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS)
@@ -270,15 +287,44 @@ class _SyncIteration:
             elif sync_age_seconds <= MATRIX_SYNC_WATCHDOG_TIMEOUT_SECONDS:
                 continue
             else:
-                logger.error(
-                    "matrix_sync_watchdog_stalled",
-                    agent=bot.agent_name,
-                    active_response_count=bot.in_flight_response_count,
-                    last_sync_time=bot.last_sync_time.isoformat() if bot.last_sync_time is not None else None,
-                    restart_reason_category="sync_activity_timeout",
-                    resulting_action="cancel_receive_loop",
-                    stale_for_seconds=sync_age_seconds,
+                cache_write_progress = bot.sync_cache_write_progress()
+                now_monotonic = time.monotonic()
+                cache_write_seconds = (
+                    cache_write_progress.seconds_in_flight(now_monotonic) if cache_write_progress is not None else None
                 )
+                if cache_write_seconds is not None and cache_write_seconds <= cache_write_grace_seconds:
+                    logger.debug(
+                        "matrix_sync_watchdog_awaiting_cache_write",
+                        agent=bot.agent_name,
+                        active_response_count=bot.in_flight_response_count,
+                        cache_write_grace_seconds=cache_write_grace_seconds,
+                        cache_write_seconds_in_flight=cache_write_seconds,
+                        resulting_action="await_sync_cache_write",
+                        stale_for_seconds=sync_age_seconds,
+                    )
+                    continue
+                if cache_write_seconds is not None:
+                    logger.error(
+                        "matrix_sync_watchdog_stalled",
+                        agent=bot.agent_name,
+                        active_response_count=bot.in_flight_response_count,
+                        cache_write_grace_seconds=cache_write_grace_seconds,
+                        cache_write_seconds_in_flight=cache_write_seconds,
+                        last_sync_time=bot.last_sync_time.isoformat() if bot.last_sync_time is not None else None,
+                        restart_reason_category="cache_write_grace_exhausted",
+                        resulting_action="cancel_receive_loop",
+                        stale_for_seconds=sync_age_seconds,
+                    )
+                else:
+                    logger.error(
+                        "matrix_sync_watchdog_stalled",
+                        agent=bot.agent_name,
+                        active_response_count=bot.in_flight_response_count,
+                        last_sync_time=bot.last_sync_time.isoformat() if bot.last_sync_time is not None else None,
+                        restart_reason_category="sync_activity_timeout",
+                        resulting_action="cancel_receive_loop",
+                        stale_for_seconds=sync_age_seconds,
+                    )
 
             watchdog_cancelled_sync.set()
             request_task_cancel(sync_task, cancel_source="sync_restart")

--- a/src/mindroom/orchestration/runtime.py
+++ b/src/mindroom/orchestration/runtime.py
@@ -171,7 +171,11 @@ def matrix_sync_cache_write_grace_seconds(runtime_paths: RuntimePaths) -> float:
     raw = (runtime_paths.env_value(_MATRIX_SYNC_CACHE_WRITE_GRACE_ENV) or "").strip()
     if not raw:
         return MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS
-    value = float(raw)
+    try:
+        value = float(raw)
+    except ValueError:
+        msg = f"{_MATRIX_SYNC_CACHE_WRITE_GRACE_ENV} must be a finite positive number"
+        raise ValueError(msg) from None
     if not math.isfinite(value) or value <= 0:
         msg = f"{_MATRIX_SYNC_CACHE_WRITE_GRACE_ENV} must be a finite positive number"
         raise ValueError(msg)

--- a/src/mindroom/runtime_shutdown.py
+++ b/src/mindroom/runtime_shutdown.py
@@ -29,6 +29,7 @@ StopReason = Literal["restart", "entity_removed", "shutdown"]
 RestartReasonCategory = Literal[
     "first_sync_timeout",
     "sync_activity_timeout",
+    "cache_write_grace_exhausted",
     "watchdog_stall",
     "sync_failure",
     "unexpected_sync_return",

--- a/tests/test_bot_sync_event_cache.py
+++ b/tests/test_bot_sync_event_cache.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
@@ -19,6 +20,12 @@ from mindroom.matrix.cache.sqlite_event_cache import SqliteEventCache
 from mindroom.matrix.cache.thread_cache_state import ThreadAppendOutcome
 from mindroom.matrix.cache.write_coordinator import EventCacheWriteCoordinator
 from mindroom.matrix.client import PermanentMatrixStartupError
+from mindroom.matrix.health import (
+    get_matrix_sync_cache_write_progress,
+    get_matrix_sync_health_snapshot,
+    mark_matrix_sync_success,
+    reset_matrix_sync_health,
+)
 from mindroom.matrix.sync_certification import SyncCacheWriteResult, SyncCheckpoint, SyncTrustState
 from mindroom.matrix.sync_tokens import load_sync_checkpoint
 from mindroom.matrix.users import AgentMatrixUser
@@ -370,6 +377,96 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
                 await asyncio.gather(response_task, return_exceptions=True)
 
         assert _load_sync_token_value(bot.storage_path, bot.agent_name) == "s_after_delayed_cache"
+
+    @pytest.mark.asyncio
+    async def test_classic_membership_write_publishes_shared_cache_progress(self, bot: AgentBot) -> None:
+        """Classic purge and join writes must publish before timeline certification."""
+        purge_started = asyncio.Event()
+        allow_purge_finish = asyncio.Event()
+        departed_room_id = "!departed:localhost"
+        joined_room_id = "!joined:localhost"
+
+        async def delayed_purge(_room_ids: object) -> None:
+            purge_started.set()
+            await allow_purge_finish.wait()
+
+        response = self._sync_response(
+            {joined_room_id: MagicMock(timeline=MagicMock(events=[]))},
+        )
+        response.rooms.leave = {departed_room_id: MagicMock()}
+        bot._first_sync_done = True
+        reset_matrix_sync_health()
+        cache_timeline = AsyncMock(return_value=SyncCacheWriteResult(complete=True))
+
+        with (
+            patch.object(bot._conversation_cache, "purge_rooms", AsyncMock(side_effect=delayed_purge)),
+            patch.object(bot._conversation_cache, "mark_room_joined", AsyncMock()) as mark_room_joined,
+            patch.object(
+                bot._conversation_cache,
+                "cache_sync_timeline_for_certification",
+                cache_timeline,
+            ),
+        ):
+            response_task = asyncio.create_task(
+                self._run_sync_response_without_startup_side_effects(bot, response),
+            )
+            try:
+                await asyncio.wait_for(purge_started.wait(), timeout=1.0)
+                progress = bot.sync_cache_write_progress()
+                cache_timeline.assert_not_awaited()
+
+                health = get_matrix_sync_health_snapshot(
+                    stale_after_seconds=0.0,
+                    cache_write_grace_seconds=600.0,
+                )
+
+                assert progress is not None
+                assert progress == get_matrix_sync_cache_write_progress(bot.agent_name)
+                assert progress.seconds_in_flight(progress.started_monotonic + 1.0) <= 600.0
+                assert health.stale_entities == ()
+
+                allow_purge_finish.set()
+                await asyncio.wait_for(response_task, timeout=1.0)
+            finally:
+                allow_purge_finish.set()
+                await asyncio.gather(response_task, return_exceptions=True)
+                reset_matrix_sync_health()
+
+        assert bot.sync_cache_write_progress() is None
+        mark_room_joined.assert_awaited_once_with(joined_room_id)
+        cache_timeline.assert_awaited_once_with(response)
+
+    @pytest.mark.asyncio
+    async def test_long_successful_cache_write_refreshes_health_on_completion(self, bot: AgentBot) -> None:
+        """A completed durable phase must not expose its old arrival time as stale."""
+        arrival_time = datetime.now(UTC) - timedelta(seconds=400)
+        completion_time = datetime.now(UTC)
+        sync_times = iter([arrival_time, completion_time])
+
+        def record_sync_progress(entity_name: str) -> datetime:
+            return mark_matrix_sync_success(entity_name, next(sync_times))
+
+        response = self._sync_response({})
+        response.rooms.leave = {}
+        bot._first_sync_done = True
+        reset_matrix_sync_health()
+        try:
+            with (
+                patch("mindroom.bot.mark_matrix_sync_success", side_effect=record_sync_progress),
+                patch.object(
+                    bot._conversation_cache,
+                    "cache_sync_timeline_for_certification",
+                    AsyncMock(return_value=SyncCacheWriteResult(complete=True)),
+                ),
+            ):
+                await self._run_sync_response_without_startup_side_effects(bot, response)
+
+            health = get_matrix_sync_health_snapshot()
+
+            assert health.stale_entities == ()
+            assert health.last_sync_time == completion_time
+        finally:
+            reset_matrix_sync_health()
 
     @pytest.mark.asyncio
     async def test_restored_first_sync_success_updates_checkpoint(self, bot: AgentBot) -> None:

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import math
 import time
 from contextlib import suppress
 from datetime import UTC, datetime, timedelta
@@ -1009,13 +1010,20 @@ def test_sync_cache_write_progress_registry_clears_after_failure() -> None:
         reset_matrix_sync_health()
 
 
-@pytest.mark.parametrize("raw", ["nan", "inf", "-inf", "0", "-1"])
+@pytest.mark.parametrize("raw", ["not-a-number", "nan", "inf", "-inf", "0", "-1"])
 def test_sync_cache_write_grace_rejects_non_finite_or_non_positive(raw: str) -> None:
-    """A non-finite or non-positive grace must not disable the bounded backstop."""
+    """An invalid grace must not disable the bounded backstop."""
     with pytest.raises(ValueError, match="must be a finite positive number"):
         matrix_sync_cache_write_grace_seconds(
             _fake_runtime_paths(MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS=raw),
         )
+
+
+@pytest.mark.parametrize("grace_seconds", [math.nan, math.inf, -math.inf, 0.0, -1.0])
+def test_health_rejects_invalid_cache_write_grace(grace_seconds: float) -> None:
+    """Every health caller must preserve the finite cache-write backstop."""
+    with pytest.raises(ValueError, match="cache_write_grace_seconds must be a finite positive number"):
+        get_matrix_sync_health_snapshot(cache_write_grace_seconds=grace_seconds)
 
 
 def test_health_reports_shared_cache_write_progress_past_grace() -> None:

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from contextlib import suppress
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -23,6 +24,15 @@ from mindroom.cancellation import (
 from mindroom.config.main import Config
 from mindroom.config.matrix import MatrixSyncConfig
 from mindroom.constants import RuntimePaths
+from mindroom.matrix.health import (
+    SyncCacheWriteProgress,
+    get_matrix_sync_cache_write_progress,
+    get_matrix_sync_health_snapshot,
+    mark_matrix_sync_loop_started,
+    mark_matrix_sync_success,
+    reset_matrix_sync_health,
+    track_matrix_sync_cache_write,
+)
 from mindroom.matrix.sync_loop import _sliding_sync_lists, _sliding_sync_room_subscriptions, sliding_own_membership_sets
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestration import runtime as runtime_helpers
@@ -37,6 +47,7 @@ from mindroom.orchestration.runtime import (
     is_sync_restart_cancel,
     log_cancelled_response,
     log_cancelled_response_source,
+    matrix_sync_cache_write_grace_seconds,
     matrix_sync_startup_timeout_seconds,
     stop_entities,
     sync_forever_with_restart,
@@ -98,6 +109,9 @@ class _FakeBot:
         if self._last_sync_monotonic is None:
             return None
         return time.monotonic() - self._last_sync_monotonic
+
+    def sync_cache_write_progress(self) -> SyncCacheWriteProgress | None:
+        return get_matrix_sync_cache_write_progress(self.agent_name)
 
     @property
     def in_flight_response_count(self) -> int:
@@ -982,6 +996,115 @@ async def test_sync_error_updates_watchdog_clock(monkeypatch: pytest.MonkeyPatch
     assert bot.first_call_cancelled is False
 
 
+def test_sync_cache_write_progress_registry_clears_after_failure() -> None:
+    """A failed durable phase must not leave watchdog and health exempt forever."""
+    reset_matrix_sync_health()
+    try:
+        with suppress(RuntimeError), track_matrix_sync_cache_write("failed_agent"):
+            msg = "cache write failed"
+            raise RuntimeError(msg)
+
+        assert get_matrix_sync_cache_write_progress("failed_agent") is None
+    finally:
+        reset_matrix_sync_health()
+
+
+@pytest.mark.parametrize("raw", ["nan", "inf", "-inf", "0", "-1"])
+def test_sync_cache_write_grace_rejects_non_finite_or_non_positive(raw: str) -> None:
+    """A non-finite or non-positive grace must not disable the bounded backstop."""
+    with pytest.raises(ValueError, match="must be a finite positive number"):
+        matrix_sync_cache_write_grace_seconds(
+            _fake_runtime_paths(MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS=raw),
+        )
+
+
+def test_health_reports_shared_cache_write_progress_past_grace() -> None:
+    """Health must stop excusing a durable phase after the shared grace expires."""
+    recent_sync_time = datetime.now(UTC) - timedelta(seconds=10)
+    reset_matrix_sync_health()
+    try:
+        mark_matrix_sync_loop_started("wedged_agent")
+        mark_matrix_sync_success("wedged_agent", recent_sync_time)
+        with track_matrix_sync_cache_write("wedged_agent"):
+            progress = get_matrix_sync_cache_write_progress("wedged_agent")
+            assert progress is not None
+
+            snapshot = get_matrix_sync_health_snapshot(
+                cache_write_grace_seconds=5.0,
+                now_monotonic=progress.started_monotonic + 6.0,
+            )
+
+        assert snapshot.stale_entities == ("wedged_agent",)
+    finally:
+        reset_matrix_sync_health()
+
+
+@pytest.mark.asyncio
+async def test_watchdog_defers_to_shared_cache_write_progress(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A slow durable phase must outlive the ordinary transport timeout."""
+    bot = _FakeBot(MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS="1")
+    cache_write_finished = asyncio.Event()
+
+    async def sync_with_slow_cache_write() -> None:
+        bot.sync_calls += 1
+        bot._last_sync_monotonic = time.monotonic()
+        try:
+            with track_matrix_sync_cache_write(bot.agent_name):
+                await asyncio.sleep(0.1)
+        except asyncio.CancelledError:
+            bot.first_call_cancelled = True
+            raise
+        cache_write_finished.set()
+        bot.running = False
+
+    bot.sync_forever = sync_with_slow_cache_write
+    monkeypatch.setattr(runtime_helpers, "MATRIX_SYNC_WATCHDOG_TIMEOUT_SECONDS", 0.02)
+    monkeypatch.setattr(runtime_helpers, "_MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS", 0.005)
+
+    reset_matrix_sync_health()
+    try:
+        await sync_forever_with_restart(bot, max_retries=1)
+    finally:
+        reset_matrix_sync_health()
+
+    assert cache_write_finished.is_set()
+    assert bot.first_call_cancelled is False
+    assert bot.sync_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_watchdog_cancels_shared_cache_write_past_grace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A wedged durable phase must still be cancelled after its finite grace."""
+    bot = _FakeBot(MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS="0.04")
+
+    async def sync_with_wedged_cache_write() -> None:
+        bot.sync_calls += 1
+        bot._last_sync_monotonic = time.monotonic()
+        try:
+            with track_matrix_sync_cache_write(bot.agent_name):
+                await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            bot.first_call_cancelled = True
+            raise
+
+    bot.sync_forever = sync_with_wedged_cache_write
+    monkeypatch.setattr(runtime_helpers, "MATRIX_SYNC_WATCHDOG_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(runtime_helpers, "_MATRIX_SYNC_WATCHDOG_POLL_INTERVAL_SECONDS", 0.005)
+    monkeypatch.setattr(runtime_helpers, "retry_delay_seconds", lambda *_args, **_kwargs: 0.0)
+    monkeypatch.setattr(runtime_helpers, "_stalled_restart_jitter_seconds", lambda: 0.0)
+
+    reset_matrix_sync_health()
+    try:
+        with capture_logs() as logs:
+            await sync_forever_with_restart(bot, max_retries=1)
+    finally:
+        reset_matrix_sync_health()
+
+    assert bot.first_call_cancelled is True
+    stall_logs = [entry for entry in logs if entry["event"] == "matrix_sync_watchdog_stalled"]
+    assert [entry["restart_reason_category"] for entry in stall_logs] == ["cache_write_grace_exhausted"]
+
+
 @pytest.mark.asyncio
 async def test_sync_iteration_wait_prioritizes_sync_failure() -> None:
     """The sync task failure should win if both child tasks finish together."""
@@ -1263,6 +1386,7 @@ async def test_sliding_sync_response_marks_sync_success() -> None:
     bot._calls_reconcile_pending = False
     bot._room_member_join_hooks_armed = False
     bot.orchestrator = None
+    bot._mark_sync_progress = AgentBot._mark_sync_progress.__get__(bot)
 
     await AgentBot._on_sync_response(bot, nio.SlidingSyncResponse("pos"))
 
@@ -1321,9 +1445,12 @@ def test_sliding_own_membership_sets_split_joins_invites_and_departures() -> Non
     assert departed_room_ids == {"!kicked:localhost", "!banned:localhost"}
 
 
-@pytest.mark.asyncio
-async def test_sliding_sync_remote_departure_fences_and_purges() -> None:
-    """A sliding response reporting a kick must fence, purge, and notify the call manager."""
+def _sliding_membership_progress_bot(
+    *,
+    purge_rooms: AsyncMock,
+    mark_room_joined: AsyncMock,
+) -> MagicMock:
+    """Build the typed bot seam used to observe Sliding membership cache writes."""
     bot = MagicMock(spec=AgentBot)
     bot.agent_name = "test_agent"
     bot.last_sync_time = None
@@ -1334,13 +1461,40 @@ async def test_sliding_sync_remote_departure_fences_and_purges() -> None:
     bot.orchestrator = None
     bot._local_departures_awaiting_sync = set()
     bot._sync_cache_trust = MagicMock()
+    bot.sync_cache_write_progress = AgentBot.sync_cache_write_progress.__get__(bot)
     bot._room_lifecycle = MagicMock()
-    bot._conversation_cache = MagicMock(purge_rooms=AsyncMock(), mark_room_joined=AsyncMock())
+    bot._conversation_cache = MagicMock(
+        purge_rooms=purge_rooms,
+        mark_room_joined=mark_room_joined,
+    )
     bot._call_manager = MagicMock(on_sync_room_membership=AsyncMock())
     bot._apply_own_room_membership_from_sliding_sync = AgentBot._apply_own_room_membership_from_sliding_sync.__get__(
         bot,
     )
     bot._apply_own_room_membership = AgentBot._apply_own_room_membership.__get__(bot)
+    return bot
+
+
+@pytest.mark.asyncio
+async def test_sliding_sync_remote_departure_fences_and_purges() -> None:
+    """A sliding response reporting a kick must fence, purge, and notify the call manager."""
+    purge_started = asyncio.Event()
+    allow_purge_finish = asyncio.Event()
+    mark_joined_started = asyncio.Event()
+    allow_mark_joined_finish = asyncio.Event()
+
+    async def delayed_purge(_room_ids: object) -> None:
+        purge_started.set()
+        await allow_purge_finish.wait()
+
+    async def delayed_mark_joined(_room_id: str) -> None:
+        mark_joined_started.set()
+        await allow_mark_joined_finish.wait()
+
+    bot = _sliding_membership_progress_bot(
+        purge_rooms=AsyncMock(side_effect=delayed_purge),
+        mark_room_joined=AsyncMock(side_effect=delayed_mark_joined),
+    )
 
     response = nio.SlidingSyncResponse(
         "pos",
@@ -1350,7 +1504,39 @@ async def test_sliding_sync_remote_departure_fences_and_purges() -> None:
         },
     )
 
-    await AgentBot._on_sync_response(bot, response)
+    reset_matrix_sync_health()
+    mark_matrix_sync_loop_started(bot.agent_name)
+    mark_matrix_sync_success(
+        bot.agent_name,
+        datetime.now(UTC) - timedelta(seconds=400),
+    )
+    response_task = asyncio.create_task(AgentBot._on_sync_response(bot, response))
+    try:
+        await asyncio.wait_for(purge_started.wait(), timeout=1.0)
+        purge_progress = bot.sync_cache_write_progress()
+        purge_health = get_matrix_sync_health_snapshot(
+            cache_write_grace_seconds=600.0,
+        )
+        assert purge_progress is not None
+        assert purge_health.stale_entities == ()
+
+        allow_purge_finish.set()
+        await asyncio.wait_for(mark_joined_started.wait(), timeout=1.0)
+        joined_progress = bot.sync_cache_write_progress()
+        joined_health = get_matrix_sync_health_snapshot(
+            cache_write_grace_seconds=600.0,
+        )
+        assert joined_progress is not None
+        assert joined_progress.started_monotonic == purge_progress.started_monotonic
+        assert joined_health.stale_entities == ()
+
+        allow_mark_joined_finish.set()
+        await asyncio.wait_for(response_task, timeout=1.0)
+    finally:
+        allow_purge_finish.set()
+        allow_mark_joined_finish.set()
+        await asyncio.gather(response_task, return_exceptions=True)
+        reset_matrix_sync_health()
 
     bot._sync_cache_trust.invalidate_for_cache_scope_cleanup.assert_called_once_with()
     bot._room_lifecycle.forget_invited_room.assert_called_once_with("!kicked:localhost")
@@ -1360,6 +1546,7 @@ async def test_sliding_sync_remote_departure_fences_and_purges() -> None:
         joined_room_ids={"!joined:localhost"},
         left_room_ids={"!kicked:localhost"},
     )
+    assert bot.sync_cache_write_progress() is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- store one per-entity monotonic durable cache-write start in `src/mindroom/matrix/health.py`
- wrap the complete classic membership plus certification phase and Sliding membership phase
- make watchdog and `/api/health` consume that same snapshot, refresh both clocks on completion, and enforce a finite positive grace
- document operator tuning and regenerate the bundled documentation references

Closes #1747

## Verification

- focused RED/GREEN coverage for classic membership, Sliding membership, long successful completion, watchdog deferral/exhaustion, cleanup, and invalid grace values
- `uv run pytest tests/test_bot_sync_event_cache.py tests/test_sync_task_cancellation.py tests/api/test_api.py -x -n 0 --no-cov -q`
- `uv run pre-commit run --all-files`
- `uv run pytest` — 12,228 passed, 54 skipped

## Design boundary

No generic tracker or second registry was added. The existing per-entity health record owns the only cache-write clock, and `bot.py` contains only lifecycle wiring. Ordinary transport timeout behavior is unchanged when no cache write is active.

## Summary by Sourcery

Unify Matrix sync cache-write tracking so watchdog and /api/health share a single per-agent durable phase snapshot and apply a bounded grace before treating sync as stale or wedged.

New Features:
- Expose a per-entity sync cache-write progress snapshot via health state for use by both the watchdog and /api/health.
- Add configuration for MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS to control the grace period for active durable sync-cache phases.

Enhancements:
- Refresh Matrix sync liveness clocks on successful completion of classic and Sliding membership cache writes to avoid spurious health failures after long writes.
- Extend AgentBot sync handling to wrap membership and certification phases in cache-write tracking while centralizing sync progress marking.
- Update watchdog behavior to defer cancellation while cache writes are within grace and to log a distinct restart reason when cache-write grace is exhausted.

Documentation:
- Document sync cache-write grace semantics, configuration, and interaction with liveness probes in dashboard and configuration docs.

Tests:
- Add focused tests covering classic and Sliding sync cache-write progress tracking, watchdog deferral and cancellation around grace, health reporting during cache writes, and invalid cache-write grace configuration values.