### PR TITLE
Enable Privata method checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
 
       - id: privata
         name: Enforce module privacy
-        entry: bash -c 'env -u VIRTUAL_ENV uv run privata .'
+        entry: bash -c 'env -u VIRTUAL_ENV uv run privata --methods .'
         language: system
         pass_filenames: false
 

--- a/justfile
+++ b/justfile
@@ -227,7 +227,7 @@ test-standard:
 
 # Check for public symbols that should be private
 check-module-privacy:
-    uv run privata .
+    uv run privata --methods .
 
 #############################
 # Developer-friendly aliases

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -457,7 +457,7 @@ dev = [
   "markdown-gfm-admonition",
   "pre-commit>=4.2",
   "pre-commit-uv>=4.1.4",
-  "privata>=0.2.1",
+  "privata>=0.8",
   "pytest>=8.4.1",
   "pytest-asyncio>=1.1",
   "pytest-cov>=6.2.1",

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -74,7 +74,7 @@ class BotRoomLifecycle:
 
     def __init__(self, deps: BotRoomLifecycleDeps) -> None:
         self.deps = deps
-        self.invited_rooms = self.load_invited_rooms()
+        self.invited_rooms = self._load_invited_rooms()
         self._pending_forgotten_invited_rooms: set[str] = set()
         self._invite_join_locks: dict[str, asyncio.Lock] = {}
         self._welcome_locks: dict[str, asyncio.Lock] = {}
@@ -115,11 +115,11 @@ class BotRoomLifecycle:
                 return cached_room
         return nio.MatrixRoom(room_id=room_id, own_user_id=self.deps.agent_user.user_id)
 
-    def should_accept_invite(self) -> bool:
+    def _should_accept_invite(self) -> bool:
         """Return whether this entity should accept one inbound room invite."""
         return should_accept_invites(self._config(), self.deps.agent_name)
 
-    def should_persist_invited_rooms(self) -> bool:
+    def _should_persist_invited_rooms(self) -> bool:
         """Return whether this entity persists invited room IDs across restarts."""
         return should_persist_invited_rooms(self._config(), self.deps.agent_name)
 
@@ -128,26 +128,26 @@ class BotRoomLifecycle:
         await self.deps.on_room_joined(room_id)
         await self.deps.on_configured_room_joined(room_id)
 
-    def invited_rooms_file_path(self) -> Path:
+    def _invited_rooms_file_path(self) -> Path:
         """Return the durable path for invited room IDs for this entity."""
         return invited_rooms_path(self.deps.runtime_paths.storage_root, self.deps.agent_name)
 
-    def load_invited_rooms(self) -> set[str]:
+    def _load_invited_rooms(self) -> set[str]:
         """Load invited rooms persisted for one eligible entity."""
-        if not self.should_persist_invited_rooms():
+        if not self._should_persist_invited_rooms():
             return set()
-        return load_invited_rooms(self.invited_rooms_file_path())
+        return load_invited_rooms(self._invited_rooms_file_path())
 
     def forget_invited_room(self, room_id: str) -> None:
         """Stop preserving an ad-hoc room after this bot leaves it."""
-        if not self.should_persist_invited_rooms():
+        if not self._should_persist_invited_rooms():
             self.invited_rooms.discard(room_id)
             return
         self._update_invited_room(room_id, remember=False)
 
     def _update_invited_room(self, room_id: str, *, remember: bool) -> None:
         """Merge one update with durable and in-memory state before saving."""
-        room_ids = load_invited_rooms(self.invited_rooms_file_path()) | self.invited_rooms
+        room_ids = load_invited_rooms(self._invited_rooms_file_path()) | self.invited_rooms
         if remember:
             self._pending_forgotten_invited_rooms.discard(room_id)
             room_ids.add(room_id)
@@ -155,7 +155,7 @@ class BotRoomLifecycle:
             self._pending_forgotten_invited_rooms.add(room_id)
         room_ids.difference_update(self._pending_forgotten_invited_rooms)
 
-        if save_invited_rooms(self.invited_rooms_file_path(), room_ids):
+        if save_invited_rooms(self._invited_rooms_file_path(), room_ids):
             self._pending_forgotten_invited_rooms.clear()
         self.invited_rooms = room_ids
 
@@ -165,7 +165,7 @@ class BotRoomLifecycle:
         joined_rooms = await get_joined_rooms(client)
         current_rooms = set(joined_rooms or [])
         desired_rooms = set(self.deps.get_configured_rooms())
-        if self.should_persist_invited_rooms():
+        if self._should_persist_invited_rooms():
             desired_rooms.update(self.invited_rooms)
 
         for room_id in desired_rooms:
@@ -190,11 +190,11 @@ class BotRoomLifecycle:
         client = self._client()
         await leave_non_dm_rooms(
             client,
-            room_ids if room_ids is not None else await self.rooms_to_leave(),
+            room_ids if room_ids is not None else await self._rooms_to_leave(),
             on_room_left=self.deps.on_room_left,
         )
 
-    async def rooms_to_leave(self) -> list[str]:
+    async def _rooms_to_leave(self) -> list[str]:
         """Return joined rooms this bot should now leave before DM filtering."""
         client = self._client()
         joined_rooms = await get_joined_rooms(client)
@@ -203,7 +203,7 @@ class BotRoomLifecycle:
 
         current_rooms = set(joined_rooms)
         configured_rooms = set(self.deps.get_configured_rooms())
-        if self.should_persist_invited_rooms():
+        if self._should_persist_invited_rooms():
             configured_rooms.update(self.invited_rooms)
         if self.deps.agent_name == ROUTER_AGENT_NAME:
             root_space_id = matrix_state_for_runtime(self.deps.runtime_paths).space_room_id
@@ -272,7 +272,7 @@ class BotRoomLifecycle:
     async def on_invite(self, room: nio.MatrixRoom, event: nio.InviteEvent) -> None:
         """Handle one inbound invite using the configured room membership policy."""
         client = self._client()
-        if not self.should_accept_invite():
+        if not self._should_accept_invite():
             self._logger().info("Ignored invite", room_id=room.room_id, sender=event.sender)
             return
 
@@ -308,7 +308,7 @@ class BotRoomLifecycle:
                 # Pre-join encrypted history can never decrypt on this device;
                 # don't post decrypt-failure notices for it.
                 raise_notice_floor(client.user_id, room.room_id)
-            if self.should_persist_invited_rooms():
+            if self._should_persist_invited_rooms():
                 self._update_invited_room(room.room_id, remember=True)
             if self.deps.agent_name == ROUTER_AGENT_NAME:
                 await self.send_welcome_message_if_empty(room.room_id, event.sender)

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -516,7 +516,7 @@ class ConversationResolver:
                 room.room_id,
                 event_info,
                 event_id=event.event_id,
-                access=self.thread_membership_access(
+                access=self._thread_membership_access(
                     mode=ThreadReadMode.DISPATCH_SNAPSHOT,
                     caller_label="coalescing_thread_id",
                 ),
@@ -543,7 +543,7 @@ class ConversationResolver:
         caller_label: str,
     ) -> _ThreadIdLookup:
         """Resolve thread membership and identify unproven dispatch candidates."""
-        access = self.thread_membership_access(
+        access = self._thread_membership_access(
             mode=mode,
             caller_label=caller_label,
         )
@@ -579,13 +579,13 @@ class ConversationResolver:
         return await resolve_related_event_thread_id_best_effort(
             room_id,
             related_event_id,
-            access=self.thread_membership_access(
+            access=self._thread_membership_access(
                 mode=ThreadReadMode.DISPATCH_SNAPSHOT,
                 caller_label=caller_label,
             ),
         )
 
-    def thread_membership_access(
+    def _thread_membership_access(
         self,
         *,
         mode: ThreadReadMode,

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -97,7 +97,7 @@ class ResponseHookService:
 
     hook_context: HookContextSupport
 
-    async def apply_before_response(  # noqa: D102
+    async def _apply_before_response(
         self,
         *,
         identity: ResponseIdentity,
@@ -120,7 +120,7 @@ class ResponseHookService:
         )
         return await emit_transform(self.hook_context.registry, EVENT_MESSAGE_BEFORE_RESPONSE, context)
 
-    async def apply_final_response_transform(  # noqa: D102
+    async def _apply_final_response_transform(
         self,
         *,
         identity: ResponseIdentity,
@@ -257,7 +257,7 @@ class MatrixCompactionLifecycle:
 
     async def start(self, event: CompactionLifecycleStart) -> str | None:
         """Send the initial visible lifecycle notice."""
-        return await self.delivery_gateway.send_compaction_lifecycle_start(
+        return await self.delivery_gateway._send_compaction_lifecycle_start(
             target=self.target,
             reply_to_event_id=self.reply_to_event_id,
             event=event,
@@ -265,21 +265,21 @@ class MatrixCompactionLifecycle:
 
     async def progress(self, event: CompactionLifecycleProgress) -> None:
         """Edit the lifecycle notice after persisted compaction progress."""
-        await self.delivery_gateway.edit_compaction_lifecycle_progress(
+        await self.delivery_gateway._edit_compaction_lifecycle_progress(
             target=self.target,
             event=event,
         )
 
     async def complete_success(self, outcome: CompactionOutcome) -> None:
         """Edit the lifecycle notice after successful compaction."""
-        await self.delivery_gateway.edit_compaction_lifecycle_success(
+        await self.delivery_gateway._edit_compaction_lifecycle_success(
             target=self.target,
             outcome=outcome,
         )
 
     async def complete_failure(self, event: CompactionLifecycleFailure) -> None:
         """Edit the lifecycle notice after failed compaction."""
-        await self.delivery_gateway.edit_compaction_lifecycle_failure(
+        await self.delivery_gateway._edit_compaction_lifecycle_failure(
             target=self.target,
             event=event,
         )
@@ -586,7 +586,7 @@ class DeliveryGateway:
     ) -> FinalDeliveryOutcome:
         """Apply before_response hooks and perform the final send or edit."""
         try:
-            draft = await self.deps.response_hooks.apply_before_response(
+            draft = await self.deps.response_hooks._apply_before_response(
                 identity=request.identity,
                 response_text=request.response_text,
                 tool_trace=request.tool_trace,
@@ -837,7 +837,7 @@ class DeliveryGateway:
             extra_content=extra_content,
         )
 
-    async def send_compaction_lifecycle_start(
+    async def _send_compaction_lifecycle_start(
         self,
         *,
         target: MessageTarget,
@@ -882,7 +882,7 @@ class DeliveryGateway:
         self.deps.logger.error("Failed to send compaction lifecycle notice", **target.log_context)
         return None
 
-    async def edit_compaction_lifecycle_progress(
+    async def _edit_compaction_lifecycle_progress(
         self,
         *,
         target: MessageTarget,
@@ -898,7 +898,7 @@ class DeliveryGateway:
             metadata=event.to_notice_metadata(),
         )
 
-    async def edit_compaction_lifecycle_success(
+    async def _edit_compaction_lifecycle_success(
         self,
         *,
         target: MessageTarget,
@@ -914,7 +914,7 @@ class DeliveryGateway:
             metadata=outcome.to_notice_metadata(),
         )
 
-    async def edit_compaction_lifecycle_failure(
+    async def _edit_compaction_lifecycle_failure(
         self,
         *,
         target: MessageTarget,
@@ -1350,7 +1350,7 @@ class DeliveryGateway:
                         tool_trace=tuple(request.tool_trace or ()),
                         extra_content=request.extra_content,
                     )
-                final_transform_draft = await self.deps.response_hooks.apply_final_response_transform(
+                final_transform_draft = await self.deps.response_hooks._apply_final_response_transform(
                     identity=request.identity,
                     response_text=final_body_candidate,
                 )

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -80,7 +80,7 @@ class EditRegenerator:
             raise RuntimeError(msg)
         return client
 
-    async def edit_regeneration_context(
+    async def _edit_regeneration_context(
         self,
         context: MessageContext,
         room: nio.MatrixRoom,
@@ -153,7 +153,7 @@ class EditRegenerator:
             return
         if turn_record.requester_id_for_source(original_event_id) != requester_user_id:
             return
-        context = await self.edit_regeneration_context(
+        context = await self._edit_regeneration_context(
             context,
             room,
             conversation_target=turn_record.conversation_target,

--- a/src/mindroom/entity_resolution.py
+++ b/src/mindroom/entity_resolution.py
@@ -266,7 +266,7 @@ class EntityIdentityRegistry:
         return self.current_entity_name_for_user_id(user_id, include_router=include_router) is not None
 
     @property
-    def internal_sender_ids(self) -> frozenset[str]:
+    def _internal_sender_ids(self) -> frozenset[str]:
         """Return current Matrix IDs trusted as managed internal senders."""
         return frozenset(matrix_id.full_id for matrix_id in self.current_ids.values())
 
@@ -363,7 +363,7 @@ def is_human_requester_id(
 
 def current_internal_sender_ids(config: Config, runtime_paths: RuntimePaths) -> frozenset[str]:
     """Return current runtime-owned Matrix IDs trusted as internal senders."""
-    sender_ids = set(entity_identity_registry(config, runtime_paths).internal_sender_ids)
+    sender_ids = set(entity_identity_registry(config, runtime_paths)._internal_sender_ids)
     if internal_user_id := mindroom_user_id(config, runtime_paths):
         sender_ids.add(internal_user_id)
     return frozenset(sender_ids)

--- a/src/mindroom/handled_turns.py
+++ b/src/mindroom/handled_turns.py
@@ -54,7 +54,7 @@ class SourceEventMetadata:
         """Normalize the timestamp once for every physical representation."""
         object.__setattr__(self, "timestamp_ms", normalize_timestamp_ms(self.timestamp_ms))
 
-    def to_record(self) -> dict[str, object]:
+    def _to_record(self) -> dict[str, object]:
         """Return a JSON-safe representation for durable metadata."""
         record: dict[str, object] = {"sender": self.sender}
         if self.timestamp_ms is not None:
@@ -64,7 +64,7 @@ class SourceEventMetadata:
         return record
 
     @classmethod
-    def from_raw(cls, raw_metadata: object) -> SourceEventMetadata | None:
+    def _from_raw(cls, raw_metadata: object) -> SourceEventMetadata | None:
         """Build source metadata from a persisted JSON-like value."""
         if not isinstance(raw_metadata, Mapping):
             return None
@@ -289,7 +289,7 @@ class TurnRecordCodec:
         return _TURN_RECORD_SCHEMA_VERSION
 
     @staticmethod
-    def to_ledger_record(record: TurnRecord) -> dict[str, object]:  # noqa: C901
+    def _to_ledger_record(record: TurnRecord) -> dict[str, object]:  # noqa: C901
         """Serialize one exact record for the versioned handled-turn ledger."""
         payload: dict[str, object] = {
             "anchor_event_id": record.anchor_event_id,
@@ -318,7 +318,7 @@ class TurnRecordCodec:
             }
         if record.source_event_metadata is not None:
             payload["source_event_metadata"] = {
-                event_id: metadata.to_record() for event_id, metadata in record.source_event_metadata.items()
+                event_id: metadata._to_record() for event_id, metadata in record.source_event_metadata.items()
             }
         if record.response_owner is not None:
             payload["response_owner"] = record.response_owner
@@ -333,7 +333,7 @@ class TurnRecordCodec:
         return payload
 
     @staticmethod
-    def from_ledger_record(event_id: str, raw_record: object) -> TurnRecord | None:
+    def _from_ledger_record(event_id: str, raw_record: object) -> TurnRecord | None:
         """Parse one record from the current ledger schema without legacy migration."""
         if not isinstance(raw_record, Mapping):
             return None
@@ -414,7 +414,7 @@ class TurnRecordCodec:
             }
         if record.source_event_metadata is not None:
             metadata[constants.MATRIX_SOURCE_EVENT_METADATA_KEY] = {
-                event_id: source_metadata.to_record()
+                event_id: source_metadata._to_record()
                 for event_id, source_metadata in record.source_event_metadata.items()
             }
         if record.response_owner is not None:
@@ -793,7 +793,7 @@ class HandledTurnLedger:
         payload = {
             _LEDGER_SCHEMA_VERSION_KEY: TurnRecordCodec.schema_version(),
             _LEDGER_RECORDS_KEY: {
-                event_id: TurnRecordCodec.to_ledger_record(record) for event_id, record in responses.items()
+                event_id: TurnRecordCodec._to_ledger_record(record) for event_id, record in responses.items()
             },
         }
         write_json_file_durable(self._responses_file, payload, temp_dir=self.base_path, indent=2)
@@ -840,7 +840,7 @@ class HandledTurnLedger:
         records: dict[str, TurnRecord] = {}
         invalid_event_ids: list[str] = []
         for event_id, raw_record in raw_records.items():
-            record = TurnRecordCodec.from_ledger_record(event_id, raw_record) if isinstance(event_id, str) else None
+            record = TurnRecordCodec._from_ledger_record(event_id, raw_record) if isinstance(event_id, str) else None
             if record is None:
                 invalid_event_ids.append(event_id if isinstance(event_id, str) else repr(event_id))
                 continue
@@ -1087,7 +1087,7 @@ def _immutable_source_event_metadata(
         normalized = (
             raw_metadata
             if isinstance(raw_metadata, SourceEventMetadata)
-            else SourceEventMetadata.from_raw(raw_metadata)
+            else SourceEventMetadata._from_raw(raw_metadata)
         )
         if normalized is not None:
             metadata[event_id] = normalized

--- a/src/mindroom/ingress_validation.py
+++ b/src/mindroom/ingress_validation.py
@@ -98,7 +98,7 @@ class IngressValidator:
                     self.deps.runtime_paths,
                 ),
                 source_kind=source_kind,
-                sender_trusts_original_sender=self.should_trust_original_sender_metadata(
+                sender_trusts_original_sender=self._should_trust_original_sender_metadata(
                     sender=sender,
                     source_kind=source_kind,
                 ),
@@ -122,7 +122,7 @@ class IngressValidator:
         registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
         return registry.current_entity_name_for_user_id(sender_id, include_router=include_router)
 
-    def should_trust_original_sender_metadata(
+    def _should_trust_original_sender_metadata(
         self,
         *,
         sender: str,
@@ -151,13 +151,13 @@ class IngressValidator:
         if not isinstance(content, dict):
             return None
         source_kind = self.event_source_kind(event, content)
-        return self.trusted_human_original_sender(
+        return self._trusted_human_original_sender(
             sender=event.sender,
             content=content,
             source_kind=source_kind,
         )
 
-    def trusted_human_original_sender(
+    def _trusted_human_original_sender(
         self,
         *,
         sender: str,
@@ -174,7 +174,7 @@ class IngressValidator:
             self.deps.runtime_paths,
         ):
             return None
-        if not self.should_trust_original_sender_metadata(
+        if not self._should_trust_original_sender_metadata(
             sender=sender,
             source_kind=source_kind,
         ):
@@ -196,7 +196,7 @@ class IngressValidator:
             return False
         return self.trusted_human_original_sender_for_event(event) is not None
 
-    def is_trusted_router_relay_event(self, event: DispatchEvent) -> bool:
+    def _is_trusted_router_relay_event(self, event: DispatchEvent) -> bool:
         """Return whether one trusted internal relay originated from the router."""
         if not self.is_trusted_internal_relay_event(event):
             return False
@@ -205,7 +205,7 @@ class IngressValidator:
 
     def router_relay_original_event_id(self, event: DispatchEvent) -> str | None:
         """Return the routed human event one trusted router relay explicitly replies to."""
-        if not self.is_trusted_router_relay_event(event):
+        if not self._is_trusted_router_relay_event(event):
             return None
         content = event.source.get("content") if isinstance(event.source, dict) else None
         if not isinstance(content, dict):
@@ -225,7 +225,7 @@ class IngressValidator:
             return False
         content_dict = cast("dict[str, Any]", content)
         return (
-            self.trusted_human_original_sender(
+            self._trusted_human_original_sender(
                 sender=sender,
                 content=content_dict,
                 source_kind=source_kind_from_content(content_dict),
@@ -236,7 +236,7 @@ class IngressValidator:
     def is_display_only_router_voice_echo(self, event: DispatchEvent) -> bool:
         """Return whether one ingress event is the router's display-only voice transcript echo."""
         content = event.source.get("content") if isinstance(event.source, dict) else None
-        return is_visible_router_voice_echo_content(content) and self.is_trusted_router_relay_event(event)
+        return is_visible_router_voice_echo_content(content) and self._is_trusted_router_relay_event(event)
 
     def should_use_trusted_router_relay_context(
         self,
@@ -247,7 +247,7 @@ class IngressValidator:
     ) -> bool:
         """Return whether dispatch context should use trusted router relay semantics."""
         if ingress_metadata is None:
-            return self.is_trusted_router_relay_event(event)
+            return self._is_trusted_router_relay_event(event)
         if ingress_metadata.source_kind != TRUSTED_INTERNAL_RELAY_SOURCE_KIND:
             return False
         sender_agent_name = self.managed_entity_name_for_sender(event.sender)

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -60,7 +60,7 @@ class InteractiveMetadata:
     options_list: tuple[dict[str, str], ...]
 
     @classmethod
-    def from_parts(
+    def _from_parts(
         cls,
         option_map: dict[str, str] | None,
         options_list: Sequence[dict[str, str]] | None,
@@ -769,7 +769,7 @@ def parse_and_format_interactive(response_text: str, extract_mapping: bool = Fal
 
     return _InteractiveResponse(
         final_text,
-        InteractiveMetadata.from_parts(
+        InteractiveMetadata._from_parts(
             option_map,
             options if extract_mapping else None,
             question_text=question,

--- a/src/mindroom/knowledge/index_retry.py
+++ b/src/mindroom/knowledge/index_retry.py
@@ -37,7 +37,7 @@ class EmbeddingRetryPolicy:
     max_backoff_seconds: float = 30.0
     jitter_ratio: float = 0.25
 
-    def backoff_seconds(self, attempt: int, *, retry_after_seconds: float | None, jitter_unit: float) -> float:
+    def _backoff_seconds(self, attempt: int, *, retry_after_seconds: float | None, jitter_unit: float) -> float:
         """Return how long to wait before ``attempt`` (1-based) is retried.
 
         A provider ``Retry-After`` hint wins over the computed backoff, but is
@@ -72,7 +72,7 @@ async def run_with_embedding_retry(
         except Exception as exc:
             if attempt >= max_attempts or not embedder_failure_is_transient(exc):
                 raise
-            delay_seconds = policy.backoff_seconds(
+            delay_seconds = policy._backoff_seconds(
                 attempt,
                 retry_after_seconds=embedder_retry_after_seconds(exc),
                 jitter_unit=jitter(),

--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -38,7 +38,7 @@ class SyncCacheWriteResult:
     runtime_diagnostics: dict[str, object] | None = None
 
     @property
-    def certified(self) -> bool:
+    def _certified(self) -> bool:
         """Return whether this result proves the sync delta reached durable cache."""
         return self.complete and not self.limited_room_ids and not self.errors
 
@@ -119,7 +119,7 @@ def sync_cache_write_diagnostics(cache_result: SyncCacheWriteResult) -> dict[str
     """Return structured log fields explaining one sync cache-write result."""
     diagnostics: dict[str, Any] = {
         "cache_write_complete": cache_result.complete,
-        "cache_write_certified": cache_result.certified,
+        "cache_write_certified": cache_result._certified,
         "cache_limited_room_count": len(cache_result.limited_room_ids),
         "cache_error_count": len(cache_result.errors),
     }

--- a/src/mindroom/matrix/thread_membership.py
+++ b/src/mindroom/matrix/thread_membership.py
@@ -28,7 +28,7 @@ Invariants enforced here (every resolver in the repo must go through this module
 
 4. Root proof is three-valued (PROVEN, NOT_A_THREAD_ROOT, PROOF_UNAVAILABLE) and proof failure never
    silently demotes to room level.
-   PROOF_UNAVAILABLE maps to ``ThreadResolution.indeterminate`` with the candidate root preserved so
+   PROOF_UNAVAILABLE maps to ``ThreadResolution._indeterminate`` with the candidate root preserved so
    callers can fail closed (mutation callers invalidate room-wide; dispatch callers coalesce on the
    candidate root and retry).
    Lookup failures and missing related events during the walk are likewise INDETERMINATE, never ROOM_LEVEL.
@@ -141,7 +141,7 @@ class ThreadResolution:
         return cls(ThreadResolutionState.ROOM_LEVEL, thread_history=thread_history)
 
     @classmethod
-    def indeterminate(
+    def _indeterminate(
         cls,
         error: Exception,
         candidate_thread_root_id: str | None = None,
@@ -226,7 +226,7 @@ def _resolution_from_root_proof(
     if proof.state is _ThreadRootProofState.NOT_A_THREAD_ROOT:
         return ThreadResolution.room_level(thread_history=proof.thread_history)
     assert proof.error is not None
-    return ThreadResolution.indeterminate(
+    return ThreadResolution._indeterminate(
         proof.error,
         candidate_thread_root_id=thread_root_id,
         thread_history=proof.thread_history,
@@ -285,11 +285,11 @@ async def resolve_related_event_thread_membership(
             related_event_info = await access.fetch_event_info(room_id, current_event_id)
         except Exception as exc:
             # Keep lookup-failed related events separately scoped for dispatch coalescing and replay checks.
-            resolution = ThreadResolution.indeterminate(exc, candidate_thread_root_id=current_event_id)
+            resolution = ThreadResolution._indeterminate(exc, candidate_thread_root_id=current_event_id)
             break
         if related_event_info is None:
             # Missing related events are still possible thread roots; demote later without losing the candidate.
-            resolution = ThreadResolution.indeterminate(
+            resolution = ThreadResolution._indeterminate(
                 ThreadMembershipLookupError(f"Related event {current_event_id} is unavailable"),
                 candidate_thread_root_id=current_event_id,
             )

--- a/src/mindroom/matrix_rtc/call_session.py
+++ b/src/mindroom/matrix_rtc/call_session.py
@@ -152,7 +152,7 @@ class CallSession:
         )
 
     @property
-    def local_identity(self) -> str:
+    def _local_identity(self) -> str:
         """Our LiveKit participant identity (``user_id:device_id``)."""
         client = self.deps.client
         return f"{client.user_id}:{required_device_id(client)}"
@@ -189,7 +189,7 @@ class CallSession:
         except BaseException:
             await self.stop()
             raise
-        logger.info("call_joined", room_id=self.room_id, identity=self.local_identity)
+        logger.info("call_joined", room_id=self.room_id, identity=self._local_identity)
 
     async def on_members_changed(self, members: list[CallMember]) -> None:
         """React to remote membership changes (key rotation/sharing)."""
@@ -293,7 +293,7 @@ class CallSession:
             finally:
                 if self.deps.on_stopped is not None:
                     await self.deps.on_stopped()
-        logger.info("call_left", room_id=self.room_id, identity=self.local_identity)
+        logger.info("call_left", room_id=self.room_id, identity=self._local_identity)
 
     async def _distribute_keys(self) -> None:
         async with self._key_distribution_lock:
@@ -400,7 +400,7 @@ class CallSession:
         self._spawn(self.deps.on_failure(message))
 
     def _apply_own_key(self, key: bytes, key_index: int) -> None:
-        self.deps.bridge.set_frame_key(self.local_identity, key, key_index)
+        self.deps.bridge.set_frame_key(self._local_identity, key, key_index)
 
     def _sync_bridge_participants(self) -> None:
         """Apply the authoritative Matrix call roster to the SFU bridge."""

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -132,7 +132,7 @@ class ConfigReloadLifecycle:
         self._requested_at = None
         await cancel_logged_task(task)
 
-    async def update_config(self) -> bool:
+    async def _update_config(self) -> bool:
         """Reload configuration from disk and dispatch the resulting update plan."""
         async with self.config_update_lock:
             # Config validation executes plugin modules and walks the filesystem;
@@ -280,7 +280,7 @@ class ConfigReloadLifecycle:
         self._requested_at = None
         logger.info("Configuration file changed, checking for updates...")
         try:
-            updated = await self.update_config()
+            updated = await self._update_config()
         except Exception as exc:
             logger.exception("Configuration update failed; will retry if a new change is queued")
             # Keep watching every file the broken load read so fixing a newly

--- a/src/mindroom/orchestration/config_updates.py
+++ b/src/mindroom/orchestration/config_updates.py
@@ -59,7 +59,7 @@ class ConfigUpdatePlan:
     added_entities: set[str] = field(default_factory=set)
 
     @property
-    def has_entity_changes(self) -> bool:
+    def _has_entity_changes(self) -> bool:
         """Return whether any bots must be created, restarted, or removed."""
         return bool(self.entities_to_restart or self.new_entities or self.removed_entities)
 
@@ -67,7 +67,7 @@ class ConfigUpdatePlan:
     def only_support_service_changes(self) -> bool:
         """Return whether only non-bot support services changed."""
         return not (
-            self.has_entity_changes
+            self._has_entity_changes
             or self.mindroom_user_changed
             or self.matrix_room_access_changed
             or self.matrix_space_changed

--- a/src/mindroom/orchestration/external_trigger_runtime.py
+++ b/src/mindroom/orchestration/external_trigger_runtime.py
@@ -40,7 +40,7 @@ class ExternalTriggerRuntimeCoordinator:
             return
 
         async def is_trigger_snapshot_ready(snapshot: TriggerDeliverySnapshot) -> bool:
-            return await self.is_ready(snapshot, bots)
+            return await self._is_ready(snapshot, bots)
 
         from mindroom.api import main as api_main  # noqa: PLC0415
 
@@ -69,7 +69,7 @@ class ExternalTriggerRuntimeCoordinator:
             return
         self.unbind()
 
-    async def is_ready(
+    async def _is_ready(
         self,
         snapshot: TriggerDeliverySnapshot,
         bots: Mapping[str, AgentBot | TeamBot],

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -82,7 +82,7 @@ class PostResponseEffectsSupport:
             raise RuntimeError(msg)
         return client
 
-    def should_queue_thread_summary(
+    def _should_queue_thread_summary(
         self,
         room_id: str,
         thread_id: str,
@@ -132,7 +132,7 @@ class PostResponseEffectsSupport:
             interactive_metadata.options_as_list(),
         )
 
-    def queue_thread_summary(
+    def _queue_thread_summary(
         self,
         room_id: str,
         thread_id: str,
@@ -184,8 +184,8 @@ class PostResponseEffectsSupport:
             register_interactive=register_interactive,
             queue_memory_persistence=queue_memory_persistence,
             persist_response_event_id=persist_response_event_id,
-            should_queue_thread_summary=self.should_queue_thread_summary,
-            queue_thread_summary=self.queue_thread_summary,
+            should_queue_thread_summary=self._should_queue_thread_summary,
+            queue_thread_summary=self._queue_thread_summary,
         )
 
 

--- a/src/mindroom/prompt_ingress_reservation.py
+++ b/src/mindroom/prompt_ingress_reservation.py
@@ -60,14 +60,14 @@ class PromptIngressReservationOwner:
             )
             metadata_transferred = True
         except BaseException:
-            await self.cancel_ready_task()
+            await self._cancel_ready_task()
             if ready_result is not None and not metadata_transferred:
                 close_ready_task_result_metadata(ready_result)
             raise
         self.admitted = True
         self.ready_task = None
 
-    async def cancel_ready_task(self) -> None:
+    async def _cancel_ready_task(self) -> None:
         """Cancel or collect the owned ready task once."""
         if self.ready_task is None:
             return
@@ -90,6 +90,6 @@ class PromptIngressReservationOwner:
         if self.admitted:
             return
         try:
-            await self.cancel_ready_task()
+            await self._cancel_ready_task()
         finally:
             self.gate.release_lane_slot(self.slot)

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -535,7 +535,7 @@ class ResponseLifecycle:
                 response_event_id=response_event_id,
                 error=error,
             )
-        await self.apply_effects_safely(
+        await self._apply_effects_safely(
             final_delivery_outcome=final_delivery_outcome,
             post_response_outcome=lambda: build_post_response_outcome(final_delivery_outcome),
             post_response_deps=post_response_deps,
@@ -544,7 +544,7 @@ class ResponseLifecycle:
             self.pipeline_timing.emit_summary(self.deps.logger, outcome=_response_outcome_label(final_delivery_outcome))
         return final_delivery_outcome
 
-    async def apply_effects_safely(
+    async def _apply_effects_safely(
         self,
         *,
         final_delivery_outcome: FinalDeliveryOutcome,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1455,7 +1455,7 @@ class ResponseRunner:
         run_message_id: str | None = None
         deferred_error: BaseException | None = None
         try:
-            run_message_id = await self.run_cancellable_response(
+            run_message_id = await self._run_cancellable_response(
                 target=target,
                 response_function=response_function,
                 thinking_message=thinking_message,
@@ -1616,10 +1616,12 @@ class ResponseRunner:
         return await self._run_locked_response_lifecycle(
             request,
             response_kind="team",
-            locked_operation=lambda resolved_target, early_placeholder_state: self.generate_team_response_helper_locked(
-                team_request,
-                resolved_target=resolved_target,
-                early_placeholder_state=early_placeholder_state,
+            locked_operation=lambda resolved_target, early_placeholder_state: (
+                self._generate_team_response_helper_locked(
+                    team_request,
+                    resolved_target=resolved_target,
+                    early_placeholder_state=early_placeholder_state,
+                )
             ),
         )
 
@@ -1640,7 +1642,7 @@ class ResponseRunner:
             ),
         )
 
-    async def generate_team_response_helper_locked(  # noqa: C901, PLR0915
+    async def _generate_team_response_helper_locked(  # noqa: C901, PLR0915
         self,
         team_request: _TeamResponseRequest,
         *,
@@ -2198,7 +2200,7 @@ class ResponseRunner:
             streaming_delivery_error_handler=settle_team_streaming_delivery_error,
         )
 
-    async def run_cancellable_response(
+    async def _run_cancellable_response(
         self,
         *,
         target: MessageTarget,
@@ -2485,7 +2487,7 @@ class ResponseRunner:
             )
             raise
 
-    async def process_and_respond(  # noqa: C901
+    async def _process_and_respond(  # noqa: C901
         self,
         request: ResponseRequest,
         *,
@@ -2632,7 +2634,7 @@ class ResponseRunner:
             request.pipeline_timing.mark("response_complete")
         return build_outcome(delivery)
 
-    async def process_and_respond_streaming(  # noqa: C901, PLR0915
+    async def _process_and_respond_streaming(  # noqa: C901, PLR0915
         self,
         request: ResponseRequest,
         *,
@@ -2823,14 +2825,14 @@ class ResponseRunner:
         return await self._run_locked_response_lifecycle(
             request,
             response_kind="ai",
-            locked_operation=lambda resolved_target, early_placeholder_state: self.generate_response_locked(
+            locked_operation=lambda resolved_target, early_placeholder_state: self._generate_response_locked(
                 request,
                 resolved_target=resolved_target,
                 early_placeholder_state=early_placeholder_state,
             ),
         )
 
-    async def generate_response_locked(
+    async def _generate_response_locked(
         self,
         request: ResponseRequest,
         *,
@@ -2942,14 +2944,14 @@ class ResponseRunner:
             progress.track_event(message_id)
             delivery_request = self._request_for_delivery(normalized_request, message_id=message_id)
             if use_streaming:
-                generation = await self.process_and_respond_streaming(
+                generation = await self._process_and_respond_streaming(
                     delivery_request,
                     run_id=response_run_id,
                     on_delivery_started=progress.note_delivery_started,
                     attempt_run_id_collector=attempt_run_ids,
                 )
             else:
-                generation = await self.process_and_respond(
+                generation = await self._process_and_respond(
                     delivery_request,
                     run_id=response_run_id,
                     on_delivery_started=progress.note_delivery_started,

--- a/src/mindroom/timing.py
+++ b/src/mindroom/timing.py
@@ -156,7 +156,7 @@ class DispatchPipelineTiming:
             self.marks["first_substantive_reply"] = now
             self.metadata["first_substantive_kind"] = kind
 
-    def elapsed_ms(self, start_label: str, end_label: str) -> float | None:
+    def _elapsed_ms(self, start_label: str, end_label: str) -> float | None:
         """Return elapsed time between two recorded phase boundaries."""
         start = self.marks.get(start_label)
         end = self.marks.get(end_label)
@@ -179,7 +179,7 @@ class DispatchPipelineTiming:
         }
         duration_pairs = (*_PRIMARY_SEGMENTS, *_PRIMARY_TOTALS, *_DIAGNOSTIC_SPANS)
         for key, start_label, end_label in duration_pairs:
-            elapsed = self.elapsed_ms(start_label, end_label)
+            elapsed = self._elapsed_ms(start_label, end_label)
             if elapsed is not None:
                 summary[key] = elapsed
         logger.debug("Dispatch pipeline timing", **summary)

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -324,7 +324,7 @@ class TurnPolicy:
             live_entity_names=live_entity_names,
         )
 
-    def filter_materializable_responders(
+    def _filter_materializable_responders(
         self,
         responder_ids: list[MatrixID],
         availability: _ResponderAvailability,
@@ -352,9 +352,9 @@ class TurnPolicy:
             self.deps.runtime.config,
             self.deps.runtime_paths,
         )
-        return self.filter_materializable_responders(available_responders, availability)
+        return self._filter_materializable_responders(available_responders, availability)
 
-    def response_owner_for_team_resolution(
+    def _response_owner_for_team_resolution(
         self,
         form_team: TeamResolution,
         responder_pool: list[MatrixID],
@@ -440,7 +440,7 @@ class TurnPolicy:
                 shared_responders.append(responder)
         return shared_responders
 
-    def team_response_action(
+    def _team_response_action(
         self,
         form_team: TeamResolution,
         responder_pool: list[MatrixID],
@@ -448,7 +448,7 @@ class TurnPolicy:
         """Return the response action implied by one team resolution."""
         if form_team.outcome is TeamOutcome.NONE:
             return None
-        response_owner = self.response_owner_for_team_resolution(form_team, responder_pool)
+        response_owner = self._response_owner_for_team_resolution(form_team, responder_pool)
         if response_owner is None:
             return ResponseAction(kind="skip")
         if self.deps.matrix_id != response_owner:
@@ -464,7 +464,7 @@ class TurnPolicy:
             rejection_message=form_team.reason,
         )
 
-    def configured_team_response_action(
+    def _configured_team_response_action(
         self,
         availability: _ResponderAvailability,
     ) -> ResponseAction | None:
@@ -497,10 +497,10 @@ class TurnPolicy:
         """Apply configured-team execution behavior before running one response action."""
         if action.kind != "individual":
             return action
-        configured_team_action = self.configured_team_response_action(self.responder_availability())
+        configured_team_action = self._configured_team_response_action(self.responder_availability())
         return configured_team_action or action
 
-    def explicit_configured_team_rejection_action(
+    def _explicit_configured_team_rejection_action(
         self,
         context: MessageContext,
         sender_visible_responders: list[MatrixID],
@@ -520,12 +520,12 @@ class TurnPolicy:
         if team_matrix_id.full_id not in sender_visible_ids:
             return None
 
-        configured_team_action = self.configured_team_response_action(availability)
+        configured_team_action = self._configured_team_response_action(availability)
         if configured_team_action is None or configured_team_action.kind != "reject":
             return None
         return configured_team_action
 
-    async def decide_team_for_sender(
+    async def _decide_team_for_sender(
         self,
         agents_in_thread: list[MatrixID],
         context: MessageContext,
@@ -574,7 +574,7 @@ class TurnPolicy:
             allow_explicit_private_agents=True,
         )
 
-    async def plan_router_dispatch(
+    async def _plan_router_dispatch(
         self,
         room: nio.MatrixRoom,
         event: DispatchEvent,
@@ -652,7 +652,7 @@ class TurnPolicy:
         router_event: DispatchEvent | None = None,
     ) -> _DispatchPlan:
         """Return the explicit policy plan for one prepared inbound turn."""
-        router_plan = await self.plan_router_dispatch(
+        router_plan = await self._plan_router_dispatch(
             room,
             event,
             dispatch,
@@ -664,7 +664,7 @@ class TurnPolicy:
         if router_plan is not None:
             return router_plan
 
-        action = await self.resolve_response_action(
+        action = await self._resolve_response_action(
             dispatch,
             room,
             is_dm,
@@ -674,7 +674,7 @@ class TurnPolicy:
             return _DispatchPlan(kind="ignore")
         return _DispatchPlan(kind="respond", response_action=action)
 
-    async def resolve_response_action(
+    async def _resolve_response_action(
         self,
         dispatch: PreparedDispatch,
         room: nio.MatrixRoom,
@@ -694,7 +694,7 @@ class TurnPolicy:
             self.deps.runtime.config,
             self.deps.runtime_paths,
         )
-        available_responders_in_room = self.filter_materializable_responders(
+        available_responders_in_room = self._filter_materializable_responders(
             sender_visible_responders_in_room,
             availability,
         )
@@ -703,7 +703,7 @@ class TurnPolicy:
         agent_is_responder_candidate = agent_matrix_id.full_id in {
             responder.full_id for responder in available_responders_in_room
         }
-        team_action = self.explicit_configured_team_rejection_action(
+        team_action = self._explicit_configured_team_rejection_action(
             context,
             sender_visible_responders_in_room,
             availability,
@@ -737,7 +737,7 @@ class TurnPolicy:
         if team_action is None:
             # Use sender-visible responders here so explicit team requests can distinguish
             # hidden members from visible-but-not-materializable members.
-            form_team = await self.decide_team_for_sender(
+            form_team = await self._decide_team_for_sender(
                 agents_in_thread,
                 context,
                 room,
@@ -746,7 +746,7 @@ class TurnPolicy:
                 availability=availability,
                 available_responders_in_room=sender_visible_responders_in_room,
             )
-            team_action = self.team_response_action(form_team, available_responders_in_room)
+            team_action = self._team_response_action(form_team, available_responders_in_room)
         if team_action is not None:
             return team_action
 

--- a/src/mindroom/turn_store.py
+++ b/src/mindroom/turn_store.py
@@ -311,7 +311,7 @@ class TurnStore:
             wait_for_persist=True,
         )
 
-    def any_source_redacted(self, source_event_ids: tuple[str, ...]) -> bool:
+    def _any_source_redacted(self, source_event_ids: tuple[str, ...]) -> bool:
         """Return whether durable state tombstones any source in one pending response."""
         return any(
             (record := self._ledger.get_turn_record(source_event_id)) is not None
@@ -348,7 +348,7 @@ class TurnStore:
                 redacted_event_id=redacted_event_id,
             )
             self._clear_pending_redaction_cleanup(redacted_event_id)
-        return self.any_source_redacted(source_event_ids)
+        return self._any_source_redacted(source_event_ids)
 
     def response_history_scope(
         self,

--- a/src/mindroom/workers/backends/docker_projection.py
+++ b/src/mindroom/workers/backends/docker_projection.py
@@ -284,7 +284,7 @@ class DockerProjectionManager:
         if self.config.host_config_path is None:
             return [], None
 
-        projection = self.projected_config(
+        projection = self._projected_config(
             paths,
             worker_key=worker_key,
             materialize=materialize_projection,
@@ -292,7 +292,7 @@ class DockerProjectionManager:
         config_dir = PurePosixPath(_container_config_dir(self.config.config_path))
         return [(projection.root, str(config_dir), True)], projection
 
-    def projected_config(
+    def _projected_config(
         self,
         paths: LocalWorkerStatePaths,
         *,
@@ -352,7 +352,7 @@ class DockerProjectionManager:
         projection_hash = hashlib.sha256(
             json.dumps(projection_manifest, sort_keys=True, separators=(",", ":")).encode("utf-8"),
         ).hexdigest()[:12]
-        projection_dir = self.worker_projected_configs_root(paths) / f"config-projection-{projection_hash}"
+        projection_dir = self._worker_projected_configs_root(paths) / f"config-projection-{projection_hash}"
         projection = _DockerProjectedConfig(
             root=projection_dir,
             projected_yaml=projected_yaml,
@@ -362,11 +362,11 @@ class DockerProjectionManager:
         projection = replace(projection, ready=self._projection_ready(projection))
         if materialize:
             self._write_projected_config(projection)
-            self.prune_projected_configs(paths, keep=projection.root)
+            self._prune_projected_configs(paths, keep=projection.root)
             return replace(projection, ready=True)
         return projection
 
-    def worker_projected_configs_root(self, paths: LocalWorkerStatePaths) -> Path:
+    def _worker_projected_configs_root(self, paths: LocalWorkerStatePaths) -> Path:
         """Return the directory containing one worker root's projected config snapshots."""
         return self._projected_configs_root / paths.root.name
 
@@ -377,9 +377,9 @@ class DockerProjectionManager:
             return {}
         return resolved_agent_policies_from_config_data(self._load_host_config_data(host_config_path))
 
-    def prune_projected_configs(self, paths: LocalWorkerStatePaths, *, keep: Path) -> None:
+    def _prune_projected_configs(self, paths: LocalWorkerStatePaths, *, keep: Path) -> None:
         """Remove stale projected config snapshots for one worker root."""
-        projection_root = self.worker_projected_configs_root(paths)
+        projection_root = self._worker_projected_configs_root(paths)
         projection_root.mkdir(parents=True, exist_ok=True)
         for sibling in projection_root.iterdir():
             if sibling == keep:

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -844,7 +844,7 @@ class KubernetesResourceManager:
             raise
         return True
 
-    def delete_deployment(self, deployment_name: str) -> None:
+    def _delete_deployment(self, deployment_name: str) -> None:
         """Delete one worker Deployment, ignoring 404s."""
         self._delete_object(self._apps.delete_namespaced_deployment, deployment_name)
 
@@ -871,7 +871,7 @@ class KubernetesResourceManager:
             return
         self._delete_object(self._core.delete_namespaced_secret, secret_name)
 
-    def agent_vault_vault_name(self, worker_key: str) -> str | None:
+    def _agent_vault_vault_name(self, worker_key: str) -> str | None:
         """Return the Agent Vault vault name backing one worker, or None when disabled."""
         cfg = self.config.agent_vault
         if cfg is None:
@@ -880,7 +880,7 @@ class KubernetesResourceManager:
 
     def _agent_vault_init_container(self, *, worker_key: str) -> dict[str, object]:
         cfg: KubernetesAgentVaultConfig | None = self.config.agent_vault
-        vault = self.agent_vault_vault_name(worker_key)
+        vault = self._agent_vault_vault_name(worker_key)
         if cfg is None or vault is None:
             msg = "Agent Vault init container requested without Agent Vault config."
             raise WorkerBackendError(msg)
@@ -914,7 +914,7 @@ class KubernetesResourceManager:
         cfg = self.config.agent_vault
         if cfg is None:
             return []
-        vault = self.agent_vault_vault_name(worker_key)
+        vault = self._agent_vault_vault_name(worker_key)
         if vault is None:
             msg = f"Agent Vault main env requested without a worker vault name for worker_key={worker_key!r}."
             raise WorkerBackendError(msg)
@@ -968,7 +968,7 @@ class KubernetesResourceManager:
         timeout_seconds: float,
     ) -> None:
         """Replace one Deployment when pod-template drift requires a full recreate."""
-        self.delete_deployment(deployment_name)
+        self._delete_deployment(deployment_name)
         self._wait_for_deployment_absent(deployment_name, timeout_seconds=timeout_seconds)
         deadline = time.time() + timeout_seconds
         while True:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -675,7 +675,7 @@ def _outcome(
         suppressed=resolved_suppressed,
         tool_trace=tool_trace,
         extra_content=dict(extra_content or {}),
-        interactive_metadata=InteractiveMetadata.from_parts(option_map, options_list),
+        interactive_metadata=InteractiveMetadata._from_parts(option_map, options_list),
     )
 
 

--- a/tests/test_agent_response_logic.py
+++ b/tests/test_agent_response_logic.py
@@ -171,11 +171,11 @@ class TestAgentResponseLogic:
             ),
         )
 
-        responder_pool = policy.filter_materializable_responders(
+        responder_pool = policy._filter_materializable_responders(
             [team_id],
             _ResponderAvailability(materializable_agent_names={"alpha", "beta"}, live_entity_names=None),
         )
-        action = policy.team_response_action(
+        action = policy._team_response_action(
             TeamResolution(
                 intent=TeamIntent.EXPLICIT_MEMBERS,
                 requested_members=[team_id],
@@ -234,8 +234,8 @@ class TestAgentResponseLogic:
             reason="Team request includes unsupported members.",
         )
         responder_pool = [ids["private_worker"], ids["shared"]]
-        owner = policy.response_owner_for_team_resolution(team_resolution, responder_pool)
-        action = policy.team_response_action(team_resolution, responder_pool)
+        owner = policy._response_owner_for_team_resolution(team_resolution, responder_pool)
+        action = policy._team_response_action(team_resolution, responder_pool)
 
         assert owner == ids["shared"]
         assert action is not None
@@ -290,11 +290,11 @@ class TestAgentResponseLogic:
             outcome=TeamOutcome.TEAM,
             mode=TeamMode.COORDINATE,
         )
-        owner = policy.response_owner_for_team_resolution(
+        owner = policy._response_owner_for_team_resolution(
             team_resolution,
             responder_pool=[ids["private_one"], ids["ops"], ids["shared"]],
         )
-        action = policy.team_response_action(
+        action = policy._team_response_action(
             team_resolution,
             responder_pool=[ids["private_one"], ids["ops"], ids["shared"]],
         )
@@ -358,7 +358,7 @@ class TestAgentResponseLogic:
             "mindroom.turn_policy.responder_candidate_entities_for_room",
             new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
         ):
-            multiple_visible_action = await policy.resolve_response_action(
+            multiple_visible_action = await policy._resolve_response_action(
                 dispatch,
                 room,
                 False,
@@ -371,7 +371,7 @@ class TestAgentResponseLogic:
             "mindroom.turn_policy.responder_candidate_entities_for_room",
             new=AsyncMock(return_value=[candidate_ids["calculator"]]),
         ):
-            single_visible_action = await policy.resolve_response_action(
+            single_visible_action = await policy._resolve_response_action(
                 dispatch,
                 room,
                 False,
@@ -441,7 +441,7 @@ class TestAgentResponseLogic:
                 new=MagicMock(return_value=TeamResolution.none()),
             ),
         ):
-            action = await policy.resolve_response_action(
+            action = await policy._resolve_response_action(
                 dispatch,
                 room,
                 False,
@@ -518,7 +518,7 @@ class TestAgentResponseLogic:
             "mindroom.turn_policy.responder_candidate_entities_for_room",
             new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
         ):
-            action = await policy.resolve_response_action(
+            action = await policy._resolve_response_action(
                 dispatch,
                 room,
                 False,
@@ -602,7 +602,7 @@ class TestAgentResponseLogic:
                 new=MagicMock(return_value=TeamResolution.none()),
             ),
         ):
-            action = await policy.resolve_response_action(
+            action = await policy._resolve_response_action(
                 dispatch,
                 room,
                 False,

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -190,7 +190,7 @@ class TestAIErrorDisplay:
             error_msg = "[test_agent] 🔴 Authentication failed. Please check your API key configuration."
             mock_ai.return_value = error_msg
 
-            await bot._response_runner.process_and_respond(
+            await bot._response_runner._process_and_respond(
                 _response_request(existing_event_id="$thinking_msg"),
             )
 
@@ -241,7 +241,7 @@ class TestAIErrorDisplay:
                 ),
             ) as mock_deliver_stream:
                 # Call the method with an existing_event_id
-                await bot._response_runner.process_and_respond_streaming(
+                await bot._response_runner._process_and_respond_streaming(
                     _response_request(existing_event_id="$thinking_msg"),
                 )
 
@@ -276,7 +276,7 @@ class TestAIErrorDisplay:
             _build_response_runner(bot)
             mock_ai.side_effect = asyncio.CancelledError()
 
-            await bot._response_runner.process_and_respond(
+            await bot._response_runner._process_and_respond(
                 _response_request(existing_event_id="$thinking_msg"),
             )
 
@@ -314,7 +314,7 @@ class TestAIErrorDisplay:
             _build_response_runner(bot)
             mock_ai.side_effect = asyncio.CancelledError(USER_STOP_CANCEL_MSG)
 
-            outcome = await bot._response_runner.process_and_respond(
+            outcome = await bot._response_runner._process_and_respond(
                 _response_request(existing_event_id="$thinking_msg"),
             )
 
@@ -382,7 +382,7 @@ class TestAIErrorDisplay:
         ):
             _build_response_runner(bot)
 
-            outcome = await bot._response_runner.process_and_respond(
+            outcome = await bot._response_runner._process_and_respond(
                 _response_request(existing_event_id="$thinking_msg"),
             )
 
@@ -449,7 +449,7 @@ class TestAIErrorDisplay:
             _build_response_runner(bot)
             mock_agent.arun = MagicMock(return_value=fake_arun_stream())
 
-            outcome = await bot._response_runner.process_and_respond(
+            outcome = await bot._response_runner._process_and_respond(
                 _response_request(existing_event_id="$thinking_msg"),
             )
 
@@ -512,7 +512,7 @@ class TestAIErrorDisplay:
             _build_response_runner(bot)
             mock_agent.arun = MagicMock(return_value=fake_arun_stream())
 
-            outcome = await bot._response_runner.process_and_respond_streaming(
+            outcome = await bot._response_runner._process_and_respond_streaming(
                 _response_request(existing_event_id="$thinking_msg"),
             )
 
@@ -562,7 +562,7 @@ class TestAIErrorDisplay:
                 _build_response_runner(bot)
                 mock_ai.return_value = error_msg
 
-                await bot._response_runner.process_and_respond(
+                await bot._response_runner._process_and_respond(
                     _response_request(
                         prompt="Help me",
                         existing_event_id=f"$thinking_{error_messages.index(error_msg)}",
@@ -614,7 +614,7 @@ class TestAIErrorDisplay:
             _build_response_runner(bot)
             mock_ai.side_effect = asyncio.CancelledError(SYNC_RESTART_CANCEL_MSG)
 
-            await bot._response_runner.process_and_respond(
+            await bot._response_runner._process_and_respond(
                 _response_request(existing_event_id="$thinking_msg"),
             )
 
@@ -645,7 +645,7 @@ class TestAIErrorDisplay:
             _build_response_runner(bot)
             mock_ai.return_value = "Response without knowledge"
 
-            generation = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner._process_and_respond(
                 _response_request(),
             )
 

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -416,7 +416,7 @@ class TestUserIdPassthrough:
 
             mock_ai.side_effect = fake_ai_response
 
-            await coordinator.process_and_respond(
+            await coordinator._process_and_respond(
                 _response_request(prompt="Hello", user_id="@alice:localhost"),
             )
 
@@ -470,7 +470,7 @@ class TestUserIdPassthrough:
 
             mock_stream.side_effect = fake_stream_agent_response
 
-            await coordinator.process_and_respond_streaming(
+            await coordinator._process_and_respond_streaming(
                 _response_request(prompt="Hello", user_id="@bob:localhost"),
             )
 

--- a/tests/test_bot_response_actions.py
+++ b/tests/test_bot_response_actions.py
@@ -111,7 +111,7 @@ class TestAgentBot(AgentBotTestBase):
             bot.orchestrator = MagicMock()
             bot.orchestrator.agent_bots = {"calculator": MagicMock()}
 
-            await bot._turn_policy.decide_team_for_sender(
+            await bot._turn_policy._decide_team_for_sender(
                 agents_in_thread=[],
                 context=context,
                 room=room,
@@ -154,7 +154,7 @@ class TestAgentBot(AgentBotTestBase):
 
         with (
             patch(
-                "mindroom.bot.TurnPolicy.decide_team_for_sender",
+                "mindroom.bot.TurnPolicy._decide_team_for_sender",
                 new=AsyncMock(
                     return_value=TeamResolution(
                         intent=TeamIntent.EXPLICIT_MEMBERS,
@@ -177,7 +177,7 @@ class TestAgentBot(AgentBotTestBase):
                 return_value=AgentResponseDecision(True),
             ) as mock_decide_agent_response,
         ):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "help me"),
                 room,
                 False,
@@ -238,7 +238,7 @@ class TestAgentBot(AgentBotTestBase):
             "mindroom.turn_policy.decide_agent_response",
             return_value=AgentResponseDecision(True),
         ) as mock_decide_agent_response:
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@alice:localhost", "calculator and general, help"),
                 room,
                 False,
@@ -296,7 +296,7 @@ class TestAgentBot(AgentBotTestBase):
             "mindroom.turn_policy.decide_agent_response",
             return_value=AgentResponseDecision(True),
         ) as mock_decide_agent_response:
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "general and research, help"),
                 room,
                 False,
@@ -355,7 +355,7 @@ class TestAgentBot(AgentBotTestBase):
             "mindroom.turn_policy.decide_agent_response",
             return_value=AgentResponseDecision(True),
         ) as mock_decide_agent_response:
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "alpha and calculator, help"),
                 room,
                 False,
@@ -415,7 +415,7 @@ class TestAgentBot(AgentBotTestBase):
             "mindroom.turn_policy.decide_agent_response",
             return_value=AgentResponseDecision(True),
         ) as mock_decide_agent_response:
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@alice:localhost", "calculator and general, help"),
                 room,
                 False,
@@ -466,7 +466,7 @@ class TestAgentBot(AgentBotTestBase):
         )
 
         with patch("mindroom.turn_policy.decide_team_formation", new=MagicMock(return_value=TeamResolution.none())):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@bob:localhost", "can someone help?"),
                 room,
                 False,
@@ -510,7 +510,7 @@ class TestAgentBot(AgentBotTestBase):
             has_non_agent_mentions=False,
         )
 
-        action = await bot._turn_policy.resolve_response_action(
+        action = await bot._turn_policy._resolve_response_action(
             _policy_dispatch(bot, room, context, "@bob:localhost", "calculator, help"),
             room,
             False,
@@ -554,7 +554,7 @@ class TestAgentBot(AgentBotTestBase):
             has_non_agent_mentions=False,
         )
 
-        action = await bot._turn_policy.resolve_response_action(
+        action = await bot._turn_policy._resolve_response_action(
             _policy_dispatch(
                 bot,
                 room,
@@ -623,7 +623,7 @@ class TestAgentBot(AgentBotTestBase):
             has_non_agent_mentions=False,
         )
 
-        action = await bot._turn_policy.resolve_response_action(
+        action = await bot._turn_policy._resolve_response_action(
             _policy_dispatch(bot, room, context, "@bob:localhost", "ops, help"),
             room,
             False,
@@ -670,7 +670,7 @@ class TestAgentBot(AgentBotTestBase):
 
         with (
             patch(
-                "mindroom.bot.TurnPolicy.decide_team_for_sender",
+                "mindroom.bot.TurnPolicy._decide_team_for_sender",
                 new=AsyncMock(
                     return_value=TeamResolution(
                         intent=TeamIntent.EXPLICIT_MEMBERS,
@@ -701,7 +701,7 @@ class TestAgentBot(AgentBotTestBase):
                 return_value=AgentResponseDecision(True),
             ) as mock_decide_agent_response,
         ):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "alpha and calculator, help"),
                 room,
                 False,
@@ -750,7 +750,7 @@ class TestAgentBot(AgentBotTestBase):
 
         with (
             patch(
-                "mindroom.bot.TurnPolicy.decide_team_for_sender",
+                "mindroom.bot.TurnPolicy._decide_team_for_sender",
                 new=AsyncMock(
                     return_value=TeamResolution(
                         intent=TeamIntent.EXPLICIT_MEMBERS,
@@ -781,7 +781,7 @@ class TestAgentBot(AgentBotTestBase):
                 return_value=AgentResponseDecision(True),
             ) as mock_decide_agent_response,
         ):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "alpha and calculator, help"),
                 room,
                 False,
@@ -841,7 +841,7 @@ class TestAgentBot(AgentBotTestBase):
             "mindroom.turn_policy.decide_agent_response",
             return_value=AgentResponseDecision(True),
         ) as mock_decide_agent_response:
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "alpha and calculator, help"),
                 room,
                 False,
@@ -882,7 +882,7 @@ class TestAgentBot(AgentBotTestBase):
 
         with (
             patch(
-                "mindroom.bot.TurnPolicy.decide_team_for_sender",
+                "mindroom.bot.TurnPolicy._decide_team_for_sender",
                 new=AsyncMock(
                     return_value=TeamResolution.individual(
                         intent=TeamIntent.IMPLICIT_THREAD_TEAM,
@@ -897,7 +897,7 @@ class TestAgentBot(AgentBotTestBase):
                 return_value=AgentResponseDecision(False),
             ) as mock_decide_agent_response,
         ):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@user:localhost", "help me"),
                 room,
                 True,
@@ -990,7 +990,7 @@ class TestAgentBot(AgentBotTestBase):
                 return_value=True,
             ) as mock_has_active_response,
         ):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 PreparedDispatch(
                     requester_user_id="@user:localhost",
                     context=context,
@@ -1070,7 +1070,7 @@ class TestAgentBot(AgentBotTestBase):
             patch("mindroom.turn_policy.decide_team_formation", new=MagicMock(return_value=TeamResolution.none())),
             patch.object(bot._response_runner, "has_active_response_for_target", return_value=True),
         ):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 PreparedDispatch(
                     requester_user_id="@user:localhost",
                     context=context,
@@ -1132,7 +1132,7 @@ class TestAgentBot(AgentBotTestBase):
         )
 
         with patch.object(bot._response_runner, "has_active_response_for_target", return_value=True):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 PreparedDispatch(
                     requester_user_id="@user:localhost",
                     context=context,
@@ -1213,7 +1213,7 @@ class TestAgentBot(AgentBotTestBase):
                 return_value=False,
             ) as mock_has_active_response,
         ):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 PreparedDispatch(
                     requester_user_id="@user:localhost",
                     context=context,
@@ -1296,7 +1296,7 @@ class TestAgentBot(AgentBotTestBase):
                 return_value=False,
             ) as mock_has_active_response,
         ):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 PreparedDispatch(
                     requester_user_id="@user:localhost",
                     context=context,
@@ -1389,7 +1389,7 @@ class TestAgentBot(AgentBotTestBase):
             envelope=envelope,
         )
 
-        plan = await bot._turn_policy.plan_router_dispatch(room, event, dispatch)
+        plan = await bot._turn_policy._plan_router_dispatch(room, event, dispatch)
 
         assert plan is not None
         assert plan.kind == "route"
@@ -1555,7 +1555,7 @@ class TestAgentBot(AgentBotTestBase):
                 return_value=AgentResponseDecision(False),
             ) as mock_decide_agent_response,
         ):
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@bas:localhost", "I fixed two issues"),
                 room,
                 False,
@@ -1620,7 +1620,7 @@ class TestAgentBot(AgentBotTestBase):
             requires_model_history_refresh=True,
         )
 
-        action = await bot._turn_policy.resolve_response_action(
+        action = await bot._turn_policy._resolve_response_action(
             _policy_dispatch(bot, room, context, "@bas:localhost", "Follow-up"),
             room,
             False,
@@ -1688,7 +1688,7 @@ class TestAgentBot(AgentBotTestBase):
             "mindroom.turn_policy.decide_agent_response",
             return_value=AgentResponseDecision(True),
         ) as mock_decide_agent_response:
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@bas:localhost", "Follow-up"),
                 room,
                 False,
@@ -1755,7 +1755,7 @@ class TestAgentBot(AgentBotTestBase):
             "mindroom.turn_policy.decide_agent_response",
             return_value=AgentResponseDecision(True),
         ) as mock_decide_agent_response:
-            action = await bot._turn_policy.resolve_response_action(
+            action = await bot._turn_policy._resolve_response_action(
                 _policy_dispatch(bot, room, context, "@bas:localhost", "Follow-up"),
                 room,
                 False,
@@ -1831,7 +1831,7 @@ class TestAgentBot(AgentBotTestBase):
             envelope=_hook_envelope(body="Follow-up", source_event_id=event.event_id, target=dispatch_target),
         )
 
-        plan = await bot._turn_policy.plan_router_dispatch(room, event, dispatch)
+        plan = await bot._turn_policy._plan_router_dispatch(room, event, dispatch)
 
         assert plan == _DispatchPlan(kind="ignore", ignore_reason="router")
 
@@ -1901,6 +1901,6 @@ class TestAgentBot(AgentBotTestBase):
             envelope=_hook_envelope(body="Follow-up", source_event_id=event.event_id, target=dispatch_target),
         )
 
-        plan = await bot._turn_policy.plan_router_dispatch(room, event, dispatch)
+        plan = await bot._turn_policy._plan_router_dispatch(room, event, dispatch)
 
         assert plan == _DispatchPlan(kind="ignore", ignore_reason="router")

--- a/tests/test_bot_sync_event_cache.py
+++ b/tests/test_bot_sync_event_cache.py
@@ -525,7 +525,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             self._sync_response({room_id: MagicMock(timeline=MagicMock(events=[message_event], limited=True))}),
         )
 
-        assert result.certified is False
+        assert result._certified is False
         assert result.limited_room_ids == (room_id,)
         assert result.errors == ()
         event_cache.mark_room_threads_gap.assert_awaited_once_with(
@@ -550,7 +550,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             self._sync_response({room_id: MagicMock(timeline=MagicMock(events=[], limited=True))}),
         )
 
-        assert result.certified is False
+        assert result._certified is False
         assert result.complete is False
         assert result.errors == (marker_error,)
         assert result.limited_room_ids == (room_id,)
@@ -606,7 +606,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
             self._sync_response({room_id: MagicMock(timeline=MagicMock(events=[], limited=True))}),
         )
 
-        assert result.certified is False
+        assert result._certified is False
         assert result.complete is False
         assert result.runtime_available is False
         assert result.limited_room_ids == (room_id,)
@@ -665,7 +665,7 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         finally:
             await _close_bound_runtime_support(bot, support)
 
-        assert result.certified is False
+        assert result._certified is False
         assert result.limited_room_ids == (room_id,)
         assert result.errors == ()
         assert cached_event is not None

--- a/tests/test_compact_context.py
+++ b/tests/test_compact_context.py
@@ -524,7 +524,7 @@ async def test_compaction_lifecycle_success_edits_notice_with_html_body(tmp_path
             new=AsyncMock(side_effect=delivered_matrix_side_effect("$notice-edit")),
         ) as mock_edit,
     ):
-        event_id = await bot._delivery_gateway.send_compaction_lifecycle_start(
+        event_id = await bot._delivery_gateway._send_compaction_lifecycle_start(
             target=target,
             reply_to_event_id="$reply",
             event=CompactionLifecycleStart(
@@ -538,7 +538,7 @@ async def test_compaction_lifecycle_success_edits_notice_with_html_body(tmp_path
                 threshold_tokens=80_000,
             ),
         )
-        await bot._delivery_gateway.edit_compaction_lifecycle_success(
+        await bot._delivery_gateway._edit_compaction_lifecycle_success(
             target=target,
             outcome=replace(outcome, lifecycle_notice_event_id=event_id, duration_ms=123),
         )

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -123,7 +123,7 @@ async def test_rapid_requests_coalesce_into_one_reload(
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.05)
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
     lifecycle = _make_lifecycle(tmp_path)
-    lifecycle.update_config = AsyncMock(return_value=True)
+    lifecycle._update_config = AsyncMock(return_value=True)
 
     lifecycle.request_reload()
     task = lifecycle._reload_task
@@ -134,7 +134,7 @@ async def test_rapid_requests_coalesce_into_one_reload(
 
     assert lifecycle._reload_task is task
     await asyncio.wait_for(task, timeout=1)
-    lifecycle.update_config.assert_awaited_once()
+    lifecycle._update_config.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -148,18 +148,18 @@ async def test_reload_drains_active_responses_before_applying(
     gate = ResponseAdmissionGate()
     assert gate.admit()
     lifecycle = _make_lifecycle(tmp_path, response_admission_gate=gate)
-    lifecycle.update_config = AsyncMock(return_value=True)
+    lifecycle._update_config = AsyncMock(return_value=True)
 
     lifecycle.request_reload()
     task = lifecycle._reload_task
     assert task is not None
 
     await asyncio.sleep(0.05)
-    lifecycle.update_config.assert_not_awaited()
+    lifecycle._update_config.assert_not_awaited()
 
     gate.release()
     await asyncio.wait_for(task, timeout=1)
-    lifecycle.update_config.assert_awaited_once()
+    lifecycle._update_config.assert_awaited_once()
     assert gate.closed is False
 
 
@@ -292,7 +292,7 @@ async def test_new_request_during_drain_keeps_waiting_for_idle(
     assert gate.admit()
     lifecycle = _make_lifecycle(tmp_path, response_admission_gate=gate)
 
-    lifecycle.update_config = AsyncMock(return_value=True)
+    lifecycle._update_config = AsyncMock(return_value=True)
 
     lifecycle.request_reload()
     await asyncio.sleep(0.06)
@@ -301,12 +301,12 @@ async def test_new_request_during_drain_keeps_waiting_for_idle(
 
     task = lifecycle._reload_task
     assert task is not None
-    lifecycle.update_config.assert_not_awaited()
+    lifecycle._update_config.assert_not_awaited()
 
     gate.release()
     await asyncio.wait_for(task, timeout=1)
 
-    lifecycle.update_config.assert_awaited_once()
+    lifecycle._update_config.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -331,14 +331,14 @@ async def test_failed_update_does_not_strand_queued_reload(
             raise RuntimeError(msg)
         return True
 
-    lifecycle.update_config = AsyncMock(side_effect=failing_then_succeeding_update)
+    lifecycle._update_config = AsyncMock(side_effect=failing_then_succeeding_update)
     lifecycle.request_reload()
     task = lifecycle._reload_task
     assert task is not None
 
     await asyncio.wait_for(task, timeout=2)
 
-    assert lifecycle.update_config.await_count == 2
+    assert lifecycle._update_config.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -360,14 +360,14 @@ async def test_config_change_during_update_triggers_second_reload(
             lifecycle.request_reload()
         return True
 
-    lifecycle.update_config = AsyncMock(side_effect=update_config_with_second_change)
+    lifecycle._update_config = AsyncMock(side_effect=update_config_with_second_change)
     lifecycle.request_reload()
     task = lifecycle._reload_task
     assert task is not None
 
     await asyncio.wait_for(task, timeout=2)
 
-    assert lifecycle.update_config.await_count == 2
+    assert lifecycle._update_config.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -419,7 +419,7 @@ async def test_cancel_clears_queued_reload(
     busy_gate = ResponseAdmissionGate()
     assert busy_gate.admit()
     lifecycle = _make_lifecycle(tmp_path, response_admission_gate=busy_gate)
-    lifecycle.update_config = AsyncMock(return_value=True)
+    lifecycle._update_config = AsyncMock(return_value=True)
 
     lifecycle.request_reload()
     task = lifecycle._reload_task
@@ -431,7 +431,7 @@ async def test_cancel_clears_queued_reload(
     assert lifecycle._reload_task is None
     assert lifecycle._requested_at is None
     assert task.done()
-    lifecycle.update_config.assert_not_awaited()
+    lifecycle._update_config.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -543,14 +543,14 @@ async def test_drain_applies_reload_after_force_timeout(
     # A response that never finishes, so the gate is never idle.
     assert gate.admit()
     lifecycle = _make_lifecycle(tmp_path, response_admission_gate=gate)
-    lifecycle.update_config = AsyncMock(return_value=True)
+    lifecycle._update_config = AsyncMock(return_value=True)
 
     lifecycle.request_reload()
     task = lifecycle._reload_task
     assert task is not None
     await asyncio.wait_for(task, timeout=2)
 
-    lifecycle.update_config.assert_awaited_once()
+    lifecycle._update_config.assert_awaited_once()
     # Admission reopens even though the forced apply ran over a live response.
     assert gate.closed is False
 
@@ -568,7 +568,7 @@ async def test_update_config_delegates_initial_load(
     )
     lifecycle = _make_lifecycle(tmp_path, current_config=None)
 
-    assert await lifecycle.update_config() is False
+    assert await lifecycle._update_config() is False
 
     lifecycle.load_initial_config.assert_awaited_once_with(new_config)
     lifecycle.apply_update_plan.assert_not_awaited()
@@ -596,7 +596,7 @@ async def test_update_config_builds_plan_and_dispatches(
         agent_bots={"router": MagicMock(), "agent1": MagicMock()},
     )
 
-    assert await lifecycle.update_config() is True
+    assert await lifecycle._update_config() is True
 
     lifecycle.load_initial_config.assert_not_awaited()
     lifecycle.apply_update_plan.assert_awaited_once()
@@ -645,7 +645,7 @@ async def test_update_config_plugin_changes_restart_all_bots(
         agent_bots={"router": MagicMock(), "agent1": MagicMock(), "agent2": MagicMock()},
     )
 
-    assert await lifecycle.update_config() is True
+    assert await lifecycle._update_config() is True
 
     _, dispatched_plan, plugin_changes = lifecycle.apply_update_plan.await_args.args
     assert dispatched_plan.entities_to_restart == {"router", "agent1", "agent2"}
@@ -671,7 +671,7 @@ async def test_update_config_loads_config_off_event_loop(
     lifecycle = _make_lifecycle(tmp_path)
     lifecycle.load_initial_config = AsyncMock(return_value=True)
 
-    update_task = asyncio.get_running_loop().create_task(lifecycle.update_config())
+    update_task = asyncio.get_running_loop().create_task(lifecycle._update_config())
     await asyncio.to_thread(load_started.wait, 5.0)
 
     # The loader thread is parked on the gate; the loop must stay live.
@@ -708,7 +708,7 @@ async def test_update_config_waits_for_lock_before_loading(
     lifecycle.config_update_lock = lock
 
     await lock.acquire()
-    update_task = asyncio.create_task(lifecycle.update_config())
+    update_task = asyncio.create_task(lifecycle._update_config())
     await asyncio.sleep(0)
     assert not to_thread_started.is_set()
 

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -1066,7 +1066,7 @@ async def test_update_config_keeps_current_config_when_new_entity_account_prepar
         patch.object(orchestrator, "_prepare_entity_accounts", new=AsyncMock(side_effect=account_error)) as prepare,
         pytest.raises(PermanentStartupError, match="share a Matrix ID"),
     ):
-        await orchestrator.config_reload.update_config()
+        await orchestrator.config_reload._update_config()
 
     assert orchestrator.config is current_config
     prepare.assert_awaited_once_with(new_config, {"writer"})
@@ -1100,7 +1100,7 @@ async def test_update_config_keeps_current_config_when_restarted_entity_account_
         patch.object(orchestrator, "_prepare_entity_accounts", new=AsyncMock(side_effect=account_error)) as prepare,
         pytest.raises(PermanentStartupError, match="share a Matrix ID"),
     ):
-        await orchestrator.config_reload.update_config()
+        await orchestrator.config_reload._update_config()
 
     assert orchestrator.config is current_config
     prepare.assert_awaited_once_with(new_config, {"general"})
@@ -1172,7 +1172,7 @@ async def test_update_config_validates_internal_user_collision_before_publish(tm
         patch.object(orchestrator, "_prepare_entity_accounts", new=AsyncMock()) as prepare_entities,
         pytest.raises(PermanentStartupError, match="internal user Matrix ID"),
     ):
-        await orchestrator.config_reload.update_config()
+        await orchestrator.config_reload._update_config()
 
     assert orchestrator.config is current_config
     prepare_entities.assert_not_awaited()
@@ -1348,7 +1348,7 @@ async def test_update_config_cancels_tasks_for_removed_plugins(
         hooks_module._AUTO_POKE_TASK = task
 
         _write_plugin_removal_test_config(tmp_path, with_plugin=False)
-        updated = await orchestrator.config_reload.update_config()
+        updated = await orchestrator.config_reload._update_config()
         await asyncio.sleep(0)
 
         assert updated is True
@@ -1459,7 +1459,7 @@ async def test_update_config_serializes_live_plugin_reload_against_staged_plugin
             patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
             patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         assert updated is False
         assert reload_task is not None
@@ -1513,7 +1513,7 @@ async def test_config_update_serializes_manual_plugin_reload_and_mcp_catalog_cha
         patch.object(orchestrator.config_reload, "apply_update_plan", new=apply_update_plan),
         patch("mindroom.orchestrator.reload_plugins", return_value=reload_result) as reload_plugins_mock,
     ):
-        config_task = asyncio.create_task(orchestrator.config_reload.update_config())
+        config_task = asyncio.create_task(orchestrator.config_reload._update_config())
         await asyncio.wait_for(apply_started.wait(), timeout=1)
         plugin_task = asyncio.create_task(orchestrator.reload_plugins_now(source="test"))
         mcp_task = asyncio.create_task(orchestrator._handle_mcp_catalog_change("demo"))
@@ -1585,7 +1585,7 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
         target: MessageTarget,
         _early_placeholder: object,
     ) -> str | None:
-        return await runner.run_cancellable_response(
+        return await runner._run_cancellable_response(
             target=target,
             response_function=response_function,
             thinking_message="Thinking...",
@@ -1596,7 +1596,7 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
     orchestrator.agent_bots["agent1"] = bot
     # The orchestrator owns one shared gate that every managed bot admits through.
     bot.admission_gate = orchestrator.config_reload.response_admission_gate
-    orchestrator.config_reload.update_config = AsyncMock(return_value=True)
+    orchestrator.config_reload._update_config = AsyncMock(return_value=True)
 
     response_task = asyncio.create_task(
         runner._run_locked_response_lifecycle(
@@ -1616,13 +1616,13 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
         assert task is not None
 
         await asyncio.sleep(0.05)
-        orchestrator.config_reload.update_config.assert_not_awaited()
+        orchestrator.config_reload._update_config.assert_not_awaited()
 
         release_response.set()
         await asyncio.wait_for(response_task, timeout=1)
         await asyncio.wait_for(task, timeout=1)
 
-        orchestrator.config_reload.update_config.assert_awaited_once()
+        orchestrator.config_reload._update_config.assert_awaited_once()
     finally:
         release_response.set()
         await asyncio.gather(response_task, return_exceptions=True)
@@ -2593,7 +2593,7 @@ async def test_orchestrator_handles_config_reload(  # noqa: PLR0915
         monkeypatch.setattr(bot, "sync_forever", AsyncMock(side_effect=asyncio.CancelledError()))
 
     # Update config
-    updated = await orchestrator.config_reload.update_config()
+    updated = await orchestrator.config_reload._update_config()
     assert updated  # Should return True since config changed
 
     # Verify updated state
@@ -2811,7 +2811,7 @@ async def test_in_flight_response_count_nonzero_during_send_response(
         target: MessageTarget,
         _early_placeholder: object,
     ) -> str | None:
-        return await runner.run_cancellable_response(
+        return await runner._run_cancellable_response(
             target=target,
             response_function=response_function,
             thinking_message="Thinking...",
@@ -3091,7 +3091,7 @@ async def test_run_cancellable_response_marks_thinking_placeholder_pending(
     async def response_function(message_id: str | None) -> None:
         assert message_id == "$thinking"
 
-    await bot._response_runner.run_cancellable_response(
+    await bot._response_runner._run_cancellable_response(
         target=MessageTarget.resolve("!room:localhost", None, "$reply"),
         response_function=response_function,
         thinking_message="Thinking...",
@@ -3118,18 +3118,18 @@ async def test_shutdown_during_active_drain_cancels_reload(
     orchestrator.agent_bots["agent1"] = mock_bot
     # An admitted response that never finishes, so the drain never goes idle.
     assert orchestrator.config_reload.response_admission_gate.admit()
-    orchestrator.config_reload.update_config = AsyncMock(return_value=True)
+    orchestrator.config_reload._update_config = AsyncMock(return_value=True)
     orchestrator.config_reload.request_reload()
     task = orchestrator.config_reload._reload_task
     assert task is not None
 
     # Let the drain loop start polling
     await asyncio.sleep(0.05)
-    orchestrator.config_reload.update_config.assert_not_awaited()
+    orchestrator.config_reload._update_config.assert_not_awaited()
 
     # Shutdown
     await orchestrator.stop()
 
     # The reload task should have been cancelled
     assert task.done()
-    orchestrator.config_reload.update_config.assert_not_awaited()
+    orchestrator.config_reload._update_config.assert_not_awaited()

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -513,7 +513,7 @@ router:
         tmp_path,
         config_text=config_text,
     )
-    projection = backend._projection_manager.projected_config(
+    projection = backend._projection_manager._projected_config(
         local_worker_state_paths_for_root(tmp_path / "workers" / "mapped-plugin"),
         materialize=True,
     )
@@ -545,7 +545,7 @@ def test_docker_worker_projection_resolves_config_includes(
         tmp_path,
         config_text=config_text,
     )
-    projection = backend._projection_manager.projected_config(
+    projection = backend._projection_manager._projected_config(
         local_worker_state_paths_for_root(tmp_path / "workers" / "split-config"),
         materialize=True,
     )
@@ -812,7 +812,7 @@ def test_docker_backend_from_runtime_reanchors_host_config_projection_and_runtim
         storage_path=tmp_path / "storage",
         runtime_paths=runtime_paths,
     )
-    projection = backend._projection_manager.projected_config(
+    projection = backend._projection_manager._projected_config(
         local_worker_state_paths_for_root(tmp_path / "workers" / "projection-test"),
         materialize=False,
     )
@@ -1114,7 +1114,7 @@ def _projection_signature_for_hash_seed(hash_seed: str, workspace_root: Path) ->
             runtime_paths=runtime_paths,
         )
         paths = local_worker_state_paths_for_root(tmp_path / "workers" / "worker-a")
-        projection = manager.projected_config(
+        projection = manager._projected_config(
             paths,
             worker_key="v1:default:shared:alpha",
             materialize=False,
@@ -2194,7 +2194,7 @@ def test_docker_projected_context_files_load_in_worker_runtime(tmp_path: Path) -
         runtime_paths=runtime_paths,
     )
     worker_paths = local_worker_state_paths_for_root(worker_root_path(tmp_path, _TEST_UNSCOPED_WORKER_KEY))
-    projection = manager.projected_config(worker_paths, worker_key=_TEST_UNSCOPED_WORKER_KEY, materialize=True)
+    projection = manager._projected_config(worker_paths, worker_key=_TEST_UNSCOPED_WORKER_KEY, materialize=True)
     projected_config = yaml.safe_load(projection.projected_yaml)
     projected_context_file = projected_config["agents"]["code"]["context_files"][0]
     worker_runtime = build_dedicated_worker_runtime_paths(
@@ -2293,7 +2293,7 @@ router:
     else:
         worker_key = resolve_unscoped_worker_key("My Agent")
 
-    projection = manager.projected_config(worker_paths, worker_key=worker_key, materialize=False)
+    projection = manager._projected_config(worker_paths, worker_key=worker_key, materialize=False)
     projected_config = yaml.safe_load(projection.projected_yaml)
 
     assert list(projected_config["agents"]) == ["My Agent"]
@@ -3418,14 +3418,14 @@ router:
         projected_configs_root=tmp_path / "projections",
         runtime_paths=runtime_paths,
     )
-    first_projection = first_manager.projected_config(paths, materialize=True)
+    first_projection = first_manager._projected_config(paths, materialize=True)
 
     renamed_manager = DockerProjectionManager(
         config=replace(base_config, config_path="/app/config-host/alt.yaml"),
         projected_configs_root=tmp_path / "projections",
         runtime_paths=runtime_paths,
     )
-    renamed_projection = renamed_manager.projected_config(paths, materialize=True)
+    renamed_projection = renamed_manager._projected_config(paths, materialize=True)
 
     assert renamed_projection.root != first_projection.root
     assert not first_projection.root.exists()
@@ -3479,13 +3479,13 @@ router:
         runtime_paths=runtime_paths,
     )
 
-    first_projection = manager.projected_config(paths, materialize=True)
+    first_projection = manager._projected_config(paths, materialize=True)
     first_projected_file = first_projection.root / ".mindroom-worker-assets" / "plugins" / "00-demo" / "helper.sh"
     assert first_projected_file.stat().st_mode & 0o777 == 0o644
 
     plugin_file.chmod(0o755)
 
-    second_projection = manager.projected_config(paths, materialize=True)
+    second_projection = manager._projected_config(paths, materialize=True)
     second_projected_file = second_projection.root / ".mindroom-worker-assets" / "plugins" / "00-demo" / "helper.sh"
 
     assert second_projection.root != first_projection.root
@@ -3538,13 +3538,13 @@ router:
         runtime_paths=runtime_paths,
     )
 
-    first_projection = manager.projected_config(paths, materialize=True)
+    first_projection = manager._projected_config(paths, materialize=True)
     first_projected_dir = first_projection.root / ".mindroom-worker-assets" / "plugins" / "00-demo"
     assert first_projected_dir.stat().st_mode & 0o777 == 0o755
 
     plugin_dir.chmod(0o700)
 
-    second_projection = manager.projected_config(paths, materialize=True)
+    second_projection = manager._projected_config(paths, materialize=True)
     second_projected_dir = second_projection.root / ".mindroom-worker-assets" / "plugins" / "00-demo"
 
     assert second_projection.root != first_projection.root

--- a/tests/test_dynamic_config_update.py
+++ b/tests/test_dynamic_config_update.py
@@ -133,7 +133,7 @@ class TestDynamicConfigUpdate:
                 mock_create_bot.return_value = new_bot_mock
 
                 # Call update_config
-                updated = await orchestrator.config_reload.update_config()
+                updated = await orchestrator.config_reload._update_config()
 
                 # Verify the update happened
                 assert updated is True
@@ -203,7 +203,7 @@ class TestDynamicConfigUpdate:
             patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
             patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         assert updated is True
         assert mock_restart.await_args.args[0].entities_to_restart == {"general", ROUTER_AGENT_NAME}
@@ -330,7 +330,7 @@ class TestDynamicConfigUpdate:
             patch("mindroom.orchestration.config_lifecycle.load_config", return_value=updated_config),
             patch("mindroom.orchestration.config_updates._identify_entities_to_restart", return_value=set()),
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         # No entities restarted, but existing bots still receive new defaults.
         assert updated is False
@@ -388,7 +388,7 @@ class TestDynamicConfigUpdate:
             patch("mindroom.orchestration.config_lifecycle.load_config", return_value=updated_config),
             patch("mindroom.orchestration.config_updates._identify_entities_to_restart", return_value=set()),
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         assert updated is False
         assert mock_bot.config == updated_config
@@ -445,7 +445,7 @@ class TestDynamicConfigUpdate:
             patch("mindroom.orchestration.config_updates._identify_entities_to_restart", return_value=set()),
             patch.object(orchestrator, "_setup_rooms_and_memberships", new=AsyncMock()) as mock_setup,
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         assert updated is True
         assert general_bot.config == updated_config
@@ -496,7 +496,7 @@ class TestDynamicConfigUpdate:
             patch("mindroom.orchestration.config_updates._identify_entities_to_restart", return_value=set()),
             patch.object(orchestrator, "_setup_rooms_and_memberships", new=AsyncMock()) as mock_setup,
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         assert updated is True
         assert general_bot.config == updated_config
@@ -549,7 +549,7 @@ class TestDynamicConfigUpdate:
             patch.object(orchestrator, "_ensure_user_account", new=AsyncMock()) as mock_ensure_user,
             patch.object(orchestrator, "_setup_rooms_and_memberships", new=AsyncMock()) as mock_setup,
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         assert updated is True
         assert orchestrator.config == updated_config
@@ -607,7 +607,7 @@ class TestDynamicConfigUpdate:
             patch.object(orchestrator, "_setup_rooms_and_memberships", new=AsyncMock()) as mock_setup,
             pytest.raises(PermanentMatrixStartupError, match="cannot be changed"),
         ):
-            await orchestrator.config_reload.update_config()
+            await orchestrator.config_reload._update_config()
 
         assert orchestrator.config == initial_config
         assert mock_bot.config == initial_config

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -200,7 +200,7 @@ def _source_metadata(*source_event_ids: str) -> dict[str, SourceEventMetadata]:
 
 def _source_metadata_records(*source_event_ids: str) -> dict[str, dict[str, object]]:
     return {
-        source_event_id: metadata.to_record()
+        source_event_id: metadata._to_record()
         for source_event_id, metadata in _source_metadata(*source_event_ids).items()
     }
 
@@ -3212,7 +3212,7 @@ async def test_handle_message_edit_recovers_missing_ledger_row_from_persisted_ru
     with (
         patch.object(bot._conversation_state_writer, "create_storage", return_value=storage),
         patch(
-            "mindroom.response_runner.ResponseRunner.process_and_respond",
+            "mindroom.response_runner.ResponseRunner._process_and_respond",
             new=AsyncMock(side_effect=process_and_respond),
         ),
         patch("mindroom.response_runner.reprioritize_auto_flush_sessions"),
@@ -3693,7 +3693,7 @@ async def test_handle_message_edit_recovers_newer_run_response_event_id_after_re
     with (
         patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
         patch(
-            "mindroom.response_runner.ResponseRunner.process_and_respond",
+            "mindroom.response_runner.ResponseRunner._process_and_respond",
             new=AsyncMock(side_effect=process_and_respond),
         ),
         patch("mindroom.response_runner.reprioritize_auto_flush_sessions"),

--- a/tests/test_external_trigger_runtime_binding.py
+++ b/tests/test_external_trigger_runtime_binding.py
@@ -105,7 +105,7 @@ async def test_runtime_coordinator_is_ready_uses_snapshot_room_and_target(tmp_pa
         "mindroom.orchestration.external_trigger_runtime.get_joined_rooms",
         side_effect=get_joined_room_ids,
     ):
-        assert await coordinator.is_ready(_snapshot(), bots) is True
+        assert await coordinator._is_ready(_snapshot(), bots) is True
 
 
 @pytest.mark.asyncio
@@ -128,7 +128,7 @@ async def test_runtime_coordinator_is_ready_rejects_unjoined_room(tmp_path: Path
         "mindroom.orchestration.external_trigger_runtime.get_joined_rooms",
         side_effect=get_joined_room_ids,
     ):
-        assert await coordinator.is_ready(_snapshot(), bots) is False
+        assert await coordinator._is_ready(_snapshot(), bots) is False
 
 
 @pytest.mark.asyncio
@@ -157,7 +157,7 @@ async def test_runtime_coordinator_is_ready_rejects_inactive_runtime(
     bots = {ROUTER_AGENT_NAME: router_bot, "code": target_bot}
 
     with patch("mindroom.orchestration.external_trigger_runtime.get_joined_rooms") as mock_get_joined_rooms:
-        assert await coordinator.is_ready(snapshot, bots) is False
+        assert await coordinator._is_ready(snapshot, bots) is False
 
     mock_get_joined_rooms.assert_not_called()
 

--- a/tests/test_handled_turns.py
+++ b/tests/test_handled_turns.py
@@ -87,7 +87,7 @@ def _write_responses_file(
             conversation_target=MessageTarget.from_metadata(raw_record.get("conversation_target")),
             timestamp=float(raw_record.get("timestamp", 0.0)),
         )
-        serialized_records[event_id] = TurnRecordCodec.to_ledger_record(record)
+        serialized_records[event_id] = TurnRecordCodec._to_ledger_record(record)
     tracker._responses_file.write_text(
         json.dumps(
             {
@@ -969,9 +969,9 @@ def test_record_without_requester_or_correlation_loads_cleanly(temp_dir: Path) -
 
 def test_current_codec_rejects_incomplete_ledger_records() -> None:
     """Current-version ledger rows require the full canonical identity and outcome fields."""
-    assert TurnRecordCodec.from_ledger_record("$event", {}) is None
+    assert TurnRecordCodec._from_ledger_record("$event", {}) is None
     assert (
-        TurnRecordCodec.from_ledger_record(
+        TurnRecordCodec._from_ledger_record(
             "$event",
             {
                 "anchor_event_id": "$event",
@@ -1285,7 +1285,7 @@ def test_partial_invalid_coalesced_ledger_rehydrates_and_persists_valid_group(te
             {
                 "schema_version": TurnRecordCodec.schema_version(),
                 "records": {
-                    "$valid": TurnRecordCodec.to_ledger_record(valid_record),
+                    "$valid": TurnRecordCodec._to_ledger_record(valid_record),
                     "$invalid": [],
                 },
             },

--- a/tests/test_ingress_lanes.py
+++ b/tests/test_ingress_lanes.py
@@ -543,7 +543,7 @@ async def test_long_running_turn_never_delays_other_ingress_from_same_sender(tmp
         patch.object(bot._turn_policy, "plan_turn", new=AsyncMock(return_value=_respond_dispatch_plan())),
         patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", return_value=False),
         patch(
-            "mindroom.response_runner.ResponseRunner.generate_response_locked",
+            "mindroom.response_runner.ResponseRunner._generate_response_locked",
             new=fake_generate_response_locked,
         ),
     ):
@@ -759,7 +759,7 @@ async def test_voice_echo_and_follow_up_slots_never_hold_another_conversation(tm
             new=AsyncMock(side_effect=fake_prepare_voice_event),
         ),
         patch(
-            "mindroom.response_runner.ResponseRunner.generate_response_locked",
+            "mindroom.response_runner.ResponseRunner._generate_response_locked",
             new=fake_generate_response_locked,
         ),
     ):
@@ -853,7 +853,7 @@ async def test_interactive_answer_during_active_turn_never_holds_sender_lane(tmp
             patch.object(bot._delivery_gateway, "send_text", new=AsyncMock(side_effect=fake_send_text)),
             patch.object(bot._conversation_resolver, "fetch_thread_history", new=AsyncMock(return_value=[])),
             patch(
-                "mindroom.response_runner.ResponseRunner.generate_response_locked",
+                "mindroom.response_runner.ResponseRunner._generate_response_locked",
                 new=fake_generate_response_locked,
             ),
         ):
@@ -1051,7 +1051,7 @@ async def test_response_failure_drains_follow_up_queue(tmp_path: Path) -> None:
         patch.object(bot._turn_policy, "plan_turn", new=AsyncMock(return_value=_respond_dispatch_plan())),
         patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", return_value=False),
         patch(
-            "mindroom.response_runner.ResponseRunner.generate_response_locked",
+            "mindroom.response_runner.ResponseRunner._generate_response_locked",
             new=fake_generate_response_locked,
         ),
     ):

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -789,14 +789,14 @@ def test_provider_retry_after_header_survives_error_classification() -> None:
 def test_retry_backoff_honors_retry_after_and_stays_bounded() -> None:
     """Backoff grows, jitters, respects Retry-After, and never exceeds the cap."""
     policy = EmbeddingRetryPolicy(initial_backoff_seconds=1.0, max_backoff_seconds=10.0, jitter_ratio=0.5)
-    assert policy.backoff_seconds(1, retry_after_seconds=None, jitter_unit=0.5) == 1.0
-    assert policy.backoff_seconds(3, retry_after_seconds=None, jitter_unit=0.5) == 4.0
-    assert policy.backoff_seconds(9, retry_after_seconds=None, jitter_unit=0.5) == 10.0
-    assert policy.backoff_seconds(1, retry_after_seconds=6.0, jitter_unit=0.5) == 6.0
-    assert policy.backoff_seconds(1, retry_after_seconds=1000.0, jitter_unit=0.5) == 10.0
-    assert policy.backoff_seconds(1, retry_after_seconds=None, jitter_unit=0.0) == 0.5
-    assert policy.backoff_seconds(1, retry_after_seconds=None, jitter_unit=1.0) == 1.5
-    assert policy.backoff_seconds(9, retry_after_seconds=None, jitter_unit=1.0) == 10.0
+    assert policy._backoff_seconds(1, retry_after_seconds=None, jitter_unit=0.5) == 1.0
+    assert policy._backoff_seconds(3, retry_after_seconds=None, jitter_unit=0.5) == 4.0
+    assert policy._backoff_seconds(9, retry_after_seconds=None, jitter_unit=0.5) == 10.0
+    assert policy._backoff_seconds(1, retry_after_seconds=6.0, jitter_unit=0.5) == 6.0
+    assert policy._backoff_seconds(1, retry_after_seconds=1000.0, jitter_unit=0.5) == 10.0
+    assert policy._backoff_seconds(1, retry_after_seconds=None, jitter_unit=0.0) == 0.5
+    assert policy._backoff_seconds(1, retry_after_seconds=None, jitter_unit=1.0) == 1.5
+    assert policy._backoff_seconds(9, retry_after_seconds=None, jitter_unit=1.0) == 10.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -3859,7 +3859,7 @@ def test_kubernetes_backend_adds_agent_vault_mint_init_container(tmp_path: Path)
     assert {"agent-vault-token", "agent-vault-bootstrap", "agent-vault-ca"} <= volume_names
 
     # No bridge/NetworkPolicy resources exist in this model.
-    assert backend._resources.agent_vault_vault_name(worker_key) == expected_vault
+    assert backend._resources._agent_vault_vault_name(worker_key) == expected_vault
 
 
 def test_agent_vault_main_env_error_names_worker_key_when_vault_name_missing(tmp_path: Path) -> None:
@@ -3877,7 +3877,7 @@ def test_agent_vault_main_env_error_names_worker_key_when_vault_name_missing(tmp
     def _missing_vault_name(_self: object, requested_worker_key: str) -> None:
         assert requested_worker_key == worker_key
 
-    backend._resources.agent_vault_vault_name = MethodType(_missing_vault_name, backend._resources)
+    backend._resources._agent_vault_vault_name = MethodType(_missing_vault_name, backend._resources)
 
     with pytest.raises(WorkerBackendError) as exc_info:
         backend._resources._agent_vault_main_env(worker_key=worker_key)
@@ -3901,7 +3901,7 @@ def test_kubernetes_backend_omits_agent_vault_when_disabled(tmp_path: Path) -> N
     assert all(v["name"] != "agent-vault-token" for v in template_spec["volumes"])
     main_env = {e["name"] for e in template_spec["containers"][0]["env"]}
     assert "MINDROOM_WORKER_EGRESS_PROXY_URL" not in main_env
-    assert backend._resources.agent_vault_vault_name(_TEST_SCOPED_WORKER_KEY_A) is None
+    assert backend._resources._agent_vault_vault_name(_TEST_SCOPED_WORKER_KEY_A) is None
 
 
 def test_agent_vault_config_from_env_defaults_and_requirements() -> None:

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -1563,7 +1563,7 @@ async def test_active_follow_up_owner_includes_later_media_payload(tmp_path: Pat
             patch.object(bot._turn_controller, "_has_newer_unresponded_in_thread", return_value=False),
             patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
             patch(
-                "mindroom.response_runner.ResponseRunner.generate_response_locked",
+                "mindroom.response_runner.ResponseRunner._generate_response_locked",
                 new=fake_generate_response_locked,
             ),
         ):

--- a/tests/test_locked_turn_delivery.py
+++ b/tests/test_locked_turn_delivery.py
@@ -78,7 +78,7 @@ async def test_agent_post_delivery_failure_settles_error_outcome(tmp_path: Path)
     with (
         patch.object(DeliveryGateway, "send_text", new=AsyncMock(return_value="$thinking")),
         patch.object(DeliveryGateway, "finalize_streamed_response", new=AsyncMock()) as mock_finalize,
-        patch.object(coordinator, "process_and_respond", new=AsyncMock(side_effect=failing_process)),
+        patch.object(coordinator, "_process_and_respond", new=AsyncMock(side_effect=failing_process)),
         patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=False),
             typing_indicator=_noop_typing,
@@ -124,7 +124,7 @@ async def test_agent_regeneration_pre_delivery_failure_leaves_prior_answer_intac
 
     with (
         patch.object(DeliveryGateway, "send_text", new=AsyncMock(return_value="$thinking")),
-        patch.object(coordinator, "process_and_respond", new=AsyncMock(side_effect=failing_process)),
+        patch.object(coordinator, "_process_and_respond", new=AsyncMock(side_effect=failing_process)),
         patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=False),
             typing_indicator=_noop_typing,
@@ -201,7 +201,7 @@ async def test_team_post_delivery_failure_settles_error_outcome_without_finalize
         _set_gateway_method(coordinator.deps.delivery_gateway, "send_text", AsyncMock(return_value="$thinking"))
         with patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=_run_response_function_directly),
         ):
             await coordinator.generate_team_response_helper(
@@ -276,7 +276,7 @@ async def test_team_pre_delivery_failure_finalizes_terminal_note_and_reraises(tm
         with (
             patch.object(
                 ResponseRunner,
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=_run_response_function_directly),
             ),
             pytest.raises(RuntimeError, match="team prep exploded"),

--- a/tests/test_matrix_spaces.py
+++ b/tests/test_matrix_spaces.py
@@ -814,7 +814,7 @@ async def test_update_config_matrix_space_change_reconciles_without_room_members
         patch.object(orchestrator, "_sync_event_cache_service", new=AsyncMock()),
         patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
     ):
-        updated = await orchestrator.config_reload.update_config()
+        updated = await orchestrator.config_reload._update_config()
 
     assert updated is True
     assert general_bot.config == updated_config

--- a/tests/test_mcp_orchestrator.py
+++ b/tests/test_mcp_orchestrator.py
@@ -274,11 +274,11 @@ async def test_external_trigger_readiness_is_per_trigger_room(tmp_path: Path) ->
         return ["!campground:example.org"]
 
     with patch("mindroom.orchestration.external_trigger_runtime.get_joined_rooms", side_effect=get_joined_room_ids):
-        assert await orchestrator._external_trigger_runtime.is_ready(
+        assert await orchestrator._external_trigger_runtime._is_ready(
             _trigger_snapshot(trigger_id="campground", room_id="!campground:example.org"),
             orchestrator.agent_bots,
         )
-        assert not await orchestrator._external_trigger_runtime.is_ready(
+        assert not await orchestrator._external_trigger_runtime._is_ready(
             _trigger_snapshot(trigger_id="campground_other", room_id="!other:example.org"),
             orchestrator.agent_bots,
         )
@@ -308,7 +308,7 @@ async def test_external_trigger_readiness_uses_matrix_joined_rooms(tmp_path: Pat
         }[client]
 
     with patch("mindroom.orchestration.external_trigger_runtime.get_joined_rooms", side_effect=get_joined_room_ids):
-        assert await orchestrator._external_trigger_runtime.is_ready(
+        assert await orchestrator._external_trigger_runtime._is_ready(
             _trigger_snapshot(),
             orchestrator.agent_bots,
         )
@@ -1411,6 +1411,6 @@ async def test_update_config_stops_mcp_entities_before_syncing_manager(tmp_path:
         patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
         patch.object(orchestrator._external_trigger_runtime, "bind_if_ready"),
     ):
-        await orchestrator.config_reload.update_config()
+        await orchestrator.config_reload._update_config()
 
     assert call_order[:2] == ["stop", "sync"]

--- a/tests/test_message_content.py
+++ b/tests/test_message_content.py
@@ -42,7 +42,7 @@ from tests.identity_helpers import persist_entity_accounts
 
 
 def _trusted_entity_sender_ids(config: Config, runtime_paths: RuntimePaths) -> frozenset[str]:
-    return entity_identity_registry(config, runtime_paths).internal_sender_ids
+    return entity_identity_registry(config, runtime_paths)._internal_sender_ids
 
 
 def _make_message_event(

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -2518,7 +2518,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator._external_trigger_runtime, "sync_api_config_snapshot", new=AsyncMock()),
             patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()) as mock_sync_runtime,
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         assert updated is False
         mock_sync_runtime.assert_awaited_once_with(
@@ -2649,7 +2649,7 @@ class TestMultiAgentOrchestrator:
                 patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
                 patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
             ):
-                updated = await orchestrator.config_reload.update_config()
+                updated = await orchestrator.config_reload._update_config()
 
             assert updated is True
             assert task.done() is False
@@ -2862,7 +2862,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator._external_trigger_runtime, "sync_api_config_snapshot", new=AsyncMock()),
             patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         assert updated is False
         mock_load_config.assert_called_once()
@@ -2910,7 +2910,7 @@ class TestMultiAgentOrchestrator:
             ),
             pytest.raises(RuntimeError, match="boom"),
         ):
-            await orchestrator.config_reload.update_config()
+            await orchestrator.config_reload._update_config()
 
         assert orchestrator.config is current_config
         assert orchestrator.hook_registry is old_hook_registry
@@ -2970,7 +2970,7 @@ class TestMultiAgentOrchestrator:
             patch("mindroom.orchestrator.clear_worker_validation_snapshot_cache") as mock_clear_snapshot_cache,
             pytest.raises(RuntimeError, match="broken plugin"),
         ):
-            await orchestrator.config_reload.update_config()
+            await orchestrator.config_reload._update_config()
 
         stop_entities_before_mcp_sync.assert_not_awaited()
         assert bot.running is True
@@ -3070,7 +3070,7 @@ class TestMultiAgentOrchestrator:
                 ),
                 pytest.raises(RuntimeError, match="stop failed"),
             ):
-                await orchestrator.config_reload.update_config()
+                await orchestrator.config_reload._update_config()
 
             assert orchestrator.config is current_config
             assert orchestrator.hook_registry is old_hook_registry
@@ -3152,7 +3152,7 @@ class TestMultiAgentOrchestrator:
                 patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
                 patch.object(orchestrator, "_emit_config_reloaded", new=AsyncMock()),
             ):
-                updated = await orchestrator.config_reload.update_config()
+                updated = await orchestrator.config_reload._update_config()
 
             assert updated is False
             loaded_hooks_module = plugin_module._MODULE_IMPORT_CACHE[hooks_path.resolve()].module
@@ -3222,7 +3222,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
         ):
             try:
-                updated = await orchestrator.config_reload.update_config()
+                updated = await orchestrator.config_reload._update_config()
                 assert updated is False
                 assert router_bot.event_cache.principal_id == "@mindroom_router:localhost"
                 assert general_bot.event_cache.principal_id == "@mindroom_general:localhost"
@@ -3293,7 +3293,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator, "_sync_memory_auto_flush_worker", new=AsyncMock()),
         ):
             try:
-                updated = await orchestrator.config_reload.update_config()
+                updated = await orchestrator.config_reload._update_config()
                 assert updated is False
                 assert orchestrator._runtime_support.event_cache is old_cache
                 assert old_cache.db_path == old_config.cache.resolve_db_path(orchestrator.runtime_paths)
@@ -3400,7 +3400,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator, "_ensure_room_invitations", new=AsyncMock()),
         ):
             try:
-                updated = await orchestrator.config_reload.update_config()
+                updated = await orchestrator.config_reload._update_config()
             finally:
                 await orchestrator._close_runtime_support_services()
 
@@ -3496,7 +3496,7 @@ class TestMultiAgentOrchestrator:
             patch.object(orchestrator, "_ensure_room_invitations", new=AsyncMock()),
         ):
             try:
-                updated = await orchestrator.config_reload.update_config()
+                updated = await orchestrator.config_reload._update_config()
             finally:
                 await orchestrator._close_runtime_support_services()
 

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -762,7 +762,7 @@ async def test_post_response_effects_register_interactive_follow_up_for_preserve
         thread_id="$thread",
         reply_to_event_id="$event",
     )
-    interactive_metadata = InteractiveMetadata.from_parts(
+    interactive_metadata = InteractiveMetadata._from_parts(
         {"1": "yes"},
         ({"emoji": "1", "label": "Yes", "value": "yes"},),
     )
@@ -802,7 +802,7 @@ async def test_post_response_effects_skip_interactive_follow_up_for_preserved_st
         thread_id="$thread",
         reply_to_event_id="$event",
     )
-    interactive_metadata = InteractiveMetadata.from_parts(
+    interactive_metadata = InteractiveMetadata._from_parts(
         {"1": "yes"},
         ({"emoji": "1", "label": "Yes", "value": "yes"},),
     )
@@ -1029,7 +1029,7 @@ async def test_generate_response_sets_queued_signal_for_human_ingress(tmp_path: 
     try:
         with patch.object(
             ResponseRunner,
-            "generate_response_locked",
+            "_generate_response_locked",
             new=AsyncMock(return_value="$response"),
         ) as mock_locked:
             task = asyncio.create_task(
@@ -1092,7 +1092,7 @@ async def test_generate_response_skips_signal_for_non_human_prompt_ingress(
     try:
         with patch.object(
             ResponseRunner,
-            "generate_response_locked",
+            "_generate_response_locked",
             new=AsyncMock(return_value="$response"),
         ):
             task = asyncio.create_task(
@@ -1164,7 +1164,7 @@ async def test_generate_response_sets_queued_signal_for_trusted_router_relay(tmp
     try:
         with patch.object(
             ResponseRunner,
-            "generate_response_locked",
+            "_generate_response_locked",
             new=AsyncMock(return_value="$response"),
         ):
             task = asyncio.create_task(
@@ -1208,7 +1208,7 @@ async def test_generate_response_detects_active_turn_before_lock_is_held(tmp_pat
 
     with (
         patch.object(coordinator._lifecycle_coordinator, "_response_lifecycle_lock", return_value=lock),
-        patch.object(ResponseRunner, "generate_response_locked", new=fake_generate_response_locked),
+        patch.object(ResponseRunner, "_generate_response_locked", new=fake_generate_response_locked),
     ):
         first_task = asyncio.create_task(
             bot._response_runner.generate_response(
@@ -1262,7 +1262,7 @@ async def test_generate_response_waits_for_lock_before_starting_placeholder_life
         with (
             patch.object(
                 ResponseRunner,
-                "process_and_respond",
+                "_process_and_respond",
                 new=AsyncMock(
                     return_value=_ResponseGenerationOutcome(
                         delivery=FinalDeliveryOutcome(
@@ -1278,7 +1278,7 @@ async def test_generate_response_waits_for_lock_before_starting_placeholder_life
             ),
             patch.object(
                 ResponseRunner,
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=fake_run_cancellable_response),
             ) as mock_run_cancellable_response,
             patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
@@ -1424,12 +1424,12 @@ async def test_generate_response_uses_post_lock_reproof_target(tmp_path: Path) -
         patch.object(coordinator, "_build_lifecycle", MagicMock(return_value=_NoopResponseLifecycle())),
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch.object(
             coordinator,
-            "process_and_respond",
+            "_process_and_respond",
             new=AsyncMock(side_effect=fake_process_and_respond),
         ),
         patch("mindroom.response_runner.should_use_streaming", AsyncMock(return_value=False)),
@@ -1511,12 +1511,12 @@ async def test_generate_response_keeps_locked_target_when_payload_preparation_re
         ),
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch.object(
             coordinator,
-            "process_and_respond",
+            "_process_and_respond",
             new=AsyncMock(side_effect=fake_process_and_respond),
         ),
         patch("mindroom.response_runner.should_use_streaming", AsyncMock(return_value=False)),
@@ -1581,7 +1581,7 @@ async def test_generate_team_response_uses_post_lock_reproof_target(tmp_path: Pa
         patch.object(coordinator, "_build_lifecycle", MagicMock(return_value=lifecycle)),
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.delivery_gateway.DeliveryGateway.deliver_final", new=AsyncMock(side_effect=fake_deliver_final)),
@@ -1662,7 +1662,7 @@ async def test_generate_team_response_keeps_locked_target_when_payload_preparati
         ),
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.delivery_gateway.DeliveryGateway.deliver_final", new=AsyncMock(side_effect=fake_deliver_final)),
@@ -1739,7 +1739,7 @@ async def test_generate_team_response_helper_sets_queued_signal(tmp_path: Path) 
     try:
         with patch.object(
             ResponseRunner,
-            "generate_team_response_helper_locked",
+            "_generate_team_response_helper_locked",
             new=AsyncMock(return_value="$team-response"),
         ) as mock_locked:
             task = asyncio.create_task(
@@ -1789,7 +1789,7 @@ async def test_generate_response_without_reservation_does_not_drain_human_backlo
 
     await lifecycle_lock.acquire()
     try:
-        with patch.object(ResponseRunner, "generate_response_locked", new=fake_locked):
+        with patch.object(ResponseRunner, "_generate_response_locked", new=fake_locked):
             task_b = asyncio.create_task(
                 bot._response_runner.generate_response(
                     ResponseRequest(
@@ -1856,7 +1856,7 @@ async def test_generate_team_response_without_reservation_does_not_drain_human_b
 
     await lifecycle_lock.acquire()
     try:
-        with patch.object(ResponseRunner, "generate_team_response_helper_locked", new=fake_locked):
+        with patch.object(ResponseRunner, "_generate_team_response_helper_locked", new=fake_locked):
             task_b = asyncio.create_task(
                 bot._response_runner.generate_team_response_helper(
                     ResponseRequest(

--- a/tests/test_response_payload_preparation.py
+++ b/tests/test_response_payload_preparation.py
@@ -336,8 +336,12 @@ async def test_generate_response_invokes_preparer_exactly_once_under_lock(tmp_pa
             "build_dispatch_payload_with_attachments",
             new=AsyncMock(return_value=DispatchPayload(prompt="built")),
         ),
-        patch.object(coordinator, "run_cancellable_response", new=AsyncMock(side_effect=fake_run_cancellable_response)),
-        patch.object(coordinator, "process_and_respond", new=AsyncMock(side_effect=fake_process_and_respond)),
+        patch.object(
+            coordinator,
+            "_run_cancellable_response",
+            new=AsyncMock(side_effect=fake_run_cancellable_response),
+        ),
+        patch.object(coordinator, "_process_and_respond", new=AsyncMock(side_effect=fake_process_and_respond)),
         patch("mindroom.response_runner.should_use_streaming", AsyncMock(return_value=False)),
     ):
         result = await coordinator.generate_response(

--- a/tests/test_response_runner_agent.py
+++ b/tests/test_response_runner_agent.py
@@ -169,7 +169,7 @@ class TestAgentBot(AgentBotTestBase):
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            generation = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner._process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -226,7 +226,7 @@ class TestAgentBot(AgentBotTestBase):
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            generation = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner._process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -289,7 +289,7 @@ class TestAgentBot(AgentBotTestBase):
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                generation = await bot._response_runner.process_and_respond_streaming(
+                generation = await bot._response_runner._process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please reply in thread",
@@ -354,7 +354,7 @@ class TestAgentBot(AgentBotTestBase):
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            await bot._response_runner.process_and_respond(
+            await bot._response_runner._process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Continue",
@@ -413,7 +413,7 @@ class TestAgentBot(AgentBotTestBase):
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            await bot._response_runner.process_and_respond(
+            await bot._response_runner._process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Continue",
@@ -468,7 +468,7 @@ class TestAgentBot(AgentBotTestBase):
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                generation = await bot._response_runner.process_and_respond_streaming(
+                generation = await bot._response_runner._process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Hello",
@@ -514,7 +514,7 @@ class TestAgentBot(AgentBotTestBase):
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            await bot._response_runner.process_and_respond(
+            await bot._response_runner._process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please inspect attachments",
@@ -584,7 +584,7 @@ class TestAgentBot(AgentBotTestBase):
                 stream_agent_response=fake_stream_agent_response,
             ),
         ):
-            await bot._response_runner.process_and_respond_streaming(
+            await bot._response_runner._process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please inspect attachments",
@@ -680,7 +680,7 @@ class TestAgentBot(AgentBotTestBase):
                 stream_agent_response=fake_stream_agent_response,
             ),
         ):
-            await bot._response_runner.process_and_respond_streaming(
+            await bot._response_runner._process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Hello",
@@ -749,7 +749,7 @@ class TestAgentBot(AgentBotTestBase):
                 stream_agent_response=fake_stream_agent_response,
             ),
         ):
-            await bot._response_runner.process_and_respond_streaming(
+            await bot._response_runner._process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Cancel me",
@@ -809,7 +809,7 @@ class TestAgentBot(AgentBotTestBase):
                 stream_agent_response=mock_stream_agent_response,
             ),
         ):
-            generation = await bot._response_runner.process_and_respond_streaming(
+            generation = await bot._response_runner._process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please continue",
@@ -870,7 +870,7 @@ class TestAgentBot(AgentBotTestBase):
             typing_indicator=_noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            generation = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner._process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please send an update",
@@ -924,7 +924,7 @@ class TestAgentBot(AgentBotTestBase):
                 typing_indicator=noop_typing_indicator,
                 ai_response=mock_ai_response,
             ):
-                await bot._response_runner.process_and_respond(
+                await bot._response_runner._process_and_respond(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please continue",
@@ -1000,7 +1000,7 @@ class TestAgentBot(AgentBotTestBase):
                 typing_indicator=_noop_typing_indicator,
                 stream_agent_response=mock_stream_agent_response,
             ):
-                generation = await bot._response_runner.process_and_respond_streaming(
+                generation = await bot._response_runner._process_and_respond_streaming(
                     _response_request(
                         room_id="!test:localhost",
                         prompt="Please reply in thread",
@@ -1060,7 +1060,7 @@ class TestAgentBot(AgentBotTestBase):
                     typing_indicator=noop_typing_indicator,
                     stream_agent_response=mock_stream,
                 ):
-                    await bot._response_runner.process_and_respond_streaming(
+                    await bot._response_runner._process_and_respond_streaming(
                         _response_request(
                             room_id="!test:localhost",
                             prompt="Please continue",
@@ -1103,7 +1103,7 @@ class TestAgentBot(AgentBotTestBase):
             bot,
             redact_message_event=redact_message_event,
             response_hooks=SimpleNamespace(
-                apply_before_response=AsyncMock(
+                _apply_before_response=AsyncMock(
                     return_value=SimpleNamespace(
                         response_text="Handled",
                         response_kind="ai",
@@ -1164,7 +1164,7 @@ class TestAgentBot(AgentBotTestBase):
             bot,
             redact_message_event=redact_message_event,
             response_hooks=SimpleNamespace(
-                apply_before_response=AsyncMock(
+                _apply_before_response=AsyncMock(
                     return_value=SimpleNamespace(
                         response_text="Handled",
                         response_kind="ai",
@@ -1221,7 +1221,7 @@ class TestAgentBot(AgentBotTestBase):
             bot,
             redact_message_event=redact_message_event,
             response_hooks=SimpleNamespace(
-                apply_before_response=AsyncMock(
+                _apply_before_response=AsyncMock(
                     return_value=SimpleNamespace(
                         response_text="Handled",
                         response_kind="ai",
@@ -1335,7 +1335,7 @@ class TestAgentBot(AgentBotTestBase):
             bot,
             redact_message_event=AsyncMock(return_value=True),
             response_hooks=SimpleNamespace(
-                apply_before_response=AsyncMock(),
+                _apply_before_response=AsyncMock(),
                 emit_after_response=AsyncMock(),
                 emit_cancelled_response=AsyncMock(),
             ),
@@ -1385,7 +1385,7 @@ class TestAgentBot(AgentBotTestBase):
             bot,
             redact_message_event=AsyncMock(return_value=False),
             response_hooks=SimpleNamespace(
-                apply_before_response=AsyncMock(),
+                _apply_before_response=AsyncMock(),
                 emit_after_response=AsyncMock(),
                 emit_cancelled_response=AsyncMock(),
             ),
@@ -1512,7 +1512,7 @@ class TestAgentBot(AgentBotTestBase):
                 rendered_body=None,
                 visible_body_state="none",
             )
-            generation = await bot._response_runner.process_and_respond_streaming(
+            generation = await bot._response_runner._process_and_respond_streaming(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Please reply in thread",
@@ -1608,7 +1608,7 @@ class TestAgentBot(AgentBotTestBase):
             typing_indicator=noop_typing_indicator,
             ai_response=mock_ai,
         ):
-            generation = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner._process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Summarize README",
@@ -1677,7 +1677,7 @@ class TestAgentBot(AgentBotTestBase):
             typing_indicator=noop_typing_indicator,
             ai_response=AsyncMock(side_effect=fake_ai_response),
         ):
-            generation = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner._process_and_respond(
                 _response_request(
                     room_id="!test:localhost",
                     prompt="Check status",
@@ -1761,7 +1761,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch.object(
                 ResponseRunner,
-                "process_and_respond",
+                "_process_and_respond",
                 new=AsyncMock(
                     return_value=_ResponseGenerationOutcome(
                         delivery=FinalDeliveryOutcome(
@@ -1776,7 +1776,7 @@ class TestAgentBot(AgentBotTestBase):
             ) as mock_process,
             patch.object(
                 ResponseRunner,
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
             patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),
@@ -1884,7 +1884,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch.object(
                 ResponseRunner,
-                "process_and_respond",
+                "_process_and_respond",
                 new=AsyncMock(
                     return_value=_ResponseGenerationOutcome(
                         delivery=FinalDeliveryOutcome(
@@ -1899,7 +1899,7 @@ class TestAgentBot(AgentBotTestBase):
             ) as mock_process,
             patch.object(
                 ResponseRunner,
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
             patch_response_runner_module(
@@ -1985,7 +1985,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch.object(
                 ResponseRunner,
-                "process_and_respond_streaming",
+                "_process_and_respond_streaming",
                 new=AsyncMock(
                     return_value=_ResponseGenerationOutcome(
                         delivery=FinalDeliveryOutcome(
@@ -2001,7 +2001,7 @@ class TestAgentBot(AgentBotTestBase):
             ) as mock_process,
             patch.object(
                 ResponseRunner,
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
             patch_response_runner_module(
@@ -2092,7 +2092,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch.object(
                 ResponseRunner,
-                "process_and_respond",
+                "_process_and_respond",
                 new=AsyncMock(
                     return_value=_ResponseGenerationOutcome(
                         delivery=FinalDeliveryOutcome(
@@ -2107,7 +2107,7 @@ class TestAgentBot(AgentBotTestBase):
             ) as mock_process,
             patch.object(
                 ResponseRunner,
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
             patch.object(
@@ -2208,7 +2208,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch.object(
                 ResponseRunner,
-                "process_and_respond",
+                "_process_and_respond",
                 new=AsyncMock(
                     return_value=_ResponseGenerationOutcome(
                         delivery=FinalDeliveryOutcome(
@@ -2448,7 +2448,7 @@ class TestAgentBot(AgentBotTestBase):
                 new_callable=AsyncMock,
             ) as mock_thread_summary,
             patch(
-                "mindroom.delivery_gateway.DeliveryGateway.send_compaction_lifecycle_start",
+                "mindroom.delivery_gateway.DeliveryGateway._send_compaction_lifecycle_start",
                 new=AsyncMock(return_value="$notice"),
             ) as mock_send_compaction_lifecycle_start,
         ):
@@ -2617,7 +2617,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch.object(
                 ResponseRunner,
-                "process_and_respond",
+                "_process_and_respond",
                 new=AsyncMock(
                     return_value=_ResponseGenerationOutcome(
                         delivery=FinalDeliveryOutcome(
@@ -2632,7 +2632,7 @@ class TestAgentBot(AgentBotTestBase):
             ),
             patch.object(
                 ResponseRunner,
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
             patch("mindroom.response_runner.should_use_streaming", new_callable=AsyncMock, return_value=False),

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -284,10 +284,10 @@ async def test_concurrent_requests_serialize_and_refresh_history_under_lock(tmp_
         ),
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
-        patch.object(coordinator, "process_and_respond", new=AsyncMock(side_effect=fake_process_and_respond)),
+        patch.object(coordinator, "_process_and_respond", new=AsyncMock(side_effect=fake_process_and_respond)),
         patch_response_runner_module(
             should_use_streaming=AsyncMock(return_value=False),
             apply_post_response_effects=AsyncMock(),
@@ -846,7 +846,7 @@ async def test_non_streaming_response_delivers_through_deliver_final(tmp_path: P
             typing_indicator=_noop_typing,
         ),
     ):
-        generation = await coordinator.process_and_respond(_plain_request(_target()))
+        generation = await coordinator._process_and_respond(_plain_request(_target()))
 
     assert generation.delivery.event_id == "$response"
     deliver_final.assert_awaited_once()
@@ -878,7 +878,7 @@ async def test_non_streaming_invisible_delivery_does_not_mark_substantive_reply(
             typing_indicator=_noop_typing,
         ),
     ):
-        generation = await coordinator.process_and_respond(request)
+        generation = await coordinator._process_and_respond(request)
 
     assert generation.delivery is delivery
     assert timing.metadata["first_visible_kind"] == "placeholder"
@@ -913,7 +913,7 @@ async def test_non_streaming_failed_edit_preserving_old_body_does_not_mark_subst
             typing_indicator=_noop_typing,
         ),
     ):
-        generation = await coordinator.process_and_respond(request)
+        generation = await coordinator._process_and_respond(request)
 
     assert generation.delivery is delivery
     assert "first_substantive_reply" not in timing.marks
@@ -945,7 +945,7 @@ async def test_streaming_response_streams_then_finalizes_through_gateway(tmp_pat
             typing_indicator=_noop_typing,
         ),
     ):
-        generation = await coordinator.process_and_respond_streaming(_plain_request(_target()))
+        generation = await coordinator._process_and_respond_streaming(_plain_request(_target()))
 
     assert generation.delivery.event_id == "$stream"
     deliver_stream.assert_awaited_once()
@@ -987,7 +987,7 @@ async def test_streaming_placeholder_only_delivery_does_not_mark_substantive_rep
             typing_indicator=_noop_typing,
         ),
     ):
-        generation = await coordinator.process_and_respond_streaming(request)
+        generation = await coordinator._process_and_respond_streaming(request)
 
     assert generation.delivery is delivery
     assert timing.metadata["first_visible_kind"] == "placeholder"
@@ -1044,7 +1044,7 @@ async def test_streaming_midstream_failure_persists_partial_and_finalizes_error(
             _plain_request(_target()),
             model_prompt="hello\n\n<mindroom_message_context>persist me</mindroom_message_context>",
         )
-        generation = await coordinator.process_and_respond_streaming(request)
+        generation = await coordinator._process_and_respond_streaming(request)
 
     # The failure does not propagate: it is logged and becomes a finalized error outcome.
     assert generation.delivery is error_outcome
@@ -1120,7 +1120,7 @@ async def test_streaming_midstream_failure_persists_partial_off_event_loop(
             typing_indicator=_noop_typing,
         ),
     ):
-        await coordinator.process_and_respond_streaming(_plain_request(_target()))
+        await coordinator._process_and_respond_streaming(_plain_request(_target()))
 
 
 @pytest.mark.asyncio
@@ -1146,12 +1146,12 @@ async def test_agent_streaming_sync_restart_cancelled_outcome_registers_retry(tm
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch.object(
             coordinator,
-            "process_and_respond_streaming",
+            "_process_and_respond_streaming",
             new=AsyncMock(return_value=_ResponseGenerationOutcome(delivery=cancelled_outcome, run_succeeded=False)),
         ),
         patch_response_runner_module(
@@ -1416,7 +1416,7 @@ async def test_terminal_settlement_finalizes_and_runs_post_effects_once(
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=run_cancellable_response),
         ),
         patch.object(lifecycle, "finalize", new=finalize),
@@ -1474,7 +1474,7 @@ async def test_terminal_settlement_registers_retry_before_rethrowing_cancel(tmp_
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=asyncio.CancelledError("sync_restart")),
         ),
         patch.object(lifecycle, "finalize", new=finalize),
@@ -1530,7 +1530,7 @@ async def test_uncommitted_interruption_rethrows_cancel_without_marking_source_h
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=asyncio.CancelledError("sync_restart")),
         ),
         patch_response_runner_module(apply_post_response_effects=post_effects),
@@ -1580,7 +1580,7 @@ async def test_cancel_cleanup_error_does_not_mark_source_handled(tmp_path: Path)
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(return_value="$placeholder"),
         ),
         patch_response_runner_module(apply_post_response_effects=AsyncMock()),
@@ -1659,7 +1659,7 @@ async def test_terminal_send_cancellation_preserves_source_replay(
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(return_value="$response"),
         ),
         patch_response_runner_module(apply_post_response_effects=AsyncMock()),
@@ -1724,7 +1724,7 @@ async def test_unrecoverable_interruption_remains_unhandled_without_outer_cancel
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(return_value="$response"),
         ),
         patch_response_runner_module(apply_post_response_effects=AsyncMock()),
@@ -1787,7 +1787,7 @@ async def test_terminal_interruption_registers_recovery_unless_user_stopped(
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(return_value="$response"),
         ),
         patch_response_runner_module(apply_post_response_effects=AsyncMock()),
@@ -1849,7 +1849,7 @@ async def test_terminal_settlement_late_cancel_keeps_settled_outcome_canonical(
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=asyncio.CancelledError("sync_restart")),
         ),
         patch.object(lifecycle, "finalize", new=finalize),
@@ -1893,7 +1893,7 @@ async def test_terminal_settlement_rethrows_generation_error_after_post_effects(
     with (
         patch.object(
             coordinator,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=RuntimeError("generation failed")),
         ),
         patch.object(lifecycle, "finalize", new=finalize),

--- a/tests/test_response_runner_session_lifecycle.py
+++ b/tests/test_response_runner_session_lifecycle.py
@@ -232,12 +232,12 @@ async def test_process_and_respond_propagates_before_response_cancellation_to_ru
             requester_id="@alice:localhost",
         )
         coordinator._persist_interrupted_recorder = MagicMock()
-        coordinator.deps.delivery_gateway.deps.response_hooks.apply_before_response = AsyncMock(
+        coordinator.deps.delivery_gateway.deps.response_hooks._apply_before_response = AsyncMock(
             side_effect=asyncio.CancelledError(USER_STOP_CANCEL_MSG),
         )
 
         with pytest.raises(asyncio.CancelledError, match=USER_STOP_CANCEL_MSG):
-            await coordinator.process_and_respond(
+            await coordinator._process_and_respond(
                 ResponseRequest(
                     thread_history=(),
                     prompt="Hello",
@@ -306,7 +306,7 @@ async def test_process_and_respond_streaming_preserves_user_stop_outcome(
         )
         coordinator.deps.delivery_gateway.deps.response_hooks.emit_cancelled_response.reset_mock()
 
-        response_event_id = await coordinator.generate_response_locked(
+        response_event_id = await coordinator._generate_response_locked(
             replace(
                 _response_request(
                     prompt="Hello",
@@ -421,10 +421,10 @@ async def test_process_and_respond_emits_session_started_after_first_persisted_t
             ),
         )
 
-        await coordinator.process_and_respond(
+        await coordinator._process_and_respond(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
         )
-        await coordinator.process_and_respond(
+        await coordinator._process_and_respond(
             _response_request(prompt="Hello again", user_id="@alice:localhost", thread_id="$thread-root"),
         )
 
@@ -501,7 +501,7 @@ async def test_process_and_respond_applies_session_started_agent_and_room_scopes
 
         mock_ai.side_effect = fake_ai_response
 
-        await coordinator.process_and_respond(
+        await coordinator._process_and_respond(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
         )
 
@@ -554,7 +554,7 @@ async def test_process_and_respond_does_not_emit_session_started_without_persist
 
         mock_ai.side_effect = fake_ai_response
 
-        await coordinator.process_and_respond(
+        await coordinator._process_and_respond(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
         )
 
@@ -678,7 +678,7 @@ async def test_session_started_hooks_continue_after_timeout(tmp_path: Path) -> N
 
         mock_ai.side_effect = fake_ai_response
 
-        await coordinator.process_and_respond(
+        await coordinator._process_and_respond(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
         )
 
@@ -750,7 +750,7 @@ async def test_session_started_hooks_continue_after_runtime_error(tmp_path: Path
 
         mock_ai.side_effect = fake_ai_response
 
-        await coordinator.process_and_respond(
+        await coordinator._process_and_respond(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
         )
 
@@ -832,7 +832,7 @@ async def test_process_and_respond_streaming_emits_session_started_after_persist
 
         mock_stream.side_effect = fake_stream_agent_response
 
-        generation = await coordinator.process_and_respond_streaming(
+        generation = await coordinator._process_and_respond_streaming(
             _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
         )
 
@@ -893,7 +893,7 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_d
 
         mock_stream.side_effect = fake_stream_agent_response
 
-        generation = await coordinator.process_and_respond_streaming(
+        generation = await coordinator._process_and_respond_streaming(
             _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
         )
 
@@ -960,7 +960,7 @@ async def test_process_and_respond_streaming_persists_interrupted_history_when_m
 
         coordinator.deps.delivery_gateway.deliver_stream.side_effect = consume_delivery
 
-        generation = await coordinator.process_and_respond_streaming(
+        generation = await coordinator._process_and_respond_streaming(
             _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
             run_id="run-1",
         )
@@ -1052,7 +1052,7 @@ async def test_process_and_respond_streaming_delivery_failure_with_visible_tools
 
         mock_stream.side_effect = fake_stream_agent_response
 
-        generation = await coordinator.process_and_respond_streaming(
+        generation = await coordinator._process_and_respond_streaming(
             _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
         )
 
@@ -1134,7 +1134,7 @@ async def test_process_and_respond_emits_session_started_after_persisted_cancell
 
         mock_ai.side_effect = fake_ai_response
 
-        generation = await coordinator.process_and_respond(
+        generation = await coordinator._process_and_respond(
             replace(
                 _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
                 existing_event_id="$thinking",
@@ -1217,7 +1217,7 @@ async def test_process_and_respond_streaming_emits_session_started_after_persist
         mock_stream.side_effect = fake_stream_agent_response
 
         with pytest.raises(asyncio.CancelledError, match="cancel"):
-            await coordinator.process_and_respond_streaming(
+            await coordinator._process_and_respond_streaming(
                 replace(
                     _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
                     existing_event_id="$thinking",
@@ -1254,7 +1254,7 @@ async def test_generate_response_locked_persists_minimal_interrupted_history_aft
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
@@ -1281,7 +1281,7 @@ async def test_generate_response_locked_persists_minimal_interrupted_history_aft
 
         mock_ai.side_effect = fake_ai_response
 
-        resolution = await coordinator.generate_response_locked(
+        resolution = await coordinator._generate_response_locked(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
             resolved_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
         )
@@ -1362,7 +1362,7 @@ async def test_private_agent_response_runner_builds_execution_identity_from_requ
             "build_execution_identity",
             side_effect=spy_build_execution_identity,
         ):
-            response_event_id = await coordinator.generate_response_locked(
+            response_event_id = await coordinator._generate_response_locked(
                 _response_request(prompt="Campground opened", user_id="@owner:localhost"),
                 resolved_target=target,
             )
@@ -1411,7 +1411,7 @@ async def test_generate_response_locked_hard_cancel_does_not_seed_seen_ids_with_
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch.object(ResponseRunner, "_active_response_event_ids", return_value={"$other-response"}),
@@ -1439,7 +1439,7 @@ async def test_generate_response_locked_hard_cancel_does_not_seed_seen_ids_with_
 
         mock_ai.side_effect = fake_ai_response
 
-        resolution = await coordinator.generate_response_locked(
+        resolution = await coordinator._generate_response_locked(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
             resolved_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
         )
@@ -1478,7 +1478,7 @@ async def test_generate_response_locked_finalizes_cancelled_task_before_delivery
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
@@ -1494,7 +1494,7 @@ async def test_generate_response_locked_finalizes_cancelled_task_before_delivery
             message_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
         )
 
-        resolution = await coordinator.generate_response_locked(
+        resolution = await coordinator._generate_response_locked(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
             resolved_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
         )
@@ -1534,7 +1534,7 @@ async def test_early_cancellation_redacts_thinking_placeholder(
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
@@ -1552,7 +1552,7 @@ async def test_early_cancellation_redacts_thinking_placeholder(
         redact_mock = AsyncMock(side_effect=redact_message_event)
         object.__setattr__(coordinator.deps.delivery_gateway.deps, "redact_message_event", redact_mock)
 
-        resolution = await coordinator.generate_response_locked(
+        resolution = await coordinator._generate_response_locked(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
             resolved_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
         )
@@ -1620,7 +1620,7 @@ async def test_generate_response_locked_returns_none_when_final_delivery_is_unha
             "generate_non_streaming_ai_response",
             new=AsyncMock(side_effect=fake_generate_non_streaming),
         ):
-            resolution = await coordinator.generate_response_locked(
+            resolution = await coordinator._generate_response_locked(
                 _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
                 resolved_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
             )
@@ -1688,7 +1688,7 @@ async def test_generate_response_locked_unhandled_delivery_outcome_does_not_pers
             ),
         )
 
-        resolution = await coordinator.generate_response_locked(
+        resolution = await coordinator._generate_response_locked(
             _response_request(prompt="Hello", user_id="@alice:localhost", thread_id="$thread-root"),
             resolved_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
         )
@@ -1774,7 +1774,7 @@ async def test_generate_response_locked_preserves_visible_stream_when_finalize_r
             "generate_streaming_ai_response",
             new=AsyncMock(side_effect=fake_generate_streaming),
         ):
-            resolution = await coordinator.generate_response_locked(
+            resolution = await coordinator._generate_response_locked(
                 request,
                 resolved_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
             )
@@ -1862,7 +1862,7 @@ async def test_generate_response_locked_preserves_visible_stream_on_late_finaliz
             "generate_streaming_ai_response",
             new=AsyncMock(side_effect=fake_generate_streaming),
         ):
-            resolution = await coordinator.generate_response_locked(
+            resolution = await coordinator._generate_response_locked(
                 request,
                 resolved_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
             )
@@ -1903,7 +1903,7 @@ async def test_process_and_respond_uses_resolved_thread_id_for_ai_logging_contex
             base_request,
             response_envelope=replace(base_request.response_envelope, target=target),
         )
-        await coordinator.process_and_respond(request)
+        await coordinator._process_and_respond(request)
 
 
 @pytest.mark.asyncio
@@ -1940,7 +1940,7 @@ async def test_process_and_respond_streaming_uses_resolved_thread_id_for_ai_logg
             base_request,
             response_envelope=replace(base_request.response_envelope, target=target),
         )
-        await coordinator.process_and_respond_streaming(request)
+        await coordinator._process_and_respond_streaming(request)
 
 
 @pytest.mark.asyncio
@@ -1971,7 +1971,7 @@ async def test_process_and_respond_passes_current_and_model_prompt_to_ai(
 
         mock_ai.side_effect = fake_ai_response
 
-        await coordinator.process_and_respond(
+        await coordinator._process_and_respond(
             _response_request(
                 prompt="Hello",
                 model_prompt="Hello with context",
@@ -2010,7 +2010,7 @@ async def test_process_and_respond_streaming_passes_current_and_model_prompt_to_
 
         mock_stream.side_effect = fake_stream_agent_response
 
-        await coordinator.process_and_respond_streaming(
+        await coordinator._process_and_respond_streaming(
             _response_request(
                 prompt="Hello",
                 model_prompt="Hello with context",
@@ -2044,7 +2044,7 @@ async def test_generate_response_locked_sets_failure_reason_for_plain_streaming_
         )
         coordinator.generate_streaming_ai_response = AsyncMock(side_effect=RuntimeError("plain boom"))
 
-        resolution = await coordinator.generate_response_locked(
+        resolution = await coordinator._generate_response_locked(
             _response_request(prompt="Hello", user_id="@bob:localhost", thread_id="$thread-root"),
             resolved_target=MessageTarget.resolve("!test:localhost", "$thread-root", "$user_msg"),
         )

--- a/tests/test_response_runner_team.py
+++ b/tests/test_response_runner_team.py
@@ -1051,7 +1051,7 @@ class TestAgentBot(AgentBotTestBase):
             ),
             patch.object(
                 ResponseRunner,
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
             patch.object(bot._conversation_cache, "get_thread_history", AsyncMock(return_value=history)),
@@ -1130,7 +1130,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch.object(
                 unwrap_extracted_collaborator(bot._response_runner),
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
             patch.object(bot._conversation_cache, "get_thread_history", AsyncMock(return_value=history)),

--- a/tests/test_response_runner_team_streaming.py
+++ b/tests/test_response_runner_team_streaming.py
@@ -775,7 +775,7 @@ async def test_generate_team_response_helper_persists_minimal_interrupted_histor
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
@@ -1238,7 +1238,7 @@ async def test_generate_team_response_helper_persists_original_user_message_for_
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
@@ -1336,7 +1336,7 @@ async def test_generate_team_response_helper_emits_session_started_after_persist
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=False)),
@@ -1423,7 +1423,7 @@ async def test_generate_team_response_helper_streaming_emits_session_started_aft
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.should_use_streaming", new=AsyncMock(return_value=True)),

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -1481,5 +1481,5 @@ def test_load_invited_rooms_returns_empty_set_for_invalid_utf8(tmp_path: Path) -
         runtime_paths=runtime_paths_for(config),
     )
 
-    assert bot._room_lifecycle.load_invited_rooms() == set()
+    assert bot._room_lifecycle._load_invited_rooms() == set()
     assert bot._room_lifecycle.invited_rooms == set()

--- a/tests/test_router_rooms.py
+++ b/tests/test_router_rooms.py
@@ -400,7 +400,7 @@ async def test_router_updates_rooms_on_config_change(monkeypatch: pytest.MonkeyP
             monkeypatch.setattr(bot, "sync_forever", mock_sync_forever)
 
         # Update config
-        updated = await orchestrator.config_reload.update_config()
+        updated = await orchestrator.config_reload._update_config()
         assert updated  # Should return True since router needs restart
 
         # Router should be recreated with new rooms

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -380,7 +380,7 @@ def test_team_request_responder_filtering_uses_actual_member_ids(tmp_path: Path)
         ),
     )
 
-    filtered = policy.filter_materializable_responders(
+    filtered = policy._filter_materializable_responders(
         [
             ids["worker"],
             ids["idle"],
@@ -1239,7 +1239,7 @@ class TestRoutingRegression:
                 return_value=AgentResponseDecision(True),
             ) as mock_decide_agent_response,
         ):
-            action = await alpha_bot._turn_policy.resolve_response_action(
+            action = await alpha_bot._turn_policy._resolve_response_action(
                 _policy_dispatch(
                     agent_name=alpha_bot.agent_name,
                     room_id=room.room_id,
@@ -1320,7 +1320,7 @@ class TestRoutingRegression:
             has_non_agent_mentions=False,
         )
 
-        action = await bot._turn_policy.resolve_response_action(
+        action = await bot._turn_policy._resolve_response_action(
             _policy_dispatch(
                 agent_name=bot.agent_name,
                 room_id=room.room_id,

--- a/tests/test_skip_mentions.py
+++ b/tests/test_skip_mentions.py
@@ -285,7 +285,7 @@ def _gateway_with_mocks(tmp_path: Path) -> tuple[DeliveryGateway, AsyncMock, Asy
     before_hooks = AsyncMock()
     after_hooks = AsyncMock()
     response_hooks = MagicMock()
-    response_hooks.apply_before_response = before_hooks
+    response_hooks._apply_before_response = before_hooks
     response_hooks.emit_after_response = after_hooks
     conversation_cache = SimpleNamespace(
         get_latest_thread_event_id_if_needed=AsyncMock(return_value=None),

--- a/tests/test_streaming_behavior.py
+++ b/tests/test_streaming_behavior.py
@@ -2140,7 +2140,7 @@ class TestStreamingBehavior:
                 typing_indicator=noop_typing,
             ),
         ):
-            generation = await bot._response_runner.process_and_respond_streaming(
+            generation = await bot._response_runner._process_and_respond_streaming(
                 ResponseRequest(
                     thread_history=[],
                     prompt="Continue",
@@ -2315,7 +2315,7 @@ class TestStreamingBehavior:
                 typing_indicator=_noop_typing_indicator,
             ),
         ):
-            generation = await bot._response_runner.process_and_respond(
+            generation = await bot._response_runner._process_and_respond(
                 ResponseRequest(
                     thread_history=[],
                     prompt="Please check the docs",
@@ -4017,7 +4017,7 @@ class TestStreamingBehavior:
             ),
         )
         response_hooks = SimpleNamespace(
-            apply_before_response=AsyncMock(
+            _apply_before_response=AsyncMock(
                 return_value=SimpleNamespace(
                     response_text="chunk",
                     response_kind="ai",
@@ -4027,7 +4027,7 @@ class TestStreamingBehavior:
                     suppress=False,
                 ),
             ),
-            apply_final_response_transform=AsyncMock(
+            _apply_final_response_transform=AsyncMock(
                 return_value=SimpleNamespace(
                     response_text="updated text",
                     response_kind="ai",
@@ -4079,8 +4079,8 @@ class TestStreamingBehavior:
         assert outcome.final_visible_event_id == "$streaming"
         assert outcome.final_visible_body == "updated text"
         assert outcome.delivery_kind == "edited"
-        response_hooks.apply_before_response.assert_not_awaited()
-        response_hooks.apply_final_response_transform.assert_awaited_once()
+        response_hooks._apply_before_response.assert_not_awaited()
+        response_hooks._apply_final_response_transform.assert_awaited_once()
         gateway.edit_text.assert_awaited_once()
         edited_request = gateway.edit_text.await_args.args[0]
         assert edited_request.event_id == "$streaming"
@@ -4128,8 +4128,8 @@ class TestStreamingBehavior:
             ),
         )
         response_hooks = SimpleNamespace(
-            apply_before_response=AsyncMock(),
-            apply_final_response_transform=AsyncMock(
+            _apply_before_response=AsyncMock(),
+            _apply_final_response_transform=AsyncMock(
                 return_value=SimpleNamespace(
                     response_text="canonical final",
                     response_kind="ai",
@@ -4178,8 +4178,8 @@ class TestStreamingBehavior:
 
         assert outcome.final_visible_event_id == "$streaming"
         assert outcome.final_visible_body == "chunk"
-        response_hooks.apply_before_response.assert_not_awaited()
-        response_hooks.apply_final_response_transform.assert_awaited_once()
+        response_hooks._apply_before_response.assert_not_awaited()
+        response_hooks._apply_final_response_transform.assert_awaited_once()
         lifecycle = ResponseLifecycle(
             ResponseLifecycleDeps(
                 response_hooks=response_hooks,
@@ -4232,8 +4232,8 @@ class TestStreamingBehavior:
             extract_mapping=True,
         )
         response_hooks = SimpleNamespace(
-            apply_before_response=AsyncMock(),
-            apply_final_response_transform=AsyncMock(
+            _apply_before_response=AsyncMock(),
+            _apply_final_response_transform=AsyncMock(
                 return_value=SimpleNamespace(
                     response_text=raw_interactive,
                     response_kind="ai",
@@ -4287,7 +4287,7 @@ class TestStreamingBehavior:
         assert list(outcome.options_list or ()) == [
             {"emoji": "✅", "label": "Approve", "value": "approve"},
         ]
-        response_hooks.apply_final_response_transform.assert_awaited_once()
+        response_hooks._apply_final_response_transform.assert_awaited_once()
         response_hooks.emit_cancelled_response.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -116,7 +116,7 @@ def _envelope() -> MessageEnvelope:
 def _delivery_gateway(tmp_path: Path) -> DeliveryGateway:
     config = _config(tmp_path)
     response_hooks = SimpleNamespace(
-        apply_before_response=AsyncMock(
+        _apply_before_response=AsyncMock(
             return_value=SimpleNamespace(
                 response_text="final answer",
                 response_kind="ai",
@@ -126,7 +126,7 @@ def _delivery_gateway(tmp_path: Path) -> DeliveryGateway:
                 suppress=False,
             ),
         ),
-        apply_final_response_transform=AsyncMock(),
+        _apply_final_response_transform=AsyncMock(),
         emit_after_response=AsyncMock(),
         emit_cancelled_response=AsyncMock(),
     )
@@ -417,8 +417,8 @@ async def test_transport_failed_terminal_update_drops_committed_interactive_meta
         transport_outcome = await streaming.finalize(_client(), restart_interrupted=True)
 
     response_hooks = SimpleNamespace(
-        apply_before_response=AsyncMock(),
-        apply_final_response_transform=AsyncMock(),
+        _apply_before_response=AsyncMock(),
+        _apply_final_response_transform=AsyncMock(),
         emit_after_response=AsyncMock(),
         emit_cancelled_response=AsyncMock(),
     )
@@ -462,8 +462,8 @@ async def test_transport_failed_terminal_update_ignores_hidden_canonical_interac
     """Preserved visible streamed replies must not register interactive metadata from hidden canonical content."""
     config = _config(tmp_path)
     response_hooks = SimpleNamespace(
-        apply_before_response=AsyncMock(),
-        apply_final_response_transform=AsyncMock(),
+        _apply_before_response=AsyncMock(),
+        _apply_final_response_transform=AsyncMock(),
         emit_after_response=AsyncMock(),
         emit_cancelled_response=AsyncMock(),
     )
@@ -644,8 +644,8 @@ async def test_streaming_placeholder_delivery_failure_stays_terminal_when_failur
     """If Matrix rejects the failure update too, finalization still returns a failed visible outcome."""
     config = _config(tmp_path)
     response_hooks = SimpleNamespace(
-        apply_before_response=AsyncMock(),
-        apply_final_response_transform=AsyncMock(),
+        _apply_before_response=AsyncMock(),
+        _apply_final_response_transform=AsyncMock(),
         emit_after_response=AsyncMock(),
         emit_cancelled_response=AsyncMock(),
     )
@@ -818,8 +818,8 @@ async def test_streamed_interactive_final_reply_registers_reactions_on_root_even
 
     envelope = _envelope()
     response_hooks = SimpleNamespace(
-        apply_before_response=AsyncMock(),
-        apply_final_response_transform=AsyncMock(
+        _apply_before_response=AsyncMock(),
+        _apply_final_response_transform=AsyncMock(
             return_value=SimpleNamespace(
                 response_text=raw_interactive,
                 response_kind="ai",
@@ -950,8 +950,8 @@ async def test_streamed_interactive_metadata_survives_unparseable_canonical_fina
     )
 
     response_hooks = SimpleNamespace(
-        apply_before_response=AsyncMock(),
-        apply_final_response_transform=AsyncMock(
+        _apply_before_response=AsyncMock(),
+        _apply_final_response_transform=AsyncMock(
             return_value=SimpleNamespace(
                 response_text=stream_outcome.canonical_final_body_candidate,
                 response_kind="ai",
@@ -1004,7 +1004,7 @@ async def test_final_response_transform_failure_keeps_visible_stream_text(tmp_pa
     config = _config(tmp_path)
     envelope = _envelope()
     response_hooks = SimpleNamespace(
-        apply_before_response=AsyncMock(
+        _apply_before_response=AsyncMock(
             return_value=SimpleNamespace(
                 response_text="chunk",
                 response_kind="ai",
@@ -1014,7 +1014,7 @@ async def test_final_response_transform_failure_keeps_visible_stream_text(tmp_pa
                 suppress=False,
             ),
         ),
-        apply_final_response_transform=AsyncMock(
+        _apply_final_response_transform=AsyncMock(
             return_value=SimpleNamespace(
                 response_text="updated text",
                 response_kind="ai",
@@ -1060,8 +1060,8 @@ async def test_final_response_transform_failure_keeps_visible_stream_text(tmp_pa
     assert outcome.terminal_status == "completed"
     assert outcome.final_visible_event_id == "$streaming"
     assert outcome.final_visible_body == "chunk"
-    response_hooks.apply_before_response.assert_not_awaited()
-    response_hooks.apply_final_response_transform.assert_awaited_once()
+    response_hooks._apply_before_response.assert_not_awaited()
+    response_hooks._apply_final_response_transform.assert_awaited_once()
     gateway.edit_text.assert_awaited_once()
     lifecycle = ResponseLifecycle(
         ResponseLifecycleDeps(
@@ -1096,8 +1096,8 @@ async def test_finalize_streamed_response_restart_interruption_preserves_cancell
     config = _config(tmp_path)
     envelope = _envelope()
     response_hooks = SimpleNamespace(
-        apply_before_response=AsyncMock(),
-        apply_final_response_transform=AsyncMock(),
+        _apply_before_response=AsyncMock(),
+        _apply_final_response_transform=AsyncMock(),
         emit_after_response=AsyncMock(),
         emit_cancelled_response=AsyncMock(),
     )
@@ -1173,7 +1173,7 @@ async def test_failed_cancelled_placeholder_cleanup_preserves_cancel_source(tmp_
 async def test_hook_failure_cleanup_propagates_restart_cancellation(tmp_path: Path) -> None:
     """Cancellation during cleanup of an ordinary hook failure must reach source settlement."""
     gateway = _delivery_gateway(tmp_path)
-    gateway.deps.response_hooks.apply_before_response.side_effect = RuntimeError("hook failed")
+    gateway.deps.response_hooks._apply_before_response.side_effect = RuntimeError("hook failed")
     gateway.deps.redact_message_event.side_effect = asyncio.CancelledError("sync_restart")
 
     with pytest.raises(asyncio.CancelledError, match="sync_restart"):

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -2089,7 +2089,7 @@ async def test_update_config_replays_cancelled_startup_maintenance_and_runs_appr
                 new=AsyncMock(),
             ) as mark_startup_runtime_support_ready,
         ):
-            updated = await orchestrator.config_reload.update_config()
+            updated = await orchestrator.config_reload._update_config()
 
         assert updated is False
         assert old_maintenance_task.cancelled()
@@ -2198,7 +2198,7 @@ async def test_orchestrator_update_config_cancels_old_tasks(tmp_path: Path) -> N
         mock_create_bot.return_value = mock_new_bot
 
         # Run update_config
-        await orchestrator.config_reload.update_config()
+        await orchestrator.config_reload._update_config()
 
         # Verify stop_entities was called with sync_tasks dict
         mock_stop_entities.assert_called_once_with(
@@ -2309,7 +2309,7 @@ async def test_new_agent_not_started_twice(tmp_path: Path) -> None:
 
         # --- act ---
         try:
-            await orchestrator.config_reload.update_config()
+            await orchestrator.config_reload._update_config()
         finally:
             for task in list(orchestrator._sync_tasks.values()):
                 task.cancel()

--- a/tests/test_system_enrich.py
+++ b/tests/test_system_enrich.py
@@ -631,7 +631,7 @@ async def test_process_and_respond_threads_system_enrichment_items(tmp_path: Pat
             ai_response=AsyncMock(side_effect=fake_ai_response),
         ),
     ):
-        generation = await bot._response_runner.process_and_respond(
+        generation = await bot._response_runner._process_and_respond(
             ResponseRequest(
                 thread_history=[],
                 prompt="Please reply",
@@ -683,7 +683,7 @@ async def test_process_and_respond_streaming_threads_system_enrichment_items(tmp
             stream_agent_response=fake_stream_agent_response,
         ),
     ):
-        generation = await bot._response_runner.process_and_respond_streaming(
+        generation = await bot._response_runner._process_and_respond_streaming(
             ResponseRequest(
                 thread_history=[],
                 prompt="Please reply",

--- a/tests/test_team_room_updates.py
+++ b/tests/test_team_room_updates.py
@@ -104,7 +104,7 @@ class TestTeamRoomUpdates:
                             mock_load_config.return_value = config2
 
                             # Update config
-                            updated = await orchestrator.config_reload.update_config()
+                            updated = await orchestrator.config_reload._update_config()
 
                             # Verify the team was restarted
                             assert updated is True
@@ -205,7 +205,7 @@ class TestTeamRoomUpdates:
                             }
 
                             # Update config
-                            updated = await orchestrator.config_reload.update_config()
+                            updated = await orchestrator.config_reload._update_config()
 
                             # Verify the new team was created
                             assert updated is True
@@ -299,7 +299,7 @@ class TestTeamRoomUpdates:
                             mock_create_bot.reset_mock()
 
                             # Update with same config
-                            updated = await orchestrator.config_reload.update_config()
+                            updated = await orchestrator.config_reload._update_config()
 
                             # Verify nothing was restarted
                             assert updated is False

--- a/tests/test_team_scheduler_context.py
+++ b/tests/test_team_scheduler_context.py
@@ -129,7 +129,7 @@ async def test_team_non_streaming_has_scheduler_context(tmp_path: Path) -> None:
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.typing_indicator", new=_noop_typing_indicator),
@@ -168,7 +168,7 @@ async def test_team_non_streaming_cancellation_edits_placeholder(tmp_path: Path)
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.typing_indicator", new=_noop_typing_indicator),
@@ -220,7 +220,7 @@ async def test_team_non_streaming_sync_restart_edits_placeholder_with_restart_no
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.typing_indicator", new=_noop_typing_indicator),
@@ -290,7 +290,7 @@ async def test_team_streaming_has_scheduler_context(tmp_path: Path) -> None:
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.typing_indicator", new=_noop_typing_indicator),
@@ -336,7 +336,7 @@ async def test_team_late_cancellation_during_post_effects_propagates(tmp_path: P
     with (
         patch.object(
             ResponseRunner,
-            "run_cancellable_response",
+            "_run_cancellable_response",
             new=AsyncMock(side_effect=fake_run_cancellable_response),
         ),
         patch("mindroom.response_runner.typing_indicator", new=_noop_typing_indicator),

--- a/tests/test_thread_context_resolution.py
+++ b/tests/test_thread_context_resolution.py
@@ -1820,13 +1820,13 @@ class TestThreadingBehavior(ThreadingBehaviorTestBase):
         with (
             patch.object(
                 resolver,
-                "thread_membership_access",
+                "_thread_membership_access",
                 MagicMock(return_value=access),
             ) as mock_access,
             patch(
                 "mindroom.conversation_resolver.resolve_event_thread_membership",
                 new=AsyncMock(
-                    return_value=ThreadResolution.indeterminate(
+                    return_value=ThreadResolution._indeterminate(
                         RuntimeError("proof unavailable"),
                         candidate_thread_root_id="$thread_root:localhost",
                     ),

--- a/tests/test_turn_controller.py
+++ b/tests/test_turn_controller.py
@@ -175,11 +175,11 @@ async def test_owner_cancel_ready_task_closes_ready_result_returned_during_cance
     owner.ready_task = asyncio.create_task(ready())
     await asyncio.sleep(0)
 
-    await owner.cancel_ready_task()
+    await owner._cancel_ready_task()
 
     assert cancelled.is_set()
     assert close_count == 1
-    await owner.cancel_ready_task()
+    await owner._cancel_ready_task()
     assert close_count == 1
 
     await owner.release()

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -626,7 +626,7 @@ class TestAgentBot(AgentBotTestBase):
             ) as mock_build_payload,
             patch.object(
                 ResponseRunner,
-                "process_and_respond",
+                "_process_and_respond",
                 new=AsyncMock(
                     return_value=_ResponseGenerationOutcome(
                         delivery=FinalDeliveryOutcome(
@@ -641,7 +641,7 @@ class TestAgentBot(AgentBotTestBase):
             ) as mock_process,
             patch.object(
                 ResponseRunner,
-                "run_cancellable_response",
+                "_run_cancellable_response",
                 new=AsyncMock(side_effect=run_cancellable_response),
             ),
             patch.object(ResponsePayloadPreparer, "_log_dispatch_latency"),
@@ -2850,7 +2850,7 @@ class TestAgentBot(AgentBotTestBase):
         gateway = replace_delivery_gateway_deps(
             bot,
             response_hooks=SimpleNamespace(
-                apply_before_response=AsyncMock(
+                _apply_before_response=AsyncMock(
                     return_value=SimpleNamespace(
                         response_text="ignored",
                         response_kind="ai",
@@ -2902,7 +2902,7 @@ class TestAgentBot(AgentBotTestBase):
         gateway = replace_delivery_gateway_deps(
             bot,
             response_hooks=SimpleNamespace(
-                apply_before_response=AsyncMock(
+                _apply_before_response=AsyncMock(
                     return_value=SimpleNamespace(
                         response_text="Updated answer",
                         response_kind="ai",
@@ -2954,7 +2954,7 @@ class TestAgentBot(AgentBotTestBase):
             bot,
             redact_message_event=AsyncMock(return_value=True),
             response_hooks=SimpleNamespace(
-                apply_before_response=AsyncMock(side_effect=RuntimeError("hook boom")),
+                _apply_before_response=AsyncMock(side_effect=RuntimeError("hook boom")),
                 emit_after_response=AsyncMock(),
                 emit_cancelled_response=AsyncMock(),
             ),
@@ -2999,7 +2999,7 @@ class TestAgentBot(AgentBotTestBase):
             bot,
             redact_message_event=AsyncMock(return_value=True),
             response_hooks=SimpleNamespace(
-                apply_before_response=AsyncMock(side_effect=asyncio.CancelledError("hook cancelled")),
+                _apply_before_response=AsyncMock(side_effect=asyncio.CancelledError("hook cancelled")),
                 emit_after_response=AsyncMock(),
                 emit_cancelled_response=AsyncMock(),
             ),

--- a/tests/test_turn_store.py
+++ b/tests/test_turn_store.py
@@ -1256,9 +1256,9 @@ def test_turn_record_codecs_preserve_explicit_unknown_source_ownership() -> None
         requester_id="@stale:example.org",
     )
 
-    ledger_recovered = TurnRecordCodec.from_ledger_record(
+    ledger_recovered = TurnRecordCodec._from_ledger_record(
         event_id,
-        TurnRecordCodec.to_ledger_record(turn_record),
+        TurnRecordCodec._to_ledger_record(turn_record),
     )
     run_metadata = TurnRecordCodec.to_run_metadata(turn_record)
     run_metadata[constants.MATRIX_EVENT_ID_METADATA_KEY] = event_id
@@ -1554,7 +1554,7 @@ def test_routed_alias_redaction_marks_owning_relay_under_lock(tmp_path: Path) ->
 
     assert marked is not None
     assert marked.source_event_prompts == {"$anchor": "keep"}
-    assert store.any_source_redacted(("$relay",)) is True
+    assert store._any_source_redacted(("$relay",)) is True
 
 
 def test_same_second_delivered_run_repairs_fractional_ledger_timestamp(tmp_path: Path) -> None:

--- a/tests/test_voice_bot_threading.py
+++ b/tests/test_voice_bot_threading.py
@@ -526,7 +526,7 @@ async def test_voice_plain_reply_unproven_thread_candidate_is_not_admitted(
         patch(
             "mindroom.conversation_resolver.resolve_event_thread_membership",
             new=AsyncMock(
-                return_value=ThreadResolution.indeterminate(
+                return_value=ThreadResolution._indeterminate(
                     RuntimeError("proof unavailable"),
                     candidate_thread_root_id="$maybe-thread-root",
                 ),

--- a/uv.lock
+++ b/uv.lock
@@ -4608,7 +4608,7 @@ dev = [
     { name = "markdown-gfm-admonition" },
     { name = "pre-commit", specifier = ">=4.2" },
     { name = "pre-commit-uv", specifier = ">=4.1.4" },
-    { name = "privata", specifier = ">=0.2.1" },
+    { name = "privata", specifier = ">=0.8.0" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
@@ -6446,11 +6446,11 @@ wheels = [
 
 [[package]]
 name = "privata"
-version = "0.2.1"
+version = "0.8.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/96/0f/4b51384e1f52f28d12717e7c883f6e27e8efaaaaf51dad1c1f9b5404be44/privata-0.2.1.tar.gz", hash = "sha256:9ed2a3e22a5ef13e90913927294368557727500d86cdec9db1a0742ea02f1e4c", size = 64697, upload-time = "2026-05-06T15:05:09.91Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/3b/f6e6a5309f448548f215f0c3000ffd1113eb0c2c4c72292d47940b77e202/privata-0.8.0.tar.gz", hash = "sha256:55b4736441757c2c7ead185782265e47b17b0ccafeec4b3f96bf66599d260081", size = 100790, upload-time = "2026-07-25T20:49:04.873Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/10/e3/05980e34d742f93c34b5b0a1cf425c25325c90354c2bb79dbc58059758cb/privata-0.2.1-py3-none-any.whl", hash = "sha256:57b94a6aec887a45b707dbf14a24d5743c08ba67cbac5c34a3f2e5c34afa2f38", size = 16327, upload-time = "2026-05-06T15:05:08.789Z" },
+    { url = "https://files.pythonhosted.org/packages/73/17/3f45184d52f4e52d5e17d323b93a2a044ef4b8b4fd8eedd844a49ad9201e/privata-0.8.0-py3-none-any.whl", hash = "sha256:b1a488bcd066c80967ea2ca0947e854a1639a0c3aae1319499e52e242b722825", size = 30058, upload-time = "2026-07-25T20:49:03.442Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Upgrade Privata from 0.2.1 to 0.8.0.
- Run Privata with `--methods` in pre-commit.
- Make all 53 reported module-local methods private and update their tests.

## Why

Method-level interface drift was not checked, so implementation-only class helpers remained public.
The updated hook now enforces both module-level and method-level privacy.

## Validation

- `uv run privata --methods .`
- `uv lock --check`
- `uv run pre-commit run --all-files`
- `uv run pytest` — 12,289 passed, 191 skipped

All Privata findings were valid in MindRoom, so no upstream Privata issue was needed.

## Summary by Sourcery

Tighten privacy boundaries by making previously public helper methods and services private, and updating all call sites and tests to use the new internal interfaces enforced by Privata.

Enhancements:
- Convert various coordinator, policy, lifecycle, gateway, matrix, retry, timing, and ledger helpers from public to private methods to better encapsulate internal behavior.
- Adjust response lifecycle and timing utilities to expose only high-level entrypoints while keeping lower-level helpers internal.
- Refine thread membership and conversation resolution APIs to treat indeterminate states and access helpers as internal implementation details.
- Improve orchestration, worker backend, and external trigger runtime APIs by hiding internal config update and projection mechanics behind private methods.
- Constrain ingress validation, entity resolution, interactive metadata, and prompt reservation helpers to be used only through controlled private interfaces.

Build:
- Update Privata dependency to version 0.8 and configure the pre-commit hook to run method-level privacy checks via the --methods flag.

Tests:
- Update unit tests to call the new private methods and services consistently, including response runners, turn policy planning, config lifecycle, delivery hooks, projection managers, sync certification, handled turns, ingress lanes, and various orchestrator and worker backends.
- Extend test coverage to validate behavior of newly-private helpers such as backoff computation, ledger codecs, sync certification flags, and thread membership indeterminate handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal application interfaces were standardized as private implementation details across room management, conversation handling, response delivery, configuration, routing, and worker operations.
  * Existing response, synchronization, validation, persistence, retry, and configuration behavior remains unchanged.

* **Chores**
  * Updated automated privacy checks and development tooling.

* **Tests**
  * Updated test coverage to align with the revised internal interfaces while preserving existing scenarios and expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->