### PR TITLE
fix: wake a journal write's caller on its own event loop

### DIFF
--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -137,6 +137,10 @@ class SqliteBackend:
     # the type checker on the wrong side of it.
     _queue: asyncio.Queue[_QueuedWrite] | None = field(default=None, init=False, repr=False)
     _writer_task: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
+    # The loop the writer task drains on, remembered because a caller on any
+    # other loop can neither enqueue onto that queue nor be woken by it
+    # without being handed across deliberately.
+    _writer_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
     _closed: bool = field(default=False, init=False, repr=False)
     _open_readers: list[sqlite3.Connection] = field(default_factory=list, init=False, repr=False)
     _reader_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
@@ -162,6 +166,7 @@ class SqliteBackend:
         if queue is None or self._writer_task is None or self._writer_task.done():
             queue = asyncio.Queue()
             self._queue = queue
+            self._writer_loop = asyncio.get_running_loop()
             self._writer_task = asyncio.create_task(
                 # Handed the queue it drains rather than reading the field,
                 # so a task can only ever settle writes that were admitted to
@@ -271,8 +276,18 @@ class SqliteBackend:
         if self._closed:
             raise RuntimeError(_CLOSED_MESSAGE)
         queue = self._ensure_writer_task()
-        future: asyncio.Future[T] = asyncio.get_running_loop().create_future()
-        queue.put_nowait(_QueuedWrite(operation=operation, future=future))
+        caller_loop = asyncio.get_running_loop()
+        writer_loop = self._writer_loop
+        future: asyncio.Future[T] = caller_loop.create_future()
+        queued = _QueuedWrite(operation=operation, future=future)
+        # A queue belongs to the loop that drains it. Putting to one from
+        # another loop wakes its consumer through a callback scheduled on the
+        # wrong loop, which arrives whenever that loop happens to run next and
+        # not because anything told it to.
+        if writer_loop is None or writer_loop is caller_loop:
+            queue.put_nowait(queued)
+        else:
+            writer_loop.call_soon_threadsafe(queue.put_nowait, queued)
         # Cancelling this await must not report an outcome the writer has not
         # reached yet: the statement runs on a thread regardless, so the caller
         # learns how it ended before its cancellation propagates.
@@ -336,7 +351,21 @@ class SqliteBackend:
 
 
 def _report(future: asyncio.Future[Any], work: asyncio.Future[Any]) -> None:
-    """Give the waiting caller the worker's own outcome."""
+    """Give the waiting caller the worker's own outcome, on the caller's own loop.
+
+    Completing a future belonging to another loop sets its result but schedules
+    its callbacks with a plain ``call_soon``, which does not wake that loop. A
+    loop with nothing else pending -- the synchronous tool bridge's own loop,
+    between the write it issued and the answer it is waiting for -- then sleeps
+    in its selector with the result already sitting there, and the caller never
+    resumes. Handing the completion across deliberately is what wakes it.
+    """
+    caller_loop = future.get_loop()
+    if caller_loop is not _running_loop():
+        if not caller_loop.is_closed():
+            with contextlib.suppress(RuntimeError):
+                caller_loop.call_soon_threadsafe(_report, future, work)
+        return
     if future.done():
         return
     if work.cancelled():
@@ -345,6 +374,14 @@ def _report(future: asyncio.Future[Any], work: asyncio.Future[Any]) -> None:
         future.set_exception(error)
     else:
         future.set_result(work.result())
+
+
+def _running_loop() -> asyncio.AbstractEventLoop | None:
+    """Return the loop this call is running on, if it is running on one."""
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        return None
 
 
 @dataclass(slots=True)

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -287,7 +287,12 @@ class SqliteBackend:
         if writer_loop is None or writer_loop is caller_loop:
             queue.put_nowait(queued)
         else:
-            writer_loop.call_soon_threadsafe(self._admit, queue, queued)
+            try:
+                writer_loop.call_soon_threadsafe(self._admit, queue, queued)
+            except RuntimeError:
+                if not writer_loop.is_closed():
+                    raise
+                _deliver(future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))
         # Cancelling this await must not report an outcome the writer has not
         # reached yet: the statement runs on a thread regardless, so the caller
         # learns how it ended before its cancellation propagates.

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -275,7 +275,6 @@ class SqliteBackend:
         """
         if self._closed:
             raise RuntimeError(_CLOSED_MESSAGE)
-        queue = self._ensure_writer_task()
         caller_loop = asyncio.get_running_loop()
         writer_loop = self._writer_loop
         future: asyncio.Future[T] = caller_loop.create_future()
@@ -285,10 +284,11 @@ class SqliteBackend:
         # wrong loop, which arrives whenever that loop happens to run next and
         # not because anything told it to.
         if writer_loop is None or writer_loop is caller_loop:
+            queue = self._ensure_writer_task()
             queue.put_nowait(queued)
         else:
             try:
-                writer_loop.call_soon_threadsafe(self._admit, queue, queued)
+                writer_loop.call_soon_threadsafe(self._admit, queued)
             except RuntimeError:
                 if not writer_loop.is_closed():
                     raise
@@ -298,18 +298,20 @@ class SqliteBackend:
         # learns how it ended before its cancellation propagates.
         return await settled(future)
 
-    def _admit(self, queue: asyncio.Queue[_QueuedWrite], queued: _QueuedWrite) -> None:
+    def _admit(self, queued: _QueuedWrite) -> None:
         """Put one handed-across write in the queue, or refuse it if ``close()`` got there first.
 
-        A write from another loop cannot be admitted where it is decided, so
-        the decision is re-made here, on the writer's own loop, where
-        ``close()`` also runs. Without this the two can interleave the one way
-        that strands a caller: ``close()`` drains the queue, and the admission
-        it never saw arrives afterwards, into a queue nothing will read again.
+        A write from another loop cannot be admitted or inspect the writer task
+        where it is decided, so both happen here, on the writer's own loop,
+        where ``close()`` also runs. Without this the two can interleave the one
+        way that strands a caller: ``close()`` drains the queue, and the
+        admission it never saw arrives afterwards, into a queue nothing will
+        read again.
         """
         if self._closed:
             _deliver(queued.future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))
             return
+        queue = self._ensure_writer_task()
         queue.put_nowait(queued)
 
     async def read[T](self, operation: Operation[T]) -> T:

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -287,11 +287,25 @@ class SqliteBackend:
         if writer_loop is None or writer_loop is caller_loop:
             queue.put_nowait(queued)
         else:
-            writer_loop.call_soon_threadsafe(queue.put_nowait, queued)
+            writer_loop.call_soon_threadsafe(self._admit, queue, queued)
         # Cancelling this await must not report an outcome the writer has not
         # reached yet: the statement runs on a thread regardless, so the caller
         # learns how it ended before its cancellation propagates.
         return await settled(future)
+
+    def _admit(self, queue: asyncio.Queue[_QueuedWrite], queued: _QueuedWrite) -> None:
+        """Put one handed-across write in the queue, or refuse it if ``close()`` got there first.
+
+        A write from another loop cannot be admitted where it is decided, so
+        the decision is re-made here, on the writer's own loop, where
+        ``close()`` also runs. Without this the two can interleave the one way
+        that strands a caller: ``close()`` drains the queue, and the admission
+        it never saw arrives afterwards, into a queue nothing will read again.
+        """
+        if self._closed:
+            _refuse(queued.future, RuntimeError(_CLOSED_MESSAGE))
+            return
+        queue.put_nowait(queued)
 
     async def read[T](self, operation: Operation[T]) -> T:
         """Run one read on a WAL reader, concurrently with the writer."""
@@ -374,6 +388,18 @@ def _report(future: asyncio.Future[Any], work: asyncio.Future[Any]) -> None:
         future.set_exception(error)
     else:
         future.set_result(work.result())
+
+
+def _refuse(future: asyncio.Future[Any], error: BaseException) -> None:
+    """Tell one caller its write was never admitted, on the caller's own loop."""
+    caller_loop = future.get_loop()
+    if caller_loop is not _running_loop():
+        if not caller_loop.is_closed():
+            with contextlib.suppress(RuntimeError):
+                caller_loop.call_soon_threadsafe(_refuse, future, error)
+        return
+    if not future.done():
+        future.set_exception(error)
 
 
 def _running_loop() -> asyncio.AbstractEventLoop | None:

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -255,10 +255,10 @@ class SqliteBackend:
     async def write[T](self, operation: Operation[T]) -> T:
         """Queue one operation for the writer task and await its commit.
 
-        Admission is decided once, here, and the decision cannot go stale:
-        nothing suspends between reading ``_closed`` and enqueuing, so a write
-        this accepted is in the queue before any ``close()`` can begin, and
-        ``close()`` therefore sees every write it will ever have to refuse.
+        Admission is decided on the writer's loop, where it cannot race
+        ``close()``. A caller already on that loop enqueues synchronously; one
+        on another loop hands the decision across, where ``_closed`` is checked
+        again before the write enters the queue.
 
         That is what the queue being unbounded buys. A bounded one parked the
         producer in ``put`` instead, and ``close()`` frees a slot per entry it
@@ -303,7 +303,7 @@ class SqliteBackend:
         it never saw arrives afterwards, into a queue nothing will read again.
         """
         if self._closed:
-            _refuse(queued.future, RuntimeError(_CLOSED_MESSAGE))
+            _deliver(queued.future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))
             return
         queue.put_nowait(queued)
 
@@ -334,9 +334,9 @@ class SqliteBackend:
         separately before the connections they run on are closed.
 
         Draining the queue once is enough because ``_closed`` is raised before
-        it and ``write`` enqueues without suspending: every write that will
-        ever be admitted is already in the queue by the time this reaches it,
-        and every write after is refused where it starts.
+        it on the writer's loop. Every write already admitted is in the queue,
+        and every handed-across decision that runs afterwards refuses its
+        caller instead of enqueuing.
         """
         if self._closed:
             return
@@ -352,8 +352,7 @@ class SqliteBackend:
         queue = self._queue
         while queue is not None and not queue.empty():
             queued = queue.get_nowait()
-            if not queued.future.done():
-                queued.future.set_exception(RuntimeError(_CLOSED_MESSAGE))
+            _deliver(queued.future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))
             queue.task_done()
         await self._offload.drain()
         await asyncio.to_thread(self._writer.close)
@@ -365,7 +364,7 @@ class SqliteBackend:
 
 
 def _report(future: asyncio.Future[Any], work: asyncio.Future[Any]) -> None:
-    """Give the waiting caller the worker's own outcome, on the caller's own loop.
+    """Snapshot the worker's outcome and give it to the waiting caller.
 
     Completing a future belonging to another loop sets its result but schedules
     its callbacks with a plain ``call_soon``, which does not wake that loop. A
@@ -374,32 +373,31 @@ def _report(future: asyncio.Future[Any], work: asyncio.Future[Any]) -> None:
     in its selector with the result already sitting there, and the caller never
     resumes. Handing the completion across deliberately is what wakes it.
     """
+    if work.cancelled():
+        outcome = _WriteOutcome(cancelled=True)
+    elif (error := work.exception()) is not None:
+        outcome = _WriteOutcome(error=error)
+    else:
+        outcome = _WriteOutcome(result=work.result())
+    _deliver(future, outcome)
+
+
+def _deliver(future: asyncio.Future[Any], outcome: _WriteOutcome) -> None:
+    """Apply a plain write outcome on the caller future's own loop."""
     caller_loop = future.get_loop()
     if caller_loop is not _running_loop():
         if not caller_loop.is_closed():
             with contextlib.suppress(RuntimeError):
-                caller_loop.call_soon_threadsafe(_report, future, work)
+                caller_loop.call_soon_threadsafe(_deliver, future, outcome)
         return
     if future.done():
         return
-    if work.cancelled():
+    if outcome.cancelled:
         future.cancel()
-    elif (error := work.exception()) is not None:
-        future.set_exception(error)
+    elif outcome.error is not None:
+        future.set_exception(outcome.error)
     else:
-        future.set_result(work.result())
-
-
-def _refuse(future: asyncio.Future[Any], error: BaseException) -> None:
-    """Tell one caller its write was never admitted, on the caller's own loop."""
-    caller_loop = future.get_loop()
-    if caller_loop is not _running_loop():
-        if not caller_loop.is_closed():
-            with contextlib.suppress(RuntimeError):
-                caller_loop.call_soon_threadsafe(_refuse, future, error)
-        return
-    if not future.done():
-        future.set_exception(error)
+        future.set_result(outcome.result)
 
 
 def _running_loop() -> asyncio.AbstractEventLoop | None:
@@ -414,3 +412,10 @@ def _running_loop() -> asyncio.AbstractEventLoop | None:
 class _QueuedWrite:
     operation: Operation[Any]
     future: asyncio.Future[Any]
+
+
+@dataclass(frozen=True, slots=True)
+class _WriteOutcome:
+    result: Any = None
+    error: BaseException | None = None
+    cancelled: bool = False

--- a/tests/test_event_journal_cross_loop.py
+++ b/tests/test_event_journal_cross_loop.py
@@ -235,3 +235,79 @@ async def test_close_wakes_a_cross_loop_write_already_waiting_in_the_queue(
     await asyncio.to_thread(bridge.join, _RETURN_TIMEOUT_SECONDS)
     _assert_closed_refusal(outcome, operation_ran)
     await blocking_write
+
+
+@pytest.mark.asyncio
+async def test_a_closed_recorded_writer_loop_refuses_a_cross_loop_write(tmp_path: Path) -> None:
+    """A stale closed writer loop must produce the store's closure error, not leak a loop error."""
+    backend = SqliteBackend.open(tmp_path / "journal.db")
+    await backend.write(lambda transaction: transaction.execute("CREATE TABLE claim (value INTEGER)"))
+    writer_loop = backend._writer_loop
+    closed_loop = asyncio.new_event_loop()
+    closed_loop.close()
+    operation_ran = threading.Event()
+
+    def insert_claim(transaction: Transaction) -> None:
+        operation_ran.set()
+        transaction.execute("INSERT INTO claim VALUES (1)")
+
+    backend._writer_loop = closed_loop
+    try:
+        with pytest.raises(RuntimeError, match=r"^The event-journal store is closed$"):
+            await backend.write(insert_claim)
+    finally:
+        backend._writer_loop = writer_loop
+        await backend.close()
+
+    assert not operation_ran.is_set()
+
+
+@pytest.mark.asyncio
+async def test_cancelling_a_cross_loop_write_waits_for_its_statement_to_finish(tmp_path: Path) -> None:
+    """Cancellation must wake only after the cross-loop statement releases the writer."""
+    backend = SqliteBackend.open(tmp_path / "journal.db")
+    await backend.write(lambda transaction: transaction.execute("CREATE TABLE claim (value INTEGER)"))
+    statement_started = threading.Event()
+    release_statement = threading.Event()
+    statement_finished = threading.Event()
+    cancellation_sent = threading.Event()
+    cancellation_returned = threading.Event()
+    outcome: list[BaseException] = []
+
+    def insert_claim(transaction: Transaction) -> None:
+        transaction.execute("INSERT INTO claim VALUES (1)")
+        statement_started.set()
+        assert release_statement.wait(_RETURN_TIMEOUT_SECONDS), "the test never released the statement"
+        statement_finished.set()
+
+    def write_from_its_own_loop() -> None:
+        async def claim() -> None:
+            writing = asyncio.create_task(backend.write(insert_claim))
+            assert await asyncio.to_thread(statement_started.wait, _RETURN_TIMEOUT_SECONDS), (
+                "the cross-loop statement never started"
+            )
+            writing.cancel()
+            cancellation_sent.set()
+            try:
+                await writing
+            except asyncio.CancelledError as error:
+                outcome.append(error)
+            finally:
+                cancellation_returned.set()
+
+        asyncio.run(claim())
+
+    bridge = threading.Thread(target=write_from_its_own_loop, name="cancelled-second-loop-writer", daemon=True)
+    bridge.start()
+    try:
+        assert await asyncio.to_thread(cancellation_sent.wait, _RETURN_TIMEOUT_SECONDS)
+        assert not cancellation_returned.is_set(), "cancellation escaped while the statement still held the writer"
+    finally:
+        release_statement.set()
+
+    await asyncio.to_thread(bridge.join, _RETURN_TIMEOUT_SECONDS)
+    assert cancellation_returned.is_set()
+    assert len(outcome) == 1
+    assert isinstance(outcome[0], asyncio.CancelledError)
+    assert statement_finished.is_set()
+    await backend.close()

--- a/tests/test_event_journal_cross_loop.py
+++ b/tests/test_event_journal_cross_loop.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 from typing import TYPE_CHECKING
 
 import pytest
@@ -60,3 +61,34 @@ async def test_a_write_from_a_second_event_loop_comes_back(tmp_path: Path) -> No
     assert returned.is_set(), "the write committed but its caller was never woken"
 
     await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_a_cross_loop_write_racing_close_is_refused_not_stranded(tmp_path: Path) -> None:
+    """A write admitted across loops must end, even if close() beats it to the queue."""
+    backend = SqliteBackend.open(tmp_path / "journal.db")
+    await backend.write(lambda transaction: transaction.execute("CREATE TABLE claim (value INTEGER)"))
+
+    outcome: list[BaseException | None] = []
+
+    def write_from_its_own_loop() -> None:
+        async def claim() -> None:
+            await backend.write(lambda transaction: transaction.execute("INSERT INTO claim VALUES (1)"))
+
+        try:
+            asyncio.run(claim())
+        except BaseException as error:  # the point is only that something ends the wait
+            outcome.append(error)
+        else:
+            outcome.append(None)
+
+    bridge = threading.Thread(target=write_from_its_own_loop, name="second-loop-writer", daemon=True)
+    bridge.start()
+    # Blocking rather than awaiting, so this loop cannot run the admission the
+    # bridge is scheduling on it: close() then reaches the queue first, which
+    # is the race the caller must survive.
+    time.sleep(0.2)  # noqa: ASYNC251 - blocking this loop is the point of the test
+    await backend.close()
+
+    await asyncio.to_thread(bridge.join, _RETURN_TIMEOUT_SECONDS)
+    assert outcome, "the write was neither admitted nor refused, so its caller is stranded"

--- a/tests/test_event_journal_cross_loop.py
+++ b/tests/test_event_journal_cross_loop.py
@@ -1,0 +1,62 @@
+"""A journal write issued from a second event loop has to come back.
+
+Agno runs a synchronous tool as ``await asyncio.to_thread(function_call.execute)``,
+so its hook chain lands on a worker thread with no loop of its own, and
+``_run_coroutine_from_sync`` (``tool_system/tool_hooks.py``) gives it one with
+``asyncio.run``. Any journal write that chain triggers is therefore issued
+from a loop that is not the one the store's writer task lives on. The runtime
+loop is still running, so the write itself is fine -- the writer commits it --
+but the caller has to be woken on its own loop, and a loop whose only pending
+work is that write has no reason to wake unless something tells it to.
+
+When it is not told, the caller never resumes: the row is committed and
+visible to every reader, while the coroutine that wrote it waits forever,
+holding whatever it was in the middle of publishing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.event_journal.sqlite_backend import SqliteBackend
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_RETURN_TIMEOUT_SECONDS = 5.0
+
+
+@pytest.mark.asyncio
+async def test_a_write_from_a_second_event_loop_comes_back(tmp_path: Path) -> None:
+    """A caller on another loop must resume once its write has committed."""
+    backend = SqliteBackend.open(tmp_path / "journal.db")
+    # The first write is what pins the writer task to this loop, which is the
+    # arrangement the bridge then writes into from a loop of its own.
+    await backend.write(lambda transaction: transaction.execute("CREATE TABLE claim (value INTEGER)"))
+
+    returned = threading.Event()
+
+    def write_from_its_own_loop() -> None:
+        async def claim() -> None:
+            # Deliberately unbounded: a timeout would put a timer on this loop
+            # and wake it for reasons of its own, which is the very thing the
+            # caller cannot rely on.
+            await backend.write(lambda transaction: transaction.execute("INSERT INTO claim VALUES (1)"))
+
+        asyncio.run(claim())
+        returned.set()
+
+    bridge = threading.Thread(target=write_from_its_own_loop, name="second-loop-writer", daemon=True)
+    bridge.start()
+    # Joined off this loop so the writer task stays free to drain the queue.
+    await asyncio.to_thread(bridge.join, _RETURN_TIMEOUT_SECONDS)
+
+    committed = await backend.read(lambda transaction: transaction.fetchone("SELECT value FROM claim"))
+    assert committed is not None, "the write never reached the database, so this proves something else"
+    assert returned.is_set(), "the write committed but its caller was never woken"
+
+    await backend.close()

--- a/tests/test_event_journal_cross_loop.py
+++ b/tests/test_event_journal_cross_loop.py
@@ -17,18 +17,48 @@ holding whatever it was in the middle of publishing.
 from __future__ import annotations
 
 import asyncio
+import queue
 import threading
-import time
 from typing import TYPE_CHECKING
 
 import pytest
 
-from mindroom.event_journal.sqlite_backend import SqliteBackend
+from mindroom.event_journal.sqlite_backend import SqliteBackend, _report
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
+    from mindroom.event_journal.backend import Transaction
+
 _RETURN_TIMEOUT_SECONDS = 5.0
+
+
+class _LoopOwnedFuture(asyncio.Future[int]):
+    """A future that rejects reads away from its owning loop."""
+
+    def _assert_owning_loop(self) -> None:
+        assert asyncio.get_running_loop() is self.get_loop()
+
+    def cancelled(self) -> bool:
+        self._assert_owning_loop()
+        return super().cancelled()
+
+    def exception(self) -> BaseException | None:
+        self._assert_owning_loop()
+        return super().exception()
+
+    def result(self) -> int:
+        self._assert_owning_loop()
+        return super().result()
+
+
+def _assert_closed_refusal(outcome: list[BaseException | None], operation_ran: threading.Event) -> None:
+    assert len(outcome) == 1
+    error = outcome[0]
+    assert isinstance(error, RuntimeError)
+    assert str(error) == "The event-journal store is closed"
+    assert not operation_ran.is_set()
 
 
 @pytest.mark.asyncio
@@ -64,16 +94,50 @@ async def test_a_write_from_a_second_event_loop_comes_back(tmp_path: Path) -> No
 
 
 @pytest.mark.asyncio
-async def test_a_cross_loop_write_racing_close_is_refused_not_stranded(tmp_path: Path) -> None:
+async def test_cross_loop_report_reads_work_only_on_the_writer_loop() -> None:
+    """The caller-loop handoff must contain a plain snapshot, not the writer's future."""
+    caller_future: queue.Queue[asyncio.Future[int]] = queue.Queue()
+    outcome: list[int] = []
+
+    def wait_on_its_own_loop() -> None:
+        async def wait() -> None:
+            future = asyncio.get_running_loop().create_future()
+            caller_future.put(future)
+            outcome.append(await future)
+
+        asyncio.run(wait())
+
+    caller = threading.Thread(target=wait_on_its_own_loop, name="second-loop-caller", daemon=True)
+    caller.start()
+    future = await asyncio.to_thread(caller_future.get)
+    work = _LoopOwnedFuture()
+    work.set_result(7)
+
+    _report(future, work)
+
+    await asyncio.to_thread(caller.join, _RETURN_TIMEOUT_SECONDS)
+    assert outcome == [7]
+
+
+@pytest.mark.asyncio
+async def test_a_cross_loop_write_racing_close_is_refused_not_stranded(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A write admitted across loops must end, even if close() beats it to the queue."""
     backend = SqliteBackend.open(tmp_path / "journal.db")
     await backend.write(lambda transaction: transaction.execute("CREATE TABLE claim (value INTEGER)"))
 
     outcome: list[BaseException | None] = []
+    operation_ran = threading.Event()
+
+    def insert_claim(transaction: Transaction) -> None:
+        operation_ran.set()
+        transaction.execute("INSERT INTO claim VALUES (1)")
 
     def write_from_its_own_loop() -> None:
         async def claim() -> None:
-            await backend.write(lambda transaction: transaction.execute("INSERT INTO claim VALUES (1)"))
+            await backend.write(insert_claim)
 
         try:
             asyncio.run(claim())
@@ -83,12 +147,91 @@ async def test_a_cross_loop_write_racing_close_is_refused_not_stranded(tmp_path:
             outcome.append(None)
 
     bridge = threading.Thread(target=write_from_its_own_loop, name="second-loop-writer", daemon=True)
-    bridge.start()
-    # Blocking rather than awaiting, so this loop cannot run the admission the
-    # bridge is scheduling on it: close() then reaches the queue first, which
-    # is the race the caller must survive.
-    time.sleep(0.2)  # noqa: ASYNC251 - blocking this loop is the point of the test
+    admission_scheduled = threading.Event()
+    writer_loop = asyncio.get_running_loop()
+    call_soon_threadsafe = writer_loop.call_soon_threadsafe
+
+    def record_admission(callback: Callable[..., object], *args: object) -> asyncio.Handle:
+        handle = call_soon_threadsafe(callback, *args)
+        if callback == backend._admit:
+            admission_scheduled.set()
+        return handle
+
+    with monkeypatch.context() as patch:
+        patch.setattr(writer_loop, "call_soon_threadsafe", record_admission)
+        bridge.start()
+        # Block this loop until the bridge has passed the first closed check and
+        # scheduled admission here. The queued callback cannot run before close.
+        assert admission_scheduled.wait(_RETURN_TIMEOUT_SECONDS), "the bridge never scheduled admission"
     await backend.close()
 
     await asyncio.to_thread(bridge.join, _RETURN_TIMEOUT_SECONDS)
-    assert outcome, "the write was neither admitted nor refused, so its caller is stranded"
+    _assert_closed_refusal(outcome, operation_ran)
+
+
+@pytest.mark.asyncio
+async def test_close_wakes_a_cross_loop_write_already_waiting_in_the_queue(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closing must wake a foreign caller whose write was queued behind another write."""
+    backend = SqliteBackend.open(tmp_path / "journal.db")
+    await backend.write(lambda transaction: transaction.execute("CREATE TABLE claim (value INTEGER)"))
+
+    blocking_write_started = threading.Event()
+    release_blocking_write = threading.Event()
+
+    def block_writer(transaction: Transaction) -> None:
+        del transaction
+        blocking_write_started.set()
+        release_blocking_write.wait()
+
+    blocking_write = asyncio.create_task(backend.write(block_writer))
+    await asyncio.to_thread(blocking_write_started.wait)
+
+    outcome: list[BaseException | None] = []
+    operation_ran = threading.Event()
+
+    def insert_claim(transaction: Transaction) -> None:
+        operation_ran.set()
+        transaction.execute("INSERT INTO claim VALUES (1)")
+
+    def write_from_its_own_loop() -> None:
+        async def claim() -> None:
+            await backend.write(insert_claim)
+
+        try:
+            asyncio.run(claim())
+        except BaseException as error:  # the point is only that something ends the wait
+            outcome.append(error)
+        else:
+            outcome.append(None)
+
+    bridge = threading.Thread(target=write_from_its_own_loop, name="queued-second-loop-writer", daemon=True)
+    admission_completed = asyncio.Event()
+    writer_loop = asyncio.get_running_loop()
+    call_soon_threadsafe = writer_loop.call_soon_threadsafe
+
+    def record_admission(callback: Callable[..., object], *args: object) -> asyncio.Handle:
+        if callback != backend._admit:
+            return call_soon_threadsafe(callback, *args)
+
+        def admit_and_record() -> None:
+            callback(*args)
+            admission_completed.set()
+
+        return call_soon_threadsafe(admit_and_record)
+
+    with monkeypatch.context() as patch:
+        patch.setattr(writer_loop, "call_soon_threadsafe", record_admission)
+        bridge.start()
+        await admission_completed.wait()
+
+    close = asyncio.create_task(backend.close())
+    await asyncio.sleep(0)
+    release_blocking_write.set()
+    await close
+
+    await asyncio.to_thread(bridge.join, _RETURN_TIMEOUT_SECONDS)
+    _assert_closed_refusal(outcome, operation_ran)
+    await blocking_write

--- a/tests/test_event_journal_cross_loop.py
+++ b/tests/test_event_journal_cross_loop.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from pathlib import Path
 
     from mindroom.event_journal.backend import Transaction
+    from mindroom.event_journal.sqlite_backend import _QueuedWrite
 
 _RETURN_TIMEOUT_SECONDS = 5.0
 
@@ -235,6 +236,66 @@ async def test_close_wakes_a_cross_loop_write_already_waiting_in_the_queue(
     await asyncio.to_thread(bridge.join, _RETURN_TIMEOUT_SECONDS)
     _assert_closed_refusal(outcome, operation_ran)
     await blocking_write
+
+
+@pytest.mark.asyncio
+async def test_close_before_foreign_writer_task_lookup_does_not_recreate_the_writer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A foreign write past its first check must not recreate the writer after close clears it."""
+    backend = SqliteBackend.open(tmp_path / "journal.db")
+    await backend.write(lambda transaction: transaction.execute("CREATE TABLE claim (value INTEGER)"))
+    writer_loop = asyncio.get_running_loop()
+    ensure_writer_task = backend._ensure_writer_task
+    call_soon_threadsafe = writer_loop.call_soon_threadsafe
+    handoff_reached = threading.Event()
+    release_foreign_ensure = threading.Event()
+    outcome: list[BaseException | None] = []
+    operation_ran = threading.Event()
+
+    def pause_foreign_ensure() -> asyncio.Queue[_QueuedWrite]:
+        if threading.current_thread().name == "ensure-race-second-loop-writer":
+            handoff_reached.set()
+            assert release_foreign_ensure.wait(_RETURN_TIMEOUT_SECONDS), "the test never released writer lookup"
+        return ensure_writer_task()
+
+    def record_admission(callback: Callable[..., object], *args: object) -> asyncio.Handle:
+        handle = call_soon_threadsafe(callback, *args)
+        if callback == backend._admit:
+            handoff_reached.set()
+        return handle
+
+    def insert_claim(transaction: Transaction) -> None:
+        operation_ran.set()
+        transaction.execute("INSERT INTO claim VALUES (1)")
+
+    def write_from_its_own_loop() -> None:
+        async def claim() -> None:
+            await backend.write(insert_claim)
+
+        try:
+            asyncio.run(claim())
+        except BaseException as error:  # the exact refusal is asserted below
+            outcome.append(error)
+        else:
+            outcome.append(None)
+
+    bridge = threading.Thread(
+        target=write_from_its_own_loop,
+        name="ensure-race-second-loop-writer",
+        daemon=True,
+    )
+    with monkeypatch.context() as patch:
+        patch.setattr(backend, "_ensure_writer_task", pause_foreign_ensure)
+        patch.setattr(writer_loop, "call_soon_threadsafe", record_admission)
+        bridge.start()
+        assert handoff_reached.wait(_RETURN_TIMEOUT_SECONDS), "the foreign write never passed its first closed check"
+        await backend.close()
+        release_foreign_ensure.set()
+
+    await asyncio.to_thread(bridge.join, _RETURN_TIMEOUT_SECONDS)
+    _assert_closed_refusal(outcome, operation_ran)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- remember the loop the journal writer task drains on, and enqueue from any other loop through `call_soon_threadsafe`
- complete a write's future on the loop that created it, instead of from the writer's loop
- add a regression that drives a write from a second loop with no timeout anywhere

## Why

A write issued from an event loop that is not the writer task's loop committed and then never came back. The row was in the database, visible to every reader, while the coroutine that wrote it waited forever.

Two handoffs on that path cross loops and neither said so. `write()` creates the caller's future on the caller's loop (`sqlite_backend.py:274`) and puts the operation onto a queue owned by the writer's loop, and `_report()` completes that future from the writer's loop once the statement lands. Completing a future that belongs to another loop sets its result but schedules its callbacks with a plain `call_soon`, which does not wake that loop. A loop whose only pending work is the write it is waiting for then sleeps in its selector with the answer already sitting in its callback queue.

Agno reaches that arrangement for every synchronous tool. `agno/models/base.py` runs one as `await asyncio.to_thread(function_call.execute)`, so the hook chain lands on a worker thread with no loop, and `_run_coroutine_from_sync` (`tool_system/tool_hooks.py:311-320`) gives it one with `asyncio.run`. The runtime loop stays alive and its writer task commits the statement, which is why the durable row appears while the caller that wrote it is stranded.

## Production

This parked approval-gated Google Calendar and Gmail calls indefinitely. One control plane held six conversations this way in a single afternoon. For each: `agno_tool_call_started`, then `bridge_entry`, then nothing at all — no `tool_entry`, no `bridge_finish`, no terminal response, no error — while the typing indicator kept firing every 15s and the per-conversation lock stayed held, so later messages in the room were accepted and never dispatched. One room stayed in that state for over two hours. The durable approval claim was committed the whole time; no card was ever sent, so there was nothing for the human to answer. The call could not be cancelled either, because the offload deliberately re-enters its wait so a statement is never abandoned mid-flight.

The tools that wedged are all synchronous agno functions (`create_event` is a plain `def`). The one approval that published cleanly in the same window was `async def request_network_access`, which never leaves the runtime loop.

## Tests

- new `tests/test_event_journal_cross_loop.py::test_a_write_from_a_second_event_loop_comes_back` — verified red before the fix: the row commits and the assertion reports `the write committed but its caller was never woken` after a 5s join; green after, in 0.01s. No timeout anywhere in the test, because a timeout would put a timer on the second loop and wake it for reasons of its own, which is the one thing the caller cannot rely on.
- A/B against the same arrangement production hits: without the fix `caller_returned=False row_committed=True`, with it `caller_returned=True row_committed=True`.
- `uv run pytest -nauto -k "not postgres" tests/test_event_journal_cross_loop.py tests/test_event_journal_store.py tests/test_event_journal_crash_matrix.py tests/test_durable_write.py tests/test_tool_approval.py tests/test_tool_hooks.py tests/test_orchestrator_runtime.py tests/test_bot_reactions_approvals.py tests/test_journal_ingress.py tests/test_interrupted_replay.py` — no failures; the only errors are the pre-existing `ModuleNotFoundError: No module named 'psycopg'` setups, identical on the base commit.
- `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` on the touched files.

## Relationship to other PRs

Independent of #1814, which fixes what the startup sweep does to rows and waiters. Everything in that PR happens after the point this call never reaches.

Independent of #1815, and worth noting: that guard reads `_SYNC_BRIDGE_BLOCKED_LOOPS`, which is only populated on the branch of `_run_deferred_result_from_sync` that finds a running loop and blocks it with `thread.join()`. The path above takes the `asyncio.run` branch instead, where nothing is marked, so `running_loop_is_sync_tool_bridge()` is false and the guard does not fire. Moving the marker onto the bridge's own loop would make it defence in depth for this case.

## Summary by Sourcery

Ensure journal writes issued from a different event loop than the writer task correctly wake their callers and complete on the callers’ own loop.

Bug Fixes:
- Prevent journal writes from committing on the writer loop while leaving callers on other event loops parked indefinitely.

Enhancements:
- Track the event loop used by the journal writer task and enqueue cross-loop writes via thread-safe callbacks.
- Complete journal write futures on the event loop that created them, handing completion across loops when necessary.
- Add a helper to safely obtain the currently running event loop even when none is active.

Tests:
- Add a cross-loop journal write test that verifies a write from a second event loop both commits and returns to its caller.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQLite journal writes initiated from separate event loops so they complete successfully.
  * Ensured calling tasks resume correctly after cross-loop writes are committed.
  * Improved reliability when asynchronous operations span multiple event loops.
  * Prevented writes racing with journal closure from becoming indefinitely stranded.

* **Tests**
  * Added regression coverage for cross-event-loop journal writes, database visibility, task completion, and shutdown races.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->