### PR TITLE
perf: isolate worker proxy HTTP from default executor

### DIFF
--- a/src/mindroom/tool_system/sandbox_proxy.py
+++ b/src/mindroom/tool_system/sandbox_proxy.py
@@ -10,7 +10,9 @@ import hashlib
 import json
 import os
 import secrets
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
+from contextvars import copy_context
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
@@ -51,7 +53,7 @@ from mindroom.workers.runtime import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Callable, Mapping
 
     from agno.tools.function import Function
     from agno.tools.toolkit import Toolkit
@@ -68,6 +70,7 @@ _DEFAULT_INLINE_ATTACHMENT_BYTES = 16 * 1024 * 1024
 _SANDBOX_ALL_EXECUTION_MODES = frozenset({"all", "sandbox_all"})
 _SANDBOX_SELECTIVE_EXECUTION_MODES = frozenset({"selective", "sandbox_selective"})
 _UNSAFE_LOCAL_EXECUTION_MODES = frozenset({"off", "local", "disabled"})
+_WORKER_PROXY_EXECUTOR = ThreadPoolExecutor(thread_name_prefix="mindroom-worker-proxy")
 
 
 class _AttachmentSavePayloadFields(TypedDict):
@@ -834,6 +837,13 @@ def _call_proxy_sync(
         )
 
 
+async def _run_in_worker_proxy_executor(call: Callable[[], object]) -> object:
+    """Run one blocking worker proxy call outside asyncio's default executor."""
+    context = copy_context()
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(_WORKER_PROXY_EXECUTOR, context.run, call)
+
+
 def _wrap_sync_function(
     function: Function,
     tool_name: str,
@@ -891,7 +901,7 @@ def _wrap_async_function(
 
     @functools.wraps(function.entrypoint)
     async def proxy_entrypoint(*args: object, **kwargs: object) -> object:
-        return await asyncio.to_thread(
+        call = functools.partial(
             _call_proxy_sync,
             runtime_paths=runtime_paths,
             tool_name=tool_name,
@@ -906,6 +916,7 @@ def _wrap_async_function(
             extra_env_passthrough=extra_env_passthrough,
             worker_target=worker_target,
         )
+        return await _run_in_worker_proxy_executor(call)
 
     wrapped.entrypoint = proxy_entrypoint
     return wrapped

--- a/src/mindroom/tool_system/sandbox_proxy.py
+++ b/src/mindroom/tool_system/sandbox_proxy.py
@@ -70,6 +70,7 @@ _DEFAULT_INLINE_ATTACHMENT_BYTES = 16 * 1024 * 1024
 _SANDBOX_ALL_EXECUTION_MODES = frozenset({"all", "sandbox_all"})
 _SANDBOX_SELECTIVE_EXECUTION_MODES = frozenset({"selective", "sandbox_selective"})
 _UNSAFE_LOCAL_EXECUTION_MODES = frozenset({"off", "local", "disabled"})
+# Process-lifetime pool: threads start lazily and ThreadPoolExecutor joins them at interpreter shutdown.
 _WORKER_PROXY_EXECUTOR = ThreadPoolExecutor(thread_name_prefix="mindroom-worker-proxy")
 
 

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -138,6 +138,7 @@ async def test_worker_proxy_executor_isolated_from_default_pool_and_preserves_co
         await default_blocker
         loop.set_default_executor(replacement_executor)
         default_executor.shutdown(wait=True)
+        replacement_executor.shutdown(wait=True)
 
 
 def test_approved_egress_tool_stays_primary_even_when_sandbox_mode_all(tmp_path: Path) -> None:

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -11,6 +11,8 @@ import os
 import stat
 import sys
 import threading
+from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
 from dataclasses import asdict
 from pathlib import Path
 from types import SimpleNamespace
@@ -101,6 +103,41 @@ _TEST_KUBERNETES_CONFIG_SNAPSHOT: dict[str, object] = {
     "knowledge_bases": {},
 }
 _TEST_RUNTIME_PATHS = resolve_runtime_paths(config_path=Path("config.yaml"), process_env={})
+
+
+@pytest.mark.asyncio
+async def test_worker_proxy_executor_isolated_from_default_pool_and_preserves_context() -> None:
+    """Worker proxy calls must not queue behind unrelated default-pool work."""
+    loop = asyncio.get_running_loop()
+    default_executor = ThreadPoolExecutor(max_workers=1)
+    replacement_executor = ThreadPoolExecutor()
+    loop.set_default_executor(default_executor)
+    default_started = threading.Event()
+    release_default = threading.Event()
+    request_scope = ContextVar[str]("test_worker_proxy_request_scope")
+
+    def block_default_executor() -> None:
+        default_started.set()
+        release_default.wait(timeout=5)
+
+    default_blocker = loop.run_in_executor(None, block_default_executor)
+    assert default_started.wait(timeout=1)
+    token = request_scope.set("request-scope")
+
+    try:
+        result = await asyncio.wait_for(
+            sandbox_proxy_module._run_in_worker_proxy_executor(request_scope.get),
+            timeout=1,
+        )
+
+        assert result == "request-scope"
+        assert not default_blocker.done()
+    finally:
+        request_scope.reset(token)
+        release_default.set()
+        await default_blocker
+        loop.set_default_executor(replacement_executor)
+        default_executor.shutdown(wait=True)
 
 
 def test_approved_egress_tool_stays_primary_even_when_sandbox_mode_all(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- run blocking sandbox-worker proxy calls on a dedicated thread pool
- preserve request ContextVars across the executor boundary
- keep the asyncio default executor available for unrelated blocking runtime work

## Testing

- uv run pytest tests/test_sandbox_proxy.py -q
- uv run ruff check src/mindroom/tool_system/sandbox_proxy.py tests/test_sandbox_proxy.py
- uv run ruff format --check src/mindroom/tool_system/sandbox_proxy.py tests/test_sandbox_proxy.py
- pre-commit hooks, including ty and vulture

## Summary by Sourcery

Isolate sandbox worker proxy HTTP calls onto a dedicated thread pool while preserving request context across the executor boundary.

New Features:
- Introduce a dedicated worker proxy thread pool for blocking sandbox proxy calls, separate from asyncio's default executor.

Enhancements:
- Preserve ContextVars when dispatching worker proxy calls to the dedicated executor instead of using the default asyncio thread pool.

Tests:
- Add an async test verifying worker proxy calls use an isolated executor and maintain request-scoped context while not being blocked by default executor work.