### PR TITLE
Clarify native Google tool OAuth metadata

### DIFF
--- a/src/mindroom/tools/gmail.py
+++ b/src/mindroom/tools/gmail.py
@@ -22,10 +22,12 @@ if TYPE_CHECKING:
     display_name="Gmail",
     description=(
         "Read and search Gmail; draft, send, reply to, and manage mailbox state through "
-        "requester-scoped MindRoom OAuth. Writes and mailbox-state changes follow the deployment's "
-        "configured approval policy. If authorization is missing or expired, call a Gmail tool to "
-        "get a fresh, short-lived MindRoom connection link for that requester; if it expires, call "
-        "again for a new link."
+        "MindRoom OAuth. OAuth credentials are requester-scoped for user and user-agent execution "
+        "(including private agents), and agent-scoped for shared agents. Writes and mailbox-state "
+        "changes follow the deployment's configured approval policy. If authorization is missing "
+        "or expired, call a Gmail tool to get a fresh MindRoom connection link. In worker-routed "
+        "execution, the link is short-lived and bound to the current requester and credential "
+        "target; if it expires, call again for a new link."
     ),
     category=ToolCategory.EMAIL,
     status=ToolStatus.REQUIRES_CONFIG,

--- a/src/mindroom/tools/gmail.py
+++ b/src/mindroom/tools/gmail.py
@@ -20,7 +20,13 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="gmail",
     display_name="Gmail",
-    description="Read, search, and manage Gmail emails",
+    description=(
+        "Read and search Gmail; draft, send, reply to, and manage mailbox state through "
+        "requester-scoped MindRoom OAuth. Writes and mailbox-state changes follow the deployment's "
+        "configured approval policy. If authorization is missing or expired, call a Gmail tool to "
+        "get a fresh, short-lived MindRoom connection link for that requester; if it expires, call "
+        "again for a new link."
+    ),
     category=ToolCategory.EMAIL,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.OAUTH,

--- a/src/mindroom/tools/google_calendar.py
+++ b/src/mindroom/tools/google_calendar.py
@@ -22,10 +22,12 @@ if TYPE_CHECKING:
     display_name="Google Calendar",
     description=(
         "Read and search Google Calendar and check availability; create, update, move, respond to, "
-        "and delete events through requester-scoped MindRoom OAuth. Writes follow the deployment's "
-        "configured approval policy. If authorization is missing or expired, call a Calendar tool "
-        "to get a fresh, short-lived MindRoom connection link for that requester; if it expires, "
-        "call again for a new link."
+        "and delete events through MindRoom OAuth. OAuth credentials are requester-scoped for user "
+        "and user-agent execution (including private agents), and agent-scoped for shared agents. "
+        "Writes follow the deployment's configured approval policy. If authorization is missing or "
+        "expired, call a Calendar tool to get a fresh MindRoom connection link. In worker-routed "
+        "execution, the link is short-lived and bound to the current requester and credential "
+        "target; if it expires, call again for a new link."
     ),
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.REQUIRES_CONFIG,

--- a/src/mindroom/tools/google_calendar.py
+++ b/src/mindroom/tools/google_calendar.py
@@ -20,7 +20,13 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="google_calendar",
     display_name="Google Calendar",
-    description="View and schedule meetings with Google Calendar",
+    description=(
+        "Read and search Google Calendar and check availability; create, update, move, respond to, "
+        "and delete events through requester-scoped MindRoom OAuth. Writes follow the deployment's "
+        "configured approval policy. If authorization is missing or expired, call a Calendar tool "
+        "to get a fresh, short-lived MindRoom connection link for that requester; if it expires, "
+        "call again for a new link."
+    ),
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.OAUTH,

--- a/src/mindroom/tools/google_drive.py
+++ b/src/mindroom/tools/google_drive.py
@@ -20,7 +20,13 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="google_drive",
     display_name="Google Drive",
-    description="Search, read, upload, and organize files in the connected user's Google Drive",
+    description=(
+        "List, search, read, and download Google Drive files; upload files, create folders, move or "
+        "rename items, and trash items through requester-scoped MindRoom OAuth. Writes follow the "
+        "deployment's configured approval policy. If authorization is missing or expired, call a "
+        "Drive tool to get a fresh, short-lived MindRoom connection link for that requester; if it "
+        "expires, call again for a new link."
+    ),
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.REQUIRES_CONFIG,
     setup_type=SetupType.OAUTH,

--- a/src/mindroom/tools/google_drive.py
+++ b/src/mindroom/tools/google_drive.py
@@ -22,10 +22,12 @@ if TYPE_CHECKING:
     display_name="Google Drive",
     description=(
         "List, search, read, and download Google Drive files; upload files, create folders, move or "
-        "rename items, and trash items through requester-scoped MindRoom OAuth. Writes follow the "
-        "deployment's configured approval policy. If authorization is missing or expired, call a "
-        "Drive tool to get a fresh, short-lived MindRoom connection link for that requester; if it "
-        "expires, call again for a new link."
+        "rename items, and trash items through MindRoom OAuth. OAuth credentials are "
+        "requester-scoped for user and user-agent execution (including private agents), and "
+        "agent-scoped for shared agents. Writes follow the deployment's configured approval policy. "
+        "If authorization is missing or expired, call a Drive tool to get a fresh MindRoom "
+        "connection link. In worker-routed execution, the link is short-lived and bound to the "
+        "current requester and credential target; if it expires, call again for a new link."
     ),
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.REQUIRES_CONFIG,

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -6584,7 +6584,7 @@
         "google-auth-oauthlib",
         "google-auth-httplib2"
       ],
-      "description": "Read and search Gmail; draft, send, reply to, and manage mailbox state through requester-scoped MindRoom OAuth. Writes and mailbox-state changes follow the deployment's configured approval policy. If authorization is missing or expired, call a Gmail tool to get a fresh, short-lived MindRoom connection link for that requester; if it expires, call again for a new link.",
+      "description": "Read and search Gmail; draft, send, reply to, and manage mailbox state through MindRoom OAuth. OAuth credentials are requester-scoped for user and user-agent execution (including private agents), and agent-scoped for shared agents. Writes and mailbox-state changes follow the deployment's configured approval policy. If authorization is missing or expired, call a Gmail tool to get a fresh MindRoom connection link. In worker-routed execution, the link is short-lived and bound to the current requester and credential target; if it expires, call again for a new link.",
       "display_name": "Gmail",
       "docs_url": "https://docs.agno.com/tools/toolkits/social/gmail",
       "function_names": [
@@ -7891,7 +7891,7 @@
         "google-auth-httplib2",
         "google-auth-oauthlib"
       ],
-      "description": "Read and search Google Calendar and check availability; create, update, move, respond to, and delete events through requester-scoped MindRoom OAuth. Writes follow the deployment's configured approval policy. If authorization is missing or expired, call a Calendar tool to get a fresh, short-lived MindRoom connection link for that requester; if it expires, call again for a new link.",
+      "description": "Read and search Google Calendar and check availability; create, update, move, respond to, and delete events through MindRoom OAuth. OAuth credentials are requester-scoped for user and user-agent execution (including private agents), and agent-scoped for shared agents. Writes follow the deployment's configured approval policy. If authorization is missing or expired, call a Calendar tool to get a fresh MindRoom connection link. In worker-routed execution, the link is short-lived and bound to the current requester and credential target; if it expires, call again for a new link.",
       "display_name": "Google Calendar",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/googlecalendar",
       "function_names": [
@@ -8071,7 +8071,7 @@
         "google-auth-httplib2",
         "google-auth-oauthlib"
       ],
-      "description": "List, search, read, and download Google Drive files; upload files, create folders, move or rename items, and trash items through requester-scoped MindRoom OAuth. Writes follow the deployment's configured approval policy. If authorization is missing or expired, call a Drive tool to get a fresh, short-lived MindRoom connection link for that requester; if it expires, call again for a new link.",
+      "description": "List, search, read, and download Google Drive files; upload files, create folders, move or rename items, and trash items through MindRoom OAuth. OAuth credentials are requester-scoped for user and user-agent execution (including private agents), and agent-scoped for shared agents. Writes follow the deployment's configured approval policy. If authorization is missing or expired, call a Drive tool to get a fresh MindRoom connection link. In worker-routed execution, the link is short-lived and bound to the current requester and credential target; if it expires, call again for a new link.",
       "display_name": "Google Drive",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/google_drive",
       "function_names": [

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -6584,7 +6584,7 @@
         "google-auth-oauthlib",
         "google-auth-httplib2"
       ],
-      "description": "Read, search, and manage Gmail emails",
+      "description": "Read and search Gmail; draft, send, reply to, and manage mailbox state through requester-scoped MindRoom OAuth. Writes and mailbox-state changes follow the deployment's configured approval policy. If authorization is missing or expired, call a Gmail tool to get a fresh, short-lived MindRoom connection link for that requester; if it expires, call again for a new link.",
       "display_name": "Gmail",
       "docs_url": "https://docs.agno.com/tools/toolkits/social/gmail",
       "function_names": [
@@ -7891,7 +7891,7 @@
         "google-auth-httplib2",
         "google-auth-oauthlib"
       ],
-      "description": "View and schedule meetings with Google Calendar",
+      "description": "Read and search Google Calendar and check availability; create, update, move, respond to, and delete events through requester-scoped MindRoom OAuth. Writes follow the deployment's configured approval policy. If authorization is missing or expired, call a Calendar tool to get a fresh, short-lived MindRoom connection link for that requester; if it expires, call again for a new link.",
       "display_name": "Google Calendar",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/googlecalendar",
       "function_names": [
@@ -8071,7 +8071,7 @@
         "google-auth-httplib2",
         "google-auth-oauthlib"
       ],
-      "description": "Search, read, upload, and organize files in the connected user's Google Drive",
+      "description": "List, search, read, and download Google Drive files; upload files, create folders, move or rename items, and trash items through requester-scoped MindRoom OAuth. Writes follow the deployment's configured approval policy. If authorization is missing or expired, call a Drive tool to get a fresh, short-lived MindRoom connection link for that requester; if it expires, call again for a new link.",
       "display_name": "Google Drive",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/google_drive",
       "function_names": [

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -161,6 +161,35 @@ def test_export_tools_metadata_json() -> None:
         assert "managed_init_args" not in first_tool
 
 
+@pytest.mark.parametrize(
+    ("tool_name", "capability_fragments"),
+    [
+        ("gmail", ("read and search", "draft", "send", "manage mailbox state")),
+        (
+            "google_calendar",
+            ("read and search", "check availability", "create", "update", "move", "respond", "delete"),
+        ),
+        (
+            "google_drive",
+            ("list", "search", "read", "download", "upload", "create folders", "move", "rename", "trash"),
+        ),
+    ],
+)
+def test_native_google_metadata_explains_capabilities_and_oauth_recovery(
+    tool_name: str,
+    capability_fragments: tuple[str, ...],
+) -> None:
+    """Native Google metadata should explain scope, approvals, and OAuth recovery."""
+    description = TOOL_METADATA[tool_name].description.lower()
+
+    for fragment in capability_fragments:
+        assert fragment in description
+    assert "requester-scoped mindroom oauth" in description
+    assert "configured approval policy" in description
+    assert "fresh, short-lived mindroom connection link" in description
+    assert "call again for a new link" in description
+
+
 def test_export_tools_metadata_json_resets_leaked_registry_entries() -> None:
     """Export should ignore temporary registry contamination from earlier tests."""
     tool_name = "test_leaked_tool"

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -184,9 +184,13 @@ def test_native_google_metadata_explains_capabilities_and_oauth_recovery(
 
     for fragment in capability_fragments:
         assert fragment in description
-    assert "requester-scoped mindroom oauth" in description
+    assert "requester-scoped for user and user-agent execution" in description
+    assert "including private agents" in description
+    assert "agent-scoped for shared agents" in description
     assert "configured approval policy" in description
-    assert "fresh, short-lived mindroom connection link" in description
+    assert "fresh mindroom connection link" in description
+    assert "worker-routed execution, the link is short-lived" in description
+    assert "bound to the current requester and credential target" in description
     assert "call again for a new link" in description
 
 


### PR DESCRIPTION
## Summary

- describe OAuth credential scope precisely: requester-scoped in user/user-agent contexts and agent-scoped for shared agents
- enumerate native Gmail, Calendar, and Drive read/write capabilities
- state that write operations follow the configured approval policy
- document fresh-link recovery, including requester/target binding for worker-routed links
- keep the generated tool metadata snapshot and behavior tests in sync

## Testing

- `uv run pytest -q`
- `uv run pre-commit run --files src/mindroom/tools/gmail.py src/mindroom/tools/google_calendar.py src/mindroom/tools/google_drive.py src/mindroom/tools_metadata.json tests/test_tools_metadata.py`