### PR TITLE
Remove test and CI deprecation warnings

### DIFF
--- a/.github/workflows/build-mindroom.yml
+++ b/.github/workflows/build-mindroom.yml
@@ -76,7 +76,7 @@ jobs:
           network=host
 
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -139,7 +139,7 @@ jobs:
 
     steps:
     - name: Login to GitHub Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}

--- a/.github/workflows/build-platform.yml
+++ b/.github/workflows/build-platform.yml
@@ -57,7 +57,7 @@ jobs:
             network=host
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           lfs: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         run: uv python install 3.13

--- a/.github/workflows/markdown-code-runner.yml
+++ b/.github/workflows/markdown-code-runner.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.13"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Run markdown-code-runner
         env:

--- a/.github/workflows/publish-helm-charts.yml
+++ b/.github/workflows/publish-helm-charts.yml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Set chart version
         id: vars
@@ -139,7 +139,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Set chart version
         id: vars
@@ -233,7 +233,7 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && inputs.release_ref || github.ref }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Set chart version
         id: vars

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/smoke-stacks.yml
+++ b/.github/workflows/smoke-stacks.yml
@@ -45,7 +45,7 @@ jobs:
           path: mindroom-stack
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         run: uv python install 3.13
@@ -54,10 +54,10 @@ jobs:
         uses: oven-sh/setup-bun@v2
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@v5
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Set up kind
         run: |
@@ -82,7 +82,7 @@ jobs:
           df -h /
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/smoke-stacks.yml
+++ b/.github/workflows/smoke-stacks.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          cache-suffix: smoke-stacks
 
       - name: Set up Python
         run: uv python install 3.13

--- a/.github/workflows/tach.yml
+++ b/.github/workflows/tach.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python
         run: uv python install 3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ dependencies = [
   "typer>=0.24",
   "uvicorn>=0.35",
   "watchfiles>=1",
+  "websockets>=14",
 ]
 [[project.authors]]
 name = "mindroom team"

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2034,7 +2034,13 @@ async def _run_api_server(
     api_main.initialize_api_app(api_main.app, runtime_paths)
     if knowledge_refresh_scheduler is not None:
         api_main.bind_orchestrator_knowledge_refresh_scheduler(api_main.app, knowledge_refresh_scheduler)
-    config = uvicorn.Config(api_main.app, host=host, port=port, log_level=log_level.lower())
+    config = uvicorn.Config(
+        api_main.app,
+        host=host,
+        port=port,
+        log_level=log_level.lower(),
+        ws="websockets-sansio",
+    )
     server = _SignalAwareUvicornServer(config, shutdown_requested)
     logger.info("embedded_api_server_starting", **api_server.log_context())
     try:

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -167,7 +167,7 @@ class TestAgentBot(AgentBotTestBase):
             del send
 
         server = _SignalAwareUvicornServer(
-            uvicorn.Config(app, host="0.0.0.0", port=0, lifespan="off"),  # noqa: S104
+            uvicorn.Config(app, host="0.0.0.0", port=0, lifespan="off", ws="websockets-sansio"),  # noqa: S104
             asyncio.Event(),
         )
         server.config.load()
@@ -205,7 +205,7 @@ class TestAgentBot(AgentBotTestBase):
                 set_api_server_address("127.0.0.1", 8765)
 
         with (
-            patch("mindroom.orchestrator.uvicorn.Config", return_value=object()),
+            patch("mindroom.orchestrator.uvicorn.Config", return_value=object()) as mock_uvicorn_config,
             patch("mindroom.orchestrator._SignalAwareUvicornServer", ReturningServer),
             patch("mindroom.api.main.initialize_api_app"),
             patch("mindroom.api.main.bind_orchestrator_knowledge_refresh_scheduler"),
@@ -220,6 +220,13 @@ class TestAgentBot(AgentBotTestBase):
                 shutdown_requested=asyncio.Event(),
             )
 
+        mock_uvicorn_config.assert_called_once_with(
+            ANY,
+            host="127.0.0.1",
+            port=0,
+            log_level="info",
+            ws="websockets-sansio",
+        )
         mock_error.assert_called_once()
         assert mock_error.call_args.args == ("fatal_embedded_api_server_exit",)
         assert get_api_server_address() is None

--- a/uv.lock
+++ b/uv.lock
@@ -4049,6 +4049,7 @@ dependencies = [
     { name = "typer" },
     { name = "uvicorn" },
     { name = "watchfiles" },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -4592,6 +4593,7 @@ requires-dist = [
     { name = "uvicorn", specifier = ">=0.35" },
     { name = "watchfiles", specifier = ">=1" },
     { name = "webexpythonsdk", marker = "extra == 'webex'" },
+    { name = "websockets", specifier = ">=14" },
     { name = "wikipedia", marker = "extra == 'wikipedia'" },
     { name = "yfinance", marker = "extra == 'yfinance'" },
     { name = "youtube-transcript-api", marker = "extra == 'youtube'" },


### PR DESCRIPTION
## Summary
- select Uvicorn’s maintained WebSockets SansIO protocol for the embedded API server
- declare WebSockets as a direct runtime dependency and protect protocol selection with a regression test
- update GitHub Actions to their Node 24 majors, removing runner deprecation annotations across workflows

OpenBB currently constrains Uvicorn below 0.41, so upgrading Uvicorn itself is not resolvable with all extras. The selected SansIO protocol is available in the supported Uvicorn range.

## Validation
- `PUPPETEER_SKIP_DOWNLOAD=true uv run pytest` (12670 passed, 54 skipped)
- `uv run pre-commit run --all-files`
- Uvicorn 0.35.0 SansIO startup/shutdown under `-W error` with WebSockets 14.0 and 17.0.1
- full CI and stack smoke passed before the workflow-only follow-up; rerun in progress

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket compatibility and reliability for the embedded API server.
  * Added the required WebSocket runtime support.

* **Chores**
  * Updated build and testing automation tools to newer versions.
  * Refreshed container registry, Kubernetes, Helm, and Python environment setup actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->