### PR TITLE
fix: coalesce OpenRouter reasoning stream details

### DIFF
--- a/docs/superpowers/plans/2026-08-04-openrouter-reasoning-details-coalescing.md
+++ b/docs/superpowers/plans/2026-08-04-openrouter-reasoning-details-coalescing.md
@@ -1,0 +1,187 @@
+# OpenRouter Reasoning-Details Coalescing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent OpenRouter streaming reasoning deltas from inflating persisted sessions and replay payloads, then safely normalize Mom's existing polluted history.
+
+**Architecture:** Add a conservative adjacent-fragment coalescer and use it at the two OpenRouter boundaries: streamed provider-data aggregation and persisted-message wire formatting. Deploy the tested source files to Mom, stop the service, back up and recursively normalize the SQLite `runs` JSON, verify it, and restart once.
+
+**Tech Stack:** Python 3.13, Agno 2.6.12, pytest, SQLite, systemd/Incus.
+
+---
+
+### Task 1: Define conservative coalescing behavior
+
+**Files:**
+- Modify: `tests/test_openai_models.py`
+- Modify: `src/mindroom/openai_models.py`
+
+- [ ] **Step 1: Write failing pure-helper tests**
+
+Add table-driven tests for adjacent `reasoning.text` dictionaries. Require string text, exact equality of every other field, and either a numeric `index` or non-empty string `id`. Verify conflicting/missing IDs, signatures, malformed entries, non-string text, non-adjacent matches, and non-text details remain separate.
+
+Also deep-copy the test input before calling the helper and assert the original list and dictionaries are byte-for-byte unchanged afterward.
+
+- [ ] **Step 2: Run the focused tests and verify RED**
+
+Run: `uv run pytest -q tests/test_openai_models.py -k reasoning_details`
+
+Expected: collection/import failure because the helper does not exist.
+
+- [ ] **Step 3: Implement the minimal helper**
+
+Add `_coalesced_openrouter_reasoning_details(details: object) -> object` to `openai_models.py`. Iterate once, copy the list, and merge only with the immediately preceding compatible detail by concatenating `text`. Return malformed/non-list inputs unchanged.
+
+- [ ] **Step 4: Run the focused tests and verify GREEN**
+
+Run: `uv run pytest -q tests/test_openai_models.py -k reasoning_details`
+
+Expected: all new helper tests pass.
+
+### Task 2: Normalize streaming storage and replay
+
+**Files:**
+- Modify: `tests/test_openai_models.py`
+- Modify: `src/mindroom/openai_models.py`
+
+- [ ] **Step 1: Write failing integration tests**
+
+Test `MindRoomOpenRouter._populate_stream_data` with two same-index deltas and assert one concatenated stored detail. Test `_format_message` with polluted history and assert the wire message is coalesced while the original `Message.provider_data` is unchanged. Verify unrelated provider data survives both paths.
+
+Include a streaming delta containing multiple reasoning-detail entries so ordering and within-delta adjacent coalescing are covered, in addition to cross-delta coalescing.
+
+Because `_populate_stream_data` is a generator, consume its output and assert the override preserves the superclass's yielded response deltas and their content in addition to the accumulated `stream_data` state.
+
+- [ ] **Step 2: Run the integration tests and verify RED**
+
+Run: `uv run pytest -q tests/test_openai_models.py -k reasoning_details`
+
+Expected: streamed details remain separate and replay emits the polluted list.
+
+- [ ] **Step 3: Implement streaming aggregation**
+
+Override `MindRoomOpenRouter._populate_stream_data`. Merge incoming `reasoning_details` into the existing stream list in place using the same compatibility rule, then pass a dataclass copy of the delta without that key to Agno's generic merger. This keeps aggregation linear rather than repeatedly rebuilding the accumulated list.
+
+- [ ] **Step 4: Implement non-mutating replay normalization**
+
+Override `MindRoomOpenRouter._format_message`. When an assistant message contains a changed reasoning-details list, create a Pydantic copy with copied provider data and pass that to Agno. Never mutate the persisted `Message`.
+
+- [ ] **Step 5: Run focused and module tests**
+
+Run: `uv run pytest -q tests/test_openai_models.py`
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Run static checks**
+
+Run: `uv run ruff check src/mindroom/openai_models.py tests/test_openai_models.py && uv run ruff format --check src/mindroom/openai_models.py tests/test_openai_models.py && uv run ty check src/mindroom/openai_models.py`
+
+Expected: zero errors.
+
+### Task 3: Build and test the database normalizer
+
+**Files:**
+- Add: `scripts/normalize_openrouter_reasoning_details.py`
+- Add: `tests/test_normalize_openrouter_reasoning_details.py`
+
+- [ ] **Step 1: Write failing migration tests**
+
+Create a temporary SQLite database with Mom's exact `mind_sessions(session_id, runs)` table/column shape. Include `reasoning_details` beneath messages, run-level `model_provider_data`, nested events, unrelated JSON, malformed details, and multiple session rows. Test dry-run leaves the database byte-identical, apply mode produces the exact recursively normalized JSON expected for each row, and all unrelated values remain identical.
+
+- [ ] **Step 2: Run migration tests and verify RED**
+
+Run: `uv run pytest -q tests/test_normalize_openrouter_reasoning_details.py`
+
+Expected: failure because the normalizer does not exist.
+
+- [ ] **Step 3: Implement the normalizer**
+
+Implement a CLI with required database path, required `--table` argument, and mutually exclusive `--dry-run`/`--apply` modes. Validate that the table is an exact identifier present in `sqlite_master` and has the required `session_id` and `runs` columns; reject unsafe identifiers or schema mismatches. Production will pass `--table mind_sessions`. Recursively locate every `reasoning_details` key and use the production helper. Before applying, checkpoint WAL, create a timestamped sibling backup with SQLite's backup API, and require `PRAGMA integrity_check = ok` on both source and backup. Update all changed rows in one `BEGIN IMMEDIATE` transaction.
+
+For each row, retain the decoded pre-image and compute the exact expected post-image using only the recursive coalescer. Re-read every row after commit and require equality with its expected post-image; require unchanged session IDs, row count, run count, and concatenated reasoning text. On any mismatch, roll back before commit or exit nonzero with the verified backup path and exact restore command.
+
+- [ ] **Step 4: Run migration tests and verify GREEN**
+
+Run: `uv run pytest -q tests/test_normalize_openrouter_reasoning_details.py`
+
+Expected: all tests pass, including backup creation and restoration of the fixture from that backup.
+
+- [ ] **Step 5: Exercise the exact CLI against a disposable copy**
+
+Copy the fixture database, run both `--dry-run` and `--apply`, inspect the emitted counts and backup path, restore the disposable database from its backup, and prove it matches the original checksum.
+
+### Task 4: Commit the implementation
+
+**Files:**
+- Modify: `src/mindroom/openai_models.py`
+- Modify: `tests/test_openai_models.py`
+- Add: `scripts/normalize_openrouter_reasoning_details.py`
+- Add: `tests/test_normalize_openrouter_reasoning_details.py`
+- Add: `docs/superpowers/plans/2026-08-04-openrouter-reasoning-details-coalescing.md`
+
+- [ ] **Step 1: Review the diff**
+
+Run: `git diff --check && git diff -- src/mindroom/openai_models.py tests/test_openai_models.py scripts/normalize_openrouter_reasoning_details.py tests/test_normalize_openrouter_reasoning_details.py`
+
+- [ ] **Step 2: Run the broader relevant suite**
+
+Run: `uv run pytest -q tests/test_openai_models.py tests/test_normalize_openrouter_reasoning_details.py && uv run ruff check src/mindroom/openai_models.py tests/test_openai_models.py scripts/normalize_openrouter_reasoning_details.py tests/test_normalize_openrouter_reasoning_details.py && uv run ruff format --check src/mindroom/openai_models.py tests/test_openai_models.py scripts/normalize_openrouter_reasoning_details.py tests/test_normalize_openrouter_reasoning_details.py && uv run ty check src/mindroom/openai_models.py scripts/normalize_openrouter_reasoning_details.py`
+
+- [ ] **Step 3: Commit locally**
+
+Run: `git add src/mindroom/openai_models.py tests/test_openai_models.py scripts/normalize_openrouter_reasoning_details.py tests/test_normalize_openrouter_reasoning_details.py && git add -f docs/superpowers/plans/2026-08-04-openrouter-reasoning-details-coalescing.md && git commit -m "fix: coalesce OpenRouter reasoning stream details"`
+
+Do not push without separate authorization.
+
+### Task 5: Preflight Mom's exact runtime target
+
+**Remote target:** NAS host alias `nas`, Incus instance `mindroom-mom`
+
+- [ ] **Step 1: Resolve the remote instance and project**
+
+Run `ssh nas 'incus list --all-projects --format csv -c e,n,s'` and require exactly one running `mindroom-mom` entry. Record its project with `incus project show <resolved-project>`. Do not use the local Incus daemon. Pass `--project <resolved-project>` explicitly to every subsequent `incus` command, for example `incus exec --project <resolved-project> mindroom-mom -- ...` and `incus file push --project <resolved-project> ... mindroom-mom/...`.
+
+- [ ] **Step 2: Resolve service configuration and identity**
+
+Run `ssh nas 'incus exec --project <resolved-project> mindroom-mom -- systemctl cat mindroom'` and record `User`, `Environment=MINDROOM_CONFIG_PATH`, `EnvironmentFile`, `WorkingDirectory`, and `ExecStart`. Require the expected checkout `/srv/mindroom` and live config `/home/basnijholt/.mindroom/config.yaml` before continuing.
+
+- [ ] **Step 3: Resolve and validate the live database**
+
+Read the effective config to resolve the exact sessions database, then inspect its SQLite schema, table/column names, `PRAGMA integrity_check`, session/run counts, WAL mode, file/WAL sizes, owner/mode, and parent filesystem free space. Require enough free space for the backup plus a separately gated `VACUUM` copy.
+
+- [ ] **Step 4: Record runtime baseline and fresh-log cursor**
+
+Record checkout SHA/status, service state, PID, `NRestarts`, current/peak memory, configured model ID, and `journalctl -u mindroom --show-cursor -n 1`. This cursor is the lower bound for post-start log inspection.
+
+### Task 6: Deploy the committed revision and normalize Mom's history
+
+**Files:**
+- Deploy from the committed revision: `src/mindroom/openai_models.py`
+- Deploy from the committed revision: `tests/test_openai_models.py`
+- Deploy from the committed revision: `scripts/normalize_openrouter_reasoning_details.py`
+- Deploy from the committed revision: `tests/test_normalize_openrouter_reasoning_details.py`
+- Data: resolved live database, expected `/home/basnijholt/.mindroom/mindroom_data/agents/mind/sessions/mind.db`
+
+- [ ] **Step 1: Deploy the exact committed files and test them**
+
+Export/copy the four files from `git show <commit>:<path>`, verify their SHA-256 checksums in the container, and run the focused OpenAI-model and normalizer tests in `/srv/mindroom`. The checkout will intentionally be dirty until the fix is published upstream.
+
+- [ ] **Step 2: Dry-run against a disposable live-data copy while service remains running**
+
+Use SQLite's backup API to create a disposable consistent copy, run the committed normalizer with `--dry-run` and then `--apply` on that copy, and verify exact per-row expected JSON, integrity, counts, and restoration from its generated backup. Do not touch the live database in this step.
+
+- [ ] **Step 3: Stop once, back up, and apply**
+
+Capture a new journal cursor, stop `mindroom.service`, verify it is inactive, and invoke the committed normalizer with `--apply` on the resolved live database. It must checkpoint WAL, create and integrity-check a timestamped sibling backup before mutation, then enforce its per-row post-image invariants. If it exits nonzero, leave the service stopped, restore atomically from the verified backup using the emitted exact command, integrity-check the restored database, and then start the service.
+
+- [ ] **Step 4: Gate optional physical compaction**
+
+Report logical size savings first. Run `VACUUM` only if meaningful physical size reduction is desired and free space exceeds twice the live database size plus safety margin. If run, integrity-check again and preserve the verified pre-migration backup.
+
+- [ ] **Step 5: Start and verify runtime behavior**
+
+Start `mindroom.service` once. Require active state, expected model ID, expected checkout status, no new `NRestarts`, and no startup errors after the captured journal cursor. Record current/peak memory and the verified backup path.
+
+- [ ] **Step 6: Verify a fresh reasoning-enabled turn**
+
+Trigger one normal Mom agent turn through the existing Matrix path (without changing configuration), trace its event in fresh logs, and inspect the newly persisted run plus replay formatting. Require adjacent compatible `reasoning_details` to be coalesced and confirm memory settles after the turn. If sending a user-visible Matrix message requires new authority, ask the user to send one and complete the persisted-run check immediately afterward.

--- a/docs/superpowers/specs/2026-08-04-openrouter-reasoning-details-coalescing-design.md
+++ b/docs/superpowers/specs/2026-08-04-openrouter-reasoning-details-coalescing-design.md
@@ -1,0 +1,53 @@
+# OpenRouter Reasoning-Details Coalescing
+
+## Problem
+
+OpenRouter emits `reasoning_details` in streaming delta chunks. Agno 2.6.12
+extends provider-data lists verbatim, so a single indexed reasoning block becomes
+thousands of tiny dictionaries. MindRoom persists and replays those dictionaries,
+inflating session storage, request payloads, token accounting, and allocator
+high-water memory.
+
+## Design
+
+Add an OpenRouter-only compatibility layer to `MindRoomOpenRouter`.
+
+- During streaming aggregation, merge adjacent dictionary fragments only when
+  both have `type == "reasoning.text"`, both have string `text` values, and
+  their dictionaries are exactly equal after removing `text`. Missing and
+  explicitly null metadata are therefore different, so signatures, IDs, and
+  future provider fields can never be silently dropped. At least one stable
+  block discriminator must also be present: a numeric `index` or a non-empty
+  string `id`. Non-adjacent fragments remain separate even when their metadata
+  matches.
+- Concatenate only the `text` field. Leave malformed values, non-text reasoning
+  types, and ambiguous or conflicting fragments separate.
+- Before wire formatting, apply the same non-mutating normalization to persisted
+  assistant messages. This immediately prevents old polluted history from being
+  replayed verbatim without rewriting the database in the request path.
+- Leave non-text reasoning types and unrelated provider data untouched.
+
+## Existing Data
+
+After deploying the compatibility layer, stop Mom's service, checkpoint its WAL,
+create a timestamped backup through SQLite's backup API, and verify the backup with
+`PRAGMA integrity_check` before mutation. Transactionally coalesce compatible
+fragments in every persisted occurrence: run messages, top-level
+`model_provider_data`, and stored events when present. Validate database integrity,
+session/run counts, detail counts, and concatenated content before and after. Run
+`VACUUM` only after validation when physical file-size reduction is desired.
+
+## Testing
+
+Regression tests will prove that:
+
+1. streamed same-index text fragments become one stored detail;
+2. different indexes or conflicting metadata remain separate;
+3. missing/conflicting signatures and IDs remain separate;
+4. malformed details, non-string text, multiple details per delta, and
+   non-adjacent matching identities are handled conservatively;
+5. replay normalization does not mutate persisted `Message` objects;
+6. unrelated provider data survives unchanged.
+
+Deployment verification will check service health, database integrity and size,
+the effective model configuration, and fresh logs after the controlled restart.

--- a/scripts/normalize_openrouter_reasoning_details.py
+++ b/scripts/normalize_openrouter_reasoning_details.py
@@ -1,0 +1,499 @@
+"""Safely coalesce OpenRouter reasoning fragments stored in session runs."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shlex
+import sqlite3
+import sys
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol, cast
+
+from mindroom.openai_models import _coalesced_openrouter_reasoning_details
+
+_SAFE_IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_REQUIRED_COLUMNS = frozenset({"session_id", "runs"})
+type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
+
+
+@dataclass(frozen=True)
+class _RowSummary:
+    session_id: str
+    raw_sha256: str
+    current_json_sha256: str
+    expected_json_sha256: str
+    changed: bool
+    runs: int
+    reasoning_details_before: int
+    reasoning_details_after: int
+
+
+@dataclass(frozen=True)
+class _ScanSummary:
+    rows: tuple[_RowSummary, ...]
+    changed_rows: int
+    runs: int
+    reasoning_details_before: int
+    reasoning_details_after: int
+    reasoning_text_sha256_before: str
+    reasoning_text_sha256_after: str
+
+
+@dataclass(frozen=True)
+class _RowAnalysis:
+    summary: _RowSummary
+    runs_after: list[JsonValue]
+
+
+class _Digest(Protocol):
+    def update(self, data: bytes, /) -> None:
+        """Add bytes to the digest."""
+
+    def hexdigest(self, /) -> str:
+        """Return the hexadecimal digest."""
+
+
+class NormalizationError(RuntimeError):
+    """Raised when normalization cannot prove that the database is safe."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        backup_path: Path | None = None,
+        restore_command: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.backup_path = backup_path
+        self.restore_command = restore_command
+
+
+def _quoted_table(table: str) -> str:
+    if not _SAFE_IDENTIFIER.fullmatch(table):
+        msg = f"table must be a safe SQLite identifier, got {table!r}"
+        raise ValueError(msg)
+    return f'"{table}"'
+
+
+def _validate_schema(connection: sqlite3.Connection, table: str) -> str:
+    quoted_table = _quoted_table(table)
+    row = connection.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+        (table,),
+    ).fetchone()
+    if row is None:
+        msg = f"table {table!r} does not exist"
+        raise ValueError(msg)
+    columns = {str(info[1]) for info in connection.execute(f"PRAGMA table_info({quoted_table})")}
+    missing = _REQUIRED_COLUMNS - columns
+    if missing:
+        msg = f"table {table!r} is missing required columns: {sorted(missing)}"
+        raise ValueError(msg)
+    return quoted_table
+
+
+def _decode_runs(raw_runs: object, session_id: object) -> list[JsonValue]:
+    if not isinstance(raw_runs, str):
+        msg = f"session {session_id!r} has a non-text runs value"
+        raise NormalizationError(msg)
+    try:
+        encoded_runs: JsonValue = json.loads(raw_runs)
+    except json.JSONDecodeError as error:
+        msg = f"session {session_id!r} does not contain double-encoded runs JSON: {error}"
+        raise NormalizationError(msg) from error
+    if not isinstance(encoded_runs, str):
+        msg = f"session {session_id!r} has a runs outer JSON value that is not a string"
+        raise NormalizationError(msg)
+    try:
+        runs: JsonValue = json.loads(encoded_runs)
+    except json.JSONDecodeError as error:
+        msg = f"session {session_id!r} has invalid inner runs JSON: {error}"
+        raise NormalizationError(msg) from error
+    if not isinstance(runs, list):
+        msg = f"session {session_id!r} has a decoded runs value that is not a list"
+        raise NormalizationError(msg)
+    return runs
+
+
+def _encode_runs(runs: list[JsonValue]) -> str:
+    return json.dumps(json.dumps(runs, separators=(",", ":")), separators=(",", ":"))
+
+
+def _normalize_value(value: JsonValue) -> JsonValue:
+    if isinstance(value, list):
+        return [_normalize_value(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+
+    normalized: dict[str, JsonValue] = {}
+    for key, child in value.items():
+        normalized_child = _normalize_value(child)
+        if key == "reasoning_details":
+            normalized_child = cast("JsonValue", _coalesced_openrouter_reasoning_details(normalized_child))
+        normalized[key] = normalized_child
+    return normalized
+
+
+def _update_reasoning_metrics(value: JsonValue, digest: _Digest) -> int:
+    count = 0
+    if isinstance(value, list):
+        for item in value:
+            count += _update_reasoning_metrics(item, digest)
+    elif isinstance(value, dict):
+        for key, child in value.items():
+            if key == "reasoning_details" and isinstance(child, list):
+                count += len(child)
+                for detail in child:
+                    if isinstance(detail, dict) and isinstance(detail.get("text"), str):
+                        digest.update(detail["text"].encode())
+            count += _update_reasoning_metrics(child, digest)
+    return count
+
+
+def _json_sha256(value: JsonValue) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _analyze_row(
+    session_id: object,
+    raw_runs: object,
+    before_digest: _Digest,
+    after_digest: _Digest,
+) -> _RowAnalysis:
+    if not isinstance(session_id, str):
+        msg = f"session_id must be text, got {session_id!r}"
+        raise NormalizationError(msg)
+    runs_before = _decode_runs(raw_runs, session_id)
+    runs_after = _normalize_value(runs_before)
+    if not isinstance(runs_after, list):
+        msg = f"session {session_id!r} normalization changed the runs container type"
+        raise NormalizationError(msg)
+    assert isinstance(raw_runs, str)
+    summary = _RowSummary(
+        session_id=session_id,
+        raw_sha256=hashlib.sha256(raw_runs.encode()).hexdigest(),
+        current_json_sha256=_json_sha256(runs_before),
+        expected_json_sha256=_json_sha256(runs_after),
+        changed=runs_before != runs_after,
+        runs=len(runs_before),
+        reasoning_details_before=_update_reasoning_metrics(runs_before, before_digest),
+        reasoning_details_after=_update_reasoning_metrics(runs_after, after_digest),
+    )
+    return _RowAnalysis(summary=summary, runs_after=runs_after)
+
+
+def _scan_database(connection: sqlite3.Connection, quoted_table: str) -> _ScanSummary:
+    cursor = connection.execute(
+        f"SELECT session_id, runs FROM {quoted_table} ORDER BY session_id",  # noqa: S608 -- identifier validated
+    )
+    rows: list[_RowSummary] = []
+    seen_session_ids: set[str] = set()
+    before_digest = hashlib.sha256()
+    after_digest = hashlib.sha256()
+    for session_id, raw_runs in cursor:
+        analysis = _analyze_row(session_id, raw_runs, before_digest, after_digest)
+        if analysis.summary.session_id in seen_session_ids:
+            msg = f"duplicate session_id prevents exact row verification: {analysis.summary.session_id!r}"
+            raise NormalizationError(msg)
+        seen_session_ids.add(analysis.summary.session_id)
+        rows.append(analysis.summary)
+        del analysis
+    summary = _ScanSummary(
+        rows=tuple(rows),
+        changed_rows=sum(row.changed for row in rows),
+        runs=sum(row.runs for row in rows),
+        reasoning_details_before=sum(row.reasoning_details_before for row in rows),
+        reasoning_details_after=sum(row.reasoning_details_after for row in rows),
+        reasoning_text_sha256_before=before_digest.hexdigest(),
+        reasoning_text_sha256_after=after_digest.hexdigest(),
+    )
+    if summary.reasoning_text_sha256_before != summary.reasoning_text_sha256_after:
+        msg = "concatenated reasoning text changed during normalization"
+        raise NormalizationError(msg)
+    return summary
+
+
+def _raw_fingerprints(connection: sqlite3.Connection, quoted_table: str) -> tuple[tuple[str, str], ...]:
+    cursor = connection.execute(
+        f"SELECT session_id, runs FROM {quoted_table} ORDER BY session_id",  # noqa: S608 -- identifier validated
+    )
+    fingerprints: list[tuple[str, str]] = []
+    for session_id, raw_runs in cursor:
+        if not isinstance(session_id, str) or not isinstance(raw_runs, str):
+            msg = f"invalid session row while fingerprinting: session_id={session_id!r}"
+            raise NormalizationError(msg)
+        fingerprints.append((session_id, hashlib.sha256(raw_runs.encode()).hexdigest()))
+        del raw_runs
+    return tuple(fingerprints)
+
+
+def _integrity_check(connection: sqlite3.Connection, label: str) -> None:
+    rows = connection.execute("PRAGMA integrity_check").fetchall()
+    if rows != [("ok",)]:
+        msg = f"{label} failed PRAGMA integrity_check: {rows!r}"
+        raise NormalizationError(msg)
+
+
+def _restore_command(backup_path: Path, database_path: Path) -> str:
+    code = (
+        "import os, shutil, sys, tempfile\n"
+        "source, destination = sys.argv[1], sys.argv[2]\n"
+        "directory = os.path.dirname(destination) or '.'\n"
+        "def fsync_directory():\n"
+        "    descriptor = os.open(directory, os.O_RDONLY | getattr(os, 'O_DIRECTORY', 0))\n"
+        "    try:\n"
+        "        os.fsync(descriptor)\n"
+        "    finally:\n"
+        "        os.close(descriptor)\n"
+        "temporary = None\n"
+        "quarantined = []\n"
+        "main_replaced = False\n"
+        "try:\n"
+        "    descriptor, temporary = tempfile.mkstemp(prefix='.' + os.path.basename(destination) + '.restore-', dir=directory)\n"
+        "    os.close(descriptor)\n"
+        "    shutil.copy2(source, temporary)\n"
+        "    with open(temporary, 'rb') as staged:\n"
+        "        os.fsync(staged.fileno())\n"
+        "    for suffix in ('-wal', '-shm'):\n"
+        "        sidecar = destination + suffix\n"
+        "        quarantine = temporary + '.quarantine-' + suffix[1:]\n"
+        "        try:\n"
+        "            os.replace(sidecar, quarantine)\n"
+        "        except FileNotFoundError:\n"
+        "            pass\n"
+        "        else:\n"
+        "            quarantined.append((sidecar, quarantine))\n"
+        "    fsync_directory()\n"
+        "    os.replace(temporary, destination)\n"
+        "    temporary = None\n"
+        "    main_replaced = True\n"
+        "    fsync_directory()\n"
+        "    for sidecar, quarantine in quarantined:\n"
+        "        os.unlink(quarantine)\n"
+        "    quarantined.clear()\n"
+        "    fsync_directory()\n"
+        "except Exception as error:\n"
+        "    rollback_errors = []\n"
+        "    if not main_replaced:\n"
+        "        for sidecar, quarantine in reversed(quarantined):\n"
+        "            if os.path.exists(quarantine):\n"
+        "                try:\n"
+        "                    os.replace(quarantine, sidecar)\n"
+        "                except Exception as rollback_error:\n"
+        "                    rollback_errors.append((quarantine, rollback_error))\n"
+        "        try:\n"
+        "            fsync_directory()\n"
+        "        except Exception as rollback_error:\n"
+        "            rollback_errors.append((directory, rollback_error))\n"
+        "    if rollback_errors:\n"
+        "        retained = [path for path, rollback_error in rollback_errors if os.path.exists(path)]\n"
+        "        raise RuntimeError('restore failed and quarantine rollback was incomplete; retained quarantine paths: ' + repr(retained)) from error\n"
+        "    raise\n"
+        "finally:\n"
+        "    if temporary is not None:\n"
+        "        try:\n"
+        "            os.unlink(temporary)\n"
+        "        except FileNotFoundError:\n"
+        "            pass\n"
+    )
+    return shlex.join([sys.executable, "-c", code, str(backup_path), str(database_path)])
+
+
+def _backup_database(
+    connection: sqlite3.Connection,
+    database_path: Path,
+    quoted_table: str,
+    source_summary: _ScanSummary,
+) -> tuple[Path, str]:
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S.%fZ")
+    backup_path = database_path.with_name(f"{database_path.name}.backup-{timestamp}")
+    with sqlite3.connect(backup_path) as backup:
+        connection.backup(backup)
+        _integrity_check(backup, "backup")
+        backup_fingerprints = _raw_fingerprints(backup, quoted_table)
+    source_fingerprints = tuple((row.session_id, row.raw_sha256) for row in source_summary.rows)
+    if backup_fingerprints != source_fingerprints:
+        msg = "backup content does not exactly match the source pre-image"
+        raise NormalizationError(msg, backup_path=backup_path)
+    return backup_path, _restore_command(backup_path, database_path)
+
+
+def _apply_rows(connection: sqlite3.Connection, quoted_table: str, source_summary: _ScanSummary) -> None:
+    connection.execute("BEGIN IMMEDIATE")
+    source_fingerprints = tuple((row.session_id, row.raw_sha256) for row in source_summary.rows)
+    if _raw_fingerprints(connection, quoted_table) != source_fingerprints:
+        msg = "database changed between backup and write transaction"
+        raise NormalizationError(msg)
+
+    select_sql = f"SELECT runs FROM {quoted_table} WHERE session_id = ?"  # noqa: S608 -- identifier validated
+    update_sql = f"UPDATE {quoted_table} SET runs = ? WHERE session_id = ?"  # noqa: S608 -- identifier validated
+    for expected in source_summary.rows:
+        selected = connection.execute(select_sql, (expected.session_id,)).fetchone()
+        if selected is None:
+            msg = f"session disappeared during write transaction: {expected.session_id!r}"
+            raise NormalizationError(msg)
+        before_digest = hashlib.sha256()
+        after_digest = hashlib.sha256()
+        analysis = _analyze_row(expected.session_id, selected[0], before_digest, after_digest)
+        if analysis.summary != expected:
+            msg = f"session changed after preflight scan: {expected.session_id!r}"
+            raise NormalizationError(msg)
+        if expected.changed:
+            cursor = connection.execute(
+                update_sql,
+                (_encode_runs(analysis.runs_after), expected.session_id),
+            )
+            if cursor.rowcount != 1:
+                msg = f"expected one updated row for session {expected.session_id!r}, got {cursor.rowcount}"
+                raise NormalizationError(msg)
+        del analysis
+    connection.commit()
+
+
+def _verify_post_image(source: _ScanSummary, actual: _ScanSummary) -> None:
+    expected_rows = tuple((row.session_id, row.expected_json_sha256) for row in source.rows)
+    actual_rows = tuple((row.session_id, row.current_json_sha256) for row in actual.rows)
+    if actual_rows != expected_rows:
+        msg = "post-commit rows do not match their exact expected post-images"
+        raise NormalizationError(msg)
+    if actual.changed_rows != 0:
+        msg = "post-commit database still contains coalescible reasoning details"
+        raise NormalizationError(msg)
+    if actual.runs != source.runs:
+        msg = "persisted run count does not match the pre-image"
+        raise NormalizationError(msg)
+    if actual.reasoning_details_before != source.reasoning_details_after:
+        msg = "persisted reasoning-details count does not match the expected post-image"
+        raise NormalizationError(msg)
+    if actual.reasoning_text_sha256_before != source.reasoning_text_sha256_after:
+        msg = "persisted reasoning text does not match the pre-image"
+        raise NormalizationError(msg)
+
+
+def _result(
+    summary: _ScanSummary,
+    *,
+    apply: bool,
+    backup_path: Path | None,
+    restore_command: str | None,
+) -> dict[str, object]:
+    return {
+        "mode": "apply" if apply else "dry-run",
+        "rows": len(summary.rows),
+        "changed_rows": summary.changed_rows,
+        "runs": summary.runs,
+        "reasoning_details_before": summary.reasoning_details_before,
+        "reasoning_details_after": summary.reasoning_details_after,
+        "reasoning_text_sha256_before": summary.reasoning_text_sha256_before,
+        "reasoning_text_sha256_after": summary.reasoning_text_sha256_after,
+        "integrity_check": "ok",
+        "backup_path": str(backup_path) if backup_path is not None else None,
+        "restore_command": restore_command,
+    }
+
+
+def normalize_database(
+    database_path: Path,
+    *,
+    table: str,
+    apply: bool,
+) -> dict[str, object]:
+    """Plan or apply recursive reasoning-details normalization to one database."""
+    database_path = Path(database_path).resolve()
+    if not database_path.is_file():
+        msg = f"database does not exist or is not a regular file: {database_path}"
+        raise ValueError(msg)
+
+    backup_path: Path | None = None
+    restore_command: str | None = None
+    connection = sqlite3.connect(database_path)
+    try:
+        quoted_table = _validate_schema(connection, table)
+        _integrity_check(connection, "source")
+        if not apply:
+            summary = _scan_database(connection, quoted_table)
+            return _result(
+                summary,
+                apply=False,
+                backup_path=None,
+                restore_command=None,
+            )
+
+        checkpoint = connection.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+        if checkpoint is None or checkpoint[0] != 0:
+            msg = f"WAL checkpoint could not complete: {checkpoint!r}"
+            raise NormalizationError(msg)  # noqa: TRY301 -- caught to attach recovery metadata
+        _integrity_check(connection, "source after WAL checkpoint")
+        source_summary = _scan_database(connection, quoted_table)
+        backup_path, restore_command = _backup_database(
+            connection,
+            database_path,
+            quoted_table,
+            source_summary,
+        )
+
+        _apply_rows(connection, quoted_table, source_summary)
+
+        _integrity_check(connection, "normalized source")
+        actual_summary = _scan_database(connection, quoted_table)
+        _verify_post_image(source_summary, actual_summary)
+        return _result(
+            source_summary,
+            apply=True,
+            backup_path=backup_path,
+            restore_command=restore_command,
+        )
+    except Exception as error:
+        if connection.in_transaction:
+            connection.rollback()
+        if isinstance(error, ValueError):
+            raise
+        if isinstance(error, NormalizationError):
+            if error.backup_path is None:
+                error.backup_path = backup_path
+            if error.restore_command is None:
+                error.restore_command = restore_command
+            raise
+        raise NormalizationError(
+            str(error),
+            backup_path=backup_path,
+            restore_command=restore_command,
+        ) from error
+    finally:
+        connection.close()
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("database", type=Path, help="SQLite sessions database")
+    parser.add_argument("--table", required=True, help="session table containing session_id and runs")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--dry-run", action="store_true", help="inspect without changing database bytes")
+    mode.add_argument("--apply", action="store_true", help="back up and apply normalization")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the command-line normalizer."""
+    args = _parse_args(argv)
+    try:
+        result = normalize_database(args.database, table=args.table, apply=args.apply)
+    except (NormalizationError, ValueError) as error:
+        payload: dict[str, object] = {"error": str(error)}
+        if isinstance(error, NormalizationError):
+            payload["backup_path"] = str(error.backup_path) if error.backup_path is not None else None
+            payload["restore_command"] = error.restore_command
+        print(json.dumps(payload, sort_keys=True), file=sys.stderr)
+        return 1
+    print(json.dumps(result, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from dataclasses import dataclass, replace
+from typing import TYPE_CHECKING, Any, cast
 
 from agno.models.deepseek import DeepSeek
 from agno.models.llama_cpp import LlamaCpp
@@ -20,11 +20,100 @@ from mindroom.openai_tool_search import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from agno.models.base import MessageData
     from agno.models.message import Message
     from agno.models.response import ModelResponse
     from agno.tools.function import Function
     from openai.types.responses import Response, ResponseStreamEvent
     from pydantic import BaseModel
+
+
+def _openrouter_detail_values_match(left: object, right: object) -> bool:
+    """Compare JSON-like metadata without equating booleans and numbers."""
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict) and isinstance(right, dict):
+        left_dict = cast("dict[object, object]", left)
+        right_dict = cast("dict[object, object]", right)
+        return left_dict.keys() == right_dict.keys() and all(
+            _openrouter_detail_values_match(left_dict[key], right_dict[key]) for key in left_dict
+        )
+    if isinstance(left, list) and isinstance(right, list):
+        return len(left) == len(right) and all(
+            _openrouter_detail_values_match(left_item, right_item)
+            for left_item, right_item in zip(left, right, strict=True)
+        )
+    return left == right
+
+
+def _openrouter_reasoning_text_detail_parts(detail: object) -> tuple[dict[str, object], str] | None:
+    """Return exact metadata and text for a fragment that can be grouped."""
+    if not isinstance(detail, dict) or not all(isinstance(key, str) for key in detail):
+        return None
+    detail_dict = cast("dict[str, object]", detail)
+    if detail_dict.get("type") != "reasoning.text":
+        return None
+    text = detail_dict.get("text")
+    if not isinstance(text, str):
+        return None
+
+    index = detail_dict.get("index")
+    detail_id = detail_dict.get("id")
+    has_stable_discriminator = type(index) in (int, float) or (isinstance(detail_id, str) and bool(detail_id))
+    if not has_stable_discriminator:
+        return None
+
+    return ({key: value for key, value in detail_dict.items() if key != "text"}, text)
+
+
+@dataclass
+class _OpenRouterReasoningTextBlock:
+    """One metadata template plus linearly accumulated adjacent text chunks."""
+
+    metadata: dict[str, object]
+    text_chunks: list[str]
+
+
+def _append_openrouter_reasoning_detail_block(blocks: list[object], detail: object) -> None:
+    """Append one detail to compact streaming blocks without concatenating text."""
+    detail_parts = _openrouter_reasoning_text_detail_parts(detail)
+    if detail_parts is None:
+        blocks.append(detail)
+        return
+
+    metadata, text = detail_parts
+    if blocks and isinstance(blocks[-1], _OpenRouterReasoningTextBlock):
+        previous_block = blocks[-1]
+        if _openrouter_detail_values_match(previous_block.metadata, metadata):
+            previous_block.text_chunks.append(text)
+            return
+    blocks.append(_OpenRouterReasoningTextBlock(metadata=metadata, text_chunks=[text]))
+
+
+def _materialized_openrouter_reasoning_detail_blocks(blocks: list[object]) -> list[object]:
+    """Convert private streaming blocks into persistable provider dictionaries."""
+    return [
+        {**block.metadata, "text": "".join(block.text_chunks)}
+        if isinstance(block, _OpenRouterReasoningTextBlock)
+        else block
+        for block in blocks
+    ]
+
+
+def _coalesced_openrouter_reasoning_details(details: object) -> object:
+    """Join only adjacent, unambiguously matching OpenRouter text fragments."""
+    if not isinstance(details, list):
+        return details
+
+    blocks: list[object] = []
+    for detail in details:
+        _append_openrouter_reasoning_detail_block(blocks, detail)
+    return _materialized_openrouter_reasoning_detail_blocks(blocks)
+
+
+_OPENROUTER_REASONING_DETAILS_BUFFER = "_mindroom_openrouter_reasoning_details_buffer"
 
 
 # Agno 2.6.12 omits arguments for empty Anthropic tool inputs; agno-agi/agno#8970 proposes the source fix.
@@ -107,6 +196,74 @@ class MindRoomOpenAILike(ChatToolArgumentsCompat, OpenAILike):
 @dataclass
 class MindRoomOpenRouter(ChatToolArgumentsCompat, OpenRouter):
     """OpenRouter model that can replay tool calls from other providers."""
+
+    def _populate_stream_data(
+        self,
+        stream_data: MessageData,
+        model_response_delta: ModelResponse,
+    ) -> Iterator[ModelResponse]:
+        """Accumulate reasoning details without retaining each text token separately."""
+        provider_data = model_response_delta.provider_data
+        if (
+            provider_data
+            and "reasoning_details" in provider_data
+            and not isinstance(provider_data["reasoning_details"], list)
+            and hasattr(stream_data, _OPENROUTER_REASONING_DETAILS_BUFFER)
+        ):
+            delattr(stream_data, _OPENROUTER_REASONING_DETAILS_BUFFER)
+        if provider_data and isinstance(provider_data.get("reasoning_details"), list):
+            buffered_details = getattr(stream_data, _OPENROUTER_REASONING_DETAILS_BUFFER, None)
+            if not isinstance(buffered_details, list):
+                buffered_details = []
+                if stream_data.response_provider_data is not None:
+                    existing_details = stream_data.response_provider_data.pop("reasoning_details", None)
+                    if isinstance(existing_details, list):
+                        for detail in existing_details:
+                            _append_openrouter_reasoning_detail_block(buffered_details, detail)
+                setattr(stream_data, _OPENROUTER_REASONING_DETAILS_BUFFER, buffered_details)
+            for detail in provider_data["reasoning_details"]:
+                _append_openrouter_reasoning_detail_block(buffered_details, detail)
+
+            remaining_provider_data = {key: value for key, value in provider_data.items() if key != "reasoning_details"}
+            sanitized_delta = replace(model_response_delta, provider_data=remaining_provider_data)
+
+            for _ in super()._populate_stream_data(stream_data, sanitized_delta):
+                yield model_response_delta
+            return
+
+        yield from super()._populate_stream_data(stream_data, model_response_delta)
+
+    def _populate_assistant_message_from_stream_data(
+        self,
+        assistant_message: Message,
+        stream_data: MessageData,
+    ) -> None:
+        """Materialize buffered reasoning fragments once before persistence."""
+        buffered_details = getattr(stream_data, _OPENROUTER_REASONING_DETAILS_BUFFER, None)
+        if isinstance(buffered_details, list):
+            if stream_data.response_provider_data is None:
+                stream_data.response_provider_data = {}
+            stream_data.response_provider_data["reasoning_details"] = _materialized_openrouter_reasoning_detail_blocks(
+                buffered_details,
+            )
+            delattr(stream_data, _OPENROUTER_REASONING_DETAILS_BUFFER)
+        super()._populate_assistant_message_from_stream_data(assistant_message, stream_data)
+
+    def _format_message(self, message: Message, compress_tool_results: bool = False) -> dict[str, Any]:
+        """Compact persisted reasoning details on replay without mutating history."""
+        if message.role == "assistant" and message.provider_data:
+            details = message.provider_data.get("reasoning_details")
+            normalized_details = _coalesced_openrouter_reasoning_details(details)
+            if normalized_details != details:
+                message = message.model_copy(
+                    update={
+                        "provider_data": {
+                            **message.provider_data,
+                            "reasoning_details": normalized_details,
+                        },
+                    },
+                )
+        return super()._format_message(message, compress_tool_results)
 
 
 @dataclass

--- a/tests/test_normalize_openrouter_reasoning_details.py
+++ b/tests/test_normalize_openrouter_reasoning_details.py
@@ -1,0 +1,492 @@
+"""Tests for the one-shot OpenRouter reasoning-details database normalizer."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shlex
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import scripts.normalize_openrouter_reasoning_details as normalizer
+from scripts.normalize_openrouter_reasoning_details import normalize_database
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "normalize_openrouter_reasoning_details.py"
+
+
+def _polluted_runs() -> list[dict[str, Any]]:
+    return [
+        {
+            "run_id": "run-1",
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "answer",
+                    "provider_data": {
+                        "reasoning_details": [
+                            {"type": "reasoning.text", "index": 0, "text": "one "},
+                            {"type": "reasoning.text", "index": 0, "text": "two"},
+                            {
+                                "type": "reasoning.text",
+                                "index": 0,
+                                "text": " signed",
+                                "signature": "sig",
+                            },
+                            {"type": "reasoning.text", "index": 0, "text": " tail"},
+                        ],
+                        "kept": {"nested": True},
+                    },
+                },
+                {"role": "user", "content": "unchanged"},
+            ],
+            "model_provider_data": {
+                "reasoning_details": [
+                    {"type": "reasoning.text", "id": "reasoning-1", "text": "model "},
+                    {"type": "reasoning.text", "id": "reasoning-1", "text": "data"},
+                ],
+                "other": [1, 2, 3],
+            },
+            "events": [
+                {
+                    "payload": {
+                        "reasoning_details": [
+                            {"type": "reasoning.text", "index": 4, "text": "event "},
+                            {"type": "reasoning.text", "index": 4, "text": "details"},
+                        ],
+                    },
+                },
+            ],
+        },
+        {
+            "run_id": "run-2",
+            "reasoning_details": "malformed-is-untouched",
+            "events": [
+                {
+                    "reasoning_details": [
+                        {"type": "reasoning.text", "index": 9, "text": 42},
+                        {"type": "reasoning.text", "index": 9, "text": "not-merged"},
+                        {"type": "reasoning.summary", "text": "kept"},
+                    ],
+                },
+            ],
+        },
+    ]
+
+
+def _expected_runs() -> list[dict[str, Any]]:
+    expected = _polluted_runs()
+    expected[0]["messages"][0]["provider_data"]["reasoning_details"] = [
+        {"type": "reasoning.text", "index": 0, "text": "one two"},
+        {
+            "type": "reasoning.text",
+            "index": 0,
+            "text": " signed",
+            "signature": "sig",
+        },
+        {"type": "reasoning.text", "index": 0, "text": " tail"},
+    ]
+    expected[0]["model_provider_data"]["reasoning_details"] = [
+        {"type": "reasoning.text", "id": "reasoning-1", "text": "model data"},
+    ]
+    expected[0]["events"][0]["payload"]["reasoning_details"] = [
+        {"type": "reasoning.text", "index": 4, "text": "event details"},
+    ]
+    return expected
+
+
+def _encode_runs(runs: list[dict[str, Any]]) -> str:
+    """Match Mom's JSON column containing a JSON-encoded runs string."""
+    return json.dumps(json.dumps(runs, separators=(",", ":")))
+
+
+def _decode_runs(value: str) -> list[dict[str, Any]]:
+    encoded_runs = json.loads(value)
+    assert isinstance(encoded_runs, str)
+    runs = json.loads(encoded_runs)
+    assert isinstance(runs, list)
+    return runs
+
+
+@pytest.fixture
+def sessions_db(tmp_path: Path) -> tuple[Path, dict[str, list[dict[str, Any]]]]:
+    """Create the same double-encoded runs storage shape used by Mom."""
+    db_path = tmp_path / "mind.db"
+    source_rows = {
+        "session-a": _polluted_runs(),
+        "session-b": [
+            {
+                "run_id": "run-3",
+                "messages": [
+                    {
+                        "role": "assistant",
+                        "provider_data": {
+                            "reasoning_details": [
+                                {"type": "reasoning.text", "index": 2, "text": "already single"},
+                            ],
+                        },
+                    },
+                ],
+                "unrelated": {"value": None},
+            },
+        ],
+    }
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("CREATE TABLE mind_sessions (session_id TEXT PRIMARY KEY, runs JSON NOT NULL)")
+        connection.executemany(
+            "INSERT INTO mind_sessions(session_id, runs) VALUES (?, ?)",
+            [(session_id, _encode_runs(runs)) for session_id, runs in source_rows.items()],
+        )
+    return db_path, source_rows
+
+
+def _rows(db_path: Path) -> dict[str, list[dict[str, Any]]]:
+    with sqlite3.connect(db_path) as connection:
+        return {
+            session_id: _decode_runs(runs)
+            for session_id, runs in connection.execute(
+                "SELECT session_id, runs FROM mind_sessions ORDER BY session_id",
+            )
+        }
+
+
+def _run_cli(db_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), str(db_path), "--table", "mind_sessions", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _result(stdout: str) -> dict[str, Any]:
+    return json.loads(stdout.strip().splitlines()[-1])
+
+
+def test_dry_run_is_byte_identical_and_reports_recursive_changes(
+    sessions_db: tuple[Path, dict[str, list[dict[str, Any]]]],
+) -> None:
+    """Dry-run reports every nested location without touching database bytes."""
+    db_path, source_rows = sessions_db
+    before = hashlib.sha256(db_path.read_bytes()).digest()
+
+    completed = _run_cli(db_path, "--dry-run")
+
+    assert completed.returncode == 0, completed.stderr
+    assert hashlib.sha256(db_path.read_bytes()).digest() == before
+    assert _rows(db_path) == source_rows
+    result = _result(completed.stdout)
+    assert result["mode"] == "dry-run"
+    assert result["rows"] == 2
+    assert result["changed_rows"] == 1
+    assert result["reasoning_details_before"] == 12
+    assert result["reasoning_details_after"] == 9
+    assert result["backup_path"] is None
+
+
+def test_apply_writes_exact_post_images_and_preserves_invariants(
+    sessions_db: tuple[Path, dict[str, list[dict[str, Any]]]],
+) -> None:
+    """Apply writes only the hand-authored expected recursive normalization."""
+    db_path, source_rows = sessions_db
+
+    completed = _run_cli(db_path, "--apply")
+
+    assert completed.returncode == 0, completed.stderr
+    assert _rows(db_path) == {
+        "session-a": _expected_runs(),
+        "session-b": source_rows["session-b"],
+    }
+    result = _result(completed.stdout)
+    assert result["mode"] == "apply"
+    assert result["changed_rows"] == 1
+    assert result["runs"] == 3
+    assert result["reasoning_text_sha256_before"] == result["reasoning_text_sha256_after"]
+    assert result["integrity_check"] == "ok"
+
+
+def test_apply_backup_is_valid_and_emitted_restore_command_restores_preimage(
+    sessions_db: tuple[Path, dict[str, list[dict[str, Any]]]],
+) -> None:
+    """The SQLite backup and emitted command restore the exact logical pre-image."""
+    db_path, source_rows = sessions_db
+    completed = _run_cli(db_path, "--apply")
+    assert completed.returncode == 0, completed.stderr
+    result = _result(completed.stdout)
+    backup_path = Path(result["backup_path"])
+
+    assert backup_path.exists()
+    with sqlite3.connect(backup_path) as backup:
+        assert backup.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+    assert _rows(backup_path) == source_rows
+    assert shlex.split(result["restore_command"])[0:2] == [sys.executable, "-c"]
+    stale_sidecars = [Path(f"{db_path}-wal"), Path(f"{db_path}-shm")]
+    for sidecar in stale_sidecars:
+        sidecar.write_bytes(b"stale")
+
+    restored = subprocess.run(
+        shlex.split(result["restore_command"]),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert restored.returncode == 0, restored.stderr
+    assert _rows(db_path) == source_rows
+    assert not any(sidecar.exists() for sidecar in stale_sidecars)
+    assert list(db_path.parent.glob(".mind.db.restore-*")) == []
+
+
+def test_post_commit_error_carries_verified_recovery_and_restores_preimage(
+    sessions_db: tuple[Path, dict[str, list[dict[str, Any]]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A verification error after commit names the backup and exact recovery command."""
+    db_path, source_rows = sessions_db
+    real_integrity_check = normalizer._integrity_check
+    checks = 0
+
+    def fail_post_commit_check(connection: sqlite3.Connection, label: str) -> None:
+        nonlocal checks
+        checks += 1
+        real_integrity_check(connection, label)
+        if checks == 4:
+            msg = "injected post-commit verification failure"
+            raise normalizer.NormalizationError(msg)
+
+    monkeypatch.setattr(normalizer, "_integrity_check", fail_post_commit_check)
+
+    with pytest.raises(normalizer.NormalizationError, match="injected") as caught:
+        normalize_database(db_path, table="mind_sessions", apply=True)
+
+    assert caught.value.backup_path is not None
+    assert caught.value.restore_command is not None
+    assert caught.value.backup_path.exists()
+    restored = subprocess.run(
+        shlex.split(caught.value.restore_command),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert restored.returncode == 0, restored.stderr
+    assert _rows(db_path) == source_rows
+
+
+def test_restore_staging_failure_keeps_live_database_intact(tmp_path: Path) -> None:
+    """A failed staging copy must not unlink or replace the live database."""
+    database_path = tmp_path / "mind.db"
+    original = b"live database bytes"
+    database_path.write_bytes(original)
+    missing_backup = tmp_path / "missing-backup.db"
+    restore_command = normalizer._restore_command(missing_backup, database_path)
+
+    restored = subprocess.run(
+        shlex.split(restore_command),
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert restored.returncode != 0
+    assert database_path.read_bytes() == original
+    assert list(tmp_path.glob(".mind.db.restore-*")) == []
+
+
+def test_restore_replace_failure_keeps_main_and_sidecars_intact(tmp_path: Path) -> None:
+    """A failed atomic replace must leave the live main DB and sidecars untouched."""
+    database_path = tmp_path / "mind.db"
+    backup_path = tmp_path / "backup.db"
+    original_files = {
+        database_path: b"live database bytes",
+        Path(f"{database_path}-wal"): b"live wal bytes",
+        Path(f"{database_path}-shm"): b"live shm bytes",
+    }
+    for path, contents in original_files.items():
+        path.write_bytes(contents)
+    backup_path.write_bytes(b"verified backup bytes")
+    command = shlex.split(normalizer._restore_command(backup_path, database_path))
+    replace_line = "    os.replace(temporary, destination)\n"
+    assert replace_line in command[2]
+    command[2] = command[2].replace(
+        replace_line,
+        "    real_replace = os.replace\n"
+        "    os.replace = lambda candidate, target: (_ for _ in ()).throw(OSError('injected replace failure')) "
+        "if candidate == temporary and target == destination else real_replace(candidate, target)\n"
+        "    os.replace(temporary, destination)\n",
+    )
+
+    restored = subprocess.run(command, check=False, capture_output=True, text=True)
+
+    assert restored.returncode != 0
+    assert {path: path.read_bytes() for path in original_files} == original_files
+    assert list(tmp_path.glob(".mind.db.restore-*")) == []
+
+
+def test_restore_main_replace_window_has_no_recognized_sqlite_sidecars(tmp_path: Path) -> None:
+    """After main replacement, old WAL/SHM must exist only under quarantine names."""
+    database_path = tmp_path / "mind.db"
+    backup_path = tmp_path / "backup.db"
+    database_path.write_bytes(b"old main")
+    backup_path.write_bytes(b"new main")
+    wal_path = Path(f"{database_path}-wal")
+    shm_path = Path(f"{database_path}-shm")
+    wal_path.write_bytes(b"valid old wal")
+    shm_path.write_bytes(b"valid old shm")
+    command = shlex.split(normalizer._restore_command(backup_path, database_path))
+    replace_line = "    os.replace(temporary, destination)\n"
+    assert replace_line in command[2]
+    command[2] = command[2].replace(
+        replace_line,
+        replace_line
+        + "    assert not os.path.exists(destination + '-wal')\n"
+        + "    assert not os.path.exists(destination + '-shm')\n"
+        + "    raise SystemExit(75)\n",
+    )
+
+    interrupted = subprocess.run(command, check=False, capture_output=True, text=True)
+
+    assert interrupted.returncode == 75, interrupted.stderr
+    assert database_path.read_bytes() == b"new main"
+    assert not wal_path.exists()
+    assert not shm_path.exists()
+    quarantines = list(tmp_path.glob(".mind.db.restore-*.quarantine-*"))
+    assert sorted(path.read_bytes() for path in quarantines) == [b"valid old shm", b"valid old wal"]
+
+
+def test_restore_rollback_failure_retains_unrecognized_quarantine(tmp_path: Path) -> None:
+    """Failed sidecar rollback retains recoverable bytes under an unrecognized name."""
+    database_path = tmp_path / "mind.db"
+    backup_path = tmp_path / "backup.db"
+    database_path.write_bytes(b"old main")
+    backup_path.write_bytes(b"new main")
+    wal_path = Path(f"{database_path}-wal")
+    shm_path = Path(f"{database_path}-shm")
+    wal_path.write_bytes(b"old wal")
+    shm_path.write_bytes(b"old shm")
+    command = shlex.split(normalizer._restore_command(backup_path, database_path))
+    replace_line = "    os.replace(temporary, destination)\n"
+    assert replace_line in command[2]
+    injection = (
+        "    real_replace = os.replace\n"
+        "    def injected_replace(candidate, target):\n"
+        "        if candidate == temporary and target == destination:\n"
+        "            raise OSError('injected main replace failure')\n"
+        "        if candidate.endswith('.quarantine-wal'):\n"
+        "            raise OSError('injected WAL rollback failure')\n"
+        "        return real_replace(candidate, target)\n"
+        "    os.replace = injected_replace\n" + replace_line
+    )
+    command[2] = command[2].replace(replace_line, injection)
+
+    failed = subprocess.run(command, check=False, capture_output=True, text=True)
+
+    assert failed.returncode != 0
+    assert "retained quarantine paths" in failed.stderr
+    assert database_path.read_bytes() == b"old main"
+    assert not wal_path.exists()
+    assert shm_path.read_bytes() == b"old shm"
+    quarantines = list(tmp_path.glob(".mind.db.restore-*.quarantine-wal"))
+    assert len(quarantines) == 1
+    assert quarantines[0].read_bytes() == b"old wal"
+
+
+def test_session_rows_are_streamed_without_fetchall(  # noqa: C901 -- proxy deliberately models cursor protocol
+    sessions_db: tuple[Path, dict[str, list[dict[str, Any]]]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Large runs rows must be consumed incrementally instead of eagerly materialized."""
+    db_path, _ = sessions_db
+    real_connect = sqlite3.connect
+
+    class CursorProxy:
+        def __init__(self, cursor: sqlite3.Cursor, *, session_rows: bool) -> None:
+            self._cursor = cursor
+            self._session_rows = session_rows
+
+        def fetchall(self) -> list[tuple[object, ...]]:
+            if self._session_rows:
+                msg = "session rows must not use fetchall"
+                raise AssertionError(msg)
+            return self._cursor.fetchall()
+
+        def fetchone(self) -> tuple[object, ...] | None:
+            return self._cursor.fetchone()
+
+        def __iter__(self) -> CursorProxy:
+            return self
+
+        def __next__(self) -> tuple[object, ...]:
+            row = self._cursor.fetchone()
+            if row is None:
+                raise StopIteration
+            return row
+
+    class ConnectionProxy:
+        def __init__(self, connection: sqlite3.Connection) -> None:
+            self._connection = connection
+
+        def execute(self, sql: str, parameters: tuple[object, ...] = ()) -> CursorProxy:
+            cursor = self._connection.execute(sql, parameters)
+            normalized_sql = " ".join(sql.lower().split())
+            return CursorProxy(
+                cursor,
+                session_rows=normalized_sql.startswith("select session_id, runs from"),
+            )
+
+        @property
+        def in_transaction(self) -> bool:
+            return self._connection.in_transaction
+
+        def close(self) -> None:
+            self._connection.close()
+
+    def streaming_connect(database: str | Path) -> ConnectionProxy:
+        return ConnectionProxy(real_connect(database))
+
+    monkeypatch.setattr(normalizer.sqlite3, "connect", streaming_connect)
+
+    result = normalize_database(db_path, table="mind_sessions", apply=False)
+
+    assert result["rows"] == 2
+    assert result["changed_rows"] == 1
+
+
+@pytest.mark.parametrize(
+    "table",
+    ["mind_sessions; DROP TABLE mind_sessions", "mind-sessions", "main.mind_sessions", ""],
+)
+def test_rejects_unsafe_table_identifiers(sessions_db: tuple[Path, object], table: str) -> None:
+    """Dynamic table names are restricted to a single safe identifier."""
+    db_path, _ = sessions_db
+
+    with pytest.raises(ValueError, match="safe SQLite identifier"):
+        normalize_database(db_path, table=table, apply=False)
+
+
+def test_rejects_schema_without_exact_required_columns(tmp_path: Path) -> None:
+    """The target table must expose the two production columns."""
+    db_path = tmp_path / "wrong.db"
+    with sqlite3.connect(db_path) as connection:
+        connection.execute("CREATE TABLE mind_sessions (session_id TEXT PRIMARY KEY, payload JSON)")
+
+    with pytest.raises(ValueError, match="required columns"):
+        normalize_database(db_path, table="mind_sessions", apply=False)
+
+
+def test_cli_requires_exactly_one_mode(sessions_db: tuple[Path, object]) -> None:
+    """CLI callers must explicitly choose inspection or mutation."""
+    db_path, _ = sessions_db
+    neither = subprocess.run(
+        [sys.executable, str(SCRIPT), str(db_path), "--table", "mind_sessions"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    both = _run_cli(db_path, "--dry-run", "--apply")
+
+    assert neither.returncode == 2
+    assert both.returncode == 2

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -2,24 +2,31 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
+from typing import LiteralString
+
 import pytest
 from agno.models.azure.openai_chat import AzureOpenAI
+from agno.models.base import MessageData
 from agno.models.deepseek import DeepSeek
 from agno.models.llama_cpp import LlamaCpp
 from agno.models.message import Message
 from agno.models.openai import OpenAIChat
 from agno.models.openai.like import OpenAILike
 from agno.models.openrouter import OpenRouter
+from agno.models.response import ModelResponse
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall, ChoiceDeltaToolCallFunction
 
 from mindroom.azure_openai_model import MindRoomAzureOpenAI
 from mindroom.openai_models import (
+    _OPENROUTER_REASONING_DETAILS_BUFFER,
     MindRoomDeepSeek,
     MindRoomLlamaCpp,
     MindRoomOpenAIChat,
     MindRoomOpenAILike,
     MindRoomOpenAIResponses,
     MindRoomOpenRouter,
+    _coalesced_openrouter_reasoning_details,
 )
 
 _CHAT_WIRE_PAIRS = [
@@ -30,6 +37,264 @@ _CHAT_WIRE_PAIRS = [
     (MindRoomDeepSeek, DeepSeek),
     (MindRoomLlamaCpp, LlamaCpp),
 ]
+
+
+@pytest.mark.parametrize(
+    ("details", "expected"),
+    [
+        (
+            [
+                {"type": "reasoning.text", "text": "first", "index": 0},
+                {"type": "reasoning.text", "text": " second", "index": 0},
+            ],
+            [{"type": "reasoning.text", "text": "first second", "index": 0}],
+        ),
+        (
+            [
+                {"type": "reasoning.text", "text": "first", "id": "reasoning-1"},
+                {"type": "reasoning.text", "text": " second", "id": "reasoning-1"},
+            ],
+            [{"type": "reasoning.text", "text": "first second", "id": "reasoning-1"}],
+        ),
+        (
+            [
+                {"type": "reasoning.text", "text": "a", "index": 0},
+                {"type": "reasoning.text", "text": "b", "index": 1},
+                {"type": "reasoning.text", "text": "c", "index": 0},
+            ],
+            [
+                {"type": "reasoning.text", "text": "a", "index": 0},
+                {"type": "reasoning.text", "text": "b", "index": 1},
+                {"type": "reasoning.text", "text": "c", "index": 0},
+            ],
+        ),
+        (
+            [
+                {"type": "reasoning.text", "text": "a", "index": 0, "id": "one"},
+                {"type": "reasoning.text", "text": "b", "index": 0, "id": "two"},
+                {"type": "reasoning.text", "text": "c", "index": 0, "signature": "one"},
+                {"type": "reasoning.text", "text": "d", "index": 0, "signature": "two"},
+                {"type": "reasoning.text", "text": "e", "index": 0},
+                {"type": "reasoning.text", "text": "f", "index": 0, "id": None},
+            ],
+            [
+                {"type": "reasoning.text", "text": "a", "index": 0, "id": "one"},
+                {"type": "reasoning.text", "text": "b", "index": 0, "id": "two"},
+                {"type": "reasoning.text", "text": "c", "index": 0, "signature": "one"},
+                {"type": "reasoning.text", "text": "d", "index": 0, "signature": "two"},
+                {"type": "reasoning.text", "text": "e", "index": 0},
+                {"type": "reasoning.text", "text": "f", "index": 0, "id": None},
+            ],
+        ),
+        (
+            [
+                {"type": "reasoning.text", "text": "a"},
+                {"type": "reasoning.text", "text": "b"},
+                {"type": "reasoning.text", "text": "c", "index": True},
+                {"type": "reasoning.text", "text": "d", "index": True},
+                {"type": "reasoning.text", "text": "e", "id": ""},
+                {"type": "reasoning.text", "text": "f", "id": ""},
+            ],
+            [
+                {"type": "reasoning.text", "text": "a"},
+                {"type": "reasoning.text", "text": "b"},
+                {"type": "reasoning.text", "text": "c", "index": True},
+                {"type": "reasoning.text", "text": "d", "index": True},
+                {"type": "reasoning.text", "text": "e", "id": ""},
+                {"type": "reasoning.text", "text": "f", "id": ""},
+            ],
+        ),
+        (
+            [
+                {"type": "reasoning.text", "text": "a", "index": 0},
+                {"type": "reasoning.text", "text": 1, "index": 0},
+                {"type": "reasoning.summary", "text": "summary", "index": 0},
+                "malformed",
+                None,
+            ],
+            [
+                {"type": "reasoning.text", "text": "a", "index": 0},
+                {"type": "reasoning.text", "text": 1, "index": 0},
+                {"type": "reasoning.summary", "text": "summary", "index": 0},
+                "malformed",
+                None,
+            ],
+        ),
+    ],
+)
+def test_openrouter_reasoning_details_coalesce_only_adjacent_compatible_text(
+    details: list[object],
+    expected: list[object],
+) -> None:
+    """Only unambiguously compatible text fragments may be joined."""
+    original = deepcopy(details)
+
+    normalized = _coalesced_openrouter_reasoning_details(details)
+
+    assert normalized == expected
+    assert details == original
+
+
+@pytest.mark.parametrize("details", [None, "details", {"type": "reasoning.text"}, 1])
+def test_openrouter_reasoning_details_leave_non_lists_unchanged(details: object) -> None:
+    """Malformed provider payloads must pass through without interpretation."""
+    assert _coalesced_openrouter_reasoning_details(details) is details
+
+
+def test_openrouter_reasoning_details_stream_coalesces_across_deltas_and_preserves_yields() -> None:
+    """Streaming storage stays compact without changing superclass output behavior."""
+    model = MindRoomOpenRouter(id="test/model", api_key="test-key")
+    stream_data = MessageData()
+    deltas = [
+        ModelResponse(
+            content="first",
+            provider_data={
+                "reasoning_details": [
+                    {"type": "reasoning.text", "text": "a", "index": 0},
+                    {"type": "reasoning.text", "text": "b", "index": 0},
+                    {"type": "reasoning.text", "text": "c", "index": 1},
+                ],
+                "trace": ["one"],
+            },
+        ),
+        ModelResponse(
+            content=" second",
+            provider_data={
+                "reasoning_details": [
+                    {"type": "reasoning.text", "text": "d", "index": 1},
+                    {"type": "reasoning.text", "text": "e", "index": 0},
+                ],
+                "trace": ["two"],
+            },
+        ),
+    ]
+
+    yielded = [item for delta in deltas for item in model._populate_stream_data(stream_data, delta)]
+
+    assert all(yielded_delta is original_delta for yielded_delta, original_delta in zip(yielded, deltas, strict=True))
+    assert [item.content for item in yielded] == ["first", " second"]
+    assert stream_data.response_content == "first second"
+    assistant = Message(role="assistant")
+    model._populate_assistant_message_from_stream_data(assistant, stream_data)
+    assert stream_data.response_provider_data == {
+        "reasoning_details": [
+            {"type": "reasoning.text", "text": "ab", "index": 0},
+            {"type": "reasoning.text", "text": "cd", "index": 1},
+            {"type": "reasoning.text", "text": "e", "index": 0},
+        ],
+        "trace": ["one", "two"],
+    }
+    assert assistant.provider_data == stream_data.response_provider_data
+
+
+def test_openrouter_reasoning_details_stream_joins_fragments_only_when_finalized() -> None:
+    """Streaming must collect text linearly, then persist one ordinary string."""
+
+    class NoConcatenationStr(str):
+        __slots__ = ()
+
+        def __add__(self, other: str, /) -> LiteralString:
+            message = "streaming concatenated reasoning fragments"
+            raise AssertionError(message)
+
+    model = MindRoomOpenRouter(id="test/model", api_key="test-key")
+    stream_data = MessageData()
+    details = [{"type": "reasoning.text", "text": NoConcatenationStr("x"), "index": 0} for _ in range(100)]
+
+    list(
+        model._populate_stream_data(
+            stream_data,
+            ModelResponse(provider_data={"reasoning_details": details}),
+        ),
+    )
+    buffered_blocks = getattr(stream_data, _OPENROUTER_REASONING_DETAILS_BUFFER)
+    assert len(buffered_blocks) == 1
+    assert not any(isinstance(block, dict) for block in buffered_blocks)
+    assistant = Message(role="assistant")
+    model._populate_assistant_message_from_stream_data(assistant, stream_data)
+
+    persisted_details = stream_data.response_provider_data["reasoning_details"]
+    assert persisted_details == [{"type": "reasoning.text", "text": "x" * 100, "index": 0}]
+    assert type(persisted_details[0]["text"]) is str
+    assert assistant.provider_data == stream_data.response_provider_data
+
+
+def test_openrouter_reasoning_details_stream_preserves_later_non_list_value() -> None:
+    """A malformed later provider value must retain Agno's replacement semantics."""
+    model = MindRoomOpenRouter(id="test/model", api_key="test-key")
+    stream_data = MessageData()
+
+    list(
+        model._populate_stream_data(
+            stream_data,
+            ModelResponse(
+                provider_data={
+                    "reasoning_details": [{"type": "reasoning.text", "text": "a", "index": 0}],
+                },
+            ),
+        ),
+    )
+    list(
+        model._populate_stream_data(
+            stream_data,
+            ModelResponse(provider_data={"reasoning_details": None}),
+        ),
+    )
+    model._populate_assistant_message_from_stream_data(Message(role="assistant"), stream_data)
+
+    assert stream_data.response_provider_data == {"reasoning_details": None}
+
+
+def test_openrouter_reasoning_details_stream_list_after_non_list_starts_a_new_sequence() -> None:
+    """A later valid list must replace the malformed value and discarded earlier list."""
+    model = MindRoomOpenRouter(id="test/model", api_key="test-key")
+    stream_data = MessageData()
+    provider_values: list[object] = [
+        [{"type": "reasoning.text", "text": "discarded", "index": 0}],
+        None,
+        [
+            {"type": "reasoning.text", "text": "kept", "index": 0},
+            {"type": "reasoning.text", "text": " together", "index": 0},
+        ],
+    ]
+
+    for provider_value in provider_values:
+        list(
+            model._populate_stream_data(
+                stream_data,
+                ModelResponse(provider_data={"reasoning_details": provider_value}),
+            ),
+        )
+    model._populate_assistant_message_from_stream_data(Message(role="assistant"), stream_data)
+
+    assert stream_data.response_provider_data == {
+        "reasoning_details": [{"type": "reasoning.text", "text": "kept together", "index": 0}],
+    }
+
+
+def test_openrouter_reasoning_details_replay_coalesces_without_mutating_history() -> None:
+    """Wire replay is normalized while persisted provider data remains untouched."""
+    model = MindRoomOpenRouter(id="test/model", api_key="test-key")
+    assistant = Message(
+        role="assistant",
+        content="answer",
+        provider_data={
+            "reasoning_details": [
+                {"type": "reasoning.text", "text": "first", "index": 0},
+                {"type": "reasoning.text", "text": " second", "index": 0},
+            ],
+            "trace": {"request_id": "request-1"},
+        },
+    )
+    original_provider_data = deepcopy(assistant.provider_data)
+
+    formatted = model._format_message(assistant)
+
+    assert formatted["reasoning_details"] == [
+        {"type": "reasoning.text", "text": "first second", "index": 0},
+    ]
+    assert assistant.provider_data == original_provider_data
+    assert assistant.provider_data["trace"] == {"request_id": "request-1"}
 
 
 def _assistant_with_argumentless_tool_call() -> Message:


### PR DESCRIPTION
## Summary

- Coalesce adjacent, metadata-compatible OpenRouter `reasoning.text` fragments during streaming without changing caller-visible deltas.
- Normalize polluted reasoning details on replay without mutating persisted message history.
- Add a bounded-memory SQLite normalizer with WAL checkpointing, verified backups, exact post-image checks, and crash-safe restore handling.
- Document the design and production migration plan.

## Root cause

Agno's generic streamed provider-data merge extends list values. OpenRouter emits `reasoning_details` as small token fragments, so long responses were persisted and replayed as hundreds of thousands of dictionaries. Reconstructing those histories caused large transient allocations, and Python/glibc retained the resulting arenas after requests completed.

## Impact

Long-context prompts no longer cause persistent reasoning-metadata amplification. Existing histories can be normalized safely with the included one-shot script while preserving session/run structure and reasoning text.

## Validation

- `uv run pytest -q tests/test_openai_models.py tests/test_normalize_openrouter_reasoning_details.py` — 63 passed locally and in the deployed NixOS container.
- Ruff lint/format and scoped production `ty` checks passed.
- All other pre-commit hooks passed; the whole-repository `ty` hook was skipped at commit because optional Playwright, macOS, LiveKit, Google, and Postgres extras are not installed in this worktree.
- Real OpenRouter `deepseek/deepseek-v4-flash-0731` smoke: 9 streamed chunks finalized into 1 replayable reasoning detail.
- Production rehearsal and migration: 921,218 details reduced to 2,279; 72 sessions and 935 runs unchanged; reasoning-text digest unchanged; SQLite integrity remained `ok`; database size reduced from 225.2 MB to 106.8 MB.

## Summary by Sourcery

Coalesce OpenRouter reasoning details during streaming and replay to reduce persisted metadata volume while preserving caller-visible behavior.

New Features:
- Introduce a helper to compact adjacent OpenRouter reasoning.text fragments into single reasoning_details entries for safe reuse across streaming and replay paths.
- Add a standalone SQLite-based normalizer CLI to recursively coalesce polluted OpenRouter reasoning_details in existing session runs while verifying integrity and enabling crash-safe restore.

Enhancements:
- Extend MindRoomOpenRouter streaming and formatting logic to buffer and materialize reasoning_details efficiently without mutating persisted message history.
- Add detailed design and implementation-plan documentation covering reasoning-details coalescing and production migration steps.

Tests:
- Add unit and integration tests for OpenRouter reasoning_details coalescing across helper, streaming, replay, and malformed-payload scenarios.
- Add comprehensive tests for the SQLite normalizer covering dry-run/apply modes, backup and restore semantics, integrity checks, error handling, and cursor-based streaming of large result sets.