### PR TITLE
Enforce CLI import boundaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,7 +350,7 @@ Teams (`src/mindroom/teams.py`) let multiple agents work together:
 - **Documentation Line Style**: In Markdown docs, write one sentence per line, and never split a single sentence across multiple lines.
 - Do not wrap things in try-excepts unless it's necessary. Avoid wrapping things that should not fail.
 - NEVER put imports in the function, unless it is to avoid circular imports or to keep a heavy import (for example a provider SDK) out of module import time. Prefer an explicit function-level `from x import Y` with `# noqa: PLC0415` over dynamic `import_module` indirection. Imports should be at the top of the file.
-- `tests/test_import_graph.py` pins which third-party packages the slim entry points (config, tool registry, sandbox runner) may import and bans provider SDKs from the primary runtime. If it fails on your change, defer the new import to first use; extend the allowlist only when the dependency is genuinely needed at import time.
+- `tests/test_import_graph.py` pins the complete third-party import surface of slim CLI, config, tool-registry, and sandbox entry points, and bans heavy optional provider, storage, and ML/data dependencies from the primary runtime. If it fails on your change, defer the new import to first use; extend the allowlist only when the dependency is genuinely needed at import time.
 - Do not use `getattr()` or `hasattr()` to weaken a typed interface or probe for fields that the declared type should guarantee.
 - If mocks or tests break, fix them to use proper typed objects or stricter mocks instead of adding dynamic attribute fallbacks in production code.
 - **Merge and forget**: Code you touch should be polished enough to never revisit. Fix rough edges in code you're already changing.

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -2,16 +2,16 @@
 
 Two guards keep import-time regressions from creeping back:
 
-1. A provider-SDK ban: importing the tool registry, config layer, sandbox
-   runner, or the primary runtime must not import any provider SDK; those load
-   on first model or tool construction. Slim entry points additionally must
-   not import the nio matrix client or the mcp SDK, which the primary runtime
-   genuinely needs at boot.
+1. A heavy-optional-dependency ban: importing the primary runtime must not
+   import provider SDKs, storage engines, or ML/data stacks; those load on
+   first use.
+   Slim entry points additionally must not import the nio matrix client or the
+   mcp SDK, which the primary runtime genuinely needs at boot.
 2. A third-party allowlist: each slim entry point may only load the
    third-party packages it loads today. Any new package in the graph fails
    loudly — either defer the import (see the CLAUDE.md import rule) or extend
-   the allowlist as a conscious, reviewed decision. The orchestrator is
-   exempt: its dependency set is large and legitimately grows.
+   the allowlist as a conscious, reviewed decision. The orchestrator uses the
+   narrower heavy-optional-dependency ban because its core boot graph is large.
 
 Each probe runs in a subprocess so the assertion sees exactly what the import
 graph pulls in.
@@ -33,6 +33,21 @@ _PROVIDER_SDK_ROOTS = (
     "groq",
     "ollama",
     "openai",
+)
+_HEAVY_OPTIONAL_RUNTIME_ROOTS = (
+    *_PROVIDER_SDK_ROOTS,
+    "agno.models.vertexai.claude",
+    "agno.vectordb.chroma",
+    "chromadb",
+    "google.auth",
+    "mem0",
+    "numpy",
+    "pandas",
+    "scipy",
+    "sentence_transformers",
+    "sklearn",
+    "torch",
+    "transformers",
 )
 _SLIM_ONLY_ROOTS = ("mcp", "nio")
 
@@ -105,6 +120,9 @@ _CLI_ROOTS = frozenset(
 )
 _ALLOWED_THIRD_PARTY_ROOTS: dict[str, frozenset[str]] = {
     "mindroom.cli.main": _CLI_ROOTS,
+    # Doctor may use the CLI, config, and HTTP stacks at import time, but no
+    # provider, storage, or other feature-specific dependency.
+    "mindroom.cli.doctor": _CLI_ROOTS | _REGISTRY_ROOTS,
     "mindroom.config.main": _CONFIG_LAYER_ROOTS,
     "mindroom.model_loading": _CONFIG_LAYER_ROOTS | frozenset({"agno"}),
     "mindroom.tool_system.declarations": frozenset({"dotenv"}),
@@ -220,22 +238,9 @@ def test_slim_entry_point_import_contract(module: str) -> None:
     )
 
 
-def test_primary_runtime_does_not_import_provider_sdks() -> None:
-    """The orchestrator import (mindroom run) loads no provider SDK; only configured ones load later."""
-    _assert_probe_clean("mindroom.orchestrator", _PROVIDER_SDK_ROOTS)
-
-
-def test_primary_runtime_defers_optional_storage_engines() -> None:
-    """MindRoom startup must defer storage engines until memory or knowledge uses them."""
-    _assert_probe_clean("mindroom.orchestrator", ("mem0", "chromadb", "agno.vectordb.chroma"))
-
-
-def test_doctor_import_does_not_import_optional_provider_sdks() -> None:
-    """Doctor must defer provider-specific diagnostics until that provider is configured."""
-    _assert_probe_clean(
-        "mindroom.cli.doctor",
-        (*_PROVIDER_SDK_ROOTS, "agno.models.vertexai.claude", "google.auth"),
-    )
+def test_primary_runtime_defers_heavy_optional_dependencies() -> None:
+    """The orchestrator import must leave provider, storage, and ML/data engines unloaded."""
+    _assert_probe_clean("mindroom.orchestrator", _HEAVY_OPTIONAL_RUNTIME_ROOTS)
 
 
 def test_openai_wire_models_import_only_the_openai_sdk() -> None:

--- a/tests/test_import_graph.py
+++ b/tests/test_import_graph.py
@@ -35,12 +35,16 @@ _PROVIDER_SDK_ROOTS = (
     "openai",
 )
 _HEAVY_OPTIONAL_RUNTIME_ROOTS = (
+    # Provider-specific clients and authentication.
     *_PROVIDER_SDK_ROOTS,
     "agno.models.vertexai.claude",
+    "google.auth",
+    "google.oauth2",
+    # Storage engines.
     "agno.vectordb.chroma",
     "chromadb",
-    "google.auth",
     "mem0",
+    # ML and data stacks.
     "numpy",
     "pandas",
     "scipy",


### PR DESCRIPTION
## Summary

- pin the complete third-party import footprint of `mindroom.cli.doctor`
- keep provider, storage, and heavy ML/data stacks out of the `mindroom run` import graph
- document why entry-point import contracts are preferred over blanket function-level imports

## Why

A blanket rule requiring every third-party import to be lazy would add indirection even inside feature modules that are already loaded lazily. Import-graph contracts protect user-visible startup paths while keeping normal module-level imports elsewhere.

## Validation

- `pytest tests/test_import_graph.py -q`
- full `pytest`: 12,428 passed, 54 skipped
- `pre-commit run --all-files`

## Summary by Sourcery

Strengthen import-graph protections for CLI and runtime entry points by expanding test coverage and documentation around pinned third-party imports and deferred loading of heavy optional dependencies.

Enhancements:
- Tighten import-graph contracts to keep heavy optional provider, storage, and ML/data dependencies out of the primary runtime startup path.
- Extend third-party import allowlisting to cover the `mindroom.cli.doctor` entry point alongside other slim CLI and config modules.

Documentation:
- Update CLAUDE.md to clarify import rules, emphasizing pinned third-party footprints for entry points and deferred loading of heavy optional dependencies.

Tests:
- Refine import graph tests to enforce the heavy-optional-dependency ban for the orchestrator and to pin the allowed third-party imports for `mindroom.cli.doctor`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded import safeguards to cover optional provider, storage, machine-learning, and data dependencies.
  * Consolidated runtime and diagnostic import checks into broader dependency validation.
  * Updated the diagnostic command’s permitted dependency set.
* **Documentation**
  * Clarified import-graph testing guidance and optional dependency policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->