### PR TITLE
test: cover live cold-room window re-entry

### DIFF
--- a/tests/test_cold_history_fence.py
+++ b/tests/test_cold_history_fence.py
@@ -333,11 +333,10 @@ async def test_cold_room_window_reentry_message_is_dispatched(
     """A cold room's window re-entry message must reach its message callback.
 
     Regression (2026-08-03, mindroom.chat "Test" room): rooms outside the
-    sliding-sync list window come back flagged ``initial`` and without
-    ``num_live`` (Tuwunel omits it), so nio classifies the delivered tail —
-    including the very message the user just sent — as HISTORY, and the
-    cold-history fence silently drops it. Every agent in every idle room
-    stops answering; the drop is only visible at debug level.
+    sliding-sync list window came back flagged ``initial`` without
+    ``num_live``, so nio correctly classified the ambiguous timeline as
+    HISTORY and the cold-history fence dropped it. Tuwunel now identifies
+    the newly arrived tail with ``num_live``, which nio must classify as LIVE.
     """
     store = DispatchObligationStore(
         tracking_path=tmp_path,
@@ -386,8 +385,8 @@ async def test_cold_room_window_reentry_message_is_dispatched(
         )
         # The room falls out of the window; nothing is delivered for it.
         await client.receive_response(sliding("s2", {}))
-        # A new user message pulls the room back in: the server flags the
-        # delivery ``initial`` and omits ``num_live``.
+        # A new user message pulls the room back in. The room is initial on
+        # this connection, while num_live identifies its newly arrived tail.
         await client.receive_response(
             sliding(
                 "s3",
@@ -395,6 +394,7 @@ async def test_cold_room_window_reentry_message_is_dispatched(
                     "!room:example.org": {
                         "initial": True,
                         "membership": "join",
+                        "num_live": 1,
                         "timeline": [_message("$cold_mention").source],
                     },
                 },

--- a/tests/test_cold_history_fence.py
+++ b/tests/test_cold_history_fence.py
@@ -327,6 +327,87 @@ async def test_real_nio_initial_history_is_fenced_and_continuation_is_live(
 
 
 @pytest.mark.asyncio
+async def test_cold_room_window_reentry_message_is_dispatched(
+    tmp_path: Path,
+) -> None:
+    """A cold room's window re-entry message must reach its message callback.
+
+    Regression (2026-08-03, mindroom.chat "Test" room): rooms outside the
+    sliding-sync list window come back flagged ``initial`` and without
+    ``num_live`` (Tuwunel omits it), so nio classifies the delivered tail —
+    including the very message the user just sent — as HISTORY, and the
+    cold-history fence silently drops it. Every agent in every idle room
+    stops answering; the drop is only visible at debug level.
+    """
+    store = DispatchObligationStore(
+        tracking_path=tmp_path,
+        principal_id="@code:example.org",
+        entity_name="code",
+    )
+    fence = ColdHistoryFence(store)
+    seen: list[str] = []
+
+    async def callback(
+        _room: nio.MatrixRoom,
+        event: nio.Event,
+    ) -> DispatchCallbackResult:
+        seen.append(event.event_id)
+        return DispatchCallbackResult.SUCCEEDED
+
+    runner = _runner(store, fence, callback)
+    client = nio.AsyncClient(
+        "https://example.org",
+        "@code:example.org",
+        config=nio.AsyncClientConfig(
+            encryption_enabled=False,
+            backfill_limited_timelines=True,
+        ),
+    )
+    owner = object()
+    runner.register_source_callbacks(client, owner=owner)
+
+    def sliding(pos: str, rooms: dict[str, object]) -> nio.SlidingSyncResponse:
+        response = nio.SlidingSyncResponse.from_dict({"pos": pos, "rooms": rooms})
+        assert isinstance(response, nio.SlidingSyncResponse)
+        return response
+
+    try:
+        # Ordinary continuation while the room is inside the list window.
+        await client.receive_response(
+            sliding(
+                "s1",
+                {
+                    "!room:example.org": {
+                        "membership": "join",
+                        "timeline": [_message("$warm").source],
+                    },
+                },
+            ),
+        )
+        # The room falls out of the window; nothing is delivered for it.
+        await client.receive_response(sliding("s2", {}))
+        # A new user message pulls the room back in: the server flags the
+        # delivery ``initial`` and omits ``num_live``.
+        await client.receive_response(
+            sliding(
+                "s3",
+                {
+                    "!room:example.org": {
+                        "initial": True,
+                        "membership": "join",
+                        "timeline": [_message("$cold_mention").source],
+                    },
+                },
+            ),
+        )
+        await wait_for_background_tasks(timeout=1, owner=owner)
+    finally:
+        await client.close()
+
+    assert seen == ["$warm", "$cold_mention"]
+
+
+@pytest.mark.asyncio
 async def test_direct_recovery_bypasses_timeline_provenance(
     tmp_path: Path,
 ) -> None:

--- a/tests/test_cold_history_fence.py
+++ b/tests/test_cold_history_fence.py
@@ -383,6 +383,8 @@ async def test_cold_room_window_reentry_message_is_dispatched(
                 },
             ),
         )
+        assert await wait_for_background_tasks(timeout=1, owner=owner)
+        assert seen == ["$warm"]
         # The room falls out of the window; nothing is delivered for it.
         await client.receive_response(sliding("s2", {}))
         # A new user message pulls the room back in. The room is initial on
@@ -400,7 +402,7 @@ async def test_cold_room_window_reentry_message_is_dispatched(
                 },
             ),
         )
-        await wait_for_background_tasks(timeout=1, owner=owner)
+        assert await wait_for_background_tasks(timeout=1, owner=owner)
     finally:
         await client.close()
 


### PR DESCRIPTION
## Summary

Updates the cold-room Sliding Sync regression test to model the corrected Tuwunel response.

A room that re-enters the list window due to a new message is returned with `initial: true` and `num_live: 1`.
Nio must classify that returned tail as live, allowing the cold-history fence to dispatch it.

## Root cause

PR #1760 exposed an older server metadata gap by enforcing nio timeline provenance at the cold-history fence.
Tuwunel previously omitted `num_live` for an initial room response, leaving nio unable to distinguish a live window-reentry event from historical range expansion.
The fix belongs in Tuwunel, which now supplies the exact live-tail count.

## Test

`test_cold_room_window_reentry_message_is_dispatched` drives a real `nio.AsyncClient` through an in-window message, room absence, and `initial` re-entry with `num_live: 1`.
It verifies that both the warm message and the live re-entry message reach the dispatch callback.
The neighboring initial-history test continues to verify that ambiguous historical delivery remains fenced.

## Validation

- `uv run pytest -q tests/test_cold_history_fence.py`
- `uv run pre-commit run --files tests/test_cold_history_fence.py`
- Full GitHub Actions pytest suite
- CodeRabbit and Sourcery review checks