### PR TITLE
Speed up CLI help imports

### DIFF
--- a/src/mindroom/cli/trigger.py
+++ b/src/mindroom/cli/trigger.py
@@ -11,19 +11,17 @@ import secrets
 import stat
 import time
 from pathlib import Path  # noqa: TC003
-from typing import cast
+from typing import TYPE_CHECKING, cast
 from urllib.parse import urlsplit, urlunsplit
 
-import httpx
 import typer
-from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
-from cryptography.hazmat.primitives.serialization import Encoding, NoEncryption, PrivateFormat, PublicFormat
-from rich.markup import escape
 
 from mindroom.cli.config import console
 from mindroom.constants import DEFAULT_MINDROOM_URL
-from mindroom.external_triggers.auth import sign_trigger_request
-from mindroom.external_triggers.store import public_key_fingerprint
+
+if TYPE_CHECKING:
+    import httpx
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 
 _DEFAULT_KEY_ID = "default"
 _DEFAULT_TIMEOUT = 10.0
@@ -46,6 +44,16 @@ def keygen(
     ),
 ) -> None:
     """Generate an Ed25519 trigger signing key."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: PLC0415
+    from cryptography.hazmat.primitives.serialization import (  # noqa: PLC0415
+        Encoding,
+        NoEncryption,
+        PrivateFormat,
+        PublicFormat,
+    )
+
+    from mindroom.external_triggers.store import public_key_fingerprint  # noqa: PLC0415
+
     private_key = Ed25519PrivateKey.generate()
     private_key_bytes = private_key.private_bytes(Encoding.Raw, PrivateFormat.Raw, NoEncryption())
     public_key_bytes = private_key.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
@@ -109,6 +117,11 @@ def send(
     key_id: str = typer.Option(_DEFAULT_KEY_ID, "--key-id", help="Trigger signing key id."),
 ) -> None:
     """Send a signed external trigger request."""
+    import httpx  # noqa: PLC0415
+    from rich.markup import escape  # noqa: PLC0415
+
+    from mindroom.external_triggers.auth import sign_trigger_request  # noqa: PLC0415
+
     request_url, path = _trigger_request_url_and_path(url, trigger_id)
     body = _trigger_body_bytes(
         kind=kind,
@@ -209,6 +222,8 @@ def _decode_data_json(data_json: str | None) -> dict[str, object]:
 
 
 def _load_private_key(key_file: Path) -> Ed25519PrivateKey:
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey  # noqa: PLC0415
+
     try:
         key_bytes = base64.b64decode(key_file.read_text(encoding="utf-8").strip(), validate=True)
     except (binascii.Error, ValueError) as exc:

--- a/tests/test_cli_trigger.py
+++ b/tests/test_cli_trigger.py
@@ -154,7 +154,7 @@ def test_trigger_send_builds_default_signed_request(monkeypatch: pytest.MonkeyPa
             },
         )
 
-    monkeypatch.setattr("mindroom.cli.trigger.httpx.post", fake_post)
+    monkeypatch.setattr(httpx, "post", fake_post)
     monkeypatch.setattr("mindroom.cli.trigger.time.time", lambda: 1234.9)
     token_values = iter(["generated-event", "nonce-1"])
     monkeypatch.setattr("mindroom.cli.trigger.secrets.token_hex", lambda _size: next(token_values))
@@ -215,7 +215,7 @@ def test_trigger_send_accepts_custom_options(monkeypatch: pytest.MonkeyPatch, tm
         captured.update(url=url, content=content, headers=headers, timeout=timeout, verify=verify)
         return _FakeResponse({"accepted": True})
 
-    monkeypatch.setattr("mindroom.cli.trigger.httpx.post", fake_post)
+    monkeypatch.setattr(httpx, "post", fake_post)
     monkeypatch.setattr("mindroom.cli.trigger.time.time", lambda: 2000)
     monkeypatch.setattr("mindroom.cli.trigger.secrets.token_hex", lambda _size: "nonce-2")
 
@@ -293,7 +293,7 @@ def test_trigger_send_uses_mindroom_url_env(monkeypatch: pytest.MonkeyPatch, tmp
         captured.update(url=url, content=content, headers=headers, timeout=timeout, verify=verify)
         return _FakeResponse({"accepted": True})
 
-    monkeypatch.setattr("mindroom.cli.trigger.httpx.post", fake_post)
+    monkeypatch.setattr(httpx, "post", fake_post)
     monkeypatch.setattr("mindroom.cli.trigger.time.time", lambda: 3000)
     token_values = iter(["event-from-env", "nonce-from-env"])
     monkeypatch.setattr("mindroom.cli.trigger.secrets.token_hex", lambda _size: next(token_values))
@@ -338,7 +338,7 @@ def test_trigger_send_reports_transport_error(monkeypatch: pytest.MonkeyPatch, t
         message = "connection refused"
         raise httpx.ConnectError(message)
 
-    monkeypatch.setattr("mindroom.cli.trigger.httpx.post", fake_post)
+    monkeypatch.setattr(httpx, "post", fake_post)
 
     result = runner.invoke(
         app,
@@ -374,7 +374,7 @@ def test_trigger_send_reports_status_error(monkeypatch: pytest.MonkeyPatch, tmp_
     def fake_post(*_args: object, **_kwargs: object) -> httpx.Response:
         return response
 
-    monkeypatch.setattr("mindroom.cli.trigger.httpx.post", fake_post)
+    monkeypatch.setattr(httpx, "post", fake_post)
 
     result = runner.invoke(
         app,
@@ -411,7 +411,7 @@ def test_trigger_send_escapes_status_error_markup(monkeypatch: pytest.MonkeyPatc
     def fake_post(*_args: object, **_kwargs: object) -> httpx.Response:
         return response
 
-    monkeypatch.setattr("mindroom.cli.trigger.httpx.post", fake_post)
+    monkeypatch.setattr(httpx, "post", fake_post)
 
     result = runner.invoke(
         app,

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -88,7 +88,23 @@ _TOOLS_ROOTS = _REGISTRY_ROOTS | frozenset(
         "zipp",
     },
 )
+# Top-level CLI help only needs command metadata and presentation libraries.
+# Command implementations must defer networking, crypto, config validation,
+# and provider imports until the selected command runs.
+_CLI_ROOTS = frozenset(
+    {
+        "annotated_doc",
+        "attr",
+        "click",
+        "dotenv",
+        "pygments",
+        "rich",
+        "shellingham",
+        "typer",
+    },
+)
 _ALLOWED_THIRD_PARTY_ROOTS: dict[str, frozenset[str]] = {
+    "mindroom.cli.main": _CLI_ROOTS,
     "mindroom.config.main": _CONFIG_LAYER_ROOTS,
     "mindroom.model_loading": _CONFIG_LAYER_ROOTS | frozenset({"agno"}),
     "mindroom.tool_system.declarations": frozenset({"dotenv"}),


### PR DESCRIPTION
## Summary

- defer signed-trigger networking, crypto, and persistence imports until their commands run
- protect `mindroom.cli.main` with the strict third-party import-footprint test
- update trigger HTTP mocks to patch the typed `httpx` module

## Root cause

The signed-trigger CLI registered its command module eagerly, and that module imported `httpx`, cryptography, Pydantic, YAML, and trigger storage code at module import time.
Every CLI invocation paid that cost, including `mindroom --help`.

## Impact

On the same Python 3.13 environment:

- `import mindroom.cli.main`: 172.2 ms → 85.4 ms (50% faster)
- `mindroom --help`: 190.6 ms → 103.8 ms (46% faster)
- imported modules: 516 → 290

Provider SDKs and trigger runtime dependencies remain unloaded until used.

## Validation

- `PUPPETEER_SKIP_DOWNLOAD=true .venv/bin/python -m pytest` — 12,379 passed, 102 skipped
- `.venv/bin/python -m pytest tests/test_import_graph.py tests/test_cli_trigger.py -q` — 26 passed
- `PUPPETEER_SKIP_DOWNLOAD=true .venv/bin/pre-commit run --all-files` — all hooks passed

## Summary by Sourcery

Defer heavy signed-trigger CLI imports to command execution to reduce CLI startup cost and enforce a minimal import footprint for the main CLI entrypoint.

Enhancements:
- Delay networking and cryptography dependency imports in the trigger CLI until the corresponding commands are executed.
- Constrain allowed third-party imports for the main CLI module to keep top-level CLI help lightweight.

Tests:
- Update trigger CLI tests to monkeypatch the typed httpx module directly and cover the new import graph constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI startup compatibility by loading optional dependencies only when the related commands are used.
* **Tests**
  * Updated CLI HTTP request tests for more reliable mocking.
  * Expanded import validation to account for approved command-line interface dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->