### PR TITLE
fix: pause and persist the mid-turn queued-message notice

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -352,6 +352,7 @@ class _AgentTurnHolder:
     attempt: _MediaAttempt | None = None
     state: _StreamingAttemptState | None = None  # streaming turns only
     attempt_started: bool = False  # streaming turns only
+    queued_notice_run_id: str | None = None  # streaming turns register durable ownership by ID
 
 
 @dataclass(frozen=True)
@@ -1049,7 +1050,7 @@ async def _run_non_streaming_agent_attempts(
             pending_retry_decision.record_retry_success()
         return _NonStreamingAttemptResult(response=response, attempt=attempt)
     finally:
-        await ai_runtime.cleanup_queued_notice_state_async(
+        ai_runtime.register_queued_notice_attempt(
             run_output=response,
             storage_factory=scope_context.storage_factory if scope_context is not None else None,
             session_id=run_context.session_id,
@@ -1965,15 +1966,19 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         if not holder.attempt_started:
             return
         holder.attempt_started = False
-        await ai_runtime.cleanup_queued_notice_state_async(
+        # Agno's agent stream yields terminal events rather than an in-memory
+        # RunOutput, so bind durable finalization to the terminal run ID.
+        ai_runtime.register_queued_notice_attempt(
             run_output=None,
             storage_factory=scope_context.storage_factory if scope_context is not None else None,
             session_id=session_id,
             session_type=SessionType.AGENT,
             entity_name=agent_name,
+            run_id=holder.queued_notice_run_id,
         )
+        holder.queued_notice_run_id = None
 
-    async def _run_streaming_attempt(  # noqa: C901
+    async def _run_streaming_attempt(  # noqa: C901, PLR0915
         run: TurnRunState,
         continuation_state: DynamicContinuationRunState,
     ) -> AsyncGenerator[AIStreamChunk | AttemptResolved, None]:
@@ -2024,6 +2029,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         )
         holder.attempt = attempt
         holder.attempt_started = True
+        holder.queued_notice_run_id = attempt.attempt_run_id
         turn_state = run.turn_state
         state = _StreamingAttemptState()
         pending_retry_decision: MediaRetryDecision | None = None
@@ -2088,6 +2094,9 @@ async def stream_agent_response(  # noqa: C901, PLR0915
             ):
                 yield stream_chunk
 
+            holder.queued_notice_run_id = (
+                state.completed_run_event.run_id if state.completed_run_event is not None else None
+            ) or attempt.attempt_run_id
             if state.media_fallback_retry is not None:
                 pending_retry_decision = state.media_fallback_retry
                 attempt.retry(
@@ -2097,6 +2106,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                     retry_media_inputs=pending_retry_decision.media_inputs,
                     run_id=continuation_state.active_run_id,
                 )
+                holder.queued_notice_run_id = attempt.attempt_run_id
                 continue
 
             run_error = state.user_error or state.stream_exception

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -352,7 +352,6 @@ class _AgentTurnHolder:
     attempt: _MediaAttempt | None = None
     state: _StreamingAttemptState | None = None  # streaming turns only
     attempt_started: bool = False  # streaming turns only
-    queued_notice_run_id: str | None = None  # streaming turns register durable ownership by ID
 
 
 @dataclass(frozen=True)
@@ -1050,8 +1049,7 @@ async def _run_non_streaming_agent_attempts(
             pending_retry_decision.record_retry_success()
         return _NonStreamingAttemptResult(response=response, attempt=attempt)
     finally:
-        ai_runtime.register_queued_notice_attempt(
-            run_output=response,
+        ai_runtime.register_queued_notice_storage(
             storage_factory=scope_context.storage_factory if scope_context is not None else None,
             session_id=run_context.session_id,
             session_type=SessionType.AGENT,
@@ -1966,19 +1964,14 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         if not holder.attempt_started:
             return
         holder.attempt_started = False
-        # Agno's agent stream yields terminal events rather than an in-memory
-        # RunOutput, so bind durable finalization to the terminal run ID.
-        ai_runtime.register_queued_notice_attempt(
-            run_output=None,
+        ai_runtime.register_queued_notice_storage(
             storage_factory=scope_context.storage_factory if scope_context is not None else None,
             session_id=session_id,
             session_type=SessionType.AGENT,
             entity_name=agent_name,
-            run_id=holder.queued_notice_run_id,
         )
-        holder.queued_notice_run_id = None
 
-    async def _run_streaming_attempt(  # noqa: C901, PLR0915
+    async def _run_streaming_attempt(  # noqa: C901
         run: TurnRunState,
         continuation_state: DynamicContinuationRunState,
     ) -> AsyncGenerator[AIStreamChunk | AttemptResolved, None]:
@@ -2029,7 +2022,6 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         )
         holder.attempt = attempt
         holder.attempt_started = True
-        holder.queued_notice_run_id = attempt.attempt_run_id
         turn_state = run.turn_state
         state = _StreamingAttemptState()
         pending_retry_decision: MediaRetryDecision | None = None
@@ -2094,9 +2086,6 @@ async def stream_agent_response(  # noqa: C901, PLR0915
             ):
                 yield stream_chunk
 
-            holder.queued_notice_run_id = (
-                state.completed_run_event.run_id if state.completed_run_event is not None else None
-            ) or attempt.attempt_run_id
             if state.media_fallback_retry is not None:
                 pending_retry_decision = state.media_fallback_retry
                 attempt.retry(
@@ -2106,7 +2095,6 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                     retry_media_inputs=pending_retry_decision.media_inputs,
                     run_id=continuation_state.active_run_id,
                 )
-                holder.queued_notice_run_id = attempt.attempt_run_id
                 continue
 
             run_error = state.user_error or state.stream_exception

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -239,13 +239,13 @@ def _append_queued_notice_if_needed(
     notice_text: str,
 ) -> None:
     notice_context = _queued_message_notice_context.get()
+    if any(message.stop_after_tool_call for message in function_call_results):
+        return
     if notice_context is not None:
         _strip_queued_notice_messages(
             messages,
             response_turn_id=notice_context.response_turn_id,
         )
-    if any(message.stop_after_tool_call for message in function_call_results):
-        return
     if notice_context is None or notice_context.state is None or not notice_context.state.has_pending_human_messages():
         return
     messages.append(

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Generator, Sequence
+from collections.abc import Set as AbstractSet
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Protocol, cast
 from uuid import uuid4
 
@@ -18,6 +19,7 @@ from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
 
+from mindroom.history_run_visibility import is_model_history_visible_run
 from mindroom.logging_config import get_logger
 from mindroom.media_fallback import append_inline_media_fallback_prompt
 from mindroom.media_inputs import MediaInputs, MediaKind
@@ -36,15 +38,16 @@ __all__ = [
     "append_inline_media_fallback_to_run_input",
     "attach_media_to_run_input",
     "cached_agent_run",
-    "cleanup_queued_notice_state_async",
     "copy_run_input",
     "discard_empty_completed_run",
+    "finalize_queued_notice_response_turn_async",
     "install_queued_message_notice_hook",
     "is_empty_completed_run",
     "media_inputs_from_run_input",
     "next_retry_run_id",
     "note_attempt_run_id",
     "queued_message_signal_context",
+    "register_queued_notice_attempt",
     "scrub_queued_notice_session_context",
 ]
 
@@ -53,7 +56,16 @@ logger = get_logger(__name__)
 type ModelRunInput = str | Sequence[Message]
 
 _QUEUED_MESSAGE_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
+_QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER = "persisted"
+_QUEUED_MESSAGE_NOTICE_RESPONSE_TURN_ID_KEY = "mindroom_queued_message_notice_response_turn_id"
 _QUEUED_MESSAGE_NOTICE_HOOK_ATTR = "_mindroom_queued_message_notice_hook_installed"
+# Keep blank lines on both sides because Agno can coalesce consecutive
+# same-role messages without inserting a separator.
+_QUEUED_MESSAGE_NOTICE_HISTORY_TEXT = (
+    '\n\n<mindroom-history-note kind="queued-message-notice">\n'
+    "A queued-message notice was delivered.\n"
+    "</mindroom-history-note>\n\n"
+)
 
 EMPTY_RESPONSE_NOTICE = "The model returned an empty response — please try again."
 
@@ -134,6 +146,18 @@ class _SupportsQueuedMessageState(Protocol):
 @dataclass
 class _QueuedMessageNoticeContext:
     state: _SupportsQueuedMessageState | None
+    response_turn_id: str = field(default_factory=lambda: str(uuid4()))
+    notice_fired: bool = False
+    storage_targets: dict[tuple[str, SessionType], _QueuedNoticeStorageTarget] = field(default_factory=dict)
+
+
+@dataclass
+class _QueuedNoticeStorageTarget:
+    storage_factory: Callable[[], BaseDb]
+    session_id: str
+    session_type: SessionType
+    entity_name: str
+    run_ids: set[str] = field(default_factory=set)
 
 
 _queued_message_notice_context: ContextVar[_QueuedMessageNoticeContext | None] = ContextVar(
@@ -145,30 +169,69 @@ _queued_message_notice_context: ContextVar[_QueuedMessageNoticeContext | None] =
 @contextmanager
 def queued_message_signal_context(
     signal: _SupportsQueuedMessageState | None,
-) -> Generator[None, None, None]:
+) -> Generator[_QueuedMessageNoticeContext, None, None]:
     """Bind one queued-message signal to the current async task."""
-    token = _queued_message_notice_context.set(_QueuedMessageNoticeContext(state=signal))
+    notice_context = _QueuedMessageNoticeContext(state=signal)
+    token = _queued_message_notice_context.set(notice_context)
     try:
-        yield
+        yield notice_context
     finally:
         _queued_message_notice_context.reset(token)
 
 
 def _has_queued_notice_marker(message: Message) -> bool:
     provider_data = message.provider_data
-    return isinstance(provider_data, dict) and provider_data.get(_QUEUED_MESSAGE_NOTICE_MARKER_KEY) is True
+    return isinstance(provider_data, dict) and provider_data.get(_QUEUED_MESSAGE_NOTICE_MARKER_KEY) in (
+        True,
+        _QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER,
+    )
 
 
-def _is_queued_notice_message(message: Message) -> bool:
+def _queued_notice_marker(message: Message) -> bool | str | None:
+    provider_data = message.provider_data
+    if not isinstance(provider_data, dict):
+        return None
+    marker = provider_data.get(_QUEUED_MESSAGE_NOTICE_MARKER_KEY)
+    return marker if marker in (True, _QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER) else None
+
+
+def _queued_notice_response_turn_id(message: Message) -> str | None:
+    provider_data = message.provider_data
+    if not isinstance(provider_data, dict):
+        return None
+    response_turn_id = provider_data.get(_QUEUED_MESSAGE_NOTICE_RESPONSE_TURN_ID_KEY)
+    return response_turn_id if isinstance(response_turn_id, str) and response_turn_id else None
+
+
+def _is_queued_notice_message(
+    message: Message,
+    *,
+    response_turn_id: str | None = None,
+) -> bool:
     """Return whether one Agno message is the hidden queued-message notice."""
-    return _has_queued_notice_marker(message)
+    if not _has_queued_notice_marker(message):
+        return False
+    if response_turn_id is None:
+        return True
+    return _queued_notice_response_turn_id(message) == response_turn_id
 
 
-def _strip_queued_notice_messages(messages: list[Message] | None) -> bool:
+def _strip_queued_notice_messages(
+    messages: list[Message] | None,
+    *,
+    response_turn_id: str | None = None,
+) -> bool:
     """Remove queued-message notices from one mutable message list."""
     if not messages:
         return False
-    filtered_messages = [message for message in messages if not _is_queued_notice_message(message)]
+    filtered_messages = [
+        message
+        for message in messages
+        if not _is_queued_notice_message(
+            message,
+            response_turn_id=response_turn_id,
+        )
+    ]
     if len(filtered_messages) == len(messages):
         return False
     messages[:] = filtered_messages
@@ -181,39 +244,63 @@ def _append_queued_notice_if_needed(
     function_call_results: Sequence[Message],
     notice_text: str,
 ) -> None:
-    _strip_queued_notice_messages(messages)
+    notice_context = _queued_message_notice_context.get()
+    if notice_context is not None:
+        _strip_queued_notice_messages(
+            messages,
+            response_turn_id=notice_context.response_turn_id,
+        )
     if any(message.stop_after_tool_call for message in function_call_results):
         return
-    notice_context = _queued_message_notice_context.get()
     if notice_context is None or notice_context.state is None or not notice_context.state.has_pending_human_messages():
         return
     messages.append(
         Message(
             role="user",
             content=notice_text,
-            provider_data={_QUEUED_MESSAGE_NOTICE_MARKER_KEY: True},
+            provider_data={
+                _QUEUED_MESSAGE_NOTICE_MARKER_KEY: True,
+                _QUEUED_MESSAGE_NOTICE_RESPONSE_TURN_ID_KEY: notice_context.response_turn_id,
+            },
         ),
     )
+    if not notice_context.notice_fired:
+        notice_context.notice_fired = True
+        logger.info(
+            "queued_message_notice_injected",
+            response_turn_id=notice_context.response_turn_id,
+        )
 
 
-def _cleanup_queued_notice_from_run_output(run_output: RunOutput | TeamRunOutput | None) -> bool:
-    """Remove queued-message notices from one returned run output."""
-    if run_output is None:
-        return False
-    changed = _strip_queued_notice_messages(run_output.messages)
+def _strip_response_turn_notice_from_run_output(
+    run_output: RunOutput | TeamRunOutput,
+    *,
+    response_turn_id: str,
+) -> bool:
+    """Remove one response's notice from a top-level or nested run output."""
+    changed = _strip_queued_notice_messages(
+        run_output.messages,
+        response_turn_id=response_turn_id,
+    )
     if isinstance(run_output, TeamRunOutput) and run_output.member_responses:
         for member_response in run_output.member_responses:
             if isinstance(member_response, RunOutput | TeamRunOutput):
-                changed = _cleanup_queued_notice_from_run_output(member_response) or changed
+                changed = (
+                    _strip_response_turn_notice_from_run_output(
+                        member_response,
+                        response_turn_id=response_turn_id,
+                    )
+                    or changed
+                )
     return changed
 
 
-def _load_session_for_cleanup(
+def _load_queued_notice_session(
     raw_session: AgentSession | TeamSession | dict[str, object],
     *,
     session_type: SessionType,
 ) -> AgentSession | TeamSession | None:
-    """Deserialize one stored Agno session for queued-notice cleanup."""
+    """Deserialize one stored Agno session for queued-notice finalization."""
     if isinstance(raw_session, dict):
         session_mapping = cast("dict[str, Any]", raw_session)
         return (
@@ -224,80 +311,297 @@ def _load_session_for_cleanup(
     return raw_session
 
 
-def _strip_queued_notice_from_session(session: AgentSession | TeamSession) -> bool:
-    changed = False
-    for run in session.runs or []:
-        if isinstance(run, (RunOutput, TeamRunOutput)):
-            changed = _cleanup_queued_notice_from_run_output(run) or changed
-    return changed
+def _session_run_outputs(session: AgentSession | TeamSession) -> list[RunOutput | TeamRunOutput]:
+    return [run for run in session.runs or [] if isinstance(run, RunOutput | TeamRunOutput)]
 
 
-def _strip_queued_notice_from_session_storage(
-    storage: BaseDb,
-    session_id: str,
+def _run_output_notice_messages(
+    run_output: RunOutput | TeamRunOutput,
     *,
-    session_type: SessionType = SessionType.AGENT,
-) -> bool:
-    """Remove queued-message notices from one persisted Agno session."""
-    raw_session = storage.get_session(session_id, session_type)
-    if raw_session is None:
-        return False
-    session = _load_session_for_cleanup(
-        cast("AgentSession | TeamSession | dict[str, object]", raw_session),
-        session_type=session_type,
+    response_turn_id: str,
+) -> list[Message]:
+    matches = [
+        message
+        for message in run_output.messages or []
+        if _is_queued_notice_message(
+            message,
+            response_turn_id=response_turn_id,
+        )
+    ]
+    if isinstance(run_output, TeamRunOutput) and run_output.member_responses:
+        for member_response in run_output.member_responses:
+            if isinstance(member_response, RunOutput | TeamRunOutput):
+                matches.extend(
+                    _run_output_notice_messages(
+                        member_response,
+                        response_turn_id=response_turn_id,
+                    ),
+                )
+    return matches
+
+
+def _new_factual_queued_notice(response_turn_id: str) -> Message:
+    return Message(
+        role="user",
+        content=_QUEUED_MESSAGE_NOTICE_HISTORY_TEXT,
+        provider_data={
+            _QUEUED_MESSAGE_NOTICE_MARKER_KEY: _QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER,
+            _QUEUED_MESSAGE_NOTICE_RESPONSE_TURN_ID_KEY: response_turn_id,
+        },
     )
-    if session is None:
+
+
+def _finalize_queued_notice_in_runs(
+    runs: Sequence[RunOutput | TeamRunOutput],
+    *,
+    response_turn_id: str,
+    destination_run_ids: AbstractSet[str] = frozenset(),
+) -> bool:
+    """Leave one factual note in the newest replayable run owned by this response."""
+    owned_run_ids = set(destination_run_ids)
+    owned_run_ids.update(
+        run.run_id
+        for run in runs
+        if run.run_id is not None
+        and _run_output_notice_messages(
+            run,
+            response_turn_id=response_turn_id,
+        )
+    )
+    destination = next(
+        (run for run in reversed(runs) if run.run_id in owned_run_ids and is_model_history_visible_run(run)),
+        None,
+    )
+    all_matches = [
+        message
+        for run in runs
+        for message in _run_output_notice_messages(
+            run,
+            response_turn_id=response_turn_id,
+        )
+    ]
+    if not all_matches and destination is None:
         return False
-    changed = _strip_queued_notice_from_session(session)
-    if changed:
-        storage.upsert_session(session)
-    return changed
+
+    destination_matches = (
+        [
+            message
+            for message in destination.messages or []
+            if _is_queued_notice_message(
+                message,
+                response_turn_id=response_turn_id,
+            )
+        ]
+        if destination is not None
+        else []
+    )
+    if (
+        len(all_matches) == 1
+        and len(destination_matches) == 1
+        and _queued_notice_marker(destination_matches[0]) == _QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER
+        and destination_matches[0].content == _QUEUED_MESSAGE_NOTICE_HISTORY_TEXT
+    ):
+        return False
+
+    insertion_index: int | None = None
+    if destination is not None and destination.messages:
+        insertion_index = next(
+            (
+                index
+                for index, message in enumerate(destination.messages)
+                if _is_queued_notice_message(
+                    message,
+                    response_turn_id=response_turn_id,
+                )
+            ),
+            None,
+        )
+
+    for run in runs:
+        _strip_response_turn_notice_from_run_output(
+            run,
+            response_turn_id=response_turn_id,
+        )
+
+    if destination is None:
+        return True
+    if destination.messages is None:
+        destination.messages = []
+    factual_notice = _new_factual_queued_notice(response_turn_id)
+    if insertion_index is None:
+        destination.messages.append(factual_notice)
+    else:
+        destination.messages.insert(min(insertion_index, len(destination.messages)), factual_notice)
+    return True
 
 
-async def cleanup_queued_notice_state_async(
+def _finalize_queued_notice_in_new_session_storage(
+    target: _QueuedNoticeStorageTarget,
+    response_turn_id: str,
+) -> None:
+    """Finalize one response in a worker-owned session storage handle."""
+    storage = target.storage_factory()
+    try:
+        raw_session = storage.get_session(target.session_id, target.session_type)
+        if raw_session is None:
+            return
+        session = _load_queued_notice_session(
+            cast("AgentSession | TeamSession | dict[str, object]", raw_session),
+            session_type=target.session_type,
+        )
+        if session is None:
+            return
+        if _finalize_queued_notice_in_runs(
+            _session_run_outputs(session),
+            response_turn_id=response_turn_id,
+            destination_run_ids=target.run_ids,
+        ):
+            storage.upsert_session(session)
+    finally:
+        storage.close()
+
+
+def register_queued_notice_attempt(
     *,
     run_output: RunOutput | TeamRunOutput | None,
     storage_factory: Callable[[], BaseDb] | None,
     session_id: str | None,
     session_type: SessionType,
     entity_name: str,
+    run_id: str | None = None,
 ) -> None:
-    """Strip queued notices using worker-owned storage off the event loop."""
-    _cleanup_queued_notice_from_run_output(run_output)
+    """Register attempt state for response-boundary queued-notice finalization."""
+    notice_context = _queued_message_notice_context.get()
+    if notice_context is None:
+        return
     if storage_factory is None or not session_id:
         return
-    try:
-        await asyncio.to_thread(
-            _strip_queued_notice_from_new_session_storage,
-            storage_factory,
-            session_id,
-            session_type=session_type,
-        )
-    except Exception:
-        logger.exception(
-            "Failed to strip queued-message notice from session history",
-            entity=entity_name,
+    target_key = (session_id, session_type)
+    target = notice_context.storage_targets.get(target_key)
+    if target is None:
+        target = _QueuedNoticeStorageTarget(
+            storage_factory=storage_factory,
             session_id=session_id,
-            session_type=session_type.value,
-        )
-
-
-def _strip_queued_notice_from_new_session_storage(
-    storage_factory: Callable[[], BaseDb],
-    session_id: str,
-    *,
-    session_type: SessionType,
-) -> None:
-    """Create, use, and close one session storage handle in its worker thread."""
-    storage = storage_factory()
-    try:
-        _strip_queued_notice_from_session_storage(
-            storage,
-            session_id,
             session_type=session_type,
+            entity_name=entity_name,
         )
-    finally:
-        storage.close()
+        notice_context.storage_targets[target_key] = target
+    registered_run_id = run_id or (run_output.run_id if run_output is not None else None)
+    if registered_run_id:
+        target.run_ids.add(registered_run_id)
+
+
+def _finalize_queued_notice_storage_targets(
+    targets: Sequence[_QueuedNoticeStorageTarget],
+    response_turn_id: str,
+) -> None:
+    """Finalize all durable targets for one response from a worker thread."""
+    for target in targets:
+        try:
+            _finalize_queued_notice_in_new_session_storage(
+                target,
+                response_turn_id,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to finalize queued-message notice in session history",
+                entity=target.entity_name,
+                session_id=target.session_id,
+                session_type=target.session_type.value,
+                response_turn_id=response_turn_id,
+            )
+
+
+async def finalize_queued_notice_response_turn_async(
+    notice_context: _QueuedMessageNoticeContext,
+) -> None:
+    """Finalize one delivered notice at the user-visible response boundary."""
+    if not notice_context.notice_fired:
+        return
+    if not notice_context.storage_targets:
+        return
+    storage_task = asyncio.create_task(
+        asyncio.to_thread(
+            _finalize_queued_notice_storage_targets,
+            tuple(notice_context.storage_targets.values()),
+            notice_context.response_turn_id,
+        ),
+    )
+    try:
+        await asyncio.shield(storage_task)
+    except asyncio.CancelledError:
+        await storage_task
+        raise
+
+
+def _queued_notice_response_turn_ids(
+    runs: Sequence[RunOutput | TeamRunOutput],
+) -> set[str]:
+    return {
+        response_turn_id
+        for run in runs
+        for message in _run_output_notice_messages_for_any_response(run)
+        if (response_turn_id := _queued_notice_response_turn_id(message)) is not None
+    }
+
+
+def _run_output_notice_messages_for_any_response(
+    run_output: RunOutput | TeamRunOutput,
+) -> list[Message]:
+    matches = [message for message in run_output.messages or [] if _has_queued_notice_marker(message)]
+    if isinstance(run_output, TeamRunOutput) and run_output.member_responses:
+        for member_response in run_output.member_responses:
+            if isinstance(member_response, RunOutput | TeamRunOutput):
+                matches.extend(_run_output_notice_messages_for_any_response(member_response))
+    return matches
+
+
+def _has_notice_marker_for_response(
+    runs: Sequence[RunOutput | TeamRunOutput],
+    *,
+    response_turn_id: str,
+    marker: bool | str,
+) -> bool:
+    return any(
+        _queued_notice_marker(message) == marker
+        for run in runs
+        for message in _run_output_notice_messages(
+            run,
+            response_turn_id=response_turn_id,
+        )
+    )
+
+
+def _recover_prior_queued_notices(
+    session: AgentSession | TeamSession,
+    *,
+    active_response_turn_id: str | None,
+) -> bool:
+    runs = _session_run_outputs(session)
+    changed = False
+    for response_turn_id in _queued_notice_response_turn_ids(runs):
+        if response_turn_id == active_response_turn_id:
+            continue
+        if not _has_notice_marker_for_response(
+            runs,
+            response_turn_id=response_turn_id,
+            marker=True,
+        ):
+            continue
+        if _has_notice_marker_for_response(
+            runs,
+            response_turn_id=response_turn_id,
+            marker=_QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER,
+        ):
+            continue
+        changed = (
+            _finalize_queued_notice_in_runs(
+                runs,
+                response_turn_id=response_turn_id,
+            )
+            or changed
+        )
+    return changed
 
 
 def scrub_queued_notice_session_context(
@@ -305,15 +609,19 @@ def scrub_queued_notice_session_context(
     scope_context: ScopeSessionContext | None,
     entity_name: str,
 ) -> None:
-    """Strip stale queued-message notices from the loaded session before replay."""
+    """Recover prior crash-left notices without touching the active response."""
     if scope_context is None or scope_context.session is None:
         return
+    notice_context = _queued_message_notice_context.get()
     try:
-        if _strip_queued_notice_from_session(scope_context.session):
+        if _recover_prior_queued_notices(
+            scope_context.session,
+            active_response_turn_id=notice_context.response_turn_id if notice_context is not None else None,
+        ):
             scope_context.storage.upsert_session(scope_context.session)
     except Exception:
         logger.exception(
-            "Failed to strip queued-message notice from loaded session history",
+            "Failed to recover queued-message notice in loaded session history",
             entity=entity_name,
             session_id=scope_context.session.session_id,
             session_type="team" if isinstance(scope_context.session, TeamSession) else "agent",
@@ -351,7 +659,7 @@ def _remove_run_from_session_storage(
     raw_session = storage.get_session(session_id, session_type)
     if raw_session is None:
         return False
-    session = _load_session_for_cleanup(
+    session = _load_queued_notice_session(
         cast("AgentSession | TeamSession | dict[str, object]", raw_session),
         session_type=session_type,
     )

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Callable, Generator, Sequence
-from collections.abc import Set as AbstractSet
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -47,7 +46,7 @@ __all__ = [
     "next_retry_run_id",
     "note_attempt_run_id",
     "queued_message_signal_context",
-    "register_queued_notice_attempt",
+    "register_queued_notice_storage",
     "scrub_queued_notice_session_context",
 ]
 
@@ -141,8 +140,7 @@ class _QueuedMessageNoticeContext:
     state: _SupportsQueuedMessageState | None
     response_turn_id: str = field(default_factory=lambda: str(uuid4()))
     notice_fired: bool = False
-    delivered_notice_text: str | None = None
-    storage_targets: dict[tuple[str, SessionType], _QueuedNoticeStorageTarget] = field(default_factory=dict)
+    storage_targets: dict[tuple[str, str, SessionType], _QueuedNoticeStorageTarget] = field(default_factory=dict)
 
 
 @dataclass
@@ -151,7 +149,6 @@ class _QueuedNoticeStorageTarget:
     session_id: str
     session_type: SessionType
     entity_name: str
-    run_ids: set[str] = field(default_factory=set)
 
 
 _queued_message_notice_context: ContextVar[_QueuedMessageNoticeContext | None] = ContextVar(
@@ -258,7 +255,6 @@ def _append_queued_notice_if_needed(
             },
         ),
     )
-    notice_context.delivered_notice_text = notice_text
     if not notice_context.notice_fired:
         notice_context.notice_fired = True
         logger.info(
@@ -315,14 +311,10 @@ def _run_output_notice_messages(
     *,
     response_turn_id: str,
 ) -> list[Message]:
-    matches = [
-        message
-        for message in run_output.messages or []
-        if _is_queued_notice_message(
-            message,
-            response_turn_id=response_turn_id,
-        )
-    ]
+    matches = _top_level_queued_notice_messages(
+        run_output,
+        response_turn_id=response_turn_id,
+    )
     if isinstance(run_output, TeamRunOutput) and run_output.member_responses:
         for member_response in run_output.member_responses:
             if isinstance(member_response, RunOutput | TeamRunOutput):
@@ -333,6 +325,21 @@ def _run_output_notice_messages(
                     ),
                 )
     return matches
+
+
+def _top_level_queued_notice_messages(
+    run_output: RunOutput | TeamRunOutput,
+    *,
+    response_turn_id: str,
+) -> list[Message]:
+    return [
+        message
+        for message in run_output.messages or []
+        if _is_queued_notice_message(
+            message,
+            response_turn_id=response_turn_id,
+        )
+    ]
 
 
 def _new_persisted_queued_notice(response_turn_id: str, notice_text: str) -> Message:
@@ -349,8 +356,6 @@ def _new_persisted_queued_notice(response_turn_id: str, notice_text: str) -> Mes
 def _queued_notice_text_to_persist(
     *,
     destination_matches: Sequence[Message],
-    all_matches: Sequence[Message],
-    fallback_notice_text: str | None,
 ) -> str | None:
     destination_live_notice = next(
         (
@@ -362,18 +367,6 @@ def _queued_notice_text_to_persist(
     )
     if destination_live_notice is not None:
         return cast("str", destination_live_notice.content)
-    if fallback_notice_text is not None:
-        return fallback_notice_text
-    live_source = next(
-        (
-            message
-            for message in reversed(all_matches)
-            if _queued_notice_marker(message) is True and isinstance(message.content, str)
-        ),
-        None,
-    )
-    if live_source is not None:
-        return cast("str", live_source.content)
     persisted_source = next(
         (
             message
@@ -390,22 +383,18 @@ def _finalize_queued_notice_in_runs(
     runs: Sequence[RunOutput | TeamRunOutput],
     *,
     response_turn_id: str,
-    destination_run_ids: AbstractSet[str] = frozenset(),
-    fallback_notice_text: str | None = None,
 ) -> bool:
-    """Leave one exact persisted notice in the newest replayable owned run."""
-    owned_run_ids = set(destination_run_ids)
-    owned_run_ids.update(
-        run.run_id
-        for run in runs
-        if run.run_id is not None
-        and _run_output_notice_messages(
-            run,
-            response_turn_id=response_turn_id,
-        )
-    )
+    """Leave one exact persisted notice where the newest replayable run saw it."""
     destination = next(
-        (run for run in reversed(runs) if run.run_id in owned_run_ids and is_model_history_visible_run(run)),
+        (
+            run
+            for run in reversed(runs)
+            if is_model_history_visible_run(run)
+            and _top_level_queued_notice_messages(
+                run,
+                response_turn_id=response_turn_id,
+            )
+        ),
         None,
     )
     all_matches = [
@@ -420,21 +409,15 @@ def _finalize_queued_notice_in_runs(
         return False
 
     destination_matches = (
-        [
-            message
-            for message in destination.messages or []
-            if _is_queued_notice_message(
-                message,
-                response_turn_id=response_turn_id,
-            )
-        ]
+        _top_level_queued_notice_messages(
+            destination,
+            response_turn_id=response_turn_id,
+        )
         if destination is not None
         else []
     )
     notice_text = _queued_notice_text_to_persist(
         destination_matches=destination_matches,
-        all_matches=all_matches,
-        fallback_notice_text=fallback_notice_text,
     )
     if (
         notice_text is not None
@@ -480,7 +463,6 @@ def _finalize_queued_notice_in_runs(
 def _finalize_queued_notice_in_new_session_storage(
     target: _QueuedNoticeStorageTarget,
     response_turn_id: str,
-    notice_text: str | None,
 ) -> None:
     """Finalize one response in a worker-owned session storage handle."""
     storage = target.storage_factory()
@@ -497,30 +479,26 @@ def _finalize_queued_notice_in_new_session_storage(
         if _finalize_queued_notice_in_runs(
             _session_run_outputs(session),
             response_turn_id=response_turn_id,
-            destination_run_ids=target.run_ids,
-            fallback_notice_text=notice_text,
         ):
             storage.upsert_session(session)
     finally:
         storage.close()
 
 
-def register_queued_notice_attempt(
+def register_queued_notice_storage(
     *,
-    run_output: RunOutput | TeamRunOutput | None,
     storage_factory: Callable[[], BaseDb] | None,
     session_id: str | None,
     session_type: SessionType,
     entity_name: str,
-    run_id: str | None = None,
 ) -> None:
-    """Register attempt state for response-boundary queued-notice finalization."""
+    """Register storage touched by one response for queued-notice finalization."""
     notice_context = _queued_message_notice_context.get()
     if notice_context is None:
         return
     if storage_factory is None or not session_id:
         return
-    target_key = (session_id, session_type)
+    target_key = (entity_name, session_id, session_type)
     target = notice_context.storage_targets.get(target_key)
     if target is None:
         target = _QueuedNoticeStorageTarget(
@@ -530,15 +508,11 @@ def register_queued_notice_attempt(
             entity_name=entity_name,
         )
         notice_context.storage_targets[target_key] = target
-    registered_run_id = run_id or (run_output.run_id if run_output is not None else None)
-    if registered_run_id:
-        target.run_ids.add(registered_run_id)
 
 
 def _finalize_queued_notice_storage_targets(
     targets: Sequence[_QueuedNoticeStorageTarget],
     response_turn_id: str,
-    notice_text: str | None,
 ) -> None:
     """Finalize all durable targets for one response from a worker thread."""
     for target in targets:
@@ -546,7 +520,6 @@ def _finalize_queued_notice_storage_targets(
             _finalize_queued_notice_in_new_session_storage(
                 target,
                 response_turn_id,
-                notice_text,
             )
         except Exception:
             logger.exception(
@@ -571,7 +544,6 @@ async def finalize_queued_notice_response_turn_async(
             _finalize_queued_notice_storage_targets,
             tuple(notice_context.storage_targets.values()),
             notice_context.response_turn_id,
-            notice_context.delivered_notice_text,
         ),
     )
     try:

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -59,13 +59,6 @@ _QUEUED_MESSAGE_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER = "persisted"
 _QUEUED_MESSAGE_NOTICE_RESPONSE_TURN_ID_KEY = "mindroom_queued_message_notice_response_turn_id"
 _QUEUED_MESSAGE_NOTICE_HOOK_ATTR = "_mindroom_queued_message_notice_hook_installed"
-# Keep blank lines on both sides because Agno can coalesce consecutive
-# same-role messages without inserting a separator.
-_QUEUED_MESSAGE_NOTICE_HISTORY_TEXT = (
-    '\n\n<mindroom-history-note kind="queued-message-notice">\n'
-    "A queued-message notice was delivered.\n"
-    "</mindroom-history-note>\n\n"
-)
 
 EMPTY_RESPONSE_NOTICE = "The model returned an empty response — please try again."
 
@@ -148,6 +141,7 @@ class _QueuedMessageNoticeContext:
     state: _SupportsQueuedMessageState | None
     response_turn_id: str = field(default_factory=lambda: str(uuid4()))
     notice_fired: bool = False
+    delivered_notice_text: str | None = None
     storage_targets: dict[tuple[str, SessionType], _QueuedNoticeStorageTarget] = field(default_factory=dict)
 
 
@@ -264,6 +258,7 @@ def _append_queued_notice_if_needed(
             },
         ),
     )
+    notice_context.delivered_notice_text = notice_text
     if not notice_context.notice_fired:
         notice_context.notice_fired = True
         logger.info(
@@ -340,10 +335,10 @@ def _run_output_notice_messages(
     return matches
 
 
-def _new_factual_queued_notice(response_turn_id: str) -> Message:
+def _new_persisted_queued_notice(response_turn_id: str, notice_text: str) -> Message:
     return Message(
         role="user",
-        content=_QUEUED_MESSAGE_NOTICE_HISTORY_TEXT,
+        content=notice_text,
         provider_data={
             _QUEUED_MESSAGE_NOTICE_MARKER_KEY: _QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER,
             _QUEUED_MESSAGE_NOTICE_RESPONSE_TURN_ID_KEY: response_turn_id,
@@ -351,13 +346,54 @@ def _new_factual_queued_notice(response_turn_id: str) -> Message:
     )
 
 
+def _queued_notice_text_to_persist(
+    *,
+    destination_matches: Sequence[Message],
+    all_matches: Sequence[Message],
+    fallback_notice_text: str | None,
+) -> str | None:
+    destination_live_notice = next(
+        (
+            message
+            for message in destination_matches
+            if _queued_notice_marker(message) is True and isinstance(message.content, str)
+        ),
+        None,
+    )
+    if destination_live_notice is not None:
+        return cast("str", destination_live_notice.content)
+    if fallback_notice_text is not None:
+        return fallback_notice_text
+    live_source = next(
+        (
+            message
+            for message in reversed(all_matches)
+            if _queued_notice_marker(message) is True and isinstance(message.content, str)
+        ),
+        None,
+    )
+    if live_source is not None:
+        return cast("str", live_source.content)
+    persisted_source = next(
+        (
+            message
+            for message in destination_matches
+            if _queued_notice_marker(message) == _QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER
+            and isinstance(message.content, str)
+        ),
+        None,
+    )
+    return cast("str", persisted_source.content) if persisted_source is not None else None
+
+
 def _finalize_queued_notice_in_runs(
     runs: Sequence[RunOutput | TeamRunOutput],
     *,
     response_turn_id: str,
     destination_run_ids: AbstractSet[str] = frozenset(),
+    fallback_notice_text: str | None = None,
 ) -> bool:
-    """Leave one factual note in the newest replayable run owned by this response."""
+    """Leave one exact persisted notice in the newest replayable owned run."""
     owned_run_ids = set(destination_run_ids)
     owned_run_ids.update(
         run.run_id
@@ -395,11 +431,17 @@ def _finalize_queued_notice_in_runs(
         if destination is not None
         else []
     )
+    notice_text = _queued_notice_text_to_persist(
+        destination_matches=destination_matches,
+        all_matches=all_matches,
+        fallback_notice_text=fallback_notice_text,
+    )
     if (
-        len(all_matches) == 1
+        notice_text is not None
+        and len(all_matches) == 1
         and len(destination_matches) == 1
         and _queued_notice_marker(destination_matches[0]) == _QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER
-        and destination_matches[0].content == _QUEUED_MESSAGE_NOTICE_HISTORY_TEXT
+        and destination_matches[0].content == notice_text
     ):
         return False
 
@@ -423,21 +465,22 @@ def _finalize_queued_notice_in_runs(
             response_turn_id=response_turn_id,
         )
 
-    if destination is None:
+    if destination is None or notice_text is None:
         return True
     if destination.messages is None:
         destination.messages = []
-    factual_notice = _new_factual_queued_notice(response_turn_id)
+    persisted_notice = _new_persisted_queued_notice(response_turn_id, notice_text)
     if insertion_index is None:
-        destination.messages.append(factual_notice)
+        destination.messages.append(persisted_notice)
     else:
-        destination.messages.insert(min(insertion_index, len(destination.messages)), factual_notice)
+        destination.messages.insert(min(insertion_index, len(destination.messages)), persisted_notice)
     return True
 
 
 def _finalize_queued_notice_in_new_session_storage(
     target: _QueuedNoticeStorageTarget,
     response_turn_id: str,
+    notice_text: str | None,
 ) -> None:
     """Finalize one response in a worker-owned session storage handle."""
     storage = target.storage_factory()
@@ -455,6 +498,7 @@ def _finalize_queued_notice_in_new_session_storage(
             _session_run_outputs(session),
             response_turn_id=response_turn_id,
             destination_run_ids=target.run_ids,
+            fallback_notice_text=notice_text,
         ):
             storage.upsert_session(session)
     finally:
@@ -494,6 +538,7 @@ def register_queued_notice_attempt(
 def _finalize_queued_notice_storage_targets(
     targets: Sequence[_QueuedNoticeStorageTarget],
     response_turn_id: str,
+    notice_text: str | None,
 ) -> None:
     """Finalize all durable targets for one response from a worker thread."""
     for target in targets:
@@ -501,6 +546,7 @@ def _finalize_queued_notice_storage_targets(
             _finalize_queued_notice_in_new_session_storage(
                 target,
                 response_turn_id,
+                notice_text,
             )
         except Exception:
             logger.exception(
@@ -525,6 +571,7 @@ async def finalize_queued_notice_response_turn_async(
             _finalize_queued_notice_storage_targets,
             tuple(notice_context.storage_targets.values()),
             notice_context.response_turn_id,
+            notice_context.delivered_notice_text,
         ),
     )
     try:

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -530,7 +530,12 @@ async def finalize_queued_notice_response_turn_async(
     try:
         await asyncio.shield(storage_task)
     except asyncio.CancelledError:
-        await storage_task
+        while not storage_task.done():
+            try:
+                await asyncio.shield(storage_task)
+            except asyncio.CancelledError:
+                continue
+        storage_task.result()
         raise
 
 

--- a/src/mindroom/execution_preparation.py
+++ b/src/mindroom/execution_preparation.py
@@ -1053,7 +1053,7 @@ def _scrub_bound_team_scope_context(
     team: Team,
     entity_name: str | None,
 ) -> None:
-    """Strip stale queued-message notices before preparing a bound team run."""
+    """Recover prior queued-message notices before preparing a bound team run."""
     ai_runtime.scrub_queued_notice_session_context(
         scope_context=scope_context,
         entity_name=entity_name or str(team.name or "Team"),

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -28,7 +28,6 @@ from mindroom.constants import (
 from mindroom.error_handling import is_model_safeguard_refusal
 from mindroom.history.storage import (
     compacted_run_ids_with,
-    is_model_history_visible_run,
     record_compaction_chunk,
     remove_runs_by_id,
     seen_event_ids_for_runs,
@@ -48,6 +47,7 @@ from mindroom.history.types import (
     HistoryScopeState,
     ResolvedHistorySettings,
 )
+from mindroom.history_run_visibility import is_model_history_visible_run
 from mindroom.hooks import EVENT_COMPACTION_AFTER, EVENT_COMPACTION_BEFORE, CompactionHookContext, emit
 from mindroom.logging_config import get_logger
 from mindroom.timing import timed
@@ -73,6 +73,7 @@ logger = get_logger(__name__)
 
 _WRAPPER_OVERHEAD_TOKENS = 200
 _OVERSIZED_RUN_NOTE = "Run truncated to fit compaction budget."
+_QUEUED_MESSAGE_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _SUMMARY_METADATA_OMIT_KEYS = frozenset(
     {
         AI_RUN_METADATA_KEY,
@@ -1107,7 +1108,12 @@ def _strip_stale_anthropic_replay_fields(messages: list[Message]) -> int:
     """Strip stale Anthropic thinking replay fields from completed turns."""
     last_user_idx = -1
     for i in range(len(messages) - 1, -1, -1):
-        if messages[i].role == "user":
+        provider_data = messages[i].provider_data
+        is_queued_notice = isinstance(provider_data, dict) and provider_data.get(_QUEUED_MESSAGE_NOTICE_MARKER_KEY) in (
+            True,
+            "persisted",
+        )
+        if messages[i].role == "user" and not is_queued_notice:
             last_user_idx = i
             break
     if last_user_idx < 0:

--- a/src/mindroom/history/storage.py
+++ b/src/mindroom/history/storage.py
@@ -29,11 +29,9 @@ from __future__ import annotations
 from copy import deepcopy
 from dataclasses import replace
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any, TypeGuard
+from typing import TYPE_CHECKING, Any
 
 from agno.db.base import SessionType
-from agno.run.agent import RunOutput
-from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
@@ -45,26 +43,19 @@ from mindroom.constants import (
     MINDROOM_MATRIX_HISTORY_METADATA_KEY,
 )
 from mindroom.history.types import HistoryScope, HistoryScopeState
+from mindroom.history_run_visibility import is_model_history_visible_run
 from mindroom.metadata_merge import deep_merge_metadata
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
 
     from agno.db.base import BaseDb
+    from agno.run.agent import RunOutput
 
 _COMPACTION_METADATA_VERSION = 2
 _MATRIX_HISTORY_METADATA_VERSION = 1
 _PENDING_COMPACTION_SCOPE_KEYS_SESSION_STATE_KEY = "mindroom_pending_compaction_scope_keys"
 _COMPACTED_RUN_ID_RETENTION_LIMIT = 1_024
-
-
-def is_model_history_visible_run(run: object) -> TypeGuard[RunOutput | TeamRunOutput]:
-    """Return whether one run is represented in Agno model history."""
-    return (
-        isinstance(run, (RunOutput, TeamRunOutput))
-        and run.parent_run_id is None
-        and run.status not in {RunStatus.paused, RunStatus.cancelled, RunStatus.error}
-    )
 
 
 def new_scope_session(*, session_id: str, scope_id: str, is_team: bool) -> AgentSession | TeamSession:

--- a/src/mindroom/history_run_visibility.py
+++ b/src/mindroom/history_run_visibility.py
@@ -1,0 +1,16 @@
+"""Shared Agno model-history run visibility policy."""
+
+from typing import TypeGuard
+
+from agno.run.agent import RunOutput
+from agno.run.base import RunStatus
+from agno.run.team import TeamRunOutput
+
+
+def is_model_history_visible_run(run: object) -> TypeGuard[RunOutput | TeamRunOutput]:
+    """Return whether one run is represented in Agno model history."""
+    return (
+        isinstance(run, (RunOutput, TeamRunOutput))
+        and run.parent_run_id is None
+        and run.status not in {RunStatus.paused, RunStatus.cancelled, RunStatus.error}
+    )

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -200,13 +200,12 @@ MIXED_PARTIAL_REPLY_HEADER = (
     "Continue from where you left off if appropriate."
 )
 QUEUED_MESSAGE_NOTICE_TEXT = (
-    "[SYSTEM NOTICE - NEWER USER MESSAGE WAITING] The user posted another message in this thread "
-    "while you were mid-turn. Treat that message as the start of the next turn, not part of this "
-    "one. Finish now with a final text response based on what you have already done - do not "
-    "address the newer message; the next turn will, and may continue, adjust, or redirect this "
-    "work. Do not start new tool calls. Only complete a tool call already in flight this turn if "
-    "stopping would leave broken or unsafe state. Write your final text as a normal response to "
-    "the original request; do not mention this notice or the queued message."
+    "[SYSTEM NOTICE — PAUSE FOR A NEWER USER MESSAGE] A newer user message arrived in this thread "
+    "while you were working. This is a PAUSE, not a cancellation of the current task. Do not make "
+    "any new tool calls. End this turn now with a final text response that explicitly says a newer "
+    "message arrived and states: (1) what you completed, (2) what remains unfinished, and (3) the "
+    "next step. If work remains, state that you will resume it on the next turn unless the newer "
+    "message explicitly tells you to stop or redirect it."
 )
 INLINE_MEDIA_FALLBACK_PROMPT = (
     "The model rejected inline attachments for this turn. "

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -204,8 +204,8 @@ QUEUED_MESSAGE_NOTICE_TEXT = (
     "while you were working. This is a PAUSE, not a cancellation of the current task. Do not make "
     "any new tool calls. End this turn now with a final text response that explicitly says a newer "
     "message arrived and states: (1) what you completed, (2) what remains unfinished, and (3) the "
-    "next step. If work remains, state that you will resume it on the next turn unless the newer "
-    "message explicitly tells you to stop or redirect it."
+    "next step. You cannot see the newer message's contents yet. If work remains, state that you "
+    "intend to resume it on the next turn, subject to the newer message's instructions."
 )
 INLINE_MEDIA_FALLBACK_PROMPT = (
     "The model rejected inline attachments for this turn. "

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, TypeVar, cast
 from agno.db.base import SessionType
 
 from mindroom.agent_storage import get_agent_session, get_team_session
-from mindroom.ai_runtime import queued_message_signal_context
+from mindroom.ai_runtime import finalize_queued_notice_response_turn_async, queued_message_signal_context
 from mindroom.hooks import EVENT_SESSION_STARTED, SessionHookContext, emit
 from mindroom.post_response_effects import apply_post_response_effects
 from mindroom.tool_system.runtime_context import resolve_tool_runtime_hook_bindings
@@ -288,8 +288,11 @@ class ResponseLifecycleCoordinator:
                     notice=notice,
                     queued_signal=queued_signal,
                 )
-                with queued_message_signal_context(queued_signal):
-                    return await locked_operation(target)
+                with queued_message_signal_context(queued_signal) as notice_context:
+                    try:
+                        return await locked_operation(target)
+                    finally:
+                        await finalize_queued_notice_response_turn_async(notice_context)
             finally:
                 if lock_acquired:
                     lifecycle_lock.release()

--- a/src/mindroom/sync_restart_retry.py
+++ b/src/mindroom/sync_restart_retry.py
@@ -18,7 +18,7 @@ from agno.run.agent import RunOutput
 from agno.run.team import TeamRunOutput
 
 from mindroom.constants import MATRIX_EVENT_ID_METADATA_KEY, MATRIX_SOURCE_EVENT_IDS_METADATA_KEY
-from mindroom.history.storage import is_model_history_visible_run
+from mindroom.history_run_visibility import is_model_history_visible_run
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -340,20 +340,22 @@ def _format_terminal_team_response(
     return _format_team_header(team_display_names) + _team_response_text(response)
 
 
-async def _cleanup_team_notice_state(
+def _register_team_notice_attempt(
     *,
     run_output: TeamRunOutput | RunOutput | None,
     scope_context: ScopeSessionContext | None,
     session_id: str | None,
     entity_name: str,
+    run_id: str | None = None,
 ) -> None:
-    """Strip queued-message notices from returned and persisted team state."""
-    await ai_runtime.cleanup_queued_notice_state_async(
+    """Register team attempt state for response-boundary notice finalization."""
+    ai_runtime.register_queued_notice_attempt(
         run_output=run_output,
         storage_factory=scope_context.storage_factory if scope_context is not None else None,
         session_id=session_id,
         session_type=SessionType.TEAM,
         entity_name=entity_name,
+        run_id=run_id,
     )
 
 
@@ -362,7 +364,7 @@ def _scrub_team_retry_notice_state(
     scope_context: ScopeSessionContext | None,
     entity_name: str,
 ) -> None:
-    """Strip queued-message notices from the loaded team session before retry."""
+    """Recover prior notices without finalizing the active team response."""
     ai_runtime.scrub_queued_notice_session_context(
         scope_context=scope_context,
         entity_name=entity_name,
@@ -2140,7 +2142,7 @@ async def team_response(  # noqa: C901, PLR0915
                         error=error_text,
                         removed_media_kinds=sorted(retry_decision.removed_kinds),
                     )
-                    await _cleanup_team_notice_state(
+                    _register_team_notice_attempt(
                         run_output=response,
                         scope_context=run.scope_context,
                         session_id=ctx.session_id,
@@ -2286,7 +2288,7 @@ async def team_response(  # noqa: C901, PLR0915
         if not holder.attempt_started:
             return
         holder.attempt_started = False
-        await _cleanup_team_notice_state(
+        _register_team_notice_attempt(
             run_output=holder.last_response,
             scope_context=scope_context,
             session_id=ctx.session_id,
@@ -2771,7 +2773,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     if isinstance(event, TeamRunOutput) and not _is_bound_team_output(event, team_id=bound_team_id):
                         logger.debug("Ignoring non-bound team run output", run_id=event.run_id)
                         continue
-                    await _cleanup_team_notice_state(
+                    _register_team_notice_attempt(
                         run_output=event,
                         scope_context=run.scope_context,
                         session_id=ctx.session_id,
@@ -3074,6 +3076,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     # this event is the stream's usage/identity source instead.
                     if event.team_id in (None, "", bound_team_id):
                         completed_run_event = event
+                        holder.attempt_run_id = event.run_id or attempt_run_id
                     continue
                 elif isinstance(event, TeamModelRequestCompletedEvent):
                     usage.track(event)
@@ -3141,11 +3144,12 @@ async def team_response_stream(  # noqa: C901, PLR0915
         if not holder.attempt_started:
             return
         holder.attempt_started = False
-        await _cleanup_team_notice_state(
+        _register_team_notice_attempt(
             run_output=None,
             scope_context=scope_context,
             session_id=ctx.session_id,
             entity_name=configured_team_name or team_label,
+            run_id=holder.attempt_run_id,
         )
 
     discard_team_empty_run = _build_team_empty_run_discard(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -340,22 +340,18 @@ def _format_terminal_team_response(
     return _format_team_header(team_display_names) + _team_response_text(response)
 
 
-def _register_team_notice_attempt(
+def _register_team_notice_storage(
     *,
-    run_output: TeamRunOutput | RunOutput | None,
     scope_context: ScopeSessionContext | None,
     session_id: str | None,
     entity_name: str,
-    run_id: str | None = None,
 ) -> None:
-    """Register team attempt state for response-boundary notice finalization."""
-    ai_runtime.register_queued_notice_attempt(
-        run_output=run_output,
+    """Register team storage for response-boundary notice finalization."""
+    ai_runtime.register_queued_notice_storage(
         storage_factory=scope_context.storage_factory if scope_context is not None else None,
         session_id=session_id,
         session_type=SessionType.TEAM,
         entity_name=entity_name,
-        run_id=run_id,
     )
 
 
@@ -1485,7 +1481,6 @@ class _TeamTurnHolder:
 
     team: Team | None = None
     team_members: ResolvedExactTeamMembers | None = None
-    last_response: RunOutput | TeamRunOutput | None = None  # blocking turns only
     attempt_started: bool = False
     attempt_run_id: str | None = None
     render_partial: Callable[[], str] = _empty_partial_text  # streaming turns only
@@ -1516,7 +1511,6 @@ def _build_team_runtime_db_callbacks(
         # Cancel snapshots taken between this release and the next attempt must
         # not see the spent attempt's partials; its completed tools already
         # carried over via the turn state.
-        holder.last_response = None
         holder.render_partial = _empty_partial_text
         holder.tool_tracker = StreamingToolTracker()
 
@@ -2091,7 +2085,6 @@ async def team_response(  # noqa: C901, PLR0915
         pending_retry_decision: MediaRetryDecision | None = None
         for retried_after_media_fallback in (False, True):
             response = None
-            holder.last_response = None
             try:
                 response = await _run(attempt_run_input, attempt_run_id)
             except Exception as e:
@@ -2126,8 +2119,6 @@ async def team_response(  # noqa: C901, PLR0915
                 error_text = get_user_friendly_error_message(e, team_name)
                 return ExcludedAttempt(RunStatus.error, error_text, run_id=attempt_run_id)
 
-            if isinstance(response, (TeamRunOutput, RunOutput)):
-                holder.last_response = response
             if isinstance(response, (TeamRunOutput, RunOutput)) and is_errored_run_output(response):
                 error_text = str(response.content or "Unknown team error")
                 retry_decision = retry_media_inputs_after_failure(
@@ -2142,8 +2133,7 @@ async def team_response(  # noqa: C901, PLR0915
                         error=error_text,
                         removed_media_kinds=sorted(retry_decision.removed_kinds),
                     )
-                    _register_team_notice_attempt(
-                        run_output=response,
+                    _register_team_notice_storage(
                         scope_context=run.scope_context,
                         session_id=ctx.session_id,
                         entity_name=configured_team_name or team_name,
@@ -2288,8 +2278,7 @@ async def team_response(  # noqa: C901, PLR0915
         if not holder.attempt_started:
             return
         holder.attempt_started = False
-        _register_team_notice_attempt(
-            run_output=holder.last_response,
+        _register_team_notice_storage(
             scope_context=scope_context,
             session_id=ctx.session_id,
             entity_name=configured_team_name or team_name,
@@ -2773,8 +2762,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     if isinstance(event, TeamRunOutput) and not _is_bound_team_output(event, team_id=bound_team_id):
                         logger.debug("Ignoring non-bound team run output", run_id=event.run_id)
                         continue
-                    _register_team_notice_attempt(
-                        run_output=event,
+                    _register_team_notice_storage(
                         scope_context=run.scope_context,
                         session_id=ctx.session_id,
                         entity_name=configured_team_name or team_label,
@@ -3144,12 +3132,10 @@ async def team_response_stream(  # noqa: C901, PLR0915
         if not holder.attempt_started:
             return
         holder.attempt_started = False
-        _register_team_notice_attempt(
-            run_output=None,
+        _register_team_notice_storage(
             scope_context=scope_context,
             session_id=ctx.session_id,
             entity_name=configured_team_name or team_label,
-            run_id=holder.attempt_run_id,
         )
 
     discard_team_empty_run = _build_team_empty_run_discard(

--- a/tach.toml
+++ b/tach.toml
@@ -271,6 +271,7 @@ visibility = [
 [[modules]]
 path = "mindroom.ai_runtime"
 depends_on = [
+    "mindroom.history_run_visibility",
     "mindroom.logging_config",
     "mindroom.media_fallback",
     "mindroom.media_inputs",
@@ -285,6 +286,16 @@ visibility = [
     "mindroom.teams",
     "mindroom.thread_summary",
     "mindroom.topic_generator",
+]
+
+[[modules]]
+path = "mindroom.history_run_visibility"
+depends_on = []
+visibility = [
+    "mindroom.ai_runtime",
+    "mindroom.history.compaction",
+    "mindroom.history.storage",
+    "mindroom.sync_restart_retry",
 ]
 
 [[modules]]
@@ -1018,6 +1029,7 @@ path = "mindroom.history.compaction"
 depends_on = [
     "mindroom.claude_prompt_cache",
     "mindroom.constants",
+    "mindroom.history_run_visibility",
     "mindroom.history.storage",
     "mindroom.history.summary_call",
     "mindroom.history.types",
@@ -1059,6 +1071,7 @@ depends_on = [
 path = "mindroom.history.storage"
 depends_on = [
     "mindroom.constants",
+    "mindroom.history_run_visibility",
     "mindroom.history.types",
     "mindroom.metadata_merge",
 ]
@@ -2058,7 +2071,7 @@ path = "mindroom.sync_restart_retry"
 depends_on = [
     "mindroom.response_admission",
     "mindroom.constants",
-    "mindroom.history.storage",
+    "mindroom.history_run_visibility",
     "mindroom.history.types",
     "mindroom.logging_config",
 ]

--- a/tests/test_history_compaction_rewrite.py
+++ b/tests/test_history_compaction_rewrite.py
@@ -1321,6 +1321,38 @@ def test_private_strip_stale_anthropic_replay_fields_preserves_tool_chain_after_
     assert final_assistant.redacted_reasoning_content == "more redacted"
 
 
+@pytest.mark.parametrize("marker", [True, "persisted"], ids=["live", "persisted"])
+def test_private_strip_stale_anthropic_replay_fields_ignores_queued_notice(marker: bool | str) -> None:
+    interrupted_assistant = Message(
+        role="assistant",
+        content="tool call",
+        provider_data={"signature": "sig-tool"},
+        reasoning_content="thinking",
+        redacted_reasoning_content="redacted",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "tool", "arguments": "{}"}},
+        ],
+    )
+    messages = [
+        Message(role="user", content="question"),
+        interrupted_assistant,
+        Message(role="tool", content="tool result", tool_call_id="call-1"),
+        Message(
+            role="user",
+            content="A queued-message notice was delivered.",
+            provider_data={
+                "mindroom_queued_message_notice": marker,
+                "mindroom_queued_message_notice_response_turn_id": "response-1",
+            },
+        ),
+    ]
+
+    assert _strip_stale_anthropic_replay_fields(messages) == 0
+    assert interrupted_assistant.provider_data == {"signature": "sig-tool"}
+    assert interrupted_assistant.reasoning_content == "thinking"
+    assert interrupted_assistant.redacted_reasoning_content == "redacted"
+
+
 def test_private_strip_stale_anthropic_replay_fields_ignores_reasoning_without_signature() -> None:
     assistant = Message(
         role="assistant",

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -71,6 +71,13 @@ from mindroom.tool_system.worker_routing import (
 from tests.identity_helpers import persist_entity_accounts
 
 _TEST_MODEL = "openai:gpt-5.4"
+_QUEUED_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
+_QUEUED_NOTICE_RESPONSE_TURN_ID_KEY = "mindroom_queued_message_notice_response_turn_id"
+_QUEUED_NOTICE_HISTORY_TEXT = (
+    '\n\n<mindroom-history-note kind="queued-message-notice">\n'
+    "A queued-message notice was delivered.\n"
+    "</mindroom-history-note>\n\n"
+)
 
 
 def _make_test_agent(name: str) -> AgnoAgent:
@@ -4492,7 +4499,7 @@ class TestTeamCompletion:
 
     @pytest.mark.asyncio
     async def test_prepare_openai_team_prompt_scrubs_queued_notices_and_uses_team_renderer(self) -> None:
-        """OpenAI team prep should match the main team path for cleanup and assistant-role rendering."""
+        """OpenAI team prep should recover notice facts and preserve assistant-role rendering."""
         config = Config(
             agents={"general": AgentConfig(display_name="GeneralAgent", role="General", rooms=[])},
             models={"default": ModelConfig(provider="openai", id="test-model")},
@@ -4501,6 +4508,7 @@ class TestTeamCompletion:
         runtime_paths = _runtime_paths()
         agent = _make_test_agent("GeneralAgent")
         team = _make_test_team(name="General Team", team_id="general-team")
+        prior_response_id = "prior-openai-team-response"
 
         with open_bound_scope_session_context(
             agents=[agent],
@@ -4523,7 +4531,10 @@ class TestTeamCompletion:
                         Message(
                             role="user",
                             content=QUEUED_MESSAGE_NOTICE_TEXT,
-                            provider_data={"mindroom_queued_message_notice": True},
+                            provider_data={
+                                _QUEUED_NOTICE_MARKER_KEY: True,
+                                _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: prior_response_id,
+                            },
                         ),
                     ],
                     member_responses=[
@@ -4534,7 +4545,10 @@ class TestTeamCompletion:
                                 Message(
                                     role="user",
                                     content=QUEUED_MESSAGE_NOTICE_TEXT,
-                                    provider_data={"mindroom_queued_message_notice": True},
+                                    provider_data={
+                                        _QUEUED_NOTICE_MARKER_KEY: True,
+                                        _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: prior_response_id,
+                                    },
                                 ),
                             ],
                         ),
@@ -4572,7 +4586,23 @@ class TestTeamCompletion:
                     if isinstance(run, (RunOutput, TeamRunOutput))
                     for message in collect_messages(run)
                 ]
-                assert not any(message.provider_data for message in persisted_messages)
+                factual_notices = [
+                    message
+                    for message in persisted_messages
+                    if isinstance(message.provider_data, dict)
+                    and message.provider_data.get(_QUEUED_NOTICE_MARKER_KEY) == "persisted"
+                ]
+                assert len(factual_notices) == 1
+                assert factual_notices[0].content == _QUEUED_NOTICE_HISTORY_TEXT
+                assert factual_notices[0].provider_data == {
+                    _QUEUED_NOTICE_MARKER_KEY: "persisted",
+                    _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: prior_response_id,
+                }
+                assert not any(
+                    isinstance(message.provider_data, dict)
+                    and message.provider_data.get(_QUEUED_NOTICE_MARKER_KEY) is True
+                    for message in persisted_messages
+                )
                 return _prepared_team_execution_context(
                     final_prompt="Previous team reply\n\nAnalyze this.",
                     messages=[
@@ -4625,7 +4655,22 @@ class TestTeamCompletion:
             persisted_messages = [
                 message for run in scope_context.session.runs or [] for message in (run.messages or [])
             ]
-        assert not any(message.provider_data for message in persisted_messages)
+        factual_notices = [
+            message
+            for message in persisted_messages
+            if isinstance(message.provider_data, dict)
+            and message.provider_data.get(_QUEUED_NOTICE_MARKER_KEY) == "persisted"
+        ]
+        assert len(factual_notices) == 1
+        assert factual_notices[0].content == _QUEUED_NOTICE_HISTORY_TEXT
+        assert factual_notices[0].provider_data == {
+            _QUEUED_NOTICE_MARKER_KEY: "persisted",
+            _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: prior_response_id,
+        }
+        assert not any(
+            isinstance(message.provider_data, dict) and message.provider_data.get(_QUEUED_NOTICE_MARKER_KEY) is True
+            for message in persisted_messages
+        )
 
     def test_collaborate_mode_delegates_to_all(self) -> None:
         """Collaborate mode sets delegate_to_all_members=True on Team."""

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -73,11 +73,6 @@ from tests.identity_helpers import persist_entity_accounts
 _TEST_MODEL = "openai:gpt-5.4"
 _QUEUED_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY = "mindroom_queued_message_notice_response_turn_id"
-_QUEUED_NOTICE_HISTORY_TEXT = (
-    '\n\n<mindroom-history-note kind="queued-message-notice">\n'
-    "A queued-message notice was delivered.\n"
-    "</mindroom-history-note>\n\n"
-)
 
 
 def _make_test_agent(name: str) -> AgnoAgent:
@@ -4586,15 +4581,15 @@ class TestTeamCompletion:
                     if isinstance(run, (RunOutput, TeamRunOutput))
                     for message in collect_messages(run)
                 ]
-                factual_notices = [
+                persisted_notices = [
                     message
                     for message in persisted_messages
                     if isinstance(message.provider_data, dict)
                     and message.provider_data.get(_QUEUED_NOTICE_MARKER_KEY) == "persisted"
                 ]
-                assert len(factual_notices) == 1
-                assert factual_notices[0].content == _QUEUED_NOTICE_HISTORY_TEXT
-                assert factual_notices[0].provider_data == {
+                assert len(persisted_notices) == 1
+                assert persisted_notices[0].content == QUEUED_MESSAGE_NOTICE_TEXT
+                assert persisted_notices[0].provider_data == {
                     _QUEUED_NOTICE_MARKER_KEY: "persisted",
                     _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: prior_response_id,
                 }
@@ -4655,15 +4650,15 @@ class TestTeamCompletion:
             persisted_messages = [
                 message for run in scope_context.session.runs or [] for message in (run.messages or [])
             ]
-        factual_notices = [
+        persisted_notices = [
             message
             for message in persisted_messages
             if isinstance(message.provider_data, dict)
             and message.provider_data.get(_QUEUED_NOTICE_MARKER_KEY) == "persisted"
         ]
-        assert len(factual_notices) == 1
-        assert factual_notices[0].content == _QUEUED_NOTICE_HISTORY_TEXT
-        assert factual_notices[0].provider_data == {
+        assert len(persisted_notices) == 1
+        assert persisted_notices[0].content == QUEUED_MESSAGE_NOTICE_TEXT
+        assert persisted_notices[0].provider_data == {
             _QUEUED_NOTICE_MARKER_KEY: "persisted",
             _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: prior_response_id,
         }

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -13,7 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 from agno.agent import Agent as AgnoAgent
-from agno.db.base import SessionType
+from agno.db.base import BaseDb, SessionType
 from agno.media import Image
 from agno.models.message import Message
 from agno.run.agent import RunCompletedEvent, RunContentEvent, RunOutput
@@ -21,13 +21,15 @@ from agno.run.base import RunStatus
 from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
+from structlog.testing import capture_logs
 
-from mindroom import turn_controller
+from mindroom import ai_runtime, turn_controller
+from mindroom.agent_storage import create_state_storage, get_agent_session
 from mindroom.ai import _PreparedAgentRun, ai_response, stream_agent_response
 from mindroom.ai_runtime import (
-    cleanup_queued_notice_state_async,
     install_queued_message_notice_hook,
     queued_message_signal_context,
+    register_queued_notice_attempt,
 )
 from mindroom.bot import AgentBot
 from mindroom.bot_runtime_view import BotRuntimeState
@@ -41,6 +43,7 @@ from mindroom.config.agent import AgentConfig
 from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
+from mindroom.constants import prompt_roles_for_history_storage
 from mindroom.conversation_resolver import MessageContext
 from mindroom.dispatch_handoff import PendingDispatchMetadata, PreparedTextEvent
 from mindroom.dispatch_source import (
@@ -69,7 +72,7 @@ from mindroom.post_response_effects import (
     apply_post_response_effects,
 )
 from mindroom.prompts import QUEUED_MESSAGE_NOTICE_TEXT
-from mindroom.response_lifecycle import _QueuedMessageState
+from mindroom.response_lifecycle import ResponseLifecycleCoordinator, _QueuedMessageState
 from mindroom.response_payload_preparation import DispatchPayloadInputs, ResponsePayloadPreparation
 from mindroom.response_runner import (
     PostLockRequestPreparationError,
@@ -95,6 +98,7 @@ from tests.conftest import (
     unwrap_extracted_collaborator,
     wrap_extracted_collaborators,
 )
+from tests.history_helpers import RecordingModel
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine
@@ -345,15 +349,77 @@ async def test_response_lifecycle_rejects_mismatched_locked_response_target(tmp_
         )
 
 
-def _notice_count(messages: list[Message]) -> int:
-    return sum(1 for message in messages if message.content == QUEUED_MESSAGE_NOTICE_TEXT)
+_QUEUED_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
+_QUEUED_NOTICE_RESPONSE_TURN_ID_KEY = "mindroom_queued_message_notice_response_turn_id"
+_QUEUED_NOTICE_HISTORY_TEXT = (
+    '\n\n<mindroom-history-note kind="queued-message-notice">\n'
+    "A queued-message notice was delivered.\n"
+    "</mindroom-history-note>\n\n"
+)
 
 
-def _queued_notice_message() -> Message:
+def _notice_messages(
+    messages: list[Message],
+    *,
+    marker: bool | str | None = None,
+    response_turn_id: str | None = None,
+) -> list[Message]:
+    matches: list[Message] = []
+    for message in messages:
+        provider_data = message.provider_data
+        if not isinstance(provider_data, dict):
+            continue
+        notice_marker = provider_data.get(_QUEUED_NOTICE_MARKER_KEY)
+        if notice_marker not in (True, "persisted"):
+            continue
+        if marker is not None and notice_marker != marker:
+            continue
+        if response_turn_id is not None and provider_data.get(_QUEUED_NOTICE_RESPONSE_TURN_ID_KEY) != response_turn_id:
+            continue
+        matches.append(message)
+    return matches
+
+
+def _notice_count(
+    messages: list[Message],
+    *,
+    marker: bool | str | None = None,
+    response_turn_id: str | None = None,
+) -> int:
+    return len(
+        _notice_messages(
+            messages,
+            marker=marker,
+            response_turn_id=response_turn_id,
+        ),
+    )
+
+
+def _queued_notice_message(
+    response_turn_id: str,
+    *,
+    marker: bool | str = True,
+    content: str = QUEUED_MESSAGE_NOTICE_TEXT,
+    from_history: bool = False,
+) -> Message:
     return Message(
         role="user",
-        content=QUEUED_MESSAGE_NOTICE_TEXT,
-        provider_data={"mindroom_queued_message_notice": True},
+        content=content,
+        provider_data={
+            _QUEUED_NOTICE_MARKER_KEY: marker,
+            _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: response_turn_id,
+        },
+        from_history=from_history,
+    )
+
+
+def _queued_notice_storage(tmp_path: Path) -> BaseDb:
+    return create_state_storage(
+        "queued_notice",
+        tmp_path,
+        subdir="sessions",
+        session_table="queued_notice_sessions",
+        prompt_roles=prompt_roles_for_history_storage(),
     )
 
 
@@ -361,6 +427,7 @@ class _FakeStorage:
     def __init__(self) -> None:
         self.session: AgentSession | TeamSession | None = None
         self.upserted = False
+        self.upsert_count = 0
         self.closed = False
 
     def get_session(self, session_id: str, _session_type: object) -> AgentSession | TeamSession | None:
@@ -371,6 +438,7 @@ class _FakeStorage:
     def upsert_session(self, session: AgentSession | TeamSession) -> AgentSession | TeamSession:
         self.session = session
         self.upserted = True
+        self.upsert_count += 1
         return session
 
     def close(self) -> None:
@@ -2875,7 +2943,7 @@ def test_notice_hook_keeps_single_notice_at_end_and_skips_stop_after_tool_call()
     )
     assert _notice_count(plain_messages) == 0
 
-    with queued_message_signal_context(_StaticQueuedState(pending=True)):
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
         queued_messages = [Message(role="user", content="hello")]
         model.format_function_call_results(
             messages=queued_messages,
@@ -2894,7 +2962,7 @@ def test_notice_hook_keeps_single_notice_at_end_and_skips_stop_after_tool_call()
             function_call_results=[Message(role="tool", content="done", stop_after_tool_call=True)],
         )
 
-    with queued_message_signal_context(_StaticQueuedState(pending=True)):
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as next_notice_context:
         next_turn_messages = [Message(role="user", content="hello")]
         model.format_function_call_results(
             messages=next_turn_messages,
@@ -2903,9 +2971,26 @@ def test_notice_hook_keeps_single_notice_at_end_and_skips_stop_after_tool_call()
 
     assert _notice_count(queued_messages) == 1
     assert queued_messages[-1].content == QUEUED_MESSAGE_NOTICE_TEXT
+    assert queued_messages[-1].provider_data == {
+        _QUEUED_NOTICE_MARKER_KEY: True,
+        _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: notice_context.response_turn_id,
+    }
     assert _notice_count(next_turn_messages) == 1
     assert next_turn_messages[-1].content == QUEUED_MESSAGE_NOTICE_TEXT
+    assert next_notice_context.response_turn_id != notice_context.response_turn_id
     assert _notice_count(stop_after_messages) == 0
+
+
+def test_default_queued_notice_requires_pause_handoff() -> None:
+    """The default notice should require an explicit pause handoff and continuation default."""
+    assert QUEUED_MESSAGE_NOTICE_TEXT == (
+        "[SYSTEM NOTICE — PAUSE FOR A NEWER USER MESSAGE] A newer user message arrived in this thread "
+        "while you were working. This is a PAUSE, not a cancellation of the current task. Do not make "
+        "any new tool calls. End this turn now with a final text response that explicitly says a newer "
+        "message arrived and states: (1) what you completed, (2) what remains unfinished, and (3) the "
+        "next step. If work remains, state that you will resume it on the next turn unless the newer "
+        "message explicitly tells you to stop or redirect it."
+    )
 
 
 def test_notice_hook_uses_configured_notice_text() -> None:
@@ -2913,7 +2998,7 @@ def test_notice_hook_uses_configured_notice_text() -> None:
     model = _FakeModel()
     install_queued_message_notice_hook(model, notice_text="Custom queued notice.")
 
-    with queued_message_signal_context(_StaticQueuedState(pending=True)):
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
         messages = [Message(role="user", content="hello")]
         model.format_function_call_results(
             messages=messages,
@@ -2921,7 +3006,64 @@ def test_notice_hook_uses_configured_notice_text() -> None:
         )
 
     assert messages[-1].content == "Custom queued notice."
-    assert messages[-1].provider_data == {"mindroom_queued_message_notice": True}
+    assert messages[-1].provider_data == {
+        _QUEUED_NOTICE_MARKER_KEY: True,
+        _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: notice_context.response_turn_id,
+    }
+
+
+def test_notice_hook_scopes_dedupe_to_response_turn_id() -> None:
+    """Tool-round dedupe should remove only notices owned by the active response."""
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        prior_notice = _queued_notice_message(
+            "prior-response",
+            marker="persisted",
+            content=_QUEUED_NOTICE_HISTORY_TEXT,
+            from_history=True,
+        )
+        current_stale_notice = _queued_notice_message(
+            notice_context.response_turn_id,
+            marker="persisted",
+            content=_QUEUED_NOTICE_HISTORY_TEXT,
+        )
+        messages = [prior_notice, current_stale_notice]
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="result")],
+        )
+
+    assert messages[0] is prior_notice
+    assert _notice_count(messages, marker="persisted", response_turn_id="prior-response") == 1
+    assert _notice_count(messages, marker="persisted", response_turn_id=notice_context.response_turn_id) == 0
+    assert _notice_count(messages, marker=True, response_turn_id=notice_context.response_turn_id) == 1
+
+
+def test_notice_hook_preserves_prior_factual_replay() -> None:
+    """A prior factual replay note should survive later tool-result formatting byte-for-byte."""
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+    prior_notice = _queued_notice_message(
+        "prior-response",
+        marker="persisted",
+        content=_QUEUED_NOTICE_HISTORY_TEXT,
+        from_history=True,
+    )
+    original = prior_notice.model_dump()
+
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        messages = [prior_notice]
+        for index in range(2):
+            model.format_function_call_results(
+                messages=messages,
+                function_call_results=[Message(role="tool", content=f"result {index}")],
+            )
+
+    assert prior_notice.model_dump() == original
+    assert _notice_count(messages, marker="persisted", response_turn_id="prior-response") == 1
+    assert _notice_count(messages, marker=True, response_turn_id=notice_context.response_turn_id) == 1
 
 
 def test_notice_reinjects_at_end_across_multiple_tool_rounds() -> None:
@@ -2941,24 +3083,46 @@ def test_notice_reinjects_at_end_across_multiple_tool_rounds() -> None:
             assert messages[-1].content == QUEUED_MESSAGE_NOTICE_TEXT
 
 
-def test_stop_after_tool_call_strips_stale_notice_without_readding() -> None:
-    """A stop-after-tool-call round should remove any stale queued notice and not append a new one."""
+def test_queued_notice_logs_once_per_response_turn() -> None:
+    """Repeated successful appends should emit one injection event for the response."""
     model = _FakeModel()
     install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
 
-    messages = [Message(role="user", content="hello")]
-    with queued_message_signal_context(_StaticQueuedState(pending=True)):
-        model.format_function_call_results(
-            messages=messages,
-            function_call_results=[Message(role="tool", content="result")],
-        )
-        model.format_function_call_results(
-            messages=messages,
-            function_call_results=[Message(role="tool", content="done", stop_after_tool_call=True)],
-        )
+    with (
+        capture_logs() as logs,
+        queued_message_signal_context(
+            _StaticQueuedState(pending=True),
+        ) as notice_context,
+    ):
+        messages = [Message(role="user", content="hello")]
+        for index in range(5):
+            model.format_function_call_results(
+                messages=messages,
+                function_call_results=[Message(role="tool", content=f"result {index}")],
+            )
 
-    assert _notice_count(messages) == 0
-    assert messages[-1].content == "done"
+    injection_logs = [entry for entry in logs if entry.get("event") == "queued_message_notice_injected"]
+    assert injection_logs == [
+        {
+            "event": "queued_message_notice_injected",
+            "log_level": "info",
+            "response_turn_id": notice_context.response_turn_id,
+        },
+    ]
+
+    with capture_logs() as no_injection_logs:
+        with queued_message_signal_context(_StaticQueuedState(pending=False)):
+            model.format_function_call_results(
+                messages=[],
+                function_call_results=[Message(role="tool", content="result")],
+            )
+        with queued_message_signal_context(_StaticQueuedState(pending=True)):
+            model.format_function_call_results(
+                messages=[],
+                function_call_results=[Message(role="tool", content="done", stop_after_tool_call=True)],
+            )
+
+    assert not any(entry.get("event") == "queued_message_notice_injected" for entry in no_injection_logs)
 
 
 def test_notice_reinjects_after_media_follow_up_message() -> None:
@@ -3007,7 +3171,7 @@ def test_notice_hook_still_installs_when_media_handler_is_missing() -> None:
 
 @pytest.mark.asyncio
 async def test_ai_response_preserves_stale_notice_before_prepare(tmp_path: Path) -> None:
-    """Loaded session history should strip stale queued notices before replay."""
+    """Loaded session history should factualize a prior crash-left live notice."""
     config = _config(tmp_path)
     storage = _FakeStorage()
     storage.session = AgentSession(
@@ -3016,7 +3180,8 @@ async def test_ai_response_preserves_stale_notice_before_prepare(tmp_path: Path)
             RunOutput(
                 run_id="run-0",
                 session_id="session-1",
-                messages=[_queued_notice_message()],
+                messages=[_queued_notice_message("prior-response")],
+                status=RunStatus.completed,
             ),
         ],
     )
@@ -3064,15 +3229,20 @@ async def test_ai_response_preserves_stale_notice_before_prepare(tmp_path: Path)
         )
 
     assert response == "final answer"
-    assert observed_notice_counts == [0]
+    assert observed_notice_counts == [1]
     assert storage.upserted is True
     assert storage.session is not None
-    assert _notice_count(storage.session.runs[0].messages or []) == 0
+    recovered = _notice_messages(
+        storage.session.runs[0].messages or [],
+        marker="persisted",
+        response_turn_id="prior-response",
+    )
+    assert [message.content for message in recovered] == [_QUEUED_NOTICE_HISTORY_TEXT]
 
 
 @pytest.mark.asyncio
-async def test_ai_response_preserves_notice_in_run_output_and_session(tmp_path: Path) -> None:
-    """Non-streaming runs should strip the hidden notice from returned and persisted history."""
+async def test_ai_response_preserves_notice_in_session(tmp_path: Path) -> None:
+    """Attempt registration should stay live until outer non-stream finalization."""
     config = _config(tmp_path)
     storage = _FakeStorage()
     model = _FakeModel()
@@ -3092,7 +3262,14 @@ async def test_ai_response_preserves_notice_in_run_output_and_session(tmp_path: 
         stored_messages = [message.model_copy(deep=True) for message in messages]
         storage.session = AgentSession(
             session_id=session_id,
-            runs=[RunOutput(run_id="run-1", session_id=session_id, messages=stored_messages)],
+            runs=[
+                RunOutput(
+                    run_id="run-1",
+                    session_id=session_id,
+                    messages=stored_messages,
+                    status=RunStatus.completed,
+                ),
+            ],
         )
         run_output = RunOutput(
             run_id="run-1",
@@ -3118,7 +3295,7 @@ async def test_ai_response_preserves_notice_in_run_output_and_session(tmp_path: 
         ),
         patch("mindroom.ai._prepare_agent_and_prompt", new=AsyncMock(return_value=_prepared_run(agent))),
         patch("mindroom.ai.close_agent_runtime_state_dbs"),
-        queued_message_signal_context(_StaticQueuedState(pending=True)),
+        queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context,
     ):
         response = await ai_response(
             make_turn_context("general", session_id="session-1"),
@@ -3126,17 +3303,22 @@ async def test_ai_response_preserves_notice_in_run_output_and_session(tmp_path: 
             runtime_paths=runtime_paths_for(config),
             config=config,
         )
+        assert storage.upserted is False
+        assert _notice_count(run_output_holder["run"].messages or [], marker=True) == 1
+        assert storage.session is not None
+        assert _notice_count(storage.session.runs[0].messages or [], marker=True) == 1
+        await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
 
     assert response == "final answer"
     assert storage.upserted is True
-    assert _notice_count(run_output_holder["run"].messages or []) == 0
     assert storage.session is not None
-    assert _notice_count(storage.session.runs[0].messages or []) == 0
+    assert _notice_count(storage.session.runs[0].messages or [], marker=True) == 0
+    assert _notice_count(storage.session.runs[0].messages or [], marker="persisted") == 1
 
 
 @pytest.mark.asyncio
 async def test_ai_response_preserves_notice_in_session_after_exception(tmp_path: Path) -> None:
-    """Non-streaming failures should still scrub persisted notices."""
+    """An error-only response should remove its live notice at the outer boundary."""
     config = _config(tmp_path)
     storage = _FakeStorage()
     model = _FakeModel()
@@ -3154,7 +3336,14 @@ async def test_ai_response_preserves_notice_in_session_after_exception(tmp_path:
         )
         storage.session = AgentSession(
             session_id=session_id,
-            runs=[RunOutput(run_id="run-1", session_id=session_id, messages=messages)],
+            runs=[
+                RunOutput(
+                    run_id="run-1",
+                    session_id=session_id,
+                    messages=messages,
+                    status=RunStatus.error,
+                ),
+            ],
         )
         error_message = "boom"
         raise RuntimeError(error_message)
@@ -3170,7 +3359,7 @@ async def test_ai_response_preserves_notice_in_session_after_exception(tmp_path:
         ),
         patch("mindroom.ai._prepare_agent_and_prompt", new=AsyncMock(return_value=_prepared_run(agent))),
         patch("mindroom.ai.close_agent_runtime_state_dbs"),
-        queued_message_signal_context(_StaticQueuedState(pending=True)),
+        queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context,
     ):
         response = await ai_response(
             make_turn_context("general", session_id="session-1"),
@@ -3178,6 +3367,9 @@ async def test_ai_response_preserves_notice_in_session_after_exception(tmp_path:
             runtime_paths=runtime_paths_for(config),
             config=config,
         )
+        assert storage.session is not None
+        assert _notice_count(storage.session.runs[0].messages or [], marker=True) == 1
+        await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
 
     assert isinstance(response, str)
     assert storage.upserted is True
@@ -3187,7 +3379,7 @@ async def test_ai_response_preserves_notice_in_session_after_exception(tmp_path:
 
 @pytest.mark.asyncio
 async def test_stream_agent_response_preserves_notice_in_session(tmp_path: Path) -> None:
-    """Streaming runs should also scrub the hidden notice from persisted history."""
+    """Streaming attempt cleanup should wait for the outer response boundary."""
     config = _config(tmp_path)
     storage = _FakeStorage()
     model = _FakeModel()
@@ -3206,7 +3398,14 @@ async def test_stream_agent_response_preserves_notice_in_session(tmp_path: Path)
         stored_messages = [message.model_copy(deep=True) for message in messages]
         storage.session = AgentSession(
             session_id=session_id,
-            runs=[RunOutput(run_id="run-1", session_id=session_id, messages=stored_messages)],
+            runs=[
+                RunOutput(
+                    run_id="run-1",
+                    session_id=session_id,
+                    messages=stored_messages,
+                    status=RunStatus.completed,
+                ),
+            ],
         )
         yield RunContentEvent(content="chunk")
         yield RunCompletedEvent(run_id="run-1", session_id=session_id)
@@ -3222,7 +3421,7 @@ async def test_stream_agent_response_preserves_notice_in_session(tmp_path: Path)
         ),
         patch("mindroom.ai._prepare_agent_and_prompt", new=AsyncMock(return_value=_prepared_run(agent))),
         patch("mindroom.ai.close_agent_runtime_state_dbs"),
-        queued_message_signal_context(_StaticQueuedState(pending=True)),
+        queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context,
     ):
         chunks = [
             chunk
@@ -3233,11 +3432,16 @@ async def test_stream_agent_response_preserves_notice_in_session(tmp_path: Path)
                 config=config,
             )
         ]
+        assert storage.upserted is False
+        assert storage.session is not None
+        assert _notice_count(storage.session.runs[0].messages or [], marker=True) == 1
+        await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
 
     assert any(isinstance(chunk, RunContentEvent) and chunk.content == "chunk" for chunk in chunks)
     assert storage.upserted is True
     assert storage.session is not None
-    assert _notice_count(storage.session.runs[0].messages or []) == 0
+    assert _notice_count(storage.session.runs[0].messages or [], marker=True) == 0
+    assert _notice_count(storage.session.runs[0].messages or [], marker="persisted") == 1
 
 
 def test_create_team_instance_installs_notice_hook_on_team_model(tmp_path: Path) -> None:
@@ -3279,65 +3483,74 @@ def test_create_team_instance_installs_notice_hook_on_team_model(tmp_path: Path)
 
 
 @pytest.mark.asyncio
-async def test_cleanup_queued_notice_state_strips_nested_team_member_responses() -> None:
-    """Team cleanup should recurse into nested member responses."""
-    run_output = TeamRunOutput(
-        run_id="run-1",
-        session_id="session-1",
-        messages=[_queued_notice_message()],
-        member_responses=[
-            RunOutput(
-                run_id="member-run-1",
-                session_id="session-1",
-                messages=[_queued_notice_message()],
-            ),
-        ],
-        status=RunStatus.completed,
-    )
+async def test_response_finalization_collapses_nested_current_notice_state() -> None:
+    """Outer finalization should leave one factual note in the top-level completed run."""
     created_storages: list[_FakeStorage] = []
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
 
-    def storage_factory() -> _FakeStorage:
-        storage = _FakeStorage()
-        storage.session = TeamSession(
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        messages: list[Message] = []
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="result")],
+        )
+        run_output = TeamRunOutput(
+            run_id="run-1",
             session_id="session-1",
-            runs=[
-                TeamRunOutput(
-                    run_id="run-1",
+            messages=[message.model_copy(deep=True) for message in messages],
+            member_responses=[
+                RunOutput(
+                    run_id="member-run-1",
                     session_id="session-1",
-                    messages=[_queued_notice_message()],
-                    member_responses=[
-                        RunOutput(
-                            run_id="member-run-1",
-                            session_id="session-1",
-                            messages=[_queued_notice_message()],
-                        ),
-                    ],
+                    messages=[message.model_copy(deep=True) for message in messages],
                     status=RunStatus.completed,
                 ),
             ],
+            status=RunStatus.completed,
         )
-        created_storages.append(storage)
-        return storage
 
-    await cleanup_queued_notice_state_async(
-        run_output=run_output,
-        storage_factory=storage_factory,
-        session_id="session-1",
-        session_type=SessionType.TEAM,
-        entity_name="queued-notice-team",
-    )
+        def storage_factory() -> _FakeStorage:
+            storage = _FakeStorage()
+            storage.session = TeamSession(
+                session_id="session-1",
+                runs=[
+                    TeamRunOutput(
+                        run_id="run-1",
+                        session_id="session-1",
+                        messages=[message.model_copy(deep=True) for message in messages],
+                        member_responses=[
+                            RunOutput(
+                                run_id="member-run-1",
+                                session_id="session-1",
+                                messages=[message.model_copy(deep=True) for message in messages],
+                                status=RunStatus.completed,
+                            ),
+                        ],
+                        status=RunStatus.completed,
+                    ),
+                ],
+            )
+            created_storages.append(storage)
+            return storage
+
+        register_queued_notice_attempt(
+            run_output=run_output,
+            storage_factory=storage_factory,
+            session_id="session-1",
+            session_type=SessionType.TEAM,
+            entity_name="queued-notice-team",
+        )
+        assert _notice_count(run_output.messages or [], marker=True) == 1
+        await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
 
     storage = created_storages[0]
-    assert _notice_count(run_output.messages or []) == 0
-    assert run_output.member_responses is not None
-    nested_member_run = run_output.member_responses[0]
-    assert isinstance(nested_member_run, RunOutput)
-    assert _notice_count(nested_member_run.messages or []) == 0
     assert storage.upserted is True
     assert storage.session is not None
     stored_team_run = storage.session.runs[0]
     assert isinstance(stored_team_run, TeamRunOutput)
-    assert _notice_count(stored_team_run.messages or []) == 0
+    assert _notice_count(stored_team_run.messages or [], marker=True) == 0
+    assert _notice_count(stored_team_run.messages or [], marker="persisted") == 1
     assert stored_team_run.member_responses is not None
     stored_member_run = stored_team_run.member_responses[0]
     assert isinstance(stored_member_run, RunOutput)
@@ -3346,8 +3559,95 @@ async def test_cleanup_queued_notice_state_strips_nested_team_member_responses()
 
 
 @pytest.mark.asyncio
+async def test_response_finalization_uses_newest_completed_same_turn_run_and_original_notice_position() -> None:
+    """Two completed attempts should leave one factual note at the newest attempt's notice position."""
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+    storage = _FakeStorage()
+
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        first_messages = [
+            Message(role="user", content="First request"),
+            Message(role="assistant", content="First tool call"),
+        ]
+        model.format_function_call_results(
+            messages=first_messages,
+            function_call_results=[Message(role="tool", content="First result")],
+        )
+        first_messages.append(Message(role="assistant", content="First final"))
+        second_messages = [
+            Message(role="user", content="Second request"),
+            Message(role="assistant", content="Second tool call"),
+        ]
+        model.format_function_call_results(
+            messages=second_messages,
+            function_call_results=[Message(role="tool", content="Second result")],
+        )
+        second_messages.append(Message(role="assistant", content="Second final"))
+        first_run = RunOutput(
+            run_id="first-completed-run",
+            session_id="session-1",
+            messages=first_messages,
+            status=RunStatus.completed,
+        )
+        second_run = RunOutput(
+            run_id="second-completed-run",
+            session_id="session-1",
+            messages=second_messages,
+            status=RunStatus.completed,
+        )
+        storage.session = AgentSession(
+            session_id="session-1",
+            runs=[
+                RunOutput(
+                    run_id=first_run.run_id,
+                    session_id=first_run.session_id,
+                    messages=[message.model_copy(deep=True) for message in first_messages],
+                    status=first_run.status,
+                ),
+                RunOutput(
+                    run_id=second_run.run_id,
+                    session_id=second_run.session_id,
+                    messages=[message.model_copy(deep=True) for message in second_messages],
+                    status=second_run.status,
+                ),
+            ],
+        )
+        for run_output in (first_run, second_run):
+            register_queued_notice_attempt(
+                run_output=run_output,
+                storage_factory=lambda: storage,
+                session_id="session-1",
+                session_type=SessionType.AGENT,
+                entity_name="general",
+            )
+
+        await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
+
+    assert storage.upsert_count == 1
+    assert storage.session is not None
+    stored_first, stored_second = storage.session.runs
+    assert _notice_count(stored_first.messages or []) == 0
+    assert [(message.role, message.content) for message in stored_second.messages or []] == [
+        ("user", "Second request"),
+        ("assistant", "Second tool call"),
+        ("tool", "Second result"),
+        ("user", _QUEUED_NOTICE_HISTORY_TEXT),
+        ("assistant", "Second final"),
+    ]
+    assert (
+        _notice_count(
+            stored_second.messages or [],
+            marker="persisted",
+            response_turn_id=notice_context.response_turn_id,
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_cleanup_keeps_session_storage_io_off_event_loop() -> None:
-    """Slow synchronous session storage must not stall concurrent asyncio work."""
+    """Slow response-boundary storage finalization must stay off the event loop."""
     request_started = threading.Event()
     release_request = threading.Event()
     created_storages: list[_BlockingStorage] = []
@@ -3363,39 +3663,624 @@ async def test_async_cleanup_keeps_session_storage_io_off_event_loop() -> None:
             release_request.wait(timeout=1)
             return super().get_session(session_id, _session_type)
 
-    def storage_factory() -> _BlockingStorage:
-        storage = _BlockingStorage()
-        storage.session = AgentSession(
-            session_id="session-1",
-            runs=[
-                RunOutput(
-                    run_id="run-1",
-                    session_id="session-1",
-                    messages=[_queued_notice_message()],
-                ),
-            ],
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        messages: list[Message] = []
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="result")],
         )
-        created_storages.append(storage)
-        return storage
 
-    cleanup_task = asyncio.create_task(
-        cleanup_queued_notice_state_async(
+        def storage_factory() -> _BlockingStorage:
+            storage = _BlockingStorage()
+            storage.session = AgentSession(
+                session_id="session-1",
+                runs=[
+                    RunOutput(
+                        run_id="run-1",
+                        session_id="session-1",
+                        messages=[message.model_copy(deep=True) for message in messages],
+                        status=RunStatus.completed,
+                    ),
+                ],
+            )
+            created_storages.append(storage)
+            return storage
+
+        register_queued_notice_attempt(
             run_output=None,
             storage_factory=storage_factory,
             session_id="session-1",
             session_type=SessionType.AGENT,
             entity_name="queued-notice-agent",
-        ),
-    )
-    try:
-        assert await asyncio.to_thread(request_started.wait, 1)
-        await asyncio.wait_for(asyncio.sleep(0), timeout=0.1)
-        assert not cleanup_task.done()
-    finally:
-        release_request.set()
+        )
+        cleanup_task = asyncio.create_task(
+            ai_runtime.finalize_queued_notice_response_turn_async(notice_context),
+        )
+        try:
+            assert await asyncio.to_thread(request_started.wait, 1)
+            await asyncio.wait_for(asyncio.sleep(0), timeout=0.1)
+            assert not cleanup_task.done()
+        finally:
+            release_request.set()
 
-    await asyncio.wait_for(cleanup_task, timeout=1)
+        await asyncio.wait_for(cleanup_task, timeout=1)
     storage = created_storages[0]
     assert storage.created_thread_id != event_loop_thread_id
     assert storage.upserted is True
     assert storage.closed is True
+
+
+@pytest.mark.asyncio
+async def test_response_turn_finalization_completes_when_cancelled_during_storage_io() -> None:
+    """Cancellation during storage I/O must not leave a durable live imperative behind."""
+    request_started = threading.Event()
+    release_request = threading.Event()
+    request_finished = threading.Event()
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+
+    class _BlockingStorage(_FakeStorage):
+        def get_session(self, session_id: str, _session_type: object) -> AgentSession | TeamSession | None:
+            request_started.set()
+            release_request.wait(timeout=1)
+            return super().get_session(session_id, _session_type)
+
+        def close(self) -> None:
+            super().close()
+            request_finished.set()
+
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        messages: list[Message] = []
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="result")],
+        )
+        run_output = RunOutput(
+            run_id="completed-run",
+            session_id="session-1",
+            messages=messages,
+            status=RunStatus.completed,
+        )
+        storage = _BlockingStorage()
+        storage.session = AgentSession(
+            session_id="session-1",
+            runs=[
+                RunOutput(
+                    run_id=run_output.run_id,
+                    session_id=run_output.session_id,
+                    messages=[message.model_copy(deep=True) for message in messages],
+                    status=run_output.status,
+                ),
+            ],
+        )
+        register_queued_notice_attempt(
+            run_output=run_output,
+            storage_factory=lambda: storage,
+            session_id="session-1",
+            session_type=SessionType.AGENT,
+            entity_name="general",
+        )
+        finalization_task = asyncio.create_task(
+            ai_runtime.finalize_queued_notice_response_turn_async(notice_context),
+        )
+        assert await asyncio.to_thread(request_started.wait, 1)
+        finalization_task.cancel()
+        release_request.set()
+        with pytest.raises(asyncio.CancelledError):
+            await finalization_task
+        assert await asyncio.to_thread(request_finished.wait, 1)
+
+    assert storage.session is not None
+    assert _notice_count(storage.session.runs[0].messages or [], marker=True) == 0
+    assert (
+        _notice_count(
+            storage.session.runs[0].messages or [],
+            marker="persisted",
+            response_turn_id=notice_context.response_turn_id,
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
+async def test_attempt_registration_deduplicates_one_session_across_fresh_factories() -> None:
+    """Fresh storage-factory closures for one session should cause one boundary open."""
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+    factory_calls = 0
+
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        messages: list[Message] = []
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="result")],
+        )
+        run_output = RunOutput(
+            run_id="completed-run",
+            session_id="session-1",
+            messages=messages,
+            status=RunStatus.completed,
+        )
+        storage = _FakeStorage()
+        storage.session = AgentSession(
+            session_id="session-1",
+            runs=[
+                RunOutput(
+                    run_id=run_output.run_id,
+                    session_id=run_output.session_id,
+                    messages=[message.model_copy(deep=True) for message in messages],
+                    status=run_output.status,
+                ),
+            ],
+        )
+
+        def fresh_storage_factory() -> Callable[[], _FakeStorage]:
+            def storage_factory() -> _FakeStorage:
+                nonlocal factory_calls
+                factory_calls += 1
+                return storage
+
+            return storage_factory
+
+        for _ in range(2):
+            register_queued_notice_attempt(
+                run_output=run_output,
+                storage_factory=fresh_storage_factory(),
+                session_id="session-1",
+                session_type=SessionType.AGENT,
+                entity_name="general",
+            )
+        await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
+
+    assert factory_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_error_responses_never_attach_notices_to_prior_completed_run() -> None:
+    """Failed responses must not accumulate their notice facts on an earlier turn."""
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+    storage = _FakeStorage()
+    prior_completed = RunOutput(
+        run_id="prior-completed",
+        session_id="session-1",
+        messages=[
+            Message(role="user", content="Prior request"),
+            Message(role="assistant", content="Prior answer"),
+        ],
+        status=RunStatus.completed,
+    )
+    storage.session = AgentSession(session_id="session-1", runs=[prior_completed])
+
+    for index in range(3):
+        with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+            messages: list[Message] = []
+            model.format_function_call_results(
+                messages=messages,
+                function_call_results=[Message(role="tool", content=f"failed result {index}")],
+            )
+            error_run = RunOutput(
+                run_id=f"error-run-{index}",
+                session_id="session-1",
+                messages=messages,
+                status=RunStatus.error,
+            )
+            assert storage.session.runs is not None
+            storage.session.runs.append(
+                RunOutput(
+                    run_id=error_run.run_id,
+                    session_id=error_run.session_id,
+                    messages=[message.model_copy(deep=True) for message in messages],
+                    status=error_run.status,
+                ),
+            )
+            register_queued_notice_attempt(
+                run_output=error_run,
+                storage_factory=lambda: storage,
+                session_id="session-1",
+                session_type=SessionType.AGENT,
+                entity_name="general",
+            )
+            await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
+
+    assert storage.session.runs is not None
+    assert _notice_count(prior_completed.messages or []) == 0
+    assert (
+        sum(
+            _notice_count(run.messages or [])
+            for run in storage.session.runs
+            if isinstance(run, RunOutput | TeamRunOutput)
+        )
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+async def test_response_lifecycle_finalizes_notice_after_locked_operation() -> None:
+    """The lifecycle boundary should finalize registered attempts after the operation returns."""
+    lifecycle = ResponseLifecycleCoordinator()
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$event")
+    envelope = _envelope(source_event_id="$event", target=target)
+    storage = _FakeStorage()
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+    observed_live_counts: list[int] = []
+
+    async def locked_operation(_target: MessageTarget) -> str:
+        lifecycle._get_or_create_queued_signal(target).add_waiting_human_message("$newer")
+        messages: list[Message] = []
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="result")],
+        )
+        run = RunOutput(
+            run_id="completed-run",
+            session_id="session-1",
+            messages=messages,
+            status=RunStatus.completed,
+        )
+        storage.session = AgentSession(
+            session_id="session-1",
+            runs=[
+                RunOutput(
+                    run_id=run.run_id,
+                    session_id=run.session_id,
+                    messages=[message.model_copy(deep=True) for message in messages],
+                    status=run.status,
+                ),
+            ],
+        )
+        register_queued_notice_attempt(
+            run_output=run,
+            storage_factory=lambda: storage,
+            session_id="session-1",
+            session_type=SessionType.AGENT,
+            entity_name="general",
+        )
+        observed_live_counts.append(_notice_count(run.messages or [], marker=True))
+        return "$response"
+
+    result = await lifecycle.run_locked_response(
+        target=target,
+        response_envelope=envelope,
+        queued_notice_reservation=None,
+        pipeline_timing=None,
+        locked_operation=locked_operation,
+    )
+
+    assert result == "$response"
+    assert observed_live_counts == [1]
+    assert storage.session is not None
+    stored_run = storage.session.runs[0]
+    assert _notice_count(stored_run.messages or [], marker=True) == 0
+    factual = _notice_messages(stored_run.messages or [], marker="persisted")
+    assert [message.content for message in factual] == [_QUEUED_NOTICE_HISTORY_TEXT]
+    assert storage.upsert_count == 1
+
+
+@pytest.mark.asyncio
+async def test_response_lifecycle_finalizes_error_state_when_operation_raises() -> None:
+    """The lifecycle finally block should remove live state when the operation raises."""
+    lifecycle = ResponseLifecycleCoordinator()
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$event")
+    envelope = _envelope(source_event_id="$event", target=target)
+    storage = _FakeStorage()
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+
+    async def locked_operation(_target: MessageTarget) -> str:
+        lifecycle._get_or_create_queued_signal(target).add_waiting_human_message("$newer")
+        messages: list[Message] = []
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="failed result")],
+        )
+        storage.session = AgentSession(
+            session_id="session-1",
+            runs=[
+                RunOutput(
+                    run_id="error-run",
+                    session_id="session-1",
+                    messages=messages,
+                    status=RunStatus.error,
+                ),
+            ],
+        )
+        register_queued_notice_attempt(
+            run_output=None,
+            storage_factory=lambda: storage,
+            session_id="session-1",
+            session_type=SessionType.AGENT,
+            entity_name="general",
+        )
+        error_message = "provider failed"
+        raise RuntimeError(error_message)
+
+    with pytest.raises(RuntimeError, match="provider failed"):
+        await lifecycle.run_locked_response(
+            target=target,
+            response_envelope=envelope,
+            queued_notice_reservation=None,
+            pipeline_timing=None,
+            locked_operation=locked_operation,
+        )
+
+    assert storage.session is not None
+    assert _notice_count(storage.session.runs[0].messages or []) == 0
+
+
+@pytest.mark.asyncio
+async def test_response_turn_finalization_is_idempotent_for_one_factual_note() -> None:
+    """Repeated boundary finalization should not rewrite an already-normalized response."""
+    storage = _FakeStorage()
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        injected_messages: list[Message] = []
+        model.format_function_call_results(
+            messages=injected_messages,
+            function_call_results=[Message(role="tool", content="result")],
+        )
+        factual = _queued_notice_message(
+            notice_context.response_turn_id,
+            marker="persisted",
+            content=_QUEUED_NOTICE_HISTORY_TEXT,
+        )
+        run = RunOutput(
+            run_id="completed-run",
+            session_id="session-1",
+            messages=[factual],
+            status=RunStatus.completed,
+        )
+        storage.session = AgentSession(
+            session_id="session-1",
+            runs=[
+                RunOutput(
+                    run_id=run.run_id,
+                    session_id=run.session_id,
+                    messages=[factual.model_copy(deep=True)],
+                    status=run.status,
+                ),
+            ],
+        )
+        original_stored = (storage.session.runs[0].messages or [])[0].model_dump()
+        register_queued_notice_attempt(
+            run_output=run,
+            storage_factory=lambda: storage,
+            session_id="session-1",
+            session_type=SessionType.AGENT,
+            entity_name="general",
+        )
+        await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
+        await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
+
+    assert storage.upsert_count == 0
+    assert storage.session is not None
+    assert (storage.session.runs[0].messages or [])[0].model_dump() == original_stored
+
+
+def test_pre_replay_crash_recovery_preserves_prior_factual_and_active_live_notice() -> None:
+    """Recovery should factualize prior live state without touching prior facts or the active response."""
+    storage = _FakeStorage()
+
+    with queued_message_signal_context(_StaticQueuedState(pending=False)) as notice_context:
+        prior_factual = _queued_notice_message(
+            "already-factual",
+            marker="persisted",
+            content=_QUEUED_NOTICE_HISTORY_TEXT,
+        )
+        prior_dump = prior_factual.model_dump()
+        active_live = _queued_notice_message(notice_context.response_turn_id)
+        storage.session = AgentSession(
+            session_id="session-1",
+            runs=[
+                RunOutput(
+                    run_id="completed-run",
+                    session_id="session-1",
+                    messages=[
+                        _queued_notice_message("crash-left"),
+                        prior_factual,
+                        active_live,
+                    ],
+                ),
+            ],
+        )
+        ai_runtime.scrub_queued_notice_session_context(
+            scope_context=SimpleNamespace(
+                storage=storage,
+                session=storage.session,
+            ),
+            entity_name="general",
+        )
+
+    assert storage.session is not None
+    stored_messages = storage.session.runs[0].messages or []
+    assert prior_factual.model_dump() == prior_dump
+    assert _notice_count(stored_messages, marker="persisted", response_turn_id="already-factual") == 1
+    assert _notice_count(stored_messages, marker="persisted", response_turn_id="crash-left") == 1
+    assert _notice_count(stored_messages, marker=True, response_turn_id="crash-left") == 0
+    assert _notice_count(stored_messages, marker=True, response_turn_id=notice_context.response_turn_id) == 1
+
+
+def test_notice_provider_data_survives_mindroom_sqlite_round_trip(tmp_path: Path) -> None:
+    """MindRoom's prompt-sanitizing SQLite storage should preserve notice ownership metadata."""
+    response_turn_id = "response-1"
+    storage = _queued_notice_storage(tmp_path)
+    storage.upsert_session(
+        AgentSession(
+            session_id="session-1",
+            agent_id="general",
+            runs=[
+                RunOutput(
+                    run_id="run-1",
+                    agent_id="general",
+                    session_id="session-1",
+                    messages=[_queued_notice_message(response_turn_id)],
+                    status=RunStatus.completed,
+                ),
+            ],
+            created_at=1,
+            updated_at=1,
+        ),
+    )
+    storage.close()
+
+    reopened_storage = _queued_notice_storage(tmp_path)
+    try:
+        session = get_agent_session(reopened_storage, "session-1")
+    finally:
+        reopened_storage.close()
+
+    assert session is not None
+    assert session.runs is not None
+    stored_run = session.runs[0]
+    assert isinstance(stored_run, RunOutput)
+    stored_notice = (stored_run.messages or [])[0]
+    assert stored_notice.content == QUEUED_MESSAGE_NOTICE_TEXT
+    assert stored_notice.provider_data == {
+        _QUEUED_NOTICE_MARKER_KEY: True,
+        _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: response_turn_id,
+    }
+    assert stored_notice.from_history is False
+
+
+async def _persist_notice_bearing_response(tmp_path: Path) -> str:
+    lifecycle = ResponseLifecycleCoordinator()
+    target = MessageTarget.resolve("!room:localhost", "$thread", "$event-1")
+    envelope = _envelope(source_event_id="$event-1", target=target)
+    response_1_model = RecordingModel(id="response-1-model", provider="fake")
+    install_queued_message_notice_hook(response_1_model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+    response_1_ids: list[str] = []
+
+    async def response_1_operation(_target: MessageTarget) -> str:
+        lifecycle._get_or_create_queued_signal(target).add_waiting_human_message("$newer")
+        messages = [Message(role="user", content="First request")]
+        response_1_model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="First tool result")],
+        )
+        notices = _notice_messages(messages, marker=True)
+        assert len(notices) == 1
+        provider_data = notices[0].provider_data
+        assert isinstance(provider_data, dict)
+        response_turn_id = provider_data[_QUEUED_NOTICE_RESPONSE_TURN_ID_KEY]
+        assert isinstance(response_turn_id, str)
+        response_1_ids.append(response_turn_id)
+        messages.append(Message(role="assistant", content="First response handoff"))
+        run_output = RunOutput(
+            run_id="run-1",
+            agent_id="general",
+            session_id="session-1",
+            messages=messages,
+            status=RunStatus.completed,
+        )
+        storage = _queued_notice_storage(tmp_path)
+        try:
+            storage.upsert_session(
+                AgentSession(
+                    session_id="session-1",
+                    agent_id="general",
+                    runs=[run_output],
+                    created_at=1,
+                    updated_at=1,
+                ),
+            )
+        finally:
+            storage.close()
+        register_queued_notice_attempt(
+            run_output=run_output,
+            storage_factory=lambda: _queued_notice_storage(tmp_path),
+            session_id="session-1",
+            session_type=SessionType.AGENT,
+            entity_name="general",
+        )
+        return "First response handoff"
+
+    response_1 = await lifecycle.run_locked_response(
+        target=target,
+        response_envelope=envelope,
+        queued_notice_reservation=None,
+        pipeline_timing=None,
+        locked_operation=response_1_operation,
+    )
+
+    assert response_1 == "First response handoff"
+    assert len(response_1_ids) == 1
+    return response_1_ids[0]
+
+
+@pytest.mark.asyncio
+async def test_prior_notice_survives_actual_next_provider_request_and_tool_round(
+    tmp_path: Path,
+) -> None:
+    """A factual notice should survive real SQLite replay and the next response's tool formatting."""
+    response_1_id = await _persist_notice_bearing_response(tmp_path)
+
+    response_2_storage = _queued_notice_storage(tmp_path)
+    recording_model = RecordingModel(id="response-2-model", provider="fake")
+    install_queued_message_notice_hook(recording_model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+    response_2_agent = AgnoAgent(
+        id="general",
+        name="General",
+        model=recording_model,
+        db=response_2_storage,
+        add_history_to_context=True,
+        num_history_runs=10,
+        store_history_messages=False,
+    )
+    try:
+        with queued_message_signal_context(_StaticQueuedState(pending=False)) as response_2_context:
+            response_2 = await response_2_agent.arun("Second request", session_id="session-1")
+            prior = next(
+                message for message in recording_model.seen_messages if message.content == _QUEUED_NOTICE_HISTORY_TEXT
+            )
+            assert prior.from_history is True
+            assert prior.provider_data == {
+                _QUEUED_NOTICE_MARKER_KEY: "persisted",
+                _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: response_1_id,
+            }
+            original_prior = prior.model_dump()
+
+            recording_model.format_function_call_results(
+                messages=recording_model.seen_messages,
+                function_call_results=[Message(role="tool", content="Second tool result")],
+            )
+
+            assert prior.model_dump() == original_prior
+            assert (
+                _notice_count(
+                    recording_model.seen_messages,
+                    marker="persisted",
+                    response_turn_id=response_1_id,
+                )
+                == 1
+            )
+            assert (
+                _notice_count(
+                    recording_model.seen_messages,
+                    response_turn_id=response_2_context.response_turn_id,
+                )
+                == 0
+            )
+
+        assert response_2.content == "ok"
+        persisted = get_agent_session(response_2_storage, "session-1")
+    finally:
+        response_2_storage.close()
+
+    assert persisted is not None
+    assert persisted.runs is not None
+    response_2_run = persisted.runs[-1]
+    assert isinstance(response_2_run, RunOutput)
+    assert all(message.content != _QUEUED_NOTICE_HISTORY_TEXT for message in response_2_run.messages or [])
+    response_1_run = persisted.runs[0]
+    assert isinstance(response_1_run, RunOutput)
+    factual = _notice_messages(
+        response_1_run.messages or [],
+        marker="persisted",
+        response_turn_id=response_1_id,
+    )
+    assert [message.content for message in factual] == [_QUEUED_NOTICE_HISTORY_TEXT]

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -2983,8 +2983,8 @@ def test_default_queued_notice_requires_pause_handoff() -> None:
         "while you were working. This is a PAUSE, not a cancellation of the current task. Do not make "
         "any new tool calls. End this turn now with a final text response that explicitly says a newer "
         "message arrived and states: (1) what you completed, (2) what remains unfinished, and (3) the "
-        "next step. If work remains, state that you will resume it on the next turn unless the newer "
-        "message explicitly tells you to stop or redirect it."
+        "next step. You cannot see the newer message's contents yet. If work remains, state that you "
+        "intend to resume it on the next turn, subject to the newer message's instructions."
     )
 
 

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -351,11 +351,6 @@ async def test_response_lifecycle_rejects_mismatched_locked_response_target(tmp_
 
 _QUEUED_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY = "mindroom_queued_message_notice_response_turn_id"
-_QUEUED_NOTICE_HISTORY_TEXT = (
-    '\n\n<mindroom-history-note kind="queued-message-notice">\n'
-    "A queued-message notice was delivered.\n"
-    "</mindroom-history-note>\n\n"
-)
 
 
 def _notice_messages(
@@ -3021,13 +3016,13 @@ def test_notice_hook_scopes_dedupe_to_response_turn_id() -> None:
         prior_notice = _queued_notice_message(
             "prior-response",
             marker="persisted",
-            content=_QUEUED_NOTICE_HISTORY_TEXT,
+            content=QUEUED_MESSAGE_NOTICE_TEXT,
             from_history=True,
         )
         current_stale_notice = _queued_notice_message(
             notice_context.response_turn_id,
             marker="persisted",
-            content=_QUEUED_NOTICE_HISTORY_TEXT,
+            content=QUEUED_MESSAGE_NOTICE_TEXT,
         )
         messages = [prior_notice, current_stale_notice]
         model.format_function_call_results(
@@ -3041,14 +3036,14 @@ def test_notice_hook_scopes_dedupe_to_response_turn_id() -> None:
     assert _notice_count(messages, marker=True, response_turn_id=notice_context.response_turn_id) == 1
 
 
-def test_notice_hook_preserves_prior_factual_replay() -> None:
-    """A prior factual replay note should survive later tool-result formatting byte-for-byte."""
+def test_notice_hook_preserves_prior_persisted_replay() -> None:
+    """A prior persisted notice should survive later tool-result formatting byte-for-byte."""
     model = _FakeModel()
     install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
     prior_notice = _queued_notice_message(
         "prior-response",
         marker="persisted",
-        content=_QUEUED_NOTICE_HISTORY_TEXT,
+        content=QUEUED_MESSAGE_NOTICE_TEXT,
         from_history=True,
     )
     original = prior_notice.model_dump()
@@ -3171,7 +3166,7 @@ def test_notice_hook_still_installs_when_media_handler_is_missing() -> None:
 
 @pytest.mark.asyncio
 async def test_ai_response_preserves_stale_notice_before_prepare(tmp_path: Path) -> None:
-    """Loaded session history should factualize a prior crash-left live notice."""
+    """Loaded session history should persist a prior crash-left live notice."""
     config = _config(tmp_path)
     storage = _FakeStorage()
     storage.session = AgentSession(
@@ -3237,7 +3232,7 @@ async def test_ai_response_preserves_stale_notice_before_prepare(tmp_path: Path)
         marker="persisted",
         response_turn_id="prior-response",
     )
-    assert [message.content for message in recovered] == [_QUEUED_NOTICE_HISTORY_TEXT]
+    assert [message.content for message in recovered] == [QUEUED_MESSAGE_NOTICE_TEXT]
 
 
 @pytest.mark.asyncio
@@ -3484,7 +3479,7 @@ def test_create_team_instance_installs_notice_hook_on_team_model(tmp_path: Path)
 
 @pytest.mark.asyncio
 async def test_response_finalization_collapses_nested_current_notice_state() -> None:
-    """Outer finalization should leave one factual note in the top-level completed run."""
+    """Outer finalization should leave one exact notice in the top-level completed run."""
     created_storages: list[_FakeStorage] = []
     model = _FakeModel()
     install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
@@ -3560,7 +3555,7 @@ async def test_response_finalization_collapses_nested_current_notice_state() -> 
 
 @pytest.mark.asyncio
 async def test_response_finalization_uses_newest_completed_same_turn_run_and_original_notice_position() -> None:
-    """Two completed attempts should leave one factual note at the newest attempt's notice position."""
+    """Two completed attempts should leave one exact notice at the newest notice position."""
     model = _FakeModel()
     install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
     storage = _FakeStorage()
@@ -3632,7 +3627,7 @@ async def test_response_finalization_uses_newest_completed_same_turn_run_and_ori
         ("user", "Second request"),
         ("assistant", "Second tool call"),
         ("tool", "Second result"),
-        ("user", _QUEUED_NOTICE_HISTORY_TEXT),
+        ("user", QUEUED_MESSAGE_NOTICE_TEXT),
         ("assistant", "Second final"),
     ]
     assert (
@@ -3987,13 +3982,14 @@ async def test_error_responses_never_attach_notices_to_prior_completed_run() -> 
 
 @pytest.mark.asyncio
 async def test_response_lifecycle_finalizes_notice_after_locked_operation() -> None:
-    """The lifecycle boundary should finalize registered attempts after the operation returns."""
+    """The lifecycle boundary should persist the exact notice shown to the model."""
     lifecycle = ResponseLifecycleCoordinator()
     target = MessageTarget.resolve("!room:localhost", "$thread", "$event")
     envelope = _envelope(source_event_id="$event", target=target)
     storage = _FakeStorage()
     model = _FakeModel()
-    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+    notice_text = "Custom queued notice."
+    install_queued_message_notice_hook(model, notice_text=notice_text)
     observed_live_counts: list[int] = []
 
     async def locked_operation(_target: MessageTarget) -> str:
@@ -4043,8 +4039,8 @@ async def test_response_lifecycle_finalizes_notice_after_locked_operation() -> N
     assert storage.session is not None
     stored_run = storage.session.runs[0]
     assert _notice_count(stored_run.messages or [], marker=True) == 0
-    factual = _notice_messages(stored_run.messages or [], marker="persisted")
-    assert [message.content for message in factual] == [_QUEUED_NOTICE_HISTORY_TEXT]
+    persisted_notices = _notice_messages(stored_run.messages or [], marker="persisted")
+    assert [message.content for message in persisted_notices] == [notice_text]
     assert storage.upsert_count == 1
 
 
@@ -4100,7 +4096,7 @@ async def test_response_lifecycle_finalizes_error_state_when_operation_raises() 
 
 
 @pytest.mark.asyncio
-async def test_response_turn_finalization_is_idempotent_for_one_factual_note() -> None:
+async def test_response_turn_finalization_is_idempotent_for_one_persisted_notice() -> None:
     """Repeated boundary finalization should not rewrite an already-normalized response."""
     storage = _FakeStorage()
     model = _FakeModel()
@@ -4112,15 +4108,15 @@ async def test_response_turn_finalization_is_idempotent_for_one_factual_note() -
             messages=injected_messages,
             function_call_results=[Message(role="tool", content="result")],
         )
-        factual = _queued_notice_message(
+        persisted_notice = _queued_notice_message(
             notice_context.response_turn_id,
             marker="persisted",
-            content=_QUEUED_NOTICE_HISTORY_TEXT,
+            content=QUEUED_MESSAGE_NOTICE_TEXT,
         )
         run = RunOutput(
             run_id="completed-run",
             session_id="session-1",
-            messages=[factual],
+            messages=[persisted_notice],
             status=RunStatus.completed,
         )
         storage.session = AgentSession(
@@ -4129,7 +4125,7 @@ async def test_response_turn_finalization_is_idempotent_for_one_factual_note() -
                 RunOutput(
                     run_id=run.run_id,
                     session_id=run.session_id,
-                    messages=[factual.model_copy(deep=True)],
+                    messages=[persisted_notice.model_copy(deep=True)],
                     status=run.status,
                 ),
             ],
@@ -4150,17 +4146,17 @@ async def test_response_turn_finalization_is_idempotent_for_one_factual_note() -
     assert (storage.session.runs[0].messages or [])[0].model_dump() == original_stored
 
 
-def test_pre_replay_crash_recovery_preserves_prior_factual_and_active_live_notice() -> None:
-    """Recovery should factualize prior live state without touching prior facts or the active response."""
+def test_pre_replay_crash_recovery_preserves_prior_persisted_and_active_live_notice() -> None:
+    """Recovery should persist prior live state without touching prior records or the active response."""
     storage = _FakeStorage()
 
     with queued_message_signal_context(_StaticQueuedState(pending=False)) as notice_context:
-        prior_factual = _queued_notice_message(
-            "already-factual",
+        prior_persisted = _queued_notice_message(
+            "already-persisted",
             marker="persisted",
-            content=_QUEUED_NOTICE_HISTORY_TEXT,
+            content=QUEUED_MESSAGE_NOTICE_TEXT,
         )
-        prior_dump = prior_factual.model_dump()
+        prior_dump = prior_persisted.model_dump()
         active_live = _queued_notice_message(notice_context.response_turn_id)
         storage.session = AgentSession(
             session_id="session-1",
@@ -4170,7 +4166,7 @@ def test_pre_replay_crash_recovery_preserves_prior_factual_and_active_live_notic
                     session_id="session-1",
                     messages=[
                         _queued_notice_message("crash-left"),
-                        prior_factual,
+                        prior_persisted,
                         active_live,
                     ],
                 ),
@@ -4186,8 +4182,8 @@ def test_pre_replay_crash_recovery_preserves_prior_factual_and_active_live_notic
 
     assert storage.session is not None
     stored_messages = storage.session.runs[0].messages or []
-    assert prior_factual.model_dump() == prior_dump
-    assert _notice_count(stored_messages, marker="persisted", response_turn_id="already-factual") == 1
+    assert prior_persisted.model_dump() == prior_dump
+    assert _notice_count(stored_messages, marker="persisted", response_turn_id="already-persisted") == 1
     assert _notice_count(stored_messages, marker="persisted", response_turn_id="crash-left") == 1
     assert _notice_count(stored_messages, marker=True, response_turn_id="crash-left") == 0
     assert _notice_count(stored_messages, marker=True, response_turn_id=notice_context.response_turn_id) == 1
@@ -4304,7 +4300,7 @@ async def _persist_notice_bearing_response(tmp_path: Path) -> str:
 async def test_prior_notice_survives_actual_next_provider_request_and_tool_round(
     tmp_path: Path,
 ) -> None:
-    """A factual notice should survive real SQLite replay and the next response's tool formatting."""
+    """The exact notice should survive real SQLite replay and next-response formatting."""
     response_1_id = await _persist_notice_bearing_response(tmp_path)
 
     response_2_storage = _queued_notice_storage(tmp_path)
@@ -4323,13 +4319,27 @@ async def test_prior_notice_survives_actual_next_provider_request_and_tool_round
         with queued_message_signal_context(_StaticQueuedState(pending=False)) as response_2_context:
             response_2 = await response_2_agent.arun("Second request", session_id="session-1")
             prior = next(
-                message for message in recording_model.seen_messages if message.content == _QUEUED_NOTICE_HISTORY_TEXT
+                message for message in recording_model.seen_messages if message.content == QUEUED_MESSAGE_NOTICE_TEXT
             )
             assert prior.from_history is True
             assert prior.provider_data == {
                 _QUEUED_NOTICE_MARKER_KEY: "persisted",
                 _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: response_1_id,
             }
+            assert [
+                (message.role, message.content)
+                for message in recording_model.seen_messages
+                if message.content
+                in {
+                    QUEUED_MESSAGE_NOTICE_TEXT,
+                    "First response handoff",
+                    "Second request",
+                }
+            ] == [
+                ("user", QUEUED_MESSAGE_NOTICE_TEXT),
+                ("assistant", "First response handoff"),
+                ("user", "Second request"),
+            ]
             original_prior = prior.model_dump()
 
             recording_model.format_function_call_results(
@@ -4363,12 +4373,12 @@ async def test_prior_notice_survives_actual_next_provider_request_and_tool_round
     assert persisted.runs is not None
     response_2_run = persisted.runs[-1]
     assert isinstance(response_2_run, RunOutput)
-    assert all(message.content != _QUEUED_NOTICE_HISTORY_TEXT for message in response_2_run.messages or [])
+    assert all(message.content != QUEUED_MESSAGE_NOTICE_TEXT for message in response_2_run.messages or [])
     response_1_run = persisted.runs[0]
     assert isinstance(response_1_run, RunOutput)
-    factual = _notice_messages(
+    persisted_notices = _notice_messages(
         response_1_run.messages or [],
         marker="persisted",
         response_turn_id=response_1_id,
     )
-    assert [message.content for message in factual] == [_QUEUED_NOTICE_HISTORY_TEXT]
+    assert [message.content for message in persisted_notices] == [QUEUED_MESSAGE_NOTICE_TEXT]

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -29,7 +29,7 @@ from mindroom.ai import _PreparedAgentRun, ai_response, stream_agent_response
 from mindroom.ai_runtime import (
     install_queued_message_notice_hook,
     queued_message_signal_context,
-    register_queued_notice_attempt,
+    register_queued_notice_storage,
 )
 from mindroom.bot import AgentBot
 from mindroom.bot_runtime_view import BotRuntimeState
@@ -3529,8 +3529,7 @@ async def test_response_finalization_collapses_nested_current_notice_state() -> 
             created_storages.append(storage)
             return storage
 
-        register_queued_notice_attempt(
-            run_output=run_output,
+        register_queued_notice_storage(
             storage_factory=storage_factory,
             session_id="session-1",
             session_type=SessionType.TEAM,
@@ -3551,6 +3550,69 @@ async def test_response_finalization_collapses_nested_current_notice_state() -> 
     assert isinstance(stored_member_run, RunOutput)
     assert _notice_count(stored_member_run.messages or []) == 0
     assert storage.closed is True
+
+
+@pytest.mark.asyncio
+async def test_response_finalization_does_not_copy_notice_to_untouched_target() -> None:
+    """Finalization should persist a notice only in storage that contains its live marker."""
+    untouched_storage = _FakeStorage()
+    noticed_storage = _FakeStorage()
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        noticed_messages = [Message(role="user", content="Outer request")]
+        model.format_function_call_results(
+            messages=noticed_messages,
+            function_call_results=[Message(role="tool", content="Outer tool result")],
+        )
+        untouched_run = RunOutput(
+            run_id="untouched-run",
+            session_id="shared-session",
+            messages=[
+                Message(role="user", content="Delegated request"),
+                Message(role="assistant", content="Delegated answer"),
+            ],
+            status=RunStatus.completed,
+        )
+        noticed_run = RunOutput(
+            run_id="noticed-run",
+            session_id="shared-session",
+            messages=noticed_messages,
+            status=RunStatus.completed,
+        )
+        untouched_storage.session = AgentSession(
+            session_id="shared-session",
+            runs=[untouched_run],
+        )
+        noticed_storage.session = AgentSession(
+            session_id="shared-session",
+            runs=[noticed_run],
+        )
+        register_queued_notice_storage(
+            storage_factory=lambda: untouched_storage,
+            session_id="shared-session",
+            session_type=SessionType.AGENT,
+            entity_name="delegated-agent",
+        )
+        register_queued_notice_storage(
+            storage_factory=lambda: noticed_storage,
+            session_id="shared-session",
+            session_type=SessionType.AGENT,
+            entity_name="outer-agent",
+        )
+
+        await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
+
+    assert untouched_storage.upsert_count == 0
+    assert untouched_storage.session is not None
+    assert [(message.role, message.content) for message in untouched_run.messages or []] == [
+        ("user", "Delegated request"),
+        ("assistant", "Delegated answer"),
+    ]
+    assert noticed_storage.upsert_count == 1
+    assert _notice_count(noticed_run.messages or [], marker=True) == 0
+    assert _notice_count(noticed_run.messages or [], marker="persisted") == 1
 
 
 @pytest.mark.asyncio
@@ -3608,14 +3670,12 @@ async def test_response_finalization_uses_newest_completed_same_turn_run_and_ori
                 ),
             ],
         )
-        for run_output in (first_run, second_run):
-            register_queued_notice_attempt(
-                run_output=run_output,
-                storage_factory=lambda: storage,
-                session_id="session-1",
-                session_type=SessionType.AGENT,
-                entity_name="general",
-            )
+        register_queued_notice_storage(
+            storage_factory=lambda: storage,
+            session_id="session-1",
+            session_type=SessionType.AGENT,
+            entity_name="general",
+        )
 
         await ai_runtime.finalize_queued_notice_response_turn_async(notice_context)
 
@@ -3683,8 +3743,7 @@ async def test_async_cleanup_keeps_session_storage_io_off_event_loop() -> None:
             created_storages.append(storage)
             return storage
 
-        register_queued_notice_attempt(
-            run_output=None,
+        register_queued_notice_storage(
             storage_factory=storage_factory,
             session_id="session-1",
             session_type=SessionType.AGENT,
@@ -3750,8 +3809,7 @@ async def test_response_turn_finalization_completes_when_cancelled_during_storag
                 ),
             ],
         )
-        register_queued_notice_attempt(
-            run_output=run_output,
+        register_queued_notice_storage(
             storage_factory=lambda: storage,
             session_id="session-1",
             session_type=SessionType.AGENT,
@@ -3831,8 +3889,7 @@ async def test_response_turn_finalization_defers_repeated_cancellation_during_st
                 ),
             ],
         )
-        register_queued_notice_attempt(
-            run_output=run_output,
+        register_queued_notice_storage(
             storage_factory=lambda: storage,
             session_id="session-1",
             session_type=SessionType.AGENT,
@@ -3868,7 +3925,7 @@ async def test_response_turn_finalization_defers_repeated_cancellation_during_st
 
 
 @pytest.mark.asyncio
-async def test_attempt_registration_deduplicates_one_session_across_fresh_factories() -> None:
+async def test_storage_registration_deduplicates_one_session_across_fresh_factories() -> None:
     """Fresh storage-factory closures for one session should cause one boundary open."""
     model = _FakeModel()
     install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
@@ -3908,8 +3965,7 @@ async def test_attempt_registration_deduplicates_one_session_across_fresh_factor
             return storage_factory
 
         for _ in range(2):
-            register_queued_notice_attempt(
-                run_output=run_output,
+            register_queued_notice_storage(
                 storage_factory=fresh_storage_factory(),
                 session_id="session-1",
                 session_type=SessionType.AGENT,
@@ -3959,8 +4015,7 @@ async def test_error_responses_never_attach_notices_to_prior_completed_run() -> 
                     status=error_run.status,
                 ),
             )
-            register_queued_notice_attempt(
-                run_output=error_run,
+            register_queued_notice_storage(
                 storage_factory=lambda: storage,
                 session_id="session-1",
                 session_type=SessionType.AGENT,
@@ -4016,8 +4071,7 @@ async def test_response_lifecycle_finalizes_notice_after_locked_operation() -> N
                 ),
             ],
         )
-        register_queued_notice_attempt(
-            run_output=run,
+        register_queued_notice_storage(
             storage_factory=lambda: storage,
             session_id="session-1",
             session_type=SessionType.AGENT,
@@ -4072,8 +4126,7 @@ async def test_response_lifecycle_finalizes_error_state_when_operation_raises() 
                 ),
             ],
         )
-        register_queued_notice_attempt(
-            run_output=None,
+        register_queued_notice_storage(
             storage_factory=lambda: storage,
             session_id="session-1",
             session_type=SessionType.AGENT,
@@ -4131,8 +4184,7 @@ async def test_response_turn_finalization_is_idempotent_for_one_persisted_notice
             ],
         )
         original_stored = (storage.session.runs[0].messages or [])[0].model_dump()
-        register_queued_notice_attempt(
-            run_output=run,
+        register_queued_notice_storage(
             storage_factory=lambda: storage,
             session_id="session-1",
             session_type=SessionType.AGENT,
@@ -4274,8 +4326,7 @@ async def _persist_notice_bearing_response(tmp_path: Path) -> str:
             )
         finally:
             storage.close()
-        register_queued_notice_attempt(
-            run_output=run_output,
+        register_queued_notice_storage(
             storage_factory=lambda: _queued_notice_storage(tmp_path),
             session_id="session-1",
             session_type=SessionType.AGENT,

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -3785,6 +3785,94 @@ async def test_response_turn_finalization_completes_when_cancelled_during_storag
 
 
 @pytest.mark.asyncio
+async def test_response_turn_finalization_defers_repeated_cancellation_during_storage_io() -> None:
+    """Repeated cancellation must not release the caller before durable finalization finishes."""
+    request_started = threading.Event()
+    release_request = threading.Event()
+    request_finished = threading.Event()
+    first_cancel_observed = asyncio.Event()
+    original_shield = asyncio.shield
+    model = _FakeModel()
+    install_queued_message_notice_hook(model, notice_text=QUEUED_MESSAGE_NOTICE_TEXT)
+
+    class _BlockingStorage(_FakeStorage):
+        def get_session(self, session_id: str, _session_type: object) -> AgentSession | TeamSession | None:
+            request_started.set()
+            release_request.wait(timeout=1)
+            return super().get_session(session_id, _session_type)
+
+        def close(self) -> None:
+            super().close()
+            request_finished.set()
+
+    async def observed_shield(task: asyncio.Task[None]) -> None:
+        try:
+            await original_shield(task)
+        except asyncio.CancelledError:
+            first_cancel_observed.set()
+            raise
+
+    with queued_message_signal_context(_StaticQueuedState(pending=True)) as notice_context:
+        messages: list[Message] = []
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="result")],
+        )
+        run_output = RunOutput(
+            run_id="completed-run",
+            session_id="session-1",
+            messages=messages,
+            status=RunStatus.completed,
+        )
+        storage = _BlockingStorage()
+        storage.session = AgentSession(
+            session_id="session-1",
+            runs=[
+                RunOutput(
+                    run_id=run_output.run_id,
+                    session_id=run_output.session_id,
+                    messages=[message.model_copy(deep=True) for message in messages],
+                    status=run_output.status,
+                ),
+            ],
+        )
+        register_queued_notice_attempt(
+            run_output=run_output,
+            storage_factory=lambda: storage,
+            session_id="session-1",
+            session_type=SessionType.AGENT,
+            entity_name="general",
+        )
+        with patch.object(ai_runtime.asyncio, "shield", new=observed_shield):
+            finalization_task = asyncio.create_task(
+                ai_runtime.finalize_queued_notice_response_turn_async(notice_context),
+            )
+            assert await asyncio.to_thread(request_started.wait, 1)
+            finalization_task.cancel()
+            await asyncio.wait_for(first_cancel_observed.wait(), timeout=1)
+            finalization_task.cancel()
+            completed, _ = await asyncio.wait({finalization_task}, timeout=0.05)
+            try:
+                assert finalization_task not in completed
+            finally:
+                release_request.set()
+            with pytest.raises(asyncio.CancelledError):
+                await finalization_task
+
+    assert request_finished.is_set()
+    assert storage.session is not None
+    assert _notice_count(storage.session.runs[0].messages or [], marker=True) == 0
+    assert (
+        _notice_count(
+            storage.session.runs[0].messages or [],
+            marker="persisted",
+            response_turn_id=notice_context.response_turn_id,
+        )
+        == 1
+    )
+
+
+@pytest.mark.asyncio
 async def test_attempt_registration_deduplicates_one_session_across_fresh_factories() -> None:
     """Fresh storage-factory closures for one session should cause one boundary open."""
     model = _FakeModel()

--- a/tests/test_team_dynamic_continuation.py
+++ b/tests/test_team_dynamic_continuation.py
@@ -293,7 +293,6 @@ def test_release_attempt_members_resets_snapshot_state() -> None:
             materialized_agent_names={"general"},
             failed_agent_names=[],
         ),
-        last_response=TeamRunOutput(content="stale"),
         render_partial=lambda: "stale partial",
     )
     stale_tracker = holder.tool_tracker
@@ -302,7 +301,6 @@ def test_release_attempt_members_resets_snapshot_state() -> None:
     release(None)
 
     assert holder.team_members is None
-    assert holder.last_response is None
     assert holder.render_partial() == ""
     assert holder.tool_tracker is not stale_tracker
 

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -1753,7 +1753,11 @@ async def test_team_response_stream_event_only_stop_after_finalizes_delivered_no
             messages=messages,
             function_call_results=[stop_after_result],
         )
-        assert not _has_live_queued_notice(messages)
+        assert [(message.role, message.content) for message in messages] == [
+            ("tool", "first result"),
+            ("user", notice_text),
+            ("tool", "stop here"),
+        ]
 
         mock_team.db = prepared_scope_context.storage
         _cleanup_and_store(
@@ -1831,6 +1835,11 @@ async def test_team_response_stream_event_only_stop_after_finalizes_delivered_no
             response_turn_id=notice_context.response_turn_id,
             notice_text=notice_text,
         )
+        assert [(message.role, message.content) for message in run.messages or []] == [
+            ("tool", "first result"),
+            ("user", notice_text),
+            ("tool", "stop here"),
+        ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -194,7 +194,7 @@ class _PendingQueuedMessageState:
         return True
 
 
-def _assert_retry_notice_finalized(
+def _assert_retry_notice_not_relocated(
     *,
     agent: AgnoAgent,
     session_id: str,
@@ -217,7 +217,7 @@ def _assert_retry_notice_finalized(
         errored_run, completed_run = scope_context.session.runs or []
         assert not _has_live_queued_notice(errored_run.messages)
         assert not _has_persisted_queued_notice(errored_run.messages)
-        assert _has_persisted_queued_notice(
+        assert not _has_persisted_queued_notice(
             completed_run.messages,
             response_turn_id=response_turn_id,
         )
@@ -619,8 +619,8 @@ async def test_team_generic_invalid_request_retry_failure_does_not_teach() -> No
 
 
 @pytest.mark.asyncio
-async def test_team_response_retry_keeps_live_notice_until_response_boundary() -> None:
-    """Non-stream retries should retain current live state until the recovered response finishes."""
+async def test_team_response_retry_does_not_relocate_failed_attempt_notice() -> None:
+    """Non-stream retries should not copy a failed attempt's notice into the successful run."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     orchestrator = MagicMock()
@@ -699,7 +699,6 @@ async def test_team_response_retry_keeps_live_notice_until_response_boundary() -
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
-        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -723,7 +722,7 @@ async def test_team_response_retry_keeps_live_notice_until_response_boundary() -
 
     assert attempts == 2
     assert "Recovered team response" in response
-    _assert_retry_notice_finalized(
+    _assert_retry_notice_not_relocated(
         agent=fake_agent,
         session_id="session-retry-clean",
         runtime_paths=runtime_paths,
@@ -1064,7 +1063,6 @@ async def test_team_response_recovers_prior_notice_and_finalizes_current_notice(
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
-        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -1515,7 +1513,6 @@ async def test_team_response_finalizes_notice_from_completed_run_before_exceptio
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
-        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -1599,6 +1596,7 @@ async def test_team_response_stream_finalizes_notice_from_completed_run_before_e
                 team_name="General Team",
                 session_id="session-stream-queued-error",
                 content="intermediate response",
+                messages=[_queued_notice_message(notice_context.response_turn_id)],
                 status=RunStatus.completed,
             ),
             prepared_scope_context.session,
@@ -1625,7 +1623,6 @@ async def test_team_response_stream_finalizes_notice_from_completed_run_before_e
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
-        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -3632,8 +3629,8 @@ async def test_team_response_stream_tracks_retry_run_id_after_hard_cancellation(
 
 
 @pytest.mark.asyncio
-async def test_team_response_stream_retry_keeps_live_notice_until_response_boundary() -> None:  # noqa: PLR0915
-    """Streaming retries should retain current live state until the recovered response finishes."""
+async def test_team_response_stream_retry_does_not_relocate_failed_attempt_notice() -> None:  # noqa: PLR0915
+    """Streaming retries should not copy a failed attempt's notice into the successful run."""
     config = _build_test_config()
     config.teams["super_team"] = TeamConfig(
         display_name="Super Team",
@@ -3730,7 +3727,6 @@ async def test_team_response_stream_retry_keeps_live_notice_until_response_bound
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
-        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -3762,7 +3758,7 @@ async def test_team_response_stream_retry_keeps_live_notice_until_response_bound
     assert attempts == 2
     assert len(chunks) == 1
     assert "Recovered streamed response" in str(chunks[0])
-    _assert_retry_notice_finalized(
+    _assert_retry_notice_not_relocated(
         agent=fake_agent,
         session_id="session-stream-retry-clean",
         runtime_paths=runtime_paths,

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -97,11 +97,6 @@ if TYPE_CHECKING:
 _TEST_MODEL = "openai:gpt-5.4"
 _QUEUED_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY = "mindroom_queued_message_notice_response_turn_id"
-_QUEUED_NOTICE_HISTORY_TEXT = (
-    '\n\n<mindroom-history-note kind="queued-message-notice">\n'
-    "A queued-message notice was delivered.\n"
-    "</mindroom-history-note>\n\n"
-)
 
 
 def _make_test_agent(name: str) -> AgnoAgent:
@@ -176,7 +171,12 @@ def _has_live_queued_notice(messages: list[Message] | None, *, response_turn_id:
     )
 
 
-def _has_factual_queued_notice(messages: list[Message] | None, *, response_turn_id: str | None = None) -> bool:
+def _has_persisted_queued_notice(
+    messages: list[Message] | None,
+    *,
+    response_turn_id: str | None = None,
+    notice_text: str = QUEUED_MESSAGE_NOTICE_TEXT,
+) -> bool:
     return any(
         isinstance(message.provider_data, dict)
         and message.provider_data.get(_QUEUED_NOTICE_MARKER_KEY) == "persisted"
@@ -184,7 +184,7 @@ def _has_factual_queued_notice(messages: list[Message] | None, *, response_turn_
             response_turn_id is None
             or message.provider_data.get(_QUEUED_NOTICE_RESPONSE_TURN_ID_KEY) == response_turn_id
         )
-        and message.content == _QUEUED_NOTICE_HISTORY_TEXT
+        and message.content == notice_text
         for message in messages or []
     )
 
@@ -216,13 +216,13 @@ def _assert_retry_notice_finalized(
         assert scope_context.session is not None
         errored_run, completed_run = scope_context.session.runs or []
         assert not _has_live_queued_notice(errored_run.messages)
-        assert not _has_factual_queued_notice(errored_run.messages)
-        assert _has_factual_queued_notice(
+        assert not _has_persisted_queued_notice(errored_run.messages)
+        assert _has_persisted_queued_notice(
             completed_run.messages,
             response_turn_id=response_turn_id,
         )
         if check_compaction:
-            assert _QUEUED_NOTICE_HISTORY_TEXT not in {
+            assert QUEUED_MESSAGE_NOTICE_TEXT not in {
                 message.content
                 for message in _compaction_replay_messages(
                     errored_run,
@@ -683,7 +683,7 @@ async def test_team_response_retry_keeps_live_notice_until_response_boundary() -
             )
             for run in prepared_scope_context.session.runs or []
         )
-        assert not any(_has_factual_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
+        assert not any(_has_persisted_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
         completed_output = TeamRunOutput(
             run_id="run-2",
             team_id=team_id,
@@ -699,6 +699,7 @@ async def test_team_response_retry_keeps_live_notice_until_response_boundary() -
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
+        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -1051,7 +1052,7 @@ async def test_team_response_recovers_prior_notice_and_finalizes_current_notice(
         assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
         assert (
             sum(
-                _has_factual_queued_notice(
+                _has_persisted_queued_notice(
                     run.messages,
                     response_turn_id=prior_response_id,
                 )
@@ -1063,6 +1064,7 @@ async def test_team_response_recovers_prior_notice_and_finalizes_current_notice(
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
+        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -1096,14 +1098,14 @@ async def test_team_response_recovers_prior_notice_and_finalizes_current_notice(
         assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
         assert (
             sum(
-                _has_factual_queued_notice(run.messages, response_turn_id=prior_response_id)
+                _has_persisted_queued_notice(run.messages, response_turn_id=prior_response_id)
                 for run in scope_context.session.runs or []
             )
             == 1
         )
         assert (
             sum(
-                _has_factual_queued_notice(
+                _has_persisted_queued_notice(
                     run.messages,
                     response_turn_id=notice_context.response_turn_id,
                 )
@@ -1115,7 +1117,7 @@ async def test_team_response_recovers_prior_notice_and_finalizes_current_notice(
 
 @pytest.mark.asyncio
 async def test_prepare_materialized_team_execution_recovers_queued_notice_when_called_directly() -> None:
-    """Shared team preparation should factualize prior live notices even outside response helpers."""
+    """Shared team preparation should persist prior live notices outside response helpers."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     fake_agent = _make_test_agent("GeneralAgent")
@@ -1167,7 +1169,7 @@ async def test_prepare_materialized_team_execution_recovers_queued_notice_when_c
             assert not any(_has_live_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
             assert (
                 sum(
-                    _has_factual_queued_notice(
+                    _has_persisted_queued_notice(
                         run.messages,
                         response_turn_id=prior_response_id,
                     )
@@ -1450,7 +1452,7 @@ async def test_prepare_bound_team_execution_context_truncates_long_fallback_mess
 
 @pytest.mark.asyncio
 async def test_team_response_finalizes_notice_from_completed_run_before_exception() -> None:
-    """A completed stored run should retain factual delivery evidence when later handling fails."""
+    """A completed stored run should retain the delivered notice when later handling fails."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     orchestrator = MagicMock()
@@ -1508,11 +1510,12 @@ async def test_team_response_finalizes_notice_from_completed_run_before_exceptio
         assert scope_context.session is not None
         prepared_scope_context = scope_context
         assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
-        assert not any(_has_factual_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_persisted_queued_notice(run.messages) for run in scope_context.session.runs or [])
         return _prepared_team_execution_context(final_prompt="Analyze this.")
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
+        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -1545,7 +1548,7 @@ async def test_team_response_finalizes_notice_from_completed_run_before_exceptio
         assert scope_context.session is not None
         assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
         assert any(
-            _has_factual_queued_notice(
+            _has_persisted_queued_notice(
                 run.messages,
                 response_turn_id=notice_context.response_turn_id,
             )
@@ -1555,7 +1558,7 @@ async def test_team_response_finalizes_notice_from_completed_run_before_exceptio
 
 @pytest.mark.asyncio
 async def test_team_response_stream_finalizes_notice_from_completed_run_before_exception() -> None:
-    """A completed streamed run should retain factual delivery evidence when later handling fails."""
+    """A completed streamed run should retain the delivered notice when later handling fails."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     orchestrator = MagicMock()
@@ -1612,7 +1615,7 @@ async def test_team_response_stream_finalizes_notice_from_completed_run_before_e
         assert scope_context.session is not None
         prepared_scope_context = scope_context
         assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
-        assert not any(_has_factual_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_persisted_queued_notice(run.messages) for run in scope_context.session.runs or [])
         return _prepared_team_execution_context(final_prompt="Analyze this.")
 
     async def fake_team_response_stream_raw(**kwargs: object) -> AsyncIterator[object]:
@@ -1622,6 +1625,7 @@ async def test_team_response_stream_finalizes_notice_from_completed_run_before_e
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
+        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
@@ -1664,7 +1668,7 @@ async def test_team_response_stream_finalizes_notice_from_completed_run_before_e
         assert scope_context.session is not None
         assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
         assert any(
-            _has_factual_queued_notice(
+            _has_persisted_queued_notice(
                 run.messages,
                 response_turn_id=notice_context.response_turn_id,
             )
@@ -1674,7 +1678,7 @@ async def test_team_response_stream_finalizes_notice_from_completed_run_before_e
 
 @pytest.mark.asyncio
 async def test_team_response_stream_event_only_stop_after_finalizes_delivered_notice() -> None:  # noqa: PLR0915
-    """An event-only stop-after stream should retain factual notice-delivery evidence."""
+    """An event-only stop-after stream should retain the exact delivered notice."""
     config = _build_test_config()
     config.teams["super_team"] = TeamConfig(
         display_name="Super Team",
@@ -1708,9 +1712,10 @@ async def test_team_response_stream_event_only_stop_after_finalizes_delivered_no
     model = mock_team.model
     assert model is not None
     assert not isinstance(model, str)
+    notice_text = "Custom team queued notice."
     install_queued_message_notice_hook(
         model,
-        notice_text=QUEUED_MESSAGE_NOTICE_TEXT,
+        notice_text=notice_text,
     )
     prepared_scope_context = None
 
@@ -1821,9 +1826,10 @@ async def test_team_response_stream_event_only_stop_after_finalizes_delivered_no
         assert scope_context.session is not None
         run = (scope_context.session.runs or [])[0]
         assert not _has_live_queued_notice(run.messages)
-        assert _has_factual_queued_notice(
+        assert _has_persisted_queued_notice(
             run.messages,
             response_turn_id=notice_context.response_turn_id,
+            notice_text=notice_text,
         )
 
 
@@ -3690,7 +3696,7 @@ async def test_team_response_stream_retry_keeps_live_notice_until_response_bound
             )
             for run in prepared_scope_context.session.runs or []
         )
-        assert not any(_has_factual_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
+        assert not any(_has_persisted_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
         completed_output = TeamRunOutput(
             run_id=current_run_id,
             team_id=team_id,
@@ -3715,6 +3721,7 @@ async def test_team_response_stream_retry_keeps_live_notice_until_response_bound
 
     with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
         notice_context.notice_fired = True
+        notice_context.delivered_notice_text = QUEUED_MESSAGE_NOTICE_TEXT
         with (
             patch("mindroom.teams.create_agent", return_value=fake_agent),
             patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -20,6 +20,7 @@ from agno.run.agent import ToolCallCompletedEvent as AgentToolCallCompletedEvent
 from agno.run.agent import ToolCallStartedEvent as AgentToolCallStartedEvent
 from agno.run.base import RunStatus
 from agno.run.team import RunCancelledEvent as TeamRunCancelledEvent
+from agno.run.team import RunCompletedEvent as TeamRunCompletedEvent
 from agno.run.team import RunContentEvent as TeamRunContentEvent
 from agno.run.team import RunErrorEvent as TeamRunErrorEvent
 from agno.run.team import TeamRunOutput
@@ -30,10 +31,15 @@ from agno.team._run import _cleanup_and_store
 from agno.utils.message import get_text_from_message
 
 from mindroom.agents import create_agent
+from mindroom.ai_runtime import (
+    finalize_queued_notice_response_turn_async,
+    install_queued_message_notice_hook,
+    queued_message_signal_context,
+)
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
-from mindroom.constants import AI_RUN_METADATA_KEY, ROUTER_AGENT_NAME
+from mindroom.constants import AI_RUN_METADATA_KEY, ROUTER_AGENT_NAME, RuntimePaths
 from mindroom.error_handling import MODEL_SAFEGUARD_REFUSAL_MESSAGE
 from mindroom.execution_preparation import (
     ThreadHistoryRenderLimits,
@@ -41,6 +47,7 @@ from mindroom.execution_preparation import (
     _PreparedExecutionContext,
     prepare_bound_team_run_context,
 )
+from mindroom.history.compaction import _compaction_replay_messages
 from mindroom.history.interrupted_replay import _render_interrupted_replay_content
 from mindroom.history.runtime import open_bound_scope_session_context
 from mindroom.history.storage import read_scope_seen_event_ids, update_scope_seen_event_ids
@@ -88,6 +95,13 @@ if TYPE_CHECKING:
 
 
 _TEST_MODEL = "openai:gpt-5.4"
+_QUEUED_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
+_QUEUED_NOTICE_RESPONSE_TURN_ID_KEY = "mindroom_queued_message_notice_response_turn_id"
+_QUEUED_NOTICE_HISTORY_TEXT = (
+    '\n\n<mindroom-history-note kind="queued-message-notice">\n'
+    "A queued-message notice was delivered.\n"
+    "</mindroom-history-note>\n\n"
+)
 
 
 def _make_test_agent(name: str) -> AgnoAgent:
@@ -139,23 +153,82 @@ def _prepared_team_execution_context(
     )
 
 
-def _queued_notice_message() -> Message:
+def _queued_notice_message(response_turn_id: str) -> Message:
     return Message(
         role="user",
         content=QUEUED_MESSAGE_NOTICE_TEXT,
-        provider_data={"mindroom_queued_message_notice": True},
+        provider_data={
+            _QUEUED_NOTICE_MARKER_KEY: True,
+            _QUEUED_NOTICE_RESPONSE_TURN_ID_KEY: response_turn_id,
+        },
     )
 
 
-def _has_queued_notice(messages: list[Message] | None) -> bool:
+def _has_live_queued_notice(messages: list[Message] | None, *, response_turn_id: str | None = None) -> bool:
     return any(
-        (
-            isinstance(message.provider_data, dict)
-            and message.provider_data.get("mindroom_queued_message_notice") is True
+        isinstance(message.provider_data, dict)
+        and message.provider_data.get(_QUEUED_NOTICE_MARKER_KEY) is True
+        and (
+            response_turn_id is None
+            or message.provider_data.get(_QUEUED_NOTICE_RESPONSE_TURN_ID_KEY) == response_turn_id
         )
-        or message.content == QUEUED_MESSAGE_NOTICE_TEXT
         for message in messages or []
     )
+
+
+def _has_factual_queued_notice(messages: list[Message] | None, *, response_turn_id: str | None = None) -> bool:
+    return any(
+        isinstance(message.provider_data, dict)
+        and message.provider_data.get(_QUEUED_NOTICE_MARKER_KEY) == "persisted"
+        and (
+            response_turn_id is None
+            or message.provider_data.get(_QUEUED_NOTICE_RESPONSE_TURN_ID_KEY) == response_turn_id
+        )
+        and message.content == _QUEUED_NOTICE_HISTORY_TEXT
+        for message in messages or []
+    )
+
+
+class _PendingQueuedMessageState:
+    def has_pending_human_messages(self) -> bool:
+        return True
+
+
+def _assert_retry_notice_finalized(
+    *,
+    agent: AgnoAgent,
+    session_id: str,
+    runtime_paths: RuntimePaths,
+    config: Config,
+    response_turn_id: str,
+    team_name: str | None = None,
+    check_compaction: bool = False,
+) -> None:
+    with open_bound_scope_session_context(
+        agents=[agent],
+        session_id=session_id,
+        runtime_paths=runtime_paths,
+        config=config,
+        execution_identity=None,
+        team_name=team_name,
+    ) as scope_context:
+        assert scope_context is not None
+        assert scope_context.session is not None
+        errored_run, completed_run = scope_context.session.runs or []
+        assert not _has_live_queued_notice(errored_run.messages)
+        assert not _has_factual_queued_notice(errored_run.messages)
+        assert _has_factual_queued_notice(
+            completed_run.messages,
+            response_turn_id=response_turn_id,
+        )
+        if check_compaction:
+            assert _QUEUED_NOTICE_HISTORY_TEXT not in {
+                message.content
+                for message in _compaction_replay_messages(
+                    errored_run,
+                    config.resolve_entity(None).history_settings,
+                )
+            }
 
 
 def _team_turn_recorder(message: str) -> TurnRecorder:
@@ -546,8 +619,8 @@ async def test_team_generic_invalid_request_retry_failure_does_not_teach() -> No
 
 
 @pytest.mark.asyncio
-async def test_team_response_retry_scrubs_queued_notice_before_second_attempt() -> None:
-    """Non-stream retries should scrub queued notices from the loaded team session before retrying."""
+async def test_team_response_retry_keeps_live_notice_until_response_boundary() -> None:
+    """Non-stream retries should retain current live state until the recovered response finishes."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     orchestrator = MagicMock()
@@ -598,13 +671,20 @@ async def test_team_response_retry_scrubs_queued_notice_before_second_attempt() 
                 team_name="General Team",
                 session_id="session-retry-clean",
                 content="Error code: 500 - audio input is not supported",
-                messages=[_queued_notice_message()],
+                messages=[_queued_notice_message(notice_context.response_turn_id)],
                 status=RunStatus.error,
             )
             _cleanup_and_store(mock_team, errored_output, prepared_scope_context.session)
             return errored_output
-        assert not any(_has_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
-        return TeamRunOutput(
+        assert any(
+            _has_live_queued_notice(
+                run.messages,
+                response_turn_id=notice_context.response_turn_id,
+            )
+            for run in prepared_scope_context.session.runs or []
+        )
+        assert not any(_has_factual_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
+        completed_output = TeamRunOutput(
             run_id="run-2",
             team_id=team_id,
             team_name="General Team",
@@ -612,31 +692,44 @@ async def test_team_response_retry_scrubs_queued_notice_before_second_attempt() 
             content="Recovered team response",
             status=RunStatus.completed,
         )
+        _cleanup_and_store(mock_team, completed_output, prepared_scope_context.session)
+        return completed_output
 
     mock_team.arun = AsyncMock(side_effect=fake_arun)
 
-    with (
-        patch("mindroom.teams.create_agent", return_value=fake_agent),
-        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
-        patch("mindroom.teams._create_team_instance", return_value=mock_team),
-        patch(
-            "mindroom.execution_preparation._prepare_bound_team_execution_context",
-            new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
-        ),
-    ):
-        response = await team_response(
-            agent_names=["general"],
-            mode=TeamMode.COORDINATE,
-            message="Analyze this.",
-            turn_recorder=_team_turn_recorder("Analyze this."),
-            orchestrator=orchestrator,
-            execution_identity=None,
-            ctx=make_turn_context(session_id="session-retry-clean"),
-            media=MediaInputs(audio=[MagicMock(name="audio_input")]),
-        )
+    with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
+        notice_context.notice_fired = True
+        with (
+            patch("mindroom.teams.create_agent", return_value=fake_agent),
+            patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+            patch("mindroom.teams._create_team_instance", return_value=mock_team),
+            patch(
+                "mindroom.execution_preparation._prepare_bound_team_execution_context",
+                new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
+            ),
+        ):
+            response = await team_response(
+                agent_names=["general"],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                turn_recorder=_team_turn_recorder("Analyze this."),
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id="session-retry-clean"),
+                media=MediaInputs(audio=[MagicMock(name="audio_input")]),
+            )
+        await finalize_queued_notice_response_turn_async(notice_context)
 
     assert attempts == 2
     assert "Recovered team response" in response
+    _assert_retry_notice_finalized(
+        agent=fake_agent,
+        session_id="session-retry-clean",
+        runtime_paths=runtime_paths,
+        config=config,
+        response_turn_id=notice_context.response_turn_id,
+        check_compaction=True,
+    )
 
 
 @pytest.mark.asyncio
@@ -657,7 +750,7 @@ async def test_team_response_fallback_run_output_cleans_queued_notice_before_for
         content=None,
         messages=[
             Message(role="assistant", content="Recovered team response"),
-            _queued_notice_message(),
+            _queued_notice_message("fallback-response"),
         ],
         status=RunStatus.completed,
     )
@@ -873,8 +966,8 @@ async def test_team_response_preserves_unseen_matrix_thread_context_with_persist
 
 
 @pytest.mark.asyncio
-async def test_team_response_scrubs_queued_notices_before_prepare_and_after_run() -> None:
-    """Team runs should not replay or persist hidden queued-message notices."""
+async def test_team_response_recovers_prior_notice_and_finalizes_current_notice() -> None:
+    """Team runs should recover prior facts and finalize current notice state at the response boundary."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     orchestrator = MagicMock()
@@ -882,6 +975,7 @@ async def test_team_response_scrubs_queued_notices_before_prepare_and_after_run(
     orchestrator.runtime_paths = runtime_paths
     orchestrator.knowledge_managers = {}
     orchestrator.agent_bots = {"general": MagicMock()}
+    prior_response_id = "prior-response"
 
     fake_agent = _make_test_agent("GeneralAgent")
     with open_bound_scope_session_context(
@@ -906,7 +1000,7 @@ async def test_team_response_scrubs_queued_notices_before_prepare_and_after_run(
                 team_id=scope_context.session.team_id,
                 team_name="General Team",
                 session_id="session-queued",
-                messages=[_queued_notice_message()],
+                messages=[_queued_notice_message(prior_response_id)],
                 status=RunStatus.completed,
             ),
             scope_context.session,
@@ -928,7 +1022,7 @@ async def test_team_response_scrubs_queued_notices_before_prepare_and_after_run(
                 team_name="General Team",
                 session_id="session-queued",
                 content="Recovered team response",
-                messages=[_queued_notice_message()],
+                messages=[_queued_notice_message(notice_context.response_turn_id)],
                 status=RunStatus.completed,
             ),
             prepared_scope_context.session,
@@ -939,7 +1033,7 @@ async def test_team_response_scrubs_queued_notices_before_prepare_and_after_run(
             team_name="General Team",
             session_id="session-queued",
             content="Recovered team response",
-            messages=[_queued_notice_message()],
+            messages=[_queued_notice_message(notice_context.response_turn_id)],
             status=RunStatus.completed,
         )
 
@@ -954,27 +1048,40 @@ async def test_team_response_scrubs_queued_notices_before_prepare_and_after_run(
         assert scope_context is not None
         assert scope_context.session is not None
         prepared_scope_context = scope_context
-        assert not any(_has_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert (
+            sum(
+                _has_factual_queued_notice(
+                    run.messages,
+                    response_turn_id=prior_response_id,
+                )
+                for run in scope_context.session.runs or []
+            )
+            == 1
+        )
         return _prepared_team_execution_context(final_prompt="Analyze this.")
 
-    with (
-        patch("mindroom.teams.create_agent", return_value=fake_agent),
-        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
-        patch("mindroom.teams._create_team_instance", return_value=mock_team),
-        patch(
-            "mindroom.execution_preparation._prepare_bound_team_execution_context",
-            new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
-        ),
-    ):
-        response = await team_response(
-            agent_names=["general"],
-            mode=TeamMode.COORDINATE,
-            message="Analyze this.",
-            turn_recorder=_team_turn_recorder("Analyze this."),
-            orchestrator=orchestrator,
-            execution_identity=None,
-            ctx=make_turn_context(session_id="session-queued"),
-        )
+    with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
+        notice_context.notice_fired = True
+        with (
+            patch("mindroom.teams.create_agent", return_value=fake_agent),
+            patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+            patch("mindroom.teams._create_team_instance", return_value=mock_team),
+            patch(
+                "mindroom.execution_preparation._prepare_bound_team_execution_context",
+                new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
+            ),
+        ):
+            response = await team_response(
+                agent_names=["general"],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                turn_recorder=_team_turn_recorder("Analyze this."),
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id="session-queued"),
+            )
+        await finalize_queued_notice_response_turn_async(notice_context)
 
     assert "Recovered team response" in response
     with open_bound_scope_session_context(
@@ -986,15 +1093,33 @@ async def test_team_response_scrubs_queued_notices_before_prepare_and_after_run(
     ) as scope_context:
         assert scope_context is not None
         assert scope_context.session is not None
-        assert not any(_has_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert (
+            sum(
+                _has_factual_queued_notice(run.messages, response_turn_id=prior_response_id)
+                for run in scope_context.session.runs or []
+            )
+            == 1
+        )
+        assert (
+            sum(
+                _has_factual_queued_notice(
+                    run.messages,
+                    response_turn_id=notice_context.response_turn_id,
+                )
+                for run in scope_context.session.runs or []
+            )
+            == 1
+        )
 
 
 @pytest.mark.asyncio
-async def test_prepare_materialized_team_execution_scrubs_queued_notices_when_called_directly() -> None:
-    """Shared team preparation should scrub loaded queued notices even outside team_response helpers."""
+async def test_prepare_materialized_team_execution_recovers_queued_notice_when_called_directly() -> None:
+    """Shared team preparation should factualize prior live notices even outside response helpers."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     fake_agent = _make_test_agent("GeneralAgent")
+    prior_response_id = "prior-direct-response"
 
     with open_bound_scope_session_context(
         agents=[fake_agent],
@@ -1015,7 +1140,7 @@ async def test_prepare_materialized_team_execution_scrubs_queued_notices_when_ca
                 team_id=scope_context.session.team_id,
                 team_name="General Team",
                 session_id="session-helper-scrub",
-                messages=[_queued_notice_message()],
+                messages=[_queued_notice_message(prior_response_id)],
                 status=RunStatus.completed,
             ),
             scope_context.session,
@@ -1039,7 +1164,17 @@ async def test_prepare_materialized_team_execution_scrubs_queued_notices_when_ca
             prepared_scope_context = kwargs["scope_context"]
             assert prepared_scope_context is not None
             assert prepared_scope_context.session is not None
-            assert not any(_has_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
+            assert not any(_has_live_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
+            assert (
+                sum(
+                    _has_factual_queued_notice(
+                        run.messages,
+                        response_turn_id=prior_response_id,
+                    )
+                    for run in prepared_scope_context.session.runs or []
+                )
+                == 1
+            )
             return _prepared_team_execution_context(final_prompt="Analyze this.")
 
         with patch(
@@ -1314,8 +1449,8 @@ async def test_prepare_bound_team_execution_context_truncates_long_fallback_mess
 
 
 @pytest.mark.asyncio
-async def test_team_response_scrubs_queued_notices_after_run_exception() -> None:
-    """Failed team runs should still remove hidden queued-message notices from history."""
+async def test_team_response_finalizes_notice_from_completed_run_before_exception() -> None:
+    """A completed stored run should retain factual delivery evidence when later handling fails."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     orchestrator = MagicMock()
@@ -1354,7 +1489,7 @@ async def test_team_response_scrubs_queued_notices_after_run_exception() -> None
                 team_name="General Team",
                 session_id="session-queued-error",
                 content="intermediate response",
-                messages=[_queued_notice_message()],
+                messages=[_queued_notice_message(notice_context.response_turn_id)],
                 status=RunStatus.completed,
             ),
             prepared_scope_context.session,
@@ -1372,27 +1507,31 @@ async def test_team_response_scrubs_queued_notices_after_run_exception() -> None
         assert scope_context is not None
         assert scope_context.session is not None
         prepared_scope_context = scope_context
-        assert not any(_has_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_factual_queued_notice(run.messages) for run in scope_context.session.runs or [])
         return _prepared_team_execution_context(final_prompt="Analyze this.")
 
-    with (
-        patch("mindroom.teams.create_agent", return_value=fake_agent),
-        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
-        patch("mindroom.teams._create_team_instance", return_value=mock_team),
-        patch(
-            "mindroom.teams.prepare_bound_team_run_context",
-            new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
-        ),
-    ):
-        response = await team_response(
-            agent_names=["general"],
-            mode=TeamMode.COORDINATE,
-            message="Analyze this.",
-            orchestrator=orchestrator,
-            execution_identity=None,
-            ctx=make_turn_context(session_id="session-queued-error"),
-            turn_recorder=_team_turn_recorder("Analyze this."),
-        )
+    with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
+        notice_context.notice_fired = True
+        with (
+            patch("mindroom.teams.create_agent", return_value=fake_agent),
+            patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+            patch("mindroom.teams._create_team_instance", return_value=mock_team),
+            patch(
+                "mindroom.teams.prepare_bound_team_run_context",
+                new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
+            ),
+        ):
+            response = await team_response(
+                agent_names=["general"],
+                mode=TeamMode.COORDINATE,
+                message="Analyze this.",
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id="session-queued-error"),
+                turn_recorder=_team_turn_recorder("Analyze this."),
+            )
+        await finalize_queued_notice_response_turn_async(notice_context)
 
     assert "boom" in response
     with open_bound_scope_session_context(
@@ -1404,12 +1543,19 @@ async def test_team_response_scrubs_queued_notices_after_run_exception() -> None
     ) as scope_context:
         assert scope_context is not None
         assert scope_context.session is not None
-        assert not any(_has_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert any(
+            _has_factual_queued_notice(
+                run.messages,
+                response_turn_id=notice_context.response_turn_id,
+            )
+            for run in scope_context.session.runs or []
+        )
 
 
 @pytest.mark.asyncio
-async def test_team_response_stream_scrubs_queued_notices_after_stream_exception() -> None:
-    """Streaming team failures should still scrub hidden queued-message notices."""
+async def test_team_response_stream_finalizes_notice_from_completed_run_before_exception() -> None:
+    """A completed streamed run should retain factual delivery evidence when later handling fails."""
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     orchestrator = MagicMock()
@@ -1436,7 +1582,7 @@ async def test_team_response_stream_scrubs_queued_notices_after_stream_exception
     mock_team = _make_test_team(name="General Team", team_id=team_id)
     boom_error = "boom"
 
-    async def failing_raw_stream() -> AsyncIterator[object]:
+    async def failing_raw_stream(run_id: str) -> AsyncIterator[object]:
         if False:
             yield None
         assert prepared_scope_context is not None
@@ -1445,12 +1591,11 @@ async def test_team_response_stream_scrubs_queued_notices_after_stream_exception
         _cleanup_and_store(
             mock_team,
             TeamRunOutput(
-                run_id="run-stream-error",
+                run_id=run_id,
                 team_id=team_id,
                 team_name="General Team",
                 session_id="session-stream-queued-error",
                 content="intermediate response",
-                messages=[_queued_notice_message()],
                 status=RunStatus.completed,
             ),
             prepared_scope_context.session,
@@ -1466,37 +1611,46 @@ async def test_team_response_stream_scrubs_queued_notices_after_stream_exception
         assert scope_context is not None
         assert scope_context.session is not None
         prepared_scope_context = scope_context
-        assert not any(_has_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_factual_queued_notice(run.messages) for run in scope_context.session.runs or [])
         return _prepared_team_execution_context(final_prompt="Analyze this.")
 
-    async def fake_team_response_stream_raw(**_kwargs: object) -> AsyncIterator[object]:
-        return failing_raw_stream()
+    async def fake_team_response_stream_raw(**kwargs: object) -> AsyncIterator[object]:
+        run_id = kwargs["run_id"]
+        assert isinstance(run_id, str)
+        return failing_raw_stream(run_id)
 
-    with (
-        patch("mindroom.teams.create_agent", return_value=fake_agent),
-        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
-        patch("mindroom.teams._create_team_instance", return_value=mock_team),
-        patch(
-            "mindroom.teams.prepare_bound_team_run_context",
-            new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
-        ),
-        patch(
-            "mindroom.teams._team_response_stream_raw",
-            new=AsyncMock(side_effect=fake_team_response_stream_raw),
-        ),
-    ):
-        chunks = [
-            chunk
-            async for chunk in team_response_stream(
-                agent_ids=[entity_ids(config, runtime_paths)["general"]],
-                mode=TeamMode.COORDINATE,
-                message="Analyze this.",
-                orchestrator=orchestrator,
-                execution_identity=None,
-                ctx=make_turn_context(session_id="session-stream-queued-error"),
-                turn_recorder=_team_turn_recorder("Analyze this."),
-            )
-        ]
+    with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
+        notice_context.notice_fired = True
+        with (
+            patch("mindroom.teams.create_agent", return_value=fake_agent),
+            patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+            patch("mindroom.teams._create_team_instance", return_value=mock_team),
+            patch(
+                "mindroom.teams.prepare_bound_team_run_context",
+                new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
+            ),
+            patch(
+                "mindroom.teams._team_response_stream_raw",
+                new=AsyncMock(side_effect=fake_team_response_stream_raw),
+            ),
+        ):
+            chunks = [
+                chunk
+                async for chunk in team_response_stream(
+                    agent_ids=[entity_ids(config, runtime_paths)["general"]],
+                    mode=TeamMode.COORDINATE,
+                    message="Analyze this.",
+                    orchestrator=orchestrator,
+                    execution_identity=None,
+                    ctx=make_turn_context(
+                        session_id="session-stream-queued-error",
+                        run_id="run-stream-error",
+                    ),
+                    turn_recorder=_team_turn_recorder("Analyze this."),
+                )
+            ]
+        await finalize_queued_notice_response_turn_async(notice_context)
 
     assert "boom" in "".join(chunk.content if hasattr(chunk, "content") else str(chunk) for chunk in chunks)
     with open_bound_scope_session_context(
@@ -1508,7 +1662,169 @@ async def test_team_response_stream_scrubs_queued_notices_after_stream_exception
     ) as scope_context:
         assert scope_context is not None
         assert scope_context.session is not None
-        assert not any(_has_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert not any(_has_live_queued_notice(run.messages) for run in scope_context.session.runs or [])
+        assert any(
+            _has_factual_queued_notice(
+                run.messages,
+                response_turn_id=notice_context.response_turn_id,
+            )
+            for run in scope_context.session.runs or []
+        )
+
+
+@pytest.mark.asyncio
+async def test_team_response_stream_event_only_stop_after_finalizes_delivered_notice() -> None:  # noqa: PLR0915
+    """An event-only stop-after stream should retain factual notice-delivery evidence."""
+    config = _build_test_config()
+    config.teams["super_team"] = TeamConfig(
+        display_name="Super Team",
+        role="Configured test team",
+        agents=["general"],
+    )
+    runtime_paths = runtime_paths_for(config)
+    orchestrator = MagicMock()
+    orchestrator.config = config
+    orchestrator.runtime_paths = runtime_paths
+    orchestrator.knowledge_managers = {}
+    orchestrator.agent_bots = {"general": MagicMock(running=True)}
+    session_id = "session-event-only-stop-after"
+    run_id = "run-event-only-stop-after"
+
+    fake_agent = _make_test_agent("GeneralAgent")
+    with open_bound_scope_session_context(
+        agents=[fake_agent],
+        session_id=session_id,
+        runtime_paths=runtime_paths,
+        config=config,
+        execution_identity=None,
+        team_name="super_team",
+        create_session_if_missing=True,
+    ) as scope_context:
+        assert scope_context is not None
+        assert scope_context.session is not None
+        scope_context.storage.upsert_session(scope_context.session)
+
+    mock_team = _make_test_team(name="General Team", team_id="super_team")
+    model = mock_team.model
+    assert model is not None
+    assert not isinstance(model, str)
+    install_queued_message_notice_hook(
+        model,
+        notice_text=QUEUED_MESSAGE_NOTICE_TEXT,
+    )
+    prepared_scope_context = None
+
+    async def fake_prepare_bound_team_execution_context(
+        _ctx: object,
+        **kwargs: object,
+    ) -> _PreparedExecutionContext:
+        nonlocal prepared_scope_context
+        scope_context = kwargs["scope_context"]
+        assert scope_context is not None
+        assert scope_context.session is not None
+        prepared_scope_context = scope_context
+        return _prepared_team_execution_context(final_prompt="Analyze this.")
+
+    async def fake_stream_raw(**kwargs: object) -> AsyncIterator[object]:
+        current_run_id = kwargs["run_id"]
+        assert current_run_id == run_id
+        assert prepared_scope_context is not None
+        assert prepared_scope_context.session is not None
+        messages: list[Message] = []
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[Message(role="tool", content="first result")],
+        )
+        assert _has_live_queued_notice(
+            messages,
+            response_turn_id=notice_context.response_turn_id,
+        )
+        stop_after_result = Message(
+            role="tool",
+            content="stop here",
+            stop_after_tool_call=True,
+        )
+        model.format_function_call_results(
+            messages=messages,
+            function_call_results=[stop_after_result],
+        )
+        assert not _has_live_queued_notice(messages)
+
+        mock_team.db = prepared_scope_context.storage
+        _cleanup_and_store(
+            mock_team,
+            TeamRunOutput(
+                run_id=run_id,
+                team_id="super_team",
+                team_name="General Team",
+                session_id=session_id,
+                messages=messages,
+                status=RunStatus.completed,
+            ),
+            prepared_scope_context.session,
+        )
+        yield TeamToolCallCompletedEvent(
+            team_id="super_team",
+            run_id=run_id,
+            session_id=session_id,
+            tool=ToolExecution(
+                tool_call_id="stop-call",
+                tool_name="finish",
+                result="stop here",
+                stop_after_tool_call=True,
+            ),
+        )
+        yield TeamRunCompletedEvent(
+            team_id="super_team",
+            run_id=run_id,
+            session_id=session_id,
+        )
+
+    with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
+        with (
+            patch("mindroom.teams.create_agent", return_value=fake_agent),
+            patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+            patch("mindroom.teams._create_team_instance", return_value=mock_team),
+            patch(
+                "mindroom.teams.prepare_bound_team_run_context",
+                new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
+            ),
+            patch("mindroom.teams._team_response_stream_raw", new=AsyncMock(side_effect=fake_stream_raw)),
+        ):
+            chunks = [
+                chunk
+                async for chunk in team_response_stream(
+                    agent_ids=[entity_ids(config, runtime_paths)["general"]],
+                    mode=TeamMode.COORDINATE,
+                    message="Analyze this.",
+                    orchestrator=orchestrator,
+                    execution_identity=None,
+                    ctx=make_turn_context(session_id=session_id, run_id=run_id),
+                    turn_recorder=_team_turn_recorder("Analyze this."),
+                    configured_team_name="super_team",
+                    show_tool_calls=False,
+                )
+            ]
+        await finalize_queued_notice_response_turn_async(notice_context)
+
+    assert notice_context.notice_fired
+    assert chunks == []
+    with open_bound_scope_session_context(
+        agents=[fake_agent],
+        session_id=session_id,
+        runtime_paths=runtime_paths,
+        config=config,
+        execution_identity=None,
+        team_name="super_team",
+    ) as scope_context:
+        assert scope_context is not None
+        assert scope_context.session is not None
+        run = (scope_context.session.runs or [])[0]
+        assert not _has_live_queued_notice(run.messages)
+        assert _has_factual_queued_notice(
+            run.messages,
+            response_turn_id=notice_context.response_turn_id,
+        )
 
 
 @pytest.mark.asyncio
@@ -2932,7 +3248,7 @@ async def test_team_response_stream_emits_plain_run_output_fallback_with_team_fo
             content=None,
             messages=[
                 Message(role="assistant", content="Recovered team response"),
-                _queued_notice_message(),
+                _queued_notice_message("fallback-stream-response"),
             ],
             status=RunStatus.completed,
         )
@@ -3301,8 +3617,8 @@ async def test_team_response_stream_tracks_retry_run_id_after_hard_cancellation(
 
 
 @pytest.mark.asyncio
-async def test_team_response_stream_retry_scrubs_queued_notice_before_second_attempt() -> None:
-    """Streaming retries should scrub queued notices from the loaded team session before retrying."""
+async def test_team_response_stream_retry_keeps_live_notice_until_response_boundary() -> None:  # noqa: PLR0915
+    """Streaming retries should retain current live state until the recovered response finishes."""
     config = _build_test_config()
     config.teams["super_team"] = TeamConfig(
         display_name="Super Team",
@@ -3343,7 +3659,7 @@ async def test_team_response_stream_retry_scrubs_queued_notice_before_second_att
         prepared_scope_context = scope_context
         return _prepared_team_execution_context(final_prompt="Analyze this.")
 
-    async def fake_stream_raw(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+    async def fake_stream_raw(*_args: object, **kwargs: object) -> AsyncIterator[object]:
         nonlocal attempts
         attempts += 1
         assert prepared_scope_context is not None
@@ -3352,56 +3668,92 @@ async def test_team_response_stream_retry_scrubs_queued_notice_before_second_att
         team_id = prepared_scope_context.session.team_id
         assert team_id is not None
         assert team_id == "super_team"
+        current_run_id = kwargs["run_id"]
+        assert isinstance(current_run_id, str)
         if attempts == 1:
             errored_output = TeamRunOutput(
-                run_id="run-1",
+                run_id=current_run_id,
                 team_id=team_id,
                 team_name="General Team",
                 session_id="session-stream-retry-clean",
                 content="Error code: 500 - audio input is not supported",
-                messages=[_queued_notice_message()],
+                messages=[_queued_notice_message(notice_context.response_turn_id)],
                 status=RunStatus.error,
             )
             _cleanup_and_store(mock_team, errored_output, prepared_scope_context.session)
             yield errored_output
             return
-        assert not any(_has_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
-        yield TeamRunOutput(
-            run_id="run-2",
+        assert any(
+            _has_live_queued_notice(
+                run.messages,
+                response_turn_id=notice_context.response_turn_id,
+            )
+            for run in prepared_scope_context.session.runs or []
+        )
+        assert not any(_has_factual_queued_notice(run.messages) for run in prepared_scope_context.session.runs or [])
+        completed_output = TeamRunOutput(
+            run_id=current_run_id,
             team_id=team_id,
             team_name="General Team",
             session_id="session-stream-retry-clean",
             content="Recovered streamed response",
             status=RunStatus.completed,
         )
+        _cleanup_and_store(mock_team, completed_output, prepared_scope_context.session)
+        yield TeamRunContentEvent(
+            team_id=team_id,
+            run_id=current_run_id,
+            session_id="session-stream-retry-clean",
+            content="Recovered streamed response",
+        )
+        yield TeamRunCompletedEvent(
+            team_id=team_id,
+            run_id=current_run_id,
+            session_id="session-stream-retry-clean",
+            content="Recovered streamed response",
+        )
 
-    with (
-        patch("mindroom.teams.create_agent", return_value=fake_agent),
-        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
-        patch("mindroom.teams._create_team_instance", return_value=mock_team),
-        patch(
-            "mindroom.teams.prepare_bound_team_run_context",
-            new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
-        ),
-        patch("mindroom.teams._team_response_stream_raw", new=AsyncMock(side_effect=fake_stream_raw)),
-    ):
-        chunks = [
-            chunk
-            async for chunk in team_response_stream(
-                agent_ids=[entity_ids(config, runtime_paths_for(config))["general"]],
-                message="Analyze this.",
-                turn_recorder=_team_turn_recorder("Analyze this."),
-                orchestrator=orchestrator,
-                execution_identity=None,
-                ctx=make_turn_context(session_id="session-stream-retry-clean"),
-                media=MediaInputs(audio=[MagicMock(name="audio_input")]),
-                configured_team_name="super_team",
-            )
-        ]
+    with queued_message_signal_context(_PendingQueuedMessageState()) as notice_context:
+        notice_context.notice_fired = True
+        with (
+            patch("mindroom.teams.create_agent", return_value=fake_agent),
+            patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+            patch("mindroom.teams._create_team_instance", return_value=mock_team),
+            patch(
+                "mindroom.teams.prepare_bound_team_run_context",
+                new=AsyncMock(side_effect=fake_prepare_bound_team_execution_context),
+            ),
+            patch("mindroom.teams._team_response_stream_raw", new=AsyncMock(side_effect=fake_stream_raw)),
+        ):
+            chunks = [
+                chunk
+                async for chunk in team_response_stream(
+                    agent_ids=[entity_ids(config, runtime_paths_for(config))["general"]],
+                    message="Analyze this.",
+                    turn_recorder=_team_turn_recorder("Analyze this."),
+                    orchestrator=orchestrator,
+                    execution_identity=None,
+                    ctx=make_turn_context(
+                        session_id="session-stream-retry-clean",
+                        run_id="run-1",
+                    ),
+                    media=MediaInputs(audio=[MagicMock(name="audio_input")]),
+                    configured_team_name="super_team",
+                )
+            ]
+        await finalize_queued_notice_response_turn_async(notice_context)
 
     assert attempts == 2
     assert len(chunks) == 1
     assert "Recovered streamed response" in str(chunks[0])
+    _assert_retry_notice_finalized(
+        agent=fake_agent,
+        session_id="session-stream-retry-clean",
+        runtime_paths=runtime_paths,
+        config=config,
+        team_name="super_team",
+        response_turn_id=notice_context.response_turn_id,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

When a human posts a newer message while an agent is mid-turn, MindRoom injects a hidden notice after tool results telling the agent to pause and hand off.
The old notice was silently erased from persisted history, so the next turn could not see why the prior response stopped.
The notice also told the agent not to mention the interruption, making compliance unobservable.

## Approach

The notice is now framed as a pause rather than a cancellation.
It forbids new tool calls and requires a final handoff stating what was completed, what remains, and what should happen next.

The history record now preserves the exact `role="user"` notice text that the model received, including configured prompt overrides.
Only the private marker changes from live to `persisted`.
The notice stays at its original position before the prior assistant handoff, and the next user request follows it normally, so replay matches the transcript the model originally saw instead of introducing a new command at the end.

## Mechanism

Each notice carries an opaque response-turn identifier.

- In-turn deduplication removes only live notices owned by the active response.
- Finalization persists one exact notice only in the newest replay-visible run that contains its own live marker.
- Untouched storage targets and successful retries that never received the notice do not gain invented history.
- Storage targets are separated by entity, session, and session type, so nested or delegated runs cannot collapse one another.
- Event-only and stop-after paths preserve the actual stored marker at its original position.
- Crash recovery derives the exact text from the crash-left live notice.
- Cancellation-safe storage finalization repeatedly drains the owned worker before returning or propagating cancellation.

Persisted notice messages are excluded from the last-real-user boundary used by Anthropic thinking-signature cleanup, so preserving them does not discard interrupted reasoning blocks.

## Testing

The primary regression test persists a first response through real SQLite storage, runs a real second Agno request, and verifies the provider sees the exact notice as historical `role="user"` content before the prior assistant handoff and the new user request.
Additional tests cover configured notice text, same-session multi-entity storage targets, retry attempts that never saw the notice, event-only team streams, dynamic continuations, crash recovery, idempotency, OpenAI-compatible team preparation, and repeated cancellation during storage I/O.

Local verification on the final commit:

- `PYTHONPATH=src uv run pytest -n 0 --no-cov -q` passed.
- `uv run pre-commit run --all-files` passed.
- `uv run tach check --dependencies --interfaces` passed.
