### PR TITLE
Delimit replayed agent audio captions

### DIFF
--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -254,16 +254,21 @@ def _context_message_from_visible_message(
     # them to the model it can continue the pattern as plain text with no trace.
     body = _context_body_from_visible_message(message, response_sender_id=response_sender_id) if body is None else body
     annotation = format_attachment_annotation(list(attachment_records))
-    if annotation:
-        body = f"{body}\n{annotation}" if body else annotation
     if (
         response_sender_id is not None
         and message.sender == response_sender_id
         and not _is_relayed_user_message(message)
     ):
+        if message.content.get("msgtype") == "m.audio":
+            body = f"[audio message: {body}]"
+        if annotation:
+            body = f"{body}\n{annotation}" if body else annotation
         # Provider APIs reject media on assistant turns, so agent-sent
-        # attachments surface through the annotation text only.
-        return Message(role="assistant", content=body)
+        # attachments surface through text annotations only. The leading
+        # separator prevents same-role provider merges from gluing messages.
+        return Message(role="assistant", content=f"\n\n{body}")
+    if annotation:
+        body = f"{body}\n{annotation}" if body else annotation
     event_id = message.event_id or None
     speaker_label = _message_speaker_label(message)
     if not speaker_label:

--- a/tests/test_execution_preparation.py
+++ b/tests/test_execution_preparation.py
@@ -899,6 +899,34 @@ def test_fallback_thread_history_delimits_agent_audio_caption(tmp_path: Path) ->
     )
 
 
+def test_fallback_thread_history_delimits_agent_audio_caption_without_attachment() -> None:
+    """An agent audio caption remains labeled when no local attachment record exists."""
+    messages = _build_thread_history_messages(
+        "Current request",
+        [
+            make_visible_message(
+                sender="@mindroom_team:localhost",
+                body="The lab closes at 7:41 PM",
+                event_id="$reply",
+            ),
+            make_visible_message(
+                sender="@mindroom_team:localhost",
+                body="Lab turnaround",
+                event_id="$voice",
+                content={"msgtype": "m.audio", "body": "Lab turnaround"},
+            ),
+        ],
+        response_sender_id="@mindroom_team:localhost",
+        config=_config(),
+    )
+
+    assert [message.role for message in messages] == ["assistant", "assistant", "user"]
+    assert [message.content for message in messages[:2]] == [
+        "\n\nThe lab closes at 7:41 PM",
+        "\n\n[audio message: Lab turnaround]",
+    ]
+
+
 def test_fallback_thread_history_unmapped_agent_media_uses_bare_separator(tmp_path: Path) -> None:
     """Unmapped assistant media keeps its caption bare while remaining self-delimiting."""
     file_path = tmp_path / "report.pdf"

--- a/tests/test_execution_preparation.py
+++ b/tests/test_execution_preparation.py
@@ -853,8 +853,54 @@ def test_fallback_thread_history_maps_raw_media_events_to_attachments(tmp_path: 
     assert [image.id for image in (messages[0].images or [])] == [attachment_id]
 
 
-def test_fallback_thread_history_agent_attachments_annotate_without_media(tmp_path: Path) -> None:
-    """Assistant-authored attachments surface as text only; providers reject assistant media."""
+def test_fallback_thread_history_delimits_agent_audio_caption(tmp_path: Path) -> None:
+    """An agent audio caption must not merge into its preceding assistant reply."""
+    voice_path = tmp_path / "voice.ogg"
+    voice_path.write_bytes(b"OggS")
+    record = register_local_attachment(
+        tmp_path,
+        voice_path,
+        kind="audio",
+        attachment_id="att_voice",
+        filename="voice.ogg",
+        mime_type="audio/ogg",
+        room_id="!room:localhost",
+    )
+    assert record is not None
+
+    messages = _build_thread_history_messages(
+        "Current request",
+        [
+            make_visible_message(
+                sender="@mindroom_team:localhost",
+                body="The lab closes at 7:41 PM",
+                event_id="$reply",
+            ),
+            make_visible_message(
+                sender="@mindroom_team:localhost",
+                body='Lab results "timing"',
+                event_id="$voice",
+                content={
+                    "msgtype": "m.audio",
+                    "body": 'Lab results "timing"',
+                    ATTACHMENT_IDS_KEY: ["att_voice"],
+                },
+            ),
+        ],
+        response_sender_id="@mindroom_team:localhost",
+        config=_config(),
+        attachment_context=_ThreadAttachmentContext(storage_path=tmp_path, room_id="!room:localhost"),
+    )
+
+    assert [message.role for message in messages] == ["assistant", "assistant", "user"]
+    assert messages[0].content == "\n\nThe lab closes at 7:41 PM"
+    assert messages[1].content == (
+        '\n\n[audio message: Lab results "timing"]\n[attachments: att_voice (audio, "voice.ogg")]'
+    )
+
+
+def test_fallback_thread_history_unmapped_agent_media_uses_bare_separator(tmp_path: Path) -> None:
+    """Unmapped assistant media keeps its caption bare while remaining self-delimiting."""
     file_path = tmp_path / "report.pdf"
     file_path.write_bytes(b"%PDF-1.4")
     record = register_local_attachment(
@@ -874,7 +920,7 @@ def test_fallback_thread_history_agent_attachments_annotate_without_media(tmp_pa
                 sender="@mindroom_team:localhost",
                 body="here is the report",
                 event_id="$agent-file",
-                content={ATTACHMENT_IDS_KEY: ["att_report"]},
+                content={"msgtype": "m.file", ATTACHMENT_IDS_KEY: ["att_report"]},
             ),
         ],
         response_sender_id="@mindroom_team:localhost",
@@ -883,7 +929,7 @@ def test_fallback_thread_history_agent_attachments_annotate_without_media(tmp_pa
     )
 
     assert messages[0].role == "assistant"
-    assert messages[0].content == 'here is the report\n[attachments: att_report (file, "report.pdf")]'
+    assert messages[0].content == '\n\nhere is the report\n[attachments: att_report (file, "report.pdf")]'
     assert not messages[0].files
 
 
@@ -1034,7 +1080,7 @@ def test_fallback_thread_history_strips_visible_tool_markers_from_assistant_cont
     )
 
     assert messages[0].role == "assistant"
-    assert messages[0].content == "Checking status.\n\n\nStill checking.\n\n\nDone."
+    assert messages[0].content == "\n\nChecking status.\n\n\nStill checking.\n\n\nDone."
     assert "🔧" not in str(messages[0].content)
 
 
@@ -1174,7 +1220,7 @@ def test_unseen_context_keeps_unpersisted_self_sent_message() -> None:
 
     assert unseen_event_ids == ["$spawn-root"]
     assert messages[0].role == "assistant"
-    assert messages[0].content == "@mindroom_missing_agent Please investigate this"
+    assert messages[0].content == "\n\n@mindroom_missing_agent Please investigate this"
 
 
 def test_unseen_context_keeps_other_agent_message_tagged() -> None:

--- a/tests/test_history_prepare_integration.py
+++ b/tests/test_history_prepare_integration.py
@@ -532,7 +532,7 @@ async def test_prepare_agent_and_prompt_uses_full_thread_fallback_for_threaded_m
     assert prepared_run.prompt_text == "\n\n".join(
         (
             render_msg_tag(sender="@alice:localhost", body="Original question", event_id="$root"),
-            "Prior diagnosis",
+            "\n\nPrior diagnosis",
             "Current message:\n"
             + render_msg_tag(sender="@alice:localhost", body="What was that?", event_id="$current"),
         ),

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -1256,14 +1256,14 @@ async def test_prepare_bound_team_execution_context_uses_team_renderer_for_trimm
     assert tuple((message.role, message.content) for message in prepared.messages) == (
         (
             "assistant",
-            "Previous team reply",
+            "\n\nPrevious team reply",
         ),
         ("user", "Analyze this."),
     )
     assert captured_prompts == [
         ("Analyze this.", None),
         ("Analyze this.", None),
-        ("assistant: Previous team reply\n\nAnalyze this.", None),
+        ("assistant: \n\nPrevious team reply\n\nAnalyze this.", None),
     ]
 
 


### PR DESCRIPTION
## The bug

When an agent sent a captioned voice message, its later replies started arriving with the caption text glued onto the end of the prose, e.g. a reply ending `... 7:41 PMLab turnaround`.

MindRoom was not appending anything at delivery time. **The model wrote it**, because MindRoom had replayed exactly that glued string into the model's own context as a few-shot example.

## Mechanism

1. `matrix_voice_message` puts the caption in the `m.audio` event `body`. This is correct per MSC2530 and is unchanged here.
2. On the next turn that audio event is not in the agent's Agno session, so it is selected as unseen thread history.
3. `_context_message_from_visible_message` rendered agent-authored events as a **bare, unlabeled assistant message** with no framing, so the injected content was literally `Lab turnaround`.
4. Agno's Claude adapter merges consecutive same-role messages by extending the content list, producing two adjacent `TextBlock`s with no separator. The model therefore read its own previous reply as `...7:41 PMLab turnaround`.
5. On a later turn the model reproduced the pattern it had been shown.

## Why the fix lives at this seam

Post-hoc coalescing is impossible anywhere in MindRoom: the left half of the glued pair comes from Agno session storage and is prepended by Agno itself, so no MindRoom stage ever sees the two messages together. The injected message must be **self-delimiting**.

## The change

9 added / 4 removed lines in one function:

```python
if message.content.get("msgtype") == "m.audio":
    body = f"[audio message: {body}]"
if annotation:
    body = f"{body}\n{annotation}" if body else annotation
return Message(role="assistant", content=f"\n\n{body}")
```

- `m.audio` bodies are annotated so a replayed caption reads as a media event rather than as prose.
- Every agent-authored replay gets a guaranteed leading separator, so a same-role merge cannot concatenate mid-sentence. This also covers the non-media cases already visible in the logs, such as a short interactive prompt following a timestamped reply.

The label is `audio message` rather than `voice message` deliberately: `m.audio` is not voice-only, since any `audio/*` mimetype maps to it, so `podcast.mp3` sent as a plain attachment would otherwise replay as `[voice message: podcast.mp3]`.

## Verification

Rendering the production scenario through the real code path and the installed Agno Claude adapter:

```
BEFORE: 'The lab closes at 7:41 PMLab turnaround'
AFTER:  '\n\nThe lab closes at 7:41 PM\n\n[audio message: Lab turnaround]'
```

The BEFORE line reproduces the exact glued string observed in production request logs.

A regression test in `tests/test_execution_preparation.py` builds a thread where the agent's text reply is immediately followed by its own captioned `m.audio`, and asserts the two assistant-role messages cannot concatenate into an unlabeled run-on. Assertions in three existing tests are updated for the new format; no assertion was loosened or dropped.

## Scope

Deliberately confined to `execution_preparation.py`. No changes to the voice tool, `client_delivery.py` (MSC2530 behavior is correct), `streaming.py`, `delivery_gateway.py`, `coalescing.py`, or `turn_controller.py`. The echo-versus-placeholder timing race that determines whether the pair ends up adjacent is a coin flip, not a bug, and is not serialized here.

## Summary by Sourcery

Ensure agent-authored messages in fallback thread history are self-delimiting so replayed audio captions cannot be merged into preceding assistant replies.

Bug Fixes:
- Prevent caption text from agent audio messages being concatenated onto prior assistant prose when history is replayed into the model context.

Enhancements:
- Prefix agent-authored context messages with a separator and annotate audio captions as explicit media events, keeping unmapped media captions bare but still separated.

Tests:
- Add regression coverage for agent audio captions in fallback thread history and update existing tests to assert the new separated assistant message format.