### PR TITLE
perf(tests): use the worksteal scheduler for the parallel test suite

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -578,6 +578,7 @@ addopts = """
     -p no:tach
     -q
     -n auto
+    --dist worksteal
     --asyncio-mode=strict
     --timeout 60
     --durations 20


### PR DESCRIPTION
## Problem

The test suite has grown to ~12,400 tests and takes over two and a half minutes on a developer machine.

Profiling showed the suite is **not CPU-bound, it is imbalance-bound**. Roughly 520 CPU-seconds of test work spread across 24 workers should finish in about 22 seconds of execution plus 29 seconds of worker startup — a floor near 51 seconds. The suite consistently took 161 seconds, a 3x gap.

The cause is xdist's default `--dist load` scheduler, which pre-assigns each worker a chunk of tests up front and never rebalances. A few files dominate total runtime — `tests/api/test_sandbox_runner_api.py` alone is about 27% of test CPU (128 CPU-seconds), because each routed request spawns a fresh `python -m mindroom.api.sandbox_runner` subprocess costing ~0.9s of cold import, and tests make 2-4 requests each. Whichever workers draw those chunks keep running long after every other worker has gone idle.

## Fix

One line in `pyproject.toml`: switch to `--dist worksteal`, so idle workers steal queued tests from busy ones and the tail stops serializing behind a few unlucky chunks.

## Measurements

24-core developer machine, full suite, schedulers alternated back to back to control for machine state:

| Scheduler | Wall time |
| --- | --- |
| `--dist load` | 161s, 162s |
| `--dist worksteal` | 94s, 81s, 71s, 66s, 68s |

Median 161s -> 71s, about **2.3x faster**.

Both arms report identical outcome counts (`12430 passed, 23 skipped`), so this changes scheduling only, not what runs.

Worker count is not the lever. `-n 12` (156s) and `-n 32` (159s) both match the `-n auto` baseline, confirming the bottleneck is distribution rather than parallelism.

## Scope: this speeds up local development only, not CI

Measured `Run tests with pytest` step duration:

| | pytest step |
| --- | --- |
| `main`, last 5 runs | 322s, 343s, 354s, 347s, 348s |
| this PR | 348s |

**No CI change, and none is expected.** GitHub-hosted runners have far fewer cores, so `-n auto` spawns only a handful of workers. Work-stealing pays off in proportion to how many workers sit idle waiting on a long tail; with a few workers each chewing through a large share of the suite, there is almost no idle tail to reclaim. The benefit lands on many-core developer machines.

That still makes this worth doing — it more than halves the local edit/test loop for anyone on a workstation — but the PR should not be read as a CI win.

## Alternatives considered and rejected

- **Lazy `chromadb` import** across `knowledge/registry.py`, `knowledge/collections.py`, `knowledge/manager.py`, `knowledge/indexing_config.py`, and `memory/config.py`. Worth roughly 3% for a 4-module, 15-site refactor that would also need runtime `isinstance` guards. Poor ratio.
- **Forkserver reuse for the sandbox runner tests.** Defeated by the warm-template cache being keyed on the python executable path, and every test builds its own venv under `tmp_path`, so each is a distinct key. Making the key resolve symlinks would be wrong in production, since two venvs symlinking the same interpreter have different `site-packages`.

Cutting the sandbox runner subprocess cost is the real remaining lever, since it is 27% of test CPU and would help CI too. That is a larger change and is left for a follow-up.

## Test plan

Full suite run five times locally, plus green CI on this PR.

The only local failures are 6 pre-existing ones in `tests/test_ci_release_dispatch.py` (`FileNotFoundError: [Errno 2] No such file or directory: 'bash'`), specific to the NixOS host used for measurement: `_run_bash` hardcodes `PATH=<bin_dir>:/usr/bin:/bin` in the child environment, and NixOS puts bash at `/run/current-system/sw/bin/bash`. They reproduce identically on clean `main` and pass on CI's ubuntu runner.

One local run reported a single transient `error` alongside byte-identical pass/fail/skip counts. An error that shifts no test outcome is a teardown-phase error, almost certainly the session-scoped Docker Postgres container cleanup. It did not recur across four subsequent runs.