### PR TITLE
Tighten durable dispatch boundaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Gemini API docs call `gemini-3.1-flash-image` Nano Banana 2, while Vertex AI doc
 ```text
 Matrix sync callback
   -> bot.py (AgentBot/TeamBot runtime shell)
-  -> dispatch_obligations.py                                (durable exact callback acceptance and restart recovery)
+  -> dispatch_obligations/                                 (durable exact callback acceptance and restart recovery)
   -> turn_controller.py (owns one turn: precheck -> normalize -> resolve -> coalesce -> decide -> execute -> record)
        -> ingress_validation.py                                  (trust, dedup, echo drop; commands exit before batching)
        -> inbound_turn_normalizer.py + conversation_resolver.py  (canonical turn input, conversation identity)
@@ -96,7 +96,12 @@ Matrix sync callback
 | `text_ingress_dispatch.py` | Text ingress dispatch path used by TurnController |
 | `turn_policy.py` | Pure turn policy: decide ignore, route, or respond for inbound turns |
 | `dispatch_replay_guard.py` | Replay-guard checks for dispatch sequencing |
-| `dispatch_obligations.py` | Durable exact Matrix callback acceptance, settlement, and startup recovery |
+| `dispatch_obligations/` | Durable exact Matrix callback storage, admission, execution, and startup recovery |
+| `turn_settlement_retry.py` | Event-loop retry owner for settling callback obligations after terminal TurnStore persistence |
+| `command_turn_executor.py` | Command execution and durable command/config mutation journals |
+| `reaction_dispatch.py` | Durable semantic routing for Matrix reactions |
+| `user_stop_reconciliation.py` | STOP ordering, response cancellation, and terminal turn reconciliation |
+| `visible_response_reconciliation.py` | Visible Matrix response recovery, adoption, and replay reconciliation |
 | `turn_store.py` | Unified durable turn access (wraps the handled-turn ledger) |
 | `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
 | `redacted_turn_cleanup.py` | Source-redaction tombstoning and serialized persisted replay cleanup |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -68,7 +68,12 @@ MindRoom's architecture consists of several key components working together.
 | `coalescing.py` | Live message coalescing gate (text dispatches immediately; media waits for attachments and a trailing caption) |
 | `text_ingress_dispatch.py` | Text ingress dispatch path used by TurnController |
 | `turn_policy.py` | Pure turn policy: decide ignore, route, or respond for inbound turns |
-| `dispatch_obligations.py` | Durable exact Matrix callback acceptance, settlement, and startup recovery |
+| `dispatch_obligations/` | Durable exact Matrix callback storage, admission, execution, and startup recovery |
+| `turn_settlement_retry.py` | Event-loop retry owner for settling callback obligations after terminal TurnStore persistence |
+| `command_turn_executor.py` | Command execution and durable command/config mutation journals |
+| `reaction_dispatch.py` | Durable semantic routing for Matrix reactions |
+| `user_stop_reconciliation.py` | STOP ordering, response cancellation, and terminal turn reconciliation |
+| `visible_response_reconciliation.py` | Visible Matrix response recovery, adoption, and replay reconciliation |
 | `turn_store.py` | Unified durable turn access (wraps the handled-turn ledger) |
 | `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
 | `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation, detached inbox responses, shutdown drains) |

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16119,7 +16119,12 @@ MindRoom's architecture consists of several key components working together.
 | `coalescing.py` | Live message coalescing gate (text dispatches immediately; media waits for attachments and a trailing caption) |
 | `text_ingress_dispatch.py` | Text ingress dispatch path used by TurnController |
 | `turn_policy.py` | Pure turn policy: decide ignore, route, or respond for inbound turns |
-| `dispatch_obligations.py` | Durable exact Matrix callback acceptance, settlement, and startup recovery |
+| `dispatch_obligations/` | Durable exact Matrix callback storage, admission, execution, and startup recovery |
+| `turn_settlement_retry.py` | Event-loop retry owner for settling callback obligations after terminal TurnStore persistence |
+| `command_turn_executor.py` | Command execution and durable command/config mutation journals |
+| `reaction_dispatch.py` | Durable semantic routing for Matrix reactions |
+| `user_stop_reconciliation.py` | STOP ordering, response cancellation, and terminal turn reconciliation |
+| `visible_response_reconciliation.py` | Visible Matrix response recovery, adoption, and replay reconciliation |
 | `turn_store.py` | Unified durable turn access (wraps the handled-turn ledger) |
 | `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
 | `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation, detached inbox responses, shutdown drains) |

--- a/skills/mindroom-docs/references/page__architecture__index.md
+++ b/skills/mindroom-docs/references/page__architecture__index.md
@@ -64,7 +64,12 @@ MindRoom's architecture consists of several key components working together.
 | `coalescing.py` | Live message coalescing gate (text dispatches immediately; media waits for attachments and a trailing caption) |
 | `text_ingress_dispatch.py` | Text ingress dispatch path used by TurnController |
 | `turn_policy.py` | Pure turn policy: decide ignore, route, or respond for inbound turns |
-| `dispatch_obligations.py` | Durable exact Matrix callback acceptance, settlement, and startup recovery |
+| `dispatch_obligations/` | Durable exact Matrix callback storage, admission, execution, and startup recovery |
+| `turn_settlement_retry.py` | Event-loop retry owner for settling callback obligations after terminal TurnStore persistence |
+| `command_turn_executor.py` | Command execution and durable command/config mutation journals |
+| `reaction_dispatch.py` | Durable semantic routing for Matrix reactions |
+| `user_stop_reconciliation.py` | STOP ordering, response cancellation, and terminal turn reconciliation |
+| `visible_response_reconciliation.py` | Visible Matrix response recovery, adoption, and replay reconciliation |
 | `turn_store.py` | Unified durable turn access (wraps the handled-turn ledger) |
 | `handled_turns.py` | Disk-backed handled-turn ledger preventing duplicate responses |
 | `response_runner.py` | Response lifecycle execution (locking, streaming vs non-streaming, cancellation, detached inbox responses, shutdown drains) |

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -135,6 +135,7 @@ from .startup_errors import PermanentStartupError
 from .sync_restart_retry import InterruptedTurnRooms
 from .turn_controller import TurnController, TurnControllerDeps
 from .turn_policy import IngressHookRunner, TurnPolicy, TurnPolicyDeps
+from .turn_settlement_retry import TurnSettlementRetry
 from .turn_store import TurnStore, TurnStoreDeps
 from .user_stop_reconciliation import UserStopReconciler, UserStopReconcilerDeps
 from .visible_response_reconciliation import VisibleResponseReconciler, VisibleResponseReconcilerDeps
@@ -427,6 +428,10 @@ class AgentBot:
             principal_id=runtime_matrix_id.full_id,
             entity_name=self.agent_name,
         )
+        self._turn_settlement_retry = TurnSettlementRetry(
+            store=self._dispatch_obligation_store,
+            background_task_owner=self._runtime_view,
+        )
         self._coalescing_gate = CoalescingGate(
             dispatch_batch=self._dispatch_coalesced_batch,
             debounce_seconds=lambda: self.config.defaults.coalescing.debounce_ms / 1000,
@@ -515,7 +520,7 @@ class AgentBot:
                 state_writer=self._conversation_state_writer,
                 resolver=self._conversation_resolver,
                 tool_runtime=self._tool_runtime_support,
-                on_terminal_turn_persisted=self._settle_turn_dispatch_obligations,
+                on_terminal_turn_persisted=self._turn_settlement_retry.retry,
             ),
         )
         self._dispatch_obligation_runner = DispatchObligationRunner(
@@ -696,14 +701,8 @@ class AgentBot:
                 conversation_cache=self._conversation_cache,
                 user_stop_reconciler=self._user_stop_reconciler,
                 ingress=self._ingress_validator,
-                reserve_prompt_ingress_order=lambda *args, **kwargs: self._turn_controller.reserve_prompt_ingress_order(
-                    *args,
-                    **kwargs,
-                ),
-                handle_interactive_selection=lambda *args, **kwargs: self._turn_controller.handle_interactive_selection(
-                    *args,
-                    **kwargs,
-                ),
+                reserve_prompt_ingress_order=self._turn_controller.reserve_prompt_ingress_order,
+                handle_interactive_selection=self._turn_controller.handle_interactive_selection,
                 emit_reaction_received_hooks=self._emit_reaction_received_hooks,
                 config_confirmation=config_confirmation.ConfigConfirmationContext(
                     runtime=self._runtime_view,
@@ -711,8 +710,6 @@ class AgentBot:
                     build_message_target=self._conversation_resolver.build_message_target,
                     delivery_gateway=self._delivery_gateway,
                 ),
-                handle_approval_action=lambda **kwargs: handle_tool_approval_action(**kwargs),
-                sender_is_authorized=lambda *args: is_authorized_sender(*args),
             ),
         )
 
@@ -1651,7 +1648,7 @@ class AgentBot:
         )
         try:
             self._rebuild_runtime_components_after_login_if_identity_changed(matrix_id_before_login)
-            self._dispatch_obligation_runner.bind_event_loop()
+            self._turn_settlement_retry.bind_event_loop()
             orchestrator = self.orchestrator
             if orchestrator is not None:
                 orchestrator.validate_managed_entity_identities()
@@ -1996,10 +1993,6 @@ class AgentBot:
             DispatchCallbackKind.INVITE,
             owner=self._runtime_view,
         )
-
-    def _settle_turn_dispatch_obligations(self, event_ids: tuple[str, ...]) -> None:
-        """Hand terminal obligation compaction to the event-loop retry owner."""
-        self._dispatch_obligation_runner.retry_turn_settlement(event_ids)
 
     def _room_for_dispatch_obligation(self, room_id: str) -> nio.MatrixRoom:
         """Resolve one recovery room without depending on a new sync response."""

--- a/src/mindroom/dispatch_obligations/runner.py
+++ b/src/mindroom/dispatch_obligations/runner.py
@@ -83,9 +83,6 @@ class DispatchObligationRunner:
     _retry_keys: dict[DispatchObligationKey, int] = field(default_factory=dict, init=False, repr=False)
     _retry_corrupt: set[DispatchObligationKey] = field(default_factory=set, init=False, repr=False)
     _retry_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
-    _event_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
-    _turn_settlement_retry_ids: set[str] = field(default_factory=set, init=False, repr=False)
-    _turn_settlement_retry_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
 
     @staticmethod
     def callbacks_for(
@@ -191,79 +188,6 @@ class DispatchObligationRunner:
             self.store.settle_intentionally_ignored_turn_sources,
             source_event_ids,
         )
-
-    def bind_event_loop(self) -> None:
-        """Bind the active runtime loop for callbacks arriving from persistence workers."""
-        self._event_loop = asyncio.get_running_loop()
-
-    def retry_turn_settlement(self, source_event_ids: tuple[str, ...]) -> None:
-        """Retry failed TurnStore compaction on the active runtime loop."""
-        try:
-            running_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            running_loop = None
-        if running_loop is None:
-            try:
-                self.store.settle_pending_from_turn_store(source_event_ids)
-            except Exception:
-                logger.exception(
-                    "turn_dispatch_obligation_initial_settlement_failed",
-                    source_event_ids=source_event_ids,
-                )
-            else:
-                return
-            event_loop = self._event_loop
-            if event_loop is None or event_loop.is_closed():
-                logger.error(
-                    "turn_dispatch_obligation_retry_loop_unavailable",
-                    source_event_ids=source_event_ids,
-                )
-                return
-            event_loop.call_soon_threadsafe(self._enqueue_turn_settlement_retry, source_event_ids)
-            return
-        self._event_loop = running_loop
-        self._enqueue_turn_settlement_retry(source_event_ids)
-
-    def _enqueue_turn_settlement_retry(self, source_event_ids: tuple[str, ...]) -> None:
-        """Add exact terminal sources to the loop-owned settlement retry set."""
-        self._turn_settlement_retry_ids.update(source_event_ids)
-        retry_task = self._turn_settlement_retry_task
-        if retry_task is not None and not retry_task.done():
-            return
-        self._turn_settlement_retry_task = create_background_task(
-            self._retry_failed_turn_settlements(),
-            name=f"retry_turn_dispatch_settlement_{self.store.entity_name}",
-            owner=self.background_task_owner,
-        )
-
-    async def _retry_failed_turn_settlements(self) -> None:
-        """Retry terminal TurnStore compaction with capped backoff until it lands."""
-        retry_delay_seconds = self._retry_initial_delay_seconds
-        try:
-            while self._turn_settlement_retry_ids:
-                source_event_ids = tuple(self._turn_settlement_retry_ids)
-                try:
-                    await run_blocking_until_complete(
-                        self.store.settle_pending_from_turn_store,
-                        source_event_ids,
-                    )
-                except asyncio.CancelledError:
-                    raise
-                except Exception:
-                    logger.exception(
-                        "turn_dispatch_obligation_settlement_retry_failed",
-                        source_event_ids=source_event_ids,
-                    )
-                    await asyncio.sleep(retry_delay_seconds)
-                    retry_delay_seconds = min(
-                        retry_delay_seconds * 2,
-                        self._retry_max_delay_seconds,
-                    )
-                else:
-                    self._turn_settlement_retry_ids.difference_update(source_event_ids)
-                    retry_delay_seconds = self._retry_initial_delay_seconds
-        finally:
-            self._turn_settlement_retry_task = None
 
     def register_source_callbacks(self, client: nio.AsyncClient, *, owner: object) -> None:
         """Register every source-backed correctness callback except delayed room lifecycle."""

--- a/src/mindroom/dispatch_obligations/runner.py
+++ b/src/mindroom/dispatch_obligations/runner.py
@@ -277,7 +277,6 @@ class DispatchObligationRunner:
         callback_kind: DispatchCallbackKind,
     ) -> DispatchObligation | None:
         """Persist exact work before its background task may be created."""
-        self._event_loop = asyncio.get_running_loop()
         try:
             obligation = self._obligation_for_event(room, event, callback_kind)
             create_result = await run_blocking_until_complete(self.store.create_pending, obligation)
@@ -392,7 +391,6 @@ class DispatchObligationRunner:
 
     async def recover_pending(self, *, turn_backed: bool | None = None) -> None:
         """Retry every valid pending callback without waiting for another sync response."""
-        self._event_loop = asyncio.get_running_loop()
         failed_keys: list[DispatchObligationKey] = []
         for obligation in await asyncio.to_thread(self.store.pending):
             if turn_backed is not None and (obligation.callback_kind in _TURN_BACKED_KINDS) != turn_backed:

--- a/src/mindroom/edit_regenerator.py
+++ b/src/mindroom/edit_regenerator.py
@@ -361,7 +361,7 @@ class EditRegenerator:
                 on_interrupted_response_recoverable=record_interrupted_turn,
                 sync_restart_retry_source_event_id=retry_source_event_id,
                 on_deferred_outcome_handled=lambda response_event_id: (
-                    self.deps.turn_store.record_turn(replace(record, response_event_id=response_event_id))
+                    self.deps.turn_store.record_responded_turn(replace(record, response_event_id=response_event_id))
                     if applied
                     else None
                 ),
@@ -426,7 +426,7 @@ class EditRegenerator:
             if regenerated_event_id is not None:
                 if not applied:
                     return
-                self.deps.turn_store.record_turn(
+                self.deps.turn_store.record_responded_turn(
                     replace(record, response_event_id=regenerated_event_id),
                 )
                 self._discard(mailbox, applied)

--- a/src/mindroom/reaction_dispatch.py
+++ b/src/mindroom/reaction_dispatch.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from mindroom import interactive
+from mindroom.approval_inbound import handle_tool_approval_action
+from mindroom.authorization import is_authorized_sender
 from mindroom.commands import config_confirmation
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.dispatch_obligations import DispatchSemanticConsumer
@@ -19,7 +21,6 @@ if TYPE_CHECKING:
     import structlog
 
     from mindroom.commands.config_confirmation import ConfigConfirmationContext
-    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.dispatch_obligations import DispatchObligationRunner
     from mindroom.ingress_validation import IngressValidator
@@ -51,8 +52,6 @@ class ReactionDispatcherDeps:
     handle_interactive_selection: Callable[..., Awaitable[None]]
     emit_reaction_received_hooks: Callable[..., Awaitable[None]]
     config_confirmation: ConfigConfirmationContext
-    handle_approval_action: Callable[..., Awaitable[bool]]
-    sender_is_authorized: Callable[[str, Config, str, RuntimePaths], bool]
 
 
 @dataclass
@@ -86,7 +85,7 @@ class ReactionDispatcher:
             )
             approval_claimed = True
 
-        approval_handled = await self.deps.handle_approval_action(
+        approval_handled = await handle_tool_approval_action(
             room=room,
             sender_id=event.sender,
             config=self.deps.runtime.config,
@@ -239,7 +238,7 @@ class ReactionDispatcher:
             )
             return
 
-        if semantic_consumer is None and not self.deps.sender_is_authorized(
+        if semantic_consumer is None and not is_authorized_sender(
             event.sender,
             self.deps.runtime.config,
             room.room_id,

--- a/src/mindroom/turn_settlement_retry.py
+++ b/src/mindroom/turn_settlement_retry.py
@@ -1,0 +1,103 @@
+"""Retry obligation settlement after terminal turn persistence."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+from mindroom.background_tasks import create_background_task, run_blocking_until_complete
+from mindroom.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from mindroom.dispatch_obligations import DispatchObligationStore
+
+logger = get_logger(__name__)
+
+_RETRY_INITIAL_DELAY_SECONDS = 1.0
+_RETRY_MAX_DELAY_SECONDS = 30.0
+
+
+@dataclass
+class TurnSettlementRetry:
+    """Land dispatch-obligation settlement after TurnStore persistence."""
+
+    store: DispatchObligationStore
+    background_task_owner: object | None = None
+    _retry_initial_delay_seconds: float = field(default=_RETRY_INITIAL_DELAY_SECONDS, repr=False)
+    _retry_max_delay_seconds: float = field(default=_RETRY_MAX_DELAY_SECONDS, repr=False)
+    _event_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
+    _source_event_ids: set[str] = field(default_factory=set, init=False, repr=False)
+    _task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
+
+    def bind_event_loop(self) -> None:
+        """Bind the active runtime loop for callbacks arriving from persistence workers."""
+        self._event_loop = asyncio.get_running_loop()
+
+    def retry(self, source_event_ids: tuple[str, ...]) -> None:
+        """Settle terminal sources now or retry them on the active runtime loop."""
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if running_loop is None:
+            try:
+                self.store.settle_pending_from_turn_store(source_event_ids)
+            except Exception:
+                logger.exception(
+                    "turn_dispatch_obligation_initial_settlement_failed",
+                    source_event_ids=source_event_ids,
+                )
+            else:
+                return
+            event_loop = self._event_loop
+            if event_loop is None or event_loop.is_closed():
+                logger.error(
+                    "turn_dispatch_obligation_retry_loop_unavailable",
+                    source_event_ids=source_event_ids,
+                )
+                return
+            event_loop.call_soon_threadsafe(self._enqueue, source_event_ids)
+            return
+        self._event_loop = running_loop
+        self._enqueue(source_event_ids)
+
+    def _enqueue(self, source_event_ids: tuple[str, ...]) -> None:
+        """Add exact terminal sources to the loop-owned settlement retry set."""
+        self._source_event_ids.update(source_event_ids)
+        if self._task is not None and not self._task.done():
+            return
+        self._task = create_background_task(
+            self._run(),
+            name=f"retry_turn_dispatch_settlement_{self.store.entity_name}",
+            owner=self.background_task_owner,
+        )
+
+    async def _run(self) -> None:
+        """Retry terminal obligation settlement with capped backoff until it lands."""
+        retry_delay_seconds = self._retry_initial_delay_seconds
+        try:
+            while self._source_event_ids:
+                source_event_ids = tuple(self._source_event_ids)
+                try:
+                    await run_blocking_until_complete(
+                        self.store.settle_pending_from_turn_store,
+                        source_event_ids,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.exception(
+                        "turn_dispatch_obligation_settlement_retry_failed",
+                        source_event_ids=source_event_ids,
+                    )
+                    await asyncio.sleep(retry_delay_seconds)
+                    retry_delay_seconds = min(
+                        retry_delay_seconds * 2,
+                        self._retry_max_delay_seconds,
+                    )
+                else:
+                    self._source_event_ids.difference_update(source_event_ids)
+                    retry_delay_seconds = self._retry_initial_delay_seconds
+        finally:
+            self._task = None

--- a/src/mindroom/turn_settlement_retry.py
+++ b/src/mindroom/turn_settlement_retry.py
@@ -84,7 +84,12 @@ class TurnSettlementRetry:
                         self.store.settle_pending_from_turn_store,
                         source_event_ids,
                     )
-                except asyncio.CancelledError:
+                except asyncio.CancelledError as error:
+                    logger.info(
+                        "turn_dispatch_obligation_settlement_retry_cancelled",
+                        source_event_ids=tuple(self._source_event_ids),
+                        cancellation_message=str(error) or None,
+                    )
                     raise
                 except Exception:
                     logger.exception(

--- a/tach.toml
+++ b/tach.toml
@@ -116,6 +116,7 @@ depends_on = [
 visibility = [
     "mindroom.bot",
     "mindroom.reaction_dispatch",
+    "mindroom.turn_settlement_retry",
 ]
 
 [[modules]]
@@ -154,6 +155,8 @@ visibility = ["mindroom.dispatch_obligations"]
 [[modules]]
 path = "mindroom.reaction_dispatch"
 depends_on = [
+    "mindroom.approval_inbound",
+    "mindroom.authorization",
     "mindroom.commands.config_confirmation",
     "mindroom.constants",
     "mindroom.dispatch_obligations",
@@ -474,7 +477,10 @@ depends_on = [
     "mindroom.matrix.visible_body",
     "mindroom.tool_approval",
 ]
-visibility = ["mindroom.bot"]
+visibility = [
+    "mindroom.bot",
+    "mindroom.reaction_dispatch",
+]
 
 [[modules]]
 path = "mindroom.tool_approval"
@@ -2872,6 +2878,7 @@ depends_on = [
     "mindroom.tool_system.worker_routing",
     "mindroom.turn_controller",
     "mindroom.turn_policy",
+    "mindroom.turn_settlement_retry",
     "mindroom.turn_store",
     "mindroom.user_stop_reconciliation",
     "mindroom.visible_response_reconciliation",
@@ -3463,6 +3470,15 @@ depends_on = [
     "mindroom.history.storage",
     "mindroom.thread_utils",
 ]
+
+[[modules]]
+path = "mindroom.turn_settlement_retry"
+depends_on = [
+    "mindroom.background_tasks",
+    "mindroom.dispatch_obligations",
+    "mindroom.logging_config",
+]
+visibility = ["mindroom.bot"]
 
 [[modules]]
 path = "mindroom.prompt_ingress_reservation"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1474,6 +1474,9 @@ def replace_turn_controller_deps(bot: RuntimeBot, **changes: object) -> TurnCont
             conversation_cache=rebuilt.deps.conversation_cache,
             user_stop_reconciler=bot._user_stop_reconciler,
             ingress=rebuilt.deps.ingress,
+            stop_manager=bot.stop_manager,
+            reserve_prompt_ingress_order=rebuilt.reserve_prompt_ingress_order,
+            handle_interactive_selection=rebuilt.handle_interactive_selection,
             config_confirmation=replace(
                 reaction_dispatcher.deps.config_confirmation,
                 runtime=rebuilt.deps.runtime,
@@ -1738,5 +1741,6 @@ def bypass_authorization(request: pytest.FixtureRequest) -> Generator[None, None
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=True),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=True),
+            patch("mindroom.reaction_dispatch.is_authorized_sender", return_value=True),
         ):
             yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1341,6 +1341,13 @@ def replace_edit_regenerator_deps(bot: RuntimeBot, **changes: object) -> EditReg
     return rebuilt
 
 
+def replace_reaction_dispatcher_deps(bot: RuntimeBot, **changes: object) -> ReactionDispatcher:
+    """Rebuild reaction dispatch after swapping collaborators captured at construction."""
+    rebuilt = ReactionDispatcher(replace(bot._reaction_dispatcher.deps, **changes))
+    bot._reaction_dispatcher = rebuilt
+    return rebuilt
+
+
 def replace_turn_controller_deps(bot: RuntimeBot, **changes: object) -> TurnController:
     """Rebuild the turn controller after swapping collaborators captured at construction."""
     sync_bot_runtime_state(bot)
@@ -1462,28 +1469,26 @@ def replace_turn_controller_deps(bot: RuntimeBot, **changes: object) -> TurnCont
     rebuilt = TurnController(replace(controller.deps, **rebuilt_changes))
     bot._turn_controller = rebuilt
     reaction_dispatcher = bot._reaction_dispatcher
-    bot._reaction_dispatcher = ReactionDispatcher(
-        replace(
-            reaction_dispatcher.deps,
+    replace_reaction_dispatcher_deps(
+        bot,
+        runtime=rebuilt.deps.runtime,
+        logger=rebuilt.deps.logger,
+        runtime_paths=rebuilt.deps.runtime_paths,
+        agent_name=rebuilt.deps.agent_name,
+        turn_policy=rebuilt.deps.turn_policy,
+        turn_store=rebuilt.deps.turn_store,
+        conversation_cache=rebuilt.deps.conversation_cache,
+        user_stop_reconciler=bot._user_stop_reconciler,
+        ingress=rebuilt.deps.ingress,
+        stop_manager=bot.stop_manager,
+        reserve_prompt_ingress_order=rebuilt.reserve_prompt_ingress_order,
+        handle_interactive_selection=rebuilt.handle_interactive_selection,
+        config_confirmation=replace(
+            reaction_dispatcher.deps.config_confirmation,
             runtime=rebuilt.deps.runtime,
-            logger=rebuilt.deps.logger,
             runtime_paths=rebuilt.deps.runtime_paths,
-            agent_name=rebuilt.deps.agent_name,
-            turn_policy=rebuilt.deps.turn_policy,
-            turn_store=rebuilt.deps.turn_store,
-            conversation_cache=rebuilt.deps.conversation_cache,
-            user_stop_reconciler=bot._user_stop_reconciler,
-            ingress=rebuilt.deps.ingress,
-            stop_manager=bot.stop_manager,
-            reserve_prompt_ingress_order=rebuilt.reserve_prompt_ingress_order,
-            handle_interactive_selection=rebuilt.handle_interactive_selection,
-            config_confirmation=replace(
-                reaction_dispatcher.deps.config_confirmation,
-                runtime=rebuilt.deps.runtime,
-                runtime_paths=rebuilt.deps.runtime_paths,
-                build_message_target=rebuilt.deps.resolver.build_message_target,
-                delivery_gateway=rebuilt.deps.delivery_gateway,
-            ),
+            build_message_target=rebuilt.deps.resolver.build_message_target,
+            delivery_gateway=rebuilt.deps.delivery_gateway,
         ),
     )
     edit_changes = {

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -32,6 +32,7 @@ from mindroom.hooks import (
     hook,
 )
 from mindroom.message_target import MessageTarget
+from mindroom.reaction_dispatch import ReactionDispatcher
 from mindroom.tool_approval import ApprovalActionResult, MatrixApprovalAction, _shutdown_approval_store
 from tests.bot_helpers import (
     AgentBotTestBase,
@@ -89,6 +90,10 @@ async def _cancel_dispatch_retry(bot: AgentBot) -> None:
     retry_task.cancel()
     with suppress(asyncio.CancelledError):
         await retry_task
+
+
+def _replace_reaction_dispatcher_deps(bot: AgentBot, **changes: object) -> None:
+    bot._reaction_dispatcher = ReactionDispatcher(replace(bot._reaction_dispatcher.deps, **changes))
 
 
 def _approval_reply_event(event_id: str = "$approval-reply") -> nio.RoomMessageText:
@@ -256,22 +261,20 @@ class TestAgentBot(AgentBotTestBase):
         room.room_id = "!test:localhost"
         room.canonical_alias = None
         event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
+        _replace_reaction_dispatcher_deps(bot, handle_interactive_selection=AsyncMock())
 
-        with (
-            patch(
-                "mindroom.bot.interactive.handle_reaction",
-                new=AsyncMock(
-                    return_value=interactive.InteractiveSelection(
-                        question_event_id="$question",
-                        question_text="Choose one",
-                        selection_key="1",
-                        selected_label="Selected",
-                        selected_value="Selected",
-                        thread_id=None,
-                    ),
+        with patch(
+            "mindroom.bot.interactive.handle_reaction",
+            new=AsyncMock(
+                return_value=interactive.InteractiveSelection(
+                    question_event_id="$question",
+                    question_text="Choose one",
+                    selection_key="1",
+                    selected_label="Selected",
+                    selected_value="Selected",
+                    thread_id=None,
                 ),
             ),
-            patch.object(bot._turn_controller, "handle_interactive_selection", new=AsyncMock()),
         ):
             await _dispatch_reaction(bot, room, event)
 
@@ -422,10 +425,8 @@ class TestAgentBot(AgentBotTestBase):
             selection_started.set()
             assert bot._coalescing_gate.lanes.unsettled_slots()
 
-        with (
-            patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)),
-            patch.object(bot._turn_controller, "handle_interactive_selection", side_effect=handle_selection),
-        ):
+        _replace_reaction_dispatcher_deps(bot, handle_interactive_selection=handle_selection)
+        with patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)):
             await _dispatch_reaction(bot, room, event)
 
         await asyncio.wait_for(selection_started.wait(), timeout=0.5)
@@ -464,10 +465,10 @@ class TestAgentBot(AgentBotTestBase):
             await release_approval.wait()
             return False
 
+        _replace_reaction_dispatcher_deps(bot, handle_interactive_selection=AsyncMock())
         with (
-            patch("mindroom.bot.handle_tool_approval_action", side_effect=delayed_approval),
+            patch("mindroom.reaction_dispatch.handle_tool_approval_action", side_effect=delayed_approval),
             patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)),
-            patch.object(bot._turn_controller, "handle_interactive_selection", new=AsyncMock()),
         ):
             reaction_task = asyncio.create_task(_dispatch_reaction(bot, room, event))
             await asyncio.wait_for(approval_started.wait(), timeout=0.5)
@@ -507,7 +508,7 @@ class TestAgentBot(AgentBotTestBase):
         approval_handler = AsyncMock(return_value=True)
         with (
             patch("mindroom.turn_policy.is_sender_allowed_for_agent_reply", return_value=False),
-            patch("mindroom.bot.handle_tool_approval_action", approval_handler),
+            patch("mindroom.reaction_dispatch.handle_tool_approval_action", approval_handler),
             patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock()) as interactive_handler,
         ):
             await _dispatch_reaction(bot, room, event)
@@ -1650,14 +1651,13 @@ class TestAgentBot(AgentBotTestBase):
             thread_id=None,
         )
         failure = RuntimeError("crash after interactive reaction claim")
+        _replace_reaction_dispatcher_deps(
+            bot,
+            handle_interactive_selection=AsyncMock(side_effect=failure),
+        )
 
         with (
             patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)),
-            patch.object(
-                bot._turn_controller,
-                "handle_interactive_selection",
-                new=AsyncMock(side_effect=failure),
-            ),
             pytest.raises(RuntimeError, match="crash after interactive reaction claim"),
         ):
             await bot._dispatch_obligation_runner.dispatch(room, event, DispatchCallbackKind.REACTION)

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -32,7 +32,6 @@ from mindroom.hooks import (
     hook,
 )
 from mindroom.message_target import MessageTarget
-from mindroom.reaction_dispatch import ReactionDispatcher
 from mindroom.tool_approval import ApprovalActionResult, MatrixApprovalAction, _shutdown_approval_store
 from tests.bot_helpers import (
     AgentBotTestBase,
@@ -46,6 +45,7 @@ from tests.bot_helpers import (
 )
 from tests.conftest import (
     make_matrix_client_mock,
+    replace_reaction_dispatcher_deps,
     runtime_paths_for,
     unwrap_extracted_collaborator,
 )
@@ -90,10 +90,6 @@ async def _cancel_dispatch_retry(bot: AgentBot) -> None:
     retry_task.cancel()
     with suppress(asyncio.CancelledError):
         await retry_task
-
-
-def _replace_reaction_dispatcher_deps(bot: AgentBot, **changes: object) -> None:
-    bot._reaction_dispatcher = ReactionDispatcher(replace(bot._reaction_dispatcher.deps, **changes))
 
 
 def _approval_reply_event(event_id: str = "$approval-reply") -> nio.RoomMessageText:
@@ -261,7 +257,7 @@ class TestAgentBot(AgentBotTestBase):
         room.room_id = "!test:localhost"
         room.canonical_alias = None
         event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
-        _replace_reaction_dispatcher_deps(bot, handle_interactive_selection=AsyncMock())
+        replace_reaction_dispatcher_deps(bot, handle_interactive_selection=AsyncMock())
 
         with patch(
             "mindroom.bot.interactive.handle_reaction",
@@ -425,7 +421,7 @@ class TestAgentBot(AgentBotTestBase):
             selection_started.set()
             assert bot._coalescing_gate.lanes.unsettled_slots()
 
-        _replace_reaction_dispatcher_deps(bot, handle_interactive_selection=handle_selection)
+        replace_reaction_dispatcher_deps(bot, handle_interactive_selection=handle_selection)
         with patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)):
             await _dispatch_reaction(bot, room, event)
 
@@ -465,7 +461,7 @@ class TestAgentBot(AgentBotTestBase):
             await release_approval.wait()
             return False
 
-        _replace_reaction_dispatcher_deps(bot, handle_interactive_selection=AsyncMock())
+        replace_reaction_dispatcher_deps(bot, handle_interactive_selection=AsyncMock())
         with (
             patch("mindroom.reaction_dispatch.handle_tool_approval_action", side_effect=delayed_approval),
             patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)),
@@ -1651,7 +1647,7 @@ class TestAgentBot(AgentBotTestBase):
             thread_id=None,
         )
         failure = RuntimeError("crash after interactive reaction claim")
-        _replace_reaction_dispatcher_deps(
+        replace_reaction_dispatcher_deps(
             bot,
             handle_interactive_selection=AsyncMock(side_effect=failure),
         )

--- a/tests/test_dispatch_obligations.py
+++ b/tests/test_dispatch_obligations.py
@@ -1788,67 +1788,6 @@ async def test_deferred_turn_retry_without_obligation_skips_backoff(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_terminal_turn_settlement_retries_autonomously(tmp_path: Path) -> None:
-    """A failed terminal compaction must retry without restart or a fabricated callback key."""
-
-    async def callback(_room: nio.MatrixRoom, _event: nio.Event) -> DispatchCallbackResult:
-        return DispatchCallbackResult.SUCCEEDED
-
-    owner = object()
-    runner = _runner(
-        _store(tmp_path),
-        callback,
-        background_task_owner=owner,
-        retry_initial_delay_seconds=0,
-        retry_max_delay_seconds=0,
-    )
-    settled = threading.Event()
-    attempts = 0
-
-    def settle_pending(_source_event_ids: tuple[str, ...]) -> None:
-        nonlocal attempts
-        attempts += 1
-        if attempts == 1:
-            message = "dispatch store unavailable"
-            raise OSError(message)
-        settled.set()
-
-    settle = MagicMock(side_effect=settle_pending)
-    runner.store.settle_pending_from_turn_store = settle
-
-    runner.bind_event_loop()
-    await asyncio.to_thread(runner.retry_turn_settlement, ("$message",))
-    assert await asyncio.wait_for(asyncio.to_thread(settled.wait), timeout=1)
-    await wait_for_background_tasks(timeout=1, owner=owner)
-
-    assert settle.call_count == 2
-    settle.assert_called_with(("$message",))
-
-
-@pytest.mark.asyncio
-async def test_terminal_turn_settlement_succeeds_in_persistence_worker_without_retry_task(tmp_path: Path) -> None:
-    """The normal post-persist callback must finish before returning from its worker."""
-
-    async def callback(_room: nio.MatrixRoom, _event: nio.Event) -> DispatchCallbackResult:
-        return DispatchCallbackResult.SUCCEEDED
-
-    owner = object()
-    runner = _runner(
-        _store(tmp_path),
-        callback,
-        background_task_owner=owner,
-    )
-    settle = MagicMock()
-    runner.store.settle_pending_from_turn_store = settle
-
-    await asyncio.to_thread(runner.retry_turn_settlement, ("$message",))
-
-    settle.assert_called_once_with(("$message",))
-    assert runner._turn_settlement_retry_task is None
-    assert await wait_for_background_tasks(timeout=0, owner=owner) is True
-
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize("entrypoint", ["direct", "admission"])
 async def test_persist_failure_notifies_once_for_every_runner_entrypoint(
     tmp_path: Path,

--- a/tests/test_edit_regenerator.py
+++ b/tests/test_edit_regenerator.py
@@ -189,6 +189,7 @@ def _harness(tmp_path: Path, *, turn_record: TurnRecord | None, receipt_order: i
         current_turn_record[0] = record
 
     turn_store.record_turn.side_effect = record_turn
+    turn_store.record_responded_turn.side_effect = record_turn
     turn_store.record_turn_durably.side_effect = record_turn
     turn_store.build_run_metadata.return_value = dict(RUN_METADATA)
     turn_store.prepare_edit_response_source.return_value = False
@@ -274,8 +275,8 @@ async def test_simple_edit_regenerates_and_records_new_response(tmp_path: Path) 
     metadata_kwargs = harness.turn_store.build_run_metadata.call_args.kwargs
     assert metadata_kwargs["additional_discovery_event_ids"] == ()
 
-    harness.turn_store.record_turn.assert_called_once()
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    harness.turn_store.record_responded_turn.assert_called_once()
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.response_event_id == NEW_RESPONSE_EVENT_ID
     assert recorded.source_event_ids == (ORIGINAL_EVENT_ID,)
     assert recorded.anchor_event_id == ORIGINAL_EVENT_ID
@@ -344,7 +345,7 @@ async def test_newer_same_source_edit_rejects_older_callback_during_generation(t
 
     harness.generate_response.assert_awaited_once()
     assert harness.generate_response.await_args.args[0].prompt == "newest body"
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.source_event_prompts == {ORIGINAL_EVENT_ID: "newest body"}
     assert recorded.source_event_revisions == {
         ORIGINAL_EVENT_ID: (1_000_010, "$edit-z:example.org"),
@@ -465,7 +466,7 @@ async def test_concurrent_coalesced_sibling_edits_are_both_retained(tmp_path: Pa
             {first_event_id: "first edited", second_event_id: "second edited"},
         ),
     ]
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.source_event_prompts == {
         first_event_id: "first edited",
         second_event_id: "second edited",
@@ -627,7 +628,7 @@ async def test_newer_edit_arriving_under_response_lock_is_drained(tmp_path: Path
         "older body",
         "newest body",
     ]
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.source_event_prompts == {ORIGINAL_EVENT_ID: "newest body"}
     assert recorded.source_event_revisions == {
         ORIGINAL_EVENT_ID: (1_000_020, "$edit-new:example.org"),
@@ -683,7 +684,7 @@ async def test_cancelled_drain_is_retried_by_waiting_newer_edit(tmp_path: Path) 
     await retry_task
 
     assert generation_count == 2
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.source_event_revisions == {
         ORIGINAL_EVENT_ID: (1_000_020, "$edit-retry:example.org"),
     }
@@ -720,7 +721,7 @@ async def test_persisted_revision_rejects_stale_edit_after_regenerator_restart(t
         server_timestamp=1_000_020,
     )
     await _handle_edit(first_harness, newer, newer_info)
-    persisted_record = first_harness.turn_store.record_turn.call_args.args[0]
+    persisted_record = first_harness.turn_store.record_responded_turn.call_args.args[0]
 
     restarted_harness = _harness(tmp_path, turn_record=persisted_record)
     older, older_info = _edit_event(
@@ -1072,7 +1073,7 @@ async def test_coalesced_edit_rebuilds_combined_prompt(tmp_path: Path) -> None:
     }
     assert metadata_call.kwargs["additional_discovery_event_ids"] == ()
 
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.response_event_id == NEW_RESPONSE_EVENT_ID
     assert recorded.source_event_prompts == {
         first_event_id: "edited first message",
@@ -1252,7 +1253,7 @@ async def test_coalesced_edit_preserves_tagged_source_metadata(tmp_path: Path) -
 
     handled_turn = harness.turn_store.build_run_metadata.call_args.args[0]
     assert handled_turn.source_event_metadata == record.source_event_metadata
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.source_event_metadata == record.source_event_metadata
 
 
@@ -1308,7 +1309,7 @@ async def test_multi_sender_coalesced_source_allows_only_its_sender_to_edit(
     request = harness.generate_response.await_args.args[0]
     assert request.user_id == sender
     assert "what is 3+3?" in request.prompt
-    assert harness.turn_store.record_turn.call_args.args[0].source_event_revisions == {
+    assert harness.turn_store.record_responded_turn.call_args.args[0].source_event_revisions == {
         original_event_id: (event.server_timestamp, event.event_id),
     }
 
@@ -1354,7 +1355,7 @@ async def test_physical_source_edit_outranks_colliding_discovery_alias(tmp_path:
     assert "human edited" in request.prompt
     assert "human base" not in request.prompt
     assert "relay base" in request.prompt
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.source_event_prompts == {
         relay_event_id: "relay base",
         human_event_id: "human edited",
@@ -1414,7 +1415,7 @@ async def test_coalesced_routed_alias_edit_updates_owned_relay_prompt(tmp_path: 
     request = harness.generate_response.await_args.args[0]
     assert "first edited" in request.prompt
     assert "first base" not in request.prompt
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.source_event_prompts == {first_relay: "first edited", second_relay: "second base"}
     assert recorded.source_event_revisions == {first_human: (event.server_timestamp, event.event_id)}
 
@@ -1674,7 +1675,7 @@ async def test_edit_after_durable_user_stop_can_regenerate(tmp_path: Path) -> No
     await _handle_edit(harness, event, event_info)
 
     harness.generate_response.assert_awaited_once()
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.user_stop_settled_receipt_order == 2
 
 
@@ -1697,7 +1698,7 @@ async def test_restart_replays_durably_committed_interrupted_edit(tmp_path: Path
     request = harness.generate_response.await_args.args[0]
     assert request.prompt == "latest after process restart"
     assert request.sync_restart_retry_source_event_id == ORIGINAL_EVENT_ID
-    recorded = harness.turn_store.record_turn.call_args.args[0]
+    recorded = harness.turn_store.record_responded_turn.call_args.args[0]
     assert recorded.source_event_revisions == {ORIGINAL_EVENT_ID: revision}
 
 

--- a/tests/test_ingress_lanes.py
+++ b/tests/test_ingress_lanes.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-from dataclasses import replace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -27,10 +26,14 @@ from mindroom.dispatch_source import (
 )
 from mindroom.matrix.thread_membership import ThreadMembershipLookupError
 from mindroom.message_target import MessageTarget
-from mindroom.reaction_dispatch import ReactionDispatcher
 from mindroom.runtime_shutdown import SYNC_RESTART_SHUTDOWN
 from tests.bot_helpers import dispatch_reaction_durably
-from tests.conftest import prepared_dispatch_result, replace_turn_controller_deps, unwrap_extracted_collaborator
+from tests.conftest import (
+    prepared_dispatch_result,
+    replace_reaction_dispatcher_deps,
+    replace_turn_controller_deps,
+    unwrap_extracted_collaborator,
+)
 from tests.test_live_message_coalescing import (
     _enqueue_for_dispatch,
     _image_event,
@@ -1077,11 +1080,9 @@ async def test_edit_and_reaction_slots_settle_before_their_execution_finishes(tm
     edit_task: asyncio.Task[None] | None = None
     reaction_task: asyncio.Task[None] | None = None
     try:
-        bot._reaction_dispatcher = ReactionDispatcher(
-            replace(
-                bot._reaction_dispatcher.deps,
-                handle_interactive_selection=blocked_selection,
-            ),
+        replace_reaction_dispatcher_deps(
+            bot,
+            handle_interactive_selection=blocked_selection,
         )
         with (
             patch.object(bot._edit_regenerator, "handle_message_edit", new=AsyncMock(side_effect=blocked_edit)),

--- a/tests/test_ingress_lanes.py
+++ b/tests/test_ingress_lanes.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from dataclasses import replace
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -26,6 +27,7 @@ from mindroom.dispatch_source import (
 )
 from mindroom.matrix.thread_membership import ThreadMembershipLookupError
 from mindroom.message_target import MessageTarget
+from mindroom.reaction_dispatch import ReactionDispatcher
 from mindroom.runtime_shutdown import SYNC_RESTART_SHUTDOWN
 from tests.bot_helpers import dispatch_reaction_durably
 from tests.conftest import prepared_dispatch_result, replace_turn_controller_deps, unwrap_extracted_collaborator
@@ -1075,13 +1077,14 @@ async def test_edit_and_reaction_slots_settle_before_their_execution_finishes(tm
     edit_task: asyncio.Task[None] | None = None
     reaction_task: asyncio.Task[None] | None = None
     try:
+        bot._reaction_dispatcher = ReactionDispatcher(
+            replace(
+                bot._reaction_dispatcher.deps,
+                handle_interactive_selection=blocked_selection,
+            ),
+        )
         with (
             patch.object(bot._edit_regenerator, "handle_message_edit", new=AsyncMock(side_effect=blocked_edit)),
-            patch.object(
-                bot._turn_controller,
-                "handle_interactive_selection",
-                new=AsyncMock(side_effect=blocked_selection),
-            ),
         ):
             edit_task = asyncio.create_task(bot._turn_controller.handle_text_event(room, edit_event))
             await asyncio.wait_for(edit_started.wait(), timeout=1.0)

--- a/tests/test_matrix_sync_tokens.py
+++ b/tests/test_matrix_sync_tokens.py
@@ -113,24 +113,12 @@ def test_dispatch_recovery_room_contract_prefers_cache_and_guarantees_room_id(tm
 
 def test_terminal_turn_settlement_hands_sqlite_work_to_event_loop_owner(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Handled-turn persistence callbacks must not run obligation SQLite inline."""
+    """Handled-turn persistence delegates settlement to its dedicated retry owner."""
     bot = _agent_bot(tmp_path)
-    retry_turn_settlement = MagicMock()
-    monkeypatch.setattr(
-        bot._dispatch_obligation_runner,
-        "retry_turn_settlement",
-        retry_turn_settlement,
-        raising=False,
-    )
-    settle_pending = MagicMock()
-    monkeypatch.setattr(bot._dispatch_obligation_store, "settle_pending_from_turn_store", settle_pending)
+    callback = bot._turn_store.deps.on_terminal_turn_persisted
 
-    bot._settle_turn_dispatch_obligations(("$message",))
-
-    settle_pending.assert_not_called()
-    retry_turn_settlement.assert_called_once_with(("$message",))
+    assert callback == bot._turn_settlement_retry.retry
 
 
 def _install_fast_response_drain(bot: AgentBot) -> None:

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -1011,6 +1011,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch("mindroom.bot.is_authorized_sender", return_value=False),
             patch("mindroom.ingress_validation.is_authorized_sender", return_value=False),
+            patch("mindroom.reaction_dispatch.is_authorized_sender", return_value=False),
         ):
             await self._invoke_handler(bot, handler_name, room, event)
 

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -66,6 +66,7 @@ from mindroom.tool_system.runtime_context import ToolRuntimeSupport
 from mindroom.turn_controller import TurnController, TurnControllerDeps
 from mindroom.turn_origin import TurnIntent
 from mindroom.turn_policy import IngressHookRunner, PreparedDispatch, ResponseAction, TurnPolicy, TurnPolicyDeps
+from mindroom.turn_settlement_retry import TurnSettlementRetry
 from mindroom.turn_store import TurnStore, TurnStoreDeps
 from mindroom.visible_response_reconciliation import VisibleResponseReconciler, VisibleResponseReconcilerDeps
 from mindroom.visible_voice_echo import VisibleVoiceEchoDeps, VisibleVoiceEchoLifecycle
@@ -1111,9 +1112,10 @@ async def test_duplicate_router_relay_claim_settles_without_restart(config: Conf
         entity_name="general",
         room=room,
     )
+    turn_settlement_retry = TurnSettlementRetry(store=obligation_store)
     harness.turn_store.deps = replace(
         harness.turn_store.deps,
-        on_terminal_turn_persisted=obligation_runner.retry_turn_settlement,
+        on_terminal_turn_persisted=turn_settlement_retry.retry,
     )
     normalization_started = asyncio.Event()
     release_normalization = asyncio.Event()
@@ -1143,8 +1145,8 @@ async def test_duplicate_router_relay_claim_settles_without_restart(config: Conf
 
     await harness.gate.drain_all()
     await harness.runner.settle_inbox_responses()
-    if obligation_runner._turn_settlement_retry_task is not None:
-        await obligation_runner._turn_settlement_retry_task
+    if turn_settlement_retry._task is not None:
+        await turn_settlement_retry._task
 
     assert not obligation_store.has_pending(first.event_id, DispatchCallbackKind.MESSAGE)
     assert not obligation_store.has_pending(second.event_id, DispatchCallbackKind.MESSAGE)

--- a/tests/test_turn_settlement_retry.py
+++ b/tests/test_turn_settlement_retry.py
@@ -1,0 +1,61 @@
+"""Turn-backed dispatch-obligation settlement retry ownership."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+
+from mindroom.background_tasks import wait_for_background_tasks
+from mindroom.dispatch_obligations import DispatchObligationStore
+from mindroom.turn_settlement_retry import TurnSettlementRetry
+
+
+@pytest.mark.asyncio
+async def test_terminal_turn_settlement_retries_autonomously() -> None:
+    """A failed terminal compaction retries without fabricating a callback key."""
+    owner = object()
+    store = MagicMock(spec=DispatchObligationStore)
+    store.entity_name = "code"
+    retry = TurnSettlementRetry(
+        store=store,
+        background_task_owner=owner,
+        _retry_initial_delay_seconds=0,
+        _retry_max_delay_seconds=0,
+    )
+    settled = threading.Event()
+    attempts = 0
+
+    def settle_pending(_source_event_ids: tuple[str, ...]) -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            message = "dispatch store unavailable"
+            raise OSError(message)
+        settled.set()
+
+    store.settle_pending_from_turn_store.side_effect = settle_pending
+
+    retry.bind_event_loop()
+    await asyncio.to_thread(retry.retry, ("$message",))
+    assert await asyncio.wait_for(asyncio.to_thread(settled.wait), timeout=1)
+    await wait_for_background_tasks(timeout=1, owner=owner)
+
+    assert store.settle_pending_from_turn_store.call_count == 2
+    store.settle_pending_from_turn_store.assert_called_with(("$message",))
+
+
+@pytest.mark.asyncio
+async def test_terminal_turn_settlement_succeeds_in_persistence_worker_without_retry_task() -> None:
+    """The normal post-persist callback finishes before returning from its worker."""
+    owner = object()
+    store = MagicMock(spec=DispatchObligationStore)
+    retry = TurnSettlementRetry(store=store, background_task_owner=owner)
+
+    await asyncio.to_thread(retry.retry, ("$message",))
+
+    store.settle_pending_from_turn_store.assert_called_once_with(("$message",))
+    assert retry._task is None
+    assert await wait_for_background_tasks(timeout=0, owner=owner) is True


### PR DESCRIPTION
## Summary

- move TurnStore-driven obligation settlement retry into a dedicated owner
- remove test-only late-binding reaction lambdas and use one shared test seam
- route regenerated visible responses through the canonical TurnStore invariant
- update architecture docs and generated references for the extracted subsystem

## Invariants

- DispatchObligationRunner owns callback admission, execution, recovery, and callback retry only.
- TurnSettlementRetry owns the independent terminal-turn-to-obligation settlement loop.
- TurnStore.record_responded_turn is the only edit-regeneration path for visible terminal outcomes.
- AgentBot remains composition wiring.

## Size

Production source: +123/-101, net +22 lines.
DispatchObligationRunner: -78 lines.
AgentBot: -7 lines.

## Validation

- full pytest suite, including PostgreSQL fuzz/stress
- focused durability, reaction, ingress, routing, STOP, and edit-regeneration suites
- tach dependencies/interfaces
- privata method boundaries
- pre-commit --all-files
- full GitHub CI and smoke suite