### PR TITLE
fix: stop the startup sweep from deleting live approval claims

### DIFF
--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
-import time
 from collections import Counter, OrderedDict
 from collections.abc import Awaitable, Callable, Iterator
 from concurrent.futures import Future, InvalidStateError
@@ -277,7 +276,6 @@ class ApprovalStartupSweep:
     # because a caller comparing two sweeps is asking whether the same work
     # was settled, not whether the same rows happened to be on disk.
     scanned: int = field(default=0, compare=False)
-    skipped_after_start: int = field(default=0, compare=False)
     skipped_in_flight: int = field(default=0, compare=False)
     dropped_never_attempted: int = field(default=0, compare=False)
 
@@ -297,7 +295,6 @@ class _SweepTally:
     """
 
     scanned: int = 0
-    skipped_after_start: int = 0
     skipped_in_flight: int = 0
     dropped_never_attempted: int = 0
 
@@ -408,13 +405,6 @@ class _ApprovalManager:
         # over. Counted rather than flagged so overlapping scopes for one
         # transaction cannot have the inner one release the outer one's hold.
         self._claiming_transaction_ids: Counter[str] = Counter()
-        # Rows claimed from here on belong to this process, whether or not the
-        # send that owns one has registered itself yet. Taken at construction
-        # rather than at the sweep, because the sweep is armed by startup gates
-        # that can be minutes late, and every claim made while waiting for them
-        # would otherwise look like one a dead process left behind. Backstop
-        # for the ownership above, which is exact but cannot outlive memory.
-        self._sweep_horizon_ns = time.time_ns()
         # Recovery that outlived the request that started it, held so it is
         # not garbage collected mid-flight.
         self._detached_card_writes: set[_DetachedCardWrite] = set()
@@ -577,7 +567,6 @@ class _ApprovalManager:
             discarded=discarded,
             failed=failed,
             scanned=tally.scanned,
-            skipped_after_start=tally.skipped_after_start,
             skipped_in_flight=tally.skipped_in_flight,
             dropped_never_attempted=tally.dropped_never_attempted,
         )
@@ -619,26 +608,6 @@ class _ApprovalManager:
                 transaction_id=claimed.transaction_id,
             )
             tally.skipped_in_flight += 1
-            return None
-        if claimed.created_at_ns >= self._sweep_horizon_ns:
-            # Claimed after this process started, so it is this process's to
-            # finish. The check above cannot always see it: a claim is
-            # committed before the send that owns it registers, and a sweep
-            # landing in that window would read a live claim as an abandoned
-            # one and delete the row out from under the caller still building
-            # its card. The ownership registered around the claim closes that
-            # window exactly; this closes it again for a row whose owner is
-            # gone from memory but whose timestamp still says it was never
-            # this sweep's to take. Nothing is owed either way -- the owner
-            # settles it or fails on its own path.
-            logger.debug(
-                "approval_startup_card_skipped_claimed_after_start",
-                room_id=room_id,
-                transaction_id=claimed.transaction_id,
-                created_at_ns=claimed.created_at_ns,
-                sweep_horizon_ns=self._sweep_horizon_ns,
-            )
-            tally.skipped_after_start += 1
             return None
         identified = await self._identified_card(room_id, claimed, tally=tally)
         if identified.card is None:

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -277,7 +277,6 @@ class ApprovalStartupSweep:
     # was settled, not whether the same rows happened to be on disk.
     scanned: int = field(default=0, compare=False)
     skipped_in_flight: int = field(default=0, compare=False)
-    skipped_live_waiter: int = field(default=0, compare=False)
     dropped_never_attempted: int = field(default=0, compare=False)
 
     @property
@@ -297,7 +296,6 @@ class _SweepTally:
 
     scanned: int = 0
     skipped_in_flight: int = 0
-    skipped_live_waiter: int = 0
     dropped_never_attempted: int = 0
 
 
@@ -570,7 +568,6 @@ class _ApprovalManager:
             failed=failed,
             scanned=tally.scanned,
             skipped_in_flight=tally.skipped_in_flight,
-            skipped_live_waiter=tally.skipped_live_waiter,
             dropped_never_attempted=tally.dropped_never_attempted,
         )
 
@@ -634,25 +631,13 @@ class _ApprovalManager:
             return None
         if identified.card.resolution is not None:
             return await self._redeliver_recorded_resolution(pending, identified.card)
-        if self._live_waiter_for_card(pending.card_event_id) is not None:
-            # This process sent this card and is still waiting on the answer.
-            # A waiter only ever gets here one way -- ``_bind_live_waiter``,
-            # reached from a fresh send -- so a card with one is not a card a
-            # dead process left, it is live work of this one's. Expiring it
-            # tells a user their request was cancelled by a restart that did
-            # not happen, seconds after they were asked for a decision.
-            #
-            # Nothing is owed either: the waiter settles the card on a click,
-            # a denial, or its own timeout. Counting it would have every
-            # pending approval hold the sweep open until the human answers.
-            logger.debug(
-                "approval_startup_card_skipped_live_waiter",
-                room_id=room_id,
-                transaction_id=identified.card.transaction_id,
-                card_event_id=identified.card.card_event_id,
+        live_waiter = self._live_waiter_for_card(pending.card_event_id)
+        if live_waiter is not None:
+            return await self._discard_live_card(
+                waiter=live_waiter,
+                reason=_STARTUP_DISCARD_REASON,
+                resolved_by=transport_sender,
             )
-            tally.skipped_live_waiter += 1
-            return None
         result = await self._discard_matrix_only_card(
             pending=pending,
             transaction_id=identified.card.transaction_id,
@@ -1145,6 +1130,25 @@ class _ApprovalManager:
                 thread_id=pending.thread_id,
                 card_event_id=pending.card_event_id,
             )
+
+    async def _discard_live_card(
+        self,
+        *,
+        waiter: _LiveApprovalWaiter,
+        reason: str,
+        resolved_by: str | None,
+    ) -> bool:
+        """Expire through the live waiter, returning whether its Matrix edit landed."""
+        claimed_waiter = self._claim_live_resolution(waiter.card_event_id)
+        if claimed_waiter is None:
+            return False
+        decision = self._new_decision(status="expired", reason=reason, resolved_by=resolved_by)
+        with self._claimed_resolution(claimed_waiter.card_event_id):
+            delivered = await self._settle_waiter_with_terminal_edit(claimed_waiter, decision)
+            if delivered:
+                with self._live_lock:
+                    self._resolved_card_event_ids.add(claimed_waiter.card_event_id)
+            return delivered
 
     async def _settle_waiter_with_terminal_edit(
         self,

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -1887,12 +1887,21 @@ class _ApprovalManager:
         return self._runtime_storage_root == storage_root
 
     def has_live_work(self) -> bool:
-        """Return whether live approvals or cancelled-send cleanup are still active."""
+        """Return whether live approvals or cancelled-send cleanup are still active.
+
+        A request publishing a transaction counts, and so does a detached
+        write still finishing one. Both hold a durable row that only they can
+        settle, and a replacement manager taking over while either is in
+        flight leaves that row with no owner anywhere -- which is the same
+        state a sweep is entitled to act on.
+        """
         with self._live_lock:
             has_waiters = bool(self._pending_by_card_event or self._resolving_card_event_ids)
             has_active_sends = bool(self._active_approval_sends)
             has_cleanup_tasks = bool(self._post_cancel_cleanup_tasks)
-        return has_waiters or has_active_sends or has_cleanup_tasks
+            has_publishing = bool(self._claiming_transaction_ids)
+            has_detached_writes = bool(self._detached_card_writes)
+        return has_waiters or has_active_sends or has_cleanup_tasks or has_publishing or has_detached_writes
 
     def _send_is_in_flight(self, transaction_id: str) -> bool:
         """Return whether this row is still owned by a send that has not come back.

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -277,6 +277,7 @@ class ApprovalStartupSweep:
     # was settled, not whether the same rows happened to be on disk.
     scanned: int = field(default=0, compare=False)
     skipped_in_flight: int = field(default=0, compare=False)
+    skipped_live_waiter: int = field(default=0, compare=False)
     dropped_never_attempted: int = field(default=0, compare=False)
 
     @property
@@ -296,6 +297,7 @@ class _SweepTally:
 
     scanned: int = 0
     skipped_in_flight: int = 0
+    skipped_live_waiter: int = 0
     dropped_never_attempted: int = 0
 
 
@@ -568,6 +570,7 @@ class _ApprovalManager:
             failed=failed,
             scanned=tally.scanned,
             skipped_in_flight=tally.skipped_in_flight,
+            skipped_live_waiter=tally.skipped_live_waiter,
             dropped_never_attempted=tally.dropped_never_attempted,
         )
 
@@ -631,13 +634,25 @@ class _ApprovalManager:
             return None
         if identified.card.resolution is not None:
             return await self._redeliver_recorded_resolution(pending, identified.card)
-        live_waiter = self._live_waiter_for_card(pending.card_event_id)
-        if live_waiter is not None:
-            return await self._discard_live_card(
-                waiter=live_waiter,
-                reason=_STARTUP_DISCARD_REASON,
-                resolved_by=transport_sender,
+        if self._live_waiter_for_card(pending.card_event_id) is not None:
+            # This process sent this card and is still waiting on the answer.
+            # A waiter only ever gets here one way -- ``_bind_live_waiter``,
+            # reached from a fresh send -- so a card with one is not a card a
+            # dead process left, it is live work of this one's. Expiring it
+            # tells a user their request was cancelled by a restart that did
+            # not happen, seconds after they were asked for a decision.
+            #
+            # Nothing is owed either: the waiter settles the card on a click,
+            # a denial, or its own timeout. Counting it would have every
+            # pending approval hold the sweep open until the human answers.
+            logger.debug(
+                "approval_startup_card_skipped_live_waiter",
+                room_id=room_id,
+                transaction_id=identified.card.transaction_id,
+                card_event_id=identified.card.card_event_id,
             )
+            tally.skipped_live_waiter += 1
+            return None
         result = await self._discard_matrix_only_card(
             pending=pending,
             transaction_id=identified.card.transaction_id,
@@ -1130,25 +1145,6 @@ class _ApprovalManager:
                 thread_id=pending.thread_id,
                 card_event_id=pending.card_event_id,
             )
-
-    async def _discard_live_card(
-        self,
-        *,
-        waiter: _LiveApprovalWaiter,
-        reason: str,
-        resolved_by: str | None,
-    ) -> bool:
-        """Expire through the live waiter, returning whether its Matrix edit landed."""
-        claimed_waiter = self._claim_live_resolution(waiter.card_event_id)
-        if claimed_waiter is None:
-            return False
-        decision = self._new_decision(status="expired", reason=reason, resolved_by=resolved_by)
-        with self._claimed_resolution(claimed_waiter.card_event_id):
-            delivered = await self._settle_waiter_with_terminal_edit(claimed_waiter, decision)
-            if delivered:
-                with self._live_lock:
-                    self._resolved_card_event_ids.add(claimed_waiter.card_event_id)
-            return delivered
 
     async def _settle_waiter_with_terminal_edit(
         self,

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import time
 from collections import OrderedDict
 from collections.abc import Awaitable, Callable, Iterator
 from concurrent.futures import Future, InvalidStateError
@@ -379,6 +380,12 @@ class _ApprovalManager:
         self._cancelled_card_event_ids = _BoundedCardEventIds(_MAX_REMEMBERED_TERMINAL_CARD_IDS)
         self._active_approval_sends: set[_ActiveApprovalSend] = set()
         self._post_cancel_cleanup_tasks: set[_PostCancelCleanupTask] = set()
+        # Rows claimed from here on belong to this process, whether or not the
+        # send that owns one has registered itself yet. Taken at construction
+        # rather than at the sweep, because the sweep is armed by startup gates
+        # that can be minutes late, and every claim made while waiting for them
+        # would otherwise look like one a dead process left behind.
+        self._sweep_horizon_ns = time.time_ns()
         # Recovery that outlived the request that started it, held so it is
         # not garbage collected mid-flight.
         self._detached_card_writes: set[_DetachedCardWrite] = set()
@@ -541,6 +548,20 @@ class _ApprovalManager:
         concerned and retrying would reach the same answer, so counting it as
         owed would keep the sweep asking forever.
         """
+        if claimed.created_at_ns >= self._sweep_horizon_ns:
+            # Claimed after this process started, so it is this process's to
+            # finish. The in-flight check below cannot see it yet: a claim is
+            # committed before the send it belongs to registers, and a sweep
+            # landing in that window would read a live claim as an abandoned
+            # one and delete the row out from under the caller still building
+            # its card. Nothing is owed here -- the owner settles it or fails
+            # on its own path -- so this is not counted as a failure either.
+            logger.debug(
+                "approval_startup_card_skipped_claimed_after_start",
+                room_id=room_id,
+                transaction_id=claimed.transaction_id,
+            )
+            return None
         if self._send_is_in_flight(claimed.transaction_id):
             # A row whose send has not come back is indistinguishable, from
             # here, from one a dead process abandoned: claimed, no event id,

--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -6,11 +6,11 @@ import asyncio
 import json
 import threading
 import time
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 from collections.abc import Awaitable, Callable, Iterator
 from concurrent.futures import Future, InvalidStateError
 from contextlib import contextmanager, suppress
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal, cast
@@ -272,11 +272,34 @@ class ApprovalStartupSweep:
 
     discarded: int
     failed: int
+    # What the pass looked at and why it left things alone. Excluded from
+    # equality because they describe the walk rather than its outcome, and
+    # because a caller comparing two sweeps is asking whether the same work
+    # was settled, not whether the same rows happened to be on disk.
+    scanned: int = field(default=0, compare=False)
+    skipped_after_start: int = field(default=0, compare=False)
+    skipped_in_flight: int = field(default=0, compare=False)
+    dropped_never_attempted: int = field(default=0, compare=False)
 
     @property
     def complete(self) -> bool:
         """Return whether nothing is left for a later sweep to retry."""
         return self.failed == 0
+
+
+@dataclass(slots=True)
+class _SweepTally:
+    """Running counts for one sweep, so a finished pass can describe itself.
+
+    A pass that settled nothing because there was nothing to settle and one
+    that settled nothing because it skipped everything are the same two
+    numbers otherwise, and only one of them means the guard is doing its job.
+    """
+
+    scanned: int = 0
+    skipped_after_start: int = 0
+    skipped_in_flight: int = 0
+    dropped_never_attempted: int = 0
 
 
 @dataclass(frozen=True, slots=True)
@@ -380,11 +403,17 @@ class _ApprovalManager:
         self._cancelled_card_event_ids = _BoundedCardEventIds(_MAX_REMEMBERED_TERMINAL_CARD_IDS)
         self._active_approval_sends: set[_ActiveApprovalSend] = set()
         self._post_cancel_cleanup_tasks: set[_PostCancelCleanupTask] = set()
+        # Transactions a request is publishing, held from before the claim is
+        # written until the send that owns it has registered or the attempt is
+        # over. Counted rather than flagged so overlapping scopes for one
+        # transaction cannot have the inner one release the outer one's hold.
+        self._claiming_transaction_ids: Counter[str] = Counter()
         # Rows claimed from here on belong to this process, whether or not the
         # send that owns one has registered itself yet. Taken at construction
         # rather than at the sweep, because the sweep is armed by startup gates
         # that can be minutes late, and every claim made while waiting for them
-        # would otherwise look like one a dead process left behind.
+        # would otherwise look like one a dead process left behind. Backstop
+        # for the ownership above, which is exact but cannot outlive memory.
         self._sweep_horizon_ns = time.time_ns()
         # Recovery that outlived the request that started it, held so it is
         # not garbage collected mid-flight.
@@ -443,36 +472,44 @@ class _ApprovalManager:
 
         transaction_id = _approval_transaction_id(approval_id)
         claimed_card = self._claimed_card_body(content=content, requested_at=requested_at)
-        # Before the send, so the window a crash can land in holds a row for a
-        # card that may not exist rather than a card that no row explains. The
-        # first is settled by presenting the transaction again; the second used
-        # to be settled by nothing at all.
-        if not await self._claim_card(room_id=room_id, transaction_id=transaction_id, card=claimed_card):
-            return self._new_decision(status="expired", reason=_DEFAULT_UNRECORDABLE_CARD_REASON, resolved_by=None)
+        # Owned before the claim is written, because the write is what makes
+        # the row visible to a sweep and the send that would speak for it does
+        # not exist yet.
+        with self._publishing(transaction_id):
+            # Claimed before the send, so the window a crash can land in holds
+            # a row for a card that may not exist rather than a card that no
+            # row explains. The first is settled by presenting the transaction
+            # again; the second used to be settled by nothing at all.
+            if not await self._claim_card(room_id=room_id, transaction_id=transaction_id, card=claimed_card):
+                return self._new_decision(
+                    status="expired",
+                    reason=_DEFAULT_UNRECORDABLE_CARD_REASON,
+                    resolved_by=None,
+                )
 
-        try:
-            waiter = await self._send_and_bind_waiter(
-                room_id=room_id,
-                thread_id=thread_id,
-                content=content,
-                claimed_card=claimed_card,
-                transaction_id=transaction_id,
-                approval_id=approval_id,
-            )
-        except ToolApprovalTransportError as exc:
-            # Raised by the transport's own preconditions, so the card never
-            # reached the homeserver and the claim can be taken back.
-            await self._forget_card(transaction_id)
-            logger.info("Approval card could not be made answerable", room_id=room_id, reason=exc.reason)
-            return self._new_decision(status="expired", reason=exc.reason, resolved_by=None)
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            # Deliberately keeps the claim. An exception out of the send says
-            # the outcome is unknown, not that nothing was sent, and abandoning
-            # the row would strand whatever did reach the room.
-            logger.warning("Failed to send approval Matrix event", room_id=room_id, exc_info=True)
-            return self._new_decision(status="expired", reason=_DEFAULT_SEND_FAILURE_REASON, resolved_by=None)
+            try:
+                waiter = await self._send_and_bind_waiter(
+                    room_id=room_id,
+                    thread_id=thread_id,
+                    content=content,
+                    claimed_card=claimed_card,
+                    transaction_id=transaction_id,
+                    approval_id=approval_id,
+                )
+            except ToolApprovalTransportError as exc:
+                # Raised by the transport's own preconditions, so the card
+                # never reached the homeserver and the claim can be taken back.
+                await self._forget_card(transaction_id)
+                logger.info("Approval card could not be made answerable", room_id=room_id, reason=exc.reason)
+                return self._new_decision(status="expired", reason=exc.reason, resolved_by=None)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                # Deliberately keeps the claim. An exception out of the send
+                # says the outcome is unknown, not that nothing was sent, and
+                # abandoning the row would strand whatever did reach the room.
+                logger.warning("Failed to send approval Matrix event", room_id=room_id, exc_info=True)
+                return self._new_decision(status="expired", reason=_DEFAULT_SEND_FAILURE_REASON, resolved_by=None)
 
         if waiter is None:
             shutdown_reason = self._current_shutdown_reason()
@@ -510,6 +547,7 @@ class _ApprovalManager:
 
         discarded = 0
         failed = 0
+        tally = _SweepTally()
         for room_id in self._configured_approval_room_ids():
             # A card whose settlement failed keeps its row deliberately, so it
             # stays inside the scan's window. Skipping it in memory is not
@@ -522,10 +560,12 @@ class _ApprovalManager:
                     break
                 cursor = (page[-1].created_at_ns, page[-1].transaction_id)
                 for claimed in page:
+                    tally.scanned += 1
                     settled = await self._settle_recovered_card(
                         room_id=room_id,
                         claimed=claimed,
                         transport_sender=transport_sender,
+                        tally=tally,
                     )
                     if settled is None:
                         continue
@@ -533,7 +573,14 @@ class _ApprovalManager:
                         discarded += 1
                     else:
                         failed += 1
-        return ApprovalStartupSweep(discarded=discarded, failed=failed)
+        return ApprovalStartupSweep(
+            discarded=discarded,
+            failed=failed,
+            scanned=tally.scanned,
+            skipped_after_start=tally.skipped_after_start,
+            skipped_in_flight=tally.skipped_in_flight,
+            dropped_never_attempted=tally.dropped_never_attempted,
+        )
 
     async def _settle_recovered_card(
         self,
@@ -541,6 +588,7 @@ class _ApprovalManager:
         room_id: str,
         claimed: StoredApprovalCard,
         transport_sender: str,
+        tally: _SweepTally,
     ) -> bool | None:
         """Settle one recovered card, or report that a later pass should try again.
 
@@ -548,20 +596,6 @@ class _ApprovalManager:
         concerned and retrying would reach the same answer, so counting it as
         owed would keep the sweep asking forever.
         """
-        if claimed.created_at_ns >= self._sweep_horizon_ns:
-            # Claimed after this process started, so it is this process's to
-            # finish. The in-flight check below cannot see it yet: a claim is
-            # committed before the send it belongs to registers, and a sweep
-            # landing in that window would read a live claim as an abandoned
-            # one and delete the row out from under the caller still building
-            # its card. Nothing is owed here -- the owner settles it or fails
-            # on its own path -- so this is not counted as a failure either.
-            logger.debug(
-                "approval_startup_card_skipped_claimed_after_start",
-                room_id=room_id,
-                transaction_id=claimed.transaction_id,
-            )
-            return None
         if self._send_is_in_flight(claimed.transaction_id):
             # A row whose send has not come back is indistinguishable, from
             # here, from one a dead process abandoned: claimed, no event id,
@@ -581,8 +615,29 @@ class _ApprovalManager:
                 room_id=room_id,
                 transaction_id=claimed.transaction_id,
             )
+            tally.skipped_in_flight += 1
             return None
-        identified = await self._identified_card(room_id, claimed)
+        if claimed.created_at_ns >= self._sweep_horizon_ns:
+            # Claimed after this process started, so it is this process's to
+            # finish. The check above cannot always see it: a claim is
+            # committed before the send that owns it registers, and a sweep
+            # landing in that window would read a live claim as an abandoned
+            # one and delete the row out from under the caller still building
+            # its card. The ownership registered around the claim closes that
+            # window exactly; this closes it again for a row whose owner is
+            # gone from memory but whose timestamp still says it was never
+            # this sweep's to take. Nothing is owed either way -- the owner
+            # settles it or fails on its own path.
+            logger.debug(
+                "approval_startup_card_skipped_claimed_after_start",
+                room_id=room_id,
+                transaction_id=claimed.transaction_id,
+                created_at_ns=claimed.created_at_ns,
+                sweep_horizon_ns=self._sweep_horizon_ns,
+            )
+            tally.skipped_after_start += 1
+            return None
+        identified = await self._identified_card(room_id, claimed, tally=tally)
         if identified.card is None:
             return None if identified.settled else False
         pending = self._trusted_pending_from_card_event(
@@ -1452,7 +1507,13 @@ class _ApprovalManager:
             return False
         return stored.sending_device_id == current
 
-    async def _identified_card(self, room_id: str, stored: StoredApprovalCard) -> _IdentifiedCard:
+    async def _identified_card(
+        self,
+        room_id: str,
+        stored: StoredApprovalCard,
+        *,
+        tally: _SweepTally,
+    ) -> _IdentifiedCard:
         """Establish which Matrix event one claimed card became, by whichever means is sound.
 
         A row with no event id is the crash window claiming turns from
@@ -1495,6 +1556,7 @@ class _ApprovalManager:
                 room_id=room_id,
                 transaction_id=stored.transaction_id,
             )
+            tally.dropped_never_attempted += 1
             await self._forget_card(stored.transaction_id)
             return _IdentifiedCard(card=None, settled=True)
         if not self._repeat_would_deduplicate(stored):
@@ -1837,18 +1899,43 @@ class _ApprovalManager:
     def _send_is_in_flight(self, transaction_id: str) -> bool:
         """Return whether this row is still owned by a send that has not come back.
 
-        Both owners count, because both end the same way: whoever holds the
-        send binds a waiter to what it returns and settles the card exactly
-        once. A cancelled requester changes which owner that is -- the send is
-        shielded and outlives the request -- and nothing else about the row.
-        Answering on the request alone would call a handed-over send finished
-        and let the sweep present its transaction a second time. This is the
-        same pair ``has_live_work`` already counts as live.
+        All three owners count, because they end the same way: whoever holds
+        the transaction settles the card exactly once. A cancelled requester
+        changes which owner that is -- the send is shielded and outlives the
+        request -- and nothing else about the row. Answering on the request
+        alone would call a handed-over send finished and let the sweep present
+        its transaction a second time.
+
+        The publishing hold is the one that covers the claim itself. A row is
+        committed before the send that owns it exists, so between those two
+        points the other two are empty and the row reads exactly like one a
+        dead process abandoned.
         """
         with self._live_lock:
-            return any(send.transaction_id == transaction_id for send in self._active_approval_sends) or any(
-                cleanup.transaction_id == transaction_id for cleanup in self._post_cancel_cleanup_tasks
+            return (
+                self._claiming_transaction_ids[transaction_id] > 0
+                or any(send.transaction_id == transaction_id for send in self._active_approval_sends)
+                or any(cleanup.transaction_id == transaction_id for cleanup in self._post_cancel_cleanup_tasks)
             )
+
+    @contextmanager
+    def _publishing(self, transaction_id: str) -> Iterator[None]:
+        """Own one transaction for as long as this request is publishing it.
+
+        Entered before the claim is written rather than after, because the
+        write is what makes the row visible and a sweep reads it the moment it
+        exists. Released once the send has registered its own hold or the
+        attempt has ended, whichever comes first.
+        """
+        with self._live_lock:
+            self._claiming_transaction_ids[transaction_id] += 1
+        try:
+            yield
+        finally:
+            with self._live_lock:
+                self._claiming_transaction_ids[transaction_id] -= 1
+                if self._claiming_transaction_ids[transaction_id] <= 0:
+                    del self._claiming_transaction_ids[transaction_id]
 
     def _live_waiter_for_card(self, card_event_id: str) -> _LiveApprovalWaiter | None:
         with self._live_lock:

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -44,13 +44,14 @@ _TApprovalTransportResult = TypeVar("_TApprovalTransportResult")
 # failure would leave answered cards clickable until the next restart.
 _STARTUP_CLEANUP_INITIAL_RETRY_SECONDS = 1.0
 _STARTUP_CLEANUP_MAX_RETRY_SECONDS = 30.0
-# How many times a sweep may come up short before it stops asking. A card that
-# survives this many passes is not waiting on anything transient, and a sweep
-# that keeps retrying it runs forever: it re-reads every room on a timer for
-# the rest of the process's life, and each pass is another chance to mistake
-# work in progress for wreckage. Giving up loudly leaves the owed rows for the
-# next restart, which is where they came from.
-_STARTUP_CLEANUP_MAX_ATTEMPTS = 10
+# How many passes may come up short before the sweep stops saying so quietly.
+# It keeps retrying past this: a pass cannot take a row that is still being
+# published, so the cost of asking again is a read, while the cost of stopping
+# is durable cleanup that no longer happens until the next restart -- and an
+# outage that outlasts any fixed budget is exactly when cleanup is owed most.
+# What changes is the volume, because a sweep still owed something this long
+# after start is not waiting on anything transient.
+_STARTUP_CLEANUP_ATTEMPTS_BEFORE_ESCALATION = 10
 
 
 class _ApprovalTransportBot(Protocol):
@@ -516,14 +517,6 @@ class ApprovalMatrixTransport:
                 return
             self._startup_cleanup_attempts += 1
             if not await self._discard_orphaned_approval_cards_on_startup():
-                if self._startup_cleanup_attempts >= _STARTUP_CLEANUP_MAX_ATTEMPTS:
-                    logger.warning(
-                        "approval_startup_sweep_abandoned",
-                        attempts=self._startup_cleanup_attempts,
-                    )
-                    self._startup_cleanup_done = True
-                    self._retire_startup_cleanup_retry()
-                    return
                 self._schedule_startup_cleanup_retry()
                 return
             self._startup_cleanup_done = True
@@ -534,12 +527,37 @@ class ApprovalMatrixTransport:
         try:
             sweep = await expire_orphaned_approval_cards_on_startup()
         except Exception as exc:
-            logger.warning("tool_approval_startup_discard_failed", error=str(exc))
+            logger.warning(
+                "tool_approval_startup_discard_failed",
+                error=str(exc),
+                attempt=self._startup_cleanup_attempts,
+                exc_info=True,
+            )
             return False
-        if sweep.discarded > 0:
-            logger.info("approval.startup_discard", discarded_count=sweep.discarded)
+        # Said unconditionally, because the healthy outcome of the guards this
+        # sweep runs under is a pass that settles nothing, and a pass that
+        # settled nothing has to be distinguishable from one that never ran.
+        logger.info(
+            "approval_startup_sweep_finished",
+            attempt=self._startup_cleanup_attempts,
+            scanned=sweep.scanned,
+            discarded=sweep.discarded,
+            owed_count=sweep.failed,
+            skipped_after_start=sweep.skipped_after_start,
+            skipped_in_flight=sweep.skipped_in_flight,
+            dropped_never_attempted=sweep.dropped_never_attempted,
+        )
         if not sweep.complete:
-            logger.warning("tool_approval_startup_discard_incomplete", owed_count=sweep.failed)
+            incomplete = (
+                logger.error
+                if self._startup_cleanup_attempts >= _STARTUP_CLEANUP_ATTEMPTS_BEFORE_ESCALATION
+                else logger.warning
+            )
+            incomplete(
+                "tool_approval_startup_discard_incomplete",
+                owed_count=sweep.failed,
+                attempt=self._startup_cleanup_attempts,
+            )
         return sweep.complete
 
     def _schedule_startup_cleanup_retry(self) -> None:

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -44,6 +44,13 @@ _TApprovalTransportResult = TypeVar("_TApprovalTransportResult")
 # failure would leave answered cards clickable until the next restart.
 _STARTUP_CLEANUP_INITIAL_RETRY_SECONDS = 1.0
 _STARTUP_CLEANUP_MAX_RETRY_SECONDS = 30.0
+# How many times a sweep may come up short before it stops asking. A card that
+# survives this many passes is not waiting on anything transient, and a sweep
+# that keeps retrying it runs forever: it re-reads every room on a timer for
+# the rest of the process's life, and each pass is another chance to mistake
+# work in progress for wreckage. Giving up loudly leaves the owed rows for the
+# next restart, which is where they came from.
+_STARTUP_CLEANUP_MAX_ATTEMPTS = 10
 
 
 class _ApprovalTransportBot(Protocol):
@@ -134,6 +141,7 @@ class ApprovalMatrixTransport:
         init=False,
         repr=False,
     )
+    _startup_cleanup_attempts: int = field(default=0, init=False, repr=False)
 
     def capture_runtime_loop(self) -> None:
         """Remember the runtime loop that owns Matrix client I/O."""
@@ -452,6 +460,7 @@ class ApprovalMatrixTransport:
         self._startup_runtime_support_ready_for_cleanup = False
         self._startup_cleanup_done = False
         self._startup_cleanup_retry_delay = _STARTUP_CLEANUP_INITIAL_RETRY_SECONDS
+        self._startup_cleanup_attempts = 0
         retry = self._startup_cleanup_retry
         self._startup_cleanup_retry = None
         if retry is not None:
@@ -505,7 +514,16 @@ class ApprovalMatrixTransport:
                 or not self._startup_runtime_support_ready_for_cleanup
             ):
                 return
+            self._startup_cleanup_attempts += 1
             if not await self._discard_orphaned_approval_cards_on_startup():
+                if self._startup_cleanup_attempts >= _STARTUP_CLEANUP_MAX_ATTEMPTS:
+                    logger.warning(
+                        "approval_startup_sweep_abandoned",
+                        attempts=self._startup_cleanup_attempts,
+                    )
+                    self._startup_cleanup_done = True
+                    self._retire_startup_cleanup_retry()
+                    return
                 self._schedule_startup_cleanup_retry()
                 return
             self._startup_cleanup_done = True

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -543,7 +543,6 @@ class ApprovalMatrixTransport:
             scanned=sweep.scanned,
             discarded=sweep.discarded,
             owed_count=sweep.failed,
-            skipped_after_start=sweep.skipped_after_start,
             skipped_in_flight=sweep.skipped_in_flight,
             dropped_never_attempted=sweep.dropped_never_attempted,
         )

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -544,7 +544,6 @@ class ApprovalMatrixTransport:
             discarded=sweep.discarded,
             owed_count=sweep.failed,
             skipped_in_flight=sweep.skipped_in_flight,
-            skipped_live_waiter=sweep.skipped_live_waiter,
             dropped_never_attempted=sweep.dropped_never_attempted,
         )
         if not sweep.complete:

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -544,6 +544,7 @@ class ApprovalMatrixTransport:
             discarded=sweep.discarded,
             owed_count=sweep.failed,
             skipped_in_flight=sweep.skipped_in_flight,
+            skipped_live_waiter=sweep.skipped_live_waiter,
             dropped_never_attempted=sweep.dropped_never_attempted,
         )
         if not sweep.complete:

--- a/tests/approval_test_support.py
+++ b/tests/approval_test_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -70,9 +71,18 @@ class FakeApprovalCards:
         self.claimed: list[str] = []
         self.attempted: list[tuple[str, str | None]] = []
         self.acknowledged: list[tuple[str, str]] = []
-        # Stands in for the claim timestamp the real table records, which is
-        # what orders the room scan and what a page cursor is built from.
-        self._claims = 0
+        # The claim timestamp the real table records, which is what orders the
+        # room scan, what a page cursor is built from, and what tells a sweep
+        # whether a row predates the process running it. A counter would order
+        # the scan just as well but would put every claim before any process
+        # start, so a double using one could not fail the way the real store
+        # can. Kept strictly increasing because two claims can land inside one
+        # clock tick and a cursor needs the pair to be unique.
+        self._last_claim_ns = 0
+        # Seeded rows are written through the same claim path but stand for
+        # work a previous process left behind, so they are stamped before any
+        # clock a live manager could have read at construction.
+        self._seeded_rows = 0
 
     @property
     def resolutions(self) -> dict[str, dict[str, Any]]:
@@ -105,11 +115,11 @@ class FakeApprovalCards:
         if transaction_id in self.rows:
             return
         self.claimed.append(transaction_id)
-        self._claims += 1
+        self._last_claim_ns = max(self._last_claim_ns + 1, time.time_ns())
         self.rows[transaction_id] = _StoredRow(
             room_id=room_id,
             card=dict(card),
-            created_at_ns=self._claims,
+            created_at_ns=self._last_claim_ns,
         )
 
     async def mark_approval_card_attempted(
@@ -194,6 +204,7 @@ class FakeApprovalCards:
         """Seed one card as if a previous process had sent it and recorded the event."""
         transaction_id = transaction_id_for(card_event_id)
         await self.claim_approval_card(room_id=room_id, transaction_id=transaction_id, card=card)
+        self._backdate_to_previous_process(transaction_id)
         await self.mark_approval_card_attempted(
             transaction_id=transaction_id,
             sending_device_id=CLAIMING_DEVICE_ID,
@@ -226,11 +237,25 @@ class FakeApprovalCards:
             transaction_id=transaction_id,
             card=card,
         )
+        self._backdate_to_previous_process(transaction_id)
         if attempted:
             await self.mark_approval_card_attempted(
                 transaction_id=transaction_id,
                 sending_device_id=sending_device_id,
             )
+
+    def _backdate_to_previous_process(self, transaction_id: str) -> None:
+        """Stamp one seeded row as older than any live manager's start.
+
+        Seeds go in through the claim path, which timestamps a row as written
+        now. A recovery test needs the opposite: a row a dead process left, so
+        that a sweep is entitled to settle it.
+        """
+        row = self.rows.get(transaction_id)
+        if row is None:
+            return
+        self._seeded_rows += 1
+        row.created_at_ns = self._seeded_rows
 
 
 def transaction_id_for(card_event_id: str) -> str:

--- a/tests/approval_test_support.py
+++ b/tests/approval_test_support.py
@@ -83,6 +83,9 @@ class FakeApprovalCards:
         # work a previous process left behind, so they are stamped before any
         # clock a live manager could have read at construction.
         self._seeded_rows = 0
+        # Set by a test that needs the next claim written at a chosen time,
+        # which is how a backward clock step looks from inside the store.
+        self._next_claim_ns: int | None = None
 
     @property
     def resolutions(self) -> dict[str, dict[str, Any]]:
@@ -115,7 +118,8 @@ class FakeApprovalCards:
         if transaction_id in self.rows:
             return
         self.claimed.append(transaction_id)
-        self._last_claim_ns = max(self._last_claim_ns + 1, time.time_ns())
+        forced, self._next_claim_ns = self._next_claim_ns, None
+        self._last_claim_ns = forced if forced is not None else max(self._last_claim_ns + 1, time.time_ns())
         self.rows[transaction_id] = _StoredRow(
             room_id=room_id,
             card=dict(card),
@@ -243,6 +247,10 @@ class FakeApprovalCards:
                 transaction_id=transaction_id,
                 sending_device_id=sending_device_id,
             )
+
+    def stamp_next_claim_ns(self, created_at_ns: int) -> None:
+        """Write the next claim at a chosen time rather than at now."""
+        self._next_claim_ns = created_at_ns
 
     def _backdate_to_previous_process(self, transaction_id: str) -> None:
         """Stamp one seeded row as older than any live manager's start.

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -1808,6 +1808,49 @@ class TestMultiAgentOrchestrator:
         assert expire_orphaned_approval_cards_on_startup.await_count == 2
 
     @pytest.mark.asyncio
+    async def test_a_startup_discard_that_never_finishes_gives_up_loudly(self, tmp_path: Path) -> None:
+        """A sweep that keeps coming up short must stop asking.
+
+        Retrying is for a pass that failed on something transient. A row that
+        survives every attempt is not that, and a sweep that keeps returning
+        for it re-reads every room on a timer for the rest of the process's
+        life -- each pass another chance to mistake work in progress for
+        wreckage. What is owed is left for the next restart and said out loud.
+        """
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
+        orchestrator.config = MagicMock()
+        orchestrator.config.tool_approval.timeout_days = 7.0
+        orchestrator.config.tool_approval.rules = []
+
+        bot = MagicMock()
+        bot.agent_name = "router"
+        bot.running = True
+        bot.client = make_matrix_client_mock(user_id="@mindroom_router:localhost")
+        orchestrator.agent_bots = {"router": bot}
+
+        with (
+            patch("mindroom.approval_transport._STARTUP_CLEANUP_INITIAL_RETRY_SECONDS", 0.0),
+            patch("mindroom.approval_transport._STARTUP_CLEANUP_MAX_ATTEMPTS", 3),
+            patch(
+                "mindroom.approval_transport.expire_orphaned_approval_cards_on_startup",
+                new=AsyncMock(return_value=ApprovalStartupSweep(discarded=0, failed=1)),
+            ) as expire_orphaned_approval_cards_on_startup,
+        ):
+            orchestrator._approval_transport.reset_startup_cleanup_gate()
+            await orchestrator._approval_transport.mark_startup_runtime_support_ready()
+            await orchestrator.handle_bot_ready(bot)
+
+            await _await_until(lambda: expire_orphaned_approval_cards_on_startup.await_count == 3)
+
+            # Nothing is waiting to try a fourth time, and a gate firing again
+            # does not restart the loop either.
+            assert _retry_tasks() == []
+            await orchestrator._approval_transport.mark_startup_runtime_support_ready()
+
+        await orchestrator._approval_transport.cancel_startup_cleanup_retry()
+        assert expire_orphaned_approval_cards_on_startup.await_count == 3
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize(
         "stop_retrying",
         [

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -15,6 +15,7 @@ import httpx
 import nio
 import pytest
 import uvicorn
+from structlog.testing import capture_logs
 
 import mindroom.tool_system.plugin_imports as plugin_module
 from mindroom.approval_manager import (
@@ -1808,14 +1809,14 @@ class TestMultiAgentOrchestrator:
         assert expire_orphaned_approval_cards_on_startup.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_a_startup_discard_that_never_finishes_gives_up_loudly(self, tmp_path: Path) -> None:
-        """A sweep that keeps coming up short must stop asking.
+    async def test_a_startup_discard_that_keeps_coming_up_short_gets_louder(self, tmp_path: Path) -> None:
+        """A sweep still owed something long after start says so at error level.
 
-        Retrying is for a pass that failed on something transient. A row that
-        survives every attempt is not that, and a sweep that keeps returning
-        for it re-reads every room on a timer for the rest of the process's
-        life -- each pass another chance to mistake work in progress for
-        wreckage. What is owed is left for the next restart and said out loud.
+        It keeps asking, because a pass cannot take a row that is still being
+        published and the outage that outlasts a fixed budget is exactly when
+        cleanup is owed most. What changes is the volume: this far in, nothing
+        transient explains it, and the quiet warning has already been ignored
+        nine times.
         """
         orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
         orchestrator.config = MagicMock()
@@ -1830,25 +1831,29 @@ class TestMultiAgentOrchestrator:
 
         with (
             patch("mindroom.approval_transport._STARTUP_CLEANUP_INITIAL_RETRY_SECONDS", 0.0),
-            patch("mindroom.approval_transport._STARTUP_CLEANUP_MAX_ATTEMPTS", 3),
+            patch("mindroom.approval_transport._STARTUP_CLEANUP_ATTEMPTS_BEFORE_ESCALATION", 3),
             patch(
                 "mindroom.approval_transport.expire_orphaned_approval_cards_on_startup",
                 new=AsyncMock(return_value=ApprovalStartupSweep(discarded=0, failed=1)),
             ) as expire_orphaned_approval_cards_on_startup,
+            capture_logs() as logs,
         ):
             orchestrator._approval_transport.reset_startup_cleanup_gate()
             await orchestrator._approval_transport.mark_startup_runtime_support_ready()
             await orchestrator.handle_bot_ready(bot)
 
-            await _await_until(lambda: expire_orphaned_approval_cards_on_startup.await_count == 3)
+            await _await_until(lambda: expire_orphaned_approval_cards_on_startup.await_count >= 4)
+            await orchestrator._approval_transport.cancel_startup_cleanup_retry()
 
-            # Nothing is waiting to try a fourth time, and a gate firing again
-            # does not restart the loop either.
-            assert _retry_tasks() == []
-            await orchestrator._approval_transport.mark_startup_runtime_support_ready()
+        incomplete = [entry for entry in logs if entry["event"] == "tool_approval_startup_discard_incomplete"]
+        assert [entry["log_level"] for entry in incomplete[:4]] == ["warning", "warning", "error", "error"]
+        assert incomplete[0]["owed_count"] == 1
 
-        await orchestrator._approval_transport.cancel_startup_cleanup_retry()
-        assert expire_orphaned_approval_cards_on_startup.await_count == 3
+        # Every pass says what it walked, including the ones that settled
+        # nothing, so a quiet sweep is not mistaken for a sweep that never ran.
+        finished = [entry for entry in logs if entry["event"] == "approval_startup_sweep_finished"]
+        assert len(finished) == len(incomplete)
+        assert finished[0]["owed_count"] == 1
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -4135,6 +4135,120 @@ async def test_startup_sweep_landing_inside_a_live_claim_leaves_it_alone(tmp_pat
     assert all(sweep == ApprovalStartupSweep(discarded=0, failed=0) for sweep in sweeps)
     assert cards.rows, "the sweep deleted the claim it landed inside"
     assert sender.await_count == 1
+    # Skipped because this process owns the transaction, not because of when
+    # the row happens to be dated.
+    assert [sweep.skipped_in_flight for sweep in sweeps] == [1] * len(sweeps)
+    assert all(sweep.skipped_after_start == 0 for sweep in sweeps)
+    assert all(sweep.scanned == 1 for sweep in sweeps)
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id=pending.card_event_id,
+        status="approved",
+        reason=None,
+    )
+    decision = await task
+
+    assert result.resolved is True
+    assert decision.status == "approved"
+
+
+@pytest.mark.asyncio
+async def test_a_claim_this_process_made_is_left_alone_once_its_owner_is_gone(tmp_path: Path) -> None:
+    """A row claimed after start is not the sweep's, even with nobody holding it.
+
+    The publishing hold covers a claim while its request is alive. A request
+    that died between the claim and the send leaves no hold at all, and the
+    row it left is indistinguishable from a dead process's -- except for the
+    one thing that does distinguish it: it was written after this process
+    started, so no dead process can have written it.
+    """
+    cards = FakeApprovalCards()
+    editor = AsyncMock(return_value=True)
+    store = initialize_approval_store(
+        test_runtime_paths(tmp_path),
+        editor=editor,
+        cards=cards,
+        approval_room_ids=lambda: {"!room:localhost"},
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+    # Claimed directly, so the row is dated after the manager was built and no
+    # request is holding it.
+    await cards.claim_approval_card(
+        room_id="!room:localhost",
+        transaction_id="mindroom-approval-orphaned-by-a-dead-request",
+        card=_approval_card(),
+    )
+
+    sweep = await store.discard_pending_on_startup()
+
+    assert sweep == ApprovalStartupSweep(discarded=0, failed=0)
+    assert sweep.skipped_after_start == 1
+    assert sweep.dropped_never_attempted == 0
+    assert set(cards.rows) == {"mindroom-approval-orphaned-by-a-dead-request"}
+
+
+@pytest.mark.asyncio
+async def test_a_live_claim_survives_a_clock_that_went_backwards(tmp_path: Path) -> None:
+    """Ownership, not the timestamp, is what protects a claim being published.
+
+    The horizon reads a wall clock, and a wall clock can step backwards under
+    it. When that happens every subsequent claim dates before the horizon and
+    looks abandoned, so the guard that has to hold is the one that knows this
+    process is publishing the transaction right now.
+    """
+    sweeps: list[ApprovalStartupSweep] = []
+
+    class SweepingDuringClaimCards(FakeApprovalCards):
+        """A card store that runs a startup sweep from inside the claim write."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.manager: _ApprovalManager | None = None
+
+        async def claim_approval_card(
+            self,
+            *,
+            room_id: str,
+            transaction_id: str,
+            card: Mapping[str, Any],
+        ) -> None:
+            await super().claim_approval_card(room_id=room_id, transaction_id=transaction_id, card=card)
+            assert self.manager is not None
+            sweeps.append(await self.manager.discard_pending_on_startup())
+
+    cards = SweepingDuringClaimCards()
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    editor = AsyncMock(return_value=True)
+    store = initialize_approval_store(
+        test_runtime_paths(tmp_path),
+        sender=sender,
+        editor=editor,
+        cards=cards,
+        approval_room_ids=lambda: {"!room:localhost"},
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+    cards.manager = store
+    # An hour into the future, so every row this test claims dates before it.
+    store._sweep_horizon_ns += 3_600_000_000_000
+
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="create_event",
+            arguments={"summary": "standup"},
+            room_id="!room:localhost",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+        ),
+    )
+    pending = await _wait_for_pending(store, sender=sender)
+
+    assert sweeps, "the sweep never ran inside the claim, so this proves nothing"
+    assert all(sweep.skipped_after_start == 0 for sweep in sweeps), "the horizon cannot be what saved this"
+    assert [sweep.skipped_in_flight for sweep in sweeps] == [1] * len(sweeps)
+    assert cards.rows, "the sweep deleted a claim this process was publishing"
 
     result = await store.handle_card_response(
         room_id="!room:localhost",

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import time
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any, Literal
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -4215,10 +4216,8 @@ async def test_startup_sweep_landing_inside_a_live_claim_leaves_it_alone(tmp_pat
     assert all(sweep == ApprovalStartupSweep(discarded=0, failed=0) for sweep in sweeps)
     assert cards.rows, "the sweep deleted the claim it landed inside"
     assert sender.await_count == 1
-    # Skipped because this process owns the transaction, not because of when
-    # the row happens to be dated.
+    # Skipped because this process owns the transaction while it publishes it.
     assert [sweep.skipped_in_flight for sweep in sweeps] == [1] * len(sweeps)
-    assert all(sweep.skipped_after_start == 0 for sweep in sweeps)
     assert all(sweep.scanned == 1 for sweep in sweeps)
 
     result = await store.handle_card_response(
@@ -4235,48 +4234,14 @@ async def test_startup_sweep_landing_inside_a_live_claim_leaves_it_alone(tmp_pat
 
 
 @pytest.mark.asyncio
-async def test_a_claim_this_process_made_is_left_alone_once_its_owner_is_gone(tmp_path: Path) -> None:
-    """A row claimed after start is not the sweep's, even with nobody holding it.
+async def test_a_live_claim_is_protected_by_ownership_not_by_its_timestamp(tmp_path: Path) -> None:
+    """What protects a claim being published is a hold, not when it was written.
 
-    The publishing hold covers a claim while its request is alive. A request
-    that died between the claim and the send leaves no hold at all, and the
-    row it left is indistinguishable from a dead process's -- except for the
-    one thing that does distinguish it: it was written after this process
-    started, so no dead process can have written it.
-    """
-    cards = FakeApprovalCards()
-    editor = AsyncMock(return_value=True)
-    store = initialize_approval_store(
-        test_runtime_paths(tmp_path),
-        editor=editor,
-        cards=cards,
-        approval_room_ids=lambda: {"!room:localhost"},
-        transport_sender=lambda: "@mindroom_router:localhost",
-    )
-    # Claimed directly, so the row is dated after the manager was built and no
-    # request is holding it.
-    await cards.claim_approval_card(
-        room_id="!room:localhost",
-        transaction_id="mindroom-approval-orphaned-by-a-dead-request",
-        card=_approval_card(),
-    )
-
-    sweep = await store.discard_pending_on_startup()
-
-    assert sweep == ApprovalStartupSweep(discarded=0, failed=0)
-    assert sweep.skipped_after_start == 1
-    assert sweep.dropped_never_attempted == 0
-    assert set(cards.rows) == {"mindroom-approval-orphaned-by-a-dead-request"}
-
-
-@pytest.mark.asyncio
-async def test_a_live_claim_survives_a_clock_that_went_backwards(tmp_path: Path) -> None:
-    """Ownership, not the timestamp, is what protects a claim being published.
-
-    The horizon reads a wall clock, and a wall clock can step backwards under
-    it. When that happens every subsequent claim dates before the horizon and
-    looks abandoned, so the guard that has to hold is the one that knows this
-    process is publishing the transaction right now.
+    Classifying by timestamp reads a wall clock, and a wall clock can step
+    backwards: after a correction every new claim dates before whatever the
+    process recorded at start and looks abandoned again. This row is dated
+    before every other row in the store and still survives, because the guard
+    that matters knows this process is publishing the transaction right now.
     """
     sweeps: list[ApprovalStartupSweep] = []
 
@@ -4310,8 +4275,9 @@ async def test_a_live_claim_survives_a_clock_that_went_backwards(tmp_path: Path)
         transport_sender=lambda: "@mindroom_router:localhost",
     )
     cards.manager = store
-    # An hour into the future, so every row this test claims dates before it.
-    store._sweep_horizon_ns += 3_600_000_000_000
+    # Dated an hour before anything else in the store, which is what a
+    # backward clock step produces and what a timestamp guard would misread.
+    cards.stamp_next_claim_ns(time.time_ns() - 3_600_000_000_000)
 
     task = asyncio.create_task(
         store.request_approval(
@@ -4326,7 +4292,6 @@ async def test_a_live_claim_survives_a_clock_that_went_backwards(tmp_path: Path)
     pending = await _wait_for_pending(store, sender=sender)
 
     assert sweeps, "the sweep never ran inside the claim, so this proves nothing"
-    assert all(sweep.skipped_after_start == 0 for sweep in sweeps), "the horizon cannot be what saved this"
     assert [sweep.skipped_in_flight for sweep in sweeps] == [1] * len(sweeps)
     assert cards.rows, "the sweep deleted a claim this process was publishing"
 

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2697,19 +2697,8 @@ async def test_the_sending_device_is_recorded_before_the_card_goes_out(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_startup_sweep_leaves_this_process_s_own_live_approval_alone(tmp_path: Path) -> None:
-    """Startup cleanup must not expire an approval this process is waiting on.
-
-    A live waiter reaches the sweep one way only: ``_bind_live_waiter``, from
-    a fresh send. So a card that has one was sent by this process and is still
-    awaiting its human, which is not what startup cleanup is for. Expiring it
-    tells that human their request was cancelled by a restart that already
-    finished before they were asked.
-
-    Nothing is owed for it either. The waiter settles the card on a click, a
-    denial, or its own timeout, and counting it would have every pending
-    approval hold the sweep open until somebody answered.
-    """
+async def test_startup_sweep_rejects_live_approval_and_releases_waiter(tmp_path: Path) -> None:
+    """Startup cleanup must return its rejection to a matching live tool call."""
     cards = FakeApprovalCards()
     sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
     editor = AsyncMock(return_value=True)
@@ -2738,36 +2727,18 @@ async def test_startup_sweep_leaves_this_process_s_own_live_approval_alone(tmp_p
     pending = await _wait_for_pending(store, sender=sender)
 
     sweep = await store.discard_pending_on_startup()
-
-    assert sweep == ApprovalStartupSweep(discarded=0, failed=0)
-    assert sweep.skipped_live_waiter == 1
-    assert not task.done(), "the sweep expired an approval this process was waiting on"
-    assert editor.await_count == 0
-    assert set(cards.rows) == {_approval_transaction_id(pending.approval_id)}
-
-    # The waiter still owns the card, so the human's answer still lands.
-    result = await store.handle_card_response(
-        room_id="!room:localhost",
-        sender_id="@user:localhost",
-        card_event_id=pending.card_event_id,
-        status="approved",
-        reason=None,
-    )
     decision = await asyncio.wait_for(task, timeout=1)
 
-    assert result.resolved is True
-    assert decision.status == "approved"
+    assert sweep == ApprovalStartupSweep(discarded=1, failed=0)
+    assert decision.status == "expired"
+    assert decision.reason == "Bot restarted before approval — original request was cancelled."
+    assert editor.await_args.args[:2] == ("!room:localhost", pending.card_event_id)
+    assert cards.rows == {}
 
 
 @pytest.mark.asyncio
-async def test_startup_sweep_does_not_retry_against_a_live_approval(tmp_path: Path) -> None:
-    """A live approval is skipped by every pass, not retried against.
-
-    Retrying an edit is for a decision already committed that the room may not
-    show. A card whose waiter is still live has no decision to redeliver, so
-    repeated passes have nothing to converge on -- they would only expire it
-    on whichever attempt finally got its edit through.
-    """
+async def test_startup_sweep_retries_live_approval_edit_that_did_not_land(tmp_path: Path) -> None:
+    """A durable live rejection must remain eligible for Matrix redelivery."""
     cards = FakeApprovalCards()
     sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
     editor = AsyncMock(side_effect=[False, True])
@@ -2795,18 +2766,14 @@ async def test_startup_sweep_does_not_retry_against_a_live_approval(tmp_path: Pa
     await _wait_for_pending(store, sender=sender)
 
     first_sweep = await store.discard_pending_on_startup()
+    decision = await asyncio.wait_for(task, timeout=1)
     second_sweep = await store.discard_pending_on_startup()
 
-    # Neither pass touches it, and neither is owed it: the request is alive.
-    assert first_sweep == ApprovalStartupSweep(discarded=0, failed=0)
-    assert second_sweep == ApprovalStartupSweep(discarded=0, failed=0)
-    assert first_sweep.skipped_live_waiter == 1
-    assert editor.await_count == 0
-    assert not task.done()
-
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
+    assert first_sweep == ApprovalStartupSweep(discarded=0, failed=1)
+    assert decision.status == "expired"
+    assert second_sweep == ApprovalStartupSweep(discarded=1, failed=0)
+    assert editor.await_count == 2
+    assert cards.rows == {}
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2697,8 +2697,19 @@ async def test_the_sending_device_is_recorded_before_the_card_goes_out(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_startup_sweep_rejects_live_approval_and_releases_waiter(tmp_path: Path) -> None:
-    """Startup cleanup must return its rejection to a matching live tool call."""
+async def test_startup_sweep_leaves_this_process_s_own_live_approval_alone(tmp_path: Path) -> None:
+    """Startup cleanup must not expire an approval this process is waiting on.
+
+    A live waiter reaches the sweep one way only: ``_bind_live_waiter``, from
+    a fresh send. So a card that has one was sent by this process and is still
+    awaiting its human, which is not what startup cleanup is for. Expiring it
+    tells that human their request was cancelled by a restart that already
+    finished before they were asked.
+
+    Nothing is owed for it either. The waiter settles the card on a click, a
+    denial, or its own timeout, and counting it would have every pending
+    approval hold the sweep open until somebody answered.
+    """
     cards = FakeApprovalCards()
     sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
     editor = AsyncMock(return_value=True)
@@ -2727,18 +2738,36 @@ async def test_startup_sweep_rejects_live_approval_and_releases_waiter(tmp_path:
     pending = await _wait_for_pending(store, sender=sender)
 
     sweep = await store.discard_pending_on_startup()
+
+    assert sweep == ApprovalStartupSweep(discarded=0, failed=0)
+    assert sweep.skipped_live_waiter == 1
+    assert not task.done(), "the sweep expired an approval this process was waiting on"
+    assert editor.await_count == 0
+    assert set(cards.rows) == {_approval_transaction_id(pending.approval_id)}
+
+    # The waiter still owns the card, so the human's answer still lands.
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id=pending.card_event_id,
+        status="approved",
+        reason=None,
+    )
     decision = await asyncio.wait_for(task, timeout=1)
 
-    assert sweep == ApprovalStartupSweep(discarded=1, failed=0)
-    assert decision.status == "expired"
-    assert decision.reason == "Bot restarted before approval — original request was cancelled."
-    assert editor.await_args.args[:2] == ("!room:localhost", pending.card_event_id)
-    assert cards.rows == {}
+    assert result.resolved is True
+    assert decision.status == "approved"
 
 
 @pytest.mark.asyncio
-async def test_startup_sweep_retries_live_approval_edit_that_did_not_land(tmp_path: Path) -> None:
-    """A durable live rejection must remain eligible for Matrix redelivery."""
+async def test_startup_sweep_does_not_retry_against_a_live_approval(tmp_path: Path) -> None:
+    """A live approval is skipped by every pass, not retried against.
+
+    Retrying an edit is for a decision already committed that the room may not
+    show. A card whose waiter is still live has no decision to redeliver, so
+    repeated passes have nothing to converge on -- they would only expire it
+    on whichever attempt finally got its edit through.
+    """
     cards = FakeApprovalCards()
     sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
     editor = AsyncMock(side_effect=[False, True])
@@ -2766,14 +2795,18 @@ async def test_startup_sweep_retries_live_approval_edit_that_did_not_land(tmp_pa
     await _wait_for_pending(store, sender=sender)
 
     first_sweep = await store.discard_pending_on_startup()
-    decision = await asyncio.wait_for(task, timeout=1)
     second_sweep = await store.discard_pending_on_startup()
 
-    assert first_sweep == ApprovalStartupSweep(discarded=0, failed=1)
-    assert decision.status == "expired"
-    assert second_sweep == ApprovalStartupSweep(discarded=1, failed=0)
-    assert editor.await_count == 2
-    assert cards.rows == {}
+    # Neither pass touches it, and neither is owed it: the request is alive.
+    assert first_sweep == ApprovalStartupSweep(discarded=0, failed=0)
+    assert second_sweep == ApprovalStartupSweep(discarded=0, failed=0)
+    assert first_sweep.skipped_live_waiter == 1
+    assert editor.await_count == 0
+    assert not task.done()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -4077,6 +4077,79 @@ async def test_startup_discard_that_never_reached_matrix_stays_recoverable(
 
 
 @pytest.mark.asyncio
+async def test_startup_sweep_landing_inside_a_live_claim_leaves_it_alone(tmp_path: Path) -> None:
+    """A sweep that runs between a claim's commit and its return must not take the row.
+
+    The claim is committed before the send it belongs to exists, so for that
+    window there is nothing in memory saying the row is spoken for. A sweep
+    reading it then sees exactly what a dead process leaves -- claimed, never
+    attempted -- and used to delete it, stranding the caller on an approval
+    whose durable card no longer existed.
+    """
+    sweeps: list[ApprovalStartupSweep] = []
+
+    class SweepingDuringClaimCards(FakeApprovalCards):
+        """A card store that runs a startup sweep from inside the claim write."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.manager: _ApprovalManager | None = None
+
+        async def claim_approval_card(
+            self,
+            *,
+            room_id: str,
+            transaction_id: str,
+            card: Mapping[str, Any],
+        ) -> None:
+            await super().claim_approval_card(room_id=room_id, transaction_id=transaction_id, card=card)
+            assert self.manager is not None
+            sweeps.append(await self.manager.discard_pending_on_startup())
+
+    cards = SweepingDuringClaimCards()
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    editor = AsyncMock(return_value=True)
+    store = initialize_approval_store(
+        test_runtime_paths(tmp_path),
+        sender=sender,
+        editor=editor,
+        cards=cards,
+        approval_room_ids=lambda: {"!room:localhost"},
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+    cards.manager = store
+
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="create_event",
+            arguments={"summary": "standup"},
+            room_id="!room:localhost",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+        ),
+    )
+    pending = await _wait_for_pending(store, sender=sender)
+
+    assert sweeps, "the sweep never ran inside the claim, so this proves nothing"
+    assert all(sweep == ApprovalStartupSweep(discarded=0, failed=0) for sweep in sweeps)
+    assert cards.rows, "the sweep deleted the claim it landed inside"
+    assert sender.await_count == 1
+
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id=pending.card_event_id,
+        status="approved",
+        reason=None,
+    )
+    decision = await task
+
+    assert result.resolved is True
+    assert decision.status == "approved"
+
+
+@pytest.mark.asyncio
 async def test_discard_pending_on_startup_skips_other_routers_cards(tmp_path: Path) -> None:
     cards = FakeApprovalCards()
     await cards.store_card("$approval", "!room:localhost", _approval_card(sender="@other_router:localhost"))

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -4234,6 +4234,75 @@ async def test_startup_sweep_landing_inside_a_live_claim_leaves_it_alone(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_a_request_publishing_a_claim_counts_as_live_work(tmp_path: Path) -> None:
+    """Runtime replacement must not step over a claim being published.
+
+    ``has_live_work`` is what a fresh runtime asks before it swaps the manager
+    out. A request between its claim write and its send holds a durable row
+    that only it can settle, so a swap there leaves the row owned by nobody --
+    exactly the state the startup sweep is entitled to act on.
+    """
+    live_work: list[bool] = []
+
+    class ObservingCards(FakeApprovalCards):
+        """A card store that asks the manager what it thinks during the claim."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.manager: _ApprovalManager | None = None
+
+        async def claim_approval_card(
+            self,
+            *,
+            room_id: str,
+            transaction_id: str,
+            card: Mapping[str, Any],
+        ) -> None:
+            await super().claim_approval_card(room_id=room_id, transaction_id=transaction_id, card=card)
+            assert self.manager is not None
+            live_work.append(self.manager.has_live_work())
+
+    cards = ObservingCards()
+    sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
+    editor = AsyncMock(return_value=True)
+    store = initialize_approval_store(
+        test_runtime_paths(tmp_path),
+        sender=sender,
+        editor=editor,
+        cards=cards,
+        approval_room_ids=lambda: {"!room:localhost"},
+        transport_sender=lambda: "@mindroom_router:localhost",
+    )
+    cards.manager = store
+    assert store.has_live_work() is False
+
+    task = asyncio.create_task(
+        store.request_approval(
+            tool_name="create_event",
+            arguments={"summary": "standup"},
+            room_id="!room:localhost",
+            requester_id="@user:localhost",
+            approver_user_id="@user:localhost",
+            timeout_seconds=30,
+        ),
+    )
+    pending = await _wait_for_pending(store, sender=sender)
+
+    assert live_work == [True]
+
+    await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id=pending.card_event_id,
+        status="approved",
+        reason=None,
+    )
+    await task
+
+    assert store.has_live_work() is False
+
+
+@pytest.mark.asyncio
 async def test_a_live_claim_is_protected_by_ownership_not_by_its_timestamp(tmp_path: Path) -> None:
     """What protects a claim being published is a hold, not when it was written.
 


### PR DESCRIPTION
## Summary

- own an approval transaction from before its claim row is written until the send registers
- keep a wall-clock horizon as the backstop for a row whose owner is gone from memory
- keep sweeping instead of giving up, and get louder instead of quieter
- report what every sweep pass walked, skipped, and dropped

## Why

`request_approval` commits the durable approval row (`_claim_card`) before the send that owns it exists; the send only registers itself in `_active_approval_sends` inside `_send_and_bind_waiter`. `_send_is_in_flight()` reads that set, so across the claim await there is nothing in memory saying the row is spoken for. The startup sweep reads exactly what a dead process leaves behind — claimed, never attempted — and deletes it in `_identified_card`, logging `approval_startup_card_dropped_never_attempted`.

That deletion is upstream of every other guard: `_forget_card` runs before the live-waiter check, before any continuation check, and the row is gone before the branch that would have protected it is reached.

The sweep is also not confined to startup. An unfinished pass reschedules itself, so a single card that can never be settled keeps it running on a 30s timer for the life of the process. One production control plane, 19 hours into its uptime, logged 17 deletions across 9 rooms in six hours with `owed_count=2` throughout. A single pass took six different rooms' rows in nine seconds.

**What this does not claim.** The deletion is not what initially wedges a conversation. In the room studied most closely, `bridge_entry` was at 18:55:19.720 and the row was still unattempted when the first sweep pass reached it at 18:59:10 — the caller had already been parked for 3m51s, and the first pass after that restart could not have run any earlier. The sweep destroys the durable card of a call that is already stuck, and takes other rooms' healthy in-flight claims with it. Why a caller parks between its claim and its send is a separate defect, still open.

## What changed

**Ownership.** `_publishing(transaction_id)` is entered before the claim write and left once the send has registered its own hold or the attempt has ended. It is a `Counter`, not a set, so overlapping scopes for one transaction cannot have the inner one release the outer one's hold. `_send_is_in_flight` consults it alongside the two existing owners.

**Horizon.** `_sweep_horizon_ns` is still taken at manager construction, now as a backstop rather than the primary guard: it covers a row whose owner died without cleanup, where the timestamp is the only remaining proof no dead process wrote it. Construction rather than first sweep, because the arming gates are late — production `rooms_and_memberships` has been observed taking 350s.

Both guards are load-bearing. Disabling the ownership hold fails `test_a_live_claim_survives_a_clock_that_went_backwards`; disabling the horizon fails `test_a_claim_this_process_made_is_left_alone_once_its_owner_is_gone` with `dropped_never_attempted=1`. Verified by mutation, not by inspection.

**Retry.** The earlier attempt cap is gone. It existed because each pass was a chance to delete live work, which is no longer true, and the arithmetic reverses: ten attempts is ~151s against a 350s startup envelope, an outage that outlasts any fixed budget is when cleanup is owed most, and the repeating sweep has been the only thing collecting rows orphaned later in a process's life. Past `_STARTUP_CLEANUP_ATTEMPTS_BEFORE_ESCALATION` the incomplete log moves from warning to error.

**Observability.** `ApprovalStartupSweep` now carries `scanned`, `skipped_after_start`, `skipped_in_flight`, `dropped_never_attempted` (excluded from equality), and one unconditional `approval_startup_sweep_finished` reports them. The healthy outcome of these guards is a pass that settles nothing, which was previously indistinguishable from a pass that never ran — and the deletion path incremented no counter at all, so those 17 production deletions appeared in no sweep total. `tool_approval_startup_discard_failed` gains `exc_info=True`; both failure lines gain `attempt`.

## Tests

`uv run pytest -q -nauto tests/test_tool_approval.py tests/test_orchestrator_runtime.py tests/test_bot_reactions_approvals.py tests/test_tool_hooks.py` — all pass. `ruff check`, `ruff format --check`, `ty check` clean on the touched files.

New:
- `test_startup_sweep_landing_inside_a_live_claim_leaves_it_alone` — drives the sweep from inside `claim_approval_card`, after the row commits and before the call returns. Verified red before the fix: the claim is deleted, the card never becomes answerable, the decision wait times out.
- `test_a_live_claim_survives_a_clock_that_went_backwards` — horizon pushed an hour into the future, so only ownership can save the claim.
- `test_a_claim_this_process_made_is_left_alone_once_its_owner_is_gone` — post-horizon row with no holder at all.
- `test_a_startup_discard_that_keeps_coming_up_short_gets_louder` — asserts the escalation actually fires, via `structlog.testing.capture_logs`.

`FakeApprovalCards` now timestamps claims with a clock like the real table (`event_journal/approvals.py:196`) instead of a counter. A counter puts every row before any process start, so the double could not fail the way the real store does. Seed helpers backdate explicitly, since they stand for a previous process's work.

## Relationship to other PRs

**#1811 should be closed or re-pointed.** Its target branch is unreachable after this: a live waiter only exists for a card this process sent, so such rows are always owned or post-horizon and the sweep skips them before `_discard_live_card` is reached. Its two new tests construct the manager and then call `request_approval`, expect `(discarded=1, failed=0)`, and get `(0, 0)` with the decision wait timing out. Merging it first is also a user-visible regression: under a backward clock step it force-expires healthy approvals, showing "Bot restarted before approval" on a bot that did not restart.

**#1807 wants this first.** Its `continuation_id` guard sits after `_identified_card`, so without this PR a detached card claimed in the same window is deleted before that guard is read. Its `create_detached_approval` awaits `_mark_attempted_then_send` directly and never builds an `_ActiveApprovalSend`, so the publishing hold added here is the only thing covering it.

Suggested order: this PR, then #1807, closing #1811.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented startup recovery from interfering with approvals currently being published.
  * Preserved approvals when requests end unexpectedly after claiming them.
  * Improved recovery behavior during clock shifts.
  * Prevented duplicate approval sends while a delivery is in progress.

* **Monitoring**
  * Added detailed startup-sweep counts for scanned, skipped, and dropped approvals.
  * Repeated incomplete sweeps now escalate from warnings to errors after ten attempts.
  * Completion logs include outstanding approval counts and sweep statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->