### PR TITLE
Stream room history recovery in bounded chunks

### DIFF
--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -374,24 +374,36 @@ class PrincipalStore:
             lambda transaction: journal.room_history_recovery(transaction, self._principal_id, room_id),
         )
 
-    async def settle_room_history_recovery(
+    async def install_room_history_recovery_chunk(
         self,
         recovery: RoomHistoryRecovery,
         *,
         events: tuple[ProjectedEvent, ...],
+        expected_membership_epoch: int,
+    ) -> bool:
+        """Project one bounded recovery chunk only while both fences match."""
+        if len(events) > _HYDRATION_INSTALL_CHUNK_SIZE:
+            msg = f"Room history recovery chunks may contain at most {_HYDRATION_INSTALL_CHUNK_SIZE} projected events"
+            raise ValueError(msg)
+        return await self._backend.write(
+            lambda transaction: _install_room_history_recovery_chunk(
+                transaction,
+                self._principal_id,
+                recovery,
+                events=events,
+                expected_membership_epoch=expected_membership_epoch,
+            ),
+        )
+
+    async def settle_room_history_recovery(
+        self,
+        recovery: RoomHistoryRecovery,
+        *,
         exhausted_server: bool,
         attempted_policy_rank: int,
         expected_membership_epoch: int,
     ) -> HistoryRecoveryOutcome:
-        """Install a recovery in bounded writes, then publish and settle once."""
-        if not await _install_hydration_chunks(
-            self._backend,
-            self._principal_id,
-            room_id=recovery.room_id,
-            events=events,
-            expected_membership_epoch=expected_membership_epoch,
-        ):
-            return HistoryRecoveryOutcome.SUPERSEDED
+        """Publish an installed recovery and settle its exact obligation once."""
         return await self._backend.write(
             lambda transaction: _settle_history_recovery(
                 transaction,
@@ -836,6 +848,35 @@ def _settle_history_recovery(
         recovery,
         exhausted_server=exhausted_server,
     )
+
+
+def _install_room_history_recovery_chunk(
+    transaction,  # noqa: ANN001 - the backend's Transaction, kept structural
+    principal_id: str,
+    recovery: RoomHistoryRecovery,
+    *,
+    events: tuple[ProjectedEvent, ...],
+    expected_membership_epoch: int,
+) -> bool:
+    """Project one chunk only while its membership and exact recovery stand."""
+    if not reads.claim_membership_epoch(
+        transaction,
+        principal_id,
+        room_id=recovery.room_id,
+        expected_membership_epoch=expected_membership_epoch,
+    ):
+        return False
+    if not journal.claim_room_history_recovery(transaction, principal_id, recovery):
+        return False
+    for event in events:
+        project(
+            transaction,
+            principal_id,
+            event,
+            receipt_order=0,
+            membership_epoch=expected_membership_epoch,
+        )
+    return True
 
 
 async def _install_hydration_chunks(

--- a/src/mindroom/event_journal/views.py
+++ b/src/mindroom/event_journal/views.py
@@ -201,16 +201,25 @@ class HydrationView(Protocol):
         """Return one room's current history-recovery obligation, if any."""
         ...
 
-    async def settle_room_history_recovery(
+    async def install_room_history_recovery_chunk(
         self,
         recovery: RoomHistoryRecovery,
         *,
         events: tuple[ProjectedEvent, ...],
+        expected_membership_epoch: int,
+    ) -> bool:
+        """Project one bounded recovery chunk only while both fences match."""
+        ...
+
+    async def settle_room_history_recovery(
+        self,
+        recovery: RoomHistoryRecovery,
+        *,
         exhausted_server: bool,
         attempted_policy_rank: int,
         expected_membership_epoch: int,
     ) -> HistoryRecoveryOutcome:
-        """Install a recovery in chunks, then publish and settle atomically."""
+        """Publish an installed recovery and settle its exact obligation."""
         ...
 
     async def conversation_is_hydrated(self, *, room_id: str, thread_id: str | None) -> bool:

--- a/src/mindroom/matrix/conversation_hydration.py
+++ b/src/mindroom/matrix/conversation_hydration.py
@@ -291,10 +291,6 @@ class _Walk:
     correctness is completeness rather than recency has to be able to tell those
     apart instead of reading a warm marker as a whole conversation.
 
-    ``exhausted_server`` says the homeserver returned no continuation token.
-    It is independent of readability: a walk can reach the start of retained
-    history while still being unable to understand an encrypted event it saw.
-
     ``unreadable`` says the walk fetched at least one event it could not read,
     which is a different failure from either bound and has to be kept apart
     from both. A walk that stopped at a ceiling knows exactly what it skipped
@@ -311,7 +307,6 @@ class _Walk:
 
     events: tuple[ProjectedEvent, ...]
     complete: bool
-    exhausted_server: bool = False
     unreadable: bool = False
 
 
@@ -712,18 +707,20 @@ class ConversationHydrator:
         start: str | None = None
         client = self._client()
         while True:
+            request_limit = min(_MESSAGES_PAGE_LIMIT, max(self.max_fetched_events - fetched, 0))
+            if request_limit == 0:
+                break
             response = await client.room_messages(
                 recovery.room_id,
                 start=start,
                 direction=nio.MessageDirection.back,
-                limit=_MESSAGES_PAGE_LIMIT,
+                limit=request_limit,
             )
             if not isinstance(response, nio.RoomMessagesResponse):
                 msg = f"Could not fetch history for {recovery.room_id!r}: {response}"
                 raise _HydrationError(msg)
             pages += 1
-            remaining = min(_MESSAGES_PAGE_LIMIT, max(self.max_fetched_events - fetched, 0))
-            page = response.chunk[:remaining]
+            page = response.chunk[:request_limit]
             fetched += len(page)
             projected_page = _project_room_page(client, recovery.room_id, page, self_sender=self.self_sender)
             unreadable = unreadable or projected_page.unreadable
@@ -915,12 +912,7 @@ class ConversationHydrator:
             raise _HydrationError(msg) from error
         return _Walk(events=tuple(events), complete=complete, unreadable=unreadable)
 
-    async def _fetch_room(
-        self,
-        room_id: str,
-        *,
-        require_server_exhaustion: bool = False,
-    ) -> _Walk:
+    async def _fetch_room(self, room_id: str) -> _Walk:
         """Walk back until this walk's job is done, or the room runs out.
 
         A server that has run out of history answers with an empty chunk and no
@@ -932,11 +924,6 @@ class ConversationHydrator:
         history than that is hydrated once the window is full. The window is
         measured in logical messages, because that is the unit a prompt is
         built from; an edit does not add a message to it, it revises one.
-
-        Proof mode ignores the logical prompt window because a page of post-gap
-        tail can fill that window while the missing interval remains on the
-        next page. Only readable server exhaustion proves the interval covered;
-        the raw-event and request ceilings still bound its cost.
 
         There are three ways this returns, and only two of them mean the walk
         finished its job. The third is the event ceiling, which is logged rather
@@ -993,14 +980,12 @@ class ConversationHydrator:
                 return _Walk(
                     events=tuple(events),
                     complete=False,
-                    exhausted_server=False,
                     unreadable=unreadable,
                 )
-            if not require_server_exhaustion and logical >= self.prompt_window_messages:
+            if logical >= self.prompt_window_messages:
                 return _Walk(
                     events=tuple(events),
                     complete=False,
-                    exhausted_server=False,
                     unreadable=unreadable,
                 )
             # An empty page is not exhaustion. The server may filter a page down
@@ -1015,7 +1000,6 @@ class ConversationHydrator:
                     # Running out of history is only completeness if the walk
                     # could read what it ran through.
                     complete=not unreadable,
-                    exhausted_server=True,
                     unreadable=unreadable,
                 )
             next_start = _advanced_room_cursor(room_id=room_id, start=start, end=response.end)
@@ -1034,7 +1018,6 @@ class ConversationHydrator:
                 return _Walk(
                     events=tuple(events),
                     complete=False,
-                    exhausted_server=False,
                     unreadable=unreadable,
                 )
             start = next_start

--- a/src/mindroom/matrix/conversation_hydration.py
+++ b/src/mindroom/matrix/conversation_hydration.py
@@ -316,6 +316,51 @@ class _Walk:
 
 
 @dataclass(frozen=True, slots=True)
+class _ProjectedRoomPage:
+    """One bounded room page after transport events become journal events."""
+
+    events: tuple[ProjectedEvent, ...]
+    logical_messages: int
+    unreadable: bool
+
+
+@dataclass(frozen=True, slots=True)
+class _RecoveryWalk:
+    """The terminal facts retained after a streamed recovery walk."""
+
+    exhausted_server: bool
+    unreadable: bool
+    superseded: bool = False
+
+
+def _project_room_page(
+    client: nio.AsyncClient,
+    room_id: str,
+    page: Sequence[nio.BaseEvent],
+    *,
+    self_sender: str,
+) -> _ProjectedRoomPage:
+    """Project one fetched page without retaining any preceding page."""
+    events: list[ProjectedEvent] = []
+    logical_messages = 0
+    unreadable = False
+    for event in page:
+        readable = _readable_event(client, event)
+        unreadable = unreadable or readable is None
+        projected = None if readable is None else _projected_from_event(room_id, readable, self_sender=self_sender)
+        if projected is None:
+            continue
+        events.append(projected)
+        if _is_logical_message(projected):
+            logical_messages += 1
+    return _ProjectedRoomPage(
+        events=tuple(events),
+        logical_messages=logical_messages,
+        unreadable=unreadable,
+    )
+
+
+@dataclass(frozen=True, slots=True)
 class _Revision:
     """The revision of a logical message that is currently on the server."""
 
@@ -403,7 +448,7 @@ class ConversationHydrator:
     # tasks rather than squeezed into their key: a recovery and the room
     # conversation are both "this room, no thread", and one of them waiting on
     # the other under a shared key is a deadlock.
-    _recoveries: dict[str, asyncio.Task[None]] = field(default_factory=dict, init=False, repr=False)
+    _recoveries: dict[str, asyncio.Task[HistoryRecoveryOutcome]] = field(default_factory=dict, init=False, repr=False)
 
     def _client(self) -> nio.AsyncClient:
         """Return the Matrix client, which only exists once the bot has logged in.
@@ -520,21 +565,21 @@ class ConversationHydrator:
             return False
         return coverage.reached_its_end or coverage.attempted_policy_rank >= self.policy
 
-    async def _shared[Key](
+    async def _shared[Key, Result](
         self,
-        running: dict[Key, asyncio.Task[None]],
+        running: dict[Key, asyncio.Task[Result]],
         key: Key,
-        start: Callable[[], Coroutine[None, None, None]],
+        start: Callable[[], Coroutine[None, None, Result]],
         *,
         name: str,
-    ) -> None:
+    ) -> Result:
         """Run one keyed piece of server work, joining whoever is already on it."""
         task = running.get(key)
         if task is None or task.done():
             task = asyncio.create_task(start(), name=name)
             running[key] = task
         try:
-            await asyncio.shield(task)
+            return await asyncio.shield(task)
         finally:
             if running.get(key) is task and task.done():
                 del running[key]
@@ -571,7 +616,7 @@ class ConversationHydrator:
             # a room the bot is no longer in the same relationship with.
             logger.info("conversation_hydration_superseded", room_id=room_id, thread_id=thread_id)
 
-    async def _repair(self, recovery: RoomHistoryRecovery) -> None:
+    async def _repair(self, recovery: RoomHistoryRecovery) -> HistoryRecoveryOutcome:
         """Walk a repairable room to server exhaustion or a configured ceiling.
 
         A room walk and not a thread walk, whichever conversation asked. The
@@ -585,6 +630,10 @@ class ConversationHydrator:
         it entirely with post-gap tail while the missing interval remains on
         the next page. The proof walk therefore continues to readable server
         exhaustion, while the raw-event and request ceilings still bound cost.
+
+        Each fetched page is projected and installed before the next request.
+        That write claims this exact recovery and membership epoch, so a retry
+        may reapply committed pages and either changing fence stops stale work.
 
         A failure here propagates. The read that triggered it fails visibly, the
         obligation stays repairable, and the next read tries again -- which is the
@@ -609,15 +658,25 @@ class ConversationHydrator:
             # is -- a later gap is a different hole and this walk was not
             # launched for it -- and the caller's loop re-reads the obligation.
             logger.info("conversation_history_recovery_already_settled", room_id=recovery.room_id)
-            return
+            return HistoryRecoveryOutcome.SUPERSEDED
         epoch = await self.store.membership_epoch(recovery.room_id)
-        walk = await self._fetch_room(recovery.room_id, require_server_exhaustion=True)
+        walk = await self._fetch_room_history_recovery(recovery, expected_membership_epoch=epoch)
+        if walk.superseded:
+            logger.info(
+                "conversation_history_recovery_settled",
+                room_id=recovery.room_id,
+                outcome=HistoryRecoveryOutcome.SUPERSEDED.value,
+                recovery_state=recovery.state.value,
+                exhausted_server=False,
+                unreadable=walk.unreadable,
+                walk_complete=False,
+            )
+            return HistoryRecoveryOutcome.SUPERSEDED
         if walk.exhausted_server and walk.unreadable:
             msg = f"Could not prove complete readable history for {recovery.room_id!r}: unreadable events remain"
             raise _HydrationError(msg)
         outcome = await self.store.settle_room_history_recovery(
             recovery,
-            events=walk.events,
             exhausted_server=walk.exhausted_server,
             attempted_policy_rank=self.policy,
             expected_membership_epoch=epoch,
@@ -634,8 +693,71 @@ class ConversationHydrator:
             recovery_state=recovery.state.value,
             exhausted_server=walk.exhausted_server,
             unreadable=walk.unreadable,
-            walk_complete=walk.complete,
+            walk_complete=walk.exhausted_server and not walk.unreadable,
         )
+        return outcome
+
+    async def _fetch_room_history_recovery(
+        self,
+        recovery: RoomHistoryRecovery,
+        *,
+        expected_membership_epoch: int,
+    ) -> _RecoveryWalk:
+        """Fetch and immediately install bounded pages for one exact recovery."""
+        logical = 0
+        fetched = 0
+        pages = 0
+        unreadable = False
+        exhausted_server = False
+        start: str | None = None
+        client = self._client()
+        while True:
+            response = await client.room_messages(
+                recovery.room_id,
+                start=start,
+                direction=nio.MessageDirection.back,
+                limit=_MESSAGES_PAGE_LIMIT,
+            )
+            if not isinstance(response, nio.RoomMessagesResponse):
+                msg = f"Could not fetch history for {recovery.room_id!r}: {response}"
+                raise _HydrationError(msg)
+            pages += 1
+            remaining = min(_MESSAGES_PAGE_LIMIT, max(self.max_fetched_events - fetched, 0))
+            page = response.chunk[:remaining]
+            fetched += len(page)
+            projected_page = _project_room_page(client, recovery.room_id, page, self_sender=self.self_sender)
+            unreadable = unreadable or projected_page.unreadable
+            logical += projected_page.logical_messages
+            installed = await self.store.install_room_history_recovery_chunk(
+                recovery,
+                events=projected_page.events,
+                expected_membership_epoch=expected_membership_epoch,
+            )
+            if not installed:
+                return _RecoveryWalk(
+                    exhausted_server=False,
+                    unreadable=unreadable,
+                    superseded=True,
+                )
+            if len(page) < len(response.chunk):
+                break
+            if not response.end:
+                exhausted_server = True
+                break
+            next_start = _advanced_room_cursor(room_id=recovery.room_id, start=start, end=response.end)
+            if fetched >= self.max_fetched_events or pages >= self.max_requests:
+                break
+            start = next_start
+        if not exhausted_server:
+            logger.warning(
+                "conversation_hydration_ceiling_reached",
+                room_id=recovery.room_id,
+                requests=pages,
+                fetched_events=fetched,
+                logical_messages=logical,
+                prompt_window_messages=self.prompt_window_messages,
+            )
+        return _RecoveryWalk(exhausted_server=exhausted_server, unreadable=unreadable)
 
     async def _fetch_thread(self, room_id: str, thread_id: str) -> _Walk:
         """Build one thread from its root and a bounded walk of its relations.

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -314,6 +314,7 @@ class _HydrationWriteShape:
     """The hydration work one real backend transaction was asked to commit."""
 
     membership_claims: int = 0
+    recovery_claims: int = 0
     projected_messages: int = 0
     hydration_markers: int = 0
     recovery_settlements: int = 0
@@ -340,9 +341,11 @@ class _HydrationWriteTransaction:
         self._inner.execute(sql, params)
 
     def fetchone(self, sql: str, params: Sequence[object] = ()) -> Mapping[str, object] | None:
-        """Run one query and record a materialized membership claim."""
+        """Run one query and record its durable fence claims."""
         if "INSERT INTO room_membership" in sql:
             self.shape.membership_claims += 1
+        if "UPDATE room_history_recovery SET state = state" in sql:
+            self.shape.recovery_claims += 1
         return self._inner.fetchone(sql, params)
 
     def fetchall(self, sql: str, params: Sequence[object] = ()) -> tuple[Mapping[str, object], ...]:
@@ -1880,6 +1883,22 @@ class TestBoundedHydrationInstallation:
         assert max(shape.projected_messages for shape in projection_shapes) <= _HYDRATION_TRANSACTION_EVENT_LIMIT
         assert all(shape.membership_claims == 1 for shape in projection_shapes)
 
+    @staticmethod
+    async def _install_recovery_events(
+        store: PrincipalStore,
+        recovery: RoomHistoryRecovery,
+        events: tuple[ProjectedEvent, ...],
+        *,
+        expected_membership_epoch: int,
+    ) -> None:
+        """Install test recovery events through independently fenced chunks."""
+        for offset in range(0, len(events), _HYDRATION_TRANSACTION_EVENT_LIMIT):
+            assert await store.install_room_history_recovery_chunk(
+                recovery,
+                events=events[offset : offset + _HYDRATION_TRANSACTION_EVENT_LIMIT],
+                expected_membership_epoch=expected_membership_epoch,
+            )
+
     async def test_ordinary_hydration_projects_in_bounded_writes_then_publishes(
         self,
         journal_store: EventJournalStore,
@@ -1933,6 +1952,102 @@ class TestBoundedHydrationInstallation:
         ]
         assert await alice.conversation_is_hydrated(room_id=ROOM, thread_id=None)
 
+    async def test_recovery_chunk_claims_both_fences_before_projection(
+        self,
+        journal_store: EventJournalStore,
+    ) -> None:
+        """A recovery page must not enter a different gap or membership."""
+        alice = journal_store.principal("agent@alice")
+        recovery = await alice.record_room_history_recovery(ROOM)
+        assert recovery is not None
+        observed = _ObservedHydrationBackend(journal_store.backend)
+        recovering = EventJournalStore(backend=observed).principal("agent@alice")
+        events = hydration_messages(3)
+
+        installed = await recovering.install_room_history_recovery_chunk(
+            recovery,
+            events=events,
+            expected_membership_epoch=await recovering.membership_epoch(ROOM),
+        )
+
+        assert installed
+        assert observed.write_shapes == [
+            _HydrationWriteShape(
+                membership_claims=1,
+                recovery_claims=1,
+                projected_messages=len(events),
+            ),
+        ]
+        assert not await recovering.conversation_is_hydrated(room_id=ROOM, thread_id=None)
+        assert await recovering.room_history_recovery(ROOM) == recovery
+
+    async def test_recovery_chunk_refuses_a_superseded_exact_recovery(
+        self,
+        journal_store: EventJournalStore,
+    ) -> None:
+        """A later gap must fence every remaining page of an older walk."""
+        alice = journal_store.principal("agent@alice")
+        stale = await alice.record_room_history_recovery(ROOM)
+        current = await alice.record_room_history_recovery(ROOM)
+        assert stale is not None
+        assert current is not None
+        observed = _ObservedHydrationBackend(journal_store.backend)
+        recovering = EventJournalStore(backend=observed).principal("agent@alice")
+
+        installed = await recovering.install_room_history_recovery_chunk(
+            stale,
+            events=hydration_messages(3),
+            expected_membership_epoch=await recovering.membership_epoch(ROOM),
+        )
+
+        assert not installed
+        assert observed.write_shapes == [
+            _HydrationWriteShape(membership_claims=1, recovery_claims=1),
+        ]
+        assert await recovering.room_history_recovery(ROOM) == current
+        assert await bodies(recovering) == []
+
+    async def test_recovery_chunk_refuses_a_stale_membership_epoch(
+        self,
+        journal_store: EventJournalStore,
+    ) -> None:
+        """Membership invalidation must fence projection before recovery lookup."""
+        alice = journal_store.principal("agent@alice")
+        recovery = await alice.record_room_history_recovery(ROOM)
+        assert recovery is not None
+        stale_epoch = await alice.membership_epoch(ROOM)
+        await alice.fence_departure(ROOM, source=DepartureSource.LOCAL)
+        observed = _ObservedHydrationBackend(journal_store.backend)
+        recovering = EventJournalStore(backend=observed).principal("agent@alice")
+
+        installed = await recovering.install_room_history_recovery_chunk(
+            recovery,
+            events=hydration_messages(3),
+            expected_membership_epoch=stale_epoch,
+        )
+
+        assert not installed
+        assert observed.write_shapes == [_HydrationWriteShape(membership_claims=1)]
+        assert await bodies(recovering) == []
+
+    async def test_recovery_chunk_rejects_more_than_the_transaction_bound(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """Callers cannot turn the page API back into one unbounded write."""
+        recovery = await alice.record_room_history_recovery(ROOM)
+        assert recovery is not None
+
+        with pytest.raises(ValueError, match="at most 256"):
+            await alice.install_room_history_recovery_chunk(
+                recovery,
+                events=hydration_messages(_HYDRATION_TRANSACTION_EVENT_LIMIT + 1),
+                expected_membership_epoch=await alice.membership_epoch(ROOM),
+            )
+
+        assert await bodies(alice, limit=_HYDRATION_TRANSACTION_EVENT_LIMIT + 1) == []
+        assert await alice.room_history_recovery(ROOM) == recovery
+
     async def test_history_recovery_projects_in_bounded_writes_then_settles(
         self,
         journal_store: EventJournalStore,
@@ -1944,13 +2059,20 @@ class TestBoundedHydrationInstallation:
         events = hydration_messages(_EVENTS_SPANNING_TWO_HYDRATION_CHUNKS)
         observed = _ObservedHydrationBackend(journal_store.backend)
         recovering = EventJournalStore(backend=observed).principal("agent@alice")
+        epoch = await recovering.membership_epoch(ROOM)
+
+        await self._install_recovery_events(
+            recovering,
+            recovery,
+            events,
+            expected_membership_epoch=epoch,
+        )
 
         outcome = await recovering.settle_room_history_recovery(
             recovery,
-            events=events,
             exhausted_server=True,
             attempted_policy_rank=2,
-            expected_membership_epoch=await recovering.membership_epoch(ROOM),
+            expected_membership_epoch=epoch,
         )
 
         assert outcome is HistoryRecoveryOutcome.REPAIRED
@@ -1960,6 +2082,7 @@ class TestBoundedHydrationInstallation:
         assert final_shape.recovery_settlements == 1
         assert final_shape.projected_messages == 0
         assert final_shape.membership_claims == 1
+        assert final_shape.recovery_claims == 1
         assert await recovering.room_history_recovery(ROOM) is None
         assert await recovering.conversation_is_hydrated(room_id=ROOM, thread_id=None)
 
@@ -1980,14 +2103,14 @@ class TestBoundedHydrationInstallation:
 
         observed = _ObservedHydrationBackend(journal_store.backend, before_write=fail_second_write)
         recovering = EventJournalStore(backend=observed).principal("agent@alice")
+        epoch = await recovering.membership_epoch(ROOM)
 
         with pytest.raises(RuntimeError, match="injected failure"):
-            await recovering.settle_room_history_recovery(
+            await self._install_recovery_events(
+                recovering,
                 recovery,
-                events=events,
-                exhausted_server=True,
-                attempted_policy_rank=2,
-                expected_membership_epoch=await recovering.membership_epoch(ROOM),
+                events,
+                expected_membership_epoch=epoch,
             )
 
         assert observed.write_shapes[0].projected_messages == _HYDRATION_TRANSACTION_EVENT_LIMIT
@@ -1995,12 +2118,17 @@ class TestBoundedHydrationInstallation:
         assert await alice.conversation_hydration_coverage(room_id=ROOM, thread_id=None) is None
         assert await alice.room_history_recovery(ROOM) == recovery
 
+        await self._install_recovery_events(
+            alice,
+            recovery,
+            events,
+            expected_membership_epoch=epoch,
+        )
         outcome = await alice.settle_room_history_recovery(
             recovery,
-            events=events,
             exhausted_server=True,
             attempted_policy_rank=2,
-            expected_membership_epoch=await alice.membership_epoch(ROOM),
+            expected_membership_epoch=epoch,
         )
 
         assert outcome is HistoryRecoveryOutcome.REPAIRED
@@ -2021,7 +2149,6 @@ class TestBoundedHydrationInstallation:
 
         outcome = await recovering.settle_room_history_recovery(
             recovery,
-            events=(),
             exhausted_server=False,
             attempted_policy_rank=2,
             expected_membership_epoch=await recovering.membership_epoch(ROOM),
@@ -2029,7 +2156,7 @@ class TestBoundedHydrationInstallation:
 
         assert outcome is HistoryRecoveryOutcome.TRUNCATED
         assert observed.write_shapes == [
-            _HydrationWriteShape(membership_claims=1, hydration_markers=1),
+            _HydrationWriteShape(membership_claims=1, recovery_claims=1, hydration_markers=1),
         ]
 
     async def test_cancellation_after_a_chunk_leaves_ordinary_hydration_retryable(
@@ -2133,9 +2260,20 @@ class TestBoundedHydrationInstallation:
         recovering = EventJournalStore(backend=observed).principal("agent@alice")
         events = hydration_messages(_EVENTS_SPANNING_TWO_HYDRATION_CHUNKS)
 
+        installed = await recovering.install_room_history_recovery_chunk(
+            old_recovery,
+            events=events[:_HYDRATION_TRANSACTION_EVENT_LIMIT],
+            expected_membership_epoch=stale_epoch,
+        )
+        assert installed
+        refused = await recovering.install_room_history_recovery_chunk(
+            old_recovery,
+            events=events[_HYDRATION_TRANSACTION_EVENT_LIMIT:],
+            expected_membership_epoch=stale_epoch,
+        )
+        assert not refused
         outcome = await recovering.settle_room_history_recovery(
             old_recovery,
-            events=events,
             exhausted_server=True,
             attempted_policy_rank=2,
             expected_membership_epoch=stale_epoch,
@@ -2417,7 +2555,6 @@ class TestRecoveryFinalizesOnlyItsExactObligation:
         settlement = asyncio.create_task(
             recovering.settle_room_history_recovery(
                 old_recovery,
-                events=(),
                 exhausted_server=True,
                 attempted_policy_rank=2,
                 expected_membership_epoch=await reader.membership_epoch(ROOM),

--- a/tests/test_room_history_recovery.py
+++ b/tests/test_room_history_recovery.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar, Self
 
 import nio
 import pytest
@@ -18,9 +18,16 @@ from mindroom.event_journal import (
     ProjectedEvent,
     RoomHistoryRecovery,
 )
-from mindroom.matrix.conversation_hydration import ConversationHydrator, _HydrationError
+from mindroom.matrix import conversation_hydration
+from mindroom.matrix.conversation_hydration import (
+    _MESSAGES_PAGE_LIMIT,
+    ConversationHydrator,
+    _HydrationError,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from mindroom.event_journal import EventJournalStore, PrincipalStore
 
 pytestmark = pytest.mark.asyncio
@@ -56,6 +63,7 @@ def raw(
     *,
     ts: int,
     thread_id: str | None = None,
+    replaces: str | None = None,
 ) -> dict[str, Any]:
     """Build one raw Matrix message event."""
     content: dict[str, Any] = {"msgtype": "m.text", "body": body}
@@ -63,6 +71,15 @@ def raw(
         content["m.relates_to"] = {
             "rel_type": "m.thread",
             "event_id": thread_id,
+        }
+    if replaces is not None:
+        content["m.relates_to"] = {
+            "rel_type": "m.replace",
+            "event_id": replaces,
+        }
+        content["m.new_content"] = {
+            "msgtype": "m.text",
+            "body": body,
         }
     return {
         "event_id": event_id,
@@ -103,6 +120,131 @@ class PagedClient:
             return page
         sources, end = page
         return nio.RoomMessagesResponse(ROOM, [parse(source) for source in sources], "start", end)
+
+
+@dataclass
+class LazyEditedHistoryClient:
+    """Generate edit-heavy backwards history one bounded page at a time."""
+
+    total_events: int
+    before_page: Callable[[int], Awaitable[None]] | None = None
+    calls: int = 0
+    generated_events: int = 0
+    olm: object | None = None
+
+    @staticmethod
+    def _source(index: int) -> dict[str, Any]:
+        logical_index = index // 5
+        position = index % 5
+        original_event_id = f"$message-{logical_index}"
+        base_ts = 1_000_000 - logical_index * 10
+        if position == 4:
+            return raw(
+                original_event_id,
+                f"message {logical_index}",
+                ts=base_ts,
+            )
+        revision = 4 - position
+        return raw(
+            f"$edit-{logical_index}-{revision}",
+            f"message {logical_index} edit {revision}",
+            ts=base_ts + revision,
+            replaces=original_event_id,
+        )
+
+    async def room_messages(
+        self,
+        room_id: str,
+        start: str | None = None,
+        direction: object = None,
+        limit: int = 10,
+    ) -> nio.RoomMessagesResponse:
+        """Build only the page requested by the current recovery iteration."""
+        del room_id, start, direction
+        self.calls += 1
+        if self.before_page is not None:
+            await self.before_page(self.calls)
+        page_size = min(limit, self.total_events - self.generated_events)
+        first = self.generated_events
+        sources = [self._source(index) for index in range(first, first + page_size)]
+        self.generated_events += page_size
+        end = None if self.generated_events == self.total_events else f"page-{self.calls}"
+        return nio.RoomMessagesResponse(ROOM, [parse(source) for source in sources], "start", end)
+
+
+@dataclass
+class RecordingRecoveryStore:
+    """Record recovery API boundaries while delegating durable work."""
+
+    principal: PrincipalStore
+    fail_before_chunk: int | None = None
+    installed_batch_sizes: list[int] = field(default_factory=list)
+    settlements: int = 0
+
+    async def room_history_recovery(self, room_id: str) -> RoomHistoryRecovery | None:
+        """Delegate recovery lookup."""
+        return await self.principal.room_history_recovery(room_id)
+
+    async def membership_epoch(self, room_id: str) -> int:
+        """Delegate membership lookup."""
+        return await self.principal.membership_epoch(room_id)
+
+    async def install_room_history_recovery_chunk(
+        self,
+        recovery: RoomHistoryRecovery,
+        *,
+        events: tuple[ProjectedEvent, ...],
+        expected_membership_epoch: int,
+    ) -> bool:
+        """Record one bounded batch and optionally crash before installing it."""
+        next_chunk = len(self.installed_batch_sizes) + 1
+        if self.fail_before_chunk == next_chunk:
+            msg = "injected recovery installation crash"
+            raise RuntimeError(msg)
+        self.installed_batch_sizes.append(len(events))
+        return await self.principal.install_room_history_recovery_chunk(
+            recovery,
+            events=events,
+            expected_membership_epoch=expected_membership_epoch,
+        )
+
+    async def settle_room_history_recovery(
+        self,
+        recovery: RoomHistoryRecovery,
+        *,
+        exhausted_server: bool,
+        attempted_policy_rank: int,
+        expected_membership_epoch: int,
+    ) -> HistoryRecoveryOutcome:
+        """Record terminal settlement without accepting a recovered event tuple."""
+        self.settlements += 1
+        return await self.principal.settle_room_history_recovery(
+            recovery,
+            exhausted_server=exhausted_server,
+            attempted_policy_rank=attempted_policy_rank,
+            expected_membership_epoch=expected_membership_epoch,
+        )
+
+
+class CountingProjectedEvent(ProjectedEvent):
+    """Track how many projected recovery events remain live simultaneously."""
+
+    __slots__ = ()
+
+    live: ClassVar[int] = 0
+    peak: ClassVar[int] = 0
+
+    def __new__(cls, *args: object, **kwargs: object) -> Self:
+        """Count one projected event when the hydrator constructs it."""
+        del args, kwargs
+        instance = object.__new__(cls)
+        cls.live += 1
+        cls.peak = max(cls.peak, cls.live)
+        return instance
+
+    def __del__(self) -> None:
+        """Release the count when no page or accumulator retains this event."""
+        type(self).live -= 1
 
 
 def hydrator(
@@ -149,6 +291,179 @@ async def bodies(principal: PrincipalStore, thread_id: str | None = None) -> lis
     """Return the room's visible message bodies, oldest first."""
     page = await principal.read_conversation(room_id=ROOM, thread_id=thread_id, limit=50)
     return [str(message.content["body"]) for message in page.messages]
+
+
+async def visible_message_count(principal: PrincipalStore) -> int:
+    """Return the number of projected logical messages in the test room."""
+    row = await principal._backend.read(
+        lambda transaction: transaction.fetchone(
+            """
+            SELECT count(*) AS count FROM visible_messages
+            WHERE principal_id = ? AND room_id = ?
+            """,
+            (principal._principal_id, ROOM),
+        ),
+    )
+    assert row is not None
+    return int(row["count"])
+
+
+async def install_recovery_events(
+    principal: PrincipalStore,
+    recovery: RoomHistoryRecovery,
+    events: tuple[ProjectedEvent, ...],
+    *,
+    expected_membership_epoch: int | None = None,
+) -> bool:
+    """Install one test-sized recovery batch through both durable fences."""
+    epoch = (
+        await principal.membership_epoch(recovery.room_id)
+        if expected_membership_epoch is None
+        else expected_membership_epoch
+    )
+    return await principal.install_room_history_recovery_chunk(
+        recovery,
+        events=events,
+        expected_membership_epoch=epoch,
+    )
+
+
+async def test_repair_streams_twenty_thousand_edit_heavy_events_in_page_batches(
+    principal: PrincipalStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A maximum proof walk must never become one maximum-sized Python tuple."""
+    CountingProjectedEvent.live = 0
+    CountingProjectedEvent.peak = 0
+    monkeypatch.setattr(conversation_hydration, "ProjectedEvent", CountingProjectedEvent)
+    recovery = await principal.record_room_history_recovery(ROOM)
+    assert recovery is not None
+    client = LazyEditedHistoryClient(total_events=20_000)
+    recording = RecordingRecoveryStore(principal)
+    repair = ConversationHydrator(
+        store=recording,  # type: ignore[arg-type]
+        runtime=SimpleNamespace(client=client),  # type: ignore[arg-type]
+        self_sender=BOT,
+    )
+
+    outcome = await repair._repair(recovery)
+
+    assert outcome is HistoryRecoveryOutcome.REPAIRED
+    assert client.generated_events == 20_000
+    assert len(recording.installed_batch_sizes) == 200
+    assert max(recording.installed_batch_sizes) <= _MESSAGES_PAGE_LIMIT
+    assert CountingProjectedEvent.peak <= _MESSAGES_PAGE_LIMIT * 2
+    assert recording.settlements == 1
+    assert await visible_message_count(principal) == 4_000
+    page = await principal.read_conversation(room_id=ROOM, thread_id=None, limit=10)
+    assert all(str(message.content["body"]).endswith("edit 4") for message in page.messages)
+    assert await principal.room_history_recovery(ROOM) is None
+
+
+async def test_recovery_crash_keeps_obligation_open_and_retry_converges(
+    principal: PrincipalStore,
+) -> None:
+    """Committed recovery pages are safe to re-fetch after an interrupted walk."""
+    recovery = await principal.record_room_history_recovery(ROOM)
+    assert recovery is not None
+    crashing_store = RecordingRecoveryStore(principal, fail_before_chunk=4)
+    crashing_client = LazyEditedHistoryClient(total_events=500)
+    crashing_repair = ConversationHydrator(
+        store=crashing_store,  # type: ignore[arg-type]
+        runtime=SimpleNamespace(client=crashing_client),  # type: ignore[arg-type]
+        self_sender=BOT,
+    )
+
+    with pytest.raises(RuntimeError, match="injected recovery installation crash"):
+        await crashing_repair._repair(recovery)
+
+    assert crashing_store.installed_batch_sizes == [100, 100, 100]
+    assert crashing_store.settlements == 0
+    assert await principal.room_history_recovery(ROOM) == recovery
+    assert not await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
+    assert await visible_message_count(principal) == 60
+
+    retry_store = RecordingRecoveryStore(principal)
+    retry_client = LazyEditedHistoryClient(total_events=500)
+    retry = ConversationHydrator(
+        store=retry_store,  # type: ignore[arg-type]
+        runtime=SimpleNamespace(client=retry_client),  # type: ignore[arg-type]
+        self_sender=BOT,
+    )
+
+    outcome = await retry._repair(recovery)
+
+    assert outcome is HistoryRecoveryOutcome.REPAIRED
+    assert retry_store.installed_batch_sizes == [100, 100, 100, 100, 100]
+    assert retry_store.settlements == 1
+    assert await visible_message_count(principal) == 100
+    page = await principal.read_conversation(room_id=ROOM, thread_id=None, limit=100)
+    assert len(page.messages) == 100
+    assert all(str(message.content["body"]).endswith("edit 4") for message in page.messages)
+
+
+async def test_membership_epoch_change_stops_recovery_before_final_settlement(
+    principal: PrincipalStore,
+) -> None:
+    """A page fetched after departure cannot enter or publish the new membership."""
+
+    async def fence_before_second_page(page_number: int) -> None:
+        if page_number == 2:
+            await principal.fence_departure(ROOM, source=DepartureSource.LOCAL)
+
+    recovery = await principal.record_room_history_recovery(ROOM)
+    assert recovery is not None
+    client = LazyEditedHistoryClient(total_events=300, before_page=fence_before_second_page)
+    recording = RecordingRecoveryStore(principal)
+    repair = ConversationHydrator(
+        store=recording,  # type: ignore[arg-type]
+        runtime=SimpleNamespace(client=client),  # type: ignore[arg-type]
+        self_sender=BOT,
+    )
+
+    outcome = await repair._repair(recovery)
+
+    assert outcome is HistoryRecoveryOutcome.SUPERSEDED
+    assert client.calls == 2
+    assert recording.installed_batch_sizes == [100, 100]
+    assert recording.settlements == 0
+    assert await principal.room_history_recovery(ROOM) is None
+    assert await visible_message_count(principal) == 0
+    assert not await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
+
+
+async def test_new_recovery_revision_stops_stale_walk_before_final_settlement(
+    principal: PrincipalStore,
+) -> None:
+    """A later gap prevents an older walk from installing another page."""
+    newer: RoomHistoryRecovery | None = None
+
+    async def supersede_before_second_page(page_number: int) -> None:
+        nonlocal newer
+        if page_number == 2:
+            newer = await principal.record_room_history_recovery(ROOM)
+
+    recovery = await principal.record_room_history_recovery(ROOM)
+    assert recovery is not None
+    client = LazyEditedHistoryClient(total_events=300, before_page=supersede_before_second_page)
+    recording = RecordingRecoveryStore(principal)
+    repair = ConversationHydrator(
+        store=recording,  # type: ignore[arg-type]
+        runtime=SimpleNamespace(client=client),  # type: ignore[arg-type]
+        self_sender=BOT,
+    )
+
+    outcome = await repair._repair(recovery)
+
+    assert outcome is HistoryRecoveryOutcome.SUPERSEDED
+    assert client.calls == 2
+    assert recording.installed_batch_sizes == [100, 100]
+    assert recording.settlements == 0
+    assert newer is not None
+    assert newer.revision == recovery.revision + 1
+    assert await principal.room_history_recovery(ROOM) == newer
+    assert await visible_message_count(principal) == 20
+    assert not await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
 
 
 async def test_repair_ignores_a_post_gap_first_page_and_walks_to_server_exhaustion(
@@ -274,7 +589,7 @@ async def test_bad_event_at_server_exhaustion_stays_repairable(principal: Princi
 
 
 async def test_repair_pagination_error_leaves_the_obligation_repairable(principal: PrincipalStore) -> None:
-    """A failed history request must not install or terminally classify its partial answer."""
+    """A failed request may leave retry-safe pages but cannot publish them as whole."""
     client = PagedClient(
         pages=[
             ([raw("$partial", "partial", ts=2_000)], "next"),
@@ -287,7 +602,8 @@ async def test_repair_pagination_error_leaves_the_obligation_repairable(principa
         await hydrator(principal, client).ensure_hydrated(room_id=ROOM, thread_id=None)
 
     assert await principal.room_history_recovery(ROOM) == recovery
-    assert await bodies(principal) == []
+    assert await bodies(principal) == ["partial"]
+    assert not await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
 
 
 async def test_repair_repeated_token_leaves_the_obligation_repairable(principal: PrincipalStore) -> None:
@@ -455,7 +771,6 @@ async def test_recording_retracts_completeness_for_the_room_and_all_threads(
 
     outcome = await principal.settle_room_history_recovery(
         recovery,
-        events=(),
         exhausted_server=False,
         attempted_policy_rank=3,
         expected_membership_epoch=await principal.membership_epoch(ROOM),
@@ -477,9 +792,13 @@ async def test_truncated_obligation_leaves_bounded_context_readable_but_incomple
     """A spent recovery ceiling exposes context without certifying completeness."""
     await mark_complete(principal, None)
     recovery = await principal.record_room_history_recovery(ROOM)
+    assert await install_recovery_events(
+        principal,
+        recovery,
+        (projected("$new", "new", ts=2_000),),
+    )
     outcome = await principal.settle_room_history_recovery(
         recovery,
-        events=(projected("$new", "new", ts=2_000),),
         exhausted_server=False,
         attempted_policy_rank=3,
         expected_membership_epoch=await principal.membership_epoch(ROOM),
@@ -501,7 +820,6 @@ async def test_a_new_abandonment_resets_truncated_to_repairable(principal: Princ
     assert (
         await principal.settle_room_history_recovery(
             recovery,
-            events=(),
             exhausted_server=False,
             attempted_policy_rank=1,
             expected_membership_epoch=await principal.membership_epoch(ROOM),
@@ -525,10 +843,10 @@ async def test_settlement_publishes_only_after_paginated_events_and_repairs_obli
     """Only the final commit publishes coverage and clears the exact obligation."""
     recovery = await principal.record_room_history_recovery(ROOM)
     events = tuple(projected(f"${index}", str(index), ts=index) for index in range(1, 6))
+    assert await install_recovery_events(principal, recovery, events)
 
     outcome = await principal.settle_room_history_recovery(
         recovery,
-        events=events,
         exhausted_server=True,
         attempted_policy_rank=4,
         expected_membership_epoch=await principal.membership_epoch(ROOM),
@@ -558,13 +876,17 @@ async def test_successful_room_repair_restores_existing_thread_completeness(
     recovery = await principal.record_room_history_recovery(ROOM)
     assert recovery is not None
     assert not await principal.conversation_is_hydrated(room_id=ROOM, thread_id=thread_id)
-
-    outcome = await principal.settle_room_history_recovery(
+    assert await install_recovery_events(
+        principal,
         recovery,
-        events=(
+        (
             projected(thread_id, "root", ts=1),
             projected("$reply", "reply", ts=2, thread_id=thread_id),
         ),
+    )
+
+    outcome = await principal.settle_room_history_recovery(
+        recovery,
         exhausted_server=True,
         attempted_policy_rank=4,
         expected_membership_epoch=await principal.membership_epoch(ROOM),
@@ -580,13 +902,17 @@ async def test_successful_room_repair_restores_existing_thread_completeness(
 
 
 async def test_exact_object_mismatch_publishes_nothing(principal: PrincipalStore) -> None:
-    """An older walk may add facts but cannot publish over a newer abandonment."""
+    """An older walk can neither add facts nor publish over a newer abandonment."""
     stale = await principal.record_room_history_recovery(ROOM)
     current = await principal.record_room_history_recovery(ROOM)
+    assert not await install_recovery_events(
+        principal,
+        stale,
+        (projected("$stale", "stale", ts=1),),
+    )
 
     outcome = await principal.settle_room_history_recovery(
         stale,
-        events=(projected("$stale", "stale", ts=1),),
         exhausted_server=True,
         attempted_policy_rank=4,
         expected_membership_epoch=await principal.membership_epoch(ROOM),
@@ -594,10 +920,7 @@ async def test_exact_object_mismatch_publishes_nothing(principal: PrincipalStore
 
     assert outcome is HistoryRecoveryOutcome.SUPERSEDED
     assert await principal.room_history_recovery(ROOM) == current
-    assert [
-        message.content["body"]
-        for message in (await principal.read_conversation(room_id=ROOM, thread_id=None, limit=10)).messages
-    ] == ["stale"]
+    assert (await principal.read_conversation(room_id=ROOM, thread_id=None, limit=10)).messages == ()
     assert not await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
 
 
@@ -607,10 +930,14 @@ async def test_repeated_recovery_supersedes_an_in_flight_settlement(
     """A later identical abandonment cannot be discharged by an older walk."""
     old = await principal.record_room_history_recovery(ROOM)
     newer = await principal.record_room_history_recovery(ROOM)
+    assert not await install_recovery_events(
+        principal,
+        old,
+        (projected("$stale", "stale", ts=1),),
+    )
 
     outcome = await principal.settle_room_history_recovery(
         old,
-        events=(projected("$stale", "stale", ts=1),),
         exhausted_server=True,
         attempted_policy_rank=4,
         expected_membership_epoch=await principal.membership_epoch(ROOM),
@@ -619,10 +946,7 @@ async def test_repeated_recovery_supersedes_an_in_flight_settlement(
     assert outcome is HistoryRecoveryOutcome.SUPERSEDED
     assert newer.revision == old.revision + 1
     assert await principal.room_history_recovery(ROOM) == newer
-    assert [
-        message.content["body"]
-        for message in (await principal.read_conversation(room_id=ROOM, thread_id=None, limit=10)).messages
-    ] == ["stale"]
+    assert (await principal.read_conversation(room_id=ROOM, thread_id=None, limit=10)).messages == ()
     assert not await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
 
 
@@ -630,10 +954,14 @@ async def test_repaired_revision_is_not_reused_by_a_later_gap(principal: Princip
     """Deleting a repaired row must not let a stale walk consume a new gap."""
     first = await principal.record_room_history_recovery(ROOM)
     assert first is not None
+    assert await install_recovery_events(
+        principal,
+        first,
+        (projected("$first", "first", ts=1),),
+    )
     assert (
         await principal.settle_room_history_recovery(
             first,
-            events=(projected("$first", "first", ts=1),),
             exhausted_server=True,
             attempted_policy_rank=4,
             expected_membership_epoch=await principal.membership_epoch(ROOM),
@@ -642,10 +970,14 @@ async def test_repaired_revision_is_not_reused_by_a_later_gap(principal: Princip
     )
     current = await principal.record_room_history_recovery(ROOM)
     assert current is not None
+    assert not await install_recovery_events(
+        principal,
+        first,
+        (projected("$stale", "stale", ts=2),),
+    )
 
     stale_outcome = await principal.settle_room_history_recovery(
         first,
-        events=(projected("$stale", "stale", ts=2),),
         exhausted_server=True,
         attempted_policy_rank=4,
         expected_membership_epoch=await principal.membership_epoch(ROOM),
@@ -662,10 +994,15 @@ async def test_expected_membership_mismatch_installs_neither_events_nor_settleme
 ) -> None:
     """A recovery walk from the wrong membership cannot leave either of its effects."""
     recovery = await principal.record_room_history_recovery(ROOM)
+    assert not await install_recovery_events(
+        principal,
+        recovery,
+        (projected("$wrong-epoch", "wrong", ts=1),),
+        expected_membership_epoch=1,
+    )
 
     outcome = await principal.settle_room_history_recovery(
         recovery,
-        events=(projected("$wrong-epoch", "wrong", ts=1),),
         exhausted_server=True,
         attempted_policy_rank=4,
         expected_membership_epoch=1,

--- a/tests/test_room_history_recovery.py
+++ b/tests/test_room_history_recovery.py
@@ -103,6 +103,7 @@ class PagedClient:
 
     pages: list[tuple[list[dict[str, Any]], str | None] | nio.RoomMessagesError]
     calls: int = 0
+    requested_limits: list[int] = field(default_factory=list)
     olm: object | None = None
 
     async def room_messages(
@@ -113,7 +114,8 @@ class PagedClient:
         limit: int = 10,
     ) -> nio.RoomMessagesResponse | nio.RoomMessagesError:
         """Return the next configured page."""
-        del room_id, start, direction, limit
+        del room_id, start, direction
+        self.requested_limits.append(limit)
         page = self.pages[self.calls]
         self.calls += 1
         if isinstance(page, nio.RoomMessagesError):
@@ -667,6 +669,7 @@ async def test_repair_raw_event_ceiling_stops_inside_a_page(principal: Principal
     assert recovery is not None
     assert recovery.state is HistoryRecoveryState.TRUNCATED
     assert client.calls == 1
+    assert client.requested_limits == [1]
     assert await bodies(principal) == ["newest"]
     assert await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
     assert not await principal.conversation_is_complete(room_id=ROOM, thread_id=None)


### PR DESCRIPTION
## Summary

- stream room-history recovery pages directly into the event journal instead of retaining the complete walk
- fence every installed chunk by the exact recovery revision/state and membership epoch, then publish hydration only in the terminal settlement
- keep retries idempotent and preserve repaired, truncated, superseded, unreadable-history, and server-exhaustion behavior

## Testing

- `uv run pytest --no-cov` (13,382 passed, 123 skipped)
- focused hydration, recovery, and journal suites (545 tests)
- changed-file pre-commit hooks, including Ruff, ty, vulture, Tach boundaries, and module privacy
- live Matrix `recovery-cliff` profile (`PASS`)

## Summary by Sourcery

Stream room history recovery directly into the event journal in bounded, independently fenced chunks and finalize recovery only via a terminal settlement that respects recovery and membership epochs.

New Features:
- Add a chunked room history recovery installation API that projects bounded pages while fencing on both the recovery object and membership epoch.

Enhancements:
- Refine ConversationHydrator to stream recovery pages, track recovery outcomes explicitly, and separate page projection from terminal settlement.
- Enforce transaction-bounded recovery chunk sizes and add durable fence claims for recovery in the journal backend.
- Strengthen recovery and hydration behavior around superseded gaps, membership changes, unreadable history, and retry idempotence.

Tests:
- Extend recovery and hydration test suites to cover chunked installation, crash and retry semantics, membership-epoch fencing, superseded recoveries, and bounded projection limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Room-history recovery now installs bounded event chunks incrementally.
  * Large histories use paginated recovery to limit memory usage.
  * Recovery progress can be retried safely after interruptions or failures.
  * Recovery detects stale membership or superseded requests before applying changes.

* **Bug Fixes**
  * Successfully installed pages are preserved when later pagination fails.
  * Recovery prevents partial installation when validation checks are outdated.
  * Recovery now handles edited event histories more reliably during hydration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->