### PR TITLE
test: cover the recovered timeline event provenance

### DIFF
--- a/tests/test_cold_history_fence.py
+++ b/tests/test_cold_history_fence.py
@@ -177,7 +177,11 @@ async def test_live_and_direct_dispatch_do_not_read_pending_state(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "provenance",
-    [nio.TimelineEventProvenance.LIVE, nio.TimelineEventProvenance.HISTORY],
+    [
+        nio.TimelineEventProvenance.LIVE,
+        nio.TimelineEventProvenance.RECOVERED,
+        nio.TimelineEventProvenance.HISTORY,
+    ],
 )
 async def test_invite_and_decrypt_fences_override_timeline_provenance(
     provenance: nio.TimelineEventProvenance,

--- a/tests/test_cold_history_fence.py
+++ b/tests/test_cold_history_fence.py
@@ -150,12 +150,16 @@ async def test_history_requires_one_exact_pending_obligation() -> None:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "provenance",
-    [nio.TimelineEventProvenance.LIVE, None],
+    [
+        nio.TimelineEventProvenance.LIVE,
+        nio.TimelineEventProvenance.RECOVERED,
+        None,
+    ],
 )
 async def test_live_and_direct_dispatch_do_not_read_pending_state(
     provenance: nio.TimelineEventProvenance | None,
 ) -> None:
-    """Live nio delivery and explicit non-nio dispatch are current work."""
+    """Live delivery, proven gap recovery, and explicit non-nio dispatch are current work."""
     obligations = _PendingObligations()
     fence = ColdHistoryFence(obligations)
 
@@ -214,6 +218,9 @@ def test_best_effort_admission_requires_matching_live_event_provenance() -> None
     fence.observe_event_provenance("$history", nio.TimelineEventProvenance.HISTORY)
     assert not fence.event_is_live("$history")
     assert not fence.event_is_live("$live")
+
+    fence.observe_event_provenance("$recovered", nio.TimelineEventProvenance.RECOVERED)
+    assert not fence.event_is_live("$recovered")
 
 
 @pytest.mark.asyncio

--- a/tests/test_dispatch_obligations.py
+++ b/tests/test_dispatch_obligations.py
@@ -248,6 +248,10 @@ def _encrypted_image_source(event_id: str) -> dict[str, object]:
     }
 
 
+async def _drop_historical_event(_room: nio.MatrixRoom, _event: nio.Event) -> None:
+    """Ignore the non-live events a runner would otherwise cache."""
+
+
 def _runner(
     store: DispatchObligationStore,
     callback: Callable[[nio.MatrixRoom, nio.Event], Awaitable[DispatchCallbackResult]],
@@ -256,12 +260,14 @@ def _runner(
     background_task_owner: object | None = None,
     retry_initial_delay_seconds: float = 1.0,
     retry_max_delay_seconds: float = 30.0,
+    cache_historical_event: Callable[[nio.MatrixRoom, nio.Event], Awaitable[None]] = _drop_historical_event,
 ) -> DispatchObligationRunner:
     return DispatchObligationRunner(
         store=store,
         callbacks={DispatchCallbackKind.MESSAGE: callback},
         room_for_id=lambda room_id: nio.MatrixRoom(room_id, "@code:example.org"),
         turn_is_terminal=turn_is_terminal,
+        cache_historical_event=cache_historical_event,
         background_task_owner=background_task_owner,
         _retry_initial_delay_seconds=retry_initial_delay_seconds,
         _retry_max_delay_seconds=retry_max_delay_seconds,
@@ -1560,6 +1566,35 @@ async def test_retry_survives_contention_with_callback_marking_deferred(
 
     assert attempts == 2
     assert not store.has_pending(event_id, DispatchCallbackKind.MESSAGE)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provenance", "cached"),
+    [
+        (nio.TimelineEventProvenance.LIVE, False),
+        (nio.TimelineEventProvenance.RECOVERED, True),
+        (nio.TimelineEventProvenance.HISTORY, True),
+    ],
+)
+async def test_only_live_events_skip_the_admission_history_cache(
+    tmp_path: Path,
+    provenance: nio.TimelineEventProvenance,
+    cached: bool,
+) -> None:
+    """Live events reach the cache through sync; every other provenance must not."""
+    cache = AsyncMock(return_value=None)
+
+    async def callback(_room: nio.MatrixRoom, _event: nio.Event) -> DispatchCallbackResult:
+        return DispatchCallbackResult.SUCCEEDED
+
+    runner = _runner(_store(tmp_path), callback, cache_historical_event=cache)
+    room = nio.MatrixRoom(_ROOM_ID, _PRINCIPAL_ID)
+    event = _message_event(f"$provenance-{provenance.value}")
+
+    await runner._admit_source_event(room, event, provenance)
+
+    assert cache.await_count == int(cached)
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -3053,7 +3053,7 @@ async def test_nio_limited_recovery_caches_history_before_dispatch(tmp_path: Pat
         add_admission = _register_counted_source_callbacks(bot, client)
         response = _limited_empty_classic_response(room_id)
         await client.receive_response(response)
-        await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+        assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
 
         add_admission.assert_called_once()
         assert response.recovered_room_ids == frozenset({room_id})
@@ -3106,7 +3106,7 @@ async def test_nio_recovered_gap_mention_reaches_the_real_response_runner(tmp_pa
         # The recovery client never logs in, so room classification cannot be served.
         with patch("mindroom.text_ingress_dispatch.is_dm_room", AsyncMock(return_value=False)):
             await client.receive_response(_limited_empty_classic_response(room_id))
-            await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+            assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
             await drain_coalescing(bot)
 
         generate_response.assert_awaited_once()
@@ -3162,7 +3162,7 @@ async def test_nio_unproven_recovery_caches_history_behind_the_cold_fence(tmp_pa
         _register_counted_source_callbacks(bot, client)
         response = _limited_empty_classic_response(room_id)
         await client.receive_response(response)
-        await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+        assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
 
         assert await bot.event_cache.get_event(room_id, history_text.event_id) is not None
         assert await bot.event_cache.get_event(room_id, history_image.event_id) is not None

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -22,6 +22,7 @@ from mindroom.bot import AgentBot, TeamBot, _create_best_effort_task_wrapper
 from mindroom.coalescing import CoalescingDrainResult, CoalescingGate, IngressAdmissionClosedError, ReadyPendingEvent
 from mindroom.coalescing_batch import CoalescedBatch, CoalescingKey, PendingEvent
 from mindroom.config.agent import AgentConfig
+from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
 from mindroom.config.matrix import MatrixSyncConfig
 from mindroom.config.models import ModelConfig
@@ -58,6 +59,8 @@ from tests.bot_helpers import _configured_team_test_config, _configured_team_use
 from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
+    drain_coalescing,
+    install_generate_response_mock,
     install_runtime_cache_support,
     install_shutdown_drain_mocks,
     make_matrix_client_mock,
@@ -78,19 +81,20 @@ if TYPE_CHECKING:
 _CACHE_GENERATION = "test-cache-generation"
 
 
-def _config(tmp_path: Path) -> Config:
+def _config(tmp_path: Path, *, authorize_senders: bool = False) -> Config:
     runtime_paths = test_runtime_paths(tmp_path)
     return bind_runtime_paths(
         Config(
             agents={"code": AgentConfig(display_name="Code", rooms=["!room:localhost"])},
             models={"default": ModelConfig(provider="test", id="test-model")},
+            authorization=AuthorizationConfig(default_room_access=authorize_senders),
         ),
         runtime_paths,
     )
 
 
-def _agent_bot(tmp_path: Path, *, agent_name: str = "code") -> AgentBot:
-    config = _config(tmp_path)
+def _agent_bot(tmp_path: Path, *, agent_name: str = "code", authorize_senders: bool = False) -> AgentBot:
+    config = _config(tmp_path, authorize_senders=authorize_senders)
     bot = AgentBot(
         agent_user=AgentMatrixUser(
             agent_name=agent_name,
@@ -672,6 +676,23 @@ def _text_event(event_id: str, body: str, origin_server_ts: int) -> nio.RoomMess
             "event_id": event_id,
             "sender": "@user:localhost",
             "origin_server_ts": origin_server_ts,
+            "room_id": "!room:localhost",
+            "type": "m.room.message",
+        },
+    )
+
+
+def _mention_event(event_id: str, body: str, mentioned_user_id: str) -> nio.RoomMessageText:
+    return nio.RoomMessageText.from_dict(
+        {
+            "content": {
+                "body": body,
+                "msgtype": "m.text",
+                "m.mentions": {"user_ids": [mentioned_user_id]},
+            },
+            "event_id": event_id,
+            "sender": "@user:localhost",
+            "origin_server_ts": 1,
             "room_id": "!room:localhost",
             "type": "m.room.message",
         },
@@ -3009,7 +3030,17 @@ async def test_nio_limited_recovery_caches_history_before_dispatch(tmp_path: Pat
             end="p_gap_start",
         ),
     )
-    turn_callback = AsyncMock(return_value=DispatchCallbackResult.SUCCEEDED)
+    was_cached_at_dispatch: list[bool] = []
+
+    async def observe_cache_before_turn(
+        room: nio.MatrixRoom,
+        event: nio.Event,
+    ) -> DispatchCallbackResult:
+        cached = await bot.event_cache.get_event(room.room_id, event.event_id)
+        was_cached_at_dispatch.append(cached is not None)
+        return DispatchCallbackResult.SUCCEEDED
+
+    turn_callback = AsyncMock(side_effect=observe_cache_before_turn)
     callbacks = cast("dict[DispatchCallbackKind, Any]", bot._dispatch_obligation_runner.callbacks)
     callbacks.update(
         {
@@ -3031,7 +3062,57 @@ async def test_nio_limited_recovery_caches_history_before_dispatch(tmp_path: Pat
         assert await bot.event_cache.get_event(room_id, history_text.event_id) is not None
         assert await bot.event_cache.get_event(room_id, history_image.event_id) is not None
         assert bot._dispatch_obligation_store.pending() == ()
-        assert turn_callback.await_count == 2
+        # Both turns ran, and each one already had its own source event cached.
+        assert was_cached_at_dispatch == [True, True]
+    finally:
+        await client.close()
+        await cache_root.close()
+
+
+@pytest.mark.asyncio
+async def test_nio_recovered_gap_mention_reaches_the_real_response_runner(tmp_path: Path) -> None:
+    """The restart-gap message nio 0.36 proves continuous must reach a real reply."""
+    bot = _agent_bot(tmp_path, authorize_senders=True)
+    cache_root = SqliteEventCache(tmp_path / "history-event-cache.db")
+    await cache_root.initialize()
+    bot.event_cache = cache_root.for_principal(bot.matrix_id.full_id)
+    client = nio.AsyncClient(
+        "https://example.org",
+        bot.matrix_id.full_id,
+        config=nio.AsyncClientConfig(
+            encryption_enabled=False,
+            backfill_limited_timelines=True,
+        ),
+    )
+    bot.client = client
+    client.next_batch = "s_before_gap"
+    room_id = "!room:localhost"
+    await bot._conversation_cache.mark_room_joined(room_id)
+    mention = bot.agent_user.user_id
+    gap_mention = _mention_event("$gap-mention", f"{mention}: ping", mention)
+    client._recovery_room_messages = AsyncMock(
+        return_value=nio.RoomMessagesResponse(
+            room_id=room_id,
+            chunk=[gap_mention],
+            start="s_before_gap",
+            end="p_gap_start",
+        ),
+    )
+    generate_response = AsyncMock(return_value="$gap-reply")
+    install_generate_response_mock(bot, generate_response)
+
+    try:
+        _register_counted_source_callbacks(bot, client)
+        # The recovery client never logs in, so room classification cannot be served.
+        with patch("mindroom.text_ingress_dispatch.is_dm_room", AsyncMock(return_value=False)):
+            await client.receive_response(_limited_empty_classic_response(room_id))
+            await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+            await drain_coalescing(bot)
+
+        generate_response.assert_awaited_once()
+        assert generate_response.await_args.kwargs["prompt"] == f"{mention}: ping"
+        assert bot._turn_store.is_durably_handled(gap_mention.event_id)
+        assert bot._dispatch_obligation_store.pending() == ()
     finally:
         await client.close()
         await cache_root.close()

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -3038,6 +3038,61 @@ async def test_nio_limited_recovery_caches_history_before_dispatch(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_nio_unproven_recovery_caches_history_behind_the_cold_fence(tmp_path: Path) -> None:
+    """A walk that never proves continuity stays cold history: cached, never answered."""
+    bot = _agent_bot(tmp_path)
+    cache_root = SqliteEventCache(tmp_path / "history-event-cache.db")
+    await cache_root.initialize()
+    bot.event_cache = cache_root.for_principal(bot.matrix_id.full_id)
+    client = nio.AsyncClient(
+        "https://example.org",
+        bot.matrix_id.full_id,
+        config=nio.AsyncClientConfig(
+            encryption_enabled=False,
+            backfill_limited_timelines=True,
+        ),
+    )
+    bot.client = client
+    client.next_batch = "s_before_gap"
+    room_id = "!room:localhost"
+    await bot._conversation_cache.mark_room_joined(room_id)
+    history_text = _text_event("$unproven-text", "old text", 1)
+    history_image = _image_event("$unproven-image", "old image", 2)
+    # An unbound walk that runs out of events without reaching the window's
+    # own token never proves the recovered events follow the held baseline.
+    client._recovery_room_messages = AsyncMock(
+        return_value=nio.RoomMessagesResponse(
+            room_id=room_id,
+            chunk=[history_text, history_image],
+            start="s_before_gap",
+            end=None,
+        ),
+    )
+    turn_callback = AsyncMock(return_value=DispatchCallbackResult.SUCCEEDED)
+    callbacks = cast("dict[DispatchCallbackKind, Any]", bot._dispatch_obligation_runner.callbacks)
+    callbacks.update(
+        {
+            DispatchCallbackKind.MESSAGE: turn_callback,
+            DispatchCallbackKind.MEDIA: turn_callback,
+        },
+    )
+
+    try:
+        _register_counted_source_callbacks(bot, client)
+        response = _limited_empty_classic_response(room_id)
+        await client.receive_response(response)
+        await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+
+        assert await bot.event_cache.get_event(room_id, history_text.event_id) is not None
+        assert await bot.event_cache.get_event(room_id, history_image.event_id) is not None
+        assert bot._dispatch_obligation_store.pending() == ()
+        turn_callback.assert_not_awaited()
+    finally:
+        await client.close()
+        await cache_root.close()
+
+
+@pytest.mark.asyncio
 async def test_nio_retries_recovered_event_when_cache_admission_fails(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Why

mindroom-nio 0.36 (merged in #1791) added a third `TimelineEventProvenance` value:

```python
class TimelineEventProvenance(str, Enum):
    LIVE = "live"
    RECOVERED = "recovered"   # new in 0.36
    HISTORY = "history"
```

`RECOVERED` marks timeline events that a bounded `/messages` walk proved follow the held room baseline — the restart gap — as opposed to unverified cold `HISTORY`. #1791 widened the admission cache predicate to `provenance is not LIVE` so those events still reach the event cache, and the cold history fence admits them as ordinary turn work because `admit_source` only fences `HISTORY`.

That merged with thin coverage:

- No test named `RECOVERED` anywhere, so neither the cache predicate nor the fence's treatment of it was pinned.
- Renaming `test_nio_limited_recovery_caches_history_before_cold_fence` to assert dispatch removed the only end-to-end proof that unproven history stays fenced.
- Nothing followed a proven gap message into an actual reply, which is the behaviour the nio release was cut for.

## What

Tests only; no production changes.

| Test | Pins |
|---|---|
| `test_only_live_events_skip_the_admission_history_cache` | Parametrized over all three provenances: `LIVE` skips the admission cache (it arrives via the sync response), `RECOVERED` and `HISTORY` are cached. |
| `test_nio_unproven_recovery_caches_history_behind_the_cold_fence` | An unbound `/messages` walk that exhausts without reaching the window token stays `HISTORY`: cached, `pending() == ()`, never dispatched. Restores the lost integration proof. |
| `test_nio_recovered_gap_mention_reaches_the_real_response_runner` | Drives nio recovery of a mention through the bot's real message callback and asserts the response runner produced a reply for it. |
| `test_nio_limited_recovery_caches_history_before_dispatch` | The turn callback now reads the event cache as it runs, so "cached before dispatch" is asserted rather than implied by the name. |
| `test_live_and_direct_dispatch_do_not_read_pending_state` | `RECOVERED` is admitted without consulting the pending-obligation ledger. |
| `test_invite_and_decrypt_fences_override_timeline_provenance` | Invite and decrypt-notice fences still win over `RECOVERED`. |
| `test_best_effort_admission_requires_matching_live_event_provenance` | `event_is_live` stays false for `RECOVERED`, keeping gap call state out of the call runtime. |

`_config` / `_agent_bot` gained an `authorize_senders` flag (default off, so existing tests are unchanged) because the end-to-end test needs a sender the agent may answer. `_runner` in `test_dispatch_obligations.py` gained a `cache_historical_event` parameter.

## Verification

Every new assertion was checked against a deliberately broken implementation:

| Mutation | Tests that fail |
|---|---|
| Cache predicate back to `is HISTORY` | `test_only_live_events_skip_the_admission_history_cache[recovered-True]` |
| Drop the cache write entirely | `test_nio_limited_recovery_caches_history_before_dispatch` |
| Fence `RECOVERED` as cold history | `...do_not_read_pending_state[recovered]`, `test_nio_limited_recovery_caches_history_before_dispatch`, `test_nio_recovered_gap_mention_reaches_the_real_response_runner` |
| Stop fencing `HISTORY` | `test_nio_unproven_recovery_caches_history_behind_the_cold_fence` |

`pytest tests/test_matrix_sync_continuity.py tests/test_cold_history_fence.py tests/test_dispatch_obligations.py tests/test_multi_agent_bot.py` passes, as does `pre-commit run --files` over the three changed files.

## Summary by Sourcery

Extend test coverage around Matrix timeline event provenance to pin the behavior of RECOVERED events across admission, caching, fencing, and dispatch.

Enhancements:
- Augment test helpers and fixtures with sender authorization flags and injectable historical-event caching to support new provenance scenarios.

Tests:
- Add admission runner test ensuring only LIVE events bypass the history cache while RECOVERED and HISTORY are cached.
- Add end-to-end tests for nio recovery of gap messages, including proven mentions reaching the real response runner and unproven history remaining fenced and undispatched.
- Tighten the limited recovery test to assert historical events are cached before dispatch rather than inferring it.
- Extend cold history fence tests to cover RECOVERED provenance, including pending-state lookup, invite/decrypt overrides, and live-provenance matching semantics.