### PR TITLE
Widen Classic Sync timeline window

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -190,7 +190,7 @@ _DELIVERY_RECOVERY_RETRY_MAX_DELAY_SECONDS = 30.0
 # forces a limited-sync gap backfill. This only widens the timeline window; it
 # leaves every other section at server defaults so no event type is filtered
 # out.
-_SYNC_TIMELINE_LIMIT = 50
+_SYNC_TIMELINE_LIMIT = 5000
 _SYNC_FILTER: dict[str, object] = {"room": {"timeline": {"limit": _SYNC_TIMELINE_LIMIT}}}
 
 

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -185,13 +185,9 @@ _CLASSIC_SYNC_REBUILD_BACKOFF_INITIAL_SECONDS = 1.0
 _CLASSIC_SYNC_REBUILD_BACKOFF_MAX_SECONDS = 30.0
 _DELIVERY_RECOVERY_RETRY_INITIAL_DELAY_SECONDS = 1.0
 _DELIVERY_RECOVERY_RETRY_MAX_DELAY_SECONDS = 30.0
-# Raise the per-room timeline limit above the homeserver default (~10) so a
-# room has to flood much harder before the server truncates its timeline and
-# forces a limited-sync gap backfill. This only widens the timeline window; it
-# leaves every other section at server defaults so no event type is filtered
-# out.
-_SYNC_TIMELINE_LIMIT = 5000
-_SYNC_FILTER: dict[str, object] = {"room": {"timeline": {"limit": _SYNC_TIMELINE_LIMIT}}}
+_SYNC_FILTER: dict[str, object] = {
+    "room": {"timeline": {"limit": constants.CLASSIC_SYNC_TIMELINE_LIMIT}},
+}
 
 
 def _classic_sync_rebuild_backoff_seconds(attempt: int) -> float:

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -22,6 +22,10 @@ ROUTER_AGENT_NAME = "router"
 VISIBLE_ROUTER_VOICE_ECHO_KEY = "com.mindroom.visible_router_voice_echo"
 CONFIG_CONFIRMATION_REACTION_KEY = "com.mindroom.config_confirmation_reaction"
 DEFAULT_MINDROOM_URL = "http://127.0.0.1:8765"
+# Raise the per-room Classic Sync timeline limit above the homeserver default
+# (~10) so a room has to flood much harder before the server truncates its
+# timeline and forces a limited-sync gap backfill.
+CLASSIC_SYNC_TIMELINE_LIMIT = 5000
 DEFAULT_COMPACTION_TIMEOUT_SECONDS = 600.0
 DEFAULT_TOOL_OUTPUT_AUTO_SAVE_THRESHOLD_BYTES = 50 * 1024
 KNOWLEDGE_FILE_INDEX_CONCURRENCY_ENV = "MINDROOM_KNOWLEDGE_FILE_INDEX_CONCURRENCY"

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast, runtime_checkable
 import nio
 
 from mindroom.constants import (
+    CLASSIC_SYNC_TIMELINE_LIMIT,
     CONFIG_CONFIRMATION_REACTION_KEY,
     STREAM_STATUS_KEY,
     VISIBLE_ROUTER_VOICE_ECHO_KEY,
@@ -73,11 +74,11 @@ DEFAULT_MATRIX_SYNC_STORAGE = MatrixSyncStorage()
 # limited-timeline gap; exceeding it abandons the gap and leaves the room
 # unrecovered. nio's 200 is far below what a MindRoom room produces: a
 # streaming turn emits an `m.replace` edit per progressive update, so concurrent
-# agent turns can overrun even the 5000-event sync window this client requests,
-# and a short stall accumulates thousands of events. 100000 is twenty sync
-# windows of catch-up, enough that only an outage rather than a busy minute
-# abandons history, while still bounding held parsed events per room.
-_BACKFILL_MAX_EVENTS = 100000
+# agent turns can overrun even the requested sync window, and a short stall
+# accumulates thousands of events. Twenty sync windows of catch-up ensure that
+# only an outage rather than a busy minute abandons history, while still
+# bounding held parsed events per room.
+_BACKFILL_MAX_EVENTS = 20 * CLASSIC_SYNC_TIMELINE_LIMIT
 
 
 @runtime_checkable

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -72,12 +72,12 @@ DEFAULT_MATRIX_SYNC_STORAGE = MatrixSyncStorage()
 # How many recovered history events nio may hold for one room while it closes a
 # limited-timeline gap; exceeding it abandons the gap and leaves the room
 # unrecovered. nio's 200 is far below what a MindRoom room produces: a
-# streaming turn emits an `m.replace` edit per progressive update, so a handful
-# of concurrent agent turns already overruns the 50-event sync window this
-# client requests, and a short stall accumulates hundreds of events. 2000 is
-# forty sync windows of catch-up, enough that only an outage rather than a busy
-# minute abandons history, while still bounding held parsed events per room.
-_BACKFILL_MAX_EVENTS = 2000
+# streaming turn emits an `m.replace` edit per progressive update, so concurrent
+# agent turns can overrun even the 5000-event sync window this client requests,
+# and a short stall accumulates thousands of events. 100000 is twenty sync
+# windows of catch-up, enough that only an outage rather than a busy minute
+# abandons history, while still bounding held parsed events per room.
+_BACKFILL_MAX_EVENTS = 100000
 
 
 @runtime_checkable

--- a/tests/test_live_matrix_fuzz.py
+++ b/tests/test_live_matrix_fuzz.py
@@ -856,7 +856,7 @@ def test_recovery_cliff_fault_shape_exceeds_one_live_window_and_one_recovery_pum
             timeline_limit=100,
             recovery_max_pages=10,
             recovery_page_size=50,
-            recovery_max_events=2_000,
+            recovery_max_events=100_000,
             context_event_count=601,
             root_count=100,
         )
@@ -876,11 +876,13 @@ def test_recovery_cliff_fault_shape_accepts_the_recovery_cap_and_refuses_the_fir
             encoding="utf-8",
         )
 
-        shape = recovery_cliff_fault_shape(stack.config_path, root_count=1_499)
+        baseline = recovery_cliff_fault_shape(stack.config_path, root_count=1)
+        capacity_root_count = baseline.recovery_max_events - baseline.context_event_count + baseline.timeline_limit
+        shape = recovery_cliff_fault_shape(stack.config_path, root_count=capacity_root_count)
         assert shape.context_event_count + shape.root_count - shape.timeline_limit == shape.recovery_max_events
 
         with pytest.raises(ValueError, match="exceeds nio's configured room recovery cap"):
-            recovery_cliff_fault_shape(stack.config_path, root_count=1_500)
+            recovery_cliff_fault_shape(stack.config_path, root_count=capacity_root_count + 1)
     finally:
         stack.close()
 

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -148,8 +148,8 @@ def test_matrix_client_config_enables_limited_timeline_backfill() -> None:
 def test_matrix_client_config_backfills_far_past_the_sync_window() -> None:
     """A room busy enough to truncate its sync window must still be recoverable.
 
-    nio's default event cap abandons recovery after four sync windows of
-    catch-up, which a single burst of streaming agent edits already exceeds.
+    nio's default event cap cannot hold even one requested sync window, which a
+    single burst of streaming agent edits can already exceed.
     """
     config = matrix_client_config()
 

--- a/tests/test_matrix_client_session.py
+++ b/tests/test_matrix_client_session.py
@@ -12,8 +12,8 @@ from unittest.mock import AsyncMock, Mock
 import nio
 import pytest
 
-from mindroom.bot import _SYNC_TIMELINE_LIMIT
 from mindroom.constants import (
+    CLASSIC_SYNC_TIMELINE_LIMIT,
     CONFIG_CONFIRMATION_REACTION_KEY,
     STREAM_STATUS_KEY,
     VISIBLE_ROUTER_VOICE_ECHO_KEY,
@@ -153,7 +153,7 @@ def test_matrix_client_config_backfills_far_past_the_sync_window() -> None:
     """
     config = matrix_client_config()
 
-    assert config.backfill_max_events >= 20 * _SYNC_TIMELINE_LIMIT
+    assert config.backfill_max_events >= 20 * CLASSIC_SYNC_TIMELINE_LIMIT
     assert config.backfill_max_events > nio.AsyncClientConfig().backfill_max_events
 
 

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1514,6 +1514,8 @@ async def test_default_sync_mode_is_classic_with_raised_timeline_limit() -> None
 
     await AgentBot.sync_forever(bot)
 
+    # Pin the external /sync request contract; deriving this expectation from
+    # production configuration would let an accidental limit change pass.
     assert captured == [{"room": {"timeline": {"limit": 5000}}}]
 
 

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -18,7 +18,7 @@ import pytest
 from structlog.testing import capture_logs
 
 from mindroom.background_tasks import wait_for_background_tasks
-from mindroom.bot import _SYNC_TIMELINE_LIMIT, AgentBot, _classic_sync_rebuild_backoff_seconds
+from mindroom.bot import AgentBot, _classic_sync_rebuild_backoff_seconds
 from mindroom.bot_runtime_view import BotRuntimeState
 from mindroom.cancellation import (
     SYNC_RESTART_CANCEL_MSG,
@@ -1514,7 +1514,7 @@ async def test_default_sync_mode_is_classic_with_raised_timeline_limit() -> None
 
     await AgentBot.sync_forever(bot)
 
-    assert captured == [{"room": {"timeline": {"limit": _SYNC_TIMELINE_LIMIT}}}]
+    assert captured == [{"room": {"timeline": {"limit": 5000}}}]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- raise the Classic Sync per-room timeline limit from 50 to 5,000
- raise the nio recovery cap from 2,000 to 100,000, preserving the existing 20x safety margin
- update sync-filter and recovery-cliff regression coverage

## Why

A 100-concurrent-thread stress run produced 4,093 delivery-recovery retries. Streaming edits can overrun the 50-event room window, forcing limited-timeline backfill and creating multi-second send tails. A 5,000-event window absorbs that burst while leaving steady-state long-poll traffic unchanged.

nio holds the complete limited live window behind a recovery gap. Keeping the old 2,000-event cap would therefore abandon every full 5,000-event limited response immediately; 100,000 preserves the prior 20-window recovery margin.

## Validation

- all pre-commit hooks pass on the five touched files
- `uv run pytest -m "not requires_matrix" --deselect=tests/test_handled_turns.py::test_a_cancelled_committed_write_keeps_claiming_the_turn_was_handled`: 13,415 passed, 41 skipped
- the deselected cancellation test fails identically on exact `origin/main` for both SQLite and Postgres in this local environment
- focused sync and recovery tests pass
- independent exact-range review found no Critical or Important issues

## Summary by Sourcery

Raise Classic Sync timeline window and nio recovery cap to better handle high-throughput rooms while keeping busy rooms recoverable, and align tests and docs with the new limits.

Enhancements:
- Increase Classic Sync per-room timeline limit from 50 to 5,000 events.
- Increase nio per-room recovery cap from 2,000 to 100,000 events to maintain a multi-window recovery margin.
- Adjust recovery cliff fault-shape tests to compute capacities from config rather than hard-coding event counts.
- Clarify test documentation around nio's default event cap behavior with respect to sync windows.

Tests:
- Update sync filter and recovery tests to assert the widened 5,000-event timeline limit and the 100,000-event recovery cap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matrix timeline synchronization and backfill capacity, allowing substantially more historical events to be retained and recovered.
  * Reduced the likelihood of recovery failures when processing large catch-up windows.
  * Improved handling of extended synchronization periods and concurrent updates.

* **Tests**
  * Updated recovery and synchronization checks to validate expanded event limits, larger catch-up windows, and capacity boundaries.
  * Added coverage to ensure synchronization remains reliable at configured limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->