### PR TITLE
Baseline tokenless membership from state and timeline

### DIFF
--- a/docs/architecture/bot-runtime.md
+++ b/docs/architecture/bot-runtime.md
@@ -99,6 +99,7 @@ Checkpoint mutations serialize their epoch check, durable transform, and runtime
 Malformed or future continuity records are durably repaired to an empty cold record before startup room lifecycle restoration.
 Continuity reads and writes run off the event loop, and retry decisions use the checkpoint already loaded or applied by `SyncCacheTrust`.
 Classic Sync response-owned lifecycle hooks and their durable de-duplication markers complete before `SyncCacheTrust` certifies the response checkpoint.
+The tokenless room-member baseline remains pending across rejected response attempts and records membership from both the state block and the timeline, while a restored-token timeline remains a catch-up stream that may emit missed joins.
 Live `room-member-joined` hooks are at-least-once because hook emission happens before the durable seen marker, so a marker write failure replays the hook instead of losing it.
 Invite and response-owned lifecycle paths use the same runner directly because they are outside nio timeline fanout.
 Current invite callbacks bypass cold-history admission because they represent live membership work, while their callback runner still provides exact durable retry.

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -188,6 +188,7 @@ class _RoomMemberJoinSyncHookPlan:
     emit_state: bool = False
     emit_timeline: bool = False
     record_state_seen: bool = False
+    record_timeline_seen: bool = False
 
 
 def _create_best_effort_task_wrapper(
@@ -1444,11 +1445,15 @@ class AgentBot:
         emit_certified_state = (
             decision.state is SyncTrustState.CERTIFIED and not first_sync_response and hooks_were_armed
         )
+        tokenless_baseline = self._sync_cache_trust.tokenless_baseline_pending()
         return _RoomMemberJoinSyncHookPlan(
             arm_after_response=True,
             emit_state=emit_certified_state,
             emit_timeline=restored_token_first_sync_response,
-            record_state_seen=decision.state is SyncTrustState.CERTIFIED and not emit_certified_state,
+            record_state_seen=(
+                tokenless_baseline or (decision.state is SyncTrustState.CERTIFIED and not emit_certified_state)
+            ),
+            record_timeline_seen=tokenless_baseline,
         )
 
     async def _run_pre_certification_sync_response_side_effects(
@@ -1459,7 +1464,11 @@ class AgentBot:
     ) -> None:
         """Finish source-backed lifecycle work before certifying its sync position."""
         if room_member_join_hook_plan.record_state_seen:
-            await self._emit_room_member_joined_sync_state_hooks(response, record_only=True)
+            await self._emit_room_member_joined_sync_state_hooks(
+                response,
+                record_only=True,
+                include_timeline_baseline=room_member_join_hook_plan.record_timeline_seen,
+            )
         if room_member_join_hook_plan.emit_timeline:
             await self._emit_room_member_joined_sync_timeline_hooks(response)
         if room_member_join_hook_plan.emit_state:
@@ -2314,6 +2323,7 @@ class AgentBot:
         response: nio.SyncResponse,
         *,
         record_only: bool = False,
+        include_timeline_baseline: bool = False,
     ) -> None:
         """Expose or record human joins that matrix-nio delivers through sync room state."""
         if self.agent_name != ROUTER_AGENT_NAME:
@@ -2330,6 +2340,7 @@ class AgentBot:
             config=self.config,
             runtime_paths=self.runtime_paths,
             record_only=record_only,
+            include_timeline_baseline=include_timeline_baseline,
         )
         for room, event in plan.dispatch_events:
             await self._dispatch_obligation_runner.dispatch(

--- a/src/mindroom/matrix/room_member_joins.py
+++ b/src/mindroom/matrix/room_member_joins.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
+from itertools import chain
 from threading import Lock
 from typing import TYPE_CHECKING
 from weakref import WeakValueDictionary
@@ -287,6 +288,7 @@ def room_member_sync_state_plan(
     config: Config,
     runtime_paths: RuntimePaths,
     record_only: bool = False,
+    include_timeline_baseline: bool = False,
 ) -> _RoomMemberSyncPlan:
     """Classify state events into durable hook dispatches and baseline markers."""
     dispatch_events: list[tuple[nio.MatrixRoom, nio.RoomMemberEvent]] = []
@@ -294,7 +296,13 @@ def room_member_sync_state_plan(
     limited_room_ids = frozenset(
         room_id for room_id, join_info in response.rooms.join.items() if join_info.timeline.limited
     )
-    for room, event in _room_member_events_from_sync_state(response, rooms=rooms):
+    events = _room_member_events_from_sync_state(response, rooms=rooms)
+    if include_timeline_baseline:
+        events = chain(
+            events,
+            _room_member_events_from_sync_timeline(response, rooms=rooms),
+        )
+    for room, event in events:
         if record_only or room.room_id in limited_room_ids:
             record_events.append((room, event))
             continue

--- a/src/mindroom/matrix/sync_cache_trust.py
+++ b/src/mindroom/matrix/sync_cache_trust.py
@@ -208,6 +208,10 @@ class SyncCacheTrust:
         """Return whether NIO must advance retained work before a safe replay."""
         return bool(self._unresolved_recovery_room_ids or self._replay_required_after_recovery)
 
+    def tokenless_baseline_pending(self) -> bool:
+        """Return whether the next accepted response establishes a tokenless baseline."""
+        return self._tokenless_baseline_pending
+
     def acknowledge_dispatch_persist_failures(self) -> None:
         """Settle source failures irrelevant to non-checkpointed transports."""
         self._observed_dispatch_persist_failure_epoch = self._dispatch_persist_failure_epoch

--- a/tests/test_room_member_hooks.py
+++ b/tests/test_room_member_hooks.py
@@ -659,6 +659,61 @@ async def test_router_emits_room_member_joined_from_first_restored_token_sync_ti
 
 
 @pytest.mark.asyncio
+async def test_tokenless_timeline_only_baseline_prevents_later_false_join(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A first-sync timeline member is existing state, even without state duplication."""
+    seen: list[str] = []
+
+    @hook(EVENT_ROOM_MEMBER_JOINED)
+    async def joined(ctx: RoomMemberJoinedContext) -> None:
+        seen.append(ctx.event_id)
+
+    bot = _router_bot(tmp_path)
+    room = _room()
+    bot._first_sync_done = False
+    bot._room_member_join_hooks_armed = False
+    assert await bot._sync_cache_trust.prepare_startup() is None
+    bot.client.rooms = {room.room_id: room}
+    bot.client.next_batch = None
+    bot.hook_registry = HookRegistry.from_plugins([_plugin("onboarding", [joined])])
+    bot._emit_agent_lifecycle_event = AsyncMock()
+    bot._maybe_start_startup_thread_prewarm = MagicMock()
+    bot._maybe_start_deferred_overdue_task_drain = MagicMock()
+    monkeypatch.setattr(
+        bot._conversation_cache,
+        "cache_sync_timeline_for_certification",
+        AsyncMock(return_value=SyncCacheWriteResult(complete=True)),
+    )
+
+    await bot._on_sync_response(
+        _sync_response_with_state(
+            room.room_id,
+            [],
+            timeline_events=[
+                _room_member_event(
+                    event_id="$timeline-baseline",
+                    prev_membership=None,
+                ),
+            ],
+        ),
+    )
+
+    assert seen == []
+
+    await bot._on_room_member(
+        room,
+        _room_member_event(
+            event_id="$later-profile",
+            prev_membership=None,
+        ),
+    )
+
+    assert seen == []
+
+
+@pytest.mark.asyncio
 async def test_router_ignores_restored_token_first_sync_full_state_member_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -909,13 +964,32 @@ async def test_unknown_pos_resync_does_not_emit_room_member_joined_snapshot(
     await bot._on_sync_response(
         _sync_response_with_state(
             room.room_id,
-            [_room_member_event(event_id="$state-snapshot")],
+            [],
+            timeline_events=[
+                _room_member_event(
+                    event_id="$timeline-snapshot",
+                    prev_membership=None,
+                ),
+            ],
         ),
     )
 
     assert seen == []
 
-    await bot._on_room_member(room, _room_member_event(event_id="$live", user_id="@bob:localhost"))
+    await bot._on_room_member(
+        room,
+        _room_member_event(
+            event_id="$later-profile",
+            prev_membership=None,
+        ),
+    )
+
+    assert seen == []
+
+    await bot._on_room_member(
+        room,
+        _room_member_event(event_id="$live", user_id="@bob:localhost"),
+    )
 
     assert seen == ["$live"]
 
@@ -1053,13 +1127,32 @@ async def test_uncertain_first_sync_reset_does_not_emit_room_member_joined_snaps
     await bot._on_sync_response(
         _sync_response_with_state(
             room.room_id,
-            [_room_member_event(event_id="$state-snapshot")],
+            [],
+            timeline_events=[
+                _room_member_event(
+                    event_id="$timeline-snapshot",
+                    prev_membership=None,
+                ),
+            ],
         ),
     )
 
     assert seen == []
 
-    await bot._on_room_member(room, _room_member_event(event_id="$live", user_id="@bob:localhost"))
+    await bot._on_room_member(
+        room,
+        _room_member_event(
+            event_id="$later-profile",
+            prev_membership=None,
+        ),
+    )
+
+    assert seen == []
+
+    await bot._on_room_member(
+        room,
+        _room_member_event(event_id="$live", user_id="@bob:localhost"),
+    )
 
     assert seen == ["$live"]
 


### PR DESCRIPTION
## Purpose

Prevent a tokenless first sync from later misclassifying an existing member's profile update as a new join.

Matrix can place membership describing the start of a fresh-sync timeline in either the state block or the timeline.

The baseline now records both sources and remains pending across response attempts that reject and replay the cursor.

Restored-token timelines remain catch-up streams and can still emit genuinely missed joins.

This is an independent first layer of the smaller replacement for #1783 and does not depend on the nio change.

## Exact revision

- Base: `a5a6a338b19234f0f1fbb8fef78ae6796a732fc2`
- Head: `0cae35f7691827cca50d880c8fa69d70354564ed`
- Diff: 5 files, +124/-7
- Production Python: +26/-3
- Tests: +97/-4

## Verification

- Full MindRoom suite on this exact branch: 12,898 passed, 23 skipped
- Changed-file pre-commit hooks: passed
- Targeted `ty` check for all changed Python files: passed
- `git diff --check`: passed

## Follow-up

The Classic startup-cursor repair is stacked separately in [MindRoom#1788](https://github.com/mindroom-ai/mindroom/pull/1788) so this bug fix can be reviewed and landed on its own.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved room-member synchronization during initial and restored sessions.
  * Prevented baseline membership events and subsequent profile updates from triggering duplicate onboarding notifications.
  * Ensured genuine member joins appearing after a restored session continue to generate notifications.
  * Improved handling of membership data received through both room state and timeline events.

* **Documentation**
  * Documented tokenless baseline behavior and restored-session catch-up handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->