### PR TITLE
Test live reads during startup source refresh

### DIFF
--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -970,6 +970,11 @@ async def test_live_read_does_not_wait_for_running_startup_source_refresh(
 
             assert [message.event_id for message in live_result] == [thread_id]
             assert startup_refresh.done() is False
+
+            release_source_call.set()
+            startup_result = await asyncio.wait_for(startup_refresh, timeout=1.0)
+            assert startup_result == []
+            assert startup_result.is_full_history is True
     finally:
         release_source_call.set()
         await asyncio.gather(

--- a/tests/test_event_cache.py
+++ b/tests/test_event_cache.py
@@ -923,6 +923,64 @@ async def test_startup_source_refresh_does_not_join_foreground_refill(
 
 
 @pytest.mark.asyncio
+async def test_live_read_does_not_wait_for_running_startup_source_refresh(
+    tmp_path: Path,
+) -> None:
+    """A running startup scan must not occupy the live same-thread read lane."""
+    room_id = "!room:localhost"
+    thread_id = "$thread:localhost"
+    event_cache = SqliteEventCache(tmp_path / "event_cache.db")
+    await event_cache.initialize()
+    await _replace_thread(event_cache, room_id, thread_id, [_clear_payload(thread_id, body="Cached root")])
+    conversation_cache = _conversation_cache_for_thread_reads(tmp_path, event_cache, client=MagicMock())
+    coordinator = EventCacheWriteCoordinator(logger=conversation_cache.logger)
+    conversation_cache.runtime.event_cache_write_coordinator = coordinator
+    source_call_started = asyncio.Event()
+    release_source_call = asyncio.Event()
+    startup_refresh: asyncio.Task[ThreadHistoryResult] | None = None
+    live_read: asyncio.Task[ThreadHistoryResult] | None = None
+
+    async def blocking_source_refresh(*_args: object, **_kwargs: object) -> ThreadHistoryResult:
+        source_call_started.set()
+        await release_source_call.wait()
+        return thread_history_result([], is_full_history=True)
+
+    try:
+        with patch(
+            "mindroom.matrix.conversation_cache.refresh_thread_history_from_source",
+            AsyncMock(side_effect=blocking_source_refresh),
+        ):
+            startup_refresh = asyncio.create_task(
+                conversation_cache.refresh_startup_thread_history_from_source(
+                    room_id,
+                    thread_id,
+                    caller_label="startup_auto_resume_freshness",
+                ),
+            )
+            await asyncio.wait_for(source_call_started.wait(), timeout=1.0)
+
+            live_read = asyncio.create_task(
+                conversation_cache.get_dispatch_thread_history(
+                    room_id,
+                    thread_id,
+                    caller_label="live_dispatch",
+                ),
+            )
+            live_result = await asyncio.wait_for(live_read, timeout=1.0)
+
+            assert [message.event_id for message in live_result] == [thread_id]
+            assert startup_refresh.done() is False
+    finally:
+        release_source_call.set()
+        await asyncio.gather(
+            *(task for task in (startup_refresh, live_read) if task is not None),
+            return_exceptions=True,
+        )
+        await coordinator.close()
+        await event_cache.close()
+
+
+@pytest.mark.asyncio
 async def test_cancelled_startup_source_refresh_leaves_no_shared_refill_state(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

- keep startup auto-resume on the direct guarded source-refresh path added by #1741
- add the missing reverse-order starvation regression: a live dispatch read completes while an older startup source scan is already running
- add no scheduler, priority, cancellation, singleflight, or production machinery

## Why this is better than main

Main already has the narrow production fix, and its tests cover foreground-first refill isolation, startup cancellation cleanup, and concurrent live mutation ordering.
It does not directly prove the original startup-first starvation case.
`tests/test_event_cache.py` now fails if startup refresh re-enters the coordinated strict path and blocks a live read until timeout.

## Why this complexity is necessary

Two explicit asyncio barriers make the race deterministic: the source scan is held open, then the live read must complete before the scan is released.
The test uses the real conversation cache, SQLite event cache, and write coordinator; only the external source fetch is replaced.
This adds no production complexity.

## Validation

- `pytest -n 0 --no-cov` for the four startup refresh isolation, starvation, cancellation, and live-mutation invariants
- full pre-commit hook suite
- mutation proof: routing startup refresh through `STRICT_SOURCE_REFRESH` makes the new test fail with `TimeoutError`; restoring the direct source path makes it pass

## Summary by Sourcery

Add coverage to ensure live dispatch reads are not blocked by a running startup source refresh scan.

New Features:
- Introduce a deterministic async test case for startup refresh vs live read interaction in the event/conversation cache.

Tests:
- Add an asyncio-based regression test verifying that a live thread history read completes even when a startup source refresh is already in progress.