### PR TITLE
fix: do not expire an approval this process is still waiting on

### DIFF
--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -586,13 +586,24 @@ class _ApprovalManager:
             return None
         if identified.card.resolution is not None:
             return await self._redeliver_recorded_resolution(pending, identified.card)
-        live_waiter = self._live_waiter_for_card(pending.card_event_id)
-        if live_waiter is not None:
-            return await self._discard_live_card(
-                waiter=live_waiter,
-                reason=_STARTUP_DISCARD_REASON,
-                resolved_by=transport_sender,
+        if self._live_waiter_for_card(pending.card_event_id) is not None:
+            # This process sent this card and is still waiting on the answer.
+            # A waiter only ever gets here one way -- ``_bind_live_waiter``,
+            # reached from a fresh send -- so a card with one is not a card a
+            # dead process left, it is live work of this one's. Expiring it
+            # tells a user their request was cancelled by a restart that had
+            # already finished before they were asked to decide.
+            #
+            # Nothing is owed either: the waiter settles the card on a click,
+            # a denial, or its own timeout. Counting it would have every
+            # pending approval hold the sweep open until somebody answered.
+            logger.debug(
+                "approval_startup_card_skipped_live_waiter",
+                room_id=room_id,
+                transaction_id=identified.card.transaction_id,
+                card_event_id=identified.card.card_event_id,
             )
+            return None
         result = await self._discard_matrix_only_card(
             pending=pending,
             transaction_id=identified.card.transaction_id,
@@ -1085,25 +1096,6 @@ class _ApprovalManager:
                 thread_id=pending.thread_id,
                 card_event_id=pending.card_event_id,
             )
-
-    async def _discard_live_card(
-        self,
-        *,
-        waiter: _LiveApprovalWaiter,
-        reason: str,
-        resolved_by: str | None,
-    ) -> bool:
-        """Expire through the live waiter, returning whether its Matrix edit landed."""
-        claimed_waiter = self._claim_live_resolution(waiter.card_event_id)
-        if claimed_waiter is None:
-            return False
-        decision = self._new_decision(status="expired", reason=reason, resolved_by=resolved_by)
-        with self._claimed_resolution(claimed_waiter.card_event_id):
-            delivered = await self._settle_waiter_with_terminal_edit(claimed_waiter, decision)
-            if delivered:
-                with self._live_lock:
-                    self._resolved_card_event_ids.add(claimed_waiter.card_event_id)
-            return delivered
 
     async def _settle_waiter_with_terminal_edit(
         self,

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -2696,8 +2696,15 @@ async def test_the_sending_device_is_recorded_before_the_card_goes_out(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_startup_sweep_rejects_live_approval_and_releases_waiter(tmp_path: Path) -> None:
-    """Startup cleanup must return its rejection to a matching live tool call."""
+async def test_startup_sweep_leaves_this_process_s_own_live_approval_alone(tmp_path: Path) -> None:
+    """Startup cleanup must not expire an approval this process is waiting on.
+
+    A live waiter reaches the sweep one way only: ``_bind_live_waiter``, from
+    a fresh send. So a card that has one was sent by this process and is still
+    awaiting its human, which is not what startup cleanup is for. Expiring it
+    tells that human their request was cancelled by a restart that already
+    finished before they were asked.
+    """
     cards = FakeApprovalCards()
     sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
     editor = AsyncMock(return_value=True)
@@ -2726,18 +2733,35 @@ async def test_startup_sweep_rejects_live_approval_and_releases_waiter(tmp_path:
     pending = await _wait_for_pending(store, sender=sender)
 
     sweep = await store.discard_pending_on_startup()
+
+    assert sweep == ApprovalStartupSweep(discarded=0, failed=0)
+    assert not task.done(), "the sweep expired an approval this process was waiting on"
+    assert editor.await_count == 0
+    assert set(cards.rows) == {_approval_transaction_id(pending.approval_id)}
+
+    # The waiter still owns the card, so the human's answer still lands.
+    result = await store.handle_card_response(
+        room_id="!room:localhost",
+        sender_id="@user:localhost",
+        card_event_id=pending.card_event_id,
+        status="approved",
+        reason=None,
+    )
     decision = await asyncio.wait_for(task, timeout=1)
 
-    assert sweep == ApprovalStartupSweep(discarded=1, failed=0)
-    assert decision.status == "expired"
-    assert decision.reason == "Bot restarted before approval — original request was cancelled."
-    assert editor.await_args.args[:2] == ("!room:localhost", pending.card_event_id)
-    assert cards.rows == {}
+    assert result.resolved is True
+    assert decision.status == "approved"
 
 
 @pytest.mark.asyncio
-async def test_startup_sweep_retries_live_approval_edit_that_did_not_land(tmp_path: Path) -> None:
-    """A durable live rejection must remain eligible for Matrix redelivery."""
+async def test_startup_sweep_does_not_retry_against_a_live_approval(tmp_path: Path) -> None:
+    """A live approval is skipped by every pass, not retried against.
+
+    Retrying an edit is for a decision already committed that the room may not
+    show. A card whose waiter is still live has no decision to redeliver, so
+    repeated passes have nothing to converge on -- they would only expire it
+    on whichever attempt finally got its edit through.
+    """
     cards = FakeApprovalCards()
     sender = AsyncMock(return_value=SentApprovalEvent("$approval"))
     editor = AsyncMock(side_effect=[False, True])
@@ -2765,14 +2789,17 @@ async def test_startup_sweep_retries_live_approval_edit_that_did_not_land(tmp_pa
     await _wait_for_pending(store, sender=sender)
 
     first_sweep = await store.discard_pending_on_startup()
-    decision = await asyncio.wait_for(task, timeout=1)
     second_sweep = await store.discard_pending_on_startup()
 
-    assert first_sweep == ApprovalStartupSweep(discarded=0, failed=1)
-    assert decision.status == "expired"
-    assert second_sweep == ApprovalStartupSweep(discarded=1, failed=0)
-    assert editor.await_count == 2
-    assert cards.rows == {}
+    # Neither pass touches it, and neither is owed it: the request is alive.
+    assert first_sweep == ApprovalStartupSweep(discarded=0, failed=0)
+    assert second_sweep == ApprovalStartupSweep(discarded=0, failed=0)
+    assert editor.await_count == 0
+    assert not task.done()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reverts the behaviour added by #1811, which is on `main` as `3f2fe8b3b`. Raised separately from #1812 because changing a just-merged PR's stated behaviour should be visible on its own.

## The branch cannot match what it was written for

#1811 settles a recovered card through its live waiter, on the premise that "replayed work already had a live waiter for the recovered card". No code path produces that state.

`_pending_by_card_event` is written in exactly one place, `_bind_live_waiter` (`approval_manager.py:973`), reached from two call sites:

- `_send_and_bind_waiter` (`:860`), after a successful **fresh** send
- `_cleanup_cancelled_send_when_event_arrives` (`:913`), which binds only to settle as cancelled and pop the entry again

Nothing on the recovery or resume path binds a waiter to a recovered card. So the branch can only ever match a card this process just published and is actively waiting on — which is exactly what its own test sets up: construct manager, `request_approval(tool_name="send_email", ...)`, wait for the send, run the sweep, assert `discarded=1` and `decision.reason == "Bot restarted before approval — original request was cancelled."` No replay, no recovery, no restart.

There is nothing to gate with a "was recovered" flag, because nothing recovered ever gets a waiter. Hence a revert rather than a narrowing.

Checked against #1807 as well: it adds no `_bind_live_waiter` call and `create_detached_approval` allocates no waiter future, so it does not create the state either.

## Production exposure

```
container start                                     18:54:38
18:56:06.514  request_network_access  agno_tool_call_started
18:56:06.569  request_network_access  bridge_entry
18:56:46.361  request_network_access  agno_tool_call_started
18:56:46.500  request_network_access  bridge_entry
first sweep pass                                    18:59:10
```

The gates that arm the sweep wait on room and membership sync, which has been observed taking 26s to 350s. Startup replay is also when approvals get created, so the window in which cards appear and the window before the first pass are the same window. Both of those cards would have been expired under the requester about two and a half minutes after he was asked, citing a restart that had already finished.

Those two are also the `owed_count: 2` that kept that pod's sweep re-running every 30s all afternoon: the pre-#1811 path could not settle them either, because `_claim_matrix_cleanup` returns False when the card event is in `_pending_by_card_event` (`:1974`), and counted them as owed.

## What this does

Skips a card with a live waiter and does not count it as owed. The waiter settles it on a click, a denial, or its own timeout; counting it would have every pending approval hold the sweep open until somebody answered. `_discard_live_card` is removed — nothing else reaches it.

The two tests are inverted rather than deleted, since the states they set up are worth pinning:

- `test_startup_sweep_rejects_live_approval_and_releases_waiter` → `test_startup_sweep_leaves_this_process_s_own_live_approval_alone`: the request stays pending, no Matrix edit is made, the row survives, and the human's later approval still lands.
- `test_startup_sweep_retries_live_approval_edit_that_did_not_land` → `test_startup_sweep_does_not_retry_against_a_live_approval`: a live card has no committed decision to redeliver, so repeated passes have nothing to converge on — they would only expire it on whichever attempt got its edit through.

## Tests

`uv run pytest -q -nauto tests/test_tool_approval.py tests/test_orchestrator_runtime.py tests/test_tool_hooks.py` — exit 0. `ruff check` clean.

Stacks cleanly with #1812, which touches the same function but different lines.

## Summary by Sourcery

Prevent startup cleanup from expiring approvals that this process is still actively waiting on, and ensure such live approvals are skipped without being counted as owed.

Bug Fixes:
- Stop discarding live approvals during startup sweep when this process has an active waiter for the card, avoiding incorrect expirations after restart.

Enhancements:
- Log when startup sweep encounters and skips a live approval waiter so these cases are observable in production.

Tests:
- Update startup sweep tests to assert that live approvals are left pending, not retried or expired, and that their waiters remain responsible for resolution.