### PR TITLE
fix: refuse an approval-gated tool called from a sync bridge

### DIFF
--- a/src/mindroom/sync_bridge_state.py
+++ b/src/mindroom/sync_bridge_state.py
@@ -2,13 +2,13 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 from weakref import WeakSet
 
 if TYPE_CHECKING:
-    import asyncio
     from collections.abc import Iterator
 
 _SYNC_BRIDGE_BLOCKED_LOOPS: WeakSet[object] = WeakSet()
@@ -31,3 +31,21 @@ def is_loop_blocked_by_sync_tool_bridge(loop: asyncio.AbstractEventLoop) -> bool
     """Return whether synchronous tool execution is currently blocking one event loop."""
     with _SYNC_BRIDGE_BLOCKED_LOOPS_LOCK:
         return loop in _SYNC_BRIDGE_BLOCKED_LOOPS
+
+
+def running_loop_is_sync_tool_bridge() -> bool:
+    """Return whether the caller is running on a bridge loop, not the runtime loop.
+
+    A synchronous tool bridge runs its async work on a loop of its own while
+    the runtime loop that spawned it is blocked waiting for the thread. Both
+    facts are needed to recognise the situation from inside that work: the
+    caller's own loop is not the marked one, and some loop is marked. Asking
+    only whether a loop is blocked would also be true when read from the
+    blocked loop itself, which is never a bridge.
+    """
+    try:
+        current = asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    with _SYNC_BRIDGE_BLOCKED_LOOPS_LOCK:
+        return any(loop is not current for loop in _SYNC_BRIDGE_BLOCKED_LOOPS)

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -27,12 +27,13 @@ from mindroom.hooks import (
 from mindroom.llm_request_logging import current_llm_request_log_context
 from mindroom.logging_config import get_logger
 from mindroom.oauth.providers import OAuthConnectionRequired, oauth_connection_required_payload
-from mindroom.sync_bridge_state import sync_tool_bridge_blocked_loop
+from mindroom.sync_bridge_state import running_loop_is_sync_tool_bridge, sync_tool_bridge_blocked_loop
 from mindroom.timing import elapsed_ms_since, emit_timing_event
 from mindroom.tool_approval import (
     ToolApprovalCall,
     ToolApprovalScriptError,
     ToolCallWorkflowOrigin,
+    evaluate_tool_approval,
     request_tool_approval_for_call,
 )
 from mindroom.tool_system.runtime_context import (
@@ -61,6 +62,11 @@ if TYPE_CHECKING:
         HookRoomStateQuerier,
     )
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
+_SYNC_TOOL_BRIDGE_APPROVAL_REASON = (
+    "This tool needs approval, and it was called synchronously, which blocks the runtime "
+    "MindRoom would need in order to ask for one. Ask again so it runs asynchronously, or "
+    "use a tool that does not require approval."
+)
 _DECLINED_RESULT_TEMPLATE = (
     "[TOOL CALL DECLINED]\n"
     "Tool: {tool_name}\n"
@@ -454,6 +460,30 @@ async def _emit_after_call(
     await emit(hook_registry, EVENT_TOOL_AFTER_CALL, after_context)
 
 
+async def _approval_would_be_required(
+    *,
+    resolved_context: _ResolvedToolContext,
+    args: dict[str, Any],
+    tool_name: str,
+) -> bool:
+    """Return whether policy wants an approval for one call, without asking for it."""
+    if resolved_context.config is None or resolved_context.runtime_paths is None:
+        return False
+    try:
+        requires_approval, _ = await evaluate_tool_approval(
+            resolved_context.config,
+            resolved_context.runtime_paths,
+            tool_name,
+            deepcopy(args),
+            resolved_context.agent_name,
+        )
+    except ToolApprovalScriptError:
+        # A policy that cannot be read is handled by the normal path below,
+        # which declines with its own reason.
+        return True
+    return requires_approval
+
+
 async def _maybe_block_for_tool_approval(
     *,
     resolved_context: _ResolvedToolContext,
@@ -463,6 +493,24 @@ async def _maybe_block_for_tool_approval(
 ) -> str | None:
     if resolved_context.config is None or resolved_context.runtime_paths is None:
         return None
+
+    if running_loop_is_sync_tool_bridge() and await _approval_would_be_required(
+        resolved_context=resolved_context,
+        args=args,
+        tool_name=tool_name,
+    ):
+        # This tool was called synchronously, so its async work is running on a
+        # loop of its own while the runtime loop is blocked waiting for the
+        # thread. Everything an approval needs is on the far side of that
+        # block: the event-journal writer task drains on the runtime loop, and
+        # so does Matrix I/O. Asking anyway writes a durable claim nothing can
+        # settle and parks this call behind it, holding typing and the
+        # conversation lock for as long as the process lives.
+        #
+        # Only refused when the policy actually wants an approval: everything
+        # else is free to run here, and most tools do.
+        logger.warning("approval_refused_on_sync_tool_bridge", tool_name=tool_name)
+        return _format_declined_result(tool_name, _SYNC_TOOL_BRIDGE_APPROVAL_REASON)
 
     try:
         approval_decision = await request_tool_approval_for_call(

--- a/tach.toml
+++ b/tach.toml
@@ -4537,6 +4537,7 @@ from = ["mindroom.tool_approval"]
 [[interfaces]]
 expose = [
     "is_loop_blocked_by_sync_tool_bridge",
+    "running_loop_is_sync_tool_bridge",
     "sync_tool_bridge_blocked_loop",
 ]
 from = ["mindroom.sync_bridge_state"]

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -1914,9 +1914,9 @@ async def test_sync_tool_approval_execute_on_runtime_loop_fails_fast(tmp_path: P
     assert result.result == (
         "[TOOL CALL DECLINED]\n"
         "Tool: echo\n"
-        "Reason: Cannot perform Matrix approval transport while synchronous FunctionCall.execute() "
-        "is blocking the MindRoom runtime loop; use FunctionCall.aexecute() or run execute() "
-        "outside the runtime event loop.\n\n"
+        "Reason: This tool needs approval, and it was called synchronously, which blocks the "
+        "runtime MindRoom would need in order to ask for one. Ask again so it runs "
+        "asynchronously, or use a tool that does not require approval.\n\n"
         "Adjust your approach — try a different tool or different arguments."
     )
     client.room_send.assert_not_awaited()


### PR DESCRIPTION
This is the one that stops a conversation wedging. The sweep PRs (#1811, #1813, #1812, #1814) all govern what happens to rows and waiters that exist *after* the claim; this is about a caller that never gets that far.

## What happens today

A synchronous agno tool (`create_event`, `send_email` — plain `def`) has its async hook work run on a loop of its own, in a thread the runtime loop is blocked joining (`tool_system/tool_hooks.py:341`, marked with `sync_tool_bridge_blocked_loop`). Everything an approval needs is on the far side of that block:

- `SqliteBackend.write()` creates the caller's future on the **bridge** loop and enqueues onto a queue whose writer task drains on the **runtime** loop (`event_journal/sqlite_backend.py:159-172`, `:273-279`).
- The runtime loop cannot drain it, because it is inside `thread.join()`.

Reproduced with a 30-line probe against the real backend:

```text
runtime-loop write: 'runtime'            <- writer task created on the runtime loop
bridge loop id4426764112 (runtime id4426534928) same=False
bridge thread alive after join timeout: True
bridge write result: {}                  <- no result, no exception, 15s later
```

`asyncio.wait_for(..., timeout=5)` around the write did not interrupt it. So the claim row is written, the caller never resumes, typing and the conversation lock are held, and the durable row has no owner in memory — which is also how a startup sweep comes to read it as abandoned.

Production signature matches: every wedged approval was a plain `def`; the one that published cleanly was `async def request_network_access`. One room held a typing indicator for 53 minutes.

## What this does

Refuse before the claim exists, using the same blocked-loop marker `approval_transport.py:184` already uses for the Matrix half of this hazard, and say why in a sentence the person in the room can act on.

Gated on the policy actually wanting an approval — `evaluate_tool_approval` is cheap and pure, and running it early costs nothing on a path about to be declined, whereas refusing every synchronous tool call would take out the ones needing no approval, which is most of them. That was caught by an existing test going red when the first version was too broad.

Placed in `tool_system.tool_hooks` rather than `approval_manager`: tach keeps `approval_manager` narrow, `sync_bridge_state` is already visible to the hook layer, and the hook layer is where the bridge is created. `running_loop_is_sync_tool_bridge()` is added to that module's interface — it distinguishes "some other loop is blocked" from "I am the blocked loop", which `is_loop_blocked_by_sync_tool_bridge` alone cannot do from inside bridge work.

## This is a stopgap, and a visible one

Approval-gated synchronous tools now **decline instead of hanging**. Better than silent infinite typing; not the same as working. Calendar and Gmail writes are affected until the real repair lands. Worth telling affected users.

The repair, in ascending order of correctness:

1. Fix the wakeup — resolve the caller's future via `future.get_loop().call_soon_threadsafe(...)`, and stop sharing one `asyncio.Queue` across loops (`put_nowait` from the bridge thread into a queue owned by the writer's loop is also not thread-safe).
2. Remove the second loop — route journal writes through the runtime loop the way Matrix I/O already is, so the sync bridge never touches the store.
3. Stop blocking the runtime loop for synchronous tool execution at all, which kills the class rather than an instance.

## Tests

`uv run pytest -q -nauto tests/test_tool_approval.py tests/test_tool_hooks.py tests/test_orchestrator_runtime.py tests/test_bot_reactions_approvals.py` — exit 0. `ruff check`, `ruff format`, `ty check`, tach all clean.

An existing test already covered this exact path and asserted the transport's developer-facing message. It reached the transport because a fresh store builds its journal writer on the bridge loop; in production the writer already exists on the runtime loop and the claim parks first. Same refusal, earlier and more legible, so its expectation moves with it.

Stacks cleanly with #1814 — different files.

## Summary by Sourcery

Decline approval-gated synchronous tool calls that would run on a blocked sync bridge loop, preventing wedged conversations and replacing silent hangs with a clear user-facing refusal message.

New Features:
- Add pre-check logic to determine whether a tool call would require approval without initiating the approval flow.
- Introduce a helper to detect when code is running on a synchronous tool bridge event loop.

Enhancements:
- Update tool approval handling so synchronous, approval-requiring calls on the sync bridge are refused immediately with a clearer explanation instead of attempting an approval that cannot complete.
- Expose the new sync-bridge detection helper through the tach interface for use by other components.

Tests:
- Adjust existing approval transport tests to assert the new, more user-focused decline reason for synchronous, approval-gated tool calls.