### PR TITLE
Let compaction summaries condense stale context

### DIFF
--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -337,9 +337,10 @@ Your job is to produce one merged handoff summary as plain text.
 Return only the summary text.
 
 Rules:
-- Retain the information from <previous_summary> needed to continue the current work, but condense it rather than copying wording verbatim.
+- Retain the information from <previous_summary> needed to continue the current work.
 - Omit resolved, superseded, stale, or exploratory detail when it no longer affects current state or future work.
 - Incorporate relevant new information from <new_conversation>.
+- Keep retained wording stable when practical, but condense it when needed.
 - Preserve exact technical details only while they remain load-bearing, including file paths, function names, class names, commands, Matrix IDs, model names, config keys, numeric thresholds, ports, URLs, and error text.
 - Preserve tool activity when it matters to current state, especially file edits, commands, and tool results.
 - Do not invent facts.

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -337,13 +337,11 @@ Your job is to produce one merged handoff summary as plain text.
 Return only the summary text.
 
 Rules:
-- Treat <previous_summary> as source material, not text that must be preserved.
-- Rewrite the full merged summary from scratch on every pass.
-- Compaction is intentionally lossy: keep only information useful for continuing the current work.
-- Drop superseded plans, resolved errors, completed intermediate steps, exploratory dead ends, and stale detail.
-- Collapse completed work into brief outcomes and prioritize current state, constraints, decisions, and next steps.
+- Use <previous_summary> as context and retain the information needed to continue the current work.
+- Condense that information instead of copying previous wording verbatim.
+- Omit resolved, superseded, stale, or exploratory detail when it no longer affects current state or future work.
+- Collapse completed work into brief outcomes while retaining current constraints, decisions, next steps, and critical context.
 - Add only the new information from <new_conversation>.
-- Do not preserve wording merely to keep future prompt prefixes stable.
 - Preserve exact technical details only while they remain load-bearing, including file paths, function names, class names, commands, Matrix IDs, model names, config keys, numeric thresholds, ports, URLs, and error text.
 - Preserve tool activity when it matters to current state, especially file edits, commands, and tool results.
 - Do not invent facts.

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -337,11 +337,9 @@ Your job is to produce one merged handoff summary as plain text.
 Return only the summary text.
 
 Rules:
-- Use <previous_summary> as context and retain the information needed to continue the current work.
-- Condense that information instead of copying previous wording verbatim.
+- Retain the information from <previous_summary> needed to continue the current work, but condense it rather than copying wording verbatim.
 - Omit resolved, superseded, stale, or exploratory detail when it no longer affects current state or future work.
-- Collapse completed work into brief outcomes while retaining current constraints, decisions, next steps, and critical context.
-- Add only the new information from <new_conversation>.
+- Incorporate relevant new information from <new_conversation>.
 - Preserve exact technical details only while they remain load-bearing, including file paths, function names, class names, commands, Matrix IDs, model names, config keys, numeric thresholds, ports, URLs, and error text.
 - Preserve tool activity when it matters to current state, especially file edits, commands, and tool results.
 - Do not invent facts.

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -337,10 +337,14 @@ Your job is to produce one merged handoff summary as plain text.
 Return only the summary text.
 
 Rules:
-- Preserve all still-relevant information from <previous_summary>.
+- Treat <previous_summary> as source material, not text that must be preserved.
+- Rewrite the full merged summary from scratch on every pass.
+- Compaction is intentionally lossy: keep only information useful for continuing the current work.
+- Drop superseded plans, resolved errors, completed intermediate steps, exploratory dead ends, and stale detail.
+- Collapse completed work into brief outcomes and prioritize current state, constraints, decisions, and next steps.
 - Add only the new information from <new_conversation>.
-- Keep unchanged wording verbatim when it is still correct so future prompt prefixes remain stable.
-- Never paraphrase away exact technical details such as file paths, function names, class names, commands, Matrix IDs, model names, config keys, numeric thresholds, ports, URLs, or error text.
+- Do not preserve wording merely to keep future prompt prefixes stable.
+- Preserve exact technical details only while they remain load-bearing, including file paths, function names, class names, commands, Matrix IDs, model names, config keys, numeric thresholds, ports, URLs, and error text.
 - Preserve tool activity when it matters to current state, especially file edits, commands, and tool results.
 - Do not invent facts.
 - If a section has no content, write `None.`


### PR DESCRIPTION
## Summary

- retain prior-summary context needed to continue the work while allowing obsolete detail to fall out
- keep retained wording stable when practical, but condense it when needed
- incorporate relevant new information and preserve exact technical facts while they remain load-bearing
- keep existing smaller-input retry and output-truncation safeguards unchanged

## Verification

- `uv run pytest -q -x -n auto --no-cov`
- `uv run pytest tests/test_compaction_invariants.py tests/test_history_summary_call.py tests/test_history_compaction_rewrite.py tests/test_vertex_claude_context_guard.py -q -x -n auto --no-cov`
- `uv run pre-commit run --files src/mindroom/prompts.py`