### PR TITLE
docs: tracking/ is the journal home, not a parallel turn ledger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,6 @@ docs/superpowers/
 
 # Swift Package Manager build artifacts (macOS menubar app)
 macos/MindRoom/.build/
+
+# Agent task scratch files
+.claude/TASK-*.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,7 +210,7 @@ Matrix sync callback
 - `learning/` – Per-agent Agno Learning preference data
 - `chroma/` – ChromaDB storage backing the memory system
 - `knowledge_db/` – Knowledge base vector stores for file-backed RAG
-- `tracking/` – Durable handled-turn ledger plus exact callback obligations and compact terminal tombstones
+- `tracking/` – The event journal database (`event_journal.db` plus its lock and binding files), which owns handled-turn records, and sidecar runtime state such as room-member join tracking; `<agent>_responded.json` files here are pre-journal ledgers kept only for the one-time upgrade import
 - `credentials/` – JSON secrets synchronized from `.env`
 - `encryption_keys/` – Matrix E2E encryption keys
 - `sync_continuity/` – Crash-atomic Matrix checkpoints and pending join decrypt fences


### PR DESCRIPTION
## Summary

- Fix the `tracking/` line in CLAUDE.md: it still described the pre-journal world ("durable handled-turn ledger"), which sent a storage-ownership audit hunting for a parallel store that no longer exists. Since #1800, handled-turn records live in the journal's `turn_records` table; `tracking/` holds the journal database itself (plus lock/binding files and sidecar state), and `<agent>_responded.json` is only the one-time upgrade import source.
- Gitignore `.claude/TASK-*.md` agent scratch files (one `git add -A` away from being committed).

## Explicitly NOT deleting the legacy importer

`HandledTurnLedger._import_legacy_ledger` and `legacy_responses_file_path` were considered for deletion and rejected: #1800 merged on 2026-08-08, so every installation upgrading from a release older than five days still depends on that import. Removing it now would silently re-answer entire backlogs (`tests/test_upgrade_from_pre_journal_storage.py` documents exactly this failure). Revisit after the pre-journal releases are meaningfully out of circulation.

## Tests

Docs and gitignore only; no code changes.

## Summary by Sourcery

Clarify the role of the tracking/ directory in the storage layout and prevent temporary agent task scratch files from being committed.

Build:
- Extend .gitignore to exclude .claude/TASK-*.md agent scratch files from version control.

Documentation:
- Update CLAUDE.md to describe tracking/ as the event journal database owning handled-turn records and upgrade ledgers.