### PR TITLE
fix: release live approvals during startup cleanup

### DIFF
--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -540,6 +540,9 @@ class _ApprovalManager:
         None is neither: the row is finished with as far as this pass is
         concerned and retrying would reach the same answer, so counting it as
         owed would keep the sweep asking forever.
+
+        A recorded resolution always wins. Otherwise a matching live waiter
+        owns the expiration; only an ownerless card uses Matrix-only cleanup.
         """
         if self._send_is_in_flight(claimed.transaction_id):
             # A row whose send has not come back is indistinguishable, from
@@ -1090,7 +1093,7 @@ class _ApprovalManager:
         reason: str,
         resolved_by: str | None,
     ) -> bool:
-        """Expire a recovered card and return its decision to the live tool call."""
+        """Expire through the live waiter, returning whether its Matrix edit landed."""
         claimed_waiter = self._claim_live_resolution(waiter.card_event_id)
         if claimed_waiter is None:
             return False

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -583,6 +583,13 @@ class _ApprovalManager:
             return None
         if identified.card.resolution is not None:
             return await self._redeliver_recorded_resolution(pending, identified.card)
+        live_waiter = self._live_waiter_for_card(pending.card_event_id)
+        if live_waiter is not None:
+            return await self._discard_live_card(
+                waiter=live_waiter,
+                reason=_STARTUP_DISCARD_REASON,
+                resolved_by=transport_sender,
+            )
         result = await self._discard_matrix_only_card(
             pending=pending,
             transaction_id=identified.card.transaction_id,
@@ -1075,6 +1082,24 @@ class _ApprovalManager:
                 thread_id=pending.thread_id,
                 card_event_id=pending.card_event_id,
             )
+
+    async def _discard_live_card(
+        self,
+        *,
+        waiter: _LiveApprovalWaiter,
+        reason: str,
+        resolved_by: str | None,
+    ) -> bool:
+        """Expire a recovered card and return its decision to the live tool call."""
+        claimed_waiter = self._claim_live_resolution(waiter.card_event_id)
+        if claimed_waiter is None:
+            return False
+        decision = self._new_decision(status="expired", reason=reason, resolved_by=resolved_by)
+        with self._claimed_resolution(claimed_waiter.card_event_id):
+            delivered = await self._settle_waiter_with_terminal_edit(claimed_waiter, decision)
+            with self._live_lock:
+                self._resolved_card_event_ids.add(claimed_waiter.card_event_id)
+            return delivered
 
     async def _settle_waiter_with_terminal_edit(
         self,

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -1100,8 +1100,9 @@ class _ApprovalManager:
         decision = self._new_decision(status="expired", reason=reason, resolved_by=resolved_by)
         with self._claimed_resolution(claimed_waiter.card_event_id):
             delivered = await self._settle_waiter_with_terminal_edit(claimed_waiter, decision)
-            with self._live_lock:
-                self._resolved_card_event_ids.add(claimed_waiter.card_event_id)
+            if delivered:
+                with self._live_lock:
+                    self._resolved_card_event_ids.add(claimed_waiter.card_event_id)
             return delivered
 
     async def _settle_waiter_with_terminal_edit(

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2696,6 +2696,46 @@ async def test_the_sending_device_is_recorded_before_the_card_goes_out(tmp_path:
 
 
 @pytest.mark.asyncio
+async def test_startup_sweep_rejects_live_approval_and_releases_waiter(tmp_path: Path) -> None:
+    """Startup cleanup must return its rejection to a matching live tool call."""
+    cards = FakeApprovalCards()
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    editor = AsyncMock(return_value=True)
+    store = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        sender=sender,
+        editor=editor,
+        cards=cards,
+        approval_room_ids=lambda: {"!room:localhost"},
+        transport_sender=lambda: "@mindroom_router:localhost",
+        sending_device=lambda: CLAIMING_DEVICE_ID,
+        locate_card=AsyncMock(return_value=None),
+    )
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="send_email",
+            arguments={},
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+        ),
+    )
+
+    pending = await _wait_for_pending(store, sender=sender)
+
+    sweep = await store.discard_pending_on_startup()
+    decision = await asyncio.wait_for(task, timeout=1)
+
+    assert sweep == ApprovalStartupSweep(discarded=1, failed=0)
+    assert decision.status == "expired"
+    assert decision.reason == "Bot restarted before approval — original request was cancelled."
+    assert editor.await_args.args[:2] == ("!room:localhost", pending.card_event_id)
+    assert cards.rows == {}
+
+
+@pytest.mark.asyncio
 async def test_a_sweep_landing_inside_the_attempt_write_leaves_the_send_alone(tmp_path: Path) -> None:
     """The attempt is committed inside the registered send, never ahead of it.
 

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2736,6 +2736,46 @@ async def test_startup_sweep_rejects_live_approval_and_releases_waiter(tmp_path:
 
 
 @pytest.mark.asyncio
+async def test_startup_sweep_retries_live_approval_edit_that_did_not_land(tmp_path: Path) -> None:
+    """A durable live rejection must remain eligible for Matrix redelivery."""
+    cards = FakeApprovalCards()
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    editor = AsyncMock(side_effect=[False, True])
+    store = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        sender=sender,
+        editor=editor,
+        cards=cards,
+        approval_room_ids=lambda: {"!room:localhost"},
+        transport_sender=lambda: "@mindroom_router:localhost",
+        sending_device=lambda: CLAIMING_DEVICE_ID,
+        locate_card=AsyncMock(return_value=None),
+    )
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="send_email",
+            arguments={},
+            room_id="!room:localhost",
+            thread_id="$thread",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+        ),
+    )
+    await _wait_for_pending(store, sender=sender)
+
+    first_sweep = await store.discard_pending_on_startup()
+    decision = await asyncio.wait_for(task, timeout=1)
+    second_sweep = await store.discard_pending_on_startup()
+
+    assert first_sweep == ApprovalStartupSweep(discarded=0, failed=1)
+    assert decision.status == "expired"
+    assert second_sweep == ApprovalStartupSweep(discarded=1, failed=0)
+    assert editor.await_count == 2
+    assert cards.rows == {}
+
+
+@pytest.mark.asyncio
 async def test_a_sweep_landing_inside_the_attempt_write_leaves_the_send_alone(tmp_path: Path) -> None:
     """The attempt is committed inside the registered send, never ahead of it.
 


### PR DESCRIPTION
## Summary

- route startup rejection through a matching live approval waiter
- preserve recorded-resolution redelivery before rejecting pending cards
- add deterministic cleanup-to-waiter regression coverage

## Why

Startup cleanup intentionally expires orphaned approvals. When replayed work already had a live waiter for the recovered card, Matrix-only cleanup refused to resolve it and the waiter never received the terminal decision. The tool hook could then remain blocked until its long approval timeout.

## Tests

- `uv run pytest -q tests/test_tool_approval.py tests/test_tool_hooks.py`
- `uv run ruff check src/mindroom/approval_manager.py tests/test_tool_approval.py`
- `uv run ruff format --check src/mindroom/approval_manager.py tests/test_tool_approval.py`
- `uv run ty check src/mindroom/approval_manager.py tests/test_tool_approval.py`

## Summary by Sourcery

Ensure startup cleanup delivers expiry decisions to live tool approval waiters instead of silently discarding recovered cards.

Bug Fixes:
- Route startup discard of orphaned approvals through any matching live approval waiter so tool calls receive a terminal expired decision and unblock.

Enhancements:
- Add a dedicated helper for discarding live approvals and marking them as resolved when recovered during startup.

Tests:
- Add regression test covering startup sweep behavior when a live approval waiter exists for the recovered card, ensuring the waiter receives an expired decision and state is cleaned up.