### PR TITLE
Refresh pre-commit hooks and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: "v2.21.1"
+    rev: "v2.26.0"
     hooks:
       - id: pyproject-fmt
         args: ["--table-format", "long", "--no-generate-python-version-classifiers"]
@@ -94,7 +94,7 @@ repos:
         require_serial: true
 
   - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v10.2.1
+    rev: v10.8.0
     hooks:
       - id: eslint
         files: ^frontend/.*\.(js|jsx|ts|tsx)$

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -277,7 +277,8 @@ function AppContent() {
 
   const getPlatformUrl = () => {
     const configured = (import.meta as any).env?.VITE_PLATFORM_URL as
-      string | undefined;
+      | string
+      | undefined;
     if (configured && configured.length > 0) return configured;
     if (typeof window !== "undefined") {
       const host = window.location.host;

--- a/frontend/src/components/Integrations/Integrations.tsx
+++ b/frontend/src/components/Integrations/Integrations.tsx
@@ -1125,7 +1125,10 @@ export function Integrations() {
                 onChange={(value) =>
                   setFilterMode(
                     value as
-                      "all" | "available" | "unconfigured" | "configured",
+                      | "all"
+                      | "available"
+                      | "unconfigured"
+                      | "configured",
                   )
                 }
                 size="sm"

--- a/frontend/src/components/shared/HistoryContextSection.tsx
+++ b/frontend/src/components/shared/HistoryContextSection.tsx
@@ -11,7 +11,9 @@ import {
 } from "@/types/config";
 
 type HistoryFieldName =
-  "num_history_runs" | "num_history_messages" | "max_tool_calls_from_history";
+  | "num_history_runs"
+  | "num_history_messages"
+  | "max_tool_calls_from_history";
 
 type HistoryContextFormValues = {
   num_history_runs?: number | null;

--- a/frontend/src/hooks/useTools.ts
+++ b/frontend/src/hooks/useTools.ts
@@ -7,7 +7,13 @@ export interface ToolFieldSchema {
   name: string;
   label: string;
   type:
-    "boolean" | "number" | "password" | "select" | "string[]" | "text" | "url";
+    | "boolean"
+    | "number"
+    | "password"
+    | "select"
+    | "string[]"
+    | "text"
+    | "url";
   required?: boolean;
   default?: unknown;
   placeholder?: string | null;

--- a/frontend/src/lib/configValidation.ts
+++ b/frontend/src/lib/configValidation.ts
@@ -16,7 +16,8 @@ export interface ValidationConfigDiagnostic {
 }
 
 export type ConfigDiagnostic =
-  GlobalConfigDiagnostic | ValidationConfigDiagnostic;
+  | GlobalConfigDiagnostic
+  | ValidationConfigDiagnostic;
 
 export function getConfigValidationIssues(
   diagnostics: ConfigDiagnostic[],

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -6,7 +6,10 @@ export type MemorySearchMode = "keyword" | "semantic";
 export type WorkerScope = "shared" | "user" | "user_agent";
 export type PrivateWorkerScope = Exclude<WorkerScope, "shared">;
 export type AgentPolicySource =
-  "private.per" | "agent.worker_scope" | "defaults.worker_scope" | "unscoped";
+  | "private.per"
+  | "agent.worker_scope"
+  | "defaults.worker_scope"
+  | "unscoped";
 export type AgentPoliciesByAgent = Record<string, AgentPolicy>;
 export const DEFAULT_PRIVATE_KNOWLEDGE_PATH = "memory";
 export const SHARED_CONTEXT_FILE_PLACEHOLDER = "SOUL.md";

--- a/frontend/src/types/toolConfig.ts
+++ b/frontend/src/types/toolConfig.ts
@@ -1,7 +1,12 @@
 // Tool configuration type definitions
 
 export type FieldType =
-  "text" | "password" | "number" | "boolean" | "select" | "url";
+  | "text"
+  | "password"
+  | "number"
+  | "boolean"
+  | "select"
+  | "url";
 
 export interface ToolConfigField {
   name: string;
@@ -27,7 +32,12 @@ export interface ToolConfigSchema {
   icon?: string;
   fields: ToolConfigField[];
   category?:
-    "search" | "files" | "communication" | "development" | "data" | "other";
+    | "search"
+    | "files"
+    | "communication"
+    | "development"
+    | "data"
+    | "other";
 }
 
 // Tool-specific configuration values

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -544,6 +544,11 @@ per-file-ignores."src/mindroom/tools/*" = [
   "PLC0415", # `import` should be at the top-level of a file"
 ]
 
+[tool.vulture]
+paths = [ "src/mindroom", "vulture_whitelist.py" ]
+min_confidence = 60
+sort_by_size = true
+
 [tool.ty.environment]
 python-version = "3.13"
 [[tool.ty.overrides]]
@@ -596,8 +601,3 @@ exclude_lines = [
   "if TYPE_CHECKING",
   "if __name__ == .__main__.:",
 ]
-
-[tool.vulture]
-paths = [ "src/mindroom", "vulture_whitelist.py" ]
-min_confidence = 60
-sort_by_size = true


### PR DESCRIPTION
## Summary

- Apply the frontend formatting changes produced by Prettier on current `main`.
- Autoupdate `pyproject-fmt` from 2.21.1 to 2.26.0.
- Autoupdate the ESLint mirror from 10.2.1 to 10.8.0.
- Apply the resulting `pyproject.toml` table ordering.

Ruff remains pinned at 0.15.11 because 0.16.1 activates 1,686 existing violations under the repository lint configuration and requires a dedicated migration.

## Validation

- `pre-commit run --all-files`