### PR TITLE
Prevent stale Git index locks from blocking knowledge refreshes

### DIFF
--- a/src/mindroom/file_locks.py
+++ b/src/mindroom/file_locks.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import asyncio
 import fcntl
 from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -15,12 +17,57 @@ if TYPE_CHECKING:
 _DEFAULT_POLL_SECONDS = 0.1
 
 __all__ = [
+    "InheritedFileLockCapability",
     "acquire_shared_file_lock",
     "advisory_file_lock",
     "async_exclusive_file_lock",
+    "current_inherited_file_lock",
+    "expose_inherited_file_lock",
     "file_lock_is_held",
     "release_file_lock",
 ]
+
+
+@dataclass
+class InheritedFileLockCapability:
+    """A task-local authority to pass one still-owned lock into a subprocess."""
+
+    scope: Path
+    lock_file: TextIO
+    active: bool = True
+
+    def fileno_for(self, scope: Path) -> int | None:
+        """Return the descriptor only while this capability owns the same scope."""
+        if not self.active or self.lock_file.closed or self.scope != scope.resolve():
+            return None
+        return self.lock_file.fileno()
+
+
+_inherited_file_lock: ContextVar[InheritedFileLockCapability | None] = ContextVar(
+    "inherited_file_lock",
+    default=None,
+)
+
+
+@contextmanager
+def expose_inherited_file_lock(
+    lock_file: TextIO,
+    *,
+    scope: Path,
+) -> Iterator[InheritedFileLockCapability]:
+    """Expose an owned lock to subprocess launchers in this task context."""
+    capability = InheritedFileLockCapability(scope=scope.resolve(), lock_file=lock_file)
+    token = _inherited_file_lock.set(capability)
+    try:
+        yield capability
+    finally:
+        capability.active = False
+        _inherited_file_lock.reset(token)
+
+
+def current_inherited_file_lock() -> InheritedFileLockCapability | None:
+    """Return the task-local capability; callers must validate it at point of use."""
+    return _inherited_file_lock.get()
 
 
 def _open_lock_file(lock_path: Path) -> TextIO:
@@ -91,7 +138,8 @@ async def async_exclusive_file_lock(
     lock_path: Path,
     *,
     poll_seconds: float = _DEFAULT_POLL_SECONDS,
-) -> AsyncIterator[None]:
+    retain_for_inherited_fds: bool = False,
+) -> AsyncIterator[TextIO]:
     """Acquire an exclusive advisory file lock without blocking the event loop."""
     lock_file = _open_lock_file(lock_path)
     acquired = False
@@ -102,8 +150,10 @@ async def async_exclusive_file_lock(
                 acquired = True
             except BlockingIOError:
                 await asyncio.sleep(poll_seconds)
-        yield
+        yield lock_file
     finally:
-        if acquired:
+        if acquired and not retain_for_inherited_fds:
             fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+        # With retention enabled, close without LOCK_UN: a subprocess may have
+        # inherited this open-file description and must keep the lock held.
         lock_file.close()

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -17,10 +17,11 @@ import asyncio
 import base64
 import os
 import re
+import signal
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 from urllib.parse import urlparse
 
 from mindroom.credentials import get_runtime_shared_credentials_manager
@@ -48,6 +49,72 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 __all__ = ["GitKnowledgeSource", "GitSyncResult"]
+
+_REFRESH_SUBPROCESS_ENV = "MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"
+_OwnedTaskResult = TypeVar("_OwnedTaskResult")
+
+
+def _git_process_group_is_owned_here() -> bool:
+    """Return whether this process, rather than an outer refresh, must reap Git."""
+    return os.name != "nt" and os.environ.get(_REFRESH_SUBPROCESS_ENV) != "1"
+
+
+def _process_group_exists(process_group_id: int) -> bool:
+    try:
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+async def _wait_for_process_group_exit(process_group_id: int, *, wait_seconds: float = 1.0) -> None:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + wait_seconds
+    while _process_group_exists(process_group_id) and loop.time() < deadline:  # noqa: ASYNC110
+        await asyncio.sleep(0.01)
+    if _process_group_exists(process_group_id):
+        logger.warning(
+            "Knowledge Git process group survived termination wait",
+            process_group_id=process_group_id,
+            wait_seconds=wait_seconds,
+        )
+
+
+async def _drain_owned_task(task: asyncio.Task[_OwnedTaskResult]) -> asyncio.CancelledError | None:
+    """Wait through repeated caller cancellation until owned work settles."""
+    cancellation: asyncio.CancelledError | None = None
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            if cancellation is None:
+                cancellation = exc
+    return cancellation
+
+
+async def _terminate_git_process(
+    process: asyncio.subprocess.Process,
+    *,
+    owned_process_group_id: int | None,
+) -> None:
+    group_signalled = False
+    if owned_process_group_id is None:
+        if process.returncode is not None:
+            return
+        with suppress(ProcessLookupError):
+            process.kill()
+    else:
+        try:
+            os.killpg(owned_process_group_id, signal.SIGKILL)
+            group_signalled = True
+        except ProcessLookupError:
+            pass
+    with suppress(ProcessLookupError):
+        await process.wait()
+    if group_signalled and owned_process_group_id is not None:
+        await _wait_for_process_group_exit(owned_process_group_id)
 
 
 def _http_credentials(
@@ -471,35 +538,65 @@ class GitKnowledgeSource:
         repo_root = cwd or self.source_path
         capability = current_inherited_file_lock()
         inherited_lock_fd = None if capability is None else capability.fileno_for(self.source_path)
-        process = await asyncio.create_subprocess_exec(
-            "git",
-            *args,
-            cwd=str(repo_root),
-            env=None if env is None else {**os.environ, **env},
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
-            pass_fds=(() if inherited_lock_fd is None else (inherited_lock_fd,)),
+        owns_process_group = _git_process_group_is_owned_here()
+        spawn_task = asyncio.create_task(
+            asyncio.create_subprocess_exec(
+                "git",
+                *args,
+                cwd=str(repo_root),
+                env=None if env is None else {**os.environ, **env},
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                pass_fds=(() if inherited_lock_fd is None else (inherited_lock_fd,)),
+                start_new_session=owns_process_group,
+            ),
         )
+        spawn_cancellation = await _drain_owned_task(spawn_task)
+        process = spawn_task.result()
+        owned_process_group_id = process.pid if owns_process_group else None
+        if spawn_cancellation is not None:
+            cleanup_task = asyncio.create_task(
+                _terminate_git_process(process, owned_process_group_id=owned_process_group_id),
+            )
+            await _drain_owned_task(cleanup_task)
+            cleanup_task.result()
+            raise spawn_cancellation from None
         try:
             timeout_seconds = self._sync_timeout_seconds()
             if timeout_seconds is None:
                 stdout, stderr = await process.communicate()
             else:
                 stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=timeout_seconds)
-        except asyncio.CancelledError:
-            with suppress(ProcessLookupError):
-                process.kill()
-            with suppress(ProcessLookupError):
-                await process.wait()
-            raise
+        except asyncio.CancelledError as exc:
+            cleanup_task = asyncio.create_task(
+                _terminate_git_process(process, owned_process_group_id=owned_process_group_id),
+            )
+            await _drain_owned_task(cleanup_task)
+            cleanup_task.result()
+            raise exc from None
         except TimeoutError as exc:
-            with suppress(ProcessLookupError):
-                process.kill()
-            with suppress(ProcessLookupError):
-                await process.wait()
+            cleanup_task = asyncio.create_task(
+                _terminate_git_process(process, owned_process_group_id=owned_process_group_id),
+            )
+            cancellation = await _drain_owned_task(cleanup_task)
+            cleanup_task.result()
+            if cancellation is not None:
+                raise cancellation from None
             command = " ".join(["git", *(redact_url_credentials(arg) for arg in args)])
             msg = f"Git command timed out after {timeout_seconds:.0f}s: {command}"
             raise RuntimeError(msg) from exc
+
+        # A completed Git leader may still leave a filter/helper behind. Direct
+        # refreshes own a private group and must drain it before releasing the
+        # inherited source lock. A refresh subprocess leaves this to its outer
+        # process-group supervisor instead.
+        cleanup_task = asyncio.create_task(
+            _terminate_git_process(process, owned_process_group_id=owned_process_group_id),
+        )
+        cancellation = await _drain_owned_task(cleanup_task)
+        cleanup_task.result()
+        if cancellation is not None:
+            raise cancellation from None
 
         if process.returncode == 0:
             return stdout.decode("utf-8", errors="replace")

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -19,10 +19,12 @@ import os
 import re
 from contextlib import suppress
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
 from mindroom.credentials import get_runtime_shared_credentials_manager
+from mindroom.file_locks import current_inherited_file_lock
 from mindroom.knowledge.file_listing import (
     git_checkout_present,
     git_tracked_relative_paths_from_checkout,
@@ -39,8 +41,6 @@ from mindroom.knowledge.redaction import (
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
-    from pathlib import Path
-
     from mindroom.config.knowledge import KnowledgeGitConfig
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -353,12 +353,19 @@ class GitKnowledgeSource:
         return await self._rev_parse("HEAD")
 
     async def sync(self) -> GitSyncResult:
-        """Fetch and force-align one configured Git repository checkout."""
+        """Fetch and force-align one configured Git repository checkout.
+
+        An existing index lock is recoverable only while this task holds the
+        source-root file lock whose descriptor every Git child inherits. A Git
+        descendant that outlives its Python parent therefore keeps later
+        refreshes outside this transaction boundary until it exits.
+        """
         git_config = self._git_config()
         if git_config is None:
             return GitSyncResult(head=None, updated=False)
 
         async with self._sync_lock:
+            self._clear_orphaned_index_lock()
             changed_files, removed_files, updated = await self._sync_once(git_config)
             current_head = await self._rev_parse("HEAD")
             self._last_synced_head = current_head
@@ -404,6 +411,41 @@ class GitKnowledgeSource:
     def _clear_lfs_hydrated_head(self) -> None:
         self.lfs_hydrated_head_path.unlink(missing_ok=True)
 
+    def _git_index_lock_path(self) -> Path | None:
+        """Resolve the index lock for a repository or linked worktree."""
+        dot_git = self.source_path / ".git"
+        if dot_git.is_dir():
+            return dot_git / "index.lock"
+        try:
+            git_file = dot_git.read_text(encoding="utf-8").strip()
+        except OSError:
+            return None
+        prefix, separator, raw_git_dir = git_file.partition(":")
+        if prefix.lower() != "gitdir" or not separator or not raw_git_dir.strip():
+            return None
+        git_dir = Path(raw_git_dir.strip())
+        if not git_dir.is_absolute():
+            git_dir = dot_git.parent / git_dir
+        return git_dir.resolve() / "index.lock"
+
+    def _clear_orphaned_index_lock(self) -> None:
+        """Remove a Git index lock left behind before this owned sync began."""
+        capability = current_inherited_file_lock()
+        if capability is None or capability.fileno_for(self.source_path) is None:
+            return
+        lock_path = self._git_index_lock_path()
+        if lock_path is None:
+            return
+        try:
+            lock_path.unlink()
+        except FileNotFoundError:
+            return
+        logger.warning(
+            "Removed orphaned knowledge Git index lock",
+            base_id=self.base_id,
+            lock_path=str(lock_path),
+        )
+
     async def _checkout_present(self) -> bool:
         return await asyncio.to_thread(
             git_checkout_present,
@@ -419,6 +461,8 @@ class GitKnowledgeSource:
         env: dict[str, str] | None = None,
     ) -> str:
         repo_root = cwd or self.source_path
+        capability = current_inherited_file_lock()
+        inherited_lock_fd = None if capability is None else capability.fileno_for(self.source_path)
         process = await asyncio.create_subprocess_exec(
             "git",
             *args,
@@ -426,6 +470,7 @@ class GitKnowledgeSource:
             env=None if env is None else {**os.environ, **env},
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
+            pass_fds=(() if inherited_lock_fd is None else (inherited_lock_fd,)),
         )
         try:
             timeout_seconds = self._sync_timeout_seconds()

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -440,6 +440,14 @@ class GitKnowledgeSource:
             lock_path.unlink()
         except FileNotFoundError:
             return
+        except OSError as exc:
+            logger.warning(
+                "Could not remove orphaned knowledge Git index lock",
+                base_id=self.base_id,
+                lock_path=str(lock_path),
+                error=str(exc),
+            )
+            return
         logger.warning(
             "Removed orphaned knowledge Git index lock",
             base_id=self.base_id,

--- a/src/mindroom/knowledge/refresh_locks.py
+++ b/src/mindroom/knowledge/refresh_locks.py
@@ -17,12 +17,12 @@ from pathlib import Path
 from threading import Lock
 from typing import TYPE_CHECKING
 
-from mindroom.file_locks import async_exclusive_file_lock
+from mindroom.file_locks import async_exclusive_file_lock, expose_inherited_file_lock
 from mindroom.knowledge.registry import resolve_refresh_target
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
-    from typing import Literal
+    from typing import Literal, TextIO
 
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -106,10 +106,14 @@ def _refresh_file_lock_path(key: KnowledgeSourceRoot) -> Path:
 
 
 @asynccontextmanager
-async def _acquire_refresh_file_lock(key: KnowledgeSourceRoot) -> AsyncIterator[None]:
+async def _acquire_refresh_file_lock(key: KnowledgeSourceRoot) -> AsyncIterator[TextIO]:
     """Serialize source-root refresh and mutation work across processes."""
-    async with async_exclusive_file_lock(_refresh_file_lock_path(key), poll_seconds=_REFRESH_FILE_LOCK_POLL_SECONDS):
-        yield
+    async with async_exclusive_file_lock(
+        _refresh_file_lock_path(key),
+        poll_seconds=_REFRESH_FILE_LOCK_POLL_SECONDS,
+        retain_for_inherited_fds=True,
+    ) as lock_file:
+        yield lock_file
 
 
 @asynccontextmanager
@@ -130,8 +134,9 @@ async def refresh_source_root_lock(key: KnowledgeSourceRoot) -> AsyncIterator[No
     order rather than queueing, and the borrow counts that keep the lock table from
     evicting a live entry would never be recorded.
     """
-    async with _acquire_refresh_lock(key), _acquire_refresh_file_lock(key):
-        yield
+    async with _acquire_refresh_lock(key), _acquire_refresh_file_lock(key) as lock_file:
+        with expose_inherited_file_lock(lock_file, scope=Path(key.knowledge_path)):
+            yield
 
 
 def mark_refresh_active(key: KnowledgeRefreshTarget) -> None:

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -218,6 +218,10 @@ async def refresh_knowledge_binding_in_subprocess(
         raise
 
     if return_code != 0:
+        # The refresh leader can crash while one of its Git descendants keeps
+        # running in the session. Drain that process group before reconciliation
+        # tries to reacquire the source-root lock inherited by those descendants.
+        await _terminate_refresh_subprocess(process)
         msg = f"Knowledge refresh subprocess failed for {base_id!r} with exit code {return_code}"
         await _reconcile_failed_refresh_subprocess(key, initial_state=initial_state, error=msg)
         raise RuntimeError(msg)
@@ -270,23 +274,51 @@ def _subprocess_session_kwargs() -> _SubprocessSessionKwargs:
     return {"start_new_session": True}
 
 
-async def _terminate_refresh_subprocess(process: asyncio.subprocess.Process) -> None:
-    if process.returncode is not None:
-        return
-    if os.name == "nt":
-        process.terminate()
-    else:
-        with suppress(ProcessLookupError):
-            os.killpg(process.pid, signal.SIGTERM)
+def _process_group_exists(process_group_id: int) -> bool:
     try:
-        await asyncio.wait_for(process.wait(), timeout=10)
-    except TimeoutError:
-        if os.name == "nt":
+        os.killpg(process_group_id, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+async def _wait_for_process_group_exit(process_group_id: int, *, wait_seconds: float = 1.0) -> None:
+    deadline = asyncio.get_running_loop().time() + wait_seconds
+    # There is no asyncio readiness primitive for POSIX process-group exit.
+    while _process_group_exists(process_group_id) and asyncio.get_running_loop().time() < deadline:  # noqa: ASYNC110
+        await asyncio.sleep(0.01)
+
+
+async def _terminate_refresh_subprocess(process: asyncio.subprocess.Process) -> None:
+    if os.name == "nt":
+        if process.returncode is not None:
+            return
+        process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=10)
+        except TimeoutError:
             process.kill()
-        else:
+            await process.wait()
+        return
+
+    process_group_id = process.pid
+    with suppress(ProcessLookupError):
+        os.killpg(process_group_id, signal.SIGTERM)
+    if process.returncode is None:
+        try:
+            await asyncio.wait_for(process.wait(), timeout=10)
+        except TimeoutError:
             with suppress(ProcessLookupError):
-                os.killpg(process.pid, signal.SIGKILL)
-        await process.wait()
+                os.killpg(process_group_id, signal.SIGKILL)
+            await process.wait()
+            await _wait_for_process_group_exit(process_group_id)
+            return
+    if _process_group_exists(process_group_id):
+        with suppress(ProcessLookupError):
+            os.killpg(process_group_id, signal.SIGKILL)
+        await _wait_for_process_group_exit(process_group_id)
 
 
 async def _drain_owned_cleanup_task(cleanup_task: asyncio.Task[None]) -> asyncio.CancelledError | None:

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -217,11 +217,13 @@ async def refresh_knowledge_binding_in_subprocess(
             cleanup_task.result()
         raise
 
+    cleanup_task = asyncio.create_task(_terminate_refresh_subprocess(process))
+    cancellation = await _drain_owned_cleanup_task(cleanup_task)
+    cleanup_task.result()
+    if cancellation is not None:
+        raise cancellation from None
+
     if return_code != 0:
-        # The refresh leader can crash while one of its Git descendants keeps
-        # running in the session. Drain that process group before reconciliation
-        # tries to reacquire the source-root lock inherited by those descendants.
-        await _terminate_refresh_subprocess(process)
         msg = f"Knowledge refresh subprocess failed for {base_id!r} with exit code {return_code}"
         await _reconcile_failed_refresh_subprocess(key, initial_state=initial_state, error=msg)
         raise RuntimeError(msg)

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -285,10 +285,17 @@ def _process_group_exists(process_group_id: int) -> bool:
 
 
 async def _wait_for_process_group_exit(process_group_id: int, *, wait_seconds: float = 1.0) -> None:
-    deadline = asyncio.get_running_loop().time() + wait_seconds
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + wait_seconds
     # There is no asyncio readiness primitive for POSIX process-group exit.
-    while _process_group_exists(process_group_id) and asyncio.get_running_loop().time() < deadline:  # noqa: ASYNC110
+    while _process_group_exists(process_group_id) and loop.time() < deadline:  # noqa: ASYNC110
         await asyncio.sleep(0.01)
+    if _process_group_exists(process_group_id):
+        logger.warning(
+            "Knowledge refresh process group survived termination wait",
+            process_group_id=process_group_id,
+            wait_seconds=wait_seconds,
+        )
 
 
 async def _terminate_refresh_subprocess(process: asyncio.subprocess.Process) -> None:

--- a/tests/test_file_locks.py
+++ b/tests/test_file_locks.py
@@ -4,12 +4,13 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import threading
 from typing import TYPE_CHECKING
 
 import pytest
 
-from mindroom.file_locks import advisory_file_lock, async_exclusive_file_lock
+from mindroom.file_locks import advisory_file_lock, async_exclusive_file_lock, file_lock_is_held
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -58,6 +59,38 @@ async def test_async_exclusive_file_lock_released_on_cancellation(tmp_path: Path
 
     # A cancelled waiter/holder must release the lock, so this acquires without hanging.
     assert await asyncio.wait_for(acquire_once(), timeout=2)
+
+
+@pytest.mark.asyncio
+async def test_async_exclusive_file_lock_outlives_parent_handle_when_fd_is_inherited(tmp_path: Path) -> None:
+    lock_path = tmp_path / "index.lock"
+
+    async with async_exclusive_file_lock(
+        lock_path,
+        poll_seconds=0.01,
+        retain_for_inherited_fds=True,
+    ) as lock_file:
+        inherited_fd = os.dup(lock_file.fileno())
+
+    try:
+        assert file_lock_is_held(lock_path) is True
+    finally:
+        os.close(inherited_fd)
+
+    assert file_lock_is_held(lock_path) is False
+
+
+@pytest.mark.asyncio
+async def test_async_exclusive_file_lock_releases_inherited_fd_by_default(tmp_path: Path) -> None:
+    lock_path = tmp_path / "index.lock"
+
+    async with async_exclusive_file_lock(lock_path, poll_seconds=0.01) as lock_file:
+        inherited_fd = os.dup(lock_file.fileno())
+
+    try:
+        assert file_lock_is_held(lock_path) is False
+    finally:
+        os.close(inherited_fd)
 
 
 def test_advisory_file_lock_exclusive_blocks_second_holder(tmp_path: Path) -> None:

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -21,11 +21,13 @@ from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.knowledge.git_source import GitKnowledgeSource, GitSyncResult
 from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.redaction import redact_url_credentials
+from mindroom.knowledge.refresh_locks import refresh_source_root_lock
 from mindroom.knowledge.refresh_runner import refresh_knowledge_binding
 from mindroom.knowledge.registry import (
     get_published_index,
     published_index_metadata_path,
     resolve_published_index_key,
+    source_root_for_published_index_key,
 )
 from tests.conftest import runtime_paths_for
 from tests.knowledge_test_support import (
@@ -127,6 +129,121 @@ async def test_git_source_sync_does_not_mutate_index_directly(
     assert not hasattr(manager, "index_file")
     assert result == GitSyncResult(head="rev-source-only", updated=True)
     assert manager.git_source.last_synced_head == "rev-source-only"
+
+
+@pytest.mark.asyncio
+async def test_git_source_sync_without_source_root_ownership_preserves_index_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A direct sync must not classify a possibly live Git lock as orphaned."""
+    manager = _git_manager(tmp_path)
+    git_dir = manager.knowledge_path / ".git"
+    git_dir.mkdir(parents=True)
+    lock_path = git_dir / "index.lock"
+    lock_path.write_text("", encoding="utf-8")
+
+    async def _sync_once(_git_config: KnowledgeGitConfig) -> tuple[set[str], set[str], bool]:
+        assert lock_path.exists() is True
+        return set(), set(), False
+
+    async def _rev_parse(_ref: str) -> str:
+        return "unchanged"
+
+    monkeypatch.setattr(manager.git_source, "_sync_once", _sync_once)
+    monkeypatch.setattr(manager.git_source, "_rev_parse", _rev_parse)
+
+    await manager.git_source.sync()
+
+    assert lock_path.exists() is True
+
+
+@pytest.mark.asyncio
+async def test_git_source_sync_with_expired_inherited_capability_preserves_index_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A child task cannot retain cleanup authority after its owner's context exits."""
+    manager = _git_manager(tmp_path)
+    git_dir = manager.knowledge_path / ".git"
+    git_dir.mkdir(parents=True)
+    lock_path = git_dir / "index.lock"
+    lock_path.write_text("", encoding="utf-8")
+    released = asyncio.Event()
+
+    async def _sync_once(_git_config: KnowledgeGitConfig) -> tuple[set[str], set[str], bool]:
+        assert lock_path.exists() is True
+        return set(), set(), False
+
+    async def _rev_parse(_ref: str) -> str:
+        return "unchanged"
+
+    async def _sync_after_release() -> None:
+        await released.wait()
+        await manager.git_source.sync()
+
+    monkeypatch.setattr(manager.git_source, "_sync_once", _sync_once)
+    monkeypatch.setattr(manager.git_source, "_rev_parse", _rev_parse)
+    key = resolve_published_index_key(
+        "docs",
+        config=manager.config,
+        runtime_paths=manager.runtime_paths,
+    )
+    source_root = source_root_for_published_index_key(key)
+
+    async with refresh_source_root_lock(source_root):
+        inherited_task = asyncio.create_task(_sync_after_release())
+
+    released.set()
+    await inherited_task
+
+    assert lock_path.exists() is True
+
+
+@pytest.mark.asyncio
+async def test_run_git_inherits_owned_source_root_lock(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A Git descendant must keep refresh ownership if its Python parent exits."""
+    manager = _git_manager(tmp_path)
+
+    class _SuccessfulProcess:
+        returncode = 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    subprocess_kwargs: dict[str, object] = {}
+
+    async def _fake_create_subprocess_exec(*_args: object, **kwargs: object) -> _SuccessfulProcess:
+        subprocess_kwargs.update(kwargs)
+        return _SuccessfulProcess()
+
+    async def _sync_once(_git_config: KnowledgeGitConfig) -> tuple[set[str], set[str], bool]:
+        await manager.git_source._run_git(["status"])
+        return set(), set(), False
+
+    async def _rev_parse(_ref: str) -> str:
+        return "unchanged"
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(manager.git_source, "_sync_once", _sync_once)
+    monkeypatch.setattr(manager.git_source, "_rev_parse", _rev_parse)
+    key = resolve_published_index_key(
+        "docs",
+        config=manager.config,
+        runtime_paths=manager.runtime_paths,
+    )
+    source_root = source_root_for_published_index_key(key)
+
+    async with refresh_source_root_lock(source_root):
+        await manager.git_source.sync()
+
+    inherited_fds = subprocess_kwargs["pass_fds"]
+    assert isinstance(inherited_fds, tuple)
+    assert len(inherited_fds) == 1
+    assert isinstance(inherited_fds[0], int)
 
 
 @pytest.mark.asyncio
@@ -497,6 +614,128 @@ async def test_existing_single_branch_checkout_switches_to_new_remote_branch(tmp
     assert release_lookup.index is not None
     assert [document.content for document in release_lookup.index.knowledge.search("branch", max_results=5)] == [
         "release branch content",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_recovers_orphaned_git_index_lock(tmp_path: Path) -> None:
+    """A crashed refresh must not leave every later Git refresh permanently wedged."""
+    remote_work = tmp_path / "remote-work"
+    remote_work.mkdir()
+
+    async def _git(cwd: Path, *args: str) -> None:
+        await asyncio.to_thread(
+            subprocess.run,
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    await _git(remote_work, "init", "-b", "main")
+    await _git(remote_work, "config", "user.email", "tests@example.com")
+    await _git(remote_work, "config", "user.name", "MindRoom Tests")
+    (remote_work / "doc.md").write_text("before crash", encoding="utf-8")
+    await _git(remote_work, "add", "doc.md")
+    await _git(remote_work, "commit", "-m", "before")
+    remote_bare = tmp_path / "remote.git"
+    await asyncio.to_thread(
+        subprocess.run,
+        ["git", "clone", "--bare", str(remote_work), str(remote_bare)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    docs_path = tmp_path / "checkout"
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={"docs": KnowledgeGitConfig(repo_url=str(remote_bare), branch="main")},
+    )
+    runtime_paths = runtime_paths_for(config)
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    (remote_work / "doc.md").write_text("after crash", encoding="utf-8")
+    await _git(remote_work, "commit", "-am", "after")
+    await _git(remote_work, "push", str(remote_bare), "main")
+    lock_path = docs_path / ".git" / "index.lock"
+    lock_path.write_text("", encoding="utf-8")
+
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    lookup = get_published_index("docs", config=config, runtime_paths=runtime_paths)
+
+    assert lock_path.exists() is False
+    assert result.index_published is True
+    assert lookup.index is not None
+    assert [document.content for document in lookup.index.knowledge.search("crash", max_results=5)] == [
+        "after crash",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_recovers_orphaned_index_lock_in_linked_worktree(tmp_path: Path) -> None:
+    """Recovery must follow a linked worktree's .git pointer to its real index lock."""
+    remote_work = tmp_path / "remote-work"
+    remote_work.mkdir()
+
+    async def _git(cwd: Path, *args: str) -> None:
+        await asyncio.to_thread(
+            subprocess.run,
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    await _git(remote_work, "init", "-b", "main")
+    await _git(remote_work, "config", "user.email", "tests@example.com")
+    await _git(remote_work, "config", "user.name", "MindRoom Tests")
+    (remote_work / "doc.md").write_text("linked worktree content", encoding="utf-8")
+    await _git(remote_work, "add", "doc.md")
+    await _git(remote_work, "commit", "-m", "main")
+    remote_bare = tmp_path / "remote.git"
+    await asyncio.to_thread(
+        subprocess.run,
+        ["git", "clone", "--bare", str(remote_work), str(remote_bare)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    seed_checkout = tmp_path / "seed-checkout"
+    await asyncio.to_thread(
+        subprocess.run,
+        ["git", "clone", str(remote_bare), str(seed_checkout)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    docs_path = tmp_path / "worktree-checkout"
+    await _git(seed_checkout, "worktree", "add", "--detach", str(docs_path), "HEAD")
+    dot_git = docs_path / ".git"
+    git_dir = Path(dot_git.read_text(encoding="utf-8").removeprefix("gitdir:").strip())
+    lock_path = git_dir / "index.lock"
+    lock_path.write_text("", encoding="utf-8")
+
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={"docs": KnowledgeGitConfig(repo_url=str(remote_bare), branch="main")},
+    )
+    runtime_paths = runtime_paths_for(config)
+
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    lookup = get_published_index("docs", config=config, runtime_paths=runtime_paths)
+
+    assert lock_path.exists() is False
+    assert result.index_published is True
+    assert lookup.index is not None
+    assert [document.content for document in lookup.index.knowledge.search("linked", max_results=5)] == [
+        "linked worktree content",
     ]
 
 

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -201,6 +201,51 @@ async def test_git_source_sync_with_expired_inherited_capability_preserves_index
 
 
 @pytest.mark.asyncio
+async def test_git_source_sync_continues_when_orphaned_lock_cannot_be_removed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cleanup failure must leave Git responsible for reporting the repository error."""
+    manager = _git_manager(tmp_path)
+    git_dir = manager.knowledge_path / ".git"
+    git_dir.mkdir(parents=True)
+    lock_path = git_dir / "index.lock"
+    lock_path.write_text("", encoding="utf-8")
+    sync_attempted = False
+    original_unlink = Path.unlink
+
+    def _refuse_lock_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        if path == lock_path:
+            msg = "refused"
+            raise PermissionError(msg)
+        original_unlink(path, *args, **kwargs)
+
+    async def _sync_once(_git_config: KnowledgeGitConfig) -> tuple[set[str], set[str], bool]:
+        nonlocal sync_attempted
+        sync_attempted = True
+        return set(), set(), False
+
+    async def _rev_parse(_ref: str) -> str:
+        return "unchanged"
+
+    monkeypatch.setattr(Path, "unlink", _refuse_lock_unlink)
+    monkeypatch.setattr(manager.git_source, "_sync_once", _sync_once)
+    monkeypatch.setattr(manager.git_source, "_rev_parse", _rev_parse)
+    key = resolve_published_index_key(
+        "docs",
+        config=manager.config,
+        runtime_paths=manager.runtime_paths,
+    )
+    source_root = source_root_for_published_index_key(key)
+
+    async with refresh_source_root_lock(source_root):
+        await manager.git_source.sync()
+
+    assert sync_attempted is True
+    assert lock_path.exists() is True
+
+
+@pytest.mark.asyncio
 async def test_run_git_inherits_owned_source_root_lock(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -10,8 +10,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
+import shlex
+import signal
 import subprocess
+from contextlib import suppress
 from pathlib import Path
+from threading import Event, Thread
 
 import pytest
 
@@ -22,7 +27,10 @@ from mindroom.knowledge.git_source import GitKnowledgeSource, GitSyncResult
 from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.redaction import redact_url_credentials
 from mindroom.knowledge.refresh_locks import refresh_source_root_lock
-from mindroom.knowledge.refresh_runner import refresh_knowledge_binding
+from mindroom.knowledge.refresh_runner import (
+    refresh_knowledge_binding,
+    refresh_knowledge_binding_in_subprocess,
+)
 from mindroom.knowledge.registry import (
     get_published_index,
     published_index_metadata_path,
@@ -718,6 +726,164 @@ async def test_refresh_recovers_orphaned_git_index_lock(tmp_path: Path) -> None:
     assert [document.content for document in lookup.index.knowledge.search("crash", max_results=5)] == [
         "after crash",
     ]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process groups and POSIX shell filters are required")
+@pytest.mark.asyncio
+async def test_crashed_git_subprocess_recovers_index_lock_on_next_refresh(  # noqa: C901, PLR0915
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real crashed checkout must not block the next subprocess refresh."""
+    remote_work = tmp_path / "remote-work"
+    remote_work.mkdir()
+
+    async def _git(cwd: Path, *args: str) -> None:
+        await asyncio.to_thread(
+            subprocess.run,
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    async def _git_output(cwd: Path, *args: str) -> str:
+        result = await asyncio.to_thread(
+            subprocess.run,
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.strip()
+
+    await _git(remote_work, "init", "-b", "main")
+    await _git(remote_work, "config", "user.email", "tests@example.com")
+    await _git(remote_work, "config", "user.name", "MindRoom Tests")
+    (remote_work / "doc.md").write_text("before crash", encoding="utf-8")
+    await _git(remote_work, "add", "doc.md")
+    await _git(remote_work, "commit", "-m", "before")
+    remote_bare = tmp_path / "remote.git"
+    await asyncio.to_thread(
+        subprocess.run,
+        ["git", "clone", "--bare", str(remote_work), str(remote_bare)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    docs_path = tmp_path / "checkout"
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={"docs": KnowledgeGitConfig(repo_url=str(remote_bare), branch="main")},
+        modes={"docs": "files"},
+    )
+    runtime_paths = runtime_paths_for(config)
+    await refresh_knowledge_binding_in_subprocess("docs", config=config, runtime_paths=runtime_paths)
+
+    lock_path = docs_path / ".git" / "index.lock"
+    ready_path = tmp_path / "filter-ready"
+    release_path = tmp_path / "filter-release"
+    filter_script = tmp_path / "blocking-smudge.sh"
+    filter_script.write_text(
+        """#!/bin/sh
+ready_path=$1
+release_path=$2
+trap '' TERM
+echo $$ > "$ready_path"
+while [ ! -e "$release_path" ]; do
+    sleep 0.05
+done
+cat
+""",
+        encoding="utf-8",
+    )
+    filter_script.chmod(0o755)
+    filter_command = " ".join(shlex.quote(str(path)) for path in (filter_script, ready_path, release_path))
+    await _git(docs_path, "config", "filter.blocking.smudge", filter_command)
+    await _git(docs_path, "config", "filter.blocking.clean", "cat")
+    await _git(docs_path, "config", "filter.blocking.required", "true")
+
+    (remote_work / ".gitattributes").write_text("doc.md filter=blocking\n", encoding="utf-8")
+    (remote_work / "doc.md").write_text("after crash", encoding="utf-8")
+    await _git(remote_work, "add", ".gitattributes", "doc.md")
+    await _git(remote_work, "commit", "-m", "after")
+    await _git(remote_work, "push", str(remote_bare), "main")
+
+    real_create_subprocess_exec = asyncio.create_subprocess_exec
+    refresh_processes: list[asyncio.subprocess.Process] = []
+
+    async def _capture_refresh_process(*args: object, **kwargs: object) -> asyncio.subprocess.Process:
+        process = await real_create_subprocess_exec(*args, **kwargs)
+        refresh_processes.append(process)
+        return process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _capture_refresh_process)
+    refresh_task = asyncio.create_task(
+        refresh_knowledge_binding_in_subprocess("docs", config=config, runtime_paths=runtime_paths),
+    )
+
+    async def _wait_for_filter() -> int:
+        while True:
+            if ready_path.exists():
+                try:
+                    return int(ready_path.read_text(encoding="utf-8"))
+                except ValueError:
+                    pass
+            if refresh_task.done():
+                await refresh_task
+                pytest.fail("refresh exited before the blocking filter started")
+            await asyncio.sleep(0.01)
+
+    watchdog_stop = Event()
+    watchdog_fired = Event()
+    watchdog: Thread | None = None
+
+    def _release_filter_if_cleanup_stalls() -> None:
+        if not watchdog_stop.wait(timeout=20):
+            watchdog_fired.set()
+            release_path.touch()
+
+    try:
+        filter_pid = await asyncio.wait_for(_wait_for_filter(), timeout=30)
+        assert filter_pid > 0
+        assert len(refresh_processes) == 1
+        watchdog = Thread(target=_release_filter_if_cleanup_stalls, daemon=True)
+        watchdog.start()
+        os.kill(refresh_processes[0].pid, signal.SIGKILL)
+        with pytest.raises(RuntimeError, match=r"failed.*exit code"):
+            await refresh_task
+    finally:
+        release_path.touch()
+        watchdog_stop.set()
+        if watchdog is not None:
+            watchdog.join(timeout=1)
+        if not refresh_task.done():
+            refresh_task.cancel()
+            done, _pending = await asyncio.wait({refresh_task}, timeout=5)
+            if not done and refresh_processes:
+                with suppress(ProcessLookupError):
+                    os.killpg(refresh_processes[0].pid, signal.SIGKILL)
+                done, _pending = await asyncio.wait({refresh_task}, timeout=5)
+            if not done:
+                pytest.fail("refresh task survived test cleanup")
+        with suppress(asyncio.CancelledError, RuntimeError):
+            refresh_task.result()
+
+    assert watchdog is not None
+    assert watchdog.is_alive() is False
+    assert watchdog_fired.is_set() is False
+
+    lock_path.write_text("", encoding="utf-8")
+    await refresh_knowledge_binding_in_subprocess("docs", config=config, runtime_paths=runtime_paths)
+
+    assert lock_path.exists() is False
+    assert (docs_path / "doc.md").read_text(encoding="utf-8") == "after crash"
+    assert await _git_output(docs_path, "rev-parse", "HEAD") == await _git_output(remote_work, "rev-parse", "HEAD")
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -14,6 +14,7 @@ import os
 import shlex
 import signal
 import subprocess
+import sys
 from contextlib import suppress
 from pathlib import Path
 from threading import Event, Thread
@@ -21,6 +22,8 @@ from threading import Event, Thread
 import pytest
 
 import mindroom.knowledge.git_source as knowledge_git_source_module
+import mindroom.knowledge.refresh_locks as knowledge_refresh_locks
+from mindroom import file_locks
 from mindroom.config.knowledge import KnowledgeGitConfig
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.knowledge.git_source import GitKnowledgeSource, GitSyncResult
@@ -260,6 +263,7 @@ async def test_run_git_inherits_owned_source_root_lock(
 ) -> None:
     """A Git descendant must keep refresh ownership if its Python parent exits."""
     manager = _git_manager(tmp_path)
+    monkeypatch.setenv(knowledge_git_source_module._REFRESH_SUBPROCESS_ENV, "1")
 
     class _SuccessfulProcess:
         returncode = 0
@@ -297,6 +301,91 @@ async def test_run_git_inherits_owned_source_root_lock(
     assert isinstance(inherited_fds, tuple)
     assert len(inherited_fds) == 1
     assert isinstance(inherited_fds[0], int)
+    assert subprocess_kwargs["start_new_session"] is False
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process groups and inherited file descriptors require POSIX")
+@pytest.mark.asyncio
+async def test_direct_run_git_cancellation_during_spawn_drains_descendants(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation after spawn but before handle delivery must drain descendants."""
+    manager = _git_manager(tmp_path)
+    key = resolve_published_index_key(
+        "docs",
+        config=manager.config,
+        runtime_paths=manager.runtime_paths,
+    )
+    source_root = source_root_for_published_index_key(key)
+    refresh_lock_path = knowledge_refresh_locks._refresh_file_lock_path(source_root)
+    real_create_subprocess_exec = asyncio.create_subprocess_exec
+    spawned = asyncio.Event()
+    release_spawn = asyncio.Event()
+    spawned_process: asyncio.subprocess.Process | None = None
+    helper_ready_path = tmp_path / "spawn-race-helper-ready"
+    script = f"""
+import os
+import signal
+import time
+
+child_pid = os.fork()
+if child_pid == 0:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    os.dup2(devnull_fd, 1)
+    os.dup2(devnull_fd, 2)
+    os.close(devnull_fd)
+    with open({str(helper_ready_path)!r}, "w") as ready_file:
+        ready_file.write("ready")
+    time.sleep(60)
+    os._exit(0)
+
+time.sleep(60)
+"""
+
+    async def _spawn_git_like_process(*_args: object, **kwargs: object) -> asyncio.subprocess.Process:
+        nonlocal spawned_process
+        spawned_process = await real_create_subprocess_exec(sys.executable, "-c", script, **kwargs)
+        for _attempt in range(500):
+            if helper_ready_path.exists():
+                break
+            await asyncio.sleep(0.01)
+        else:
+            msg = "Git-like helper did not start"
+            raise AssertionError(msg)
+        spawned.set()
+        try:
+            await release_spawn.wait()
+        except asyncio.CancelledError:
+            spawned_process.kill()
+            await spawned_process.wait()
+            raise
+        return spawned_process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn_git_like_process)
+    try:
+        async with refresh_source_root_lock(source_root):
+            task = asyncio.create_task(manager.git_source._run_git(["status"]))
+            await asyncio.wait_for(spawned.wait(), timeout=5)
+            task.cancel()
+            await asyncio.sleep(0)
+            release_spawn.set()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert file_locks.file_lock_is_held(refresh_lock_path) is False
+    finally:
+        release_spawn.set()
+        if spawned_process is not None:
+            with suppress(ProcessLookupError):
+                os.killpg(spawned_process.pid, signal.SIGKILL)
+            with suppress(ProcessLookupError):
+                await spawned_process.wait()
+        for _attempt in range(100):
+            if not file_locks.file_lock_is_held(refresh_lock_path):
+                break
+            await asyncio.sleep(0.01)
 
 
 @pytest.mark.asyncio
@@ -886,6 +975,193 @@ cat
     assert await _git_output(docs_path, "rev-parse", "HEAD") == await _git_output(remote_work, "rev-parse", "HEAD")
 
 
+@pytest.mark.skipif(os.name == "nt", reason="process groups and POSIX shell filters are required")
+@pytest.mark.asyncio
+async def test_direct_refresh_timeout_drains_git_descendants_before_releasing_source_lock(  # noqa: PLR0915
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A direct refresh timeout must not leave a descendant holding its source lock."""
+    remote_work = tmp_path / "remote-work"
+    remote_work.mkdir()
+
+    async def _git(cwd: Path, *args: str) -> None:
+        await asyncio.to_thread(
+            subprocess.run,
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+    await _git(remote_work, "init", "-b", "main")
+    await _git(remote_work, "config", "user.email", "tests@example.com")
+    await _git(remote_work, "config", "user.name", "MindRoom Tests")
+    (remote_work / "doc.md").write_text("before timeout", encoding="utf-8")
+    await _git(remote_work, "add", "doc.md")
+    await _git(remote_work, "commit", "-m", "before")
+    remote_bare = tmp_path / "remote.git"
+    await asyncio.to_thread(
+        subprocess.run,
+        ["git", "clone", "--bare", str(remote_work), str(remote_bare)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    docs_path = tmp_path / "checkout"
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={
+            "docs": KnowledgeGitConfig(
+                repo_url=str(remote_bare),
+                branch="main",
+                sync_timeout_seconds=5,
+            ),
+        },
+        modes={"docs": "files"},
+    )
+    runtime_paths = runtime_paths_for(config)
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    monkeypatch.setattr(GitKnowledgeSource, "_sync_timeout_seconds", lambda _self: 1.0)
+
+    ready_path = tmp_path / "filter-ready"
+    release_path = tmp_path / "filter-release"
+    filter_script = tmp_path / "blocking-smudge.sh"
+    filter_script.write_text(
+        """#!/bin/sh
+ready_path=$1
+release_path=$2
+trap '' TERM
+echo $$ > "$ready_path"
+while [ ! -e "$release_path" ]; do
+    sleep 0.05
+done
+cat
+""",
+        encoding="utf-8",
+    )
+    filter_script.chmod(0o755)
+    filter_command = " ".join(shlex.quote(str(path)) for path in (filter_script, ready_path, release_path))
+    await _git(docs_path, "config", "filter.blocking.smudge", filter_command)
+    await _git(docs_path, "config", "filter.blocking.clean", "cat")
+    await _git(docs_path, "config", "filter.blocking.required", "true")
+
+    (remote_work / ".gitattributes").write_text("doc.md filter=blocking\n", encoding="utf-8")
+    (remote_work / "doc.md").write_text("after timeout", encoding="utf-8")
+    await _git(remote_work, "add", ".gitattributes", "doc.md")
+    await _git(remote_work, "commit", "-m", "after")
+    await _git(remote_work, "push", str(remote_bare), "main")
+
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    source_root = source_root_for_published_index_key(key)
+    refresh_lock_path = knowledge_refresh_locks._refresh_file_lock_path(source_root)
+    filter_pid: int | None = None
+    watchdog_stop = Event()
+    watchdog_fired = Event()
+
+    def _release_filter_if_cleanup_stalls() -> None:
+        if not watchdog_stop.wait(timeout=5):
+            watchdog_fired.set()
+            release_path.touch()
+
+    watchdog = Thread(target=_release_filter_if_cleanup_stalls, daemon=True)
+    watchdog.start()
+    try:
+        with pytest.raises(RuntimeError, match=r"Git command timed out after 1s"):
+            await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+        filter_pid = int(ready_path.read_text(encoding="utf-8"))
+
+        assert watchdog_fired.is_set() is False
+        assert file_locks.file_lock_is_held(refresh_lock_path) is False
+    finally:
+        watchdog_stop.set()
+        release_path.touch()
+        watchdog.join(timeout=1)
+        if filter_pid is not None:
+            with suppress(ProcessLookupError):
+                os.kill(filter_pid, signal.SIGKILL)
+        for _attempt in range(100):
+            if not file_locks.file_lock_is_held(refresh_lock_path):
+                break
+            await asyncio.sleep(0.01)
+
+    index_lock_path = docs_path / ".git" / "index.lock"
+    index_lock_path.write_text("", encoding="utf-8")
+
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert index_lock_path.exists() is False
+    assert result.index_published is True
+    assert (docs_path / "doc.md").read_text(encoding="utf-8") == "after timeout"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process groups require POSIX")
+@pytest.mark.asyncio
+async def test_direct_run_git_drains_descendant_after_successful_leader_exit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful Git leader must not leave a helper holding its source lock."""
+    manager = _git_manager(tmp_path)
+    key = resolve_published_index_key(
+        "docs",
+        config=manager.config,
+        runtime_paths=manager.runtime_paths,
+    )
+    source_root = source_root_for_published_index_key(key)
+    refresh_lock_path = knowledge_refresh_locks._refresh_file_lock_path(source_root)
+    real_create_subprocess_exec = asyncio.create_subprocess_exec
+    spawned_process: asyncio.subprocess.Process | None = None
+    script = """
+import os
+import signal
+import time
+
+ready_read_fd, ready_write_fd = os.pipe()
+child_pid = os.fork()
+if child_pid == 0:
+    os.close(ready_read_fd)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    os.dup2(devnull_fd, 1)
+    os.dup2(devnull_fd, 2)
+    os.close(devnull_fd)
+    os.write(ready_write_fd, b"1")
+    os.close(ready_write_fd)
+    time.sleep(60)
+    os._exit(0)
+
+os.close(ready_write_fd)
+os.read(ready_read_fd, 1)
+os.close(ready_read_fd)
+os._exit(0)
+"""
+
+    async def _spawn_git_like_process(*_args: object, **kwargs: object) -> asyncio.subprocess.Process:
+        nonlocal spawned_process
+        spawned_process = await real_create_subprocess_exec(sys.executable, "-c", script, **kwargs)
+        return spawned_process
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _spawn_git_like_process)
+    try:
+        async with refresh_source_root_lock(source_root):
+            assert await manager.git_source._run_git(["status"]) == ""
+
+        assert file_locks.file_lock_is_held(refresh_lock_path) is False
+    finally:
+        if spawned_process is not None:
+            with suppress(ProcessLookupError):
+                os.killpg(spawned_process.pid, signal.SIGKILL)
+        for _attempt in range(100):
+            if not file_locks.file_lock_is_held(refresh_lock_path):
+                break
+            await asyncio.sleep(0.01)
+
+
 @pytest.mark.asyncio
 async def test_refresh_recovers_orphaned_index_lock_in_linked_worktree(tmp_path: Path) -> None:
     """Recovery must follow a linked worktree's .git pointer to its real index lock."""
@@ -1190,6 +1466,7 @@ async def test_run_git_redacts_credentials_in_error_message(
 ) -> None:
     """Git command errors should not leak embedded URL credentials."""
     manager = _git_manager(tmp_path)
+    monkeypatch.setenv(knowledge_git_source_module._REFRESH_SUBPROCESS_ENV, "1")
 
     class _FailingProcess:
         returncode = 128
@@ -1233,6 +1510,7 @@ async def test_run_git_timeout_kills_subprocess_and_raises_runtime_error(
     manager = _git_manager(tmp_path, sync_timeout_seconds=5)
 
     class _HangingProcess:
+        pid = 12345
         returncode: int | None = None
 
         def __init__(self) -> None:
@@ -1252,9 +1530,11 @@ async def test_run_git_timeout_kills_subprocess_and_raises_runtime_error(
             return -9
 
     process = _HangingProcess()
+    signalled_groups: list[tuple[int, signal.Signals]] = []
 
     async def _fake_create_subprocess_exec(*args: object, **kwargs: object) -> _HangingProcess:
-        _ = args, kwargs
+        _ = args
+        assert kwargs["start_new_session"] is True
         return process
 
     async def _fake_wait_for(awaitable: object, **kwargs: float) -> tuple[bytes, bytes]:
@@ -1264,15 +1544,29 @@ async def test_run_git_timeout_kills_subprocess_and_raises_runtime_error(
             close()
         raise TimeoutError
 
+    async def _fake_wait_for_process_group_exit(_process_group_id: int, *, wait_seconds: float = 1.0) -> None:
+        _ = wait_seconds
+
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
     monkeypatch.setattr(asyncio, "wait_for", _fake_wait_for)
+    monkeypatch.setattr(
+        knowledge_git_source_module.os,
+        "killpg",
+        lambda process_group_id, sig: signalled_groups.append((process_group_id, sig)),
+    )
+    monkeypatch.setattr(
+        knowledge_git_source_module,
+        "_wait_for_process_group_exit",
+        _fake_wait_for_process_group_exit,
+    )
     monkeypatch.setattr(manager.git_source, "_sync_timeout_seconds", lambda: 1.0)
 
     with pytest.raises(RuntimeError, match=r"Git command timed out after 1s: git fetch origin main"):
         await manager.git_source._run_git(["fetch", "origin", "main"])
 
-    assert process.kill_called is True
+    assert process.kill_called is False
     assert process.wait_called is True
+    assert signalled_groups == [(12345, signal.SIGKILL)]
 
 
 @pytest.mark.asyncio
@@ -1282,6 +1576,7 @@ async def test_run_git_preserves_index_lock_and_does_not_retry(
 ) -> None:
     """Git lock failures should surface immediately without deleting the lock file."""
     manager = _git_manager(tmp_path)
+    monkeypatch.setenv(knowledge_git_source_module._REFRESH_SUBPROCESS_ENV, "1")
     repo_root = tmp_path / "repo"
     git_dir = repo_root / ".git"
     git_dir.mkdir(parents=True, exist_ok=True)
@@ -1326,6 +1621,7 @@ async def test_run_git_cancellation_kills_subprocess(
     wait_forever = asyncio.Event()
 
     class _HangingProcess:
+        pid = 12345
         returncode: int | None = None
 
         def __init__(self) -> None:
@@ -1345,12 +1641,27 @@ async def test_run_git_cancellation_kills_subprocess(
             return -9
 
     process = _HangingProcess()
+    signalled_groups: list[tuple[int, signal.Signals]] = []
 
     async def _fake_create_subprocess_exec(*args: object, **kwargs: object) -> _HangingProcess:
-        _ = args, kwargs
+        _ = args
+        assert kwargs["start_new_session"] is True
         return process
 
+    async def _fake_wait_for_process_group_exit(_process_group_id: int, *, wait_seconds: float = 1.0) -> None:
+        _ = wait_seconds
+
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(
+        knowledge_git_source_module.os,
+        "killpg",
+        lambda process_group_id, sig: signalled_groups.append((process_group_id, sig)),
+    )
+    monkeypatch.setattr(
+        knowledge_git_source_module,
+        "_wait_for_process_group_exit",
+        _fake_wait_for_process_group_exit,
+    )
 
     task = asyncio.create_task(manager.git_source._run_git(["fetch", "origin", "main"]))
     await asyncio.sleep(0)
@@ -1359,8 +1670,57 @@ async def test_run_git_cancellation_kills_subprocess(
     with pytest.raises(asyncio.CancelledError):
         await task
 
-    assert process.kill_called is True
+    assert process.kill_called is False
     assert process.wait_called is True
+    assert signalled_groups == [(12345, signal.SIGKILL)]
+
+
+@pytest.mark.asyncio
+async def test_run_git_success_cleanup_finishes_before_cancellation_propagates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation cannot abandon a successful Git command's group drain."""
+    manager = _git_manager(tmp_path)
+    cleanup_started = asyncio.Event()
+    cleanup_release = asyncio.Event()
+    cleanup_finished = asyncio.Event()
+
+    class _SuccessfulProcess:
+        pid = 12345
+        returncode = 0
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            return b"", b""
+
+    async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _SuccessfulProcess:
+        return _SuccessfulProcess()
+
+    async def _fake_terminate(
+        _process: _SuccessfulProcess,
+        *,
+        owned_process_group_id: int | None,
+    ) -> None:
+        assert owned_process_group_id == 12345
+        cleanup_started.set()
+        await cleanup_release.wait()
+        cleanup_finished.set()
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_git_source_module, "_terminate_git_process", _fake_terminate)
+
+    task = asyncio.create_task(manager.git_source._run_git(["status"]))
+    await cleanup_started.wait()
+    task.cancel()
+    await asyncio.sleep(0)
+    try:
+        assert task.done() is False
+    finally:
+        cleanup_release.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cleanup_finished.is_set()
 
 
 @pytest.mark.asyncio
@@ -1375,6 +1735,7 @@ async def test_run_git_reports_the_git_failure_when_stderr_holds_an_unparseable_
     destroy the diagnostic exactly when something has already gone wrong.
     """
     manager = _git_manager(tmp_path)
+    monkeypatch.setenv(knowledge_git_source_module._REFRESH_SUBPROCESS_ENV, "1")
 
     class _FailingProcess:
         returncode = 128

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -5933,6 +5933,20 @@ async def test_cancelled_subprocess_refresh_reconciles_running_state(
 
 @pytest.mark.skipif(os.name == "nt", reason="process groups require POSIX")
 @pytest.mark.asyncio
+async def test_process_group_exit_wait_warns_when_group_survives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A bounded drain must explain any process group it cannot retire."""
+    monkeypatch.setattr(knowledge_refresh_runner, "_process_group_exists", lambda _process_group_id: True)
+
+    with capture_logs() as logs:
+        await knowledge_refresh_runner._wait_for_process_group_exit(12345, wait_seconds=0)
+
+    assert any(log.get("event") == "Knowledge refresh process group survived termination wait" for log in logs)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="process groups require POSIX")
+@pytest.mark.asyncio
 async def test_terminate_refresh_subprocess_kills_surviving_process_group_member(tmp_path: Path) -> None:
     """A Git-like grandchild that ignores SIGTERM must not outlive its refresh leader."""
     descendant_lock_path = tmp_path / "descendant.lock"
@@ -5966,7 +5980,7 @@ time.sleep(60)
     )
     os.close(ready_write_fd)
     try:
-        assert await asyncio.wait_for(asyncio.to_thread(os.read, ready_read_fd, 1), timeout=1) == b"1"
+        assert await asyncio.wait_for(asyncio.to_thread(os.read, ready_read_fd, 1), timeout=30) == b"1"
         assert file_locks.file_lock_is_held(descendant_lock_path) is True
 
         await knowledge_refresh_runner._terminate_refresh_subprocess(process)

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -6,10 +6,11 @@ import asyncio
 import base64
 import json
 import os
+import signal
 import subprocess
 import sys
 import traceback
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
 from pathlib import Path
@@ -2215,6 +2216,32 @@ async def test_source_root_lock_takes_the_in_loop_half_before_the_cross_process_
         events.append("body")
 
     assert events == ["acquire in_loop", "acquire file", "body", "release file", "release in_loop"]
+
+
+@pytest.mark.asyncio
+async def test_source_root_lock_capability_expires_in_inherited_task_context(tmp_path: Path) -> None:
+    """A task created under the lock cannot retain cleanup authority after release."""
+    source_path = (tmp_path / "docs").resolve()
+    source_root = knowledge_registry.KnowledgeSourceRoot(
+        storage_root=str(tmp_path.resolve()),
+        knowledge_path=str(source_path),
+    )
+    inspect_after_release = asyncio.Event()
+    observed_fds: list[int | None] = []
+
+    async def _inspect_inherited_context() -> None:
+        capability = file_locks.current_inherited_file_lock()
+        assert capability is not None
+        await inspect_after_release.wait()
+        observed_fds.append(capability.fileno_for(source_path))
+
+    async with knowledge_refresh_locks.refresh_source_root_lock(source_root):
+        inherited_task = asyncio.create_task(_inspect_inherited_context())
+
+    inspect_after_release.set()
+    await inherited_task
+
+    assert observed_fds == [None]
 
 
 @pytest.mark.asyncio
@@ -5904,6 +5931,54 @@ async def test_cancelled_subprocess_refresh_reconciles_running_state(
     assert state.reason == "refresh_cancelled"
 
 
+@pytest.mark.skipif(os.name == "nt", reason="process groups require POSIX")
+@pytest.mark.asyncio
+async def test_terminate_refresh_subprocess_kills_surviving_process_group_member(tmp_path: Path) -> None:
+    """A Git-like grandchild that ignores SIGTERM must not outlive its refresh leader."""
+    descendant_lock_path = tmp_path / "descendant.lock"
+    ready_read_fd, ready_write_fd = os.pipe()
+    script = f"""
+import fcntl
+import os
+import signal
+import time
+
+child_pid = os.fork()
+if child_pid == 0:
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
+    lock_file = open({str(descendant_lock_path)!r}, "w")
+    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+    os.write({ready_write_fd}, b"1")
+    os.close({ready_write_fd})
+    time.sleep(60)
+    os._exit(0)
+
+os.close({ready_write_fd})
+signal.signal(signal.SIGTERM, lambda *_args: os._exit(0))
+time.sleep(60)
+"""
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        script,
+        start_new_session=True,
+        pass_fds=(ready_write_fd,),
+    )
+    os.close(ready_write_fd)
+    try:
+        assert await asyncio.wait_for(asyncio.to_thread(os.read, ready_read_fd, 1), timeout=1) == b"1"
+        assert file_locks.file_lock_is_held(descendant_lock_path) is True
+
+        await knowledge_refresh_runner._terminate_refresh_subprocess(process)
+
+        assert file_locks.file_lock_is_held(descendant_lock_path) is False
+    finally:
+        with suppress(ProcessLookupError):
+            os.killpg(process.pid, signal.SIGKILL)
+        await process.wait()
+        os.close(ready_read_fd)
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("pending_reason", [None, "source_changed", "git_source_updated", "manual_reindex"])
 async def test_wedged_subprocess_refresh_is_terminated_after_timeout(
@@ -6227,7 +6302,13 @@ async def test_failed_subprocess_refresh_reconciles_running_state(
     async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _Process:
         return _Process()
 
+    terminated: list[_Process] = []
+
+    async def _fake_terminate(process: _Process) -> None:
+        terminated.append(process)
+
     monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_refresh_runner, "_terminate_refresh_subprocess", _fake_terminate)
 
     with pytest.raises(RuntimeError, match="exit code 137"):
         await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
@@ -6242,6 +6323,7 @@ async def test_failed_subprocess_refresh_reconciles_running_state(
     assert state.reason == "refresh_failed"
     assert state.last_error is not None
     assert "exit code 137" in state.last_error
+    assert len(terminated) == 1
 
 
 @pytest.mark.asyncio
@@ -6295,7 +6377,11 @@ async def test_failed_subprocess_refresh_does_not_overwrite_newer_success(
     async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _Process:
         return _Process()
 
+    async def _fake_terminate(_process: _Process) -> None:
+        pass
+
     monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_refresh_runner, "_terminate_refresh_subprocess", _fake_terminate)
 
     with pytest.raises(RuntimeError, match="exit code 137"):
         await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
@@ -6364,7 +6450,11 @@ async def test_failed_subprocess_refresh_reconciles_running_state_after_newer_pu
     async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _Process:
         return _Process()
 
+    async def _fake_terminate(_process: _Process) -> None:
+        pass
+
     monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_refresh_runner, "_terminate_refresh_subprocess", _fake_terminate)
 
     with pytest.raises(RuntimeError, match="exit code 137"):
         await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -5735,8 +5735,12 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
         captured_stdin = process.stdin
         return process
 
+    async def _fake_terminate(_process: _Process) -> None:
+        pass
+
     monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
     monkeypatch.setattr(knowledge_refresh_runner, "_subprocess_session_kwargs", dict)
+    monkeypatch.setattr(knowledge_refresh_runner, "_terminate_refresh_subprocess", _fake_terminate)
 
     await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
         "docs",
@@ -5943,6 +5947,59 @@ async def test_process_group_exit_wait_warns_when_group_survives(
         await knowledge_refresh_runner._wait_for_process_group_exit(12345, wait_seconds=0)
 
     assert any(log.get("event") == "Knowledge refresh process group survived termination wait" for log in logs)
+
+
+@pytest.mark.asyncio
+async def test_successful_refresh_subprocess_drains_its_process_group(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A successful worker must not leave a lock-holding Git helper behind."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    (docs_path / "doc.md").write_text("refresh me", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    terminated = asyncio.Event()
+
+    class _Stdin:
+        def write(self, _payload: bytes) -> None:
+            pass
+
+        async def drain(self) -> None:
+            pass
+
+        def close(self) -> None:
+            pass
+
+        async def wait_closed(self) -> None:
+            pass
+
+    class _Process:
+        def __init__(self) -> None:
+            self.returncode: int | None = None
+            self.stdin = _Stdin()
+
+        async def wait(self) -> int:
+            self.returncode = 0
+            return 0
+
+    async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> _Process:
+        return _Process()
+
+    async def _fake_terminate(_process: _Process) -> None:
+        terminated.set()
+
+    monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_refresh_runner, "_terminate_refresh_subprocess", _fake_terminate)
+
+    await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
+        "docs",
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+
+    assert terminated.is_set()
 
 
 @pytest.mark.skipif(os.name == "nt", reason="process groups require POSIX")
@@ -6522,7 +6579,11 @@ async def test_refresh_subprocess_receives_conservative_thread_env(
         captured_env.update(kwargs["env"])
         return _Process()
 
+    async def _fake_terminate(_process: _Process) -> None:
+        pass
+
     monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_refresh_runner, "_terminate_refresh_subprocess", _fake_terminate)
 
     await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
         "docs",
@@ -8236,6 +8297,7 @@ async def test_git_failure_redacts_authorization_headers_from_raised_and_metadat
         _ = (args, kwargs)
         return _FailedGitProcess()
 
+    monkeypatch.setenv(knowledge_git_source_module._REFRESH_SUBPROCESS_ENV, "1")
     monkeypatch.setattr(asyncio, "create_subprocess_exec", _fail_git_command)
 
     with pytest.raises(RuntimeError) as exc_info:


### PR DESCRIPTION
## Summary

- recover orphaned Git index locks only while holding the matching source-root refresh lock
- pass that lock into Git descendants so ownership survives a refresh leader exiting
- drain failed refresh process groups before reconciliation
- support both regular repositories and linked worktrees

## Safety

- direct Git sync without refresh ownership never removes an index lock
- expired task-local capabilities cannot authorize cleanup or descriptor inheritance
- existing file-lock release behavior is unchanged unless descendant retention is explicitly enabled

## Verification

- full pytest suite
- focused file-lock, Git-source, and knowledge-manager tests
- changed-file pre-commit hooks, including Ruff, ty, Vulture, Tach, and module privacy checks

## Summary by Sourcery

Ensure knowledge refreshes can safely recover stale Git index locks while preserving lock ownership semantics and draining crashed refresh subprocess groups.

Bug Fixes:
- Prevent direct Git syncs without refresh ownership from deleting potentially live index.lock files.
- Ensure orphaned Git index locks left by crashed refreshes are cleaned up only when the source-root lock is owned, including for linked worktrees.
- Guarantee refresh subprocess termination also kills stubborn descendant processes and releases any locks they hold.

Enhancements:
- Introduce task-local file lock inheritance capabilities so refresh-owned locks can be passed into Git subprocesses safely.
- Extend async file lock handling to optionally retain locks for inherited file descriptors while still supporting default release behavior.
- Propagate refresh source-root locks into Git subprocesses and use them to detect and clear orphaned index locks at the start of syncs.

Tests:
- Add unit tests covering lock inheritance semantics, capability expiry in child tasks, and async file lock retention behavior.
- Add knowledge source and manager tests verifying index.lock preservation during non-owned syncs and cleanup after crashed refreshes, including linked worktrees.
- Add tests ensuring refresh subprocess termination drains process groups and integrates with existing refresh failure handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved coordination of file locks across refresh operations and subprocesses.
  - Added automatic recovery for stale Git index locks, including linked worktrees.

- **Bug Fixes**
  - Refresh failures now terminate subprocesses and descendants more reliably, including processes that ignore graceful termination.
  - Prevented active locks from being removed incorrectly during synchronization.
  - Improved cleanup and recovery when refresh operations fail.

- **Tests**
  - Added coverage for inherited locks, stale Git lock recovery, subprocess termination, and refresh failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->