### PR TITLE
Fix repository-owned pytest warnings

### DIFF
--- a/src/mindroom/custom_tools/gmail.py
+++ b/src/mindroom/custom_tools/gmail.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agno.tools.gmail import GmailTools as AgnoGmailTools
+from agno.tools.google.gmail import GmailTools as AgnoGmailTools
 
 from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.logging_config import get_logger

--- a/src/mindroom/custom_tools/google_calendar.py
+++ b/src/mindroom/custom_tools/google_calendar.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agno.tools.googlecalendar import GoogleCalendarTools as AgnoGoogleCalendarTools
+from agno.tools.google.calendar import GoogleCalendarTools as AgnoGoogleCalendarTools
 
 from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.logging_config import get_logger

--- a/src/mindroom/custom_tools/google_sheets.py
+++ b/src/mindroom/custom_tools/google_sheets.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from agno.tools.googlesheets import GoogleSheetsTools as AgnoGoogleSheetsTools
+from agno.tools.google.sheets import GoogleSheetsTools as AgnoGoogleSheetsTools
 
 from mindroom.custom_tools.google_service import ThreadLocalGoogleServiceMixin, google_service_account_configured
 from mindroom.logging_config import get_logger

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -5017,11 +5017,9 @@ def test_supabase_cookie_auth_allows_access(
     """Platform requests should authenticate from the mindroom_jwt cookie."""
     valid_cookie_token = "valid-cookie-token"  # noqa: S105
     _set_platform_auth(valid_tokens={valid_cookie_token})
+    test_client.cookies.set("mindroom_jwt", valid_cookie_token)
 
-    response = test_client.post(
-        "/api/config/load",
-        cookies={"mindroom_jwt": valid_cookie_token},
-    )
+    response = test_client.post("/api/config/load")
     assert response.status_code == 200
 
 
@@ -5119,10 +5117,10 @@ def test_platform_frontend_redirects_to_login_when_cookie_invalid(
         valid_tokens={"valid-cookie-token"},
         platform_login_url="https://app.example.com/auth/login",
     )
+    test_client.cookies.set("mindroom_jwt", "definitely-invalid")
 
     response = test_client.get(
         "/agents",
-        cookies={"mindroom_jwt": "definitely-invalid"},
         follow_redirects=False,
     )
     assert response.status_code == 307
@@ -5145,11 +5143,9 @@ def test_platform_frontend_serves_dashboard_with_valid_cookie(
         valid_tokens={valid_cookie_token},
         platform_login_url="https://app.example.com/auth/login",
     )
+    test_client.cookies.set("mindroom_jwt", valid_cookie_token)
 
-    response = test_client.get(
-        "/",
-        cookies={"mindroom_jwt": valid_cookie_token},
-    )
+    response = test_client.get("/")
     assert response.status_code == 200
     assert "MindRoom Dashboard" in response.text
 
@@ -5172,10 +5168,10 @@ def test_platform_frontend_redirects_when_cookie_account_mismatches(
         account_id="account-owner",
         user_id="other-account",
     )
+    test_client.cookies.set("mindroom_jwt", valid_cookie_token)
 
     response = test_client.get(
         "/",
-        cookies={"mindroom_jwt": valid_cookie_token},
         follow_redirects=False,
     )
     assert response.status_code == 307

--- a/tests/test_gmail_tools.py
+++ b/tests/test_gmail_tools.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from agno.tools.gmail import GmailTools as AgnoGmailTools
+from agno.tools.google.gmail import GmailTools as AgnoGmailTools
 
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -34,6 +34,7 @@ from mindroom.matrix.health import (
     reset_matrix_sync_health,
     track_matrix_sync_cache_write,
 )
+from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.sync_loop import _sliding_sync_lists, _sliding_sync_room_subscriptions, sliding_own_membership_sets
 from mindroom.matrix.users import AgentMatrixUser
 from mindroom.orchestration import runtime as runtime_helpers
@@ -1838,6 +1839,7 @@ async def test_orchestrator_tracks_sync_tasks(tmp_path: Path) -> None:
         # Create mock bot
         mock_bot = AsyncMock()
         mock_bot.agent_name = "test_agent"
+        mock_bot.matrix_id = MatrixID.parse("@mindroom_test_agent:localhost")
         mock_bot.start = AsyncMock()
         mock_bot.rooms = []
         mock_create_bot.return_value = mock_bot
@@ -1905,11 +1907,13 @@ async def test_start_runtime_waits_for_shutdown_after_initial_sync_generation_ex
 
     router_bot = AsyncMock()
     router_bot.agent_name = "router"
+    router_bot.matrix_id = MatrixID.parse("@mindroom_router:localhost")
     router_bot.running = True
     router_bot.stop = AsyncMock()
 
     general_bot = AsyncMock()
     general_bot.agent_name = "general"
+    general_bot.matrix_id = MatrixID.parse("@mindroom_general:localhost")
     general_bot.running = True
     general_bot.stop = AsyncMock()
 
@@ -1969,11 +1973,13 @@ async def test_start_runtime_starts_sync_before_startup_maintenance_completes(tm
 
     router_bot = AsyncMock()
     router_bot.agent_name = "router"
+    router_bot.matrix_id = MatrixID.parse("@mindroom_router:localhost")
     router_bot.running = True
     router_bot.stop = AsyncMock()
 
     general_bot = AsyncMock()
     general_bot.agent_name = "general"
+    general_bot.matrix_id = MatrixID.parse("@mindroom_general:localhost")
     general_bot.running = True
     general_bot.stop = AsyncMock()
 
@@ -2263,7 +2269,10 @@ async def test_new_agent_not_started_twice(tmp_path: Path) -> None:
 
         mock_existing_bot = AsyncMock()
         mock_existing_bot.config = old_config
-        orchestrator.agent_bots = {"general": mock_existing_bot, "router": AsyncMock()}
+        mock_existing_bot.matrix_id = MatrixID.parse("@mindroom_general:localhost")
+        mock_router_bot = AsyncMock()
+        mock_router_bot.matrix_id = MatrixID.parse("@mindroom_router:localhost")
+        orchestrator.agent_bots = {"general": mock_existing_bot, "router": mock_router_bot}
 
         async def existing_sync_loop() -> None:
             await asyncio.sleep(60)
@@ -2298,8 +2307,14 @@ async def test_new_agent_not_started_twice(tmp_path: Path) -> None:
         # Mock bot creation — record every call
         created_bots: list[AsyncMock] = []
 
-        def make_bot(*args, **kwargs) -> AsyncMock:  # noqa: ANN002, ANN003, ARG001
+        def make_bot(
+            _entity_name: str,
+            agent_user: AgentMatrixUser,
+            *_args: object,
+            **_kwargs: object,
+        ) -> AsyncMock:
             bot = AsyncMock()
+            bot.matrix_id = agent_user.matrix_id
             bot.try_start = AsyncMock(return_value=True)
             bot.sync_forever = AsyncMock()
             created_bots.append(bot)


### PR DESCRIPTION
## Summary

- Move Gmail, Calendar, and Sheets wrappers to current Agno import paths.
- Give orchestrator tests real Matrix IDs for synchronous identity properties.
- Store API test cookies on TestClient instead of deprecated per-request cookie arguments.

## Why

Agno 2.8.0 still keeps the old imports only as deprecated compatibility shims, so upgrading alone does not remove these warnings. AsyncMock identities also created unawaited coroutines when cache binding called the synchronous full ID property.

## Impact

MindRoom-owned pytest warnings are removed without filtering or hiding upstream dependency warnings. Runtime behavior is unchanged.

## Checks

- uv sync --all-extras
- focused warning tests: 31 passed with zero warnings
- strict AsyncMock warning checks: passed with RuntimeWarning and PytestUnraisableExceptionWarning promoted to errors
- uv run pytest: 12426 passed, 54 skipped, 9 upstream-only warnings
- uv run pre-commit run --all-files: passed

## Summary by Sourcery

Update Google tool imports to current Agno namespaces and adjust tests to remove repository-owned pytest warnings without changing runtime behavior.

Bug Fixes:
- Assign real MatrixID values to orchestrator test bots to avoid AsyncMock identity-related warnings.
- Use TestClient cookie storage instead of per-request cookie arguments in API tests to eliminate deprecation warnings.

Enhancements:
- Align Gmail, Calendar, and Sheets tool wrappers and related tests with the new Agno Google module import paths.