### PR TITLE
perf: keep agent state reads off the event loop

### DIFF
--- a/src/mindroom/agent_storage.py
+++ b/src/mindroom/agent_storage.py
@@ -12,7 +12,7 @@ from agno.run.agent import RunOutput
 from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
-from sqlalchemy import Engine, create_engine, event
+from sqlalchemy import Engine, create_engine
 
 from mindroom.constants import prompt_roles_for_history_storage
 from mindroom.runtime_resolution import resolve_agent_runtime
@@ -22,15 +22,12 @@ if TYPE_CHECKING:
 
     from agno.agent import Agent
     from agno.session import Session
-    from sqlalchemy.engine.interfaces import DBAPIConnection
-    from sqlalchemy.pool import ConnectionPoolEntry
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 _BUSY_TIMEOUT_SECONDS = 30.0
-_BUSY_TIMEOUT_MILLISECONDS = int(_BUSY_TIMEOUT_SECONDS * 1000)
 
 __all__ = [
     "create_culture_storage",
@@ -69,32 +66,11 @@ def create_state_storage(
 
 
 def _state_engine(db_file: str) -> Engine:
-    """Build the engine one agent's state database is reached through.
-
-    Agno would build this itself from a path. It is built here to say two
-    things it does not: readers may proceed while a write is in flight, and a
-    statement that finds the database locked waits rather than failing. Both
-    matter because these are the databases a response reads on its way to
-    answering, and one agent's flush must not turn another's read into an
-    error.
-    """
-    engine = create_engine(
+    """Build an engine that waits for state-database locks before failing."""
+    return create_engine(
         f"sqlite:///{db_file}",
         connect_args={"timeout": _BUSY_TIMEOUT_SECONDS},
     )
-
-    @event.listens_for(engine, "connect")
-    def _set_pragmas(connection: DBAPIConnection, _record: ConnectionPoolEntry) -> None:
-        cursor = connection.cursor()
-        try:
-            # Left on the connection for its lifetime: WAL is a property of
-            # the database file, the timeout of the connection reading it.
-            cursor.execute("PRAGMA journal_mode=WAL")
-            cursor.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MILLISECONDS}")
-        finally:
-            cursor.close()
-
-    return engine
 
 
 def _create_sqlite_state_storage(

--- a/src/mindroom/agent_storage.py
+++ b/src/mindroom/agent_storage.py
@@ -12,6 +12,7 @@ from agno.run.agent import RunOutput
 from agno.run.team import TeamRunOutput
 from agno.session.agent import AgentSession
 from agno.session.team import TeamSession
+from sqlalchemy import Engine, create_engine, event
 
 from mindroom.constants import prompt_roles_for_history_storage
 from mindroom.runtime_resolution import resolve_agent_runtime
@@ -21,10 +22,15 @@ if TYPE_CHECKING:
 
     from agno.agent import Agent
     from agno.session import Session
+    from sqlalchemy.engine.interfaces import DBAPIConnection
+    from sqlalchemy.pool import ConnectionPoolEntry
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+
+_BUSY_TIMEOUT_SECONDS = 30.0
+_BUSY_TIMEOUT_MILLISECONDS = int(_BUSY_TIMEOUT_SECONDS * 1000)
 
 __all__ = [
     "create_culture_storage",
@@ -62,6 +68,35 @@ def create_state_storage(
     )
 
 
+def _state_engine(db_file: str) -> Engine:
+    """Build the engine one agent's state database is reached through.
+
+    Agno would build this itself from a path. It is built here to say two
+    things it does not: readers may proceed while a write is in flight, and a
+    statement that finds the database locked waits rather than failing. Both
+    matter because these are the databases a response reads on its way to
+    answering, and one agent's flush must not turn another's read into an
+    error.
+    """
+    engine = create_engine(
+        f"sqlite:///{db_file}",
+        connect_args={"timeout": _BUSY_TIMEOUT_SECONDS},
+    )
+
+    @event.listens_for(engine, "connect")
+    def _set_pragmas(connection: DBAPIConnection, _record: ConnectionPoolEntry) -> None:
+        cursor = connection.cursor()
+        try:
+            # Left on the connection for its lifetime: WAL is a property of
+            # the database file, the timeout of the connection reading it.
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute(f"PRAGMA busy_timeout={_BUSY_TIMEOUT_MILLISECONDS}")
+        finally:
+            cursor.close()
+
+    return engine
+
+
 def _create_sqlite_state_storage(
     storage_name: str,
     state_root: Path,
@@ -74,13 +109,14 @@ def _create_sqlite_state_storage(
     db_dir = state_root / subdir
     db_dir.mkdir(parents=True, exist_ok=True)
     db_file = str(db_dir / f"{storage_name}.db")
+    engine = _state_engine(db_file)
     if prompt_roles is not None:
         return _PromptSanitizingSqliteDb(
             prompt_roles=prompt_roles,
             session_table=session_table,
-            db_file=db_file,
+            db_engine=engine,
         )
-    return SqliteDb(session_table=session_table, db_file=db_file)
+    return SqliteDb(session_table=session_table, db_engine=engine)
 
 
 def create_session_storage(
@@ -135,9 +171,9 @@ class _PromptSanitizingSqliteDb(SqliteDb):
         *,
         prompt_roles: frozenset[str],
         session_table: str,
-        db_file: str,
+        db_engine: Engine,
     ) -> None:
-        super().__init__(session_table=session_table, db_file=db_file)
+        super().__init__(session_table=session_table, db_engine=db_engine)
         self._prompt_roles = prompt_roles
 
     def upsert_session(

--- a/src/mindroom/agent_storage.py
+++ b/src/mindroom/agent_storage.py
@@ -114,9 +114,13 @@ def _create_sqlite_state_storage(
         return _PromptSanitizingSqliteDb(
             prompt_roles=prompt_roles,
             session_table=session_table,
+            db_file=db_file,
             db_engine=engine,
         )
-    return SqliteDb(session_table=session_table, db_engine=engine)
+    # Both: the engine is what the database is reached through, and the path
+    # is what it reports itself as. Handing over an engine alone leaves
+    # ``db_file`` empty on a store that is very much file-backed.
+    return SqliteDb(session_table=session_table, db_file=db_file, db_engine=engine)
 
 
 def create_session_storage(
@@ -171,9 +175,10 @@ class _PromptSanitizingSqliteDb(SqliteDb):
         *,
         prompt_roles: frozenset[str],
         session_table: str,
+        db_file: str,
         db_engine: Engine,
     ) -> None:
-        super().__init__(session_table=session_table, db_engine=db_engine)
+        super().__init__(session_table=session_table, db_file=db_file, db_engine=db_engine)
         self._prompt_roles = prompt_roles
 
     def upsert_session(

--- a/src/mindroom/memory/auto_flush.py
+++ b/src/mindroom/memory/auto_flush.py
@@ -295,7 +295,10 @@ def _load_agent_session(
         runtime_paths,
         execution_identity=execution_identity,
     )
-    return get_agent_session(storage, session_id)
+    try:
+        return get_agent_session(storage, session_id)
+    finally:
+        storage.close()
 
 
 def _entry_priority_key(entry: _FlushSessionEntry, now: int) -> tuple[int, int]:

--- a/src/mindroom/memory/auto_flush.py
+++ b/src/mindroom/memory/auto_flush.py
@@ -582,7 +582,8 @@ class MemoryAutoFlushWorker:
                 strict=False,
             )
 
-            session = _load_agent_session(
+            session = await asyncio.to_thread(
+                _load_agent_session,
                 config,
                 self.runtime_paths,
                 agent_name,
@@ -690,7 +691,8 @@ class MemoryAutoFlushWorker:
             return
 
         latest_session_updated_at: int | None = None
-        latest_session = _load_agent_session(
+        latest_session = await asyncio.to_thread(
+            _load_agent_session,
             config,
             self.runtime_paths,
             agent_name,
@@ -747,7 +749,8 @@ class MemoryAutoFlushWorker:
         execution_identity: ToolExecutionIdentity | None = None,
     ) -> bool:
         effective_storage_path = self.storage_path
-        session = _load_agent_session(
+        session = await asyncio.to_thread(
+            _load_agent_session,
             config,
             self.runtime_paths,
             agent_name,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1037,14 +1037,33 @@ class ResponseRunner:
             reply_to_event_id=reply_to_event_id,
         )
 
-    def _has_queued_forced_compaction(
+    async def _has_queued_forced_compaction(
         self,
         *,
         session_id: str,
         scope: HistoryScope,
         execution_identity: ToolExecutionIdentity | None,
     ) -> bool:
-        """Return whether this scope should compact before creating a reply placeholder."""
+        """Return whether this scope should compact before creating a reply placeholder.
+
+        Read on a thread. This runs before a placeholder is sent, so every
+        turn pays for it, and the statement underneath is a row out of a
+        session database large enough to have been measured in seconds.
+        """
+        return await asyncio.to_thread(
+            self._read_queued_forced_compaction,
+            session_id=session_id,
+            scope=scope,
+            execution_identity=execution_identity,
+        )
+
+    def _read_queued_forced_compaction(
+        self,
+        *,
+        session_id: str,
+        scope: HistoryScope,
+        execution_identity: ToolExecutionIdentity | None,
+    ) -> bool:
         storage = None
         try:
             storage = self.deps.state_writer.create_storage(execution_identity, scope=scope)
@@ -1297,7 +1316,7 @@ class ResponseRunner:
         if (
             placeholder_message is not None
             and request.existing_event_id is None
-            and not self._has_queued_forced_compaction(
+            and not await self._has_queued_forced_compaction(
                 session_id=resolved_target.session_id,
                 scope=history_scope,
                 execution_identity=execution_identity,

--- a/tests/test_agent_state_storage_concurrency.py
+++ b/tests/test_agent_state_storage_concurrency.py
@@ -1,0 +1,110 @@
+"""How one agent's state database behaves while another statement holds it."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import TYPE_CHECKING
+
+import pytest
+from sqlalchemy import text
+
+from mindroom.agent_storage import create_state_storage
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from agno.db.base import BaseDb
+
+
+def _storage(tmp_path: Path) -> BaseDb:
+    return create_state_storage(
+        "probe",
+        tmp_path,
+        subdir="sessions",
+        session_table="probe_sessions",
+    )
+
+
+def test_a_state_database_is_opened_for_concurrent_readers(tmp_path: Path) -> None:
+    """WAL and a wait, rather than the default of blocking readers and failing fast.
+
+    These are the databases a response reads on its way to answering. Under the
+    rollback journal a flush in progress makes those reads wait on a lock the
+    reader cannot see, and without a busy timeout a contended statement raises
+    `database is locked` instead of waiting for its turn.
+    """
+    storage = _storage(tmp_path)
+
+    with storage.db_engine.connect() as connection:
+        assert connection.execute(text("PRAGMA journal_mode")).scalar() == "wal"
+        assert connection.execute(text("PRAGMA busy_timeout")).scalar() == 30_000
+
+
+def test_a_read_waits_for_a_writer_rather_than_failing(tmp_path: Path) -> None:
+    """A statement that finds the database locked waits for it, up to the timeout."""
+    storage = _storage(tmp_path)
+    with storage.db_engine.connect() as setup:
+        setup.execute(text("CREATE TABLE probe (value TEXT)"))
+        setup.commit()
+
+    holding = threading.Event()
+    release = threading.Event()
+
+    def hold_write_lock() -> None:
+        with storage.db_engine.connect() as writer:
+            writer.execute(text("BEGIN IMMEDIATE"))
+            writer.execute(text("INSERT INTO probe (value) VALUES ('held')"))
+            holding.set()
+            release.wait(timeout=5)
+            writer.execute(text("COMMIT"))
+
+    holder = threading.Thread(target=hold_write_lock, name="probe-writer")
+    holder.start()
+    try:
+        assert holding.wait(timeout=5)
+        with storage.db_engine.connect() as reader:
+            # Under WAL this returns the pre-write snapshot immediately rather
+            # than raising, which is the property the response path needs.
+            assert reader.execute(text("SELECT count(*) FROM probe")).scalar() == 0
+    finally:
+        release.set()
+        holder.join(timeout=5)
+
+    assert not holder.is_alive()
+
+
+@pytest.mark.asyncio
+async def test_reading_a_session_does_not_hold_the_event_loop(tmp_path: Path) -> None:
+    """A slow state read must not stop everything else the loop is running.
+
+    The read is synchronous down to a SQLite statement and these databases have
+    been measured at over a second for a single row, so the loop has to stay
+    free while it happens.
+    """
+    storage = _storage(tmp_path)
+    with storage.db_engine.connect() as setup:
+        setup.execute(text("CREATE TABLE slow (value TEXT)"))
+        setup.commit()
+
+    ticks = 0
+
+    async def tick() -> None:
+        nonlocal ticks
+        while True:
+            ticks += 1
+            await asyncio.sleep(0.01)
+
+    def slow_read() -> None:
+        with storage.db_engine.connect() as connection:
+            connection.execute(text("SELECT count(*) FROM slow")).scalar()
+            time.sleep(0.3)
+
+    ticker = asyncio.create_task(tick())
+    try:
+        await asyncio.to_thread(slow_read)
+    finally:
+        ticker.cancel()
+
+    assert ticks > 5, "the loop was blocked while the state database was read"

--- a/tests/test_agent_state_storage_concurrency.py
+++ b/tests/test_agent_state_storage_concurrency.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import asyncio
 import threading
-import time
 from typing import TYPE_CHECKING
 
-import pytest
 from sqlalchemy import text
 
 from mindroom.agent_storage import create_state_storage
@@ -27,19 +24,14 @@ def _storage(tmp_path: Path) -> BaseDb:
     )
 
 
-def test_a_state_database_is_opened_for_concurrent_readers(tmp_path: Path) -> None:
-    """WAL and a wait, rather than the default of blocking readers and failing fast.
-
-    These are the databases a response reads on its way to answering. Under the
-    rollback journal a flush in progress makes those reads wait on a lock the
-    reader cannot see, and without a busy timeout a contended statement raises
-    `database is locked` instead of waiting for its turn.
-    """
+def test_a_state_database_keeps_rollback_journal_and_waits_for_locks(tmp_path: Path) -> None:
+    """Network-compatible rollback journaling retains a long lock timeout."""
     storage = _storage(tmp_path)
 
     with storage.db_engine.connect() as connection:
-        assert connection.execute(text("PRAGMA journal_mode")).scalar() == "wal"
+        assert connection.execute(text("PRAGMA journal_mode")).scalar() == "delete"
         assert connection.execute(text("PRAGMA busy_timeout")).scalar() == 30_000
+    storage.close()
 
 
 def test_a_read_waits_for_a_writer_rather_than_failing(tmp_path: Path) -> None:
@@ -51,60 +43,44 @@ def test_a_read_waits_for_a_writer_rather_than_failing(tmp_path: Path) -> None:
 
     holding = threading.Event()
     release = threading.Event()
+    reading = threading.Event()
+    finished = threading.Event()
+    result: list[int] = []
+    errors: list[Exception] = []
 
     def hold_write_lock() -> None:
         with storage.db_engine.connect() as writer:
-            writer.execute(text("BEGIN IMMEDIATE"))
+            writer.execute(text("BEGIN EXCLUSIVE"))
             writer.execute(text("INSERT INTO probe (value) VALUES ('held')"))
             holding.set()
             release.wait(timeout=5)
             writer.execute(text("COMMIT"))
 
+    def read_after_lock() -> None:
+        try:
+            reading.set()
+            with storage.db_engine.connect() as reader:
+                result.append(reader.execute(text("SELECT count(*) FROM probe")).scalar_one())
+        except Exception as error:  # pragma: no cover - asserted below
+            errors.append(error)
+        finally:
+            finished.set()
+
     holder = threading.Thread(target=hold_write_lock, name="probe-writer")
+    reader = threading.Thread(target=read_after_lock, name="probe-reader")
     holder.start()
     try:
         assert holding.wait(timeout=5)
-        with storage.db_engine.connect() as reader:
-            # Under WAL this returns the pre-write snapshot immediately rather
-            # than raising, which is the property the response path needs.
-            assert reader.execute(text("SELECT count(*) FROM probe")).scalar() == 0
+        reader.start()
+        assert reading.wait(timeout=5)
+        assert not finished.wait(timeout=0.1), "reader did not wait for the exclusive writer"
     finally:
         release.set()
         holder.join(timeout=5)
+        reader.join(timeout=5)
 
     assert not holder.is_alive()
-
-
-@pytest.mark.asyncio
-async def test_reading_a_session_does_not_hold_the_event_loop(tmp_path: Path) -> None:
-    """A slow state read must not stop everything else the loop is running.
-
-    The read is synchronous down to a SQLite statement and these databases have
-    been measured at over a second for a single row, so the loop has to stay
-    free while it happens.
-    """
-    storage = _storage(tmp_path)
-    with storage.db_engine.connect() as setup:
-        setup.execute(text("CREATE TABLE slow (value TEXT)"))
-        setup.commit()
-
-    ticks = 0
-
-    async def tick() -> None:
-        nonlocal ticks
-        while True:
-            ticks += 1
-            await asyncio.sleep(0.01)
-
-    def slow_read() -> None:
-        with storage.db_engine.connect() as connection:
-            connection.execute(text("SELECT count(*) FROM slow")).scalar()
-            time.sleep(0.3)
-
-    ticker = asyncio.create_task(tick())
-    try:
-        await asyncio.to_thread(slow_read)
-    finally:
-        ticker.cancel()
-
-    assert ticks > 5, "the loop was blocked while the state database was read"
+    assert not reader.is_alive()
+    assert errors == []
+    assert result == [1]
+    storage.close()

--- a/tests/test_memory_auto_flush.py
+++ b/tests/test_memory_auto_flush.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -237,6 +240,57 @@ async def test_worker_respects_batch_limits(
     await worker._run_cycle(config)
 
     assert len(writes) == 1
+
+
+@pytest.mark.asyncio
+async def test_worker_session_load_does_not_block_the_event_loop(
+    tmp_path: Path,
+    config: Config,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A blocked session read must run outside the worker's event loop."""
+    mark_auto_flush_dirty_session(
+        tmp_path,
+        config,
+        agent_name="general",
+        session_id="s1",
+    )
+    started = threading.Event()
+    loop_advanced = threading.Event()
+    release = threading.Event()
+    observed_progress = threading.Event()
+
+    def _blocking_load(*_args: object, **_kwargs: object) -> _FakeSession:
+        started.set()
+        assert release.wait(timeout=5)
+        return _FakeSession(updated_at=100, messages=[])
+
+    def _release_after_observing_loop() -> None:
+        assert started.wait(timeout=5)
+        if loop_advanced.wait(timeout=0.5):
+            observed_progress.set()
+        release.set()
+
+    monkeypatch.setattr("mindroom.memory.auto_flush._load_agent_session", _blocking_load)
+    worker = MemoryAutoFlushWorker(
+        storage_path=tmp_path,
+        runtime_paths=runtime_paths_for(config),
+        config_provider=lambda: config,
+    )
+    monkeypatch.setattr(worker, "_process_session_key", AsyncMock())
+    observer = threading.Thread(target=_release_after_observing_loop, name="auto-flush-loop-observer")
+    observer.start()
+    try:
+        task = asyncio.create_task(worker._run_cycle(config))
+        assert await asyncio.to_thread(started.wait, 5)
+        loop_advanced.set()
+        await task
+    finally:
+        release.set()
+        observer.join(timeout=5)
+
+    assert observed_progress.is_set(), "session read blocked the event loop"
+    assert not observer.is_alive()
 
 
 @pytest.mark.asyncio
@@ -782,8 +836,13 @@ def test_load_agent_session_passes_execution_identity_for_private_agents(
     captured: dict[str, object] = {}
 
     class _DummyStorage:
+        closed = False
+
         def get_session(self, session_id: str, _session_type: object) -> None:
             captured["session_id"] = session_id
+
+        def close(self) -> None:
+            self.closed = True
 
     def _fake_create_session_storage(
         agent_name: str,
@@ -796,7 +855,9 @@ def test_load_agent_session_passes_execution_identity_for_private_agents(
         captured["config"] = config
         captured["runtime_paths"] = runtime_paths
         captured["execution_identity"] = execution_identity
-        return _DummyStorage()
+        storage = _DummyStorage()
+        captured["storage"] = storage
+        return storage
 
     monkeypatch.setattr("mindroom.memory.auto_flush.create_session_storage", _fake_create_session_storage)
 
@@ -813,6 +874,8 @@ def test_load_agent_session_passes_execution_identity_for_private_agents(
     assert captured["execution_identity"] == alice_identity
     assert captured["agent_name"] == "mind"
     assert captured["session_id"] == "session-alice"
+    assert isinstance(captured["storage"], _DummyStorage)
+    assert captured["storage"].closed is True
 
 
 def test_load_agent_session_uses_canonical_session_helper(
@@ -820,7 +883,7 @@ def test_load_agent_session_uses_canonical_session_helper(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Auto-flush should not locally coerce raw Agno session payloads."""
-    storage = object()
+    storage = MagicMock()
     sentinel = object()
 
     def _fake_create_session_storage(*_args: object, **_kwargs: object) -> object:
@@ -836,6 +899,7 @@ def test_load_agent_session_uses_canonical_session_helper(
     )
 
     assert _load_agent_session(config, runtime_paths_for(config), "general", "session-1") is sentinel
+    storage.close.assert_called_once_with()
 
 
 def test_reprioritize_private_sessions_stays_within_private_scope(tmp_path: Path) -> None:

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -1120,7 +1120,8 @@ async def test_generate_response_skips_signal_for_non_human_prompt_ingress(
     assert not queued_signal.is_set()
 
 
-def test_forced_compaction_placeholder_check_degrades_on_storage_error(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_forced_compaction_placeholder_check_degrades_on_storage_error(tmp_path: Path) -> None:
     """Storage errors in the placeholder-ordering hint should not abort response generation."""
     bot = _bot(tmp_path)
     coordinator = unwrap_extracted_collaborator(bot._response_runner)
@@ -1131,13 +1132,56 @@ def test_forced_compaction_placeholder_check_degrades_on_storage_error(tmp_path:
         "create_storage",
         side_effect=RuntimeError("storage unavailable"),
     ):
-        result = coordinator._has_queued_forced_compaction(
+        result = await coordinator._has_queued_forced_compaction(
             session_id="session",
             scope=scope,
             execution_identity=None,
         )
 
     assert result is False
+
+
+@pytest.mark.asyncio
+async def test_forced_compaction_placeholder_check_does_not_block_event_loop(tmp_path: Path) -> None:
+    """A blocked compaction-state read must run outside the response event loop."""
+    coordinator = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    scope = HistoryScope(kind="agent", scope_id="home")
+    started = threading.Event()
+    loop_advanced = threading.Event()
+    release = threading.Event()
+    observed_progress = threading.Event()
+
+    def _blocking_read(**_kwargs: object) -> bool:
+        started.set()
+        assert release.wait(timeout=5)
+        return False
+
+    def _release_after_observing_loop() -> None:
+        assert started.wait(timeout=5)
+        if loop_advanced.wait(timeout=0.5):
+            observed_progress.set()
+        release.set()
+
+    observer = threading.Thread(target=_release_after_observing_loop, name="compaction-loop-observer")
+    observer.start()
+    try:
+        with patch.object(coordinator, "_read_queued_forced_compaction", side_effect=_blocking_read):
+            task = asyncio.create_task(
+                coordinator._has_queued_forced_compaction(
+                    session_id="session",
+                    scope=scope,
+                    execution_identity=None,
+                ),
+            )
+            assert await asyncio.to_thread(started.wait, 5)
+            loop_advanced.set()
+            assert await task is False
+    finally:
+        release.set()
+        observer.join(timeout=5)
+
+    assert observed_progress.is_set(), "compaction-state read blocked the event loop"
+    assert not observer.is_alive()
 
 
 @pytest.mark.asyncio

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -315,7 +315,3 @@ FINAL  # unused variable (src/mindroom/event_journal/models.py)
 # Named only inside a `cast("_RoomIdEvent", event)` string literal, which
 # vulture does not resolve.
 _RoomIdEvent  # unused class (src/mindroom/matrix/journal_ingress.py)
-
-# Registered by decorator, never called by name.
-_.set_pragmas  # SQLAlchemy connect listener (src/mindroom/agent_storage.py)
-_set_pragmas  # SQLAlchemy connect listener (src/mindroom/agent_storage.py)

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -315,3 +315,7 @@ FINAL  # unused variable (src/mindroom/event_journal/models.py)
 # Named only inside a `cast("_RoomIdEvent", event)` string literal, which
 # vulture does not resolve.
 _RoomIdEvent  # unused class (src/mindroom/matrix/journal_ingress.py)
+
+# Registered by decorator, never called by name.
+_.set_pragmas  # SQLAlchemy connect listener (src/mindroom/agent_storage.py)
+_set_pragmas  # SQLAlchemy connect listener (src/mindroom/agent_storage.py)


### PR DESCRIPTION
## Problem

Synchronous agent-state reads are reached from async response paths. A slow SQLite read can therefore stall Matrix sync, typing, and unrelated room responses on the same event loop.

## What this changes

- Runs auto-flush session loads on worker threads.
- Runs the forced-compaction placeholder check on a worker thread.
- Keeps SQLite rollback journaling for network and shared-storage compatibility.
- Sets a 30-second SQLite busy timeout so lock contention waits instead of failing immediately.
- Closes ephemeral auto-flush storage handles deterministically.

Writes remain on their existing serialized paths. Moving read-modify-write operations to threads needs a separate per-session locking design.

## Tests

- Production-path regressions prove both state-read call sites leave the event loop free while storage is blocked.
- Mutation checks prove those regressions fail when either thread offload is removed.
- SQLite coverage verifies rollback journal mode, the 30-second busy timeout, and waiting behind an exclusive writer.
- The forced-compaction storage-error path is awaited and covered.
- Focused pytest, import-graph checks, Ruff, formatting, ty, Tach, Vulture, and the complete pre-commit suite pass locally.