### PR TITLE
fix: own cross-loop writes before loop handoff

### DIFF
--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -141,6 +141,12 @@ class SqliteBackend:
     # other loop can neither enqueue onto that queue nor be woken by it
     # without being handed across deliberately.
     _writer_loop: asyncio.AbstractEventLoop | None = field(default=None, init=False, repr=False)
+    _admission_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
+    _pending_admissions: dict[asyncio.Future[Any], _QueuedWrite] = field(
+        default_factory=dict,
+        init=False,
+        repr=False,
+    )
     _closed: bool = field(default=False, init=False, repr=False)
     _open_readers: list[sqlite3.Connection] = field(default_factory=list, init=False, repr=False)
     _reader_lock: threading.Lock = field(default_factory=threading.Lock, init=False, repr=False)
@@ -276,23 +282,36 @@ class SqliteBackend:
         if self._closed:
             raise RuntimeError(_CLOSED_MESSAGE)
         caller_loop = asyncio.get_running_loop()
-        writer_loop = self._writer_loop
         future: asyncio.Future[T] = caller_loop.create_future()
         queued = _QueuedWrite(operation=operation, future=future)
         # A queue belongs to the loop that drains it. Putting to one from
         # another loop wakes its consumer through a callback scheduled on the
         # wrong loop, which arrives whenever that loop happens to run next and
         # not because anything told it to.
-        if writer_loop is None or writer_loop is caller_loop:
-            queue = self._ensure_writer_task()
-            queue.put_nowait(queued)
-        else:
+        with self._admission_lock:
+            if self._closed:
+                raise RuntimeError(_CLOSED_MESSAGE)
+            writer_loop = self._writer_loop
+            if writer_loop is None or writer_loop is caller_loop:
+                queue = self._ensure_writer_task()
+                queue.put_nowait(queued)
+            else:
+                # Shutdown must own this handoff before it is scheduled. A
+                # stopped-but-open loop accepts call_soon_threadsafe() without
+                # ever running its callback, so the callback itself cannot be
+                # the first place the write becomes visible to close().
+                self._pending_admissions[future] = queued
+        if writer_loop is not None and writer_loop is not caller_loop:
             try:
                 writer_loop.call_soon_threadsafe(self._admit, queued)
             except RuntimeError:
-                if not writer_loop.is_closed():
+                with self._admission_lock:
+                    still_pending = self._pending_admissions.pop(future, None) is not None
+                    closed = self._closed
+                if still_pending and not (closed or writer_loop.is_closed()):
                     raise
-                _deliver(future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))
+                if still_pending:
+                    _deliver(future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))
         # Cancelling this await must not report an outcome the writer has not
         # reached yet: the statement runs on a thread regardless, so the caller
         # learns how it ended before its cancellation propagates.
@@ -308,11 +327,17 @@ class SqliteBackend:
         admission it never saw arrives afterwards, into a queue nothing will
         read again.
         """
-        if self._closed:
+        with self._admission_lock:
+            if self._pending_admissions.pop(queued.future, None) is None:
+                return
+            if self._closed:
+                refused = True
+            else:
+                refused = False
+                queue = self._ensure_writer_task()
+                queue.put_nowait(queued)
+        if refused:
             _deliver(queued.future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))
-            return
-        queue = self._ensure_writer_task()
-        queue.put_nowait(queued)
 
     async def read[T](self, operation: Operation[T]) -> T:
         """Run one read on a WAL reader, concurrently with the writer."""
@@ -345,9 +370,14 @@ class SqliteBackend:
         and every handed-across decision that runs afterwards refuses its
         caller instead of enqueuing.
         """
-        if self._closed:
-            return
-        self._closed = True
+        with self._admission_lock:
+            if self._closed:
+                return
+            self._closed = True
+            pending_admissions = tuple(self._pending_admissions.values())
+            self._pending_admissions.clear()
+        for queued in pending_admissions:
+            _deliver(queued.future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))
         writer_task = self._writer_task
         self._writer_task = None
         if writer_task is not None:

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -318,26 +318,17 @@ class SqliteBackend:
         return await settled(future)
 
     def _admit(self, queued: _QueuedWrite) -> None:
-        """Put one handed-across write in the queue, or refuse it if ``close()`` got there first.
+        """Put one still-pending handed-across write in the writer queue.
 
         A write from another loop cannot be admitted or inspect the writer task
         where it is decided, so both happen here, on the writer's own loop,
-        where ``close()`` also runs. Without this the two can interleave the one
-        way that strands a caller: ``close()`` drains the queue, and the
-        admission it never saw arrives afterwards, into a queue nothing will
-        read again.
+        under the lock that lets ``close()`` claim pending handoffs first.
         """
         with self._admission_lock:
             if self._pending_admissions.pop(queued.future, None) is None:
                 return
-            if self._closed:
-                refused = True
-            else:
-                refused = False
-                queue = self._ensure_writer_task()
-                queue.put_nowait(queued)
-        if refused:
-            _deliver(queued.future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))
+            queue = self._ensure_writer_task()
+            queue.put_nowait(queued)
 
     async def read[T](self, operation: Operation[T]) -> T:
         """Run one read on a WAL reader, concurrently with the writer."""

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -261,10 +261,10 @@ class SqliteBackend:
     async def write[T](self, operation: Operation[T]) -> T:
         """Queue one operation for the writer task and await its commit.
 
-        Admission is decided on the writer's loop, where it cannot race
-        ``close()``. A caller already on that loop enqueues synchronously; one
-        on another loop hands the decision across, where ``_closed`` is checked
-        again before the write enters the queue.
+        Admission is coordinated with ``close()`` under the admission lock. A
+        caller already on the writer's loop enqueues synchronously; one on
+        another loop registers its handoff before scheduling the admission
+        callback. The callback enqueues only while it still owns that handoff.
 
         That is what the queue being unbounded buys. A bounded one parked the
         producer in ``put`` instead, and ``close()`` frees a slot per entry it
@@ -307,8 +307,7 @@ class SqliteBackend:
             except RuntimeError:
                 with self._admission_lock:
                     still_pending = self._pending_admissions.pop(future, None) is not None
-                    closed = self._closed
-                if still_pending and not (closed or writer_loop.is_closed()):
+                if still_pending and not writer_loop.is_closed():
                     raise
                 if still_pending:
                     _deliver(future, _WriteOutcome(error=RuntimeError(_CLOSED_MESSAGE)))

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -365,10 +365,10 @@ class SqliteBackend:
         Reads are not the writer task's to finish, so they are drained
         separately before the connections they run on are closed.
 
-        Draining the queue once is enough because ``_closed`` is raised before
-        it on the writer's loop. Every write already admitted is in the queue,
-        and every handed-across decision that runs afterwards refuses its
-        caller instead of enqueuing.
+        Draining the queue once is enough because raising ``_closed`` under the
+        admission lock also claims and refuses every pending handoff. Every
+        write already admitted is in the queue, and callbacks for claimed
+        handoffs later see that they no longer own an admission and do nothing.
         """
         with self._admission_lock:
             if self._closed:

--- a/tests/test_event_journal_cross_loop.py
+++ b/tests/test_event_journal_cross_loop.py
@@ -299,6 +299,83 @@ async def test_close_before_foreign_writer_task_lookup_does_not_recreate_the_wri
 
 
 @pytest.mark.asyncio
+async def test_close_wakes_a_handoff_scheduled_after_the_writer_loop_stops(  # noqa: PLR0915
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Shutdown must own a foreign handoff before its callback is scheduled."""
+    backend = SqliteBackend.open(tmp_path / "journal.db")
+    writer_loop = asyncio.new_event_loop()
+    writer_ready = threading.Event()
+    shutdown_finished = threading.Event()
+    writer_thread = threading.Thread(target=writer_loop.run_forever, name="writer-loop")
+
+    async def initialize() -> None:
+        await backend.write(lambda transaction: transaction.execute("CREATE TABLE claim (value INTEGER)"))
+        writer_ready.set()
+
+    writer_loop.call_soon_threadsafe(asyncio.create_task, initialize())
+    writer_thread.start()
+    assert writer_ready.wait(_RETURN_TIMEOUT_SECONDS), "the writer loop never initialized"
+
+    handoff_reached = threading.Event()
+    release_handoff = threading.Event()
+    call_soon_threadsafe = writer_loop.call_soon_threadsafe
+
+    def pause_admission(callback: Callable[..., object], *args: object) -> asyncio.Handle:
+        if callback == backend._admit:
+            handoff_reached.set()
+            assert release_handoff.wait(_RETURN_TIMEOUT_SECONDS), "the test never released admission"
+        return call_soon_threadsafe(callback, *args)
+
+    outcome: list[BaseException | None] = []
+    operation_ran = threading.Event()
+
+    def insert_claim(transaction: Transaction) -> None:
+        operation_ran.set()
+        transaction.execute("INSERT INTO claim VALUES (1)")
+
+    def write_from_its_own_loop() -> None:
+        try:
+            asyncio.run(backend.write(insert_claim))
+        except BaseException as error:  # the exact refusal is asserted below
+            outcome.append(error)
+        else:
+            outcome.append(None)
+
+    bridge = threading.Thread(target=write_from_its_own_loop, name="stopped-loop-writer", daemon=True)
+
+    async def close_and_stop() -> None:
+        await backend.close()
+        shutdown_finished.set()
+        writer_loop.stop()
+
+    try:
+        with monkeypatch.context() as patch:
+            patch.setattr(writer_loop, "call_soon_threadsafe", pause_admission)
+            bridge.start()
+            assert handoff_reached.wait(_RETURN_TIMEOUT_SECONDS), "the foreign write never reached its handoff"
+            asyncio.run_coroutine_threadsafe(close_and_stop(), writer_loop)
+            assert shutdown_finished.wait(_RETURN_TIMEOUT_SECONDS), "the backend never closed"
+            writer_thread.join(_RETURN_TIMEOUT_SECONDS)
+            assert not writer_thread.is_alive(), "the writer loop never stopped"
+            release_handoff.set()
+            bridge.join(_RETURN_TIMEOUT_SECONDS)
+
+        assert not bridge.is_alive(), "the stopped writer loop stranded the foreign write"
+        _assert_closed_refusal(outcome, operation_ran)
+    finally:
+        release_handoff.set()
+        if bridge.is_alive():
+            writer_loop.call_soon(writer_loop.stop)
+            restart = threading.Thread(target=writer_loop.run_forever, name="restarted-writer-loop")
+            restart.start()
+            restart.join(_RETURN_TIMEOUT_SECONDS)
+            bridge.join(_RETURN_TIMEOUT_SECONDS)
+        writer_loop.close()
+
+
+@pytest.mark.asyncio
 async def test_a_closed_recorded_writer_loop_refuses_a_cross_loop_write(tmp_path: Path) -> None:
     """A stale closed writer loop must produce the store's closure error, not leak a loop error."""
     backend = SqliteBackend.open(tmp_path / "journal.db")

--- a/tests/test_event_journal_cross_loop.py
+++ b/tests/test_event_journal_cross_loop.py
@@ -62,6 +62,30 @@ def _assert_closed_refusal(outcome: list[BaseException | None], operation_ran: t
     assert not operation_ran.is_set()
 
 
+def _stop_test_loops(
+    writer_loop: asyncio.AbstractEventLoop,
+    writer_thread: threading.Thread,
+    bridge: threading.Thread,
+    release_handoff: threading.Event,
+) -> None:
+    """Release a paused handoff and stop every loop thread the test started."""
+    release_handoff.set()
+    if writer_thread.is_alive():
+        if bridge.is_alive():
+            bridge.join(_RETURN_TIMEOUT_SECONDS)
+        writer_loop.call_soon_threadsafe(writer_loop.stop)
+        writer_thread.join(_RETURN_TIMEOUT_SECONDS)
+    elif bridge.is_alive():
+        restart = threading.Thread(target=writer_loop.run_forever, name="restarted-writer-loop")
+        restart.start()
+        bridge.join(_RETURN_TIMEOUT_SECONDS)
+        writer_loop.call_soon_threadsafe(writer_loop.stop)
+        restart.join(_RETURN_TIMEOUT_SECONDS)
+        assert not restart.is_alive(), "cleanup could not stop the restarted writer loop"
+    assert not writer_thread.is_alive(), "cleanup could not stop the writer loop"
+    writer_loop.close()
+
+
 @pytest.mark.asyncio
 async def test_a_write_from_a_second_event_loop_comes_back(tmp_path: Path) -> None:
     """A caller on another loop must resume once its write has committed."""
@@ -298,8 +322,7 @@ async def test_close_before_foreign_writer_task_lookup_does_not_recreate_the_wri
     _assert_closed_refusal(outcome, operation_ran)
 
 
-@pytest.mark.asyncio
-async def test_close_wakes_a_handoff_scheduled_after_the_writer_loop_stops(  # noqa: PLR0915
+def test_close_wakes_a_handoff_scheduled_after_the_writer_loop_stops(  # noqa: PLR0915
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -313,10 +336,6 @@ async def test_close_wakes_a_handoff_scheduled_after_the_writer_loop_stops(  # n
     async def initialize() -> None:
         await backend.write(lambda transaction: transaction.execute("CREATE TABLE claim (value INTEGER)"))
         writer_ready.set()
-
-    writer_loop.call_soon_threadsafe(asyncio.create_task, initialize())
-    writer_thread.start()
-    assert writer_ready.wait(_RETURN_TIMEOUT_SECONDS), "the writer loop never initialized"
 
     handoff_reached = threading.Event()
     release_handoff = threading.Event()
@@ -351,6 +370,9 @@ async def test_close_wakes_a_handoff_scheduled_after_the_writer_loop_stops(  # n
         writer_loop.stop()
 
     try:
+        writer_loop.call_soon_threadsafe(asyncio.create_task, initialize())
+        writer_thread.start()
+        assert writer_ready.wait(_RETURN_TIMEOUT_SECONDS), "the writer loop never initialized"
         with monkeypatch.context() as patch:
             patch.setattr(writer_loop, "call_soon_threadsafe", pause_admission)
             bridge.start()
@@ -365,14 +387,7 @@ async def test_close_wakes_a_handoff_scheduled_after_the_writer_loop_stops(  # n
         assert not bridge.is_alive(), "the stopped writer loop stranded the foreign write"
         _assert_closed_refusal(outcome, operation_ran)
     finally:
-        release_handoff.set()
-        if bridge.is_alive():
-            writer_loop.call_soon(writer_loop.stop)
-            restart = threading.Thread(target=writer_loop.run_forever, name="restarted-writer-loop")
-            restart.start()
-            restart.join(_RETURN_TIMEOUT_SECONDS)
-            bridge.join(_RETURN_TIMEOUT_SECONDS)
-        writer_loop.close()
+        _stop_test_loops(writer_loop, writer_thread, bridge, release_handoff)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- register foreign-loop writes before scheduling their writer-loop admission callback
- let `close()` atomically claim and refuse pending handoffs even when the writer loop has stopped
- add a deterministic regression for `call_soon_threadsafe()` succeeding on a stopped-but-open loop

## Why

A foreign write could pass the initial closed check, pause before scheduling `_admit`, and lose its writer loop to clean shutdown. `call_soon_threadsafe()` accepts callbacks on a stopped loop without running them, so neither `_admit` nor its closure recheck executed and the caller waited forever.

Pending handoffs are now registered under the same lock that raises `_closed`. Shutdown owns and refuses every registered handoff before stopping the writer loop; a callback that later runs sees that its handoff was already claimed and exits.

## Tests

- regression verified red on merged #1816: caller remained alive until the stopped writer loop was restarted
- `uv run pytest tests/test_event_journal_cross_loop.py -x -n 0 --no-cov -q`
- `uv run pytest tests/test_event_journal_store.py -k "cancelled_write or closing_the_store" -x -n 0 --no-cov -q`
- Ruff check and format, ty, diff check, touched-file pre-commit hooks

## Summary by Sourcery

Ensure cross-loop journal writes are safely refused during backend shutdown when the writer loop has stopped but the store is still open.

Bug Fixes:
- Prevent foreign-loop writes from hanging indefinitely when scheduled via call_soon_threadsafe on a stopped writer loop.
- Ensure close() atomically claims and rejects all pending cross-loop write handoffs before stopping the writer loop.

Enhancements:
- Track pending cross-loop write admissions under a dedicated lock so shutdown can deterministically own and resolve them.
- Guard write admission and close() with a shared admission lock to avoid races between new writes and shutdown.

Tests:
- Add a deterministic regression test that verifies close() wakes and refuses a handoff scheduled after the writer loop stops.