### PR TITLE
Fix fresh-worktree frontend pre-commit setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,17 +110,17 @@ repos:
 
   - repo: local
     hooks:
-      # Each hook must bootstrap a fresh checkout without running Puppeteer's browser download.
+      # Each hook must bootstrap a fresh checkout without downloading Puppeteer's browser.
       - id: check-bun-lock
         name: Check bun.lock is up to date
-        entry: bash -c 'cd frontend && bun install --frozen-lockfile --ignore-scripts'
+        entry: bash -c 'cd frontend && PUPPETEER_SKIP_DOWNLOAD=true bun install --frozen-lockfile'
         language: system
         files: ^frontend/(package\.json|bun\.lock)$
         pass_filenames: false
 
       - id: typescript-check
         name: TypeScript type checking
-        entry: bash -c 'cd frontend && bun install --frozen-lockfile --ignore-scripts && bun run type-check'
+        entry: bash -c 'cd frontend && PUPPETEER_SKIP_DOWNLOAD=true bun install --frozen-lockfile && bun run type-check'
         language: system
         files: ^frontend/.*\.(ts|tsx)$
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -110,18 +110,19 @@ repos:
 
   - repo: local
     hooks:
-      - id: typescript-check
-        name: TypeScript type checking
-        entry: bash -c 'cd frontend && bun run type-check'
-        language: system
-        files: ^frontend/.*\.(ts|tsx)$
-        pass_filenames: false
-
+      # Each hook must bootstrap a fresh checkout without running Puppeteer's browser download.
       - id: check-bun-lock
         name: Check bun.lock is up to date
-        entry: bash -c 'cd frontend && bun install --frozen-lockfile'
+        entry: bash -c 'cd frontend && bun install --frozen-lockfile --ignore-scripts'
         language: system
-        files: ^frontend/package\.json$
+        files: ^frontend/(package\.json|bun\.lock)$
+        pass_filenames: false
+
+      - id: typescript-check
+        name: TypeScript type checking
+        entry: bash -c 'cd frontend && bun install --frozen-lockfile --ignore-scripts && bun run type-check'
+        language: system
+        files: ^frontend/.*\.(ts|tsx)$
         pass_filenames: false
 
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## What changed

- Make the bun lock freshness hook run before TypeScript validation.
- Make both frontend hooks install frozen dependencies when `node_modules` is absent.
- Disable dependency lifecycle scripts during hook setup, so Puppeteer cannot download Chrome during pre-commit.
- Validate changes to either `frontend/package.json` or `frontend/bun.lock`.

## Root cause

`uv sync --all-extras` only installs Python dependencies.
In a fresh checkout, the TypeScript hook ran before any frontend install, so `tsc` was missing.
The later lock freshness hook performed a normal Bun install, which ran Puppeteer's postinstall and attempted a Chrome download.

## Impact

A fresh agent worktree can now run the documented setup and full pre-commit sequence without manual frontend setup or browser downloads.
Frozen-lock enforcement remains active and fails cleanly when `package.json` and `bun.lock` disagree.

## Validation

- Fresh baseline reproduction: `uv sync --all-extras && uv run pre-commit run --all-files` reproduced missing `tsc` and failed Chrome download.
- Fresh committed worktree: same exact command sequence passes.
- Deliberately stale `frontend/package.json`: `check-bun-lock` fails without modifying `bun.lock`.
- `uv run pre-commit run --all-files` passes.
- `uv run pytest` passes: 12,426 passed, 54 skipped.

## Summary by Sourcery

Adjust frontend pre-commit hooks so a fresh checkout bootstraps dependencies safely before TypeScript checks, avoiding Puppeteer browser downloads.

Enhancements:
- Reorder frontend pre-commit hooks so bun lock freshness runs before TypeScript validation.
- Update both frontend hooks to install frozen dependencies when node_modules is absent, while ignoring lifecycle scripts to prevent Puppeteer downloads.
- Broaden bun lock validation to run when either frontend/package.json or frontend/bun.lock changes.