### PR TITLE
Preserve prepared durable Matrix payloads during send

### DIFF
--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -657,6 +657,7 @@ class DeliveryGateway:
             dict(claimed.payload),
             retry_sync_recovery=retry_sync_recovery,
             transaction_id=claimed.transaction_id,
+            content_is_prepared=True,
         )
         if isinstance(outcome, MatrixDeliveryFailure):
             detail = _matrix_delivery_failure_reason(outcome)
@@ -966,6 +967,7 @@ class DeliveryGateway:
                 operation="edit_message",
                 retry_sync_recovery=request.retry_sync_recovery,
                 transaction_id=claimed.transaction_id,
+                content_is_prepared=True,
             )
             if isinstance(outcome, MatrixDeliveryFailure):
                 detail = _matrix_delivery_failure_reason(outcome)

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -802,9 +802,9 @@ class DeliveryGateway:
         # row holding the oversized original while Matrix received an MXC
         # reference, and a recovery resend would upload again -- minting a new
         # MXC, and new encrypted-file keys, under a transaction ID the
-        # homeserver had already accepted. Preparing twice is harmless: an
-        # already-prepared payload is below the size limit, so this is a no-op
-        # for it, including on the recovery path.
+        # homeserver had already accepted. An attempted row is already frozen,
+        # so preparation is skipped and `enqueue` leaves that stored payload
+        # untouched for the claimed send below.
         content = await self._prepared_for_the_wire(
             room_id,
             content,
@@ -941,8 +941,9 @@ class DeliveryGateway:
         # is built here: the row has to hold the finished wire event. A sidecar
         # uploaded after the claim would leave the row holding the oversized
         # original while Matrix received an MXC reference, and a resend would
-        # upload again under a transaction ID already accepted. Preparing an
-        # already-prepared payload is a no-op, so the recovery path is safe.
+        # upload again under a transaction ID already accepted. An attempted
+        # row is already frozen, so preparation is skipped and
+        # `enqueue` leaves that stored envelope untouched for the claimed send.
         envelope = await self._prepared_for_the_wire(
             room_id,
             envelope,

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -1563,13 +1563,13 @@ class DeliveryGateway:
         """Prepare a payload for the wire, unless a frozen one already exists.
 
         Preparation can upload a sidecar, so it must not run for a turn whose
-        answer is already acknowledged. That row is what `flush` returns, its
-        payload is frozen and `enqueue` refuses to overwrite it, so preparing
-        again would upload an attachment nothing can ever reference -- or fail,
-        and take down a rerun whose answer is already durable and visible.
+        row has already been attempted. That row is frozen and `enqueue`
+        refuses to overwrite it, so preparing again would upload an attachment
+        nothing can ever reference -- or fail before the durable payload gets
+        another chance to reach Matrix.
         """
         existing = await self.deps.outbox.load_delivery(turn_id=turn_id, stage=stage)
-        if existing is not None and existing.acknowledged_event_id is not None:
+        if existing is not None and existing.attempted:
             return content
         return await prepare_large_message(self._client(), room_id, content)
 

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -354,8 +354,14 @@ async def send_message_outcome(
     operation: str = "send_message",
     retry_sync_recovery: bool = False,
     transaction_id: str | None = None,
+    content_is_prepared: bool = False,
 ) -> MatrixSendOutcome:
-    """Send a message to a Matrix room and return the delivered payload or a typed failure."""
+    """Send a message to a Matrix room and return the delivered payload or a typed failure.
+
+    ``content_is_prepared`` is reserved for durable payloads already frozen in
+    the outbox. Those bytes must reach Matrix verbatim so the durable record
+    remains an exact description of the wire event.
+    """
     if not _can_send_to_encrypted_room(client, room_id, operation=operation):
         return MatrixDeliveryFailure(
             MatrixDeliveryFailureKind.ENCRYPTION_GUARD,
@@ -384,12 +390,14 @@ async def send_message_outcome(
         room_id=room_id,
         message_type=message_type,
     )
-    content_sent = await prepare_large_message(
-        client,
-        room_id,
-        content,
-        room_encrypted=room_encryption_override,
-    )
+    content_sent = content
+    if not content_is_prepared:
+        content_sent = await prepare_large_message(
+            client,
+            room_id,
+            content,
+            room_encrypted=room_encryption_override,
+        )
     emit_timing_event(
         "Matrix send timing",
         phase="prepare_finish",

--- a/tests/test_locked_turn_delivery.py
+++ b/tests/test_locked_turn_delivery.py
@@ -63,9 +63,10 @@ class _FakeHomeserver:
         operation: str = "send_message",
         retry_sync_recovery: bool = False,
         transaction_id: str | None = None,
+        content_is_prepared: bool = False,
     ) -> MatrixSendOutcome:
         """Accept one send, deduplicating on transaction ID like a homeserver."""
-        del operation, retry_sync_recovery
+        del operation, retry_sync_recovery, content_is_prepared
         if content.get("body") == "Thinking...":
             self.placeholder_sends.append((transaction_id, content.get(STREAM_STATUS_KEY)))
         if transaction_id is not None and transaction_id in self._event_id_by_transaction:

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -14,6 +14,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import nio
 import pytest
 
 from mindroom.config.agent import AgentConfig
@@ -503,6 +504,65 @@ class TestTurnDeliveryGoesThroughTheOutbox:
 
         assert list(outbox.rows) == [("$cause", "final")]
         assert outbox.rows["$cause", "final"].acknowledged_event_id == "$streamed"
+
+    async def test_an_oversized_terminal_edit_sends_the_frozen_payload_verbatim(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Wire delivery must not prepare an already-frozen outbox payload again.
+
+        A large edit becomes a sidecar-backed ``m.file`` replacement before
+        the outbox freezes it. Preparing that envelope a second time promotes
+        the inner ``m.file`` type to the outer edit without its required URL,
+        so nio rejects the event and later history reads cannot hydrate it.
+        """
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        client = AsyncMock(spec=nio.AsyncClient)
+        room = MagicMock()
+        room.encrypted = False
+        client.rooms = {_ROOM_ID: room}
+        client.olm = None
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/sidecar"}),
+            None,
+        )
+        client.room_send.return_value = nio.RoomSendResponse(event_id="$edit", room_id=_ROOM_ID)
+        gateway.deps.runtime.client = client
+        terminal = gateway._durable_terminal_edit(
+            "$cause",
+            MessageTarget.resolve(_ROOM_ID, None, None, room_mode=True),
+        )
+        assert terminal is not None
+        answer = "x" * 125_000
+
+        delivered = await terminal(
+            client,
+            _ROOM_ID,
+            "$streamed",
+            {
+                "msgtype": "m.text",
+                "body": answer,
+                "io.mindroom.stream_status": "completed",
+            },
+            answer,
+        )
+
+        assert delivered is not None
+        assert client.upload.await_count == 1, "wire delivery uploaded a second sidecar"
+        frozen = outbox.rows["$cause", "final"].payload
+        wire_content = client.room_send.await_args.kwargs["content"]
+        assert wire_content == frozen
+        parsed = nio.Event.parse_event(
+            {
+                "event_id": "$edit",
+                "sender": _AGENT_USER_ID,
+                "origin_server_ts": 1,
+                "type": "m.room.message",
+                "content": wire_content,
+            },
+        )
+        assert not isinstance(parsed, nio.BadEvent)
 
     async def test_a_streamed_terminal_edit_freezes_its_fallback_body_too(
         self,

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -564,6 +564,56 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         )
         assert not isinstance(parsed, nio.BadEvent)
 
+    async def test_an_unacknowledged_oversized_edit_reuses_its_frozen_payload(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A live retry must not rebuild an attempted outbox payload.
+
+        Once the first send is attempted, its sidecar URI and transaction ID
+        are frozen together even when Matrix refuses the send. A live rerun
+        must retry that row directly: uploading a replacement can fail before
+        the durable payload gets another chance to reach Matrix.
+        """
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        client = AsyncMock(spec=nio.AsyncClient)
+        room = MagicMock()
+        room.encrypted = False
+        client.rooms = {_ROOM_ID: room}
+        client.olm = None
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/sidecar"}),
+            None,
+        )
+        client.room_send.return_value = nio.RoomSendError(message="temporary refusal")
+        gateway.deps.runtime.client = client
+        terminal = gateway._durable_terminal_edit(
+            "$cause",
+            MessageTarget.resolve(_ROOM_ID, None, None, room_mode=True),
+        )
+        assert terminal is not None
+        answer = "x" * 125_000
+        content = {
+            "msgtype": "m.text",
+            "body": answer,
+            "io.mindroom.stream_status": "completed",
+        }
+
+        first = await terminal(client, _ROOM_ID, "$streamed", content, answer)
+
+        assert first is None
+        frozen = dict(outbox.rows["$cause", "final"].payload)
+        assert outbox.rows["$cause", "final"].attempted
+        client.upload.side_effect = AssertionError("live retry uploaded a replacement sidecar")
+        client.room_send.return_value = nio.RoomSendResponse(event_id="$edit", room_id=_ROOM_ID)
+
+        delivered = await terminal(client, _ROOM_ID, "$streamed", content, answer)
+
+        assert delivered is not None
+        assert client.upload.await_count == 1
+        assert client.room_send.await_args.kwargs["content"] == frozen
+
     async def test_a_streamed_terminal_edit_freezes_its_fallback_body_too(
         self,
         tmp_path: Path,


### PR DESCRIPTION
## Summary

- treat payloads frozen by a durable outbox attempt as already prepared
- preserve the frozen Matrix event exactly at the wire boundary
- keep normal large-message preparation and all existing send safety checks
- retry an unacknowledged attempted row without creating an orphaned replacement sidecar

## Root cause

Large terminal edits are converted to sidecar-backed Matrix events before the outbox freezes them. The send boundary prepared those frozen events a second time, which could produce an invalid outer event and leave later history reads unable to hydrate the conversation.

A live rerun could also prepare a replacement before discovering that an attempted outbox row was already frozen. That extra upload was unusable and could fail before the durable payload received another send attempt.

## Regression coverage

The regressions drive oversized terminal edits through the real delivery gateway and large-message preparation while mocking only the external Matrix client. They verify:

- one sidecar upload and exact equality between the frozen outbox payload and the wire payload
- successful nio parsing of the delivered event
- reuse of an attempted, unacknowledged frozen payload on a live retry

## Verification

- focused delivery and large-message tests
- full Python test suite
- pre-commit hooks for all changed files