### PR TITLE
ci: retry Gitleaks download failures

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -22,7 +22,10 @@ jobs:
       - name: Install gitleaks
         run: |
           GITLEAKS_VERSION=8.18.4
-          curl -sSL https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz -o gitleaks.tar.gz
+          curl --fail --location --silent --show-error \
+            --retry 5 --retry-all-errors --retry-delay 2 \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            --output gitleaks.tar.gz
           tar -xzf gitleaks.tar.gz gitleaks && sudo mv gitleaks /usr/local/bin/
       - name: Secret scan (gitleaks)
         run: gitleaks detect --no-banner --redact || true

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,6 +24,7 @@ jobs:
           GITLEAKS_VERSION=8.18.4
           curl --fail --location --silent --show-error \
             --retry 5 --retry-all-errors --retry-delay 2 \
+            --connect-timeout 10 --max-time 30 --retry-max-time 60 \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             --output gitleaks.tar.gz
           tar -xzf gitleaks.tar.gz gitleaks && sudo mv gitleaks /usr/local/bin/


### PR DESCRIPTION
## Summary

- reject HTTP errors when downloading the pinned Gitleaks release
- retry transient transfer failures before archive extraction

## Why

Security runs intermittently saved an HTTP error response as `gitleaks.tar.gz`, then failed extraction with `gzip: stdin: not in gzip format`. The same asset succeeded seconds later in parallel runs.

## Validation

- `uv run pre-commit run --all-files`
- `uv run pre-commit run check-yaml --files .github/workflows/security-scan.yml`
- exact hardened download produced a valid gzip containing an x86-64 ELF binary
- `uv run pytest`: 13,442 passed; 2 existing macOS cancellation-test failures in `tests/test_handled_turns.py` outside this workflow-only diff

## Summary by Sourcery

CI:
- Harden the Gitleaks installation step in the security scan workflow by using curl failure handling and retry options for the pinned release download.