### PR TITLE
fix: keep streaming agents visible to router

### DIFF
--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -2105,20 +2105,21 @@ class TurnController:
         event_info = EventInfo.from_event(event.source)
         if not isinstance(event.body, str):
             return TurnDispatchOutcome.INTENTIONALLY_IGNORED
+        prechecked_event = self._precheck_dispatch_event(room, event, is_edit=event_info.is_edit)
+        if prechecked_event is None:
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
         event_content = event.source.get("content") if isinstance(event.source, dict) else None
         if isinstance(event_content, dict) and event_content.get(STREAM_STATUS_KEY) in {
             STREAM_STATUS_PENDING,
             STREAM_STATUS_STREAMING,
         }:
-            await self._append_live_event_with_timing(
-                room.room_id,
-                event,
-                event_info=event_info,
-                dispatch_timing=None,
-            )
-            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
-        prechecked_event = self._precheck_dispatch_event(room, event, is_edit=event_info.is_edit)
-        if prechecked_event is None:
+            if self.deps.ingress.managed_entity_name_for_sender(event.sender) is not None:
+                await self._append_live_event_with_timing(
+                    room.room_id,
+                    event,
+                    event_info=event_info,
+                    dispatch_timing=None,
+                )
             return TurnDispatchOutcome.INTENTIONALLY_IGNORED
 
         dispatch_timing = create_dispatch_pipeline_timing(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -2103,16 +2103,17 @@ class TurnController:
     ) -> TurnDispatchOutcome:
         """Handle one text message inside the per-turn conversation lookup scope."""
         event_info = EventInfo.from_event(event.source)
-        if not isinstance(event.body, str):
+        event_content = event.source.get("content") if isinstance(event.source, dict) else None
+        is_nonterminal_stream = isinstance(event_content, dict) and event_content.get(STREAM_STATUS_KEY) in {
+            STREAM_STATUS_PENDING,
+            STREAM_STATUS_STREAMING,
+        }
+        if not isinstance(event.body, str) or (is_nonterminal_stream and event_info.is_edit):
             return TurnDispatchOutcome.INTENTIONALLY_IGNORED
         prechecked_event = self._precheck_dispatch_event(room, event, is_edit=event_info.is_edit)
         if prechecked_event is None:
             return TurnDispatchOutcome.INTENTIONALLY_IGNORED
-        event_content = event.source.get("content") if isinstance(event.source, dict) else None
-        if isinstance(event_content, dict) and event_content.get(STREAM_STATUS_KEY) in {
-            STREAM_STATUS_PENDING,
-            STREAM_STATUS_STREAMING,
-        }:
+        if is_nonterminal_stream:
             if self.deps.ingress.managed_entity_name_for_sender(event.sender) is not None:
                 await self._append_live_event_with_timing(
                     room.room_id,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -2110,6 +2110,12 @@ class TurnController:
             STREAM_STATUS_PENDING,
             STREAM_STATUS_STREAMING,
         }:
+            await self._append_live_event_with_timing(
+                room.room_id,
+                event,
+                event_info=event_info,
+                dispatch_timing=None,
+            )
             return TurnDispatchOutcome.INTENTIONALLY_IGNORED
         prechecked_event = self._precheck_dispatch_event(room, event, is_edit=event_info.is_edit)
         if prechecked_event is None:

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -32,6 +32,8 @@ from mindroom.constants import (
     ORIGINAL_SENDER_KEY,
     SKIP_MENTIONS_KEY,
     SOURCE_KIND_KEY,
+    STREAM_STATUS_KEY,
+    STREAM_STATUS_PENDING,
     VISIBLE_ROUTER_VOICE_ECHO_KEY,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
     VOICE_TRANSCRIPT_KEY,
@@ -84,6 +86,7 @@ from tests.conftest import (
     dispatch_context_result,
     install_generate_response_mock,
     install_send_response_mock,
+    make_conversation_cache_mock,
     make_matrix_client_mock,
     message_origin,
     prepare_payload_via_seam,
@@ -7125,6 +7128,32 @@ async def test_sidecar_gate_failure_retries_original_media_callback(tmp_path: Pa
     assert outcome is _IngressAdmissionOutcome.ADMITTED
     assert drain_result.dispatch_failure_count == 1
     retry_pending_source.assert_called_once_with(sidecar.event_id, DispatchCallbackKind.MEDIA)
+
+
+@pytest.mark.asyncio
+async def test_router_caches_agent_pending_thread_placeholder_before_ignoring_dispatch(tmp_path: Path) -> None:
+    """Keep an active agent visible to router history while its response is still streaming."""
+    bot = _make_bot(tmp_path, agent_name="router")
+    room = _make_room()
+    placeholder = _text_event(
+        event_id="$agent-placeholder",
+        body="Thinking...",
+        sender="@mindroom_test_agent:localhost",
+        thread_id="$thread",
+    )
+    content = placeholder.source["content"]
+    assert isinstance(content, dict)
+    content[STREAM_STATUS_KEY] = STREAM_STATUS_PENDING
+    conversation_cache = make_conversation_cache_mock()
+    controller = replace_turn_controller_deps(bot, conversation_cache=conversation_cache)
+
+    await controller.handle_text_event(room, placeholder)
+
+    conversation_cache.append_live_event.assert_awaited_once_with(
+        room.room_id,
+        placeholder,
+        event_info=EventInfo.from_event(placeholder.source),
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -39,6 +39,7 @@ from mindroom.constants import (
     VOICE_TRANSCRIPT_KEY,
 )
 from mindroom.conversation_resolver import MessageContext
+from mindroom.dispatch_callback_outcome import TurnDispatchOutcome
 from mindroom.dispatch_handoff import (
     DispatchEvent,
     DispatchIngressMetadata,
@@ -7147,13 +7148,47 @@ async def test_router_caches_agent_pending_thread_placeholder_before_ignoring_di
     conversation_cache = make_conversation_cache_mock()
     controller = replace_turn_controller_deps(bot, conversation_cache=conversation_cache)
 
-    await controller.handle_text_event(room, placeholder)
+    outcome = await controller.handle_text_event(room, placeholder)
 
+    assert outcome is TurnDispatchOutcome.INTENTIONALLY_IGNORED
     conversation_cache.append_live_event.assert_awaited_once_with(
         room.room_id,
         placeholder,
         event_info=EventInfo.from_event(placeholder.source),
     )
+
+
+@pytest.mark.parametrize(
+    "sender",
+    [
+        pytest.param("@user:localhost", id="accepted-human"),
+        pytest.param("@mindroom_router:localhost", id="rejected-self"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_router_does_not_cache_nonterminal_stream_without_accepted_managed_sender(
+    tmp_path: Path,
+    sender: str,
+) -> None:
+    """Reject cache writes unless ingress accepts a managed entity's stream."""
+    bot = _make_bot(tmp_path, agent_name="router")
+    room = _make_room()
+    placeholder = _text_event(
+        event_id="$untrusted-placeholder",
+        body="Thinking...",
+        sender=sender,
+        thread_id="$thread",
+    )
+    content = placeholder.source["content"]
+    assert isinstance(content, dict)
+    content[STREAM_STATUS_KEY] = STREAM_STATUS_PENDING
+    conversation_cache = make_conversation_cache_mock()
+    controller = replace_turn_controller_deps(bot, conversation_cache=conversation_cache)
+
+    outcome = await controller.handle_text_event(room, placeholder)
+
+    assert outcome is TurnDispatchOutcome.INTENTIONALLY_IGNORED
+    conversation_cache.append_live_event.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -34,6 +34,7 @@ from mindroom.constants import (
     SOURCE_KIND_KEY,
     STREAM_STATUS_KEY,
     STREAM_STATUS_PENDING,
+    STREAM_STATUS_STREAMING,
     VISIBLE_ROUTER_VOICE_ECHO_KEY,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
     VOICE_TRANSCRIPT_KEY,
@@ -7156,6 +7157,43 @@ async def test_router_caches_agent_pending_thread_placeholder_before_ignoring_di
         placeholder,
         event_info=EventInfo.from_event(placeholder.source),
     )
+
+
+@pytest.mark.asyncio
+async def test_router_skips_intermediate_agent_stream_edit_without_precheck_or_cache(tmp_path: Path) -> None:
+    """Keep progressive stream edits on the pre-existing fast ignore path."""
+    bot = _make_bot(tmp_path, agent_name="router")
+    room = _make_room()
+    streaming_edit = _text_event(
+        event_id="$agent-stream-edit",
+        body="* partial response",
+        sender="@mindroom_test_agent:localhost",
+    )
+    content = streaming_edit.source["content"]
+    assert isinstance(content, dict)
+    content[STREAM_STATUS_KEY] = STREAM_STATUS_STREAMING
+    content["m.new_content"] = {
+        "msgtype": "m.text",
+        "body": "partial response",
+        STREAM_STATUS_KEY: STREAM_STATUS_STREAMING,
+    }
+    content["m.relates_to"] = {
+        "rel_type": "m.replace",
+        "event_id": "$agent-placeholder",
+    }
+    assert EventInfo.from_event(streaming_edit.source).is_edit
+    conversation_cache = make_conversation_cache_mock()
+    controller = replace_turn_controller_deps(bot, conversation_cache=conversation_cache)
+
+    with patch(
+        "mindroom.turn_controller.TurnController._precheck_dispatch_event",
+        side_effect=AssertionError("intermediate stream edits must skip ingress precheck"),
+    ) as precheck:
+        outcome = await controller.handle_text_event(room, streaming_edit)
+
+    assert outcome is TurnDispatchOutcome.INTENTIONALLY_IGNORED
+    precheck.assert_not_called()
+    conversation_cache.append_live_event.assert_not_awaited()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- add a regression test showing the router loses an agent's pending threaded placeholder
- cache pending and streaming events before intentionally skipping them for dispatch
- preserve the optimized fast path for ordinary router ingress

## Root cause

The router intentionally ignores nonterminal agent stream events for dispatch, but the early return also skipped conversation-cache bookkeeping. The later terminal m.replace event carries no thread relation, so the router could no longer see that the agent was already participating and emitted a redundant mention.

The fix restores only the missing cache write for pending and streaming events. These events remain non-dispatchable, and other early-skipped router messages still avoid shared ingress work.

## Regression origin

This regression was introduced by [PR #639](https://github.com/mindroom-ai/mindroom/pull/639), `perf: skip redundant router ingress work`, merged as [`13b127eff`](https://github.com/mindroom-ai/mindroom/commit/13b127effcd2c0378d7559fa6f808dcbcffb1d41). The exact parent-to-merge diff moves `_append_live_event_with_timing` from before the `pending`/`streaming` early return to after it, which causes those events to stop reaching the conversation cache. Before PR #639, the cache append ran first.

## Commit structure

1. test: reproduce missing router stream placeholder cache
2. fix: cache nonterminal stream events before dispatch skip

## Verification

- regression test: passes at branch tip and fails on commit 1
- tests/test_live_message_coalescing.py: 167 passed
- TestRouterSkipsSingleAgent: 9 passed
- tests/test_event_cache_write_coordination.py: 37 passed
- full pytest suite with PUPPETEER_SKIP_DOWNLOAD=true: 12,819 passed, 122 skipped

## Summary by Sourcery

Ensure router caches nonterminal agent stream events so streaming agents remain visible in conversation history and avoid redundant mentions.

Bug Fixes:
- Cache pending and streaming agent events in the conversation cache before they are intentionally skipped for dispatch, preventing the router from losing track of active agent placeholders.

Tests:
- Add an async regression test verifying the router appends pending threaded agent placeholder events to the conversation cache even when dispatch is intentionally ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved valid pending and streaming conversation updates in the live conversation cache.
  * Ensured managed agent streaming placeholders remain available even when dispatch is ignored.
  * Prevented untrusted or invalid streaming placeholders from being added to the cache.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->