### PR TITLE
Fix Matrix message self-mention dispatch

### DIFF
--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -8,13 +8,14 @@ from typing import TYPE_CHECKING, Any, Literal
 
 import nio
 
-from mindroom.constants import ORIGINAL_SENDER_KEY, SKIP_MENTIONS_KEY
+from mindroom.constants import ORIGINAL_SENDER_KEY, SKIP_MENTIONS_KEY, SOURCE_KIND_KEY
 from mindroom.custom_tools.attachment_helpers import resolve_context_thread_id
 from mindroom.custom_tools.attachments import (
     resolve_send_attachments,
     send_context_attachments,
     send_resolved_attachments,
 )
+from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.interactive import (
     add_reaction_buttons,
     clear_interactive_question,
@@ -89,6 +90,7 @@ class MatrixMessageOperations:
             extra_content[SKIP_MENTIONS_KEY] = True
         elif context.requester_id != context.client.user_id:
             extra_content[ORIGINAL_SENDER_KEY] = context.requester_id
+            extra_content[SOURCE_KIND_KEY] = TRUSTED_INTERNAL_RELAY_SOURCE_KIND
         if message_extras:
             extra_content.update(build_message_extras_content(message_extras))
         content = format_message_with_mentions(

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -32,7 +32,7 @@ from mindroom.matrix.client_visible_messages import (
     thread_root_body_preview,
     trusted_visible_sender_ids,
 )
-from mindroom.matrix.mentions import format_message_with_mentions
+from mindroom.matrix.mentions import format_message_with_mentions, is_managed_entity_user_id
 from mindroom.matrix.message_builder import build_reaction_content
 from mindroom.matrix.message_extras import build_message_extras_content
 
@@ -88,7 +88,11 @@ class MatrixMessageOperations:
         extra_content: dict[str, Any] = {}
         if ignore_mentions:
             extra_content[SKIP_MENTIONS_KEY] = True
-        elif context.requester_id != context.client.user_id:
+        elif context.requester_id != context.client.user_id and not is_managed_entity_user_id(
+            context.requester_id,
+            context.config,
+            context.runtime_paths,
+        ):
             extra_content[ORIGINAL_SENDER_KEY] = context.requester_id
             extra_content[SOURCE_KIND_KEY] = TRUSTED_INTERNAL_RELAY_SOURCE_KIND
         if message_extras:

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -16,6 +16,7 @@ from mindroom.custom_tools.attachments import (
     send_resolved_attachments,
 )
 from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+from mindroom.entity_resolution import entity_identity_registry
 from mindroom.interactive import (
     add_reaction_buttons,
     clear_interactive_question,
@@ -32,7 +33,7 @@ from mindroom.matrix.client_visible_messages import (
     thread_root_body_preview,
     trusted_visible_sender_ids,
 )
-from mindroom.matrix.mentions import format_message_with_mentions, is_managed_entity_user_id
+from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_reaction_content
 from mindroom.matrix.message_extras import build_message_extras_content
 
@@ -88,11 +89,10 @@ class MatrixMessageOperations:
         extra_content: dict[str, Any] = {}
         if ignore_mentions:
             extra_content[SKIP_MENTIONS_KEY] = True
-        elif context.requester_id != context.client.user_id and not is_managed_entity_user_id(
-            context.requester_id,
+        elif context.requester_id != context.client.user_id and not entity_identity_registry(
             context.config,
             context.runtime_paths,
-        ):
+        ).is_managed_user_id(context.requester_id):
             extra_content[ORIGINAL_SENDER_KEY] = context.requester_id
             extra_content[SOURCE_KIND_KEY] = TRUSTED_INTERNAL_RELAY_SOURCE_KIND
         if message_extras:

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -16,7 +16,7 @@ from mindroom.custom_tools.attachments import (
     send_resolved_attachments,
 )
 from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
-from mindroom.entity_resolution import entity_identity_registry
+from mindroom.entity_resolution import is_human_requester_id
 from mindroom.interactive import (
     add_reaction_buttons,
     clear_interactive_question,
@@ -89,10 +89,11 @@ class MatrixMessageOperations:
         extra_content: dict[str, Any] = {}
         if ignore_mentions:
             extra_content[SKIP_MENTIONS_KEY] = True
-        elif context.requester_id != context.client.user_id and not entity_identity_registry(
+        elif context.requester_id != context.client.user_id and is_human_requester_id(
+            context.requester_id,
             context.config,
             context.runtime_paths,
-        ).is_managed_user_id(context.requester_id):
+        ):
             extra_content[ORIGINAL_SENDER_KEY] = context.requester_id
             extra_content[SOURCE_KIND_KEY] = TRUSTED_INTERNAL_RELAY_SOURCE_KIND
         if message_extras:

--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -348,6 +348,19 @@ def mindroom_user_id(config: Config, runtime_paths: RuntimePaths) -> str | None:
     )
 
 
+def is_human_requester_id(
+    user_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> bool:
+    """Return whether one Matrix user ID represents a human requester."""
+    if entity_identity_registry(config, runtime_paths).is_managed_user_id(user_id):
+        return False
+    if user_id in config.bot_accounts:
+        return False
+    return user_id != mindroom_user_id(config, runtime_paths)
+
+
 def current_internal_sender_ids(config: Config, runtime_paths: RuntimePaths) -> frozenset[str]:
     """Return current runtime-owned Matrix IDs trusted as internal senders."""
     sender_ids = set(entity_identity_registry(config, runtime_paths).internal_sender_ids)

--- a/src/mindroom/ingress_validation.py
+++ b/src/mindroom/ingress_validation.py
@@ -24,7 +24,7 @@ from mindroom.dispatch_source import (
     source_kind_bypasses_coalescing,
     source_kind_from_content,
 )
-from mindroom.entity_resolution import entity_identity_registry
+from mindroom.entity_resolution import entity_identity_registry, is_human_requester_id
 from mindroom.handled_turns import TurnRecord
 from mindroom.matrix.event_info import reply_to_event_id_from_content
 from mindroom.matrix.media import is_audio_message_event
@@ -92,6 +92,11 @@ class IngressValidator:
             trusted_requester = requester_id_from_trusted_original_sender(
                 original_sender=original_sender,
                 original_sender_entity_name=self.managed_entity_name_for_sender(original_sender),
+                original_sender_is_human=is_human_requester_id(
+                    original_sender,
+                    self.deps.runtime.config,
+                    self.deps.runtime_paths,
+                ),
                 source_kind=source_kind,
                 sender_trusts_original_sender=self.should_trust_original_sender_metadata(
                     sender=sender,
@@ -163,7 +168,11 @@ class IngressValidator:
         original_sender = content.get(ORIGINAL_SENDER_KEY)
         if not isinstance(original_sender, str) or not original_sender:
             return None
-        if self.managed_entity_name_for_sender(original_sender) is not None:
+        if not is_human_requester_id(
+            original_sender,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        ):
             return None
         if not self.should_trust_original_sender_metadata(
             sender=sender,

--- a/src/mindroom/ingress_validation.py
+++ b/src/mindroom/ingress_validation.py
@@ -258,7 +258,11 @@ class IngressValidator:
             return (
                 original_sender is not None
                 and original_sender != ""
-                and self.managed_entity_name_for_sender(original_sender) is None
+                and is_human_requester_id(
+                    original_sender,
+                    self.deps.runtime.config,
+                    self.deps.runtime_paths,
+                )
             )
         return self.is_trusted_internal_relay_event(event)
 

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -103,6 +103,15 @@ def resolve_mentioned_user_ids_from_text(
     return _mentioned_user_ids_from_replacements(replacements)
 
 
+def is_managed_entity_user_id(
+    user_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> bool:
+    """Return whether one Matrix user ID belongs to a configured entity."""
+    return entity_identity_registry(config, runtime_paths).is_managed_user_id(user_id)
+
+
 def format_entity_mention(
     entity_name: str,
     config: Config,

--- a/src/mindroom/matrix/mentions.py
+++ b/src/mindroom/matrix/mentions.py
@@ -103,15 +103,6 @@ def resolve_mentioned_user_ids_from_text(
     return _mentioned_user_ids_from_replacements(replacements)
 
 
-def is_managed_entity_user_id(
-    user_id: str,
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> bool:
-    """Return whether one Matrix user ID belongs to a configured entity."""
-    return entity_identity_registry(config, runtime_paths).is_managed_user_id(user_id)
-
-
 def format_entity_mention(
     entity_name: str,
     config: Config,

--- a/src/mindroom/tool_approval.py
+++ b/src/mindroom/tool_approval.py
@@ -26,7 +26,7 @@ from mindroom.approval_manager import (
     TransportSenderProvider,
 )
 from mindroom.constants import RuntimePaths, resolve_config_relative_path
-from mindroom.entity_resolution import entity_identity_registry, mindroom_user_id
+from mindroom.entity_resolution import is_human_requester_id
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.approval_exemptions import tool_call_is_approval_exempt
 
@@ -199,11 +199,7 @@ def resolve_tool_approval_approver(
     """Return the human requester allowed to resolve one approval request."""
     if requester_id is None or not requester_id.startswith("@") or ":" not in requester_id:
         return None
-    if entity_identity_registry(config, runtime_paths).is_managed_user_id(requester_id):
-        return None
-    if requester_id in config.bot_accounts:
-        return None
-    if requester_id == mindroom_user_id(config, runtime_paths):
+    if not is_human_requester_id(requester_id, config, runtime_paths):
         return None
     return requester_id
 

--- a/src/mindroom/turn_origin.py
+++ b/src/mindroom/turn_origin.py
@@ -162,15 +162,16 @@ def requester_id_from_trusted_original_sender(
     *,
     original_sender: str | None,
     original_sender_entity_name: str | None,
+    original_sender_is_human: bool,
     source_kind: str | None,
     sender_trusts_original_sender: bool,
 ) -> str | None:
     """Return original-sender metadata that may act as the dispatch requester."""
     if not sender_trusts_original_sender or not original_sender:
         return None
-    if original_sender_entity_name is None:
+    if original_sender_is_human:
         return original_sender
-    if source_kind == SCHEDULED_SOURCE_KIND:
+    if original_sender_entity_name is not None and source_kind == SCHEDULED_SOURCE_KIND:
         return original_sender
     return None
 

--- a/tach.toml
+++ b/tach.toml
@@ -892,6 +892,7 @@ depends_on = [
     "mindroom.constants",
     "mindroom.custom_tools.attachment_helpers",
     "mindroom.custom_tools.attachments",
+    "mindroom.entity_resolution",
     "mindroom.interactive",
     "mindroom.logging_config",
     "mindroom.matrix.client_delivery",

--- a/tests/test_ingress_validation.py
+++ b/tests/test_ingress_validation.py
@@ -9,8 +9,10 @@ import nio
 
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.main import Config
+from mindroom.config.matrix import MindRoomUserConfig
 from mindroom.constants import ORIGINAL_SENDER_KEY, SOURCE_KIND_KEY
 from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+from mindroom.entity_resolution import mindroom_user_id
 from mindroom.ingress_validation import IngressValidator, IngressValidatorDeps
 from mindroom.matrix import stale_stream_cleanup
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
@@ -25,6 +27,8 @@ def test_trusted_relay_resolves_requester_and_allows_self_authored_ingress(tmp_p
     config = bind_runtime_paths(
         Config(
             agents={"test_agent": {"display_name": "Test Agent"}},
+            bot_accounts=["@bridge_bot:localhost"],
+            mindroom_user=MindRoomUserConfig(),
             models={"default": {"provider": "test", "id": "test-model"}},
             authorization={"default_room_access": True},
         ),
@@ -102,3 +106,18 @@ def test_trusted_relay_resolves_requester_and_allows_self_authored_ingress(tmp_p
     room = nio.MatrixRoom("!room:localhost", agent_id.full_id)
 
     assert validator.precheck_event(room, event) == human_sender
+
+    for non_human_sender in ("@bridge_bot:localhost", mindroom_user_id(config, runtime_paths)):
+        assert non_human_sender is not None
+        assert (
+            validator.requester_user_id(
+                sender=agent_id.full_id,
+                source={
+                    "content": {
+                        ORIGINAL_SENDER_KEY: non_human_sender,
+                        SOURCE_KIND_KEY: TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
+                    },
+                },
+            )
+            == agent_id.full_id
+        )

--- a/tests/test_ingress_validation.py
+++ b/tests/test_ingress_validation.py
@@ -11,6 +11,7 @@ from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.config.main import Config
 from mindroom.config.matrix import MindRoomUserConfig
 from mindroom.constants import ORIGINAL_SENDER_KEY, SOURCE_KIND_KEY
+from mindroom.dispatch_handoff import DispatchIngressMetadata, DispatchPayloadMetadata
 from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.entity_resolution import mindroom_user_id
 from mindroom.ingress_validation import IngressValidator, IngressValidatorDeps
@@ -106,6 +107,20 @@ def test_trusted_relay_resolves_requester_and_allows_self_authored_ingress(tmp_p
     room = nio.MatrixRoom("!room:localhost", agent_id.full_id)
 
     assert validator.precheck_event(room, event) == human_sender
+    ingress_metadata = DispatchIngressMetadata(source_kind=TRUSTED_INTERNAL_RELAY_SOURCE_KIND)
+    router_event = nio.RoomMessageText.from_dict(
+        {
+            "event_id": "$router-relay",
+            "sender": ids["router"].full_id,
+            "origin_server_ts": 1234567890,
+            "content": {"msgtype": "m.text", "body": "relay"},
+        },
+    )
+    assert validator.should_use_trusted_router_relay_context(
+        router_event,
+        ingress_metadata=ingress_metadata,
+        payload_metadata=DispatchPayloadMetadata(original_sender=human_sender),
+    )
 
     for non_human_sender in ("@bridge_bot:localhost", mindroom_user_id(config, runtime_paths)):
         assert non_human_sender is not None
@@ -120,4 +135,9 @@ def test_trusted_relay_resolves_requester_and_allows_self_authored_ingress(tmp_p
                 },
             )
             == agent_id.full_id
+        )
+        assert not validator.should_use_trusted_router_relay_context(
+            router_event,
+            ingress_metadata=ingress_metadata,
+            payload_metadata=DispatchPayloadMetadata(original_sender=non_human_sender),
         )

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -17,8 +17,10 @@ from mindroom import interactive
 from mindroom.attachments import register_local_attachment
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
+from mindroom.constants import ORIGINAL_SENDER_KEY, SKIP_MENTIONS_KEY, SOURCE_KIND_KEY
 from mindroom.custom_tools.attachments import AttachmentTools
 from mindroom.custom_tools.matrix_message import MatrixMessageTools
+from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.interactive import parse_and_format_interactive
 from mindroom.matrix.client import DeliveredMatrixEvent, RoomThreadsPageError
 from mindroom.matrix.message_extras import MINDROOM_MESSAGE_EXTRAS_KEY
@@ -256,6 +258,35 @@ async def test_matrix_message_send_defaults_to_room_level() -> None:
     sent_content = mock_send.await_args.args[2]
     assert sent_content["body"] == "hello"
     assert "m.relates_to" not in sent_content
+
+
+@pytest.mark.asyncio
+async def test_matrix_message_active_mentions_mark_trusted_human_relay() -> None:
+    """Intentional mention dispatch should preserve a trusted human requester."""
+    tool = MatrixMessageTools()
+    ctx = _make_context(thread_id=None)
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.send_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$evt")),
+        ) as mock_send,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action="send",
+                message="@general continue work",
+                ignore_mentions=False,
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    sent_content = mock_send.await_args.args[2]
+    assert sent_content["m.mentions"] == {"user_ids": [ctx.client.user_id]}
+    assert SKIP_MENTIONS_KEY not in sent_content
+    assert sent_content[ORIGINAL_SENDER_KEY] == ctx.requester_id
+    assert sent_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -17,6 +17,7 @@ from mindroom import interactive
 from mindroom.attachments import register_local_attachment
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
+from mindroom.config.matrix import MindRoomUserConfig
 from mindroom.constants import ORIGINAL_SENDER_KEY, SKIP_MENTIONS_KEY, SOURCE_KIND_KEY
 from mindroom.custom_tools.attachments import AttachmentTools
 from mindroom.custom_tools.matrix_message import MatrixMessageTools
@@ -73,6 +74,8 @@ def _make_context(
     room_id: str = "!room:localhost",
     thread_id: str | None = "$thread:localhost",
     requester_id: str = "@user:localhost",
+    bot_accounts: list[str] | None = None,
+    mindroom_user: MindRoomUserConfig | None = None,
     resolved_thread_id: object = _DEFAULT_RESOLVED_THREAD_ID,
     reply_to_event_id: str | None = "$reply:localhost",
     storage_path: Path | None = None,
@@ -97,6 +100,8 @@ def _make_context(
                     thread_mode=agent_thread_mode,
                 ),
             },
+            bot_accounts=bot_accounts or [],
+            mindroom_user=mindroom_user,
         ),
         test_runtime_paths(runtime_root),
     )
@@ -300,6 +305,51 @@ async def test_matrix_message_active_mentions_do_not_promote_managed_requester()
     ctx = _make_context(
         thread_id=None,
         requester_id="@mindroom_router:localhost",
+    )
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.send_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$evt")),
+        ) as mock_send,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action="send",
+                message="@general continue work",
+                ignore_mentions=False,
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    sent_content = mock_send.await_args.args[2]
+    assert sent_content["m.mentions"] == {"user_ids": [ctx.client.user_id]}
+    assert SKIP_MENTIONS_KEY not in sent_content
+    assert ORIGINAL_SENDER_KEY not in sent_content
+    assert SOURCE_KIND_KEY not in sent_content
+
+
+@pytest.mark.parametrize(
+    ("requester_id", "bot_accounts", "mindroom_user"),
+    [
+        ("@bridge_bot:localhost", ["@bridge_bot:localhost"], None),
+        ("@mindroom_user:localhost", [], MindRoomUserConfig()),
+    ],
+)
+@pytest.mark.asyncio
+async def test_matrix_message_active_mentions_do_not_promote_non_human_requester(
+    requester_id: str,
+    bot_accounts: list[str],
+    mindroom_user: MindRoomUserConfig | None,
+) -> None:
+    """Trusted relay provenance should require a human requester."""
+    tool = MatrixMessageTools()
+    ctx = _make_context(
+        thread_id=None,
+        requester_id=requester_id,
+        bot_accounts=bot_accounts,
+        mindroom_user=mindroom_user,
     )
 
     with (

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -72,6 +72,7 @@ def _make_context(
     *,
     room_id: str = "!room:localhost",
     thread_id: str | None = "$thread:localhost",
+    requester_id: str = "@user:localhost",
     resolved_thread_id: object = _DEFAULT_RESOLVED_THREAD_ID,
     reply_to_event_id: str | None = "$reply:localhost",
     storage_path: Path | None = None,
@@ -121,7 +122,7 @@ def _make_context(
                 thread_id if resolved_thread_id is _DEFAULT_RESOLVED_THREAD_ID else resolved_thread_id,
             ),
         ),
-        requester_id="@user:localhost",
+        requester_id=requester_id,
         client=client,
         config=config,
         runtime_paths=runtime_paths_for(config),
@@ -258,6 +259,9 @@ async def test_matrix_message_send_defaults_to_room_level() -> None:
     sent_content = mock_send.await_args.args[2]
     assert sent_content["body"] == "hello"
     assert "m.relates_to" not in sent_content
+    assert sent_content[SKIP_MENTIONS_KEY] is True
+    assert ORIGINAL_SENDER_KEY not in sent_content
+    assert SOURCE_KIND_KEY not in sent_content
 
 
 @pytest.mark.asyncio
@@ -287,6 +291,38 @@ async def test_matrix_message_active_mentions_mark_trusted_human_relay() -> None
     assert SKIP_MENTIONS_KEY not in sent_content
     assert sent_content[ORIGINAL_SENDER_KEY] == ctx.requester_id
     assert sent_content[SOURCE_KIND_KEY] == TRUSTED_INTERNAL_RELAY_SOURCE_KIND
+
+
+@pytest.mark.asyncio
+async def test_matrix_message_active_mentions_do_not_promote_managed_requester() -> None:
+    """Intentional mention dispatch should not classify managed requesters as humans."""
+    tool = MatrixMessageTools()
+    ctx = _make_context(
+        thread_id=None,
+        requester_id="@mindroom_router:localhost",
+    )
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.send_message_result",
+            new=AsyncMock(side_effect=delivered_matrix_side_effect("$evt")),
+        ) as mock_send,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action="send",
+                message="@general continue work",
+                ignore_mentions=False,
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    sent_content = mock_send.await_args.args[2]
+    assert sent_content["m.mentions"] == {"user_ids": [ctx.client.user_id]}
+    assert SKIP_MENTIONS_KEY not in sent_content
+    assert ORIGINAL_SENDER_KEY not in sent_content
+    assert SOURCE_KIND_KEY not in sent_content
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -31,6 +31,7 @@ from mindroom.approval_manager import (
 from mindroom.config.agent import AgentConfig
 from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
+from mindroom.config.matrix import MindRoomUserConfig
 from mindroom.config.models import ModelConfig
 from mindroom.entity_resolution import entity_identity_registry, mindroom_user_id
 from mindroom.logging_config import get_logger
@@ -2930,12 +2931,14 @@ def test_resolve_tool_approval_approver_rejects_internal_users(tmp_path: Path) -
         Config(
             agents={"code": AgentConfig(display_name="Code", role="Help with coding", rooms=["!room:localhost"])},
             bot_accounts=["@bridge_bot:localhost"],
+            mindroom_user=MindRoomUserConfig(),
             models={"default": ModelConfig(provider="openai", id="gpt-5.4")},
         ),
         runtime_paths,
     )
     persist_entity_accounts(config, runtime_paths, usernames={"router": "actual_router", "code": "actual_code"})
     internal_user_id = mindroom_user_id(config, runtime_paths)
+    assert internal_user_id is not None
     agent_user_id = entity_identity_registry(config, runtime_paths).current_id("code").full_id
 
     assert resolve_tool_approval_approver(config, runtime_paths, None) is None

--- a/tests/test_turn_origin.py
+++ b/tests/test_turn_origin.py
@@ -140,10 +140,25 @@ def test_requester_id_from_trusted_original_sender_accepts_human_metadata() -> N
         requester_id_from_trusted_original_sender(
             original_sender="@human:localhost",
             original_sender_entity_name=None,
+            original_sender_is_human=True,
             source_kind=HOOK_DISPATCH_SOURCE_KIND,
             sender_trusts_original_sender=True,
         )
         == "@human:localhost"
+    )
+
+
+def test_requester_id_from_trusted_original_sender_rejects_non_human_unmanaged_metadata() -> None:
+    """Unmanaged bot and internal-user metadata must not become a human requester."""
+    assert (
+        requester_id_from_trusted_original_sender(
+            original_sender="@bridge_bot:localhost",
+            original_sender_entity_name=None,
+            original_sender_is_human=False,
+            source_kind=HOOK_DISPATCH_SOURCE_KIND,
+            sender_trusts_original_sender=True,
+        )
+        is None
     )
 
 
@@ -153,6 +168,7 @@ def test_requester_id_from_trusted_original_sender_accepts_managed_scheduled_fir
         requester_id_from_trusted_original_sender(
             original_sender="@mindroom_router:localhost",
             original_sender_entity_name="router",
+            original_sender_is_human=False,
             source_kind=SCHEDULED_SOURCE_KIND,
             sender_trusts_original_sender=True,
         )
@@ -166,6 +182,7 @@ def test_requester_id_from_trusted_original_sender_rejects_managed_plain_hooks()
         requester_id_from_trusted_original_sender(
             original_sender="@mindroom_router:localhost",
             original_sender_entity_name="router",
+            original_sender_is_human=False,
             source_kind=HOOK_SOURCE_KIND,
             sender_trusts_original_sender=True,
         )
@@ -179,6 +196,7 @@ def test_requester_id_from_trusted_original_sender_requires_original_sender() ->
         requester_id_from_trusted_original_sender(
             original_sender=None,
             original_sender_entity_name=None,
+            original_sender_is_human=False,
             source_kind=HOOK_DISPATCH_SOURCE_KIND,
             sender_trusts_original_sender=True,
         )


### PR DESCRIPTION
## Summary

- mark mention-enabled `matrix_message` sends as trusted relays only for canonical human requesters
- reject managed entities, configured bot accounts, and the internal MindRoom user at both relay emission and ingress requester promotion
- reuse the same human-requester policy for tool approvals
- add regressions for self-trigger dispatch and every non-human requester class

## Testing

- `pytest -q`
- `pre-commit run --all-files`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved requester identification so automated, managed, and internal accounts are not treated as human requesters.
  * Prevented non-human senders from being incorrectly attributed as the original sender.
  * Restricted tool approval resolution to eligible human requesters.
  * Improved trusted relay handling and scheduled message attribution.
  * Refined Matrix message mention behavior, preserving mentions for trusted human requesters while suppressing them for automated sources.
* **Tests**
  * Added coverage for human, managed, bot, internal, and trusted relay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->