### PR TITLE
deps: update mindroom-nio to 0.36.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
   "mdit-py-plugins>=0.5",
   "mem0ai>=0.1.115",
   # Arbitrary Olm to-device encryption uses the fork's tested internal API; update only with its round-trip tests.
-  "mindroom-nio[e2e]==0.35",
+  "mindroom-nio[e2e]==0.36",
   "openai",
   "packaging>=24",
   "pydantic>=2",

--- a/src/mindroom/dispatch_obligations/runner.py
+++ b/src/mindroom/dispatch_obligations/runner.py
@@ -274,7 +274,7 @@ class DispatchObligationRunner:
     ) -> None:
         """Route every correctness-critical timeline event through one nio owner."""
         self.observe_event_provenance(event.event_id, provenance)
-        if provenance is nio.TimelineEventProvenance.HISTORY:
+        if provenance is not nio.TimelineEventProvenance.LIVE:
             try:
                 await self.cache_historical_event(room, event)
             except asyncio.CancelledError:

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -2981,8 +2981,8 @@ async def test_nio_gap_generation_is_rebuilt_after_dispatch_failure(
 
 
 @pytest.mark.asyncio
-async def test_nio_limited_recovery_caches_history_before_cold_fence(tmp_path: Path) -> None:
-    """Recovered text and media must reach the cache without becoming turns."""
+async def test_nio_limited_recovery_caches_history_before_dispatch(tmp_path: Path) -> None:
+    """Continuity-recovered text and media must be cached before dispatch."""
     bot = _agent_bot(tmp_path)
     cache_root = SqliteEventCache(tmp_path / "history-event-cache.db")
     await cache_root.initialize()
@@ -3031,18 +3031,18 @@ async def test_nio_limited_recovery_caches_history_before_cold_fence(tmp_path: P
         assert await bot.event_cache.get_event(room_id, history_text.event_id) is not None
         assert await bot.event_cache.get_event(room_id, history_image.event_id) is not None
         assert bot._dispatch_obligation_store.pending() == ()
-        turn_callback.assert_not_awaited()
+        assert turn_callback.await_count == 2
     finally:
         await client.close()
         await cache_root.close()
 
 
 @pytest.mark.asyncio
-async def test_nio_retries_history_when_cache_admission_fails(
+async def test_nio_retries_recovered_event_when_cache_admission_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A failed history cache write must leave nio recovery work retryable."""
+    """A failed recovered-event cache write must leave nio work retryable."""
     bot = _agent_bot(tmp_path)
     cache_root = SqliteEventCache(tmp_path / "history-event-cache.db")
     await cache_root.initialize()
@@ -3087,6 +3087,9 @@ async def test_nio_retries_history_when_cache_admission_fails(
         )
 
     monkeypatch.setattr(bot.event_cache, "store_events_batch", fail_first_cache_write)
+    turn_callback = AsyncMock(return_value=DispatchCallbackResult.SUCCEEDED)
+    callbacks = cast("dict[DispatchCallbackKind, Any]", bot._dispatch_obligation_runner.callbacks)
+    callbacks[DispatchCallbackKind.MESSAGE] = turn_callback
     bot._dispatch_obligation_runner.register_source_callbacks(
         client,
         owner=bot._runtime_view,
@@ -3110,6 +3113,7 @@ async def test_nio_retries_history_when_cache_admission_fails(
         assert response.recovered_room_ids == frozenset({room_id})
         assert await bot.event_cache.get_event(room_id, history_text.event_id) is not None
         assert bot._dispatch_obligation_store.pending() == ()
+        turn_callback.assert_awaited_once()
     finally:
         await client.close()
         await cache_root.close()

--- a/uv.lock
+++ b/uv.lock
@@ -4516,7 +4516,7 @@ requires-dist = [
     { name = "mdit-py-plugins", specifier = ">=0.5" },
     { name = "mem0ai", specifier = ">=0.1.115" },
     { name = "mem0ai", marker = "extra == 'mem0'", specifier = ">=0.1.115" },
-    { name = "mindroom-nio", extras = ["e2e"], specifier = "==0.35.0" },
+    { name = "mindroom-nio", extras = ["e2e"], specifier = "==0.36.0" },
     { name = "moviepy", marker = "extra == 'moviepy-video-tools'" },
     { name = "neo4j", marker = "extra == 'neo4j'" },
     { name = "newspaper4k", marker = "extra == 'newspaper'" },
@@ -4627,7 +4627,7 @@ dev = [
 
 [[package]]
 name = "mindroom-nio"
-version = "0.35.0"
+version = "0.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4639,9 +4639,9 @@ dependencies = [
     { name = "pycryptodome" },
     { name = "unpaddedbase64" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/6b/803cb852282b1b04c6aac39ebb0903dd26e60c1107cbd278843289a83b79/mindroom_nio-0.35.0.tar.gz", hash = "sha256:f6fc0bf414b8fae9569b245e51c88c2e8018c806fabc01fcc742b0c9af196585", size = 206627, upload-time = "2026-08-05T04:52:08.982Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/6f/f0bbe89ac730823be200d2d3fbb91c632b9cb211977b65f7721822be5622/mindroom_nio-0.36.0.tar.gz", hash = "sha256:e80fb6301894416540591885dd9948763949d0658632fe62f13f45f0a7d3dbc9", size = 207316, upload-time = "2026-08-05T21:08:16.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d8/6e/9e21228aed977e34e794e3bfc5bb196dda2076693e60b667f72a4a0c1263/mindroom_nio-0.35.0-py3-none-any.whl", hash = "sha256:b9088191ee7146dca35283619b21fe796479276d4474f0c62b4a8d2103579ee0", size = 236889, upload-time = "2026-08-05T04:52:07.485Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3c/beb4ef028025611de962757046d054f32523f72c2b7ccccaf4b5b65a205e/mindroom_nio-0.36.0-py3-none-any.whl", hash = "sha256:c5a48a33f3a40b7e8b2bdfdadf56df531b159ceb1d7453d56779c162c01b0182", size = 237602, upload-time = "2026-08-05T21:08:14.909Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- pin `mindroom-nio[e2e]` to release `0.36.0`
- consume [mindroom-nio#48](https://github.com/mindroom-ai/mindroom-nio/pull/48), which fixes continuity recovery after a process restart with `pos=None` and a persisted room baseline
- cache continuity-proven `RECOVERED` events before durable dispatch while keeping cold `HISTORY` fenced
- refresh locked PyPI artifacts and hashes

The restart fix is distinct from [mindroom-tuwunel#12](https://github.com/mindroom-ai/mindroom-tuwunel/pull/12), which fixes `num_live` for room re-entry within an existing Sliding Sync connection.

## Validation

- `uv lock --check`
- `uv run pre-commit run --files pyproject.toml uv.lock src/mindroom/dispatch_obligations/runner.py tests/test_matrix_sync_continuity.py`
- 153 focused cold-history-fence and Matrix sync-continuity tests passed
- GitHub Actions Python 3.13 suite passed