### PR TITLE
Prevent interactive reactions from blocking room dispatch

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -573,6 +573,10 @@ class AgentBot:
         )
         self._membership_fence = MembershipFence(
             store=self._journal_store.principal(self._journal_principal_id),
+            clear_departed_room=lambda room_id: interactive.clear_interactive_questions_for_room(
+                room_id,
+                self.agent_name,
+            ),
         )
         self._relations = RelationLookup(
             store=self._journal_store.principal(self._journal_principal_id),

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -832,6 +832,7 @@ class AgentBot:
                 user_stop_reconciler=self._user_stop_reconciler,
                 ingress=self._ingress_validator,
                 reserve_prompt_ingress_order=self._turn_controller.reserve_prompt_ingress_order,
+                build_message_target=self._conversation_resolver.build_message_target,
                 handle_interactive_selection=self._turn_controller.handle_interactive_selection,
                 start_interactive_selection=self._turn_controller.start_interactive_selection,
                 emit_reaction_received_hooks=self._emit_reaction_received_hooks,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -668,7 +668,10 @@ class AgentBot:
                 on_room_lifecycle=self._on_room_member,
                 on_redaction=self._on_redaction,
                 on_decryption_failure=self._on_decryption_failure,
-                source_has_live_owner=self._coalescing_gate.has_pending_source_event,
+                source_has_live_owner=lambda event_id: (
+                    self._coalescing_gate.has_pending_source_event(event_id)
+                    or self._response_runner.has_live_inbox_response(event_id)
+                ),
                 turn_has_live_claim=self._turn_store.has_live_turn_claim,
             ),
             room_for_id=self._room_for_journal_event,
@@ -813,6 +816,7 @@ class AgentBot:
                 visible_voice_echo=self._visible_voice_echo,
                 visible_responses=self._visible_responses,
                 retry_dispatch_sources=self._journal_dispatcher.retry_turn_sources,
+                settle_dispatch_sources=self._journal_dispatcher.settle_intentionally_ignored_turn_sources,
             ),
         )
         self._reaction_dispatcher = ReactionDispatcher(
@@ -829,6 +833,7 @@ class AgentBot:
                 ingress=self._ingress_validator,
                 reserve_prompt_ingress_order=self._turn_controller.reserve_prompt_ingress_order,
                 handle_interactive_selection=self._turn_controller.handle_interactive_selection,
+                start_interactive_selection=self._turn_controller.start_interactive_selection,
                 emit_reaction_received_hooks=self._emit_reaction_received_hooks,
                 config_confirmation=config_confirmation.ConfigConfirmationContext(
                     runtime=self._runtime_view,
@@ -2348,10 +2353,10 @@ class AgentBot:
         assert isinstance(event, nio.RedactionEvent)
         await self._turn_store.mark_source_redacted(event.redacts)
 
-    async def _on_reaction(self, room: nio.MatrixRoom, event: nio.ReactionEvent) -> None:
+    async def _on_reaction(self, room: nio.MatrixRoom, event: nio.ReactionEvent) -> TurnDispatchOutcome:
         """Handle reaction events for interactive questions, stop functionality, and config confirmations."""
         async with self._conversation_resolver.turn_lookup_scope():
-            await self._reaction_dispatcher.dispatch(room, event)
+            return await self._reaction_dispatcher.dispatch(room, event)
 
     async def _on_room_member(
         self,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -817,6 +817,7 @@ class AgentBot:
                 visible_responses=self._visible_responses,
                 retry_dispatch_sources=self._journal_dispatcher.retry_turn_sources,
                 settle_dispatch_sources=self._journal_dispatcher.settle_intentionally_ignored_turn_sources,
+                dispatch_source_is_terminal=self._journal_dispatcher.source_is_terminal,
             ),
         )
         self._reaction_dispatcher = ReactionDispatcher(

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -650,6 +650,7 @@ class AgentBot:
             matrix_id=runtime_matrix_id,
             resolver=self._conversation_resolver,
             hook_context=self._hook_context_support,
+            membership=self._journal_store.principal(self._journal_principal_id),
         )
         self._turn_store = TurnStore(
             TurnStoreDeps(
@@ -690,6 +691,7 @@ class AgentBot:
             runtime_paths=self.runtime_paths,
             delivery_gateway=self._delivery_gateway,
             conversation_reader=self._conversation_reader,
+            membership=self._journal_store.principal(self._journal_principal_id),
         )
         self._ingress_hook_runner = IngressHookRunner(
             hook_context=self._hook_context_support,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -833,6 +833,7 @@ class AgentBot:
                 ingress=self._ingress_validator,
                 reserve_prompt_ingress_order=self._turn_controller.reserve_prompt_ingress_order,
                 build_message_target=self._conversation_resolver.build_message_target,
+                enqueue_interactive_selection=self._turn_controller.enqueue_interactive_selection,
                 handle_interactive_selection=self._turn_controller.handle_interactive_selection,
                 start_interactive_selection=self._turn_controller.start_interactive_selection,
                 emit_reaction_received_hooks=self._emit_reaction_received_hooks,

--- a/src/mindroom/custom_tools/matrix_conversation_operations.py
+++ b/src/mindroom/custom_tools/matrix_conversation_operations.py
@@ -18,6 +18,7 @@ from mindroom.custom_tools.attachments import (
 from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.entity_resolution import is_human_requester_id
 from mindroom.interactive import (
+    InteractiveMetadata,
     add_reaction_buttons,
     clear_interactive_question,
     parse_and_format_interactive,
@@ -115,6 +116,7 @@ class MatrixMessageOperations:
         event_id: str | None,
         room_id: str,
         thread_id: str | None,
+        expected_membership_epoch: int | None,
     ) -> None:
         if original_text is None or event_id is None or not should_create_interactive_question(original_text):
             return
@@ -123,20 +125,62 @@ class MatrixMessageOperations:
         if response.interactive_metadata is None:
             return
 
-        register_interactive_question(
-            event_id,
-            room_id,
-            thread_id,
-            response.interactive_metadata.option_map,
-            context.agent_name,
-            question_text=response.interactive_metadata.question_text,
-            option_labels=response.interactive_metadata.option_labels,
+        await self._register_interactive(
+            context,
+            event_id=event_id,
+            room_id=room_id,
+            thread_id=thread_id,
+            metadata=response.interactive_metadata,
+            expected_membership_epoch=expected_membership_epoch,
         )
+
+    async def _register_interactive(
+        self,
+        context: ToolRuntimeContext,
+        *,
+        event_id: str,
+        room_id: str,
+        thread_id: str | None,
+        metadata: InteractiveMetadata,
+        expected_membership_epoch: int | None,
+    ) -> None:
+        """Register a direct Matrix question only for the membership that sent it."""
+
+        def register() -> None:
+            register_interactive_question(
+                event_id,
+                room_id,
+                thread_id,
+                metadata.option_map,
+                context.agent_name,
+                question_text=metadata.question_text,
+                option_labels=metadata.option_labels,
+            )
+
+        membership = context.membership
+        if membership is None:
+            register()
+        elif context.membership_turn_id is not None and room_id == context.room_id:
+            if not await membership.run_if_turn_membership_current(
+                turn_id=context.membership_turn_id,
+                room_id=room_id,
+                fallback_membership_epoch=expected_membership_epoch,
+                operation=register,
+            ):
+                return
+        elif expected_membership_epoch is None:
+            register()
+        elif not await membership.run_if_membership_epoch(
+            room_id=room_id,
+            expected_membership_epoch=expected_membership_epoch,
+            operation=register,
+        ):
+            return
         await add_reaction_buttons(
             context.client,
             room_id,
             event_id,
-            response.interactive_metadata.options_as_list(),
+            metadata.options_as_list(),
         )
 
     async def _message_send_or_reply(  # noqa: C901, PLR0911, PLR0912
@@ -172,6 +216,11 @@ class MatrixMessageOperations:
             )
 
         original_text = text
+        expected_membership_epoch = (
+            await context.membership.membership_epoch(room_id)
+            if context.membership is not None and text is not None and should_create_interactive_question(text)
+            else None
+        )
         event_id: str | None = None
         if text is not None:
             event_id = await self._send_matrix_text(
@@ -195,6 +244,7 @@ class MatrixMessageOperations:
             event_id=event_id,
             room_id=room_id,
             thread_id=effective_thread_id,
+            expected_membership_epoch=expected_membership_epoch,
         )
 
         attachment_event_ids: list[str] = []
@@ -635,6 +685,11 @@ class MatrixMessageOperations:
 
         clear_interactive_question(target)
         interactive_response = parse_and_format_interactive(new_text, extract_mapping=True)
+        expected_membership_epoch = (
+            await context.membership.membership_epoch(room_id)
+            if context.membership is not None and interactive_response.interactive_metadata is not None
+            else None
+        )
         formatted_text = interactive_response.formatted_text
         extras_content = build_message_extras_content(message_extras) if message_extras else None
         content = format_message_with_mentions(
@@ -661,20 +716,13 @@ class MatrixMessageOperations:
                 message="Failed to edit message in Matrix.",
             )
         if interactive_response.interactive_metadata is not None:
-            register_interactive_question(
-                target,
-                room_id,
-                thread_id,
-                interactive_response.interactive_metadata.option_map,
-                context.agent_name,
-                question_text=interactive_response.interactive_metadata.question_text,
-                option_labels=interactive_response.interactive_metadata.option_labels,
-            )
-            await add_reaction_buttons(
-                context.client,
-                room_id,
-                target,
-                interactive_response.interactive_metadata.options_as_list(),
+            await self._register_interactive(
+                context,
+                event_id=target,
+                room_id=room_id,
+                thread_id=thread_id,
+                metadata=interactive_response.interactive_metadata,
+                expected_membership_epoch=expected_membership_epoch,
             )
 
         return self._result(

--- a/src/mindroom/dispatch_callback_outcome.py
+++ b/src/mindroom/dispatch_callback_outcome.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 
 
 class TurnDispatchOutcome(StrEnum):
-    """Ownership disposition returned by one message or media callback."""
+    """Ownership disposition returned by one message, media, or reaction callback."""
 
     DEFERRED = "deferred"
     INTENTIONALLY_IGNORED = "intentionally_ignored"

--- a/src/mindroom/dispatch_source.py
+++ b/src/mindroom/dispatch_source.py
@@ -24,6 +24,7 @@ HOOK_SOURCE_KIND = "hook"
 HOOK_DISPATCH_SOURCE_KIND = "hook_dispatch"
 EXTERNAL_TRIGGER_SOURCE_KIND = "external_trigger"
 ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND = "active_thread_follow_up"
+INTERACTIVE_SELECTION_SOURCE_KIND = "interactive_selection"
 TRUSTED_INTERNAL_RELAY_SOURCE_KIND = "trusted_internal_relay"
 AUTO_RESUME_MESSAGE = (
     "[System: Previous response was interrupted by service restart. Please continue where you left off.]"
@@ -52,6 +53,7 @@ _AUTOMATION_SOURCE_KINDS: frozenset[str] = frozenset(
 )
 _COALESCING_BYPASS_SOURCE_KINDS: frozenset[str] = _AUTOMATION_SOURCE_KINDS | frozenset(
     {
+        INTERACTIVE_SELECTION_SOURCE_KIND,
         TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     },
 )

--- a/src/mindroom/event_journal/journal.py
+++ b/src/mindroom/event_journal/journal.py
@@ -301,12 +301,12 @@ def _advance_membership_epoch(
     # survive, as everything above does, because they are still the proof that
     # these events already had their one turn.
     #
-    # Only the turn-backed kinds. A redaction, a reaction, an approval reply
-    # and a decryption failure do not enqueue an answer, so the epoch predicate
-    # never blocks them and none of them is unanswerable. A redaction in
-    # particular still owes real cleanup -- removing the redacted request from
-    # durable turn and session state -- and sweeping it up here would drop that
-    # work silently and let the redacted content survive in later context.
+    # Only the turn-backed kinds and reactions already claimed by an interactive
+    # response. Other reactions do not enqueue an answer and still owe their
+    # hook work. A redaction in particular still owes real cleanup -- removing
+    # the redacted request from durable turn and session state -- and sweeping
+    # it up here would drop that work silently and let the redacted content
+    # survive in later context.
     turn_backed = tuple(sorted(kind.value for kind in TURN_BACKED_KINDS))
     kind_placeholders = ", ".join("?" for _ in turn_backed)
     transaction.execute(
@@ -314,9 +314,19 @@ def _advance_membership_epoch(
         UPDATE journal_events
         SET state = ?, source_json = '', semantic_consumer = NULL
         WHERE principal_id = ? AND room_id = ? AND state = 'pending'
-          AND kind IN ({kind_placeholders})
+          AND (
+            kind IN ({kind_placeholders})
+            OR (kind = ? AND semantic_consumer = ?)
+          )
         """,  # noqa: S608 - placeholders are generated, values are still bound
-        (SETTLED_STATE, principal_id, room_id, *turn_backed),
+        (
+            SETTLED_STATE,
+            principal_id,
+            room_id,
+            *turn_backed,
+            EventKind.REACTION.value,
+            SemanticConsumer.INTERACTIVE_REACTION.value,
+        ),
     )
     return epoch
 
@@ -832,8 +842,8 @@ def claim_semantic_consumer(
     principal_id: str,
     event_id: str,
     consumer: SemanticConsumer,
-) -> SemanticConsumer:
-    """Record the sole consumer of one event, returning whoever holds it.
+) -> SemanticConsumer | None:
+    """Record the sole consumer, or retire a stale interactive reaction.
 
     First claim wins, durably. A replay after a crash therefore cannot let a
     second consumer act on the same reaction.
@@ -843,14 +853,22 @@ def claim_semantic_consumer(
         UPDATE journal_events
         SET semantic_consumer = COALESCE(semantic_consumer, ?)
         WHERE principal_id = ? AND event_id = ? AND state = 'pending'
-        RETURNING semantic_consumer
+        RETURNING semantic_consumer, room_id, kind, membership_epoch
         """,
         (consumer.value, principal_id, event_id),
     )
     if row is None:
         msg = f"Cannot claim a consumer for settled or missing event {event_id!r}"
         raise RuntimeError(msg)
-    return SemanticConsumer(row["semantic_consumer"])
+    claimed = SemanticConsumer(row["semantic_consumer"])
+    if (
+        claimed is SemanticConsumer.INTERACTIVE_REACTION
+        and EventKind(row["kind"]) is EventKind.REACTION
+        and int(row["membership_epoch"]) != current_membership_epoch(transaction, principal_id, row["room_id"])
+    ):
+        settle(transaction, principal_id, event_id)
+        return None
+    return claimed
 
 
 def _journal_event(row: Row) -> JournalEvent:

--- a/src/mindroom/event_journal/journal.py
+++ b/src/mindroom/event_journal/journal.py
@@ -40,6 +40,8 @@ from .projection import ProjectedEvent, project
 from .schema import PENDING_STATE, SETTLED_STATE
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from .backend import Row, Transaction
     from .models import InboundEvent
 
@@ -427,6 +429,30 @@ def note_membership_restarted(transaction: Transaction, principal_id: str, room_
     )
 
 
+def note_membership_restarted_after(
+    transaction: Transaction,
+    principal_id: str,
+    room_id: str,
+    cleanup: Callable[[], None],
+) -> None:
+    """Clear external departure state before atomically rearming one room."""
+    if not _claim_departure_fence(transaction, principal_id, room_id):
+        return
+    cleanup()
+    note_membership_restarted(transaction, principal_id, room_id)
+
+
+def cleanup_fenced_departure(
+    transaction: Transaction,
+    principal_id: str,
+    room_id: str,
+    cleanup: Callable[[], None],
+) -> None:
+    """Clean external state only while this room is still durably departed."""
+    if _claim_departure_fence(transaction, principal_id, room_id):
+        cleanup()
+
+
 def retire_owed_departure_reports(transaction: Transaction, principal_id: str, room_id: str) -> None:
     """Forget reports that can no longer arrive, so a real departure still fences."""
     transaction.execute(
@@ -470,6 +496,19 @@ def _membership_state(transaction: Transaction, principal_id: str, room_id: str)
         departure_fenced=bool(row["departure_fenced"]),
         owed_reports=int(row["owed_departure_reports"]),
     )
+
+
+def _claim_departure_fence(transaction: Transaction, principal_id: str, room_id: str) -> bool:
+    """Lock one room's membership row and return its departure-fence state."""
+    row = transaction.fetchone(
+        """
+        UPDATE room_membership SET departure_fenced = departure_fenced
+        WHERE principal_id = ? AND room_id = ?
+        RETURNING departure_fenced
+        """,
+        (principal_id, room_id),
+    )
+    return row is not None and bool(row["departure_fenced"])
 
 
 def _write_departure_state(

--- a/src/mindroom/event_journal/membership.py
+++ b/src/mindroom/event_journal/membership.py
@@ -34,7 +34,7 @@ from mindroom.logging_config import get_logger
 from .models import DepartureOutcome, DepartureSource
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Callable, Iterable
 
 logger = get_logger(__name__)
 
@@ -65,7 +65,16 @@ class MembershipView(Protocol):
         """Apply one observation of a departure, invalidating at most once per departure."""
         ...
 
-    async def note_membership_restarted(self, room_id: str) -> None:
+    async def cleanup_fenced_departure(self, room_id: str, cleanup: Callable[[], None]) -> None:
+        """Clean external state only while one room remains durably departed."""
+        ...
+
+    async def note_membership_restarted(
+        self,
+        room_id: str,
+        *,
+        cleanup: Callable[[], None] | None = None,
+    ) -> None:
         """Record a confirmed join, so the room's next departure fences again."""
         ...
 
@@ -83,6 +92,7 @@ class MembershipFence:
     """Advance a room's membership epoch exactly once per departure."""
 
     store: MembershipView
+    clear_departed_room: Callable[[str], None] | None = None
     # Rooms owing a sync report, and how many more sync responses that report
     # may still appear in. Recovered from the journal on the first sync
     # response, because a restart between a local departure and its report
@@ -95,6 +105,7 @@ class MembershipFence:
         outcome = await self.store.fence_departure(room_id, source=DepartureSource.LOCAL)
         self._log(room_id, outcome)
         self._track(room_id, outcome)
+        await self._clear_room(room_id, outcome)
 
     async def fence_reported_departures(self, room_ids: Iterable[str]) -> None:
         """Fence departures a sync reported, absorbing the report local ones are owed.
@@ -111,11 +122,23 @@ class MembershipFence:
             outcome = await self.store.fence_departure(room_id, source=DepartureSource.REPORTED)
             self._log(room_id, outcome)
             self._track(room_id, outcome)
+            await self._clear_room(room_id, outcome)
         await self._expire_unarrived_reports()
 
     async def note_membership_restarted(self, room_id: str) -> None:
         """Record a confirmed join, so this room's next departure fences again."""
-        await self.store.note_membership_restarted(room_id)
+        clear_departed_room = self.clear_departed_room
+        cleanup = None if clear_departed_room is None else lambda: clear_departed_room(room_id)
+        await self.store.note_membership_restarted(room_id, cleanup=cleanup)
+
+    async def _clear_room(self, room_id: str, outcome: DepartureOutcome) -> None:
+        """Clear external state only for the departure that advanced the epoch."""
+        clear_departed_room = self.clear_departed_room
+        if outcome.fenced and clear_departed_room is not None:
+            await self.store.cleanup_fenced_departure(
+                room_id,
+                lambda: clear_departed_room(room_id),
+            )
 
     def _track(self, room_id: str, outcome: DepartureOutcome) -> None:
         """Start, keep, or drop the window an owed report may still arrive in."""

--- a/src/mindroom/event_journal/reads.py
+++ b/src/mindroom/event_journal/reads.py
@@ -338,12 +338,13 @@ def claim_membership_epoch(
     room_id: str,
     expected_membership_epoch: int,
 ) -> bool:
-    """Materialize and claim the expected room membership for one write.
+    """Materialize and claim the expected active room membership for one write.
 
     A write claim rather than a ``SELECT`` takes the same row lock as the
     membership fence. The two operations therefore have a total order: rows
     committed before a fence are deleted by it, while a writer after the fence
-    observes the advanced epoch and refuses its stale work.
+    refuses work until the room has rejoined, even if it captured the advanced
+    epoch while the departure cleanup was still pending.
 
     Materializing epoch zero matters because a lock on a row that does not yet
     exist orders nothing. The inserted row says exactly what absence said while
@@ -355,7 +356,7 @@ def claim_membership_epoch(
         VALUES (?, ?, 0)
         ON CONFLICT (principal_id, room_id) DO UPDATE
             SET membership_epoch = room_membership.membership_epoch
-        RETURNING membership_epoch AS epoch
+        RETURNING membership_epoch AS epoch, departure_fenced
         """,
         (principal_id, room_id),
     )
@@ -363,7 +364,7 @@ def claim_membership_epoch(
         msg = f"Room membership for {room_id!r} is missing immediately after it was claimed"
         raise RuntimeError(msg)
     current_epoch = int(row["epoch"])
-    return current_epoch == expected_membership_epoch
+    return current_epoch == expected_membership_epoch and not bool(row["departure_fenced"])
 
 
 def mark_conversation_hydrated(

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -218,6 +218,44 @@ class PrincipalStore:
             ),
         )
 
+    async def run_if_turn_membership_current(
+        self,
+        *,
+        turn_id: str,
+        room_id: str,
+        operation: Callable[[], None],
+        fallback_membership_epoch: int | None = None,
+    ) -> bool:
+        """Run a side effect only while its admitted turn still owns the room membership."""
+        return await self._backend.write(
+            lambda transaction: _run_if_turn_membership_current(
+                transaction,
+                self._principal_id,
+                turn_id=turn_id,
+                room_id=room_id,
+                operation=operation,
+                fallback_membership_epoch=fallback_membership_epoch,
+            ),
+        )
+
+    async def run_if_membership_epoch(
+        self,
+        *,
+        room_id: str,
+        expected_membership_epoch: int,
+        operation: Callable[[], None],
+    ) -> bool:
+        """Run a side effect only while one captured room membership remains current."""
+        return await self._backend.write(
+            lambda transaction: _run_if_membership_epoch(
+                transaction,
+                self._principal_id,
+                room_id=room_id,
+                expected_membership_epoch=expected_membership_epoch,
+                operation=operation,
+            ),
+        )
+
     async def note_membership_restarted(
         self,
         room_id: str,
@@ -787,6 +825,57 @@ def _turn_membership_is_current(
         # Nothing the journal admitted, so nothing a rejoin invalidated.
         return True
     return admitted == journal.current_membership_epoch(transaction, principal_id, room_id)
+
+
+def _run_if_membership_epoch(
+    transaction,  # noqa: ANN001 - the backend's Transaction, kept structural
+    principal_id: str,
+    *,
+    room_id: str,
+    expected_membership_epoch: int,
+    operation: Callable[[], None],
+) -> bool:
+    """Claim one membership row and run a synchronous side effect if its epoch matches."""
+    if not reads.claim_membership_epoch(
+        transaction,
+        principal_id,
+        room_id=room_id,
+        expected_membership_epoch=expected_membership_epoch,
+    ):
+        return False
+    operation()
+    return True
+
+
+def _run_if_turn_membership_current(
+    transaction,  # noqa: ANN001 - the backend's Transaction, kept structural
+    principal_id: str,
+    *,
+    turn_id: str,
+    room_id: str,
+    operation: Callable[[], None],
+    fallback_membership_epoch: int | None = None,
+) -> bool:
+    """Claim a turn's admitted membership before running one synchronous side effect."""
+    admitted = journal.admitted_membership_epoch(transaction, principal_id, turn_id)
+    if admitted is None:
+        if fallback_membership_epoch is not None:
+            return _run_if_membership_epoch(
+                transaction,
+                principal_id,
+                room_id=room_id,
+                expected_membership_epoch=fallback_membership_epoch,
+                operation=operation,
+            )
+        operation()
+        return True
+    return _run_if_membership_epoch(
+        transaction,
+        principal_id,
+        room_id=room_id,
+        expected_membership_epoch=admitted,
+        operation=operation,
+    )
 
 
 def _enqueue_delivery(

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -168,8 +168,8 @@ class PrincipalStore:
         self,
         event_id: str,
         consumer: SemanticConsumer,
-    ) -> SemanticConsumer:
-        """Record the sole consumer of one event, returning whoever holds it."""
+    ) -> SemanticConsumer | None:
+        """Record the sole consumer, or retire a stale interactive reaction."""
         return await self._backend.write(
             lambda transaction: journal.claim_semantic_consumer(
                 transaction,

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -26,7 +26,7 @@ from .models import DeliveryAcknowledgement
 from .projection import drop_refetched_message, install_refetched_revision, project
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Callable, Mapping, Sequence
     from pathlib import Path
 
     from .backend import Backend, Transaction
@@ -207,10 +207,36 @@ class PrincipalStore:
             ),
         )
 
-    async def note_membership_restarted(self, room_id: str) -> None:
-        """Record a confirmed join, so the room's next departure fences again."""
+    async def cleanup_fenced_departure(self, room_id: str, cleanup: Callable[[], None]) -> None:
+        """Clean external state only while one room remains durably departed."""
         await self._backend.write(
-            lambda transaction: journal.note_membership_restarted(transaction, self._principal_id, room_id),
+            lambda transaction: journal.cleanup_fenced_departure(
+                transaction,
+                self._principal_id,
+                room_id,
+                cleanup,
+            ),
+        )
+
+    async def note_membership_restarted(
+        self,
+        room_id: str,
+        *,
+        cleanup: Callable[[], None] | None = None,
+    ) -> None:
+        """Rearm one room after any committed-departure cleanup succeeds."""
+        if cleanup is None:
+            await self._backend.write(
+                lambda transaction: journal.note_membership_restarted(transaction, self._principal_id, room_id),
+            )
+            return
+        await self._backend.write(
+            lambda transaction: journal.note_membership_restarted_after(
+                transaction,
+                self._principal_id,
+                room_id,
+                cleanup,
+            ),
         )
 
     async def retire_owed_departure_reports(self, room_id: str) -> None:

--- a/src/mindroom/event_journal/views.py
+++ b/src/mindroom/event_journal/views.py
@@ -108,8 +108,8 @@ class DispatchView(ReplayView, AdmissionView, Protocol):
         self,
         event_id: str,
         consumer: SemanticConsumer,
-    ) -> SemanticConsumer:
-        """Record the sole consumer of one event, returning whoever holds it."""
+    ) -> SemanticConsumer | None:
+        """Record the sole consumer, or retire a stale interactive reaction."""
         ...
 
 

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -304,13 +304,20 @@ def restore_selection(selection: InteractiveSelection) -> None:
     if question is None:
         return
     with _thread_lock:
-        if selection.question_event_id not in _claimed_questions:
+        event_id = selection.question_event_id
+        if event_id not in _claimed_questions:
             return
-        if selection.question_event_id in _active_questions:
-            _claimed_questions.pop(selection.question_event_id, None)
+        if _persistence_file is not None and _persistence_lock_file is not None:
+            with advisory_file_lock(_persistence_lock_file, exclusive=False):
+                persisted_questions = _load_persisted_questions()
+            _claimed_questions.pop(event_id, None)
+            _dirty_question_ids.discard(event_id)
+            _deleted_question_ids.discard(event_id)
+            _set_active_questions_locked(_apply_local_changes_locked(persisted_questions))
             return
-        _store_active_question_locked(selection.question_event_id, _copy_question(question))
-        _claimed_questions.pop(selection.question_event_id, None)
+        if event_id not in _active_questions:
+            _store_active_question_locked(event_id, _copy_question(question))
+        _claimed_questions.pop(event_id, None)
 
 
 def _apply_local_changes_locked(
@@ -896,21 +903,33 @@ def clear_interactive_question(event_id: str) -> None:
 def clear_interactive_questions_for_room(room_id: str, creator_agent: str) -> None:
     """Durably consume one departed agent's active and claimed questions."""
     with _thread_lock:
-        _refresh_active_questions_locked()
-        removed_event_ids = {
-            event_id
-            for event_id, question in _active_questions.items()
-            if question.room_id == room_id and question.creator_agent == creator_agent
-        }
-        removed_event_ids.update(
+        claimed_event_ids = {
             event_id
             for event_id, question in _claimed_questions.items()
             if question.room_id == room_id and question.creator_agent == creator_agent
-        )
-        for event_id in removed_event_ids:
-            _remove_active_question_locked(event_id)
-            _deleted_question_ids.add(event_id)
-        _persist_local_changes_locked(rebuild_on_read_error=False)
+        }
+        if _persistence_file is None or _persistence_lock_file is None:
+            removed_event_ids = claimed_event_ids | {
+                event_id
+                for event_id, question in _active_questions.items()
+                if question.room_id == room_id and question.creator_agent == creator_agent
+            }
+            for event_id in removed_event_ids:
+                _remove_active_question_locked(event_id)
+        else:
+            _persistence_file.parent.mkdir(parents=True, exist_ok=True)
+            with advisory_file_lock(_persistence_lock_file):
+                questions = _apply_local_changes_locked(_load_persisted_questions())
+                removed_event_ids = claimed_event_ids | {
+                    event_id
+                    for event_id, question in questions.items()
+                    if question.room_id == room_id and question.creator_agent == creator_agent
+                }
+                remaining_questions = {
+                    event_id: question for event_id, question in questions.items() if event_id not in removed_event_ids
+                }
+                _write_active_questions_atomically_locked(remaining_questions)
+                _replace_active_questions_locked(remaining_questions)
 
         for event_id in removed_event_ids:
             _claimed_questions.pop(event_id, None)

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -128,7 +128,7 @@ _persistence_lock_file: Path | None = None
 _thread_lock = threading.RLock()
 _dirty_question_ids: set[str] = set()
 _deleted_question_ids: set[str] = set()
-_claimed_question_ids: set[str] = set()
+_claimed_questions: dict[str, _InteractiveQuestion] = {}
 
 # Constants
 # Match interactive code blocks
@@ -236,7 +236,7 @@ def _replace_active_questions_locked(questions: dict[str, _InteractiveQuestion])
     """Replace in-memory state after a successful load or save."""
     global _active_questions
     _active_questions = {
-        event_id: question for event_id, question in questions.items() if event_id not in _claimed_question_ids
+        event_id: question for event_id, question in questions.items() if event_id not in _claimed_questions
     }
     _dirty_question_ids.clear()
     _deleted_question_ids.clear()
@@ -246,7 +246,7 @@ def _set_active_questions_locked(questions: dict[str, _InteractiveQuestion]) -> 
     """Replace the in-memory snapshot without clearing pending local changes."""
     global _active_questions
     _active_questions = {
-        event_id: question for event_id, question in questions.items() if event_id not in _claimed_question_ids
+        event_id: question for event_id, question in questions.items() if event_id not in _claimed_questions
     }
 
 
@@ -282,7 +282,7 @@ def _claim_question_locked(event_id: str, question: _InteractiveQuestion) -> _In
         _persist_local_changes_locked(rebuild_on_read_error=False)
     claimed_question = _copy_question(question)
     del _active_questions[event_id]
-    _claimed_question_ids.add(event_id)
+    _claimed_questions[event_id] = claimed_question
     return claimed_question
 
 
@@ -293,9 +293,9 @@ def commit_selection(selection: InteractiveSelection) -> None:
     with _thread_lock:
         _deleted_question_ids.add(selection.question_event_id)
         _persist_local_changes_locked(rebuild_on_read_error=False)
-        _claimed_question_ids.discard(selection.question_event_id)
         _dirty_question_ids.discard(selection.question_event_id)
         _deleted_question_ids.discard(selection.question_event_id)
+        _claimed_questions.pop(selection.question_event_id, None)
 
 
 def restore_selection(selection: InteractiveSelection) -> None:
@@ -304,10 +304,13 @@ def restore_selection(selection: InteractiveSelection) -> None:
     if question is None:
         return
     with _thread_lock:
-        _claimed_question_ids.discard(selection.question_event_id)
+        if selection.question_event_id not in _claimed_questions:
+            return
         if selection.question_event_id in _active_questions:
+            _claimed_questions.pop(selection.question_event_id, None)
             return
         _store_active_question_locked(selection.question_event_id, _copy_question(question))
+        _claimed_questions.pop(selection.question_event_id, None)
 
 
 def _apply_local_changes_locked(
@@ -890,6 +893,36 @@ def clear_interactive_question(event_id: str) -> None:
         logger.info("Cleared interactive question", event_id=event_id)
 
 
+def clear_interactive_questions_for_room(room_id: str, creator_agent: str) -> None:
+    """Durably consume one departed agent's active and claimed questions."""
+    with _thread_lock:
+        _refresh_active_questions_locked()
+        removed_event_ids = {
+            event_id
+            for event_id, question in _active_questions.items()
+            if question.room_id == room_id and question.creator_agent == creator_agent
+        }
+        removed_event_ids.update(
+            event_id
+            for event_id, question in _claimed_questions.items()
+            if question.room_id == room_id and question.creator_agent == creator_agent
+        )
+        for event_id in removed_event_ids:
+            _remove_active_question_locked(event_id)
+            _deleted_question_ids.add(event_id)
+        _persist_local_changes_locked(rebuild_on_read_error=False)
+
+        for event_id in removed_event_ids:
+            _claimed_questions.pop(event_id, None)
+
+    logger.info(
+        "Cleared interactive questions for departed room",
+        room_id=room_id,
+        creator_agent=creator_agent,
+        question_count=len(removed_event_ids),
+    )
+
+
 async def add_reaction_buttons(
     client: nio.AsyncClient,
     room_id: str,
@@ -925,6 +958,6 @@ def _cleanup() -> None:
         _active_questions.clear()
         _dirty_question_ids.clear()
         _deleted_question_ids.clear()
-        _claimed_question_ids.clear()
+        _claimed_questions.clear()
         _persistence_file = None
         _persistence_lock_file = None

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -414,6 +414,10 @@ class JournalDispatcher:
         event = _RUNNING_EVENT.get()
         return None if event is None else event.semantic_consumer
 
+    async def source_is_terminal(self, event_id: str) -> bool:
+        """Return whether an admitted source has finished its journal work."""
+        return await self.store.load_event(event_id) is not None and not await self.store.is_pending(event_id)
+
     async def claim_semantic_consumer(self, consumer: SemanticConsumer) -> bool:
         """Freeze the running event's consumer if it remains actionable."""
         event = _RUNNING_EVENT.get()

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -414,13 +414,15 @@ class JournalDispatcher:
         event = _RUNNING_EVENT.get()
         return None if event is None else event.semantic_consumer
 
-    async def claim_semantic_consumer(self, consumer: SemanticConsumer) -> None:
-        """Freeze the running event's consumer before it acts on it."""
+    async def claim_semantic_consumer(self, consumer: SemanticConsumer) -> bool:
+        """Freeze the running event's consumer if it remains actionable."""
         event = _RUNNING_EVENT.get()
         if event is None:
             msg = "A semantic consumer can only be claimed inside a journal callback"
             raise RuntimeError(msg)
         claimed = await self.store.claim_semantic_consumer(event.event_id, consumer)
+        if claimed is None:
+            return False
         if claimed is not consumer:
             msg = f"Journal event is already owned by {claimed.value!r}"
             raise RuntimeError(msg)
@@ -430,6 +432,7 @@ class JournalDispatcher:
             # registration waited for the callback's deferred return, a fast
             # response could discard nothing and then be added back forever.
             self._deferred_reaction_ids.add(event.event_id)
+        return True
 
     async def receipt_order(self) -> int:
         """Return the durable admission order of the running event."""

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -70,12 +70,6 @@ type _RoomLifecycleCallback = Callable[[nio.MatrixRoom, nio.RoomMemberEvent], Aw
 type _RedactionCallback = Callable[[nio.MatrixRoom, nio.RedactionEvent], Awaitable[None]]
 type _DecryptionFailureCallback = Callable[[nio.MatrixRoom, nio.MegolmEvent], Awaitable[None]]
 
-# Interactive reactions are the only reaction path whose response may outlive
-# its callback. Keep this dispatcher concern separate from TURN_BACKED_KINDS:
-# generic reactions must still replay before the agent fleet is released and
-# must not count as unfinished conversation turns in journal queries.
-_DEFERRABLE_KINDS = TURN_BACKED_KINDS | {EventKind.REACTION}
-
 
 @dataclass(frozen=True, slots=True)
 class JournalCallbacks:
@@ -116,6 +110,9 @@ class JournalDispatcher:
     # an event that is still in hand would parse every event twice and discard
     # the decryption state nio attached to the original.
     _live_events: dict[str, tuple[nio.MatrixRoom, nio.Event]] = field(default_factory=dict, init=False, repr=False)
+    # Reactions normally complete inline. Only one whose callback explicitly
+    # deferred has a managed response owner worth probing on later scans.
+    _deferred_reaction_ids: set[str] = field(default_factory=set, init=False, repr=False)
 
     def __post_init__(self) -> None:
         """Build the worker and admission adapter this dispatcher owns."""
@@ -299,7 +296,7 @@ class JournalDispatcher:
         this replaces; a wrong "gone" costs a re-dispatch that ``TurnStore``
         then has to refuse.
         """
-        if event.kind not in _DEFERRABLE_KINDS:
+        if event.kind not in TURN_BACKED_KINDS and event.event_id not in self._deferred_reaction_ids:
             # A completing callback settles or raises. It never defers, so a
             # deferral for one of these kinds cannot exist to begin with.
             return True
@@ -333,7 +330,8 @@ class JournalDispatcher:
             # not exist yet. Live events are unaffected: their responders are
             # whatever is running now.
             return False
-        if event.kind in _DEFERRABLE_KINDS and self._has_live_owner(event.event_id):
+        has_deferrable_owner = event.kind in TURN_BACKED_KINDS or event.event_id in self._deferred_reaction_ids
+        if has_deferrable_owner and self._has_live_owner(event.event_id):
             # A coalescing batch or a running turn already holds this source
             # and will hand it back. Starting a second turn on it does not
             # answer twice, but the loser of the claim blocks until the winner
@@ -390,7 +388,13 @@ class JournalDispatcher:
             return True
         token = _RUNNING_EVENT.set(event)
         try:
-            return await binding.run(self, room, matrix_event)
+            settles = await binding.run(self, room, matrix_event)
+            if event.kind is EventKind.REACTION:
+                if settles:
+                    self._deferred_reaction_ids.discard(event.event_id)
+                else:
+                    self._deferred_reaction_ids.add(event.event_id)
+            return settles
         finally:
             _RUNNING_EVENT.reset(token)
 
@@ -430,10 +434,12 @@ class JournalDispatcher:
         the worker still lists these events as deferred to a turn that has now
         ended, and nothing else would ever clear them.
         """
+        self._deferred_reaction_ids.difference_update(event_ids)
         self._worker.release(event_ids)
 
     async def settle_intentionally_ignored_turn_sources(self, event_ids: tuple[str, ...]) -> None:
         """Settle turn-backed events that produced no dispatch payload."""
+        self._deferred_reaction_ids.difference_update(event_ids)
         self._worker.release(event_ids)
         await self.store.settle_many(event_ids)
 
@@ -443,6 +449,7 @@ class JournalDispatcher:
 
     def retry_turn_sources(self, event_ids: tuple[str, ...]) -> None:
         """Return several undelivered turn sources to the worker."""
+        self._deferred_reaction_ids.difference_update(event_ids)
         self._worker.release(event_ids)
         self._worker.wake()
 

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -6,8 +6,8 @@ work or handed it to a turn, and who is allowed to consume a reaction that
 several features could each claim.
 
 The important asymmetry is between callbacks that finish and callbacks that
-defer. A reaction is done when its handler returns. A message is not: it enters
-coalescing and a turn, which may still be running long after the callback
+defer. Most reactions finish in their handler; an interactive reaction and a
+message hand work to a response task that may still run long after the callback
 returns. So a deferring handler leaves its event pending, and the source is
 settled when its answer is durably owed to a room -- the FINAL outbox enqueue
 -- or when the turn deliberately owes no answer at all. That is why a crash
@@ -64,11 +64,17 @@ _LIFECYCLE_PAGE_SIZE = 256
 
 type _MessageCallback = Callable[[nio.MatrixRoom, nio.RoomMessageFormatted], Awaitable[TurnDispatchOutcome]]
 type _MediaCallback = Callable[[nio.MatrixRoom, MatrixMediaEvent], Awaitable[TurnDispatchOutcome]]
-type _ReactionCallback = Callable[[nio.MatrixRoom, nio.ReactionEvent], Awaitable[None]]
+type _ReactionCallback = Callable[[nio.MatrixRoom, nio.ReactionEvent], Awaitable[TurnDispatchOutcome]]
 type _ApprovalCallback = Callable[[nio.MatrixRoom, nio.UnknownEvent], Awaitable[None]]
 type _RoomLifecycleCallback = Callable[[nio.MatrixRoom, nio.RoomMemberEvent], Awaitable[None]]
 type _RedactionCallback = Callable[[nio.MatrixRoom, nio.RedactionEvent], Awaitable[None]]
 type _DecryptionFailureCallback = Callable[[nio.MatrixRoom, nio.MegolmEvent], Awaitable[None]]
+
+# Interactive reactions are the only reaction path whose response may outlive
+# its callback. Keep this dispatcher concern separate from TURN_BACKED_KINDS:
+# generic reactions must still replay before the agent fleet is released and
+# must not count as unfinished conversation turns in journal queries.
+_DEFERRABLE_KINDS = TURN_BACKED_KINDS | {EventKind.REACTION}
 
 
 @dataclass(frozen=True, slots=True)
@@ -293,7 +299,7 @@ class JournalDispatcher:
         this replaces; a wrong "gone" costs a re-dispatch that ``TurnStore``
         then has to refuse.
         """
-        if event.kind not in TURN_BACKED_KINDS:
+        if event.kind not in _DEFERRABLE_KINDS:
             # A completing callback settles or raises. It never defers, so a
             # deferral for one of these kinds cannot exist to begin with.
             return True
@@ -327,7 +333,7 @@ class JournalDispatcher:
             # not exist yet. Live events are unaffected: their responders are
             # whatever is running now.
             return False
-        if event.kind in TURN_BACKED_KINDS and self._has_live_owner(event.event_id):
+        if event.kind in _DEFERRABLE_KINDS and self._has_live_owner(event.event_id):
             # A coalescing batch or a running turn already holds this source
             # and will hand it back. Starting a second turn on it does not
             # answer twice, but the loser of the claim blocks until the winner
@@ -533,7 +539,7 @@ def _completing(
 _BINDINGS: dict[EventKind, _Binding] = {
     EventKind.MESSAGE: _Binding(TEXTUAL_MESSAGE_EVENT_TYPE, _turn_backed(lambda c: c.on_message)),
     EventKind.MEDIA: _Binding(MATRIX_MEDIA_EVENT_TYPES, _turn_backed(lambda c: c.on_media)),
-    EventKind.REACTION: _Binding(nio.ReactionEvent, _completing(lambda c: c.on_reaction)),
+    EventKind.REACTION: _Binding(nio.ReactionEvent, _turn_backed(lambda c: c.on_reaction)),
     EventKind.APPROVAL: _Binding(nio.UnknownEvent, _completing(lambda c: c.on_approval)),
     EventKind.ROOM_LIFECYCLE: _Binding(nio.RoomMemberEvent, _completing(lambda c: c.on_room_lifecycle)),
     EventKind.REDACTION: _Binding(nio.RedactionEvent, _completing(lambda c: c.on_redaction)),

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -62,6 +62,14 @@ _RUNNING_EVENT: ContextVar[JournalEvent | None] = ContextVar("running_journal_ev
 # walk continues past it; this only bounds how much is held at once.
 _LIFECYCLE_PAGE_SIZE = 256
 
+
+def _needs_turn_replay(event: JournalEvent) -> bool:
+    """Return whether replay needs responders and turn recovery semantics."""
+    return event.kind in TURN_BACKED_KINDS or (
+        event.kind is EventKind.REACTION and event.semantic_consumer is SemanticConsumer.INTERACTIVE_REACTION
+    )
+
+
 type _MessageCallback = Callable[[nio.MatrixRoom, nio.RoomMessageFormatted], Awaitable[TurnDispatchOutcome]]
 type _MediaCallback = Callable[[nio.MatrixRoom, MatrixMediaEvent], Awaitable[TurnDispatchOutcome]]
 type _ReactionCallback = Callable[[nio.MatrixRoom, nio.ReactionEvent], Awaitable[TurnDispatchOutcome]]
@@ -296,11 +304,12 @@ class JournalDispatcher:
         this replaces; a wrong "gone" costs a re-dispatch that ``TurnStore``
         then has to refuse.
         """
-        if event.kind not in TURN_BACKED_KINDS and event.event_id not in self._deferred_reaction_ids:
+        needs_turn_replay = _needs_turn_replay(event)
+        if not needs_turn_replay and event.event_id not in self._deferred_reaction_ids:
             # A completing callback settles or raises. It never defers, so a
             # deferral for one of these kinds cannot exist to begin with.
             return True
-        if not self._turn_replay_released and event.event_id not in self._live_events:
+        if needs_turn_replay and not self._turn_replay_released and event.event_id not in self._live_events:
             # Replay is parked on the fleet, and it is released by draining
             # rather than by calling back, so nothing here has died.
             return True
@@ -321,16 +330,13 @@ class JournalDispatcher:
         journal was meant to remove, and it answered the wrong question: a turn
         can be terminal with nothing durable behind it.
         """
-        if (
-            event.kind in TURN_BACKED_KINDS
-            and not self._turn_replay_released
-            and event.event_id not in self._live_events
-        ):
+        needs_turn_replay = _needs_turn_replay(event)
+        if needs_turn_replay and not self._turn_replay_released and event.event_id not in self._live_events:
             # A turn replayed from a previous process needs responders that may
             # not exist yet. Live events are unaffected: their responders are
             # whatever is running now.
             return False
-        has_deferrable_owner = event.kind in TURN_BACKED_KINDS or event.event_id in self._deferred_reaction_ids
+        has_deferrable_owner = needs_turn_replay or event.event_id in self._deferred_reaction_ids
         if has_deferrable_owner and self._has_live_owner(event.event_id):
             # A coalescing batch or a running turn already holds this source
             # and will hand it back. Starting a second turn on it does not
@@ -359,7 +365,7 @@ class JournalDispatcher:
                 return True
         if room is None:
             room = self.room_for_id(event.room_id)
-        with turn_dispatch_recovery_scope(active=replaying and event.kind in TURN_BACKED_KINDS):
+        with turn_dispatch_recovery_scope(active=replaying and needs_turn_replay):
             return await self._invoke(event, room, matrix_event)
 
     async def _invoke(
@@ -386,13 +392,18 @@ class JournalDispatcher:
                 payload_type=type(matrix_event).__name__,
             )
             return True
+        if event.kind is EventKind.REACTION and event.semantic_consumer is SemanticConsumer.INTERACTIVE_REACTION:
+            self._deferred_reaction_ids.add(event.event_id)
         token = _RUNNING_EVENT.set(event)
         try:
             settles = await binding.run(self, room, matrix_event)
             if event.kind is EventKind.REACTION:
                 if settles:
                     self._deferred_reaction_ids.discard(event.event_id)
-                else:
+                elif self.semantic_consumer() is not SemanticConsumer.INTERACTIVE_REACTION:
+                    # The real interactive path registered before starting its
+                    # detached owner, so terminal settlement can safely remove
+                    # it even if that owner finishes before this callback.
                     self._deferred_reaction_ids.add(event.event_id)
             return settles
         finally:
@@ -414,6 +425,11 @@ class JournalDispatcher:
             msg = f"Journal event is already owned by {claimed.value!r}"
             raise RuntimeError(msg)
         _RUNNING_EVENT.set(replace(event, semantic_consumer=consumer))
+        if event.kind is EventKind.REACTION and consumer is SemanticConsumer.INTERACTIVE_REACTION:
+            # Register before the detached response can start and settle. If
+            # registration waited for the callback's deferred return, a fast
+            # response could discard nothing and then be added back forever.
+            self._deferred_reaction_ids.add(event.event_id)
 
     async def receipt_order(self) -> int:
         """Return the durable admission order of the running event."""

--- a/src/mindroom/post_response_effects.py
+++ b/src/mindroom/post_response_effects.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
     from mindroom.constants import RuntimePaths
     from mindroom.delivery_gateway import DeliveryGateway
+    from mindroom.event_journal import PrincipalStore
     from mindroom.final_delivery import FinalDeliveryOutcome
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.conversation_reads import ConversationReader
@@ -74,6 +75,7 @@ class PostResponseEffectsSupport:
     runtime_paths: RuntimePaths
     delivery_gateway: DeliveryGateway
     conversation_reader: ConversationReader
+    membership: PrincipalStore
 
     def _client(self) -> nio.AsyncClient:
         """Return the current Matrix client for interactive follow-up effects."""
@@ -115,17 +117,24 @@ class PostResponseEffectsSupport:
         target: MessageTarget,
         interactive_metadata: interactive.InteractiveMetadata,
         agent_name: str,
+        membership_turn_id: str,
     ) -> None:
         """Persist one interactive response and add its reaction buttons."""
-        interactive.register_interactive_question(
-            event_id,
-            room_id,
-            target.resolved_thread_id,
-            interactive_metadata.option_map,
-            agent_name,
-            question_text=interactive_metadata.question_text,
-            option_labels=interactive_metadata.option_labels,
+        registered = await self.membership.run_if_turn_membership_current(
+            turn_id=membership_turn_id,
+            room_id=room_id,
+            operation=lambda: interactive.register_interactive_question(
+                event_id,
+                room_id,
+                target.resolved_thread_id,
+                interactive_metadata.option_map,
+                agent_name,
+                question_text=interactive_metadata.question_text,
+                option_labels=interactive_metadata.option_labels,
+            ),
         )
+        if not registered:
+            return
         await interactive.add_reaction_buttons(
             self._client(),
             room_id,
@@ -164,6 +173,7 @@ class PostResponseEffectsSupport:
         *,
         room_id: str,
         interactive_agent_name: str,
+        membership_turn_id: str,
         queue_memory_persistence: Callable[[], None] | None = None,
         persist_response_event_id: Callable[[str, str], None] | None = None,
     ) -> PostResponseEffectsDeps:
@@ -180,6 +190,7 @@ class PostResponseEffectsSupport:
                 target=target,
                 interactive_metadata=interactive_metadata,
                 agent_name=interactive_agent_name,
+                membership_turn_id=membership_turn_id,
             )
 
         return PostResponseEffectsDeps(

--- a/src/mindroom/reaction_dispatch.py
+++ b/src/mindroom/reaction_dispatch.py
@@ -182,6 +182,8 @@ class ReactionDispatcher:
                 user_id=event.sender,
                 source_event_id=event.event_id,
             ),
+            room_id=room.room_id,
+            question_event_id=selection.question_event_id,
             source_event_id=event.event_id,
             thread_id=selection.thread_id,
         )

--- a/src/mindroom/reaction_dispatch.py
+++ b/src/mindroom/reaction_dispatch.py
@@ -169,12 +169,15 @@ class ReactionDispatcher:
             return TurnDispatchOutcome.INTENTIONALLY_IGNORED if interactive_claimed else None
         if not interactive_claimed:
             try:
-                await self.deps.journal_dispatcher.claim_semantic_consumer(
+                claimed = await self.deps.journal_dispatcher.claim_semantic_consumer(
                     SemanticConsumer.INTERACTIVE_REACTION,
                 )
             except BaseException:
                 interactive.restore_selection(selection)
                 raise
+            if not claimed:
+                interactive.commit_selection(selection)
+                return TurnDispatchOutcome.INTENTIONALLY_IGNORED
 
         try:
             response_target = self.deps.build_message_target(

--- a/src/mindroom/reaction_dispatch.py
+++ b/src/mindroom/reaction_dispatch.py
@@ -50,6 +50,7 @@ class ReactionDispatcherDeps:
     ingress: IngressValidator
     reserve_prompt_ingress_order: Callable[..., PromptIngressReservationOwner]
     build_message_target: Callable[..., MessageTarget]
+    enqueue_interactive_selection: Callable[..., Awaitable[None]]
     handle_interactive_selection: Callable[..., Awaitable[None]]
     start_interactive_selection: Callable[..., Awaitable[None]]
     emit_reaction_received_hooks: Callable[..., Awaitable[None]]
@@ -150,6 +151,8 @@ class ReactionDispatcher:
         room: nio.MatrixRoom,
         event: nio.ReactionEvent,
         consumer: SemanticConsumer | None,
+        reservation_owner: PromptIngressReservationOwner,
+        requester_user_id: str,
     ) -> TurnDispatchOutcome | None:
         """Route an interactive choice only to its claimed question."""
         interactive_claimed = consumer is SemanticConsumer.INTERACTIVE_REACTION
@@ -179,18 +182,16 @@ class ReactionDispatcher:
                 thread_id=selection.thread_id,
                 reply_to_event_id=selection.question_event_id,
             )
-            await self.deps.start_interactive_selection(
-                self.deps.handle_interactive_selection(
-                    room,
-                    selection=selection,
-                    user_id=event.sender,
-                    source_event_id=event.event_id,
-                    response_target=response_target,
-                ),
-                response_target=response_target,
-                source_event_id=event.event_id,
+            await self.deps.enqueue_interactive_selection(
+                reservation_owner,
+                room,
+                selection=selection,
+                requester_user_id=requester_user_id,
                 user_id=event.sender,
-                selected_value=selection.selected_value,
+                source_event_id=event.event_id,
+                response_target=response_target,
+                handle_interactive_selection=self.deps.handle_interactive_selection,
+                start_interactive_selection=self.deps.start_interactive_selection,
             )
         except BaseException:
             interactive.restore_selection(selection)
@@ -202,6 +203,8 @@ class ReactionDispatcher:
         room: nio.MatrixRoom,
         event: nio.ReactionEvent,
         consumer: SemanticConsumer | None,
+        reservation_owner: PromptIngressReservationOwner,
+        requester_user_id: str,
     ) -> TurnDispatchOutcome | None:
         """Route one authorized reaction among the non-config consumers."""
         if await self._maybe_handle_approval_reaction(room, event, consumer):
@@ -215,6 +218,8 @@ class ReactionDispatcher:
             room,
             event,
             consumer,
+            reservation_owner,
+            requester_user_id,
         )
 
     async def _route_reaction(  # noqa: PLR0911 - explicit terminal outcome for each consumer branch
@@ -288,6 +293,8 @@ class ReactionDispatcher:
                     room,
                     event,
                     semantic_consumer,
+                    reservation_owner,
+                    requester_user_id,
                 )
             ) is not None:
                 return outcome

--- a/src/mindroom/reaction_dispatch.py
+++ b/src/mindroom/reaction_dispatch.py
@@ -11,6 +11,7 @@ from mindroom.approval_inbound import handle_tool_approval_action
 from mindroom.authorization import is_authorized_sender
 from mindroom.commands import config_confirmation
 from mindroom.constants import ROUTER_AGENT_NAME
+from mindroom.dispatch_callback_outcome import TurnDispatchOutcome
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.event_journal import SemanticConsumer
 
@@ -48,6 +49,7 @@ class ReactionDispatcherDeps:
     ingress: IngressValidator
     reserve_prompt_ingress_order: Callable[..., PromptIngressReservationOwner]
     handle_interactive_selection: Callable[..., Awaitable[None]]
+    start_interactive_selection: Callable[..., Awaitable[None]]
     emit_reaction_received_hooks: Callable[..., Awaitable[None]]
     config_confirmation: ConfigConfirmationContext
 
@@ -147,11 +149,11 @@ class ReactionDispatcher:
         event: nio.ReactionEvent,
         consumer: SemanticConsumer | None,
         reservation_owner: PromptIngressReservationOwner,
-    ) -> bool:
+    ) -> TurnDispatchOutcome | None:
         """Route an interactive choice only to its claimed question."""
         interactive_claimed = consumer is SemanticConsumer.INTERACTIVE_REACTION
         if consumer is not None and not interactive_claimed:
-            return False
+            return None
         selection = await interactive.handle_reaction(
             self._client(),
             event,
@@ -160,7 +162,7 @@ class ReactionDispatcher:
             self.deps.runtime_paths,
         )
         if selection is None:
-            return interactive_claimed
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED if interactive_claimed else None
         if not interactive_claimed:
             try:
                 await self.deps.journal_dispatcher.claim_semantic_consumer(
@@ -173,13 +175,17 @@ class ReactionDispatcher:
         # The selection's response may wait behind this conversation's active
         # turn, so release the sender's lane before response completion.
         await reservation_owner.release()
-        await self.deps.handle_interactive_selection(
-            room,
-            selection=selection,
-            user_id=event.sender,
+        await self.deps.start_interactive_selection(
+            self.deps.handle_interactive_selection(
+                room,
+                selection=selection,
+                user_id=event.sender,
+                source_event_id=event.event_id,
+            ),
             source_event_id=event.event_id,
+            thread_id=selection.thread_id,
         )
-        return True
+        return TurnDispatchOutcome.DEFERRED
 
     async def _maybe_handle_nonconfig_reaction(
         self,
@@ -187,15 +193,15 @@ class ReactionDispatcher:
         event: nio.ReactionEvent,
         consumer: SemanticConsumer | None,
         reservation_owner: PromptIngressReservationOwner,
-    ) -> bool:
+    ) -> TurnDispatchOutcome | None:
         """Route one authorized reaction among the non-config consumers."""
         if await self._maybe_handle_approval_reaction(room, event, consumer):
-            return True
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
         if consumer is None and not self.deps.turn_policy.can_reply_to_sender(event.sender):
             self.deps.logger.debug("Ignoring reaction due to reply permissions", sender=event.sender)
-            return True
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
         if await self._maybe_handle_stop_reaction(event, consumer):
-            return True
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
         return await self._maybe_handle_interactive_reaction(
             room,
             event,
@@ -203,12 +209,12 @@ class ReactionDispatcher:
             reservation_owner,
         )
 
-    async def _route_reaction(
+    async def _route_reaction(  # noqa: PLR0911 - explicit terminal outcome for each consumer branch
         self,
         room: nio.MatrixRoom,
         event: nio.ReactionEvent,
         semantic_consumer: SemanticConsumer | None,
-    ) -> None:
+    ) -> TurnDispatchOutcome:
         """Classify and execute one reaction that has no completed hook claim."""
         pending_change = (
             await config_confirmation.resolve_reaction_pending_change(
@@ -221,7 +227,7 @@ class ReactionDispatcher:
             else None
         )
         if semantic_consumer is SemanticConsumer.CONFIG_CONFIRMATION and pending_change is None:
-            return
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
         if pending_change is not None and pending_change.decision_event_id is not None:
             if semantic_consumer is None:
                 await self.deps.journal_dispatcher.claim_semantic_consumer(
@@ -233,7 +239,7 @@ class ReactionDispatcher:
                 event,
                 pending_change,
             )
-            return
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
 
         if semantic_consumer is None and not is_authorized_sender(
             event.sender,
@@ -242,7 +248,7 @@ class ReactionDispatcher:
             self.deps.runtime_paths,
         ):
             self.deps.logger.debug("ignoring_reaction_from_unauthorized_sender", user_id=event.sender)
-            return
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
 
         requester_user_id = self.deps.ingress.requester_user_id(
             sender=event.sender,
@@ -257,7 +263,7 @@ class ReactionDispatcher:
             if pending_change is not None:
                 if semantic_consumer is None and not self.deps.turn_policy.can_reply_to_sender(event.sender):
                     self.deps.logger.debug("Ignoring reaction due to reply permissions", sender=event.sender)
-                    return
+                    return TurnDispatchOutcome.INTENTIONALLY_IGNORED
                 if semantic_consumer is None:
                     await self.deps.journal_dispatcher.claim_semantic_consumer(
                         SemanticConsumer.CONFIG_CONFIRMATION,
@@ -267,15 +273,17 @@ class ReactionDispatcher:
                     room,
                     event,
                 )
-                return
+                return TurnDispatchOutcome.INTENTIONALLY_IGNORED
 
-            if await self._maybe_handle_nonconfig_reaction(
-                room,
-                event,
-                semantic_consumer,
-                reservation_owner,
-            ):
-                return
+            if (
+                outcome := await self._maybe_handle_nonconfig_reaction(
+                    room,
+                    event,
+                    semantic_consumer,
+                    reservation_owner,
+                )
+            ) is not None:
+                return outcome
         finally:
             await reservation_owner.release()
 
@@ -287,8 +295,9 @@ class ReactionDispatcher:
             event=event,
             correlation_id=event.event_id,
         )
+        return TurnDispatchOutcome.INTENTIONALLY_IGNORED
 
-    async def dispatch(self, room: nio.MatrixRoom, event: nio.ReactionEvent) -> None:
+    async def dispatch(self, room: nio.MatrixRoom, event: nio.ReactionEvent) -> TurnDispatchOutcome:
         """Route one reaction to its sole durable semantic consumer."""
         semantic_consumer = self.deps.journal_dispatcher.semantic_consumer()
         if semantic_consumer is SemanticConsumer.REACTION_HOOKS:
@@ -297,5 +306,5 @@ class ReactionDispatcher:
                 event=event,
                 correlation_id=event.event_id,
             )
-            return
-        await self._route_reaction(room, event, semantic_consumer)
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
+        return await self._route_reaction(room, event, semantic_consumer)

--- a/src/mindroom/reaction_dispatch.py
+++ b/src/mindroom/reaction_dispatch.py
@@ -175,18 +175,22 @@ class ReactionDispatcher:
         # The selection's response may wait behind this conversation's active
         # turn, so release the sender's lane before response completion.
         await reservation_owner.release()
-        await self.deps.start_interactive_selection(
-            self.deps.handle_interactive_selection(
-                room,
-                selection=selection,
-                user_id=event.sender,
+        try:
+            await self.deps.start_interactive_selection(
+                self.deps.handle_interactive_selection(
+                    room,
+                    selection=selection,
+                    user_id=event.sender,
+                    source_event_id=event.event_id,
+                ),
+                room_id=room.room_id,
+                question_event_id=selection.question_event_id,
                 source_event_id=event.event_id,
-            ),
-            room_id=room.room_id,
-            question_event_id=selection.question_event_id,
-            source_event_id=event.event_id,
-            thread_id=selection.thread_id,
-        )
+                thread_id=selection.thread_id,
+            )
+        except BaseException:
+            interactive.restore_selection(selection)
+            raise
         return TurnDispatchOutcome.DEFERRED
 
     async def _maybe_handle_nonconfig_reaction(

--- a/src/mindroom/reaction_dispatch.py
+++ b/src/mindroom/reaction_dispatch.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.ingress_validation import IngressValidator
     from mindroom.journal_dispatch import JournalDispatcher
+    from mindroom.message_target import MessageTarget
     from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner
     from mindroom.runtime_protocols import SupportsClientConfigOrchestrator
     from mindroom.stop import StopManager
@@ -48,6 +49,7 @@ class ReactionDispatcherDeps:
     user_stop_reconciler: UserStopReconciler
     ingress: IngressValidator
     reserve_prompt_ingress_order: Callable[..., PromptIngressReservationOwner]
+    build_message_target: Callable[..., MessageTarget]
     handle_interactive_selection: Callable[..., Awaitable[None]]
     start_interactive_selection: Callable[..., Awaitable[None]]
     emit_reaction_received_hooks: Callable[..., Awaitable[None]]
@@ -172,17 +174,21 @@ class ReactionDispatcher:
                 raise
 
         try:
+            response_target = self.deps.build_message_target(
+                room_id=room.room_id,
+                thread_id=selection.thread_id,
+                reply_to_event_id=selection.question_event_id,
+            )
             await self.deps.start_interactive_selection(
                 self.deps.handle_interactive_selection(
                     room,
                     selection=selection,
                     user_id=event.sender,
                     source_event_id=event.event_id,
+                    response_target=response_target,
                 ),
-                room_id=room.room_id,
-                question_event_id=selection.question_event_id,
+                response_target=response_target,
                 source_event_id=event.event_id,
-                thread_id=selection.thread_id,
                 user_id=event.sender,
                 selected_value=selection.selected_value,
             )

--- a/src/mindroom/reaction_dispatch.py
+++ b/src/mindroom/reaction_dispatch.py
@@ -148,7 +148,6 @@ class ReactionDispatcher:
         room: nio.MatrixRoom,
         event: nio.ReactionEvent,
         consumer: SemanticConsumer | None,
-        reservation_owner: PromptIngressReservationOwner,
     ) -> TurnDispatchOutcome | None:
         """Route an interactive choice only to its claimed question."""
         interactive_claimed = consumer is SemanticConsumer.INTERACTIVE_REACTION
@@ -172,9 +171,6 @@ class ReactionDispatcher:
                 interactive.restore_selection(selection)
                 raise
 
-        # The selection's response may wait behind this conversation's active
-        # turn, so release the sender's lane before response completion.
-        await reservation_owner.release()
         try:
             await self.deps.start_interactive_selection(
                 self.deps.handle_interactive_selection(
@@ -187,6 +183,8 @@ class ReactionDispatcher:
                 question_event_id=selection.question_event_id,
                 source_event_id=event.event_id,
                 thread_id=selection.thread_id,
+                user_id=event.sender,
+                selected_value=selection.selected_value,
             )
         except BaseException:
             interactive.restore_selection(selection)
@@ -198,7 +196,6 @@ class ReactionDispatcher:
         room: nio.MatrixRoom,
         event: nio.ReactionEvent,
         consumer: SemanticConsumer | None,
-        reservation_owner: PromptIngressReservationOwner,
     ) -> TurnDispatchOutcome | None:
         """Route one authorized reaction among the non-config consumers."""
         if await self._maybe_handle_approval_reaction(room, event, consumer):
@@ -212,7 +209,6 @@ class ReactionDispatcher:
             room,
             event,
             consumer,
-            reservation_owner,
         )
 
     async def _route_reaction(  # noqa: PLR0911 - explicit terminal outcome for each consumer branch
@@ -286,7 +282,6 @@ class ReactionDispatcher:
                     room,
                     event,
                     semantic_consumer,
-                    reservation_owner,
                 )
             ) is not None:
                 return outcome

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -86,6 +86,10 @@ class ResponseLifecycleReservation:
             raise RuntimeError(msg)
         await self._acquire_task
 
+    def _owns_lifecycle_lock(self) -> bool:
+        """Return whether this reservation currently holds its canonical lock."""
+        return self._owns_lock
+
     async def _release(self) -> None:
         acquire_task = self._acquire_task
         if acquire_task is not None and not acquire_task.done():
@@ -333,11 +337,12 @@ class ResponseLifecycleCoordinator:
         queued_signal: _QueuedMessageState,
         response_envelope: MessageEnvelope,
         signal_queued_message: bool,
+        lifecycle_lock_owned_by_response: bool,
     ) -> str | None:
         existing_turn = queued_signal.begin_response_turn()
         if not signal_queued_message:
             return None
-        if not (existing_turn or lifecycle_lock.locked()):
+        if not (existing_turn or (lifecycle_lock.locked() and not lifecycle_lock_owned_by_response)):
             return None
         if not self._should_signal_queued_message(response_envelope):
             return None
@@ -375,7 +380,8 @@ class ResponseLifecycleCoordinator:
             lifecycle_lock=lifecycle_lock,
             queued_signal=queued_signal,
             response_envelope=response_envelope,
-            signal_queued_message=signal_queued_message and reservation is None,
+            signal_queued_message=signal_queued_message,
+            lifecycle_lock_owned_by_response=(reservation._owns_lifecycle_lock() if reservation is not None else False),
         )
         lock_acquired = False
         try:

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -52,11 +52,13 @@ class ResponseLifecycleReservation:
     _response_turn_active: bool = True
 
     async def _acquire(self) -> None:
-        if self._lifecycle_lock.locked():
+        try:
+            if self._lifecycle_lock.locked():
+                self._ready.set()
+            await self._lifecycle_lock.acquire()
+            self._owns_lock = True
+        finally:
             self._ready.set()
-        await self._lifecycle_lock.acquire()
-        self._owns_lock = True
-        self._ready.set()
 
     async def _wait_until_reserved(self) -> None:
         """Wait until this owner has acquired or queued on its lifecycle lock."""

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -42,11 +42,14 @@ class ResponseLifecycleReservation:
     _coordinator: ResponseLifecycleCoordinator
     _lifecycle_key: ResponseLifecycleKey
     _lifecycle_lock: asyncio.Lock
+    _queued_signal: _QueuedMessageState
+    _notice: str | None
     _ready: asyncio.Event = field(default_factory=asyncio.Event)
     _acquire_task: asyncio.Task[None] | None = None
     _release_task: asyncio.Task[None] | None = None
     _owns_lock: bool = False
     _consumed: bool = False
+    _response_turn_active: bool = True
 
     async def _acquire(self) -> None:
         if self._lifecycle_lock.locked():
@@ -79,16 +82,18 @@ class ResponseLifecycleReservation:
         self._consumed = True
         return self._lifecycle_lock
 
-    async def _wait_until_acquired(self) -> None:
+    async def wait_until_acquired(self) -> None:
         """Wait until the reservation owns its lifecycle lock."""
         if self._acquire_task is None:
             msg = "Response lifecycle reservation has not started"
             raise RuntimeError(msg)
         await self._acquire_task
 
-    def _owns_lifecycle_lock(self) -> bool:
-        """Return whether this reservation currently holds its canonical lock."""
-        return self._owns_lock
+    def _consume_notice(self) -> None:
+        if self._notice is None:
+            return
+        self._queued_signal.consume_waiting_human_message(self._notice)
+        self._notice = None
 
     async def _release(self) -> None:
         acquire_task = self._acquire_task
@@ -98,6 +103,10 @@ class ResponseLifecycleReservation:
         if self._owns_lock:
             self._owns_lock = False
             self._lifecycle_lock.release()
+        self._consume_notice()
+        if self._response_turn_active:
+            self._response_turn_active = False
+            self._queued_signal.finish_response_turn()
 
     async def release(self) -> None:
         """Release or cancel this reservation exactly once."""
@@ -275,12 +284,26 @@ class ResponseLifecycleCoordinator:
         self._response_lifecycle_locks[lock_key] = lock
         return lock
 
-    async def reserve_response_lifecycle(self, target: MessageTarget) -> ResponseLifecycleReservation:
+    async def reserve_response_lifecycle(
+        self,
+        response_envelope: MessageEnvelope,
+    ) -> ResponseLifecycleReservation:
         """Reserve FIFO admission on one canonical lifecycle before response preparation."""
+        target = response_envelope.target
+        lifecycle_lock = self._response_lifecycle_lock(target)
+        queued_signal = self._get_or_create_queued_signal(target)
         reservation = ResponseLifecycleReservation(
             _coordinator=self,
             _lifecycle_key=target.lifecycle_key,
-            _lifecycle_lock=self._response_lifecycle_lock(target),
+            _lifecycle_lock=lifecycle_lock,
+            _queued_signal=queued_signal,
+            _notice=self._begin_response_turn_notice(
+                lifecycle_lock=lifecycle_lock,
+                queued_signal=queued_signal,
+                response_envelope=response_envelope,
+                signal_queued_message=True,
+                lifecycle_lock_owned_by_response=False,
+            ),
         )
         try:
             await reservation._wait_until_reserved()
@@ -360,6 +383,72 @@ class ResponseLifecycleCoordinator:
             return
         queued_signal.consume_waiting_human_message(notice)
 
+    def _start_response_turn(
+        self,
+        *,
+        target: MessageTarget,
+        response_envelope: MessageEnvelope,
+        signal_queued_message: bool,
+        reservation: ResponseLifecycleReservation | None,
+    ) -> tuple[asyncio.Lock, _QueuedMessageState, str | None]:
+        if reservation is not None:
+            return reservation.consume(self, target), reservation._queued_signal, None
+        lifecycle_lock = self._response_lifecycle_lock(target)
+        queued_signal = self._get_or_create_queued_signal(target)
+        notice = self._begin_response_turn_notice(
+            lifecycle_lock=lifecycle_lock,
+            queued_signal=queued_signal,
+            response_envelope=response_envelope,
+            signal_queued_message=signal_queued_message,
+            lifecycle_lock_owned_by_response=False,
+        )
+        return lifecycle_lock, queued_signal, notice
+
+    @staticmethod
+    async def _acquire_response_turn_lock(
+        lifecycle_lock: asyncio.Lock,
+        reservation: ResponseLifecycleReservation | None,
+    ) -> None:
+        if reservation is not None:
+            await reservation.wait_until_acquired()
+            return
+        await lifecycle_lock.acquire()
+
+    def _consume_response_turn_notice(
+        self,
+        *,
+        reservation: ResponseLifecycleReservation | None,
+        notice: str | None,
+        queued_signal: _QueuedMessageState,
+    ) -> None:
+        if reservation is not None:
+            reservation._consume_notice()
+            return
+        self._consume_queued_human_notice(notice=notice, queued_signal=queued_signal)
+
+    @staticmethod
+    async def _release_response_turn_lock(
+        lifecycle_lock: asyncio.Lock,
+        reservation: ResponseLifecycleReservation | None,
+    ) -> None:
+        if reservation is not None:
+            await reservation.release()
+            return
+        lifecycle_lock.release()
+
+    async def _finish_response_turn(
+        self,
+        *,
+        reservation: ResponseLifecycleReservation | None,
+        notice: str | None,
+        queued_signal: _QueuedMessageState,
+    ) -> None:
+        if reservation is not None:
+            await reservation.release()
+            return
+        self._consume_queued_human_notice(notice=notice, queued_signal=queued_signal)
+        queued_signal.finish_response_turn()
+
     async def run_locked_response(
         self,
         *,
@@ -372,30 +461,23 @@ class ResponseLifecycleCoordinator:
         """Run one locked response operation with shared queued-message bookkeeping."""
         self._assert_target_matches_envelope(target, response_envelope)
         reservation = _current_response_lifecycle_reservation.get()
-        lifecycle_lock = (
-            reservation.consume(self, target) if reservation is not None else self._response_lifecycle_lock(target)
-        )
-        queued_signal = self._get_or_create_queued_signal(target)
-        notice = self._begin_response_turn_notice(
-            lifecycle_lock=lifecycle_lock,
-            queued_signal=queued_signal,
+        lifecycle_lock, queued_signal, notice = self._start_response_turn(
+            target=target,
             response_envelope=response_envelope,
             signal_queued_message=signal_queued_message,
-            lifecycle_lock_owned_by_response=(reservation._owns_lifecycle_lock() if reservation is not None else False),
+            reservation=reservation,
         )
         lock_acquired = False
         try:
             if pipeline_timing is not None:
                 pipeline_timing.mark("lock_wait_start")
-            if reservation is None:
-                await lifecycle_lock.acquire()
-            else:
-                await reservation._wait_until_acquired()
+            await self._acquire_response_turn_lock(lifecycle_lock, reservation)
             lock_acquired = True
             if pipeline_timing is not None:
                 pipeline_timing.mark("lock_acquired")
             try:
-                notice = self._consume_queued_human_notice(
+                self._consume_response_turn_notice(
+                    reservation=reservation,
                     notice=notice,
                     queued_signal=queued_signal,
                 )
@@ -406,18 +488,13 @@ class ResponseLifecycleCoordinator:
                         await finalize_queued_notice_response_turn_async(notice_context)
             finally:
                 if lock_acquired:
-                    if reservation is None:
-                        lifecycle_lock.release()
-                    else:
-                        await reservation.release()
+                    await self._release_response_turn_lock(lifecycle_lock, reservation)
         finally:
-            if reservation is not None:
-                await reservation.release()
-            self._consume_queued_human_notice(
+            await self._finish_response_turn(
+                reservation=reservation,
                 notice=notice,
                 queued_signal=queued_signal,
             )
-            queued_signal.finish_response_turn()
 
     async def run_locked_target_operation(
         self,

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -302,7 +302,6 @@ class ResponseLifecycleCoordinator:
                 queued_signal=queued_signal,
                 response_envelope=response_envelope,
                 signal_queued_message=True,
-                lifecycle_lock_owned_by_response=False,
             ),
         )
         try:
@@ -360,12 +359,11 @@ class ResponseLifecycleCoordinator:
         queued_signal: _QueuedMessageState,
         response_envelope: MessageEnvelope,
         signal_queued_message: bool,
-        lifecycle_lock_owned_by_response: bool,
     ) -> str | None:
         existing_turn = queued_signal.begin_response_turn()
         if not signal_queued_message:
             return None
-        if not (existing_turn or (lifecycle_lock.locked() and not lifecycle_lock_owned_by_response)):
+        if not (existing_turn or lifecycle_lock.locked()):
             return None
         if not self._should_signal_queued_message(response_envelope):
             return None
@@ -400,7 +398,6 @@ class ResponseLifecycleCoordinator:
             queued_signal=queued_signal,
             response_envelope=response_envelope,
             signal_queued_message=signal_queued_message,
-            lifecycle_lock_owned_by_response=False,
         )
         return lifecycle_lock, queued_signal, notice
 

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import contextmanager
+from contextvars import ContextVar
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, TypeVar, cast
 
@@ -16,7 +18,7 @@ from mindroom.post_response_effects import apply_post_response_effects
 from mindroom.tool_system.runtime_context import resolve_tool_runtime_hook_bindings
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Iterator
 
     from agno.db.base import BaseDb
     from structlog.stdlib import BoundLogger
@@ -31,6 +33,91 @@ if TYPE_CHECKING:
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
 _LockedResponseResult = TypeVar("_LockedResponseResult")
+
+
+@dataclass(slots=True)
+class ResponseLifecycleReservation:
+    """Own an early place in one coordinator's canonical lifecycle lock."""
+
+    _coordinator: ResponseLifecycleCoordinator
+    _lifecycle_key: ResponseLifecycleKey
+    _lifecycle_lock: asyncio.Lock
+    _ready: asyncio.Event = field(default_factory=asyncio.Event)
+    _acquire_task: asyncio.Task[None] | None = None
+    _release_task: asyncio.Task[None] | None = None
+    _owns_lock: bool = False
+    _consumed: bool = False
+
+    async def _acquire(self) -> None:
+        if self._lifecycle_lock.locked():
+            self._ready.set()
+        await self._lifecycle_lock.acquire()
+        self._owns_lock = True
+        self._ready.set()
+
+    async def _wait_until_reserved(self) -> None:
+        """Wait until this owner has acquired or queued on its lifecycle lock."""
+        if self._acquire_task is None:
+            self._acquire_task = asyncio.create_task(self._acquire())
+        await self._ready.wait()
+
+    def consume(
+        self,
+        coordinator: ResponseLifecycleCoordinator,
+        target: MessageTarget,
+    ) -> asyncio.Lock:
+        """Transfer this reservation to its exact response lifecycle."""
+        if self._coordinator is not coordinator:
+            msg = "Response lifecycle reservation belongs to a different coordinator"
+            raise ValueError(msg)
+        if self._lifecycle_key != target.lifecycle_key:
+            msg = "Response lifecycle reservation target does not match the response target"
+            raise ValueError(msg)
+        if self._consumed:
+            msg = "Response lifecycle reservation was already consumed"
+            raise RuntimeError(msg)
+        self._consumed = True
+        return self._lifecycle_lock
+
+    async def _wait_until_acquired(self) -> None:
+        """Wait until the reservation owns its lifecycle lock."""
+        if self._acquire_task is None:
+            msg = "Response lifecycle reservation has not started"
+            raise RuntimeError(msg)
+        await self._acquire_task
+
+    async def _release(self) -> None:
+        acquire_task = self._acquire_task
+        if acquire_task is not None and not acquire_task.done():
+            acquire_task.cancel()
+            await asyncio.gather(acquire_task, return_exceptions=True)
+        if self._owns_lock:
+            self._owns_lock = False
+            self._lifecycle_lock.release()
+
+    async def release(self) -> None:
+        """Release or cancel this reservation exactly once."""
+        if self._release_task is None:
+            self._release_task = asyncio.create_task(self._release())
+        await asyncio.shield(self._release_task)
+
+
+_current_response_lifecycle_reservation: ContextVar[ResponseLifecycleReservation | None] = ContextVar(
+    "current_response_lifecycle_reservation",
+    default=None,
+)
+
+
+@contextmanager
+def response_lifecycle_reservation_context(
+    reservation: ResponseLifecycleReservation,
+) -> Iterator[None]:
+    """Carry one detached response's lifecycle reservation into execution."""
+    token = _current_response_lifecycle_reservation.set(reservation)
+    try:
+        yield
+    finally:
+        _current_response_lifecycle_reservation.reset(token)
 
 
 @dataclass
@@ -184,6 +271,20 @@ class ResponseLifecycleCoordinator:
         self._response_lifecycle_locks[lock_key] = lock
         return lock
 
+    async def reserve_response_lifecycle(self, target: MessageTarget) -> ResponseLifecycleReservation:
+        """Reserve FIFO admission on one canonical lifecycle before response preparation."""
+        reservation = ResponseLifecycleReservation(
+            _coordinator=self,
+            _lifecycle_key=target.lifecycle_key,
+            _lifecycle_lock=self._response_lifecycle_lock(target),
+        )
+        try:
+            await reservation._wait_until_reserved()
+        except BaseException:
+            await reservation.release()
+            raise
+        return reservation
+
     def _get_or_create_queued_signal(self, target: MessageTarget) -> _QueuedMessageState:
         """Return the queued-message signal for one canonical conversation thread."""
         lifecycle_key = target.lifecycle_key
@@ -265,19 +366,25 @@ class ResponseLifecycleCoordinator:
     ) -> _LockedResponseResult:
         """Run one locked response operation with shared queued-message bookkeeping."""
         self._assert_target_matches_envelope(target, response_envelope)
-        lifecycle_lock = self._response_lifecycle_lock(target)
+        reservation = _current_response_lifecycle_reservation.get()
+        lifecycle_lock = (
+            reservation.consume(self, target) if reservation is not None else self._response_lifecycle_lock(target)
+        )
         queued_signal = self._get_or_create_queued_signal(target)
         notice = self._begin_response_turn_notice(
             lifecycle_lock=lifecycle_lock,
             queued_signal=queued_signal,
             response_envelope=response_envelope,
-            signal_queued_message=signal_queued_message,
+            signal_queued_message=signal_queued_message and reservation is None,
         )
         lock_acquired = False
         try:
             if pipeline_timing is not None:
                 pipeline_timing.mark("lock_wait_start")
-            await lifecycle_lock.acquire()
+            if reservation is None:
+                await lifecycle_lock.acquire()
+            else:
+                await reservation._wait_until_acquired()
             lock_acquired = True
             if pipeline_timing is not None:
                 pipeline_timing.mark("lock_acquired")
@@ -293,8 +400,13 @@ class ResponseLifecycleCoordinator:
                         await finalize_queued_notice_response_turn_async(notice_context)
             finally:
                 if lock_acquired:
-                    lifecycle_lock.release()
+                    if reservation is None:
+                        lifecycle_lock.release()
+                    else:
+                        await reservation.release()
         finally:
+            if reservation is not None:
+                await reservation.release()
             self._consume_queued_human_notice(
                 notice=notice,
                 queued_signal=queued_signal,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -92,6 +92,7 @@ from .response_lifecycle import (
     ResponseLifecycle,
     ResponseLifecycleCoordinator,
     ResponseLifecycleDeps,
+    ResponseLifecycleReservation,
 )
 
 if TYPE_CHECKING:
@@ -937,6 +938,10 @@ class ResponseRunner:
             target=target,
             response_envelope=response_envelope,
         )
+
+    async def reserve_response_lifecycle(self, target: MessageTarget) -> ResponseLifecycleReservation:
+        """Reserve one canonical response lifecycle before detached preparation starts."""
+        return await self._lifecycle_coordinator.reserve_response_lifecycle(target)
 
     async def _run_in_tool_context(
         self,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -939,9 +939,12 @@ class ResponseRunner:
             response_envelope=response_envelope,
         )
 
-    async def reserve_response_lifecycle(self, target: MessageTarget) -> ResponseLifecycleReservation:
+    async def reserve_response_lifecycle(
+        self,
+        response_envelope: MessageEnvelope,
+    ) -> ResponseLifecycleReservation:
         """Reserve one canonical response lifecycle before detached preparation starts."""
-        return await self._lifecycle_coordinator.reserve_response_lifecycle(target)
+        return await self._lifecycle_coordinator.reserve_response_lifecycle(response_envelope)
 
     async def _run_in_tool_context(
         self,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -473,6 +473,7 @@ class _InboxResponseOwnership:
 
     recovery_proof_ready: Callable[[], bool]
     on_failure: Callable[[], None] | None
+    source_event_ids: frozenset[str]
 
 
 @dataclass
@@ -499,15 +500,21 @@ class ResponseRunner:
         name: str,
         recovery_proof_ready: Callable[[], bool],
         on_failure: Callable[[], None] | None = None,
+        source_event_ids: tuple[str, ...] = (),
     ) -> asyncio.Task[None]:
         """Own one detached inbox response until it completes or a drain settles it."""
         task = asyncio.create_task(response, name=name)
         self._inbox_response_tasks[task] = _InboxResponseOwnership(
             recovery_proof_ready=recovery_proof_ready,
             on_failure=on_failure,
+            source_event_ids=frozenset(source_event_ids),
         )
         task.add_done_callback(self._finish_inbox_response_task)
         return task
+
+    def has_live_inbox_response(self, source_event_id: str) -> bool:
+        """Return whether a managed response task still owns one journal source."""
+        return any(source_event_id in ownership.source_event_ids for ownership in self._inbox_response_tasks.values())
 
     @property
     def pending_inbox_response_count(self) -> int:

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1765,6 +1765,7 @@ class ResponseRunner:
             post_response_deps=lambda: self.deps.post_response_effects.build_deps(
                 room_id=request.room_id,
                 interactive_agent_name=self.deps.agent_name,
+                membership_turn_id=request.response_envelope.source_event_id,
             ),
         )
         return final_outcome.final_visible_event_id if final_outcome.mark_handled else None
@@ -1886,6 +1887,7 @@ class ResponseRunner:
                 post_response_deps=lambda: self.deps.post_response_effects.build_deps(
                     room_id=request.room_id,
                     interactive_agent_name=self.deps.agent_name,
+                    membership_turn_id=request.response_envelope.source_event_id,
                 ),
             )
         requester_user_id = request.user_id or ""
@@ -2323,6 +2325,7 @@ class ResponseRunner:
             post_response_deps=lambda: self.deps.post_response_effects.build_deps(
                 room_id=request.room_id,
                 interactive_agent_name=self.deps.agent_name,
+                membership_turn_id=request.response_envelope.source_event_id,
                 persist_response_event_id=persist_response_event_id,
             ),
             streaming_delivery_error_handler=settle_team_streaming_delivery_error,
@@ -3090,6 +3093,7 @@ class ResponseRunner:
             post_response_deps=lambda: self.deps.post_response_effects.build_deps(
                 room_id=request.room_id,
                 interactive_agent_name=self.deps.agent_name,
+                membership_turn_id=request.response_envelope.source_event_id,
                 queue_memory_persistence=queue_memory_persistence,
                 persist_response_event_id=persist_response_event_id,
             ),

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
+    from mindroom.event_journal import PrincipalStore
     from mindroom.hooks import HookMatrixAdmin, HookMessageSender, HookRoomStatePutter, HookRoomStateQuerier
     from mindroom.matrix.conversation_reads import ConversationReader
     from mindroom.matrix.identity import MatrixID
@@ -88,6 +89,8 @@ class ToolRuntimeContext:
     message_received_depth: int = 0
     orchestrator: OrchestratorRuntime | None = None
     tool_function_filter: Callable[[Function], bool] | None = None
+    membership: PrincipalStore | None = None
+    membership_turn_id: str | None = None
 
     @property
     def room_id(self) -> str:
@@ -212,6 +215,7 @@ class ToolRuntimeSupport:
     matrix_id: MatrixID
     resolver: ConversationResolver
     hook_context: HookContextSupport
+    membership: PrincipalStore
 
     def build_context(
         self,
@@ -250,6 +254,8 @@ class ToolRuntimeSupport:
             room_state_putter=self.hook_context.room_state_putter(),
             message_received_depth=(source_envelope.message_received_depth if source_envelope is not None else 0),
             orchestrator=self.runtime.orchestrator,
+            membership=self.membership,
+            membership_turn_id=source_envelope.source_event_id if source_envelope is not None else None,
         )
 
     def build_dispatch_context(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -120,7 +120,7 @@ from mindroom.turn_store import record_deferred_outcome_response, record_user_st
 from mindroom.visible_voice_echo import VisibleVoiceEchoRequest
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Sequence
+    from collections.abc import Awaitable, Callable, Coroutine, Sequence
 
     import nio
     import structlog
@@ -329,6 +329,7 @@ class TurnControllerDeps:
     visible_voice_echo: VisibleVoiceEchoLifecycle
     visible_responses: VisibleResponseReconciler
     retry_dispatch_sources: Callable[[tuple[str, ...]], None]
+    settle_dispatch_sources: Callable[[tuple[str, ...]], Awaitable[None]]
 
 
 @dataclass
@@ -1129,6 +1130,38 @@ class TurnController:
             ),
             replay_guard=replay_guard,
         )
+
+    async def start_interactive_selection(
+        self,
+        response: Coroutine[Any, Any, None],
+        *,
+        source_event_id: str,
+        thread_id: str | None,
+    ) -> None:
+        """Transfer one selection response from journal dispatch to runner ownership."""
+        response_started = asyncio.Event()
+
+        async def run_owned_response() -> None:
+            response_started.set()
+            await response
+            # Terminal delivery normally settles the discovery alias in its
+            # outbox transaction. This idempotent fallback also handles an
+            # already-terminal replay that has no new delivery to enqueue.
+            await self.deps.settle_dispatch_sources((source_event_id,))
+
+        self.deps.response_runner.track_inbox_response(
+            run_owned_response(),
+            name=f"interactive_selection_response:{source_event_id}",
+            recovery_proof_ready=lambda: (
+                thread_id is not None and self.deps.interrupted_turn_rooms.contains(source_event_id)
+            ),
+            on_failure=lambda: self.deps.retry_dispatch_sources((source_event_id,)),
+            source_event_ids=(source_event_id,),
+        )
+        # Let the owned task enter before its journal callback reports the
+        # handoff. It may then wait on its canonical per-thread response lock
+        # without holding the room-wide journal lane.
+        await response_started.wait()
 
     async def handle_interactive_selection(
         self,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -87,7 +87,6 @@ from mindroom.matrix.media import (
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 from mindroom.matrix.thread_history_result import ThreadHistoryResult
 from mindroom.matrix.thread_membership import ThreadMembershipLookupError
-from mindroom.message_target import MessageTarget
 from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner as _PromptIngressReservationOwner
 from mindroom.response_lifecycle import response_lifecycle_reservation_context
 from mindroom.response_payload_preparation import (
@@ -136,7 +135,7 @@ if TYPE_CHECKING:
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
     from mindroom.matrix.relation_lookup import RelationLookup
-    from mindroom.message_target import ResponseLifecycleKey
+    from mindroom.message_target import MessageTarget, ResponseLifecycleKey
     from mindroom.response_lifecycle import QueuedHumanNoticeReservation
     from mindroom.response_runner import ResponseRunner
     from mindroom.sync_restart_retry import InterruptedTurnRooms
@@ -1166,19 +1165,12 @@ class TurnController:
         self,
         response: Coroutine[Any, Any, None],
         *,
-        room_id: str,
-        question_event_id: str,
+        response_target: MessageTarget,
         source_event_id: str,
-        thread_id: str | None,
         user_id: str,
         selected_value: str,
     ) -> None:
         """Transfer one selection response from journal dispatch to runner ownership."""
-        response_target = MessageTarget.resolve(
-            room_id=room_id,
-            thread_id=thread_id,
-            reply_to_event_id=question_event_id,
-        )
         response_envelope = self._interactive_selection_response_envelope(
             target=response_target,
             user_id=user_id,
@@ -1209,7 +1201,8 @@ class TurnController:
                 owned_response,
                 name=f"interactive_selection_response:{source_event_id}",
                 recovery_proof_ready=lambda: (
-                    thread_id is not None and self.deps.interrupted_turn_rooms.contains(source_event_id)
+                    response_target.source_thread_id is not None
+                    and self.deps.interrupted_turn_rooms.contains(source_event_id)
                 ),
                 on_failure=lambda: self.deps.retry_dispatch_sources((source_event_id,)),
                 source_event_ids=(source_event_id,),
@@ -1229,14 +1222,21 @@ class TurnController:
         selection: interactive.InteractiveSelection,
         user_id: str,
         source_event_id: str,
+        response_target: MessageTarget | None = None,
     ) -> None:
         """Own claim settlement around one validated interactive selection."""
+        target = response_target or self.deps.resolver.build_message_target(
+            room_id=room.room_id,
+            thread_id=selection.thread_id,
+            reply_to_event_id=selection.question_event_id,
+        )
         try:
             await self._execute_interactive_selection(
                 room,
                 selection=selection,
                 user_id=user_id,
                 source_event_id=source_event_id,
+                response_target=target,
             )
             interactive.commit_selection(selection)
         except BaseException:
@@ -1250,6 +1250,7 @@ class TurnController:
         selection: interactive.InteractiveSelection,
         user_id: str,
         source_event_id: str,
+        response_target: MessageTarget,
     ) -> None:
         """Execute one selection after its caller transfers claim ownership."""
         if await self._interactive_selection_is_durably_terminal(
@@ -1267,11 +1268,6 @@ class TurnController:
             )
             if selection.thread_id
             else []
-        )
-        response_target = self.deps.resolver.build_message_target(
-            room_id=room.room_id,
-            thread_id=selection.thread_id,
-            reply_to_event_id=selection.question_event_id,
         )
         selection_handled_turn = self.deps.turn_store.attach_response_context(
             TurnRecord.create(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1133,6 +1133,35 @@ class TurnController:
             replay_guard=replay_guard,
         )
 
+    def _interactive_selection_response_envelope(
+        self,
+        *,
+        target: MessageTarget,
+        user_id: str,
+        source_event_id: str,
+        selected_value: str,
+        attachment_ids: tuple[str, ...] = (),
+    ) -> MessageEnvelope:
+        """Build the canonical response envelope for one interactive selection."""
+        registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
+        return MessageEnvelope(
+            source_event_id=source_event_id,
+            target=target,
+            body=f"The user selected: {selected_value}",
+            attachment_ids=attachment_ids,
+            mentioned_agents=(),
+            agent_name=self.deps.agent_name,
+            origin=classify_turn_origin(
+                transport_sender_id=user_id,
+                requester_id=user_id,
+                sender_entity_name=registry.current_entity_name_for_user_id(user_id),
+                requester_entity_name=registry.current_entity_name_for_user_id(user_id),
+                source_kind=MESSAGE_SOURCE_KIND,
+                original_sender=None,
+                trusted_user_relay=False,
+            ),
+        )
+
     async def start_interactive_selection(
         self,
         response: Coroutine[Any, Any, None],
@@ -1141,6 +1170,8 @@ class TurnController:
         question_event_id: str,
         source_event_id: str,
         thread_id: str | None,
+        user_id: str,
+        selected_value: str,
     ) -> None:
         """Transfer one selection response from journal dispatch to runner ownership."""
         response_target = MessageTarget.resolve(
@@ -1148,8 +1179,14 @@ class TurnController:
             thread_id=thread_id,
             reply_to_event_id=question_event_id,
         )
+        response_envelope = self._interactive_selection_response_envelope(
+            target=response_target,
+            user_id=user_id,
+            source_event_id=source_event_id,
+            selected_value=selected_value,
+        )
         try:
-            reservation = await self.deps.response_runner.reserve_response_lifecycle(response_target)
+            reservation = await self.deps.response_runner.reserve_response_lifecycle(response_envelope)
         except BaseException:
             response.close()
             raise
@@ -1157,6 +1194,7 @@ class TurnController:
         async def run_owned_response() -> None:
             try:
                 with response_lifecycle_reservation_context(reservation):
+                    await reservation.wait_until_acquired()
                     await response
                 # Terminal delivery normally settles the discovery alias in its
                 # outbox transaction. This idempotent fallback also handles an
@@ -1324,23 +1362,12 @@ class TurnController:
             raise self._interactive_selection_retry_error(source_event_id) from error
         selection_attachment_ids = tuple(selection_payload.attachment_ids or ())
         selection_matrix_run_metadata = self.deps.turn_store.build_run_metadata(selection_handled_turn)
-        registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
-        response_envelope = MessageEnvelope(
-            source_event_id=source_event_id,
+        response_envelope = self._interactive_selection_response_envelope(
             target=response_target,
-            body=f"The user selected: {selection.selected_value}",
+            user_id=user_id,
+            source_event_id=source_event_id,
+            selected_value=selection.selected_value,
             attachment_ids=selection_attachment_ids,
-            mentioned_agents=(),
-            agent_name=self.deps.agent_name,
-            origin=classify_turn_origin(
-                transport_sender_id=user_id,
-                requester_id=user_id,
-                sender_entity_name=registry.current_entity_name_for_user_id(user_id),
-                requester_entity_name=registry.current_entity_name_for_user_id(user_id),
-                source_kind=MESSAGE_SOURCE_KIND,
-                original_sender=None,
-                trusted_user_relay=False,
-            ),
         )
 
         record_interrupted_turn, record_deferred_outcome, record_user_stop = self._build_response_settlement_callbacks(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1139,10 +1139,8 @@ class TurnController:
         thread_id: str | None,
     ) -> None:
         """Transfer one selection response from journal dispatch to runner ownership."""
-        response_started = asyncio.Event()
 
         async def run_owned_response() -> None:
-            response_started.set()
             await response
             # Terminal delivery normally settles the discovery alias in its
             # outbox transaction. This idempotent fallback also handles an
@@ -1158,10 +1156,8 @@ class TurnController:
             on_failure=lambda: self.deps.retry_dispatch_sources((source_event_id,)),
             source_event_ids=(source_event_id,),
         )
-        # Let the owned task enter before its journal callback reports the
-        # handoff. It may then wait on its canonical per-thread response lock
-        # without holding the room-wide journal lane.
-        await response_started.wait()
+        # Ownership registration is synchronous, and the task cannot execute
+        # until this callback yields after reporting its deferred handoff.
 
     async def handle_interactive_selection(
         self,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -52,6 +52,7 @@ from mindroom.dispatch_replay_guard import (
 )
 from mindroom.dispatch_source import (
     IMAGE_SOURCE_KIND,
+    INTERACTIVE_SELECTION_SOURCE_KIND,
     MEDIA_SOURCE_KIND,
     MESSAGE_SOURCE_KIND,
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
@@ -121,7 +122,7 @@ from mindroom.turn_store import record_deferred_outcome_response, record_user_st
 from mindroom.visible_voice_echo import VisibleVoiceEchoRequest
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Coroutine, Sequence
+    from collections.abc import Awaitable, Callable, Sequence
 
     import nio
     import structlog
@@ -146,6 +147,20 @@ if TYPE_CHECKING:
 
 _QUEUED_NOTICE_METADATA_KIND = "queued_notice_reservation"
 _PENDING_TURN_CLAIM_METADATA_KIND = "pending_turn_claim"
+_INTERACTIVE_SELECTION_METADATA_KIND = "interactive_selection"
+
+
+@dataclass(frozen=True)
+class _InteractiveSelectionDispatch:
+    """Deferred selection work carried through receipt-ordered coalescing."""
+
+    response_factory: Callable[[], Awaitable[None]]
+    start_response: Callable[..., Awaitable[None]]
+    restore_selection: Callable[[], None]
+    response_target: MessageTarget
+    source_event_id: str
+    user_id: str
+    selected_value: str
 
 
 def _room_level_context_event(event: PreparedIngress) -> PreparedIngress:
@@ -1163,12 +1178,13 @@ class TurnController:
 
     async def start_interactive_selection(
         self,
-        response: Coroutine[Any, Any, None],
+        response_factory: Callable[[], Awaitable[None]],
         *,
         response_target: MessageTarget,
         source_event_id: str,
         user_id: str,
         selected_value: str,
+        on_failure: Callable[[], None],
     ) -> None:
         """Transfer one selection response from journal dispatch to runner ownership."""
         response_envelope = self._interactive_selection_response_envelope(
@@ -1180,18 +1196,21 @@ class TurnController:
         try:
             reservation = await self.deps.response_runner.reserve_response_lifecycle(response_envelope)
         except BaseException:
-            response.close()
+            on_failure()
             raise
 
         async def run_owned_response() -> None:
             try:
                 with response_lifecycle_reservation_context(reservation):
                     await reservation.wait_until_acquired()
-                    await response
+                    await response_factory()
                 # Terminal delivery normally settles the discovery alias in its
                 # outbox transaction. This idempotent fallback also handles an
                 # already-terminal replay that has no new delivery to enqueue.
                 await self.deps.settle_dispatch_sources((source_event_id,))
+            except BaseException:
+                on_failure()
+                raise
             finally:
                 await reservation.release()
 
@@ -1209,11 +1228,96 @@ class TurnController:
             )
         except BaseException:
             owned_response.close()
-            response.close()
             await reservation.release()
+            on_failure()
             raise
         # Ownership registration is synchronous, and the task cannot execute
         # until this callback yields after reporting its deferred handoff.
+
+    async def enqueue_interactive_selection(
+        self,
+        reservation_owner: _PromptIngressReservationOwner,
+        room: nio.MatrixRoom,
+        *,
+        selection: interactive.InteractiveSelection,
+        requester_user_id: str,
+        user_id: str,
+        source_event_id: str,
+        response_target: MessageTarget,
+        handle_interactive_selection: Callable[..., Awaitable[None]],
+        start_interactive_selection: Callable[..., Awaitable[None]],
+    ) -> None:
+        """Queue a selection handoff as a FIFO barrier behind earlier ingress."""
+
+        def restore_selection() -> None:
+            interactive.restore_selection(selection)
+
+        dispatch = _InteractiveSelectionDispatch(
+            response_factory=lambda: handle_interactive_selection(
+                room,
+                selection=selection,
+                user_id=user_id,
+                source_event_id=source_event_id,
+                response_target=response_target,
+            ),
+            start_response=start_interactive_selection,
+            restore_selection=restore_selection,
+            response_target=response_target,
+            source_event_id=source_event_id,
+            user_id=user_id,
+            selected_value=selection.selected_value,
+        )
+        pending_event = PendingEvent(
+            event=PreparedIngress(
+                sender=user_id,
+                event_id=source_event_id,
+                body="",
+                source={},
+                source_kind_override=INTERACTIVE_SELECTION_SOURCE_KIND,
+                requester_user_id=requester_user_id,
+                source_kind=INTERACTIVE_SELECTION_SOURCE_KIND,
+            ),
+            room=room,
+            dispatch_metadata=(
+                PendingDispatchMetadata(
+                    kind=_INTERACTIVE_SELECTION_METADATA_KIND,
+                    payload=dispatch,
+                    close=restore_selection,
+                    target_key=response_target.lifecycle_key,
+                ),
+            ),
+        )
+        await reservation_owner.admit(
+            requester_coalescing_key(
+                room.room_id,
+                response_target.lifecycle_key.thread_id,
+                requester_user_id,
+            ),
+            source_event_id=source_event_id,
+            source_kind=INTERACTIVE_SELECTION_SOURCE_KIND,
+            ready_result=ReadyPendingEvent(pending_event=pending_event),
+        )
+
+    async def _dispatch_interactive_selection_turn(self, turn: PreparedTurn) -> bool:
+        """Start one receipt-ordered selection barrier and transfer its claim."""
+        items = [item for item in turn.dispatch_metadata if item.kind == _INTERACTIVE_SELECTION_METADATA_KIND]
+        if not items:
+            return False
+        if len(items) != 1 or len(turn.handled_turn.source_event_ids) != 1:
+            msg = "Interactive selection dispatch must be a single FIFO barrier"
+            raise ValueError(msg)
+        item = items[0]
+        dispatch = cast("_InteractiveSelectionDispatch", item.payload)
+        await dispatch.start_response(
+            dispatch.response_factory,
+            response_target=dispatch.response_target,
+            source_event_id=dispatch.source_event_id,
+            user_id=dispatch.user_id,
+            selected_value=dispatch.selected_value,
+            on_failure=dispatch.restore_selection,
+        )
+        item.finish_once(lambda: None)
+        return True
 
     async def handle_interactive_selection(
         self,
@@ -1766,6 +1870,8 @@ class TurnController:
 
     async def handle_prepared_turn(self, turn: PreparedTurn) -> None:
         """Dispatch one logical turn emitted directly by the coalescing gate."""
+        if await self._dispatch_interactive_selection_turn(turn):
+            return
         coalescing_key = turn.ingress.coalescing_key
         assert coalescing_key is not None
         _consume_queued_notice_reservations_from_metadata(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -346,6 +346,7 @@ class TurnControllerDeps:
     visible_responses: VisibleResponseReconciler
     retry_dispatch_sources: Callable[[tuple[str, ...]], None]
     settle_dispatch_sources: Callable[[tuple[str, ...]], Awaitable[None]]
+    dispatch_source_is_terminal: Callable[[str], Awaitable[bool]]
 
 
 @dataclass
@@ -1348,6 +1349,14 @@ class TurnController:
             )
             interactive.commit_selection(selection)
         except BaseException:
+            try:
+                source_is_terminal = await self.deps.dispatch_source_is_terminal(source_event_id)
+            except BaseException:
+                interactive.restore_selection(selection)
+                raise
+            if source_is_terminal:
+                interactive.commit_selection(selection)
+                return
             interactive.restore_selection(selection)
             raise
 
@@ -1416,6 +1425,7 @@ class TurnController:
                 f"You selected: {selection.selection_key} {selection.selected_value}\n\nProcessing your response..."
             ),
             recovered_response_event_id=ack_event_id,
+            delivery_turn_id=source_event_id,
             # This acknowledgement is the placeholder the selection's answer
             # then edits, which is what `existing_event_is_placeholder` below
             # says, so it is the turn's initial delivery and not its answer.
@@ -1455,7 +1465,7 @@ class TurnController:
                     selection_handled_turn,
                     event_id,
                 ),
-                delivery_turn_id=selection_handled_turn.anchor_event_id,
+                delivery_turn_id=source_event_id,
             )
             if response_event_id is not None:
                 await self.deps.turn_store.record_responded_turn(
@@ -1518,7 +1528,9 @@ class TurnController:
         source_event_id: str,
     ) -> bool:
         """Return whether the question or exact selection source is durably terminal."""
-        return any(self.deps.turn_store.is_handled(event_id) for event_id in {question_event_id, source_event_id})
+        return any(
+            self.deps.turn_store.is_handled(event_id) for event_id in {question_event_id, source_event_id}
+        ) or await self.deps.dispatch_source_is_terminal(source_event_id)
 
     async def _require_durable_interactive_selection(
         self,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -87,7 +87,9 @@ from mindroom.matrix.media import (
 from mindroom.matrix.message_content import is_v2_sidecar_text_preview
 from mindroom.matrix.thread_history_result import ThreadHistoryResult
 from mindroom.matrix.thread_membership import ThreadMembershipLookupError
+from mindroom.message_target import MessageTarget
 from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner as _PromptIngressReservationOwner
+from mindroom.response_lifecycle import response_lifecycle_reservation_context
 from mindroom.response_payload_preparation import (
     DispatchPayloadInputs,
     ResponsePayloadPreparation,
@@ -134,7 +136,7 @@ if TYPE_CHECKING:
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.matrix.identity import MatrixID
     from mindroom.matrix.relation_lookup import RelationLookup
-    from mindroom.message_target import MessageTarget, ResponseLifecycleKey
+    from mindroom.message_target import ResponseLifecycleKey
     from mindroom.response_lifecycle import QueuedHumanNoticeReservation
     from mindroom.response_runner import ResponseRunner
     from mindroom.sync_restart_retry import InterruptedTurnRooms
@@ -1135,27 +1137,50 @@ class TurnController:
         self,
         response: Coroutine[Any, Any, None],
         *,
+        room_id: str,
+        question_event_id: str,
         source_event_id: str,
         thread_id: str | None,
     ) -> None:
         """Transfer one selection response from journal dispatch to runner ownership."""
+        response_target = MessageTarget.resolve(
+            room_id=room_id,
+            thread_id=thread_id,
+            reply_to_event_id=question_event_id,
+        )
+        try:
+            reservation = await self.deps.response_runner.reserve_response_lifecycle(response_target)
+        except BaseException:
+            response.close()
+            raise
 
         async def run_owned_response() -> None:
-            await response
-            # Terminal delivery normally settles the discovery alias in its
-            # outbox transaction. This idempotent fallback also handles an
-            # already-terminal replay that has no new delivery to enqueue.
-            await self.deps.settle_dispatch_sources((source_event_id,))
+            try:
+                with response_lifecycle_reservation_context(reservation):
+                    await response
+                # Terminal delivery normally settles the discovery alias in its
+                # outbox transaction. This idempotent fallback also handles an
+                # already-terminal replay that has no new delivery to enqueue.
+                await self.deps.settle_dispatch_sources((source_event_id,))
+            finally:
+                await reservation.release()
 
-        self.deps.response_runner.track_inbox_response(
-            run_owned_response(),
-            name=f"interactive_selection_response:{source_event_id}",
-            recovery_proof_ready=lambda: (
-                thread_id is not None and self.deps.interrupted_turn_rooms.contains(source_event_id)
-            ),
-            on_failure=lambda: self.deps.retry_dispatch_sources((source_event_id,)),
-            source_event_ids=(source_event_id,),
-        )
+        owned_response = run_owned_response()
+        try:
+            self.deps.response_runner.track_inbox_response(
+                owned_response,
+                name=f"interactive_selection_response:{source_event_id}",
+                recovery_proof_ready=lambda: (
+                    thread_id is not None and self.deps.interrupted_turn_rooms.contains(source_event_id)
+                ),
+                on_failure=lambda: self.deps.retry_dispatch_sources((source_event_id,)),
+                source_event_ids=(source_event_id,),
+            )
+        except BaseException:
+            owned_response.close()
+            response.close()
+            await reservation.release()
+            raise
         # Ownership registration is synchronous, and the task cannot execute
         # until this callback yields after reporting its deferred handoff.
 

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1200,16 +1200,20 @@ class TurnController:
             raise
 
         async def run_owned_response() -> None:
+            response_claim_transferred = False
             try:
                 with response_lifecycle_reservation_context(reservation):
                     await reservation.wait_until_acquired()
-                    await response_factory()
+                    response = response_factory()
+                    response_claim_transferred = True
+                    await response
                 # Terminal delivery normally settles the discovery alias in its
                 # outbox transaction. This idempotent fallback also handles an
                 # already-terminal replay that has no new delivery to enqueue.
                 await self.deps.settle_dispatch_sources((source_event_id,))
             except BaseException:
-                on_failure()
+                if not response_claim_transferred:
+                    on_failure()
                 raise
             finally:
                 await reservation.release()

--- a/src/mindroom/visible_response_reconciliation.py
+++ b/src/mindroom/visible_response_reconciliation.py
@@ -144,6 +144,7 @@ class VisibleResponseReconciler:
         recovered_response_event_id: str | None,
         skip_mentions: bool = False,
         as_placeholder: bool = False,
+        delivery_turn_id: str | None = None,
     ) -> str | None:
         """Send and durably bind one non-model reply unless recovery already found it.
 
@@ -179,6 +180,9 @@ class VisibleResponseReconciler:
         before the model finished with nothing pending to replay and
         "Thinking..." in the room for good.
 
+        ``delivery_turn_id`` names a distinct admitted event when that event,
+        rather than the handled-turn anchor, authorized the room membership.
+
         A send that genuinely is not a turn -- a voice echo, a reconciliation
         notice -- has no identity a restart can resolve and does not belong
         here at all; it builds its own ``SendTextRequest`` and the gateway
@@ -191,7 +195,7 @@ class VisibleResponseReconciler:
                 target=target,
                 response_text=response_text,
                 skip_mentions=skip_mentions,
-                delivery_turn_id=handled_turn.anchor_event_id,
+                delivery_turn_id=delivery_turn_id or handled_turn.anchor_event_id,
                 delivery_stage=DeliveryStage.INITIAL if as_placeholder else DeliveryStage.FINAL,
             ),
         )

--- a/tach.toml
+++ b/tach.toml
@@ -93,6 +93,7 @@ depends_on = []
 visibility = [
     "mindroom.bot",
     "mindroom.journal_dispatch",
+    "mindroom.reaction_dispatch",
     "mindroom.turn_controller",
 ]
 
@@ -262,6 +263,7 @@ depends_on = [
     "mindroom.authorization",
     "mindroom.commands.config_confirmation",
     "mindroom.constants",
+    "mindroom.dispatch_callback_outcome",
     "mindroom.entity_resolution",
     "mindroom.event_journal",
     "mindroom.user_stop_reconciliation",

--- a/tach.toml
+++ b/tach.toml
@@ -266,6 +266,7 @@ depends_on = [
     "mindroom.dispatch_callback_outcome",
     "mindroom.entity_resolution",
     "mindroom.event_journal",
+    "mindroom.message_target",
     "mindroom.user_stop_reconciliation",
 ]
 visibility = ["mindroom.bot"]

--- a/tach.toml
+++ b/tach.toml
@@ -266,7 +266,6 @@ depends_on = [
     "mindroom.dispatch_callback_outcome",
     "mindroom.entity_resolution",
     "mindroom.event_journal",
-    "mindroom.message_target",
     "mindroom.user_stop_reconciliation",
 ]
 visibility = ["mindroom.bot"]

--- a/tests/ai_user_id_helpers.py
+++ b/tests/ai_user_id_helpers.py
@@ -444,6 +444,7 @@ def _build_response_runner(
         matrix_id=bot.matrix_id,
         resolver=bot._conversation_resolver,
         hook_context=hook_context,
+        membership=MagicMock(),
     )
 
     post_response_effects = PostResponseEffectsSupport(
@@ -452,6 +453,7 @@ def _build_response_runner(
         runtime_paths=runtime_paths,
         delivery_gateway=delivery_gateway,
         conversation_reader=make_conversation_reader_mock(),
+        membership=MagicMock(),
     )
     bot._knowledge_access_support = knowledge_access_support or _knowledge_access_support()
 
@@ -523,10 +525,11 @@ class _InertPostResponseEffects(PostResponseEffectsSupport):
         *,
         room_id: str,
         interactive_agent_name: str,
+        membership_turn_id: str,
         queue_memory_persistence: Callable[[], None] | None = None,
         persist_response_event_id: Callable[[str, str], None] | None = None,
     ) -> PostResponseEffectsDeps:
-        del room_id, interactive_agent_name, queue_memory_persistence, persist_response_event_id
+        del room_id, interactive_agent_name, membership_turn_id, queue_memory_persistence, persist_response_event_id
         return PostResponseEffectsDeps(logger=self.logger)
 
 
@@ -541,5 +544,6 @@ def _install_inert_post_response_effects(coordinator: ResponseRunner) -> None:
             runtime_paths=support.runtime_paths,
             delivery_gateway=support.delivery_gateway,
             conversation_reader=support.conversation_reader,
+            membership=support.membership,
         ),
     )

--- a/tests/bot_helpers.py
+++ b/tests/bot_helpers.py
@@ -1077,8 +1077,20 @@ class FencedRoomRecorder:
         self.fenced_room_ids.append(room_id)
         return DepartureOutcome(DepartureObservation.FENCED, len(self.fenced_room_ids), 0)
 
-    async def note_membership_restarted(self, room_id: str) -> None:
+    async def cleanup_fenced_departure(self, room_id: str, cleanup: Callable[[], None]) -> None:
+        """Run cleanup for every departure this focused recorder accepted."""
+        if room_id in self.fenced_room_ids:
+            cleanup()
+
+    async def note_membership_restarted(
+        self,
+        room_id: str,
+        *,
+        cleanup: Callable[[], None] | None = None,
+    ) -> None:
         """Accept a confirmed join without recording it."""
+        if cleanup is not None and room_id in self.fenced_room_ids:
+            cleanup()
 
     async def retire_owed_departure_reports(self, room_id: str) -> None:
         """Accept a retirement that can never happen here: nothing is ever owed."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2222,7 +2222,9 @@ def replace_turn_controller_deps(bot: RuntimeBot, **changes: object) -> TurnCont
         stop_manager=bot.stop_manager,
         reserve_prompt_ingress_order=rebuilt.reserve_prompt_ingress_order,
         build_message_target=rebuilt.deps.resolver.build_message_target,
+        enqueue_interactive_selection=rebuilt.enqueue_interactive_selection,
         handle_interactive_selection=rebuilt.handle_interactive_selection,
+        start_interactive_selection=rebuilt.start_interactive_selection,
         config_confirmation=replace(
             reaction_dispatcher.deps.config_confirmation,
             runtime=rebuilt.deps.runtime,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2221,6 +2221,7 @@ def replace_turn_controller_deps(bot: RuntimeBot, **changes: object) -> TurnCont
         ingress=rebuilt.deps.ingress,
         stop_manager=bot.stop_manager,
         reserve_prompt_ingress_order=rebuilt.reserve_prompt_ingress_order,
+        build_message_target=rebuilt.deps.resolver.build_message_target,
         handle_interactive_selection=rebuilt.handle_interactive_selection,
         config_confirmation=replace(
             reaction_dispatcher.deps.config_confirmation,

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -288,6 +288,7 @@ class TestAgentBot(AgentBotTestBase):
         await bot._response_runner.drain_inbox_responses()
         assert seen == []
         assert event.event_id not in bot._journal_dispatcher._deferred_reaction_ids
+        assert event.event_id not in bot._journal_dispatcher._worker._deferred
 
     @pytest.mark.asyncio
     async def test_recovered_interactive_reaction_keeps_its_durable_consumer(

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from contextlib import suppress
+from contextlib import nullcontext, suppress
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
@@ -21,8 +21,12 @@ from mindroom.approval_manager import (
     initialize_approval_store,
 )
 from mindroom.bot import AgentBot
+from mindroom.coalescing import ReadyPendingEvent
+from mindroom.coalescing_batch import PendingEvent, PreparedTurn, requester_coalescing_key
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.dispatch_callback_outcome import TurnDispatchOutcome
+from mindroom.dispatch_handoff import PreparedIngress
+from mindroom.dispatch_source import MESSAGE_SOURCE_KIND
 from mindroom.event_journal import EventClass, EventKind, SemanticConsumer
 from mindroom.handled_turns import TurnRecord, with_user_stop
 from mindroom.hooks import (
@@ -56,7 +60,7 @@ from tests.conftest import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable, Coroutine
+    from collections.abc import Awaitable, Callable
     from pathlib import Path
 
     from mindroom.matrix.users import AgentMatrixUser
@@ -525,12 +529,12 @@ class TestAgentBot(AgentBotTestBase):
         assert bot._coalescing_gate.lanes.all_settled()
 
     @pytest.mark.asyncio
-    async def test_interactive_reaction_reserves_lifecycle_before_releasing_prompt_lane(
+    async def test_interactive_reaction_enqueues_barrier_before_releasing_prompt_lane(
         self,
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
     ) -> None:
-        """Selection startup must reserve its lifecycle before releasing ingress order."""
+        """Selection handoff must enter its FIFO barrier before releasing ingress order."""
         config = self._config_for_storage(tmp_path)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
@@ -550,9 +554,8 @@ class TestAgentBot(AgentBotTestBase):
         reservation_owner.release = AsyncMock()
         release_count_during_startup = -1
 
-        async def blocked_start(response: Coroutine[object, object, None], **_kwargs: object) -> None:
+        async def blocked_enqueue(*_args: object, **_kwargs: object) -> None:
             nonlocal release_count_during_startup
-            response.close()
             release_count_during_startup = reservation_owner.release.await_count
             startup_observed.set()
             await release_startup.wait()
@@ -560,7 +563,7 @@ class TestAgentBot(AgentBotTestBase):
         replace_reaction_dispatcher_deps(
             bot,
             reserve_prompt_ingress_order=MagicMock(return_value=reservation_owner),
-            start_interactive_selection=blocked_start,
+            enqueue_interactive_selection=blocked_enqueue,
         )
         with patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)):
             dispatch = asyncio.create_task(_dispatch_reaction(bot, room, event))
@@ -570,6 +573,75 @@ class TestAgentBot(AgentBotTestBase):
             await dispatch
 
         reservation_owner.release.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_interactive_reaction_waits_for_earlier_same_thread_ingress(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A reaction response must not overtake an earlier queued thread message."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        room = nio.MatrixRoom("!test:localhost", bot.matrix_id.full_id)
+        selection = interactive.InteractiveSelection(
+            question_event_id="$question",
+            question_text="Choose one",
+            selection_key="👍",
+            selected_label="Selected",
+            selected_value="Selected",
+            thread_id="$thread-a",
+        )
+        reaction = _reaction_event("👍", "$reaction")
+        message_dispatch_started = asyncio.Event()
+        release_message_dispatch = asyncio.Event()
+        execution_order: list[str] = []
+        original_dispatch = bot._coalescing_gate._dispatch_turn
+
+        async def dispatch_turn(turn: PreparedTurn) -> None:
+            if turn.event.event_id == "$earlier":
+                message_dispatch_started.set()
+                await release_message_dispatch.wait()
+                execution_order.append("message")
+                return
+            await original_dispatch(turn)
+
+        async def start_selection(
+            _response_factory: Callable[[], Awaitable[None]],
+            **_kwargs: object,
+        ) -> None:
+            execution_order.append("reaction")
+
+        monkeypatch.setattr(bot._coalescing_gate, "_dispatch_turn", dispatch_turn)
+        replace_reaction_dispatcher_deps(bot, start_interactive_selection=start_selection)
+        earlier_owner = bot._turn_controller.reserve_prompt_ingress_order(room, "@user:localhost")
+        earlier_event = PreparedIngress(
+            sender="@user:localhost",
+            event_id="$earlier",
+            body="Earlier message",
+            source={"content": {"msgtype": "m.text", "body": "Earlier message"}},
+            requester_user_id="@user:localhost",
+            source_kind=MESSAGE_SOURCE_KIND,
+        )
+        await earlier_owner.admit(
+            requester_coalescing_key(room.room_id, "$thread-a", "@user:localhost"),
+            source_event_id=earlier_event.event_id,
+            source_kind=MESSAGE_SOURCE_KIND,
+            ready_result=ReadyPendingEvent(pending_event=PendingEvent(event=earlier_event, room=room)),
+        )
+
+        try:
+            await asyncio.wait_for(message_dispatch_started.wait(), timeout=1.0)
+            with patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)):
+                await _dispatch_reaction(bot, room, reaction)
+            release_message_dispatch.set()
+            await asyncio.wait_for(bot._coalescing_gate.drain_all(), timeout=1.0)
+            assert execution_order == ["message", "reaction"]
+        finally:
+            release_message_dispatch.set()
+            await bot._coalescing_gate.drain_all()
 
     @pytest.mark.asyncio
     async def test_interactive_reaction_response_does_not_hold_room_journal_lane(
@@ -691,11 +763,8 @@ class TestAgentBot(AgentBotTestBase):
                 await older_entered.wait()
                 await _dispatch_reaction(bot, room, reaction)
 
-                target = MessageTarget.resolve(room.room_id, selection.thread_id, selection.question_event_id)
-                response_runner = unwrap_extracted_collaborator(bot._response_runner)
-                queued_signal = response_runner._lifecycle_coordinator._get_or_create_queued_signal(target)
                 assert not preparation_started.is_set()
-                assert queued_signal.pending_human_message_event_ids == {reaction.event_id}
+                assert bot._journal_dispatcher.callbacks.source_has_live_owner(reaction.event_id)
 
                 release_older.set()
                 assert await older == "$older-response"
@@ -728,17 +797,101 @@ class TestAgentBot(AgentBotTestBase):
             reply_to_event_id="$question",
         )
         await bot._turn_controller.start_interactive_selection(
-            prepare_forever(),
+            prepare_forever,
             response_target=target,
             source_event_id="$reaction",
             user_id="@user:localhost",
             selected_value="Selected",
+            on_failure=lambda: None,
         )
         await asyncio.wait_for(preparation_started.wait(), timeout=1.0)
         assert bot._response_runner.has_active_response_for_target(target)
 
         assert await bot._response_runner.drain_inbox_responses(cancel_after_seconds=0.01) is False
         assert not bot._response_runner.has_active_response_for_target(target)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure_stage", ["acquire", "queued_cancel"])
+    async def test_interactive_prestart_failure_restores_claimed_selection(
+        self,
+        failure_stage: str,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Outer response ownership must restore a claim before preparation starts."""
+        interactive._cleanup()
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        room = nio.MatrixRoom("!test:localhost", bot.matrix_id.full_id)
+        question = interactive._InteractiveQuestion(
+            room_id=room.room_id,
+            thread_id="$thread-a",
+            options={"👍": "Selected"},
+            creator_agent=bot.agent_name,
+        )
+        selection = interactive.InteractiveSelection(
+            question_event_id="$question",
+            question_text="Choose one",
+            selection_key="👍",
+            selected_label="Selected",
+            selected_value="Selected",
+            thread_id="$thread-a",
+            claimed_question=question,
+        )
+        interactive._claimed_question_ids.add(selection.question_event_id)
+        target = bot._conversation_resolver.build_message_target(
+            room_id=room.room_id,
+            thread_id=selection.thread_id,
+            reply_to_event_id=selection.question_event_id,
+        )
+        response_entered = asyncio.Event()
+
+        async def response() -> None:
+            response_entered.set()
+
+        lifecycle_lock = unwrap_extracted_collaborator(
+            bot._response_runner,
+        )._lifecycle_coordinator._response_lifecycle_lock(target)
+        lock_owned_by_test = False
+        if failure_stage == "acquire":
+            acquisition_error = RuntimeError("simulated lifecycle acquisition failure")
+
+            async def fail_acquire() -> bool:
+                raise acquisition_error
+
+            acquire_patch = patch.object(lifecycle_lock, "acquire", new=fail_acquire)
+        else:
+            await lifecycle_lock.acquire()
+            lock_owned_by_test = True
+            acquire_patch = nullcontext()
+
+        try:
+            with acquire_patch:
+                await bot._turn_controller.start_interactive_selection(
+                    response,
+                    response_target=target,
+                    source_event_id="$reaction",
+                    user_id="@user:localhost",
+                    selected_value=selection.selected_value,
+                    on_failure=lambda: interactive.restore_selection(selection),
+                )
+                if failure_stage == "queued_cancel":
+                    assert await bot._response_runner.drain_inbox_responses(cancel_after_seconds=0.01) is False
+                else:
+                    await bot._response_runner.drain_inbox_responses()
+
+            assert not response_entered.is_set()
+            assert selection.question_event_id in interactive._active_questions
+            assert selection.question_event_id not in interactive._claimed_question_ids
+            if lock_owned_by_test:
+                lifecycle_lock.release()
+                lock_owned_by_test = False
+            assert not bot._response_runner.has_active_response_for_target(target)
+        finally:
+            if lock_owned_by_test:
+                lifecycle_lock.release()
+            await bot._response_runner.drain_inbox_responses()
+            interactive._cleanup()
 
     @pytest.mark.asyncio
     async def test_interactive_reaction_reserves_same_thread_lifecycle_before_preparation(

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -127,6 +127,20 @@ def _reaction_event(key: str, event_id: str) -> nio.ReactionEvent:
     return event
 
 
+def _message_event(event_id: str) -> nio.RoomMessageText:
+    event = nio.Event.parse_event(
+        {
+            "type": "m.room.message",
+            "event_id": event_id,
+            "sender": "@user:localhost",
+            "origin_server_ts": 2,
+            "content": {"msgtype": "m.text", "body": "Another thread"},
+        },
+    )
+    assert isinstance(event, nio.RoomMessageText)
+    return event
+
+
 def _install_reaction_recorder(bot: AgentBot) -> list[str]:
     """Install a real reaction hook and return its observed event IDs."""
     seen: list[str] = []
@@ -424,6 +438,69 @@ class TestAgentBot(AgentBotTestBase):
         await asyncio.wait_for(selection_started.wait(), timeout=0.5)
         await asyncio.wait_for(bot._coalescing_gate.drain_all(), timeout=1.0)
         assert bot._coalescing_gate.lanes.all_settled()
+
+    @pytest.mark.asyncio
+    async def test_interactive_reaction_response_does_not_hold_room_journal_lane(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A parked selection response must not delay a different root thread."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        room = nio.MatrixRoom("!test:localhost", bot.matrix_id.full_id)
+        reaction = _reaction_event("👍", "$interactive-reaction")
+        message = _message_event("$other-thread-root")
+        selection = interactive.InteractiveSelection(
+            question_event_id="$question",
+            question_text="Choose one",
+            selection_key="👍",
+            selected_label="Selected",
+            selected_value="Selected",
+            thread_id="$thread-a",
+        )
+        selection_started = asyncio.Event()
+        release_selection = asyncio.Event()
+        message_started = asyncio.Event()
+
+        async def blocked_selection(*_args: object, **_kwargs: object) -> None:
+            selection_started.set()
+            await release_selection.wait()
+
+        async def handle_other_thread(*_args: object, **_kwargs: object) -> TurnDispatchOutcome:
+            message_started.set()
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
+
+        replace_reaction_dispatcher_deps(bot, handle_interactive_selection=blocked_selection)
+        monkeypatch.setattr(
+            unwrap_extracted_collaborator(bot._turn_controller),
+            "handle_text_event",
+            handle_other_thread,
+        )
+        bot._journal_dispatcher.start()
+        try:
+            with patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)):
+                await bot._journal_dispatcher.admit_out_of_band(
+                    room,
+                    reaction,
+                    EventKind.REACTION,
+                    EventClass.ACTIONABLE,
+                )
+                await asyncio.wait_for(selection_started.wait(), timeout=1.0)
+                await bot._journal_dispatcher.admit_out_of_band(
+                    room,
+                    message,
+                    EventKind.MESSAGE,
+                    EventClass.ACTIONABLE,
+                )
+
+                await asyncio.wait_for(message_started.wait(), timeout=0.2)
+                assert reaction.event_id in await bot._journal_dispatcher.unsettled_event_ids()
+        finally:
+            release_selection.set()
+            await bot._journal_dispatcher.stop()
 
     @pytest.mark.asyncio
     async def test_checkmark_interactive_reaction_reserves_before_tool_approval_lookup(

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -54,6 +54,7 @@ from tests.conftest import (
     install_relation_lookup,
     make_matrix_client_mock,
     replace_reaction_dispatcher_deps,
+    replace_turn_controller_deps,
     request_envelope,
     runtime_paths_for,
     unwrap_extracted_collaborator,
@@ -809,6 +810,61 @@ class TestAgentBot(AgentBotTestBase):
 
         assert await bot._response_runner.drain_inbox_responses(cancel_after_seconds=0.01) is False
         assert not bot._response_runner.has_active_response_for_target(target)
+
+    def test_replaced_turn_controller_rebinds_interactive_reaction_callbacks(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Reaction dispatch must use the controller rebuilt by test dependency swaps."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+
+        controller = replace_turn_controller_deps(bot)
+
+        assert bot._reaction_dispatcher.deps.enqueue_interactive_selection == controller.enqueue_interactive_selection
+        assert bot._reaction_dispatcher.deps.start_interactive_selection == controller.start_interactive_selection
+
+    @pytest.mark.asyncio
+    async def test_interactive_postresponse_settlement_failure_does_not_run_prestart_cleanup(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Journal cleanup after a completed response must not restore its selection."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        settlement_error = OSError("simulated journal settlement failure")
+        settle_dispatch_sources = AsyncMock(side_effect=settlement_error)
+        controller = replace_turn_controller_deps(
+            bot,
+            settle_dispatch_sources=settle_dispatch_sources,
+            retry_dispatch_sources=MagicMock(),
+        )
+        response_completed = asyncio.Event()
+        prestart_cleanup = MagicMock()
+
+        async def response() -> None:
+            response_completed.set()
+
+        target = bot._conversation_resolver.build_message_target(
+            room_id="!test:localhost",
+            thread_id="$thread-a",
+            reply_to_event_id="$question",
+        )
+        await controller.start_interactive_selection(
+            response,
+            response_target=target,
+            source_event_id="$reaction",
+            user_id="@user:localhost",
+            selected_value="Selected",
+            on_failure=prestart_cleanup,
+        )
+        await bot._response_runner.drain_inbox_responses()
+
+        assert response_completed.is_set()
+        settle_dispatch_sources.assert_awaited_once_with(("$reaction",))
+        prestart_cleanup.assert_not_called()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("failure_stage", ["acquire", "queued_cancel"])

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -540,6 +540,61 @@ class TestAgentBot(AgentBotTestBase):
             interactive._cleanup()
 
     @pytest.mark.asyncio
+    async def test_departure_while_claimed_selection_waits_discards_selection(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A fence makes a claimed selection terminal while it waits for its response lock."""
+        interactive._cleanup()
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        room = nio.MatrixRoom("!test:localhost", bot.matrix_id.full_id)
+        question = _message_event("$question")
+        await bot._journal_dispatcher.admit_out_of_band(
+            room,
+            question,
+            EventKind.MESSAGE,
+            EventClass.CONTEXT_ONLY,
+        )
+        interactive.register_interactive_question(
+            question.event_id,
+            room.room_id,
+            None,
+            {"👍": "Selected"},
+            bot.agent_name,
+        )
+        reaction = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
+        target = MessageTarget.resolve(room.room_id, None, question.event_id)
+        lifecycle_lock = unwrap_extracted_collaborator(
+            bot._response_runner,
+        )._lifecycle_coordinator._response_lifecycle_lock(target)
+        await lifecycle_lock.acquire()
+
+        try:
+            await asyncio.wait_for(_dispatch_reaction(bot, room, reaction), timeout=1.0)
+            stored_reaction = await bot._journal_principal().load_event(reaction.event_id)
+            assert stored_reaction is not None
+            assert stored_reaction.semantic_consumer is SemanticConsumer.INTERACTIVE_REACTION
+            assert question.event_id in interactive._claimed_question_ids
+
+            await bot._journal_principal().fence_departure(room.room_id, source=DepartureSource.LOCAL)
+            assert reaction.event_id not in await bot._journal_dispatcher.unsettled_event_ids()
+
+            lifecycle_lock.release()
+            await asyncio.wait_for(bot._coalescing_gate.drain_all(), timeout=1.0)
+            await asyncio.wait_for(bot._response_runner.drain_inbox_responses(), timeout=1.0)
+
+            assert question.event_id not in interactive._active_questions
+            assert question.event_id not in interactive._claimed_question_ids
+        finally:
+            if lifecycle_lock.locked():
+                lifecycle_lock.release()
+            await asyncio.wait_for(bot._response_runner.drain_inbox_responses(), timeout=1.0)
+            interactive._cleanup()
+
+    @pytest.mark.asyncio
     async def test_interactive_reaction_selection_reserves_prompt_order(
         self,
         mock_agent_user: AgentMatrixUser,

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -517,6 +517,7 @@ class TestAgentBot(AgentBotTestBase):
                 assert reaction.event_id in await bot._journal_dispatcher.unsettled_event_ids()
         finally:
             release_selection.set()
+            await bot._response_runner.drain_inbox_responses()
             await bot._journal_dispatcher.stop()
 
     @pytest.mark.asyncio

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -497,6 +497,7 @@ class TestAgentBot(AgentBotTestBase):
                 )
 
                 await asyncio.wait_for(message_started.wait(), timeout=0.2)
+                assert bot._journal_dispatcher.callbacks.source_has_live_owner(reaction.event_id)
                 assert reaction.event_id in await bot._journal_dispatcher.unsettled_event_ids()
         finally:
             release_selection.set()

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -31,8 +31,10 @@ from mindroom.hooks import (
     ReactionReceivedContext,
     hook,
 )
+from mindroom.matrix.thread_history_result import thread_history_result
 from mindroom.message_target import MessageTarget
 from mindroom.response_runner import ResponseRequest, ResponseRunner
+from mindroom.room_thread_modes import set_room_thread_mode_override
 from mindroom.tool_approval import ApprovalActionResult, MatrixApprovalAction, _shutdown_approval_store
 from tests.approval_test_support import FakeApprovalCards
 from tests.bot_helpers import (
@@ -720,17 +722,19 @@ class TestAgentBot(AgentBotTestBase):
             preparation_started.set()
             await asyncio.Event().wait()
 
+        target = bot._conversation_resolver.build_message_target(
+            room_id="!test:localhost",
+            thread_id="$thread-a",
+            reply_to_event_id="$question",
+        )
         await bot._turn_controller.start_interactive_selection(
             prepare_forever(),
-            room_id="!test:localhost",
-            question_event_id="$question",
+            response_target=target,
             source_event_id="$reaction",
-            thread_id="$thread-a",
             user_id="@user:localhost",
             selected_value="Selected",
         )
         await asyncio.wait_for(preparation_started.wait(), timeout=1.0)
-        target = MessageTarget.resolve("!test:localhost", "$thread-a", "$question")
         assert bot._response_runner.has_active_response_for_target(target)
 
         assert await bot._response_runner.drain_inbox_responses(cancel_after_seconds=0.01) is False
@@ -833,6 +837,64 @@ class TestAgentBot(AgentBotTestBase):
             release_interactive.set()
             if newer_task is not None:
                 await asyncio.gather(newer_task, return_exceptions=True)
+            await bot._response_runner.drain_inbox_responses()
+
+    @pytest.mark.asyncio
+    async def test_interactive_reaction_keeps_room_mode_target_across_handoff(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Reaction reservation and execution must share one configured target."""
+        config = self._config_for_storage(tmp_path)
+        runtime_paths = runtime_paths_for(config)
+        room = nio.MatrixRoom("!test:localhost", mock_agent_user.user_id)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        reaction = _reaction_event("👍", "$interactive-reaction")
+        selection = interactive.InteractiveSelection(
+            question_event_id="$question",
+            question_text="Choose one",
+            selection_key="👍",
+            selected_label="Selected",
+            selected_value="Selected",
+            thread_id="$original-thread",
+        )
+        set_room_thread_mode_override(
+            runtime_paths,
+            room_id=room.room_id,
+            mode="room",
+            set_by="@admin:localhost",
+        )
+        resolved_targets: list[MessageTarget] = []
+
+        async def generate_locked(
+            _self: ResponseRunner,
+            _request: ResponseRequest,
+            *,
+            resolved_target: MessageTarget,
+            early_placeholder_state: object,
+        ) -> str:
+            del early_placeholder_state
+            resolved_targets.append(resolved_target)
+            return "$response"
+
+        bot._conversation_resolver.fetch_thread_history = AsyncMock(
+            return_value=thread_history_result([], is_full_history=True),
+        )
+        bot._visible_responses.recovered_response_event_id = AsyncMock(return_value=None)
+        bot._visible_responses.deliver_recoverable_text = AsyncMock(return_value="$ack")
+        try:
+            with (
+                patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)),
+                patch.object(ResponseRunner, "_generate_response_locked", new=generate_locked),
+            ):
+                await _dispatch_reaction(bot, room, reaction)
+                await bot._response_runner.drain_inbox_responses()
+
+            assert [target.resolved_thread_id for target in resolved_targets] == [None]
+            assert reaction.event_id not in await bot._journal_dispatcher.unsettled_event_ids()
+        finally:
             await bot._response_runner.drain_inbox_responses()
 
     @pytest.mark.asyncio

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -54,7 +54,7 @@ from tests.conftest import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Awaitable, Callable
+    from collections.abc import Awaitable, Callable, Coroutine
     from pathlib import Path
 
     from mindroom.matrix.users import AgentMatrixUser
@@ -523,6 +523,53 @@ class TestAgentBot(AgentBotTestBase):
         assert bot._coalescing_gate.lanes.all_settled()
 
     @pytest.mark.asyncio
+    async def test_interactive_reaction_reserves_lifecycle_before_releasing_prompt_lane(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Selection startup must reserve its lifecycle before releasing ingress order."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        room = MagicMock(room_id="!test:localhost", canonical_alias=None)
+        event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
+        selection = interactive.InteractiveSelection(
+            question_event_id="$question",
+            question_text="Choose one",
+            selection_key="👍",
+            selected_label="Selected",
+            selected_value="Selected",
+            thread_id="$thread-a",
+        )
+        startup_observed = asyncio.Event()
+        release_startup = asyncio.Event()
+        reservation_owner = MagicMock()
+        reservation_owner.release = AsyncMock()
+        release_count_during_startup = -1
+
+        async def blocked_start(response: Coroutine[object, object, None], **_kwargs: object) -> None:
+            nonlocal release_count_during_startup
+            response.close()
+            release_count_during_startup = reservation_owner.release.await_count
+            startup_observed.set()
+            await release_startup.wait()
+
+        replace_reaction_dispatcher_deps(
+            bot,
+            reserve_prompt_ingress_order=MagicMock(return_value=reservation_owner),
+            start_interactive_selection=blocked_start,
+        )
+        with patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)):
+            dispatch = asyncio.create_task(_dispatch_reaction(bot, room, event))
+            await startup_observed.wait()
+            assert release_count_during_startup == 0
+            release_startup.set()
+            await dispatch
+
+        reservation_owner.release.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_interactive_reaction_response_does_not_hold_room_journal_lane(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -588,6 +635,77 @@ class TestAgentBot(AgentBotTestBase):
             await bot._journal_dispatcher.stop()
 
     @pytest.mark.asyncio
+    async def test_interactive_preparation_waits_for_older_same_thread_response(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Selection pre-generation work must wait behind its reserved lifecycle lock."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        room = nio.MatrixRoom("!test:localhost", bot.matrix_id.full_id)
+        reaction = _reaction_event("👍", "$interactive-reaction")
+        selection = interactive.InteractiveSelection(
+            question_event_id="$question",
+            question_text="Choose one",
+            selection_key="👍",
+            selected_label="Selected",
+            selected_value="Selected",
+            thread_id="$thread-a",
+        )
+        older_target = MessageTarget.resolve(room.room_id, selection.thread_id, "$older")
+        older_entered = asyncio.Event()
+        release_older = asyncio.Event()
+        preparation_started = asyncio.Event()
+
+        async def generate_locked(
+            _self: ResponseRunner,
+            _request: ResponseRequest,
+            *,
+            resolved_target: MessageTarget,
+            early_placeholder_state: object,
+        ) -> str:
+            del resolved_target, early_placeholder_state
+            older_entered.set()
+            await release_older.wait()
+            return "$older-response"
+
+        async def handle_selection(*_args: object, **_kwargs: object) -> None:
+            preparation_started.set()
+
+        replace_reaction_dispatcher_deps(bot, handle_interactive_selection=handle_selection)
+        older: asyncio.Task[str | None] | None = None
+        try:
+            with (
+                patch.object(ResponseRunner, "_generate_response_locked", new=generate_locked),
+                patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)),
+            ):
+                older = asyncio.create_task(
+                    bot._response_runner.generate_response(
+                        _direct_response_request(older_target, "older", "$older"),
+                    ),
+                )
+                await older_entered.wait()
+                await _dispatch_reaction(bot, room, reaction)
+
+                target = MessageTarget.resolve(room.room_id, selection.thread_id, selection.question_event_id)
+                response_runner = unwrap_extracted_collaborator(bot._response_runner)
+                queued_signal = response_runner._lifecycle_coordinator._get_or_create_queued_signal(target)
+                assert not preparation_started.is_set()
+                assert queued_signal.pending_human_message_event_ids == {reaction.event_id}
+
+                release_older.set()
+                assert await older == "$older-response"
+                await preparation_started.wait()
+                await bot._response_runner.drain_inbox_responses()
+        finally:
+            release_older.set()
+            if older is not None:
+                await asyncio.gather(older, return_exceptions=True)
+            await bot._response_runner.drain_inbox_responses()
+
+    @pytest.mark.asyncio
     async def test_cancelled_interactive_preparation_releases_same_thread_reservation(
         self,
         mock_agent_user: AgentMatrixUser,
@@ -608,6 +726,8 @@ class TestAgentBot(AgentBotTestBase):
             question_event_id="$question",
             source_event_id="$reaction",
             thread_id="$thread-a",
+            user_id="@user:localhost",
+            selected_value="Selected",
         )
         await asyncio.wait_for(preparation_started.wait(), timeout=1.0)
         target = MessageTarget.resolve("!test:localhost", "$thread-a", "$question")

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -444,6 +444,59 @@ class TestAgentBot(AgentBotTestBase):
             interactive._cleanup()
 
     @pytest.mark.asyncio
+    async def test_departure_consumes_question_restored_after_selection_failure(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A departure retires retry state whose reaction it makes terminal."""
+        interactive._cleanup()
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        room = MagicMock(room_id="!test:localhost")
+        event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
+        event.source = {
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": "$question",
+                    "key": "👍",
+                },
+            },
+        }
+        interactive.register_interactive_question(
+            "$question",
+            room.room_id,
+            None,
+            {"👍": "approve"},
+            bot.agent_name,
+        )
+
+        try:
+            with patch.object(
+                bot._turn_controller,
+                "_execute_interactive_selection",
+                new=AsyncMock(side_effect=OSError("pending write failed")),
+            ):
+                await _dispatch_reaction(bot, room, event)
+                await bot._response_runner.drain_inbox_responses()
+
+            assert "$question" in interactive._active_questions
+            assert event.event_id in await bot._journal_dispatcher.unsettled_event_ids()
+
+            await bot._membership_fence.fence_local_departure(room.room_id)
+
+            assert "$question" not in interactive._active_questions
+            assert event.event_id not in await bot._journal_dispatcher.unsettled_event_ids()
+            interactive._cleanup()
+            interactive.init_persistence(tmp_path)
+            assert "$question" not in interactive._active_questions
+        finally:
+            await bot._response_runner.drain_inbox_responses()
+            interactive._cleanup()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("failure_stage", ["reserve", "track"])
     async def test_interactive_reaction_start_failure_restores_claimed_selection(
         self,
@@ -577,17 +630,24 @@ class TestAgentBot(AgentBotTestBase):
             stored_reaction = await bot._journal_principal().load_event(reaction.event_id)
             assert stored_reaction is not None
             assert stored_reaction.semantic_consumer is SemanticConsumer.INTERACTIVE_REACTION
-            assert question.event_id in interactive._claimed_question_ids
+            assert question.event_id in interactive._claimed_questions
 
-            await bot._journal_principal().fence_departure(room.room_id, source=DepartureSource.LOCAL)
+            await bot._membership_fence.fence_local_departure(room.room_id)
             assert reaction.event_id not in await bot._journal_dispatcher.unsettled_event_ids()
+
+            # Model a process exit before the detached response gets the lock.
+            # The departure itself must already have consumed the persisted
+            # question because its reaction is now terminal and cannot replay.
+            interactive._cleanup()
+            interactive.init_persistence(tmp_path)
+            assert question.event_id not in interactive._active_questions
 
             lifecycle_lock.release()
             await asyncio.wait_for(bot._coalescing_gate.drain_all(), timeout=1.0)
             await asyncio.wait_for(bot._response_runner.drain_inbox_responses(), timeout=1.0)
 
             assert question.event_id not in interactive._active_questions
-            assert question.event_id not in interactive._claimed_question_ids
+            assert question.event_id not in interactive._claimed_questions
         finally:
             if lifecycle_lock.locked():
                 lifecycle_lock.release()
@@ -996,7 +1056,7 @@ class TestAgentBot(AgentBotTestBase):
             thread_id="$thread-a",
             claimed_question=question,
         )
-        interactive._claimed_question_ids.add(selection.question_event_id)
+        interactive._claimed_questions[selection.question_event_id] = question
         target = bot._conversation_resolver.build_message_target(
             room_id=room.room_id,
             thread_id=selection.thread_id,
@@ -1040,7 +1100,7 @@ class TestAgentBot(AgentBotTestBase):
 
             assert not response_entered.is_set()
             assert selection.question_event_id in interactive._active_questions
-            assert selection.question_event_id not in interactive._claimed_question_ids
+            assert selection.question_event_id not in interactive._claimed_questions
             if lock_owned_by_test:
                 lifecycle_lock.release()
                 lock_owned_by_test = False

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -398,7 +398,10 @@ class TestAgentBot(AgentBotTestBase):
             ):
                 await _dispatch_reaction(bot, room, event)
 
+            await bot._response_runner.drain_inbox_responses()
             assert "$question" in interactive._active_questions
+            assert event.event_id in await bot._journal_dispatcher.unsettled_event_ids()
+            assert not bot._journal_dispatcher.callbacks.source_has_live_owner(event.event_id)
         finally:
             interactive._cleanup()
 

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -285,7 +285,9 @@ class TestAgentBot(AgentBotTestBase):
         ):
             await _dispatch_reaction(bot, room, event)
 
+        await bot._response_runner.drain_inbox_responses()
         assert seen == []
+        assert event.event_id not in bot._journal_dispatcher._deferred_reaction_ids
 
     @pytest.mark.asyncio
     async def test_recovered_interactive_reaction_keeps_its_durable_consumer(

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -437,6 +437,55 @@ class TestAgentBot(AgentBotTestBase):
             interactive._cleanup()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("failure_stage", ["reserve", "track"])
+    async def test_interactive_reaction_start_failure_restores_claimed_selection(
+        self,
+        failure_stage: str,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A failed reservation or task registration must restore the claimed question."""
+        interactive._cleanup()
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        room = MagicMock(room_id="!test:localhost")
+        event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
+        event.source = {
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": "$question",
+                    "key": "👍",
+                },
+            },
+        }
+        interactive._active_questions["$question"] = interactive._InteractiveQuestion(
+            room_id=room.room_id,
+            thread_id="$thread-a",
+            options={"👍": "approve"},
+            creator_agent=bot.agent_name,
+        )
+        error = RuntimeError(f"{failure_stage} failed")
+        reservation_patch = (
+            patch.object(bot._response_runner, "reserve_response_lifecycle", new=AsyncMock(side_effect=error))
+            if failure_stage == "reserve"
+            else patch.object(bot._response_runner, "track_inbox_response", side_effect=error)
+        )
+
+        try:
+            with reservation_patch:
+                await _dispatch_reaction(bot, room, event)
+
+            assert "$question" in interactive._active_questions
+            assert event.event_id in await bot._journal_dispatcher.unsettled_event_ids()
+            assert not bot._journal_dispatcher.callbacks.source_has_live_owner(event.event_id)
+            target = MessageTarget.resolve(room.room_id, "$thread-a", "$question")
+            assert not bot._response_runner.has_active_response_for_target(target)
+        finally:
+            interactive._cleanup()
+
+    @pytest.mark.asyncio
     async def test_interactive_reaction_selection_reserves_prompt_order(
         self,
         mock_agent_user: AgentMatrixUser,

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -32,6 +32,7 @@ from mindroom.hooks import (
     hook,
 )
 from mindroom.message_target import MessageTarget
+from mindroom.response_runner import ResponseRequest, ResponseRunner
 from mindroom.tool_approval import ApprovalActionResult, MatrixApprovalAction, _shutdown_approval_store
 from tests.approval_test_support import FakeApprovalCards
 from tests.bot_helpers import (
@@ -47,6 +48,7 @@ from tests.conftest import (
     install_relation_lookup,
     make_matrix_client_mock,
     replace_reaction_dispatcher_deps,
+    request_envelope,
     runtime_paths_for,
     unwrap_extracted_collaborator,
 )
@@ -178,6 +180,19 @@ async def _dispatch_message(bot: AgentBot, room: nio.MatrixRoom, event: nio.Room
     event.decrypted = False
     await bot._journal_dispatcher.admit_out_of_band(room, event, EventKind.MESSAGE, EventClass.ACTIONABLE)
     await bot._journal_dispatcher.drain_once()
+
+
+def _direct_response_request(target: MessageTarget, prompt: str, source_event_id: str) -> ResponseRequest:
+    return ResponseRequest(
+        prompt=prompt,
+        thread_history=[],
+        user_id="@user:localhost",
+        response_envelope=request_envelope(
+            target=target,
+            reply_to_event_id=source_event_id,
+            prompt=prompt,
+        ),
+    )
 
 
 class TestAgentBot(AgentBotTestBase):
@@ -409,6 +424,8 @@ class TestAgentBot(AgentBotTestBase):
                 assert "$question" in interactive._active_questions
                 assert event.event_id in await bot._journal_dispatcher.unsettled_event_ids()
                 assert not bot._journal_dispatcher.callbacks.source_has_live_owner(event.event_id)
+                target = MessageTarget.resolve(room.room_id, None, "$question")
+                assert not bot._response_runner.has_active_response_for_target(target)
 
                 await bot._journal_dispatcher.drain_once()
                 await bot._response_runner.drain_inbox_responses()
@@ -520,6 +537,134 @@ class TestAgentBot(AgentBotTestBase):
             release_selection.set()
             await bot._response_runner.drain_inbox_responses()
             await bot._journal_dispatcher.stop()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_interactive_preparation_releases_same_thread_reservation(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Cancelling detached preparation must release its early lifecycle reservation."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        preparation_started = asyncio.Event()
+
+        async def prepare_forever() -> None:
+            preparation_started.set()
+            await asyncio.Event().wait()
+
+        await bot._turn_controller.start_interactive_selection(
+            prepare_forever(),
+            room_id="!test:localhost",
+            question_event_id="$question",
+            source_event_id="$reaction",
+            thread_id="$thread-a",
+        )
+        await asyncio.wait_for(preparation_started.wait(), timeout=1.0)
+        target = MessageTarget.resolve("!test:localhost", "$thread-a", "$question")
+        assert bot._response_runner.has_active_response_for_target(target)
+
+        assert await bot._response_runner.drain_inbox_responses(cancel_after_seconds=0.01) is False
+        assert not bot._response_runner.has_active_response_for_target(target)
+
+    @pytest.mark.asyncio
+    async def test_interactive_reaction_reserves_same_thread_lifecycle_before_preparation(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A newer same-thread response must wait behind selection preparation."""
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        room = nio.MatrixRoom("!test:localhost", bot.matrix_id.full_id)
+        reaction = _reaction_event("👍", "$interactive-reaction")
+        selection = interactive.InteractiveSelection(
+            question_event_id="$question",
+            question_text="Choose one",
+            selection_key="👍",
+            selected_label="Selected",
+            selected_value="Selected",
+            thread_id="$thread-a",
+        )
+        target = MessageTarget.resolve(room.room_id, selection.thread_id, "$question")
+        (
+            preparation_started,
+            release_preparation,
+            interactive_entered,
+            release_interactive,
+            newer_lock_attempted,
+            newer_entered,
+        ) = (asyncio.Event() for _ in range(6))
+        lifecycle_lock = unwrap_extracted_collaborator(
+            bot._response_runner,
+        )._lifecycle_coordinator._response_lifecycle_lock(target)
+        acquire_lifecycle_lock = lifecycle_lock.acquire
+
+        async def tracked_acquire() -> bool:
+            current_task = asyncio.current_task()
+            if current_task is not None and current_task.get_name() == "newer-same-thread-response":
+                newer_lock_attempted.set()
+            return await acquire_lifecycle_lock()
+
+        lifecycle_lock.acquire = tracked_acquire  # type: ignore[method-assign]
+
+        async def handle_selection(*_args: object, **_kwargs: object) -> None:
+            preparation_started.set()
+            await release_preparation.wait()
+            await bot._response_runner.generate_response(
+                _direct_response_request(target, "interactive", reaction.event_id),
+            )
+
+        async def generate_locked(
+            _self: ResponseRunner,
+            request: ResponseRequest,
+            *,
+            resolved_target: MessageTarget,
+            early_placeholder_state: object,
+        ) -> str:
+            del resolved_target, early_placeholder_state
+            if request.prompt == "interactive":
+                interactive_entered.set()
+                await release_interactive.wait()
+                return "$interactive-response"
+            newer_entered.set()
+            return "$newer-response"
+
+        replace_reaction_dispatcher_deps(bot, handle_interactive_selection=handle_selection)
+        newer_task: asyncio.Task[str | None] | None = None
+        try:
+            with (
+                patch("mindroom.bot.interactive.handle_reaction", new=AsyncMock(return_value=selection)),
+                patch.object(ResponseRunner, "_generate_response_locked", new=generate_locked),
+            ):
+                await _dispatch_reaction(bot, room, reaction)
+                await asyncio.wait_for(preparation_started.wait(), timeout=1.0)
+
+                newer_target = MessageTarget.resolve(room.room_id, selection.thread_id, "$newer")
+                newer_task = asyncio.create_task(
+                    bot._response_runner.generate_response(
+                        _direct_response_request(newer_target, "newer", "$newer"),
+                    ),
+                    name="newer-same-thread-response",
+                )
+                await asyncio.wait_for(newer_lock_attempted.wait(), timeout=1.0)
+                assert not newer_entered.is_set()
+
+                release_preparation.set()
+                await asyncio.wait_for(interactive_entered.wait(), timeout=1.0)
+                assert not newer_entered.is_set()
+
+                release_interactive.set()
+                await asyncio.wait_for(newer_entered.wait(), timeout=1.0)
+                assert await newer_task == "$newer-response"
+                await bot._response_runner.drain_inbox_responses()
+        finally:
+            release_preparation.set()
+            release_interactive.set()
+            if newer_task is not None:
+                await asyncio.gather(newer_task, return_exceptions=True)
+            await bot._response_runner.drain_inbox_responses()
 
     @pytest.mark.asyncio
     async def test_checkmark_interactive_reaction_reserves_before_tool_approval_lookup(

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -381,6 +381,15 @@ class TestAgentBot(AgentBotTestBase):
         room = MagicMock()
         room.room_id = "!test:localhost"
         event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
+        event.source = {
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": "$question",
+                    "key": "👍",
+                },
+            },
+        }
         interactive._active_questions["$question"] = interactive._InteractiveQuestion(
             room_id=room.room_id,
             thread_id=None,
@@ -389,19 +398,21 @@ class TestAgentBot(AgentBotTestBase):
         )
 
         try:
-            with (
-                patch.object(
-                    bot._turn_controller,
-                    "_execute_interactive_selection",
-                    new=AsyncMock(side_effect=OSError("pending write failed")),
-                ),
-            ):
+            execute = AsyncMock(side_effect=(OSError("pending write failed"), None))
+            with patch.object(bot._turn_controller, "_execute_interactive_selection", new=execute):
                 await _dispatch_reaction(bot, room, event)
 
-            await bot._response_runner.drain_inbox_responses()
-            assert "$question" in interactive._active_questions
-            assert event.event_id in await bot._journal_dispatcher.unsettled_event_ids()
-            assert not bot._journal_dispatcher.callbacks.source_has_live_owner(event.event_id)
+                await bot._response_runner.drain_inbox_responses()
+                assert "$question" in interactive._active_questions
+                assert event.event_id in await bot._journal_dispatcher.unsettled_event_ids()
+                assert not bot._journal_dispatcher.callbacks.source_has_live_owner(event.event_id)
+
+                await bot._journal_dispatcher.drain_once()
+                await bot._response_runner.drain_inbox_responses()
+
+            assert "$question" not in interactive._active_questions
+            assert event.event_id not in await bot._journal_dispatcher.unsettled_event_ids()
+            assert execute.await_count == 2
         finally:
             interactive._cleanup()
 

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -27,7 +27,7 @@ from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.dispatch_callback_outcome import TurnDispatchOutcome
 from mindroom.dispatch_handoff import PreparedIngress
 from mindroom.dispatch_source import MESSAGE_SOURCE_KIND
-from mindroom.event_journal import EventClass, EventKind, SemanticConsumer
+from mindroom.event_journal import DepartureSource, EventClass, EventKind, SemanticConsumer
 from mindroom.handled_turns import TurnRecord, with_user_stop
 from mindroom.hooks import (
     EVENT_REACTION_RECEIVED,
@@ -489,6 +489,53 @@ class TestAgentBot(AgentBotTestBase):
             assert not bot._journal_dispatcher.callbacks.source_has_live_owner(event.event_id)
             target = MessageTarget.resolve(room.room_id, "$thread-a", "$question")
             assert not bot._response_runner.has_active_response_for_target(target)
+        finally:
+            interactive._cleanup()
+
+    @pytest.mark.asyncio
+    async def test_departure_winning_interactive_claim_race_discards_selection(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A selection from an ended membership cannot start or remain active."""
+        interactive._cleanup()
+        config = self._config_for_storage(tmp_path)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+        room = MagicMock(room_id="!test:localhost")
+        event = self._make_handler_event("reaction", sender="@user:localhost", event_id="$reaction")
+        event.source = {
+            "content": {
+                "m.relates_to": {
+                    "rel_type": "m.annotation",
+                    "event_id": "$question",
+                    "key": "👍",
+                },
+            },
+        }
+        interactive._active_questions["$question"] = interactive._InteractiveQuestion(
+            room_id=room.room_id,
+            thread_id=None,
+            options={"👍": "approve"},
+            creator_agent=bot.agent_name,
+        )
+        execute = AsyncMock()
+        replace_reaction_dispatcher_deps(bot, handle_interactive_selection=execute)
+        dispatcher = unwrap_extracted_collaborator(bot._journal_dispatcher)
+        original_claim = dispatcher.claim_semantic_consumer
+
+        async def claim_after_departure(consumer: SemanticConsumer) -> bool:
+            await bot._journal_principal().fence_departure(room.room_id, source=DepartureSource.LOCAL)
+            return await original_claim(consumer)
+
+        try:
+            with patch.object(dispatcher, "claim_semantic_consumer", side_effect=claim_after_departure):
+                await _dispatch_reaction(bot, room, event)
+
+            assert "$question" not in interactive._active_questions
+            execute.assert_not_awaited()
+            assert event.event_id not in await bot._journal_dispatcher.unsettled_event_ids()
         finally:
             interactive._cleanup()
 

--- a/tests/test_dispatch_source.py
+++ b/tests/test_dispatch_source.py
@@ -14,6 +14,7 @@ from mindroom.dispatch_source import (
     HOOK_DISPATCH_SOURCE_KIND,
     HOOK_SOURCE_KIND,
     IMAGE_SOURCE_KIND,
+    INTERACTIVE_SELECTION_SOURCE_KIND,
     MEDIA_SOURCE_KIND,
     MESSAGE_SOURCE_KIND,
     SCHEDULED_SOURCE_KIND,
@@ -51,6 +52,7 @@ def test_scheduled_history_limit_from_content(content: dict[str, object], expect
         HOOK_SOURCE_KIND,
         HOOK_DISPATCH_SOURCE_KIND,
         SCHEDULED_SOURCE_KIND,
+        INTERACTIVE_SELECTION_SOURCE_KIND,
         TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
     ],
 )

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -3906,6 +3906,7 @@ async def test_on_reaction_tracks_response_event_id(tmp_path: Path) -> None:
 
         # Process the reaction event
         await dispatch_reaction_durably(bot, room, reaction_event)
+        await bot._response_runner.drain_inbox_responses()
 
         # Verify that the bot tracked the response correctly
         assert bot._turn_store.is_handled("$question:example.com")
@@ -4006,6 +4007,7 @@ async def test_on_reaction_leaves_question_retryable_when_ack_response_is_suppre
         # The worker records the failure and leaves the event pending rather
         # than propagating it, so the question stays retryable.
         await dispatch_reaction_durably(bot, room, reaction_event)
+        await bot._response_runner.drain_inbox_responses()
 
         assert await bot._journal_dispatcher.store.is_pending(reaction_event.event_id)
         assert bot._turn_store.is_handled("$question:example.com") is False
@@ -4241,6 +4243,7 @@ async def test_on_reaction_respects_agent_reply_permissions(tmp_path: Path) -> N
         mock_generate_response.assert_not_called()
 
         await dispatch_reaction_durably(bot, room, allowed_reaction)
+        await bot._response_runner.drain_inbox_responses()
 
     interactive._active_questions.clear()
 

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -1581,6 +1581,50 @@ class TestDeliveryIsScopedToTheMembershipThatAuthorizedIt:
 
         assert not await alice.turn_membership_is_current(turn_id="$turn", room_id=ROOM)
 
+    async def test_stale_turn_cannot_register_after_rejoin(self, alice: PrincipalStore) -> None:
+        """A post-delivery side effect must retain the membership that authorized its turn."""
+        await admit(alice, "$turn")
+        registered: list[str] = []
+
+        assert await alice.run_if_turn_membership_current(
+            turn_id="$turn",
+            room_id=ROOM,
+            operation=lambda: registered.append("current"),
+        )
+
+        await alice.fence_departure(ROOM, source=DepartureSource.LOCAL)
+        await alice.note_membership_restarted(ROOM)
+
+        assert not await alice.run_if_turn_membership_current(
+            turn_id="$turn",
+            room_id=ROOM,
+            fallback_membership_epoch=await alice.membership_epoch(ROOM),
+            operation=lambda: registered.append("stale"),
+        )
+        assert registered == ["current"]
+
+    async def test_stale_epoch_cannot_register_after_rejoin(self, alice: PrincipalStore) -> None:
+        """Direct Matrix tools retain the target-room epoch captured before transport."""
+        expected_epoch = await alice.membership_epoch(ROOM)
+        await alice.fence_departure(ROOM, source=DepartureSource.LOCAL)
+        await alice.note_membership_restarted(ROOM)
+        registered: list[str] = []
+
+        accepted = await alice.run_if_membership_epoch(
+            room_id=ROOM,
+            expected_membership_epoch=expected_epoch,
+            operation=lambda: registered.append("stale"),
+        )
+
+        assert not accepted
+        assert not await alice.run_if_turn_membership_current(
+            turn_id="$synthetic-turn",
+            room_id=ROOM,
+            fallback_membership_epoch=expected_epoch,
+            operation=lambda: registered.append("stale synthetic"),
+        )
+        assert registered == []
+
     async def test_one_rooms_fence_does_not_silence_another_room(self, alice: PrincipalStore) -> None:
         """Leaving one room says nothing about a turn running in a different one."""
         await admit(alice, "$turn")
@@ -2525,6 +2569,69 @@ class TestDepartureCleanupAndRejoinAreCrossProcessOrdered:
             await asyncio.gather(cleanup, return_exceptions=True)
 
         assert operation_order == ["departure cleanup", "rejoin cleanup"]
+
+
+class TestInteractiveRegistrationAndDepartureAreCrossProcessOrdered:
+    """Question registration and departure share one PostgreSQL membership-row lock."""
+
+    async def test_departure_waits_for_a_current_turn_registration(
+        self,
+        rival_stores: RivalStores,
+    ) -> None:
+        """A registration that wins the row claim is subsequently removed by the fence."""
+        principal_id = "agent@alice"
+        first = rival_stores.first.principal(principal_id)
+        second = rival_stores.second.principal(principal_id)
+        await admit(first, "$turn")
+        registration_claimed = threading.Event()
+        release_registration = threading.Event()
+        operation_order: list[str] = []
+
+        def pause_after_claim() -> None:
+            registration_claimed.set()
+            assert release_registration.wait(_WORKER_WAIT_SECONDS), "the registration was never released"
+
+        registering = EventJournalStore(
+            backend=_PausingBackend(
+                rival_stores.first.backend,
+                pause_after_claim,
+                statement_matches=lambda sql: "INSERT INTO room_membership" in sql,
+            ),
+        ).principal(principal_id)
+        registration = asyncio.create_task(
+            registering.run_if_turn_membership_current(
+                turn_id="$turn",
+                room_id=ROOM,
+                operation=lambda: operation_order.append("registration"),
+            ),
+        )
+        try:
+            await asyncio.to_thread(registration_claimed.wait, _WORKER_WAIT_SECONDS)
+            assert registration_claimed.is_set(), "the registration never claimed the membership row"
+
+            async def fence_and_cleanup() -> None:
+                await second.fence_departure(ROOM, source=DepartureSource.REPORTED)
+                await second.cleanup_fenced_departure(
+                    ROOM,
+                    lambda: operation_order.append("departure cleanup"),
+                )
+
+            departure = asyncio.create_task(fence_and_cleanup())
+            await _await_queued_racers(
+                rival_stores.database_url,
+                application_name=rival_stores.racer_application_name,
+                expected=1,
+            )
+            assert not departure.done()
+
+            release_registration.set()
+            accepted, _ = await asyncio.gather(registration, departure)
+        finally:
+            release_registration.set()
+            await asyncio.gather(registration, return_exceptions=True)
+
+        assert accepted
+        assert operation_order == ["registration", "departure cleanup"]
 
 
 class TestAFenceCannotBeSteppedOverByAConcurrentWalk:

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -44,6 +44,7 @@ from mindroom.event_journal import (
     HistoryRecoveryOutcome,
     InboundEvent,
     ProjectedEvent,
+    SemanticConsumer,
     TerminalTurnWrite,
     delivery_transaction_id,
 )
@@ -1447,6 +1448,36 @@ class TestDeliveryIsScopedToTheMembershipThatAuthorizedIt:
 
         assert transaction_id is None
         assert await alice.load_delivery(turn_id="$turn", stage=DeliveryStage.FINAL) is None
+
+    async def test_departure_retires_claimed_interactive_reactions_but_keeps_hooks(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """Only reactions that would start an answer become stale at departure."""
+        await admit(alice, "$interactive", kind=EventKind.REACTION)
+        await admit(alice, "$hook", kind=EventKind.REACTION)
+        await alice.claim_semantic_consumer("$interactive", SemanticConsumer.INTERACTIVE_REACTION)
+        await alice.claim_semantic_consumer("$hook", SemanticConsumer.REACTION_HOOKS)
+
+        await alice.fence_departure(ROOM, source=DepartureSource.LOCAL)
+
+        assert [event.event_id for event in await alice.pending()] == ["$hook"]
+
+    async def test_interactive_claim_after_departure_retires_the_stale_reaction(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """A departure that wins the race prevents a later model-backed claim."""
+        await admit(alice, "$interactive", kind=EventKind.REACTION)
+        await alice.fence_departure(ROOM, source=DepartureSource.LOCAL)
+
+        claimed = await alice.claim_semantic_consumer(
+            "$interactive",
+            SemanticConsumer.INTERACTIVE_REACTION,
+        )
+
+        assert claimed is None
+        assert await alice.pending() == ()
 
     async def test_an_unattempted_row_enqueued_before_the_fence_is_deleted_by_it(
         self,

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -2475,6 +2475,58 @@ def _watch_until_queued_or_finished(
             time.sleep(_QUEUE_POLL_SECONDS)
 
 
+class TestDepartureCleanupAndRejoinAreCrossProcessOrdered:
+    """Departure cleanup and rejoin share one PostgreSQL membership-row lock."""
+
+    async def test_rejoin_waits_for_departure_cleanup_claim(
+        self,
+        rival_stores: RivalStores,
+    ) -> None:
+        """A second store cannot rearm a room while old-state cleanup owns it."""
+        principal_id = "agent@alice"
+        first = rival_stores.first.principal(principal_id)
+        second = rival_stores.second.principal(principal_id)
+        await first.fence_departure(ROOM, source=DepartureSource.REPORTED)
+        cleanup_claimed = threading.Event()
+        release_cleanup = threading.Event()
+        operation_order: list[str] = []
+
+        def pause_after_claim() -> None:
+            cleanup_claimed.set()
+            assert release_cleanup.wait(_WORKER_WAIT_SECONDS), "the departure cleanup was never released"
+
+        cleaning = EventJournalStore(
+            backend=_PausingBackend(
+                rival_stores.first.backend,
+                pause_after_claim,
+                statement_matches=lambda sql: "UPDATE room_membership SET departure_fenced" in sql,
+            ),
+        ).principal(principal_id)
+        cleanup = asyncio.create_task(
+            cleaning.cleanup_fenced_departure(ROOM, lambda: operation_order.append("departure cleanup")),
+        )
+        try:
+            await asyncio.to_thread(cleanup_claimed.wait, _WORKER_WAIT_SECONDS)
+            assert cleanup_claimed.is_set(), "the departure cleanup never claimed the membership row"
+            rejoin = asyncio.create_task(
+                second.note_membership_restarted(ROOM, cleanup=lambda: operation_order.append("rejoin cleanup")),
+            )
+            await _await_queued_racers(
+                rival_stores.database_url,
+                application_name=rival_stores.racer_application_name,
+                expected=1,
+            )
+            assert not rejoin.done()
+
+            release_cleanup.set()
+            await asyncio.gather(cleanup, rejoin)
+        finally:
+            release_cleanup.set()
+            await asyncio.gather(cleanup, return_exceptions=True)
+
+        assert operation_order == ["departure cleanup", "rejoin cleanup"]
+
+
 class TestAFenceCannotBeSteppedOverByAConcurrentWalk:
     """What a hydrating writer and a fencing writer do to one PostgreSQL database.
 

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -1625,6 +1625,30 @@ class TestDeliveryIsScopedToTheMembershipThatAuthorizedIt:
         )
         assert registered == []
 
+    async def test_current_epoch_cannot_register_until_membership_restarts(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """A departed room's advanced epoch is not an active membership."""
+        await alice.fence_departure(ROOM, source=DepartureSource.LOCAL)
+        fenced_epoch = await alice.membership_epoch(ROOM)
+        registered: list[str] = []
+
+        assert not await alice.run_if_membership_epoch(
+            room_id=ROOM,
+            expected_membership_epoch=fenced_epoch,
+            operation=lambda: registered.append("departed"),
+        )
+
+        await alice.note_membership_restarted(ROOM)
+
+        assert await alice.run_if_membership_epoch(
+            room_id=ROOM,
+            expected_membership_epoch=fenced_epoch,
+            operation=lambda: registered.append("rejoined"),
+        )
+        assert registered == ["rejoined"]
+
     async def test_one_rooms_fence_does_not_silence_another_room(self, alice: PrincipalStore) -> None:
         """Leaving one room says nothing about a turn running in a different one."""
         await admit(alice, "$turn")
@@ -1781,6 +1805,7 @@ class TestMembershipEpoch:
         )
 
         await alice.fence_departure(ROOM, source=DepartureSource.LOCAL)
+        await alice.note_membership_restarted(ROOM)
         await alice.install_hydrated_conversation(
             room_id=ROOM,
             thread_id=None,

--- a/tests/test_ingress_lanes.py
+++ b/tests/test_ingress_lanes.py
@@ -1010,7 +1010,7 @@ async def test_interactive_answer_during_active_turn_never_holds_sender_lane(tmp
                 await answer_task
         with interactive._thread_lock:
             interactive._remove_active_question_locked("$question")
-            interactive._claimed_question_ids.discard("$question")
+            interactive._claimed_questions.pop("$question", None)
 
 
 @pytest.mark.asyncio

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -35,7 +35,7 @@ class TestInteractiveFunctions:
         interactive._active_questions.clear()
         interactive._dirty_question_ids.clear()
         interactive._deleted_question_ids.clear()
-        interactive._claimed_question_ids.clear()
+        interactive._claimed_questions.clear()
         interactive._persistence_file = None
         interactive._persistence_lock_file = None
         runtime_paths = test_runtime_paths(Path(tempfile.mkdtemp()))
@@ -61,7 +61,7 @@ class TestInteractiveFunctions:
         interactive._active_questions.clear()
         interactive._dirty_question_ids.clear()
         interactive._deleted_question_ids.clear()
-        interactive._claimed_question_ids.clear()
+        interactive._claimed_questions.clear()
         interactive._persistence_file = None
         interactive._persistence_lock_file = None
 
@@ -1360,6 +1360,125 @@ Just let me know your preference!"""
         interactive._cleanup()
         interactive.init_persistence(tmp_path)
 
+        assert interactive._active_questions == {}
+
+    @pytest.mark.asyncio
+    async def test_clear_departed_agent_questions_consumes_active_and_claimed_state(
+        self,
+        mock_client: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """A departure consumes only that agent's questions, including an in-flight claim."""
+        interactive.init_persistence(tmp_path)
+        target_room = "!departed:localhost"
+        questions = {
+            "$active": (target_room, "test_agent"),
+            "$claimed": (target_room, "test_agent"),
+            "$other-agent": (target_room, "other_agent"),
+            "$other-room": ("!other:localhost", "test_agent"),
+        }
+        for event_id, (room_id, agent_name) in questions.items():
+            interactive.register_interactive_question(
+                event_id,
+                room_id,
+                None,
+                {"✅": "yes"},
+                agent_name,
+            )
+
+        event = MagicMock(spec=nio.ReactionEvent)
+        event.sender = "@user:localhost"
+        event.reacts_to = "$claimed"
+        event.key = "✅"
+        selection = await interactive.handle_reaction(
+            mock_client,
+            event,
+            "test_agent",
+            self.config,
+            runtime_paths_for(self.config),
+        )
+        assert selection is not None
+
+        interactive.clear_interactive_questions_for_room(target_room, "test_agent")
+        interactive.restore_selection(selection)
+
+        assert set(interactive._active_questions) == {"$other-agent", "$other-room"}
+
+        interactive._cleanup()
+        interactive.init_persistence(tmp_path)
+
+        assert set(interactive._active_questions) == {"$other-agent", "$other-room"}
+
+    def test_clear_departed_agent_questions_retries_failed_persistence(self, tmp_path: Path) -> None:
+        """A failed active-question deletion remains flushable on join retry."""
+        interactive.init_persistence(tmp_path)
+        persistence_file = tmp_path / "tracking" / "interactive_questions.json"
+        interactive.register_interactive_question(
+            "$question",
+            "!departed:localhost",
+            None,
+            {"✅": "yes"},
+            "test_agent",
+        )
+        original_write = interactive._write_active_questions_atomically_locked
+
+        with patch(
+            "mindroom.interactive._write_active_questions_atomically_locked",
+            side_effect=(OSError("disk unavailable"), None),
+        ) as write:
+            with pytest.raises(OSError, match="disk unavailable"):
+                interactive.clear_interactive_questions_for_room("!departed:localhost", "test_agent")
+            write.side_effect = original_write
+            interactive.clear_interactive_questions_for_room("!departed:localhost", "test_agent")
+
+        interactive._cleanup()
+        interactive.init_persistence(tmp_path)
+
+        assert json.loads(persistence_file.read_text()) == {}
+        assert interactive._active_questions == {}
+
+    @pytest.mark.asyncio
+    async def test_failed_commit_keeps_claim_recoverable(
+        self,
+        mock_client: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """A failed durable consume leaves its claim available for departure cleanup."""
+        interactive.init_persistence(tmp_path)
+        interactive.register_interactive_question(
+            "$question",
+            "!departed:localhost",
+            None,
+            {"✅": "yes"},
+            "test_agent",
+        )
+        event = MagicMock(spec=nio.ReactionEvent)
+        event.sender = "@user:localhost"
+        event.reacts_to = "$question"
+        event.key = "✅"
+        selection = await interactive.handle_reaction(
+            mock_client,
+            event,
+            "test_agent",
+            self.config,
+            runtime_paths_for(self.config),
+        )
+        assert selection is not None
+
+        with (
+            patch(
+                "mindroom.interactive._write_active_questions_atomically_locked",
+                side_effect=OSError("disk unavailable"),
+            ),
+            pytest.raises(OSError, match="disk unavailable"),
+        ):
+            interactive.commit_selection(selection)
+
+        assert "$question" in interactive._claimed_questions
+        interactive.clear_interactive_questions_for_room("!departed:localhost", "test_agent")
+
+        interactive._cleanup()
+        interactive.init_persistence(tmp_path)
         assert interactive._active_questions == {}
 
     @pytest.mark.asyncio

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -1437,6 +1437,74 @@ Just let me know your preference!"""
         assert json.loads(persistence_file.read_text()) == {}
         assert interactive._active_questions == {}
 
+    def test_clear_departed_agent_questions_uses_one_exclusive_file_lock(self, tmp_path: Path) -> None:
+        """The persisted snapshot must stay locked from its read through filtering and replacement."""
+        interactive.init_persistence(tmp_path)
+        interactive.register_interactive_question(
+            "$question",
+            "!departed:localhost",
+            None,
+            {"✅": "yes"},
+            "test_agent",
+        )
+
+        with patch(
+            "mindroom.interactive.advisory_file_lock",
+            wraps=interactive.advisory_file_lock,
+        ) as persistence_lock:
+            interactive.clear_interactive_questions_for_room("!departed:localhost", "test_agent")
+
+        assert persistence_lock.call_count == 1
+        assert persistence_lock.call_args.kwargs.get("exclusive", True)
+
+    @pytest.mark.asyncio
+    async def test_restore_does_not_resurrect_a_question_another_process_removed(
+        self,
+        mock_client: AsyncMock,
+        tmp_path: Path,
+    ) -> None:
+        """A durable external deletion wins over one process's in-flight claim."""
+        interactive.init_persistence(tmp_path)
+        persistence_file = tmp_path / "tracking" / "interactive_questions.json"
+        interactive.register_interactive_question(
+            "$claimed",
+            "!departed:localhost",
+            None,
+            {"✅": "yes"},
+            "test_agent",
+        )
+        event = MagicMock(spec=nio.ReactionEvent)
+        event.sender = "@user:localhost"
+        event.reacts_to = "$claimed"
+        event.key = "✅"
+        selection = await interactive.handle_reaction(
+            mock_client,
+            event,
+            "test_agent",
+            self.config,
+            runtime_paths_for(self.config),
+        )
+        assert selection is not None
+
+        assert interactive._persistence_lock_file is not None
+        with interactive.advisory_file_lock(interactive._persistence_lock_file):
+            interactive._write_active_questions_atomically_locked({})
+
+        interactive.restore_selection(selection)
+        interactive.register_interactive_question(
+            "$current",
+            "!current:localhost",
+            None,
+            {"✅": "yes"},
+            "test_agent",
+        )
+
+        interactive._cleanup()
+        interactive.init_persistence(tmp_path)
+
+        assert set(json.loads(persistence_file.read_text())) == {"$current"}
+        assert set(interactive._active_questions) == {"$current"}
+
     @pytest.mark.asyncio
     async def test_failed_commit_keeps_claim_recoverable(
         self,

--- a/tests/test_journal_ingress.py
+++ b/tests/test_journal_ingress.py
@@ -21,6 +21,7 @@ from mindroom.constants import (
     STREAM_STATUS_STREAMING,
 )
 from mindroom.dispatch_callback_outcome import TurnDispatchOutcome
+from mindroom.dispatch_recovery_context import turn_dispatch_recovery_active
 from mindroom.event_journal import (
     DepartureSource,
     EventClass,
@@ -1930,6 +1931,28 @@ class TestDeferralOwnership:
         message = await self._admitted(alice, text_event("$m"), EventKind.MESSAGE)
 
         assert dispatcher._deferral_is_live(message) is True
+
+    async def test_interactive_reaction_replay_waits_for_fleet_recovery(self, alice: PrincipalStore) -> None:
+        """A claimed selection needs the same startup boundary as the turn it resumes."""
+        recovered: list[bool] = []
+
+        async def on_reaction(_room: nio.MatrixRoom, _event: nio.Event) -> TurnDispatchOutcome:
+            recovered.append(turn_dispatch_recovery_active())
+            return TurnDispatchOutcome.INTENTIONALLY_IGNORED
+
+        dispatcher = self._dispatcher(alice)
+        dispatcher.callbacks = replace(dispatcher.callbacks, on_reaction=on_reaction)
+        await self._admitted(alice, reaction_event("$r"), EventKind.REACTION)
+        await alice.claim_semantic_consumer("$r", SemanticConsumer.INTERACTIVE_REACTION)
+        reaction = await alice.load_event("$r")
+        assert reaction is not None
+
+        assert await dispatcher._run_event(reaction) is False
+        assert recovered == []
+
+        dispatcher.release_turn_replay()
+        assert await dispatcher._run_event(reaction) is True
+        assert recovered == [True]
 
     async def test_a_source_the_coalescing_gate_still_holds_is_owned(self, alice: PrincipalStore) -> None:
         """A batch still debouncing has no turn claim yet, and is not abandoned."""

--- a/tests/test_journal_membership_fence.py
+++ b/tests/test_journal_membership_fence.py
@@ -161,6 +161,11 @@ async def test_join_retries_departure_cleanup_before_rearming_the_fence(
         await membership.fence_local_departure(ROOM)
 
     assert await principal.membership_epoch(ROOM) == 1
+    assert not await principal.run_if_membership_epoch(
+        room_id=ROOM,
+        expected_membership_epoch=0,
+        operation=lambda: calls.append("stale registration"),
+    )
 
     await membership.note_membership_restarted(ROOM)
 

--- a/tests/test_journal_membership_fence.py
+++ b/tests/test_journal_membership_fence.py
@@ -24,6 +24,8 @@ from mindroom.event_journal import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from mindroom.event_journal import EventJournalStore, PrincipalStore
 
 pytestmark = pytest.mark.asyncio
@@ -63,9 +65,18 @@ class RecordingStore:
             self.advanced.append(room_id)
         return outcome
 
-    async def note_membership_restarted(self, room_id: str) -> None:
+    async def cleanup_fenced_departure(self, room_id: str, cleanup: Callable[[], None]) -> None:
+        """Clean external state only while one room remains durably departed."""
+        await self.principal.cleanup_fenced_departure(room_id, cleanup)
+
+    async def note_membership_restarted(
+        self,
+        room_id: str,
+        *,
+        cleanup: Callable[[], None] | None = None,
+    ) -> None:
         """Record a confirmed join."""
-        await self.principal.note_membership_restarted(room_id)
+        await self.principal.note_membership_restarted(room_id, cleanup=cleanup)
 
     async def retire_owed_departure_reports(self, room_id: str) -> None:
         """Forget reports that can no longer arrive."""
@@ -129,6 +140,115 @@ async def test_a_sync_reported_departure_fences(
 
     assert store.advanced == [ROOM]
     assert await principal.membership_epoch(ROOM) == 1
+
+
+async def test_join_retries_departure_cleanup_before_rearming_the_fence(
+    store: RecordingStore,
+    principal: PrincipalStore,
+) -> None:
+    """A failed post-commit cleanup is retried before the room becomes active."""
+    calls: list[str] = []
+
+    def cleanup(room_id: str) -> None:
+        calls.append(room_id)
+        if len(calls) == 1:
+            error_message = "question persistence failed"
+            raise OSError(error_message)
+
+    membership = MembershipFence(store=store, clear_departed_room=cleanup)
+
+    with pytest.raises(OSError, match="question persistence failed"):
+        await membership.fence_local_departure(ROOM)
+
+    assert await principal.membership_epoch(ROOM) == 1
+
+    await membership.note_membership_restarted(ROOM)
+
+    assert calls == [ROOM, ROOM]
+    assert await principal.membership_epoch(ROOM) == 1
+
+
+async def test_restart_join_closes_the_post_fence_cleanup_gap(
+    store: RecordingStore,
+    principal: PrincipalStore,
+) -> None:
+    """A join retries cleanup when a process exited just after the fence committed."""
+    await principal.fence_departure(ROOM, source=DepartureSource.REPORTED)
+    calls: list[str] = []
+    restarted = MembershipFence(store=store, clear_departed_room=calls.append)
+
+    await restarted.note_membership_restarted(ROOM)
+
+    assert calls == [ROOM]
+    assert (await principal.fence_departure(ROOM, source=DepartureSource.REPORTED)).fenced
+
+
+async def test_departure_cleanup_runs_only_for_the_fencing_observation(
+    store: RecordingStore,
+) -> None:
+    """A replayed departure report cannot clear state from a later membership."""
+    calls: list[str] = []
+    membership = MembershipFence(store=store, clear_departed_room=calls.append)
+
+    await membership.fence_local_departure(ROOM)
+    await membership.fence_reported_departures([ROOM])
+
+    assert calls == [ROOM]
+
+
+async def test_departure_cleanup_rechecks_the_fence_after_a_concurrent_rejoin(
+    store: RecordingStore,
+) -> None:
+    """A delayed old-departure cleanup cannot erase new-membership state."""
+    calls: list[str] = []
+    membership = MembershipFence(store=store, clear_departed_room=calls.append)
+    cleanup_entered = asyncio.Event()
+    release_cleanup = asyncio.Event()
+    original_cleanup = store.cleanup_fenced_departure
+
+    async def delayed_cleanup(room_id: str, cleanup: Callable[[], None]) -> None:
+        cleanup_entered.set()
+        await release_cleanup.wait()
+        await original_cleanup(room_id, cleanup)
+
+    store.cleanup_fenced_departure = delayed_cleanup  # type: ignore[method-assign]
+    departure = asyncio.create_task(membership.fence_reported_departures([ROOM]))
+    await cleanup_entered.wait()
+
+    await membership.note_membership_restarted(ROOM)
+    calls.clear()
+    calls.append("new-membership-question")
+    release_cleanup.set()
+    await departure
+
+    assert calls == ["new-membership-question"]
+
+
+async def test_delayed_leave_report_does_not_clean_the_rejoined_membership(
+    store: RecordingStore,
+) -> None:
+    """The owed report for an old local leave cannot clean new-membership state."""
+    calls: list[str] = []
+    membership = MembershipFence(store=store, clear_departed_room=calls.append)
+
+    await membership.fence_local_departure(ROOM)
+    await membership.note_membership_restarted(ROOM)
+    calls.clear()
+    await membership.fence_reported_departures([ROOM])
+
+    assert calls == []
+
+
+async def test_ordinary_join_does_not_clear_live_interactive_state(
+    store: RecordingStore,
+) -> None:
+    """A join with no recovery fence leaves current-membership questions alone."""
+    calls: list[str] = []
+    membership = MembershipFence(store=store, clear_departed_room=calls.append)
+
+    await membership.note_membership_restarted(ROOM)
+
+    assert calls == []
 
 
 async def test_the_echo_of_a_local_departure_does_not_fence_again(

--- a/tests/test_matrix_message_tool.py
+++ b/tests/test_matrix_message_tool.py
@@ -90,6 +90,8 @@ def _make_context(
     storage_path: Path | None = None,
     attachment_ids: tuple[str, ...] = (),
     agent_thread_mode: str = "thread",
+    membership: object | None = None,
+    membership_turn_id: str | None = None,
 ) -> ToolRuntimeContext:
     runtime_root = storage_path or Path(tempfile.mkdtemp())
     config = bind_runtime_paths(
@@ -134,6 +136,8 @@ def _make_context(
         room=None,
         storage_path=storage_path,
         attachment_ids=attachment_ids,
+        membership=membership,
+        membership_turn_id=membership_turn_id,
     )
 
 
@@ -621,6 +625,98 @@ async def test_matrix_message_send_interactive_block_registers_question_and_adds
             {"emoji": "❌", "label": "Reject", "value": "reject"},
         ],
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ["send", "edit"])
+@pytest.mark.parametrize("guard", ["source turn", "target epoch"])
+async def test_matrix_message_does_not_register_interactive_state_after_membership_changes(
+    action: str,
+    guard: str,
+) -> None:
+    """Direct sends and edits retain the membership that authorized transport."""
+    tool = MatrixMessageTools()
+    operation_order: list[str] = []
+
+    async def membership_epoch(_room_id: str) -> int:
+        operation_order.append("epoch")
+        return 7
+
+    async def reject_turn_registration(**_kwargs: object) -> bool:
+        operation_order.append("turn guard")
+        return False
+
+    async def reject_epoch_registration(**_kwargs: object) -> bool:
+        operation_order.append("epoch guard")
+        return False
+
+    delivered = delivered_matrix_side_effect("$delivered")
+
+    async def transport(*args: object, **kwargs: object) -> DeliveredMatrixEvent:
+        operation_order.append("transport")
+        return await delivered(*args, **kwargs)
+
+    membership = MagicMock()
+    membership.membership_epoch = AsyncMock(side_effect=membership_epoch)
+    membership.run_if_turn_membership_current = AsyncMock(side_effect=reject_turn_registration)
+    membership.run_if_membership_epoch = AsyncMock(side_effect=reject_epoch_registration)
+    ctx = _make_context(
+        thread_id="$ctx-thread:localhost",
+        membership=membership,
+        membership_turn_id="$source" if guard == "source turn" else None,
+    )
+    serve_conversation_reader(
+        ctx.conversation_reader,
+        [make_visible_message(event_id="$latest", timestamp=1, sender="@alice:localhost", body="latest")],
+    )
+    interactive_message = """Please choose.
+
+```interactive
+{"question":"Pick","options":[{"emoji":"✅","label":"Yes","value":"yes"}]}
+```"""
+
+    with (
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.send_message_result",
+            new=AsyncMock(side_effect=transport),
+        ),
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.edit_message_result",
+            new=AsyncMock(side_effect=transport),
+        ),
+        patch("mindroom.custom_tools.matrix_conversation_operations.register_interactive_question") as register,
+        patch(
+            "mindroom.custom_tools.matrix_conversation_operations.add_reaction_buttons",
+            new_callable=AsyncMock,
+        ) as add_reactions,
+        tool_runtime_context(ctx),
+    ):
+        payload = json.loads(
+            await tool.matrix_message(
+                action=action,
+                message=interactive_message,
+                target="$target" if action == "edit" else None,
+            ),
+        )
+
+    assert payload["status"] == "ok"
+    register.assert_not_called()
+    add_reactions.assert_not_awaited()
+    if guard == "source turn":
+        membership.membership_epoch.assert_awaited_once_with(ctx.room_id)
+        membership.run_if_turn_membership_current.assert_awaited_once_with(
+            turn_id="$source",
+            room_id=ctx.room_id,
+            fallback_membership_epoch=7,
+            operation=ANY,
+        )
+        membership.run_if_membership_epoch.assert_not_awaited()
+        assert operation_order == ["epoch", "transport", "turn guard"]
+    else:
+        membership.membership_epoch.assert_awaited_once_with(ctx.room_id)
+        membership.run_if_turn_membership_current.assert_not_awaited()
+        membership.run_if_membership_epoch.assert_awaited_once()
+        assert operation_order == ["epoch", "transport", "epoch guard"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_queued_message_notify.py
+++ b/tests/test_queued_message_notify.py
@@ -849,10 +849,12 @@ async def test_post_response_effects_queues_summary_with_stale_hint_inside_margi
         runtime_paths=runtime_paths,
         delivery_gateway=MagicMock(),
         conversation_reader=conversation_reader,
+        membership=MagicMock(),
     )
     deps = support.build_deps(
         room_id="!room:localhost",
         interactive_agent_name="general",
+        membership_turn_id="$source",
     )
     thread_history = [
         ResolvedVisibleMessage.synthetic(
@@ -953,10 +955,12 @@ async def test_post_response_effects_queues_summary_with_entity_model_for_adhoc_
         runtime_paths=runtime_paths,
         delivery_gateway=MagicMock(),
         conversation_reader=conversation_reader,
+        membership=MagicMock(),
     )
     deps = support.build_deps(
         room_id="!adhoc:localhost",
         interactive_agent_name="general",
+        membership_turn_id="$source",
     )
     thread_history = [
         ResolvedVisibleMessage.synthetic(

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1450,6 +1450,29 @@ async def test_queued_response_lifecycle_reservation_cancellation_does_not_leak_
 
 
 @pytest.mark.asyncio
+async def test_response_lifecycle_reservation_surfaces_lock_acquire_failure() -> None:
+    """A failed acquire task must wake reservation startup and remain observable."""
+    coordinator = ResponseLifecycleCoordinator()
+    envelope = _queued_envelope("$interactive")
+    lifecycle_lock = coordinator._response_lifecycle_lock(envelope.target)
+
+    async def fail_acquire() -> bool:
+        msg = "lock acquire failed"
+        raise RuntimeError(msg)
+
+    lifecycle_lock.acquire = fail_acquire  # type: ignore[method-assign]
+    reservation = await asyncio.wait_for(
+        coordinator.reserve_response_lifecycle(envelope),
+        timeout=0.1,
+    )
+    try:
+        with pytest.raises(RuntimeError, match="lock acquire failed"):
+            await reservation.wait_until_acquired()
+    finally:
+        await reservation.release()
+
+
+@pytest.mark.asyncio
 async def test_response_lifecycle_reservation_rejects_wrong_target_and_coordinator() -> None:
     """A reservation can only enter its creating coordinator and lifecycle key."""
     coordinator = ResponseLifecycleCoordinator()

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -33,10 +33,10 @@ from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client import DeliveredMatrixEvent
 from mindroom.matrix.thread_history_result import ThreadHistoryResult
-from mindroom.message_target import ResponseLifecycleKey
+from mindroom.message_target import MessageTarget, ResponseLifecycleKey
 from mindroom.post_response_effects import PostResponseEffectsDeps, ResponseOutcome, apply_post_response_effects
 from mindroom.response_attempt import ResponseAttemptDeps, ResponseAttemptRequest, ResponseAttemptRunner
-from mindroom.response_lifecycle import ResponseLifecycleCoordinator
+from mindroom.response_lifecycle import ResponseLifecycleCoordinator, response_lifecycle_reservation_context
 from mindroom.response_payload_preparation import (
     DispatchPayloadInputs,
     ResponsePayloadPreparation,
@@ -84,7 +84,6 @@ if TYPE_CHECKING:
     from nio import AsyncClient
 
     from mindroom.hooks import MessageEnvelope
-    from mindroom.message_target import MessageTarget
 
 
 def _preparation(target: MessageTarget, envelope: MessageEnvelope) -> ResponsePayloadPreparation:
@@ -1345,6 +1344,76 @@ def test_reserve_waiting_human_message_requires_active_turn() -> None:
     envelope = _queued_envelope("$first")
 
     assert coordinator.reserve_waiting_human_message(target=envelope.target, response_envelope=envelope) is None
+
+
+@pytest.mark.asyncio
+async def test_response_lifecycle_reservation_is_not_its_own_queued_human_turn() -> None:
+    """An early reservation must not signal the interactive response about itself."""
+    coordinator = ResponseLifecycleCoordinator()
+    envelope = _queued_envelope("$interactive")
+    reservation = await coordinator.reserve_response_lifecycle(envelope.target)
+    observed_pending: list[int] = []
+
+    async def locked_operation(_target: MessageTarget) -> str:
+        queued_signal = coordinator._get_or_create_queued_signal(envelope.target)
+        observed_pending.append(queued_signal.pending_human_messages)
+        return "interactive"
+
+    with response_lifecycle_reservation_context(reservation):
+        result = await coordinator.run_locked_response(
+            target=envelope.target,
+            response_envelope=envelope,
+            pipeline_timing=None,
+            locked_operation=locked_operation,
+        )
+
+    assert result == "interactive"
+    assert observed_pending == [0]
+
+
+@pytest.mark.asyncio
+async def test_queued_response_lifecycle_reservation_cancellation_does_not_leak_lock() -> None:
+    """Cancelling a queued reservation removes it without stealing the released lock."""
+    coordinator = ResponseLifecycleCoordinator()
+    envelope = _queued_envelope("$interactive")
+    lifecycle_lock = coordinator._response_lifecycle_lock(envelope.target)
+    await lifecycle_lock.acquire()
+    reservation = await coordinator.reserve_response_lifecycle(envelope.target)
+
+    await reservation.release()
+    await reservation.release()
+    lifecycle_lock.release()
+
+    assert (
+        await asyncio.wait_for(
+            coordinator.run_locked_response(
+                target=envelope.target,
+                response_envelope=envelope,
+                pipeline_timing=None,
+                locked_operation=lambda _target: asyncio.sleep(0, result="next"),
+            ),
+            timeout=1.0,
+        )
+        == "next"
+    )
+
+
+@pytest.mark.asyncio
+async def test_response_lifecycle_reservation_rejects_wrong_target_and_coordinator() -> None:
+    """A reservation can only enter its creating coordinator and lifecycle key."""
+    coordinator = ResponseLifecycleCoordinator()
+    other_coordinator = ResponseLifecycleCoordinator()
+    envelope = _queued_envelope("$interactive")
+    other_target = MessageTarget.resolve("!room:localhost", "$other-thread", "$other")
+    reservation = await coordinator.reserve_response_lifecycle(envelope.target)
+
+    try:
+        with pytest.raises(ValueError, match="different coordinator"):
+            reservation.consume(other_coordinator, envelope.target)
+        with pytest.raises(ValueError, match="target does not match"):
+            reservation.consume(coordinator, other_target)
+    finally:
+        await reservation.release()
 
 
 @pytest.mark.asyncio

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1372,6 +1372,61 @@ async def test_response_lifecycle_reservation_is_not_its_own_queued_human_turn()
 
 
 @pytest.mark.asyncio
+async def test_queued_lifecycle_reservation_preserves_notice_for_older_active_response() -> None:
+    """A reserved human response queued behind an older turn still signals that turn."""
+    coordinator = ResponseLifecycleCoordinator()
+    first_envelope = _queued_envelope("$first")
+    second_envelope = _queued_envelope("$second")
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    second_bookkeeping_started = asyncio.Event()
+
+    async def first_operation(_target: MessageTarget) -> str:
+        first_entered.set()
+        await release_first.wait()
+        return "first"
+
+    first = asyncio.create_task(
+        coordinator.run_locked_response(
+            target=first_envelope.target,
+            response_envelope=first_envelope,
+            pipeline_timing=None,
+            locked_operation=first_operation,
+        ),
+    )
+    await first_entered.wait()
+    reservation = await coordinator.reserve_response_lifecycle(second_envelope.target)
+    begin_notice = coordinator._begin_response_turn_notice
+
+    def tracked_begin_notice(**kwargs: object) -> str | None:
+        result = begin_notice(**kwargs)  # type: ignore[arg-type]
+        response_envelope = kwargs["response_envelope"]
+        if response_envelope is second_envelope:
+            second_bookkeeping_started.set()
+        return result
+
+    with (
+        patch.object(coordinator, "_begin_response_turn_notice", side_effect=tracked_begin_notice),
+        response_lifecycle_reservation_context(reservation),
+    ):
+        second = asyncio.create_task(
+            coordinator.run_locked_response(
+                target=second_envelope.target,
+                response_envelope=second_envelope,
+                pipeline_timing=None,
+                locked_operation=lambda _target: asyncio.sleep(0, result="second"),
+            ),
+        )
+        await second_bookkeeping_started.wait()
+        queued_signal = coordinator._get_or_create_queued_signal(second_envelope.target)
+        assert queued_signal.pending_human_message_event_ids == {"$second"}
+
+        release_first.set()
+        assert await first == "first"
+        assert await second == "second"
+
+
+@pytest.mark.asyncio
 async def test_queued_response_lifecycle_reservation_cancellation_does_not_leak_lock() -> None:
     """Cancelling a queued reservation removes it without stealing the released lock."""
     coordinator = ResponseLifecycleCoordinator()

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -193,6 +193,33 @@ async def test_failed_detached_inbox_response_returns_sources_to_retry_owner() -
     on_failure.assert_called_once_with()
 
 
+@pytest.mark.asyncio
+async def test_detached_inbox_response_owns_source_until_task_finishes() -> None:
+    """Journal replay must not reclaim a source while its response task is alive."""
+    runner = ResponseRunner(deps=MagicMock())
+    response_started = asyncio.Event()
+    release_response = asyncio.Event()
+
+    async def parked_response() -> None:
+        response_started.set()
+        await release_response.wait()
+
+    response_task = runner.track_inbox_response(
+        parked_response(),
+        name="test_source_owned_inbox_response",
+        recovery_proof_ready=lambda: False,
+        source_event_ids=("$reaction",),
+    )
+
+    assert runner.has_live_inbox_response("$reaction")
+    await response_started.wait()
+    release_response.set()
+    await response_task
+    await asyncio.sleep(0)
+
+    assert not runner.has_live_inbox_response("$reaction")
+
+
 class RecordingStopManager(StopManager):
     """Real StopManager whose deferred clear is made immediate and observable."""
 

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1351,12 +1351,14 @@ async def test_response_lifecycle_reservation_is_not_its_own_queued_human_turn()
     """An early reservation must not signal the interactive response about itself."""
     coordinator = ResponseLifecycleCoordinator()
     envelope = _queued_envelope("$interactive")
-    reservation = await coordinator.reserve_response_lifecycle(envelope.target)
+    reservation = await coordinator.reserve_response_lifecycle(envelope)
     observed_pending: list[int] = []
+    observed_active_turns: list[int] = []
 
     async def locked_operation(_target: MessageTarget) -> str:
         queued_signal = coordinator._get_or_create_queued_signal(envelope.target)
         observed_pending.append(queued_signal.pending_human_messages)
+        observed_active_turns.append(queued_signal._active_response_turns)
         return "interactive"
 
     with response_lifecycle_reservation_context(reservation):
@@ -1369,6 +1371,8 @@ async def test_response_lifecycle_reservation_is_not_its_own_queued_human_turn()
 
     assert result == "interactive"
     assert observed_pending == [0]
+    assert observed_active_turns == [1]
+    assert not coordinator.has_active_response_for_target(envelope.target)
 
 
 @pytest.mark.asyncio
@@ -1379,7 +1383,6 @@ async def test_queued_lifecycle_reservation_preserves_notice_for_older_active_re
     second_envelope = _queued_envelope("$second")
     first_entered = asyncio.Event()
     release_first = asyncio.Event()
-    second_bookkeeping_started = asyncio.Event()
 
     async def first_operation(_target: MessageTarget) -> str:
         first_entered.set()
@@ -1395,20 +1398,11 @@ async def test_queued_lifecycle_reservation_preserves_notice_for_older_active_re
         ),
     )
     await first_entered.wait()
-    reservation = await coordinator.reserve_response_lifecycle(second_envelope.target)
-    begin_notice = coordinator._begin_response_turn_notice
+    reservation = await coordinator.reserve_response_lifecycle(second_envelope)
+    queued_signal = coordinator._get_or_create_queued_signal(second_envelope.target)
+    assert queued_signal.pending_human_message_event_ids == {"$second"}
 
-    def tracked_begin_notice(**kwargs: object) -> str | None:
-        result = begin_notice(**kwargs)  # type: ignore[arg-type]
-        response_envelope = kwargs["response_envelope"]
-        if response_envelope is second_envelope:
-            second_bookkeeping_started.set()
-        return result
-
-    with (
-        patch.object(coordinator, "_begin_response_turn_notice", side_effect=tracked_begin_notice),
-        response_lifecycle_reservation_context(reservation),
-    ):
+    with response_lifecycle_reservation_context(reservation):
         second = asyncio.create_task(
             coordinator.run_locked_response(
                 target=second_envelope.target,
@@ -1417,9 +1411,6 @@ async def test_queued_lifecycle_reservation_preserves_notice_for_older_active_re
                 locked_operation=lambda _target: asyncio.sleep(0, result="second"),
             ),
         )
-        await second_bookkeeping_started.wait()
-        queued_signal = coordinator._get_or_create_queued_signal(second_envelope.target)
-        assert queued_signal.pending_human_message_event_ids == {"$second"}
 
         release_first.set()
         assert await first == "first"
@@ -1433,10 +1424,15 @@ async def test_queued_response_lifecycle_reservation_cancellation_does_not_leak_
     envelope = _queued_envelope("$interactive")
     lifecycle_lock = coordinator._response_lifecycle_lock(envelope.target)
     await lifecycle_lock.acquire()
-    reservation = await coordinator.reserve_response_lifecycle(envelope.target)
+    reservation = await coordinator.reserve_response_lifecycle(envelope)
+    queued_signal = coordinator._get_or_create_queued_signal(envelope.target)
+    assert queued_signal.pending_human_message_event_ids == {envelope.source_event_id}
+    assert queued_signal.has_active_response_turn()
 
     await reservation.release()
     await reservation.release()
+    assert queued_signal.pending_human_message_event_ids == set()
+    assert not queued_signal.has_active_response_turn()
     lifecycle_lock.release()
 
     assert (
@@ -1460,7 +1456,7 @@ async def test_response_lifecycle_reservation_rejects_wrong_target_and_coordinat
     other_coordinator = ResponseLifecycleCoordinator()
     envelope = _queued_envelope("$interactive")
     other_target = MessageTarget.resolve("!room:localhost", "$other-thread", "$other")
-    reservation = await coordinator.reserve_response_lifecycle(envelope.target)
+    reservation = await coordinator.reserve_response_lifecycle(envelope)
 
     try:
         with pytest.raises(ValueError, match="different coordinator"):

--- a/tests/test_streaming_finalize.py
+++ b/tests/test_streaming_finalize.py
@@ -26,7 +26,7 @@ from mindroom.delivery_gateway import (
     ResponseIdentity,
 )
 from mindroom.dispatch_source import MESSAGE_SOURCE_KIND
-from mindroom.final_delivery import StreamTransportOutcome
+from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
 from mindroom.hooks import MessageEnvelope
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client import DeliveredMatrixEvent
@@ -49,7 +49,7 @@ from tests.conftest import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Callable
     from pathlib import Path
 
 
@@ -899,6 +899,13 @@ async def test_streamed_interactive_final_reply_registers_reactions_on_root_even
         _room_send_response("$reaction-no"),
         _room_send_response("$reaction-test"),
     ]
+    membership = MagicMock()
+
+    def register_if_current(*, operation: Callable[[], None], **_kwargs: object) -> bool:
+        operation()
+        return True
+
+    membership.run_if_turn_membership_current = AsyncMock(side_effect=register_if_current)
     interactive._cleanup()
     try:
         support = PostResponseEffectsSupport(
@@ -907,6 +914,7 @@ async def test_streamed_interactive_final_reply_registers_reactions_on_root_even
             runtime_paths=runtime_paths_for(config),
             delivery_gateway=Mock(),
             conversation_reader=make_conversation_reader_mock(),
+            membership=membership,
         )
         await apply_post_response_effects(
             final_outcome,
@@ -914,6 +922,7 @@ async def test_streamed_interactive_final_reply_registers_reactions_on_root_even
             support.build_deps(
                 room_id=target.room_id,
                 interactive_agent_name="code",
+                membership_turn_id="$source",
             ),
         )
 
@@ -927,6 +936,59 @@ async def test_streamed_interactive_final_reply_registers_reactions_on_root_even
         assert reaction_targets == ["$displayed-root", "$displayed-root", "$displayed-root"]
         assert "$obsolete-edit" not in reaction_targets
         assert reaction_keys == ["✅", "❌", "🧪"]
+        membership.run_if_turn_membership_current.assert_awaited_once()
+    finally:
+        interactive._cleanup()
+
+
+@pytest.mark.asyncio
+async def test_stale_response_skips_interactive_registration_and_buttons(tmp_path: Path) -> None:
+    """A response that finished after its membership ended cannot create a live question."""
+    config = _config(tmp_path)
+    client = make_matrix_client_mock()
+    membership = MagicMock()
+    membership.run_if_turn_membership_current = AsyncMock(return_value=False)
+    target = MessageTarget.resolve("!room:localhost", None, "$source")
+    formatted = interactive.parse_and_format_interactive(
+        """Choose one.
+
+```interactive
+{"question":"Pick","options":[{"emoji":"✅","label":"Yes","value":"yes"}]}
+```""",
+        extract_mapping=True,
+    )
+    assert formatted.interactive_metadata is not None
+    outcome = FinalDeliveryOutcome(
+        terminal_status="completed",
+        event_id="$question",
+        is_visible_response=True,
+        final_visible_body=formatted.formatted_text,
+        delivery_kind="sent",
+        interactive_metadata=formatted.interactive_metadata,
+    )
+    support = PostResponseEffectsSupport(
+        runtime=SimpleNamespace(client=client, config=config),
+        logger=get_logger("tests.post_response"),
+        runtime_paths=runtime_paths_for(config),
+        delivery_gateway=Mock(),
+        conversation_reader=make_conversation_reader_mock(),
+        membership=membership,
+    )
+
+    interactive._cleanup()
+    try:
+        await apply_post_response_effects(
+            outcome,
+            ResponseOutcome(interactive_target=target),
+            support.build_deps(
+                room_id=target.room_id,
+                interactive_agent_name="code",
+                membership_turn_id="$source",
+            ),
+        )
+
+        assert "$question" not in interactive._active_questions
+        client.room_send.assert_not_awaited()
     finally:
         interactive._cleanup()
 

--- a/tests/test_thread_export_projected_history.py
+++ b/tests/test_thread_export_projected_history.py
@@ -554,6 +554,7 @@ async def test_rejoining_the_room_forces_one_fresh_hydration(router: PrincipalSt
     homeserver.reset_counts()
 
     await router.fence_departure(ROOM, source=DepartureSource.LOCAL)
+    await router.note_membership_restarted(ROOM)
     homeserver.relations[ROOT] = [
         raw("$a:example.org", "first", ts=200, thread_id=ROOT),
         raw("$b:example.org", "second", ts=300, thread_id=ROOT),

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -454,6 +454,9 @@ def _build_harness(
     async def _settle_ignored_dispatch_sources(source_event_ids: tuple[str, ...]) -> None:
         ignored_dispatch_sources.append(source_event_ids)
 
+    async def _dispatch_source_is_terminal(_source_event_id: str) -> bool:
+        return False
+
     def _retry_dispatch_sources(source_event_ids: tuple[str, ...]) -> None:
         retried_dispatch_sources.append(source_event_ids)
 
@@ -534,6 +537,7 @@ def _build_harness(
             visible_responses=visible_responses,
             retry_dispatch_sources=_retry_dispatch_sources,
             settle_dispatch_sources=_settle_ignored_dispatch_sources,
+            dispatch_source_is_terminal=_dispatch_source_is_terminal,
         ),
     )
     controller_ref.append(controller)
@@ -2707,6 +2711,7 @@ async def test_interactive_selection_acks_generates_and_records_once(config: Con
     assert ack_request.response_text.startswith("You selected: 1 Option 1")
     assert ack_request.target.resolved_thread_id == selection.thread_id
     assert ack_request.target.reply_to_event_id == selection.question_event_id
+    assert ack_request.delivery_turn_id == "$selection:localhost"
 
     assert len(harness.runner.requests) == 1
     request = harness.runner.requests[0]

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -412,6 +412,7 @@ def _build_harness(
         matrix_id=matrix_id,
         resolver=resolver,
         hook_context=hook_context,
+        membership=MagicMock(),
     )
     journal_store = open_event_journal(
         config.event_journal,

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -533,6 +533,7 @@ def _build_harness(
             ),
             visible_responses=visible_responses,
             retry_dispatch_sources=_retry_dispatch_sources,
+            settle_dispatch_sources=_settle_ignored_dispatch_sources,
         ),
     )
     controller_ref.append(controller)


### PR DESCRIPTION
## Summary

- hand interactive-selection responses to managed inbox tasks
- keep reaction journal sources pending until durable terminal settlement
- let unrelated work in the same room continue while response waits
- preserve existing canonical per-thread response serialization
- park durably claimed interactive-reaction replay until fleet recovery
- register deferral ownership before fast detached responses can settle

## Tests

- cross-thread journal-lane regression
- detached source-ownership lifecycle
- fast terminal handoff leaves no stale deferred ID
- failed handoff retries the exact journal source and settles on success
- claimed interactive replay waits for fleet release and enters recovery scope
- affected journal/reaction/turn/response suites on SQLite and PostgreSQL
- sync continuity, ingress lane, and live coalescing suites
- full suite; all change-related failures fixed, unrelated PostgreSQL load timeouts passed in isolated reruns
- pre-commit lint, format, type, dependency, and architecture gates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive reactions and approval selections can run asynchronously without blocking unrelated messages.
  * Reaction handling now reports clear outcomes for completed, deferred, ignored, and unauthorized actions.
  * Response processing can reserve its turn to preserve orderly queued-response handling.

* **Bug Fixes**
  * Failed interactive handoffs remain retryable and recover when reactions are replayed.
  * Dispatch ownership is retained during active processing and released reliably afterward.
  * Deferred reactions are tracked consistently through recovery, retries, and completion.
  * Concurrent response notices and lifecycle locks are handled more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->