### PR TITLE
Defer heavy startup dependencies

### DIFF
--- a/src/mindroom/cli/doctor.py
+++ b/src/mindroom/cli/doctor.py
@@ -11,9 +11,6 @@ from urllib.parse import urlparse
 
 import httpx
 import typer
-from agno.models.vertexai.claude import Claude as VertexAIClaude
-from anthropic import APIStatusError
-from google.auth.exceptions import DefaultCredentialsError, RefreshError
 
 from mindroom import constants
 from mindroom.constants import RuntimePaths, env_key_for_provider, runtime_env_path
@@ -21,7 +18,6 @@ from mindroom.credentials_sync import sync_env_to_credentials
 from mindroom.embedder_health import probe_embedder, semantic_embedder_configured
 from mindroom.embedding_errors import EMBEDDER_UNREACHABLE_DETAIL
 from mindroom.embeddings import create_sentence_transformers_embedder
-from mindroom.google_adc import load_google_application_credentials
 from mindroom.matrix.health import (
     MSC4186_UNSTABLE_FEATURE,
     matrix_versions_url,
@@ -36,6 +32,9 @@ from .config import activate_cli_runtime, console, load_config_quiet
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+
+    from anthropic import APIStatusError
+    from google.auth.exceptions import DefaultCredentialsError, RefreshError
 
     from mindroom.config.models import ModelConfig
 
@@ -322,6 +321,9 @@ def _classify_vertexai_claude_error(
     | httpx.HTTPError,
 ) -> tuple[bool | None, str]:
     """Classify one Vertex AI Claude validation failure for doctor output."""
+    from anthropic import APIStatusError  # noqa: PLC0415
+    from google.auth.exceptions import DefaultCredentialsError, RefreshError  # noqa: PLC0415
+
     if isinstance(exc, APIStatusError):
         return False, _vertexai_claude_api_error_detail(exc)
     if isinstance(exc, DefaultCredentialsError):
@@ -374,6 +376,8 @@ def _validate_vertexai_claude_connection(
     client_params = dict(extra_kwargs.get("client_params") or {})
     google_application_credentials = runtime_env_path(runtime_paths, "GOOGLE_APPLICATION_CREDENTIALS")
     if "credentials" not in client_params and google_application_credentials is not None:
+        from mindroom.google_adc import load_google_application_credentials  # noqa: PLC0415
+
         try:
             client_params["credentials"] = load_google_application_credentials(str(google_application_credentials))
         except PermanentStartupError as exc:
@@ -384,6 +388,10 @@ def _validate_vertexai_claude_connection(
     extra_kwargs.setdefault("project_id", project_id)
     extra_kwargs.setdefault("region", region)
     extra_kwargs.setdefault("timeout", 10)
+
+    from agno.models.vertexai.claude import Claude as VertexAIClaude  # noqa: PLC0415
+    from anthropic import APIStatusError  # noqa: PLC0415
+    from google.auth.exceptions import DefaultCredentialsError, RefreshError  # noqa: PLC0415
 
     try:
         model = VertexAIClaude(id=model_config.id, **extra_kwargs)

--- a/src/mindroom/knowledge/indexing_config.py
+++ b/src/mindroom/knowledge/indexing_config.py
@@ -12,7 +12,6 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple, cast
 
 from agno.knowledge.embedder.base import Embedder
-from agno.vectordb.chroma import ChromaDb
 
 from mindroom.embeddings import effective_knowledge_embedder_signature
 from mindroom.knowledge.redaction import credential_free_url_identity
@@ -256,6 +255,8 @@ class _CollectionExistenceEmbedder(Embedder):
 
 def chroma_collection_exists(storage_path: Path, collection_name: str) -> bool:
     """Check collection existence without constructing Agno Knowledge."""
+    from agno.vectordb.chroma import ChromaDb  # noqa: PLC0415
+
     vector_db = ChromaDb(
         collection=collection_name,
         path=str(storage_path),

--- a/src/mindroom/knowledge/refresh_scheduler.py
+++ b/src/mindroom/knowledge/refresh_scheduler.py
@@ -44,48 +44,6 @@ _MAX_CONCURRENT_REFRESHES_ENV = "MINDROOM_KNOWLEDGE_REFRESH_CONCURRENCY"
 _REFRESH_CLAIM_RETRY_SECONDS = 0.1
 
 
-async def _refresh_knowledge_binding(
-    base_id: str,
-    *,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    force_reindex: bool = False,
-) -> KnowledgeRefreshResult:
-    """Load the heavy in-process refresh path only for an explicit refresh."""
-    from mindroom.knowledge.refresh_runner import refresh_knowledge_binding as run_refresh  # noqa: PLC0415
-
-    return await run_refresh(
-        base_id,
-        config=config,
-        runtime_paths=runtime_paths,
-        execution_identity=execution_identity,
-        force_reindex=force_reindex,
-    )
-
-
-async def _refresh_knowledge_binding_in_subprocess(
-    base_id: str,
-    *,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    execution_identity: ToolExecutionIdentity | None = None,
-    force_reindex: bool = False,
-) -> None:
-    """Load subprocess refresh machinery only when scheduled work starts."""
-    from mindroom.knowledge.refresh_runner import (  # noqa: PLC0415
-        refresh_knowledge_binding_in_subprocess as run_refresh,
-    )
-
-    await run_refresh(
-        base_id,
-        config=config,
-        runtime_paths=runtime_paths,
-        execution_identity=execution_identity,
-        force_reindex=force_reindex,
-    )
-
-
 def _default_max_concurrent_refreshes() -> int:
     raw_value = os.getenv(_MAX_CONCURRENT_REFRESHES_ENV)
     if raw_value is None:
@@ -168,6 +126,8 @@ class KnowledgeRefreshScheduler:
         force_reindex: bool = False,
     ) -> KnowledgeRefreshResult:
         """Run a refresh immediately and wait for it."""
+        from mindroom.knowledge.refresh_runner import refresh_knowledge_binding  # noqa: PLC0415
+
         with suppress(ValueError):
             key = resolve_refresh_target(
                 base_id,
@@ -177,7 +137,7 @@ class KnowledgeRefreshScheduler:
                 create=False,
             )
             self._pending.pop(key, None)
-        return await _refresh_knowledge_binding(
+        return await refresh_knowledge_binding(
             base_id,
             config=config,
             runtime_paths=runtime_paths,
@@ -301,9 +261,11 @@ class KnowledgeRefreshScheduler:
             self._start_task(key, pending_request)
 
     async def _run_refresh(self, key: KnowledgeRefreshTarget, request: _ScheduledRefresh) -> None:
+        from mindroom.knowledge.refresh_runner import refresh_knowledge_binding_in_subprocess  # noqa: PLC0415
+
         async with self._refresh_semaphore():
             try:
-                await _refresh_knowledge_binding_in_subprocess(
+                await refresh_knowledge_binding_in_subprocess(
                     key.base_id,
                     config=request.config,
                     runtime_paths=request.runtime_paths,

--- a/src/mindroom/knowledge/refresh_scheduler.py
+++ b/src/mindroom/knowledge/refresh_scheduler.py
@@ -22,10 +22,6 @@ from mindroom.knowledge.refresh_locks import (
     is_refresh_active,
     mark_scheduled_refresh_inactive,
 )
-from mindroom.knowledge.refresh_runner import (
-    refresh_knowledge_binding,
-    refresh_knowledge_binding_in_subprocess,
-)
 from mindroom.knowledge.registry import (
     KnowledgeRefreshTarget,
     load_published_index_state,
@@ -46,6 +42,48 @@ logger = get_logger(__name__)
 _DEFAULT_MAX_CONCURRENT_REFRESHES = 1
 _MAX_CONCURRENT_REFRESHES_ENV = "MINDROOM_KNOWLEDGE_REFRESH_CONCURRENCY"
 _REFRESH_CLAIM_RETRY_SECONDS = 0.1
+
+
+async def _refresh_knowledge_binding(
+    base_id: str,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None = None,
+    force_reindex: bool = False,
+) -> KnowledgeRefreshResult:
+    """Load the heavy in-process refresh path only for an explicit refresh."""
+    from mindroom.knowledge.refresh_runner import refresh_knowledge_binding as run_refresh  # noqa: PLC0415
+
+    return await run_refresh(
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+        force_reindex=force_reindex,
+    )
+
+
+async def _refresh_knowledge_binding_in_subprocess(
+    base_id: str,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    execution_identity: ToolExecutionIdentity | None = None,
+    force_reindex: bool = False,
+) -> None:
+    """Load subprocess refresh machinery only when scheduled work starts."""
+    from mindroom.knowledge.refresh_runner import (  # noqa: PLC0415
+        refresh_knowledge_binding_in_subprocess as run_refresh,
+    )
+
+    await run_refresh(
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+        force_reindex=force_reindex,
+    )
 
 
 def _default_max_concurrent_refreshes() -> int:
@@ -139,7 +177,7 @@ class KnowledgeRefreshScheduler:
                 create=False,
             )
             self._pending.pop(key, None)
-        return await refresh_knowledge_binding(
+        return await _refresh_knowledge_binding(
             base_id,
             config=config,
             runtime_paths=runtime_paths,
@@ -265,7 +303,7 @@ class KnowledgeRefreshScheduler:
     async def _run_refresh(self, key: KnowledgeRefreshTarget, request: _ScheduledRefresh) -> None:
         async with self._refresh_semaphore():
             try:
-                await refresh_knowledge_binding_in_subprocess(
+                await _refresh_knowledge_binding_in_subprocess(
                     key.base_id,
                     config=request.config,
                     runtime_paths=request.runtime_paths,

--- a/src/mindroom/knowledge/registry.py
+++ b/src/mindroom/knowledge/registry.py
@@ -13,8 +13,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, ParamSpec, Protocol, TypeVar, cast
 
-from agno.vectordb.chroma import ChromaDb
-
 from mindroom.embedding_factory import create_configured_embedder, embedder_client_signature
 from mindroom.knowledge.availability import KnowledgeAvailability
 from mindroom.knowledge.index_metadata import (
@@ -377,6 +375,8 @@ def _build_published_index_vector_db(
     config: Config,
     runtime_paths: RuntimePaths,
 ) -> _PublishedIndexVectorDb:
+    from agno.vectordb.chroma import ChromaDb  # noqa: PLC0415
+
     return cast(
         "_PublishedIndexVectorDb",
         ChromaDb(

--- a/src/mindroom/memory/config.py
+++ b/src/mindroom/memory/config.py
@@ -6,8 +6,6 @@ import hashlib
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal, Protocol, cast
 
-from mem0 import AsyncMemory
-
 from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
 from mindroom.embedding_factory import resolve_embedder_settings
 from mindroom.embeddings import effective_mem0_embedder_signature, ensure_sentence_transformers_dependencies
@@ -17,6 +15,8 @@ from mindroom.timing import timed
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+    from mem0 import AsyncMemory
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -253,6 +253,8 @@ async def create_memory_instance(
         Configured AsyncMemory instance
 
     """
+    from mem0 import AsyncMemory  # noqa: PLC0415
+
     config_dict = _get_memory_config(storage_path, config, runtime_paths)
     if config.memory.embedder.provider == "sentence_transformers":
         ensure_sentence_transformers_dependencies(runtime_paths)

--- a/tests/api/test_knowledge_api.py
+++ b/tests/api/test_knowledge_api.py
@@ -313,8 +313,7 @@ def test_status_reports_persisted_count_without_loading_collection(tmp_path: Pat
     # construction to mindroom.knowledge.collections.
     with (
         patch("mindroom.knowledge.collections.ChromaDb", _BrokenVectorDb),
-        patch("mindroom.knowledge.registry.ChromaDb", _BrokenVectorDb),
-        patch("mindroom.knowledge.indexing_config.ChromaDb", _BrokenVectorDb),
+        patch("agno.vectordb.chroma.ChromaDb", _BrokenVectorDb),
         patch(
             "mindroom.knowledge.manager.create_configured_embedder",
             side_effect=AssertionError("embedder should not load"),

--- a/tests/knowledge_test_support.py
+++ b/tests/knowledge_test_support.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 import pytest
 from agno.knowledge.document.base import Document
 from agno.knowledge.embedder.base import Embedder
+from agno.vectordb import chroma as agno_chroma
 
 import mindroom.knowledge.refresh_locks as knowledge_refresh_locks
 import mindroom.knowledge.registry as knowledge_registry
@@ -289,8 +290,7 @@ def patch_vector_store(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
         "mindroom.knowledge.manager.create_configured_embedder",
         lambda *_args, **_kwargs: _FakeEmbedder(),
     )
-    monkeypatch.setattr("mindroom.knowledge.indexing_config.ChromaDb", _VectorDb)
-    monkeypatch.setattr("mindroom.knowledge.registry.ChromaDb", _VectorDb)
+    monkeypatch.setattr(agno_chroma, "ChromaDb", _VectorDb)
     monkeypatch.setattr("mindroom.knowledge.registry.StrictSearchKnowledge", _Knowledge)
     monkeypatch.setattr("mindroom.knowledge.registry.create_configured_embedder", lambda *_args, **_kwargs: object())
     knowledge_registry._published_indexes.clear()

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, patch
 
+import agno.models.vertexai.claude as vertexai_claude_module
 import httpx
 import pytest
 import structlog
@@ -22,6 +23,7 @@ from google.auth.exceptions import DefaultCredentialsError
 from typer.testing import CliRunner
 
 import mindroom.constants as constants_module
+import mindroom.google_adc as google_adc_module
 from mindroom.agents import ensure_default_agent_workspaces
 from mindroom.cli import config as config_cli
 from mindroom.cli import migrate as migrate_cli
@@ -3034,7 +3036,7 @@ class TestDoctor:
             def get_client(self) -> SimpleNamespace:
                 return SimpleNamespace(messages=_FakeMessages())
 
-        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _FakeVertexModel)
+        monkeypatch.setattr(vertexai_claude_module, "Claude", _FakeVertexModel)
 
         result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
         assert result.exit_code == 0
@@ -3092,8 +3094,8 @@ class TestDoctor:
             def get_client(self) -> SimpleNamespace:
                 return SimpleNamespace(messages=_FakeMessages())
 
-        monkeypatch.setattr("mindroom.cli.doctor.load_google_application_credentials", _load_adc)
-        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _FakeVertexModel)
+        monkeypatch.setattr(google_adc_module, "load_google_application_credentials", _load_adc)
+        monkeypatch.setattr(vertexai_claude_module, "Claude", _FakeVertexModel)
 
         result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
 
@@ -3140,7 +3142,7 @@ class TestDoctor:
             def get_client(self) -> SimpleNamespace:
                 return SimpleNamespace(messages=_FakeMessages())
 
-        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _FakeVertexModel)
+        monkeypatch.setattr(vertexai_claude_module, "Claude", _FakeVertexModel)
 
         result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
         assert result.exit_code == 0
@@ -3201,7 +3203,7 @@ class TestDoctor:
             def get_client(self) -> SimpleNamespace:
                 return SimpleNamespace(messages=_MissingCredentialsMessages())
 
-        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _MissingCredentialsModel)
+        monkeypatch.setattr(vertexai_claude_module, "Claude", _MissingCredentialsModel)
 
         result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
         assert result.exit_code == 0
@@ -3286,7 +3288,7 @@ class TestDoctor:
             def get_client(self) -> SimpleNamespace:
                 return SimpleNamespace(messages=_RejectedMessages())
 
-        monkeypatch.setattr("mindroom.cli.doctor.VertexAIClaude", _RejectedModel)
+        monkeypatch.setattr(vertexai_claude_module, "Claude", _RejectedModel)
 
         result = _invoke_with_runtime(["doctor"], cfg, storage_path=storage)
         assert result.exit_code == 1

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -225,6 +225,19 @@ def test_primary_runtime_does_not_import_provider_sdks() -> None:
     _assert_probe_clean("mindroom.orchestrator", _PROVIDER_SDK_ROOTS)
 
 
+def test_primary_runtime_defers_optional_storage_engines() -> None:
+    """MindRoom startup must defer storage engines until memory or knowledge uses them."""
+    _assert_probe_clean("mindroom.orchestrator", ("mem0", "chromadb", "agno.vectordb.chroma"))
+
+
+def test_doctor_import_does_not_import_optional_provider_sdks() -> None:
+    """Doctor must defer provider-specific diagnostics until that provider is configured."""
+    _assert_probe_clean(
+        "mindroom.cli.doctor",
+        (*_PROVIDER_SDK_ROOTS, "agno.models.vertexai.claude", "google.auth"),
+    )
+
+
 def test_openai_wire_models_import_only_the_openai_sdk() -> None:
     """Agno's azure package init pulls the anthropic SDK; only the azure branch should pay that."""
     non_openai_roots = tuple(root for root in _PROVIDER_SDK_ROOTS if root != "openai")

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -919,7 +919,7 @@ async def test_shared_local_watch_index_refreshes_on_access_without_blocking_rea
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     doc.write_text("shared local new", encoding="utf-8")
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
         refresh_knowledge_binding,
     )
     scheduler = KnowledgeRefreshScheduler()
@@ -5284,7 +5284,7 @@ async def test_refresh_scheduler_runs_independent_per_binding_tasks(
             raise RuntimeError(msg)
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("a", config=config, runtime_paths=runtime_paths)
     scheduler.schedule_refresh("a", config=config, runtime_paths=runtime_paths)
@@ -5330,7 +5330,7 @@ async def test_refresh_scheduler_probes_embedder_after_persisted_refresh_failure
         assert health_recorder is not None
         probe_reasons.append(reason)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -5370,7 +5370,7 @@ async def test_refresh_scheduler_skips_probe_for_non_embedder_subprocess_failure
         del health_recorder
         probe_reasons.append(reason)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -5410,7 +5410,7 @@ async def test_refresh_scheduler_does_not_probe_after_successful_refresh(
         msg = f"unexpected embedder probe: {reason}"
         raise AssertionError(msg)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -5446,7 +5446,7 @@ async def test_successful_subprocess_refresh_probes_to_clear_stale_health(
         assert health_recorder is not None
         probe_reasons.append(reason)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     try:
@@ -5491,7 +5491,7 @@ async def test_refresh_scheduled_before_reload_cannot_probe_old_config(
         del health_recorder
         probe_reasons.append(reason)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -5570,7 +5570,7 @@ async def test_refresh_scheduler_coalesces_duplicate_schedule_while_active(
             second_started.set()
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     await first_started.wait()
@@ -5616,7 +5616,7 @@ async def test_refresh_scheduler_refresh_now_runs_directly_with_force_reindex(
             availability=KnowledgeAvailability.READY,
         )
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding", _fake_refresh)
 
     result = await scheduler.refresh_now("docs", config=config, runtime_paths=runtime_paths, force_reindex=True)
 
@@ -6134,7 +6134,7 @@ async def test_refresh_scheduler_shutdown_suppresses_completed_refresh_failures(
         msg = "refresh failed"
         raise RuntimeError(msg)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     await asyncio.sleep(0)
@@ -6159,7 +6159,7 @@ async def test_refresh_scheduler_does_not_schedule_after_shutdown(
         calls += 1
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding", _fake_refresh)
 
     await scheduler.shutdown()
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -6190,7 +6190,7 @@ async def test_refresh_status_is_visible_across_scheduler_instances(
         return object()
 
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
         _blocked_refresh,
     )
 
@@ -6228,7 +6228,7 @@ async def test_refresh_scheduler_claim_is_exclusive_across_instances(
         return object()
 
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
         _blocked_refresh,
     )
 
@@ -6275,7 +6275,7 @@ async def test_refresh_scheduler_retries_request_after_direct_refresh_owner_fini
         return object()
 
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
         _record_refresh,
     )
 
@@ -6334,7 +6334,7 @@ async def test_refresh_scheduler_limits_concurrent_subprocess_refreshes(
             active_refreshes -= 1
 
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
         _blocked_refresh,
     )
 
@@ -8118,8 +8118,8 @@ async def test_refresh_scheduler_manual_reindex_runs_without_background_queue(
             availability=KnowledgeAvailability.READY,
         )
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding", _fake_refresh)
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("docs", config=old_config, runtime_paths=runtime_paths)
     await first_started.wait()

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -919,7 +919,7 @@ async def test_shared_local_watch_index_refreshes_on_access_without_blocking_rea
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     doc.write_text("shared local new", encoding="utf-8")
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess",
         refresh_knowledge_binding,
     )
     scheduler = KnowledgeRefreshScheduler()
@@ -5284,7 +5284,7 @@ async def test_refresh_scheduler_runs_independent_per_binding_tasks(
             raise RuntimeError(msg)
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("a", config=config, runtime_paths=runtime_paths)
     scheduler.schedule_refresh("a", config=config, runtime_paths=runtime_paths)
@@ -5330,7 +5330,7 @@ async def test_refresh_scheduler_probes_embedder_after_persisted_refresh_failure
         assert health_recorder is not None
         probe_reasons.append(reason)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -5370,7 +5370,7 @@ async def test_refresh_scheduler_skips_probe_for_non_embedder_subprocess_failure
         del health_recorder
         probe_reasons.append(reason)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -5410,7 +5410,7 @@ async def test_refresh_scheduler_does_not_probe_after_successful_refresh(
         msg = f"unexpected embedder probe: {reason}"
         raise AssertionError(msg)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -5446,7 +5446,7 @@ async def test_successful_subprocess_refresh_probes_to_clear_stale_health(
         assert health_recorder is not None
         probe_reasons.append(reason)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     try:
@@ -5491,7 +5491,7 @@ async def test_refresh_scheduled_before_reload_cannot_probe_old_config(
         del health_recorder
         probe_reasons.append(reason)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
     monkeypatch.setattr("mindroom.knowledge.refresh_scheduler.check_embedder_health", _fake_check)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -5570,7 +5570,7 @@ async def test_refresh_scheduler_coalesces_duplicate_schedule_while_active(
             second_started.set()
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     await first_started.wait()
@@ -5616,7 +5616,7 @@ async def test_refresh_scheduler_refresh_now_runs_directly_with_force_reindex(
             availability=KnowledgeAvailability.READY,
         )
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding", _fake_refresh)
 
     result = await scheduler.refresh_now("docs", config=config, runtime_paths=runtime_paths, force_reindex=True)
 
@@ -6134,7 +6134,7 @@ async def test_refresh_scheduler_shutdown_suppresses_completed_refresh_failures(
         msg = "refresh failed"
         raise RuntimeError(msg)
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
     await asyncio.sleep(0)
@@ -6159,7 +6159,7 @@ async def test_refresh_scheduler_does_not_schedule_after_shutdown(
         calls += 1
         return object()
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding", _fake_refresh)
 
     await scheduler.shutdown()
     scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
@@ -6190,7 +6190,7 @@ async def test_refresh_status_is_visible_across_scheduler_instances(
         return object()
 
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess",
         _blocked_refresh,
     )
 
@@ -6228,7 +6228,7 @@ async def test_refresh_scheduler_claim_is_exclusive_across_instances(
         return object()
 
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess",
         _blocked_refresh,
     )
 
@@ -6275,7 +6275,7 @@ async def test_refresh_scheduler_retries_request_after_direct_refresh_owner_fini
         return object()
 
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess",
         _record_refresh,
     )
 
@@ -6334,7 +6334,7 @@ async def test_refresh_scheduler_limits_concurrent_subprocess_refreshes(
             active_refreshes -= 1
 
     monkeypatch.setattr(
-        "mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess",
+        "mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess",
         _blocked_refresh,
     )
 
@@ -8118,8 +8118,8 @@ async def test_refresh_scheduler_manual_reindex_runs_without_background_queue(
             availability=KnowledgeAvailability.READY,
         )
 
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding", _fake_refresh)
-    monkeypatch.setattr("mindroom.knowledge.refresh_scheduler._refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding", _fake_refresh)
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
 
     scheduler.schedule_refresh("docs", config=old_config, runtime_paths=runtime_paths)
     await first_started.wait()

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, Protocol
 import pytest
 from agno.knowledge.document.base import Document
 from agno.knowledge.embedder.base import Embedder
+from agno.vectordb import chroma as agno_chroma
 from chromadb.errors import InternalError, NotFoundError
 from structlog.testing import capture_logs
 
@@ -421,8 +422,7 @@ def fake_vector_store(
     monkeypatch.setattr(knowledge_manager_module, "Knowledge", _FakeKnowledge)
     monkeypatch.setattr(knowledge_collections_module, "Knowledge", _FakeKnowledge)
     monkeypatch.setattr(knowledge_manager_module, "create_configured_embedder", lambda *_a, **_k: embedder)
-    monkeypatch.setattr("mindroom.knowledge.indexing_config.ChromaDb", _FakeVectorDb)
-    monkeypatch.setattr(knowledge_registry, "ChromaDb", _FakeVectorDb)
+    monkeypatch.setattr(agno_chroma, "ChromaDb", _FakeVectorDb)
     monkeypatch.setattr(knowledge_registry, "StrictSearchKnowledge", _FakeKnowledge)
     monkeypatch.setattr(knowledge_registry, "create_configured_embedder", lambda *_a, **_k: embedder)
 

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from mem0 import AsyncMemory
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.embeddings.openai import OpenAIEmbedding
 
@@ -544,7 +545,7 @@ class TestMemoryConfig:
 
     @pytest.mark.asyncio
     @patch("mindroom.memory.config.ensure_sentence_transformers_dependencies")
-    @patch("mindroom.memory.config.AsyncMemory.from_config")
+    @patch.object(AsyncMemory, "from_config")
     async def test_create_memory_instance_auto_installs_sentence_transformers(
         self,
         mock_from_config: MagicMock,
@@ -595,7 +596,7 @@ class TestMemoryConfig:
         memory = SimpleNamespace(vector_store=object(), embedding_model=object())
 
         with (
-            patch("mindroom.memory.config.AsyncMemory.from_config", return_value=memory),
+            patch.object(AsyncMemory, "from_config", return_value=memory),
             patch("mindroom.embedding_factory.create_configured_embedder", return_value=strict_embedder),
         ):
             result = await create_memory_instance(tmp_path / "memory", config, _runtime_paths(tmp_path))


### PR DESCRIPTION
## What changed

- defer Vertex AI Claude, Anthropic, and Google auth imports until Doctor checks a configured Vertex provider
- defer Mem0 until the first Mem0-backed memory operation
- defer Chroma and heavy knowledge-refresh machinery until knowledge storage or refresh is actually used
- add import-graph guards for Doctor provider SDKs and runtime storage engines

## Why

Cold profiling found that `mindroom doctor` imported the full Vertex/Anthropic stack even for non-Vertex configs, while `mindroom run` imported Mem0 and Chroma before config-dependent runtime work needed them.

Measured in fresh Python subprocesses on this checkout:

- `mindroom.cli.doctor` import: 497 ms -> 191 ms (62% faster)
- `mindroom.orchestrator` import: 1,659 ms -> 1,169 ms (30% faster)
- orchestrator module count: 3,307 -> 2,838

`mindroom config validate` remains around 0.45 seconds.
Its remaining cost is actual schema and tool metadata validation; avoiding that would require a larger generated-metadata design and is intentionally out of scope.

## Validation

- `PUPPETEER_SKIP_DOWNLOAD=true .venv/bin/python -m pytest` (12,257 passed, 226 skipped)
- `PUPPETEER_SKIP_DOWNLOAD=true .venv/bin/pre-commit run --all-files`

## Summary by Sourcery

Defer heavy provider SDK and storage engine imports so CLI startup and orchestrator runtime only load them when corresponding Vertex AI, memory, or knowledge features are actually used.

Enhancements:
- Lazy-load Vertex AI Claude, Anthropic, Google ADC, Mem0, and Chroma-related components inside the specific doctor, memory, and knowledge paths that require them to reduce cold-start overhead.
- Introduce internal wrapper functions and module-level guards around refresh scheduling and vector DB construction to keep the core runtime import graph lean.

Tests:
- Update memory, knowledge, and CLI doctor tests to patch the underlying third-party modules instead of eagerly imported symbols, aligning with the new lazy-import behavior.
- Extend import-graph tests to assert that the primary runtime and doctor commands do not import optional provider SDKs or storage engines during initial module import.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Reduced startup overhead by loading optional storage, memory, AI provider, and authentication components only when needed.
  - Improved compatibility when optional integrations are not installed.

- **Bug Fixes**
  - Preserved existing knowledge refresh, memory creation, and diagnostic behavior while preventing unnecessary dependency loading.

- **Tests**
  - Added regression coverage for deferred optional imports.
  - Updated integration and refresh tests to reflect the improved loading behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->