### PR TITLE
fix: keep attachment cleanup off event loop

### DIFF
--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -52,6 +52,7 @@ _CLEANUP_INTERVAL = timedelta(hours=1)
 _last_cleanup_time_by_storage_path: dict[Path, datetime] = {}
 _attachment_cleanup_lock = Lock()
 _attachment_cleanup_claim_tokens_by_storage_path: dict[Path, object] = {}
+_attachment_cleanup_scheduled_tokens_by_storage_path: dict[Path, object] = {}
 _ATTACHMENT_CLEANUP_TASK_OWNER = object()
 
 
@@ -504,6 +505,29 @@ def _release_attachment_cleanup_claim(storage_path: Path, claim_token: object) -
             del _attachment_cleanup_claim_tokens_by_storage_path[storage_path]
 
 
+def _claim_attachment_cleanup_schedule(storage_path: Path) -> object | None:
+    """Claim the cheap pre-worker scheduling slot for one storage path."""
+    now = datetime.now(UTC)
+    with _attachment_cleanup_lock:
+        if storage_path in _attachment_cleanup_scheduled_tokens_by_storage_path:
+            return None
+        if storage_path in _attachment_cleanup_claim_tokens_by_storage_path:
+            return None
+        last_cleanup_time = _last_cleanup_time_by_storage_path.get(storage_path)
+        if last_cleanup_time is not None and now - last_cleanup_time < _CLEANUP_INTERVAL:
+            return None
+        schedule_token = object()
+        _attachment_cleanup_scheduled_tokens_by_storage_path[storage_path] = schedule_token
+    return schedule_token
+
+
+def _release_attachment_cleanup_schedule(storage_path: Path, schedule_token: object) -> None:
+    """Release a pre-worker scheduling slot owned by this cleanup task."""
+    with _attachment_cleanup_lock:
+        if _attachment_cleanup_scheduled_tokens_by_storage_path.get(storage_path) is schedule_token:
+            del _attachment_cleanup_scheduled_tokens_by_storage_path[storage_path]
+
+
 def _claim_and_cleanup_attachment_storage(storage_path: Path) -> None:
     """Resolve, claim, and clean one storage path in the calling worker."""
     try:
@@ -528,6 +552,14 @@ def _claim_and_cleanup_attachment_storage(storage_path: Path) -> None:
         _release_attachment_cleanup_claim(resolved_storage_path, claim_token)
 
 
+async def _run_scheduled_attachment_cleanup(storage_path: Path, schedule_token: object) -> None:
+    """Run one claimed cleanup job and release its scheduling slot."""
+    try:
+        await run_blocking_until_complete(_claim_and_cleanup_attachment_storage, storage_path)
+    finally:
+        _release_attachment_cleanup_schedule(storage_path, schedule_token)
+
+
 def _finish_attachment_cleanup_task(task: asyncio.Task[object]) -> None:
     """Log an unexpected scheduling failure after worker cleanup completes."""
     try:
@@ -535,7 +567,7 @@ def _finish_attachment_cleanup_task(task: asyncio.Task[object]) -> None:
     except asyncio.CancelledError:
         pass
     except Exception:
-        logger.exception("Failed to prune expired attachment storage")
+        logger.exception("Attachment cleanup background task failed")
 
 
 def _maybe_cleanup_attachment_storage(storage_path: Path) -> None:
@@ -547,15 +579,21 @@ def _maybe_cleanup_attachment_storage(storage_path: Path) -> None:
         return
 
     scheduling_started = time.monotonic()
+    schedule_token = _claim_attachment_cleanup_schedule(storage_path)
+    if schedule_token is None:
+        return
+    cleanup_coroutine = _run_scheduled_attachment_cleanup(storage_path, schedule_token)
     try:
         cleanup_task = create_background_task(
-            run_blocking_until_complete(_claim_and_cleanup_attachment_storage, storage_path),
+            cleanup_coroutine,
             name="attachment_cleanup",
             owner=_ATTACHMENT_CLEANUP_TASK_OWNER,
             log_exceptions=False,
         )
     except Exception:
-        logger.exception("Failed to prune expired attachment storage")
+        cleanup_coroutine.close()
+        _release_attachment_cleanup_schedule(storage_path, schedule_token)
+        logger.exception("Failed to schedule attachment storage cleanup")
         return
     cleanup_task.add_done_callback(_finish_attachment_cleanup_task)
     logger.debug(

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -385,7 +385,7 @@ def _remove_paths(paths: list[Path]) -> int:
     removed = 0
     for path in paths:
         try:
-            path.unlink(missing_ok=True)
+            path.unlink()
         except OSError:
             continue
         removed += 1
@@ -434,7 +434,7 @@ def _prune_orphan_incoming_media(
         if media_mtime is None or media_mtime >= cutoff:
             continue
         try:
-            media_path.unlink(missing_ok=True)
+            media_path.unlink()
         except OSError:
             continue
         removed += 1

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -11,12 +11,14 @@ import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from threading import Lock
 from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 import nio
 
 from .attachment_ids import normalize_attachment_id
+from .background_tasks import create_background_task, run_blocking_until_complete, wait_for_background_tasks
 from .constants import ATTACHMENT_IDS_KEY
 from .logging_config import get_logger
 from .matrix.media import (
@@ -47,6 +49,9 @@ _AttachmentKind = Literal["audio", "file", "image", "video"]
 _ATTACHMENT_RETENTION_DAYS = 30
 _CLEANUP_INTERVAL = timedelta(hours=1)
 _last_cleanup_time_by_storage_path: dict[Path, datetime] = {}
+_attachment_cleanup_lock = Lock()
+_attachment_cleanup_claim_tokens_by_storage_path: dict[Path, object] = {}
+_ATTACHMENT_CLEANUP_TASK_OWNER = object()
 
 
 @dataclass(frozen=True)
@@ -339,6 +344,7 @@ def _collect_attachment_cleanup_state(
     *,
     cutoff: datetime,
 ) -> tuple[
+    int,
     set[Path],
     dict[Path, int],
     list[tuple[AttachmentRecord, Path]],
@@ -349,8 +355,10 @@ def _collect_attachment_cleanup_state(
     active_media_ref_counts: dict[Path, int] = {}
     expired_records: list[tuple[AttachmentRecord, Path]] = []
     stale_record_paths: list[Path] = []
+    metadata_files_scanned = 0
 
     for record_path in _attachments_dir(storage_path).glob("*.json"):
+        metadata_files_scanned += 1
         record = load_attachment(storage_path, record_path.stem)
         if record is None:
             record_mtime = _record_mtime(record_path)
@@ -367,7 +375,7 @@ def _collect_attachment_cleanup_state(
         active_media_paths.add(resolved_media_path)
         active_media_ref_counts[resolved_media_path] = active_media_ref_counts.get(resolved_media_path, 0) + 1
 
-    return active_media_paths, active_media_ref_counts, expired_records, stale_record_paths
+    return metadata_files_scanned, active_media_paths, active_media_ref_counts, expired_records, stale_record_paths
 
 
 def _remove_paths(paths: list[Path]) -> int:
@@ -387,19 +395,17 @@ def _prune_expired_records_and_collect_removable_media_paths(
     *,
     expired_records: list[tuple[AttachmentRecord, Path]],
     active_media_ref_counts: dict[Path, int],
-) -> set[Path]:
+) -> tuple[set[Path], int]:
     """Delete expired metadata records and collect removable managed media files."""
     removable_media_paths: set[Path] = set()
-    for record, record_path in expired_records:
-        with contextlib.suppress(OSError):
-            record_path.unlink(missing_ok=True)
-
+    expired_records_deleted = _remove_paths([record_path for _record, record_path in expired_records])
+    for record, _record_path in expired_records:
         resolved_media_path = record.local_path.resolve()
         if not _is_managed_media_path(storage_path, resolved_media_path):
             continue
         if active_media_ref_counts.get(resolved_media_path, 0) == 0:
             removable_media_paths.add(resolved_media_path)
-    return removable_media_paths
+    return removable_media_paths, expired_records_deleted
 
 
 def _prune_orphan_incoming_media(
@@ -407,16 +413,18 @@ def _prune_orphan_incoming_media(
     *,
     cutoff: datetime,
     active_media_paths: set[Path],
-) -> int:
+) -> tuple[int, int]:
     """Delete old incoming-media files that are no longer referenced."""
     incoming_media_dir = _incoming_media_dir(storage_path)
     if not incoming_media_dir.is_dir():
-        return 0
+        return 0, 0
 
     removed = 0
+    incoming_media_files_scanned = 0
     for media_path in incoming_media_dir.iterdir():
         if not media_path.is_file():
             continue
+        incoming_media_files_scanned += 1
         resolved_media_path = media_path.resolve()
         if resolved_media_path in active_media_paths:
             continue
@@ -428,17 +436,18 @@ def _prune_orphan_incoming_media(
         except OSError:
             continue
         removed += 1
-    return removed
+    return removed, incoming_media_files_scanned
 
 
 def _cleanup_attachment_storage(storage_path: Path) -> None:
     """Prune expired attachment metadata and managed media files."""
+    started = time.monotonic()
     attachments_dir = _attachments_dir(storage_path)
     if not attachments_dir.is_dir():
         return
 
     cutoff = datetime.now(UTC) - timedelta(days=_ATTACHMENT_RETENTION_DAYS)
-    active_media_paths, active_media_ref_counts, expired_records, stale_record_paths = (
+    metadata_files_scanned, active_media_paths, active_media_ref_counts, expired_records, stale_record_paths = (
         _collect_attachment_cleanup_state(
             storage_path,
             cutoff=cutoff,
@@ -446,13 +455,13 @@ def _cleanup_attachment_storage(storage_path: Path) -> None:
     )
     stale_records_removed = _remove_paths(stale_record_paths)
 
-    removable_media_paths = _prune_expired_records_and_collect_removable_media_paths(
+    removable_media_paths, expired_records_deleted = _prune_expired_records_and_collect_removable_media_paths(
         storage_path,
         expired_records=expired_records,
         active_media_ref_counts=active_media_ref_counts,
     )
     expired_media_removed = _remove_paths(list(removable_media_paths))
-    orphan_media_removed = _prune_orphan_incoming_media(
+    orphan_media_removed, incoming_media_files_scanned = _prune_orphan_incoming_media(
         storage_path,
         cutoff=cutoff,
         active_media_paths=active_media_paths,
@@ -464,21 +473,124 @@ def _cleanup_attachment_storage(storage_path: Path) -> None:
         expired_media_removed=expired_media_removed,
         orphan_media_removed=orphan_media_removed,
         active_media_paths=len(active_media_paths),
+        metadata_files_scanned=metadata_files_scanned,
+        incoming_media_files_scanned=incoming_media_files_scanned,
+        files_scanned=metadata_files_scanned + incoming_media_files_scanned,
+        files_deleted=(stale_records_removed + expired_records_deleted + expired_media_removed + orphan_media_removed),
+        total_cleanup_duration_ms=(time.monotonic() - started) * 1000,
     )
+
+
+def _claim_due_attachment_cleanup(storage_path: Path) -> tuple[Path, object, datetime] | None:
+    """Atomically claim one due storage path for attachment cleanup."""
+    resolved_storage_path = storage_path.resolve()
+    cleanup_started_at = datetime.now(UTC)
+    with _attachment_cleanup_lock:
+        if resolved_storage_path in _attachment_cleanup_claim_tokens_by_storage_path:
+            return None
+        last_cleanup_time = _last_cleanup_time_by_storage_path.get(resolved_storage_path)
+        if last_cleanup_time is not None and cleanup_started_at - last_cleanup_time < _CLEANUP_INTERVAL:
+            return None
+        claim_token = object()
+        _attachment_cleanup_claim_tokens_by_storage_path[resolved_storage_path] = claim_token
+    return resolved_storage_path, claim_token, cleanup_started_at
+
+
+def _record_attachment_cleanup_success(
+    storage_path: Path,
+    claim_token: object,
+    cleanup_started_at: datetime,
+) -> None:
+    """Update throttle state only when current claim completed successfully."""
+    with _attachment_cleanup_lock:
+        if _attachment_cleanup_claim_tokens_by_storage_path.get(storage_path) is claim_token:
+            _last_cleanup_time_by_storage_path[storage_path] = cleanup_started_at
+
+
+def _release_attachment_cleanup_claim(storage_path: Path, claim_token: object) -> None:
+    """Release a cleanup claim only when it still belongs to this cleanup."""
+    with _attachment_cleanup_lock:
+        if _attachment_cleanup_claim_tokens_by_storage_path.get(storage_path) is claim_token:
+            del _attachment_cleanup_claim_tokens_by_storage_path[storage_path]
+
+
+def _finish_attachment_cleanup_task(
+    task: asyncio.Task[object],
+    *,
+    storage_path: Path,
+    claim_token: object,
+    cleanup_started_at: datetime,
+) -> None:
+    """Record background cleanup result and release its matching claim."""
+    try:
+        task.result()
+    except asyncio.CancelledError:
+        pass
+    except Exception:
+        logger.exception("Failed to prune expired attachment storage")
+    else:
+        _record_attachment_cleanup_success(storage_path, claim_token, cleanup_started_at)
+    finally:
+        _release_attachment_cleanup_claim(storage_path, claim_token)
+
+
+def _run_attachment_cleanup_synchronously(
+    storage_path: Path,
+    claim_token: object,
+    cleanup_started_at: datetime,
+) -> None:
+    """Run cleanup directly when no event loop is available."""
+    try:
+        _cleanup_attachment_storage(storage_path)
+    except Exception:
+        logger.exception("Failed to prune expired attachment storage")
+    else:
+        _record_attachment_cleanup_success(storage_path, claim_token, cleanup_started_at)
+    finally:
+        _release_attachment_cleanup_claim(storage_path, claim_token)
 
 
 def _maybe_cleanup_attachment_storage(storage_path: Path) -> None:
     """Run cleanup at most once per ``_CLEANUP_INTERVAL``."""
-    resolved_storage_path = storage_path.resolve()
-    now = datetime.now(UTC)
-    last_cleanup_time = _last_cleanup_time_by_storage_path.get(resolved_storage_path)
-    if last_cleanup_time is not None and now - last_cleanup_time < _CLEANUP_INTERVAL:
+    cleanup_claim = _claim_due_attachment_cleanup(storage_path)
+    if cleanup_claim is None:
         return
+    resolved_storage_path, claim_token, cleanup_started_at = cleanup_claim
     try:
-        _cleanup_attachment_storage(resolved_storage_path)
-        _last_cleanup_time_by_storage_path[resolved_storage_path] = now
+        asyncio.get_running_loop()
+    except RuntimeError:
+        _run_attachment_cleanup_synchronously(resolved_storage_path, claim_token, cleanup_started_at)
+        return
+
+    scheduling_started = time.monotonic()
+    try:
+        cleanup_task = create_background_task(
+            run_blocking_until_complete(_cleanup_attachment_storage, resolved_storage_path),
+            name="attachment_cleanup",
+            owner=_ATTACHMENT_CLEANUP_TASK_OWNER,
+            log_exceptions=False,
+        )
     except Exception:
         logger.exception("Failed to prune expired attachment storage")
+        _release_attachment_cleanup_claim(resolved_storage_path, claim_token)
+        return
+    cleanup_task.add_done_callback(
+        lambda task: _finish_attachment_cleanup_task(
+            task,
+            storage_path=resolved_storage_path,
+            claim_token=claim_token,
+            cleanup_started_at=cleanup_started_at,
+        ),
+    )
+    logger.debug(
+        "Attachment cleanup scheduled",
+        event_loop_scheduling_duration_ms=(time.monotonic() - scheduling_started) * 1000,
+    )
+
+
+async def wait_for_attachment_cleanup_tasks() -> bool:
+    """Drain attachment cleanup tasks during orderly process shutdown."""
+    return await wait_for_background_tasks(owner=_ATTACHMENT_CLEANUP_TASK_OWNER)
 
 
 def register_local_attachment(

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -10,6 +10,7 @@ import mimetypes
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from functools import partial
 from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Literal
@@ -496,17 +497,6 @@ def _claim_due_attachment_cleanup(storage_path: Path) -> tuple[Path, object, dat
     return resolved_storage_path, claim_token, cleanup_started_at
 
 
-def _record_attachment_cleanup_success(
-    storage_path: Path,
-    claim_token: object,
-    cleanup_started_at: datetime,
-) -> None:
-    """Update throttle state only when current claim completed successfully."""
-    with _attachment_cleanup_lock:
-        if _attachment_cleanup_claim_tokens_by_storage_path.get(storage_path) is claim_token:
-            _last_cleanup_time_by_storage_path[storage_path] = cleanup_started_at
-
-
 def _release_attachment_cleanup_claim(storage_path: Path, claim_token: object) -> None:
     """Release a cleanup claim only when it still belongs to this cleanup."""
     with _attachment_cleanup_lock:
@@ -514,74 +504,60 @@ def _release_attachment_cleanup_claim(storage_path: Path, claim_token: object) -
             del _attachment_cleanup_claim_tokens_by_storage_path[storage_path]
 
 
-def _finish_attachment_cleanup_task(
-    task: asyncio.Task[object],
-    *,
-    storage_path: Path,
-    claim_token: object,
-    cleanup_started_at: datetime,
-) -> None:
-    """Record background cleanup result and release its matching claim."""
+def _claim_and_cleanup_attachment_storage(storage_path: Path) -> None:
+    """Resolve, claim, and clean one storage path in the calling worker."""
+    try:
+        cleanup_claim = _claim_due_attachment_cleanup(storage_path)
+    except Exception:
+        logger.exception("Failed to prune expired attachment storage")
+        return
+
+    if cleanup_claim is None:
+        return
+
+    resolved_storage_path, claim_token, cleanup_started_at = cleanup_claim
+    try:
+        _cleanup_attachment_storage(resolved_storage_path)
+    except Exception:
+        logger.exception("Failed to prune expired attachment storage")
+    else:
+        with _attachment_cleanup_lock:
+            if _attachment_cleanup_claim_tokens_by_storage_path.get(resolved_storage_path) is claim_token:
+                _last_cleanup_time_by_storage_path[resolved_storage_path] = cleanup_started_at
+    finally:
+        _release_attachment_cleanup_claim(resolved_storage_path, claim_token)
+
+
+def _finish_attachment_cleanup_task(task: asyncio.Task[object]) -> None:
+    """Log an unexpected scheduling failure after worker cleanup completes."""
     try:
         task.result()
     except asyncio.CancelledError:
         pass
     except Exception:
         logger.exception("Failed to prune expired attachment storage")
-    else:
-        _record_attachment_cleanup_success(storage_path, claim_token, cleanup_started_at)
-    finally:
-        _release_attachment_cleanup_claim(storage_path, claim_token)
-
-
-def _run_attachment_cleanup_synchronously(
-    storage_path: Path,
-    claim_token: object,
-    cleanup_started_at: datetime,
-) -> None:
-    """Run cleanup directly when no event loop is available."""
-    try:
-        _cleanup_attachment_storage(storage_path)
-    except Exception:
-        logger.exception("Failed to prune expired attachment storage")
-    else:
-        _record_attachment_cleanup_success(storage_path, claim_token, cleanup_started_at)
-    finally:
-        _release_attachment_cleanup_claim(storage_path, claim_token)
 
 
 def _maybe_cleanup_attachment_storage(storage_path: Path) -> None:
     """Run cleanup at most once per ``_CLEANUP_INTERVAL``."""
-    cleanup_claim = _claim_due_attachment_cleanup(storage_path)
-    if cleanup_claim is None:
-        return
-    resolved_storage_path, claim_token, cleanup_started_at = cleanup_claim
     try:
         asyncio.get_running_loop()
     except RuntimeError:
-        _run_attachment_cleanup_synchronously(resolved_storage_path, claim_token, cleanup_started_at)
+        _claim_and_cleanup_attachment_storage(storage_path)
         return
 
     scheduling_started = time.monotonic()
     try:
         cleanup_task = create_background_task(
-            run_blocking_until_complete(_cleanup_attachment_storage, resolved_storage_path),
+            run_blocking_until_complete(_claim_and_cleanup_attachment_storage, storage_path),
             name="attachment_cleanup",
             owner=_ATTACHMENT_CLEANUP_TASK_OWNER,
             log_exceptions=False,
         )
     except Exception:
         logger.exception("Failed to prune expired attachment storage")
-        _release_attachment_cleanup_claim(resolved_storage_path, claim_token)
         return
-    cleanup_task.add_done_callback(
-        lambda task: _finish_attachment_cleanup_task(
-            task,
-            storage_path=resolved_storage_path,
-            claim_token=claim_token,
-            cleanup_started_at=cleanup_started_at,
-        ),
-    )
+    cleanup_task.add_done_callback(_finish_attachment_cleanup_task)
     logger.debug(
         "Attachment cleanup scheduled",
         event_loop_scheduling_duration_ms=(time.monotonic() - scheduling_started) * 1000,
@@ -702,19 +678,21 @@ async def _register_media_attachment(
     )
     if local_media_path is None:
         return None
-    return await asyncio.to_thread(
-        register_local_attachment,
-        storage_path,
-        local_media_path,
-        kind=kind,
-        attachment_id=_attachment_id_for_event(event_id),
-        filename=filename,
-        mime_type=mime_type,
-        room_id=room_id,
-        thread_id=thread_id,
-        source_event_id=event_id,
-        sender=sender,
-        event_timestamp=event_timestamp,
+    return await run_blocking_until_complete(
+        partial(
+            register_local_attachment,
+            storage_path,
+            local_media_path,
+            kind=kind,
+            attachment_id=_attachment_id_for_event(event_id),
+            filename=filename,
+            mime_type=mime_type,
+            room_id=room_id,
+            thread_id=thread_id,
+            source_event_id=event_id,
+            sender=sender,
+            event_timestamp=event_timestamp,
+        ),
     )
 
 

--- a/src/mindroom/attachments.py
+++ b/src/mindroom/attachments.py
@@ -472,6 +472,7 @@ def _cleanup_attachment_storage(storage_path: Path) -> None:
         "Attachment cleanup completed",
         stale_records_removed=stale_records_removed,
         expired_records_removed=len(expired_records),
+        expired_records_deleted=expired_records_deleted,
         expired_media_removed=expired_media_removed,
         orphan_media_removed=orphan_media_removed,
         active_media_paths=len(active_media_paths),
@@ -582,19 +583,12 @@ def _maybe_cleanup_attachment_storage(storage_path: Path) -> None:
     schedule_token = _claim_attachment_cleanup_schedule(storage_path)
     if schedule_token is None:
         return
-    cleanup_coroutine = _run_scheduled_attachment_cleanup(storage_path, schedule_token)
-    try:
-        cleanup_task = create_background_task(
-            cleanup_coroutine,
-            name="attachment_cleanup",
-            owner=_ATTACHMENT_CLEANUP_TASK_OWNER,
-            log_exceptions=False,
-        )
-    except Exception:
-        cleanup_coroutine.close()
-        _release_attachment_cleanup_schedule(storage_path, schedule_token)
-        logger.exception("Failed to schedule attachment storage cleanup")
-        return
+    cleanup_task = create_background_task(
+        _run_scheduled_attachment_cleanup(storage_path, schedule_token),
+        name="attachment_cleanup",
+        owner=_ATTACHMENT_CLEANUP_TASK_OWNER,
+        log_exceptions=False,
+    )
     cleanup_task.add_done_callback(_finish_attachment_cleanup_task)
     logger.debug(
         "Attachment cleanup scheduled",

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -17,6 +17,7 @@ import uvicorn
 from mindroom import constants
 from mindroom.agents import ensure_default_agent_workspaces
 from mindroom.approval_transport import ApprovalMatrixTransport
+from mindroom.attachments import wait_for_attachment_cleanup_tasks
 from mindroom.authorization import is_authorized_sender
 from mindroom.background_tasks import create_background_task, wait_for_background_tasks
 from mindroom.constants import ROUTER_AGENT_NAME
@@ -1953,6 +1954,7 @@ class _MultiAgentOrchestrator:
 
         stop_tasks = [bot.stop(shutdown_intent=ORDERLY_SHUTDOWN) for bot in self.agent_bots.values()]
         await asyncio.gather(*stop_tasks)
+        await wait_for_attachment_cleanup_tasks()
         # Last, because every bot borrows it: closing it earlier would pull the
         # store out from under a bot still draining its outbox.
         if self._open_journal is not None:

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -396,6 +396,42 @@ async def test_attachment_cleanup_does_not_block_event_loop(tmp_path: Path) -> N
 
 
 @pytest.mark.asyncio
+async def test_attachment_cleanup_does_not_resolve_storage_path_on_event_loop(tmp_path: Path) -> None:
+    """Cleanup storage resolution should run in a worker, not event loop."""
+    slow_resolution_started = threading.Event()
+    release_slow_resolution = threading.Event()
+    slow_resolution_timed_out = threading.Event()
+    file_path = tmp_path / "payload.txt"
+    file_path.write_text("payload", encoding="utf-8")
+    original_resolve = Path.resolve
+
+    def slow_resolve(path: Path, strict: bool = False) -> Path:
+        if path == tmp_path:
+            slow_resolution_started.set()
+            if not release_slow_resolution.wait(timeout=1):
+                slow_resolution_timed_out.set()
+        return original_resolve(path, strict=strict)
+
+    async def heartbeat() -> None:
+        assert await asyncio.to_thread(slow_resolution_started.wait, 2)
+        release_slow_resolution.set()
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    with patch.object(Path, "resolve", new=slow_resolve):
+        registered = register_local_attachment(
+            tmp_path,
+            file_path,
+            kind="file",
+            attachment_id="att_responsive_cleanup_resolution",
+            room_id="!room:localhost",
+        )
+        await heartbeat_task
+        assert registered is not None
+        assert not slow_resolution_timed_out.is_set()
+        assert await attachments_module.wait_for_attachment_cleanup_tasks()
+
+
+@pytest.mark.asyncio
 async def test_attachment_cleanup_deduplicates_in_flight_storage_path(tmp_path: Path) -> None:
     """Only one cleanup may run for a storage path while its scan is active."""
     cleanup_started = threading.Event()
@@ -435,6 +471,93 @@ async def test_attachment_cleanup_deduplicates_in_flight_storage_path(tmp_path: 
 
     assert first is not None
     assert second is not None
+
+
+@pytest.mark.asyncio
+async def test_attachment_cleanup_failure_retries_without_throttle_or_stranded_claim(tmp_path: Path) -> None:
+    """Failed cleanup must release its claim and leave its path due for retry."""
+    file_path = tmp_path / "payload.txt"
+    file_path.write_text("payload", encoding="utf-8")
+    last_cleanup_times: dict[Path, datetime] = {}
+    cleanup_claims: dict[Path, object] = {}
+
+    with (
+        patch("mindroom.attachments._last_cleanup_time_by_storage_path", last_cleanup_times),
+        patch("mindroom.attachments._attachment_cleanup_claim_tokens_by_storage_path", cleanup_claims),
+        patch(
+            "mindroom.attachments._cleanup_attachment_storage",
+            side_effect=[RuntimeError("first cleanup fails"), None],
+        ) as mock_cleanup,
+    ):
+        first = register_local_attachment(
+            tmp_path,
+            file_path,
+            kind="file",
+            attachment_id="att_failed_cleanup",
+            room_id="!room:localhost",
+        )
+        assert await attachments_module.wait_for_attachment_cleanup_tasks()
+        assert last_cleanup_times == {}
+        assert cleanup_claims == {}
+
+        second = register_local_attachment(
+            tmp_path,
+            file_path,
+            kind="file",
+            attachment_id="att_retried_cleanup",
+            room_id="!room:localhost",
+        )
+        assert await attachments_module.wait_for_attachment_cleanup_tasks()
+
+    assert first is not None
+    assert second is not None
+    assert mock_cleanup.call_count == 2
+    assert tmp_path.resolve() in last_cleanup_times
+    assert cleanup_claims == {}
+
+
+@pytest.mark.asyncio
+async def test_media_registration_cancellation_drains_attachment_cleanup_worker(tmp_path: Path) -> None:
+    """Cancelling media registration waits for its cleanup worker to finish."""
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+    cleanup_finished = threading.Event()
+    cleanup_claims: dict[Path, object] = {}
+
+    def blocking_cleanup(_storage_path: Path) -> None:
+        cleanup_started.set()
+        assert release_cleanup.wait(timeout=2)
+        cleanup_finished.set()
+
+    with (
+        patch("mindroom.attachments._attachment_cleanup_claim_tokens_by_storage_path", cleanup_claims),
+        patch("mindroom.attachments._cleanup_attachment_storage", side_effect=blocking_cleanup),
+    ):
+        registration_task = asyncio.create_task(
+            _register_media_attachment(
+                storage_path=tmp_path,
+                event_id="$cancel_cleanup",
+                media_bytes=b"payload",
+                mime_type="application/octet-stream",
+                room_id="!room:localhost",
+                thread_id=None,
+                sender="@sender:localhost",
+                event_timestamp=1,
+                filename="payload.bin",
+                kind="file",
+            ),
+        )
+        assert await asyncio.to_thread(cleanup_started.wait, 2)
+        registration_task.cancel()
+        await asyncio.sleep(0)
+        assert not registration_task.done()
+        release_cleanup.set()
+        with pytest.raises(asyncio.CancelledError):
+            await registration_task
+
+    assert cleanup_finished.is_set()
+    assert await attachments_module.wait_for_attachment_cleanup_tasks()
+    assert cleanup_claims == {}
 
 
 def test_attachment_cleanup_logs_scan_and_deletion_counts(tmp_path: Path) -> None:

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -437,6 +437,8 @@ async def test_attachment_cleanup_deduplicates_in_flight_storage_path(tmp_path: 
     cleanup_started = threading.Event()
     release_cleanup = threading.Event()
     cleanup_calls = 0
+    cleanup_claims: dict[Path, object] = {}
+    scheduled_cleanups: dict[Path, object] = {}
     file_path = tmp_path / "payload.txt"
     file_path.write_text("payload", encoding="utf-8")
 
@@ -447,8 +449,13 @@ async def test_attachment_cleanup_deduplicates_in_flight_storage_path(tmp_path: 
         assert release_cleanup.wait(timeout=1)
 
     with (
-        patch("mindroom.attachments._last_cleanup_time_by_storage_path", {}),
+        patch("mindroom.attachments._attachment_cleanup_claim_tokens_by_storage_path", cleanup_claims),
+        patch("mindroom.attachments._attachment_cleanup_scheduled_tokens_by_storage_path", scheduled_cleanups),
         patch("mindroom.attachments._cleanup_attachment_storage", side_effect=blocking_cleanup),
+        patch(
+            "mindroom.attachments.create_background_task",
+            wraps=attachments_module.create_background_task,
+        ) as mock_create_background_task,
     ):
         first = register_local_attachment(
             tmp_path,
@@ -458,6 +465,8 @@ async def test_attachment_cleanup_deduplicates_in_flight_storage_path(tmp_path: 
             room_id="!room:localhost",
         )
         assert await asyncio.to_thread(cleanup_started.wait, 2)
+        assert tmp_path in scheduled_cleanups
+        assert tmp_path.resolve() in cleanup_claims
         second = register_local_attachment(
             tmp_path,
             file_path,
@@ -466,8 +475,11 @@ async def test_attachment_cleanup_deduplicates_in_flight_storage_path(tmp_path: 
             room_id="!room:localhost",
         )
         release_cleanup.set()
-        assert cleanup_calls == 1
         assert await attachments_module.wait_for_attachment_cleanup_tasks()
+        assert cleanup_calls == 1
+        assert mock_create_background_task.call_count == 1
+        assert scheduled_cleanups == {}
+        assert cleanup_claims == {}
 
     assert first is not None
     assert second is not None

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -611,6 +611,7 @@ def test_attachment_cleanup_logs_scan_and_deletion_counts(tmp_path: Path) -> Non
     assert cleanup_log["metadata_files_scanned"] == 2
     assert cleanup_log["incoming_media_files_scanned"] == 1
     assert cleanup_log["files_scanned"] == 3
+    assert cleanup_log["expired_records_deleted"] == 0
     assert cleanup_log["files_deleted"] == 1
 
 

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import json
 import os
@@ -13,6 +14,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import nio
 import pytest
 
+import mindroom.attachments as attachments_module
 import mindroom.matrix.media as media_module
 from mindroom.attachment_ids import merge_attachment_ids, unique_attachment_ids
 from mindroom.attachment_media import attachment_records_to_media, resolve_scoped_attachments
@@ -355,6 +357,116 @@ def test_register_local_attachment_throttles_cleanup_runs(tmp_path: Path) -> Non
     assert first is not None
     assert second is not None
     mock_cleanup.assert_called_once_with(tmp_path.resolve())
+
+
+@pytest.mark.asyncio
+async def test_attachment_cleanup_does_not_block_event_loop(tmp_path: Path) -> None:
+    """Cleanup metadata scans should yield event loop while a worker reads disk."""
+    slow_read_started = threading.Event()
+    release_slow_read = threading.Event()
+    slow_read_timed_out = threading.Event()
+    file_path = tmp_path / "payload.txt"
+    file_path.write_text("payload", encoding="utf-8")
+    original_read_text = Path.read_text
+
+    def slow_read_text(path: Path, *args: object, **kwargs: object) -> str:
+        if path.suffix == ".json" and path.parent.name == "attachments":
+            slow_read_started.set()
+            if not release_slow_read.wait(timeout=1):
+                slow_read_timed_out.set()
+        return original_read_text(path, *args, **kwargs)
+
+    async def heartbeat() -> None:
+        assert await asyncio.to_thread(slow_read_started.wait, 2)
+        release_slow_read.set()
+
+    heartbeat_task = asyncio.create_task(heartbeat())
+    with patch.object(Path, "read_text", new=slow_read_text):
+        registered = register_local_attachment(
+            tmp_path,
+            file_path,
+            kind="file",
+            attachment_id="att_responsive_cleanup",
+            room_id="!room:localhost",
+        )
+        await heartbeat_task
+        assert registered is not None
+        assert not slow_read_timed_out.is_set()
+        assert await attachments_module.wait_for_attachment_cleanup_tasks()
+
+
+@pytest.mark.asyncio
+async def test_attachment_cleanup_deduplicates_in_flight_storage_path(tmp_path: Path) -> None:
+    """Only one cleanup may run for a storage path while its scan is active."""
+    cleanup_started = threading.Event()
+    release_cleanup = threading.Event()
+    cleanup_calls = 0
+    file_path = tmp_path / "payload.txt"
+    file_path.write_text("payload", encoding="utf-8")
+
+    def blocking_cleanup(_storage_path: Path) -> None:
+        nonlocal cleanup_calls
+        cleanup_calls += 1
+        cleanup_started.set()
+        assert release_cleanup.wait(timeout=1)
+
+    with (
+        patch("mindroom.attachments._last_cleanup_time_by_storage_path", {}),
+        patch("mindroom.attachments._cleanup_attachment_storage", side_effect=blocking_cleanup),
+    ):
+        first = register_local_attachment(
+            tmp_path,
+            file_path,
+            kind="file",
+            attachment_id="att_first_cleanup_claim",
+            room_id="!room:localhost",
+        )
+        assert await asyncio.to_thread(cleanup_started.wait, 2)
+        second = register_local_attachment(
+            tmp_path,
+            file_path,
+            kind="file",
+            attachment_id="att_second_cleanup_claim",
+            room_id="!room:localhost",
+        )
+        release_cleanup.set()
+        assert cleanup_calls == 1
+        assert await attachments_module.wait_for_attachment_cleanup_tasks()
+
+    assert first is not None
+    assert second is not None
+
+
+def test_attachment_cleanup_logs_scan_and_deletion_counts(tmp_path: Path) -> None:
+    """Cleanup log should expose scan and successful deletion totals."""
+    active_media_path = tmp_path / "active.txt"
+    active_media_path.write_text("active", encoding="utf-8")
+    registered = register_local_attachment(
+        tmp_path,
+        active_media_path,
+        kind="file",
+        attachment_id="att_active_cleanup_metrics",
+        room_id="!room:localhost",
+    )
+    assert registered is not None
+
+    stale_metadata_path = tmp_path / "attachments" / "att_stale_cleanup_metrics.json"
+    stale_metadata_path.write_text("not json", encoding="utf-8")
+    orphan_media_path = tmp_path / "incoming_media" / "orphan.bin"
+    orphan_media_path.parent.mkdir(parents=True, exist_ok=True)
+    orphan_media_path.write_bytes(b"orphan")
+    stale_timestamp = (datetime.now(UTC) - timedelta(days=45)).timestamp()
+    os.utime(stale_metadata_path, (stale_timestamp, stale_timestamp))
+    os.utime(orphan_media_path, (stale_timestamp, stale_timestamp))
+
+    with patch("mindroom.attachments.logger.debug") as mock_debug:
+        attachments_module._cleanup_attachment_storage(tmp_path)
+
+    cleanup_log = mock_debug.call_args.kwargs
+    assert cleanup_log["metadata_files_scanned"] == 2
+    assert cleanup_log["incoming_media_files_scanned"] == 1
+    assert cleanup_log["files_scanned"] == 3
+    assert cleanup_log["files_deleted"] == 2
 
 
 def test_merge_attachment_ids_preserves_order() -> None:

--- a/tests/test_attachments.py
+++ b/tests/test_attachments.py
@@ -594,14 +594,24 @@ def test_attachment_cleanup_logs_scan_and_deletion_counts(tmp_path: Path) -> Non
     os.utime(stale_metadata_path, (stale_timestamp, stale_timestamp))
     os.utime(orphan_media_path, (stale_timestamp, stale_timestamp))
 
-    with patch("mindroom.attachments.logger.debug") as mock_debug:
+    original_unlink = Path.unlink
+
+    def unlink_after_concurrent_removal(path: Path, *, missing_ok: bool = False) -> None:
+        if path == stale_metadata_path and path.exists():
+            original_unlink(path)
+        original_unlink(path, missing_ok=missing_ok)
+
+    with (
+        patch.object(Path, "unlink", new=unlink_after_concurrent_removal),
+        patch("mindroom.attachments.logger.debug") as mock_debug,
+    ):
         attachments_module._cleanup_attachment_storage(tmp_path)
 
     cleanup_log = mock_debug.call_args.kwargs
     assert cleanup_log["metadata_files_scanned"] == 2
     assert cleanup_log["incoming_media_files_scanned"] == 1
     assert cleanup_log["files_scanned"] == 3
-    assert cleanup_log["files_deleted"] == 2
+    assert cleanup_log["files_deleted"] == 1
 
 
 def test_merge_attachment_ids_preserves_order() -> None:


### PR DESCRIPTION
## Summary

- run attachment path resolution, metadata scans, reads, and deletions outside the asyncio event loop
- deduplicate concurrent cleanup per resolved storage path and drain accepted work during cancellation and shutdown
- preserve the hourly throttle and retention rules while logging scan, deletion, total-duration, and event-loop scheduling metrics
- add deterministic regressions for responsiveness, slow path resolution, deduplication, failure retry, cancellation drain, and metrics

## Test plan

- `uv run pytest -q tests/test_attachments.py tests/test_attachments_tool.py tests/test_matrix_message_tool.py tests/test_orchestrator_runtime.py`
- `uv run pre-commit run --all-files`
- `uv run ty check src/mindroom/attachments.py src/mindroom/orchestrator.py`
- `uv run tach check --dependencies --interfaces`

## Broader suite

- `uv run pytest -m "not requires_matrix"`: 13,410 passed and 41 skipped; two failures remain in the untouched handled-turn cancellation test (SQLite and Postgres), and reproduce when run alone.

## Summary by Sourcery

Run attachment cleanup and media registration work off the event loop while ensuring cleanup tasks are coordinated and drained on shutdown.

Enhancements:
- Track and throttle attachment cleanup per resolved storage path using claim tokens and locking to prevent concurrent runs on the same storage location.
- Execute attachment cleanup and media registration filesystem work in background workers while recording cleanup and scheduling metrics for observability.
- Ensure orchestrator shutdown waits for outstanding attachment cleanup tasks to complete, avoiding stranded background work.

Tests:
- Add asynchronous regression tests covering non-blocking cleanup, off-loop path resolution, per-storage-path deduplication, failure retry semantics, cancellation draining, and cleanup metrics logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented overlapping attachment cleanup runs from processing the same storage simultaneously.
  * Improved cleanup reliability, including safe retries after failures and removal of stale metadata.
  * Prevented attachment cleanup and media registration from blocking normal application activity.

* **Enhancements**
  * Added cleanup scan, deletion, and duration statistics.
  * Ensured pending attachment cleanup tasks finish during application shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->