### PR TITLE
Reuse OAuth discovery outside MCP

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -220,6 +220,7 @@ After MindRoom has a cached requester-specific catalog, the toolkit also exposes
 `discovery: auto` performs protected-resource metadata discovery from the configured `resource` or server `url`, then resolves authorization-server metadata.
 MindRoom tries `/.well-known/oauth-protected-resource` at the resource origin and at the resource path.
 It then reads the advertised authorization server and fetches OAuth authorization-server metadata.
+If the protected-resource metadata does not advertise an authorization server, MindRoom also looks for OAuth authorization-server metadata at the protected-resource origin.
 The discovered metadata supplies the authorization endpoint, token endpoint, optional registration endpoint, supported token endpoint auth methods, and supported PKCE methods.
 
 If `dynamic_client_registration` is enabled and no client config has been stored yet, MindRoom registers a public client lazily when the first OAuth flow starts.

--- a/docs/oauth-framework.md
+++ b/docs/oauth-framework.md
@@ -26,6 +26,9 @@ The access layer must strip any client-supplied copies of the trusted headers be
 Plugins may declare an `oauth_module` in `mindroom.plugin.json`.
 That module exposes `register_oauth_providers(settings, runtime_paths)` and returns `OAuthProvider` objects.
 This keeps FastAPI routing and state handling in core while still letting plugin authors define provider IDs, scopes, token exchange details, optional claim validators, and tool metadata.
+Plugins can use `OAuthDiscoveryConfig` with `oauth_runtime_bootstrapper()` to resolve protected-resource and authorization-server metadata lazily and optionally register an OAuth client.
+Automatic discovery first checks protected-resource metadata at the resource origin and path, then uses the advertised authorization server or falls back to authorization-server metadata at the resource origin.
+Dynamic client registration requires a provider-specific `client_config_services` entry and stores generated client configuration only in the primary runtime.
 
 OAuth token writes always go through `resolve_request_credentials_target()` and `save_scoped_credentials()`.
 For private agents, the target worker key is derived from the authenticated requester and the agent's saved `worker_scope`, so a user-owned OAuth token lands under the same scope normal tools will read at runtime.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -213,6 +213,34 @@ MindRoom stores the verifier in pending state and passes it as the fifth argumen
 For example, an Acme Drive provider can store OAuth tokens in `acme_drive_oauth` while the `acme_drive` tool settings document contains only options such as file-size limits or capability toggles.
 Tokens and client secrets must never be written to `config.yaml`, prompt files, logs, or tool responses.
 
+Providers that publish protected-resource metadata can resolve endpoints and optionally register a client lazily with the generic discovery bootstrapper:
+
+```python
+from mindroom.oauth import OAuthDiscoveryConfig, OAuthProvider, oauth_runtime_bootstrapper
+
+provider = OAuthProvider(
+    id="acme_drive",
+    display_name="Acme Drive",
+    authorization_url="",
+    token_url="",
+    scopes=("files.read",),
+    credential_service="acme_drive_oauth",
+    client_config_services=("acme_drive_oauth_client",),
+    token_endpoint_auth_method="none",
+    pkce_code_challenge_method="S256",
+    runtime_bootstrapper=oauth_runtime_bootstrapper(
+        OAuthDiscoveryConfig(
+            resource="https://api.acme.example",
+            token_endpoint_auth_method="none",
+            pkce_code_challenge_method="S256",
+        ),
+    ),
+)
+```
+
+Automatic discovery checks protected-resource metadata at the resource origin and path, then uses the advertised authorization server or falls back to authorization-server metadata at the resource origin.
+Dynamic client registration requires a provider-specific `client_config_services` entry and runs only in the primary runtime.
+
 OAuth-backed tools should set `setup_type=SetupType.OAUTH` and `auth_provider="<provider_id>"` in `@register_tool_with_metadata`.
 When credentials are missing, return a concise instruction containing a browser-openable URL built with `mindroom.oauth.build_oauth_connect_instruction(provider, runtime_paths, worker_target=...)`.
 The user can complete OAuth and retry the same tool request.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -10939,6 +10939,7 @@ After MindRoom has a cached requester-specific catalog, the toolkit also exposes
 `discovery: auto` performs protected-resource metadata discovery from the configured `resource` or server `url`, then resolves authorization-server metadata.
 MindRoom tries `/.well-known/oauth-protected-resource` at the resource origin and at the resource path.
 It then reads the advertised authorization server and fetches OAuth authorization-server metadata.
+If the protected-resource metadata does not advertise an authorization server, MindRoom also looks for OAuth authorization-server metadata at the protected-resource origin.
 The discovered metadata supplies the authorization endpoint, token endpoint, optional registration endpoint, supported token endpoint auth methods, and supported PKCE methods.
 
 If `dynamic_client_registration` is enabled and no client config has been stored yet, MindRoom registers a public client lazily when the first OAuth flow starts.
@@ -11688,6 +11689,34 @@ Set `pkce_code_challenge_method="S256"` when the upstream OAuth provider require
 MindRoom stores the verifier in pending state and passes it as the fifth argument to custom `token_exchanger` callbacks.
 For example, an Acme Drive provider can store OAuth tokens in `acme_drive_oauth` while the `acme_drive` tool settings document contains only options such as file-size limits or capability toggles.
 Tokens and client secrets must never be written to `config.yaml`, prompt files, logs, or tool responses.
+
+Providers that publish protected-resource metadata can resolve endpoints and optionally register a client lazily with the generic discovery bootstrapper:
+
+```python
+from mindroom.oauth import OAuthDiscoveryConfig, OAuthProvider, oauth_runtime_bootstrapper
+
+provider = OAuthProvider(
+    id="acme_drive",
+    display_name="Acme Drive",
+    authorization_url="",
+    token_url="",
+    scopes=("files.read",),
+    credential_service="acme_drive_oauth",
+    client_config_services=("acme_drive_oauth_client",),
+    token_endpoint_auth_method="none",
+    pkce_code_challenge_method="S256",
+    runtime_bootstrapper=oauth_runtime_bootstrapper(
+        OAuthDiscoveryConfig(
+            resource="https://api.acme.example",
+            token_endpoint_auth_method="none",
+            pkce_code_challenge_method="S256",
+        ),
+    ),
+)
+```
+
+Automatic discovery checks protected-resource metadata at the resource origin and path, then uses the advertised authorization server or falls back to authorization-server metadata at the resource origin.
+Dynamic client registration requires a provider-specific `client_config_services` entry and runs only in the primary runtime.
 
 OAuth-backed tools should set `setup_type=SetupType.OAUTH` and `auth_provider="<provider_id>"` in `@register_tool_with_metadata`.
 When credentials are missing, return a concise instruction containing a browser-openable URL built with `mindroom.oauth.build_oauth_connect_instruction(provider, runtime_paths, worker_target=...)`.
@@ -12957,6 +12986,9 @@ The access layer must strip any client-supplied copies of the trusted headers be
 Plugins may declare an `oauth_module` in `mindroom.plugin.json`.
 That module exposes `register_oauth_providers(settings, runtime_paths)` and returns `OAuthProvider` objects.
 This keeps FastAPI routing and state handling in core while still letting plugin authors define provider IDs, scopes, token exchange details, optional claim validators, and tool metadata.
+Plugins can use `OAuthDiscoveryConfig` with `oauth_runtime_bootstrapper()` to resolve protected-resource and authorization-server metadata lazily and optionally register an OAuth client.
+Automatic discovery first checks protected-resource metadata at the resource origin and path, then uses the advertised authorization server or falls back to authorization-server metadata at the resource origin.
+Dynamic client registration requires a provider-specific `client_config_services` entry and stores generated client configuration only in the primary runtime.
 
 OAuth token writes always go through `resolve_request_credentials_target()` and `save_scoped_credentials()`.
 For private agents, the target worker key is derived from the authenticated requester and the agent's saved `worker_scope`, so a user-owned OAuth token lands under the same scope normal tools will read at runtime.

--- a/skills/mindroom-docs/references/page__mcp__index.md
+++ b/skills/mindroom-docs/references/page__mcp__index.md
@@ -216,6 +216,7 @@ After MindRoom has a cached requester-specific catalog, the toolkit also exposes
 `discovery: auto` performs protected-resource metadata discovery from the configured `resource` or server `url`, then resolves authorization-server metadata.
 MindRoom tries `/.well-known/oauth-protected-resource` at the resource origin and at the resource path.
 It then reads the advertised authorization server and fetches OAuth authorization-server metadata.
+If the protected-resource metadata does not advertise an authorization server, MindRoom also looks for OAuth authorization-server metadata at the protected-resource origin.
 The discovered metadata supplies the authorization endpoint, token endpoint, optional registration endpoint, supported token endpoint auth methods, and supported PKCE methods.
 
 If `dynamic_client_registration` is enabled and no client config has been stored yet, MindRoom registers a public client lazily when the first OAuth flow starts.

--- a/skills/mindroom-docs/references/page__oauth-framework__index.md
+++ b/skills/mindroom-docs/references/page__oauth-framework__index.md
@@ -22,6 +22,9 @@ The access layer must strip any client-supplied copies of the trusted headers be
 Plugins may declare an `oauth_module` in `mindroom.plugin.json`.
 That module exposes `register_oauth_providers(settings, runtime_paths)` and returns `OAuthProvider` objects.
 This keeps FastAPI routing and state handling in core while still letting plugin authors define provider IDs, scopes, token exchange details, optional claim validators, and tool metadata.
+Plugins can use `OAuthDiscoveryConfig` with `oauth_runtime_bootstrapper()` to resolve protected-resource and authorization-server metadata lazily and optionally register an OAuth client.
+Automatic discovery first checks protected-resource metadata at the resource origin and path, then uses the advertised authorization server or falls back to authorization-server metadata at the resource origin.
+Dynamic client registration requires a provider-specific `client_config_services` entry and stores generated client configuration only in the primary runtime.
 
 OAuth token writes always go through `resolve_request_credentials_target()` and `save_scoped_credentials()`.
 For private agents, the target worker key is derived from the authenticated requester and the agent's saved `worker_scope`, so a user-owned OAuth token lands under the same scope normal tools will read at runtime.

--- a/skills/mindroom-docs/references/page__plugins__index.md
+++ b/skills/mindroom-docs/references/page__plugins__index.md
@@ -209,6 +209,34 @@ MindRoom stores the verifier in pending state and passes it as the fifth argumen
 For example, an Acme Drive provider can store OAuth tokens in `acme_drive_oauth` while the `acme_drive` tool settings document contains only options such as file-size limits or capability toggles.
 Tokens and client secrets must never be written to `config.yaml`, prompt files, logs, or tool responses.
 
+Providers that publish protected-resource metadata can resolve endpoints and optionally register a client lazily with the generic discovery bootstrapper:
+
+```python
+from mindroom.oauth import OAuthDiscoveryConfig, OAuthProvider, oauth_runtime_bootstrapper
+
+provider = OAuthProvider(
+    id="acme_drive",
+    display_name="Acme Drive",
+    authorization_url="",
+    token_url="",
+    scopes=("files.read",),
+    credential_service="acme_drive_oauth",
+    client_config_services=("acme_drive_oauth_client",),
+    token_endpoint_auth_method="none",
+    pkce_code_challenge_method="S256",
+    runtime_bootstrapper=oauth_runtime_bootstrapper(
+        OAuthDiscoveryConfig(
+            resource="https://api.acme.example",
+            token_endpoint_auth_method="none",
+            pkce_code_challenge_method="S256",
+        ),
+    ),
+)
+```
+
+Automatic discovery checks protected-resource metadata at the resource origin and path, then uses the advertised authorization server or falls back to authorization-server metadata at the resource origin.
+Dynamic client registration requires a provider-specific `client_config_services` entry and runs only in the primary runtime.
+
 OAuth-backed tools should set `setup_type=SetupType.OAUTH` and `auth_provider="<provider_id>"` in `@register_tool_with_metadata`.
 When credentials are missing, return a concise instruction containing a browser-openable URL built with `mindroom.oauth.build_oauth_connect_instruction(provider, runtime_paths, worker_target=...)`.
 The user can complete OAuth and retry the same tool request.

--- a/src/mindroom/mcp/oauth.py
+++ b/src/mindroom/mcp/oauth.py
@@ -2,55 +2,20 @@
 
 from __future__ import annotations
 
-import asyncio
-import json
-import time
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal
-from urllib.parse import ParseResult, urlparse, urlunparse
+from typing import TYPE_CHECKING
 
-import httpx
-
-from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.mcp.toolkit import require_mcp_server_manager
-from mindroom.oauth.providers import OAuthProvider, OAuthProviderError, OAuthRuntimeEndpoints
-from mindroom.server_fetch_url import ServerFetchUrlError, validate_server_fetch_url
+from mindroom.oauth.discovery import (
+    OAuthDiscoveryConfig,
+    oauth_runtime_bootstrapper,
+)
+from mindroom.oauth.providers import OAuthProvider, OAuthProviderError
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Iterable
+    from collections.abc import Iterable
 
-    from mindroom.constants import RuntimePaths
     from mindroom.mcp.config import MCPOAuthConfig, MCPServerConfig
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
-
-_DISCOVERY_TIMEOUT_SECONDS = 5.0
-_DISCOVERY_CACHE_TTL_SECONDS = 3600.0
-_JSON_CONTENT_TYPE = "application/json"
-_DYNAMIC_CLIENT_SOURCE = "oauth_dynamic_client_registration"
-_PUBLIC_TOKEN_ENDPOINT_AUTH_METHOD = "none"  # noqa: S105
-_TokenEndpointAuthMethod = Literal["none", "client_secret_post", "client_secret_basic"]
-
-
-@dataclass(frozen=True, slots=True)
-class _DiscoveredMCPOAuthMetadata:
-    """Resolved OAuth metadata for one MCP protected resource."""
-
-    authorization_url: str
-    token_url: str
-    registration_url: str | None
-    token_endpoint_auth_method: _TokenEndpointAuthMethod
-
-
-@dataclass(frozen=True, slots=True)
-class _CachedDiscovery:
-    """Cached OAuth discovery result with an expiry."""
-
-    metadata: _DiscoveredMCPOAuthMetadata
-    expires_at: float
-
-
-_DISCOVERY_CACHE: dict[tuple[object, ...], _CachedDiscovery] = {}
-_DYNAMIC_CLIENT_REGISTRATION_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 def mcp_oauth_provider_id(server_id: str, auth_config: MCPOAuthConfig | None) -> str:
@@ -98,16 +63,13 @@ async def disconnect_mcp_oauth_request_session(
     server_id = _mcp_oauth_server_id_for_provider_id(mcp_servers, provider_id)
     if server_id is None:
         return
-
     manager = require_mcp_server_manager()
     if manager is not None:
         await manager.disconnect_request_session(server_id, worker_target=worker_target)
 
 
 def _display_name(server_id: str, auth_config: MCPOAuthConfig) -> str:
-    if auth_config.display_name:
-        return auth_config.display_name
-    return f"MCP {server_id.replace('_', ' ').title()}"
+    return auth_config.display_name or f"MCP {server_id.replace('_', ' ').title()}"
 
 
 def _manual_endpoint(value: str | None, *, field_name: str, server_id: str) -> str:
@@ -121,376 +83,25 @@ def _configured_endpoint(value: str | None) -> str:
     return value.strip() if isinstance(value, str) and value.strip() else ""
 
 
-def _url_origin(parsed: ParseResult) -> str:
-    return urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
-
-
-def _protected_resource_metadata_urls(resource: str) -> tuple[str, ...]:
-    parsed = urlparse(resource)
-    origin = _url_origin(parsed)
-    base_url = f"{origin}/.well-known/oauth-protected-resource"
-    path = parsed.path if parsed.path and parsed.path != "/" else ""
-    urls = [base_url]
-    if path:
-        urls.append(f"{base_url}{path}")
-    return tuple(dict.fromkeys(urls))
-
-
-def _authorization_server_metadata_urls(authorization_server: str) -> tuple[str, ...]:
-    parsed = urlparse(authorization_server)
-    origin = _url_origin(parsed)
-    path = parsed.path.rstrip("/")
-    urls: list[str] = []
-    if path:
-        urls.append(f"{origin}/.well-known/oauth-authorization-server{path}")
-    urls.append(f"{origin}/.well-known/oauth-authorization-server")
-    if path:
-        urls.append(f"{authorization_server.rstrip('/')}/.well-known/oauth-authorization-server")
-    return tuple(dict.fromkeys(urls))
-
-
-async def _validate_discovery_url(url: str, runtime_paths: RuntimePaths) -> None:
-    parsed = urlparse(url)
-    allow_insecure = runtime_paths.env_flag("MINDROOM_MCP_OAUTH_ALLOW_INSECURE_DISCOVERY")
-    allow_private = runtime_paths.env_flag("MINDROOM_MCP_OAUTH_ALLOW_PRIVATE_DISCOVERY")
-    if parsed.scheme != "https" and not allow_insecure:
-        msg = f"MCP OAuth discovery requires HTTPS URL: {url}"
-        raise OAuthProviderError(msg)
-    try:
-        await asyncio.to_thread(validate_server_fetch_url, url, allow_private_networks=allow_private)
-    except ServerFetchUrlError as exc:
-        msg = "MCP OAuth discovery refused unsafe URL"
-        raise OAuthProviderError(msg) from exc
-
-
-def _metadata_cache_key(
-    server_id: str,
-    server_config: MCPServerConfig,
-    runtime_paths: RuntimePaths,
-) -> tuple[object, ...]:
-    auth_config = server_config.auth
-    return (
-        server_id,
-        server_config.url,
-        json.dumps(auth_config.model_dump(mode="json"), sort_keys=True) if auth_config is not None else None,
-        runtime_paths.env_flag("MINDROOM_MCP_OAUTH_ALLOW_INSECURE_DISCOVERY"),
-        runtime_paths.env_flag("MINDROOM_MCP_OAUTH_ALLOW_PRIVATE_DISCOVERY"),
-    )
-
-
-def _metadata_from_cache(
-    server_id: str,
-    server_config: MCPServerConfig,
-    runtime_paths: RuntimePaths,
-) -> _DiscoveredMCPOAuthMetadata | None:
-    cached = _DISCOVERY_CACHE.get(_metadata_cache_key(server_id, server_config, runtime_paths))
-    if cached is None or cached.expires_at <= time.time():
-        return None
-    return cached.metadata
-
-
-def _store_metadata_cache(
-    server_id: str,
-    server_config: MCPServerConfig,
-    runtime_paths: RuntimePaths,
-    metadata: _DiscoveredMCPOAuthMetadata,
-) -> None:
-    _DISCOVERY_CACHE[_metadata_cache_key(server_id, server_config, runtime_paths)] = _CachedDiscovery(
-        metadata=metadata,
-        expires_at=time.time() + _DISCOVERY_CACHE_TTL_SECONDS,
-    )
-
-
-async def _validate_metadata_endpoints(
-    metadata: _DiscoveredMCPOAuthMetadata,
-    runtime_paths: RuntimePaths,
-) -> None:
-    await _validate_discovery_url(metadata.authorization_url, runtime_paths)
-    await _validate_discovery_url(metadata.token_url, runtime_paths)
-    if metadata.registration_url is not None:
-        await _validate_discovery_url(metadata.registration_url, runtime_paths)
-
-
-async def _fetch_json(
-    client: httpx.AsyncClient,
-    url: str,
-    runtime_paths: RuntimePaths,
-    *,
-    optional: bool = False,
-) -> dict[str, Any] | None:
-    await _validate_discovery_url(url, runtime_paths)
-    try:
-        response = await client.get(url, headers={"Accept": _JSON_CONTENT_TYPE})
-        if optional and response.status_code in {404, 410}:
-            return None
-        response.raise_for_status()
-        payload = response.json()
-    except Exception as exc:
-        if optional:
-            return None
-        msg = f"MCP OAuth metadata request failed for {url}"
-        raise OAuthProviderError(msg) from exc
-    if not isinstance(payload, dict):
-        msg = f"MCP OAuth metadata at {url} is not a JSON object"
-        raise OAuthProviderError(msg)
-    return payload
-
-
-async def _discover_protected_resource_authorization_server(
-    client: httpx.AsyncClient,
-    auth_config: MCPOAuthConfig,
-    server_config: MCPServerConfig,
-    runtime_paths: RuntimePaths,
-) -> str:
-    if auth_config.authorization_server:
-        return auth_config.authorization_server.strip()
-    resource = auth_config.resource or server_config.url
-    if not resource:
-        msg = "MCP OAuth discovery requires resource or remote server URL"
-        raise OAuthProviderError(msg)
-    for metadata_url in _protected_resource_metadata_urls(resource):
-        metadata = await _fetch_json(client, metadata_url, runtime_paths, optional=True)
-        if metadata is None:
-            continue
-        authorization_servers = metadata.get("authorization_servers")
-        if isinstance(authorization_servers, list):
-            for entry in authorization_servers:
-                if isinstance(entry, str) and entry.strip():
-                    return entry.strip()
-    msg = "MCP OAuth protected-resource metadata did not advertise an authorization server"
-    raise OAuthProviderError(msg)
-
-
-async def _discover_authorization_server_metadata(
-    client: httpx.AsyncClient,
-    authorization_server: str,
-    runtime_paths: RuntimePaths,
-) -> dict[str, Any]:
-    for metadata_url in _authorization_server_metadata_urls(authorization_server):
-        metadata = await _fetch_json(client, metadata_url, runtime_paths, optional=True)
-        if metadata is not None:
-            return metadata
-    msg = f"MCP OAuth authorization-server metadata was not found for {authorization_server}"
-    raise OAuthProviderError(msg)
-
-
-def _metadata_string(metadata: dict[str, Any], key: str) -> str | None:
-    value = metadata.get(key)
-    return value.strip() if isinstance(value, str) and value.strip() else None
-
-
-def _validate_discovered_capabilities(
-    auth_config: MCPOAuthConfig,
-    metadata: dict[str, Any],
-    *,
-    token_endpoint_auth_method: str,
-) -> None:
-    supported_auth_methods = metadata.get("token_endpoint_auth_methods_supported")
-    if isinstance(supported_auth_methods, list) and token_endpoint_auth_method not in supported_auth_methods:
-        msg = (
-            "MCP OAuth authorization server does not support configured "
-            f"token_endpoint_auth_method '{token_endpoint_auth_method}'"
-        )
-        raise OAuthProviderError(msg)
-    supported_pkce_methods = metadata.get("code_challenge_methods_supported")
-    if (
-        auth_config.pkce_code_challenge_method is not None
-        and isinstance(supported_pkce_methods, list)
-        and auth_config.pkce_code_challenge_method not in supported_pkce_methods
-    ):
-        msg = "MCP OAuth authorization server does not support configured PKCE challenge method"
-        raise OAuthProviderError(msg)
-
-
-async def _resolve_mcp_oauth_metadata(
-    server_id: str,
-    server_config: MCPServerConfig,
-    runtime_paths: RuntimePaths,
-) -> _DiscoveredMCPOAuthMetadata:
-    cached = _metadata_from_cache(server_id, server_config, runtime_paths)
-    if cached is not None:
-        return cached
-
+def _oauth_discovery_config(server_config: MCPServerConfig) -> OAuthDiscoveryConfig:
     auth_config = server_config.auth
     if auth_config is None:
-        msg = f"MCP server '{server_id}' is not OAuth-backed"
+        msg = "MCP server is not OAuth-backed"
         raise OAuthProviderError(msg)
-
-    if auth_config.discovery == "manual":
-        metadata = _DiscoveredMCPOAuthMetadata(
-            authorization_url=_manual_endpoint(
-                auth_config.authorization_url,
-                field_name="authorization_url",
-                server_id=server_id,
-            ),
-            token_url=_manual_endpoint(auth_config.token_url, field_name="token_url", server_id=server_id),
-            registration_url=_configured_endpoint(auth_config.registration_url) or None,
-            token_endpoint_auth_method=auth_config.token_endpoint_auth_method,
-        )
-        await _validate_metadata_endpoints(metadata, runtime_paths)
-        _store_metadata_cache(server_id, server_config, runtime_paths, metadata)
-        return metadata
-
-    async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS, follow_redirects=False) as client:
-        authorization_server = await _discover_protected_resource_authorization_server(
-            client,
-            auth_config,
-            server_config,
-            runtime_paths,
-        )
-        as_metadata = await _discover_authorization_server_metadata(client, authorization_server, runtime_paths)
-
-    authorization_url = _configured_endpoint(auth_config.authorization_url) or _metadata_string(
-        as_metadata,
-        "authorization_endpoint",
-    )
-    token_url = _configured_endpoint(auth_config.token_url) or _metadata_string(as_metadata, "token_endpoint")
-    if authorization_url is None or token_url is None:
-        msg = "MCP OAuth authorization-server metadata did not include required endpoints"
-        raise OAuthProviderError(msg)
-    registration_url = _configured_endpoint(auth_config.registration_url) or _metadata_string(
-        as_metadata,
-        "registration_endpoint",
-    )
-    _validate_discovered_capabilities(
-        auth_config,
-        as_metadata,
+    return OAuthDiscoveryConfig(
+        resource=auth_config.resource or server_config.url or "",
+        discovery=auth_config.discovery,
+        authorization_server=auth_config.authorization_server,
+        authorization_url=auth_config.authorization_url,
+        token_url=auth_config.token_url,
+        registration_url=auth_config.registration_url,
+        dynamic_client_registration=auth_config.dynamic_client_registration,
         token_endpoint_auth_method=auth_config.token_endpoint_auth_method,
+        pkce_code_challenge_method=auth_config.pkce_code_challenge_method,
+        allow_insecure_env="MINDROOM_MCP_OAUTH_ALLOW_INSECURE_DISCOVERY",
+        allow_private_env="MINDROOM_MCP_OAUTH_ALLOW_PRIVATE_DISCOVERY",
+        error_label="MCP OAuth",
     )
-    metadata = _DiscoveredMCPOAuthMetadata(
-        authorization_url=authorization_url,
-        token_url=token_url,
-        registration_url=registration_url,
-        token_endpoint_auth_method=auth_config.token_endpoint_auth_method,
-    )
-    await _validate_metadata_endpoints(metadata, runtime_paths)
-    _store_metadata_cache(server_id, server_config, runtime_paths, metadata)
-    return metadata
-
-
-def _stored_client_config_exists(provider: OAuthProvider, runtime_paths: RuntimePaths) -> bool:
-    return provider.client_config_resolution(runtime_paths) is not None
-
-
-def _client_registration_payload(
-    provider: OAuthProvider,
-    auth_config: MCPOAuthConfig,
-    runtime_paths: RuntimePaths,
-) -> dict[str, Any]:
-    payload: dict[str, Any] = {
-        "client_name": provider.display_name,
-        "redirect_uris": [provider.default_redirect_uri(runtime_paths)],
-        "grant_types": ["authorization_code", "refresh_token"],
-        "response_types": ["code"],
-        "token_endpoint_auth_method": auth_config.token_endpoint_auth_method,
-    }
-    if provider.scopes:
-        payload["scope"] = " ".join(provider.scopes)
-    return payload
-
-
-async def _register_dynamic_client(
-    provider: OAuthProvider,
-    server_config: MCPServerConfig,
-    metadata: _DiscoveredMCPOAuthMetadata,
-    runtime_paths: RuntimePaths,
-) -> None:
-    auth_config = server_config.auth
-    if auth_config is None:
-        return
-    if not auth_config.dynamic_client_registration:
-        return
-    if metadata.registration_url is None:
-        return
-
-    lock = _DYNAMIC_CLIENT_REGISTRATION_LOCKS.setdefault(provider.id, asyncio.Lock())
-    async with lock:
-        if _stored_client_config_exists(provider, runtime_paths):
-            return
-        await _validate_discovery_url(metadata.registration_url, runtime_paths)
-        payload = _client_registration_payload(provider, auth_config, runtime_paths)
-        try:
-            async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS, follow_redirects=False) as client:
-                response = await client.post(
-                    metadata.registration_url,
-                    json=payload,
-                    headers={"Accept": _JSON_CONTENT_TYPE, "Content-Type": _JSON_CONTENT_TYPE},
-                )
-                response.raise_for_status()
-                registration = response.json()
-        except Exception as exc:
-            msg = "MCP OAuth dynamic client registration failed"
-            raise OAuthProviderError(msg) from exc
-        if not isinstance(registration, dict):
-            msg = "MCP OAuth dynamic client registration response is not a JSON object"
-            raise OAuthProviderError(msg)
-        client_id = registration.get("client_id")
-        if not isinstance(client_id, str) or not client_id.strip():
-            msg = "MCP OAuth dynamic client registration did not return client_id"
-            raise OAuthProviderError(msg)
-        client_secret = registration.get("client_secret")
-        stored_registration = _stored_client_registration(
-            provider,
-            runtime_paths,
-            auth_config=auth_config,
-            client_id=client_id,
-            client_secret=client_secret,
-            registration=registration,
-        )
-        service = provider.client_config_services[0]
-        get_runtime_credentials_manager(runtime_paths).save_credentials(service, stored_registration)
-
-
-def _stored_client_registration(
-    provider: OAuthProvider,
-    runtime_paths: RuntimePaths,
-    *,
-    auth_config: MCPOAuthConfig,
-    client_id: str,
-    client_secret: object,
-    registration: dict[str, Any],
-) -> dict[str, Any]:
-    if auth_config.token_endpoint_auth_method != _PUBLIC_TOKEN_ENDPOINT_AUTH_METHOD and (
-        not isinstance(client_secret, str) or not client_secret.strip()
-    ):
-        msg = "MCP OAuth dynamic client registration did not return client_secret"
-        raise OAuthProviderError(msg)
-
-    stored_registration: dict[str, Any] = {
-        "client_id": client_id.strip(),
-        "redirect_uri": provider.default_redirect_uri(runtime_paths),
-        "_source": _DYNAMIC_CLIENT_SOURCE,
-        "_oauth_provider": provider.id,
-    }
-    if isinstance(client_secret, str) and client_secret.strip():
-        stored_registration["client_secret"] = client_secret.strip()
-    for key in (
-        "client_id_issued_at",
-        "client_secret_expires_at",
-        "registration_client_uri",
-        "registration_access_token",
-        "token_endpoint_auth_method",
-    ):
-        value = registration.get(key)
-        if isinstance(value, str | int | float) and not isinstance(value, bool):
-            stored_registration[key] = value
-    return stored_registration
-
-
-def _mcp_runtime_bootstrapper(
-    server_id: str,
-    server_config: MCPServerConfig,
-) -> Callable[[OAuthProvider, RuntimePaths], Awaitable[OAuthRuntimeEndpoints]]:
-    async def bootstrap(provider: OAuthProvider, runtime_paths: RuntimePaths) -> OAuthRuntimeEndpoints:
-        metadata = await _resolve_mcp_oauth_metadata(server_id, server_config, runtime_paths)
-        await _register_dynamic_client(provider, server_config, metadata, runtime_paths)
-        return OAuthRuntimeEndpoints(
-            authorization_url=metadata.authorization_url,
-            token_url=metadata.token_url,
-            token_endpoint_auth_method=metadata.token_endpoint_auth_method,
-        )
-
-    return bootstrap
 
 
 def mcp_oauth_provider(server_id: str, server_config: MCPServerConfig) -> OAuthProvider:
@@ -530,7 +141,7 @@ def mcp_oauth_provider(server_id: str, server_config: MCPServerConfig) -> OAuthP
         pkce_code_challenge_method=auth_config.pkce_code_challenge_method,
         allow_empty_scopes=True,
         status_capabilities=(f"{_display_name(server_id, auth_config)} MCP access",),
-        runtime_bootstrapper=_mcp_runtime_bootstrapper(server_id, server_config),
+        runtime_bootstrapper=oauth_runtime_bootstrapper(_oauth_discovery_config(server_config)),
     )
 
 

--- a/src/mindroom/mcp/oauth.py
+++ b/src/mindroom/mcp/oauth.py
@@ -9,7 +9,7 @@ from mindroom.oauth.discovery import (
     OAuthDiscoveryConfig,
     oauth_runtime_bootstrapper,
 )
-from mindroom.oauth.providers import OAuthProvider, OAuthProviderError
+from mindroom.oauth.providers import OAuthProvider
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -87,7 +87,7 @@ def _oauth_discovery_config(server_config: MCPServerConfig) -> OAuthDiscoveryCon
     auth_config = server_config.auth
     if auth_config is None:
         msg = "MCP server is not OAuth-backed"
-        raise OAuthProviderError(msg)
+        raise ValueError(msg)
     return OAuthDiscoveryConfig(
         resource=auth_config.resource or server_config.url or "",
         discovery=auth_config.discovery,

--- a/src/mindroom/oauth/__init__.py
+++ b/src/mindroom/oauth/__init__.py
@@ -1,5 +1,6 @@
 """Generic OAuth provider framework."""
 
+from mindroom.oauth.discovery import OAuthDiscoveryConfig, oauth_runtime_bootstrapper
 from mindroom.oauth.providers import (
     OAuthClaimValidationError,
     OAuthClientConfigResolution,
@@ -13,9 +14,11 @@ from mindroom.oauth.providers import (
 __all__ = [
     "OAuthClaimValidationError",
     "OAuthClientConfigResolution",
+    "OAuthDiscoveryConfig",
     "OAuthProvider",
     "OAuthProviderError",
     "OAuthRefreshRejectedError",
     "is_oauth_loopback_hostname",
     "oauth_connect_url_requires_host_browser",
+    "oauth_runtime_bootstrapper",
 ]

--- a/src/mindroom/oauth/discovery.py
+++ b/src/mindroom/oauth/discovery.py
@@ -1,0 +1,382 @@
+"""Reusable OAuth metadata discovery and dynamic client registration."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import ParseResult, urlparse, urlunparse
+
+import httpx
+
+from mindroom.credential_policy import RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY
+from mindroom.credentials import get_runtime_credentials_manager
+from mindroom.oauth.providers import OAuthProvider, OAuthProviderError, OAuthRuntimeEndpoints
+from mindroom.server_fetch_url import ServerFetchUrlError, validate_server_fetch_url
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from mindroom.constants import RuntimePaths
+
+_DISCOVERY_TIMEOUT_SECONDS = 5.0
+_DISCOVERY_CACHE_TTL_SECONDS = 3600.0
+_JSON_CONTENT_TYPE = "application/json"
+_DYNAMIC_CLIENT_SOURCE = "oauth_dynamic_client_registration"
+_PUBLIC_TOKEN_ENDPOINT_AUTH_METHOD = "none"  # noqa: S105
+_TokenEndpointAuthMethod = Literal["none", "client_secret_post", "client_secret_basic"]
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthDiscoveryConfig:
+    """Configuration for one protected-resource OAuth authorization server."""
+
+    resource: str
+    discovery: Literal["auto", "manual"] = "auto"
+    authorization_server: str | None = None
+    authorization_url: str | None = None
+    token_url: str | None = None
+    registration_url: str | None = None
+    dynamic_client_registration: bool = True
+    token_endpoint_auth_method: _TokenEndpointAuthMethod = "client_secret_post"  # noqa: S105
+    pkce_code_challenge_method: Literal["S256"] | None = None
+    allow_insecure_env: str = "MINDROOM_OAUTH_ALLOW_INSECURE_DISCOVERY"
+    allow_private_env: str = "MINDROOM_OAUTH_ALLOW_PRIVATE_DISCOVERY"
+    error_label: str = "OAuth"
+
+
+@dataclass(frozen=True, slots=True)
+class _DiscoveredOAuthMetadata:
+    authorization_url: str
+    token_url: str
+    registration_url: str | None
+    token_endpoint_auth_method: _TokenEndpointAuthMethod
+
+
+@dataclass(frozen=True, slots=True)
+class _CachedDiscovery:
+    metadata: _DiscoveredOAuthMetadata
+    expires_at: float
+
+
+_DISCOVERY_CACHE: dict[tuple[object, ...], _CachedDiscovery] = {}
+_DYNAMIC_CLIENT_REGISTRATION_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _configured_endpoint(value: str | None) -> str:
+    return value.strip() if isinstance(value, str) and value.strip() else ""
+
+
+def _url_origin(parsed: ParseResult) -> str:
+    return urlunparse((parsed.scheme, parsed.netloc, "", "", "", ""))
+
+
+def _protected_resource_metadata_urls(resource: str) -> tuple[str, ...]:
+    parsed = urlparse(resource)
+    origin = _url_origin(parsed)
+    base_url = f"{origin}/.well-known/oauth-protected-resource"
+    path = parsed.path if parsed.path and parsed.path != "/" else ""
+    urls = [base_url]
+    if path:
+        urls.append(f"{base_url}{path}")
+    return tuple(dict.fromkeys(urls))
+
+
+def _authorization_server_metadata_urls(authorization_server: str) -> tuple[str, ...]:
+    parsed = urlparse(authorization_server)
+    origin = _url_origin(parsed)
+    path = parsed.path.rstrip("/")
+    urls: list[str] = []
+    if path:
+        urls.append(f"{origin}/.well-known/oauth-authorization-server{path}")
+    urls.append(f"{origin}/.well-known/oauth-authorization-server")
+    if path:
+        urls.append(f"{authorization_server.rstrip('/')}/.well-known/oauth-authorization-server")
+    return tuple(dict.fromkeys(urls))
+
+
+async def _validate_url(url: str, config: OAuthDiscoveryConfig, runtime_paths: RuntimePaths) -> None:
+    parsed = urlparse(url)
+    allow_insecure = runtime_paths.env_flag(config.allow_insecure_env)
+    allow_private = runtime_paths.env_flag(config.allow_private_env)
+    if parsed.scheme != "https" and not allow_insecure:
+        msg = f"{config.error_label} discovery requires HTTPS URL: {url}"
+        raise OAuthProviderError(msg)
+    try:
+        await asyncio.to_thread(validate_server_fetch_url, url, allow_private_networks=allow_private)
+    except ServerFetchUrlError as exc:
+        msg = f"{config.error_label} discovery refused unsafe URL"
+        raise OAuthProviderError(msg) from exc
+
+
+async def _fetch_json(
+    client: httpx.AsyncClient,
+    url: str,
+    config: OAuthDiscoveryConfig,
+    runtime_paths: RuntimePaths,
+    *,
+    optional: bool = False,
+) -> dict[str, Any] | None:
+    await _validate_url(url, config, runtime_paths)
+    try:
+        response = await client.get(url, headers={"Accept": _JSON_CONTENT_TYPE})
+        if optional and response.status_code in {404, 410}:
+            return None
+        response.raise_for_status()
+        payload = response.json()
+    except Exception as exc:
+        if optional:
+            return None
+        msg = f"{config.error_label} metadata request failed for {url}"
+        raise OAuthProviderError(msg) from exc
+    if not isinstance(payload, dict):
+        msg = f"{config.error_label} metadata at {url} is not a JSON object"
+        raise OAuthProviderError(msg)
+    return payload
+
+
+def _metadata_string(metadata: dict[str, Any], key: str) -> str | None:
+    value = metadata.get(key)
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+async def _authorization_server(
+    client: httpx.AsyncClient,
+    config: OAuthDiscoveryConfig,
+    runtime_paths: RuntimePaths,
+) -> str | None:
+    if config.authorization_server:
+        return config.authorization_server.strip()
+    for metadata_url in _protected_resource_metadata_urls(config.resource.strip()):
+        metadata = await _fetch_json(client, metadata_url, config, runtime_paths, optional=True)
+        if metadata is None:
+            continue
+        authorization_servers = metadata.get("authorization_servers")
+        if isinstance(authorization_servers, list):
+            for entry in authorization_servers:
+                if isinstance(entry, str) and entry.strip():
+                    return entry.strip()
+    return None
+
+
+async def _authorization_metadata(
+    client: httpx.AsyncClient,
+    config: OAuthDiscoveryConfig,
+    runtime_paths: RuntimePaths,
+) -> dict[str, Any]:
+    authorization_server = await _authorization_server(client, config, runtime_paths)
+    metadata_base = authorization_server or _url_origin(urlparse(config.resource.strip()))
+    for metadata_url in _authorization_server_metadata_urls(metadata_base):
+        metadata = await _fetch_json(client, metadata_url, config, runtime_paths, optional=True)
+        if metadata is not None:
+            return metadata
+    msg = f"{config.error_label} authorization-server metadata was not found for {metadata_base}"
+    raise OAuthProviderError(msg)
+
+
+def _validate_capabilities(config: OAuthDiscoveryConfig, metadata: dict[str, Any]) -> None:
+    supported_auth_methods = metadata.get("token_endpoint_auth_methods_supported")
+    if isinstance(supported_auth_methods, list) and config.token_endpoint_auth_method not in supported_auth_methods:
+        msg = (
+            f"{config.error_label} authorization server does not support configured "
+            f"token_endpoint_auth_method '{config.token_endpoint_auth_method}'"
+        )
+        raise OAuthProviderError(msg)
+    supported_pkce_methods = metadata.get("code_challenge_methods_supported")
+    if (
+        config.pkce_code_challenge_method is not None
+        and isinstance(supported_pkce_methods, list)
+        and config.pkce_code_challenge_method not in supported_pkce_methods
+    ):
+        msg = f"{config.error_label} authorization server does not support configured PKCE challenge method"
+        raise OAuthProviderError(msg)
+
+
+def _cache_key(config: OAuthDiscoveryConfig, runtime_paths: RuntimePaths) -> tuple[object, ...]:
+    return (
+        config,
+        runtime_paths.env_flag(config.allow_insecure_env),
+        runtime_paths.env_flag(config.allow_private_env),
+    )
+
+
+async def _validate_metadata(
+    metadata: _DiscoveredOAuthMetadata,
+    config: OAuthDiscoveryConfig,
+    runtime_paths: RuntimePaths,
+) -> None:
+    await _validate_url(metadata.authorization_url, config, runtime_paths)
+    await _validate_url(metadata.token_url, config, runtime_paths)
+    if metadata.registration_url is not None:
+        await _validate_url(metadata.registration_url, config, runtime_paths)
+
+
+async def _discover_metadata(
+    config: OAuthDiscoveryConfig,
+    runtime_paths: RuntimePaths,
+) -> _DiscoveredOAuthMetadata:
+    if config.discovery == "auto":
+        resource = config.resource.strip()
+        parsed_resource = urlparse(resource)
+        if not resource or not parsed_resource.scheme or not parsed_resource.netloc:
+            msg = f"{config.error_label} auto discovery requires a protected-resource URL"
+            raise OAuthProviderError(msg)
+        await _validate_url(resource, config, runtime_paths)
+
+    key = _cache_key(config, runtime_paths)
+    cached = _DISCOVERY_CACHE.get(key)
+    if cached is not None and cached.expires_at > time.time():
+        await _validate_metadata(cached.metadata, config, runtime_paths)
+        return cached.metadata
+
+    if config.discovery == "manual":
+        authorization_url = _configured_endpoint(config.authorization_url)
+        token_url = _configured_endpoint(config.token_url)
+        if not authorization_url or not token_url:
+            msg = f"{config.error_label} manual discovery requires authorization_url and token_url"
+            raise OAuthProviderError(msg)
+        metadata = _DiscoveredOAuthMetadata(
+            authorization_url=authorization_url,
+            token_url=token_url,
+            registration_url=_configured_endpoint(config.registration_url) or None,
+            token_endpoint_auth_method=config.token_endpoint_auth_method,
+        )
+    else:
+        async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS, follow_redirects=False) as client:
+            discovered = await _authorization_metadata(client, config, runtime_paths)
+        _validate_capabilities(config, discovered)
+        authorization_url = _configured_endpoint(config.authorization_url) or _metadata_string(
+            discovered,
+            "authorization_endpoint",
+        )
+        token_url = _configured_endpoint(config.token_url) or _metadata_string(discovered, "token_endpoint")
+        if authorization_url is None or token_url is None:
+            msg = f"{config.error_label} authorization-server metadata did not include required endpoints"
+            raise OAuthProviderError(msg)
+        metadata = _DiscoveredOAuthMetadata(
+            authorization_url=authorization_url,
+            token_url=token_url,
+            registration_url=_configured_endpoint(config.registration_url)
+            or _metadata_string(discovered, "registration_endpoint"),
+            token_endpoint_auth_method=config.token_endpoint_auth_method,
+        )
+
+    await _validate_metadata(metadata, config, runtime_paths)
+    _DISCOVERY_CACHE[key] = _CachedDiscovery(
+        metadata=metadata,
+        expires_at=time.time() + _DISCOVERY_CACHE_TTL_SECONDS,
+    )
+    return metadata
+
+
+def _registration_payload(provider: OAuthProvider, runtime_paths: RuntimePaths) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "client_name": provider.display_name,
+        "redirect_uris": [provider.default_redirect_uri(runtime_paths)],
+        "grant_types": ["authorization_code", "refresh_token"],
+        "response_types": ["code"],
+        "token_endpoint_auth_method": provider.token_endpoint_auth_method,
+    }
+    if provider.scopes:
+        payload["scope"] = " ".join(provider.scopes)
+    return payload
+
+
+def _stored_registration(
+    provider: OAuthProvider,
+    runtime_paths: RuntimePaths,
+    registration: dict[str, Any],
+) -> dict[str, Any]:
+    client_id = registration.get("client_id")
+    if not isinstance(client_id, str) or not client_id.strip():
+        msg = f"{provider.display_name} OAuth dynamic client registration did not return client_id"
+        raise OAuthProviderError(msg)
+    client_secret = registration.get("client_secret")
+    if provider.token_endpoint_auth_method != _PUBLIC_TOKEN_ENDPOINT_AUTH_METHOD and (
+        not isinstance(client_secret, str) or not client_secret.strip()
+    ):
+        msg = f"{provider.display_name} OAuth dynamic client registration did not return client_secret"
+        raise OAuthProviderError(msg)
+    stored: dict[str, Any] = {
+        "client_id": client_id.strip(),
+        "redirect_uri": provider.default_redirect_uri(runtime_paths),
+        "_source": _DYNAMIC_CLIENT_SOURCE,
+        "_oauth_provider": provider.id,
+        RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+    }
+    if isinstance(client_secret, str) and client_secret.strip():
+        stored["client_secret"] = client_secret.strip()
+    for key in (
+        "client_id_issued_at",
+        "client_secret_expires_at",
+        "registration_client_uri",
+        "registration_access_token",
+        "token_endpoint_auth_method",
+    ):
+        value = registration.get(key)
+        if isinstance(value, str | int | float) and not isinstance(value, bool):
+            stored[key] = value
+    return stored
+
+
+async def _register_client(
+    provider: OAuthProvider,
+    config: OAuthDiscoveryConfig,
+    metadata: _DiscoveredOAuthMetadata,
+    runtime_paths: RuntimePaths,
+) -> None:
+    if not config.dynamic_client_registration or metadata.registration_url is None:
+        return
+    lock = _DYNAMIC_CLIENT_REGISTRATION_LOCKS.setdefault(provider.id, asyncio.Lock())
+    async with lock:
+        if provider.client_config_resolution(runtime_paths) is not None:
+            return
+        credentials_manager = get_runtime_credentials_manager(runtime_paths)
+        if credentials_manager.current_worker_key is not None:
+            msg = f"{config.error_label} dynamic client registration must run in the primary runtime"
+            raise OAuthProviderError(msg)
+        await _validate_url(metadata.registration_url, config, runtime_paths)
+        try:
+            async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS, follow_redirects=False) as client:
+                response = await client.post(
+                    metadata.registration_url,
+                    json=_registration_payload(provider, runtime_paths),
+                    headers={"Accept": _JSON_CONTENT_TYPE, "Content-Type": _JSON_CONTENT_TYPE},
+                )
+                response.raise_for_status()
+                registration = response.json()
+        except Exception as exc:
+            msg = f"{config.error_label} dynamic client registration failed"
+            raise OAuthProviderError(msg) from exc
+        if not isinstance(registration, dict):
+            msg = f"{config.error_label} dynamic client registration response is not a JSON object"
+            raise OAuthProviderError(msg)
+        service = provider.all_client_config_services[0]
+        credentials_manager.save_credentials(
+            service,
+            _stored_registration(provider, runtime_paths, registration),
+        )
+
+
+def oauth_runtime_bootstrapper(
+    config: OAuthDiscoveryConfig,
+) -> Callable[[OAuthProvider, RuntimePaths], Awaitable[OAuthRuntimeEndpoints]]:
+    """Build a provider bootstrapper using OAuth discovery and optional DCR."""
+
+    async def bootstrap(provider: OAuthProvider, runtime_paths: RuntimePaths) -> OAuthRuntimeEndpoints:
+        if config.token_endpoint_auth_method != provider.token_endpoint_auth_method:
+            msg = f"{config.error_label} token endpoint auth method must match the OAuth provider"
+            raise OAuthProviderError(msg)
+        if config.pkce_code_challenge_method != provider.pkce_code_challenge_method:
+            msg = f"{config.error_label} PKCE method must match the OAuth provider"
+            raise OAuthProviderError(msg)
+        metadata = await _discover_metadata(config, runtime_paths)
+        await _register_client(provider, config, metadata, runtime_paths)
+        return OAuthRuntimeEndpoints(
+            authorization_url=metadata.authorization_url,
+            token_url=metadata.token_url,
+            token_endpoint_auth_method=metadata.token_endpoint_auth_method,
+        )
+
+    return bootstrap

--- a/src/mindroom/oauth/discovery.py
+++ b/src/mindroom/oauth/discovery.py
@@ -64,6 +64,10 @@ _DISCOVERY_CACHE: dict[tuple[object, ...], _CachedDiscovery] = {}
 _DYNAMIC_CLIENT_REGISTRATION_LOCKS: dict[str, asyncio.Lock] = {}
 
 
+class _MetadataCandidateError(OAuthProviderError):
+    """One metadata candidate existed but could not be read."""
+
+
 def _configured_endpoint(value: str | None) -> str:
     return value.strip() if isinstance(value, str) and value.strip() else ""
 
@@ -126,13 +130,11 @@ async def _fetch_json(
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
-        if optional:
-            return None
         msg = f"{config.error_label} metadata request failed for {url}"
-        raise OAuthProviderError(msg) from exc
+        raise _MetadataCandidateError(msg) from exc
     if not isinstance(payload, dict):
         msg = f"{config.error_label} metadata at {url} is not a JSON object"
-        raise OAuthProviderError(msg)
+        raise _MetadataCandidateError(msg)
     return payload
 
 
@@ -148,15 +150,24 @@ async def _authorization_server(
 ) -> str | None:
     if config.authorization_server:
         return config.authorization_server.strip()
+    last_error: _MetadataCandidateError | None = None
+    found_metadata = False
     for metadata_url in _protected_resource_metadata_urls(config.resource.strip()):
-        metadata = await _fetch_json(client, metadata_url, config, runtime_paths, optional=True)
+        try:
+            metadata = await _fetch_json(client, metadata_url, config, runtime_paths, optional=True)
+        except _MetadataCandidateError as exc:
+            last_error = exc
+            continue
         if metadata is None:
             continue
+        found_metadata = True
         authorization_servers = metadata.get("authorization_servers")
         if isinstance(authorization_servers, list):
             for entry in authorization_servers:
                 if isinstance(entry, str) and entry.strip():
                     return entry.strip()
+    if last_error is not None and not found_metadata:
+        raise last_error
     return None
 
 
@@ -167,10 +178,17 @@ async def _authorization_metadata(
 ) -> dict[str, Any]:
     authorization_server = await _authorization_server(client, config, runtime_paths)
     metadata_base = authorization_server or _url_origin(urlparse(config.resource.strip()))
+    last_error: _MetadataCandidateError | None = None
     for metadata_url in _authorization_server_metadata_urls(metadata_base):
-        metadata = await _fetch_json(client, metadata_url, config, runtime_paths, optional=True)
+        try:
+            metadata = await _fetch_json(client, metadata_url, config, runtime_paths, optional=True)
+        except _MetadataCandidateError as exc:
+            last_error = exc
+            continue
         if metadata is not None:
             return metadata
+    if last_error is not None:
+        raise last_error
     msg = f"{config.error_label} authorization-server metadata was not found for {metadata_base}"
     raise OAuthProviderError(msg)
 
@@ -332,6 +350,9 @@ async def _register_client(
     async with lock:
         if provider.client_config_resolution(runtime_paths) is not None:
             return
+        if not provider.client_config_services:
+            msg = f"{config.error_label} dynamic client registration requires a provider-specific client config service"
+            raise OAuthProviderError(msg)
         credentials_manager = get_runtime_credentials_manager(runtime_paths)
         if credentials_manager.current_worker_key is not None:
             msg = f"{config.error_label} dynamic client registration must run in the primary runtime"
@@ -352,7 +373,7 @@ async def _register_client(
         if not isinstance(registration, dict):
             msg = f"{config.error_label} dynamic client registration response is not a JSON object"
             raise OAuthProviderError(msg)
-        service = provider.all_client_config_services[0]
+        service = provider.client_config_services[0]
         credentials_manager.save_credentials(
             service,
             _stored_registration(provider, runtime_paths, registration),

--- a/src/mindroom/oauth/discovery.py
+++ b/src/mindroom/oauth/discovery.py
@@ -13,7 +13,11 @@ import httpx
 from mindroom.credential_policy import RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.oauth.providers import OAuthProvider, OAuthProviderError, OAuthRuntimeEndpoints
-from mindroom.server_fetch_url import ServerFetchUrlError, validate_server_fetch_url
+from mindroom.server_fetch_url import (
+    ServerFetchAsyncHTTPTransport,
+    ServerFetchUrlError,
+    validate_server_fetch_url,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -112,6 +116,16 @@ async def _validate_url(url: str, config: OAuthDiscoveryConfig, runtime_paths: R
     except ServerFetchUrlError as exc:
         msg = f"{config.error_label} discovery refused unsafe URL"
         raise OAuthProviderError(msg) from exc
+
+
+def _http_client(config: OAuthDiscoveryConfig, runtime_paths: RuntimePaths) -> httpx.AsyncClient:
+    return httpx.AsyncClient(
+        timeout=_DISCOVERY_TIMEOUT_SECONDS,
+        follow_redirects=False,
+        transport=ServerFetchAsyncHTTPTransport(
+            allow_private_networks=runtime_paths.env_flag(config.allow_private_env),
+        ),
+    )
 
 
 async def _fetch_json(
@@ -261,7 +275,7 @@ async def _discover_metadata(
             token_endpoint_auth_method=config.token_endpoint_auth_method,
         )
     else:
-        async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS, follow_redirects=False) as client:
+        async with _http_client(config, runtime_paths) as client:
             discovered = await _authorization_metadata(client, config, runtime_paths)
         _validate_capabilities(config, discovered)
         authorization_url = _configured_endpoint(config.authorization_url) or _metadata_string(
@@ -359,7 +373,7 @@ async def _register_client(
             raise OAuthProviderError(msg)
         await _validate_url(metadata.registration_url, config, runtime_paths)
         try:
-            async with httpx.AsyncClient(timeout=_DISCOVERY_TIMEOUT_SECONDS, follow_redirects=False) as client:
+            async with _http_client(config, runtime_paths) as client:
                 response = await client.post(
                     metadata.registration_url,
                     json=_registration_payload(provider, runtime_paths),

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -69,6 +69,16 @@ def test_mcp_registry_import_does_not_cycle_in_fresh_interpreter() -> None:
     )
 
 
+def test_mcp_oauth_helpers_reject_non_oauth_server_consistently() -> None:
+    """Both MCP OAuth entry points should use the same precondition error type."""
+    server_config = MCPServerConfig(transport="streamable-http", url="https://mcp.example.test")
+
+    with pytest.raises(ValueError, match="not OAuth-backed"):
+        _oauth_discovery_config(server_config)
+    with pytest.raises(ValueError, match="not OAuth-backed"):
+        mcp_oauth_provider("example", server_config)
+
+
 def _oauth_mcp_server_config() -> MCPServerConfig:
     return MCPServerConfig(
         transport="streamable-http",

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -12,15 +12,18 @@ import pytest
 
 from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
-from mindroom.credential_policy import credential_service_policy
+from mindroom.credential_policy import RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY, credential_service_policy
 from mindroom.credentials import get_runtime_credentials_manager, save_scoped_credentials
 from mindroom.mcp.config import MCPServerConfig
 from mindroom.mcp.oauth import (
-    _DISCOVERY_CACHE,
-    _DYNAMIC_CLIENT_REGISTRATION_LOCKS,
-    _resolve_mcp_oauth_metadata,
+    _oauth_discovery_config,
     mcp_oauth_provider,
     mcp_oauth_provider_id,
+)
+from mindroom.oauth.discovery import (
+    _DISCOVERY_CACHE,
+    _DYNAMIC_CLIENT_REGISTRATION_LOCKS,
+    _discover_metadata,
 )
 from mindroom.oauth.providers import OAuthProvider, OAuthProviderError
 from mindroom.oauth.registry import clear_oauth_provider_cache, load_oauth_providers
@@ -241,7 +244,7 @@ async def test_mcp_oauth_provider_discovers_metadata_and_registers_public_client
     runtime_paths = _runtime_paths(tmp_path)
     _FakeDiscoveryClient.gets = []
     _FakeDiscoveryClient.posts = []
-    monkeypatch.setattr("mindroom.mcp.oauth.httpx.AsyncClient", _FakeDiscoveryClient)
+    monkeypatch.setattr("mindroom.oauth.discovery.httpx.AsyncClient", _FakeDiscoveryClient)
     provider = mcp_oauth_provider("demo", _auto_oauth_mcp_server_config())
     code_verifier = provider.issue_pkce_code_verifier()
     assert code_verifier is not None
@@ -288,6 +291,7 @@ async def test_mcp_oauth_provider_discovers_metadata_and_registers_public_client
         "token_endpoint_auth_method": "none",
         "_source": "oauth_dynamic_client_registration",
         "_oauth_provider": "mcp_demo",
+        RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
     }
 
 
@@ -308,7 +312,7 @@ async def test_mcp_oauth_discovery_skips_optional_invalid_json_metadata(
 
     _FakeDiscoveryClient.gets = []
     _FakeDiscoveryClient.posts = []
-    monkeypatch.setattr("mindroom.mcp.oauth.httpx.AsyncClient", _InvalidFirstDiscoveryClient)
+    monkeypatch.setattr("mindroom.oauth.discovery.httpx.AsyncClient", _InvalidFirstDiscoveryClient)
     provider = mcp_oauth_provider("demo", _auto_oauth_mcp_server_config())
     code_verifier = provider.issue_pkce_code_verifier()
     assert code_verifier is not None
@@ -346,11 +350,11 @@ async def test_mcp_oauth_metadata_cache_includes_runtime_discovery_policy(tmp_pa
         },
     )
 
-    metadata = await _resolve_mcp_oauth_metadata("demo", server_config, permissive_paths)
+    metadata = await _discover_metadata(_oauth_discovery_config(server_config), permissive_paths)
     assert metadata.authorization_url == "http://auth.example.test/authorize"
 
     with pytest.raises(OAuthProviderError, match="requires HTTPS URL"):
-        await _resolve_mcp_oauth_metadata("demo", server_config, strict_paths)
+        await _discover_metadata(_oauth_discovery_config(server_config), strict_paths)
 
 
 @pytest.mark.asyncio
@@ -388,7 +392,7 @@ async def test_mcp_oauth_dynamic_client_registration_is_serialized(
 
     _FakeDiscoveryClient.gets = []
     _FakeDiscoveryClient.posts = []
-    monkeypatch.setattr("mindroom.mcp.oauth.httpx.AsyncClient", _SlowRegistrationDiscoveryClient)
+    monkeypatch.setattr("mindroom.oauth.discovery.httpx.AsyncClient", _SlowRegistrationDiscoveryClient)
     provider = mcp_oauth_provider("demo", _auto_oauth_mcp_server_config())
     first_verifier = provider.issue_pkce_code_verifier()
     second_verifier = provider.issue_pkce_code_verifier()
@@ -443,7 +447,7 @@ async def test_mcp_oauth_discovery_rejects_hostname_resolving_to_private_address
         to_thread_calls += 1
         return func(*args, **kwargs)
 
-    monkeypatch.setattr("mindroom.mcp.oauth.asyncio.to_thread", fake_to_thread)
+    monkeypatch.setattr("mindroom.oauth.discovery.asyncio.to_thread", fake_to_thread)
     provider = mcp_oauth_provider("demo", _auto_oauth_mcp_server_config())
     code_verifier = provider.issue_pkce_code_verifier()
     assert code_verifier is not None
@@ -473,7 +477,7 @@ async def test_mcp_oauth_discovery_rejects_metadata_hostname(tmp_path: Path) -> 
     )
 
     with pytest.raises(OAuthProviderError, match="refused unsafe URL"):
-        await _resolve_mcp_oauth_metadata("demo", server_config, runtime_paths)
+        await _discover_metadata(_oauth_discovery_config(server_config), runtime_paths)
 
 
 def test_oauth_provider_allows_public_clients_without_secret_and_empty_scopes(tmp_path: Path) -> None:

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -17,6 +17,7 @@ from mindroom.oauth.discovery import (
     _discover_metadata,
 )
 from mindroom.oauth.providers import OAuthProviderError
+from mindroom.server_fetch_url import ServerFetchUrlError
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -76,6 +77,23 @@ class _ResourceOriginDiscoveryClient:
         del headers
         self.posts.append((url, json))
         return _Response({"client_id": "registered-public-client"}, 201)
+
+
+def _install_dns_rebinding(monkeypatch: pytest.MonkeyPatch, *, safe_resolutions: int) -> None:
+    remaining_safe_resolutions = safe_resolutions
+
+    def resolve(*_args: object, **_kwargs: object) -> list[tuple[object, ...]]:
+        nonlocal remaining_safe_resolutions
+        address = "93.184.216.34" if remaining_safe_resolutions > 0 else "10.0.0.5"
+        remaining_safe_resolutions -= 1
+        return [(0, 0, 0, "", (address, 0))]
+
+    async def unexpected_connect(*_args: object, **_kwargs: object) -> None:
+        msg = "unsafe address reached the network backend"
+        raise AssertionError(msg)
+
+    monkeypatch.setattr("mindroom.server_fetch_url.socket.getaddrinfo", resolve)
+    monkeypatch.setattr("mindroom.server_fetch_url.AnyIOBackend.connect_tcp", unexpected_connect)
 
 
 @pytest.fixture(autouse=True)
@@ -199,6 +217,21 @@ async def test_cached_endpoints_are_revalidated_before_reuse(
 
 
 @pytest.mark.asyncio
+async def test_discovery_revalidates_dns_when_connecting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Discovery must reject a hostname that rebinds before the connection."""
+    _install_dns_rebinding(monkeypatch, safe_resolutions=2)
+    runtime_paths = resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path, process_env={})
+
+    with pytest.raises(OAuthProviderError, match="metadata request failed") as error:
+        await _discover_metadata(OAuthDiscoveryConfig(resource="https://resource.example.test"), runtime_paths)
+
+    assert isinstance(error.value.__cause__, ServerFetchUrlError)
+
+
+@pytest.mark.asyncio
 async def test_dynamic_registration_requires_provider_specific_client_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -236,6 +269,46 @@ async def test_dynamic_registration_requires_provider_specific_client_config(
 
     assert _ResourceOriginDiscoveryClient.posts == []
     assert get_runtime_credentials_manager(runtime_paths).load_credentials("shared_example_oauth_client") is None
+
+
+@pytest.mark.asyncio
+async def test_dynamic_registration_revalidates_dns_when_connecting(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Client registration must reject a hostname that rebinds before the connection."""
+    _install_dns_rebinding(monkeypatch, safe_resolutions=4)
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={"MINDROOM_PUBLIC_URL": "https://mindroom.example.test"},
+    )
+    provider = OAuthProvider(
+        id="rebound_registration",
+        display_name="Rebound Registration",
+        authorization_url="",
+        token_url="",
+        scopes=(),
+        allow_empty_scopes=True,
+        credential_service="rebound_registration_oauth",
+        client_config_services=("rebound_registration_oauth_client",),
+        token_endpoint_auth_method="none",  # noqa: S106
+        runtime_bootstrapper=oauth_runtime_bootstrapper(
+            OAuthDiscoveryConfig(
+                resource="",
+                discovery="manual",
+                authorization_url="https://auth.example.test/authorize",
+                token_url="https://auth.example.test/token",  # noqa: S106
+                registration_url="https://auth.example.test/register",
+                token_endpoint_auth_method="none",  # noqa: S106
+            ),
+        ),
+    )
+
+    with pytest.raises(OAuthProviderError, match="dynamic client registration failed") as error:
+        await provider.runtime_endpoints(runtime_paths)
+
+    assert isinstance(error.value.__cause__, ServerFetchUrlError)
 
 
 @pytest.mark.asyncio

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -199,16 +199,17 @@ async def test_cached_endpoints_are_revalidated_before_reuse(
 
 
 @pytest.mark.asyncio
-async def test_dynamic_registration_supports_shared_only_client_config(
+async def test_dynamic_registration_requires_provider_specific_client_config(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """DCR should persist clients to a provider's shared service when needed."""
+    """DCR clients must not be stored in services shared by multiple providers."""
     runtime_paths = resolve_runtime_paths(
         config_path=tmp_path / "config.yaml",
         storage_path=tmp_path,
         process_env={"MINDROOM_PUBLIC_URL": "https://mindroom.example.test"},
     )
+    _ResourceOriginDiscoveryClient.posts = []
     monkeypatch.setattr("mindroom.oauth.discovery.httpx.AsyncClient", _ResourceOriginDiscoveryClient)
     provider = OAuthProvider(
         id="shared_example",
@@ -230,11 +231,43 @@ async def test_dynamic_registration_supports_shared_only_client_config(
         ),
     )
 
-    await provider.runtime_endpoints(runtime_paths)
+    with pytest.raises(OAuthProviderError, match="provider-specific client config service"):
+        await provider.runtime_endpoints(runtime_paths)
 
-    stored = get_runtime_credentials_manager(runtime_paths).load_credentials("shared_example_oauth_client")
-    assert stored is not None
-    assert stored["client_id"] == "registered-public-client"
+    assert _ResourceOriginDiscoveryClient.posts == []
+    assert get_runtime_credentials_manager(runtime_paths).load_credentials("shared_example_oauth_client") is None
+
+
+@pytest.mark.asyncio
+async def test_discovery_reports_the_last_candidate_fetch_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A broken final candidate must not be reported as absent metadata."""
+
+    class _InvalidJsonResponse(_Response):
+        def json(self) -> dict[str, Any]:
+            msg = "invalid metadata JSON"
+            raise ValueError(msg)
+
+    class _InvalidMetadataClient(_ResourceOriginDiscoveryClient):
+        async def get(self, url: str, *, headers: Mapping[str, str] | None = None) -> _Response:
+            del headers
+            if url.endswith("/.well-known/oauth-protected-resource"):
+                return _Response({}, 404)
+            return _InvalidJsonResponse({})
+
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={},
+    )
+    monkeypatch.setattr("mindroom.oauth.discovery.httpx.AsyncClient", _InvalidMetadataClient)
+
+    with pytest.raises(OAuthProviderError, match="metadata request failed") as error:
+        await _discover_metadata(OAuthDiscoveryConfig(resource="https://resource.example.test"), runtime_paths)
+
+    assert isinstance(error.value.__cause__, ValueError)
 
 
 @pytest.mark.asyncio
@@ -261,7 +294,7 @@ async def test_dynamic_registration_refuses_dedicated_worker_storage(
         scopes=(),
         allow_empty_scopes=True,
         credential_service="worker_example_oauth",
-        shared_client_config_services=("worker_example_oauth_client",),
+        client_config_services=("worker_example_oauth_client",),
         token_endpoint_auth_method="none",  # noqa: S106
         pkce_code_challenge_method="S256",
         runtime_bootstrapper=oauth_runtime_bootstrapper(

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -1,0 +1,327 @@
+"""Tests for reusable protected-resource OAuth discovery."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from mindroom.constants import resolve_runtime_paths
+from mindroom.credential_policy import RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY
+from mindroom.credentials import get_runtime_credentials_manager
+from mindroom.oauth import OAuthDiscoveryConfig, OAuthProvider, oauth_runtime_bootstrapper
+from mindroom.oauth.discovery import (
+    _DISCOVERY_CACHE,
+    _DYNAMIC_CLIENT_REGISTRATION_LOCKS,
+    _discover_metadata,
+)
+from mindroom.oauth.providers import OAuthProviderError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+
+class _Response:
+    def __init__(self, payload: dict[str, Any], status_code: int = 200) -> None:
+        self.payload = payload
+        self.status_code = status_code
+
+    def json(self) -> dict[str, Any]:
+        return self.payload
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            raise RuntimeError(self.status_code)
+
+
+class _ResourceOriginDiscoveryClient:
+    gets: ClassVar[list[str]] = []
+    posts: ClassVar[list[tuple[str, dict[str, Any]]]] = []
+
+    def __init__(self, *args: object, **kwargs: object) -> None:
+        del args, kwargs
+
+    async def __aenter__(self) -> _ResourceOriginDiscoveryClient:
+        return self
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+    async def get(self, url: str, *, headers: Mapping[str, str] | None = None) -> _Response:
+        del headers
+        self.gets.append(url)
+        if url == "https://resource.example.test/.well-known/oauth-protected-resource":
+            return _Response({}, 404)
+        if url == "https://resource.example.test/.well-known/oauth-authorization-server":
+            return _Response(
+                {
+                    "authorization_endpoint": "https://auth.example.test/authorize",
+                    "token_endpoint": "https://auth.example.test/token",
+                    "registration_endpoint": "https://auth.example.test/register",
+                    "token_endpoint_auth_methods_supported": ["none"],
+                    "code_challenge_methods_supported": ["S256"],
+                },
+            )
+        return _Response({}, 404)
+
+    async def post(
+        self,
+        url: str,
+        *,
+        json: dict[str, Any],
+        headers: Mapping[str, str] | None = None,
+    ) -> _Response:
+        del headers
+        self.posts.append((url, json))
+        return _Response({"client_id": "registered-public-client"}, 201)
+
+
+@pytest.fixture(autouse=True)
+def _allow_example_test_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    _DISCOVERY_CACHE.clear()
+    _DYNAMIC_CLIENT_REGISTRATION_LOCKS.clear()
+    monkeypatch.setattr(
+        "mindroom.server_fetch_url.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(0, 0, 0, "", ("93.184.216.34", 0))],
+    )
+
+
+@pytest.mark.asyncio
+async def test_resource_origin_metadata_registers_public_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """App-domain metadata should bootstrap a PKCE public client without a secret."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={"MINDROOM_PUBLIC_URL": "https://mindroom.example.test"},
+    )
+    _ResourceOriginDiscoveryClient.gets = []
+    _ResourceOriginDiscoveryClient.posts = []
+    monkeypatch.setattr("mindroom.oauth.discovery.httpx.AsyncClient", _ResourceOriginDiscoveryClient)
+    provider = OAuthProvider(
+        id="example",
+        display_name="Example",
+        authorization_url="",
+        token_url="",
+        scopes=(),
+        allow_empty_scopes=True,
+        credential_service="example_oauth",
+        client_config_services=("example_oauth_client",),
+        token_endpoint_auth_method="none",  # noqa: S106
+        pkce_code_challenge_method="S256",
+        extra_auth_params={"resource": "https://resource.example.test"},
+        extra_token_params={"resource": "https://resource.example.test"},
+        runtime_bootstrapper=oauth_runtime_bootstrapper(
+            OAuthDiscoveryConfig(
+                resource="https://resource.example.test",
+                token_endpoint_auth_method="none",  # noqa: S106
+                pkce_code_challenge_method="S256",
+            ),
+        ),
+    )
+    verifier = provider.issue_pkce_code_verifier()
+    assert verifier is not None
+
+    authorization_url = await provider.authorization_uri_async(
+        runtime_paths,
+        state="state-token",
+        code_verifier=verifier,
+    )
+
+    query = parse_qs(urlparse(authorization_url).query)
+    assert query["client_id"] == ["registered-public-client"]
+    assert query["resource"] == ["https://resource.example.test"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert _ResourceOriginDiscoveryClient.gets == [
+        "https://resource.example.test/.well-known/oauth-protected-resource",
+        "https://resource.example.test/.well-known/oauth-authorization-server",
+    ]
+    assert _ResourceOriginDiscoveryClient.posts == [
+        (
+            "https://auth.example.test/register",
+            {
+                "client_name": "Example",
+                "redirect_uris": ["https://mindroom.example.test/api/oauth/example/callback"],
+                "grant_types": ["authorization_code", "refresh_token"],
+                "response_types": ["code"],
+                "token_endpoint_auth_method": "none",
+            },
+        ),
+    ]
+    assert get_runtime_credentials_manager(runtime_paths).load_credentials("example_oauth_client") == {
+        "client_id": "registered-public-client",
+        "redirect_uri": "https://mindroom.example.test/api/oauth/example/callback",
+        "_source": "oauth_dynamic_client_registration",
+        "_oauth_provider": "example",
+        RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY: True,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("resource", ["  ", "resource.example.test"])
+async def test_auto_discovery_requires_an_absolute_resource(tmp_path: Path, resource: str) -> None:
+    """Auto discovery should fail clearly when no protected resource is configured."""
+    runtime_paths = resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path, process_env={})
+
+    with pytest.raises(OAuthProviderError, match="auto discovery requires a protected-resource URL"):
+        await _discover_metadata(OAuthDiscoveryConfig(resource=resource), runtime_paths)
+
+
+@pytest.mark.asyncio
+async def test_cached_endpoints_are_revalidated_before_reuse(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cached endpoints must not bypass current network safety checks."""
+    runtime_paths = resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path, process_env={})
+    blocked_auth_host = False
+
+    def resolve(host: str, *_args: object, **_kwargs: object) -> list[tuple[object, ...]]:
+        address = "10.0.0.5" if blocked_auth_host and host == "auth.example.test" else "93.184.216.34"
+        return [(0, 0, 0, "", (address, 0))]
+
+    monkeypatch.setattr("mindroom.server_fetch_url.socket.getaddrinfo", resolve)
+    monkeypatch.setattr("mindroom.oauth.discovery.httpx.AsyncClient", _ResourceOriginDiscoveryClient)
+    config = OAuthDiscoveryConfig(
+        resource="https://resource.example.test",
+        token_endpoint_auth_method="none",  # noqa: S106
+        pkce_code_challenge_method="S256",
+    )
+    await _discover_metadata(config, runtime_paths)
+    blocked_auth_host = True
+
+    with pytest.raises(OAuthProviderError, match="refused unsafe URL"):
+        await _discover_metadata(config, runtime_paths)
+
+
+@pytest.mark.asyncio
+async def test_dynamic_registration_supports_shared_only_client_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DCR should persist clients to a provider's shared service when needed."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={"MINDROOM_PUBLIC_URL": "https://mindroom.example.test"},
+    )
+    monkeypatch.setattr("mindroom.oauth.discovery.httpx.AsyncClient", _ResourceOriginDiscoveryClient)
+    provider = OAuthProvider(
+        id="shared_example",
+        display_name="Shared Example",
+        authorization_url="",
+        token_url="",
+        scopes=(),
+        allow_empty_scopes=True,
+        credential_service="shared_example_oauth",
+        shared_client_config_services=("shared_example_oauth_client",),
+        token_endpoint_auth_method="none",  # noqa: S106
+        pkce_code_challenge_method="S256",
+        runtime_bootstrapper=oauth_runtime_bootstrapper(
+            OAuthDiscoveryConfig(
+                resource="https://resource.example.test",
+                token_endpoint_auth_method="none",  # noqa: S106
+                pkce_code_challenge_method="S256",
+            ),
+        ),
+    )
+
+    await provider.runtime_endpoints(runtime_paths)
+
+    stored = get_runtime_credentials_manager(runtime_paths).load_credentials("shared_example_oauth_client")
+    assert stored is not None
+    assert stored["client_id"] == "registered-public-client"
+
+
+@pytest.mark.asyncio
+async def test_dynamic_registration_refuses_dedicated_worker_storage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OAuth app clients must be provisioned in the primary runtime."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path,
+        process_env={
+            "MINDROOM_PUBLIC_URL": "https://mindroom.example.test",
+            "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY": "worker-a",
+        },
+    )
+    _ResourceOriginDiscoveryClient.posts = []
+    monkeypatch.setattr("mindroom.oauth.discovery.httpx.AsyncClient", _ResourceOriginDiscoveryClient)
+    provider = OAuthProvider(
+        id="worker_example",
+        display_name="Worker Example",
+        authorization_url="",
+        token_url="",
+        scopes=(),
+        allow_empty_scopes=True,
+        credential_service="worker_example_oauth",
+        shared_client_config_services=("worker_example_oauth_client",),
+        token_endpoint_auth_method="none",  # noqa: S106
+        pkce_code_challenge_method="S256",
+        runtime_bootstrapper=oauth_runtime_bootstrapper(
+            OAuthDiscoveryConfig(
+                resource="https://resource.example.test",
+                token_endpoint_auth_method="none",  # noqa: S106
+                pkce_code_challenge_method="S256",
+            ),
+        ),
+    )
+
+    with pytest.raises(OAuthProviderError, match="primary runtime"):
+        await provider.runtime_endpoints(runtime_paths)
+
+    assert _ResourceOriginDiscoveryClient.posts == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("discovery_config", "error"),
+    [
+        (
+            OAuthDiscoveryConfig(
+                resource="",
+                discovery="manual",
+                authorization_url="https://auth.example.test/authorize",
+                token_url="https://auth.example.test/token",  # noqa: S106
+                token_endpoint_auth_method="none",  # noqa: S106
+            ),
+            "token endpoint auth method",
+        ),
+        (
+            OAuthDiscoveryConfig(
+                resource="",
+                discovery="manual",
+                authorization_url="https://auth.example.test/authorize",
+                token_url="https://auth.example.test/token",  # noqa: S106
+                pkce_code_challenge_method="S256",
+            ),
+            "PKCE method",
+        ),
+    ],
+)
+async def test_bootstrap_rejects_provider_method_mismatch(
+    tmp_path: Path,
+    discovery_config: OAuthDiscoveryConfig,
+    error: str,
+) -> None:
+    """Discovery and provider runtime methods must agree."""
+    runtime_paths = resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path, process_env={})
+    provider = OAuthProvider(
+        id="mismatched",
+        display_name="Mismatched",
+        authorization_url="",
+        token_url="",
+        scopes=("read",),
+        credential_service="mismatched_oauth",
+        client_config_services=("mismatched_oauth_client",),
+        runtime_bootstrapper=oauth_runtime_bootstrapper(discovery_config),
+    )
+
+    with pytest.raises(OAuthProviderError, match=error):
+        await provider.runtime_endpoints(runtime_paths)

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -80,6 +80,8 @@ class _ResourceOriginDiscoveryClient:
 
 
 def _install_dns_rebinding(monkeypatch: pytest.MonkeyPatch, *, safe_resolutions: int) -> None:
+    # Discovery uses two safe preflight resolutions before the guarded dial;
+    # manual DCR uses three endpoint preflights plus a registration preflight.
     remaining_safe_resolutions = safe_resolutions
 
     def resolve(*_args: object, **_kwargs: object) -> list[tuple[object, ...]]:
@@ -396,6 +398,7 @@ async def test_dynamic_registration_refuses_dedicated_worker_storage(
                 authorization_url="https://auth.example.test/authorize",
                 token_url="https://auth.example.test/token",  # noqa: S106
                 token_endpoint_auth_method="none",  # noqa: S106
+                pkce_code_challenge_method=None,
             ),
             "token endpoint auth method",
         ),
@@ -405,6 +408,7 @@ async def test_dynamic_registration_refuses_dedicated_worker_storage(
                 discovery="manual",
                 authorization_url="https://auth.example.test/authorize",
                 token_url="https://auth.example.test/token",  # noqa: S106
+                token_endpoint_auth_method="client_secret_post",  # noqa: S106
                 pkce_code_challenge_method="S256",
             ),
             "PKCE method",
@@ -426,6 +430,8 @@ async def test_bootstrap_rejects_provider_method_mismatch(
         scopes=("read",),
         credential_service="mismatched_oauth",
         client_config_services=("mismatched_oauth_client",),
+        token_endpoint_auth_method="client_secret_post",  # noqa: S106
+        pkce_code_challenge_method=None,
         runtime_bootstrapper=oauth_runtime_bootstrapper(discovery_config),
     )
 


### PR DESCRIPTION
## Summary
- extract protected-resource discovery and dynamic client registration into the generic OAuth layer
- keep MCP OAuth behavior on the shared implementation
- support authorization servers that publish metadata directly on the protected-resource origin
- keep runtime-created clients primary-runtime-only and revalidate cached endpoints against current network policy

## Validation
- `uv run pytest -q tests/test_oauth_discovery.py tests/test_mcp_oauth.py`
- `uv run pre-commit run --all-files`
- `uv run tach check`

## Summary by Sourcery

Extract reusable OAuth discovery and dynamic client registration into a generic module and integrate MCP OAuth with the shared discovery/bootstrap flow.

New Features:
- Add a generic OAuthDiscoveryConfig and oauth_runtime_bootstrapper to support protected-resource based metadata discovery and dynamic client registration across providers.
- Support authorization servers that publish metadata on the protected resource origin in addition to dedicated authorization server URLs.

Enhancements:
- Refactor MCP OAuth to use the shared OAuth discovery/runtime bootstrapper instead of its own bespoke discovery logic.
- Ensure dynamically registered OAuth clients are stored as runtime-bootstrapped configurations and can target shared client-config services.
- Revalidate cached OAuth discovery endpoints against current network safety policy before reuse and enforce primary-runtime-only dynamic client registration.

Tests:
- Add a dedicated test_oauth_discovery suite covering generic OAuth discovery, caching, and dynamic client registration behavior, including primary-runtime-only constraints.
- Update MCP OAuth tests to use the shared discovery module’s internals and to validate the new caching and dynamic registration semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic OAuth discovery using protected-resource and authorization-server metadata.
  * Added optional dynamic client registration with PKCE, token authentication, caching, and security validation.
  * Added reusable OAuth configuration and runtime bootstrapping for integrations and plugins.
* **Documentation**
  * Expanded OAuth and plugin guidance with discovery, registration, configuration, and fallback behavior.
* **Bug Fixes**
  * Improved validation for unsafe hosts, invalid metadata, DNS rebinding, and incompatible provider settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->