### PR TITLE
Fix GPT-5.6 memory extraction requests

### DIFF
--- a/src/mindroom/memory/_mem0_openai.py
+++ b/src/mindroom/memory/_mem0_openai.py
@@ -1,0 +1,19 @@
+"""MindRoom compatibility for Mem0's OpenAI memory extractor."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mem0.llms.openai import OpenAILLM
+
+from mindroom.model_defaults import OPENAI_GPT_LUNA
+
+
+class MindRoomMem0OpenAILLM(OpenAILLM):
+    """Remove request parameters unsupported by specific OpenAI memory models."""
+
+    def _get_common_params(self, **kwargs: object) -> dict[str, Any]:
+        params = super()._get_common_params(**kwargs)
+        if self.config.model == OPENAI_GPT_LUNA:
+            params.pop("top_p", None)
+        return params

--- a/src/mindroom/memory/_mem0_openai.py
+++ b/src/mindroom/memory/_mem0_openai.py
@@ -2,20 +2,58 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
 
 from mem0.llms.openai import OpenAILLM
 
 from mindroom.model_defaults import OPENAI_GPT_LUNA, OPENAI_GPT_TERRA
 
+if TYPE_CHECKING:
+    from mem0.configs.llms.base import BaseLlmConfig
+
 MEM0_OPENAI_MODELS_WITHOUT_TOP_P = frozenset({OPENAI_GPT_LUNA, OPENAI_GPT_TERRA})
+
+
+class _TopPFilteringCompletions:
+    """Filter unsupported sampling controls at the final provider boundary."""
+
+    def __init__(self, completions: object) -> None:
+        self._completions = completions
+
+    def create(self, *args: object, **kwargs: object) -> object:
+        kwargs.pop("top_p", None)
+        return cast("Any", self._completions).create(*args, **kwargs)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._completions, name)
+
+
+class _TopPFilteringChat:
+    """Preserve chat APIs while replacing only its completions resource."""
+
+    def __init__(self, chat: object) -> None:
+        self._chat = chat
+        self.completions = _TopPFilteringCompletions(cast("Any", chat).completions)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._chat, name)
+
+
+class _TopPFilteringClient:
+    """Preserve OpenAI client APIs while filtering chat completions."""
+
+    def __init__(self, client: object) -> None:
+        self._client = client
+        self.chat = _TopPFilteringChat(cast("Any", client).chat)
+
+    def __getattr__(self, name: str) -> object:
+        return getattr(self._client, name)
 
 
 class MindRoomMem0OpenAILLM(OpenAILLM):
     """Remove request parameters unsupported by specific OpenAI memory models."""
 
-    def _get_common_params(self, **kwargs: object) -> dict[str, Any]:
-        params = super()._get_common_params(**kwargs)
+    def __init__(self, config: BaseLlmConfig) -> None:
+        super().__init__(config)
         if self.config.model in MEM0_OPENAI_MODELS_WITHOUT_TOP_P:
-            params.pop("top_p", None)
-        return params
+            self.client = cast("Any", _TopPFilteringClient(self.client))

--- a/src/mindroom/memory/_mem0_openai.py
+++ b/src/mindroom/memory/_mem0_openai.py
@@ -6,7 +6,9 @@ from typing import Any
 
 from mem0.llms.openai import OpenAILLM
 
-from mindroom.model_defaults import OPENAI_GPT_LUNA
+from mindroom.model_defaults import OPENAI_GPT_LUNA, OPENAI_GPT_TERRA
+
+MEM0_OPENAI_MODELS_WITHOUT_TOP_P = frozenset({OPENAI_GPT_LUNA, OPENAI_GPT_TERRA})
 
 
 class MindRoomMem0OpenAILLM(OpenAILLM):
@@ -14,6 +16,6 @@ class MindRoomMem0OpenAILLM(OpenAILLM):
 
     def _get_common_params(self, **kwargs: object) -> dict[str, Any]:
         params = super()._get_common_params(**kwargs)
-        if self.config.model == OPENAI_GPT_LUNA:
+        if self.config.model in MEM0_OPENAI_MODELS_WITHOUT_TOP_P:
             params.pop("top_p", None)
         return params

--- a/src/mindroom/memory/_mem0_openai.py
+++ b/src/mindroom/memory/_mem0_openai.py
@@ -2,58 +2,33 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, cast
-
-from mem0.llms.openai import OpenAILLM
+from typing import TYPE_CHECKING
 
 from mindroom.model_defaults import OPENAI_GPT_LUNA, OPENAI_GPT_TERRA
 
 if TYPE_CHECKING:
-    from mem0.configs.llms.base import BaseLlmConfig
+    from collections.abc import Callable
 
-MEM0_OPENAI_MODELS_WITHOUT_TOP_P = frozenset({OPENAI_GPT_LUNA, OPENAI_GPT_TERRA})
+    from mem0.llms.openai import OpenAILLM
+
+_MEM0_OPENAI_MODELS_WITHOUT_TOP_P = frozenset({OPENAI_GPT_LUNA, OPENAI_GPT_TERRA})
 
 
-class _TopPFilteringCompletions:
-    """Filter unsupported sampling controls at the final provider boundary."""
+def _without_top_p(create: Callable[..., object]) -> Callable[..., object]:
+    """Return a completion callable that omits the unsupported ``top_p`` parameter."""
 
-    def __init__(self, completions: object) -> None:
-        self._completions = completions
-
-    def create(self, *args: object, **kwargs: object) -> object:
+    def create_without_top_p(*args: object, **kwargs: object) -> object:
         kwargs.pop("top_p", None)
-        return cast("Any", self._completions).create(*args, **kwargs)
+        return create(*args, **kwargs)
 
-    def __getattr__(self, name: str) -> object:
-        return getattr(self._completions, name)
-
-
-class _TopPFilteringChat:
-    """Preserve chat APIs while replacing only its completions resource."""
-
-    def __init__(self, chat: object) -> None:
-        self._chat = chat
-        self.completions = _TopPFilteringCompletions(cast("Any", chat).completions)
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self._chat, name)
+    return create_without_top_p
 
 
-class _TopPFilteringClient:
-    """Preserve OpenAI client APIs while filtering chat completions."""
-
-    def __init__(self, client: object) -> None:
-        self._client = client
-        self.chat = _TopPFilteringChat(cast("Any", client).chat)
-
-    def __getattr__(self, name: str) -> object:
-        return getattr(self._client, name)
-
-
-class MindRoomMem0OpenAILLM(OpenAILLM):
-    """Remove request parameters unsupported by specific OpenAI memory models."""
-
-    def __init__(self, config: BaseLlmConfig) -> None:
-        super().__init__(config)
-        if self.config.model in MEM0_OPENAI_MODELS_WITHOUT_TOP_P:
-            self.client = cast("Any", _TopPFilteringClient(self.client))
+def install_mem0_openai_compatibility(llm: OpenAILLM) -> None:
+    """Install model-specific request filtering on an existing Mem0 OpenAI LLM."""
+    if llm.config.model not in _MEM0_OPENAI_MODELS_WITHOUT_TOP_P:
+        return
+    completions = llm.client.chat.completions
+    completions.create = _without_top_p(  # type: ignore[method-assign]  # ty: ignore[invalid-assignment]
+        completions.create,
+    )

--- a/src/mindroom/memory/config.py
+++ b/src/mindroom/memory/config.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mem0 import AsyncMemory
+    from mem0.llms.openai import OpenAILLM
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -264,13 +265,9 @@ async def create_memory_instance(
     memory = AsyncMemory.from_config(config_dict)
     memory_llm = config.memory.llm
     if memory_llm is not None and memory_llm.provider == "openai":
-        from mindroom.memory._mem0_openai import (  # noqa: PLC0415
-            MEM0_OPENAI_MODELS_WITHOUT_TOP_P,
-            MindRoomMem0OpenAILLM,
-        )
+        from mindroom.memory._mem0_openai import install_mem0_openai_compatibility  # noqa: PLC0415
 
-        if memory_llm.config.get("model") in MEM0_OPENAI_MODELS_WITHOUT_TOP_P:
-            memory.llm = MindRoomMem0OpenAILLM(memory.llm.config)
+        install_mem0_openai_compatibility(cast("OpenAILLM", memory.llm))
     if config.memory.embedder.provider == "openai":
         # Mem0's own OpenAI embedder indexes response.data[0] without validation
         # and can expose raw provider errors. Reuse MindRoom's strict boundary.

--- a/src/mindroom/memory/config.py
+++ b/src/mindroom/memory/config.py
@@ -10,7 +10,7 @@ from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
 from mindroom.embedding_factory import resolve_embedder_settings
 from mindroom.embeddings import effective_mem0_embedder_signature, ensure_sentence_transformers_dependencies
 from mindroom.logging_config import get_logger
-from mindroom.model_defaults import MEMORY_OLLAMA_LLM, OLLAMA_HOST_DEFAULT, OPENAI_GPT_LUNA
+from mindroom.model_defaults import MEMORY_OLLAMA_LLM, OLLAMA_HOST_DEFAULT
 from mindroom.timing import timed
 
 if TYPE_CHECKING:
@@ -263,10 +263,14 @@ async def create_memory_instance(
     # Mem0 expects a dict for configuration, not config objects
     memory = AsyncMemory.from_config(config_dict)
     memory_llm = config.memory.llm
-    if memory_llm is not None and memory_llm.provider == "openai" and memory_llm.config.get("model") == OPENAI_GPT_LUNA:
-        from mindroom.memory._mem0_openai import MindRoomMem0OpenAILLM  # noqa: PLC0415
+    if memory_llm is not None and memory_llm.provider == "openai":
+        from mindroom.memory._mem0_openai import (  # noqa: PLC0415
+            MEM0_OPENAI_MODELS_WITHOUT_TOP_P,
+            MindRoomMem0OpenAILLM,
+        )
 
-        memory.llm = MindRoomMem0OpenAILLM(memory.llm.config)
+        if memory_llm.config.get("model") in MEM0_OPENAI_MODELS_WITHOUT_TOP_P:
+            memory.llm = MindRoomMem0OpenAILLM(memory.llm.config)
     if config.memory.embedder.provider == "openai":
         # Mem0's own OpenAI embedder indexes response.data[0] without validation
         # and can expose raw provider errors. Reuse MindRoom's strict boundary.

--- a/src/mindroom/memory/config.py
+++ b/src/mindroom/memory/config.py
@@ -10,7 +10,7 @@ from mindroom.credentials_sync import get_api_key_for_provider, get_ollama_host
 from mindroom.embedding_factory import resolve_embedder_settings
 from mindroom.embeddings import effective_mem0_embedder_signature, ensure_sentence_transformers_dependencies
 from mindroom.logging_config import get_logger
-from mindroom.model_defaults import MEMORY_OLLAMA_LLM, OLLAMA_HOST_DEFAULT
+from mindroom.model_defaults import MEMORY_OLLAMA_LLM, OLLAMA_HOST_DEFAULT, OPENAI_GPT_LUNA
 from mindroom.timing import timed
 
 if TYPE_CHECKING:
@@ -262,6 +262,11 @@ async def create_memory_instance(
     # Create AsyncMemory instance with dictionary config directly
     # Mem0 expects a dict for configuration, not config objects
     memory = AsyncMemory.from_config(config_dict)
+    memory_llm = config.memory.llm
+    if memory_llm is not None and memory_llm.provider == "openai" and memory_llm.config.get("model") == OPENAI_GPT_LUNA:
+        from mindroom.memory._mem0_openai import MindRoomMem0OpenAILLM  # noqa: PLC0415
+
+        memory.llm = MindRoomMem0OpenAILLM(memory.llm.config)
     if config.memory.embedder.provider == "openai":
         # Mem0's own OpenAI embedder indexes response.data[0] without validation
         # and can expose raw provider errors. Reuse MindRoom's strict boundary.

--- a/tach.toml
+++ b/tach.toml
@@ -1824,9 +1824,15 @@ depends_on = [
     "mindroom.embedding_factory",
     "mindroom.embeddings",
     "mindroom.logging_config",
+    "mindroom.memory._mem0_openai",
     "mindroom.timing",
 ]
 visibility = ["mindroom.memory._backend"]
+
+[[modules]]
+path = "mindroom.memory._mem0_openai"
+depends_on = ["mindroom.model_defaults"]
+visibility = ["mindroom.memory.config"]
 
 [[modules]]
 path = "mindroom.memory._file_backend"

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -10,6 +10,7 @@ import pytest
 from mem0 import AsyncMemory
 from mem0.configs.embeddings.base import BaseEmbedderConfig
 from mem0.embeddings.openai import OpenAIEmbedding
+from mem0.llms.openai import OpenAILLM
 
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
@@ -117,6 +118,59 @@ class TestMemoryConfig:
         assert result["llm"]["provider"] == "openai"
         assert result["llm"]["config"]["model"] == "gpt-4"
         assert result["llm"]["config"]["api_key"] == "test-key"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("model_id", "expected_top_p"),
+        [
+            ("gpt-5.6-luna", None),
+            ("gpt-4", 0.8),
+        ],
+    )
+    async def test_mem0_openai_top_p_support_is_model_specific(
+        self,
+        tmp_path: Path,
+        model_id: str,
+        expected_top_p: float | None,
+    ) -> None:
+        """Memory extraction must omit only sampling controls rejected by its model."""
+        memory = MemoryConfig(
+            embedder=_MemoryEmbedderConfig(
+                provider="ollama",
+                config=EmbedderConfig(model="nomic-embed-text", host="http://localhost:11434"),
+            ),
+            llm=_MemoryLLMConfig(
+                provider="openai",
+                config={
+                    "api_key": "test-key",
+                    "model": model_id,
+                    "temperature": 0.1,
+                    "top_p": 0.8,
+                },
+            ),
+        )
+        config = Config(memory=memory, router=RouterConfig(model="default"))
+
+        def fake_from_config(config_dict: dict) -> SimpleNamespace:
+            return SimpleNamespace(
+                llm=OpenAILLM(config_dict["llm"]["config"]),
+                vector_store=object(),
+            )
+
+        with patch.object(AsyncMemory, "from_config", side_effect=fake_from_config):
+            instance = await create_memory_instance(tmp_path / "memory", config, _runtime_paths(tmp_path))
+
+        response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+        create_completion = MagicMock(return_value=response)
+        instance.llm.client.chat.completions.create = create_completion
+        instance.llm.generate_response([{"role": "user", "content": "remember this"}])
+
+        request_params = create_completion.call_args.kwargs
+        assert request_params["temperature"] == 0.1
+        if expected_top_p is None:
+            assert "top_p" not in request_params
+        else:
+            assert request_params["top_p"] == expected_top_p
 
     def test_get_memory_config_passes_configured_embedding_dimensions(
         self,

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -124,6 +124,7 @@ class TestMemoryConfig:
         ("model_id", "expected_top_p"),
         [
             ("gpt-5.6-luna", None),
+            ("gpt-5.6-terra", None),
             ("gpt-4", 0.8),
         ],
     )

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -27,7 +27,7 @@ from mindroom.memory.config import (
     _memory_collection_name,
     create_memory_instance,
 )
-from mindroom.model_defaults import MEMORY_OLLAMA_LLM, OLLAMA_HOST_DEFAULT
+from mindroom.model_defaults import MEMORY_OLLAMA_LLM, OLLAMA_HOST_DEFAULT, OPENAI_GPT_LUNA, OPENAI_GPT_TERRA
 from mindroom.openai_embedder import MindRoomOpenAIEmbedder
 from mindroom.orchestrator import _MultiAgentOrchestrator
 from mindroom.path_globs import matches_root_glob
@@ -123,10 +123,10 @@ class TestMemoryConfig:
     @pytest.mark.parametrize(
         ("model_id", "expected_top_p", "legacy_request_builder"),
         [
-            ("gpt-5.6-luna", None, False),
-            ("gpt-5.6-terra", None, False),
+            (OPENAI_GPT_LUNA, None, False),
+            (OPENAI_GPT_TERRA, None, False),
             ("gpt-4", 0.8, False),
-            ("gpt-5.6-terra", None, True),
+            (OPENAI_GPT_TERRA, None, True),
         ],
         ids=["luna", "terra", "gpt-4", "terra-legacy-mem0"],
     )
@@ -158,18 +158,17 @@ class TestMemoryConfig:
         create_completion = MagicMock(return_value=response)
         fake_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create_completion)))
 
-        def fake_from_config(config_dict: dict) -> SimpleNamespace:
-            return SimpleNamespace(
-                llm=OpenAILLM(config_dict["llm"]["config"]),
-                vector_store=object(),
-            )
+        with patch("mem0.llms.openai.OpenAI", return_value=fake_client):
+            mem0_llm = OpenAILLM(memory.llm.config)
 
-        with (
-            patch.object(AsyncMemory, "from_config", side_effect=fake_from_config),
-            patch("mem0.llms.openai.OpenAI", return_value=fake_client),
+        with patch.object(
+            AsyncMemory,
+            "from_config",
+            return_value=SimpleNamespace(llm=mem0_llm, vector_store=object()),
         ):
             instance = await create_memory_instance(tmp_path / "memory", config, _runtime_paths(tmp_path))
 
+        assert instance.llm is mem0_llm
         messages = [{"role": "user", "content": "remember this"}]
         if legacy_request_builder:
 

--- a/tests/test_memory_config.py
+++ b/tests/test_memory_config.py
@@ -121,18 +121,21 @@ class TestMemoryConfig:
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
-        ("model_id", "expected_top_p"),
+        ("model_id", "expected_top_p", "legacy_request_builder"),
         [
-            ("gpt-5.6-luna", None),
-            ("gpt-5.6-terra", None),
-            ("gpt-4", 0.8),
+            ("gpt-5.6-luna", None, False),
+            ("gpt-5.6-terra", None, False),
+            ("gpt-4", 0.8, False),
+            ("gpt-5.6-terra", None, True),
         ],
+        ids=["luna", "terra", "gpt-4", "terra-legacy-mem0"],
     )
     async def test_mem0_openai_top_p_support_is_model_specific(
         self,
         tmp_path: Path,
         model_id: str,
         expected_top_p: float | None,
+        legacy_request_builder: bool,
     ) -> None:
         """Memory extraction must omit only sampling controls rejected by its model."""
         memory = MemoryConfig(
@@ -151,6 +154,9 @@ class TestMemoryConfig:
             ),
         )
         config = Config(memory=memory, router=RouterConfig(model="default"))
+        response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+        create_completion = MagicMock(return_value=response)
+        fake_client = SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=create_completion)))
 
         def fake_from_config(config_dict: dict) -> SimpleNamespace:
             return SimpleNamespace(
@@ -158,13 +164,28 @@ class TestMemoryConfig:
                 vector_store=object(),
             )
 
-        with patch.object(AsyncMemory, "from_config", side_effect=fake_from_config):
+        with (
+            patch.object(AsyncMemory, "from_config", side_effect=fake_from_config),
+            patch("mem0.llms.openai.OpenAI", return_value=fake_client),
+        ):
             instance = await create_memory_instance(tmp_path / "memory", config, _runtime_paths(tmp_path))
 
-        response = SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
-        create_completion = MagicMock(return_value=response)
-        instance.llm.client.chat.completions.create = create_completion
-        instance.llm.generate_response([{"role": "user", "content": "remember this"}])
+        messages = [{"role": "user", "content": "remember this"}]
+        if legacy_request_builder:
+
+            def legacy_generate_response(llm: OpenAILLM, request_messages: list[dict[str, str]]) -> object:
+                return llm.client.chat.completions.create(
+                    model=llm.config.model,
+                    messages=request_messages,
+                    temperature=llm.config.temperature,
+                    max_tokens=llm.config.max_tokens,
+                    top_p=llm.config.top_p,
+                )
+
+            with patch.object(OpenAILLM, "generate_response", legacy_generate_response):
+                instance.llm.generate_response(messages)
+        else:
+            instance.llm.generate_response(messages)
 
         request_params = create_completion.call_args.kwargs
         assert request_params["temperature"] == 0.1


### PR DESCRIPTION
## Summary

- wrap Mem0's OpenAI memory extractor at the final provider boundary
- omit only `top_p` for `gpt-5.6-luna` and `gpt-5.6-terra`
- preserve other request parameters and other OpenAI models
- support both minimum and current Mem0 request builders
- cover final outbound completion kwargs with model-specific regression cases

## Verification

- `uv run pre-commit run --all-files`
- relevant memory/import suite: 132 passed
- full core suite passed with one existing cancellation test excluded
- excluded test's SQLite and PostgreSQL cases also fail on untouched `origin/main`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory integrations for Luna and Terra models by omitting the unsupported `top_p` request parameter.
  * Preserved existing request behavior for models that support `top_p`.

* **Tests**
  * Added coverage for current and legacy request-building paths to verify model-specific parameter handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->