### PR TITLE
docs: make Matrix pipeline simplification feasibility-first

### DIFF
--- a/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
+++ b/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
@@ -62,8 +62,7 @@ Sliding Sync exposed recovery gaps, but most current complexity comes from MindR
 - An unrecovered room keeps the bot unready instead of silently becoming history.
 - Conversation reads are bounded and indexed after at most one successful hydration per conversation and membership epoch.
 - Intermediate edit bodies and edit chains are not retained.
-- MindRoom intentionally tombstones a logical message when its currently visible edit is redacted, even though a Matrix client may reveal the original body after that redaction.
-- This visible divergence is the accepted cost of not retaining edit history that the homeserver may also have purged.
+- Redacting a current edit restores the server-authoritative previous visible revision without retaining a local edit chain.
 - Initial and terminal response deliveries are idempotent across crashes.
 - The final implementation PR head must not leave both the old and replacement production paths active.
 - The single implementation PR must be green and must remove every active owner it replaces before merge.
@@ -116,11 +115,21 @@ Including sender in the unresolved-edit key prevents an attacker from evicting t
 
 When the original arrives, only its sender's unresolved edit may apply, and all unresolved rows for that target are deleted.
 
-Redacting the logical original or its currently visible replacement tombstones the logical message.
+Admission records every redaction target as a compact durable tombstone before projection so an original or edit arriving later cannot resurrect redacted content.
+
+Redacting the logical original tombstones the logical message.
+
+Redacting the currently visible replacement marks the logical row with a durable refresh token derived from the redaction's journal receipt order.
+
+A strict conversation read waits for one shared point refetch of the logical original and its current relations instead of serving content known to be stale.
+
+The point refetch uses the same relation traversal and reducer as initial hydration, retains no edit chain, and installs the reconstructed visible row only when both the membership epoch and exact refresh token still match.
+
+A newer edit or redaction changes the projection revision and prevents an older in-flight refetch from overwriting it.
+
+Successful conditional installation clears the refresh token, while failure or cancellation leaves it durable and makes strict reads fail closed until retry succeeds.
 
 Redacting an already superseded replacement does not change visible content.
-
-MindRoom does not reconstruct an earlier edit body after redaction because it intentionally does not retain that history and both homeserver forks may already have purged it.
 
 ### Bounded conversation reads
 
@@ -151,6 +160,8 @@ A room-scoped conversation may perform one serialized initial `/messages` traver
 Concurrent first readers share one hydration task, and hydration becomes complete only after successful pagination and an atomic membership-epoch-checked installation.
 
 Failure remains a visible readiness or request failure rather than reviving room-wide repair scans.
+
+Current-edit redaction reuses this hydrator for a logical-message point refetch rather than introducing a second history-repair implementation.
 
 ### Deterministic delivery
 
@@ -195,6 +206,9 @@ The prototype must demonstrate:
 - Principal isolation through bound store views.
 - Exact journal deduplication and pending replay on SQLite and PostgreSQL.
 - Correct ordered and shuffled edit reduction, including pre-original cross-sender edits.
+- Current-edit redaction restoring the latest remaining server revision without retaining previous bodies.
+- A durable refresh token surviving restart, strict reads waiting for it, and refetch failure serving no stale content.
+- A newer edit racing point refetch and winning through conditional installation.
 - Bounded cursor reads over a 100,000-message room conversation.
 - One indexed projection update per edit and no retained intermediate edit chain.
 - Zero SQLite lock failures under 50 concurrent Matrix conversations with an explicit `busy_timeout`.
@@ -226,6 +240,7 @@ It must prove:
 - The realistic restart case where bounded `/messages` exhaustion returns an empty chunk and omits `end` still recovers and replies once.
 - Cold history populates context and never starts a turn.
 - A root, reply, edit, and redaction relation tree reports and supplies the required recursive depth.
+- Redacting the latest edit reveals the prior unredacted edit when the server still retains it and reveals the original body after superseded edits have been purged.
 - Edit-heavy streaming leaves one latest logical message without durable intermediate bodies.
 - Deterministic retry after server acceptance creates one Matrix event.
 
@@ -311,6 +326,7 @@ The single implementation PR tracks these results as its internal checkpoints co
 | Historical turns | Zero from `HISTORY` or a cold baseline. |
 | Model reruns after durable completion | Zero. |
 | Edit storage | One visible row per logical message and at most one unresolved row per target and sender. |
+| Current-edit redaction | Strict reads return the server-authoritative prior revision after point refetch and never stale content. |
 | Conversation reads | Bounded cursor pages using the conversation index. |
 | Post-hydration room scans | Zero. |
 | SQLite lock failures | Zero in the 50-conversation stress run. |
@@ -361,6 +377,7 @@ Stop and redesign if any of these occur:
 - The prototype loses or duplicates an admitted actionable event.
 - Accepted deterministic delivery can display content different from the durable model result.
 - Correct hydration requires retaining edit chains or restoring room-wide repair scans.
+- Current-edit redaction cannot recover the server-authoritative visible revision through the shared point hydrator without serving stale content.
 - Principal isolation cannot be expressed through one bound store interface.
 - SQLite still produces lock failures with one writer and a configured `busy_timeout`.
 - A cutover needs the old and new active paths simultaneously after merge.

--- a/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
+++ b/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
@@ -63,6 +63,7 @@ Sliding Sync exposed recovery gaps, but most current complexity comes from MindR
 - Conversation reads are bounded and indexed after at most one successful hydration per conversation and membership epoch.
 - Intermediate edit bodies and edit chains are not retained.
 - Redacting a current edit restores the server-authoritative previous visible revision without retaining a local edit chain.
+- No read path may serve a revision after that revision's redaction has been durably admitted, so a pending refetch omits the message rather than returning deleted content.
 - Initial and terminal response deliveries are idempotent across crashes.
 - The final implementation PR head must not leave both the old and replacement production paths active.
 - The single implementation PR must be green and must remove every active owner it replaces before merge.
@@ -119,15 +120,21 @@ Admission records every redaction target as a compact durable tombstone before p
 
 Redacting the logical original tombstones the logical message.
 
-Redacting the currently visible replacement marks the logical row with a durable refresh token derived from the redaction's journal receipt order.
+Redacting the currently visible replacement clears the row's visible body and marks the logical row with a durable refresh token derived from the redaction's journal receipt order.
+
+Clearing the body in the same admission transaction is required because a redacted revision must never be readable, and a stale-but-visible row would otherwise let any non-strict caller serve content the sender deleted.
 
 A strict conversation read waits for one shared point refetch of the logical original and its current relations instead of serving content known to be stale.
+
+A non-strict read never waits and never serves a body-cleared row, so it omits that logical message until a refetch installs the server-authoritative revision.
 
 The point refetch uses the same relation traversal and reducer as initial hydration, retains no edit chain, and installs the reconstructed visible row only when both the membership epoch and exact refresh token still match.
 
 A newer edit or redaction changes the projection revision and prevents an older in-flight refetch from overwriting it.
 
 Successful conditional installation clears the refresh token, while failure or cancellation leaves it durable and makes strict reads fail closed until retry succeeds.
+
+The next strict read of that conversation drives the retry, so no background refresh worker exists and a permanently unreachable homeserver degrades reads rather than accumulating retry state.
 
 Redacting an already superseded replacement does not change visible content.
 
@@ -189,6 +196,24 @@ PostgreSQL implements the same behavioral contract without a second application 
 
 The two backends run the same admission, projection, membership, pagination, and outbox contract tests.
 
+### Homeserver behavior that is not observable from this repository
+
+These facts come from the fork repositories and the deployment configuration rather than from MindRoom source, so implementation must not rediscover them by debugging.
+
+Tuwunel purges superseded `m.replace` events on a background job, which is why edit-redaction recovery must ask the server instead of trusting any local history.
+
+The purge is disabled by default in the fork but enabled in the MindRoom production deployment, with a 24-hour minimum age, an hourly interval, and a 10,000-event batch size.
+
+That 24-hour floor means a current-edit refetch normally returns the true previous edit and returns the original body only once superseded edits have aged out, and both outcomes are correct because every Matrix client sees the same server state.
+
+The purge exists to reclaim storage from MindRoom's own streaming edit churn, which this plan already treats as transient, so it is not a reason to retain edit history locally.
+
+Tuwunel and the MindRoom Synapse fork both cap recursive relation traversal at depth three in source, and neither advertises that cap, which is why the required depth must be read from `recursion_depth` on each page.
+
+Both homeservers deduplicate a repeated transaction ID per sending device rather than per access token, and MindRoom persists its device across restarts, so deterministic outbox retries survive a crash but would not survive re-login with a new device.
+
+Synapse expires stored transaction mappings on a periodic cleanup, so the real-server proof must record how long a deterministic retry stays idempotent rather than assuming it is unbounded.
+
 ## Feasibility Proof Before Production Cutover
 
 The first implementation work occurs on an isolated prototype branch that is not separately merged into `main`.
@@ -209,6 +234,7 @@ The prototype must demonstrate:
 - Current-edit redaction restoring the latest remaining server revision without retaining previous bodies.
 - A durable refresh token surviving restart, strict reads waiting for it, and refetch failure serving no stale content.
 - A newer edit racing point refetch and winning through conditional installation.
+- Non-strict reads omitting a body-cleared message instead of returning the redacted revision, on every read path, including across a restart with the refetch still pending.
 - Bounded cursor reads over a 100,000-message room conversation.
 - One indexed projection update per edit and no retained intermediate edit chain.
 - Zero SQLite lock failures under 50 concurrent Matrix conversations with an explicit `busy_timeout`.
@@ -327,6 +353,7 @@ The single implementation PR tracks these results as its internal checkpoints co
 | Model reruns after durable completion | Zero. |
 | Edit storage | One visible row per logical message and at most one unresolved row per target and sender. |
 | Current-edit redaction | Strict reads return the server-authoritative prior revision after point refetch and never stale content. |
+| Redacted revision exposure | Zero reads of any kind return a revision whose redaction was durably admitted. |
 | Conversation reads | Bounded cursor pages using the conversation index. |
 | Post-hydration room scans | Zero. |
 | SQLite lock failures | Zero in the 50-conversation stress run. |

--- a/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
+++ b/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
@@ -1,0 +1,1067 @@
+# Matrix Event Journal and Conversation Projection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace MindRoom's overlapping Matrix cache, callback-obligation, history-repair, and visible-delivery state machines with one durable ingress journal, one latest-visible-message projection, and one idempotent terminal-delivery outbox while preserving zero-loss recovery and fast conversation reconstruction.
+
+**Architecture:** Nio remains the transport authority for `LIVE`, `RECOVERED`, and `HISTORY`, while MindRoom collapses provenance at durable admission into `ACTIONABLE` or `CONTEXT_ONLY`, projects each logical message into one current row, resumes actionable work from the journal after crashes, and retries initial and final Matrix delivery with deterministic transaction IDs.
+
+**Tech Stack:** Python 3.13, mindroom-nio 0.36 or newer, asyncio, SQLite with WAL, PostgreSQL through psycopg, pytest, Hypothesis, Tuwunel, Synapse, and Matrix Client-Server APIs.
+
+## Global Constraints
+
+- The MindRoom work is one implementation branch and one implementation PR, even though it is split into reviewable commits below.
+- The small recursive-relations prerequisite lands first as its own mindroom-nio PR because repositories cannot share an atomic commit.
+- Do not merge an intermediate commit that contains both the old and new production paths.
+- Do not add a feature flag, shadow writer, compatibility facade, dual-read fallback, or runtime switch between the old and new designs.
+- New code may exist unused during an early commit on the unmerged branch, but the cutover commit must delete the replaced production path in the same commit.
+- The final implementation diff must contain fewer production source lines than `origin/main` by at least 8,000 lines across the files in the removal ledger below.
+- The target is a reduction of at least 10,000 production source lines, and missing that target requires a written explanation in the implementation PR.
+- If the final reduction is below 8,000 lines, stop and redesign instead of asking reviewers to merge an architectural transition.
+- If any third review round still finds a new correctness class, stop patching and reconsider the design before continuing.
+- Nio is the only owner of transport provenance, limited-timeline recovery, room baselines, pagination safety, and callback redelivery.
+- MindRoom must not infer recovery from pagination cursors, repeated membership events, timestamps, `limited`, `prev_batch`, or server-specific response shapes.
+- MindRoom must map `LIVE` and `RECOVERED` to `ACTIONABLE` and must map `HISTORY` to `CONTEXT_ONLY` exactly once at admission.
+- Code after durable admission must not branch on raw nio provenance.
+- The no-loss guarantee begins after the bot completes its first successful baseline response and publishes readiness.
+- Before readiness, historical events may populate context but must never create turns.
+- After readiness, an actionable event must either become durably pending before nio accepts it or cause `nio.CallbackNotAcceptedError` so nio and the Matrix cursor remain retryable.
+- A persistence failure must never advance the application-owned Classic Sync checkpoint.
+- An unrecovered room must keep the bot unready and must not be converted into best-effort history.
+- Conversation reads must not scan a room after that conversation has been hydrated once.
+- Thread hydration must use one recursive event-relations traversal rooted at the thread event rather than room-wide `/messages` scans.
+- Room-scoped conversations may perform one serialized initial `/messages` pagination, but the result must be installed atomically and all later reads must use the projection.
+- A server that cannot provide Matrix v1.10 recursive relations must fail the strict thread-hydration contract rather than trigger a room-scan repair subsystem.
+- Intermediate AI edit bodies and edit chains are not durable product data.
+- A logical message has one projection row whose latest visible content is replaced in place.
+- An out-of-order older edit must not overwrite a newer projected edit.
+- An edit whose original has not arrived may occupy one latest-unresolved row for that target, but a second edit must replace that row instead of extending a chain.
+- Redacting the current edit must trigger a point hydration of that logical message because the previous edit body is intentionally not retained.
+- A strict conversation read must wait for that point hydration instead of serving content known to be stale.
+- SQLite must have exactly one writer task per store, while reads may use separate read connections.
+- PostgreSQL must implement the same contract and pass the same backend tests before the cutover commit is considered complete.
+- The hot path must not create one SQLite connection per callback or per cache concern.
+- Initial response sends and terminal response sends or edits must use a durable outbox and deterministic Matrix transaction IDs.
+- Intermediate streaming edits may be coalesced in memory and may be lost during a crash because the next terminal update restores the latest visible state.
+- An outbox payload becomes immutable when its first send attempt begins, because the homeserver may have accepted that transaction ID even if the client did not observe the response.
+- The final response body must always be durably enqueued before delivery.
+- Existing source redaction, authorization, E2EE metadata, media transcript, large-message sidecar, reaction, command, and room-membership semantics remain in scope.
+- Backward-compatible cache schemas are out of scope, but the existing `SyncContinuityStore` checkpoint format remains readable so a stopped deployment can resume without dropping messages during cutover.
+- Do not add production code to `bot.py` beyond construction, registration, lifecycle calls, and routing into focused collaborators.
+- Use dataclasses and typed protocols for boundaries, and do not use `getattr()` or `hasattr()` to weaken nio or storage types.
+- Every task below begins with a failing test or measurable failing check and ends with a focused commit.
+
+---
+
+## Why This Plan Is Executable
+
+The current overlapping subsystem contains 20,248 production lines across `src/mindroom/matrix/cache/`, `client_thread_history.py`, `conversation_cache.py`, `dispatch_obligations/`, `handled_turns.py`, `turn_store.py`, the cold-history fence, and sync cache-trust modules.
+
+The implementation is not complete merely when the new tables and interfaces work.
+
+It is complete only when the old owners named in the removal ledger are gone, the final source budget is met, and the same crash and load tests prove the replacement.
+
+The work stays on one unmerged branch so temporary scaffolding cannot become a second permanent architecture.
+
+The implementation PR must contain this table with actual measured values before review.
+
+| Gate | Required result |
+| --- | --- |
+| Actionable event durability | Zero lost or duplicate turns across every enumerated crash point. |
+| Historical admission | `HISTORY` populates context and never starts a turn. |
+| Restart recovery | The realistic `messages([], None)` restart case replies exactly once. |
+| Edit storage | 10,000 edits of 100 logical messages leave 100 visible rows and at most 100 unresolved-edit rows. |
+| Conversation query | `EXPLAIN` shows the room/thread/order index and no room-wide scan. |
+| SQLite contention | Zero `database is locked` errors in the 50-thread stress run. |
+| Delivery idempotency | Crashing after Matrix accepts an initial or final send creates one visible response. |
+| Production source size | At least 8,000 net lines removed, with 10,000 lines as the target. |
+| Competing paths | No old cache, dispatch-obligation, history-repair, or non-idempotent terminal-send fallback remains. |
+
+If a gate fails, fix the design that owns the failure rather than adding a fallback around it.
+
+## State Model
+
+The storage package exposes four durable concepts and no generic cache API.
+
+```python
+class EventActionability(StrEnum):
+    ACTIONABLE = "actionable"
+    CONTEXT_ONLY = "context_only"
+
+
+class JournalOutcome(StrEnum):
+    PENDING = "pending"
+    COMPLETED = "completed"
+    INTENTIONALLY_IGNORED = "intentionally_ignored"
+
+
+@dataclass(frozen=True, slots=True)
+class MatrixEventEnvelope:
+    principal_id: str
+    room_id: str
+    event_id: str
+    event_kind: MatrixEventKind
+    actionability: EventActionability
+    event_source: dict[str, object]
+    membership_epoch: int
+    provenance: nio.TimelineEventProvenance
+
+
+@dataclass(frozen=True, slots=True)
+class ConversationKey:
+    principal_id: str
+    room_id: str
+    thread_id: str | None
+```
+
+The `provenance` field is retained only in the journal's diagnostic data until the event settles.
+
+The pending worker receives `actionability`, not raw provenance.
+
+The public store contract is deliberately small.
+
+```python
+class MatrixEventStore(Protocol):
+    async def admit(self, envelope: MatrixEventEnvelope) -> JournalAdmission: ...
+    async def pending(self, *, limit: int) -> tuple[JournalEvent, ...]: ...
+    async def settle(self, event_id: str, outcome: JournalOutcome) -> None: ...
+    async def load_conversation(self, key: ConversationKey) -> ConversationProjection: ...
+    async def install_hydration(self, hydration: ConversationHydration) -> None: ...
+    async def enqueue_delivery(self, delivery: OutboxDelivery) -> None: ...
+    async def pending_deliveries(self, *, limit: int) -> tuple[OutboxDelivery, ...]: ...
+    async def mark_delivered(self, key: OutboxKey, event_id: str) -> None: ...
+    async def mark_room_joined(self, room_id: str) -> int: ...
+    async def mark_room_departed(self, room_id: str) -> int: ...
+```
+
+`JournalAdmission` returns the durable receipt order, whether the event was newly inserted, and whether actionable work remains pending.
+
+It does not expose storage-specific rows or cache trust.
+
+## SQL Shape
+
+SQLite and PostgreSQL use equivalent constraints and indexes with backend-appropriate identity syntax.
+
+```sql
+CREATE TABLE matrix_event_journal (
+    principal_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    room_id TEXT NOT NULL,
+    event_kind TEXT NOT NULL,
+    actionability TEXT NOT NULL,
+    event_json TEXT,
+    provenance TEXT,
+    membership_epoch INTEGER NOT NULL,
+    receipt_order INTEGER NOT NULL,
+    outcome TEXT NOT NULL,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (principal_id, event_id)
+);
+
+CREATE INDEX matrix_event_journal_pending
+ON matrix_event_journal(principal_id, outcome, receipt_order);
+
+CREATE TABLE visible_messages (
+    principal_id TEXT NOT NULL,
+    room_id TEXT NOT NULL,
+    logical_event_id TEXT NOT NULL,
+    thread_id TEXT,
+    sender TEXT NOT NULL,
+    created_ts INTEGER NOT NULL,
+    latest_event_id TEXT NOT NULL,
+    latest_event_ts INTEGER NOT NULL,
+    visible_json TEXT NOT NULL,
+    needs_refresh INTEGER NOT NULL DEFAULT 0,
+    redacted INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (principal_id, room_id, logical_event_id)
+);
+
+CREATE INDEX visible_messages_conversation
+ON visible_messages(principal_id, room_id, thread_id, created_ts, logical_event_id);
+
+CREATE TABLE pending_message_edits (
+    principal_id TEXT NOT NULL,
+    room_id TEXT NOT NULL,
+    logical_event_id TEXT NOT NULL,
+    sender TEXT NOT NULL,
+    edit_event_id TEXT NOT NULL,
+    edit_ts INTEGER NOT NULL,
+    edit_json TEXT NOT NULL,
+    PRIMARY KEY (principal_id, room_id, logical_event_id)
+);
+
+CREATE TABLE conversation_hydration (
+    principal_id TEXT NOT NULL,
+    room_id TEXT NOT NULL,
+    thread_id TEXT,
+    membership_epoch INTEGER NOT NULL,
+    complete INTEGER NOT NULL,
+    PRIMARY KEY (principal_id, room_id, thread_id)
+);
+
+CREATE TABLE response_outbox (
+    principal_id TEXT NOT NULL,
+    turn_id TEXT NOT NULL,
+    stage TEXT NOT NULL,
+    transaction_id TEXT NOT NULL,
+    room_id TEXT NOT NULL,
+    target_event_id TEXT,
+    content_json TEXT NOT NULL,
+    attempted INTEGER NOT NULL DEFAULT 0,
+    delivered_event_id TEXT,
+    PRIMARY KEY (principal_id, turn_id, stage),
+    UNIQUE (principal_id, transaction_id)
+);
+```
+
+SQLite must represent an unthreaded conversation with a canonical empty storage key rather than depending on nullable primary-key equality.
+
+The typed API continues to expose `thread_id: str | None` and performs the storage conversion in one helper.
+
+## Projection Rules
+
+- A non-edit message inserts one `visible_messages` row keyed by its own event ID.
+- A valid same-sender `m.replace` event updates the target row only when `(origin_server_ts, event_id)` is newer than `(latest_event_ts, latest_event_id)`.
+- A replacement never changes `created_ts`, `logical_event_id`, room, thread, or sender.
+- An edit without an original upserts one `pending_message_edits` row using the same ordering comparison.
+- Arrival of the original atomically applies and deletes the unresolved row when the sender matches.
+- A redaction of the original tombstones the visible row.
+- A redaction of the latest replacement marks the row `needs_refresh=1` and schedules a point hydration.
+- A redaction of an already superseded replacement changes no visible state.
+- Media transcription, large-message hydration, and normalized visible content update the same `visible_json` row.
+- Once a context-only event is projected, its journal payload is deleted because replaying the projection is idempotent.
+- Once an ignored own echo or intermediate AI edit is projected, its journal row is deleted because it can never create a turn.
+- A terminal actionable source retains only its compact identity and outcome for deduplication, not its edit body or full event JSON.
+- A pending actionable source retains the exact replay event JSON and E2EE security metadata until settlement.
+
+## Deterministic Delivery Rules
+
+Use UUIDv5 with a fixed MindRoom namespace and the string `principal_id:turn_id:stage` to derive the Matrix transaction ID.
+
+The `stage` values are `initial` and `final`.
+
+The initial row represents either the first substantive send or the placeholder send.
+
+The final row represents the terminal send when no visible event exists or the terminal `m.replace` when one does.
+
+The outbox row must be committed before calling `room_send`.
+
+Retrying a row must pass its stored transaction ID through `send_message_result` or `edit_message_result`.
+
+The row's content and target event ID become immutable when `attempted` changes to true.
+
+Intermediate stream updates remain in the existing in-memory `StreamingResponse` coalescer and do not create outbox rows.
+
+## Removal Ledger
+
+The final implementation must delete or replace the following production owners.
+
+| Current owner | Required final state |
+| --- | --- |
+| `src/mindroom/matrix/cache/` | Delete the 29-file cache package after moving only normalized projection behavior into `matrix/event_store/`. |
+| `src/mindroom/matrix/client_thread_history.py` | Delete room-scan, refill, gap, snapshot, and repair logic after focused hydration exists. |
+| `src/mindroom/matrix/conversation_cache.py` | Replace with a small `conversation_projection.py` reader and hydrator. |
+| `src/mindroom/dispatch_obligations/` | Delete after journal admission and pending-worker replay own exact callbacks. |
+| `src/mindroom/dispatch_admission.py` | Delete after actionability becomes part of journal admission. |
+| `src/mindroom/cold_history_fence.py` | Delete after the provenance mapping happens in the admission adapter. |
+| `src/mindroom/matrix/sync_cache_trust.py` | Delete cache-generation trust and retain only direct checkpoint publication. |
+| `src/mindroom/matrix/sync_certification.py` | Delete cache certification and replace it with a response-accepted predicate. |
+| `src/mindroom/turn_settlement_retry.py` | Delete after journal settlement is the pending worker's responsibility. |
+| `src/mindroom/matrix/cache/write_coordinator.py` | Delete with the cache package and use one store writer. |
+| Advisory `notify_outbound_*` paths | Delete after acknowledged sends update the projection through the event store. |
+| Duplicated handled-source state | Remove from `handled_turns.py` and `turn_store.py` after the journal is the source identity owner. |
+
+The implementation may retain AI-run metadata in `TurnStore`, but it must not retain a second pending-source, response-idempotency, or callback-replay state machine.
+
+---
+
+## Task 1: Freeze the Contract and the Deletion Budget
+
+**Files:**
+
+- Create: `tests/test_matrix_event_store_contract.py`
+- Create: `tests/test_matrix_event_pipeline_crashes.py`
+- Create: `tests/test_matrix_event_pipeline_performance.py`
+- Modify: `tests/test_matrix_sync_continuity.py`
+- Modify: `tests/test_streaming_e2e.py`
+
+- [ ] **Step 1: Record the source baseline.**
+
+Run:
+
+```bash
+wc -l \
+  src/mindroom/matrix/cache/*.py \
+  src/mindroom/matrix/client_thread_history.py \
+  src/mindroom/matrix/conversation_cache.py \
+  src/mindroom/dispatch_obligations/*.py \
+  src/mindroom/handled_turns.py \
+  src/mindroom/turn_store.py \
+  src/mindroom/cold_history_fence.py \
+  src/mindroom/dispatch_admission.py \
+  src/mindroom/matrix/sync_cache_trust.py \
+  src/mindroom/matrix/sync_certification.py \
+  src/mindroom/matrix/sync_continuity.py
+```
+
+Expected: the current baseline totals 20,248 lines on commit `b639b6ef3`.
+
+- [ ] **Step 2: Add table-driven crash-point tests.**
+
+Cover these crash points for one actionable source.
+
+1. Crash before journal commit.
+2. Crash after journal commit but before nio records admission.
+3. Crash after nio records admission but before the worker starts.
+4. Crash after the worker records a pending turn but before model execution.
+5. Crash after model execution but before final outbox commit.
+6. Crash after final outbox commit but before Matrix accepts the transaction.
+7. Crash after Matrix accepts the transaction but before the outbox records the event ID.
+8. Crash after outbox acknowledgement but before journal settlement.
+
+Assert that cases one through three replay the event, cases four through eight resume durable work, and every case produces one terminal turn and one visible response.
+
+- [ ] **Step 3: Change the realistic restart regression to bounded exhaustion with no `end`.**
+
+Keep the production sequence in `tests/test_matrix_sync_continuity.py` with a persisted baseline, a fresh `prev_batch`, exact unchanged own membership, and `messages([], None)`.
+
+Assert that the initial-window message is `RECOVERED`, reaches durable actionable admission, and receives exactly one reply.
+
+Keep negative tests for no baseline, missing or mismatched membership, pagination failure, repeated cursor, cap abandonment, and cold history.
+
+- [ ] **Step 4: Add the edit compaction contract.**
+
+Generate 10,000 ordered and shuffled edits across 100 logical messages.
+
+Assert that the projection contains 100 visible rows, retains the newest body per message, stores no settled intermediate edit JSON, and uses at most 100 unresolved rows when originals are deliberately withheld.
+
+- [ ] **Step 5: Add the indexed conversation-read contract.**
+
+Create 500 visible messages in one thread and 10,000 messages in unrelated rooms and threads.
+
+Assert exact chronological output and assert through `EXPLAIN QUERY PLAN` that SQLite uses `visible_messages_conversation`.
+
+Add the PostgreSQL equivalent with `EXPLAIN (FORMAT JSON)` and assert an index scan over the conversation index.
+
+- [ ] **Step 6: Add the outbox idempotency contract.**
+
+Make the fake Matrix server accept the deterministic transaction and then raise a connection error before returning the event ID.
+
+Restart the worker and assert that retrying the same transaction produces the same event ID and one visible event.
+
+- [ ] **Step 7: Run the new tests and confirm they fail for missing interfaces.**
+
+Run:
+
+```bash
+uv run pytest -q \
+  tests/test_matrix_event_store_contract.py \
+  tests/test_matrix_event_pipeline_crashes.py \
+  tests/test_matrix_event_pipeline_performance.py \
+  tests/test_matrix_sync_continuity.py \
+  tests/test_streaming_e2e.py
+```
+
+Expected: the new store and pipeline tests fail because `mindroom.matrix.event_store` does not exist yet, while existing tests still pass outside the selected new cases.
+
+- [ ] **Step 8: Commit the red contract.**
+
+```bash
+git add tests/test_matrix_event_store_contract.py \
+  tests/test_matrix_event_pipeline_crashes.py \
+  tests/test_matrix_event_pipeline_performance.py \
+  tests/test_matrix_sync_continuity.py \
+  tests/test_streaming_e2e.py
+git commit -m "test: define durable Matrix event pipeline contract"
+```
+
+## Task 2: Implement the Storage-Neutral Domain and Projection Reducer
+
+**Files:**
+
+- Create: `src/mindroom/matrix/event_store/__init__.py`
+- Create: `src/mindroom/matrix/event_store/types.py`
+- Create: `src/mindroom/matrix/event_store/protocol.py`
+- Create: `src/mindroom/matrix/event_store/projection.py`
+- Create: `tests/test_matrix_event_projection.py`
+
+- [ ] **Step 1: Write reducer tests before implementation.**
+
+Cover original arrival, latest edit replacement, older delayed edit rejection, cross-sender edit rejection, edit-before-original, original arrival after edit, original redaction, current-edit redaction, superseded-edit redaction, media transcript update, and thread-order stability.
+
+- [ ] **Step 2: Implement the typed domain.**
+
+Add `EventActionability`, `MatrixEventKind`, `JournalOutcome`, `MatrixEventEnvelope`, `JournalAdmission`, `JournalEvent`, `ConversationKey`, `VisibleMessage`, `ConversationProjection`, `ConversationHydration`, `OutboxKey`, and `OutboxDelivery` as frozen slotted dataclasses or string enums.
+
+Keep storage rows private to each backend.
+
+- [ ] **Step 3: Implement pure projection decisions.**
+
+Make `projection.py` a side-effect-free reducer that returns typed insert, replace, ignore, tombstone, unresolved-edit, or refresh-required decisions.
+
+Do not import SQLite, PostgreSQL, nio clients, bot runtime objects, or Matrix network helpers into this module.
+
+- [ ] **Step 4: Run the focused reducer tests.**
+
+```bash
+uv run pytest -q tests/test_matrix_event_projection.py
+```
+
+Expected: all projection reducer tests pass.
+
+- [ ] **Step 5: Commit the domain and reducer.**
+
+```bash
+git add src/mindroom/matrix/event_store tests/test_matrix_event_projection.py
+git commit -m "feat: define Matrix event journal and projection domain"
+```
+
+## Task 3: Implement One-Writer SQLite and PostgreSQL Stores
+
+**Files:**
+
+- Create: `src/mindroom/matrix/event_store/schema.py`
+- Create: `src/mindroom/matrix/event_store/sqlite.py`
+- Create: `src/mindroom/matrix/event_store/postgres.py`
+- Create: `src/mindroom/matrix/event_store/writer.py`
+- Modify: `tests/test_matrix_event_store_contract.py`
+- Modify: `tests/conftest.py`
+
+- [ ] **Step 1: Parameterize one backend contract.**
+
+Run every journal, projection, hydration, membership, compaction, and outbox behavior against SQLite and PostgreSQL through the `MatrixEventStore` protocol.
+
+Skip PostgreSQL only when the repository's standard PostgreSQL test fixture is unavailable.
+
+- [ ] **Step 2: Implement the SQLite schema and one writer.**
+
+Open one WAL-mode writer connection for the store lifetime and route typed write commands through one bounded asyncio queue.
+
+Batch commands that are already concurrently waiting, but complete each caller only after the transaction containing its command commits.
+
+Use separate short-lived or pooled read connections without creating additional writers.
+
+- [ ] **Step 3: Implement atomic admission and projection.**
+
+One admission transaction must verify the room membership epoch, insert or deduplicate the journal event, apply the projection reducer, compact context-only payloads when safe, and return `JournalAdmission`.
+
+A failed statement must roll back the whole admission.
+
+- [ ] **Step 4: Implement the PostgreSQL backend with identical semantics.**
+
+Use a transaction and row constraints equivalent to SQLite.
+
+Do not add PostgreSQL-only recovery behavior or a second protocol.
+
+- [ ] **Step 5: Prove bounded edit storage and indexed reads.**
+
+Run:
+
+```bash
+uv run pytest -q \
+  tests/test_matrix_event_store_contract.py \
+  tests/test_matrix_event_projection.py \
+  tests/test_matrix_event_pipeline_performance.py
+```
+
+Expected: backend contracts, edit compaction, and query-plan assertions pass for every available backend.
+
+- [ ] **Step 6: Commit the stores.**
+
+```bash
+git add src/mindroom/matrix/event_store tests/test_matrix_event_store_contract.py tests/conftest.py
+git commit -m "feat: persist Matrix journal and visible projection"
+```
+
+## Task 4: Cut Ingress Over to the Journal and Delete Dispatch Obligations
+
+**Files:**
+
+- Create: `src/mindroom/matrix/event_ingress.py`
+- Create: `src/mindroom/matrix/event_worker.py`
+- Create: `tests/test_matrix_event_ingress.py`
+- Modify: `src/mindroom/runtime_support.py`
+- Modify: `src/mindroom/bot.py`
+- Modify: `src/mindroom/turn_controller.py`
+- Modify: `src/mindroom/dispatch_handoff.py`
+- Modify: `src/mindroom/dispatch_replay_guard.py`
+- Delete: `src/mindroom/dispatch_obligations/`
+- Delete: `src/mindroom/dispatch_admission.py`
+- Delete: `src/mindroom/cold_history_fence.py`
+- Delete: `src/mindroom/turn_settlement_retry.py`
+- Rewrite: `tests/test_dispatch_obligations.py` as journal and worker tests, then rename or delete it.
+
+- [ ] **Step 1: Add exact provenance-mapping tests.**
+
+Assert `LIVE -> ACTIONABLE`, `RECOVERED -> ACTIONABLE`, and `HISTORY -> CONTEXT_ONLY` for every supported message, media, reaction, approval, room-lifecycle, redaction, and decryption-failure event kind.
+
+Assert that downstream handler inputs contain actionability but not raw provenance.
+
+- [ ] **Step 2: Add the nio admission adapter.**
+
+Register exactly one `AsyncClient.add_event_admission_callback` that builds `MatrixEventEnvelope`, awaits `store.admit`, and raises `nio.CallbackNotAcceptedError` on any durability or membership-epoch rejection.
+
+The callback must not execute commands, turns, hooks, reactions, or visible delivery.
+
+- [ ] **Step 3: Add the pending worker.**
+
+Load pending rows by receipt order, claim one row only in memory, dispatch it through one typed event-kind mapping, settle it after the semantic owner commits, and leave it pending on cancellation or failure.
+
+Startup must wake the worker before readiness can report healthy actionable processing.
+
+No durable `running` state is needed because a crash must leave the row pending.
+
+- [ ] **Step 4: Preserve typed replay inputs.**
+
+Move only the exact event serialization and E2EE security metadata needed from `dispatch_obligations/events.py` into `event_ingress.py`.
+
+Reject corrupt replay sources explicitly and do not invent fallback events.
+
+- [ ] **Step 5: Wire the composition root.**
+
+Make `runtime_support.py` construct one shared backend and one principal-bound view.
+
+Make `bot.py` register the admission adapter, start and stop the pending worker, and route existing semantic handlers through its public methods.
+
+Do not move classification, retries, or storage SQL into `bot.py`.
+
+- [ ] **Step 6: Remove the old path in the same cutover commit.**
+
+Delete dispatch obligations, the cold-history fence, dispatch admission, settlement retry, callback-kind retry scheduling, semantic-consumer claims, and their composition-root fields.
+
+Remove tests that assert the deleted implementation rather than retained behavior.
+
+- [ ] **Step 7: Run ingress, crash, and sync-continuity tests.**
+
+```bash
+uv run pytest -q \
+  tests/test_matrix_event_ingress.py \
+  tests/test_matrix_event_pipeline_crashes.py \
+  tests/test_matrix_sync_continuity.py \
+  tests/test_cold_history_fence.py \
+  tests/test_dispatch_obligations.py
+```
+
+Expected: the new ingress and crash contracts pass, and deleted implementation tests are removed or rewritten rather than preserved through adapters.
+
+- [ ] **Step 8: Commit the ingress cutover and deletion together.**
+
+```bash
+git add -A src/mindroom tests
+git commit -m "refactor: replace dispatch obligations with event journal"
+```
+
+## Task 5: Replace Cache Repair with Direct Projection Reads and One-Time Hydration
+
+**Files:**
+
+- Create: `src/mindroom/matrix/conversation_projection.py`
+- Create: `src/mindroom/matrix/conversation_hydration.py`
+- Create: `tests/test_conversation_projection.py`
+- Modify: `src/mindroom/conversation_resolver.py`
+- Modify: `src/mindroom/matrix/reply_chain.py`
+- Modify: `src/mindroom/reaction_dispatch.py`
+- Modify: `src/mindroom/matrix/stale_stream_cleanup.py`
+- Modify: `src/mindroom/hooks/sender.py`
+- Modify: `src/mindroom/streaming.py`
+- Modify: `src/mindroom/runtime_support.py`
+- Modify: `src/mindroom/bot.py`
+- Delete: `src/mindroom/matrix/cache/`
+- Delete: `src/mindroom/matrix/client_thread_history.py`
+- Delete: `src/mindroom/matrix/conversation_cache.py`
+- Delete or rewrite: `tests/test_event_cache*.py`
+- Delete or rewrite: `tests/test_thread_history.py`
+- Delete or rewrite: `tests/test_bot_sync_event_cache.py`
+- Delete or rewrite: `tests/test_matrix_event_cache*.py`
+
+- [ ] **Step 1: Add conversation-reader behavior tests.**
+
+Cover a hydrated thread, an unhydrated thread, concurrent first readers, an unthreaded room conversation, redacted content, media transcript content, large-message content, a current-edit redaction requiring point refresh, a leave/rejoin epoch, and a backend outage.
+
+- [ ] **Step 2: Implement the projection reader.**
+
+`ConversationProjectionReader.get_conversation` must perform one indexed store call and return the existing canonical resolved-message type expected by prompt assembly.
+
+It must not know about gaps, snapshots, trust generations, refills, stale fallbacks, or write coordinators.
+
+- [ ] **Step 3: Land the recursive-relations prerequisite in mindroom-nio.**
+
+In `mindroom-ai/mindroom-nio`, add a typed `recurse: bool = False` parameter to `Api.room_get_event_relations` and `AsyncClient.room_get_event_relations`, encode `recurse=true` in the query only when requested, and cover pagination in `tests/async_client_test.py`.
+
+Release the change, bump MindRoom's nio dependency, and do not add any batch-admission or application-storage behavior to nio.
+
+The expected nio change is less than 50 production lines because the server and response iterator already implement recursive relation responses.
+
+- [ ] **Step 4: Implement one-time hydration.**
+
+For threads, fetch the root with `room_get_event`, paginate `room_get_event_relations` with `recurse=True` and no relation-type filter, reduce the returned thread replies and nested replacements into latest visible messages, and install the entire hydration in one membership-epoch-checked transaction.
+
+The recursive response may contain a historical edit chain, but MindRoom must retain only the reducer's latest visible row and at most one unresolved edit per target.
+
+For room-scoped conversations, perform one serialized `/messages` pagination and install it through the same transaction.
+
+Use one in-flight task per `ConversationKey` so concurrent first readers share the network work.
+
+Mark hydration complete only after pagination ends successfully and the installation commits.
+
+- [ ] **Step 5: Define the homeserver contract.**
+
+At startup, read `/versions` and require Matrix v1.10 or a successful recursive-relations feature probe for strict historical thread hydration.
+
+If recursive relations are absent, report an actionable readiness failure instead of restoring full-room rescans or durable local edit chains.
+
+Add live contract coverage for recursive relation results in Task 10.
+
+- [ ] **Step 6: Replace production consumers.**
+
+Change conversation resolution, reply-chain lookup, reaction lookup, stale-stream cleanup, hooks, and streaming thread targeting to use the projection reader's narrow methods.
+
+Preserve one per-turn point-lookup memo only if a measured caller performs duplicate event lookups inside a turn.
+
+- [ ] **Step 7: Delete the cache and repair path in the same cutover commit.**
+
+Remove the 29-file cache package, room-scan history, snapshot replacement, gap markers, stale cache fallback, cache generations, advisory outbound writes, startup prewarm, and `EventCacheWriteCoordinator`.
+
+Do not keep old tests green by recreating old methods on the new reader.
+
+- [ ] **Step 8: Run projection and retained behavior tests.**
+
+```bash
+uv run pytest -q \
+  tests/test_conversation_projection.py \
+  tests/test_matrix_event_store_contract.py \
+  tests/test_thread_history.py \
+  tests/test_matrix_sync_continuity.py \
+  tests/test_streaming.py \
+  tests/test_bot_reactions_approvals.py
+```
+
+Expected: retained behavior passes through projection tests, while implementation-specific cache tests are deleted or reduced to backend contract tests.
+
+- [ ] **Step 9: Check the first deletion gate.**
+
+```bash
+git diff --numstat origin/main...HEAD -- src/mindroom
+find src/mindroom/matrix/event_store -name '*.py' -print0 | xargs -0 wc -l
+```
+
+Expected: production source is already net negative and no deleted cache module is imported.
+
+- [ ] **Step 10: Commit the projection cutover and deletion together.**
+
+```bash
+git add -A src/mindroom tests
+git commit -m "refactor: replace Matrix cache repair with visible projection"
+```
+
+## Task 6: Reduce Sync Continuity to Durable Admission and Checkpoint Publication
+
+**Files:**
+
+- Create: `src/mindroom/matrix/sync_checkpoint.py`
+- Modify: `src/mindroom/matrix/sync_continuity.py`
+- Modify: `src/mindroom/bot.py`
+- Modify: `tests/test_matrix_sync_continuity.py`
+- Delete: `src/mindroom/matrix/sync_cache_trust.py`
+- Delete: `src/mindroom/matrix/sync_certification.py`
+
+- [ ] **Step 1: Add a three-state checkpoint contract.**
+
+Test cold baseline, established continuation, and failed response.
+
+The cold baseline may persist context and then publish readiness, the established continuation may advance only after every admission commits, and a failed response must retain the prior checkpoint and reset nio's transient Classic state.
+
+- [ ] **Step 2: Implement direct checkpoint ownership.**
+
+Keep `SyncContinuityStore` as the crash-atomic file owner for the existing checkpoint and join-fence format.
+
+Replace cache certification with a small `SyncCheckpointOwner` that receives response success, `unrecovered_room_ids`, and the highest admission receipt for diagnostics.
+
+Do not attach a cache generation because the journal itself is durable and idempotent.
+
+- [ ] **Step 3: Fail closed on unrecovered responses.**
+
+If nio reports any unrecovered room after readiness, leave the prior checkpoint unchanged, reset the transient Classic sync state, keep the bot unready, and surface the exact room IDs in health diagnostics.
+
+Do not reclassify those events in MindRoom.
+
+- [ ] **Step 4: Delete cache trust and certification.**
+
+Remove generation comparison, cache pending-write diagnostics, cache availability certification, cold-cache cleanup, and cache-driven checkpoint invalidation.
+
+- [ ] **Step 5: Run continuity tests.**
+
+```bash
+uv run pytest -q tests/test_matrix_sync_continuity.py
+```
+
+Expected: baseline, restart recovery, unknown-position reset, persistence failure, cancellation, membership, and realistic `messages([], None)` tests pass without cache trust.
+
+- [ ] **Step 6: Commit the checkpoint simplification.**
+
+```bash
+git add -A src/mindroom/matrix src/mindroom/bot.py tests/test_matrix_sync_continuity.py
+git commit -m "refactor: gate Matrix checkpoints on durable admission"
+```
+
+## Task 7: Add the Durable Terminal Outbox and Coalesce Intermediate Edits
+
+**Files:**
+
+- Create: `src/mindroom/matrix/response_outbox.py`
+- Create: `tests/test_response_outbox.py`
+- Modify: `src/mindroom/matrix/client_delivery.py`
+- Modify: `src/mindroom/delivery_gateway.py`
+- Modify: `src/mindroom/streaming.py`
+- Modify: `src/mindroom/response_attempt.py`
+- Modify: `src/mindroom/visible_response_reconciliation.py`
+- Modify: `tests/test_matrix_delivery.py`
+- Modify: `tests/test_streaming_e2e.py`
+- Modify: `tests/test_streaming_edits.py`
+
+- [ ] **Step 1: Add deterministic transaction tests.**
+
+Assert stable transaction IDs across processes, different IDs for initial and final stages, immutable payloads after first attempt, and one homeserver event after an accepted-but-unacknowledged retry.
+
+- [ ] **Step 2: Thread transaction IDs through low-level delivery.**
+
+Add a required transaction ID to the outbox-owned paths in `send_message_result` and `edit_message_result` while leaving explicitly non-outbox utilities typed and deliberate.
+
+Ensure encrypted and cache-bypass sends use the supplied transaction ID instead of generating `uuid4()`.
+
+- [ ] **Step 3: Enqueue before terminal delivery.**
+
+Make the delivery gateway persist initial and final `OutboxDelivery` rows before network I/O, retry pending rows on startup, and mark them delivered with the returned event ID.
+
+The pending worker may settle the source only after the final outbox row is durably acknowledged or deliberately terminal without a visible response.
+
+- [ ] **Step 4: Keep only latest unsent intermediate content.**
+
+Retain one in-memory pending streaming body and replace it when newer model output arrives before the next edit begins.
+
+Once an edit attempt starts, freeze that payload until the attempt returns, then send only the newest accumulated body if it changed.
+
+Do not insert intermediate edit bodies into the outbox or journal.
+
+- [ ] **Step 5: Collapse visible response reconciliation.**
+
+Replace duplicate pending-visible and retry state with outbox queries keyed by turn and stage.
+
+Delete `visible_response_reconciliation.py` if no unique non-outbox behavior remains, or reduce it to a stateless adoption helper.
+
+- [ ] **Step 6: Run delivery and streaming tests.**
+
+```bash
+uv run pytest -q \
+  tests/test_response_outbox.py \
+  tests/test_matrix_delivery.py \
+  tests/test_streaming_e2e.py \
+  tests/test_streaming_edits.py \
+  tests/test_matrix_event_pipeline_crashes.py
+```
+
+Expected: duplicate-delivery crash cases pass, final content survives restart, and intermediate edits are coalesced without durable edit history.
+
+- [ ] **Step 7: Commit the outbox cutover.**
+
+```bash
+git add -A src/mindroom tests
+git commit -m "feat: deliver terminal Matrix responses through durable outbox"
+```
+
+## Task 8: Remove Duplicate Turn and Source State
+
+**Files:**
+
+- Modify: `src/mindroom/turn_store.py`
+- Modify: `src/mindroom/handled_turns.py`
+- Modify: `src/mindroom/dispatch_replay_guard.py`
+- Modify: `src/mindroom/visible_response_reconciliation.py`
+- Modify: `src/mindroom/sync_restart_retry.py`
+- Modify: `tests/test_turn_store.py`
+- Modify: `tests/test_handled_turns.py`
+- Modify: `tests/test_turn_controller_focused.py`
+- Modify: `tests/test_voice_command_processing.py`
+
+- [ ] **Step 1: Inventory every remaining durable source identity.**
+
+Run:
+
+```bash
+rg -n "source_event_id|pending.*turn|response_event_id|retry.*source|handled" \
+  src/mindroom/turn_store.py \
+  src/mindroom/handled_turns.py \
+  src/mindroom/dispatch_replay_guard.py \
+  src/mindroom/visible_response_reconciliation.py \
+  src/mindroom/sync_restart_retry.py
+```
+
+Classify each field as AI-run metadata, journal-owned ingress state, or outbox-owned delivery state.
+
+- [ ] **Step 2: Add ownership tests.**
+
+Assert that the journal is the only durable pending-source owner, the outbox is the only durable delivery-intent owner, and `TurnStore` retains only model-execution and terminal business metadata.
+
+- [ ] **Step 3: Remove duplicate owners.**
+
+Delete handled-source tombstones, pending-visible intent, retry-source journals, and response-delivery reconciliation from `HandledTurnLedger` and `TurnStore` when the journal or outbox owns the same fact.
+
+Delete entire modules when their last unique responsibility disappears.
+
+- [ ] **Step 4: Preserve only necessary turn recovery.**
+
+Keep the prompt, selected entity, model-run result, cancellation or redaction business outcome, and any facts required to avoid rerunning an already completed model call.
+
+Reference journal receipt order and outbox keys rather than copying their state.
+
+- [ ] **Step 5: Run turn recovery tests.**
+
+```bash
+uv run pytest -q \
+  tests/test_turn_store.py \
+  tests/test_handled_turns.py \
+  tests/test_turn_controller_focused.py \
+  tests/test_voice_command_processing.py \
+  tests/test_matrix_event_pipeline_crashes.py
+```
+
+Expected: model execution and redaction behavior remain correct without a second source or delivery state machine.
+
+- [ ] **Step 6: Commit the ownership cleanup.**
+
+```bash
+git add -A src/mindroom tests
+git commit -m "refactor: remove duplicate Matrix turn durability state"
+```
+
+## Task 9: Enforce the Complexity and Performance Gates
+
+**Files:**
+
+- Modify: `tests/test_matrix_event_pipeline_performance.py`
+- Create: `tests/manual/matrix_event_pipeline_stress.py`
+- Modify: `docs/architecture/bot-runtime.md`
+- Create: `docs/architecture/matrix-event-pipeline.md`
+
+- [ ] **Step 1: Add deterministic operation-count assertions.**
+
+Assert one indexed projection query per hydrated conversation read, one projection-row update per edit, no room-wide read after hydration, and no more than one unresolved row per logical message.
+
+Prefer operation counts and query plans over timing thresholds in CI.
+
+- [ ] **Step 2: Add the 50-thread stress harness.**
+
+Drive 50 concurrent threads, 500 logical messages, 10,000 streaming edits, recovered events, media hydration, redactions, and periodic restarts through SQLite.
+
+Record admission latency, writer queue latency, conversation-read latency, SQLite lock errors, duplicate turns, duplicate visible responses, unresolved journal rows, and database size.
+
+- [ ] **Step 3: Define local acceptance thresholds.**
+
+Require zero lost turns, zero duplicate turns, zero duplicate terminal responses, zero SQLite lock errors, zero room scans after hydration, p95 durable admission below 50 milliseconds, p95 hydrated conversation reads below 50 milliseconds, and p95 writer queue wait below 100 milliseconds on the standard development host.
+
+Treat timing values as manual release gates and keep deterministic structural assertions in CI.
+
+- [ ] **Step 4: Measure the source budget.**
+
+Run:
+
+```bash
+git diff --numstat origin/main...HEAD -- src/mindroom | \
+  awk '{ added += $1; deleted += $2 } END { print "added=" added, "deleted=" deleted, "net=" added-deleted }'
+```
+
+Expected: `net` is at most `-8000`, with `-10000` or lower as the target.
+
+- [ ] **Step 5: Prove deleted owners are absent.**
+
+Run:
+
+```bash
+test ! -d src/mindroom/matrix/cache
+test ! -d src/mindroom/dispatch_obligations
+test ! -e src/mindroom/matrix/client_thread_history.py
+test ! -e src/mindroom/matrix/conversation_cache.py
+test ! -e src/mindroom/cold_history_fence.py
+test ! -e src/mindroom/matrix/sync_cache_trust.py
+test ! -e src/mindroom/matrix/sync_certification.py
+rg -n "EventCacheWriteCoordinator|ThreadCacheGap|DispatchObligation" src/mindroom && exit 1 || true
+```
+
+Expected: every deletion check passes and the symbol search is empty.
+
+- [ ] **Step 6: Document the final ownership flow.**
+
+Update the runtime architecture to show `nio -> journal/projection -> pending worker -> outbox -> Matrix` and state that intermediate edits are not retained.
+
+Remove documentation for cache trust, gap repair, dispatch obligations, and advisory outbound cache updates.
+
+- [ ] **Step 7: Run the manual stress harness.**
+
+```bash
+uv run python tests/manual/matrix_event_pipeline_stress.py --threads 50 --edits 10000 --restarts 5
+```
+
+Expected: every correctness and local performance threshold passes.
+
+- [ ] **Step 8: Commit the gates and documentation.**
+
+```bash
+git add tests/test_matrix_event_pipeline_performance.py \
+  tests/manual/matrix_event_pipeline_stress.py \
+  docs/architecture/bot-runtime.md \
+  docs/architecture/matrix-event-pipeline.md
+git commit -m "test: enforce Matrix pipeline simplicity and performance"
+```
+
+## Task 10: Validate Against Real Tuwunel and Synapse
+
+**Files:**
+
+- Create: `tests/live/test_matrix_event_pipeline_live.py`
+- Modify: `tests/manual/matrix_event_pipeline_stress.py`
+- Modify: `docs/architecture/matrix-event-pipeline.md`
+
+- [ ] **Step 1: Run the realistic restart recovery case against Tuwunel.**
+
+Persist baseline `w1`, stop MindRoom, send a message, restart with `pos=None`, return the missed message and unchanged own-membership event in the initial snapshot with `prev_batch=w2`, and make `/messages?from=w1&to=w2&dir=f` return an empty chunk with no `end`.
+
+Assert provenance is `RECOVERED`, journal actionability is `ACTIONABLE`, the turn completes once, and the response is visible once.
+
+- [ ] **Step 2: Run the same case against Synapse.**
+
+Use the MindRoom Synapse compact-edit configuration and require the same observable result.
+
+- [ ] **Step 3: Validate cold history.**
+
+Start with no persisted baseline and assert that initial history hydrates the projection, creates no turn, establishes the baseline, and publishes readiness only after the journal commits.
+
+- [ ] **Step 4: Validate edit-heavy projection.**
+
+Stream an AI response with updates every 500 milliseconds, restart during the stream, allow the terminal response to finish, and assert one logical projected message with final content and no durable intermediate edit bodies.
+
+- [ ] **Step 5: Validate homeserver recursive hydration.**
+
+Create a thread with many edits, hydrate it through recursive relations on both servers, and assert that MindRoom reduces the relation tree to latest visible content without a room scan or retained edit chain.
+
+- [ ] **Step 6: Validate deployment cutover.**
+
+Stop the old runtime only after its current callbacks drain, preserve the existing continuity checkpoint, start the new runtime on that checkpoint, send a message during downtime, and assert that Matrix recovery admits and answers it once.
+
+- [ ] **Step 7: Run the live suite.**
+
+```bash
+uv run pytest -q tests/live/test_matrix_event_pipeline_live.py
+```
+
+Expected: Tuwunel and Synapse pass the same no-loss, history, edit-compaction, hydration, and idempotent-delivery contract.
+
+- [ ] **Step 8: Commit live coverage.**
+
+```bash
+git add tests/live/test_matrix_event_pipeline_live.py \
+  tests/manual/matrix_event_pipeline_stress.py \
+  docs/architecture/matrix-event-pipeline.md
+git commit -m "test: verify Matrix event pipeline on deployed servers"
+```
+
+## Task 11: Final Verification and Review Stop Gate
+
+**Files:**
+
+- Modify only files required by verified failures.
+
+- [ ] **Step 1: Run formatting, linting, typing, and focused tests.**
+
+```bash
+uv run pre-commit run --all-files
+uv run pytest -q \
+  tests/test_matrix_event_store_contract.py \
+  tests/test_matrix_event_projection.py \
+  tests/test_matrix_event_ingress.py \
+  tests/test_matrix_event_pipeline_crashes.py \
+  tests/test_matrix_event_pipeline_performance.py \
+  tests/test_conversation_projection.py \
+  tests/test_response_outbox.py \
+  tests/test_matrix_sync_continuity.py \
+  tests/test_streaming_e2e.py \
+  tests/test_turn_store.py
+```
+
+Expected: every command exits successfully.
+
+- [ ] **Step 2: Run the full test suite.**
+
+```bash
+uv run pytest -q
+```
+
+Expected: the full suite passes.
+
+- [ ] **Step 3: Re-run live and stress gates.**
+
+Run Task 9's 50-thread stress command and Task 10's live Tuwunel and Synapse suite from the final commit.
+
+Expected: every threshold and real-server contract still passes.
+
+- [ ] **Step 4: Audit for two owners of one fact.**
+
+Search journal state, turn state, delivery state, edit content, hydration completeness, checkpoint state, membership epoch, and retry ownership.
+
+For each fact, record exactly one production owner in the implementation PR description.
+
+- [ ] **Step 5: Recalculate the final deletion budget.**
+
+Run Task 9's source-budget command from the final commit.
+
+Expected: at least 8,000 net production lines are removed.
+
+- [ ] **Step 6: Apply the stop gate.**
+
+Do not request merge if a compatibility path remains, the deletion gate fails, a crash case duplicates or loses a turn, a live server needs a MindRoom provenance guess, or an intermediate edit body remains durable.
+
+- [ ] **Step 7: Commit only verified cleanup if needed.**
+
+```bash
+git add -A
+git commit -m "chore: finish Matrix event pipeline simplification"
+```
+
+## Nio Scope Decision
+
+The core implementation requires one narrow mindroom-nio change to expose the Matrix v1.10 `recurse` query parameter on the existing event-relations iterator.
+
+Nio 0.36 already supplies provenance, persisted baselines, limited-timeline recovery, admission rejection, and Classic response acknowledgement, so none of those areas should change.
+
+The recursive-relations change should remain below 50 production lines plus focused tests and must land as its own nio PR before Task 5 cuts over MindRoom history reads.
+
+Do not add a nio batch-admission API during this implementation.
+
+First remove room scans, repeated repair, competing SQLite writers, and durable intermediate edits, then measure the remaining admission cost.
+
+Open a separate mindroom-nio proposal only if the final 50-thread and 200-event recovery profiles show that per-event durable callback commits consume more than 20 percent of recovery wall time or violate the 50-millisecond admission p95.
+
+That proposal must preserve per-event room-state callback semantics and cannot be assumed to fit the earlier 250-to-500-line estimate until a red nio test demonstrates a safe batch boundary.
+
+This condition prevents a speculative transport API from becoming another permanent layer before the MindRoom simplification proves it is needed.
+
+## Expected Final Shape
+
+The intended production flow is:
+
+```text
+nio timeline recovery and provenance
+  -> MatrixEventIngress durable admission
+      -> matrix_event_journal pending source
+      -> visible_messages latest-state projection
+  -> MatrixEventWorker turn execution
+  -> response_outbox deterministic initial/final delivery
+  -> Matrix
+```
+
+Conversation reconstruction is one indexed projection read after at most one conversation hydration.
+
+Intermediate AI edits exist only in Matrix transport and the in-memory stream coalescer.
+
+The journal owns pending input, the projection owns visible context, `TurnStore` owns model-run facts, the outbox owns terminal delivery intent, nio owns recovery provenance, and `SyncContinuityStore` owns the last accepted application checkpoint.
+
+No other module may own a second copy of those facts.

--- a/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
+++ b/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
@@ -1,1067 +1,348 @@
-# Matrix Event Journal and Conversation Projection Implementation Plan
+# Matrix Event Pipeline Simplification Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+## Status
 
-**Goal:** Replace MindRoom's overlapping Matrix cache, callback-obligation, history-repair, and visible-delivery state machines with one durable ingress journal, one latest-visible-message projection, and one idempotent terminal-delivery outbox while preserving zero-loss recovery and fast conversation reconstruction.
+This is a feasibility-first architecture and cutover plan, not a prediction of every file or commit that implementation will require.
 
-**Architecture:** Nio remains the transport authority for `LIVE`, `RECOVERED`, and `HISTORY`, while MindRoom collapses provenance at durable admission into `ACTIONABLE` or `CONTEXT_ONLY`, projects each logical message into one current row, resumes actionable work from the journal after crashes, and retries initial and final Matrix delivery with deterministic transaction IDs.
+The implementation proceeds only if a focused prototype proves that the replacement is correct, fast enough, and materially smaller than the current system.
 
-**Tech Stack:** Python 3.13, mindroom-nio 0.36 or newer, asyncio, SQLite with WAL, PostgreSQL through psycopg, pytest, Hypothesis, Tuwunel, Synapse, and Matrix Client-Server APIs.
+## Goal
 
-## Global Constraints
+Replace the overlapping Matrix callback-obligation, history-repair, conversation-cache, handled-source, and visible-delivery state machines with explicit non-overlapping owners.
 
-- The MindRoom work is one implementation branch and one implementation PR, even though it is split into reviewable commits below.
-- The small recursive-relations prerequisite lands first as its own mindroom-nio PR because repositories cannot share an atomic commit.
-- Do not merge an intermediate commit that contains both the old and new production paths.
-- Do not add a feature flag, shadow writer, compatibility facade, dual-read fallback, or runtime switch between the old and new designs.
-- New code may exist unused during an early commit on the unmerged branch, but the cutover commit must delete the replaced production path in the same commit.
-- The final implementation diff must contain fewer production source lines than `origin/main` by at least 8,000 lines across the files in the removal ledger below.
-- The target is a reduction of at least 10,000 production source lines, and missing that target requires a written explanation in the implementation PR.
-- If the final reduction is below 8,000 lines, stop and redesign instead of asking reviewers to merge an architectural transition.
-- If any third review round still finds a new correctness class, stop patching and reconsider the design before continuing.
-- Nio is the only owner of transport provenance, limited-timeline recovery, room baselines, pagination safety, and callback redelivery.
-- MindRoom must not infer recovery from pagination cursors, repeated membership events, timestamps, `limited`, `prev_batch`, or server-specific response shapes.
-- MindRoom must map `LIVE` and `RECOVERED` to `ACTIONABLE` and must map `HISTORY` to `CONTEXT_ONLY` exactly once at admission.
-- Code after durable admission must not branch on raw nio provenance.
-- The no-loss guarantee begins after the bot completes its first successful baseline response and publishes readiness.
-- Before readiness, historical events may populate context but must never create turns.
-- After readiness, an actionable event must either become durably pending before nio accepts it or cause `nio.CallbackNotAcceptedError` so nio and the Matrix cursor remain retryable.
-- A persistence failure must never advance the application-owned Classic Sync checkpoint.
-- An unrecovered room must keep the bot unready and must not be converted into best-effort history.
-- Conversation reads must not scan a room after that conversation has been hydrated once.
-- Thread hydration must use one recursive event-relations traversal rooted at the thread event rather than room-wide `/messages` scans.
-- Room-scoped conversations may perform one serialized initial `/messages` pagination, but the result must be installed atomically and all later reads must use the projection.
-- A server that cannot provide Matrix v1.10 recursive relations must fail the strict thread-hydration contract rather than trigger a room-scan repair subsystem.
-- Intermediate AI edit bodies and edit chains are not durable product data.
-- A logical message has one projection row whose latest visible content is replaced in place.
-- An out-of-order older edit must not overwrite a newer projected edit.
-- An edit whose original has not arrived may occupy one latest-unresolved row for that target, but a second edit must replace that row instead of extending a chain.
-- Redacting the current edit must trigger a point hydration of that logical message because the previous edit body is intentionally not retained.
-- A strict conversation read must wait for that point hydration instead of serving content known to be stale.
-- SQLite must have exactly one writer task per store, while reads may use separate read connections.
-- PostgreSQL must implement the same contract and pass the same backend tests before the cutover commit is considered complete.
-- The hot path must not create one SQLite connection per callback or per cache concern.
-- Initial response sends and terminal response sends or edits must use a durable outbox and deterministic Matrix transaction IDs.
-- Intermediate streaming edits may be coalesced in memory and may be lost during a crash because the next terminal update restores the latest visible state.
-- An outbox payload becomes immutable when its first send attempt begins, because the homeserver may have accepted that transaction ID even if the client did not observe the response.
-- The final response body must always be durably enqueued before delivery.
-- Existing source redaction, authorization, E2EE metadata, media transcript, large-message sidecar, reaction, command, and room-membership semantics remain in scope.
-- Backward-compatible cache schemas are out of scope, but the existing `SyncContinuityStore` checkpoint format remains readable so a stopped deployment can resume without dropping messages during cutover.
-- Do not add production code to `bot.py` beyond construction, registration, lifecycle calls, and routing into focused collaborators.
-- Use dataclasses and typed protocols for boundaries, and do not use `getattr()` or `hasattr()` to weaken nio or storage types.
-- Every task below begins with a failing test or measurable failing check and ends with a focused commit.
-
----
-
-## Why This Plan Is Executable
-
-The current overlapping subsystem contains 20,248 production lines across `src/mindroom/matrix/cache/`, `client_thread_history.py`, `conversation_cache.py`, `dispatch_obligations/`, `handled_turns.py`, `turn_store.py`, the cold-history fence, and sync cache-trust modules.
-
-The implementation is not complete merely when the new tables and interfaces work.
-
-It is complete only when the old owners named in the removal ledger are gone, the final source budget is met, and the same crash and load tests prove the replacement.
-
-The work stays on one unmerged branch so temporary scaffolding cannot become a second permanent architecture.
-
-The implementation PR must contain this table with actual measured values before review.
-
-| Gate | Required result |
+| Fact | Sole owner |
 | --- | --- |
-| Actionable event durability | Zero lost or duplicate turns across every enumerated crash point. |
-| Historical admission | `HISTORY` populates context and never starts a turn. |
-| Restart recovery | The realistic `messages([], None)` restart case replies exactly once. |
-| Edit storage | 10,000 edits of 100 logical messages leave 100 visible rows and at most 100 unresolved-edit rows. |
-| Conversation query | `EXPLAIN` shows the room/thread/order index and no room-wide scan. |
-| SQLite contention | Zero `database is locked` errors in the 50-thread stress run. |
-| Delivery idempotency | Crashing after Matrix accepts an initial or final send creates one visible response. |
-| Production source size | At least 8,000 net lines removed, with 10,000 lines as the target. |
-| Competing paths | No old cache, dispatch-obligation, history-repair, or non-idempotent terminal-send fallback remains. |
-
-If a gate fails, fix the design that owns the failure rather than adding a fallback around it.
-
-## State Model
-
-The storage package exposes four durable concepts and no generic cache API.
-
-```python
-class EventActionability(StrEnum):
-    ACTIONABLE = "actionable"
-    CONTEXT_ONLY = "context_only"
-
-
-class JournalOutcome(StrEnum):
-    PENDING = "pending"
-    COMPLETED = "completed"
-    INTENTIONALLY_IGNORED = "intentionally_ignored"
-
-
-@dataclass(frozen=True, slots=True)
-class MatrixEventEnvelope:
-    principal_id: str
-    room_id: str
-    event_id: str
-    event_kind: MatrixEventKind
-    actionability: EventActionability
-    event_source: dict[str, object]
-    membership_epoch: int
-    provenance: nio.TimelineEventProvenance
-
-
-@dataclass(frozen=True, slots=True)
-class ConversationKey:
-    principal_id: str
-    room_id: str
-    thread_id: str | None
-```
-
-The `provenance` field is retained only in the journal's diagnostic data until the event settles.
-
-The pending worker receives `actionability`, not raw provenance.
-
-The public store contract is deliberately small.
-
-```python
-class MatrixEventStore(Protocol):
-    async def admit(self, envelope: MatrixEventEnvelope) -> JournalAdmission: ...
-    async def pending(self, *, limit: int) -> tuple[JournalEvent, ...]: ...
-    async def settle(self, event_id: str, outcome: JournalOutcome) -> None: ...
-    async def load_conversation(self, key: ConversationKey) -> ConversationProjection: ...
-    async def install_hydration(self, hydration: ConversationHydration) -> None: ...
-    async def enqueue_delivery(self, delivery: OutboxDelivery) -> None: ...
-    async def pending_deliveries(self, *, limit: int) -> tuple[OutboxDelivery, ...]: ...
-    async def mark_delivered(self, key: OutboxKey, event_id: str) -> None: ...
-    async def mark_room_joined(self, room_id: str) -> int: ...
-    async def mark_room_departed(self, room_id: str) -> int: ...
-```
-
-`JournalAdmission` returns the durable receipt order, whether the event was newly inserted, and whether actionable work remains pending.
-
-It does not expose storage-specific rows or cache trust.
-
-## SQL Shape
-
-SQLite and PostgreSQL use equivalent constraints and indexes with backend-appropriate identity syntax.
-
-```sql
-CREATE TABLE matrix_event_journal (
-    principal_id TEXT NOT NULL,
-    event_id TEXT NOT NULL,
-    room_id TEXT NOT NULL,
-    event_kind TEXT NOT NULL,
-    actionability TEXT NOT NULL,
-    event_json TEXT,
-    provenance TEXT,
-    membership_epoch INTEGER NOT NULL,
-    receipt_order INTEGER NOT NULL,
-    outcome TEXT NOT NULL,
-    retry_count INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (principal_id, event_id)
-);
-
-CREATE INDEX matrix_event_journal_pending
-ON matrix_event_journal(principal_id, outcome, receipt_order);
-
-CREATE TABLE visible_messages (
-    principal_id TEXT NOT NULL,
-    room_id TEXT NOT NULL,
-    logical_event_id TEXT NOT NULL,
-    thread_id TEXT,
-    sender TEXT NOT NULL,
-    created_ts INTEGER NOT NULL,
-    latest_event_id TEXT NOT NULL,
-    latest_event_ts INTEGER NOT NULL,
-    visible_json TEXT NOT NULL,
-    needs_refresh INTEGER NOT NULL DEFAULT 0,
-    redacted INTEGER NOT NULL DEFAULT 0,
-    PRIMARY KEY (principal_id, room_id, logical_event_id)
-);
-
-CREATE INDEX visible_messages_conversation
-ON visible_messages(principal_id, room_id, thread_id, created_ts, logical_event_id);
-
-CREATE TABLE pending_message_edits (
-    principal_id TEXT NOT NULL,
-    room_id TEXT NOT NULL,
-    logical_event_id TEXT NOT NULL,
-    sender TEXT NOT NULL,
-    edit_event_id TEXT NOT NULL,
-    edit_ts INTEGER NOT NULL,
-    edit_json TEXT NOT NULL,
-    PRIMARY KEY (principal_id, room_id, logical_event_id)
-);
-
-CREATE TABLE conversation_hydration (
-    principal_id TEXT NOT NULL,
-    room_id TEXT NOT NULL,
-    thread_id TEXT,
-    membership_epoch INTEGER NOT NULL,
-    complete INTEGER NOT NULL,
-    PRIMARY KEY (principal_id, room_id, thread_id)
-);
-
-CREATE TABLE response_outbox (
-    principal_id TEXT NOT NULL,
-    turn_id TEXT NOT NULL,
-    stage TEXT NOT NULL,
-    transaction_id TEXT NOT NULL,
-    room_id TEXT NOT NULL,
-    target_event_id TEXT,
-    content_json TEXT NOT NULL,
-    attempted INTEGER NOT NULL DEFAULT 0,
-    delivered_event_id TEXT,
-    PRIMARY KEY (principal_id, turn_id, stage),
-    UNIQUE (principal_id, transaction_id)
-);
-```
-
-SQLite must represent an unthreaded conversation with a canonical empty storage key rather than depending on nullable primary-key equality.
-
-The typed API continues to expose `thread_id: str | None` and performs the storage conversion in one helper.
-
-## Projection Rules
-
-- A non-edit message inserts one `visible_messages` row keyed by its own event ID.
-- A valid same-sender `m.replace` event updates the target row only when `(origin_server_ts, event_id)` is newer than `(latest_event_ts, latest_event_id)`.
-- A replacement never changes `created_ts`, `logical_event_id`, room, thread, or sender.
-- An edit without an original upserts one `pending_message_edits` row using the same ordering comparison.
-- Arrival of the original atomically applies and deletes the unresolved row when the sender matches.
-- A redaction of the original tombstones the visible row.
-- A redaction of the latest replacement marks the row `needs_refresh=1` and schedules a point hydration.
-- A redaction of an already superseded replacement changes no visible state.
-- Media transcription, large-message hydration, and normalized visible content update the same `visible_json` row.
-- Once a context-only event is projected, its journal payload is deleted because replaying the projection is idempotent.
-- Once an ignored own echo or intermediate AI edit is projected, its journal row is deleted because it can never create a turn.
-- A terminal actionable source retains only its compact identity and outcome for deduplication, not its edit body or full event JSON.
-- A pending actionable source retains the exact replay event JSON and E2EE security metadata until settlement.
-
-## Deterministic Delivery Rules
-
-Use UUIDv5 with a fixed MindRoom namespace and the string `principal_id:turn_id:stage` to derive the Matrix transaction ID.
-
-The `stage` values are `initial` and `final`.
-
-The initial row represents either the first substantive send or the placeholder send.
-
-The final row represents the terminal send when no visible event exists or the terminal `m.replace` when one does.
-
-The outbox row must be committed before calling `room_send`.
-
-Retrying a row must pass its stored transaction ID through `send_message_result` or `edit_message_result`.
-
-The row's content and target event ID become immutable when `attempted` changes to true.
-
-Intermediate stream updates remain in the existing in-memory `StreamingResponse` coalescer and do not create outbox rows.
-
-## Removal Ledger
-
-The final implementation must delete or replace the following production owners.
-
-| Current owner | Required final state |
-| --- | --- |
-| `src/mindroom/matrix/cache/` | Delete the 29-file cache package after moving only normalized projection behavior into `matrix/event_store/`. |
-| `src/mindroom/matrix/client_thread_history.py` | Delete room-scan, refill, gap, snapshot, and repair logic after focused hydration exists. |
-| `src/mindroom/matrix/conversation_cache.py` | Replace with a small `conversation_projection.py` reader and hydrator. |
-| `src/mindroom/dispatch_obligations/` | Delete after journal admission and pending-worker replay own exact callbacks. |
-| `src/mindroom/dispatch_admission.py` | Delete after actionability becomes part of journal admission. |
-| `src/mindroom/cold_history_fence.py` | Delete after the provenance mapping happens in the admission adapter. |
-| `src/mindroom/matrix/sync_cache_trust.py` | Delete cache-generation trust and retain only direct checkpoint publication. |
-| `src/mindroom/matrix/sync_certification.py` | Delete cache certification and replace it with a response-accepted predicate. |
-| `src/mindroom/turn_settlement_retry.py` | Delete after journal settlement is the pending worker's responsibility. |
-| `src/mindroom/matrix/cache/write_coordinator.py` | Delete with the cache package and use one store writer. |
-| Advisory `notify_outbound_*` paths | Delete after acknowledged sends update the projection through the event store. |
-| Duplicated handled-source state | Remove from `handled_turns.py` and `turn_store.py` after the journal is the source identity owner. |
-
-The implementation may retain AI-run metadata in `TurnStore`, but it must not retain a second pending-source, response-idempotency, or callback-replay state machine.
-
----
-
-## Task 1: Freeze the Contract and the Deletion Budget
-
-**Files:**
-
-- Create: `tests/test_matrix_event_store_contract.py`
-- Create: `tests/test_matrix_event_pipeline_crashes.py`
-- Create: `tests/test_matrix_event_pipeline_performance.py`
-- Modify: `tests/test_matrix_sync_continuity.py`
-- Modify: `tests/test_streaming_e2e.py`
-
-- [ ] **Step 1: Record the source baseline.**
-
-Run:
-
-```bash
-wc -l \
-  src/mindroom/matrix/cache/*.py \
-  src/mindroom/matrix/client_thread_history.py \
-  src/mindroom/matrix/conversation_cache.py \
-  src/mindroom/dispatch_obligations/*.py \
-  src/mindroom/handled_turns.py \
-  src/mindroom/turn_store.py \
-  src/mindroom/cold_history_fence.py \
-  src/mindroom/dispatch_admission.py \
-  src/mindroom/matrix/sync_cache_trust.py \
-  src/mindroom/matrix/sync_certification.py \
-  src/mindroom/matrix/sync_continuity.py
-```
-
-Expected: the current baseline totals 20,248 lines on commit `b639b6ef3`.
-
-- [ ] **Step 2: Add table-driven crash-point tests.**
-
-Cover these crash points for one actionable source.
-
-1. Crash before journal commit.
-2. Crash after journal commit but before nio records admission.
-3. Crash after nio records admission but before the worker starts.
-4. Crash after the worker records a pending turn but before model execution.
-5. Crash after model execution but before final outbox commit.
-6. Crash after final outbox commit but before Matrix accepts the transaction.
-7. Crash after Matrix accepts the transaction but before the outbox records the event ID.
-8. Crash after outbox acknowledgement but before journal settlement.
-
-Assert that cases one through three replay the event, cases four through eight resume durable work, and every case produces one terminal turn and one visible response.
-
-- [ ] **Step 3: Change the realistic restart regression to bounded exhaustion with no `end`.**
-
-Keep the production sequence in `tests/test_matrix_sync_continuity.py` with a persisted baseline, a fresh `prev_batch`, exact unchanged own membership, and `messages([], None)`.
-
-Assert that the initial-window message is `RECOVERED`, reaches durable actionable admission, and receives exactly one reply.
-
-Keep negative tests for no baseline, missing or mismatched membership, pagination failure, repeated cursor, cap abandonment, and cold history.
-
-- [ ] **Step 4: Add the edit compaction contract.**
-
-Generate 10,000 ordered and shuffled edits across 100 logical messages.
-
-Assert that the projection contains 100 visible rows, retains the newest body per message, stores no settled intermediate edit JSON, and uses at most 100 unresolved rows when originals are deliberately withheld.
-
-- [ ] **Step 5: Add the indexed conversation-read contract.**
-
-Create 500 visible messages in one thread and 10,000 messages in unrelated rooms and threads.
-
-Assert exact chronological output and assert through `EXPLAIN QUERY PLAN` that SQLite uses `visible_messages_conversation`.
-
-Add the PostgreSQL equivalent with `EXPLAIN (FORMAT JSON)` and assert an index scan over the conversation index.
-
-- [ ] **Step 6: Add the outbox idempotency contract.**
-
-Make the fake Matrix server accept the deterministic transaction and then raise a connection error before returning the event ID.
-
-Restart the worker and assert that retrying the same transaction produces the same event ID and one visible event.
-
-- [ ] **Step 7: Run the new tests and confirm they fail for missing interfaces.**
-
-Run:
-
-```bash
-uv run pytest -q \
-  tests/test_matrix_event_store_contract.py \
-  tests/test_matrix_event_pipeline_crashes.py \
-  tests/test_matrix_event_pipeline_performance.py \
-  tests/test_matrix_sync_continuity.py \
-  tests/test_streaming_e2e.py
-```
-
-Expected: the new store and pipeline tests fail because `mindroom.matrix.event_store` does not exist yet, while existing tests still pass outside the selected new cases.
-
-- [ ] **Step 8: Commit the red contract.**
-
-```bash
-git add tests/test_matrix_event_store_contract.py \
-  tests/test_matrix_event_pipeline_crashes.py \
-  tests/test_matrix_event_pipeline_performance.py \
-  tests/test_matrix_sync_continuity.py \
-  tests/test_streaming_e2e.py
-git commit -m "test: define durable Matrix event pipeline contract"
-```
-
-## Task 2: Implement the Storage-Neutral Domain and Projection Reducer
-
-**Files:**
-
-- Create: `src/mindroom/matrix/event_store/__init__.py`
-- Create: `src/mindroom/matrix/event_store/types.py`
-- Create: `src/mindroom/matrix/event_store/protocol.py`
-- Create: `src/mindroom/matrix/event_store/projection.py`
-- Create: `tests/test_matrix_event_projection.py`
-
-- [ ] **Step 1: Write reducer tests before implementation.**
-
-Cover original arrival, latest edit replacement, older delayed edit rejection, cross-sender edit rejection, edit-before-original, original arrival after edit, original redaction, current-edit redaction, superseded-edit redaction, media transcript update, and thread-order stability.
-
-- [ ] **Step 2: Implement the typed domain.**
-
-Add `EventActionability`, `MatrixEventKind`, `JournalOutcome`, `MatrixEventEnvelope`, `JournalAdmission`, `JournalEvent`, `ConversationKey`, `VisibleMessage`, `ConversationProjection`, `ConversationHydration`, `OutboxKey`, and `OutboxDelivery` as frozen slotted dataclasses or string enums.
-
-Keep storage rows private to each backend.
-
-- [ ] **Step 3: Implement pure projection decisions.**
-
-Make `projection.py` a side-effect-free reducer that returns typed insert, replace, ignore, tombstone, unresolved-edit, or refresh-required decisions.
-
-Do not import SQLite, PostgreSQL, nio clients, bot runtime objects, or Matrix network helpers into this module.
-
-- [ ] **Step 4: Run the focused reducer tests.**
-
-```bash
-uv run pytest -q tests/test_matrix_event_projection.py
-```
-
-Expected: all projection reducer tests pass.
-
-- [ ] **Step 5: Commit the domain and reducer.**
-
-```bash
-git add src/mindroom/matrix/event_store tests/test_matrix_event_projection.py
-git commit -m "feat: define Matrix event journal and projection domain"
-```
-
-## Task 3: Implement One-Writer SQLite and PostgreSQL Stores
-
-**Files:**
-
-- Create: `src/mindroom/matrix/event_store/schema.py`
-- Create: `src/mindroom/matrix/event_store/sqlite.py`
-- Create: `src/mindroom/matrix/event_store/postgres.py`
-- Create: `src/mindroom/matrix/event_store/writer.py`
-- Modify: `tests/test_matrix_event_store_contract.py`
-- Modify: `tests/conftest.py`
-
-- [ ] **Step 1: Parameterize one backend contract.**
-
-Run every journal, projection, hydration, membership, compaction, and outbox behavior against SQLite and PostgreSQL through the `MatrixEventStore` protocol.
-
-Skip PostgreSQL only when the repository's standard PostgreSQL test fixture is unavailable.
-
-- [ ] **Step 2: Implement the SQLite schema and one writer.**
-
-Open one WAL-mode writer connection for the store lifetime and route typed write commands through one bounded asyncio queue.
-
-Batch commands that are already concurrently waiting, but complete each caller only after the transaction containing its command commits.
-
-Use separate short-lived or pooled read connections without creating additional writers.
-
-- [ ] **Step 3: Implement atomic admission and projection.**
-
-One admission transaction must verify the room membership epoch, insert or deduplicate the journal event, apply the projection reducer, compact context-only payloads when safe, and return `JournalAdmission`.
-
-A failed statement must roll back the whole admission.
-
-- [ ] **Step 4: Implement the PostgreSQL backend with identical semantics.**
-
-Use a transaction and row constraints equivalent to SQLite.
-
-Do not add PostgreSQL-only recovery behavior or a second protocol.
-
-- [ ] **Step 5: Prove bounded edit storage and indexed reads.**
-
-Run:
-
-```bash
-uv run pytest -q \
-  tests/test_matrix_event_store_contract.py \
-  tests/test_matrix_event_projection.py \
-  tests/test_matrix_event_pipeline_performance.py
-```
-
-Expected: backend contracts, edit compaction, and query-plan assertions pass for every available backend.
-
-- [ ] **Step 6: Commit the stores.**
-
-```bash
-git add src/mindroom/matrix/event_store tests/test_matrix_event_store_contract.py tests/conftest.py
-git commit -m "feat: persist Matrix journal and visible projection"
-```
-
-## Task 4: Cut Ingress Over to the Journal and Delete Dispatch Obligations
-
-**Files:**
-
-- Create: `src/mindroom/matrix/event_ingress.py`
-- Create: `src/mindroom/matrix/event_worker.py`
-- Create: `tests/test_matrix_event_ingress.py`
-- Modify: `src/mindroom/runtime_support.py`
-- Modify: `src/mindroom/bot.py`
-- Modify: `src/mindroom/turn_controller.py`
-- Modify: `src/mindroom/dispatch_handoff.py`
-- Modify: `src/mindroom/dispatch_replay_guard.py`
-- Delete: `src/mindroom/dispatch_obligations/`
-- Delete: `src/mindroom/dispatch_admission.py`
-- Delete: `src/mindroom/cold_history_fence.py`
-- Delete: `src/mindroom/turn_settlement_retry.py`
-- Rewrite: `tests/test_dispatch_obligations.py` as journal and worker tests, then rename or delete it.
-
-- [ ] **Step 1: Add exact provenance-mapping tests.**
-
-Assert `LIVE -> ACTIONABLE`, `RECOVERED -> ACTIONABLE`, and `HISTORY -> CONTEXT_ONLY` for every supported message, media, reaction, approval, room-lifecycle, redaction, and decryption-failure event kind.
-
-Assert that downstream handler inputs contain actionability but not raw provenance.
-
-- [ ] **Step 2: Add the nio admission adapter.**
-
-Register exactly one `AsyncClient.add_event_admission_callback` that builds `MatrixEventEnvelope`, awaits `store.admit`, and raises `nio.CallbackNotAcceptedError` on any durability or membership-epoch rejection.
-
-The callback must not execute commands, turns, hooks, reactions, or visible delivery.
-
-- [ ] **Step 3: Add the pending worker.**
-
-Load pending rows by receipt order, claim one row only in memory, dispatch it through one typed event-kind mapping, settle it after the semantic owner commits, and leave it pending on cancellation or failure.
-
-Startup must wake the worker before readiness can report healthy actionable processing.
-
-No durable `running` state is needed because a crash must leave the row pending.
-
-- [ ] **Step 4: Preserve typed replay inputs.**
-
-Move only the exact event serialization and E2EE security metadata needed from `dispatch_obligations/events.py` into `event_ingress.py`.
-
-Reject corrupt replay sources explicitly and do not invent fallback events.
-
-- [ ] **Step 5: Wire the composition root.**
-
-Make `runtime_support.py` construct one shared backend and one principal-bound view.
-
-Make `bot.py` register the admission adapter, start and stop the pending worker, and route existing semantic handlers through its public methods.
-
-Do not move classification, retries, or storage SQL into `bot.py`.
-
-- [ ] **Step 6: Remove the old path in the same cutover commit.**
-
-Delete dispatch obligations, the cold-history fence, dispatch admission, settlement retry, callback-kind retry scheduling, semantic-consumer claims, and their composition-root fields.
-
-Remove tests that assert the deleted implementation rather than retained behavior.
-
-- [ ] **Step 7: Run ingress, crash, and sync-continuity tests.**
-
-```bash
-uv run pytest -q \
-  tests/test_matrix_event_ingress.py \
-  tests/test_matrix_event_pipeline_crashes.py \
-  tests/test_matrix_sync_continuity.py \
-  tests/test_cold_history_fence.py \
-  tests/test_dispatch_obligations.py
-```
-
-Expected: the new ingress and crash contracts pass, and deleted implementation tests are removed or rewritten rather than preserved through adapters.
-
-- [ ] **Step 8: Commit the ingress cutover and deletion together.**
-
-```bash
-git add -A src/mindroom tests
-git commit -m "refactor: replace dispatch obligations with event journal"
-```
-
-## Task 5: Replace Cache Repair with Direct Projection Reads and One-Time Hydration
-
-**Files:**
-
-- Create: `src/mindroom/matrix/conversation_projection.py`
-- Create: `src/mindroom/matrix/conversation_hydration.py`
-- Create: `tests/test_conversation_projection.py`
-- Modify: `src/mindroom/conversation_resolver.py`
-- Modify: `src/mindroom/matrix/reply_chain.py`
-- Modify: `src/mindroom/reaction_dispatch.py`
-- Modify: `src/mindroom/matrix/stale_stream_cleanup.py`
-- Modify: `src/mindroom/hooks/sender.py`
-- Modify: `src/mindroom/streaming.py`
-- Modify: `src/mindroom/runtime_support.py`
-- Modify: `src/mindroom/bot.py`
-- Delete: `src/mindroom/matrix/cache/`
-- Delete: `src/mindroom/matrix/client_thread_history.py`
-- Delete: `src/mindroom/matrix/conversation_cache.py`
-- Delete or rewrite: `tests/test_event_cache*.py`
-- Delete or rewrite: `tests/test_thread_history.py`
-- Delete or rewrite: `tests/test_bot_sync_event_cache.py`
-- Delete or rewrite: `tests/test_matrix_event_cache*.py`
-
-- [ ] **Step 1: Add conversation-reader behavior tests.**
-
-Cover a hydrated thread, an unhydrated thread, concurrent first readers, an unthreaded room conversation, redacted content, media transcript content, large-message content, a current-edit redaction requiring point refresh, a leave/rejoin epoch, and a backend outage.
-
-- [ ] **Step 2: Implement the projection reader.**
-
-`ConversationProjectionReader.get_conversation` must perform one indexed store call and return the existing canonical resolved-message type expected by prompt assembly.
-
-It must not know about gaps, snapshots, trust generations, refills, stale fallbacks, or write coordinators.
-
-- [ ] **Step 3: Land the recursive-relations prerequisite in mindroom-nio.**
-
-In `mindroom-ai/mindroom-nio`, add a typed `recurse: bool = False` parameter to `Api.room_get_event_relations` and `AsyncClient.room_get_event_relations`, encode `recurse=true` in the query only when requested, and cover pagination in `tests/async_client_test.py`.
-
-Release the change, bump MindRoom's nio dependency, and do not add any batch-admission or application-storage behavior to nio.
-
-The expected nio change is less than 50 production lines because the server and response iterator already implement recursive relation responses.
-
-- [ ] **Step 4: Implement one-time hydration.**
-
-For threads, fetch the root with `room_get_event`, paginate `room_get_event_relations` with `recurse=True` and no relation-type filter, reduce the returned thread replies and nested replacements into latest visible messages, and install the entire hydration in one membership-epoch-checked transaction.
-
-The recursive response may contain a historical edit chain, but MindRoom must retain only the reducer's latest visible row and at most one unresolved edit per target.
-
-For room-scoped conversations, perform one serialized `/messages` pagination and install it through the same transaction.
-
-Use one in-flight task per `ConversationKey` so concurrent first readers share the network work.
-
-Mark hydration complete only after pagination ends successfully and the installation commits.
-
-- [ ] **Step 5: Define the homeserver contract.**
-
-At startup, read `/versions` and require Matrix v1.10 or a successful recursive-relations feature probe for strict historical thread hydration.
-
-If recursive relations are absent, report an actionable readiness failure instead of restoring full-room rescans or durable local edit chains.
-
-Add live contract coverage for recursive relation results in Task 10.
-
-- [ ] **Step 6: Replace production consumers.**
-
-Change conversation resolution, reply-chain lookup, reaction lookup, stale-stream cleanup, hooks, and streaming thread targeting to use the projection reader's narrow methods.
-
-Preserve one per-turn point-lookup memo only if a measured caller performs duplicate event lookups inside a turn.
-
-- [ ] **Step 7: Delete the cache and repair path in the same cutover commit.**
-
-Remove the 29-file cache package, room-scan history, snapshot replacement, gap markers, stale cache fallback, cache generations, advisory outbound writes, startup prewarm, and `EventCacheWriteCoordinator`.
-
-Do not keep old tests green by recreating old methods on the new reader.
-
-- [ ] **Step 8: Run projection and retained behavior tests.**
-
-```bash
-uv run pytest -q \
-  tests/test_conversation_projection.py \
-  tests/test_matrix_event_store_contract.py \
-  tests/test_thread_history.py \
-  tests/test_matrix_sync_continuity.py \
-  tests/test_streaming.py \
-  tests/test_bot_reactions_approvals.py
-```
-
-Expected: retained behavior passes through projection tests, while implementation-specific cache tests are deleted or reduced to backend contract tests.
-
-- [ ] **Step 9: Check the first deletion gate.**
-
-```bash
-git diff --numstat origin/main...HEAD -- src/mindroom
-find src/mindroom/matrix/event_store -name '*.py' -print0 | xargs -0 wc -l
-```
-
-Expected: production source is already net negative and no deleted cache module is imported.
-
-- [ ] **Step 10: Commit the projection cutover and deletion together.**
-
-```bash
-git add -A src/mindroom tests
-git commit -m "refactor: replace Matrix cache repair with visible projection"
-```
-
-## Task 6: Reduce Sync Continuity to Durable Admission and Checkpoint Publication
-
-**Files:**
-
-- Create: `src/mindroom/matrix/sync_checkpoint.py`
-- Modify: `src/mindroom/matrix/sync_continuity.py`
-- Modify: `src/mindroom/bot.py`
-- Modify: `tests/test_matrix_sync_continuity.py`
-- Delete: `src/mindroom/matrix/sync_cache_trust.py`
-- Delete: `src/mindroom/matrix/sync_certification.py`
-
-- [ ] **Step 1: Add a three-state checkpoint contract.**
-
-Test cold baseline, established continuation, and failed response.
-
-The cold baseline may persist context and then publish readiness, the established continuation may advance only after every admission commits, and a failed response must retain the prior checkpoint and reset nio's transient Classic state.
-
-- [ ] **Step 2: Implement direct checkpoint ownership.**
-
-Keep `SyncContinuityStore` as the crash-atomic file owner for the existing checkpoint and join-fence format.
-
-Replace cache certification with a small `SyncCheckpointOwner` that receives response success, `unrecovered_room_ids`, and the highest admission receipt for diagnostics.
-
-Do not attach a cache generation because the journal itself is durable and idempotent.
-
-- [ ] **Step 3: Fail closed on unrecovered responses.**
-
-If nio reports any unrecovered room after readiness, leave the prior checkpoint unchanged, reset the transient Classic sync state, keep the bot unready, and surface the exact room IDs in health diagnostics.
-
-Do not reclassify those events in MindRoom.
-
-- [ ] **Step 4: Delete cache trust and certification.**
-
-Remove generation comparison, cache pending-write diagnostics, cache availability certification, cold-cache cleanup, and cache-driven checkpoint invalidation.
-
-- [ ] **Step 5: Run continuity tests.**
-
-```bash
-uv run pytest -q tests/test_matrix_sync_continuity.py
-```
-
-Expected: baseline, restart recovery, unknown-position reset, persistence failure, cancellation, membership, and realistic `messages([], None)` tests pass without cache trust.
-
-- [ ] **Step 6: Commit the checkpoint simplification.**
-
-```bash
-git add -A src/mindroom/matrix src/mindroom/bot.py tests/test_matrix_sync_continuity.py
-git commit -m "refactor: gate Matrix checkpoints on durable admission"
-```
-
-## Task 7: Add the Durable Terminal Outbox and Coalesce Intermediate Edits
-
-**Files:**
-
-- Create: `src/mindroom/matrix/response_outbox.py`
-- Create: `tests/test_response_outbox.py`
-- Modify: `src/mindroom/matrix/client_delivery.py`
-- Modify: `src/mindroom/delivery_gateway.py`
-- Modify: `src/mindroom/streaming.py`
-- Modify: `src/mindroom/response_attempt.py`
-- Modify: `src/mindroom/visible_response_reconciliation.py`
-- Modify: `tests/test_matrix_delivery.py`
-- Modify: `tests/test_streaming_e2e.py`
-- Modify: `tests/test_streaming_edits.py`
-
-- [ ] **Step 1: Add deterministic transaction tests.**
-
-Assert stable transaction IDs across processes, different IDs for initial and final stages, immutable payloads after first attempt, and one homeserver event after an accepted-but-unacknowledged retry.
-
-- [ ] **Step 2: Thread transaction IDs through low-level delivery.**
-
-Add a required transaction ID to the outbox-owned paths in `send_message_result` and `edit_message_result` while leaving explicitly non-outbox utilities typed and deliberate.
-
-Ensure encrypted and cache-bypass sends use the supplied transaction ID instead of generating `uuid4()`.
-
-- [ ] **Step 3: Enqueue before terminal delivery.**
-
-Make the delivery gateway persist initial and final `OutboxDelivery` rows before network I/O, retry pending rows on startup, and mark them delivered with the returned event ID.
-
-The pending worker may settle the source only after the final outbox row is durably acknowledged or deliberately terminal without a visible response.
-
-- [ ] **Step 4: Keep only latest unsent intermediate content.**
-
-Retain one in-memory pending streaming body and replace it when newer model output arrives before the next edit begins.
-
-Once an edit attempt starts, freeze that payload until the attempt returns, then send only the newest accumulated body if it changed.
-
-Do not insert intermediate edit bodies into the outbox or journal.
-
-- [ ] **Step 5: Collapse visible response reconciliation.**
-
-Replace duplicate pending-visible and retry state with outbox queries keyed by turn and stage.
-
-Delete `visible_response_reconciliation.py` if no unique non-outbox behavior remains, or reduce it to a stateless adoption helper.
-
-- [ ] **Step 6: Run delivery and streaming tests.**
-
-```bash
-uv run pytest -q \
-  tests/test_response_outbox.py \
-  tests/test_matrix_delivery.py \
-  tests/test_streaming_e2e.py \
-  tests/test_streaming_edits.py \
-  tests/test_matrix_event_pipeline_crashes.py
-```
-
-Expected: duplicate-delivery crash cases pass, final content survives restart, and intermediate edits are coalesced without durable edit history.
-
-- [ ] **Step 7: Commit the outbox cutover.**
-
-```bash
-git add -A src/mindroom tests
-git commit -m "feat: deliver terminal Matrix responses through durable outbox"
-```
-
-## Task 8: Remove Duplicate Turn and Source State
-
-**Files:**
-
-- Modify: `src/mindroom/turn_store.py`
-- Modify: `src/mindroom/handled_turns.py`
-- Modify: `src/mindroom/dispatch_replay_guard.py`
-- Modify: `src/mindroom/visible_response_reconciliation.py`
-- Modify: `src/mindroom/sync_restart_retry.py`
-- Modify: `tests/test_turn_store.py`
-- Modify: `tests/test_handled_turns.py`
-- Modify: `tests/test_turn_controller_focused.py`
-- Modify: `tests/test_voice_command_processing.py`
-
-- [ ] **Step 1: Inventory every remaining durable source identity.**
-
-Run:
-
-```bash
-rg -n "source_event_id|pending.*turn|response_event_id|retry.*source|handled" \
-  src/mindroom/turn_store.py \
-  src/mindroom/handled_turns.py \
-  src/mindroom/dispatch_replay_guard.py \
-  src/mindroom/visible_response_reconciliation.py \
-  src/mindroom/sync_restart_retry.py
-```
-
-Classify each field as AI-run metadata, journal-owned ingress state, or outbox-owned delivery state.
-
-- [ ] **Step 2: Add ownership tests.**
-
-Assert that the journal is the only durable pending-source owner, the outbox is the only durable delivery-intent owner, and `TurnStore` retains only model-execution and terminal business metadata.
-
-- [ ] **Step 3: Remove duplicate owners.**
-
-Delete handled-source tombstones, pending-visible intent, retry-source journals, and response-delivery reconciliation from `HandledTurnLedger` and `TurnStore` when the journal or outbox owns the same fact.
-
-Delete entire modules when their last unique responsibility disappears.
-
-- [ ] **Step 4: Preserve only necessary turn recovery.**
-
-Keep the prompt, selected entity, model-run result, cancellation or redaction business outcome, and any facts required to avoid rerunning an already completed model call.
-
-Reference journal receipt order and outbox keys rather than copying their state.
-
-- [ ] **Step 5: Run turn recovery tests.**
-
-```bash
-uv run pytest -q \
-  tests/test_turn_store.py \
-  tests/test_handled_turns.py \
-  tests/test_turn_controller_focused.py \
-  tests/test_voice_command_processing.py \
-  tests/test_matrix_event_pipeline_crashes.py
-```
-
-Expected: model execution and redaction behavior remain correct without a second source or delivery state machine.
-
-- [ ] **Step 6: Commit the ownership cleanup.**
-
-```bash
-git add -A src/mindroom tests
-git commit -m "refactor: remove duplicate Matrix turn durability state"
-```
-
-## Task 9: Enforce the Complexity and Performance Gates
-
-**Files:**
-
-- Modify: `tests/test_matrix_event_pipeline_performance.py`
-- Create: `tests/manual/matrix_event_pipeline_stress.py`
-- Modify: `docs/architecture/bot-runtime.md`
-- Create: `docs/architecture/matrix-event-pipeline.md`
-
-- [ ] **Step 1: Add deterministic operation-count assertions.**
-
-Assert one indexed projection query per hydrated conversation read, one projection-row update per edit, no room-wide read after hydration, and no more than one unresolved row per logical message.
-
-Prefer operation counts and query plans over timing thresholds in CI.
-
-- [ ] **Step 2: Add the 50-thread stress harness.**
-
-Drive 50 concurrent threads, 500 logical messages, 10,000 streaming edits, recovered events, media hydration, redactions, and periodic restarts through SQLite.
-
-Record admission latency, writer queue latency, conversation-read latency, SQLite lock errors, duplicate turns, duplicate visible responses, unresolved journal rows, and database size.
-
-- [ ] **Step 3: Define local acceptance thresholds.**
-
-Require zero lost turns, zero duplicate turns, zero duplicate terminal responses, zero SQLite lock errors, zero room scans after hydration, p95 durable admission below 50 milliseconds, p95 hydrated conversation reads below 50 milliseconds, and p95 writer queue wait below 100 milliseconds on the standard development host.
-
-Treat timing values as manual release gates and keep deterministic structural assertions in CI.
-
-- [ ] **Step 4: Measure the source budget.**
-
-Run:
-
-```bash
-git diff --numstat origin/main...HEAD -- src/mindroom | \
-  awk '{ added += $1; deleted += $2 } END { print "added=" added, "deleted=" deleted, "net=" added-deleted }'
-```
-
-Expected: `net` is at most `-8000`, with `-10000` or lower as the target.
-
-- [ ] **Step 5: Prove deleted owners are absent.**
-
-Run:
-
-```bash
-test ! -d src/mindroom/matrix/cache
-test ! -d src/mindroom/dispatch_obligations
-test ! -e src/mindroom/matrix/client_thread_history.py
-test ! -e src/mindroom/matrix/conversation_cache.py
-test ! -e src/mindroom/cold_history_fence.py
-test ! -e src/mindroom/matrix/sync_cache_trust.py
-test ! -e src/mindroom/matrix/sync_certification.py
-rg -n "EventCacheWriteCoordinator|ThreadCacheGap|DispatchObligation" src/mindroom && exit 1 || true
-```
-
-Expected: every deletion check passes and the symbol search is empty.
-
-- [ ] **Step 6: Document the final ownership flow.**
-
-Update the runtime architecture to show `nio -> journal/projection -> pending worker -> outbox -> Matrix` and state that intermediate edits are not retained.
-
-Remove documentation for cache trust, gap repair, dispatch obligations, and advisory outbound cache updates.
-
-- [ ] **Step 7: Run the manual stress harness.**
-
-```bash
-uv run python tests/manual/matrix_event_pipeline_stress.py --threads 50 --edits 10000 --restarts 5
-```
-
-Expected: every correctness and local performance threshold passes.
-
-- [ ] **Step 8: Commit the gates and documentation.**
-
-```bash
-git add tests/test_matrix_event_pipeline_performance.py \
-  tests/manual/matrix_event_pipeline_stress.py \
-  docs/architecture/bot-runtime.md \
-  docs/architecture/matrix-event-pipeline.md
-git commit -m "test: enforce Matrix pipeline simplicity and performance"
-```
-
-## Task 10: Validate Against Real Tuwunel and Synapse
-
-**Files:**
-
-- Create: `tests/live/test_matrix_event_pipeline_live.py`
-- Modify: `tests/manual/matrix_event_pipeline_stress.py`
-- Modify: `docs/architecture/matrix-event-pipeline.md`
-
-- [ ] **Step 1: Run the realistic restart recovery case against Tuwunel.**
-
-Persist baseline `w1`, stop MindRoom, send a message, restart with `pos=None`, return the missed message and unchanged own-membership event in the initial snapshot with `prev_batch=w2`, and make `/messages?from=w1&to=w2&dir=f` return an empty chunk with no `end`.
-
-Assert provenance is `RECOVERED`, journal actionability is `ACTIONABLE`, the turn completes once, and the response is visible once.
-
-- [ ] **Step 2: Run the same case against Synapse.**
-
-Use the MindRoom Synapse compact-edit configuration and require the same observable result.
-
-- [ ] **Step 3: Validate cold history.**
-
-Start with no persisted baseline and assert that initial history hydrates the projection, creates no turn, establishes the baseline, and publishes readiness only after the journal commits.
-
-- [ ] **Step 4: Validate edit-heavy projection.**
-
-Stream an AI response with updates every 500 milliseconds, restart during the stream, allow the terminal response to finish, and assert one logical projected message with final content and no durable intermediate edit bodies.
-
-- [ ] **Step 5: Validate homeserver recursive hydration.**
-
-Create a thread with many edits, hydrate it through recursive relations on both servers, and assert that MindRoom reduces the relation tree to latest visible content without a room scan or retained edit chain.
-
-- [ ] **Step 6: Validate deployment cutover.**
-
-Stop the old runtime only after its current callbacks drain, preserve the existing continuity checkpoint, start the new runtime on that checkpoint, send a message during downtime, and assert that Matrix recovery admits and answers it once.
-
-- [ ] **Step 7: Run the live suite.**
-
-```bash
-uv run pytest -q tests/live/test_matrix_event_pipeline_live.py
-```
-
-Expected: Tuwunel and Synapse pass the same no-loss, history, edit-compaction, hydration, and idempotent-delivery contract.
-
-- [ ] **Step 8: Commit live coverage.**
-
-```bash
-git add tests/live/test_matrix_event_pipeline_live.py \
-  tests/manual/matrix_event_pipeline_stress.py \
-  docs/architecture/matrix-event-pipeline.md
-git commit -m "test: verify Matrix event pipeline on deployed servers"
-```
-
-## Task 11: Final Verification and Review Stop Gate
-
-**Files:**
-
-- Modify only files required by verified failures.
-
-- [ ] **Step 1: Run formatting, linting, typing, and focused tests.**
-
-```bash
-uv run pre-commit run --all-files
-uv run pytest -q \
-  tests/test_matrix_event_store_contract.py \
-  tests/test_matrix_event_projection.py \
-  tests/test_matrix_event_ingress.py \
-  tests/test_matrix_event_pipeline_crashes.py \
-  tests/test_matrix_event_pipeline_performance.py \
-  tests/test_conversation_projection.py \
-  tests/test_response_outbox.py \
-  tests/test_matrix_sync_continuity.py \
-  tests/test_streaming_e2e.py \
-  tests/test_turn_store.py
-```
-
-Expected: every command exits successfully.
-
-- [ ] **Step 2: Run the full test suite.**
-
-```bash
-uv run pytest -q
-```
-
-Expected: the full suite passes.
-
-- [ ] **Step 3: Re-run live and stress gates.**
-
-Run Task 9's 50-thread stress command and Task 10's live Tuwunel and Synapse suite from the final commit.
-
-Expected: every threshold and real-server contract still passes.
-
-- [ ] **Step 4: Audit for two owners of one fact.**
-
-Search journal state, turn state, delivery state, edit content, hydration completeness, checkpoint state, membership epoch, and retry ownership.
-
-For each fact, record exactly one production owner in the implementation PR description.
-
-- [ ] **Step 5: Recalculate the final deletion budget.**
-
-Run Task 9's source-budget command from the final commit.
-
-Expected: at least 8,000 net production lines are removed.
-
-- [ ] **Step 6: Apply the stop gate.**
-
-Do not request merge if a compatibility path remains, the deletion gate fails, a crash case duplicates or loses a turn, a live server needs a MindRoom provenance guess, or an intermediate edit body remains durable.
-
-- [ ] **Step 7: Commit only verified cleanup if needed.**
-
-```bash
-git add -A
-git commit -m "chore: finish Matrix event pipeline simplification"
-```
-
-## Nio Scope Decision
-
-The core implementation requires one narrow mindroom-nio change to expose the Matrix v1.10 `recurse` query parameter on the existing event-relations iterator.
-
-Nio 0.36 already supplies provenance, persisted baselines, limited-timeline recovery, admission rejection, and Classic response acknowledgement, so none of those areas should change.
-
-The recursive-relations change should remain below 50 production lines plus focused tests and must land as its own nio PR before Task 5 cuts over MindRoom history reads.
-
-Do not add a nio batch-admission API during this implementation.
-
-First remove room scans, repeated repair, competing SQLite writers, and durable intermediate edits, then measure the remaining admission cost.
-
-Open a separate mindroom-nio proposal only if the final 50-thread and 200-event recovery profiles show that per-event durable callback commits consume more than 20 percent of recovery wall time or violate the 50-millisecond admission p95.
-
-That proposal must preserve per-event room-state callback semantics and cannot be assumed to fit the earlier 250-to-500-line estimate until a red nio test demonstrates a safe batch boundary.
-
-This condition prevents a speculative transport API from becoming another permanent layer before the MindRoom simplification proves it is needed.
-
-## Expected Final Shape
-
-The intended production flow is:
+| Matrix recovery provenance and callback redelivery | mindroom-nio |
+| Accepted inbound event and pending semantic work | Principal-bound Matrix event journal |
+| Latest visible conversation content | Conversation projection |
+| Completed model execution | `TurnStore` |
+| Initial and terminal Matrix delivery intent | Response outbox |
+| Last accepted application sync checkpoint | `SyncContinuityStore` |
+
+The desired production flow is:
 
 ```text
-nio timeline recovery and provenance
-  -> MatrixEventIngress durable admission
-      -> matrix_event_journal pending source
-      -> visible_messages latest-state projection
-  -> MatrixEventWorker turn execution
-  -> response_outbox deterministic initial/final delivery
+nio recovery and provenance
+  -> durable journal admission and projection update
+  -> pending event worker
+  -> durable model result
+  -> claimed deterministic outbox delivery
   -> Matrix
 ```
 
-Conversation reconstruction is one indexed projection read after at most one conversation hydration.
+Intermediate AI edits remain transient transport updates and are not durable product data.
 
-Intermediate AI edits exist only in Matrix transport and the in-memory stream coalescer.
+## Why This Is Worth Attempting
 
-The journal owns pending input, the projection owns visible context, `TurnStore` owns model-run facts, the outbox owns terminal delivery intent, nio owns recovery provenance, and `SyncContinuityStore` owns the last accepted application checkpoint.
+At baseline commit `b639b6ef3`, the overlapping subsystem contains 20,248 production lines.
 
-No other module may own a second copy of those facts.
+The 29-file `matrix/cache/` package overlaps with conversation history, dispatch obligations, sync trust, source deduplication, and response reconciliation.
+
+`conversation_cache.py` alone exposes five overlapping history-read paths plus advisory outbound notifications.
+
+This duplication makes correctness depend on several stores agreeing about the same event after restarts, limited timelines, edits, redactions, and delivery failures.
+
+The problem is not Sliding Sync alone.
+
+Sliding Sync exposed recovery gaps, but most current complexity comes from MindRoom independently repairing, caching, certifying, and replaying state that nio or one durable application store should own.
+
+## Non-Negotiable Invariants
+
+- No accepted actionable event may be lost after readiness.
+- The no-loss guarantee begins only after the first successful baseline response has committed and readiness has been published.
+- No event may create more than one semantic turn.
+- `LIVE` and `RECOVERED` events are actionable, while `HISTORY` events are context-only.
+- MindRoom must consume nio provenance and must never reconstruct it from cursors, timestamps, membership repetition, `limited`, `prev_batch`, or server-specific pagination shapes.
+- Nio must reject sync completion when MindRoom cannot durably admit an actionable callback.
+- A failed admission must not advance the application checkpoint.
+- An unrecovered room keeps the bot unready instead of silently becoming history.
+- Conversation reads are bounded and indexed after at most one successful hydration per conversation and membership epoch.
+- Intermediate edit bodies and edit chains are not retained.
+- Initial and terminal response deliveries are idempotent across crashes.
+- No merged cutover may leave both the old and replacement production paths active.
+- Every implementation PR must be green and must remove the active owner it replaces.
+- Existing authorization, E2EE metadata, media transcript, large-message sidecar, reaction, command, source-redaction, and room-membership behavior remains in scope.
+- The existing continuity-checkpoint format remains readable during cutover so downtime events can still be recovered.
+- `bot.py` remains lifecycle and dependency wiring rather than becoming an implementation owner.
+- If a third review round still finds a new correctness class, implementation stops for redesign.
+
+## State Decisions That Must Not Be Rediscovered During Implementation
+
+### Principal ownership
+
+One shared database backend may hold several principals, but runtime code receives only a principal-bound store view.
+
+Operational methods such as `admit`, `pending`, `settle`, `load_conversation`, membership changes, and delivery methods therefore do not accept `principal_id`.
+
+Inbound envelopes and conversation keys also omit `principal_id` because the bound store supplies it.
+
+This prevents callers from accidentally reading or settling another bot's rows.
+
+### Durable admission
+
+Admission performs the journal insert or deduplication, membership-epoch validation, and projection update in one transaction.
+
+The admission callback returns to nio only after that transaction commits.
+
+Context-only payloads may be compacted after projection, while actionable payloads retain the exact replay input until terminal settlement.
+
+A pending worker processes committed events in durable receipt order and leaves an event pending on cancellation or failure.
+
+No durable `running` state is needed because a process crash must make the event eligible for retry.
+
+### Visible-message projection
+
+The projection stores one row per logical message with its latest visible body.
+
+A valid same-sender edit replaces that row only when `(origin_server_ts, event_id)` is newer than the current replacement identity.
+
+An edit received before its original is stored as one latest unresolved edit per target and sender.
+
+Including sender in the unresolved-edit key prevents an attacker from evicting the legitimate author's edit before the original arrives.
+
+When the original arrives, only its sender's unresolved edit may apply, and all unresolved rows for that target are deleted.
+
+Redacting the logical original or its currently visible replacement tombstones the logical message.
+
+Redacting an already superseded replacement does not change visible content.
+
+MindRoom does not reconstruct an earlier edit body after redaction because it intentionally does not retain that history and both homeserver forks may already have purged it.
+
+### Bounded conversation reads
+
+Every conversation read requires a positive limit and an optional stable cursor composed of `(created_ts, logical_event_id)`.
+
+The store queries the newest bounded page through a principal, room, thread, timestamp, and event-ID index and returns the page in chronological order.
+
+Prompt assembly requests pages only until its context budget is satisfied.
+
+Full exports iterate explicit pages.
+
+No runtime API may materialize an unbounded room-scoped conversation.
+
+### Hydration
+
+A thread is hydrated by fetching its root and traversing recursive event relations without a relation-type filter.
+
+Mindroom-nio must expose `recurse`, parse the returned `recursion_depth`, and support a required minimum depth.
+
+MindRoom requires a reported depth of at least three on every recursive page before installing any page's events.
+
+The Matrix version advertised by `/versions` is not proof of recursion depth.
+
+Tuwunel and Synapse currently report depth three, but the real-server proof must verify behavior rather than trust that observation.
+
+A room-scoped conversation may perform one serialized initial `/messages` traversal.
+
+Concurrent first readers share one hydration task, and hydration becomes complete only after successful pagination and an atomic membership-epoch-checked installation.
+
+Failure remains a visible readiness or request failure rather than reviving room-wide repair scans.
+
+### Deterministic delivery
+
+Initial and final delivery stages use deterministic transaction IDs derived from principal, turn, and stage.
+
+The completed model result is durable in `TurnStore` before final outbox enqueue so recovery does not rerun a completed model call merely to rebuild delivery content.
+
+Enqueue may create a row or update an unattempted row.
+
+The worker then atomically claims the row by committing `attempted=true` before network I/O.
+
+Claiming makes the payload and target immutable and returns the exact stored delivery to send.
+
+An attempted but unacknowledged row is retried with the same payload and transaction ID.
+
+This ordering closes the case where Matrix accepted an older deterministic transaction while a restarted model run produced different content that could never become visible.
+
+### Storage concurrency
+
+SQLite uses one writer task and a bounded command queue.
+
+Writer and reader connections use WAL-compatible settings and an explicit `busy_timeout`.
+
+PostgreSQL implements the same behavioral contract without a second application protocol.
+
+The two backends run the same admission, projection, membership, pagination, and outbox contract tests.
+
+## Feasibility Proof Before Production Cutover
+
+The first implementation work is a disposable prototype branch that is not merged into `main`.
+
+It proves the risky primitives without wiring a second production path into MindRoom.
+
+### Store and projection proof
+
+The prototype must demonstrate:
+
+- Principal isolation through bound store views.
+- Exact journal deduplication and pending replay on SQLite and PostgreSQL.
+- Correct ordered and shuffled edit reduction, including pre-original cross-sender edits.
+- Bounded cursor reads over a 100,000-message room conversation.
+- One indexed projection update per edit and no retained intermediate edit chain.
+- Zero SQLite lock failures under 50 concurrent Matrix conversations with an explicit `busy_timeout`.
+
+### Crash proof
+
+The harness must cover these boundaries:
+
+1. Before journal commit.
+2. After journal commit but before nio records callback acceptance.
+3. After callback acceptance but before the pending worker starts.
+4. After durable turn creation but before model execution.
+5. After the model result is durable but before outbox enqueue.
+6. After outbox enqueue but before claim commits.
+7. After claim commits but before network I/O.
+8. After Matrix accepts the transaction but before acknowledgement is stored.
+9. After acknowledgement but before journal settlement.
+
+Every case must produce one terminal turn and at most one visible response.
+
+Cases five through nine must execute the model exactly once.
+
+### Real-server proof
+
+The manual harness must run against both Tuwunel and the MindRoom Synapse fork.
+
+It must prove:
+
+- The realistic restart case where bounded `/messages` exhaustion returns an empty chunk and omits `end` still recovers and replies once.
+- Cold history populates context and never starts a turn.
+- A root, reply, edit, and redaction relation tree reports and supplies the required recursive depth.
+- Edit-heavy streaming leaves one latest logical message without durable intermediate bodies.
+- Deterministic retry after server acceptance creates one Matrix event.
+
+Manual integration scripts follow the repository's existing `tests/manual/` convention.
+
+### Feasibility decision
+
+Before any production cutover, record the prototype's source size, database size, admission latency, writer-queue latency, bounded-read latency, query plans, lock failures, and crash results.
+
+Proceed only if all correctness tests pass, no room scan is required after hydration, and the replacement has a credible path to removing substantially more production code than it adds.
+
+Use the measured prototype size to set a written source-growth budget before the first cutover PR.
+
+If the prototype needs compatibility facades, multiple writers, retained edit chains, or a second recovery classifier, stop and reject this design.
+
+## Cutover Sequence
+
+### 0. mindroom-nio prerequisite
+
+Land a focused mindroom-nio PR that adds recursive relation query support, parses `recursion_depth`, and enforces an optional minimum recursion depth before yielding page events.
+
+The current MindRoom baseline already pins mindroom-nio 0.36.0, so MindRoom must bump to the first release containing this additional contract.
+
+Do not add batch admission or MindRoom storage policy to nio during this work.
+
+### 1. Ingress ownership cutover
+
+Introduce only the journal, membership epoch, principal-bound store, admission adapter, and pending worker needed to replace inbound callback durability.
+
+In the same PR, remove dispatch obligations, dispatch admission, the cold-history fence, and settlement retry ownership.
+
+The PR must pass realistic nio restart recovery, provenance mapping, crash replay, authorization, command, media, reaction, redaction, and decryption-failure behavior.
+
+It must be net simpler than the owners it deletes and must not include dormant projection or outbox frameworks.
+
+### 2. Conversation projection cutover
+
+Add latest-visible projection storage, bounded reads, and one-time thread and room hydration.
+
+Change conversation resolution, reply lookup, reaction lookup, stale-stream cleanup, hooks, and streaming thread targeting to use the bounded projection API.
+
+In the same PR, remove the Matrix cache package, conversation-cache read variants, room-scan thread history and repair, cache trust, cache certification, advisory outbound cache writes, and cache write coordination.
+
+Reduce checkpoint publication to successful durable admission plus nio's exact unrecovered-room result.
+
+Do not preserve deleted cache interfaces to keep implementation-specific tests green.
+
+### 3. Delivery ownership cutover
+
+Add the claimed deterministic outbox and durable model-result handoff.
+
+Keep only the latest unsent streaming content in memory.
+
+In the same PR, remove duplicate pending-visible, delivery-retry, handled-source, and response-reconciliation state when the journal, `TurnStore`, or outbox owns the same fact.
+
+Preserve only unique model-execution, cancellation, redaction, and business-outcome data in `TurnStore`.
+
+### 4. Final deletion and proof
+
+Remove any remaining cache, repair, replay, or delivery owner made obsolete by the cutovers.
+
+Update the architecture documentation to name one owner for each durable fact.
+
+Run the complete backend, crash, performance, full repository, and real-server suites from the final state.
+
+No cleanup PR may add a compatibility path merely to avoid deleting an old implementation-specific test.
+
+## Merge Gates
+
+Each cutover PR reports these results in its description.
+
+| Gate | Required result |
+| --- | --- |
+| Lost actionable events | Zero across the crash matrix and restart recovery. |
+| Duplicate turns | Zero. |
+| Duplicate terminal responses | Zero. |
+| Historical turns | Zero from `HISTORY` or a cold baseline. |
+| Model reruns after durable completion | Zero. |
+| Edit storage | One visible row per logical message and at most one unresolved row per target and sender. |
+| Conversation reads | Bounded cursor pages using the conversation index. |
+| Post-hydration room scans | Zero. |
+| SQLite lock failures | Zero in the 50-conversation stress run. |
+| Backend parity | The same behavioral contract passes on SQLite and PostgreSQL. |
+| Competing owners | No replaced active path remains. |
+| Source size | The PR reports additions, deletions, new-owner size, and deleted-owner size. |
+
+Timing thresholds are manual release evidence rather than flaky CI assertions.
+
+The initial performance targets are p95 durable admission below 50 milliseconds, p95 bounded conversation reads below 50 milliseconds, and p95 writer-queue wait below 100 milliseconds on the standard development host.
+
+Those targets must be recorded with host details and may be revised only from measured prototype evidence.
+
+The complete stack must be materially net negative in production source lines.
+
+The previous 8,000-line reduction remains a target, not proof by itself, because moving the same complexity into new modules would still be a failed simplification.
+
+## Expected Deletions
+
+The exact touched files are decided during implementation, but these ownership groups must disappear if their responsibility is replaced.
+
+- `matrix/cache/` and its write coordinator.
+- `matrix/client_thread_history.py` room-scan, refill, gap, snapshot, and repair behavior.
+- The overlapping history-read variants and advisory outbound notifications in `matrix/conversation_cache.py`.
+- `dispatch_obligations/`.
+- `dispatch_admission.py`.
+- `cold_history_fence.py`.
+- `turn_settlement_retry.py`.
+- Cache generation trust and certification.
+- Duplicate handled-source, pending-visible, response-idempotency, and retry-source state.
+
+The implementation may retain a small focused module under an old filename only if it still owns a unique fact and the PR explains that ownership.
+
+## Explicit Non-Goals
+
+- Retaining or reconstructing intermediate edit bodies.
+- Preserving old cache schemas or internal cache APIs.
+- Adding a MindRoom recovery classifier beside nio provenance.
+- Adding room-wide fallback repair after strict hydration fails.
+- Inferring recursive relation capability from the Matrix spec version.
+- Adding a speculative nio batch-admission API before measurement proves per-event admission is the remaining bottleneck.
+- Preserving implementation-specific tests for deleted owners.
+
+## Stop Conditions
+
+Stop and redesign if any of these occur:
+
+- The prototype loses or duplicates an admitted actionable event.
+- Accepted deterministic delivery can display content different from the durable model result.
+- Correct hydration requires retaining edit chains or restoring room-wide repair scans.
+- Principal isolation cannot be expressed through one bound store interface.
+- SQLite still produces lock failures with one writer and a configured `busy_timeout`.
+- A cutover needs the old and new active paths simultaneously after merge.
+- A cutover adds as much durable state or production code as it removes.
+- Three review rounds continue to reveal new correctness classes.
+
+Passing these gates does not guarantee that every later cutover is easy.
+
+It does establish that the core replacement is real before MindRoom undergoes another large rewrite that only sounds simpler in a plan.

--- a/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
+++ b/docs/superpowers/plans/2026-08-05-matrix-event-journal-projection.md
@@ -6,6 +6,10 @@ This is a feasibility-first architecture and cutover plan, not a prediction of e
 
 The implementation proceeds only if a focused prototype proves that the replacement is correct, fast enough, and materially smaller than the current system.
 
+All MindRoom production changes then land in one implementation PR.
+
+The required mindroom-nio change necessarily remains a separate prerequisite PR because it is a different repository.
+
 ## Goal
 
 Replace the overlapping Matrix callback-obligation, history-repair, conversation-cache, handled-source, and visible-delivery state machines with explicit non-overlapping owners.
@@ -58,9 +62,11 @@ Sliding Sync exposed recovery gaps, but most current complexity comes from MindR
 - An unrecovered room keeps the bot unready instead of silently becoming history.
 - Conversation reads are bounded and indexed after at most one successful hydration per conversation and membership epoch.
 - Intermediate edit bodies and edit chains are not retained.
+- MindRoom intentionally tombstones a logical message when its currently visible edit is redacted, even though a Matrix client may reveal the original body after that redaction.
+- This visible divergence is the accepted cost of not retaining edit history that the homeserver may also have purged.
 - Initial and terminal response deliveries are idempotent across crashes.
-- No merged cutover may leave both the old and replacement production paths active.
-- Every implementation PR must be green and must remove the active owner it replaces.
+- The final implementation PR head must not leave both the old and replacement production paths active.
+- The single implementation PR must be green and must remove every active owner it replaces before merge.
 - Existing authorization, E2EE metadata, media transcript, large-message sidecar, reaction, command, source-redaction, and room-membership behavior remains in scope.
 - The existing continuity-checkpoint format remains readable during cutover so downtime events can still be recovered.
 - `bot.py` remains lifecycle and dependency wiring rather than becoming an implementation owner.
@@ -77,6 +83,14 @@ Operational methods such as `admit`, `pending`, `settle`, `load_conversation`, m
 Inbound envelopes and conversation keys also omit `principal_id` because the bound store supplies it.
 
 This prevents callers from accidentally reading or settling another bot's rows.
+
+### Conversation identity storage
+
+Typed APIs represent an unthreaded conversation as `thread_id=None`.
+
+Durable SQLite and PostgreSQL tables represent it with `thread_id TEXT NOT NULL` and the empty string as the single canonical storage value.
+
+One shared boundary helper encodes `None` to the empty string and decodes it back, so primary keys and uniqueness constraints never depend on nullable equality.
 
 ### Durable admission
 
@@ -166,9 +180,13 @@ The two backends run the same admission, projection, membership, pagination, and
 
 ## Feasibility Proof Before Production Cutover
 
-The first implementation work is a disposable prototype branch that is not merged into `main`.
+The first implementation work occurs on an isolated prototype branch that is not separately merged into `main`.
 
 It proves the risky primitives without wiring a second production path into MindRoom.
+
+If it passes, its implementation and proof harness become the starting point of the single MindRoom implementation PR rather than being rebuilt.
+
+If it fails, the branch is discarded without adding unused architecture to `main`.
 
 ### Store and projection proof
 
@@ -219,11 +237,11 @@ Before any production cutover, record the prototype's source size, database size
 
 Proceed only if all correctness tests pass, no room scan is required after hydration, and the replacement has a credible path to removing substantially more production code than it adds.
 
-Use the measured prototype size to set a written source-growth budget before the first cutover PR.
+Use the measured prototype size to set a written source-growth budget before opening the MindRoom implementation PR.
 
 If the prototype needs compatibility facades, multiple writers, retained edit chains, or a second recovery classifier, stop and reject this design.
 
-## Cutover Sequence
+## One-PR Implementation Sequence
 
 ### 0. mindroom-nio prerequisite
 
@@ -231,17 +249,23 @@ Land a focused mindroom-nio PR that adds recursive relation query support, parse
 
 The current MindRoom baseline already pins mindroom-nio 0.36.0, so MindRoom must bump to the first release containing this additional contract.
 
+That release is a hard prerequisite for every downstream hydration change, and MindRoom must not add a fallback when depth is absent or too shallow.
+
 Do not add batch admission or MindRoom storage policy to nio during this work.
+
+All remaining phases occur on one MindRoom branch and in one implementation PR.
+
+They are internal cutover checkpoints, not separately mergeable PRs, and only the final state may be merged.
 
 ### 1. Ingress ownership cutover
 
 Introduce only the journal, membership epoch, principal-bound store, admission adapter, and pending worker needed to replace inbound callback durability.
 
-In the same PR, remove dispatch obligations, dispatch admission, the cold-history fence, and settlement retry ownership.
+Before the implementation PR can merge, remove dispatch obligations, dispatch admission, the cold-history fence, and settlement retry ownership.
 
-The PR must pass realistic nio restart recovery, provenance mapping, crash replay, authorization, command, media, reaction, redaction, and decryption-failure behavior.
+This checkpoint must pass realistic nio restart recovery, provenance mapping, crash replay, authorization, command, media, reaction, redaction, and decryption-failure behavior.
 
-It must be net simpler than the owners it deletes and must not include dormant projection or outbox frameworks.
+The journal replacement must be net simpler than the ingress owners it deletes.
 
 ### 2. Conversation projection cutover
 
@@ -249,7 +273,7 @@ Add latest-visible projection storage, bounded reads, and one-time thread and ro
 
 Change conversation resolution, reply lookup, reaction lookup, stale-stream cleanup, hooks, and streaming thread targeting to use the bounded projection API.
 
-In the same PR, remove the Matrix cache package, conversation-cache read variants, room-scan thread history and repair, cache trust, cache certification, advisory outbound cache writes, and cache write coordination.
+Before the implementation PR can merge, remove the Matrix cache package, conversation-cache read variants, room-scan thread history and repair, cache trust, cache certification, advisory outbound cache writes, and cache write coordination.
 
 Reduce checkpoint publication to successful durable admission plus nio's exact unrecovered-room result.
 
@@ -261,7 +285,7 @@ Add the claimed deterministic outbox and durable model-result handoff.
 
 Keep only the latest unsent streaming content in memory.
 
-In the same PR, remove duplicate pending-visible, delivery-retry, handled-source, and response-reconciliation state when the journal, `TurnStore`, or outbox owns the same fact.
+Before the implementation PR can merge, remove duplicate pending-visible, delivery-retry, handled-source, and response-reconciliation state when the journal, `TurnStore`, or outbox owns the same fact.
 
 Preserve only unique model-execution, cancellation, redaction, and business-outcome data in `TurnStore`.
 
@@ -273,11 +297,11 @@ Update the architecture documentation to name one owner for each durable fact.
 
 Run the complete backend, crash, performance, full repository, and real-server suites from the final state.
 
-No cleanup PR may add a compatibility path merely to avoid deleting an old implementation-specific test.
+The implementation PR may not add a compatibility path merely to avoid deleting an old implementation-specific test.
 
 ## Merge Gates
 
-Each cutover PR reports these results in its description.
+The single implementation PR tracks these results as its internal checkpoints complete and reports the final values in its description.
 
 | Gate | Required result |
 | --- | --- |
@@ -300,7 +324,7 @@ The initial performance targets are p95 durable admission below 50 milliseconds,
 
 Those targets must be recorded with host details and may be revised only from measured prototype evidence.
 
-The complete stack must be materially net negative in production source lines.
+The complete implementation diff must be materially net negative in production source lines.
 
 The previous 8,000-line reduction remains a target, not proof by itself, because moving the same complexity into new modules would still be a failed simplification.
 


### PR DESCRIPTION
## Summary

- Replaces the former 1,067-line implementation script with a 389-line feasibility-first architecture plan.
- Keeps the durable ownership model, validated state decisions, crash matrix, real-server proof, deletion targets, and stop conditions.
- Uses one MindRoom implementation PR with internal ownership cutovers; the required mindroom-nio change remains a separate cross-repository prerequisite.
- Restores Matrix-correct current-edit redaction through server-authoritative point refetch without retaining edit chains.
- Removes predetermined file lists, commit commands, and unsupported promises about implementation size.

## Key decision

No production cutover begins until an isolated prototype proves principal isolation, canonical conversation identity, bounded projection reads, edit and redaction semantics, crash-safe delivery, SQLite/PostgreSQL behavior, and live Tuwunel/Synapse recursion and restart recovery.

A passing prototype and its proof harness graduate into the single MindRoom implementation PR rather than becoming a separate merge or being rebuilt.

Current-edit redaction uses a durable refresh token and the shared point hydrator; strict reads wait or fail closed, and conditional installation prevents a stale refetch from overwriting a newer edit.

## Scope

Documentation only.