### PR TITLE
fix: key pending-event lanes on the conversation, not the room

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -673,6 +673,7 @@ class AgentBot:
             ),
             room_for_id=self._room_for_journal_event,
             on_persist_failure=self._record_dispatch_persist_failure,
+            room_is_one_conversation=self._room_scope_is_single_conversation,
             room_lifecycle_admission_enabled=lambda: (
                 self.agent_name == ROUTER_AGENT_NAME and self._first_sync_done and self._room_member_join_hooks_armed
             ),

--- a/src/mindroom/event_journal/models.py
+++ b/src/mindroom/event_journal/models.py
@@ -152,6 +152,19 @@ class JournalEvent:
     receipt_order: int
     semantic_consumer: SemanticConsumer | None = None
 
+    @property
+    def names_its_own_conversation(self) -> bool:
+        """Return whether this event says which conversation it belongs to.
+
+        A message does: ``thread_id`` is its thread, and a message without one
+        is the root of the thread it starts. Nothing else does. ``thread_id``
+        is the ``m.thread`` relation and only that, so a reaction, an edit, and
+        a redaction all record ``None`` while belonging to whatever
+        conversation the event they point at is in -- which is not recorded
+        here and cannot be inferred from here.
+        """
+        return self.kind is EventKind.MESSAGE
+
 
 # A non-empty ``__slots__`` is a TypeError on a subtype of a variable-length
 # built-in, so SLOT001 cannot be satisfied by a tuple that carries anything.

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -41,7 +41,7 @@ from mindroom.matrix.journal_ingress import (
     projected_event,
 )
 from mindroom.matrix.media import MATRIX_MEDIA_EVENT_TYPES, MatrixMediaEvent
-from mindroom.pending_event_worker import PendingEventWorker
+from mindroom.pending_event_worker import PendingEventWorker, every_room_is_threaded
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -98,6 +98,11 @@ class JournalDispatcher:
     callbacks: JournalCallbacks
     room_for_id: Callable[[str], nio.MatrixRoom]
     on_persist_failure: Callable[[], None] | None = None
+    # Whether this agent reads a room as one conversation rather than a set of
+    # threads. Only the bot knows its own thread mode, and the worker this
+    # dispatcher builds needs it to key lanes the way the response lifecycle
+    # lock keys itself.
+    room_is_one_conversation: Callable[[str], bool] = every_room_is_threaded
     room_lifecycle_admission_enabled: Callable[[], bool] = lambda: False
     # Replaying a turn needs the agent fleet up, so the orchestrator releases
     # turn-backed replay separately from the rest of startup. Until it does,
@@ -116,6 +121,7 @@ class JournalDispatcher:
         self._worker = PendingEventWorker(
             store=self.store,
             handle=self._run_event,
+            room_is_one_conversation=self.room_is_one_conversation,
             deferral_is_live=self._deferral_is_live,
             retained_event_ids=self._retained_live_event_ids,
             release_retained=self._forget_live_events,

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -108,26 +108,59 @@ def _assume_owner_is_live(event: JournalEvent) -> bool:
 # thread in it is, and a turn parked on a human decision can hold its lane for
 # as long as that decision takes. Keying on the room made every thread wait for
 # whichever one was slowest, so an unanswered approval in one silenced the rest.
-_LaneKey = tuple[str, str | None]
+#
+# A root message carries no thread relation, so keying on the raw relation
+# alone would put every root in a room back into one lane and change nothing.
+# The conversation a root belongs to is the one it starts, which is the same
+# root ``MessageTarget.resolve`` derives for the response lifecycle lock. The
+# two must name the same conversation: the lane decides what may run
+# concurrently and the lock decides what must run alone, so disagreeing keys
+# either serialise a room that need not be or admit two turns to one thread.
+_LaneKey = tuple[str, str]
+
+# The lane a whole room shares when the agent reads that room as one
+# conversation. Empty because no event owns it: it is the room's own lane, not
+# any message's.
+_WHOLE_ROOM_LANE = ""
 
 
 def _lane_key(event: JournalEvent) -> _LaneKey:
-    """Return the lane one event runs in: its thread, within its room."""
-    return (event.room_id, event.thread_id)
+    """Return the lane one event runs in: its thread root, within its room.
+
+    An event that does not name its own conversation keeps the room-wide lane
+    it has always run in. Splitting one off on the strength of an absent
+    ``m.thread`` relation would put a reaction in a lane of its own, beside the
+    thread it annotates, rather than in it.
+    """
+    if not event.names_its_own_conversation:
+        return (event.room_id, _WHOLE_ROOM_LANE)
+    return (event.room_id, event.thread_id or event.event_id)
+
+
+def every_room_is_threaded(room_id: str) -> bool:
+    """Assume thread scope, the mode ``get_entity_thread_mode`` defaults to."""
+    del room_id
+    return False
 
 
 @dataclass
 class PendingEventWorker:
-    """Drain pending journal events, in receipt order within each room.
+    """Drain pending journal events, in receipt order within each conversation.
 
-    Order is preserved per room rather than globally. A room's events are a
-    conversation and must be answered in the order they were received; two
-    different rooms are unrelated, and making one wait for the other would let
-    a single slow turn stall every other conversation the bot is in.
+    Order is preserved per conversation rather than globally. A conversation's
+    events must be answered in the order they were received; two different
+    conversations are unrelated, and making one wait for the other would let a
+    single slow turn stall every other conversation the bot is in.
     """
 
     store: ReplayView
     handle: _EventHandler
+    # Which rooms are one conversation rather than a set of threads. An agent
+    # in room scope resolves every message to the same thread root, so its
+    # response lifecycle lock already serialises the room; lanes must agree
+    # with that lock or turns would start concurrently and then take it in
+    # arrival order rather than receipt order.
+    room_is_one_conversation: Callable[[str], bool] = every_room_is_threaded
     # Asked about every deferred event on every scan. A deferral whose owner is
     # gone is durable work nobody is left to release, so the scan takes it back
     # rather than waiting for a restart to notice.
@@ -163,6 +196,12 @@ class PendingEventWorker:
     # Where the next bounded scan resumes, so a prefix of events this worker
     # cannot act on cannot spend the whole page budget on every pass.
     _scan_cursor: int | None = field(default=None, init=False, repr=False)
+
+    def _lane_key(self, event: JournalEvent) -> _LaneKey:
+        """Return the conversation one event runs in order against."""
+        if self.room_is_one_conversation(event.room_id):
+            return (event.room_id, _WHOLE_ROOM_LANE)
+        return _lane_key(event)
 
     def start(self) -> None:
         """Begin draining, including anything a previous process left behind."""
@@ -506,7 +545,7 @@ class PendingEventWorker:
             if event.event_id in self._deferred:
                 # Handed to an owner the reclaim found still alive.
                 continue
-            by_lane.setdefault(_lane_key(event), []).append(event)
+            by_lane.setdefault(self._lane_key(event), []).append(event)
         return False
 
     def _release_events_no_run_can_reach(self, retained: frozenset[str], still_pending: set[str]) -> None:
@@ -557,7 +596,7 @@ class PendingEventWorker:
                 kind=event.kind.value,
                 room_id=event.room_id,
             )
-            by_lane.setdefault(_lane_key(event), []).append(event)
+            by_lane.setdefault(self._lane_key(event), []).append(event)
         return by_lane
 
     async def _run_lane(self, events: list[JournalEvent]) -> None:
@@ -575,7 +614,7 @@ class PendingEventWorker:
         until some unrelated event woke the pump, and then run its handler a
         second time.
         """
-        key = _lane_key(events[0]) if events else ("", None)
+        key = self._lane_key(events[0]) if events else ("", _WHOLE_ROOM_LANE)
         for event in events:
             try:
                 if not await self.store.is_pending(event.event_id):

--- a/src/mindroom/pending_event_worker.py
+++ b/src/mindroom/pending_event_worker.py
@@ -68,7 +68,7 @@ def _release_nothing(event_ids: frozenset[str]) -> None:
     del event_ids
 
 
-def _in_receipt_order(by_room: dict[str, list[JournalEvent]]) -> dict[str, list[JournalEvent]]:
+def _in_receipt_order(by_lane: dict[_LaneKey, list[JournalEvent]]) -> dict[_LaneKey, list[JournalEvent]]:
     """Put each room's collected events back into receipt order.
 
     A lane runs its list verbatim, so the list is where a room's order is
@@ -86,9 +86,9 @@ def _in_receipt_order(by_room: dict[str, list[JournalEvent]]) -> dict[str, list[
     nothing to state: these lists are near-sorted and bounded by the page
     budget, which is the case a sort is cheapest on.
     """
-    for events in by_room.values():
+    for events in by_lane.values():
         events.sort(key=lambda event: event.receipt_order)
-    return by_room
+    return by_lane
 
 
 def _assume_owner_is_live(event: JournalEvent) -> bool:
@@ -102,6 +102,18 @@ def _assume_owner_is_live(event: JournalEvent) -> bool:
     """
     del event
     return True
+
+
+# What runs in order relative to what. A room is not one conversation: each
+# thread in it is, and a turn parked on a human decision can hold its lane for
+# as long as that decision takes. Keying on the room made every thread wait for
+# whichever one was slowest, so an unanswered approval in one silenced the rest.
+_LaneKey = tuple[str, str | None]
+
+
+def _lane_key(event: JournalEvent) -> _LaneKey:
+    """Return the lane one event runs in: its thread, within its room."""
+    return (event.room_id, event.thread_id)
 
 
 @dataclass
@@ -128,22 +140,22 @@ class PendingEventWorker:
     retained_event_ids: _RetainedEventIds = _nothing_is_retained
     release_retained: _ReleaseRetained = _release_nothing
     deferral_scan_seconds: float = _DEFERRAL_SCAN_SECONDS
-    _lanes: dict[str, asyncio.Task[None]] = field(default_factory=dict, init=False, repr=False)
+    _lanes: dict[_LaneKey, asyncio.Task[None]] = field(default_factory=dict, init=False, repr=False)
     _wake: asyncio.Event = field(default_factory=asyncio.Event, init=False, repr=False)
     _pump: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _retry: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _deferral_scan: asyncio.Task[None] | None = field(default=None, init=False, repr=False)
     _retry_delay_seconds: float = field(default=_INITIAL_RETRY_DELAY_SECONDS, init=False, repr=False)
-    _failed_rooms: set[str] = field(default_factory=set, init=False, repr=False)
+    _failed_lanes: set[_LaneKey] = field(default_factory=set, init=False, repr=False)
     # Events handed to a turn that is still running, kept whole rather than by
     # id. They stay pending durably so a crash replays them, but dispatching
     # one again while its turn is alive would answer the same message twice --
     # and asking whether that turn still exists is a question about this set,
     # not about wherever the scan's window currently sits.
     _deferred: dict[str, JournalEvent] = field(default_factory=dict, init=False, repr=False)
-    # Rooms a pass found work for but could not dispatch, because their lane
-    # was still busy. Their lane wakes the pump when it finishes.
-    _rooms_with_more: set[str] = field(default_factory=set, init=False, repr=False)
+    # Lanes a pass found work for but could not dispatch, because that lane
+    # was still busy. The lane wakes the pump when it finishes.
+    _lanes_with_more: set[_LaneKey] = field(default_factory=set, init=False, repr=False)
     # Events a caller is running itself, off the lanes. An event is pending in
     # the store for the whole time its handler runs, so a scan that could not
     # see these would collect one and put a second handler inside it.
@@ -222,7 +234,7 @@ class PendingEventWorker:
             except asyncio.CancelledError:
                 pass
         self._lanes.clear()
-        self._rooms_with_more.clear()
+        self._lanes_with_more.clear()
 
     async def drain_once(self) -> int:
         """Run every currently pending event to completion and return the count.
@@ -251,29 +263,29 @@ class PendingEventWorker:
         drained = 0
         attempted: frozenset[str] = frozenset()
         while True:
-            by_room = await self._collect_whole_backlog()
-            if not by_room:
+            by_lane = await self._collect_whole_backlog()
+            if not by_lane:
                 return drained
-            ids = frozenset(event.event_id for events in by_room.values() for event in events)
+            ids = frozenset(event.event_id for events in by_lane.values() for event in events)
             if ids == attempted:
                 # Nothing moved: every remaining event failed or was refused.
                 # Looping again would only repeat the same failures forever.
                 return drained
             attempted = ids
             drained += len(ids)
-            await asyncio.gather(*(self._drain_room(room_id, events) for room_id, events in by_room.items()))
+            await asyncio.gather(*(self._drain_lane(key, events) for key, events in by_lane.items()))
 
-    async def _drain_room(self, room_id: str, events: list[JournalEvent]) -> None:
-        """Run one room's events, once whatever lane owns that room is done.
+    async def _drain_lane(self, key: _LaneKey, events: list[JournalEvent]) -> None:
+        """Run one lane's events, once whatever owns that lane is done.
 
         Rechecked after each wait because the pump wakes on the same lane
         completion, so the room can be claimed again before this resumes.
         Someone else's lane is waited on rather than awaited: whether that one
         was cancelled is the pump's business, and a drain must not inherit it.
         """
-        while (active := self._lanes.get(room_id)) is not None and not active.done():
+        while (active := self._lanes.get(key)) is not None and not active.done():
             await asyncio.wait([active])
-        lane = self._start_lane(room_id, events)
+        lane = self._start_lane(key, events)
         await asyncio.wait([lane])
         # This lane is the drain's own, so whatever ended it is the drain's to
         # report. A cancelled turn is not a failed one: it leaves its event
@@ -293,17 +305,17 @@ class PendingEventWorker:
                 self._schedule_retry()
 
     async def _dispatch_ready_rooms(self) -> None:
-        by_room, more_remains = await self._collect_dispatchable()
+        by_lane, more_remains = await self._collect_dispatchable()
         started = False
-        for room_id, events in by_room.items():
-            active = self._lanes.get(room_id)
+        for key, events in by_lane.items():
+            active = self._lanes.get(key)
             if active is not None and not active.done():
-                # Nothing else will look at this room again on its own, so its
-                # lane has to wake the pump when it finishes.
-                self._rooms_with_more.add(room_id)
+                # Nothing else will look at this lane again on its own, so it
+                # has to wake the pump when it finishes.
+                self._lanes_with_more.add(key)
                 continue
             started = True
-            self._start_lane(room_id, events)
+            self._start_lane(key, events)
         if started:
             self._retry_delay_seconds = _INITIAL_RETRY_DELAY_SECONDS
         if more_remains:
@@ -333,22 +345,23 @@ class PendingEventWorker:
         else:
             self._schedule_retry()
 
-    def _start_lane(self, room_id: str, events: list[JournalEvent]) -> asyncio.Task[None]:
-        """Make one room's lane, which is the only one that room may have."""
-        self._rooms_with_more.discard(room_id)
-        lane = asyncio.create_task(self._run_lane(events), name=f"pending_event_lane_{room_id}")
-        self._lanes[room_id] = lane
-        lane.add_done_callback(lambda task: self._lane_finished(room_id, task))
+    def _start_lane(self, key: _LaneKey, events: list[JournalEvent]) -> asyncio.Task[None]:
+        """Make one thread's lane, which is the only one that thread may have."""
+        self._lanes_with_more.discard(key)
+        room_id, thread_id = key
+        lane = asyncio.create_task(self._run_lane(events), name=f"pending_event_lane_{room_id}_{thread_id}")
+        self._lanes[key] = lane
+        lane.add_done_callback(lambda task: self._lane_finished(key, task))
         return lane
 
-    def _lane_finished(self, room_id: str, lane: asyncio.Task[None]) -> None:
-        if self._lanes.get(room_id) is lane:
-            del self._lanes[room_id]
+    def _lane_finished(self, key: _LaneKey, lane: asyncio.Task[None]) -> None:
+        if self._lanes.get(key) is lane:
+            del self._lanes[key]
         if lane.cancelled():
             return
-        if room_id in self._failed_rooms:
+        if key in self._failed_lanes:
             self._schedule_retry()
-        elif room_id in self._rooms_with_more:
+        elif key in self._lanes_with_more:
             self._wake.set()
         self._schedule_deferral_scan()
 
@@ -383,7 +396,7 @@ class PendingEventWorker:
         self._retry_delay_seconds = min(self._retry_delay_seconds * 2, _MAX_RETRY_DELAY_SECONDS)
         self._wake.set()
 
-    async def _collect_dispatchable(self) -> tuple[dict[str, list[JournalEvent]], bool]:
+    async def _collect_dispatchable(self) -> tuple[dict[_LaneKey, list[JournalEvent]], bool]:
         """Group pending events this worker may act on now, by room.
 
         Returns the grouping and whether the scan stopped before the end of the
@@ -411,8 +424,8 @@ class PendingEventWorker:
         pages earlier -- and a room's lane is handed that list verbatim, so a
         handler that defers rather than settling runs twice on one source.
         """
-        by_room = self._reclaim_lost_deferrals()
-        reclaimed = frozenset(event.event_id for events in by_room.values() for event in events)
+        by_lane = self._reclaim_lost_deferrals()
+        reclaimed = frozenset(event.event_id for events in by_lane.values() for event in events)
         retained = self.retained_event_ids()
         still_pending: set[str] = set(reclaimed)
         origin = self._scan_cursor
@@ -422,7 +435,7 @@ class PendingEventWorker:
             page = await self.store.pending(limit=_BATCH_SIZE, after_receipt_order=cursor)
             reached_origin = self._collect_page(
                 page,
-                by_room,
+                by_lane,
                 still_pending,
                 already_taken=reclaimed,
                 stop_after=origin if wrapped else None,
@@ -430,7 +443,7 @@ class PendingEventWorker:
             if reached_origin or (page.reached_end and wrapped):
                 self._scan_cursor = None
                 self._release_events_no_run_can_reach(retained, still_pending)
-                return _in_receipt_order(by_room), False
+                return _in_receipt_order(by_lane), False
             if not page.reached_end:
                 cursor = page.resume_after
                 continue
@@ -439,9 +452,9 @@ class PendingEventWorker:
             # of the budget goes on it rather than on another pass.
             cursor, wrapped = None, True
         self._scan_cursor = cursor
-        return _in_receipt_order(by_room), True
+        return _in_receipt_order(by_lane), True
 
-    async def _collect_whole_backlog(self) -> dict[str, list[JournalEvent]]:
+    async def _collect_whole_backlog(self) -> dict[_LaneKey, list[JournalEvent]]:
         """Group every pending event this worker may act on, front to back.
 
         What a drain asks for, and the reason it cannot borrow the pump's scan.
@@ -450,23 +463,23 @@ class PendingEventWorker:
         stops moving, and it is that loop, not one pass of it, that has to see
         every event.
         """
-        by_room = self._reclaim_lost_deferrals()
-        reclaimed = frozenset(event.event_id for events in by_room.values() for event in events)
+        by_lane = self._reclaim_lost_deferrals()
+        reclaimed = frozenset(event.event_id for events in by_lane.values() for event in events)
         retained = self.retained_event_ids()
         still_pending: set[str] = set(reclaimed)
         cursor: int | None = None
         while True:
             page = await self.store.pending(limit=_BATCH_SIZE, after_receipt_order=cursor)
-            self._collect_page(page, by_room, still_pending, already_taken=reclaimed, stop_after=None)
+            self._collect_page(page, by_lane, still_pending, already_taken=reclaimed, stop_after=None)
             if page.reached_end:
                 self._release_events_no_run_can_reach(retained, still_pending)
-                return _in_receipt_order(by_room)
+                return _in_receipt_order(by_lane)
             cursor = page.resume_after
 
     def _collect_page(
         self,
         page: Iterable[JournalEvent],
-        by_room: dict[str, list[JournalEvent]],
+        by_lane: dict[_LaneKey, list[JournalEvent]],
         still_pending: set[str],
         *,
         already_taken: frozenset[str],
@@ -493,7 +506,7 @@ class PendingEventWorker:
             if event.event_id in self._deferred:
                 # Handed to an owner the reclaim found still alive.
                 continue
-            by_room.setdefault(event.room_id, []).append(event)
+            by_lane.setdefault(_lane_key(event), []).append(event)
         return False
 
     def _release_events_no_run_can_reach(self, retained: frozenset[str], still_pending: set[str]) -> None:
@@ -517,7 +530,7 @@ class PendingEventWorker:
         self.release_retained(unreachable)
         logger.info("pending_event_live_objects_released", count=len(unreachable))
 
-    def _reclaim_lost_deferrals(self) -> dict[str, list[JournalEvent]]:
+    def _reclaim_lost_deferrals(self) -> dict[_LaneKey, list[JournalEvent]]:
         """Take back every deferral whose owner is gone, wherever it sits.
 
         Deferral is a promise that some owner will call ``release``. Nothing
@@ -533,7 +546,7 @@ class PendingEventWorker:
         behind it for as long as the overload lasts, and the outage this is
         supposed to bound then lasts exactly as long as the one it replaced.
         """
-        by_room: dict[str, list[JournalEvent]] = {}
+        by_lane: dict[_LaneKey, list[JournalEvent]] = {}
         for event in tuple(self._deferred.values()):
             if self.deferral_is_live(event):
                 continue
@@ -544,11 +557,11 @@ class PendingEventWorker:
                 kind=event.kind.value,
                 room_id=event.room_id,
             )
-            by_room.setdefault(event.room_id, []).append(event)
-        return by_room
+            by_lane.setdefault(_lane_key(event), []).append(event)
+        return by_lane
 
     async def _run_lane(self, events: list[JournalEvent]) -> None:
-        """Run one room's events in receipt order, stopping at the first failure.
+        """Run one thread's events in receipt order, stopping at the first failure.
 
         Stopping matters: if event two fails and event three still ran, the
         room's conversation would be answered out of order, and the retry of
@@ -562,7 +575,7 @@ class PendingEventWorker:
         until some unrelated event woke the pump, and then run its handler a
         second time.
         """
-        room_id = events[0].room_id if events else ""
+        key = _lane_key(events[0]) if events else ("", None)
         for event in events:
             try:
                 if not await self.store.is_pending(event.event_id):
@@ -582,6 +595,6 @@ class PendingEventWorker:
                     kind=event.kind.value,
                     room_id=event.room_id,
                 )
-                self._failed_rooms.add(room_id)
+                self._failed_lanes.add(key)
                 return
-        self._failed_rooms.discard(room_id)
+        self._failed_lanes.discard(key)

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -42,7 +42,8 @@ from mindroom.matrix.journal_ingress import (
     parse_journal_event,
     projected_event,
 )
-from mindroom.pending_event_worker import _BATCH_SIZE, PendingEventWorker
+from mindroom.message_target import MessageTarget
+from mindroom.pending_event_worker import _BATCH_SIZE, PendingEventWorker, _lane_key
 from tests.test_event_journal_store import corrupt
 
 if TYPE_CHECKING:
@@ -1312,6 +1313,143 @@ class TestPendingEventWorker:
             with suppress(asyncio.CancelledError):
                 await drain
 
+    async def test_a_parked_root_message_does_not_hold_another_root_message(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """Two unrelated root messages are two conversations, not one.
+
+        A root carries no thread relation, so its raw thread ID is empty and
+        keying a lane on that field alone puts every root in one room into the
+        same lane -- which is the state that made a single pending approval
+        silence a whole room. The conversation a root belongs to is the one it
+        starts, so its lane is its own event ID, matching the thread root that
+        ``MessageTarget.resolve`` derives for the response lock.
+        """
+        parked = asyncio.Event()
+        second_ran = asyncio.Event()
+
+        async def handle(event: JournalEvent) -> bool:
+            if event.event_id == "$parked-root":
+                parked.set()
+                await asyncio.sleep(30)
+                return True
+            second_ran.set()
+            return True
+
+        await self._admit(alice, text_event("$parked-root", ts=1_000))
+        await self._admit(alice, text_event("$other-root", ts=2_000))
+
+        worker = PendingEventWorker(store=alice, handle=handle)
+        drain = asyncio.create_task(worker.drain_once())
+        try:
+            async with asyncio.timeout(5):
+                await parked.wait()
+                await second_ran.wait()
+        finally:
+            drain.cancel()
+            with suppress(asyncio.CancelledError):
+                await drain
+
+    async def test_a_dispatchers_room_scope_reaches_the_lanes_it_owns(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """The worker is built inside the dispatcher, so only it can say the scope.
+
+        A default is the wrong thing to fall back on here: the worker's own
+        default assumes thread scope, so a dispatcher that failed to pass the
+        agent's real mode would split a room-scoped room into a lane per root
+        and nothing would report it.
+        """
+
+        async def noop(_room: nio.MatrixRoom, _event: nio.Event) -> None:
+            return None
+
+        dispatcher = JournalDispatcher(
+            store=alice,
+            self_sender=BOT,
+            callbacks=JournalCallbacks(
+                on_message=cast("Any", noop),
+                on_media=cast("Any", noop),
+                on_reaction=cast("Any", noop),
+                on_approval=cast("Any", noop),
+                on_room_lifecycle=cast("Any", noop),
+                on_redaction=cast("Any", noop),
+                on_decryption_failure=cast("Any", noop),
+                source_has_live_owner=lambda _event_id: False,
+                turn_has_live_claim=lambda _event_id: False,
+            ),
+            room_for_id=lambda _room_id: room(),
+            room_is_one_conversation=lambda room_id: room_id == ROOM,
+        )
+
+        assert dispatcher._worker.room_is_one_conversation(ROOM)
+        assert not dispatcher._worker.room_is_one_conversation("!elsewhere:example.org")
+
+    async def test_a_room_scoped_agent_still_answers_its_room_in_one_order(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """A room-mode agent holds one conversation, so its room holds one lane.
+
+        Thread mode is not universal: an agent configured for room scope
+        resolves every message in the room to the same thread root, so the
+        response lifecycle lock serialises the whole room by design. Splitting
+        that room into a lane per root would start turns concurrently and let
+        them take that one lock in whatever order they reached it, answering
+        the room out of the order it was spoken in.
+        """
+        running = 0
+        peak = 0
+
+        async def handle(event: JournalEvent) -> bool:
+            nonlocal running, peak
+            del event
+            running += 1
+            peak = max(peak, running)
+            await asyncio.sleep(0)
+            running -= 1
+            return True
+
+        await self._admit(alice, text_event("$one", ts=1_000))
+        await self._admit(alice, text_event("$two", ts=2_000))
+
+        worker = PendingEventWorker(
+            store=alice,
+            handle=handle,
+            room_is_one_conversation=lambda room_id: room_id == ROOM,
+        )
+        await worker.drain_once()
+
+        assert peak == 1
+
+    async def test_a_lane_matches_the_thread_root_the_response_lock_uses(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """A lane and the response lifecycle lock must name the same conversation.
+
+        The lane decides what runs concurrently and the lock decides what runs
+        alone. Key them on different things and either the room over-serialises
+        or two turns answer one thread at once, so the lane key is asserted
+        against the resolved thread root rather than against itself.
+        """
+        for event_id, thread_id in (("$root", None), ("$reply", "$root")):
+            await self._admit(alice, text_event(event_id, thread_id=thread_id))
+
+        page = await alice.pending(limit=10)
+
+        assert {event.event_id for event in page} == {"$root", "$reply"}
+        for event in page:
+            target = MessageTarget.resolve(
+                room_id=event.room_id,
+                thread_id=event.thread_id or None,
+                reply_to_event_id=event.event_id,
+                thread_start_root_event_id=event.event_id,
+            )
+            assert _lane_key(event) == (target.room_id, target.resolved_thread_id)
+
     async def test_a_settled_event_never_runs_again(self, alice: PrincipalStore) -> None:
         """A settled event never runs again."""
         runs = 0
@@ -1344,11 +1482,11 @@ class TestPendingEventWorker:
 
         assert [event.event_id for event in await alice.pending()] == ["$m"]
 
-    async def test_a_failure_stops_that_rooms_later_events(
+    async def test_a_failure_stops_that_conversations_later_events(
         self,
         alice: PrincipalStore,
     ) -> None:
-        """Otherwise the room is answered out of order, and the retry lands last."""
+        """Otherwise the thread is answered out of order, and the retry lands last."""
         handled: list[str] = []
 
         async def handle(event: JournalEvent) -> bool:
@@ -1358,8 +1496,8 @@ class TestPendingEventWorker:
                 raise RuntimeError(msg)
             return True
 
-        await self._admit(alice, text_event("$first", ts=1_000))
-        await self._admit(alice, text_event("$second", ts=2_000))
+        await self._admit(alice, text_event("$first", thread_id="$topic", ts=1_000))
+        await self._admit(alice, text_event("$second", thread_id="$topic", ts=2_000))
 
         await PendingEventWorker(store=alice, handle=handle).drain_once()
 
@@ -1558,18 +1696,18 @@ class TestPendingEventWorker:
             return True
 
         worker = PendingEventWorker(store=alice, handle=handle)
-        await self._admit(alice, text_event("$slow", ts=1_000))
+        await self._admit(alice, text_event("$slow", thread_id="$topic", ts=1_000))
         worker.start()
         await _eventually(lambda: worker._lanes != {})
 
-        await self._admit(alice, text_event("$late", ts=2_000))
+        await self._admit(alice, text_event("$late", thread_id="$topic", ts=2_000))
         worker.wake()
         # Waited on rather than yielded to: the point of the test is that the
         # busy lane was noted as still owing work *before* it finished,
         # because that note is the only thing that arranges the second look. A
         # bare yield cannot fail -- a second lane over one thread is impossible
         # either way -- so it proved the wakeup without exercising it.
-        await _eventually(lambda: worker._lanes_with_more == {(ROOM, None)})
+        await _eventually(lambda: worker._lanes_with_more == {(ROOM, "$topic")})
         released.set()
 
         await _eventually(lambda: handled == ["$slow", "$late"])
@@ -1730,8 +1868,8 @@ class TestPendingEventWorker:
             handled.append(event.event_id)
             return False
 
-        await self._admit(alice, text_event("$early", ts=1_000))
-        await self._admit(alice, text_event("$late", ts=2_000))
+        await self._admit(alice, text_event("$early", thread_id="$topic", ts=1_000))
+        await self._admit(alice, text_event("$late", thread_id="$topic", ts=2_000))
         worker = PendingEventWorker(
             store=alice,
             handle=handle,
@@ -1765,7 +1903,7 @@ class TestPendingEventWorker:
         monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 2)
         monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 3)
         for index in range(8):
-            await self._admit(alice, text_event(f"$m{index}", ts=1_000 + index))
+            await self._admit(alice, text_event(f"$m{index}", thread_id="$topic", ts=1_000 + index))
 
         async def handle(event: JournalEvent) -> bool:
             del event
@@ -1777,7 +1915,7 @@ class TestPendingEventWorker:
         await worker._collect_dispatchable()
         by_lane, _more = await worker._collect_dispatchable()
 
-        assert [event.event_id for event in by_lane[(ROOM, None)]] == ["$m0", "$m1", "$m6", "$m7"]
+        assert [event.event_id for event in by_lane[(ROOM, "$topic")]] == ["$m0", "$m1", "$m6", "$m7"]
 
     async def test_a_lost_owner_is_noticed_without_any_further_admission(
         self,
@@ -2300,14 +2438,14 @@ class TestABoundedScanIsFair:
         result can hide.
         """
         for index in range(5):
-            await self._admit(alice, text_event(f"$e{index}", ts=1_000 + index), ROOM)
+            await self._admit(alice, text_event(f"$e{index}", thread_id="$topic", ts=1_000 + index), ROOM)
         admitted = await alice.pending(limit=5)
         worker = PendingEventWorker(store=alice, handle=_never_called)
         worker._scan_cursor = admitted[2].receipt_order
 
         by_lane, more_remains = await worker._collect_dispatchable()
 
-        assert [event.event_id for event in by_lane[(ROOM, None)]] == ["$e0", "$e1", "$e2", "$e3", "$e4"]
+        assert [event.event_id for event in by_lane[(ROOM, "$topic")]] == ["$e0", "$e1", "$e2", "$e3", "$e4"]
         assert not more_remains
         assert worker._scan_cursor is None
 
@@ -2328,7 +2466,7 @@ class TestABoundedScanIsFair:
         monkeypatch.setattr("mindroom.pending_event_worker._BATCH_SIZE", 1)
         monkeypatch.setattr("mindroom.pending_event_worker._MAX_SCAN_PAGES", 1)
         for index in range(3):
-            await self._admit(alice, text_event(f"$e{index}", ts=1_000 + index), ROOM)
+            await self._admit(alice, text_event(f"$e{index}", thread_id="$topic", ts=1_000 + index), ROOM)
         admitted = await alice.pending(limit=3)
         worker = PendingEventWorker(store=alice, handle=_never_called, deferral_is_live=lambda _event: False)
         worker._deferred[admitted[0].event_id] = admitted[0]
@@ -2336,7 +2474,7 @@ class TestABoundedScanIsFair:
 
         by_lane, _ = await worker._collect_dispatchable()
 
-        assert [event.event_id for event in by_lane[(ROOM, None)]] == ["$e0", "$e1"]
+        assert [event.event_id for event in by_lane[(ROOM, "$topic")]] == ["$e0", "$e1"]
 
     async def test_an_object_handed_over_mid_pass_is_not_read_as_unreachable(
         self,

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, cast
 
@@ -1276,6 +1277,41 @@ class TestPendingEventWorker:
 
         assert handled == ["$second", "$first"]
 
+    async def test_one_threads_parked_turn_does_not_hold_another_thread(self, alice: PrincipalStore) -> None:
+        """Threads are separate conversations and must not queue behind each other.
+
+        A turn can be parked for as long as a human takes to answer a tool
+        approval, which is days. Serialising a whole room behind that makes
+        every other conversation with the agent unanswerable for the same
+        period, which is what one production room did for 65 minutes: five
+        threads, one pending approval, and every one of them released within
+        two seconds of it being answered.
+        """
+        parked = asyncio.Event()
+        second_ran = asyncio.Event()
+
+        async def handle(event: JournalEvent) -> bool:
+            if event.event_id == "$parked":
+                parked.set()
+                await asyncio.sleep(30)
+                return True
+            second_ran.set()
+            return True
+
+        await self._admit(alice, text_event("$parked", thread_id="$thread-one", ts=1_000))
+        await self._admit(alice, text_event("$other", thread_id="$thread-two", ts=2_000))
+
+        worker = PendingEventWorker(store=alice, handle=handle)
+        drain = asyncio.create_task(worker.drain_once())
+        try:
+            async with asyncio.timeout(5):
+                await parked.wait()
+                await second_ran.wait()
+        finally:
+            drain.cancel()
+            with suppress(asyncio.CancelledError):
+                await drain
+
     async def test_a_settled_event_never_runs_again(self, alice: PrincipalStore) -> None:
         """A settled event never runs again."""
         runs = 0
@@ -1529,11 +1565,11 @@ class TestPendingEventWorker:
         await self._admit(alice, text_event("$late", ts=2_000))
         worker.wake()
         # Waited on rather than yielded to: the point of the test is that the
-        # busy room was noted as still owing work *before* its lane finished,
+        # busy lane was noted as still owing work *before* it finished,
         # because that note is the only thing that arranges the second look. A
-        # bare yield cannot fail -- a second lane over one room is impossible
+        # bare yield cannot fail -- a second lane over one thread is impossible
         # either way -- so it proved the wakeup without exercising it.
-        await _eventually(lambda: worker._rooms_with_more == {ROOM})
+        await _eventually(lambda: worker._lanes_with_more == {(ROOM, None)})
         released.set()
 
         await _eventually(lambda: handled == ["$slow", "$late"])
@@ -1739,9 +1775,9 @@ class TestPendingEventWorker:
         # One budget-limited pass parks the cursor part way through the
         # backlog; the next reads the tail, hits the end, and wraps.
         await worker._collect_dispatchable()
-        by_room, _more = await worker._collect_dispatchable()
+        by_lane, _more = await worker._collect_dispatchable()
 
-        assert [event.event_id for event in by_room[ROOM]] == ["$m0", "$m1", "$m6", "$m7"]
+        assert [event.event_id for event in by_lane[(ROOM, None)]] == ["$m0", "$m1", "$m6", "$m7"]
 
     async def test_a_lost_owner_is_noticed_without_any_further_admission(
         self,
@@ -2269,9 +2305,9 @@ class TestABoundedScanIsFair:
         worker = PendingEventWorker(store=alice, handle=_never_called)
         worker._scan_cursor = admitted[2].receipt_order
 
-        by_room, more_remains = await worker._collect_dispatchable()
+        by_lane, more_remains = await worker._collect_dispatchable()
 
-        assert [event.event_id for event in by_room[ROOM]] == ["$e0", "$e1", "$e2", "$e3", "$e4"]
+        assert [event.event_id for event in by_lane[(ROOM, None)]] == ["$e0", "$e1", "$e2", "$e3", "$e4"]
         assert not more_remains
         assert worker._scan_cursor is None
 
@@ -2298,9 +2334,9 @@ class TestABoundedScanIsFair:
         worker._deferred[admitted[0].event_id] = admitted[0]
         worker._scan_cursor = admitted[0].receipt_order
 
-        by_room, _ = await worker._collect_dispatchable()
+        by_lane, _ = await worker._collect_dispatchable()
 
-        assert [event.event_id for event in by_room[ROOM]] == ["$e0", "$e1"]
+        assert [event.event_id for event in by_lane[(ROOM, None)]] == ["$e0", "$e1"]
 
     async def test_an_object_handed_over_mid_pass_is_not_read_as_unreachable(
         self,


### PR DESCRIPTION
## The problem

A pending tool approval in one thread made the agent stop answering **every** thread in that room. One production room spent 65 minutes in that state with five threads waiting; all five recorded a turn within two seconds of the approval finally being decided.

The pending-event worker keyed its lanes on `room_id`, so every conversation in a room ran behind whichever one was slowest. A turn parked on a human decision holds its lane for as long as the human takes, which is days by default.

## Why the obvious fix does not work

The first version of this PR keyed on `(room_id, event.thread_id)`. That changes nothing for the reported incident: `thread_id` is the `m.thread` relation and only that, so a root message records `None` and every root in a room lands back in one lane. The blocked events in production were all roots.

The conversation a root belongs to is the one it starts. That is the same thread root `MessageTarget.resolve` derives (`resolved_thread_id = thread_id or thread_start_root_event_id`), so the lane is `thread_id or event_id`.

## The invariant this turns on

The lane and the response lifecycle lock must name the same conversation:

```python
# response_lifecycle.py
def _thread_key(target: MessageTarget) -> tuple[str, str | None]:
    return (target.room_id, target.resolved_thread_id)
```

The lane decides what may run **concurrently**; the lock decides what must run **alone**. Keys that disagree either serialise a room that need not be, or start two turns that then contend for one lock and answer a thread out of receipt order. `test_a_lane_matches_the_thread_root_the_response_lock_uses` asserts the two agree rather than asserting the lane against itself.

That invariant is what produces the other two cases:

**Non-message events keep the room-wide lane.** A reaction, an edit, and a redaction also carry no `m.thread` relation, but they belong to whatever conversation their *target* is in, which the journal event does not record. Splitting them off would put a reaction in a lane beside the thread it annotates. `JournalEvent.names_its_own_conversation` draws that line.

**Room-scoped agents keep one lane per room.** An agent in room mode resolves every message to `resolved_thread_id = None`, so its lock already serialises the room by design. A lane per root would start those turns concurrently and let them take that single lock in arrival order. Only the bot knows its own thread mode, so it passes down the predicate it already had (`_room_scope_is_single_conversation`).

## What this does not fix

The thread holding the approval still parks until the decision arrives or the approval expires. This only stops it taking the rest of the room down with it. Releasing the parked thread itself is #1807 (durable continuations) or a shorter `timeout_days`.

## Tests

Written test-first; each new test was watched failing for the right reason before the change.

| Test | Guards |
|---|---|
| `test_a_parked_root_message_does_not_hold_another_root_message` | the incident: two roots, one parked |
| `test_a_lane_matches_the_thread_root_the_response_lock_uses` | lane key equals the lock's key |
| `test_a_room_scoped_agent_still_answers_its_room_in_one_order` | room mode stays serialised |
| `test_a_dispatchers_room_scope_reaches_the_lanes_it_owns` | the predicate is actually wired |

Four mutations run against the finished change; each was killed by exactly one distinct test:

| Mutation | Killed by |
|---|---|
| root falls back to the room lane | the two thread-scope tests |
| drop the non-message guard | `test_a_recovery_drain_runs_a_room_through_its_lane_not_beside_it` |
| ignore the room-scope predicate | `test_a_room_scoped_agent_still_answers_its_room_in_one_order` |
| drop the dispatcher wiring | `test_a_dispatchers_room_scope_reaches_the_lanes_it_owns` |

Existing tests that expressed "one room" with bare roots now express one thread, since the invariant they were written for is per-conversation.

`tests/test_journal_ingress.py`: 95 passed. Full suite diffed against merge base `15a2638ce`: **72 failures on the branch, 75 on baseline, zero new** (the rest are missing optional deps in this environment).