### PR TITLE
Post-merge review follow-ups for interactive reaction dispatch

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -839,7 +839,6 @@ class AgentBot:
                 user_stop_reconciler=self._user_stop_reconciler,
                 ingress=self._ingress_validator,
                 reserve_prompt_ingress_order=self._turn_controller.reserve_prompt_ingress_order,
-                build_message_target=self._conversation_resolver.build_message_target,
                 enqueue_interactive_selection=self._turn_controller.enqueue_interactive_selection,
                 handle_interactive_selection=self._turn_controller.handle_interactive_selection,
                 start_interactive_selection=self._turn_controller.start_interactive_selection,

--- a/src/mindroom/event_journal/journal.py
+++ b/src/mindroom/event_journal/journal.py
@@ -415,7 +415,7 @@ def fence_departure(
     )
 
 
-def note_membership_restarted(transaction: Transaction, principal_id: str, room_id: str) -> None:
+def _note_membership_restarted(transaction: Transaction, principal_id: str, room_id: str) -> None:
     """Record that the bot is in a room again, so its next departure fences.
 
     Only the fenced mark is cleared. An owed sync report survives a rejoin on
@@ -441,7 +441,7 @@ def note_membership_restarted_after(
     and the fence claim above still gates the cleanup itself.
     """
     cleanup_fenced_departure(transaction, principal_id, room_id, cleanup)
-    note_membership_restarted(transaction, principal_id, room_id)
+    _note_membership_restarted(transaction, principal_id, room_id)
 
 
 def cleanup_fenced_departure(

--- a/src/mindroom/event_journal/journal.py
+++ b/src/mindroom/event_journal/journal.py
@@ -435,10 +435,12 @@ def note_membership_restarted_after(
     room_id: str,
     cleanup: Callable[[], None],
 ) -> None:
-    """Clear external departure state before atomically rearming one room."""
-    if not _claim_departure_fence(transaction, principal_id, room_id):
-        return
-    cleanup()
+    """Clear external departure state before atomically rearming one room.
+
+    Rearming unconditionally is safe: clearing an unfenced flag is a no-op,
+    and the fence claim above still gates the cleanup itself.
+    """
+    cleanup_fenced_departure(transaction, principal_id, room_id, cleanup)
     note_membership_restarted(transaction, principal_id, room_id)
 
 

--- a/src/mindroom/event_journal/membership.py
+++ b/src/mindroom/event_journal/membership.py
@@ -92,7 +92,7 @@ class MembershipFence:
     """Advance a room's membership epoch exactly once per departure."""
 
     store: MembershipView
-    clear_departed_room: Callable[[str], None] | None = None
+    clear_departed_room: Callable[[str], None] = lambda _room_id: None
     # Rooms owing a sync report, and how many more sync responses that report
     # may still appear in. Recovered from the journal on the first sync
     # response, because a restart between a local departure and its report
@@ -127,17 +127,14 @@ class MembershipFence:
 
     async def note_membership_restarted(self, room_id: str) -> None:
         """Record a confirmed join, so this room's next departure fences again."""
-        clear_departed_room = self.clear_departed_room
-        cleanup = None if clear_departed_room is None else lambda: clear_departed_room(room_id)
-        await self.store.note_membership_restarted(room_id, cleanup=cleanup)
+        await self.store.note_membership_restarted(room_id, cleanup=lambda: self.clear_departed_room(room_id))
 
     async def _clear_room(self, room_id: str, outcome: DepartureOutcome) -> None:
         """Clear external state only for the departure that advanced the epoch."""
-        clear_departed_room = self.clear_departed_room
-        if outcome.fenced and clear_departed_room is not None:
+        if outcome.fenced:
             await self.store.cleanup_fenced_departure(
                 room_id,
-                lambda: clear_departed_room(room_id),
+                lambda: self.clear_departed_room(room_id),
             )
 
     def _track(self, room_id: str, outcome: DepartureOutcome) -> None:

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -263,17 +263,12 @@ class PrincipalStore:
         cleanup: Callable[[], None] | None = None,
     ) -> None:
         """Rearm one room after any committed-departure cleanup succeeds."""
-        if cleanup is None:
-            await self._backend.write(
-                lambda transaction: journal.note_membership_restarted(transaction, self._principal_id, room_id),
-            )
-            return
         await self._backend.write(
             lambda transaction: journal.note_membership_restarted_after(
                 transaction,
                 self._principal_id,
                 room_id,
-                cleanup,
+                cleanup if cleanup is not None else lambda: None,
             ),
         )
 

--- a/src/mindroom/interactive.py
+++ b/src/mindroom/interactive.py
@@ -900,31 +900,32 @@ def clear_interactive_question(event_id: str) -> None:
         logger.info("Cleared interactive question", event_id=event_id)
 
 
+def _question_ids_for_room(
+    questions: dict[str, _InteractiveQuestion],
+    room_id: str,
+    creator_agent: str,
+) -> set[str]:
+    """Return the questions one agent created in one room."""
+    return {
+        event_id
+        for event_id, question in questions.items()
+        if question.room_id == room_id and question.creator_agent == creator_agent
+    }
+
+
 def clear_interactive_questions_for_room(room_id: str, creator_agent: str) -> None:
     """Durably consume one departed agent's active and claimed questions."""
     with _thread_lock:
-        claimed_event_ids = {
-            event_id
-            for event_id, question in _claimed_questions.items()
-            if question.room_id == room_id and question.creator_agent == creator_agent
-        }
+        claimed_event_ids = _question_ids_for_room(_claimed_questions, room_id, creator_agent)
         if _persistence_file is None or _persistence_lock_file is None:
-            removed_event_ids = claimed_event_ids | {
-                event_id
-                for event_id, question in _active_questions.items()
-                if question.room_id == room_id and question.creator_agent == creator_agent
-            }
+            removed_event_ids = claimed_event_ids | _question_ids_for_room(_active_questions, room_id, creator_agent)
             for event_id in removed_event_ids:
                 _remove_active_question_locked(event_id)
         else:
             _persistence_file.parent.mkdir(parents=True, exist_ok=True)
             with advisory_file_lock(_persistence_lock_file):
                 questions = _apply_local_changes_locked(_load_persisted_questions())
-                removed_event_ids = claimed_event_ids | {
-                    event_id
-                    for event_id, question in questions.items()
-                    if question.room_id == room_id and question.creator_agent == creator_agent
-                }
+                removed_event_ids = claimed_event_ids | _question_ids_for_room(questions, room_id, creator_agent)
                 remaining_questions = {
                     event_id: question for event_id, question in questions.items() if event_id not in removed_event_ids
                 }

--- a/src/mindroom/journal_dispatch.py
+++ b/src/mindroom/journal_dispatch.py
@@ -397,14 +397,11 @@ class JournalDispatcher:
         token = _RUNNING_EVENT.set(event)
         try:
             settles = await binding.run(self, room, matrix_event)
-            if event.kind is EventKind.REACTION:
-                if settles:
-                    self._deferred_reaction_ids.discard(event.event_id)
-                elif self.semantic_consumer() is not SemanticConsumer.INTERACTIVE_REACTION:
-                    # The real interactive path registered before starting its
-                    # detached owner, so terminal settlement can safely remove
-                    # it even if that owner finishes before this callback.
-                    self._deferred_reaction_ids.add(event.event_id)
+            if event.kind is EventKind.REACTION and settles:
+                # A deferring reaction is never re-added here: the interactive
+                # path registered before starting its detached owner, so a fast
+                # owner's terminal settlement is not undone by this callback.
+                self._deferred_reaction_ids.discard(event.event_id)
             return settles
         finally:
             _RUNNING_EVENT.reset(token)
@@ -457,13 +454,11 @@ class JournalDispatcher:
         the worker still lists these events as deferred to a turn that has now
         ended, and nothing else would ever clear them.
         """
-        self._deferred_reaction_ids.difference_update(event_ids)
-        self._worker.release(event_ids)
+        self._release_sources(event_ids)
 
     async def settle_intentionally_ignored_turn_sources(self, event_ids: tuple[str, ...]) -> None:
         """Settle turn-backed events that produced no dispatch payload."""
-        self._deferred_reaction_ids.difference_update(event_ids)
-        self._worker.release(event_ids)
+        self._release_sources(event_ids)
         await self.store.settle_many(event_ids)
 
     def retry_turn_source(self, event_id: str) -> None:
@@ -472,9 +467,13 @@ class JournalDispatcher:
 
     def retry_turn_sources(self, event_ids: tuple[str, ...]) -> None:
         """Return several undelivered turn sources to the worker."""
+        self._release_sources(event_ids)
+        self._worker.wake()
+
+    def _release_sources(self, event_ids: tuple[str, ...]) -> None:
+        """Release worker ownership and forget any deferred-reaction markers."""
         self._deferred_reaction_ids.difference_update(event_ids)
         self._worker.release(event_ids)
-        self._worker.wake()
 
     async def unsettled_event_ids(self) -> frozenset[str]:
         """Return every event that still owes semantic work."""

--- a/src/mindroom/reaction_dispatch.py
+++ b/src/mindroom/reaction_dispatch.py
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.ingress_validation import IngressValidator
     from mindroom.journal_dispatch import JournalDispatcher
-    from mindroom.message_target import MessageTarget
     from mindroom.prompt_ingress_reservation import PromptIngressReservationOwner
     from mindroom.runtime_protocols import SupportsClientConfigOrchestrator
     from mindroom.stop import StopManager
@@ -49,7 +48,6 @@ class ReactionDispatcherDeps:
     user_stop_reconciler: UserStopReconciler
     ingress: IngressValidator
     reserve_prompt_ingress_order: Callable[..., PromptIngressReservationOwner]
-    build_message_target: Callable[..., MessageTarget]
     enqueue_interactive_selection: Callable[..., Awaitable[None]]
     handle_interactive_selection: Callable[..., Awaitable[None]]
     start_interactive_selection: Callable[..., Awaitable[None]]
@@ -180,11 +178,6 @@ class ReactionDispatcher:
                 return TurnDispatchOutcome.INTENTIONALLY_IGNORED
 
         try:
-            response_target = self.deps.build_message_target(
-                room_id=room.room_id,
-                thread_id=selection.thread_id,
-                reply_to_event_id=selection.question_event_id,
-            )
             await self.deps.enqueue_interactive_selection(
                 reservation_owner,
                 room,
@@ -192,7 +185,6 @@ class ReactionDispatcher:
                 requester_user_id=requester_user_id,
                 user_id=event.sender,
                 source_event_id=event.event_id,
-                response_target=response_target,
                 handle_interactive_selection=self.deps.handle_interactive_selection,
                 start_interactive_selection=self.deps.start_interactive_selection,
             )

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -576,6 +576,22 @@ class ResponseRunner:
         self._incomplete_inbox_responses_recoverable &= cancelled_responses_recoverable
         return False
 
+    def _post_response_deps(
+        self,
+        request: ResponseRequest,
+        *,
+        queue_memory_persistence: Callable[[], None] | None = None,
+        persist_response_event_id: Callable[[str, str], None] | None = None,
+    ) -> PostResponseEffectsDeps:
+        """Build post-response effect deps bound to one request's room and source turn."""
+        return self.deps.post_response_effects.build_deps(
+            room_id=request.room_id,
+            interactive_agent_name=self.deps.agent_name,
+            membership_turn_id=request.response_envelope.source_event_id,
+            queue_memory_persistence=queue_memory_persistence,
+            persist_response_event_id=persist_response_event_id,
+        )
+
     def _client(self) -> nio.AsyncClient:
         """Return the current Matrix client required for response coordination."""
         client = self.deps.runtime.client
@@ -1762,11 +1778,7 @@ class ResponseRunner:
         final_outcome = await lifecycle.finalize(
             FinalDeliveryOutcome.cancelled_for_empty_prompt(),
             build_post_response_outcome=lambda _final_outcome: ResponseOutcome(),
-            post_response_deps=lambda: self.deps.post_response_effects.build_deps(
-                room_id=request.room_id,
-                interactive_agent_name=self.deps.agent_name,
-                membership_turn_id=request.response_envelope.source_event_id,
-            ),
+            post_response_deps=lambda: self._post_response_deps(request),
         )
         return final_outcome.final_visible_event_id if final_outcome.mark_handled else None
 
@@ -1884,11 +1896,7 @@ class ResponseRunner:
                 user_id=request.user_id,
                 run_id=str(uuid4()),
                 build_post_response_outcome=lambda _final_outcome: ResponseOutcome(),
-                post_response_deps=lambda: self.deps.post_response_effects.build_deps(
-                    room_id=request.room_id,
-                    interactive_agent_name=self.deps.agent_name,
-                    membership_turn_id=request.response_envelope.source_event_id,
-                ),
+                post_response_deps=lambda: self._post_response_deps(request),
             )
         requester_user_id = request.user_id or ""
         _memory_prompt, _memory_thread_history, prepared_prompt, model_thread_history = (
@@ -2322,10 +2330,8 @@ class ResponseRunner:
             user_id=requester_user_id,
             run_id=response_run_id,
             build_post_response_outcome=build_team_post_response_outcome,
-            post_response_deps=lambda: self.deps.post_response_effects.build_deps(
-                room_id=request.room_id,
-                interactive_agent_name=self.deps.agent_name,
-                membership_turn_id=request.response_envelope.source_event_id,
+            post_response_deps=lambda: self._post_response_deps(
+                request,
                 persist_response_event_id=persist_response_event_id,
             ),
             streaming_delivery_error_handler=settle_team_streaming_delivery_error,
@@ -3090,10 +3096,8 @@ class ResponseRunner:
             user_id=request.user_id,
             run_id=response_run_id,
             build_post_response_outcome=build_post_response_outcome,
-            post_response_deps=lambda: self.deps.post_response_effects.build_deps(
-                room_id=request.room_id,
-                interactive_agent_name=self.deps.agent_name,
-                membership_turn_id=request.response_envelope.source_event_id,
+            post_response_deps=lambda: self._post_response_deps(
+                request,
                 queue_memory_persistence=queue_memory_persistence,
                 persist_response_event_id=persist_response_event_id,
             ),

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1239,6 +1239,18 @@ class TurnController:
         # Ownership registration is synchronous, and the task cannot execute
         # until this callback yields after reporting its deferred handoff.
 
+    def _interactive_selection_target(
+        self,
+        room_id: str,
+        selection: interactive.InteractiveSelection,
+    ) -> MessageTarget:
+        """Return the canonical response target for one interactive selection."""
+        return self.deps.resolver.build_message_target(
+            room_id=room_id,
+            thread_id=selection.thread_id,
+            reply_to_event_id=selection.question_event_id,
+        )
+
     async def enqueue_interactive_selection(
         self,
         reservation_owner: _PromptIngressReservationOwner,
@@ -1248,11 +1260,11 @@ class TurnController:
         requester_user_id: str,
         user_id: str,
         source_event_id: str,
-        response_target: MessageTarget,
         handle_interactive_selection: Callable[..., Awaitable[None]],
         start_interactive_selection: Callable[..., Awaitable[None]],
     ) -> None:
         """Queue a selection handoff as a FIFO barrier behind earlier ingress."""
+        response_target = self._interactive_selection_target(room.room_id, selection)
 
         def restore_selection() -> None:
             interactive.restore_selection(selection)
@@ -1334,11 +1346,7 @@ class TurnController:
         response_target: MessageTarget | None = None,
     ) -> None:
         """Own claim settlement around one validated interactive selection."""
-        target = response_target or self.deps.resolver.build_message_target(
-            room_id=room.room_id,
-            thread_id=selection.thread_id,
-            reply_to_event_id=selection.question_event_id,
-        )
+        target = response_target or self._interactive_selection_target(room.room_id, selection)
         try:
             await self._execute_interactive_selection(
                 room,

--- a/tests/ai_user_id_helpers.py
+++ b/tests/ai_user_id_helpers.py
@@ -53,6 +53,7 @@ from tests.conftest import bind_runtime_paths as _bind_runtime_paths
 from tests.conftest import (
     ignore_final_delivery_handoff,
     make_conversation_reader_mock,
+    make_membership_stub,
     make_outbox_mock,
     make_relation_lookup,
     request_envelope,
@@ -444,7 +445,7 @@ def _build_response_runner(
         matrix_id=bot.matrix_id,
         resolver=bot._conversation_resolver,
         hook_context=hook_context,
-        membership=MagicMock(),
+        membership=make_membership_stub(),
     )
 
     post_response_effects = PostResponseEffectsSupport(
@@ -453,7 +454,7 @@ def _build_response_runner(
         runtime_paths=runtime_paths,
         delivery_gateway=delivery_gateway,
         conversation_reader=make_conversation_reader_mock(),
-        membership=MagicMock(),
+        membership=make_membership_stub(),
     )
     bot._knowledge_access_support = knowledge_access_support or _knowledge_access_support()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2221,7 +2221,6 @@ def replace_turn_controller_deps(bot: RuntimeBot, **changes: object) -> TurnCont
         ingress=rebuilt.deps.ingress,
         stop_manager=bot.stop_manager,
         reserve_prompt_ingress_order=rebuilt.reserve_prompt_ingress_order,
-        build_message_target=rebuilt.deps.resolver.build_message_target,
         enqueue_interactive_selection=rebuilt.enqueue_interactive_selection,
         handle_interactive_selection=rebuilt.handle_interactive_selection,
         start_interactive_selection=rebuilt.start_interactive_selection,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,6 +70,7 @@ from mindroom.event_journal import (
     OutboxDelivery,
     OutboxView,
     PendingTurnView,
+    PrincipalStore,
     RelationView,
     TerminalTurnWrite,
     VisibleMessage,
@@ -1602,6 +1603,23 @@ def make_conversation_reader_mock() -> ConversationReader:
             read=AsyncMock(return_value=page),
             read_strict=AsyncMock(return_value=page),
             latest_thread_event_id=AsyncMock(return_value=None),
+        ),
+    )
+
+
+def make_membership_stub() -> PrincipalStore:
+    """Return a membership view that treats every epoch as current and runs side effects."""
+
+    async def run_operation(*, operation: Callable[[], None], **_kwargs: object) -> bool:
+        operation()
+        return True
+
+    return cast(
+        "PrincipalStore",
+        SimpleNamespace(
+            membership_epoch=AsyncMock(return_value=0),
+            run_if_turn_membership_current=run_operation,
+            run_if_membership_epoch=run_operation,
         ),
     )
 

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -863,7 +863,7 @@ class TestAgentBot(AgentBotTestBase):
                     EventClass.ACTIONABLE,
                 )
 
-                await asyncio.wait_for(message_started.wait(), timeout=0.2)
+                await asyncio.wait_for(message_started.wait(), timeout=1.0)
                 assert bot._journal_dispatcher.callbacks.source_has_live_owner(reaction.event_id)
                 assert reaction.event_id in await bot._journal_dispatcher.unsettled_event_ids()
         finally:
@@ -998,10 +998,11 @@ class TestAgentBot(AgentBotTestBase):
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         settlement_error = OSError("simulated journal settlement failure")
         settle_dispatch_sources = AsyncMock(side_effect=settlement_error)
+        retry_dispatch_sources = MagicMock()
         controller = replace_turn_controller_deps(
             bot,
             settle_dispatch_sources=settle_dispatch_sources,
-            retry_dispatch_sources=MagicMock(),
+            retry_dispatch_sources=retry_dispatch_sources,
         )
         response_completed = asyncio.Event()
         prestart_cleanup = MagicMock()
@@ -1027,6 +1028,8 @@ class TestAgentBot(AgentBotTestBase):
         assert response_completed.is_set()
         settle_dispatch_sources.assert_awaited_once_with(("$reaction",))
         prestart_cleanup.assert_not_called()
+        # The failed settlement must hand the exact journal source back for retry.
+        retry_dispatch_sources.assert_called_once_with(("$reaction",))
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize("failure_stage", ["acquire", "queued_cancel"])


### PR DESCRIPTION
## Summary

Follow-ups from the post-merge review of #1823, limited to changes that are net deletions or strengthen review-flagged coverage. Complements #1825 (which carries the functional fixes).

- Deduplicate the deferred-reaction release bookkeeping behind `JournalDispatcher._release_sources` and drop the unreachable re-add branch in `_invoke` (only interactive reactions defer, and they register their marker durably before the callback returns).
- Extract `ResponseRunner._post_response_deps` for the four identical post-response deps constructions, so a fifth site cannot forget `membership_turn_id`.
- Extract `interactive._question_ids_for_room` for the room/creator filter spelled three times in departure cleanup.
- Build the interactive selection response target inside `TurnController` through one shared helper; `ReactionDispatcherDeps.build_message_target` duplicated the fallback byte-for-byte. `handle_interactive_selection` and `start_interactive_selection` deliberately stay in the deps: they are the declared seam the reaction tests fake through `replace_reaction_dispatcher_deps`.
- Unify membership rearm on one write path: `PrincipalStore.note_membership_restarted` always routes through `note_membership_restarted_after` (no-op cleanup when none), the journal helper reuses `cleanup_fenced_departure` plus an unconditional rearm, and `MembershipFence.clear_departed_room` defaults to a no-op callable. The journal-internal rearm helper is now private.
- Test fixes flagged by review: the unawaitable `MagicMock` membership in the runner helper is now a typed stub that runs the gated operation; the failed-settlement test asserts `retry_dispatch_sources` hands back the exact source; a 200ms wait that could flake under parallel runs is widened.

## Deliberately not done

- Reservation null-object refactor in `run_locked_response`: hottest lock path, no bug behind it.
- Flock timeout / sync-escalation in `clear_interactive_questions_for_room` and duplicate-departure-report dedupe: both need a maintainer design decision on transactional coupling; raising here so they do not vanish.

## Tests

- Affected suites (reactions/approvals, interactive, membership fence, journal store, response runner, matrix message tool, turn controller, ingress lanes, edit regeneration, journal ingress, queued notify, streaming finalize, thread export, ai user id, dispatch source) pass on SQLite and PostgreSQL.
- `pre-commit` on all changed files and `tach check --dependencies --interfaces` pass.

## Merge note

May need a trivial rebase after #1825 (adjacent hunks in `turn_controller.handle_interactive_selection` and `bot.py` wiring).

## Summary by Sourcery

Simplify interactive reaction dispatch and membership restart handling while strengthening post-response dependency construction and test coverage.

Enhancements:
- Factor shared post-response dependency construction into a ResponseRunner helper bound to the request room and source turn.
- Extract a reusable helper for filtering interactive questions by room and creator to reduce duplication in departure cleanup.
- Centralize deferred reaction source release through a JournalDispatcher helper and clarify reaction settlement bookkeeping semantics.
- Move interactive selection message target construction into TurnController to be the single source of truth for interactive response targets.
- Unify membership restart and fenced-departure cleanup paths so PrincipalStore and MembershipFence always rearm rooms through a consistent write path.

Tests:
- Introduce a membership stub used in tests that treats epochs as current and executes gated operations instead of relying on MagicMock.
- Tighten assertions around interactive post-response settlement failure to ensure retry dispatch receives the exact source.
- Relax a reaction approval test timeout to reduce flakiness under parallel execution.
- Adjust reaction dispatcher dependencies in test helpers to match the new interactive selection target construction interface.