### PR TITLE
perf: cache the knowledge storage key to keep path resolution off the event loop

### DIFF
--- a/src/mindroom/knowledge/indexing_config.py
+++ b/src/mindroom/knowledge/indexing_config.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
+from functools import lru_cache
 from typing import TYPE_CHECKING, NamedTuple, cast
 
 from agno.knowledge.embedder.base import Embedder
@@ -271,8 +272,14 @@ def _safe_identifier(value: str) -> str:
     return sanitized or "default"
 
 
+@lru_cache(maxsize=64)
 def storage_key_for_base(base_id: str, knowledge_path: Path) -> str:
-    """Return the persisted storage-directory key for one knowledge base binding."""
+    """Return the persisted storage-directory key for one knowledge base binding.
+
+    Cached because this runs on the event loop for every agent turn while
+    ``Path.resolve`` is a blocking syscall against the knowledge source root,
+    which can be a network mount.
+    """
     digest_source = f"{base_id}:{knowledge_path.resolve()}"
     digest = hashlib.sha256(digest_source.encode("utf-8")).hexdigest()[:8]
     return f"{_safe_identifier(base_id)}_{digest}"

--- a/tests/test_knowledge_indexing_config.py
+++ b/tests/test_knowledge_indexing_config.py
@@ -8,12 +8,13 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import replace
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from mindroom.knowledge.indexing_config import IndexingSettings, storage_key_for_base
 
 if TYPE_CHECKING:
-    from pathlib import Path
+    import pytest
 
 
 def _settings(base_id: str = "docs") -> IndexingSettings:
@@ -69,6 +70,25 @@ def test_storage_key_for_base_sanitizes_unsafe_identifiers(tmp_path: Path) -> No
     key = storage_key_for_base("my docs/v1", knowledge_path)
     assert key.startswith("my_docs_v1_")
     assert key != storage_key_for_base("my docs.v1", knowledge_path)
+
+
+def test_storage_key_for_base_resolves_each_path_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Repeated lookups must not re-enter the filesystem, which can be a slow network mount."""
+    storage_key_for_base.cache_clear()
+    knowledge_path = tmp_path / "docs"
+    resolved: list[Path] = []
+    original_resolve = Path.resolve
+
+    def counting_resolve(self: Path, strict: bool = False) -> Path:
+        resolved.append(self)
+        return original_resolve(self, strict=strict)
+
+    monkeypatch.setattr(Path, "resolve", counting_resolve)
+    first = storage_key_for_base("docs", knowledge_path)
+    second = storage_key_for_base("docs", knowledge_path)
+
+    assert first == second
+    assert resolved == [knowledge_path]
 
 
 def test_indexing_settings_metadata_round_trip() -> None:


### PR DESCRIPTION
## Problem

`storage_key_for_base` hashes the base ID together with the resolved knowledge source path:

```python
digest_source = f"{base_id}:{knowledge_path.resolve()}"
```

`Path.resolve` is a blocking `realpath` syscall. The function runs on the asyncio event loop on every agent turn, via `generate_streaming_ai_response` -> `resolve_for_agent` -> `get_published_index` -> `published_index_storage_path`.

When the knowledge source root is a network filesystem, an unresponsive mount blocks the whole single-threaded control plane inside that syscall. Because it is the loop that is blocked and not just one coroutine, every agent's Matrix sync loop stalls at the same time and the readiness endpoint stops answering. This has been observed in a deployment where the source root is an NFS mount.

## Fix

The function is pure for a given `(base_id, knowledge_path)` pair, so memoize it with `lru_cache(maxsize=64)`. That is the same pattern already used for the analogous filesystem-touching helpers in `matrix/state.py`.

Two paths that are spelled differently but resolve to the same target still produce the same digest, since a cache miss falls through to the original resolution. The persisted key format is unchanged and stays byte-identical, which the existing `test_storage_key_for_base_pins_persisted_key_format` continues to pin.

## Tests

New `test_storage_key_for_base_resolves_each_path_once` counts `Path.resolve` calls and asserts that a repeated lookup does not re-enter the filesystem. It fails on `main` and passes here.

The rest of the knowledge suite (`pytest tests/ -k knowledge`) passes, as do `ruff check`, `ruff format --check`, and `ty check`.

## Summary by Sourcery

Cache knowledge base storage key computation to avoid repeated blocking path resolution on the event loop.

Bug Fixes:
- Prevent event-loop stalls by memoizing storage_key_for_base so repeated lookups do not re-resolve filesystem paths.

Enhancements:
- Add an LRU cache around storage_key_for_base to reuse computed storage keys for the same base and knowledge path.
- Document the rationale for caching storage_key_for_base, noting the blocking nature of Path.resolve on network mounts.

Tests:
- Add a test ensuring storage_key_for_base resolves a given path only once and reuses the cached result on subsequent calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved repeated knowledge indexing configuration lookups for faster response times.

* **Bug Fixes**
  * Ensured repeated path-based lookups consistently return the same storage key while avoiding unnecessary path resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->