### PR TITLE
Fix sync recovery restart boundaries after #1758

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -102,6 +102,8 @@ Malformed or future continuity records are durably repaired to an empty cold rec
 Continuity reads and writes run off the event loop, and retry decisions use the checkpoint already loaded or applied by `SyncCacheTrust`.
 Classic Sync response-owned lifecycle hooks and their durable de-duplication markers complete before `SyncCacheTrust` certifies the response checkpoint.
 `RoomMemberHookLifecycle` owns Classic baseline and catch-up authority while keeping Sliding Sync history fenced.
+It retains the full-state baseline in memory across uncertain responses and records it only at a certifiable response, after exact admitted lifecycle obligations can fence their room/member markers.
+If the one-shot Classic full-state request fails, the receive iteration exits so its replacement requests full state again before capturing a baseline.
 Classic and Sliding response handlers drain admitted room-member lifecycle obligations before checkpoint certification or response readiness, so generic startup recovery cannot race onboarding work.
 Malformed room-member lifecycle obligations fence snapshot-marker writes for their entire room and remain durable for operator repair.
 Live `room-member-joined` hooks are at-least-once because hook emission happens before the durable seen marker, so a marker write failure replays the hook instead of losing it.

--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -88,17 +88,21 @@ The registered `DispatchObligationRunner` source callback durably accepts each r
 The pinned nio recovery contract publishes a recovered-room outcome only after every non-live callback succeeds and republishes every open gap as unrecovered on each response.
 Raw sync-cache continuity remains owned separately by `SyncCacheTrust`, so a durable pending dispatch obligation is sufficient to preserve a certified checkpoint.
 `SyncCacheTrust` certifies a complete recovered response, rewinds every locally incomplete, failed, or nio-unrecovered response to the retained pre-gap checkpoint, and relies on nio's persisted aggregate gap state instead of duplicating it.
+A safe-checkpoint startup retains its catch-up replay debt through intermediate nio recovery settlement and clears that debt only after a response certifies.
 A positioned limited room absent from both typed outcome sets has no real nio recovery gap and may certify, including membership-reset windows.
 When no generation-safe checkpoint exists, `SyncCacheTrust` lets one locally complete and error-free limited response advance without a token reset so nio can position itself and classify that gap.
 Classic receive-loop exit also reconciles nio's live cursor with the last certified checkpoint, covering cancellation after nio applies a response but before its response callback starts.
+A server-rejected Classic cursor clears the persisted transport token and rejected historical recovery generations while moving every unstarted live event into a fresh synthetic generation for later dispatch.
 The pinned mindroom-nio contract supplies durable `LIVE` or `HISTORY` provenance with every timeline-event admission.
 The aggregate admission owner durably caches every historical event through the room-ordered sync mutation path before applying the cold-history dispatch fence, so `/messages` recovery cannot complete without its point rows and redaction effects.
-`ColdHistoryFence` admits live events immediately and admits historical events only when the exact event and callback kind are already durably pending.
+`ColdHistoryFence` admits live events immediately and admits historical events only when the exact callback is already pending or the room-member lifecycle phase explicitly owns catch-up recovery.
 The same event-scoped provenance gates auxiliary room callbacks, so one live event cannot license unrelated historical call-state mutations.
 Checkpoint mutations serialize their epoch check, durable transform, and runtime publication, while continuity revisions prevent older completed tasks from overwriting newer join-fence state.
 Malformed or future continuity records are durably repaired to an empty cold record before startup room lifecycle restoration.
 Continuity reads and writes run off the event loop, and retry decisions use the checkpoint already loaded or applied by `SyncCacheTrust`.
 Classic Sync response-owned lifecycle hooks and their durable de-duplication markers complete before `SyncCacheTrust` certifies the response checkpoint.
+`RoomMemberHookLifecycle` owns baseline, catch-up, and live phases, persists authorized timeline joins while ordinary hooks are fenced, and drains those lifecycle obligations before certification.
+Malformed room-member lifecycle obligations fence snapshot-marker writes for their entire room and remain durable for operator repair.
 Live `room-member-joined` hooks are at-least-once because hook emission happens before the durable seen marker, so a marker write failure replays the hook instead of losing it.
 Invite and response-owned lifecycle paths use the same runner directly because they are outside nio timeline fanout.
 Current invite callbacks bypass cold-history admission because they represent live membership work, while their callback runner still provides exact durable retry.

--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -88,20 +88,21 @@ The registered `DispatchObligationRunner` source callback durably accepts each r
 The pinned nio recovery contract publishes a recovered-room outcome only after every non-live callback succeeds and republishes every open gap as unrecovered on each response.
 Raw sync-cache continuity remains owned separately by `SyncCacheTrust`, so a durable pending dispatch obligation is sufficient to preserve a certified checkpoint.
 `SyncCacheTrust` certifies a complete recovered response, rewinds every locally incomplete, failed, or nio-unrecovered response to the retained pre-gap checkpoint, and relies on nio's persisted aggregate gap state instead of duplicating it.
-A safe-checkpoint startup retains its catch-up replay debt through intermediate nio recovery settlement and clears that debt only after a response certifies.
+A safe-checkpoint startup retains its catch-up replay debt through intermediate nio recovery settlement, then discharges that one-shot debt when a response certifies, resets to the retained safe checkpoint for replay, or discards continuity.
 A positioned limited room absent from both typed outcome sets has no real nio recovery gap and may certify, including membership-reset windows.
 When no generation-safe checkpoint exists, `SyncCacheTrust` lets one locally complete and error-free limited response advance without a token reset so nio can position itself and classify that gap.
 Classic receive-loop exit also reconciles nio's live cursor with the last certified checkpoint, covering cancellation after nio applies a response but before its response callback starts.
 A server-rejected Classic cursor clears the persisted transport token and rejected historical recovery generations while moving every unstarted live event into a fresh synthetic generation for later dispatch.
 The pinned mindroom-nio contract supplies durable `LIVE` or `HISTORY` provenance with every timeline-event admission.
 The aggregate admission owner durably caches every historical event through the room-ordered sync mutation path before applying the cold-history dispatch fence, so `/messages` recovery cannot complete without its point rows and redaction effects.
-`ColdHistoryFence` admits live events immediately and admits historical events only when the exact callback is already pending or the room-member lifecycle phase explicitly owns catch-up recovery.
+`ColdHistoryFence` admits live events immediately and admits historical events only when the exact callback is already pending or the Classic room-member lifecycle phase explicitly owns catch-up recovery.
 The same event-scoped provenance gates auxiliary room callbacks, so one live event cannot license unrelated historical call-state mutations.
 Checkpoint mutations serialize their epoch check, durable transform, and runtime publication, while continuity revisions prevent older completed tasks from overwriting newer join-fence state.
 Malformed or future continuity records are durably repaired to an empty cold record before startup room lifecycle restoration.
 Continuity reads and writes run off the event loop, and retry decisions use the checkpoint already loaded or applied by `SyncCacheTrust`.
 Classic Sync response-owned lifecycle hooks and their durable de-duplication markers complete before `SyncCacheTrust` certifies the response checkpoint.
-`RoomMemberHookLifecycle` owns baseline, catch-up, and live phases, persists authorized timeline joins while ordinary hooks are fenced, and drains those lifecycle obligations before certification.
+`RoomMemberHookLifecycle` owns Classic baseline and catch-up authority while keeping Sliding Sync history fenced.
+Classic and Sliding response handlers drain admitted room-member lifecycle obligations before checkpoint certification or response readiness, so generic startup recovery cannot race onboarding work.
 Malformed room-member lifecycle obligations fence snapshot-marker writes for their entire room and remain durable for operator repair.
 Live `room-member-joined` hooks are at-least-once because hook emission happens before the durable seen marker, so a marker write failure replays the hook instead of losing it.
 Invite and response-owned lifecycle paths use the same runner directly because they are outside nio timeline fanout.

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -117,7 +117,7 @@ from .knowledge import KnowledgeAccessSupport
 from .logging_config import get_logger
 from .matrix.avatar import check_and_set_avatar
 from .matrix.client_room_admin import get_joined_rooms
-from .matrix.client_session import PermanentMatrixStartupError
+from .matrix.client_session import PermanentMatrixStartupError, timeline_event_has_authoritative_room_state
 from .matrix.joined_room_history import cache_fenced_world_readable_join_history
 from .matrix.room_member_joins import (
     RoomMemberJoin,
@@ -335,6 +335,7 @@ class AgentBot:
     _turn_controller: TurnController
     _room_lifecycle: BotRoomLifecycle
     _local_departures_awaiting_sync: set[str]
+    _rejected_sync_room_ids: set[str]
     _sync_continuity_store: SyncContinuityStore
     _sync_cache_trust: SyncCacheTrust
     _cold_history_fence: ColdHistoryFence
@@ -391,6 +392,7 @@ class AgentBot:
         self._call_manager: CallManager | None = None
         self._calls_reconcile_pending = False
         self._local_departures_awaiting_sync = set()
+        self._rejected_sync_room_ids = set()
 
         async def send_room_lifecycle_response(
             *,
@@ -1587,6 +1589,7 @@ class AgentBot:
         if _response.status_code == "M_UNKNOWN_POS":
             client = self.client
             assert client is not None
+            self._rejected_sync_room_ids.update(client.rooms)
 
             async def reject_position() -> None:
                 try:
@@ -1692,12 +1695,17 @@ class AgentBot:
 
     def _admit_live_call_event(self, _room: nio.MatrixRoom, event: nio.Event) -> bool:
         """Admit call-runtime room state only for this live nio delivery."""
-        return self._cold_history_fence.event_is_live(event.event_id)
+        return self._cold_history_fence.event_is_live(event.event_id) and timeline_event_has_authoritative_room_state()
 
     async def _apply_own_room_membership_from_sync(self, response: nio.SyncResponse) -> None:
         """Apply this bot's authoritative joined/left room sections before other sync work."""
         joined_room_ids = set(response.rooms.join)
-        left_room_ids = set(response.rooms.leave)
+        client = self.client
+        rejected_position_departures = self._rejected_sync_room_ids - joined_room_ids
+        if client is not None:
+            for room_id in rejected_position_departures:
+                client.rooms.pop(room_id, None)
+        left_room_ids = set(response.rooms.leave) | rejected_position_departures
         timeline_departure_room_ids = {
             room_id
             for room_id, room_info in response.rooms.join.items()
@@ -1713,6 +1721,7 @@ class AgentBot:
             left_room_ids=left_room_ids,
             departed_room_ids=left_room_ids | timeline_departure_room_ids,
         )
+        self._rejected_sync_room_ids.clear()
 
     async def _apply_own_room_membership_from_sliding_sync(self, response: nio.SlidingSyncResponse) -> None:
         """Apply this bot's room memberships reported by one sliding sync response."""
@@ -1949,6 +1958,7 @@ class AgentBot:
         call_manager = self._call_manager
         self._call_manager = None
         self._calls_reconcile_pending = False
+        self._rejected_sync_room_ids.clear()
         if call_manager is not None:
             await call_manager.shutdown()
 

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -340,6 +340,7 @@ class AgentBot:
     _room_member_join_hooks_armed: bool
     _restored_token_catchup_pending: bool
     _room_member_join_bootstrap_pending: bool
+    _room_member_join_baseline_record_pending: bool
     _sliding_sync_startup_warning_emitted: bool
     _turn_controller: TurnController
     _room_lifecycle: BotRoomLifecycle
@@ -378,6 +379,7 @@ class AgentBot:
         self._room_member_join_hooks_armed = False
         self._restored_token_catchup_pending = False
         self._room_member_join_bootstrap_pending = self.agent_name == ROUTER_AGENT_NAME
+        self._room_member_join_baseline_record_pending = self.agent_name == ROUTER_AGENT_NAME
         self._room_member_join_lock = asyncio.Lock()
         self._sliding_sync_startup_warning_emitted = False
         self._runtime_view = BotRuntimeState(
@@ -1212,6 +1214,7 @@ class AgentBot:
         self._sync_shutting_down = False
         if self.agent_name == ROUTER_AGENT_NAME and not self._room_member_join_hooks_armed:
             self._room_member_join_bootstrap_pending = True
+            self._room_member_join_baseline_record_pending = True
         self._response_runner.resume_pending_admissions()
         self._calls_reconcile_pending = self._call_manager is not None
         mark_matrix_sync_loop_started(self.agent_name)
@@ -1490,16 +1493,22 @@ class AgentBot:
         room_member_join_hooks_were_armed: bool,
     ) -> tuple[_RoomMemberJoinSyncHookPlan, bool]:
         """Apply one Classic response through transport and cache owners."""
-        if self.agent_name == ROUTER_AGENT_NAME and not room_member_join_hooks_were_armed:
+        if (
+            self.agent_name == ROUTER_AGENT_NAME
+            and not room_member_join_hooks_were_armed
+            and not self._room_member_join_bootstrap_pending
+        ):
             self._room_member_join_bootstrap_pending = True
+            self._room_member_join_baseline_record_pending = True
         self._apply_transport_recovery_outcome(
             unrecovered_room_ids=response.unrecovered_room_ids,
             transport="classic",
         )
         with track_matrix_sync_cache_write(self.agent_name):
             try:
-                if self._room_member_join_bootstrap_pending:
+                if self._room_member_join_baseline_record_pending:
                     await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
+                    self._room_member_join_baseline_record_pending = False
                 await self._apply_own_room_membership_from_sync(response)
                 await cache_fenced_world_readable_join_history(
                     cast("nio.AsyncClient", self.client),
@@ -1552,7 +1561,7 @@ class AgentBot:
                 raise
             try:
                 (
-                    _decision,
+                    applied_decision,
                     room_member_join_hook_plan,
                     rejected_response,
                 ) = await self._apply_sync_response_after_dispatch_acceptance(
@@ -1570,9 +1579,10 @@ class AgentBot:
                     error_type=type(error).__name__,
                 )
                 raise
-        if _decision.state is SyncTrustState.CERTIFIED and not rejected_response:
+        if applied_decision.state is SyncTrustState.CERTIFIED and not rejected_response:
             self._restored_token_catchup_pending = False
             self._room_member_join_bootstrap_pending = False
+            self._room_member_join_baseline_record_pending = False
         self._mark_sync_progress()
         return room_member_join_hook_plan, rejected_response
 
@@ -1658,6 +1668,7 @@ class AgentBot:
                 self._room_member_join_hooks_armed = False
                 self._restored_token_catchup_pending = False
                 self._room_member_join_bootstrap_pending = self.agent_name == ROUTER_AGENT_NAME
+                self._room_member_join_baseline_record_pending = self.agent_name == ROUTER_AGENT_NAME
             self.logger.warning(
                 "matrix_sync_token_rejected",
                 status_code=_response.status_code,
@@ -2004,6 +2015,7 @@ class AgentBot:
         self._room_member_join_hooks_armed = False
         self._restored_token_catchup_pending = False
         self._room_member_join_bootstrap_pending = False
+        self._room_member_join_baseline_record_pending = False
         self._room_member_callback_registered = False
         clear_matrix_sync_state(self.agent_name)
         await self._emit_agent_lifecycle_event(EVENT_AGENT_STOPPED, stop_reason=shutdown_intent.stop_reason)

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1525,8 +1525,8 @@ class AgentBot:
             await self._room_lifecycle.observe_trusted_sync_rooms(
                 room_id for room_id, room in response.rooms.items() if room.membership == "join"
             )
-        await self._dispatch_obligation_runner.drain_pending_room_lifecycle()
-        self._room_member_hook_lifecycle.certified()
+        if self._room_member_hook_lifecycle.response_drain_required:
+            await self._dispatch_obligation_runner.drain_pending_room_lifecycle()
         self._mark_sync_progress()
 
     async def _on_sync_response(self, _response: nio.SyncResponse | nio.SlidingSyncResponse) -> None:
@@ -1594,7 +1594,6 @@ class AgentBot:
                     decision = await self._sync_cache_trust.reject_unknown_pos()
                     if cleanup_succeeded:
                         self._apply_client_rewind_decision(decision)
-                        self._room_member_hook_lifecycle.unknown_position()
                     else:
                         self._sync_cache_trust.defer_replay_after_pre_certification_failure()
 
@@ -2270,13 +2269,11 @@ class AgentBot:
     async def _emit_room_member_joined_sync_state_hooks(
         self,
         response: nio.SyncResponse,
-        *,
-        record_only: bool = False,
     ) -> None:
-        """Expose or record human joins that matrix-nio delivers through sync room state."""
+        """Expose human joins that matrix-nio delivers through sync room state."""
         if self.agent_name != ROUTER_AGENT_NAME:
             return
-        if not record_only and not self.hook_registry.has_hooks(EVENT_ROOM_MEMBER_JOINED):
+        if not self.hook_registry.has_hooks(EVENT_ROOM_MEMBER_JOINED):
             return
         client = self.client
         if client is None:
@@ -2287,7 +2284,6 @@ class AgentBot:
             rooms=client.rooms,
             config=self.config,
             runtime_paths=self.runtime_paths,
-            record_only=record_only,
         )
         for room, event in plan.dispatch_events:
             await self._dispatch_obligation_runner.dispatch(

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -86,7 +86,7 @@ from mindroom.tool_system.worker_routing import tool_execution_identity
 from . import constants, interactive
 from .agents import create_agent, show_tool_calls_for_agent
 from .authorization import is_authorized_sender
-from .background_tasks import create_background_task, wait_for_background_tasks
+from .background_tasks import create_background_task, run_coroutine_until_complete, wait_for_background_tasks
 from .coalescing import CoalescingGate
 from .coalescing_batch import CoalescingKey, PendingEvent, is_active_follow_up_coalescing_key
 from .cold_history_fence import ColdHistoryFence
@@ -329,7 +329,6 @@ class AgentBot:
     _startup_thread_prewarm_task: asyncio.Task[None] | None
     _call_manager: CallManager | None
     _calls_reconcile_pending: bool
-    _room_member_callback_registered: bool
     _room_member_hook_lifecycle: RoomMemberHookLifecycle
     _sliding_sync_startup_warning_emitted: bool
     _turn_controller: TurnController
@@ -365,7 +364,6 @@ class AgentBot:
         self._orchestrator_ready_handled = False
         self._sync_shutting_down = False
         self._hook_registry_state = HookRegistryState(HookRegistry.empty())
-        self._room_member_callback_registered = False
         self._room_member_hook_lifecycle = RoomMemberHookLifecycle(
             enabled=self.agent_name == ROUTER_AGENT_NAME,
         )
@@ -556,7 +554,6 @@ class AgentBot:
             on_source_rejected=self._handle_rejected_dispatch_source,
             background_task_owner=self._runtime_view,
             room_lifecycle_admission_enabled=self._room_member_hook_lifecycle.admission_enabled,
-            room_lifecycle_execution_enabled=lambda: self._room_member_hook_lifecycle.callback_execution_enabled,
         )
         self._post_response_effects_support = PostResponseEffectsSupport(
             runtime=self._runtime_view,
@@ -1218,6 +1215,7 @@ class AgentBot:
         )
         cast("Any", client).next_batch = sync_token
         self._room_member_hook_lifecycle.prepare_startup(
+            transport=self.config.matrix_sync.mode,
             resuming_position=sync_token is not None,
         )
 
@@ -1387,30 +1385,6 @@ class AgentBot:
         self.last_sync_time = mark_matrix_sync_success(self.agent_name)
         self._last_sync_monotonic = time.monotonic()
 
-    def _register_room_member_callback_after_initial_sync(self) -> None:
-        """Start listening for live member joins after startup history is drained."""
-        if self.agent_name != ROUTER_AGENT_NAME or self._room_member_callback_registered:
-            return
-        client = self.client
-        if client is None:
-            return
-        client.add_event_callback(self._create_room_member_task_wrapper(), nio.RoomMemberEvent)
-        self._room_member_callback_registered = True
-
-    def _create_room_member_task_wrapper(self) -> Callable[[nio.MatrixRoom, nio.Event], Awaitable[None]]:
-        """Run live join work only after its matching admission succeeds."""
-        durable_callback = self._dispatch_obligation_runner.task_wrapper(
-            DispatchCallbackKind.ROOM_LIFECYCLE,
-            owner=self._runtime_view,
-        )
-
-        async def wrapper(room: nio.MatrixRoom, event: nio.Event) -> None:
-            if not isinstance(event, nio.RoomMemberEvent):
-                return
-            await durable_callback(room, event)
-
-        return wrapper
-
     async def _run_pre_certification_sync_response_side_effects(
         self,
         response: nio.SyncResponse,
@@ -1430,7 +1404,6 @@ class AgentBot:
     ) -> None:
         """Run side effects that do not own raw sync checkpoint safety."""
         if first_sync_response:
-            self._register_room_member_callback_after_initial_sync()
             await self._emit_agent_lifecycle_event(EVENT_BOT_READY)
 
         orchestrator = self.orchestrator
@@ -1536,6 +1509,7 @@ class AgentBot:
             await self._room_lifecycle.observe_trusted_sync_rooms(
                 room_id for room_id, room in response.rooms.items() if room.membership == "join"
             )
+        await self._dispatch_obligation_runner.drain_pending_room_lifecycle()
         self._room_member_hook_lifecycle.certified()
         self._mark_sync_progress()
 
@@ -1584,19 +1558,21 @@ class AgentBot:
             return
         if _response.status_code == "M_UNKNOWN_POS":
             client = self.client
-            try:
-                if client is not None:
-                    await invalidate_rejected_sync_position(client)
-            except Exception as error:
-                self.logger.warning(
-                    "matrix_sync_rejected_transport_cleanup_failed",
-                    error=str(error),
-                    error_type=type(error).__name__,
-                )
-            finally:
-                decision = await self._sync_cache_trust.reject_unknown_pos()
-                self._apply_client_rewind_decision(decision)
-                self._room_member_hook_lifecycle.unknown_position()
+            cleanup_succeeded = False
+
+            async def reject_position() -> None:
+                nonlocal cleanup_succeeded
+                try:
+                    if client is not None:
+                        await invalidate_rejected_sync_position(client)
+                    cleanup_succeeded = True
+                finally:
+                    decision = await self._sync_cache_trust.reject_unknown_pos()
+                    if cleanup_succeeded:
+                        self._apply_client_rewind_decision(decision)
+                        self._room_member_hook_lifecycle.unknown_position()
+
+            await run_coroutine_until_complete(reject_position())
             self.logger.warning(
                 "matrix_sync_token_rejected",
                 status_code=_response.status_code,
@@ -1941,7 +1917,6 @@ class AgentBot:
         self._first_sync_done = False
         self._orchestrator_ready_handled = False
         self._room_member_hook_lifecycle.stop()
-        self._room_member_callback_registered = False
         clear_matrix_sync_state(self.agent_name)
         await self._emit_agent_lifecycle_event(EVENT_AGENT_STOPPED, stop_reason=shutdown_intent.stop_reason)
 
@@ -2111,7 +2086,7 @@ class AgentBot:
                 room_ids=self.rooms,
                 timeout_ms=_SYNC_TIMEOUT_MS,
                 sync_filter=_SYNC_FILTER,
-                first_sync_done=not self._room_member_hook_lifecycle.full_state_required,
+                first_sync_done=(self._first_sync_done and not self._room_member_hook_lifecycle.full_state_required),
             )
         finally:
             self._reconcile_classic_sync_cursor_after_loop_exit()
@@ -2295,12 +2270,11 @@ class AgentBot:
                 DispatchCallbackKind.ROOM_LIFECYCLE,
             )
         if plan.record_events:
-            marker_fence = await self._dispatch_obligation_runner.room_lifecycle_marker_fence()
+            fenced_members, corrupt_room_ids = await self._dispatch_obligation_runner.room_lifecycle_marker_fence()
             record_events = tuple(
                 (room, event)
                 for room, event in plan.record_events
-                if room.room_id not in marker_fence.corrupt_room_ids
-                and (room.room_id, event.state_key) not in marker_fence.member_ids
+                if room.room_id not in corrupt_room_ids and (room.room_id, event.state_key) not in fenced_members
             )
         else:
             record_events = ()

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1392,6 +1392,11 @@ class AgentBot:
         room_member_plan: RoomMemberResponsePlan,
     ) -> None:
         """Finish source-backed lifecycle work before certifying its sync position."""
+        if room_member_plan.baseline_record_events is not None:
+            await self._record_room_member_joined_events(
+                room_member_plan.baseline_record_events,
+            )
+            self._room_member_hook_lifecycle.baseline_recorded()
         if room_member_plan.drain_captured_timeline:
             await self._dispatch_obligation_runner.drain_pending_room_lifecycle()
         if room_member_plan.dispatch_state:
@@ -1430,9 +1435,19 @@ class AgentBot:
         )
         with track_matrix_sync_cache_write(self.agent_name):
             try:
-                if self._room_member_hook_lifecycle.baseline_record_pending:
-                    await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
-                    self._room_member_hook_lifecycle.baseline_recorded()
+                if self._room_member_hook_lifecycle.baseline_capture_pending:
+                    client = self.client
+                    assert client is not None
+                    baseline_plan = room_member_sync_state_plan(
+                        response,
+                        rooms=client.rooms,
+                        config=self.config,
+                        runtime_paths=self.runtime_paths,
+                        record_only=True,
+                    )
+                    self._room_member_hook_lifecycle.capture_baseline(
+                        baseline_plan.record_events,
+                    )
                 await self._apply_own_room_membership_from_sync(response)
                 await cache_fenced_world_readable_join_history(
                     cast("nio.AsyncClient", self.client),
@@ -1556,6 +1571,14 @@ class AgentBot:
             # sync checkpoint, so classic token rejection must not run here.
             self._warn_if_sliding_sync_never_succeeded(_response)
             return
+        if self._room_member_hook_lifecycle.baseline_capture_pending:
+            client = self.client
+            assert client is not None
+            client.stop_sync_forever()
+            self.logger.warning(
+                "matrix_sync_full_state_request_failed_restarting",
+                status_code=_response.status_code,
+            )
         if _response.status_code == "M_UNKNOWN_POS":
             client = self.client
             cleanup_succeeded = False
@@ -2271,15 +2294,22 @@ class AgentBot:
                 event,
                 DispatchCallbackKind.ROOM_LIFECYCLE,
             )
-        if plan.record_events:
-            fenced_members, corrupt_room_ids = await self._dispatch_obligation_runner.room_lifecycle_marker_fence()
-            record_events = tuple(
-                (room, event)
-                for room, event in plan.record_events
-                if room.room_id not in corrupt_room_ids and (room.room_id, event.state_key) not in fenced_members
-            )
-        else:
-            record_events = ()
+        await self._record_room_member_joined_events(plan.record_events)
+
+    async def _record_room_member_joined_events(
+        self,
+        events: Iterable[tuple[nio.MatrixRoom, nio.RoomMemberEvent]],
+    ) -> None:
+        """Persist snapshot markers that are not fenced by exact lifecycle work."""
+        candidate_events = tuple(events)
+        if not candidate_events:
+            return
+        fenced_members, corrupt_room_ids = await self._dispatch_obligation_runner.room_lifecycle_marker_fence()
+        record_events = tuple(
+            (room, event)
+            for room, event in candidate_events
+            if room.room_id not in corrupt_room_ids and (room.room_id, event.state_key) not in fenced_members
+        )
         if record_events:
             async with self._room_member_join_lock:
                 await asyncio.to_thread(

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1571,6 +1571,8 @@ class AgentBot:
                     if cleanup_succeeded:
                         self._apply_client_rewind_decision(decision)
                         self._room_member_hook_lifecycle.unknown_position()
+                    else:
+                        self._sync_cache_trust.defer_replay_after_pre_certification_failure()
 
             await run_coroutine_until_complete(reject_position())
             self.logger.warning(

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -57,6 +57,7 @@ from mindroom.matrix.sync_certification import (
     SyncCacheWriteResult,
     SyncCertificationDecision,
     SyncTrustState,
+    defer_sync_response_after_dispatch_persist_failure,
 )
 from mindroom.matrix.sync_continuity import SyncContinuityStore
 from mindroom.matrix.sync_loop import run_matrix_sync_forever, sliding_own_membership_sets
@@ -112,7 +113,7 @@ from .knowledge import KnowledgeAccessSupport
 from .logging_config import get_logger
 from .matrix.avatar import check_and_set_avatar
 from .matrix.client_room_admin import get_joined_rooms
-from .matrix.client_session import PermanentMatrixStartupError
+from .matrix.client_session import PermanentMatrixStartupError, invalidate_rejected_sync_position
 from .matrix.joined_room_history import cache_fenced_world_readable_join_history
 from .matrix.room_member_joins import (
     RoomMemberJoin,
@@ -337,6 +338,7 @@ class AgentBot:
     _calls_reconcile_pending: bool
     _room_member_callback_registered: bool
     _room_member_join_hooks_armed: bool
+    _restored_token_catchup_pending: bool
     _sliding_sync_startup_warning_emitted: bool
     _turn_controller: TurnController
     _room_lifecycle: BotRoomLifecycle
@@ -373,6 +375,7 @@ class AgentBot:
         self._hook_registry_state = HookRegistryState(HookRegistry.empty())
         self._room_member_callback_registered = False
         self._room_member_join_hooks_armed = False
+        self._restored_token_catchup_pending = False
         self._room_member_join_lock = asyncio.Lock()
         self._sliding_sync_startup_warning_emitted = False
         self._runtime_view = BotRuntimeState(
@@ -553,7 +556,7 @@ class AgentBot:
             ),
             room_for_id=self._room_for_dispatch_obligation,
             turn_is_terminal=self._turn_store.is_durably_handled,
-            on_persist_failure=self._record_dispatch_persist_failure,
+            on_persist_failure=self._sync_cache_trust.record_dispatch_persist_failure,
             source_admission=self._cold_history_fence.admit_source,
             observe_event_provenance=self._cold_history_fence.observe_event_provenance,
             cache_historical_event=self._conversation_cache.cache_historical_event,
@@ -1221,6 +1224,7 @@ class AgentBot:
             transport_resume_token=cast("Any", client).loaded_sync_token,
         )
         cast("Any", client).next_batch = sync_token
+        self._restored_token_catchup_pending = self._sync_cache_trust.retry_token() is not None
 
     async def _certify_sync_response(
         self,
@@ -1276,9 +1280,7 @@ class AgentBot:
         # that in-memory fallback aligned without rewriting its durable token,
         # which remains paired atomically with any stored recovery generation.
         raw_client.loaded_sync_token = retry_token or ""
-        if not rewound:
-            return False, retry_token is not None
-        return True, retry_token is not None
+        return rewound, retry_token is not None
 
     def _reconcile_classic_sync_cursor_after_loop_exit(self) -> None:
         """Settle aborted-response state and restore certified continuity."""
@@ -1343,14 +1345,6 @@ class AgentBot:
             unrecovered_room_ids=sorted(unrecovered_room_ids),
         )
 
-    def _record_dispatch_persist_failure(self) -> None:
-        """Let NIO retry rejected source work before replaying safe continuity."""
-        self._sync_cache_trust.record_dispatch_persist_failure()
-
-    def _handle_pre_certification_failure(self) -> None:
-        """Defer safe replay until NIO gets one response to settle retained work."""
-        self._sync_cache_trust.defer_replay_after_pre_certification_failure()
-
     async def _apply_sync_response_after_dispatch_acceptance(
         self,
         decision: SyncCertificationDecision,
@@ -1362,14 +1356,8 @@ class AgentBot:
         """Apply certification only when every source callback reached durable ownership."""
         if self._sync_cache_trust.consume_dispatch_persist_failure():
             if decision.unresolved_recovery_room_ids:
-                deferred = replace(
+                deferred = defer_sync_response_after_dispatch_persist_failure(
                     decision,
-                    state=SyncTrustState.UNCERTAIN,
-                    checkpoint_to_save=None,
-                    clear_saved_token=False,
-                    reset_client_token=False,
-                    replay_required_after_recovery=True,
-                    reason="dispatch_persist_failed",
                 )
                 applied = await self._apply_sync_response_decision(
                     deferred,
@@ -1447,7 +1435,7 @@ class AgentBot:
         return _RoomMemberJoinSyncHookPlan(
             arm_after_response=True,
             emit_state=emit_certified_state,
-            emit_timeline=restored_token_first_sync_response,
+            emit_timeline=(decision.state is SyncTrustState.CERTIFIED and restored_token_first_sync_response),
             record_state_seen=decision.state is SyncTrustState.CERTIFIED and not emit_certified_state,
         )
 
@@ -1508,9 +1496,9 @@ class AgentBot:
                     cache_event=self._conversation_cache.cache_historical_event,
                 )
             except BaseException:
-                self._handle_pre_certification_failure()
+                self._sync_cache_trust.defer_replay_after_pre_certification_failure()
                 raise
-            restored_token_first_sync_response = (
+            restored_token_first_sync_response = self._restored_token_catchup_pending or (
                 first_sync_response and self._sync_cache_trust.state is SyncTrustState.PENDING
             )
             try:
@@ -1546,7 +1534,7 @@ class AgentBot:
                     room_member_join_hook_plan=room_member_join_hook_plan,
                 )
             except BaseException:
-                self._handle_pre_certification_failure()
+                self._sync_cache_trust.defer_replay_after_pre_certification_failure()
                 raise
             try:
                 (
@@ -1568,6 +1556,8 @@ class AgentBot:
                     error_type=type(error).__name__,
                 )
                 raise
+        if _decision.state is SyncTrustState.CERTIFIED:
+            self._restored_token_catchup_pending = False
         self._mark_sync_progress()
         return room_member_join_hook_plan, rejected_response
 
@@ -1610,6 +1600,12 @@ class AgentBot:
             await self._handle_sliding_sync_response(_response)
         if dispatch_persist_failure_rejected_response:
             return
+        if (
+            isinstance(_response, nio.SyncResponse)
+            and first_sync_response
+            and self._sync_cache_trust.state is not SyncTrustState.CERTIFIED
+        ):
+            return
         self._first_sync_done = True
         self._room_member_join_hooks_armed = room_member_join_hook_plan.arm_after_response
 
@@ -1637,9 +1633,21 @@ class AgentBot:
             self._warn_if_sliding_sync_never_succeeded(_response)
             return
         if _response.status_code == "M_UNKNOWN_POS":
-            decision = await self._sync_cache_trust.reject_unknown_pos()
-            self._apply_client_rewind_decision(decision)
-            self._room_member_join_hooks_armed = False
+            client = self.client
+            try:
+                if client is not None:
+                    await invalidate_rejected_sync_position(client)
+            except Exception as error:
+                self.logger.warning(
+                    "matrix_sync_rejected_transport_cleanup_failed",
+                    error=str(error),
+                    error_type=type(error).__name__,
+                )
+            finally:
+                decision = await self._sync_cache_trust.reject_unknown_pos()
+                self._apply_client_rewind_decision(decision)
+                self._room_member_join_hooks_armed = False
+                self._restored_token_catchup_pending = False
             self.logger.warning(
                 "matrix_sync_token_rejected",
                 status_code=_response.status_code,
@@ -1984,6 +1992,7 @@ class AgentBot:
         self._first_sync_done = False
         self._orchestrator_ready_handled = False
         self._room_member_join_hooks_armed = False
+        self._restored_token_catchup_pending = False
         self._room_member_callback_registered = False
         clear_matrix_sync_state(self.agent_name)
         await self._emit_agent_lifecycle_event(EVENT_AGENT_STOPPED, stop_reason=shutdown_intent.stop_reason)
@@ -2338,11 +2347,12 @@ class AgentBot:
                 DispatchCallbackKind.ROOM_LIFECYCLE,
             )
         if plan.record_events:
-            unsettled_members = await self._dispatch_obligation_runner.unsettled_room_lifecycle_member_ids()
+            marker_fence = await self._dispatch_obligation_runner.room_lifecycle_marker_fence()
             record_events = tuple(
                 (room, event)
                 for room, event in plan.record_events
-                if (room.room_id, event.state_key) not in unsettled_members
+                if room.room_id not in marker_fence.corrupt_room_ids
+                and (room.room_id, event.state_key) not in marker_fence.member_ids
             )
         else:
             record_events = ()

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1261,6 +1261,10 @@ class AgentBot:
             return
         _, has_retry_token = self._rewind_client_to_retry_token()
         self._room_member_hook_lifecycle.rewound(has_retry_token=has_retry_token)
+        if self.config.matrix_sync.mode == "classic" and self._room_member_hook_lifecycle.baseline_capture_pending:
+            client = self.client
+            assert client is not None
+            client.stop_sync_forever()
 
     def _rewind_client_to_retry_token(self) -> tuple[bool, bool]:
         """Move the Matrix client to the exact generation-safe retry cursor."""
@@ -1393,10 +1397,6 @@ class AgentBot:
         room_member_plan: RoomMemberResponsePlan,
     ) -> None:
         """Finish source-backed lifecycle work before certifying its sync position."""
-        if room_member_plan.baseline_record_events is not None:
-            await self._record_room_member_joined_events(
-                room_member_plan.baseline_record_events,
-            )
         if room_member_plan.drain_captured_timeline:
             await self._dispatch_obligation_runner.drain_pending_room_lifecycle()
         if room_member_plan.baseline_record_events is not None:

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -339,6 +339,7 @@ class AgentBot:
     _room_member_callback_registered: bool
     _room_member_join_hooks_armed: bool
     _restored_token_catchup_pending: bool
+    _room_member_join_bootstrap_pending: bool
     _sliding_sync_startup_warning_emitted: bool
     _turn_controller: TurnController
     _room_lifecycle: BotRoomLifecycle
@@ -376,6 +377,7 @@ class AgentBot:
         self._room_member_callback_registered = False
         self._room_member_join_hooks_armed = False
         self._restored_token_catchup_pending = False
+        self._room_member_join_bootstrap_pending = self.agent_name == ROUTER_AGENT_NAME
         self._room_member_join_lock = asyncio.Lock()
         self._sliding_sync_startup_warning_emitted = False
         self._runtime_view = BotRuntimeState(
@@ -1208,6 +1210,8 @@ class AgentBot:
         own startup timeout for the pre-first-response window.
         """
         self._sync_shutting_down = False
+        if self.agent_name == ROUTER_AGENT_NAME and not self._room_member_join_hooks_armed:
+            self._room_member_join_bootstrap_pending = True
         self._response_runner.resume_pending_admissions()
         self._calls_reconcile_pending = self._call_manager is not None
         mark_matrix_sync_loop_started(self.agent_name)
@@ -1433,10 +1437,14 @@ class AgentBot:
             decision.state is SyncTrustState.CERTIFIED and not first_sync_response and hooks_were_armed
         )
         return _RoomMemberJoinSyncHookPlan(
-            arm_after_response=True,
+            arm_after_response=hooks_were_armed or decision.state is SyncTrustState.CERTIFIED,
             emit_state=emit_certified_state,
             emit_timeline=(decision.state is SyncTrustState.CERTIFIED and restored_token_first_sync_response),
-            record_state_seen=decision.state is SyncTrustState.CERTIFIED and not emit_certified_state,
+            record_state_seen=(
+                decision.state is SyncTrustState.CERTIFIED
+                and not emit_certified_state
+                and not self._room_member_join_bootstrap_pending
+            ),
         )
 
     async def _run_pre_certification_sync_response_side_effects(
@@ -1482,12 +1490,16 @@ class AgentBot:
         room_member_join_hooks_were_armed: bool,
     ) -> tuple[_RoomMemberJoinSyncHookPlan, bool]:
         """Apply one Classic response through transport and cache owners."""
+        if self.agent_name == ROUTER_AGENT_NAME and not room_member_join_hooks_were_armed:
+            self._room_member_join_bootstrap_pending = True
         self._apply_transport_recovery_outcome(
             unrecovered_room_ids=response.unrecovered_room_ids,
             transport="classic",
         )
         with track_matrix_sync_cache_write(self.agent_name):
             try:
+                if self._room_member_join_bootstrap_pending:
+                    await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
                 await self._apply_own_room_membership_from_sync(response)
                 await cache_fenced_world_readable_join_history(
                     cast("nio.AsyncClient", self.client),
@@ -1522,6 +1534,8 @@ class AgentBot:
                 next_batch=response.next_batch,
                 cache_result=cache_result,
             )
+            if restored_token_first_sync_response and decision.unresolved_recovery_room_ids:
+                decision = replace(decision, replay_required_after_recovery=True)
             room_member_join_hook_plan = self._room_member_join_sync_hook_plan(
                 first_sync_response=first_sync_response,
                 restored_token_first_sync_response=restored_token_first_sync_response,
@@ -1556,8 +1570,9 @@ class AgentBot:
                     error_type=type(error).__name__,
                 )
                 raise
-        if _decision.state is SyncTrustState.CERTIFIED:
+        if _decision.state is SyncTrustState.CERTIFIED and not rejected_response:
             self._restored_token_catchup_pending = False
+            self._room_member_join_bootstrap_pending = False
         self._mark_sync_progress()
         return room_member_join_hook_plan, rejected_response
 
@@ -1599,12 +1614,6 @@ class AgentBot:
         elif isinstance(_response, nio.SlidingSyncResponse):
             await self._handle_sliding_sync_response(_response)
         if dispatch_persist_failure_rejected_response:
-            return
-        if (
-            isinstance(_response, nio.SyncResponse)
-            and first_sync_response
-            and self._sync_cache_trust.state is not SyncTrustState.CERTIFIED
-        ):
             return
         self._first_sync_done = True
         self._room_member_join_hooks_armed = room_member_join_hook_plan.arm_after_response
@@ -1648,6 +1657,7 @@ class AgentBot:
                 self._apply_client_rewind_decision(decision)
                 self._room_member_join_hooks_armed = False
                 self._restored_token_catchup_pending = False
+                self._room_member_join_bootstrap_pending = self.agent_name == ROUTER_AGENT_NAME
             self.logger.warning(
                 "matrix_sync_token_rejected",
                 status_code=_response.status_code,
@@ -1993,6 +2003,7 @@ class AgentBot:
         self._orchestrator_ready_handled = False
         self._room_member_join_hooks_armed = False
         self._restored_token_catchup_pending = False
+        self._room_member_join_bootstrap_pending = False
         self._room_member_callback_registered = False
         clear_matrix_sync_state(self.agent_name)
         await self._emit_agent_lifecycle_event(EVENT_AGENT_STOPPED, stop_reason=shutdown_intent.stop_reason)
@@ -2163,7 +2174,7 @@ class AgentBot:
                 room_ids=self.rooms,
                 timeout_ms=_SYNC_TIMEOUT_MS,
                 sync_filter=_SYNC_FILTER,
-                first_sync_done=self._first_sync_done,
+                first_sync_done=(self._first_sync_done and not self._room_member_join_bootstrap_pending),
             )
         finally:
             self._reconcile_classic_sync_cursor_after_loop_exit()

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -121,6 +121,7 @@ from .matrix.client_session import PermanentMatrixStartupError, invalidate_rejec
 from .matrix.joined_room_history import cache_fenced_world_readable_join_history
 from .matrix.room_member_joins import (
     RoomMemberJoin,
+    RoomMemberSnapshot,
     emit_room_member_join_at_least_once,
     record_room_member_joins_seen_from_events,
     room_member_sync_state_plan,
@@ -2298,7 +2299,7 @@ class AgentBot:
 
     async def _record_room_member_joined_events(
         self,
-        events: Iterable[tuple[nio.MatrixRoom, nio.RoomMemberEvent]],
+        events: Iterable[RoomMemberSnapshot],
     ) -> None:
         """Persist snapshot markers that are not fenced by exact lifecycle work."""
         candidate_events = tuple(events)
@@ -2306,9 +2307,10 @@ class AgentBot:
             return
         fenced_members, corrupt_room_ids = await self._dispatch_obligation_runner.room_lifecycle_marker_fence()
         record_events = tuple(
-            (room, event)
-            for room, event in candidate_events
-            if room.room_id not in corrupt_room_ids and (room.room_id, event.state_key) not in fenced_members
+            snapshot
+            for snapshot in candidate_events
+            if snapshot.room_id not in corrupt_room_ids
+            and (snapshot.room_id, snapshot.event.state_key) not in fenced_members
         )
         if record_events:
             async with self._room_member_join_lock:

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, cast
 from uuid import uuid4
@@ -50,6 +50,10 @@ from mindroom.matrix.health import (
 )
 from mindroom.matrix.presence import build_agent_status_message, set_presence_status
 from mindroom.matrix.room_cleanup import cleanup_all_orphaned_bots
+from mindroom.matrix.room_member_hook_lifecycle import (
+    RoomMemberHookLifecycle,
+    RoomMemberResponsePlan,
+)
 from mindroom.matrix.rooms import leave_non_dm_rooms
 from mindroom.matrix.state import resolve_room_aliases
 from mindroom.matrix.sync_cache_trust import SyncCacheTrust
@@ -120,7 +124,6 @@ from .matrix.room_member_joins import (
     emit_room_member_join_at_least_once,
     record_room_member_joins_seen_from_events,
     room_member_sync_state_plan,
-    room_member_sync_timeline_events,
 )
 from .matrix.to_device import AuthenticatedToDeviceEvent
 from .media_inputs import MediaInputs
@@ -179,16 +182,6 @@ _SYNC_TIMEOUT_MS = 30000
 # out.
 _SYNC_TIMELINE_LIMIT = 50
 _SYNC_FILTER: dict[str, object] = {"room": {"timeline": {"limit": _SYNC_TIMELINE_LIMIT}}}
-
-
-@dataclass(frozen=True, slots=True)
-class _RoomMemberJoinSyncHookPlan:
-    """Room-member join hook actions derived from one sync response."""
-
-    arm_after_response: bool = True
-    emit_state: bool = False
-    emit_timeline: bool = False
-    record_state_seen: bool = False
 
 
 def _create_best_effort_task_wrapper(
@@ -337,10 +330,7 @@ class AgentBot:
     _call_manager: CallManager | None
     _calls_reconcile_pending: bool
     _room_member_callback_registered: bool
-    _room_member_join_hooks_armed: bool
-    _restored_token_catchup_pending: bool
-    _room_member_join_bootstrap_pending: bool
-    _room_member_join_baseline_record_pending: bool
+    _room_member_hook_lifecycle: RoomMemberHookLifecycle
     _sliding_sync_startup_warning_emitted: bool
     _turn_controller: TurnController
     _room_lifecycle: BotRoomLifecycle
@@ -376,10 +366,9 @@ class AgentBot:
         self._sync_shutting_down = False
         self._hook_registry_state = HookRegistryState(HookRegistry.empty())
         self._room_member_callback_registered = False
-        self._room_member_join_hooks_armed = False
-        self._restored_token_catchup_pending = False
-        self._room_member_join_bootstrap_pending = self.agent_name == ROUTER_AGENT_NAME
-        self._room_member_join_baseline_record_pending = self.agent_name == ROUTER_AGENT_NAME
+        self._room_member_hook_lifecycle = RoomMemberHookLifecycle(
+            enabled=self.agent_name == ROUTER_AGENT_NAME,
+        )
         self._room_member_join_lock = asyncio.Lock()
         self._sliding_sync_startup_warning_emitted = False
         self._runtime_view = BotRuntimeState(
@@ -566,9 +555,8 @@ class AgentBot:
             cache_historical_event=self._conversation_cache.cache_historical_event,
             on_source_rejected=self._handle_rejected_dispatch_source,
             background_task_owner=self._runtime_view,
-            room_lifecycle_admission_enabled=lambda: (
-                self.agent_name == ROUTER_AGENT_NAME and self._first_sync_done and self._room_member_join_hooks_armed
-            ),
+            room_lifecycle_admission_enabled=self._room_member_hook_lifecycle.admission_enabled,
+            room_lifecycle_execution_enabled=lambda: self._room_member_hook_lifecycle.callback_execution_enabled,
         )
         self._post_response_effects_support = PostResponseEffectsSupport(
             runtime=self._runtime_view,
@@ -1212,9 +1200,7 @@ class AgentBot:
         own startup timeout for the pre-first-response window.
         """
         self._sync_shutting_down = False
-        if self.agent_name == ROUTER_AGENT_NAME and not self._room_member_join_hooks_armed:
-            self._room_member_join_bootstrap_pending = True
-            self._room_member_join_baseline_record_pending = True
+        self._room_member_hook_lifecycle.begin_sync_loop()
         self._response_runner.resume_pending_admissions()
         self._calls_reconcile_pending = self._call_manager is not None
         mark_matrix_sync_loop_started(self.agent_name)
@@ -1231,7 +1217,9 @@ class AgentBot:
             transport_resume_token=cast("Any", client).loaded_sync_token,
         )
         cast("Any", client).next_batch = sync_token
-        self._restored_token_catchup_pending = self._sync_cache_trust.retry_token() is not None
+        self._room_member_hook_lifecycle.prepare_startup(
+            resuming_position=sync_token is not None,
+        )
 
     async def _certify_sync_response(
         self,
@@ -1272,7 +1260,8 @@ class AgentBot:
         """Apply one cache-certification rewind to the Matrix client cursor."""
         if not decision.reset_client_token:
             return
-        self._rewind_client_to_retry_token()
+        _, has_retry_token = self._rewind_client_to_retry_token()
+        self._room_member_hook_lifecycle.rewound(has_retry_token=has_retry_token)
 
     def _rewind_client_to_retry_token(self) -> tuple[bool, bool]:
         """Move the Matrix client to the exact generation-safe retry cursor."""
@@ -1299,6 +1288,7 @@ class AgentBot:
         rewound, has_retry_token = self._rewind_client_to_retry_token()
         if not rewound:
             return
+        self._room_member_hook_lifecycle.rewound(has_retry_token=has_retry_token)
         self.logger.warning(
             "matrix_sync_receive_loop_exit_rewound_uncertified_cursor",
             has_retry_token=has_retry_token,
@@ -1309,6 +1299,7 @@ class AgentBot:
         rewound, has_retry_token = self._rewind_client_to_retry_token()
         if not rewound:
             return
+        self._room_member_hook_lifecycle.rewound(has_retry_token=has_retry_token)
         self.logger.warning(
             "pre_certification_sync_side_effect_failed_replaying_sync",
             has_retry_token=has_retry_token,
@@ -1357,9 +1348,8 @@ class AgentBot:
         decision: SyncCertificationDecision,
         *,
         cache_result: SyncCacheWriteResult,
-        room_member_join_hook_plan: _RoomMemberJoinSyncHookPlan,
         response: nio.SyncResponse,
-    ) -> tuple[SyncCertificationDecision, _RoomMemberJoinSyncHookPlan, bool]:
+    ) -> tuple[SyncCertificationDecision, bool]:
         """Apply certification only when every source callback reached durable ownership."""
         if self._sync_cache_trust.consume_dispatch_persist_failure():
             if decision.unresolved_recovery_room_ids:
@@ -1371,18 +1361,16 @@ class AgentBot:
                     cache_result=cache_result,
                     joined_room_ids=response.rooms.join,
                 )
-                return applied, _RoomMemberJoinSyncHookPlan(arm_after_response=False), True
+                return applied, True
             self._sync_cache_trust.reject_response_before_certification()
             self._rewind_sync_after_pre_certification_failure()
-            return decision, _RoomMemberJoinSyncHookPlan(arm_after_response=False), True
+            return decision, True
         applied = await self._apply_sync_response_decision(
             decision,
             cache_result=cache_result,
             joined_room_ids=response.rooms.join,
         )
-        if applied.reset_client_token:
-            room_member_join_hook_plan = _RoomMemberJoinSyncHookPlan(arm_after_response=False)
-        return applied, room_member_join_hook_plan, False
+        return applied, False
 
     def seconds_since_last_sync_activity(self) -> float | None:
         """Return elapsed seconds since the last sync-loop activity seen by the watchdog."""
@@ -1423,45 +1411,16 @@ class AgentBot:
 
         return wrapper
 
-    def _room_member_join_sync_hook_plan(
-        self,
-        *,
-        first_sync_response: bool,
-        restored_token_first_sync_response: bool,
-        hooks_were_armed: bool,
-        decision: SyncCertificationDecision,
-    ) -> _RoomMemberJoinSyncHookPlan:
-        """Return room-member join hook actions for one certified sync response."""
-        if decision.reset_client_token:
-            return _RoomMemberJoinSyncHookPlan(arm_after_response=False)
-        # The first restored-token sync is requested with full_state=True, so its
-        # state block is a current snapshot. Only the timeline is a catch-up stream.
-        emit_certified_state = (
-            decision.state is SyncTrustState.CERTIFIED and not first_sync_response and hooks_were_armed
-        )
-        return _RoomMemberJoinSyncHookPlan(
-            arm_after_response=hooks_were_armed or decision.state is SyncTrustState.CERTIFIED,
-            emit_state=emit_certified_state,
-            emit_timeline=(decision.state is SyncTrustState.CERTIFIED and restored_token_first_sync_response),
-            record_state_seen=(
-                decision.state is SyncTrustState.CERTIFIED
-                and not emit_certified_state
-                and not self._room_member_join_bootstrap_pending
-            ),
-        )
-
     async def _run_pre_certification_sync_response_side_effects(
         self,
         response: nio.SyncResponse,
         *,
-        room_member_join_hook_plan: _RoomMemberJoinSyncHookPlan,
+        room_member_plan: RoomMemberResponsePlan,
     ) -> None:
         """Finish source-backed lifecycle work before certifying its sync position."""
-        if room_member_join_hook_plan.record_state_seen:
-            await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
-        if room_member_join_hook_plan.emit_timeline:
-            await self._emit_room_member_joined_sync_timeline_hooks(response)
-        if room_member_join_hook_plan.emit_state:
+        if room_member_plan.drain_captured_timeline:
+            await self._dispatch_obligation_runner.drain_pending_room_lifecycle()
+        if room_member_plan.dispatch_state:
             await self._emit_room_member_joined_sync_state_hooks(response)
 
     async def _run_sync_response_side_effects(
@@ -1490,25 +1449,17 @@ class AgentBot:
         response: nio.SyncResponse,
         *,
         first_sync_response: bool,
-        room_member_join_hooks_were_armed: bool,
-    ) -> tuple[_RoomMemberJoinSyncHookPlan, bool]:
+    ) -> bool:
         """Apply one Classic response through transport and cache owners."""
-        if (
-            self.agent_name == ROUTER_AGENT_NAME
-            and not room_member_join_hooks_were_armed
-            and not self._room_member_join_bootstrap_pending
-        ):
-            self._room_member_join_bootstrap_pending = True
-            self._room_member_join_baseline_record_pending = True
         self._apply_transport_recovery_outcome(
             unrecovered_room_ids=response.unrecovered_room_ids,
             transport="classic",
         )
         with track_matrix_sync_cache_write(self.agent_name):
             try:
-                if self._room_member_join_baseline_record_pending:
+                if self._room_member_hook_lifecycle.baseline_record_pending:
                     await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
-                    self._room_member_join_baseline_record_pending = False
+                    self._room_member_hook_lifecycle.baseline_recorded()
                 await self._apply_own_room_membership_from_sync(response)
                 await cache_fenced_world_readable_join_history(
                     cast("nio.AsyncClient", self.client),
@@ -1519,9 +1470,6 @@ class AgentBot:
             except BaseException:
                 self._sync_cache_trust.defer_replay_after_pre_certification_failure()
                 raise
-            restored_token_first_sync_response = self._restored_token_catchup_pending or (
-                first_sync_response and self._sync_cache_trust.state is SyncTrustState.PENDING
-            )
             try:
                 cache_result = await self._conversation_cache.cache_sync_timeline_for_certification(response)
             except asyncio.CancelledError as exc:
@@ -1543,31 +1491,22 @@ class AgentBot:
                 next_batch=response.next_batch,
                 cache_result=cache_result,
             )
-            if restored_token_first_sync_response and decision.unresolved_recovery_room_ids:
-                decision = replace(decision, replay_required_after_recovery=True)
-            room_member_join_hook_plan = self._room_member_join_sync_hook_plan(
-                first_sync_response=first_sync_response,
-                restored_token_first_sync_response=restored_token_first_sync_response,
-                hooks_were_armed=room_member_join_hooks_were_armed,
+            room_member_plan = self._room_member_hook_lifecycle.plan_response(
                 decision=decision,
+                first_sync_response=first_sync_response,
             )
             try:
                 await self._run_pre_certification_sync_response_side_effects(
                     response,
-                    room_member_join_hook_plan=room_member_join_hook_plan,
+                    room_member_plan=room_member_plan,
                 )
             except BaseException:
                 self._sync_cache_trust.defer_replay_after_pre_certification_failure()
                 raise
             try:
-                (
-                    applied_decision,
-                    room_member_join_hook_plan,
-                    rejected_response,
-                ) = await self._apply_sync_response_after_dispatch_acceptance(
+                applied_decision, rejected_response = await self._apply_sync_response_after_dispatch_acceptance(
                     decision,
                     cache_result=cache_result,
-                    room_member_join_hook_plan=room_member_join_hook_plan,
                     response=response,
                 )
             except asyncio.CancelledError:
@@ -1580,11 +1519,9 @@ class AgentBot:
                 )
                 raise
         if applied_decision.state is SyncTrustState.CERTIFIED and not rejected_response:
-            self._restored_token_catchup_pending = False
-            self._room_member_join_bootstrap_pending = False
-            self._room_member_join_baseline_record_pending = False
+            self._room_member_hook_lifecycle.certified()
         self._mark_sync_progress()
-        return room_member_join_hook_plan, rejected_response
+        return rejected_response
 
     async def _handle_sliding_sync_response(self, response: nio.SlidingSyncResponse) -> None:
         """Apply one Sliding response through membership and transport owners."""
@@ -1599,34 +1536,28 @@ class AgentBot:
             await self._room_lifecycle.observe_trusted_sync_rooms(
                 room_id for room_id, room in response.rooms.items() if room.membership == "join"
             )
+        self._room_member_hook_lifecycle.certified()
         self._mark_sync_progress()
 
     async def _on_sync_response(self, _response: nio.SyncResponse | nio.SlidingSyncResponse) -> None:
         """Track successful sync responses for health checks and watchdogs."""
         first_sync_response = not self._first_sync_done
         dispatch_persist_failure_rejected_response = False
-        room_member_join_hooks_were_armed = self._room_member_join_hooks_armed
-        room_member_join_hook_plan = _RoomMemberJoinSyncHookPlan()
         self._mark_sync_progress()
 
         if self._sync_shutting_down:
             return
 
         if isinstance(_response, nio.SyncResponse):
-            (
-                room_member_join_hook_plan,
-                dispatch_persist_failure_rejected_response,
-            ) = await self._handle_classic_sync_response(
+            dispatch_persist_failure_rejected_response = await self._handle_classic_sync_response(
                 _response,
                 first_sync_response=first_sync_response,
-                room_member_join_hooks_were_armed=room_member_join_hooks_were_armed,
             )
         elif isinstance(_response, nio.SlidingSyncResponse):
             await self._handle_sliding_sync_response(_response)
         if dispatch_persist_failure_rejected_response:
             return
         self._first_sync_done = True
-        self._room_member_join_hooks_armed = room_member_join_hook_plan.arm_after_response
 
         await self._run_sync_response_side_effects(
             first_sync_response=first_sync_response,
@@ -1665,10 +1596,7 @@ class AgentBot:
             finally:
                 decision = await self._sync_cache_trust.reject_unknown_pos()
                 self._apply_client_rewind_decision(decision)
-                self._room_member_join_hooks_armed = False
-                self._restored_token_catchup_pending = False
-                self._room_member_join_bootstrap_pending = self.agent_name == ROUTER_AGENT_NAME
-                self._room_member_join_baseline_record_pending = self.agent_name == ROUTER_AGENT_NAME
+                self._room_member_hook_lifecycle.unknown_position()
             self.logger.warning(
                 "matrix_sync_token_rejected",
                 status_code=_response.status_code,
@@ -2012,10 +1940,7 @@ class AgentBot:
         self._last_sync_monotonic = None
         self._first_sync_done = False
         self._orchestrator_ready_handled = False
-        self._room_member_join_hooks_armed = False
-        self._restored_token_catchup_pending = False
-        self._room_member_join_bootstrap_pending = False
-        self._room_member_join_baseline_record_pending = False
+        self._room_member_hook_lifecycle.stop()
         self._room_member_callback_registered = False
         clear_matrix_sync_state(self.agent_name)
         await self._emit_agent_lifecycle_event(EVENT_AGENT_STOPPED, stop_reason=shutdown_intent.stop_reason)
@@ -2186,7 +2111,7 @@ class AgentBot:
                 room_ids=self.rooms,
                 timeout_ms=_SYNC_TIMEOUT_MS,
                 sync_filter=_SYNC_FILTER,
-                first_sync_done=(self._first_sync_done and not self._room_member_join_bootstrap_pending),
+                first_sync_done=not self._room_member_hook_lifecycle.full_state_required,
             )
         finally:
             self._reconcile_classic_sync_cursor_after_loop_exit()
@@ -2388,28 +2313,6 @@ class AgentBot:
                     runtime_paths=self.runtime_paths,
                     storage_root=self.runtime_paths.storage_root,
                 )
-
-    async def _emit_room_member_joined_sync_timeline_hooks(self, response: nio.SyncResponse) -> None:
-        """Expose human joins from a restored-token catch-up sync timeline."""
-        if self.agent_name != ROUTER_AGENT_NAME:
-            return
-        if not self.hook_registry.has_hooks(EVENT_ROOM_MEMBER_JOINED):
-            return
-        client = self.client
-        if client is None:
-            return
-
-        for room, event in room_member_sync_timeline_events(
-            response,
-            rooms=client.rooms,
-            config=self.config,
-            runtime_paths=self.runtime_paths,
-        ):
-            await self._dispatch_obligation_runner.dispatch(
-                room,
-                event,
-                DispatchCallbackKind.ROOM_LIFECYCLE,
-            )
 
     async def _on_decryption_failure(self, room: nio.MatrixRoom, event: nio.MegolmEvent) -> None:
         await self._handle_decryption_failure_event(

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -117,7 +117,7 @@ from .knowledge import KnowledgeAccessSupport
 from .logging_config import get_logger
 from .matrix.avatar import check_and_set_avatar
 from .matrix.client_room_admin import get_joined_rooms
-from .matrix.client_session import PermanentMatrixStartupError, invalidate_rejected_sync_position
+from .matrix.client_session import PermanentMatrixStartupError
 from .matrix.joined_room_history import cache_fenced_world_readable_join_history
 from .matrix.room_member_joins import (
     RoomMemberJoin,
@@ -1397,9 +1397,13 @@ class AgentBot:
             await self._record_room_member_joined_events(
                 room_member_plan.baseline_record_events,
             )
-            self._room_member_hook_lifecycle.baseline_recorded()
         if room_member_plan.drain_captured_timeline:
             await self._dispatch_obligation_runner.drain_pending_room_lifecycle()
+        if room_member_plan.baseline_record_events is not None:
+            await self._record_room_member_joined_events(
+                room_member_plan.baseline_record_events,
+            )
+            self._room_member_hook_lifecycle.baseline_recorded()
         if room_member_plan.dispatch_state:
             await self._emit_room_member_joined_sync_state_hooks(response)
 
@@ -1582,20 +1586,17 @@ class AgentBot:
             )
         if _response.status_code == "M_UNKNOWN_POS":
             client = self.client
-            cleanup_succeeded = False
+            assert client is not None
 
             async def reject_position() -> None:
-                nonlocal cleanup_succeeded
                 try:
-                    if client is not None:
-                        await invalidate_rejected_sync_position(client)
-                    cleanup_succeeded = True
-                finally:
-                    decision = await self._sync_cache_trust.reject_unknown_pos()
-                    if cleanup_succeeded:
-                        self._apply_client_rewind_decision(decision)
-                    else:
-                        self._sync_cache_trust.defer_replay_after_pre_certification_failure()
+                    await cast("Any", client).invalidate_rejected_sync_position()
+                except BaseException:
+                    await self._sync_cache_trust.reject_unknown_pos()
+                    self._sync_cache_trust.defer_replay_after_pre_certification_failure()
+                    raise
+                decision = await self._sync_cache_trust.reject_unknown_pos()
+                self._apply_client_rewind_decision(decision)
 
             await run_coroutine_until_complete(reject_position())
             self.logger.warning(

--- a/src/mindroom/cold_history_fence.py
+++ b/src/mindroom/cold_history_fence.py
@@ -66,6 +66,7 @@ class ColdHistoryFence:
         source_event_id: str,
         callback_kind: DispatchCallbackKind,
         provenance: nio.TimelineEventProvenance | None = None,
+        allow_historical_recovery: bool = False,
     ) -> DispatchSourceAdmission:
         """Apply invite, decrypt-notice, and event-provenance policy."""
         if callback_kind is DispatchCallbackKind.INVITE:
@@ -73,6 +74,8 @@ class ColdHistoryFence:
         if callback_kind is DispatchCallbackKind.DECRYPTION_FAILURE and self.decrypt_notice_is_fenced(room_id):
             return DispatchSourceAdmission.DECRYPT_NOTICE_FENCED
         if provenance is not nio.TimelineEventProvenance.HISTORY:
+            return DispatchSourceAdmission.ACCEPTED
+        if callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE and allow_historical_recovery:
             return DispatchSourceAdmission.ACCEPTED
         if await asyncio.to_thread(
             self.obligations.has_pending,

--- a/src/mindroom/cold_history_fence.py
+++ b/src/mindroom/cold_history_fence.py
@@ -66,7 +66,6 @@ class ColdHistoryFence:
         source_event_id: str,
         callback_kind: DispatchCallbackKind,
         provenance: nio.TimelineEventProvenance | None = None,
-        allow_historical_recovery: bool = False,
     ) -> DispatchSourceAdmission:
         """Apply invite, decrypt-notice, and event-provenance policy."""
         if callback_kind is DispatchCallbackKind.INVITE:
@@ -75,7 +74,7 @@ class ColdHistoryFence:
             return DispatchSourceAdmission.DECRYPT_NOTICE_FENCED
         if provenance is not nio.TimelineEventProvenance.HISTORY:
             return DispatchSourceAdmission.ACCEPTED
-        if callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE and allow_historical_recovery:
+        if callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE:
             return DispatchSourceAdmission.ACCEPTED
         if await asyncio.to_thread(
             self.obligations.has_pending,

--- a/src/mindroom/cold_history_fence.py
+++ b/src/mindroom/cold_history_fence.py
@@ -40,7 +40,7 @@ def _decrypt_not_fenced(_room_id: str) -> bool:
 
 @dataclass(slots=True)
 class ColdHistoryFence:
-    """Admit live events and exact durable retries of historical events."""
+    """Admit live work, lifecycle-gated history, and exact durable historical retries."""
 
     obligations: _PendingDispatchObligations
     decrypt_notice_is_fenced: _DecryptNoticeFence = _decrypt_not_fenced
@@ -67,13 +67,15 @@ class ColdHistoryFence:
         callback_kind: DispatchCallbackKind,
         provenance: nio.TimelineEventProvenance | None = None,
     ) -> DispatchSourceAdmission:
-        """Apply invite, decrypt-notice, and event-provenance policy."""
+        """Apply invite, decrypt-notice, lifecycle, and event-provenance policy."""
         if callback_kind is DispatchCallbackKind.INVITE:
             return DispatchSourceAdmission.ACCEPTED
         if callback_kind is DispatchCallbackKind.DECRYPTION_FAILURE and self.decrypt_notice_is_fenced(room_id):
             return DispatchSourceAdmission.DECRYPT_NOTICE_FENCED
         if provenance is not nio.TimelineEventProvenance.HISTORY:
             return DispatchSourceAdmission.ACCEPTED
+        # RoomMemberHookLifecycle.admission_enabled already gates which
+        # historical membership phases may reach this callback kind.
         if callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE:
             return DispatchSourceAdmission.ACCEPTED
         if await asyncio.to_thread(

--- a/src/mindroom/dispatch_obligations/events.py
+++ b/src/mindroom/dispatch_obligations/events.py
@@ -140,18 +140,26 @@ def parse_recovery_event(obligation: DispatchObligation) -> DispatchEvent:
         if invite_source_event_id(obligation.room_id, event_source_json) != obligation.source_event_id:
             msg = f"corrupt dispatch obligation event {obligation.source_event_id!r}/'invite'"
             raise DispatchObligationCorruptionError(msg)
-        event = nio.InviteEvent.parse_event(dict(obligation.event_source))
+        try:
+            event = nio.InviteEvent.parse_event(dict(obligation.event_source))
+        except Exception as exc:
+            msg = f"corrupt dispatch obligation event {obligation.source_event_id!r}/'invite'"
+            raise DispatchObligationCorruptionError(msg) from exc
         if not isinstance(event, nio.InviteEvent):
             msg = f"corrupt dispatch obligation event {obligation.source_event_id!r}/'invite'"
             raise DispatchObligationCorruptionError(msg)
         return event
     event_source = dict(obligation.event_source)
     security_metadata = event_source.pop(_RECOVERY_SECURITY_METADATA_KEY, None)
-    event = (
-        parse_matrix_media_event_source(event_source)
-        if obligation.callback_kind is DispatchCallbackKind.MEDIA
-        else nio.Event.parse_event(event_source)
-    )
+    try:
+        event = (
+            parse_matrix_media_event_source(event_source)
+            if obligation.callback_kind is DispatchCallbackKind.MEDIA
+            else nio.Event.parse_event(event_source)
+        )
+    except Exception as exc:
+        msg = f"corrupt dispatch obligation event {obligation.source_event_id!r}/{obligation.callback_kind.value!r}"
+        raise DispatchObligationCorruptionError(msg) from exc
     if not isinstance(event, nio.Event) or event.event_id != obligation.source_event_id:
         msg = f"corrupt dispatch obligation event {obligation.source_event_id!r}/{obligation.callback_kind.value!r}"
         raise DispatchObligationCorruptionError(msg)

--- a/src/mindroom/dispatch_obligations/runner.py
+++ b/src/mindroom/dispatch_obligations/runner.py
@@ -55,9 +55,6 @@ logger = get_logger(__name__)
 _RETRY_INITIAL_DELAY_SECONDS = 1.0
 _RETRY_MAX_DELAY_SECONDS = 30.0
 _TURN_BACKED_KINDS = frozenset({DispatchCallbackKind.MESSAGE, DispatchCallbackKind.MEDIA})
-_NON_LIFECYCLE_CALLBACK_KIND_VALUES = frozenset(
-    kind.value for kind in DispatchCallbackKind if kind is not DispatchCallbackKind.ROOM_LIFECYCLE
-)
 
 _SourceAdmission = Callable[
     [str, str, DispatchCallbackKind, nio.TimelineEventProvenance | None, bool],
@@ -70,15 +67,6 @@ _SourceRejectionCallback = Callable[
     Awaitable[None],
 ]
 _RoomLifecycleAdmission = Callable[[nio.TimelineEventProvenance], bool]
-_RoomLifecycleExecution = Callable[[], bool]
-
-
-@dataclass(frozen=True, slots=True)
-class _RoomLifecycleMarkerFence:
-    """Snapshot markers blocked by exact or corrupt lifecycle obligations."""
-
-    member_ids: frozenset[tuple[str, str]]
-    corrupt_room_ids: frozenset[str]
 
 
 async def _admit_all_sources(
@@ -96,6 +84,36 @@ def _ignore_event_provenance(
     _provenance: nio.TimelineEventProvenance,
 ) -> None:
     pass
+
+
+def _may_be_room_lifecycle(callback_kind: str) -> bool:
+    """Fence known lifecycle rows and unknown kinds that cannot be ruled out."""
+    try:
+        return DispatchCallbackKind(callback_kind) is DispatchCallbackKind.ROOM_LIFECYCLE
+    except ValueError:
+        return True
+
+
+def _log_corrupt_obligation(obligation: DispatchObligation) -> None:
+    logger.error(
+        "dispatch_obligation_recovery_corrupt",
+        source_event_id=obligation.source_event_id,
+        callback_kind=obligation.callback_kind.value,
+        room_id=obligation.room_id,
+    )
+
+
+def _room_lifecycle_event(obligation: DispatchObligation) -> nio.RoomMemberEvent | None:
+    """Parse one lifecycle event, logging malformed retained work once."""
+    try:
+        event = parse_recovery_event(obligation)
+    except DispatchObligationCorruptionError:
+        _log_corrupt_obligation(obligation)
+        return None
+    if not isinstance(event, nio.RoomMemberEvent):
+        _log_corrupt_obligation(obligation)
+        return None
+    return event
 
 
 async def _ignore_historical_event_cache(
@@ -130,7 +148,6 @@ class DispatchObligationRunner:
     on_source_rejected: _SourceRejectionCallback | None = None
     background_task_owner: object | None = None
     room_lifecycle_admission_enabled: _RoomLifecycleAdmission = lambda _provenance: False
-    room_lifecycle_execution_enabled: _RoomLifecycleExecution = lambda: False
     _retry_initial_delay_seconds: float = field(default=_RETRY_INITIAL_DELAY_SECONDS, repr=False)
     _retry_max_delay_seconds: float = field(default=_RETRY_MAX_DELAY_SECONDS, repr=False)
     _active: set[DispatchObligationKey] = field(default_factory=set, init=False, repr=False)
@@ -244,57 +261,34 @@ class DispatchObligationRunner:
             source_event_ids,
         )
 
-    async def room_lifecycle_marker_fence(self) -> _RoomLifecycleMarkerFence:
+    async def room_lifecycle_marker_fence(
+        self,
+    ) -> tuple[frozenset[tuple[str, str]], frozenset[str]]:
         """Return exact member and room-wide corruption fences for snapshot markers."""
-        pending = await asyncio.to_thread(self.store.pending_with_corruption)
+        obligations, corrupt_rows = await asyncio.to_thread(self.store.pending_with_corruption)
         members: set[tuple[str, str]] = set()
         corrupt_room_ids = {
-            row.room_id for row in pending.corrupt_rows if row.callback_kind not in _NON_LIFECYCLE_CALLBACK_KIND_VALUES
+            room_id
+            for _source_event_id, callback_kind, room_id in corrupt_rows
+            if _may_be_room_lifecycle(callback_kind)
         }
-        for obligation in pending.obligations:
+        for obligation in obligations:
             if obligation.callback_kind is not DispatchCallbackKind.ROOM_LIFECYCLE:
                 continue
-            try:
-                event = parse_recovery_event(obligation)
-            except DispatchObligationCorruptionError:
-                event = None
-            if not isinstance(event, nio.RoomMemberEvent):
-                logger.error(
-                    "dispatch_obligation_recovery_corrupt",
-                    source_event_id=obligation.source_event_id,
-                    callback_kind=obligation.callback_kind.value,
-                    room_id=obligation.room_id,
-                )
+            event = _room_lifecycle_event(obligation)
+            if event is None:
                 corrupt_room_ids.add(obligation.room_id)
                 continue
             members.add((obligation.room_id, event.state_key))
-        return _RoomLifecycleMarkerFence(
-            member_ids=frozenset(members),
-            corrupt_room_ids=frozenset(corrupt_room_ids),
-        )
+        return frozenset(members), frozenset(corrupt_room_ids)
 
     async def drain_pending_room_lifecycle(self) -> None:
         """Complete every valid captured member callback before certification."""
         for obligation in await asyncio.to_thread(self.store.pending):
             if obligation.callback_kind is not DispatchCallbackKind.ROOM_LIFECYCLE:
                 continue
-            try:
-                event = parse_recovery_event(obligation)
-            except DispatchObligationCorruptionError:
-                logger.error(  # noqa: TRY400
-                    "dispatch_obligation_recovery_corrupt",
-                    source_event_id=obligation.source_event_id,
-                    callback_kind=obligation.callback_kind.value,
-                    room_id=obligation.room_id,
-                )
-                continue
-            if not isinstance(event, nio.RoomMemberEvent):
-                logger.error(
-                    "dispatch_obligation_recovery_corrupt",
-                    source_event_id=obligation.source_event_id,
-                    callback_kind=obligation.callback_kind.value,
-                    room_id=obligation.room_id,
-                )
+            event = _room_lifecycle_event(obligation)
+            if event is None:
                 continue
             await self._run_persisted(
                 obligation,
@@ -565,6 +559,8 @@ class DispatchObligationRunner:
         """Retry every valid pending callback without waiting for another sync response."""
         failed_keys: list[DispatchObligationKey] = []
         for obligation in await asyncio.to_thread(self.store.pending):
+            if obligation.callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE:
+                continue
             if turn_backed is not None and (obligation.callback_kind in _TURN_BACKED_KINDS) != turn_backed:
                 continue
             try:
@@ -579,12 +575,7 @@ class DispatchObligationRunner:
             except asyncio.CancelledError:
                 raise
             except DispatchObligationCorruptionError:
-                logger.error(  # noqa: TRY400
-                    "dispatch_obligation_recovery_corrupt",
-                    source_event_id=obligation.source_event_id,
-                    callback_kind=obligation.callback_kind.value,
-                    room_id=obligation.room_id,
-                )
+                _log_corrupt_obligation(obligation)
             except Exception:
                 logger.exception(
                     "dispatch_obligation_recovery_failed",
@@ -598,6 +589,8 @@ class DispatchObligationRunner:
 
     def _schedule_retry(self, key: DispatchObligationKey) -> None:
         """Ensure one failed exact callback remains autonomously retry-owned."""
+        if key.callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE:
+            return
         if key in self._retry_corrupt:
             return
         self._retry_keys.setdefault(key, 0)
@@ -793,11 +786,6 @@ class _DispatchObligationTaskWrapper:
         key = self.runner._obligation_for_event(room, event, self.callback_kind).key
         obligation = _ADMITTED_OBLIGATION.get()
         _ADMITTED_OBLIGATION.set(None)
-        if (
-            self.callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE
-            and not self.runner.room_lifecycle_execution_enabled()
-        ):
-            return
         if obligation is not None and obligation.key == key:
             self.runner._schedule_background_obligation(
                 obligation,

--- a/src/mindroom/dispatch_obligations/runner.py
+++ b/src/mindroom/dispatch_obligations/runner.py
@@ -93,15 +93,6 @@ def _may_be_room_lifecycle(callback_kind: str) -> bool:
         return True
 
 
-def _log_corrupt_obligation(obligation: DispatchObligation) -> None:
-    logger.error(
-        "dispatch_obligation_recovery_corrupt",
-        source_event_id=obligation.source_event_id,
-        callback_kind=obligation.callback_kind.value,
-        room_id=obligation.room_id,
-    )
-
-
 async def _ignore_historical_event_cache(
     _room: nio.MatrixRoom,
     _event: nio.Event,
@@ -326,12 +317,7 @@ class DispatchObligationRunner:
             return
         _ADMITTED_OBLIGATION.set(None)
         try:
-            obligation = await self.persist(
-                room,
-                event,
-                callback_kind,
-                provenance,
-            )
+            obligation = await self.persist(room, event, callback_kind, provenance)
         except asyncio.CancelledError:
             raise
         except Exception as error:
@@ -519,17 +505,9 @@ class DispatchObligationRunner:
             event = parse_recovery_event(obligation)
         if obligation.requires_pending_check:
             with turn_dispatch_recovery_scope(active=obligation.callback_kind in _TURN_BACKED_KINDS):
-                await self._run_obligation(
-                    obligation,
-                    room=room,
-                    event=event,
-                )
+                await self._run_obligation(obligation, room=room, event=event)
             return
-        await self._run_obligation(
-            obligation,
-            room=room,
-            event=event,
-        )
+        await self._run_obligation(obligation, room=room, event=event)
 
     def _room_lifecycle_event(self, obligation: DispatchObligation) -> nio.RoomMemberEvent | None:
         """Parse one lifecycle event, logging malformed retained work once."""
@@ -548,7 +526,12 @@ class DispatchObligationRunner:
         if obligation.key in self._reported_corrupt:
             return
         self._reported_corrupt.add(obligation.key)
-        _log_corrupt_obligation(obligation)
+        logger.error(
+            "dispatch_obligation_recovery_corrupt",
+            source_event_id=obligation.source_event_id,
+            callback_kind=obligation.callback_kind.value,
+            room_id=obligation.room_id,
+        )
 
     async def recover_pending(self, *, turn_backed: bool | None = None) -> None:
         """Retry every valid pending callback without waiting for another sync response."""
@@ -675,8 +658,7 @@ class DispatchObligationRunner:
         event: DispatchEvent,
     ) -> bool:
         """Run one obligation, returning whether this caller acquired its live claim."""
-        claimed = await self._claim(obligation.key)
-        if not claimed:
+        if not await self._claim(obligation.key):
             return False
         try:
             if obligation.requires_pending_check and not await asyncio.to_thread(

--- a/src/mindroom/dispatch_obligations/runner.py
+++ b/src/mindroom/dispatch_obligations/runner.py
@@ -57,7 +57,7 @@ _RETRY_MAX_DELAY_SECONDS = 30.0
 _TURN_BACKED_KINDS = frozenset({DispatchCallbackKind.MESSAGE, DispatchCallbackKind.MEDIA})
 
 _SourceAdmission = Callable[
-    [str, str, DispatchCallbackKind, nio.TimelineEventProvenance | None, bool],
+    [str, str, DispatchCallbackKind, nio.TimelineEventProvenance | None],
     Awaitable[DispatchSourceAdmission],
 ]
 _EventProvenanceObserver = Callable[[str, nio.TimelineEventProvenance], None]
@@ -74,7 +74,6 @@ async def _admit_all_sources(
     _source_event_id: str,
     _callback_kind: DispatchCallbackKind,
     _provenance: nio.TimelineEventProvenance | None,
-    _allow_historical_recovery: bool,
 ) -> DispatchSourceAdmission:
     return DispatchSourceAdmission.ACCEPTED
 
@@ -101,19 +100,6 @@ def _log_corrupt_obligation(obligation: DispatchObligation) -> None:
         callback_kind=obligation.callback_kind.value,
         room_id=obligation.room_id,
     )
-
-
-def _room_lifecycle_event(obligation: DispatchObligation) -> nio.RoomMemberEvent | None:
-    """Parse one lifecycle event, logging malformed retained work once."""
-    try:
-        event = parse_recovery_event(obligation)
-    except DispatchObligationCorruptionError:
-        _log_corrupt_obligation(obligation)
-        return None
-    if not isinstance(event, nio.RoomMemberEvent):
-        _log_corrupt_obligation(obligation)
-        return None
-    return event
 
 
 async def _ignore_historical_event_cache(
@@ -151,9 +137,10 @@ class DispatchObligationRunner:
     _retry_initial_delay_seconds: float = field(default=_RETRY_INITIAL_DELAY_SECONDS, repr=False)
     _retry_max_delay_seconds: float = field(default=_RETRY_MAX_DELAY_SECONDS, repr=False)
     _active: set[DispatchObligationKey] = field(default_factory=set, init=False, repr=False)
-    _active_condition: asyncio.Condition = field(default_factory=asyncio.Condition, init=False, repr=False)
+    _active_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
     _retry_keys: dict[DispatchObligationKey, int] = field(default_factory=dict, init=False, repr=False)
     _retry_corrupt: set[DispatchObligationKey] = field(default_factory=set, init=False, repr=False)
+    _reported_corrupt: set[DispatchObligationKey] = field(default_factory=set, init=False, repr=False)
     _retry_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
 
     @staticmethod
@@ -275,7 +262,7 @@ class DispatchObligationRunner:
         for obligation in obligations:
             if obligation.callback_kind is not DispatchCallbackKind.ROOM_LIFECYCLE:
                 continue
-            event = _room_lifecycle_event(obligation)
+            event = self._room_lifecycle_event(obligation)
             if event is None:
                 corrupt_room_ids.add(obligation.room_id)
                 continue
@@ -287,14 +274,13 @@ class DispatchObligationRunner:
         for obligation in await asyncio.to_thread(self.store.pending):
             if obligation.callback_kind is not DispatchCallbackKind.ROOM_LIFECYCLE:
                 continue
-            event = _room_lifecycle_event(obligation)
+            event = self._room_lifecycle_event(obligation)
             if event is None:
                 continue
             await self._run_persisted(
                 obligation,
                 room=self.room_for_id(obligation.room_id),
                 event=event,
-                wait_for_active=True,
             )
 
     def register_source_callbacks(self, client: nio.AsyncClient, *, owner: object) -> None:
@@ -345,10 +331,6 @@ class DispatchObligationRunner:
                 event,
                 callback_kind,
                 provenance,
-                allow_historical_recovery=(
-                    callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE
-                    and provenance is nio.TimelineEventProvenance.HISTORY
-                ),
             )
         except asyncio.CancelledError:
             raise
@@ -410,8 +392,6 @@ class DispatchObligationRunner:
         event: DispatchEvent,
         callback_kind: DispatchCallbackKind,
         provenance: nio.TimelineEventProvenance | None = None,
-        *,
-        allow_historical_recovery: bool = False,
     ) -> DispatchObligation | None:
         """Persist exact work before its background task may be created."""
         try:
@@ -421,7 +401,6 @@ class DispatchObligationRunner:
                 obligation.source_event_id,
                 callback_kind,
                 provenance,
-                allow_historical_recovery,
             )
             if admission is not DispatchSourceAdmission.ACCEPTED:
                 if self.on_source_rejected is not None:
@@ -533,7 +512,6 @@ class DispatchObligationRunner:
         *,
         room: nio.MatrixRoom,
         event: DispatchEvent,
-        wait_for_active: bool = False,
     ) -> None:
         """Execute work whose exact durable obligation already exists."""
         if room.room_id != obligation.room_id or dispatch_event_source(event) != obligation.event_source:
@@ -545,15 +523,32 @@ class DispatchObligationRunner:
                     obligation,
                     room=room,
                     event=event,
-                    wait_for_active=wait_for_active,
                 )
             return
         await self._run_obligation(
             obligation,
             room=room,
             event=event,
-            wait_for_active=wait_for_active,
         )
+
+    def _room_lifecycle_event(self, obligation: DispatchObligation) -> nio.RoomMemberEvent | None:
+        """Parse one lifecycle event, logging malformed retained work once."""
+        try:
+            event = parse_recovery_event(obligation)
+        except DispatchObligationCorruptionError:
+            self._log_corrupt_obligation_once(obligation)
+            return None
+        if not isinstance(event, nio.RoomMemberEvent):
+            self._log_corrupt_obligation_once(obligation)
+            return None
+        return event
+
+    def _log_corrupt_obligation_once(self, obligation: DispatchObligation) -> None:
+        """Log one parseable retained row once per runner lifetime."""
+        if obligation.key in self._reported_corrupt:
+            return
+        self._reported_corrupt.add(obligation.key)
+        _log_corrupt_obligation(obligation)
 
     async def recover_pending(self, *, turn_backed: bool | None = None) -> None:
         """Retry every valid pending callback without waiting for another sync response."""
@@ -575,7 +570,7 @@ class DispatchObligationRunner:
             except asyncio.CancelledError:
                 raise
             except DispatchObligationCorruptionError:
-                _log_corrupt_obligation(obligation)
+                self._log_corrupt_obligation_once(obligation)
             except Exception:
                 logger.exception(
                     "dispatch_obligation_recovery_failed",
@@ -678,12 +673,9 @@ class DispatchObligationRunner:
         *,
         room: nio.MatrixRoom,
         event: DispatchEvent,
-        wait_for_active: bool = False,
     ) -> bool:
         """Run one obligation, returning whether this caller acquired its live claim."""
-        claimed = (
-            await self._claim_when_available(obligation.key) if wait_for_active else await self._claim(obligation.key)
-        )
+        claimed = await self._claim(obligation.key)
         if not claimed:
             return False
         try:
@@ -754,23 +746,15 @@ class DispatchObligationRunner:
         await run_blocking_until_complete(self.store.settle, obligation.key, outcome)
 
     async def _claim(self, key: DispatchObligationKey) -> bool:
-        async with self._active_condition:
+        async with self._active_lock:
             if key in self._active:
                 return False
             self._active.add(key)
             return True
 
-    async def _claim_when_available(self, key: DispatchObligationKey) -> bool:
-        """Wait until this exact callback has no competing in-process owner."""
-        async with self._active_condition:
-            await self._active_condition.wait_for(lambda: key not in self._active)
-            self._active.add(key)
-            return True
-
     async def _release(self, key: DispatchObligationKey) -> None:
-        async with self._active_condition:
+        async with self._active_lock:
             self._active.discard(key)
-            self._active_condition.notify_all()
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/dispatch_obligations/runner.py
+++ b/src/mindroom/dispatch_obligations/runner.py
@@ -60,7 +60,7 @@ _NON_LIFECYCLE_CALLBACK_KIND_VALUES = frozenset(
 )
 
 _SourceAdmission = Callable[
-    [str, str, DispatchCallbackKind, nio.TimelineEventProvenance | None],
+    [str, str, DispatchCallbackKind, nio.TimelineEventProvenance | None, bool],
     Awaitable[DispatchSourceAdmission],
 ]
 _EventProvenanceObserver = Callable[[str, nio.TimelineEventProvenance], None]
@@ -69,6 +69,8 @@ _SourceRejectionCallback = Callable[
     [nio.MatrixRoom, DispatchEvent, DispatchCallbackKind, DispatchSourceAdmission],
     Awaitable[None],
 ]
+_RoomLifecycleAdmission = Callable[[nio.TimelineEventProvenance], bool]
+_RoomLifecycleExecution = Callable[[], bool]
 
 
 @dataclass(frozen=True, slots=True)
@@ -84,6 +86,7 @@ async def _admit_all_sources(
     _source_event_id: str,
     _callback_kind: DispatchCallbackKind,
     _provenance: nio.TimelineEventProvenance | None,
+    _allow_historical_recovery: bool,
 ) -> DispatchSourceAdmission:
     return DispatchSourceAdmission.ACCEPTED
 
@@ -126,11 +129,12 @@ class DispatchObligationRunner:
     cache_historical_event: _HistoricalEventCache = _ignore_historical_event_cache
     on_source_rejected: _SourceRejectionCallback | None = None
     background_task_owner: object | None = None
-    room_lifecycle_admission_enabled: Callable[[], bool] = lambda: False
+    room_lifecycle_admission_enabled: _RoomLifecycleAdmission = lambda _provenance: False
+    room_lifecycle_execution_enabled: _RoomLifecycleExecution = lambda: False
     _retry_initial_delay_seconds: float = field(default=_RETRY_INITIAL_DELAY_SECONDS, repr=False)
     _retry_max_delay_seconds: float = field(default=_RETRY_MAX_DELAY_SECONDS, repr=False)
     _active: set[DispatchObligationKey] = field(default_factory=set, init=False, repr=False)
-    _active_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
+    _active_condition: asyncio.Condition = field(default_factory=asyncio.Condition, init=False, repr=False)
     _retry_keys: dict[DispatchObligationKey, int] = field(default_factory=dict, init=False, repr=False)
     _retry_corrupt: set[DispatchObligationKey] = field(default_factory=set, init=False, repr=False)
     _retry_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
@@ -269,6 +273,36 @@ class DispatchObligationRunner:
             corrupt_room_ids=frozenset(corrupt_room_ids),
         )
 
+    async def drain_pending_room_lifecycle(self) -> None:
+        """Complete every valid captured member callback before certification."""
+        for obligation in await asyncio.to_thread(self.store.pending):
+            if obligation.callback_kind is not DispatchCallbackKind.ROOM_LIFECYCLE:
+                continue
+            try:
+                event = parse_recovery_event(obligation)
+            except DispatchObligationCorruptionError:
+                logger.error(  # noqa: TRY400
+                    "dispatch_obligation_recovery_corrupt",
+                    source_event_id=obligation.source_event_id,
+                    callback_kind=obligation.callback_kind.value,
+                    room_id=obligation.room_id,
+                )
+                continue
+            if not isinstance(event, nio.RoomMemberEvent):
+                logger.error(
+                    "dispatch_obligation_recovery_corrupt",
+                    source_event_id=obligation.source_event_id,
+                    callback_kind=obligation.callback_kind.value,
+                    room_id=obligation.room_id,
+                )
+                continue
+            await self._run_persisted(
+                obligation,
+                room=self.room_for_id(obligation.room_id),
+                event=event,
+                wait_for_active=True,
+            )
+
     def register_source_callbacks(self, client: nio.AsyncClient, *, owner: object) -> None:
         """Register every source-backed correctness callback except delayed room lifecycle."""
         client.add_event_admission_callback(self._admit_source_event)
@@ -307,24 +341,37 @@ class DispatchObligationRunner:
                 raise
             except Exception as error:
                 raise nio.CallbackNotAcceptedError(str(error)) from error
-        callback_kind = self._admission_kind(event)
+        callback_kind = self._admission_kind(event, provenance)
         if callback_kind is None:
             return
         _ADMITTED_OBLIGATION.set(None)
         try:
-            obligation = await self.persist(room, event, callback_kind, provenance)
+            obligation = await self.persist(
+                room,
+                event,
+                callback_kind,
+                provenance,
+                allow_historical_recovery=(
+                    callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE
+                    and provenance is nio.TimelineEventProvenance.HISTORY
+                ),
+            )
         except asyncio.CancelledError:
             raise
         except Exception as error:
             raise nio.CallbackNotAcceptedError(str(error)) from error
         _ADMITTED_OBLIGATION.set(obligation)
 
-    def _admission_kind(self, event: nio.Event) -> DispatchCallbackKind | None:
+    def _admission_kind(
+        self,
+        event: nio.Event,
+        provenance: nio.TimelineEventProvenance,
+    ) -> DispatchCallbackKind | None:
         """Return the one durable callback kind owned by a timeline event."""
         for policy in SOURCE_CALLBACK_POLICIES:
             if policy.matches(event):
                 return policy.callback_kind
-        if isinstance(event, nio.RoomMemberEvent) and self.room_lifecycle_admission_enabled():
+        if isinstance(event, nio.RoomMemberEvent) and self.room_lifecycle_admission_enabled(provenance):
             return DispatchCallbackKind.ROOM_LIFECYCLE
         return None
 
@@ -369,6 +416,8 @@ class DispatchObligationRunner:
         event: DispatchEvent,
         callback_kind: DispatchCallbackKind,
         provenance: nio.TimelineEventProvenance | None = None,
+        *,
+        allow_historical_recovery: bool = False,
     ) -> DispatchObligation | None:
         """Persist exact work before its background task may be created."""
         try:
@@ -378,6 +427,7 @@ class DispatchObligationRunner:
                 obligation.source_event_id,
                 callback_kind,
                 provenance,
+                allow_historical_recovery,
             )
             if admission is not DispatchSourceAdmission.ACCEPTED:
                 if self.on_source_rejected is not None:
@@ -489,6 +539,7 @@ class DispatchObligationRunner:
         *,
         room: nio.MatrixRoom,
         event: DispatchEvent,
+        wait_for_active: bool = False,
     ) -> None:
         """Execute work whose exact durable obligation already exists."""
         if room.room_id != obligation.room_id or dispatch_event_source(event) != obligation.event_source:
@@ -496,9 +547,19 @@ class DispatchObligationRunner:
             event = parse_recovery_event(obligation)
         if obligation.requires_pending_check:
             with turn_dispatch_recovery_scope(active=obligation.callback_kind in _TURN_BACKED_KINDS):
-                await self._run_obligation(obligation, room=room, event=event)
+                await self._run_obligation(
+                    obligation,
+                    room=room,
+                    event=event,
+                    wait_for_active=wait_for_active,
+                )
             return
-        await self._run_obligation(obligation, room=room, event=event)
+        await self._run_obligation(
+            obligation,
+            room=room,
+            event=event,
+            wait_for_active=wait_for_active,
+        )
 
     async def recover_pending(self, *, turn_backed: bool | None = None) -> None:
         """Retry every valid pending callback without waiting for another sync response."""
@@ -624,9 +685,13 @@ class DispatchObligationRunner:
         *,
         room: nio.MatrixRoom,
         event: DispatchEvent,
+        wait_for_active: bool = False,
     ) -> bool:
         """Run one obligation, returning whether this caller acquired its live claim."""
-        if not await self._claim(obligation.key):
+        claimed = (
+            await self._claim_when_available(obligation.key) if wait_for_active else await self._claim(obligation.key)
+        )
+        if not claimed:
             return False
         try:
             if obligation.requires_pending_check and not await asyncio.to_thread(
@@ -696,15 +761,23 @@ class DispatchObligationRunner:
         await run_blocking_until_complete(self.store.settle, obligation.key, outcome)
 
     async def _claim(self, key: DispatchObligationKey) -> bool:
-        async with self._active_lock:
+        async with self._active_condition:
             if key in self._active:
                 return False
             self._active.add(key)
             return True
 
+    async def _claim_when_available(self, key: DispatchObligationKey) -> bool:
+        """Wait until this exact callback has no competing in-process owner."""
+        async with self._active_condition:
+            await self._active_condition.wait_for(lambda: key not in self._active)
+            self._active.add(key)
+            return True
+
     async def _release(self, key: DispatchObligationKey) -> None:
-        async with self._active_lock:
+        async with self._active_condition:
             self._active.discard(key)
+            self._active_condition.notify_all()
 
 
 @dataclass(frozen=True, slots=True)
@@ -720,6 +793,11 @@ class _DispatchObligationTaskWrapper:
         key = self.runner._obligation_for_event(room, event, self.callback_kind).key
         obligation = _ADMITTED_OBLIGATION.get()
         _ADMITTED_OBLIGATION.set(None)
+        if (
+            self.callback_kind is DispatchCallbackKind.ROOM_LIFECYCLE
+            and not self.runner.room_lifecycle_execution_enabled()
+        ):
+            return
         if obligation is not None and obligation.key == key:
             self.runner._schedule_background_obligation(
                 obligation,

--- a/src/mindroom/dispatch_obligations/runner.py
+++ b/src/mindroom/dispatch_obligations/runner.py
@@ -68,6 +68,14 @@ _SourceRejectionCallback = Callable[
 ]
 
 
+@dataclass(frozen=True, slots=True)
+class _RoomLifecycleMarkerFence:
+    """Snapshot markers blocked by exact or corrupt lifecycle obligations."""
+
+    member_ids: frozenset[tuple[str, str]]
+    corrupt_room_ids: frozenset[str]
+
+
 async def _admit_all_sources(
     _room_id: str,
     _source_event_id: str,
@@ -229,19 +237,36 @@ class DispatchObligationRunner:
             source_event_ids,
         )
 
-    async def unsettled_room_lifecycle_member_ids(self) -> frozenset[tuple[str, str]]:
-        """Return room/member identities still owned by lifecycle obligations."""
-        obligations = await asyncio.to_thread(self.store.pending)
+    async def room_lifecycle_marker_fence(self) -> _RoomLifecycleMarkerFence:
+        """Return exact member and room-wide corruption fences for snapshot markers."""
+        pending = await asyncio.to_thread(self.store.pending_with_corruption)
         members: set[tuple[str, str]] = set()
-        for obligation in obligations:
+        corrupt_room_ids = {
+            row.room_id
+            for row in pending.corrupt_rows
+            if row.callback_kind == DispatchCallbackKind.ROOM_LIFECYCLE.value
+        }
+        for obligation in pending.obligations:
             if obligation.callback_kind is not DispatchCallbackKind.ROOM_LIFECYCLE:
                 continue
-            event = parse_recovery_event(obligation)
+            try:
+                event = parse_recovery_event(obligation)
+            except DispatchObligationCorruptionError:
+                event = None
             if not isinstance(event, nio.RoomMemberEvent):
-                msg = f"Room lifecycle obligation {obligation.source_event_id!r} is not a member event"
-                raise DispatchObligationCorruptionError(msg)
+                logger.error(
+                    "dispatch_obligation_recovery_corrupt",
+                    source_event_id=obligation.source_event_id,
+                    callback_kind=obligation.callback_kind.value,
+                    room_id=obligation.room_id,
+                )
+                corrupt_room_ids.add(obligation.room_id)
+                continue
             members.add((obligation.room_id, event.state_key))
-        return frozenset(members)
+        return _RoomLifecycleMarkerFence(
+            member_ids=frozenset(members),
+            corrupt_room_ids=frozenset(corrupt_room_ids),
+        )
 
     def register_source_callbacks(self, client: nio.AsyncClient, *, owner: object) -> None:
         """Register every source-backed correctness callback except delayed room lifecycle."""

--- a/src/mindroom/dispatch_obligations/runner.py
+++ b/src/mindroom/dispatch_obligations/runner.py
@@ -55,6 +55,9 @@ logger = get_logger(__name__)
 _RETRY_INITIAL_DELAY_SECONDS = 1.0
 _RETRY_MAX_DELAY_SECONDS = 30.0
 _TURN_BACKED_KINDS = frozenset({DispatchCallbackKind.MESSAGE, DispatchCallbackKind.MEDIA})
+_NON_LIFECYCLE_CALLBACK_KIND_VALUES = frozenset(
+    kind.value for kind in DispatchCallbackKind if kind is not DispatchCallbackKind.ROOM_LIFECYCLE
+)
 
 _SourceAdmission = Callable[
     [str, str, DispatchCallbackKind, nio.TimelineEventProvenance | None],
@@ -242,9 +245,7 @@ class DispatchObligationRunner:
         pending = await asyncio.to_thread(self.store.pending_with_corruption)
         members: set[tuple[str, str]] = set()
         corrupt_room_ids = {
-            row.room_id
-            for row in pending.corrupt_rows
-            if row.callback_kind == DispatchCallbackKind.ROOM_LIFECYCLE.value
+            row.room_id for row in pending.corrupt_rows if row.callback_kind not in _NON_LIFECYCLE_CALLBACK_KIND_VALUES
         }
         for obligation in pending.obligations:
             if obligation.callback_kind is not DispatchCallbackKind.ROOM_LIFECYCLE:

--- a/src/mindroom/dispatch_obligations/storage.py
+++ b/src/mindroom/dispatch_obligations/storage.py
@@ -121,6 +121,23 @@ class DispatchObligation:
 
 
 @dataclass(frozen=True, slots=True)
+class _CorruptDispatchObligationRow:
+    """Raw identity retained for one pending row whose payload cannot be decoded."""
+
+    source_event_id: str
+    callback_kind: str
+    room_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class _PendingDispatchObligations:
+    """Valid pending work plus explicit identities for retained corrupt rows."""
+
+    obligations: tuple[DispatchObligation, ...]
+    corrupt_rows: tuple[_CorruptDispatchObligationRow, ...]
+
+
+@dataclass(frozen=True, slots=True)
 class _StoredRow:
     room_id: str
     event_source_json: str
@@ -635,8 +652,8 @@ class DispatchObligationStore:
             eligible_states=(_PENDING_STATE, _DEFERRED_STATE),
         )
 
-    def pending(self) -> tuple[DispatchObligation, ...]:
-        """Return valid pending work oldest-first while retaining corrupt rows."""
+    def pending_with_corruption(self) -> _PendingDispatchObligations:
+        """Return valid pending work and expose retained corrupt row identities."""
         with self._lock, self._connection() as connection:
             rows = connection.execute(
                 """
@@ -650,16 +667,31 @@ class DispatchObligationStore:
                 (self.principal_id, self.entity_name),
             ).fetchall()
         obligations: list[DispatchObligation] = []
+        corrupt_rows: list[_CorruptDispatchObligationRow] = []
         for row in rows:
             try:
                 obligations.append(self._pending_obligation_from_row(row))
             except DispatchObligationCorruptionError:
+                corrupt_rows.append(
+                    _CorruptDispatchObligationRow(
+                        source_event_id=row["source_event_id"],
+                        callback_kind=row["callback_kind"],
+                        room_id=row["room_id"],
+                    ),
+                )
                 logger.error(  # noqa: TRY400
                     "dispatch_obligation_pending_row_corrupt",
                     source_event_id=row["source_event_id"],
                     callback_kind=row["callback_kind"],
                 )
-        return tuple(obligations)
+        return _PendingDispatchObligations(
+            obligations=tuple(obligations),
+            corrupt_rows=tuple(corrupt_rows),
+        )
+
+    def pending(self) -> tuple[DispatchObligation, ...]:
+        """Return valid pending work oldest-first while retaining corrupt rows."""
+        return self.pending_with_corruption().obligations
 
     def unsettled_source_event_ids(self) -> frozenset[str]:
         """Return raw source IDs whose callbacks are not terminal."""

--- a/src/mindroom/dispatch_obligations/storage.py
+++ b/src/mindroom/dispatch_obligations/storage.py
@@ -147,6 +147,7 @@ class DispatchObligationStore:
             self.entity_name,
         )
         self._lock = threading.Lock()
+        self._reported_corrupt_rows: set[tuple[str, str, str]] = set()
         with self._lock, self._connection() as connection:
             connection.execute("PRAGMA journal_mode = WAL")
             connection.execute("BEGIN IMMEDIATE")
@@ -660,19 +661,27 @@ class DispatchObligationStore:
             try:
                 obligations.append(self._pending_obligation_from_row(row))
             except DispatchObligationCorruptionError:
-                corrupt_rows.append(
-                    (
-                        row["source_event_id"],
-                        row["callback_kind"],
-                        row["room_id"],
-                    ),
+                identity = (
+                    row["source_event_id"],
+                    row["callback_kind"],
+                    row["room_id"],
                 )
-                logger.error(  # noqa: TRY400
-                    "dispatch_obligation_pending_row_corrupt",
-                    source_event_id=row["source_event_id"],
-                    callback_kind=row["callback_kind"],
-                )
+                corrupt_rows.append(identity)
+                self._log_corrupt_row_once(identity)
         return tuple(obligations), tuple(corrupt_rows)
+
+    def _log_corrupt_row_once(self, identity: tuple[str, str, str]) -> None:
+        """Log one retained corrupt row once per store lifetime."""
+        with self._lock:
+            if identity in self._reported_corrupt_rows:
+                return
+            self._reported_corrupt_rows.add(identity)
+        source_event_id, callback_kind, _room_id = identity
+        logger.error(
+            "dispatch_obligation_pending_row_corrupt",
+            source_event_id=source_event_id,
+            callback_kind=callback_kind,
+        )
 
     def pending(self) -> tuple[DispatchObligation, ...]:
         """Return valid pending work oldest-first while retaining corrupt rows."""

--- a/src/mindroom/dispatch_obligations/storage.py
+++ b/src/mindroom/dispatch_obligations/storage.py
@@ -121,23 +121,6 @@ class DispatchObligation:
 
 
 @dataclass(frozen=True, slots=True)
-class _CorruptDispatchObligationRow:
-    """Raw identity retained for one pending row whose payload cannot be decoded."""
-
-    source_event_id: str
-    callback_kind: str
-    room_id: str
-
-
-@dataclass(frozen=True, slots=True)
-class _PendingDispatchObligations:
-    """Valid pending work plus explicit identities for retained corrupt rows."""
-
-    obligations: tuple[DispatchObligation, ...]
-    corrupt_rows: tuple[_CorruptDispatchObligationRow, ...]
-
-
-@dataclass(frozen=True, slots=True)
 class _StoredRow:
     room_id: str
     event_source_json: str
@@ -652,7 +635,12 @@ class DispatchObligationStore:
             eligible_states=(_PENDING_STATE, _DEFERRED_STATE),
         )
 
-    def pending_with_corruption(self) -> _PendingDispatchObligations:
+    def pending_with_corruption(
+        self,
+    ) -> tuple[
+        tuple[DispatchObligation, ...],
+        tuple[tuple[str, str, str], ...],
+    ]:
         """Return valid pending work and expose retained corrupt row identities."""
         with self._lock, self._connection() as connection:
             rows = connection.execute(
@@ -667,16 +655,16 @@ class DispatchObligationStore:
                 (self.principal_id, self.entity_name),
             ).fetchall()
         obligations: list[DispatchObligation] = []
-        corrupt_rows: list[_CorruptDispatchObligationRow] = []
+        corrupt_rows: list[tuple[str, str, str]] = []
         for row in rows:
             try:
                 obligations.append(self._pending_obligation_from_row(row))
             except DispatchObligationCorruptionError:
                 corrupt_rows.append(
-                    _CorruptDispatchObligationRow(
-                        source_event_id=row["source_event_id"],
-                        callback_kind=row["callback_kind"],
-                        room_id=row["room_id"],
+                    (
+                        row["source_event_id"],
+                        row["callback_kind"],
+                        row["room_id"],
                     ),
                 )
                 logger.error(  # noqa: TRY400
@@ -684,14 +672,12 @@ class DispatchObligationStore:
                     source_event_id=row["source_event_id"],
                     callback_kind=row["callback_kind"],
                 )
-        return _PendingDispatchObligations(
-            obligations=tuple(obligations),
-            corrupt_rows=tuple(corrupt_rows),
-        )
+        return tuple(obligations), tuple(corrupt_rows)
 
     def pending(self) -> tuple[DispatchObligation, ...]:
         """Return valid pending work oldest-first while retaining corrupt rows."""
-        return self.pending_with_corruption().obligations
+        obligations, _corrupt_rows = self.pending_with_corruption()
+        return obligations
 
     def unsettled_source_event_ids(self) -> frozenset[str]:
         """Return raw source IDs whose callbacks are not terminal."""

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -276,14 +276,6 @@ def matrix_client_config(*, http_headers: Mapping[str, str] | None = None) -> ni
     )
 
 
-async def invalidate_rejected_sync_position(client: nio.AsyncClient) -> None:
-    """Durably discard a rejected Classic cursor for MindRoom-owned clients."""
-    if not isinstance(client, _MindRoomAsyncClient):
-        msg = f"Unsupported Matrix client type {type(client).__name__!r}"
-        raise TypeError(msg)
-    await client.invalidate_rejected_sync_position()
-
-
 def _create_matrix_client(
     homeserver: str,
     runtime_paths: RuntimePaths,
@@ -506,7 +498,6 @@ async def restore_login(
 __all__ = [
     "PermanentMatrixStartupError",
     "create_authenticated_client",
-    "invalidate_rejected_sync_position",
     "login",
     "login_flows",
     "login_with_token",

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -84,13 +84,19 @@ class _MindRoomAsyncClient(nio.AsyncClient):
     async def invalidate_rejected_sync_position(self) -> None:
         """Discard a server-rejected Classic cursor and its recovery generations."""
         async with self._sync_response_lock:
-            if self.store is not None:
-                # Clear the poisoned transport position before callback drain so
-                # cancellation cannot reintroduce an M_UNKNOWN_POS restart loop.
-                self.store.save_sync_token("")
-            await drain_recovery_dispatches(self._recovery)
+            while True:
+                try:
+                    await drain_recovery_dispatches(self._recovery)
+                except Exception as error:
+                    logger.warning(
+                        "matrix_rejected_sync_recovery_dispatch_failed",
+                        error=str(error),
+                        error_type=type(error).__name__,
+                    )
+                else:
+                    break
             recovery_room_ids = set(self._recovery.gaps)
-            recovery_room_ids.update(room_id for room_id, generation in self._recovery.events if generation > 0)
+            recovery_room_ids.update(room_id for room_id, _generation in self._recovery.events)
             if recovery_room_ids:
                 async with self._recovery_room_state(recovery_room_ids):
                     plan = merge_recovery_plans(
@@ -99,6 +105,10 @@ class _MindRoomAsyncClient(nio.AsyncClient):
                             room_id=room_id,
                             timeline_events=(),
                             user_id=self.user_id,
+                            # In pinned nio, a terminal membership asks the
+                            # recovery owner to reset rejected history while
+                            # rehoming unstarted LIVE work. It does not mutate
+                            # the Matrix room's actual membership.
                             membership="leave",
                         )
                         for room_id in sorted(recovery_room_ids)
@@ -109,9 +119,12 @@ class _MindRoomAsyncClient(nio.AsyncClient):
                         token=None,
                         plan=plan,
                     )
+            if self.store is not None:
+                # Publish tokenless transport state only after every rejected
+                # generation is durably sanitized. A crash before this write
+                # safely retries M_UNKNOWN_POS cleanup from the old token.
+                self.store.save_sync_token("")
             self._recovery.outcomes.clear()
-            self.next_batch = None
-            self.loaded_sync_token = ""
 
     def encrypt(
         self,
@@ -265,8 +278,10 @@ def matrix_client_config(*, http_headers: Mapping[str, str] | None = None) -> ni
 
 async def invalidate_rejected_sync_position(client: nio.AsyncClient) -> None:
     """Durably discard a rejected Classic cursor for MindRoom-owned clients."""
-    if isinstance(client, _MindRoomAsyncClient):
-        await client.invalidate_rejected_sync_position()
+    if not isinstance(client, _MindRoomAsyncClient):
+        msg = f"Unsupported Matrix client type {type(client).__name__!r}"
+        raise TypeError(msg)
+    await client.invalidate_rejected_sync_position()
 
 
 def _create_matrix_client(

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 import os
 import ssl as ssl_module
 from contextlib import asynccontextmanager
+from contextvars import ContextVar
 from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 import nio
 from nio.client.sync_recovery import (
+    PendingEventKind,
     drain_recovery_dispatches,
     merge_recovery_plans,
     persist_response_plan,
@@ -31,9 +33,14 @@ from mindroom.matrix.to_device import AuthenticatedToDeviceEvent
 from mindroom.startup_errors import PermanentStartupError
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, Mapping
+    from collections.abc import AsyncGenerator, Callable, Mapping
 
 logger = get_logger(__name__)
+
+_TIMELINE_EVENT_HAS_AUTHORITATIVE_ROOM_STATE: ContextVar[bool] = ContextVar(
+    "mindroom_timeline_event_has_authoritative_room_state",
+    default=True,
+)
 
 _PERMANENT_MATRIX_STARTUP_ERROR_CODES = frozenset(
     {
@@ -65,6 +72,11 @@ class PermanentMatrixStartupError(PermanentStartupError):
     """Raised for Matrix startup failures that should not be retried."""
 
 
+def timeline_event_has_authoritative_room_state() -> bool:
+    """Return whether the current nio callback was allowed to update room state."""
+    return _TIMELINE_EVENT_HAS_AUTHORITATIVE_ROOM_STATE.get()
+
+
 @runtime_checkable
 class _AsyncRequestHeaders(Protocol):
     async def prepare(self) -> None:
@@ -81,6 +93,37 @@ class _MindRoomAsyncClient(nio.AsyncClient):
         if isinstance(headers, _AsyncRequestHeaders):
             await headers.prepare()
         return await super().send(*args, **kwargs)
+
+    async def _dispatch_timeline_event(
+        self,
+        room_id: str,
+        event: nio.Event | nio.BadEventType | nio.EphemeralEvent | nio.AccountDataEvent,
+        was_completed: bool,
+        kind: PendingEventKind,
+        provenance: nio.TimelineEventProvenance,
+        sync_origin: bool,
+        apply_room_state: bool,
+        admission_accepted: bool,
+        mark_admission_accepted: Callable[[], None],
+    ) -> nio.Event | nio.BadEventType | nio.EphemeralEvent | nio.AccountDataEvent | None:
+        """Expose nio's state-suppression decision to same-task auxiliary callbacks."""
+        token = _TIMELINE_EVENT_HAS_AUTHORITATIVE_ROOM_STATE.set(
+            kind != "timeline" or not sync_origin or apply_room_state,
+        )
+        try:
+            return await super()._dispatch_timeline_event(
+                room_id,
+                event,
+                was_completed,
+                kind,
+                provenance,
+                sync_origin,
+                apply_room_state,
+                admission_accepted,
+                mark_admission_accepted,
+            )
+        finally:
+            _TIMELINE_EVENT_HAS_AUTHORITATIVE_ROOM_STATE.reset(token)
 
     async def invalidate_rejected_sync_position(self) -> None:
         """Discard a server-rejected Classic cursor and its recovery generations."""
@@ -115,10 +158,17 @@ class _MindRoomAsyncClient(nio.AsyncClient):
                         for room_id in sorted(recovery_room_ids)
                     )
                     # The fresh tokenless response is the new room-state
-                    # authority; retained events preserve callbacks only.
+                    # authority. Retained timeline events preserve source-
+                    # backed callbacks only; transient and account-data
+                    # events cannot replay without applying stale state.
+                    events = tuple(
+                        replace(event, apply_room_state=False) for event in plan.events if event.kind == "timeline"
+                    )
+                    event_room_ids = {event.room_id for event in events}
                     plan = replace(
                         plan,
-                        events=tuple(replace(event, apply_room_state=False) for event in plan.events),
+                        gaps=tuple(gap for gap in plan.gaps if gap.room_id in event_room_ids),
+                        events=events,
                     )
                     persist_response_plan(
                         self._recovery,
@@ -514,4 +564,5 @@ __all__ = [
     "olm_store_dir",
     "olm_store_exists",
     "restore_login",
+    "timeline_event_has_authoritative_room_state",
 ]

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import ssl as ssl_module
 from contextlib import asynccontextmanager
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
@@ -112,6 +113,12 @@ class _MindRoomAsyncClient(nio.AsyncClient):
                             membership="leave",
                         )
                         for room_id in sorted(recovery_room_ids)
+                    )
+                    # The fresh tokenless response is the new room-state
+                    # authority; retained events preserve callbacks only.
+                    plan = replace(
+                        plan,
+                        events=tuple(replace(event, apply_room_state=False) for event in plan.events),
                     )
                     persist_response_plan(
                         self._recovery,

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -9,7 +9,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 import nio
-from nio.client.sync_recovery import RecoveryPlan, drain_recovery_dispatches, persist_response_plan
+from nio.client.sync_recovery import (
+    drain_recovery_dispatches,
+    merge_recovery_plans,
+    persist_response_plan,
+    plan_room_timeline,
+)
 
 from mindroom.constants import (
     CONFIG_CONFIRMATION_REACTION_KEY,
@@ -88,11 +93,21 @@ class _MindRoomAsyncClient(nio.AsyncClient):
             recovery_room_ids.update(room_id for room_id, generation in self._recovery.events if generation > 0)
             if recovery_room_ids:
                 async with self._recovery_room_state(recovery_room_ids):
+                    plan = merge_recovery_plans(
+                        plan_room_timeline(
+                            self._recovery,
+                            room_id=room_id,
+                            timeline_events=(),
+                            user_id=self.user_id,
+                            membership="leave",
+                        )
+                        for room_id in sorted(recovery_room_ids)
+                    )
                     persist_response_plan(
                         self._recovery,
                         self._recovery_store,
                         token=None,
-                        plan=RecoveryPlan(clear_rooms=frozenset(recovery_room_ids)),
+                        plan=plan,
                     )
             self._recovery.outcomes.clear()
             self.next_batch = None

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 
 import nio
+from nio.client.sync_recovery import RecoveryPlan, drain_recovery_dispatches, persist_response_plan
 
 from mindroom.constants import (
     CONFIG_CONFIRMATION_REACTION_KEY,
@@ -74,6 +75,28 @@ class _MindRoomAsyncClient(nio.AsyncClient):
         if isinstance(headers, _AsyncRequestHeaders):
             await headers.prepare()
         return await super().send(*args, **kwargs)
+
+    async def invalidate_rejected_sync_position(self) -> None:
+        """Discard a server-rejected Classic cursor and its recovery generations."""
+        async with self._sync_response_lock:
+            if self.store is not None:
+                # Clear the poisoned transport position before callback drain so
+                # cancellation cannot reintroduce an M_UNKNOWN_POS restart loop.
+                self.store.save_sync_token("")
+            await drain_recovery_dispatches(self._recovery)
+            recovery_room_ids = set(self._recovery.gaps)
+            recovery_room_ids.update(room_id for room_id, generation in self._recovery.events if generation > 0)
+            if recovery_room_ids:
+                async with self._recovery_room_state(recovery_room_ids):
+                    persist_response_plan(
+                        self._recovery,
+                        self._recovery_store,
+                        token=None,
+                        plan=RecoveryPlan(clear_rooms=frozenset(recovery_room_ids)),
+                    )
+            self._recovery.outcomes.clear()
+            self.next_batch = None
+            self.loaded_sync_token = ""
 
     def encrypt(
         self,
@@ -223,6 +246,12 @@ def matrix_client_config(*, http_headers: Mapping[str, str] | None = None) -> ni
         custom_headers=cast("dict[str, str] | None", custom_headers),
         replace_rotated_device_keys=True,
     )
+
+
+async def invalidate_rejected_sync_position(client: nio.AsyncClient) -> None:
+    """Durably discard a rejected Classic cursor for MindRoom-owned clients."""
+    if isinstance(client, _MindRoomAsyncClient):
+        await client.invalidate_rejected_sync_position()
 
 
 def _create_matrix_client(
@@ -447,6 +476,7 @@ async def restore_login(
 __all__ = [
     "PermanentMatrixStartupError",
     "create_authenticated_client",
+    "invalidate_rejected_sync_position",
     "login",
     "login_flows",
     "login_with_token",

--- a/src/mindroom/matrix/room_member_hook_lifecycle.py
+++ b/src/mindroom/matrix/room_member_hook_lifecycle.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 import nio
 
 from mindroom.matrix.sync_certification import SyncCertificationDecision, SyncTrustState
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class _RoomMemberHookPhase(Enum):
@@ -26,6 +29,7 @@ class _RoomMemberHookPhase(Enum):
 class RoomMemberResponsePlan:
     """Room-member work that must precede one response's certification."""
 
+    baseline_record_events: tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...] | None = None
     drain_captured_timeline: bool = False
     dispatch_state: bool = False
 
@@ -36,13 +40,18 @@ class RoomMemberHookLifecycle:
 
     enabled: bool
     _phase: _RoomMemberHookPhase = field(init=False)
+    _baseline_record_events: tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...] | None = field(
+        init=False,
+        default=None,
+        repr=False,
+    )
 
     def __post_init__(self) -> None:
         """Start enabled owners behind a tokenless baseline fence."""
         self._phase = _RoomMemberHookPhase.BASELINE if self.enabled else _RoomMemberHookPhase.DISABLED
 
     @property
-    def baseline_record_pending(self) -> bool:
+    def _baseline_record_pending(self) -> bool:
         """Return whether the next full-state response needs baseline markers."""
         return self._phase in {
             _RoomMemberHookPhase.BASELINE,
@@ -57,6 +66,11 @@ class RoomMemberHookLifecycle:
             _RoomMemberHookPhase.FULL_STATE_CATCHUP,
             _RoomMemberHookPhase.CATCHUP,
         }
+
+    @property
+    def baseline_capture_pending(self) -> bool:
+        """Return whether the next Classic response carries a new full-state baseline."""
+        return self._baseline_record_pending and self._baseline_record_events is None
 
     def admission_enabled(self, provenance: nio.TimelineEventProvenance) -> bool:
         """Return whether one member event should enter durable callback ownership."""
@@ -78,16 +92,31 @@ class RoomMemberHookLifecycle:
         """Initialize startup without carrying Classic history authority into Sliding."""
         if not self.enabled:
             self._phase = _RoomMemberHookPhase.DISABLED
+            self._discard_baseline()
             return
         if transport == "sliding":
             self._phase = _RoomMemberHookPhase.SLIDING_CATCHUP
+            self._discard_baseline()
             return
         self._phase = _RoomMemberHookPhase.FULL_STATE_CATCHUP if resuming_position else _RoomMemberHookPhase.BASELINE
+        self._discard_baseline()
 
     def begin_sync_loop(self) -> None:
         """Prepare a replacement Classic loop to reacquire full state."""
         if self._phase is _RoomMemberHookPhase.CATCHUP:
             self._phase = _RoomMemberHookPhase.FULL_STATE_CATCHUP
+        if self._baseline_record_pending:
+            self._discard_baseline()
+
+    def capture_baseline(
+        self,
+        events: Iterable[tuple[nio.MatrixRoom, nio.RoomMemberEvent]],
+    ) -> None:
+        """Retain one full-state snapshot until its response lineage can certify."""
+        if not self.baseline_capture_pending:
+            msg = f"Cannot capture a room-member baseline while phase is {self._phase.value!r}"
+            raise RuntimeError(msg)
+        self._baseline_record_events = tuple(events)
 
     def baseline_recorded(self) -> None:
         """Advance after the exact full-state baseline markers reach durability."""
@@ -97,6 +126,10 @@ class RoomMemberHookLifecycle:
         }:
             msg = f"Cannot record a room-member baseline while phase is {self._phase.value!r}"
             raise RuntimeError(msg)
+        if self._baseline_record_events is None:
+            msg = "Cannot record a room-member baseline before its full-state response is captured"
+            raise RuntimeError(msg)
+        self._discard_baseline()
         self._phase = _RoomMemberHookPhase.CATCHUP
 
     def plan_response(
@@ -107,7 +140,13 @@ class RoomMemberHookLifecycle:
     ) -> RoomMemberResponsePlan:
         """Return lifecycle work required before applying one certification decision."""
         certified = decision.state is SyncTrustState.CERTIFIED and not decision.reset_client_token
+        if certified and self.baseline_capture_pending:
+            msg = "Cannot certify room-member hooks without a captured full-state baseline"
+            raise RuntimeError(msg)
         return RoomMemberResponsePlan(
+            baseline_record_events=(
+                self._baseline_record_events if certified and self._baseline_record_pending else None
+            ),
             drain_captured_timeline=(certified and self._phase is not _RoomMemberHookPhase.DISABLED),
             dispatch_state=(certified and self._phase is _RoomMemberHookPhase.LIVE and not first_sync_response),
         )
@@ -115,19 +154,32 @@ class RoomMemberHookLifecycle:
     def certified(self) -> None:
         """Enter live hook operation after every pre-certification effect succeeds."""
         if self.enabled:
+            self._discard_baseline()
             self._phase = _RoomMemberHookPhase.LIVE
 
     def rewound(self, *, has_retry_token: bool) -> None:
         """Fence callbacks until the replacement position is safely consumed."""
         if not self.enabled:
             return
-        self._phase = _RoomMemberHookPhase.CATCHUP if has_retry_token else _RoomMemberHookPhase.BASELINE
+        if not has_retry_token:
+            self._phase = _RoomMemberHookPhase.BASELINE
+            self._discard_baseline()
+            return
+        if self._baseline_record_pending:
+            return
+        self._phase = _RoomMemberHookPhase.CATCHUP
 
     def unknown_position(self) -> None:
         """Treat a server-rejected cursor as a fresh tokenless baseline."""
         if self.enabled:
             self._phase = _RoomMemberHookPhase.BASELINE
+            self._discard_baseline()
 
     def stop(self) -> None:
         """Disable all lifecycle admission after the owning bot stops."""
         self._phase = _RoomMemberHookPhase.DISABLED
+        self._discard_baseline()
+
+    def _discard_baseline(self) -> None:
+        """Drop an obsolete full-state snapshot."""
+        self._baseline_record_events = None

--- a/src/mindroom/matrix/room_member_hook_lifecycle.py
+++ b/src/mindroom/matrix/room_member_hook_lifecycle.py
@@ -23,7 +23,6 @@ class _RoomMemberHookPhase(Enum):
     BASELINE = "baseline"
     FULL_STATE_CATCHUP = "full_state_catchup"
     CATCHUP = "catchup"
-    SLIDING_CATCHUP = "sliding_catchup"
     LIVE = "live"
 
 
@@ -75,6 +74,11 @@ class RoomMemberHookLifecycle:
         """Return whether the next Classic response carries a new full-state baseline."""
         return self._baseline_record_pending and self._baseline_record_events is None
 
+    @property
+    def response_drain_required(self) -> bool:
+        """Return whether this owner has admitted lifecycle callbacks to drain."""
+        return self._phase is not _RoomMemberHookPhase.DISABLED
+
     def admission_enabled(self, provenance: nio.TimelineEventProvenance) -> bool:
         """Return whether one member event should enter durable callback ownership."""
         if self._phase is _RoomMemberHookPhase.DISABLED:
@@ -99,7 +103,7 @@ class RoomMemberHookLifecycle:
             self._discard_baseline()
             return
         if transport == "sliding":
-            self._phase = _RoomMemberHookPhase.SLIDING_CATCHUP
+            self._phase = _RoomMemberHookPhase.LIVE
             self._discard_baseline()
             return
         self._phase = _RoomMemberHookPhase.FULL_STATE_CATCHUP if resuming_position else _RoomMemberHookPhase.BASELINE
@@ -172,12 +176,6 @@ class RoomMemberHookLifecycle:
         if self._baseline_record_pending:
             return
         self._phase = _RoomMemberHookPhase.CATCHUP
-
-    def unknown_position(self) -> None:
-        """Treat a server-rejected cursor as a fresh tokenless baseline."""
-        if self.enabled:
-            self._phase = _RoomMemberHookPhase.BASELINE
-            self._discard_baseline()
 
     def stop(self) -> None:
         """Disable all lifecycle admission after the owning bot stops."""

--- a/src/mindroom/matrix/room_member_hook_lifecycle.py
+++ b/src/mindroom/matrix/room_member_hook_lifecycle.py
@@ -40,6 +40,7 @@ class RoomMemberHookLifecycle:
 
     enabled: bool
     _phase: _RoomMemberHookPhase = field(init=False)
+    _transport: Literal["classic", "sliding"] = field(init=False, default="classic")
     _baseline_record_events: tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...] | None = field(
         init=False,
         default=None,
@@ -81,7 +82,7 @@ class RoomMemberHookLifecycle:
         return self._phase in {
             _RoomMemberHookPhase.FULL_STATE_CATCHUP,
             _RoomMemberHookPhase.CATCHUP,
-        }
+        } or (self._phase is _RoomMemberHookPhase.LIVE and self._transport == "classic")
 
     def prepare_startup(
         self,
@@ -90,6 +91,7 @@ class RoomMemberHookLifecycle:
         resuming_position: bool,
     ) -> None:
         """Initialize startup without carrying Classic history authority into Sliding."""
+        self._transport = transport
         if not self.enabled:
             self._phase = _RoomMemberHookPhase.DISABLED
             self._discard_baseline()

--- a/src/mindroom/matrix/room_member_hook_lifecycle.py
+++ b/src/mindroom/matrix/room_member_hook_lifecycle.py
@@ -13,6 +13,8 @@ from mindroom.matrix.sync_certification import SyncCertificationDecision, SyncTr
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
+    from mindroom.matrix.room_member_joins import RoomMemberSnapshot
+
 
 class _RoomMemberHookPhase(Enum):
     """One room-member hook admission and baseline phase."""
@@ -29,7 +31,7 @@ class _RoomMemberHookPhase(Enum):
 class RoomMemberResponsePlan:
     """Room-member work that must precede one response's certification."""
 
-    baseline_record_events: tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...] | None = None
+    baseline_record_events: tuple[RoomMemberSnapshot, ...] | None = None
     drain_captured_timeline: bool = False
     dispatch_state: bool = False
 
@@ -41,7 +43,7 @@ class RoomMemberHookLifecycle:
     enabled: bool
     _phase: _RoomMemberHookPhase = field(init=False)
     _transport: Literal["classic", "sliding"] = field(init=False, default="classic")
-    _baseline_record_events: tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...] | None = field(
+    _baseline_record_events: tuple[RoomMemberSnapshot, ...] | None = field(
         init=False,
         default=None,
         repr=False,
@@ -112,7 +114,7 @@ class RoomMemberHookLifecycle:
 
     def capture_baseline(
         self,
-        events: Iterable[tuple[nio.MatrixRoom, nio.RoomMemberEvent]],
+        events: Iterable[RoomMemberSnapshot],
     ) -> None:
         """Retain one full-state snapshot until its response lineage can certify."""
         if not self.baseline_capture_pending:

--- a/src/mindroom/matrix/room_member_hook_lifecycle.py
+++ b/src/mindroom/matrix/room_member_hook_lifecycle.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
+from typing import Literal
 
 import nio
 
@@ -17,6 +18,7 @@ class _RoomMemberHookPhase(Enum):
     BASELINE = "baseline"
     FULL_STATE_CATCHUP = "full_state_catchup"
     CATCHUP = "catchup"
+    SLIDING_CATCHUP = "sliding_catchup"
     LIVE = "live"
 
 
@@ -38,11 +40,6 @@ class RoomMemberHookLifecycle:
     def __post_init__(self) -> None:
         """Start enabled owners behind a tokenless baseline fence."""
         self._phase = _RoomMemberHookPhase.BASELINE if self.enabled else _RoomMemberHookPhase.DISABLED
-
-    @property
-    def callback_execution_enabled(self) -> bool:
-        """Return whether nio's ordinary member callback may execute now."""
-        return self._phase is _RoomMemberHookPhase.LIVE
 
     @property
     def baseline_record_pending(self) -> bool:
@@ -72,10 +69,18 @@ class RoomMemberHookLifecycle:
             _RoomMemberHookPhase.CATCHUP,
         }
 
-    def prepare_startup(self, *, resuming_position: bool) -> None:
-        """Initialize one process startup from its selected Classic position."""
+    def prepare_startup(
+        self,
+        *,
+        transport: Literal["classic", "sliding"],
+        resuming_position: bool,
+    ) -> None:
+        """Initialize startup without carrying Classic history authority into Sliding."""
         if not self.enabled:
             self._phase = _RoomMemberHookPhase.DISABLED
+            return
+        if transport == "sliding":
+            self._phase = _RoomMemberHookPhase.SLIDING_CATCHUP
             return
         self._phase = _RoomMemberHookPhase.FULL_STATE_CATCHUP if resuming_position else _RoomMemberHookPhase.BASELINE
 
@@ -103,7 +108,7 @@ class RoomMemberHookLifecycle:
         """Return lifecycle work required before applying one certification decision."""
         certified = decision.state is SyncTrustState.CERTIFIED and not decision.reset_client_token
         return RoomMemberResponsePlan(
-            drain_captured_timeline=(certified and self._phase is _RoomMemberHookPhase.CATCHUP),
+            drain_captured_timeline=(certified and self._phase is not _RoomMemberHookPhase.DISABLED),
             dispatch_state=(certified and self._phase is _RoomMemberHookPhase.LIVE and not first_sync_response),
         )
 

--- a/src/mindroom/matrix/room_member_hook_lifecycle.py
+++ b/src/mindroom/matrix/room_member_hook_lifecycle.py
@@ -1,0 +1,128 @@
+"""Own room-member hook bootstrap, catch-up, and live phases."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+import nio
+
+from mindroom.matrix.sync_certification import SyncCertificationDecision, SyncTrustState
+
+
+class _RoomMemberHookPhase(Enum):
+    """One room-member hook admission and baseline phase."""
+
+    DISABLED = "disabled"
+    BASELINE = "baseline"
+    FULL_STATE_CATCHUP = "full_state_catchup"
+    CATCHUP = "catchup"
+    LIVE = "live"
+
+
+@dataclass(frozen=True, slots=True)
+class RoomMemberResponsePlan:
+    """Room-member work that must precede one response's certification."""
+
+    drain_captured_timeline: bool = False
+    dispatch_state: bool = False
+
+
+@dataclass(slots=True)
+class RoomMemberHookLifecycle:
+    """Own the phase transitions that fence room-member hook delivery."""
+
+    enabled: bool
+    _phase: _RoomMemberHookPhase = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Start enabled owners behind a tokenless baseline fence."""
+        self._phase = _RoomMemberHookPhase.BASELINE if self.enabled else _RoomMemberHookPhase.DISABLED
+
+    @property
+    def callback_execution_enabled(self) -> bool:
+        """Return whether nio's ordinary member callback may execute now."""
+        return self._phase is _RoomMemberHookPhase.LIVE
+
+    @property
+    def baseline_record_pending(self) -> bool:
+        """Return whether the next full-state response needs baseline markers."""
+        return self._phase in {
+            _RoomMemberHookPhase.BASELINE,
+            _RoomMemberHookPhase.FULL_STATE_CATCHUP,
+        }
+
+    @property
+    def full_state_required(self) -> bool:
+        """Return whether a Classic replacement loop must request full state."""
+        return self._phase in {
+            _RoomMemberHookPhase.BASELINE,
+            _RoomMemberHookPhase.FULL_STATE_CATCHUP,
+            _RoomMemberHookPhase.CATCHUP,
+        }
+
+    def admission_enabled(self, provenance: nio.TimelineEventProvenance) -> bool:
+        """Return whether one member event should enter durable callback ownership."""
+        if self._phase is _RoomMemberHookPhase.DISABLED:
+            return False
+        if provenance is nio.TimelineEventProvenance.LIVE:
+            return True
+        return self._phase in {
+            _RoomMemberHookPhase.FULL_STATE_CATCHUP,
+            _RoomMemberHookPhase.CATCHUP,
+        }
+
+    def prepare_startup(self, *, resuming_position: bool) -> None:
+        """Initialize one process startup from its selected Classic position."""
+        if not self.enabled:
+            self._phase = _RoomMemberHookPhase.DISABLED
+            return
+        self._phase = _RoomMemberHookPhase.FULL_STATE_CATCHUP if resuming_position else _RoomMemberHookPhase.BASELINE
+
+    def begin_sync_loop(self) -> None:
+        """Prepare a replacement Classic loop to reacquire full state."""
+        if self._phase is _RoomMemberHookPhase.CATCHUP:
+            self._phase = _RoomMemberHookPhase.FULL_STATE_CATCHUP
+
+    def baseline_recorded(self) -> None:
+        """Advance after the exact full-state baseline markers reach durability."""
+        if self._phase not in {
+            _RoomMemberHookPhase.BASELINE,
+            _RoomMemberHookPhase.FULL_STATE_CATCHUP,
+        }:
+            msg = f"Cannot record a room-member baseline while phase is {self._phase.value!r}"
+            raise RuntimeError(msg)
+        self._phase = _RoomMemberHookPhase.CATCHUP
+
+    def plan_response(
+        self,
+        decision: SyncCertificationDecision,
+        *,
+        first_sync_response: bool,
+    ) -> RoomMemberResponsePlan:
+        """Return lifecycle work required before applying one certification decision."""
+        certified = decision.state is SyncTrustState.CERTIFIED and not decision.reset_client_token
+        return RoomMemberResponsePlan(
+            drain_captured_timeline=(certified and self._phase is _RoomMemberHookPhase.CATCHUP),
+            dispatch_state=(certified and self._phase is _RoomMemberHookPhase.LIVE and not first_sync_response),
+        )
+
+    def certified(self) -> None:
+        """Enter live hook operation after every pre-certification effect succeeds."""
+        if self.enabled:
+            self._phase = _RoomMemberHookPhase.LIVE
+
+    def rewound(self, *, has_retry_token: bool) -> None:
+        """Fence callbacks until the replacement position is safely consumed."""
+        if not self.enabled:
+            return
+        self._phase = _RoomMemberHookPhase.CATCHUP if has_retry_token else _RoomMemberHookPhase.BASELINE
+
+    def unknown_position(self) -> None:
+        """Treat a server-rejected cursor as a fresh tokenless baseline."""
+        if self.enabled:
+            self._phase = _RoomMemberHookPhase.BASELINE
+
+    def stop(self) -> None:
+        """Disable all lifecycle admission after the owning bot stops."""
+        self._phase = _RoomMemberHookPhase.DISABLED

--- a/src/mindroom/matrix/room_member_joins.py
+++ b/src/mindroom/matrix/room_member_joins.py
@@ -42,11 +42,19 @@ class RoomMemberJoin:
 
 
 @dataclass(frozen=True, slots=True)
+class RoomMemberSnapshot:
+    """One authoritative room-member state event to mark as already seen."""
+
+    room_id: str
+    event: nio.RoomMemberEvent
+
+
+@dataclass(frozen=True, slots=True)
 class _RoomMemberSyncPlan:
     """Classified room-member state work for one sync response."""
 
     dispatch_events: tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...] = ()
-    record_events: tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...] = ()
+    record_events: tuple[RoomMemberSnapshot, ...] = ()
 
 
 def _room_member_join_tracking_path(storage_root: Path) -> Path:
@@ -150,7 +158,7 @@ def _human_join_user_id(
 
 
 def record_room_member_joins_seen_from_events(
-    events: Iterable[tuple[nio.MatrixRoom, nio.RoomMemberEvent]],
+    events: Iterable[RoomMemberSnapshot],
     *,
     config: Config,
     runtime_paths: RuntimePaths,
@@ -158,10 +166,10 @@ def record_room_member_joins_seen_from_events(
 ) -> None:
     """Record human room-member events with one durable batch update."""
     room_user_ids: list[tuple[str, str]] = []
-    for room, event in events:
-        user_id = _human_join_user_id(event, config=config, runtime_paths=runtime_paths)
+    for snapshot in events:
+        user_id = _human_join_user_id(snapshot.event, config=config, runtime_paths=runtime_paths)
         if user_id is not None:
-            room_user_ids.append((room.room_id, user_id))
+            room_user_ids.append((snapshot.room_id, user_id))
     _mark_room_member_joins_seen(storage_root, room_user_ids)
 
 
@@ -254,15 +262,13 @@ def _room_member_events_from_sync_state(
     response: nio.SyncResponse,
     *,
     rooms: Mapping[str, nio.MatrixRoom],
-) -> Iterator[tuple[nio.MatrixRoom, nio.RoomMemberEvent]]:
+) -> Iterator[tuple[str, nio.MatrixRoom | None, nio.RoomMemberEvent]]:
     """Yield room-member events from sync state with their resolved room."""
     for room_id, join_info in response.rooms.join.items():
         room = rooms.get(room_id)
-        if room is None:
-            continue
         for event in join_info.state:
             if isinstance(event, nio.RoomMemberEvent):
-                yield room, event
+                yield room_id, room, event
 
 
 def room_member_sync_state_plan(
@@ -275,13 +281,15 @@ def room_member_sync_state_plan(
 ) -> _RoomMemberSyncPlan:
     """Classify state events into durable hook dispatches and baseline markers."""
     dispatch_events: list[tuple[nio.MatrixRoom, nio.RoomMemberEvent]] = []
-    record_events: list[tuple[nio.MatrixRoom, nio.RoomMemberEvent]] = []
+    record_events: list[RoomMemberSnapshot] = []
     limited_room_ids = frozenset(
         room_id for room_id, join_info in response.rooms.join.items() if join_info.timeline.limited
     )
-    for room, event in _room_member_events_from_sync_state(response, rooms=rooms):
-        if record_only or room.room_id in limited_room_ids:
-            record_events.append((room, event))
+    for room_id, room, event in _room_member_events_from_sync_state(response, rooms=rooms):
+        if record_only or room_id in limited_room_ids:
+            record_events.append(RoomMemberSnapshot(room_id, event))
+            continue
+        if room is None:
             continue
         if (
             _room_member_join_from_event(
@@ -295,7 +303,7 @@ def room_member_sync_state_plan(
         ):
             dispatch_events.append((room, event))
         elif event.prev_membership in {None, "join"}:
-            record_events.append((room, event))
+            record_events.append(RoomMemberSnapshot(room_id, event))
     return _RoomMemberSyncPlan(
         dispatch_events=tuple(dispatch_events),
         record_events=tuple(record_events),

--- a/src/mindroom/matrix/room_member_joins.py
+++ b/src/mindroom/matrix/room_member_joins.py
@@ -265,21 +265,6 @@ def _room_member_events_from_sync_state(
                 yield room, event
 
 
-def _room_member_events_from_sync_timeline(
-    response: nio.SyncResponse,
-    *,
-    rooms: Mapping[str, nio.MatrixRoom],
-) -> Iterator[tuple[nio.MatrixRoom, nio.RoomMemberEvent]]:
-    """Yield room-member events from sync timelines with their resolved room."""
-    for room_id, join_info in response.rooms.join.items():
-        room = rooms.get(room_id)
-        if room is None:
-            continue
-        for event in join_info.timeline.events:
-            if isinstance(event, nio.RoomMemberEvent):
-                yield room, event
-
-
 def room_member_sync_state_plan(
     response: nio.SyncResponse,
     *,
@@ -314,28 +299,6 @@ def room_member_sync_state_plan(
     return _RoomMemberSyncPlan(
         dispatch_events=tuple(dispatch_events),
         record_events=tuple(record_events),
-    )
-
-
-def room_member_sync_timeline_events(
-    response: nio.SyncResponse,
-    *,
-    rooms: Mapping[str, nio.MatrixRoom],
-    config: Config,
-    runtime_paths: RuntimePaths,
-) -> tuple[tuple[nio.MatrixRoom, nio.RoomMemberEvent], ...]:
-    """Return eligible live joins carried by a restored-token timeline."""
-    return tuple(
-        (room, event)
-        for room, event in _room_member_events_from_sync_timeline(response, rooms=rooms)
-        if _room_member_join_from_event(
-            room,
-            event,
-            config=config,
-            runtime_paths=runtime_paths,
-            require_previous_membership=False,
-        )
-        is not None
     )
 
 

--- a/src/mindroom/matrix/sync_cache_trust.py
+++ b/src/mindroom/matrix/sync_cache_trust.py
@@ -42,6 +42,7 @@ class SyncCacheTrust:
     # Ephemeral context for typed nio outcomes while the durable checkpoint is withheld.
     _unresolved_recovery_room_ids: frozenset[str] = field(default=frozenset(), init=False, repr=False)
     _replay_required_after_recovery: bool = field(default=False, init=False, repr=False)
+    _safe_checkpoint_catchup_pending: bool = field(default=False, init=False, repr=False)
     _mutation_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
     _dispatch_persist_failure_epoch: int = field(default=0, init=False, repr=False)
     _observed_dispatch_persist_failure_epoch: int = field(default=0, init=False, repr=False)
@@ -78,6 +79,7 @@ class SyncCacheTrust:
         self.checkpoint = None
         self._clear_recovery_handoff()
         safe_token = loaded.token if loaded is not None else None
+        self._safe_checkpoint_catchup_pending = safe_token is not None
         nio_token = transport_resume_token or None
         startup_token = safe_token
         if nio_token is not None and nio_token != safe_token:
@@ -157,6 +159,7 @@ class SyncCacheTrust:
                 self._cache_scope_epoch += 1
                 self.state = SyncTrustState.UNCERTAIN
                 self.checkpoint = None
+                self._safe_checkpoint_catchup_pending = False
                 if self._unresolved_recovery_room_ids:
                     self._replay_required_after_recovery = True
                 if await self._clear_saved_locked():
@@ -240,6 +243,7 @@ class SyncCacheTrust:
             tokenless_baseline_pending=self._tokenless_baseline_pending,
             unresolved_recovery_room_ids=self._unresolved_recovery_room_ids,
             replay_required_after_recovery=self._replay_required_after_recovery,
+            replay_after_unresolved_recovery=self._safe_checkpoint_catchup_pending,
         )
         return replace(decision, cache_scope_epoch=self._cache_scope_epoch)
 
@@ -275,6 +279,8 @@ class SyncCacheTrust:
                 )
                 self._unresolved_recovery_room_ids = decision.unresolved_recovery_room_ids
                 self._replay_required_after_recovery = decision.replay_required_after_recovery
+                if decision.state is SyncTrustState.CERTIFIED or decision.clear_saved_token:
+                    self._safe_checkpoint_catchup_pending = False
                 if decision.reset_client_token:
                     self._refresh_tokenless_baseline_pending()
                 else:
@@ -291,6 +297,7 @@ class SyncCacheTrust:
                 decision = handle_unknown_pos()
                 await self._apply_decision_locked(decision)
                 self._clear_recovery_handoff()
+                self._safe_checkpoint_catchup_pending = False
                 self._refresh_tokenless_baseline_pending()
                 return decision
 

--- a/src/mindroom/matrix/sync_cache_trust.py
+++ b/src/mindroom/matrix/sync_cache_trust.py
@@ -70,11 +70,7 @@ class SyncCacheTrust:
         self._saved_checkpoint = None if record is None else record.checkpoint
         loaded = self._load_valid_checkpoint(self._saved_checkpoint)
         if loaded is None and await self.invalidate_for_cache_scope_cleanup():
-            try:
-                await cache.purge_principal()
-            except Exception as exc:
-                cache.disable("untrusted_principal_cache_cleanup_failed")
-                self.logger.warning("matrix_untrusted_principal_cache_disabled", error=str(exc))
+            await self._purge_untrusted_principal_cache()
 
         self.checkpoint = None
         self._clear_recovery_handoff()
@@ -294,11 +290,19 @@ class SyncCacheTrust:
         return await run_coroutine_until_complete(apply())
 
     async def reject_unknown_pos(self) -> SyncCertificationDecision:
-        """Invalidate a checkpoint rejected by the homeserver."""
+        """Invalidate a checkpoint and cache scope rejected by the homeserver."""
 
         async def reject() -> SyncCertificationDecision:
             async with self._mutation_lock:
-                decision = handle_unknown_pos()
+                self._cache_scope_epoch += 1
+                decision = replace(
+                    handle_unknown_pos(),
+                    cache_scope_epoch=self._cache_scope_epoch,
+                )
+                # The purge first fences reads synchronously. A failed checkpoint
+                # clear disables writes, so reversing this order could preserve
+                # rejected-scope rows across process restart.
+                await self._purge_untrusted_principal_cache()
                 await self._apply_decision_locked(decision)
                 self._clear_recovery_handoff()
                 self._safe_checkpoint_catchup_pending = False
@@ -306,6 +310,15 @@ class SyncCacheTrust:
                 return decision
 
         return await run_coroutine_until_complete(reject())
+
+    async def _purge_untrusted_principal_cache(self) -> None:
+        """Remove cache rows whose room scope no certified position can prove."""
+        cache = self.runtime.event_cache
+        try:
+            await cache.purge_principal()
+        except Exception as exc:
+            cache.disable("untrusted_principal_cache_cleanup_failed")
+            self.logger.warning("matrix_untrusted_principal_cache_disabled", error=str(exc))
 
     async def _apply_decision_locked(
         self,

--- a/src/mindroom/matrix/sync_cache_trust.py
+++ b/src/mindroom/matrix/sync_cache_trust.py
@@ -279,7 +279,11 @@ class SyncCacheTrust:
                 )
                 self._unresolved_recovery_room_ids = decision.unresolved_recovery_room_ids
                 self._replay_required_after_recovery = decision.replay_required_after_recovery
-                if decision.state is SyncTrustState.CERTIFIED or decision.clear_saved_token:
+                if (
+                    decision.state is SyncTrustState.CERTIFIED
+                    or decision.clear_saved_token
+                    or decision.reset_client_token
+                ):
                     self._safe_checkpoint_catchup_pending = False
                 if decision.reset_client_token:
                     self._refresh_tokenless_baseline_pending()

--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -161,7 +161,7 @@ def certify_sync_response(
     )
     if cache_result.unrecovered_room_ids and token is not None:
         return _uncertain_decision(
-            reason=cast("str", reason),
+            reason=reason or "sync_recovery_incomplete",
             unresolved_recovery_room_ids=unresolved_recovery_room_ids,
             replay_required_after_recovery=replay_required_after_recovery,
         )
@@ -179,9 +179,12 @@ def certify_sync_response(
         )
 
     if reason is not None:
+        tokenless_limited_baseline = (
+            tokenless_baseline_pending and cache_result.complete and reason == "limited_sync_timeline"
+        )
         return _uncertain_decision(
             reason=reason,
-            reset_client_token=reason != "limited_sync_timeline",
+            reset_client_token=not tokenless_limited_baseline,
         )
 
     checkpoint = SyncCheckpoint(token=cast("str", token))

--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -141,6 +141,7 @@ def certify_sync_response(
     tokenless_baseline_pending: bool = False,
     unresolved_recovery_room_ids: frozenset[str] = frozenset(),
     replay_required_after_recovery: bool = False,
+    replay_after_unresolved_recovery: bool = False,
 ) -> SyncCertificationDecision:
     """Return the certifier decision for one sync response."""
     token = normalize_sync_token(next_batch)
@@ -154,6 +155,9 @@ def certify_sync_response(
     )
     replay_required_after_recovery = replay_required_after_recovery or bool(
         cache_result.errors or not cache_result.complete,
+    )
+    replay_required_after_recovery = replay_required_after_recovery or bool(
+        replay_after_unresolved_recovery and cache_result.unrecovered_room_ids,
     )
     if cache_result.unrecovered_room_ids and token is not None:
         return _uncertain_decision(

--- a/src/mindroom/matrix/sync_certification.py
+++ b/src/mindroom/matrix/sync_certification.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from typing import TYPE_CHECKING, Any, cast
 
@@ -157,7 +157,7 @@ def certify_sync_response(
     )
     if cache_result.unrecovered_room_ids and token is not None:
         return _uncertain_decision(
-            reason=reason or "sync_recovery_incomplete",
+            reason=cast("str", reason),
             unresolved_recovery_room_ids=unresolved_recovery_room_ids,
             replay_required_after_recovery=replay_required_after_recovery,
         )
@@ -175,19 +175,30 @@ def certify_sync_response(
         )
 
     if reason is not None:
-        tokenless_limited_baseline = (
-            tokenless_baseline_pending and cache_result.complete and reason == "limited_sync_timeline"
-        )
-        reset_client_token = not tokenless_limited_baseline
         return _uncertain_decision(
             reason=reason,
-            reset_client_token=reset_client_token,
+            reset_client_token=reason != "limited_sync_timeline",
         )
 
     checkpoint = SyncCheckpoint(token=cast("str", token))
     return SyncCertificationDecision(
         state=SyncTrustState.CERTIFIED,
         checkpoint_to_save=checkpoint,
+    )
+
+
+def defer_sync_response_after_dispatch_persist_failure(
+    decision: SyncCertificationDecision,
+) -> SyncCertificationDecision:
+    """Preserve NIO recovery while a rejected callback waits for redispatch."""
+    return replace(
+        decision,
+        state=SyncTrustState.UNCERTAIN,
+        checkpoint_to_save=None,
+        clear_saved_token=False,
+        reset_client_token=False,
+        replay_required_after_recovery=True,
+        reason="dispatch_persist_failed",
     )
 
 

--- a/tach.toml
+++ b/tach.toml
@@ -4304,6 +4304,7 @@ expose = [
     "olm_store_dir",
     "olm_store_exists",
     "restore_login",
+    "timeline_event_has_authoritative_room_state",
 ]
 from = ["mindroom.matrix.client_session"]
 

--- a/tach.toml
+++ b/tach.toml
@@ -4295,6 +4295,7 @@ from = ["mindroom.matrix.client_room_admin"]
 expose = [
     "PermanentMatrixStartupError",
     "create_authenticated_client",
+    "invalidate_rejected_sync_position",
     "login",
     "login_flows",
     "login_with_token",

--- a/tach.toml
+++ b/tach.toml
@@ -4295,7 +4295,6 @@ from = ["mindroom.matrix.client_room_admin"]
 expose = [
     "PermanentMatrixStartupError",
     "create_authenticated_client",
-    "invalidate_rejected_sync_position",
     "login",
     "login_flows",
     "login_with_token",

--- a/tests/test_cold_history_fence.py
+++ b/tests/test_cold_history_fence.py
@@ -148,6 +148,31 @@ async def test_history_requires_one_exact_pending_obligation() -> None:
 
 
 @pytest.mark.asyncio
+async def test_lifecycle_catchup_may_admit_authorized_historical_recovery() -> None:
+    """The lifecycle phase owner may admit recovered joins without opening other history."""
+    obligations = _PendingObligations()
+    fence = ColdHistoryFence(obligations)
+
+    lifecycle = await fence.admit_source(
+        "!room:example.org",
+        "$member",
+        DispatchCallbackKind.ROOM_LIFECYCLE,
+        nio.TimelineEventProvenance.HISTORY,
+        allow_historical_recovery=True,
+    )
+    message = await fence.admit_source(
+        "!room:example.org",
+        "$message",
+        DispatchCallbackKind.MESSAGE,
+        nio.TimelineEventProvenance.HISTORY,
+        allow_historical_recovery=True,
+    )
+
+    assert lifecycle is DispatchSourceAdmission.ACCEPTED
+    assert message is DispatchSourceAdmission.COLD_HISTORY_FENCED
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "provenance",
     [nio.TimelineEventProvenance.LIVE, None],

--- a/tests/test_cold_history_fence.py
+++ b/tests/test_cold_history_fence.py
@@ -158,14 +158,12 @@ async def test_lifecycle_catchup_may_admit_authorized_historical_recovery() -> N
         "$member",
         DispatchCallbackKind.ROOM_LIFECYCLE,
         nio.TimelineEventProvenance.HISTORY,
-        allow_historical_recovery=True,
     )
     message = await fence.admit_source(
         "!room:example.org",
         "$message",
         DispatchCallbackKind.MESSAGE,
         nio.TimelineEventProvenance.HISTORY,
-        allow_historical_recovery=True,
     )
 
     assert lifecycle is DispatchSourceAdmission.ACCEPTED

--- a/tests/test_dispatch_obligations.py
+++ b/tests/test_dispatch_obligations.py
@@ -90,6 +90,22 @@ def _message_event(event_id: str) -> nio.RoomMessageText:
     return event
 
 
+def _member_event(event_id: str) -> nio.RoomMemberEvent:
+    event = nio.RoomMemberEvent.from_dict(
+        {
+            "type": "m.room.member",
+            "event_id": event_id,
+            "sender": "@user:example.org",
+            "state_key": "@user:example.org",
+            "origin_server_ts": 1_234,
+            "content": {"membership": "join"},
+            "unsigned": {"prev_content": {"membership": "leave"}},
+        },
+    )
+    assert isinstance(event, nio.RoomMemberEvent)
+    return event
+
+
 def _reaction_obligation(event_id: str) -> DispatchObligation:
     """Build one replayable reaction obligation."""
     return replace(
@@ -1276,6 +1292,47 @@ async def test_concurrent_duplicate_dispatch_runs_callback_once(tmp_path: Path) 
     await first
 
     assert not _store(tmp_path).has_pending("$duplicate", DispatchCallbackKind.MESSAGE)
+
+
+@pytest.mark.asyncio
+async def test_room_lifecycle_drain_waits_for_exact_active_owner(tmp_path: Path) -> None:
+    """Certification drain must wait for an active callback instead of skipping it."""
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    attempts = 0
+
+    async def callback(_room: nio.MatrixRoom, _event: nio.Event) -> DispatchCallbackResult:
+        nonlocal attempts
+        attempts += 1
+        entered.set()
+        await release.wait()
+        return DispatchCallbackResult.SUCCEEDED
+
+    store = _store(tmp_path)
+    runner = DispatchObligationRunner(
+        store=store,
+        callbacks={DispatchCallbackKind.ROOM_LIFECYCLE: callback},
+        room_for_id=lambda room_id: nio.MatrixRoom(room_id, _PRINCIPAL_ID),
+        turn_is_terminal=lambda _event_id: False,
+    )
+    room = nio.MatrixRoom(_ROOM_ID, _PRINCIPAL_ID)
+    event = _member_event("$member")
+    obligation = await runner.persist(room, event, DispatchCallbackKind.ROOM_LIFECYCLE)
+    assert obligation is not None
+
+    active = asyncio.create_task(runner._run_persisted(obligation, room=room, event=event))
+    await entered.wait()
+    drain = asyncio.create_task(runner.drain_pending_room_lifecycle())
+    await asyncio.sleep(0)
+
+    assert not drain.done()
+
+    release.set()
+    await active
+    await drain
+
+    assert attempts == 1
+    assert not store.has_pending(event.event_id, DispatchCallbackKind.ROOM_LIFECYCLE)
 
 
 @pytest.mark.asyncio

--- a/tests/test_dispatch_obligations.py
+++ b/tests/test_dispatch_obligations.py
@@ -666,6 +666,7 @@ def test_malformed_persisted_source_is_not_invented_into_recovery(tmp_path: Path
     restarted = _store(tmp_path)
     with patch("mindroom.dispatch_obligations.storage.logger") as logger:
         assert restarted.pending() == (valid,)
+        assert restarted.pending() == (valid,)
 
     logger.error.assert_called_once_with(
         "dispatch_obligation_pending_row_corrupt",
@@ -699,8 +700,10 @@ async def test_recovery_isolates_unreplayable_matrix_source(tmp_path: Path) -> N
         recovered.append(event.event_id)
         return DispatchCallbackResult.SUCCEEDED
 
+    runner = _runner(store, callback)
     with patch("mindroom.dispatch_obligations.runner.logger") as logger:
-        await _runner(store, callback).recover_pending()
+        await runner.recover_pending()
+        await runner.recover_pending()
 
     assert recovered == ["$valid-event"]
     logger.error.assert_called_once_with(
@@ -1292,58 +1295,6 @@ async def test_concurrent_duplicate_dispatch_runs_callback_once(tmp_path: Path) 
     await first
 
     assert not _store(tmp_path).has_pending("$duplicate", DispatchCallbackKind.MESSAGE)
-
-
-@pytest.mark.asyncio
-async def test_room_lifecycle_drain_waits_for_exact_active_owner(tmp_path: Path) -> None:
-    """Certification drain must wait for an active callback instead of skipping it."""
-    entered = asyncio.Event()
-    release = asyncio.Event()
-    attempts = 0
-
-    async def callback(_room: nio.MatrixRoom, _event: nio.Event) -> DispatchCallbackResult:
-        nonlocal attempts
-        attempts += 1
-        entered.set()
-        await release.wait()
-        return DispatchCallbackResult.SUCCEEDED
-
-    store = _store(tmp_path)
-    pending_loaded = asyncio.Event()
-    event_loop = asyncio.get_running_loop()
-    original_pending = store.pending
-
-    def observed_pending() -> list[DispatchObligation]:
-        pending = original_pending()
-        event_loop.call_soon_threadsafe(pending_loaded.set)
-        return pending
-
-    store.pending = observed_pending
-    runner = DispatchObligationRunner(
-        store=store,
-        callbacks={DispatchCallbackKind.ROOM_LIFECYCLE: callback},
-        room_for_id=lambda room_id: nio.MatrixRoom(room_id, _PRINCIPAL_ID),
-        turn_is_terminal=lambda _event_id: False,
-    )
-    room = nio.MatrixRoom(_ROOM_ID, _PRINCIPAL_ID)
-    event = _member_event("$member")
-    obligation = await runner.persist(room, event, DispatchCallbackKind.ROOM_LIFECYCLE)
-    assert obligation is not None
-
-    active = asyncio.create_task(runner._run_persisted(obligation, room=room, event=event))
-    await entered.wait()
-    drain = asyncio.create_task(runner.drain_pending_room_lifecycle())
-    await pending_loaded.wait()
-    await asyncio.sleep(0)
-
-    assert not drain.done()
-
-    release.set()
-    await active
-    await drain
-
-    assert attempts == 1
-    assert not store.has_pending(event.event_id, DispatchCallbackKind.ROOM_LIFECYCLE)
 
 
 @pytest.mark.asyncio

--- a/tests/test_dispatch_obligations.py
+++ b/tests/test_dispatch_obligations.py
@@ -1309,6 +1309,16 @@ async def test_room_lifecycle_drain_waits_for_exact_active_owner(tmp_path: Path)
         return DispatchCallbackResult.SUCCEEDED
 
     store = _store(tmp_path)
+    pending_loaded = asyncio.Event()
+    event_loop = asyncio.get_running_loop()
+    original_pending = store.pending
+
+    def observed_pending() -> list[DispatchObligation]:
+        pending = original_pending()
+        event_loop.call_soon_threadsafe(pending_loaded.set)
+        return pending
+
+    store.pending = observed_pending
     runner = DispatchObligationRunner(
         store=store,
         callbacks={DispatchCallbackKind.ROOM_LIFECYCLE: callback},
@@ -1323,6 +1333,7 @@ async def test_room_lifecycle_drain_waits_for_exact_active_owner(tmp_path: Path)
     active = asyncio.create_task(runner._run_persisted(obligation, room=room, event=event))
     await entered.wait()
     drain = asyncio.create_task(runner.drain_pending_room_lifecycle())
+    await pending_loaded.wait()
     await asyncio.sleep(0)
 
     assert not drain.done()
@@ -1333,6 +1344,34 @@ async def test_room_lifecycle_drain_waits_for_exact_active_owner(tmp_path: Path)
 
     assert attempts == 1
     assert not store.has_pending(event.event_id, DispatchCallbackKind.ROOM_LIFECYCLE)
+
+
+@pytest.mark.asyncio
+async def test_generic_recovery_leaves_room_lifecycle_for_response_owner(tmp_path: Path) -> None:
+    """Startup recovery must not race the response-owned lifecycle barrier."""
+    attempts = 0
+
+    async def callback(_room: nio.MatrixRoom, _event: nio.Event) -> DispatchCallbackResult:
+        nonlocal attempts
+        attempts += 1
+        return DispatchCallbackResult.SUCCEEDED
+
+    store = _store(tmp_path)
+    runner = DispatchObligationRunner(
+        store=store,
+        callbacks={DispatchCallbackKind.ROOM_LIFECYCLE: callback},
+        room_for_id=lambda room_id: nio.MatrixRoom(room_id, _PRINCIPAL_ID),
+        turn_is_terminal=lambda _event_id: False,
+    )
+    room = nio.MatrixRoom(_ROOM_ID, _PRINCIPAL_ID)
+    event = _member_event("$response-owned-member")
+    obligation = await runner.persist(room, event, DispatchCallbackKind.ROOM_LIFECYCLE)
+    assert obligation is not None
+
+    await runner.recover_pending(turn_backed=False)
+
+    assert attempts == 0
+    assert store.has_pending(event.event_id, DispatchCallbackKind.ROOM_LIFECYCLE)
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -208,6 +208,66 @@ async def test_unrecovered_timeline_gap_survives_client_restart(tmp_path: Path) 
         await restarted.close()
 
 
+@pytest.mark.asyncio
+async def test_rejected_sync_position_is_removed_from_nio_restart_store(tmp_path: Path) -> None:
+    """A server-rejected cursor and its recovery generation must not survive restart."""
+    room_id = "!room:example.org"
+    user_id = "@mindroom_agent:example.org"
+    device_id = "AGENTDEVICE"
+    config = matrix_client_config()
+
+    def load_client() -> _MindRoomAsyncClient:
+        client = _MindRoomAsyncClient(
+            "https://example.org",
+            user_id,
+            device_id=device_id,
+            store_path=str(tmp_path),
+            config=config,
+        )
+        client.restore_login(user_id, device_id, "access-token")
+        client.load_store()
+        return client
+
+    client = load_client()
+    client.next_batch = "s_before_gap"
+    response = nio.SyncResponse(
+        "s_rejected",
+        nio.Rooms(
+            invite={},
+            join={
+                room_id: nio.RoomInfo(
+                    nio.Timeline([], limited=True, prev_batch="p_before_gap"),
+                    state=[],
+                    ephemeral=[],
+                    account_data=[],
+                ),
+            },
+            leave={},
+        ),
+        nio.DeviceOneTimeKeyCount(None, None),
+        nio.DeviceList(changed=[], left=[]),
+        to_device_events=[],
+        presence_events=[],
+    )
+    client._recovery_room_messages = AsyncMock(side_effect=OSError("temporary failure"))
+    await client.receive_response(response)
+
+    assert client.loaded_sync_token == "s_rejected"  # noqa: S105
+    assert tuple(cast("Any", client)._recovery.gaps) == (room_id,)
+
+    await client_session.invalidate_rejected_sync_position(client)
+    await client.close()
+    assert client.store is not None
+    cast("Any", client.store).database.close()
+
+    restarted = load_client()
+    try:
+        assert not restarted.loaded_sync_token
+        assert not cast("Any", restarted)._recovery.gaps
+    finally:
+        await restarted.close()
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are unavailable on Windows")
 def test_matrix_store_directory_is_owner_only(tmp_path: Path) -> None:
     """Private Olm identity material is inaccessible to other local users."""

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -285,6 +285,94 @@ async def test_rejected_sync_position_is_removed_from_nio_restart_store(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_rejected_sync_position_reset_failure_keeps_durable_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed generation reset must not publish a tokenless stale generation."""
+    user_id = "@mindroom_agent:example.org"
+    device_id = "AGENTDEVICE"
+    client = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=matrix_client_config(),
+    )
+    assert client.store is not None
+    room_id = "!room:example.org"
+    client.next_batch = "s_before_gap"
+    client._recovery_room_messages = AsyncMock(side_effect=OSError("temporary failure"))
+    await client.receive_response(
+        nio.SyncResponse(
+            "s_rejected",
+            nio.Rooms(
+                invite={},
+                join={
+                    room_id: nio.RoomInfo(
+                        nio.Timeline([], limited=True, prev_batch="p_before_gap"),
+                        state=[],
+                        ephemeral=[],
+                        account_data=[],
+                    ),
+                },
+                leave={},
+            ),
+            nio.DeviceOneTimeKeyCount(None, None),
+            nio.DeviceList(changed=[], left=[]),
+            to_device_events=[],
+            presence_events=[],
+        ),
+    )
+    assert client.loaded_sync_token == "s_rejected"  # noqa: S105
+    monkeypatch.setattr(
+        client_session,
+        "persist_response_plan",
+        Mock(side_effect=OSError("reset write failed")),
+    )
+
+    with pytest.raises(OSError, match="reset write failed"):
+        await client_session.invalidate_rejected_sync_position(client)
+
+    await client.close()
+    cast("Any", client.store).database.close()
+    restarted = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=matrix_client_config(),
+    )
+    try:
+        assert restarted.loaded_sync_token == "s_rejected"  # noqa: S105
+    finally:
+        await restarted.close()
+
+
+@pytest.mark.asyncio
+async def test_rejected_sync_position_consumes_all_deferred_dispatch_errors(
+    tmp_path: Path,
+) -> None:
+    """Discarded recovery generations must not poison later fresh responses."""
+    client = _load_persisted_client(
+        tmp_path,
+        user_id="@mindroom_agent:example.org",
+        device_id="AGENTDEVICE",
+        config=matrix_client_config(),
+    )
+    recovery = cast("Any", client)._recovery
+    recovery._deferred_dispatch_errors.extend(
+        [
+            OSError("first rejected callback failed"),
+            OSError("second rejected callback failed"),
+        ],
+    )
+
+    await client_session.invalidate_rejected_sync_position(client)
+
+    assert recovery._deferred_dispatch_errors == []
+    await client.close()
+
+
+@pytest.mark.asyncio
 async def test_rejected_sync_position_preserves_unadmitted_live_events(tmp_path: Path) -> None:
     """Rejected recovery history must not discard later live callback work."""
     room_id = "!room:example.org"
@@ -381,6 +469,65 @@ async def test_rejected_sync_position_preserves_unadmitted_live_events(tmp_path:
         assert admitted == [(live_event.event_id, nio.TimelineEventProvenance.LIVE)]
     finally:
         await restarted.close()
+
+
+@pytest.mark.asyncio
+async def test_sliding_initial_timeline_reports_only_num_live_tail_as_live(tmp_path: Path) -> None:
+    """Pinned nio must distinguish Sliding snapshot history from its explicit live tail."""
+    user_id = "@mindroom_agent:example.org"
+    client = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id="AGENTDEVICE",
+        config=matrix_client_config(),
+    )
+    admitted: list[tuple[str, nio.TimelineEventProvenance]] = []
+
+    async def admit(
+        _room: nio.MatrixRoom,
+        event: nio.Event,
+        provenance: nio.TimelineEventProvenance,
+    ) -> None:
+        admitted.append((event.event_id, provenance))
+
+    def member(event_id: str, member_id: str) -> nio.RoomMemberEvent:
+        event = nio.RoomMemberEvent.from_dict(
+            {
+                "type": "m.room.member",
+                "event_id": event_id,
+                "sender": member_id,
+                "state_key": member_id,
+                "origin_server_ts": 1,
+                "content": {"membership": "join"},
+                "unsigned": {"prev_content": {"membership": "leave"}},
+            },
+        )
+        assert isinstance(event, nio.RoomMemberEvent)
+        return event
+
+    client.add_event_admission_callback(admit)
+    await client.receive_response(
+        nio.SlidingSyncResponse(
+            "p1",
+            rooms={
+                "!room:example.org": nio.SlidingSyncRoom(
+                    initial=True,
+                    membership="join",
+                    timeline=[
+                        member("$snapshot", "@alice:example.org"),
+                        member("$live", "@bob:example.org"),
+                    ],
+                    num_live=1,
+                ),
+            },
+        ),
+    )
+
+    assert admitted == [
+        ("$snapshot", nio.TimelineEventProvenance.HISTORY),
+        ("$live", nio.TimelineEventProvenance.LIVE),
+    ]
+    await client.close()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are unavailable on Windows")

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -284,6 +284,105 @@ async def test_rejected_sync_position_is_removed_from_nio_restart_store(tmp_path
         await restarted.close()
 
 
+@pytest.mark.asyncio
+async def test_rejected_sync_position_preserves_unadmitted_live_events(tmp_path: Path) -> None:
+    """Rejected recovery history must not discard later live callback work."""
+    room_id = "!room:example.org"
+    user_id = "@mindroom_agent:example.org"
+    device_id = "AGENTDEVICE"
+    config = matrix_client_config()
+    admitted: list[tuple[str, nio.TimelineEventProvenance]] = []
+
+    async def admit(
+        _room: nio.MatrixRoom,
+        event: nio.Event,
+        provenance: nio.TimelineEventProvenance,
+    ) -> None:
+        admitted.append((event.event_id, provenance))
+
+    live_event = nio.RoomMessageText.from_dict(
+        {
+            "content": {"body": "live", "msgtype": "m.text"},
+            "event_id": "$live-unadmitted:example.org",
+            "origin_server_ts": 1,
+            "sender": "@alice:example.org",
+            "type": "m.room.message",
+        },
+    )
+    assert isinstance(live_event, nio.RoomMessageText)
+    client = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=config,
+    )
+    client.add_event_admission_callback(admit)
+    client.next_batch = "s_before_gap"
+    client._recovery_room_messages = AsyncMock(side_effect=OSError("temporary failure"))
+    await client.receive_response(
+        nio.SyncResponse(
+            "s_rejected",
+            nio.Rooms(
+                invite={},
+                join={
+                    room_id: nio.RoomInfo(
+                        nio.Timeline(
+                            [live_event],
+                            limited=True,
+                            prev_batch="p_before_gap",
+                        ),
+                        state=[],
+                        ephemeral=[],
+                        account_data=[],
+                    ),
+                },
+                leave={},
+            ),
+            nio.DeviceOneTimeKeyCount(None, None),
+            nio.DeviceList(changed=[], left=[]),
+            to_device_events=[],
+            presence_events=[],
+        ),
+    )
+
+    recovery = cast("Any", client)._recovery
+    assert admitted == []
+    assert not recovery._active_dispatches
+    assert [event.event_id for events in recovery.events.values() for event in events] == [live_event.event_id]
+
+    await client_session.invalidate_rejected_sync_position(client)
+    await client.close()
+    assert client.store is not None
+    cast("Any", client.store).database.close()
+
+    restarted = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=config,
+    )
+    restarted.add_event_admission_callback(admit)
+    try:
+        assert not restarted.loaded_sync_token
+        queued = [event for events in cast("Any", restarted)._recovery.events.values() for event in events]
+        assert [(event.event_id, event.is_live) for event in queued] == [(live_event.event_id, True)]
+
+        await restarted.receive_response(
+            nio.SyncResponse(
+                "s_fresh",
+                nio.Rooms(invite={}, join={}, leave={}),
+                nio.DeviceOneTimeKeyCount(None, None),
+                nio.DeviceList(changed=[], left=[]),
+                to_device_events=[],
+                presence_events=[],
+            ),
+        )
+
+        assert admitted == [(live_event.event_id, nio.TimelineEventProvenance.LIVE)]
+    finally:
+        await restarted.close()
+
+
 @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits are unavailable on Windows")
 def test_matrix_store_directory_is_owner_only(tmp_path: Path) -> None:
     """Private Olm identity material is inaccessible to other local users."""

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -266,7 +266,7 @@ async def test_rejected_sync_position_is_removed_from_nio_restart_store(tmp_path
     assert client.loaded_sync_token == "s_rejected"  # noqa: S105
     assert tuple(cast("Any", client)._recovery.gaps) == (room_id,)
 
-    await client_session.invalidate_rejected_sync_position(client)
+    await client.invalidate_rejected_sync_position()
     await client.close()
     assert client.store is not None
     cast("Any", client.store).database.close()
@@ -331,7 +331,7 @@ async def test_rejected_sync_position_reset_failure_keeps_durable_token(
     )
 
     with pytest.raises(OSError, match="reset write failed"):
-        await client_session.invalidate_rejected_sync_position(client)
+        await client.invalidate_rejected_sync_position()
 
     await client.close()
     cast("Any", client.store).database.close()
@@ -366,7 +366,7 @@ async def test_rejected_sync_position_consumes_all_deferred_dispatch_errors(
         ],
     )
 
-    await client_session.invalidate_rejected_sync_position(client)
+    await client.invalidate_rejected_sync_position()
 
     assert recovery._deferred_dispatch_errors == []
     await client.close()
@@ -438,7 +438,7 @@ async def test_rejected_sync_position_preserves_unadmitted_live_events(tmp_path:
     assert not recovery._active_dispatches
     assert [event.event_id for events in recovery.events.values() for event in events] == [live_event.event_id]
 
-    await client_session.invalidate_rejected_sync_position(client)
+    await client.invalidate_rejected_sync_position()
     await client.close()
     assert client.store is not None
     cast("Any", client.store).database.close()

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -143,6 +143,26 @@ def test_matrix_client_config_enables_limited_timeline_backfill() -> None:
     assert config.store_sync_tokens is True
 
 
+def _load_persisted_client(
+    tmp_path: Path,
+    *,
+    user_id: str,
+    device_id: str,
+    config: nio.AsyncClientConfig,
+) -> _MindRoomAsyncClient:
+    """Load one authenticated MindRoom client from its persisted nio store."""
+    client = _MindRoomAsyncClient(
+        "https://example.org",
+        user_id,
+        device_id=device_id,
+        store_path=str(tmp_path),
+        config=config,
+    )
+    client.restore_login(user_id, device_id, "access-token")
+    client.load_store()
+    return client
+
+
 @pytest.mark.asyncio
 async def test_unrecovered_timeline_gap_survives_client_restart(tmp_path: Path) -> None:
     """Nio must durably retain a gap when MindRoom advances its own sync token."""
@@ -173,19 +193,12 @@ async def test_unrecovered_timeline_gap_survives_client_restart(tmp_path: Path) 
             presence_events=[],
         )
 
-    def load_client() -> _MindRoomAsyncClient:
-        client = _MindRoomAsyncClient(
-            "https://example.org",
-            user_id,
-            device_id=device_id,
-            store_path=str(tmp_path),
-            config=config,
-        )
-        client.restore_login(user_id, device_id, "access-token")
-        client.load_store()
-        return client
-
-    client = load_client()
+    client = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=config,
+    )
     client.next_batch = "s_before_gap"
     client._recovery_room_messages = AsyncMock(side_effect=OSError("temporary failure"))
 
@@ -198,7 +211,12 @@ async def test_unrecovered_timeline_gap_survives_client_restart(tmp_path: Path) 
     assert limited_response.unrecovered_room_ids == {room_id}
     assert later_response.unrecovered_room_ids == {room_id}
 
-    restarted = load_client()
+    restarted = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=config,
+    )
     try:
         recovery = cast("Any", restarted)._recovery
         assert restarted.loaded_sync_token == "s_later"  # noqa: S105
@@ -216,19 +234,12 @@ async def test_rejected_sync_position_is_removed_from_nio_restart_store(tmp_path
     device_id = "AGENTDEVICE"
     config = matrix_client_config()
 
-    def load_client() -> _MindRoomAsyncClient:
-        client = _MindRoomAsyncClient(
-            "https://example.org",
-            user_id,
-            device_id=device_id,
-            store_path=str(tmp_path),
-            config=config,
-        )
-        client.restore_login(user_id, device_id, "access-token")
-        client.load_store()
-        return client
-
-    client = load_client()
+    client = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=config,
+    )
     client.next_batch = "s_before_gap"
     response = nio.SyncResponse(
         "s_rejected",
@@ -260,7 +271,12 @@ async def test_rejected_sync_position_is_removed_from_nio_restart_store(tmp_path
     assert client.store is not None
     cast("Any", client.store).database.close()
 
-    restarted = load_client()
+    restarted = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=config,
+    )
     try:
         assert not restarted.loaded_sync_token
         assert not cast("Any", restarted)._recovery.gaps

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -566,6 +566,77 @@ async def test_rejected_sync_position_replay_cannot_overwrite_fresh_member_state
 
 
 @pytest.mark.asyncio
+async def test_rejected_sync_position_drops_stale_room_account_data(tmp_path: Path) -> None:
+    """A fresh tokenless response must not recreate a departed room from retained account data."""
+    room_id = "!room:example.org"
+    user_id = "@mindroom_agent:example.org"
+    device_id = "AGENTDEVICE"
+    client = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=matrix_client_config(),
+    )
+    client.next_batch = "s_before_gap"
+    client._recovery_room_messages = AsyncMock(side_effect=OSError("temporary failure"))
+    await client.receive_response(
+        nio.SyncResponse(
+            "s_rejected",
+            nio.Rooms(
+                invite={},
+                join={
+                    room_id: nio.RoomInfo(
+                        nio.Timeline([], limited=True, prev_batch="p_before_gap"),
+                        state=[],
+                        ephemeral=[],
+                        account_data=[
+                            nio.FullyReadEvent.from_dict(
+                                {
+                                    "type": "m.fully_read",
+                                    "content": {"event_id": "$stale-marker"},
+                                },
+                            ),
+                        ],
+                    ),
+                },
+                leave={},
+            ),
+            nio.DeviceOneTimeKeyCount(None, None),
+            nio.DeviceList(changed=[], left=[]),
+            to_device_events=[],
+            presence_events=[],
+        ),
+    )
+
+    await client.invalidate_rejected_sync_position()
+    await client.close()
+    assert client.store is not None
+    cast("Any", client.store).database.close()
+
+    restarted = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=matrix_client_config(),
+    )
+    try:
+        await restarted.receive_response(
+            nio.SyncResponse(
+                "s_fresh",
+                nio.Rooms(invite={}, join={}, leave={}),
+                nio.DeviceOneTimeKeyCount(None, None),
+                nio.DeviceList(changed=[], left=[]),
+                to_device_events=[],
+                presence_events=[],
+            ),
+        )
+
+        assert room_id not in restarted.rooms
+    finally:
+        await restarted.close()
+
+
+@pytest.mark.asyncio
 async def test_sliding_initial_timeline_reports_only_num_live_tail_as_live(tmp_path: Path) -> None:
     """Pinned nio must distinguish Sliding snapshot history from its explicit live tail."""
     user_id = "@mindroom_agent:example.org"

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -472,6 +472,100 @@ async def test_rejected_sync_position_preserves_unadmitted_live_events(tmp_path:
 
 
 @pytest.mark.asyncio
+async def test_rejected_sync_position_replay_cannot_overwrite_fresh_member_state(tmp_path: Path) -> None:
+    """Preserved callback debt must not reapply rejected membership state after a fresh baseline."""
+    room_id = "!room:example.org"
+    user_id = "@mindroom_agent:example.org"
+    member_id = "@alice:example.org"
+    device_id = "AGENTDEVICE"
+
+    def member_event(event_id: str, membership: str, previous_membership: str) -> nio.RoomMemberEvent:
+        event = nio.RoomMemberEvent.from_dict(
+            {
+                "content": {"membership": membership},
+                "event_id": event_id,
+                "origin_server_ts": 1,
+                "sender": member_id,
+                "state_key": member_id,
+                "type": "m.room.member",
+                "unsigned": {"prev_content": {"membership": previous_membership}},
+            },
+        )
+        assert isinstance(event, nio.RoomMemberEvent)
+        return event
+
+    old_join = member_event("$old-join", "join", "leave")
+    fresh_leave = member_event("$fresh-leave", "leave", "join")
+    client = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=matrix_client_config(),
+    )
+    client.next_batch = "s_before_gap"
+    client._recovery_room_messages = AsyncMock(side_effect=OSError("temporary failure"))
+    await client.receive_response(
+        nio.SyncResponse(
+            "s_rejected",
+            nio.Rooms(
+                invite={},
+                join={
+                    room_id: nio.RoomInfo(
+                        nio.Timeline([old_join], limited=True, prev_batch="p_before_gap"),
+                        state=[],
+                        ephemeral=[],
+                        account_data=[],
+                    ),
+                },
+                leave={},
+            ),
+            nio.DeviceOneTimeKeyCount(None, None),
+            nio.DeviceList(changed=[], left=[]),
+            to_device_events=[],
+            presence_events=[],
+        ),
+    )
+
+    await client.invalidate_rejected_sync_position()
+    await client.close()
+    assert client.store is not None
+    cast("Any", client.store).database.close()
+
+    restarted = _load_persisted_client(
+        tmp_path,
+        user_id=user_id,
+        device_id=device_id,
+        config=matrix_client_config(),
+    )
+    try:
+        await restarted.receive_response(
+            nio.SyncResponse(
+                "s_fresh",
+                nio.Rooms(
+                    invite={},
+                    join={
+                        room_id: nio.RoomInfo(
+                            nio.Timeline([], limited=False, prev_batch=None),
+                            state=[fresh_leave],
+                            ephemeral=[],
+                            account_data=[],
+                        ),
+                    },
+                    leave={},
+                ),
+                nio.DeviceOneTimeKeyCount(None, None),
+                nio.DeviceList(changed=[], left=[]),
+                to_device_events=[],
+                presence_events=[],
+            ),
+        )
+
+        assert member_id not in restarted.rooms[room_id].users
+    finally:
+        await restarted.close()
+
+
+@pytest.mark.asyncio
 async def test_sliding_initial_timeline_reports_only_num_live_tail_as_live(tmp_path: Path) -> None:
     """Pinned nio must distinguish Sliding snapshot history from its explicit live tail."""
     user_id = "@mindroom_agent:example.org"

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -1807,10 +1807,53 @@ async def test_unknown_pos_first_sync_clears_client_and_saved_token(tmp_path: Pa
 
 @pytest.mark.asyncio
 async def test_unknown_pos_cleanup_cancellation_still_clears_mindroom_checkpoint(tmp_path: Path) -> None:
-    """Cancellation while draining NIO recovery cannot preserve the rejected checkpoint."""
+    """Cancellation must wait for accepted NIO cleanup before clearing trust."""
     bot = _agent_bot(tmp_path)
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     bot.client.next_batch = "s_rejected"
+    bot.client.loaded_sync_token = "s_rejected"  # noqa: S105
+    save_sync_token(tmp_path, bot.agent_name, "s_rejected", cache_generation=_CACHE_GENERATION)
+    sync_error = MagicMock(spec=nio.SyncError)
+    sync_error.status_code = "M_UNKNOWN_POS"
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    cleanup_completed = False
+
+    async def blocked_cleanup(_client: nio.AsyncClient) -> None:
+        nonlocal cleanup_completed
+        cleanup_started.set()
+        await release_cleanup.wait()
+        cleanup_completed = True
+
+    with patch(
+        "mindroom.bot.invalidate_rejected_sync_position",
+        side_effect=blocked_cleanup,
+    ):
+        task = asyncio.create_task(bot._on_sync_error(sync_error))
+        await cleanup_started.wait()
+        task.cancel("watchdog restart")
+        await asyncio.sleep(0)
+
+        assert not task.done()
+
+        release_cleanup.set()
+        with pytest.raises(asyncio.CancelledError, match="watchdog restart"):
+            await task
+
+    assert bot.client.next_batch is None
+    assert bot.client.loaded_sync_token == ""
+    assert cleanup_completed
+    assert _load_sync_token_value(tmp_path, bot.agent_name) is None
+    assert bot._sync_cache_trust.state is SyncTrustState.UNCERTAIN
+
+
+@pytest.mark.asyncio
+async def test_unknown_pos_cleanup_failure_keeps_rejected_client_position(tmp_path: Path) -> None:
+    """Failed transport sanitation must restart without exposing stale gaps tokenlessly."""
+    bot = _agent_bot(tmp_path)
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    bot.client.next_batch = "s_rejected"
+    bot.client.loaded_sync_token = "s_rejected"  # noqa: S105
     save_sync_token(tmp_path, bot.agent_name, "s_rejected", cache_generation=_CACHE_GENERATION)
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
@@ -1818,13 +1861,14 @@ async def test_unknown_pos_cleanup_cancellation_still_clears_mindroom_checkpoint
     with (
         patch(
             "mindroom.bot.invalidate_rejected_sync_position",
-            AsyncMock(side_effect=asyncio.CancelledError("watchdog restart")),
+            AsyncMock(side_effect=OSError("recovery reset failed")),
         ),
-        pytest.raises(asyncio.CancelledError, match="watchdog restart"),
+        pytest.raises(OSError, match="recovery reset failed"),
     ):
         await bot._on_sync_error(sync_error)
 
-    assert bot.client.next_batch is None
+    assert bot.client.next_batch == "s_rejected"
+    assert bot.client.loaded_sync_token == "s_rejected"  # noqa: S105
     assert _load_sync_token_value(tmp_path, bot.agent_name) is None
     assert bot._sync_cache_trust.state is SyncTrustState.UNCERTAIN
 
@@ -1840,7 +1884,8 @@ async def test_unknown_pos_restored_first_sync_saves_later_checkpoint(tmp_path: 
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
-    await bot._on_sync_error(sync_error)
+    with patch("mindroom.bot.invalidate_rejected_sync_position", AsyncMock()):
+        await bot._on_sync_error(sync_error)
 
     bot._first_sync_done = True
     response = _sync_response("s_later")
@@ -1868,7 +1913,8 @@ async def test_unknown_pos_after_first_sync_clears_client_and_saved_token(tmp_pa
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
-    await bot._on_sync_error(sync_error)
+    with patch("mindroom.bot.invalidate_rejected_sync_position", AsyncMock()):
+        await bot._on_sync_error(sync_error)
 
     assert bot.client.next_batch is None
     assert _load_sync_token_value(tmp_path, bot.agent_name) is None
@@ -1886,7 +1932,8 @@ async def test_unknown_pos_non_restored_runtime_allows_later_checkpoint(tmp_path
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
-    await bot._on_sync_error(sync_error)
+    with patch("mindroom.bot.invalidate_rejected_sync_position", AsyncMock()):
+        await bot._on_sync_error(sync_error)
 
     bot.client.next_batch = "s_later_after_unknown_pos"
     response = _sync_response(

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -1792,7 +1792,37 @@ async def test_unknown_pos_first_sync_clears_client_and_saved_token(tmp_path: Pa
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
-    await bot._on_sync_error(sync_error)
+    invalidate_rejected_sync_position = AsyncMock()
+    with patch(
+        "mindroom.bot.invalidate_rejected_sync_position",
+        invalidate_rejected_sync_position,
+    ):
+        await bot._on_sync_error(sync_error)
+
+    invalidate_rejected_sync_position.assert_awaited_once_with(bot.client)
+    assert bot.client.next_batch is None
+    assert _load_sync_token_value(tmp_path, bot.agent_name) is None
+    assert bot._sync_cache_trust.state is SyncTrustState.UNCERTAIN
+
+
+@pytest.mark.asyncio
+async def test_unknown_pos_cleanup_cancellation_still_clears_mindroom_checkpoint(tmp_path: Path) -> None:
+    """Cancellation while draining NIO recovery cannot preserve the rejected checkpoint."""
+    bot = _agent_bot(tmp_path)
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    bot.client.next_batch = "s_rejected"
+    save_sync_token(tmp_path, bot.agent_name, "s_rejected", cache_generation=_CACHE_GENERATION)
+    sync_error = MagicMock(spec=nio.SyncError)
+    sync_error.status_code = "M_UNKNOWN_POS"
+
+    with (
+        patch(
+            "mindroom.bot.invalidate_rejected_sync_position",
+            AsyncMock(side_effect=asyncio.CancelledError("watchdog restart")),
+        ),
+        pytest.raises(asyncio.CancelledError, match="watchdog restart"),
+    ):
+        await bot._on_sync_error(sync_error)
 
     assert bot.client.next_batch is None
     assert _load_sync_token_value(tmp_path, bot.agent_name) is None
@@ -2199,7 +2229,7 @@ async def test_classic_loop_exit_defers_rewind_until_nio_retries_failure(
         cache_generation=_CACHE_GENERATION,
     )
 
-    bot._record_dispatch_persist_failure()
+    bot._sync_cache_trust.record_dispatch_persist_failure()
     assert bot.client.next_batch == "s_after_rejected"
     bot._reconcile_classic_sync_cursor_after_loop_exit()
     assert bot.client.next_batch == "s_after_rejected"

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -3473,7 +3473,6 @@ async def test_certification_cancellation_is_not_logged_as_durability_failure(
         await bot._handle_classic_sync_response(
             response,
             first_sync_response=False,
-            room_member_join_hooks_were_armed=True,
         )
 
     assert not any(entry["event"] == "matrix_sync_certification_apply_failed" for entry in logs)

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -1793,13 +1793,10 @@ async def test_unknown_pos_first_sync_clears_client_and_saved_token(tmp_path: Pa
     sync_error.status_code = "M_UNKNOWN_POS"
 
     invalidate_rejected_sync_position = AsyncMock()
-    with patch(
-        "mindroom.bot.invalidate_rejected_sync_position",
-        invalidate_rejected_sync_position,
-    ):
-        await bot._on_sync_error(sync_error)
+    bot.client.invalidate_rejected_sync_position = invalidate_rejected_sync_position
+    await bot._on_sync_error(sync_error)
 
-    invalidate_rejected_sync_position.assert_awaited_once_with(bot.client)
+    invalidate_rejected_sync_position.assert_awaited_once_with()
     assert bot.client.next_batch is None
     assert _load_sync_token_value(tmp_path, bot.agent_name) is None
     assert bot._sync_cache_trust.state is SyncTrustState.UNCERTAIN
@@ -1819,16 +1816,14 @@ async def test_unknown_pos_cleanup_cancellation_still_clears_mindroom_checkpoint
     release_cleanup = asyncio.Event()
     cleanup_completed = False
 
-    async def blocked_cleanup(_client: nio.AsyncClient) -> None:
+    async def blocked_cleanup() -> None:
         nonlocal cleanup_completed
         cleanup_started.set()
         await release_cleanup.wait()
         cleanup_completed = True
 
-    with patch(
-        "mindroom.bot.invalidate_rejected_sync_position",
-        side_effect=blocked_cleanup,
-    ):
+    bot.client.invalidate_rejected_sync_position = AsyncMock(side_effect=blocked_cleanup)
+    try:
         task = asyncio.create_task(bot._on_sync_error(sync_error))
         await cleanup_started.wait()
         task.cancel("watchdog restart")
@@ -1839,6 +1834,8 @@ async def test_unknown_pos_cleanup_cancellation_still_clears_mindroom_checkpoint
         release_cleanup.set()
         with pytest.raises(asyncio.CancelledError, match="watchdog restart"):
             await task
+    finally:
+        release_cleanup.set()
 
     assert bot.client.next_batch is None
     assert bot.client.loaded_sync_token == ""
@@ -1863,13 +1860,8 @@ async def test_unknown_pos_cleanup_failure_keeps_rejected_client_position(tmp_pa
 
     bot.client.sync_forever = AsyncMock(side_effect=rejected_sync_loop)
 
-    with (
-        patch(
-            "mindroom.bot.invalidate_rejected_sync_position",
-            AsyncMock(side_effect=OSError("recovery reset failed")),
-        ),
-        pytest.raises(OSError, match="recovery reset failed"),
-    ):
+    bot.client.invalidate_rejected_sync_position = AsyncMock(side_effect=OSError("recovery reset failed"))
+    with pytest.raises(OSError, match="recovery reset failed"):
         await bot.sync_forever()
 
     assert bot.client.next_batch == "s_rejected"
@@ -1889,8 +1881,8 @@ async def test_unknown_pos_restored_first_sync_saves_later_checkpoint(tmp_path: 
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
-    with patch("mindroom.bot.invalidate_rejected_sync_position", AsyncMock()):
-        await bot._on_sync_error(sync_error)
+    bot.client.invalidate_rejected_sync_position = AsyncMock()
+    await bot._on_sync_error(sync_error)
 
     bot._first_sync_done = True
     response = _sync_response("s_later")
@@ -1918,8 +1910,8 @@ async def test_unknown_pos_after_first_sync_clears_client_and_saved_token(tmp_pa
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
-    with patch("mindroom.bot.invalidate_rejected_sync_position", AsyncMock()):
-        await bot._on_sync_error(sync_error)
+    bot.client.invalidate_rejected_sync_position = AsyncMock()
+    await bot._on_sync_error(sync_error)
 
     assert bot.client.next_batch is None
     assert _load_sync_token_value(tmp_path, bot.agent_name) is None
@@ -1937,8 +1929,8 @@ async def test_unknown_pos_non_restored_runtime_allows_later_checkpoint(tmp_path
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
-    with patch("mindroom.bot.invalidate_rejected_sync_position", AsyncMock()):
-        await bot._on_sync_error(sync_error)
+    bot.client.invalidate_rejected_sync_position = AsyncMock()
+    await bot._on_sync_error(sync_error)
 
     bot.client.next_batch = "s_later_after_unknown_pos"
     response = _sync_response(

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -1849,7 +1849,7 @@ async def test_unknown_pos_cleanup_cancellation_still_clears_mindroom_checkpoint
 
 @pytest.mark.asyncio
 async def test_unknown_pos_cleanup_failure_keeps_rejected_client_position(tmp_path: Path) -> None:
-    """Failed transport sanitation must restart without exposing stale gaps tokenlessly."""
+    """Loop exit after failed sanitation must preserve the rejected position."""
     bot = _agent_bot(tmp_path)
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     bot.client.next_batch = "s_rejected"
@@ -1858,6 +1858,11 @@ async def test_unknown_pos_cleanup_failure_keeps_rejected_client_position(tmp_pa
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"
 
+    async def rejected_sync_loop(**_kwargs: object) -> None:
+        await bot._on_sync_error(sync_error)
+
+    bot.client.sync_forever = AsyncMock(side_effect=rejected_sync_loop)
+
     with (
         patch(
             "mindroom.bot.invalidate_rejected_sync_position",
@@ -1865,7 +1870,7 @@ async def test_unknown_pos_cleanup_failure_keeps_rejected_client_position(tmp_pa
         ),
         pytest.raises(OSError, match="recovery reset failed"),
     ):
-        await bot._on_sync_error(sync_error)
+        await bot.sync_forever()
 
     assert bot.client.next_batch == "s_rejected"
     assert bot.client.loaded_sync_token == "s_rejected"  # noqa: S105

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -1894,6 +1894,118 @@ async def test_unknown_pos_restored_first_sync_saves_later_checkpoint(tmp_path: 
 
 
 @pytest.mark.asyncio
+async def test_unknown_pos_after_cold_restart_purges_rooms_missing_from_fresh_baseline(
+    tmp_path: Path,
+) -> None:
+    """A rejected restored cursor cannot leave inaccessible room history cached."""
+    principal_id = "@mindroom_code:localhost"
+    room_id = "!departed:localhost"
+    event_id = "$cached-before-departure"
+    event = {
+        "content": {"body": "private history", "msgtype": "m.text"},
+        "event_id": event_id,
+        "origin_server_ts": 1,
+        "room_id": room_id,
+        "sender": "@user:localhost",
+        "type": "m.room.message",
+    }
+    cache_path = tmp_path / "event-cache.db"
+    seed_root = SqliteEventCache(cache_path)
+    await seed_root.initialize()
+    seed_cache = seed_root.for_principal(principal_id)
+    await seed_cache.store_event(event_id, room_id, event)
+    cache_generation = seed_cache.cache_generation
+    assert cache_generation is not None
+    save_sync_token(
+        tmp_path,
+        "code",
+        "s_rejected",
+        cache_generation=cache_generation,
+    )
+    await seed_root.close()
+
+    restarted_root = SqliteEventCache(cache_path)
+    await restarted_root.initialize()
+    restarted_cache = restarted_root.for_principal(principal_id)
+    assert await restarted_cache.get_event(room_id, event_id) == event
+    bot = _agent_bot(tmp_path)
+    bot.event_cache = restarted_cache
+    bot.client = make_matrix_client_mock(user_id=principal_id)
+    bot.client.rooms = {}
+    bot.client.next_batch = await bot._sync_cache_trust.prepare_startup()
+    bot.client.invalidate_rejected_sync_position = AsyncMock()
+    sync_error = MagicMock(spec=nio.SyncError)
+    sync_error.status_code = "M_UNKNOWN_POS"
+
+    try:
+        await bot._on_sync_error(sync_error)
+        await bot._on_sync_response(_sync_response("s_fresh"))
+
+        assert bot._rejected_sync_room_ids == set()
+        assert await restarted_cache.get_event(room_id, event_id) is None
+        checkpoint = load_sync_checkpoint(tmp_path, bot.agent_name)
+        assert checkpoint is not None
+        assert checkpoint.token == "s_fresh"  # noqa: S105
+    finally:
+        await restarted_root.close()
+
+
+@pytest.mark.asyncio
+async def test_unknown_pos_checkpoint_clear_failure_still_purges_cache_across_restart(
+    tmp_path: Path,
+) -> None:
+    """Failed token deletion cannot prevent durable rejected-scope cleanup."""
+    principal_id = "@mindroom_code:localhost"
+    room_id = "!departed:localhost"
+    event_id = "$cached-before-rejection"
+    event = {
+        "content": {"body": "private history", "msgtype": "m.text"},
+        "event_id": event_id,
+        "origin_server_ts": 1,
+        "room_id": room_id,
+        "sender": "@user:localhost",
+        "type": "m.room.message",
+    }
+    cache_path = tmp_path / "event-cache.db"
+    first_root = SqliteEventCache(cache_path)
+    await first_root.initialize()
+    first_cache = first_root.for_principal(principal_id)
+    await first_cache.store_event(event_id, room_id, event)
+    cache_generation = first_cache.cache_generation
+    assert cache_generation is not None
+    save_sync_token(
+        tmp_path,
+        "code",
+        "s_rejected",
+        cache_generation=cache_generation,
+    )
+    first_bot = _agent_bot(tmp_path)
+    first_bot.event_cache = first_cache
+    assert await first_bot._sync_cache_trust.prepare_startup() == "s_rejected"
+
+    try:
+        with patch.object(
+            first_bot._sync_continuity_store,
+            "clear_checkpoint",
+            side_effect=OSError("checkpoint cannot be removed"),
+        ):
+            await first_bot._sync_cache_trust.reject_unknown_pos()
+    finally:
+        await first_root.close()
+
+    reopened_root = SqliteEventCache(cache_path)
+    await reopened_root.initialize()
+    reopened_cache = reopened_root.for_principal(principal_id)
+    restarted_bot = _agent_bot(tmp_path)
+    restarted_bot.event_cache = reopened_cache
+    try:
+        assert await restarted_bot._sync_cache_trust.prepare_startup() == "s_rejected"
+        assert await reopened_cache.get_event(room_id, event_id) is None
+    finally:
+        await reopened_root.close()
+
+
+@pytest.mark.asyncio
 async def test_unknown_pos_after_first_sync_clears_client_and_saved_token(tmp_path: Path) -> None:
     """Post-start M_UNKNOWN_POS must not leave a poisoned sync token in place."""
     bot = _agent_bot(tmp_path)

--- a/tests/test_nio_recovery_consumer_contract.py
+++ b/tests/test_nio_recovery_consumer_contract.py
@@ -349,8 +349,8 @@ async def test_real_nio_terminal_gap_retries_from_safe_checkpoint(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_real_nio_timeout_can_recover_without_replanning_the_gap(tmp_path: Path) -> None:
-    """A transient timeout must leave nio's live cursor free to drain the same gap."""
+async def test_real_nio_timeout_settles_before_safe_checkpoint_replay(tmp_path: Path) -> None:
+    """A transient timeout must settle nio's gap before replaying the safe catch-up."""
     room_id = "!transient-history:localhost"
     client = nio.AsyncClient(
         "https://localhost",
@@ -414,14 +414,20 @@ async def test_real_nio_timeout_can_recover_without_replanning_the_gap(tmp_path:
                     complete=True,
                 ),
             )
+            replayed = await trust.certify_response(
+                next_batch="s_replayed",
+                cache_result=SyncCacheWriteResult(complete=True),
+            )
     finally:
         await client.close()
 
     assert gap_response.unrecovered_room_ids == frozenset({room_id})
     assert recovery_response.recovered_room_ids == frozenset({room_id})
-    assert recovered.state is SyncTrustState.CERTIFIED
+    assert recovered.reason == "sync_cache_replay_required"
+    assert recovered.reset_client_token is True
+    assert replayed.state is SyncTrustState.CERTIFIED
     assert load_sync_checkpoint(tmp_path, "code") == SyncCheckpoint(
-        "s_recovered",
+        "s_replayed",
         cache_generation=_CACHE_GENERATION,
     )
 

--- a/tests/test_room_member_hook_lifecycle.py
+++ b/tests/test_room_member_hook_lifecycle.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import nio
+import pytest
 
 from mindroom.matrix.room_member_hook_lifecycle import (
     RoomMemberHookLifecycle,
@@ -26,10 +27,35 @@ def test_tokenless_baseline_transitions_to_catchup_until_certified() -> None:
     lifecycle = RoomMemberHookLifecycle(enabled=True)
     lifecycle.prepare_startup(transport="classic", resuming_position=False)
 
-    assert lifecycle.baseline_record_pending
+    assert lifecycle._baseline_record_pending
     assert lifecycle.full_state_required
     assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
     assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
+    assert lifecycle.baseline_capture_pending
+
+    lifecycle.capture_baseline(())
+
+    uncertain_baseline = lifecycle.plan_response(
+        _decision(SyncTrustState.UNCERTAIN),
+        first_sync_response=False,
+    )
+    certifiable_baseline = lifecycle.plan_response(
+        _decision(SyncTrustState.CERTIFIED),
+        first_sync_response=False,
+    )
+
+    assert uncertain_baseline.baseline_record_events is None
+    assert certifiable_baseline.baseline_record_events == ()
+
+    lifecycle.rewound(has_retry_token=True)
+    assert not lifecycle.baseline_capture_pending
+    assert (
+        lifecycle.plan_response(
+            _decision(SyncTrustState.CERTIFIED),
+            first_sync_response=False,
+        ).baseline_record_events
+        == ()
+    )
 
     lifecycle.baseline_recorded()
     plan = lifecycle.plan_response(
@@ -37,7 +63,7 @@ def test_tokenless_baseline_transitions_to_catchup_until_certified() -> None:
         first_sync_response=False,
     )
 
-    assert not lifecycle.baseline_record_pending
+    assert not lifecycle._baseline_record_pending
     assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
     assert not plan.drain_captured_timeline
 
@@ -52,23 +78,43 @@ def test_tokenless_baseline_transitions_to_catchup_until_certified() -> None:
     assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
 
 
+def test_tokenless_rewind_discards_stale_baseline_and_rearms_capture() -> None:
+    """A tokenless reset must replace rather than certify the rejected snapshot."""
+    lifecycle = RoomMemberHookLifecycle(enabled=True)
+    lifecycle.prepare_startup(transport="classic", resuming_position=True)
+    lifecycle.capture_baseline(())
+
+    lifecycle.rewound(has_retry_token=False)
+
+    assert lifecycle._baseline_record_pending
+    assert lifecycle.baseline_capture_pending
+    with pytest.raises(RuntimeError, match="without a captured full-state baseline"):
+        lifecycle.plan_response(
+            _decision(SyncTrustState.CERTIFIED),
+            first_sync_response=False,
+        )
+
+
 def test_safe_rewind_and_loop_replacement_require_full_state_catchup() -> None:
     """A safe rewind must capture replay joins and reacquire a replacement baseline."""
     lifecycle = RoomMemberHookLifecycle(enabled=True)
     lifecycle.prepare_startup(transport="classic", resuming_position=False)
+    lifecycle.capture_baseline(())
     lifecycle.baseline_recorded()
     lifecycle.certified()
 
     lifecycle.rewound(has_retry_token=True)
     assert lifecycle.full_state_required
-    assert not lifecycle.baseline_record_pending
+    assert not lifecycle._baseline_record_pending
     assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
 
     lifecycle.begin_sync_loop()
-    assert lifecycle.baseline_record_pending
+    assert lifecycle._baseline_record_pending
+    assert lifecycle.baseline_capture_pending
 
+    lifecycle.capture_baseline(())
     lifecycle.baseline_recorded()
-    assert not lifecycle.baseline_record_pending
+    assert not lifecycle._baseline_record_pending
 
 
 def test_unknown_position_and_stop_reset_phase_boundaries() -> None:
@@ -77,7 +123,7 @@ def test_unknown_position_and_stop_reset_phase_boundaries() -> None:
     lifecycle.prepare_startup(transport="classic", resuming_position=True)
     lifecycle.unknown_position()
 
-    assert lifecycle.baseline_record_pending
+    assert lifecycle._baseline_record_pending
     assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
     assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
 
@@ -90,6 +136,7 @@ def test_live_response_drains_admitted_timeline_before_dispatching_state() -> No
     """Normal responses drain response-owned live work and dispatch state deltas."""
     lifecycle = RoomMemberHookLifecycle(enabled=True)
     lifecycle.prepare_startup(transport="classic", resuming_position=False)
+    lifecycle.capture_baseline(())
     lifecycle.baseline_recorded()
     lifecycle.certified()
 
@@ -108,7 +155,7 @@ def test_sliding_startup_admits_only_live_events_without_classic_baseline() -> N
 
     lifecycle.prepare_startup(transport="sliding", resuming_position=True)
 
-    assert not lifecycle.baseline_record_pending
+    assert not lifecycle._baseline_record_pending
     assert not lifecycle.full_state_required
     assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
     assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)

--- a/tests/test_room_member_hook_lifecycle.py
+++ b/tests/test_room_member_hook_lifecycle.py
@@ -117,18 +117,16 @@ def test_safe_rewind_and_loop_replacement_require_full_state_catchup() -> None:
     assert not lifecycle._baseline_record_pending
 
 
-def test_unknown_position_and_stop_reset_phase_boundaries() -> None:
-    """Rejected positions restart at a history baseline and stop disables admission."""
+def test_stop_disables_phase_boundaries() -> None:
+    """Stop must disable admission and response-owned lifecycle drains."""
     lifecycle = RoomMemberHookLifecycle(enabled=True)
     lifecycle.prepare_startup(transport="classic", resuming_position=True)
-    lifecycle.unknown_position()
 
-    assert lifecycle._baseline_record_pending
-    assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
-    assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
+    assert lifecycle.response_drain_required
 
     lifecycle.stop()
     assert not lifecycle.full_state_required
+    assert not lifecycle.response_drain_required
     assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
 
 
@@ -157,8 +155,10 @@ def test_sliding_startup_admits_only_live_events_without_classic_baseline() -> N
 
     assert not lifecycle._baseline_record_pending
     assert not lifecycle.full_state_required
+    assert lifecycle.response_drain_required
     assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
     assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
 
-    lifecycle.certified()
-    assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
+    disabled = RoomMemberHookLifecycle(enabled=False)
+    disabled.prepare_startup(transport="sliding", resuming_position=True)
+    assert not disabled.response_drain_required

--- a/tests/test_room_member_hook_lifecycle.py
+++ b/tests/test_room_member_hook_lifecycle.py
@@ -1,0 +1,105 @@
+"""Tests for the room-member hook bootstrap and catch-up phase owner."""
+
+from __future__ import annotations
+
+import nio
+
+from mindroom.matrix.room_member_hook_lifecycle import (
+    RoomMemberHookLifecycle,
+)
+from mindroom.matrix.sync_certification import SyncCertificationDecision, SyncTrustState
+
+
+def _decision(
+    state: SyncTrustState,
+    *,
+    reset_client_token: bool = False,
+) -> SyncCertificationDecision:
+    return SyncCertificationDecision(
+        state=state,
+        reset_client_token=reset_client_token,
+    )
+
+
+def test_tokenless_baseline_transitions_to_catchup_until_certified() -> None:
+    """A consumed tokenless baseline must capture later incremental joins."""
+    lifecycle = RoomMemberHookLifecycle(enabled=True)
+    lifecycle.prepare_startup(resuming_position=False)
+
+    assert lifecycle.baseline_record_pending
+    assert lifecycle.full_state_required
+    assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
+    assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
+
+    lifecycle.baseline_recorded()
+    plan = lifecycle.plan_response(
+        _decision(SyncTrustState.UNCERTAIN),
+        first_sync_response=False,
+    )
+
+    assert not lifecycle.baseline_record_pending
+    assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
+    assert not lifecycle.callback_execution_enabled
+    assert not plan.drain_captured_timeline
+
+    certified = lifecycle.plan_response(
+        _decision(SyncTrustState.CERTIFIED),
+        first_sync_response=False,
+    )
+    assert certified.drain_captured_timeline
+
+    lifecycle.certified()
+    assert lifecycle.callback_execution_enabled
+    assert not lifecycle.full_state_required
+    assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
+
+
+def test_safe_rewind_and_loop_replacement_require_full_state_catchup() -> None:
+    """A safe rewind must capture replay joins and reacquire a replacement baseline."""
+    lifecycle = RoomMemberHookLifecycle(enabled=True)
+    lifecycle.prepare_startup(resuming_position=False)
+    lifecycle.baseline_recorded()
+    lifecycle.certified()
+
+    lifecycle.rewound(has_retry_token=True)
+    assert lifecycle.full_state_required
+    assert not lifecycle.baseline_record_pending
+    assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
+
+    lifecycle.begin_sync_loop()
+    assert lifecycle.baseline_record_pending
+
+    lifecycle.baseline_recorded()
+    assert not lifecycle.baseline_record_pending
+
+
+def test_unknown_position_and_stop_reset_phase_boundaries() -> None:
+    """Rejected positions restart at a history baseline and stop disables admission."""
+    lifecycle = RoomMemberHookLifecycle(enabled=True)
+    lifecycle.prepare_startup(resuming_position=True)
+    lifecycle.unknown_position()
+
+    assert lifecycle.baseline_record_pending
+    assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
+    assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
+
+    lifecycle.stop()
+    assert not lifecycle.full_state_required
+    assert not lifecycle.callback_execution_enabled
+    assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
+
+
+def test_live_response_dispatches_state_without_bootstrap_drain() -> None:
+    """Normal live responses keep state-delta dispatch separate from catch-up draining."""
+    lifecycle = RoomMemberHookLifecycle(enabled=True)
+    lifecycle.prepare_startup(resuming_position=False)
+    lifecycle.baseline_recorded()
+    lifecycle.certified()
+
+    plan = lifecycle.plan_response(
+        _decision(SyncTrustState.CERTIFIED),
+        first_sync_response=False,
+    )
+
+    assert plan.dispatch_state
+    assert not plan.drain_captured_timeline

--- a/tests/test_room_member_hook_lifecycle.py
+++ b/tests/test_room_member_hook_lifecycle.py
@@ -24,7 +24,7 @@ def _decision(
 def test_tokenless_baseline_transitions_to_catchup_until_certified() -> None:
     """A consumed tokenless baseline must capture later incremental joins."""
     lifecycle = RoomMemberHookLifecycle(enabled=True)
-    lifecycle.prepare_startup(resuming_position=False)
+    lifecycle.prepare_startup(transport="classic", resuming_position=False)
 
     assert lifecycle.baseline_record_pending
     assert lifecycle.full_state_required
@@ -39,7 +39,6 @@ def test_tokenless_baseline_transitions_to_catchup_until_certified() -> None:
 
     assert not lifecycle.baseline_record_pending
     assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
-    assert not lifecycle.callback_execution_enabled
     assert not plan.drain_captured_timeline
 
     certified = lifecycle.plan_response(
@@ -49,7 +48,6 @@ def test_tokenless_baseline_transitions_to_catchup_until_certified() -> None:
     assert certified.drain_captured_timeline
 
     lifecycle.certified()
-    assert lifecycle.callback_execution_enabled
     assert not lifecycle.full_state_required
     assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
 
@@ -57,7 +55,7 @@ def test_tokenless_baseline_transitions_to_catchup_until_certified() -> None:
 def test_safe_rewind_and_loop_replacement_require_full_state_catchup() -> None:
     """A safe rewind must capture replay joins and reacquire a replacement baseline."""
     lifecycle = RoomMemberHookLifecycle(enabled=True)
-    lifecycle.prepare_startup(resuming_position=False)
+    lifecycle.prepare_startup(transport="classic", resuming_position=False)
     lifecycle.baseline_recorded()
     lifecycle.certified()
 
@@ -76,7 +74,7 @@ def test_safe_rewind_and_loop_replacement_require_full_state_catchup() -> None:
 def test_unknown_position_and_stop_reset_phase_boundaries() -> None:
     """Rejected positions restart at a history baseline and stop disables admission."""
     lifecycle = RoomMemberHookLifecycle(enabled=True)
-    lifecycle.prepare_startup(resuming_position=True)
+    lifecycle.prepare_startup(transport="classic", resuming_position=True)
     lifecycle.unknown_position()
 
     assert lifecycle.baseline_record_pending
@@ -85,14 +83,13 @@ def test_unknown_position_and_stop_reset_phase_boundaries() -> None:
 
     lifecycle.stop()
     assert not lifecycle.full_state_required
-    assert not lifecycle.callback_execution_enabled
     assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
 
 
-def test_live_response_dispatches_state_without_bootstrap_drain() -> None:
-    """Normal live responses keep state-delta dispatch separate from catch-up draining."""
+def test_live_response_drains_admitted_timeline_before_dispatching_state() -> None:
+    """Normal responses drain response-owned live work and dispatch state deltas."""
     lifecycle = RoomMemberHookLifecycle(enabled=True)
-    lifecycle.prepare_startup(resuming_position=False)
+    lifecycle.prepare_startup(transport="classic", resuming_position=False)
     lifecycle.baseline_recorded()
     lifecycle.certified()
 
@@ -102,4 +99,16 @@ def test_live_response_dispatches_state_without_bootstrap_drain() -> None:
     )
 
     assert plan.dispatch_state
-    assert not plan.drain_captured_timeline
+    assert plan.drain_captured_timeline
+
+
+def test_sliding_startup_admits_only_live_events_without_classic_baseline() -> None:
+    """Sliding startup must never inherit Classic historical catch-up authority."""
+    lifecycle = RoomMemberHookLifecycle(enabled=True)
+
+    lifecycle.prepare_startup(transport="sliding", resuming_position=True)
+
+    assert not lifecycle.baseline_record_pending
+    assert not lifecycle.full_state_required
+    assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
+    assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)

--- a/tests/test_room_member_hook_lifecycle.py
+++ b/tests/test_room_member_hook_lifecycle.py
@@ -75,7 +75,7 @@ def test_tokenless_baseline_transitions_to_catchup_until_certified() -> None:
 
     lifecycle.certified()
     assert not lifecycle.full_state_required
-    assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
+    assert lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
 
 
 def test_tokenless_rewind_discards_stale_baseline_and_rearms_capture() -> None:
@@ -159,3 +159,6 @@ def test_sliding_startup_admits_only_live_events_without_classic_baseline() -> N
     assert not lifecycle.full_state_required
     assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)
     assert lifecycle.admission_enabled(nio.TimelineEventProvenance.LIVE)
+
+    lifecycle.certified()
+    assert not lifecycle.admission_enabled(nio.TimelineEventProvenance.HISTORY)

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -1406,6 +1406,7 @@ async def test_unknown_pos_resync_does_not_emit_room_member_joined_snapshot(
     sync_error.status_code = "M_UNKNOWN_POS"
 
     await bot._on_sync_error(sync_error)
+    bot.client.stop_sync_forever.assert_called_once_with()
     assert (
         bot._dispatch_obligation_runner._admission_kind(
             _room_member_event(event_id="$timeline-snapshot"),

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -26,7 +26,13 @@ from mindroom.hooks import EVENT_ROOM_MEMBER_JOINED, HookRegistry, RoomMemberJoi
 from mindroom.matrix import room_member_joins
 from mindroom.matrix.sync_certification import SyncCacheWriteResult, SyncCheckpoint, SyncTrustState
 from mindroom.matrix.users import AgentMatrixUser
-from tests.conftest import TEST_PASSWORD, bind_runtime_paths, install_runtime_cache_support, test_runtime_paths
+from tests.conftest import (
+    TEST_PASSWORD,
+    bind_runtime_paths,
+    install_runtime_cache_support,
+    test_runtime_paths,
+    wrap_extracted_collaborators,
+)
 from tests.identity_helpers import persist_entity_accounts
 from tests.sync_continuity_helpers import load_sync_checkpoint, save_sync_token
 
@@ -935,7 +941,6 @@ async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
 @pytest.mark.asyncio
 async def test_restored_join_catchup_survives_recovery_settlement(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Intermediate recovery settlement must not consume restored timeline catch-up."""
     seen: list[str] = []
@@ -951,6 +956,7 @@ async def test_restored_join_catchup_survives_recovery_settlement(
     bot.client.rooms = {room.room_id: room}
     bot.client.loaded_sync_token = ""
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    wrap_extracted_collaborators(bot, "_conversation_cache")
     cache_generation = bot.event_cache.cache_generation
     assert cache_generation is not None
     save_sync_token(
@@ -960,23 +966,15 @@ async def test_restored_join_catchup_survives_recovery_settlement(
         cache_generation=cache_generation,
     )
     await bot._prepare_matrix_sync_continuity()
-    monkeypatch.setattr(
-        bot._conversation_cache,
-        "cache_sync_timeline_for_certification",
-        AsyncMock(
-            return_value=SyncCacheWriteResult(complete=True),
-        ),
+    bot._conversation_cache.cache_sync_timeline_for_certification = AsyncMock(
+        return_value=SyncCacheWriteResult(complete=True),
     )
-    monkeypatch.setattr(
-        bot,
-        "_apply_own_room_membership_from_sync",
-        AsyncMock(
-            side_effect=[
-                RuntimeError("transient membership failure"),
-                None,
-                None,
-            ],
-        ),
+    bot._conversation_cache.mark_room_joined = AsyncMock(
+        side_effect=[
+            RuntimeError("transient membership failure"),
+            None,
+            None,
+        ],
     )
 
     failed_catchup = _sync_response_with_state(
@@ -1024,7 +1022,6 @@ async def test_restored_join_catchup_survives_recovery_settlement(
 @pytest.mark.asyncio
 async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """An empty recovery response must rewind without consuming catch-up state."""
     seen: list[str] = []
@@ -1041,6 +1038,7 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     bot.client.rooms = {room.room_id: room}
     bot.client.loaded_sync_token = ""
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    wrap_extracted_collaborators(bot, "_conversation_cache")
     cache_generation = bot.event_cache.cache_generation
     assert cache_generation is not None
     save_sync_token(
@@ -1050,22 +1048,18 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
         cache_generation=cache_generation,
     )
     await bot._prepare_matrix_sync_continuity()
-    monkeypatch.setattr(
-        bot._conversation_cache,
-        "cache_sync_timeline_for_certification",
-        AsyncMock(
-            side_effect=[
-                SyncCacheWriteResult(
-                    complete=True,
-                    unrecovered_room_ids=frozenset({gap_room_id}),
-                ),
-                SyncCacheWriteResult(
-                    complete=True,
-                    recovered_room_ids=frozenset({gap_room_id}),
-                ),
-                SyncCacheWriteResult(complete=True),
-            ],
-        ),
+    bot._conversation_cache.cache_sync_timeline_for_certification = AsyncMock(
+        side_effect=[
+            SyncCacheWriteResult(
+                complete=True,
+                unrecovered_room_ids=frozenset({gap_room_id}),
+            ),
+            SyncCacheWriteResult(
+                complete=True,
+                recovered_room_ids=frozenset({gap_room_id}),
+            ),
+            SyncCacheWriteResult(complete=True),
+        ],
     )
 
     catchup = _sync_response_with_state(
@@ -1162,7 +1156,6 @@ async def test_unknown_pos_resync_does_not_emit_room_member_joined_snapshot(
 @pytest.mark.asyncio
 async def test_unknown_pos_limited_baseline_stays_fenced_until_certified(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A post-start tokenless baseline must be recorded before hooks re-arm."""
     seen: list[str] = []
@@ -1176,18 +1169,15 @@ async def test_unknown_pos_limited_baseline_stays_fenced_until_certified(
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_rejected"
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
-    monkeypatch.setattr(
-        bot._conversation_cache,
-        "cache_sync_timeline_for_certification",
-        AsyncMock(
-            side_effect=[
-                SyncCacheWriteResult(
-                    complete=True,
-                    limited_room_ids=(room.room_id,),
-                ),
-                SyncCacheWriteResult(complete=True),
-            ],
-        ),
+    wrap_extracted_collaborators(bot, "_conversation_cache")
+    bot._conversation_cache.cache_sync_timeline_for_certification = AsyncMock(
+        side_effect=[
+            SyncCacheWriteResult(
+                complete=True,
+                limited_room_ids=(room.room_id,),
+            ),
+            SyncCacheWriteResult(complete=True),
+        ],
     )
     sync_error = MagicMock(spec=nio.SyncError)
     sync_error.status_code = "M_UNKNOWN_POS"

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -135,9 +135,7 @@ def _router_bot(
     bot.client = MagicMock()
     bot.client.homeserver = "http://localhost:8008"
     bot._first_sync_done = True
-    bot._room_member_join_hooks_armed = True
-    bot._room_member_join_bootstrap_pending = False
-    bot._room_member_join_baseline_record_pending = False
+    bot._room_member_hook_lifecycle.certified()
     return bot
 
 
@@ -643,7 +641,7 @@ async def test_router_emits_room_member_joined_from_first_restored_token_sync_ti
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_join_hooks_armed = False
+    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
     bot._sync_cache_trust.state = SyncTrustState.PENDING
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_restored"
@@ -657,12 +655,14 @@ async def test_router_emits_room_member_joined_from_first_restored_token_sync_ti
         AsyncMock(return_value=SyncCacheWriteResult(complete=True)),
     )
 
+    catchup_join = _room_member_event(event_id="$catchup-join", prev_membership=None)
+    await bot._dispatch_obligation_runner._admit_source_event(
+        room,
+        catchup_join,
+        nio.TimelineEventProvenance.HISTORY,
+    )
     await bot._on_sync_response(
-        _sync_response_with_state(
-            room.room_id,
-            [],
-            timeline_events=[_room_member_event(event_id="$catchup-join", prev_membership=None)],
-        ),
+        _sync_response_with_state(room.room_id, [], timeline_events=[catchup_join]),
     )
 
     assert seen == ["$catchup-join"]
@@ -683,7 +683,7 @@ async def test_router_ignores_restored_token_first_sync_full_state_member_snapsh
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_join_hooks_armed = False
+    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
     bot._sync_cache_trust.state = SyncTrustState.PENDING
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_restored"
@@ -729,7 +729,7 @@ async def test_router_ignores_restored_token_timeline_profile_update_for_existin
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_join_hooks_armed = False
+    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
     bot._sync_cache_trust.state = SyncTrustState.PENDING
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_restored"
@@ -953,7 +953,7 @@ async def test_restored_join_catchup_survives_recovery_settlement(
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_join_hooks_armed = False
+    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
     bot.client.rooms = {room.room_id: room}
     bot.client.loaded_sync_token = ""
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
@@ -981,7 +981,6 @@ async def test_restored_join_catchup_survives_recovery_settlement(
     failed_catchup = _sync_response_with_state(
         room.room_id,
         [_room_member_event(event_id="$stale-baseline-member", user_id="@bob:localhost")],
-        timeline_events=[_room_member_event(event_id="$failed-catchup", prev_membership=None)],
     )
     bot.client.next_batch = "s_failed"
     with pytest.raises(RuntimeError, match="transient membership failure"):
@@ -998,14 +997,23 @@ async def test_restored_join_catchup_survives_recovery_settlement(
 
     assert bot.client.next_batch == "s_restored"
     assert bot._first_sync_done
-    assert not bot._room_member_join_hooks_armed
+    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
 
+    catchup_after_recovery = _room_member_event(
+        event_id="$catchup-after-recovery",
+        prev_membership=None,
+    )
+    await bot._dispatch_obligation_runner._admit_source_event(
+        room,
+        catchup_after_recovery,
+        nio.TimelineEventProvenance.HISTORY,
+    )
     bot.client.next_batch = "s_replay"
     await bot._on_sync_response(
         _sync_response_with_state(
             room.room_id,
             [],
-            timeline_events=[_room_member_event(event_id="$catchup-after-recovery", prev_membership=None)],
+            timeline_events=[catchup_after_recovery],
         ),
     )
 
@@ -1035,7 +1043,7 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     room = _room()
     gap_room_id = "!gap:localhost"
     bot._first_sync_done = False
-    bot._room_member_join_hooks_armed = False
+    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
     bot.client.rooms = {room.room_id: room}
     bot.client.loaded_sync_token = ""
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
@@ -1069,13 +1077,18 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
         timeline_events=[_room_member_event(event_id="$catchup-before-recovery", prev_membership=None)],
     )
     catchup.unrecovered_room_ids = frozenset({gap_room_id})
+    await bot._dispatch_obligation_runner._admit_source_event(
+        room,
+        catchup.rooms.join[room.room_id].timeline.events[0],
+        nio.TimelineEventProvenance.HISTORY,
+    )
     await bot._on_sync_response(catchup)
 
     assert seen == []
-    assert bot._restored_token_catchup_pending
+    assert bot._room_member_hook_lifecycle.full_state_required
     assert bot._first_sync_done
     assert bot._room_member_callback_registered
-    assert not bot._room_member_join_hooks_armed
+    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
 
     recovery = _sync_response_with_state(
         room.room_id,
@@ -1093,9 +1106,9 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
 
     assert seen == []
     assert bot.client.next_batch == "s_restored"
-    assert bot._restored_token_catchup_pending
+    assert bot._room_member_hook_lifecycle.full_state_required
     assert bot._first_sync_done
-    assert not bot._room_member_join_hooks_armed
+    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
 
     replay = _sync_response_with_state(
         room.room_id,
@@ -1110,10 +1123,16 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
         ],
     )
     bot.client.next_batch = "s_replay"
+    for event in replay.rooms.join[room.room_id].timeline.events:
+        await bot._dispatch_obligation_runner._admit_source_event(
+            room,
+            event,
+            nio.TimelineEventProvenance.HISTORY,
+        )
     await bot._on_sync_response(replay)
 
     assert seen == ["$catchup-before-recovery", "$join-during-recovery"]
-    assert not bot._restored_token_catchup_pending
+    assert not bot._room_member_hook_lifecycle.full_state_required
     assert bot._first_sync_done
 
     await bot._on_room_member(
@@ -1153,6 +1172,7 @@ async def test_unknown_pos_resync_does_not_emit_room_member_joined_snapshot(
     assert (
         bot._dispatch_obligation_runner._admission_kind(
             _room_member_event(event_id="$timeline-snapshot"),
+            nio.TimelineEventProvenance.HISTORY,
         )
         is None
     )
@@ -1208,18 +1228,118 @@ async def test_unknown_pos_limited_baseline_stays_fenced_until_certified(
         ),
     )
 
-    assert not bot._room_member_join_hooks_armed
+    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
 
-    await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
+    bot._register_room_member_callback_after_initial_sync()
+    room_member_admission = bot._dispatch_obligation_runner._admit_source_event
+    room_member_callback = bot.client.add_event_callback.call_args.args[0]
+    live_event = _room_member_event(
+        event_id="$join-during-bootstrap",
+        user_id="@bob:localhost",
+        prev_membership=None,
+    )
+    await room_member_admission(
+        room,
+        live_event,
+        nio.TimelineEventProvenance.LIVE,
+    )
+    await room_member_callback(room, live_event)
+    await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
-    assert bot._room_member_join_hooks_armed
+    assert seen == []
+
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [],
+            timeline_events=[live_event],
+        ),
+    )
+
+    assert bot._room_member_hook_lifecycle.callback_execution_enabled
+    assert seen == ["$join-during-bootstrap"]
 
     await bot._on_room_member(
         room,
         _room_member_event(event_id="$profile-update", prev_membership=None),
     )
 
+    assert seen == ["$join-during-bootstrap"]
+
+
+@pytest.mark.asyncio
+async def test_post_start_rewind_captures_member_join_until_replay_certifies(
+    tmp_path: Path,
+) -> None:
+    """A safe-checkpoint replay must retain joins received while hooks are fenced."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    room = _room()
+    bot._first_sync_done = False
+    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
+    bot.client.rooms = {room.room_id: room}
+    bot.client.loaded_sync_token = ""
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    wrap_extracted_collaborators(bot, "_conversation_cache")
+    cache_generation = bot.event_cache.cache_generation
+    assert cache_generation is not None
+    save_sync_token(
+        tmp_path,
+        bot.agent_name,
+        "s_safe",
+        cache_generation=cache_generation,
+    )
+    await bot._prepare_matrix_sync_continuity()
+    bot._conversation_cache.cache_sync_timeline_for_certification = AsyncMock(
+        side_effect=[
+            SyncCacheWriteResult(complete=True),
+            SyncCacheWriteResult(complete=False),
+            SyncCacheWriteResult(complete=True),
+        ],
+    )
+
+    await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
+    assert bot._room_member_hook_lifecycle.callback_execution_enabled
+    assert not bot._room_member_hook_lifecycle.full_state_required
+
+    bot.client.next_batch = "s_failed"
+    await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
+    assert bot.client.next_batch == "s_next"
+    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
+
+    room_member_admission = bot._dispatch_obligation_runner._admit_source_event
+    room_member_callback = bot.client.add_event_callback.call_args.args[0]
+    live_event = _room_member_event(
+        event_id="$join-during-replay",
+        user_id="@carol:localhost",
+        prev_membership=None,
+    )
+    await room_member_admission(
+        room,
+        live_event,
+        nio.TimelineEventProvenance.LIVE,
+    )
+    await room_member_callback(room, live_event)
+    await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+
     assert seen == []
+
+    bot.client.next_batch = "s_replayed"
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [],
+            timeline_events=[live_event],
+        ),
+    )
+
+    assert seen == ["$join-during-replay"]
+    assert bot._room_member_hook_lifecycle.callback_execution_enabled
 
 
 @pytest.mark.asyncio
@@ -1291,7 +1411,7 @@ async def test_member_callback_runs_exact_pending_lifecycle_obligation(
     bot.client.rooms = {room.room_id: room}
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
     bot._first_sync_done = True
-    bot._room_member_join_hooks_armed = True
+    bot._room_member_hook_lifecycle.certified()
     bot._register_room_member_callback_after_initial_sync()
     room_member_callback = bot.client.add_event_callback.call_args.args[0]
     event = _room_member_event(event_id="$pending-member")
@@ -1327,7 +1447,7 @@ async def test_uncertain_first_sync_reset_does_not_emit_room_member_joined_snaps
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_join_hooks_armed = False
+    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
     bot._sync_cache_trust.state = SyncTrustState.PENDING
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_restored"
@@ -1349,6 +1469,7 @@ async def test_uncertain_first_sync_reset_does_not_emit_room_member_joined_snaps
     assert (
         bot._dispatch_obligation_runner._admission_kind(
             _room_member_event(event_id="$timeline-snapshot"),
+            nio.TimelineEventProvenance.HISTORY,
         )
         is None
     )
@@ -1460,8 +1581,15 @@ def test_room_member_join_admission_ignores_initial_sync_history(tmp_path: Path)
     """Initial sync history must not enter the delayed live-callback boundary."""
     bot = _router_bot(tmp_path)
     bot._first_sync_done = False
+    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=False)
 
-    assert bot._dispatch_obligation_runner._admission_kind(_room_member_event()) is None
+    assert (
+        bot._dispatch_obligation_runner._admission_kind(
+            _room_member_event(),
+            nio.TimelineEventProvenance.HISTORY,
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -137,6 +137,7 @@ def _router_bot(
     bot._first_sync_done = True
     bot._room_member_join_hooks_armed = True
     bot._room_member_join_bootstrap_pending = False
+    bot._room_member_join_baseline_record_pending = False
     return bot
 
 
@@ -1023,7 +1024,7 @@ async def test_restored_join_catchup_survives_recovery_settlement(
 async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     tmp_path: Path,
 ) -> None:
-    """An empty recovery response must rewind without consuming catch-up state."""
+    """Recovery settlement must rewind without tombstoning later incremental state."""
     seen: list[str] = []
 
     @hook(EVENT_ROOM_MEMBER_JOINED)
@@ -1076,7 +1077,16 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     assert bot._room_member_callback_registered
     assert not bot._room_member_join_hooks_armed
 
-    recovery = _sync_response_with_state(room.room_id, [])
+    recovery = _sync_response_with_state(
+        room.room_id,
+        [
+            _room_member_event(
+                event_id="$join-during-recovery-state",
+                user_id="@carol:localhost",
+                prev_membership=None,
+            ),
+        ],
+    )
     recovery.recovered_room_ids = frozenset({gap_room_id})
     bot.client.next_batch = "s_recovered"
     await bot._on_sync_response(recovery)
@@ -1090,12 +1100,19 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     replay = _sync_response_with_state(
         room.room_id,
         [],
-        timeline_events=[_room_member_event(event_id="$catchup-before-recovery", prev_membership=None)],
+        timeline_events=[
+            _room_member_event(event_id="$catchup-before-recovery", prev_membership=None),
+            _room_member_event(
+                event_id="$join-during-recovery",
+                user_id="@carol:localhost",
+                prev_membership=None,
+            ),
+        ],
     )
     bot.client.next_batch = "s_replay"
     await bot._on_sync_response(replay)
 
-    assert seen == ["$catchup-before-recovery"]
+    assert seen == ["$catchup-before-recovery", "$join-during-recovery"]
     assert not bot._restored_token_catchup_pending
     assert bot._first_sync_done
 
@@ -1104,7 +1121,7 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
         _room_member_event(event_id="$profile-update", user_id="@bob:localhost", prev_membership=None),
     )
 
-    assert seen == ["$catchup-before-recovery"]
+    assert seen == ["$catchup-before-recovery", "$join-during-recovery"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -811,6 +811,70 @@ async def test_router_ignores_restored_token_timeline_profile_update_for_existin
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("hook_enabled", "pending_prev_membership"),
+    [(True, "join"), (False, "leave")],
+    ids=["ignored-profile", "hook-disabled-join"],
+)
+async def test_restored_baseline_revisits_member_after_pending_lifecycle_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    hook_enabled: bool,
+    pending_prev_membership: str,
+) -> None:
+    """Settled lifecycle work must release its member's retained baseline marker."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    room = _room()
+    bot._first_sync_done = False
+    bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
+    bot._sync_cache_trust.state = SyncTrustState.PENDING
+    bot.client.rooms = {room.room_id: room}
+    bot.client.next_batch = "s_restored"
+    if hook_enabled:
+        bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    bot._emit_agent_lifecycle_event = AsyncMock()
+    bot._maybe_start_startup_thread_prewarm = MagicMock()
+    bot._maybe_start_deferred_overdue_task_drain = MagicMock()
+    monkeypatch.setattr(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(return_value=SyncCacheWriteResult(complete=True)),
+    )
+    pending = _room_member_event(
+        event_id="$pending-lifecycle",
+        prev_membership=pending_prev_membership,
+    )
+    await bot._dispatch_obligation_runner._admit_source_event(
+        room,
+        pending,
+        nio.TimelineEventProvenance.HISTORY,
+    )
+
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [_room_member_event(event_id="$existing-member", prev_membership=None)],
+            timeline_events=[pending],
+        ),
+    )
+    if not hook_enabled:
+        bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    await bot._on_room_member(
+        room,
+        _room_member_event(event_id="$later-profile", prev_membership=None),
+    )
+
+    assert seen == []
+
+
+@pytest.mark.asyncio
 async def test_router_ignores_sync_state_member_snapshot_without_previous_membership(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -1020,7 +1020,7 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
 
     bot = _router_bot(tmp_path)
     room = _room()
-    gap_room_id = "!gap:localhost"
+    gap_room_id = room.room_id
     bot._first_sync_done = False
     bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
     bot.client.rooms = {room.room_id: room}
@@ -1053,7 +1053,13 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     catchup = _sync_response_with_state(
         room.room_id,
         [_room_member_event(event_id="$existing-member", user_id="@bob:localhost")],
-        timeline_events=[_room_member_event(event_id="$catchup-before-recovery", prev_membership=None)],
+        timeline_events=[
+            _room_member_event(
+                event_id="$catchup-before-recovery",
+                user_id="@bob:localhost",
+                prev_membership=None,
+            ),
+        ],
     )
     catchup.unrecovered_room_ids = frozenset({gap_room_id})
     await bot._dispatch_obligation_runner._admit_source_event(
@@ -1064,6 +1070,7 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     await bot._on_sync_response(catchup)
 
     assert seen == []
+    assert bot._room_member_hook_lifecycle._baseline_record_pending
     assert bot._room_member_hook_lifecycle.full_state_required
     assert bot._first_sync_done
 
@@ -1083,6 +1090,7 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
 
     assert seen == []
     assert bot.client.next_batch == "s_restored"
+    assert bot._room_member_hook_lifecycle._baseline_record_pending
     assert bot._room_member_hook_lifecycle.full_state_required
     assert bot._first_sync_done
 
@@ -1090,7 +1098,11 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
         room.room_id,
         [],
         timeline_events=[
-            _room_member_event(event_id="$catchup-before-recovery", prev_membership=None),
+            _room_member_event(
+                event_id="$catchup-before-recovery",
+                user_id="@bob:localhost",
+                prev_membership=None,
+            ),
             _room_member_event(
                 event_id="$join-during-recovery",
                 user_id="@carol:localhost",

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -24,6 +24,7 @@ from mindroom.dispatch_obligations import DispatchCallbackKind
 from mindroom.entity_resolution import mindroom_user_id
 from mindroom.hooks import EVENT_ROOM_MEMBER_JOINED, HookRegistry, RoomMemberJoinedContext, hook
 from mindroom.matrix import room_member_joins
+from mindroom.matrix.client_session import _MindRoomAsyncClient
 from mindroom.matrix.sync_certification import SyncCacheWriteResult, SyncCheckpoint, SyncTrustState
 from mindroom.matrix.users import AgentMatrixUser
 from tests.conftest import (
@@ -132,7 +133,8 @@ def _router_bot(
     persist_entity_accounts(config, runtime_paths, usernames={ROUTER_AGENT_NAME: "mindroom_router"})
     bot = AgentBot(_router_user(), tmp_path, config=config, runtime_paths=runtime_paths)
     install_runtime_cache_support(bot)
-    bot.client = MagicMock()
+    bot.client = MagicMock(spec=_MindRoomAsyncClient)
+    bot.client.user_id = bot.agent_user.user_id
     bot.client.homeserver = "http://localhost:8008"
     bot._first_sync_done = True
     bot._room_member_hook_lifecycle.certified()
@@ -161,29 +163,6 @@ def test_room_member_joined_is_a_builtin_hook_event() -> None:
     registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
 
     assert registry.has_hooks(EVENT_ROOM_MEMBER_JOINED)
-
-
-def test_router_registers_room_member_callback_after_initial_sync(tmp_path: Path) -> None:
-    """The router should start listening for member events only after startup sync."""
-    bot = _router_bot(tmp_path)
-
-    bot._register_room_member_callback_after_initial_sync()
-    bot._register_room_member_callback_after_initial_sync()
-
-    bot.client.add_event_admission_callback.assert_not_called()
-    bot.client.add_event_callback.assert_called_once()
-    assert bot.client.add_event_callback.call_args.args[1] is nio.RoomMemberEvent
-
-
-def test_non_router_does_not_register_room_member_callback(tmp_path: Path) -> None:
-    """Non-router bots should not register duplicate member-event callbacks."""
-    bot = _agent_bot(tmp_path)
-    bot.client = MagicMock()
-
-    bot._register_room_member_callback_after_initial_sync()
-
-    bot.client.add_event_admission_callback.assert_not_called()
-    bot.client.add_event_callback.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -404,7 +383,7 @@ async def test_cancelled_sync_state_member_hook_is_directly_recoverable(
     )
     assert load_sync_checkpoint(tmp_path, bot.agent_name) is None
 
-    await bot._dispatch_obligation_runner.recover_pending()
+    await bot._dispatch_obligation_runner.drain_pending_room_lifecycle()
 
     assert attempts == 2
     assert not bot._dispatch_obligation_store.has_pending(
@@ -641,7 +620,7 @@ async def test_router_emits_room_member_joined_from_first_restored_token_sync_ti
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
+    bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
     bot._sync_cache_trust.state = SyncTrustState.PENDING
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_restored"
@@ -683,7 +662,7 @@ async def test_router_ignores_restored_token_first_sync_full_state_member_snapsh
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
+    bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
     bot._sync_cache_trust.state = SyncTrustState.PENDING
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_restored"
@@ -729,7 +708,7 @@ async def test_router_ignores_restored_token_timeline_profile_update_for_existin
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
+    bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
     bot._sync_cache_trust.state = SyncTrustState.PENDING
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_restored"
@@ -953,7 +932,7 @@ async def test_restored_join_catchup_survives_recovery_settlement(
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
+    bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
     bot.client.rooms = {room.room_id: room}
     bot.client.loaded_sync_token = ""
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
@@ -997,7 +976,7 @@ async def test_restored_join_catchup_survives_recovery_settlement(
 
     assert bot.client.next_batch == "s_restored"
     assert bot._first_sync_done
-    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
+    assert bot._room_member_hook_lifecycle.full_state_required
 
     catchup_after_recovery = _room_member_event(
         event_id="$catchup-after-recovery",
@@ -1043,7 +1022,7 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     room = _room()
     gap_room_id = "!gap:localhost"
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
+    bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
     bot.client.rooms = {room.room_id: room}
     bot.client.loaded_sync_token = ""
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
@@ -1087,8 +1066,6 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     assert seen == []
     assert bot._room_member_hook_lifecycle.full_state_required
     assert bot._first_sync_done
-    assert bot._room_member_callback_registered
-    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
 
     recovery = _sync_response_with_state(
         room.room_id,
@@ -1108,7 +1085,6 @@ async def test_restored_join_catchup_waits_for_nio_gap_settlement(
     assert bot.client.next_batch == "s_restored"
     assert bot._room_member_hook_lifecycle.full_state_required
     assert bot._first_sync_done
-    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
 
     replay = _sync_response_with_state(
         room.room_id,
@@ -1228,11 +1204,7 @@ async def test_unknown_pos_limited_baseline_stays_fenced_until_certified(
         ),
     )
 
-    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
-
-    bot._register_room_member_callback_after_initial_sync()
     room_member_admission = bot._dispatch_obligation_runner._admit_source_event
-    room_member_callback = bot.client.add_event_callback.call_args.args[0]
     live_event = _room_member_event(
         event_id="$join-during-bootstrap",
         user_id="@bob:localhost",
@@ -1243,8 +1215,6 @@ async def test_unknown_pos_limited_baseline_stays_fenced_until_certified(
         live_event,
         nio.TimelineEventProvenance.LIVE,
     )
-    await room_member_callback(room, live_event)
-    await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
     assert seen == []
 
@@ -1256,7 +1226,7 @@ async def test_unknown_pos_limited_baseline_stays_fenced_until_certified(
         ),
     )
 
-    assert bot._room_member_hook_lifecycle.callback_execution_enabled
+    assert not bot._room_member_hook_lifecycle.full_state_required
     assert seen == ["$join-during-bootstrap"]
 
     await bot._on_room_member(
@@ -1281,7 +1251,7 @@ async def test_post_start_rewind_captures_member_join_until_replay_certifies(
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
+    bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
     bot.client.rooms = {room.room_id: room}
     bot.client.loaded_sync_token = ""
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
@@ -1304,16 +1274,14 @@ async def test_post_start_rewind_captures_member_join_until_replay_certifies(
     )
 
     await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
-    assert bot._room_member_hook_lifecycle.callback_execution_enabled
     assert not bot._room_member_hook_lifecycle.full_state_required
 
     bot.client.next_batch = "s_failed"
     await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
     assert bot.client.next_batch == "s_next"
-    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
+    assert bot._room_member_hook_lifecycle.full_state_required
 
     room_member_admission = bot._dispatch_obligation_runner._admit_source_event
-    room_member_callback = bot.client.add_event_callback.call_args.args[0]
     live_event = _room_member_event(
         event_id="$join-during-replay",
         user_id="@carol:localhost",
@@ -1324,8 +1292,6 @@ async def test_post_start_rewind_captures_member_join_until_replay_certifies(
         live_event,
         nio.TimelineEventProvenance.LIVE,
     )
-    await room_member_callback(room, live_event)
-    await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
     assert seen == []
 
@@ -1339,15 +1305,15 @@ async def test_post_start_rewind_captures_member_join_until_replay_certifies(
     )
 
     assert seen == ["$join-during-replay"]
-    assert bot._room_member_hook_lifecycle.callback_execution_enabled
+    assert not bot._room_member_hook_lifecycle.full_state_required
 
 
 @pytest.mark.asyncio
-async def test_registered_room_member_callback_uses_delivery_time_arming_state(
+async def test_response_owned_member_drain_uses_admission_time_phase(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Queued recovery-sync member events should not emit after hooks re-arm."""
+    """Historical recovery events stay fenced while later live work drains by response."""
     seen: list[str] = []
 
     @hook(EVENT_ROOM_MEMBER_JOINED)
@@ -1359,9 +1325,7 @@ async def test_registered_room_member_callback_uses_delivery_time_arming_state(
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_rejected"
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
-    bot._register_room_member_callback_after_initial_sync()
     room_member_admission = bot._dispatch_obligation_runner._admit_source_event
-    room_member_callback = bot.client.add_event_callback.call_args.args[0]
     monkeypatch.setattr(
         bot._conversation_cache,
         "cache_sync_timeline_for_certification",
@@ -1377,9 +1341,7 @@ async def test_registered_room_member_callback_uses_delivery_time_arming_state(
         timeline_event,
         nio.TimelineEventProvenance.HISTORY,
     )
-    await room_member_callback(room, timeline_event)
     await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
-    await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
 
     assert seen == []
 
@@ -1389,17 +1351,22 @@ async def test_registered_room_member_callback_uses_delivery_time_arming_state(
         live_event,
         nio.TimelineEventProvenance.LIVE,
     )
-    await room_member_callback(room, live_event)
-    await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [],
+            timeline_events=[live_event],
+        ),
+    )
 
     assert seen == ["$live"]
 
 
 @pytest.mark.asyncio
-async def test_member_callback_runs_exact_pending_lifecycle_obligation(
+async def test_response_barrier_runs_exact_pending_lifecycle_obligation(
     tmp_path: Path,
 ) -> None:
-    """A member callback may retry its exact durable lifecycle work."""
+    """The response barrier retries exact durable lifecycle work."""
     seen: list[str] = []
 
     @hook(EVENT_ROOM_MEMBER_JOINED)
@@ -1412,8 +1379,6 @@ async def test_member_callback_runs_exact_pending_lifecycle_obligation(
     bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
     bot._first_sync_done = True
     bot._room_member_hook_lifecycle.certified()
-    bot._register_room_member_callback_after_initial_sync()
-    room_member_callback = bot.client.add_event_callback.call_args.args[0]
     event = _room_member_event(event_id="$pending-member")
     obligation = await bot._dispatch_obligation_runner.persist(
         room,
@@ -1422,8 +1387,7 @@ async def test_member_callback_runs_exact_pending_lifecycle_obligation(
     )
     assert obligation is not None
 
-    await room_member_callback(room, event)
-    await wait_for_background_tasks(timeout=1.0, owner=bot._runtime_view)
+    await bot._dispatch_obligation_runner.drain_pending_room_lifecycle()
 
     assert seen == ["$pending-member"]
     assert not bot._dispatch_obligation_store.has_pending(
@@ -1447,7 +1411,7 @@ async def test_uncertain_first_sync_reset_does_not_emit_room_member_joined_snaps
     bot = _router_bot(tmp_path)
     room = _room()
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
+    bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
     bot._sync_cache_trust.state = SyncTrustState.PENDING
     bot.client.rooms = {room.room_id: room}
     bot.client.next_batch = "s_restored"
@@ -1581,7 +1545,10 @@ def test_room_member_join_admission_ignores_initial_sync_history(tmp_path: Path)
     """Initial sync history must not enter the delayed live-callback boundary."""
     bot = _router_bot(tmp_path)
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=False)
+    bot._room_member_hook_lifecycle.prepare_startup(
+        transport="classic",
+        resuming_position=False,
+    )
 
     assert (
         bot._dispatch_obligation_runner._admission_kind(
@@ -1589,6 +1556,58 @@ def test_room_member_join_admission_ignores_initial_sync_history(tmp_path: Path)
             nio.TimelineEventProvenance.HISTORY,
         )
         is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_sliding_response_drains_only_live_room_member_obligations(tmp_path: Path) -> None:
+    """Sliding readiness must settle its live tail without admitting snapshot history."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    room = _room()
+    bot.client.rooms = {room.room_id: room}
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    bot._room_member_hook_lifecycle.prepare_startup(
+        transport="sliding",
+        resuming_position=True,
+    )
+    history = _room_member_event(event_id="$sliding-history")
+    live = _room_member_event(event_id="$sliding-live", user_id="@bob:localhost")
+
+    await bot._dispatch_obligation_runner._admit_source_event(
+        room,
+        history,
+        nio.TimelineEventProvenance.HISTORY,
+    )
+    await bot._dispatch_obligation_runner._admit_source_event(
+        room,
+        live,
+        nio.TimelineEventProvenance.LIVE,
+    )
+
+    assert not bot._dispatch_obligation_store.has_pending(
+        history.event_id,
+        DispatchCallbackKind.ROOM_LIFECYCLE,
+    )
+    assert bot._dispatch_obligation_store.has_pending(
+        live.event_id,
+        DispatchCallbackKind.ROOM_LIFECYCLE,
+    )
+
+    await bot._handle_sliding_sync_response(nio.SlidingSyncResponse("pos"))
+
+    assert seen == [live.event_id]
+    assert not bot._dispatch_obligation_store.has_pending(
+        live.event_id,
+        DispatchCallbackKind.ROOM_LIFECYCLE,
+    )
+    assert not bot._room_member_hook_lifecycle.admission_enabled(
+        nio.TimelineEventProvenance.HISTORY,
     )
 
 

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -10,7 +10,7 @@ import stat
 import threading
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
 import pytest
@@ -490,12 +490,9 @@ async def test_sync_room_lifecycle_persist_failure_rewinds_once(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("record_only", [False, True])
 async def test_sync_state_baseline_markers_batch_one_worker_write(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
-    *,
-    record_only: bool,
 ) -> None:
     """Full-state baseline recording must write once without blocking the event loop."""
 
@@ -523,7 +520,6 @@ async def test_sync_state_baseline_markers_batch_one_worker_write(
 
     await bot._emit_room_member_joined_sync_state_hooks(
         _sync_response_with_state(room.room_id, events),
-        record_only=record_only,
     )
 
     assert len(save_threads) == 1
@@ -547,14 +543,18 @@ async def test_sync_state_marker_update_waits_for_live_marker_lock(tmp_path: Pat
     room = _room()
     bot.client.rooms = {room.room_id: room}
     await bot._room_member_join_lock.acquire()
-    marker_task = asyncio.create_task(
-        bot._emit_room_member_joined_sync_state_hooks(
-            _sync_response_with_state(
-                room.room_id,
-                [_room_member_event(event_id="$baseline", prev_membership=None)],
-            ),
-            record_only=True,
+    plan = room_member_joins.room_member_sync_state_plan(
+        _sync_response_with_state(
+            room.room_id,
+            [_room_member_event(event_id="$baseline", prev_membership=None)],
         ),
+        rooms=bot.client.rooms,
+        config=bot.config,
+        runtime_paths=bot.runtime_paths,
+        record_only=True,
+    )
+    marker_task = asyncio.create_task(
+        bot._record_room_member_joined_events(plan.record_events),
     )
     try:
         await asyncio.sleep(0.05)
@@ -1078,18 +1078,29 @@ async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
                 (event_source_json, event.event_id),
             )
 
-    await bot._emit_room_member_joined_sync_state_hooks(
+    plan = room_member_joins.room_member_sync_state_plan(
         _sync_response_with_state(
             room.room_id,
             [_room_member_event(event_id="$profile-snapshot", prev_membership="join")],
             timeline_limited=True,
         ),
+        rooms=bot.client.rooms,
+        config=bot.config,
+        runtime_paths=bot.runtime_paths,
         record_only=True,
     )
-    await bot._dispatch_obligation_runner.drain_pending_room_lifecycle()
+    with (
+        patch("mindroom.dispatch_obligations.runner.logger") as runner_logger,
+        patch("mindroom.dispatch_obligations.storage.logger") as storage_logger,
+    ):
+        await bot._record_room_member_joined_events(plan.record_events)
+        await bot._dispatch_obligation_runner.drain_pending_room_lifecycle()
+        await bot._record_room_member_joined_events(plan.record_events)
+        await bot._dispatch_obligation_runner.drain_pending_room_lifecycle()
 
     assert event.event_id in bot._dispatch_obligation_store.unsettled_source_event_ids()
     assert not (bot.runtime_paths.storage_root / "tracking" / "room_member_joins.json").exists()
+    assert runner_logger.error.call_count + storage_logger.error.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -1795,6 +1806,18 @@ async def test_sliding_response_drains_only_live_room_member_obligations(tmp_pat
     assert not bot._room_member_hook_lifecycle.admission_enabled(
         nio.TimelineEventProvenance.HISTORY,
     )
+
+
+@pytest.mark.asyncio
+async def test_sliding_response_skips_lifecycle_drain_when_hooks_are_disabled(tmp_path: Path) -> None:
+    """Non-router Sliding responses must not scan for lifecycle work they cannot own."""
+    bot = _agent_bot(tmp_path)
+    drain = AsyncMock()
+    bot._dispatch_obligation_runner.drain_pending_room_lifecycle = drain
+
+    await bot._handle_sliding_sync_response(nio.SlidingSyncResponse("pos"))
+
+    drain.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -130,6 +130,7 @@ def _router_bot(
     bot.client.homeserver = "http://localhost:8008"
     bot._first_sync_done = True
     bot._room_member_join_hooks_armed = True
+    bot._room_member_join_bootstrap_pending = False
     return bot
 
 
@@ -877,7 +878,7 @@ async def test_limited_state_snapshot_does_not_settle_delayed_lifecycle_replay(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("corruption", ["invalid-json", "wrong-event-type"])
+@pytest.mark.parametrize("corruption", ["invalid-json", "wrong-event-type", "invalid-callback-kind"])
 async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
     tmp_path: Path,
     corruption: str,
@@ -893,24 +894,30 @@ async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
         DispatchCallbackKind.ROOM_LIFECYCLE,
     )
     assert obligation is not None
-    event_source_json = (
-        "{"
-        if corruption == "invalid-json"
-        else json.dumps(
-            {
-                "content": {"body": "not membership", "msgtype": "m.text"},
-                "event_id": event.event_id,
-                "origin_server_ts": 1,
-                "sender": event.sender,
-                "type": "m.room.message",
-            },
-        )
-    )
     with sqlite3.connect(bot._dispatch_obligation_store._database_path) as connection:
-        connection.execute(
-            "UPDATE dispatch_obligations SET event_source_json = ? WHERE source_event_id = ?",
-            (event_source_json, event.event_id),
-        )
+        if corruption == "invalid-callback-kind":
+            connection.execute(
+                "UPDATE dispatch_obligations SET callback_kind = ? WHERE source_event_id = ?",
+                ("not-a-callback-kind", event.event_id),
+            )
+        else:
+            event_source_json = (
+                "{"
+                if corruption == "invalid-json"
+                else json.dumps(
+                    {
+                        "content": {"body": "not membership", "msgtype": "m.text"},
+                        "event_id": event.event_id,
+                        "origin_server_ts": 1,
+                        "sender": event.sender,
+                        "type": "m.room.message",
+                    },
+                )
+            )
+            connection.execute(
+                "UPDATE dispatch_obligations SET event_source_json = ? WHERE source_event_id = ?",
+                (event_source_json, event.event_id),
+            )
 
     await bot._emit_room_member_joined_sync_state_hooks(
         _sync_response_with_state(
@@ -921,10 +928,7 @@ async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
         record_only=True,
     )
 
-    assert bot._dispatch_obligation_store.has_pending(
-        event.event_id,
-        DispatchCallbackKind.ROOM_LIFECYCLE,
-    )
+    assert event.event_id in bot._dispatch_obligation_store.unsettled_source_event_ids()
     assert not (bot.runtime_paths.storage_root / "tracking" / "room_member_joins.json").exists()
 
 
@@ -975,15 +979,27 @@ async def test_restored_join_catchup_survives_recovery_settlement(
         ),
     )
 
+    failed_catchup = _sync_response_with_state(
+        room.room_id,
+        [_room_member_event(event_id="$stale-baseline-member", user_id="@bob:localhost")],
+        timeline_events=[_room_member_event(event_id="$failed-catchup", prev_membership=None)],
+    )
     bot.client.next_batch = "s_failed"
     with pytest.raises(RuntimeError, match="transient membership failure"):
-        await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
+        await bot._on_sync_response(failed_catchup)
 
+    bot.mark_sync_loop_started()
     bot.client.next_batch = "s_settled"
-    await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [_room_member_event(event_id="$refreshed-baseline-member", user_id="@bob:localhost")],
+        ),
+    )
 
     assert bot.client.next_batch == "s_restored"
-    assert not bot._first_sync_done
+    assert bot._first_sync_done
+    assert not bot._room_member_join_hooks_armed
 
     bot.client.next_batch = "s_replay"
     await bot._on_sync_response(
@@ -996,6 +1012,105 @@ async def test_restored_join_catchup_survives_recovery_settlement(
 
     assert seen == ["$catchup-after-recovery"]
     assert bot._first_sync_done
+
+    await bot._on_room_member(
+        room,
+        _room_member_event(event_id="$profile-update", user_id="@bob:localhost", prev_membership=None),
+    )
+
+    assert seen == ["$catchup-after-recovery"]
+
+
+@pytest.mark.asyncio
+async def test_restored_join_catchup_waits_for_nio_gap_settlement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty recovery response must rewind without consuming catch-up state."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    room = _room()
+    gap_room_id = "!gap:localhost"
+    bot._first_sync_done = False
+    bot._room_member_join_hooks_armed = False
+    bot.client.rooms = {room.room_id: room}
+    bot.client.loaded_sync_token = ""
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    cache_generation = bot.event_cache.cache_generation
+    assert cache_generation is not None
+    save_sync_token(
+        tmp_path,
+        bot.agent_name,
+        "s_restored",
+        cache_generation=cache_generation,
+    )
+    await bot._prepare_matrix_sync_continuity()
+    monkeypatch.setattr(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(
+            side_effect=[
+                SyncCacheWriteResult(
+                    complete=True,
+                    unrecovered_room_ids=frozenset({gap_room_id}),
+                ),
+                SyncCacheWriteResult(
+                    complete=True,
+                    recovered_room_ids=frozenset({gap_room_id}),
+                ),
+                SyncCacheWriteResult(complete=True),
+            ],
+        ),
+    )
+
+    catchup = _sync_response_with_state(
+        room.room_id,
+        [_room_member_event(event_id="$existing-member", user_id="@bob:localhost")],
+        timeline_events=[_room_member_event(event_id="$catchup-before-recovery", prev_membership=None)],
+    )
+    catchup.unrecovered_room_ids = frozenset({gap_room_id})
+    await bot._on_sync_response(catchup)
+
+    assert seen == []
+    assert bot._restored_token_catchup_pending
+    assert bot._first_sync_done
+    assert bot._room_member_callback_registered
+    assert not bot._room_member_join_hooks_armed
+
+    recovery = _sync_response_with_state(room.room_id, [])
+    recovery.recovered_room_ids = frozenset({gap_room_id})
+    bot.client.next_batch = "s_recovered"
+    await bot._on_sync_response(recovery)
+
+    assert seen == []
+    assert bot.client.next_batch == "s_restored"
+    assert bot._restored_token_catchup_pending
+    assert bot._first_sync_done
+    assert not bot._room_member_join_hooks_armed
+
+    replay = _sync_response_with_state(
+        room.room_id,
+        [],
+        timeline_events=[_room_member_event(event_id="$catchup-before-recovery", prev_membership=None)],
+    )
+    bot.client.next_batch = "s_replay"
+    await bot._on_sync_response(replay)
+
+    assert seen == ["$catchup-before-recovery"]
+    assert not bot._restored_token_catchup_pending
+    assert bot._first_sync_done
+
+    await bot._on_room_member(
+        room,
+        _room_member_event(event_id="$profile-update", user_id="@bob:localhost", prev_membership=None),
+    )
+
+    assert seen == ["$catchup-before-recovery"]
 
 
 @pytest.mark.asyncio
@@ -1042,6 +1157,62 @@ async def test_unknown_pos_resync_does_not_emit_room_member_joined_snapshot(
     await bot._on_room_member(room, _room_member_event(event_id="$live", user_id="@bob:localhost"))
 
     assert seen == ["$live"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_pos_limited_baseline_stays_fenced_until_certified(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A post-start tokenless baseline must be recorded before hooks re-arm."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    room = _room()
+    bot.client.rooms = {room.room_id: room}
+    bot.client.next_batch = "s_rejected"
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    monkeypatch.setattr(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(
+            side_effect=[
+                SyncCacheWriteResult(
+                    complete=True,
+                    limited_room_ids=(room.room_id,),
+                ),
+                SyncCacheWriteResult(complete=True),
+            ],
+        ),
+    )
+    sync_error = MagicMock(spec=nio.SyncError)
+    sync_error.status_code = "M_UNKNOWN_POS"
+
+    await bot._on_sync_error(sync_error)
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [_room_member_event(event_id="$baseline-member")],
+            timeline_limited=True,
+        ),
+    )
+
+    assert not bot._room_member_join_hooks_armed
+
+    await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
+
+    assert bot._room_member_join_hooks_armed
+
+    await bot._on_room_member(
+        room,
+        _room_member_event(event_id="$profile-update", prev_membership=None),
+    )
+
+    assert seen == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -864,7 +864,10 @@ async def test_limited_state_snapshot_does_not_settle_delayed_lifecycle_replay(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("corruption", ["invalid-json", "wrong-event-type", "invalid-callback-kind"])
+@pytest.mark.parametrize(
+    "corruption",
+    ["invalid-json", "invalid-field-type", "wrong-event-type", "invalid-callback-kind"],
+)
 async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
     tmp_path: Path,
     corruption: str,
@@ -887,10 +890,14 @@ async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
                 ("not-a-callback-kind", event.event_id),
             )
         else:
-            event_source_json = (
-                "{"
-                if corruption == "invalid-json"
-                else json.dumps(
+            if corruption == "invalid-json":
+                event_source_json = "{"
+            elif corruption == "invalid-field-type":
+                corrupt_source = dict(event.source)
+                corrupt_source["origin_server_ts"] = "not-an-integer"
+                event_source_json = json.dumps(corrupt_source)
+            else:
+                event_source_json = json.dumps(
                     {
                         "content": {"body": "not membership", "msgtype": "m.text"},
                         "event_id": event.event_id,
@@ -899,7 +906,6 @@ async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
                         "type": "m.room.message",
                     },
                 )
-            )
             connection.execute(
                 "UPDATE dispatch_obligations SET event_source_json = ? WHERE source_event_id = ?",
                 (event_source_json, event.event_id),
@@ -913,6 +919,7 @@ async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
         ),
         record_only=True,
     )
+    await bot._dispatch_obligation_runner.drain_pending_room_lifecycle()
 
     assert event.event_id in bot._dispatch_obligation_store.unsettled_source_event_ids()
     assert not (bot.runtime_paths.storage_root / "tracking" / "room_member_joins.json").exists()

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -806,6 +806,96 @@ async def test_router_ignores_limited_sync_state_member_snapshot(
 
 
 @pytest.mark.asyncio
+async def test_classic_live_gap_recovers_member_join_before_snapshot_marker(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Classic live-gap history must retain the exact join before state is marked."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    room_id = "!limited:localhost"
+    history_join = _room_member_event(event_id="$history-join")
+    state_member = _room_member_event(event_id="$limited-state", prev_membership=None)
+    client = nio.AsyncClient(
+        "https://example.org",
+        bot.matrix_id.full_id,
+        config=nio.AsyncClientConfig(
+            encryption_enabled=False,
+            backfill_limited_timelines=True,
+        ),
+    )
+    bot.client = client
+    client.next_batch = "s_before_gap"
+    client._recovery_room_messages = AsyncMock(
+        return_value=nio.RoomMessagesResponse(
+            room_id=room_id,
+            chunk=[history_join],
+            start="s_before_gap",
+            end="p_gap_start",
+        ),
+    )
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    bot._dispatch_obligation_runner.register_source_callbacks(
+        client,
+        owner=bot._runtime_view,
+    )
+    await bot._conversation_cache.mark_room_joined(room_id)
+    response = nio.SyncResponse.from_dict(
+        {
+            "next_batch": "s_after_gap",
+            "device_one_time_keys_count": {},
+            "device_lists": {"changed": [], "left": []},
+            "rooms": {
+                "invite": {},
+                "leave": {},
+                "join": {
+                    room_id: {
+                        "timeline": {
+                            "events": [],
+                            "limited": True,
+                            "prev_batch": "p_gap_start",
+                        },
+                        "state": {"events": [state_member.source]},
+                        "ephemeral": {"events": []},
+                        "account_data": {"events": []},
+                    },
+                },
+            },
+            "to_device": {"events": []},
+            "presence": {"events": []},
+            "account_data": {"events": []},
+        },
+    )
+    assert isinstance(response, nio.SyncResponse)
+    monkeypatch.setattr(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(return_value=SyncCacheWriteResult.from_sync_response(response, complete=True)),
+    )
+
+    try:
+        await client.receive_response(response)
+        await bot._on_sync_response(response)
+
+        assert response.recovered_room_ids == frozenset({room_id})
+        assert seen == [history_join.event_id]
+
+        await bot._on_room_member(
+            client.rooms[room_id],
+            _room_member_event(event_id="$profile-update", prev_membership=None),
+        )
+
+        assert seen == [history_join.event_id]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
 async def test_limited_state_snapshot_does_not_settle_delayed_lifecycle_replay(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -24,12 +24,13 @@ from mindroom.dispatch_obligations import DispatchCallbackKind
 from mindroom.entity_resolution import mindroom_user_id
 from mindroom.hooks import EVENT_ROOM_MEMBER_JOINED, HookRegistry, RoomMemberJoinedContext, hook
 from mindroom.matrix import room_member_joins
-from mindroom.matrix.client_session import _MindRoomAsyncClient
+from mindroom.matrix.client_session import _MindRoomAsyncClient, matrix_client_config
 from mindroom.matrix.sync_certification import SyncCacheWriteResult, SyncCheckpoint, SyncTrustState
 from mindroom.matrix.users import AgentMatrixUser
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
+    install_call_manager_mock,
     install_runtime_cache_support,
     test_runtime_paths,
     wrap_extracted_collaborators,
@@ -163,6 +164,126 @@ def test_room_member_joined_is_a_builtin_hook_event() -> None:
     registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
 
     assert registry.has_hooks(EVENT_ROOM_MEMBER_JOINED)
+
+
+@pytest.mark.parametrize(
+    ("fresh_membership", "retained_membership"),
+    [("join", "leave"), ("leave", "join")],
+)
+@pytest.mark.asyncio
+async def test_retained_live_membership_cannot_override_fresh_call_membership(
+    tmp_path: Path,
+    fresh_membership: str,
+    retained_membership: str,
+) -> None:
+    """Call reconciliation must reject retained membership that contradicts fresh room state."""
+    bot = _router_bot(tmp_path)
+    room = nio.MatrixRoom("!call:localhost", bot.agent_user.user_id)
+    client = _MindRoomAsyncClient(
+        "https://example.org",
+        bot.agent_user.user_id,
+        config=matrix_client_config(),
+    )
+    client.rooms[room.room_id] = room
+    bot.client = client
+    fresh = _room_member_event(
+        event_id="$fresh",
+        user_id=bot.agent_user.user_id,
+        membership=fresh_membership,
+        prev_membership=retained_membership,
+    )
+    retained = _room_member_event(
+        event_id="$retained",
+        user_id=bot.agent_user.user_id,
+        membership=retained_membership,
+        prev_membership=fresh_membership,
+    )
+    room.handle_membership(fresh)
+    admitted: list[bool] = []
+
+    async def observe_provenance(
+        _room: nio.MatrixRoom,
+        event: nio.Event,
+        provenance: nio.TimelineEventProvenance,
+    ) -> None:
+        bot._cold_history_fence.observe_event_provenance(event.event_id, provenance)
+
+    async def admit_call_event(callback_room: nio.MatrixRoom, event: nio.Event) -> None:
+        admitted.append(bot._admit_live_call_event(callback_room, event))
+
+    client.add_event_admission_callback(observe_provenance)
+    client.add_event_callback(admit_call_event, nio.RoomMemberEvent)
+    try:
+        await client._dispatch_timeline_event(
+            room.room_id,
+            retained,
+            False,
+            "timeline",
+            nio.TimelineEventProvenance.LIVE,
+            True,
+            False,
+            False,
+            lambda: None,
+        )
+
+        assert admitted == [False]
+        assert (bot.agent_user.user_id in room.users) == (fresh_membership == "join")
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_tokenless_baseline_treats_pre_reset_absent_rooms_as_departed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A same-client reset must reconcile rooms omitted from the fresh full-state response."""
+    joined_room_id = "!joined:localhost"
+    departed_room_id = "!departed:localhost"
+    bot = _router_bot(tmp_path)
+    client = _MindRoomAsyncClient("https://example.org", bot.agent_user.user_id)
+    client.rooms = {
+        joined_room_id: nio.MatrixRoom(joined_room_id, bot.agent_user.user_id),
+        departed_room_id: nio.MatrixRoom(departed_room_id, bot.agent_user.user_id),
+    }
+    bot.client = client
+    purged_room_ids: list[set[str]] = []
+    membership_updates: list[tuple[set[str], set[str]]] = []
+
+    class CallManagerProbe:
+        async def on_sync_room_membership(
+            self,
+            *,
+            joined_room_ids: set[str],
+            left_room_ids: set[str],
+        ) -> None:
+            membership_updates.append((joined_room_ids, left_room_ids))
+
+    async def purge_rooms(room_ids: set[str]) -> None:
+        purged_room_ids.append(room_ids)
+
+    monkeypatch.setattr(bot._conversation_cache, "purge_rooms", purge_rooms)
+    monkeypatch.setattr(bot._conversation_cache, "mark_room_joined", AsyncMock())
+    monkeypatch.setattr(
+        bot._sync_cache_trust,
+        "invalidate_for_cache_scope_cleanup",
+        AsyncMock(return_value=True),
+    )
+    install_call_manager_mock(bot, CallManagerProbe())
+    sync_error = MagicMock(spec=nio.SyncError)
+    sync_error.status_code = "M_UNKNOWN_POS"
+    try:
+        await bot._on_sync_error(sync_error)
+        await bot._apply_own_room_membership_from_sync(
+            _sync_response_with_state(joined_room_id, []),
+        )
+
+        assert purged_room_ids == [{departed_room_id}]
+        assert membership_updates == [({joined_room_id}, {departed_room_id})]
+        assert departed_room_id not in client.rooms
+        assert bot._rejected_sync_room_ids == set()
+    finally:
+        await client.close()
 
 
 @pytest.mark.asyncio
@@ -1422,10 +1543,67 @@ async def test_unknown_pos_resync_does_not_emit_room_member_joined_snapshot(
     )
 
     assert seen == []
+    assert bot._rejected_sync_room_ids == set()
 
     await bot._on_room_member(room, _room_member_event(event_id="$live", user_id="@bob:localhost"))
 
     assert seen == ["$live"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_pos_room_scope_is_not_reapplied_to_incremental_response(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A limited baseline may stay uncertified without making later incremental omissions departures."""
+    bot = _router_bot(tmp_path)
+    room = _room()
+    bot.client.rooms = {room.room_id: room}
+    bot.client.next_batch = "s_rejected"
+    membership_updates: list[tuple[set[str], set[str]]] = []
+
+    class CallManagerProbe:
+        async def on_sync_room_membership(
+            self,
+            *,
+            joined_room_ids: set[str],
+            left_room_ids: set[str],
+        ) -> None:
+            membership_updates.append((joined_room_ids, left_room_ids))
+
+    install_call_manager_mock(bot, CallManagerProbe())
+    monkeypatch.setattr(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(
+            side_effect=[
+                SyncCacheWriteResult(
+                    complete=True,
+                    limited_room_ids=(room.room_id,),
+                ),
+                SyncCacheWriteResult(complete=True),
+            ],
+        ),
+    )
+    sync_error = MagicMock(spec=nio.SyncError)
+    sync_error.status_code = "M_UNKNOWN_POS"
+
+    await bot._on_sync_error(sync_error)
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [],
+            timeline_limited=True,
+        ),
+    )
+    assert bot._rejected_sync_room_ids == set()
+
+    incremental = _sync_response_with_state(room.room_id, [])
+    incremental.rooms.join = {}
+    await bot._on_sync_response(incremental)
+
+    assert room.room_id in bot.client.rooms
+    assert membership_updates == [({room.room_id}, set()), (set(), set())]
 
 
 @pytest.mark.asyncio
@@ -1466,6 +1644,8 @@ async def test_unknown_pos_limited_baseline_stays_fenced_until_certified(
         ),
     )
 
+    assert bot._rejected_sync_room_ids == set()
+
     room_member_admission = bot._dispatch_obligation_runner._admit_source_event
     live_event = _room_member_event(
         event_id="$join-during-bootstrap",
@@ -1490,6 +1670,7 @@ async def test_unknown_pos_limited_baseline_stays_fenced_until_certified(
 
     assert not bot._room_member_hook_lifecycle.full_state_required
     assert seen == ["$join-during-bootstrap"]
+    assert bot._rejected_sync_room_ids == set()
 
     await bot._on_room_member(
         room,

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -694,6 +694,83 @@ async def test_router_ignores_restored_token_first_sync_full_state_member_snapsh
 
 
 @pytest.mark.asyncio
+async def test_same_token_classic_full_state_records_missing_client_room_members(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A same-token NIO response must record its full state without a materialized room."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    bot._first_sync_done = False
+    bot._room_member_hook_lifecycle.prepare_startup(transport="classic", resuming_position=True)
+    bot._sync_cache_trust.state = SyncTrustState.PENDING
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    bot._emit_agent_lifecycle_event = AsyncMock()
+    bot._maybe_start_startup_thread_prewarm = MagicMock()
+    bot._maybe_start_deferred_overdue_task_drain = MagicMock()
+    room_id = "!restored:localhost"
+    existing_member = _room_member_event(event_id="$full-state-existing-member")
+    client = nio.AsyncClient(
+        "https://example.org",
+        bot.matrix_id.full_id,
+        config=nio.AsyncClientConfig(
+            encryption_enabled=False,
+            backfill_limited_timelines=True,
+        ),
+    )
+    bot.client = client
+    client.user_id = bot.matrix_id.full_id
+    client.next_batch = "s_restored"
+    response = nio.SyncResponse.from_dict(
+        {
+            "next_batch": "s_restored",
+            "device_one_time_keys_count": {},
+            "device_lists": {"changed": [], "left": []},
+            "rooms": {
+                "invite": {},
+                "leave": {},
+                "join": {
+                    room_id: {
+                        "timeline": {"events": [], "limited": False},
+                        "state": {"events": [existing_member.source]},
+                        "ephemeral": {"events": []},
+                        "account_data": {"events": []},
+                    },
+                },
+            },
+            "to_device": {"events": []},
+            "presence": {"events": []},
+            "account_data": {"events": []},
+        },
+    )
+    assert isinstance(response, nio.SyncResponse)
+    monkeypatch.setattr(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(return_value=SyncCacheWriteResult.from_sync_response(response, complete=True)),
+    )
+
+    try:
+        await client.receive_response(response)
+        assert room_id not in client.rooms
+
+        await bot._on_sync_response(response)
+        await bot._on_room_member(
+            nio.MatrixRoom(room_id, bot.matrix_id.full_id),
+            _room_member_event(event_id="$profile-update", prev_membership=None),
+        )
+
+        assert seen == []
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
 async def test_router_ignores_restored_token_timeline_profile_update_for_existing_member(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
+import sqlite3
 import stat
 import threading
 from types import SimpleNamespace
@@ -26,7 +28,7 @@ from mindroom.matrix.sync_certification import SyncCacheWriteResult, SyncCheckpo
 from mindroom.matrix.users import AgentMatrixUser
 from tests.conftest import TEST_PASSWORD, bind_runtime_paths, install_runtime_cache_support, test_runtime_paths
 from tests.identity_helpers import persist_entity_accounts
-from tests.sync_continuity_helpers import load_sync_checkpoint
+from tests.sync_continuity_helpers import load_sync_checkpoint, save_sync_token
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -872,6 +874,128 @@ async def test_limited_state_snapshot_does_not_settle_delayed_lifecycle_replay(
         event.event_id,
         DispatchCallbackKind.ROOM_LIFECYCLE,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("corruption", ["invalid-json", "wrong-event-type"])
+async def test_corrupt_lifecycle_obligation_fences_snapshot_markers(
+    tmp_path: Path,
+    corruption: str,
+) -> None:
+    """Corrupt lifecycle work remains visible without aborting or marking its room."""
+    bot = _router_bot(tmp_path)
+    room = _room()
+    bot.client.rooms = {room.room_id: room}
+    event = _room_member_event(event_id="$corrupt-lifecycle")
+    obligation = await bot._dispatch_obligation_runner.persist(
+        room,
+        event,
+        DispatchCallbackKind.ROOM_LIFECYCLE,
+    )
+    assert obligation is not None
+    event_source_json = (
+        "{"
+        if corruption == "invalid-json"
+        else json.dumps(
+            {
+                "content": {"body": "not membership", "msgtype": "m.text"},
+                "event_id": event.event_id,
+                "origin_server_ts": 1,
+                "sender": event.sender,
+                "type": "m.room.message",
+            },
+        )
+    )
+    with sqlite3.connect(bot._dispatch_obligation_store._database_path) as connection:
+        connection.execute(
+            "UPDATE dispatch_obligations SET event_source_json = ? WHERE source_event_id = ?",
+            (event_source_json, event.event_id),
+        )
+
+    await bot._emit_room_member_joined_sync_state_hooks(
+        _sync_response_with_state(
+            room.room_id,
+            [_room_member_event(event_id="$profile-snapshot", prev_membership="join")],
+            timeline_limited=True,
+        ),
+        record_only=True,
+    )
+
+    assert bot._dispatch_obligation_store.has_pending(
+        event.event_id,
+        DispatchCallbackKind.ROOM_LIFECYCLE,
+    )
+    assert not (bot.runtime_paths.storage_root / "tracking" / "room_member_joins.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_restored_join_catchup_survives_recovery_settlement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Intermediate recovery settlement must not consume restored timeline catch-up."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    room = _room()
+    bot._first_sync_done = False
+    bot._room_member_join_hooks_armed = False
+    bot.client.rooms = {room.room_id: room}
+    bot.client.loaded_sync_token = ""
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    cache_generation = bot.event_cache.cache_generation
+    assert cache_generation is not None
+    save_sync_token(
+        tmp_path,
+        bot.agent_name,
+        "s_restored",
+        cache_generation=cache_generation,
+    )
+    await bot._prepare_matrix_sync_continuity()
+    monkeypatch.setattr(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(
+            return_value=SyncCacheWriteResult(complete=True),
+        ),
+    )
+    monkeypatch.setattr(
+        bot,
+        "_apply_own_room_membership_from_sync",
+        AsyncMock(
+            side_effect=[
+                RuntimeError("transient membership failure"),
+                None,
+                None,
+            ],
+        ),
+    )
+
+    bot.client.next_batch = "s_failed"
+    with pytest.raises(RuntimeError, match="transient membership failure"):
+        await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
+
+    bot.client.next_batch = "s_settled"
+    await bot._on_sync_response(_sync_response_with_state(room.room_id, []))
+
+    assert bot.client.next_batch == "s_restored"
+    assert not bot._first_sync_done
+
+    bot.client.next_batch = "s_replay"
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [],
+            timeline_events=[_room_member_event(event_id="$catchup-after-recovery", prev_membership=None)],
+        ),
+    )
+
+    assert seen == ["$catchup-after-recovery"]
+    assert bot._first_sync_done
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_cache_trust.py
+++ b/tests/test_sync_cache_trust.py
@@ -611,10 +611,6 @@ async def test_safe_checkpoint_catchup_replays_after_recovery_before_certifying(
             recovered_room_ids=frozenset({second_room_id}),
         ),
     )
-    replayed = await trust.certify_response(
-        next_batch="s_replayed",
-        cache_result=SyncCacheWriteResult(complete=True),
-    )
     post_certification_room_id = "!post-certification:localhost"
     post_certification_gap = await trust.certify_response(
         next_batch="s_post_certification_gap",
@@ -634,10 +630,9 @@ async def test_safe_checkpoint_catchup_replays_after_recovery_before_certifying(
     assert first_gap.replay_required_after_recovery is True
     assert first_recovery.reason == "sync_cache_replay_required"
     assert first_recovery.reset_client_token is True
-    assert second_gap.replay_required_after_recovery is True
-    assert second_recovery.reason == "sync_cache_replay_required"
-    assert second_recovery.reset_client_token is True
-    assert replayed.state is SyncTrustState.CERTIFIED
+    assert second_gap.replay_required_after_recovery is False
+    assert second_recovery.state is SyncTrustState.CERTIFIED
+    assert second_recovery.reset_client_token is False
     assert post_certification_gap.replay_required_after_recovery is False
     assert post_certification_recovery.state is SyncTrustState.CERTIFIED
     assert trust.retry_token() == "s_post_certification_recovery"

--- a/tests/test_sync_cache_trust.py
+++ b/tests/test_sync_cache_trust.py
@@ -573,20 +573,94 @@ async def test_terminal_unrecovered_gap_rewinds_after_outcome_disappears(
 
 
 @pytest.mark.asyncio
-async def test_recovered_outcome_settles_prior_gap_and_certifies(tmp_path: Path) -> None:
-    """A later positive NIO outcome must settle exact recovery debt."""
+async def test_safe_checkpoint_catchup_replays_after_recovery_before_certifying(
+    tmp_path: Path,
+) -> None:
+    """Startup catch-up debt must survive recovery until one clean replay certifies."""
     trust, _cache, _runtime = _trust(tmp_path)
     save_sync_token(tmp_path, "code", "s_before_gap", cache_generation=_GENERATION)
     assert await trust.prepare_startup() == "s_before_gap"
+    first_room_id = "!first:localhost"
+    second_room_id = "!second:localhost"
+
+    first_gap = await trust.certify_response(
+        next_batch="s_first_gap",
+        cache_result=SyncCacheWriteResult(
+            complete=True,
+            unrecovered_room_ids=frozenset({first_room_id}),
+        ),
+    )
+    first_recovery = await trust.certify_response(
+        next_batch="s_first_recovery",
+        cache_result=SyncCacheWriteResult(
+            complete=True,
+            recovered_room_ids=frozenset({first_room_id}),
+        ),
+    )
+    second_gap = await trust.certify_response(
+        next_batch="s_second_gap",
+        cache_result=SyncCacheWriteResult(
+            complete=True,
+            unrecovered_room_ids=frozenset({second_room_id}),
+        ),
+    )
+    second_recovery = await trust.certify_response(
+        next_batch="s_second_recovery",
+        cache_result=SyncCacheWriteResult(
+            complete=True,
+            recovered_room_ids=frozenset({second_room_id}),
+        ),
+    )
+    replayed = await trust.certify_response(
+        next_batch="s_replayed",
+        cache_result=SyncCacheWriteResult(complete=True),
+    )
+    post_certification_room_id = "!post-certification:localhost"
+    post_certification_gap = await trust.certify_response(
+        next_batch="s_post_certification_gap",
+        cache_result=SyncCacheWriteResult(
+            complete=True,
+            unrecovered_room_ids=frozenset({post_certification_room_id}),
+        ),
+    )
+    post_certification_recovery = await trust.certify_response(
+        next_batch="s_post_certification_recovery",
+        cache_result=SyncCacheWriteResult(
+            complete=True,
+            recovered_room_ids=frozenset({post_certification_room_id}),
+        ),
+    )
+
+    assert first_gap.replay_required_after_recovery is True
+    assert first_recovery.reason == "sync_cache_replay_required"
+    assert first_recovery.reset_client_token is True
+    assert second_gap.replay_required_after_recovery is True
+    assert second_recovery.reason == "sync_cache_replay_required"
+    assert second_recovery.reset_client_token is True
+    assert replayed.state is SyncTrustState.CERTIFIED
+    assert post_certification_gap.replay_required_after_recovery is False
+    assert post_certification_recovery.state is SyncTrustState.CERTIFIED
+    assert trust.retry_token() == "s_post_certification_recovery"
+    assert load_sync_checkpoint(tmp_path, "code") == SyncCheckpoint(
+        "s_post_certification_recovery",
+        cache_generation=_GENERATION,
+    )
+
+
+@pytest.mark.asyncio
+async def test_tokenless_cold_start_recovery_certifies_without_replay(tmp_path: Path) -> None:
+    """A tokenless cold startup must not invent safe-checkpoint catch-up debt."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    assert await trust.prepare_startup() is None
     room_id = "!room:localhost"
-    await trust.certify_response(
+
+    gap = await trust.certify_response(
         next_batch="s_after_gap",
         cache_result=SyncCacheWriteResult(
             complete=True,
             unrecovered_room_ids=frozenset({room_id}),
         ),
     )
-
     recovered = await trust.certify_response(
         next_batch="s_after_recovery",
         cache_result=SyncCacheWriteResult(
@@ -595,6 +669,7 @@ async def test_recovered_outcome_settles_prior_gap_and_certifies(tmp_path: Path)
         ),
     )
 
+    assert gap.replay_required_after_recovery is False
     assert recovered.state is SyncTrustState.CERTIFIED
     assert load_sync_checkpoint(tmp_path, "code") == SyncCheckpoint(
         "s_after_recovery",

--- a/tests/test_sync_cache_trust.py
+++ b/tests/test_sync_cache_trust.py
@@ -910,7 +910,7 @@ async def test_cold_limited_initial_window_rewinds_until_certified(tmp_path: Pat
 @pytest.mark.asyncio
 async def test_unknown_position_limited_window_keeps_rewinding_until_certified(tmp_path: Path) -> None:
     """M_UNKNOWN_POS recovery cannot advance past an uncertified window."""
-    trust, _cache, _runtime = _trust(tmp_path)
+    trust, cache, _runtime = _trust(tmp_path)
 
     unknown = await trust.reject_unknown_pos()
     initial = await trust.certify_response(
@@ -923,6 +923,46 @@ async def test_unknown_position_limited_window_keeps_rewinding_until_certified(t
 
     assert unknown.reset_client_token is True
     assert initial.reset_client_token is True
+    cache.purge_principal.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unknown_position_purge_failure_disables_cache(tmp_path: Path) -> None:
+    """Rejected continuity cannot expose rows when principal cleanup fails."""
+    trust, cache, _runtime = _trust(tmp_path)
+    cache.purge_principal.side_effect = RuntimeError("purge failed")
+
+    decision = await trust.reject_unknown_pos()
+
+    assert decision.state is SyncTrustState.UNCERTAIN
+    cache.disable.assert_called_once_with("untrusted_principal_cache_cleanup_failed")
+    trust.logger.warning.assert_any_call(
+        "matrix_untrusted_principal_cache_disabled",
+        error="purge failed",
+    )
+
+
+@pytest.mark.asyncio
+async def test_unknown_position_rejects_pre_purge_certification_plan(tmp_path: Path) -> None:
+    """A response planned before rejected-position cleanup cannot certify afterward."""
+    trust, _cache, _runtime = _trust(tmp_path)
+    cache_result = SyncCacheWriteResult(complete=True)
+    stale_decision = trust.plan_response(
+        next_batch="s_stale",
+        cache_result=cache_result,
+    )
+
+    await trust.reject_unknown_pos()
+    applied, _record = await trust.apply_response(
+        stale_decision,
+        cache_result=cache_result,
+    )
+
+    assert applied.reason == "cache_scope_invalidated"
+    assert applied.reset_client_token is True
+    assert trust.state is SyncTrustState.UNCERTAIN
+    assert trust.checkpoint is None
+    assert load_sync_checkpoint(tmp_path, "code") is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_certification.py
+++ b/tests/test_sync_certification.py
@@ -11,6 +11,7 @@ from mindroom.matrix.sync_certification import (
     SyncCheckpoint,
     SyncTrustState,
     certify_sync_response,
+    defer_sync_response_after_dispatch_persist_failure,
     handle_unknown_pos,
     sync_cache_write_diagnostics,
 )
@@ -139,6 +140,28 @@ def test_unrecovered_room_outweighs_independent_limited_room() -> None:
     )
 
     assert decision.reason == "sync_recovery_incomplete"
+
+
+def test_dispatch_persist_failure_defers_recovery_before_safe_replay() -> None:
+    """Rejected recovered work must settle in NIO before cache-safe replay."""
+    room_id = "!pending:localhost"
+    planned = certify_sync_response(
+        next_batch="s_after_gap",
+        cache_result=SyncCacheWriteResult(
+            complete=True,
+            unrecovered_room_ids=frozenset({room_id}),
+        ),
+    )
+
+    deferred = defer_sync_response_after_dispatch_persist_failure(planned)
+
+    assert deferred.state is SyncTrustState.UNCERTAIN
+    assert deferred.checkpoint_to_save is None
+    assert deferred.clear_saved_token is False
+    assert deferred.reset_client_token is False
+    assert deferred.unresolved_recovery_room_ids == frozenset({room_id})
+    assert deferred.replay_required_after_recovery is True
+    assert deferred.reason == "dispatch_persist_failed"
 
 
 def test_recovery_outcomes_fail_closed_only_for_nio_unrecovered_rooms() -> None:

--- a/tests/test_sync_certification.py
+++ b/tests/test_sync_certification.py
@@ -142,6 +142,29 @@ def test_unrecovered_room_outweighs_independent_limited_room() -> None:
     assert decision.reason == "sync_recovery_incomplete"
 
 
+def test_checkpoint_catchup_requests_replay_only_after_unresolved_recovery() -> None:
+    """Safe catch-up policy must not rewind a complete response without a gap."""
+    room_id = "!pending:localhost"
+
+    unresolved = certify_sync_response(
+        next_batch="s_gap",
+        cache_result=SyncCacheWriteResult(
+            complete=True,
+            unrecovered_room_ids=frozenset({room_id}),
+        ),
+        replay_after_unresolved_recovery=True,
+    )
+    complete = certify_sync_response(
+        next_batch="s_complete",
+        cache_result=SyncCacheWriteResult(complete=True),
+        replay_after_unresolved_recovery=True,
+    )
+
+    assert unresolved.replay_required_after_recovery is True
+    assert complete.state is SyncTrustState.CERTIFIED
+    assert complete.reset_client_token is False
+
+
 def test_dispatch_persist_failure_defers_recovery_before_safe_replay() -> None:
     """Rejected recovered work must settle in NIO before cache-safe replay."""
     room_id = "!pending:localhost"

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1241,6 +1241,54 @@ async def test_full_state_stays_enabled_until_first_sync_response() -> None:
 
 
 @pytest.mark.asyncio
+async def test_failed_full_state_request_restarts_before_incremental_sync() -> None:
+    """A first-request SyncError must not let an incremental response become the baseline."""
+    full_state_values: list[bool] = []
+    incremental_sync_attempted = False
+    sync_calls = 0
+
+    class FakeClient:
+        stop_requested = False
+
+        def stop_sync_forever(self) -> None:
+            self.stop_requested = True
+
+        async def sync_forever(self, *, timeout: int, full_state: bool, sync_filter: object = None) -> None:  # noqa: ASYNC109, ARG002
+            nonlocal incremental_sync_attempted, sync_calls
+            sync_calls += 1
+            full_state_values.append(full_state)
+            if sync_calls == 1:
+                error = MagicMock(spec=nio.SyncError)
+                error.status_code = "M_LIMIT_EXCEEDED"
+                await AgentBot._on_sync_error(bot, error)
+                incremental_sync_attempted = not self.stop_requested
+            self.stop_requested = False
+
+    bot = MagicMock(spec=AgentBot)
+    bot.agent_name = "test_agent"
+    bot.logger = MagicMock()
+    bot._first_sync_done = True
+    bot._last_sync_monotonic = None
+    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=True)
+    bot._room_member_hook_lifecycle.prepare_startup(
+        transport="classic",
+        resuming_position=True,
+    )
+    bot._sync_shutting_down = False
+    bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
+    bot.rooms = []
+    bot.client = FakeClient()
+
+    bot._room_member_hook_lifecycle.begin_sync_loop()
+    await AgentBot.sync_forever(bot)
+    bot._room_member_hook_lifecycle.begin_sync_loop()
+    await AgentBot.sync_forever(bot)
+
+    assert not incremental_sync_attempted
+    assert full_state_values == [True, True]
+
+
+@pytest.mark.asyncio
 async def test_full_state_only_after_successful_first_sync() -> None:
     """sync_forever should stop requesting full state after a successful first sync."""
     full_state_values: list[bool] = []

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1888,6 +1888,7 @@ async def test_agent_bot_stop_preserves_restart_shutdown_intent() -> None:
     bot._emit_agent_lifecycle_event = AsyncMock()
     bot._call_manager = None
     bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=False)
+    bot._rejected_sync_room_ids = set()
 
     await AgentBot.stop(bot, shutdown_intent=SYNC_RESTART_SHUTDOWN)
 

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1218,6 +1218,7 @@ async def test_full_state_stays_enabled_until_first_sync_response() -> None:
 
     bot = MagicMock(spec=AgentBot)
     bot._first_sync_done = False
+    bot._room_member_join_bootstrap_pending = True
     bot._sync_shutting_down = False
     bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
     bot.rooms = []
@@ -1259,6 +1260,7 @@ async def test_full_state_only_after_successful_first_sync() -> None:
     bot.agent_name = "test_agent"
     bot.last_sync_time = None
     bot._first_sync_done = False
+    bot._room_member_join_bootstrap_pending = False
     bot._sync_shutting_down = False
     bot._calls_reconcile_pending = False
     bot._room_member_join_hooks_armed = False
@@ -1282,6 +1284,28 @@ async def test_full_state_only_after_successful_first_sync() -> None:
     await AgentBot.sync_forever(bot)
 
     assert full_state_values == [True, False]
+
+
+@pytest.mark.asyncio
+async def test_pending_member_bootstrap_forces_replacement_full_state() -> None:
+    """A post-start lifecycle bootstrap must reacquire full state on loop replacement."""
+    full_state_values: list[bool] = []
+
+    class FakeClient:
+        async def sync_forever(self, *, timeout: int, full_state: bool, sync_filter: object = None) -> None:  # noqa: ASYNC109, ARG002
+            full_state_values.append(full_state)
+
+    bot = MagicMock(spec=AgentBot)
+    bot._first_sync_done = True
+    bot._room_member_join_bootstrap_pending = True
+    bot._sync_shutting_down = False
+    bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
+    bot.rooms = []
+    bot.client = FakeClient()
+
+    await AgentBot.sync_forever(bot)
+
+    assert full_state_values == [True]
 
 
 @pytest.mark.asyncio
@@ -1383,6 +1407,7 @@ async def test_default_sync_mode_is_classic_with_raised_timeline_limit() -> None
 
     bot = MagicMock(spec=AgentBot)
     bot._first_sync_done = True
+    bot._room_member_join_bootstrap_pending = False
     bot._sync_shutting_down = False
     bot.config = Config()
     bot.rooms = []

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1209,7 +1209,7 @@ async def test_sync_iteration_cancel_preserves_restart_shutdown_source() -> None
 
 @pytest.mark.asyncio
 async def test_full_state_stays_enabled_until_first_sync_response() -> None:
-    """A cancelled first sync must keep requesting full state on retry."""
+    """Every bot must keep requesting full state until its first response."""
     full_state_values: list[bool] = []
 
     class FakeClient:
@@ -1219,7 +1219,7 @@ async def test_full_state_stays_enabled_until_first_sync_response() -> None:
 
     bot = MagicMock(spec=AgentBot)
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=True)
+    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=False)
     bot._sync_shutting_down = False
     bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
     bot.rooms = []
@@ -1261,7 +1261,7 @@ async def test_full_state_only_after_successful_first_sync() -> None:
     bot.agent_name = "test_agent"
     bot.last_sync_time = None
     bot._first_sync_done = False
-    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=True)
+    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=False)
     bot._sync_shutting_down = False
     bot._calls_reconcile_pending = False
     bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
@@ -1278,9 +1278,22 @@ async def test_full_state_only_after_successful_first_sync() -> None:
         event_cache_write_coordinator=make_event_cache_write_coordinator_mock(),
     )
 
-    # Call the real sync_forever method
     await AgentBot.sync_forever(bot)
-    bot._room_member_hook_lifecycle.certified()
+    bot._mark_sync_progress = MagicMock()
+    bot._handle_classic_sync_response = AsyncMock(return_value=False)
+    bot._run_sync_response_side_effects = AsyncMock()
+    bot._calls_reconcile_pending = False
+    await AgentBot._on_sync_response(
+        bot,
+        nio.SyncResponse(
+            "s_first",
+            nio.Rooms(invite={}, join={}, leave={}),
+            nio.DeviceOneTimeKeyCount(None, None),
+            nio.DeviceList(changed=[], left=[]),
+            to_device_events=[],
+            presence_events=[],
+        ),
+    )
     await AgentBot.sync_forever(bot)
 
     assert full_state_values == [True, False]
@@ -1298,7 +1311,10 @@ async def test_pending_member_bootstrap_forces_replacement_full_state() -> None:
     bot = MagicMock(spec=AgentBot)
     bot._first_sync_done = True
     bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=True)
-    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
+    bot._room_member_hook_lifecycle.prepare_startup(
+        transport="classic",
+        resuming_position=True,
+    )
     bot._sync_shutting_down = False
     bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
     bot.rooms = []
@@ -1436,7 +1452,12 @@ async def test_sliding_sync_response_marks_sync_success(tmp_path: Path) -> None:
 
     assert bot.last_sync_time is not None
     assert bot._first_sync_done is True
-    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
+    assert (
+        bot._room_member_hook_lifecycle.admission_enabled(
+            nio.TimelineEventProvenance.LIVE,
+        )
+        is False
+    )
 
 
 def test_matrix_sync_change_restarts_existing_entities() -> None:
@@ -1677,7 +1698,9 @@ async def test_sliding_sync_error_skips_classic_token_rejection(
         await bot._on_sync_error(error)
 
     assert bot._sync_continuity_store.load().checkpoint is not None
-    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
+    assert not bot._room_member_hook_lifecycle.admission_enabled(
+        nio.TimelineEventProvenance.LIVE,
+    )
     assert not any(entry["log_level"] == "warning" for entry in logs)
 
 

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -37,6 +37,7 @@ from mindroom.matrix.health import (
     track_matrix_sync_cache_write,
 )
 from mindroom.matrix.identity import MatrixID
+from mindroom.matrix.room_member_hook_lifecycle import RoomMemberHookLifecycle
 from mindroom.matrix.sync_certification import SyncCheckpoint, SyncTrustState
 from mindroom.matrix.sync_loop import _sliding_sync_lists, _sliding_sync_room_subscriptions, sliding_own_membership_sets
 from mindroom.matrix.users import AgentMatrixUser
@@ -1218,7 +1219,7 @@ async def test_full_state_stays_enabled_until_first_sync_response() -> None:
 
     bot = MagicMock(spec=AgentBot)
     bot._first_sync_done = False
-    bot._room_member_join_bootstrap_pending = True
+    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=True)
     bot._sync_shutting_down = False
     bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
     bot.rooms = []
@@ -1260,10 +1261,9 @@ async def test_full_state_only_after_successful_first_sync() -> None:
     bot.agent_name = "test_agent"
     bot.last_sync_time = None
     bot._first_sync_done = False
-    bot._room_member_join_bootstrap_pending = False
+    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=True)
     bot._sync_shutting_down = False
     bot._calls_reconcile_pending = False
-    bot._room_member_join_hooks_armed = False
     bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
     bot.rooms = []
     bot.client = FakeClient()
@@ -1280,7 +1280,7 @@ async def test_full_state_only_after_successful_first_sync() -> None:
 
     # Call the real sync_forever method
     await AgentBot.sync_forever(bot)
-    await AgentBot._on_sync_response(bot, MagicMock())
+    bot._room_member_hook_lifecycle.certified()
     await AgentBot.sync_forever(bot)
 
     assert full_state_values == [True, False]
@@ -1297,7 +1297,8 @@ async def test_pending_member_bootstrap_forces_replacement_full_state() -> None:
 
     bot = MagicMock(spec=AgentBot)
     bot._first_sync_done = True
-    bot._room_member_join_bootstrap_pending = True
+    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=True)
+    bot._room_member_hook_lifecycle.prepare_startup(resuming_position=True)
     bot._sync_shutting_down = False
     bot.config = Config(matrix_sync=MatrixSyncConfig(mode="classic"))
     bot.rooms = []
@@ -1339,6 +1340,7 @@ async def test_sliding_sync_mode_uses_sliding_sync_forever() -> None:
     bot = MagicMock(spec=AgentBot)
     bot.agent_name = "code"
     bot._first_sync_done = False
+    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=False)
     bot.rooms = ["!alpha:localhost", "#lobby:localhost", "!beta:localhost"]
     bot.config = Config(matrix_sync=MatrixSyncConfig(mode="sliding", sliding_timeline_limit=7))
     bot.client = FakeClient()
@@ -1407,7 +1409,8 @@ async def test_default_sync_mode_is_classic_with_raised_timeline_limit() -> None
 
     bot = MagicMock(spec=AgentBot)
     bot._first_sync_done = True
-    bot._room_member_join_bootstrap_pending = False
+    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=True)
+    bot._room_member_hook_lifecycle.certified()
     bot._sync_shutting_down = False
     bot.config = Config()
     bot.rooms = []
@@ -1423,7 +1426,6 @@ async def test_sliding_sync_response_marks_sync_success(tmp_path: Path) -> None:
     """A sliding sync response must feed the watchdog clock and first-sync lifecycle."""
     bot = _sliding_response_bot(tmp_path)
     bot._first_sync_done = False
-    bot._room_member_join_hooks_armed = False
 
     with patch.object(
         bot,
@@ -1434,7 +1436,7 @@ async def test_sliding_sync_response_marks_sync_success(tmp_path: Path) -> None:
 
     assert bot.last_sync_time is not None
     assert bot._first_sync_done is True
-    assert bot._room_member_join_hooks_armed is True
+    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
 
 
 def test_matrix_sync_change_restarts_existing_entities() -> None:
@@ -1523,7 +1525,6 @@ def _sliding_response_bot(tmp_path: Path) -> AgentBot:
     install_runtime_cache_support(bot)
     bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     bot._first_sync_done = True
-    bot._room_member_join_hooks_armed = True
     return bot
 
 
@@ -1676,7 +1677,7 @@ async def test_sliding_sync_error_skips_classic_token_rejection(
         await bot._on_sync_error(error)
 
     assert bot._sync_continuity_store.load().checkpoint is not None
-    assert bot._room_member_join_hooks_armed is True
+    assert not bot._room_member_hook_lifecycle.callback_execution_enabled
     assert not any(entry["log_level"] == "warning" for entry in logs)
 
 
@@ -1824,6 +1825,7 @@ async def test_agent_bot_stop_preserves_restart_shutdown_intent() -> None:
     bot.prepare_for_sync_shutdown = AsyncMock()
     bot._emit_agent_lifecycle_event = AsyncMock()
     bot._call_manager = None
+    bot._room_member_hook_lifecycle = RoomMemberHookLifecycle(enabled=False)
 
     await AgentBot.stop(bot, shutdown_intent=SYNC_RESTART_SHUTDOWN)
 

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1500,12 +1500,6 @@ async def test_sliding_sync_response_marks_sync_success(tmp_path: Path) -> None:
 
     assert bot.last_sync_time is not None
     assert bot._first_sync_done is True
-    assert (
-        bot._room_member_hook_lifecycle.admission_enabled(
-            nio.TimelineEventProvenance.LIVE,
-        )
-        is False
-    )
 
 
 def test_matrix_sync_change_restarts_existing_entities() -> None:
@@ -1746,9 +1740,6 @@ async def test_sliding_sync_error_skips_classic_token_rejection(
         await bot._on_sync_error(error)
 
     assert bot._sync_continuity_store.load().checkpoint is not None
-    assert not bot._room_member_hook_lifecycle.admission_enabled(
-        nio.TimelineEventProvenance.LIVE,
-    )
     assert not any(entry["log_level"] == "warning" for entry in logs)
 
 


### PR DESCRIPTION
## Purpose

Close restart-safety gaps discovered after #1758 was merged.

This change invalidates rejected NIO sync positions without discarding queued live events, treats safe-checkpoint catch-up as one replay debt, and fences lifecycle snapshot markers when retained durable callback rows are corrupt.

It extracts one room-member lifecycle phase owner that records the Classic full-state baseline once, durably captures live and authorized recovered joins while hooks are fenced, and makes each Classic or Sliding response drain its admitted lifecycle obligations before checkpoint certification or readiness.

The full-state baseline now remains in memory while recovery is uncertain, is recorded only at a certifiable response while exact lifecycle obligations still fence matching members, and is reacquired on a replacement receive loop if NIO's one-shot full-state request fails.

A tokenless Classic rewind now stops the active receive loop so its replacement requests a real full-state baseline instead of accepting an incremental response as authoritative.

Source-backed timeline events retained across rejected-position invalidation preserve callback debt without mutating room state after the fresh tokenless response establishes new state authority.

Transient and room-account-data events from the rejected generation are discarded because NIO cannot replay those callbacks without applying stale room state.

NIO's state-suppression decision is propagated to auxiliary call admission, so retained membership and call-state callbacks cannot contradict the fresh baseline.

The pre-reset joined-room scope is compared exactly once with the fresh tokenless full-state response, making omitted rooms authoritative departures without misclassifying later incremental omissions.

Rejected Classic positions also purge the exact principal cache namespace before a new baseline can certify, so a process restart with an empty NIO room map cannot retain history for a room omitted by the fresh authoritative scope.

Principal cleanup begins before checkpoint-clear failure can disable cache writes, keeping rejected-scope rows durably absent across restart even when the rejected token file cannot be removed in that process.

After admitted lifecycle work settles, the retained baseline is revisited before certification so ignored profile changes and hook-disabled joins cannot leave existing members looking newly joined later.

Persisted Matrix parser failures are normalized into retained durable-corruption rows so malformed lifecycle work fences its room without wedging response certification.

Corrupt retained rows are reported once per long-lived storage or runner owner while remaining pending for operator repair.

Classic live-gap backfill remains admitted after startup reaches LIVE, while Sliding history stays fenced, so recovered membership joins are durably handled before a limited-response state snapshot can mark that member as already seen.

Full-state member markers retain their authoritative response room IDs independently of NIO's materialized room cache, including restored Classic responses whose unchanged token makes NIO skip room construction.

Entity readiness remains independent from lifecycle-hook admission while that membership catch-up is uncertified.

Sliding lifecycle handling uses the same live phase as steady state and scans durable lifecycle work only for the router that can admit it.

## Exact revision

- Base: `6a86a26387093761d506fd3796c562e051060ace`
- Head: `0a3192c8b6fd7e8f4c63c495983c9bfd3c05a797`
- Diff: 22 files, +2786/-359
- Production Python: +625/-268
- Tests: +2152/-90
- Architecture documentation: +8/-1

## Dependencies and landing order

This is a follow-up to merged #1758 and has no unreleased dependency.

#1731 is already merged and remains independent of this repair.

Land this repair before #1759 so the coordinator builds on the corrected recovery and lifecycle-bootstrap boundaries.

## Verification

- `uv run pytest -n auto tests/test_dispatch_obligations.py tests/test_sync_continuity_store.py tests/test_sync_certification.py tests/test_sync_cache_trust.py tests/test_nio_recovery_consumer_contract.py tests/test_matrix_sync_continuity.py tests/test_bot_sync_event_cache.py tests/test_matrix_cache_interaction_contract.py tests/test_matrix_event_cache_fuzz.py tests/test_import_graph.py tests/test_room_member_hooks.py tests/test_room_member_hook_lifecycle.py tests/test_cold_history_fence.py tests/test_matrix_client_session.py tests/test_sync_task_cancellation.py`: 620 passed, 1 skipped
- Focused `ty` check for all changed production modules: passed
- Changed-file pre-commit hooks, including Ruff, vulture, Tach, and module privacy: passed with the repository-wide `ty` hook skipped because this Linux host cannot resolve the macOS-only `AppKit`, `ApplicationServices`, and `Quartz` modules
- `git diff --check`: passed

The full repository suite was not run locally.

No local Docker or live Matrix gate was run because this patch is covered by focused persistence, restart, certification, callback, sync-loop, and cache contract tests.

Current-head GitHub CI passed, including Python 3.13 tests, smoke, static/security checks, plugin checks, and all MindRoom and minimal image builds; deploy/release jobs were skipped.

## Review state

A seeded Codex verification confirmed rejected-position sanitation, state-authority propagation, one-shot room-scope reconciliation, cold-restart principal cleanup, and checkpoint-clear failure ordering after the final local design correction.

Two fresh independent Codex reviewers approved exact head `0a3192c8b6fd7e8f4c63c495983c9bfd3c05a797` against exact base `6a86a26387093761d506fd3796c562e051060ace`.

One fresh external Claude Code reviewer independently approved the same exact head and base.

The head and base were reverified after all three reports, with no unresolved current GitHub review threads.
