### PR TITLE
feat: add requester-scoped GitHub App OAuth

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -424,8 +424,7 @@ Workers mount those canonical private-instance roots.
 They do not own them.
 
 The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+The Google Drive, Docs, Gmail, Calendar, and Sheets OAuth providers are an exception: the dashboard can connect scoped `user` and `user_agent` credentials, while the tools still execute in the primary MindRoom runtime.
 GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
 Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime instead.
 

--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -365,7 +365,7 @@ Adding or removing tools via chat does not discard existing per-agent overrides 
 `worker_tools` decides which tools run in the sandbox proxy instead of the main MindRoom process.
 When omitted, MindRoom routes `coding`, `docker`, `file`, `python`, and `shell` through the proxy by default.
 Registry-backed tools can be listed in `worker_tools`, and MindRoom will attempt to route them through the worker runtime.
-Some local-only tools stay in the primary runtime even when listed: `attachments`, `desktop`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, `google_sheets`, and `homeassistant`.
+Some local-only tools stay in the primary runtime even when listed: `attachments`, `desktop`, `github`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, `google_sheets`, and `homeassistant`.
 Dedicated Docker workers also receive a projected read-only config snapshot so config-relative plugins, knowledge bases, and other worker-safe assets remain available without exposing unrelated primary-runtime state.
 Agent-scoped workers snapshot only that agent's projected context files and assigned knowledge bases, while scopes that intentionally share one worker across multiple agents keep the broader shared projection for that worker.
 Writable file-memory paths are rewritten into worker-owned state instead of being mounted from the host config tree.
@@ -376,7 +376,7 @@ Some integrations require `worker_scope` unset or `shared` because their credent
 That list includes `spotify`, `homeassistant`, and non-OAuth configured `mcp_<server_id>` tools.
 OAuth-backed remote MCP tools use requester-scoped OAuth credentials and can be used with `worker_scope: user` or `worker_scope: user_agent`.
 Among those shared-scope integrations, `homeassistant` always stays local regardless of `worker_tools` and is never proxied to the sandbox.
-`gmail`, `google_calendar`, `google_docs`, `google_drive`, and `google_sheets` also always stay local.
+`github`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, and `google_sheets` also always stay local.
 `spotify` can still be proxied through the sandbox.
 The built-in `memory`, `delegate`, and `self_config` tools are also created directly in the primary runtime today and are not routed through `worker_tools`.
 
@@ -424,8 +424,9 @@ Workers mount those canonical private-instance roots.
 They do not own them.
 
 The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-OAuth providers that support scoped dashboard flows, such as the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the Google tools still execute in the primary MindRoom runtime.
+OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
+For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
 Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime instead.
 
 For more details on storage layout and isolation, see [Sandbox Proxy Isolation](../deployment/sandbox-proxy.md).

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -645,8 +645,9 @@ With `MINDROOM_WORKER_BACKEND=docker` or `MINDROOM_WORKER_BACKEND=kubernetes`, M
 - `worker_scope` does **not** change where agent data is stored.
   All scopes read and write the same agent storage directory (`agents/<name>/`).
 - The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-  OAuth providers that support scoped dashboard flows, such as the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-  For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the Google tools still execute in the primary MindRoom runtime.
+  OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
+  For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+  GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
   Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime.
 - `user` mode shares one runtime across multiple agents for a single user, so agents in that runtime can access each other's files.
   Use `user_agent` for per-agent isolation.

--- a/docs/deployment/sandbox-proxy.md
+++ b/docs/deployment/sandbox-proxy.md
@@ -645,8 +645,7 @@ With `MINDROOM_WORKER_BACKEND=docker` or `MINDROOM_WORKER_BACKEND=kubernetes`, M
 - `worker_scope` does **not** change where agent data is stored.
   All scopes read and write the same agent storage directory (`agents/<name>/`).
 - The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-  OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-  For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+  The Google Drive, Docs, Gmail, Calendar, and Sheets OAuth providers are an exception: the dashboard can connect scoped `user` and `user_agent` credentials, while the tools still execute in the primary MindRoom runtime.
   GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
   Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime.
 - `user` mode shares one runtime across multiple agents for a single user, so agents in that runtime can access each other's files.

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -462,7 +462,7 @@ Below is a representative selection:
 
 ### Development Tools
 - **docker** - Manage Docker containers (requires Docker installed)
-- **github** - Interact with GitHub repositories (requires token)
+- **github** - Interact with GitHub repositories (requester-scoped OAuth or explicit access token)
 - **jira** - Jira issue tracking (requires API token)
 - **linear** - Linear issue tracking (requires API key)
 
@@ -596,11 +596,11 @@ Some tools need additional setup:
 - **googlesearch** - Set up Google API credentials
 - **tavily** - Get API key from Tavily
 - **exa** - Get API key from Exa
-- **github** - Create a GitHub personal access token
 - **telegram** - Create a Telegram bot and get token
 - **email** - Configure SMTP server details
 
 ### Tools requiring OAuth:
+- **github** - GitHub App user OAuth, with an explicit access token or `GITHUB_ACCESS_TOKEN` as a higher-precedence alternative
 - **gmail**, **google_calendar**, **google_docs**, **google_drive**, **google_sheets** - Google OAuth
 - **homeassistant** - Home Assistant OAuth or long-lived access token
 - **spotify** - Manually supplied Spotify OAuth access token

--- a/docs/dev/agent_configuration.md
+++ b/docs/dev/agent_configuration.md
@@ -599,7 +599,7 @@ Some tools need additional setup:
 - **telegram** - Create a Telegram bot and get token
 - **email** - Configure SMTP server details
 
-### Tools requiring OAuth:
+### Tools requiring OAuth or credentials:
 - **github** - GitHub App user OAuth, with an explicit access token or `GITHUB_ACCESS_TOKEN` as a higher-precedence alternative
 - **gmail**, **google_calendar**, **google_docs**, **google_drive**, **google_sheets** - Google OAuth
 - **homeassistant** - Home Assistant OAuth or long-lived access token

--- a/docs/oauth-framework.md
+++ b/docs/oauth-framework.md
@@ -5,7 +5,7 @@ icon: lucide/key-round
 # OAuth Integration Framework
 
 MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account.
-Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, optional PKCE requirements, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
+Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, optional PKCE requirements, requester-only credential placement, explicitly permitted manual fallback fields and runtime environment names, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
 
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/status`, and `/api/oauth/{provider}/disconnect`.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
@@ -30,16 +30,16 @@ Plugins can use `OAuthDiscoveryConfig` with `oauth_runtime_bootstrapper()` to re
 Automatic discovery first checks protected-resource metadata at the resource origin and path, then uses the advertised authorization server or falls back to authorization-server metadata at the resource origin.
 Dynamic client registration requires a provider-specific `client_config_services` entry and stores generated client configuration only in the primary runtime.
 
-OAuth token writes always go through `resolve_request_credentials_target()` and `save_scoped_credentials()`.
-For private agents, the target worker key is derived from the authenticated requester and the agent's saved `worker_scope`, so a user-owned OAuth token lands under the same scope normal tools will read at runtime.
-For shared-scope agents, OAuth tokens land in a per-agent primary-runtime store, so a connection made for one agent never becomes visible to other agents.
-Only agents without any worker scope share OAuth tokens through the global credential store.
+OAuth token writes always go through the provider's credential-target resolver and `save_scoped_credentials()`.
+Providers can declare that credentials follow the requester independently of agent worker reuse.
+GitHub uses that policy, so its managed token always lands in the requester's `user` scope and can never fall back to a shared or global token store.
+For providers without that policy, private-agent tokens follow the authenticated requester and the agent's saved `worker_scope`, shared-scope agent tokens use a per-agent primary-runtime store, and unscoped agents use the global credential store.
 If MindRoom cannot resolve the authenticated dashboard user to the requester carried by a conversation-issued link, the link fails closed and no credential is saved.
 Credential placement and visibility policy is centralized in `src/mindroom/credential_policy.py`.
 That module owns service classification, OAuth token field filtering, local-only credential service names, and worker-grantable rejections.
 Storage, API routing, OAuth provider loading, and worker identity derivation stay in their existing modules.
 Tools should declare `auth_provider` and, when credentials are missing, return a concise connect instruction that points at the generic `authorize` route for the provider and agent.
-Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need Google OAuth client config or user refresh tokens.
+GitHub and Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need OAuth client config or user refresh tokens.
 OAuth token documents and editable tool setting documents should be separate services.
 The OAuth callback writes only the provider's `credential_service`, while dashboard configuration reads and writes the provider's `tool_config_service` when one is declared.
 OAuth app client config is stored separately from both of those services.
@@ -64,6 +64,7 @@ Identity restrictions are provider settings, not MindRoom policy.
 Providers can enforce allowed email domains, allowed hosted-domain claims, and custom claim validators.
 If a configured restriction cannot be checked from verified provider claims, the callback fails closed and no credential is saved.
 
+The built-in GitHub provider uses the generic framework for GitHub App user tokens, requests no classic OAuth scopes, and requires S256 PKCE.
 Built-in Google providers use the generic framework for Drive, Docs, Calendar, Sheets, and Gmail.
 Each provider has minimal service-specific scopes, stores OAuth tokens under its own `*_oauth` service, stores editable tool settings separately, and uses `/api/oauth/*`.
 Each provider first checks its provider-specific client config service, then the shared `google_oauth_client` service.

--- a/docs/tools/project-management.md
+++ b/docs/tools/project-management.md
@@ -29,7 +29,7 @@ Use these tools when you need repository context, issue tracking, documentation 
 
 The `todo` tool is available without credentials.
 The other tools on this page are registered as `status=requires_config`, so they stay unavailable in the dashboard until their required credentials or connection fields are present.
-None of these tools declare an `auth_provider`, and `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes, so project-management tools are configured through stored tool credentials or environment variables rather than a dedicated dashboard OAuth flow.
+GitHub supports requester-scoped OAuth through MindRoom's built-in `github` provider, while the remaining project-management tools use stored tool credentials or environment variables.
 Password and token fields should be stored through the dashboard or credential store instead of inline YAML.
 Most upstream SDKs also read environment variables, including `GITHUB_ACCESS_TOKEN`, `BITBUCKET_USERNAME`, `BITBUCKET_PASSWORD`, `BITBUCKET_TOKEN`, `JIRA_SERVER_URL`, `JIRA_USERNAME`, `JIRA_PASSWORD`, `JIRA_TOKEN`, `LINEAR_API_KEY`, `CLICKUP_API_KEY`, `MASTER_SPACE_ID`, `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, `CONFLUENCE_API_KEY`, `CONFLUENCE_PASSWORD`, `NOTION_API_KEY`, `NOTION_DATABASE_ID`, `TRELLO_API_KEY`, `TRELLO_API_SECRET`, `TRELLO_TOKEN`, `TODOIST_API_TOKEN`, `ZENDESK_USERNAME`, `ZENDESK_PASSWORD`, and `ZENDESK_COMPANY_NAME`.
 Several registry fields on this page are marked optional in metadata even though the upstream tool effectively requires them at runtime, so the notes below call out the practical requirement level for each tool.
@@ -50,8 +50,19 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 
 | Option | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
-| `access_token` | `password` | `no` | `null` | GitHub personal access token or GitHub App token. |
+| `access_token` | `password` | `no` | `null` | Optional explicit GitHub access token; takes precedence over OAuth when set. |
 | `base_url` | `url` | `no` | `null` | Optional GitHub Enterprise API base URL such as `https://github.example.com/api/v3`. |
+
+### OAuth Setup
+
+Choose **Connect with GitHub** on the Tools dashboard to use requester-scoped GitHub App user OAuth.
+For a self-hosted installation, configure the GitHub App client ID and client secret under the `github_oauth_client` credential service and register `/api/oauth/github/callback` on the installation's public URL as the callback URL.
+MindRoom requests no classic OAuth scopes because GitHub App user tokens use the app's fine-grained permissions.
+When a requester has not connected GitHub, tool calls return a structured `OAuthConnectionRequired` result containing that requester's connect URL.
+MindRoom refreshes expiring access tokens through the existing scoped OAuth refresh flow and persists rotated access and refresh tokens.
+
+Choose **Use access token** instead to save an explicit token, or set `GITHUB_ACCESS_TOKEN` in the runtime environment.
+An explicit token always takes precedence over requester-scoped OAuth credentials.
 
 ### Example
 
@@ -71,7 +82,7 @@ get_pull_request("mindroom-ai/mindroom", 123)
 
 ### Notes
 
-- `access_token` is marked optional in MindRoom metadata, but the upstream client raises at startup if neither `access_token` nor `GITHUB_ACCESS_TOKEN` is present.
+- The tool can start without credentials; its functions return a requester-bound OAuth connection link until GitHub is connected or an explicit token is configured.
 - Use `base_url` only for GitHub Enterprise, and set it to the API endpoint such as `/api/v3` rather than the human-facing site root.
 - `github` is the best fit on this page when you need repository file operations or rich pull-request inspection in addition to issue tracking.
 

--- a/docs/tools/project-management.md
+++ b/docs/tools/project-management.md
@@ -50,7 +50,7 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 
 | Option | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
-| `access_token` | `password` | `no` | `null` | Optional explicit GitHub access token; takes precedence over OAuth when set. |
+| `access_token` | `password` | `no` | `null` | Optional explicit GitHub access token; takes precedence over OAuth when non-blank. |
 | `base_url` | `url` | `no` | `null` | Optional GitHub Enterprise API base URL such as `https://github.example.com/api/v3`. |
 
 ### OAuth Setup
@@ -63,7 +63,8 @@ When a requester has not connected GitHub, tool calls return a structured `OAuth
 MindRoom refreshes expiring access tokens through the existing scoped OAuth refresh flow and persists rotated access and refresh tokens.
 
 Choose **Use access token** instead to save an explicit token, or set `GITHUB_ACCESS_TOKEN` in the runtime environment.
-An explicit token always takes precedence over requester-scoped OAuth credentials.
+A non-blank saved `access_token` takes precedence over a non-blank `GITHUB_ACCESS_TOKEN`, which takes precedence over requester-scoped OAuth credentials.
+Whitespace-only token values are treated as absent.
 
 ### Example
 

--- a/docs/tools/project-management.md
+++ b/docs/tools/project-management.md
@@ -58,6 +58,7 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 Choose **Connect with GitHub** on the Tools dashboard to use requester-scoped GitHub App user OAuth.
 For a self-hosted installation, configure the GitHub App client ID and client secret under the `github_oauth_client` credential service and register `/api/oauth/github/callback` on the installation's public URL as the callback URL.
 MindRoom requests no classic OAuth scopes because GitHub App user tokens use the app's fine-grained permissions.
+Managed GitHub credentials follow the requester independently of the agent's worker scope and stay in the primary MindRoom runtime.
 When a requester has not connected GitHub, tool calls return a structured `OAuthConnectionRequired` result containing that requester's connect URL.
 MindRoom refreshes expiring access tokens through the existing scoped OAuth refresh flow and persists rotated access and refresh tokens.
 

--- a/frontend/src/components/Integrations/Integrations.test.tsx
+++ b/frontend/src/components/Integrations/Integrations.test.tsx
@@ -152,6 +152,7 @@ vi.mock("@/hooks/useTools", () => ({
     docs_url: tool.docs_url,
     oauth_fallback_fields: tool.oauth_fallback_fields,
     manual_auth_configured: tool.manual_auth_configured,
+    environment_auth_configured: tool.environment_auth_configured,
   }),
 }));
 
@@ -1106,6 +1107,9 @@ describe("Integrations", () => {
         screen.getByText(/Requester-scoped tool status is preview only/i),
       ).toBeInTheDocument();
     });
+    expect(
+      screen.getByText(/OAuth-backed integrations can be connected/i),
+    ).toBeInTheDocument();
   });
 
   it("hides shared-only integrations for isolating worker scopes", async () => {
@@ -1590,6 +1594,67 @@ describe("Integrations", () => {
       expect(refetch).toHaveBeenCalledTimes(1);
     });
     expect(mockGenericOAuthOnDisconnect).not.toHaveBeenCalled();
+  });
+
+  it("reports an environment OAuth fallback without offering to remove it", async () => {
+    mockUseTools.mockReturnValue({
+      tools: [
+        {
+          name: "github",
+          display_name: "GitHub",
+          description: "Manage GitHub repositories",
+          icon: "SiGithub",
+          icon_color: null,
+          category: "developer",
+          status: "available",
+          setup_type: "oauth",
+          auth_provider: "github",
+          config_fields: [
+            {
+              name: "access_token",
+              label: "Access Token",
+              type: "password",
+              required: false,
+            },
+            {
+              name: "base_url",
+              label: "Base URL",
+              type: "url",
+              required: false,
+            },
+          ],
+          oauth_fallback_fields: ["access_token"],
+          manual_auth_configured: false,
+          environment_auth_configured: true,
+          helper_text: null,
+          docs_url: null,
+          dependencies: null,
+        },
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      statusAuthoritative: true,
+    });
+
+    render(<Integrations />);
+
+    const githubCard = await waitFor(() => {
+      const card = screen.getByText("GitHub").closest(".h-full");
+      expect(card).toBeInstanceOf(HTMLElement);
+      return card as HTMLElement;
+    });
+    expect(
+      within(githubCard).getByText("Environment Access Token"),
+    ).toBeInTheDocument();
+    expect(
+      within(githubCard).getByRole("button", { name: "Configure" }),
+    ).toBeInTheDocument();
+    expect(
+      within(githubCard).queryByRole("button", { name: "Connect with GitHub" }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(githubCard).queryByRole("button", { name: "Remove access token" }),
+    ).not.toBeInTheDocument();
   });
 
   it("ignores stale shared-scope reloads after switching scope mid-action", async () => {

--- a/frontend/src/components/Integrations/Integrations.test.tsx
+++ b/frontend/src/components/Integrations/Integrations.test.tsx
@@ -74,6 +74,7 @@ const {
   mockPlexOnAction,
   mockPlexOnDisconnect,
   mockGenericOAuthOnAction,
+  mockGenericOAuthOnDisconnect,
   mockGenericOAuthLoadStatus,
   mockGoogleDriveLoadStatus,
   mockGoogleGmailLoadStatus,
@@ -91,6 +92,7 @@ const {
   mockPlexOnAction: vi.fn(),
   mockPlexOnDisconnect: vi.fn(),
   mockGenericOAuthOnAction: vi.fn(),
+  mockGenericOAuthOnDisconnect: vi.fn(),
   mockGenericOAuthLoadStatus: vi
     .fn()
     .mockResolvedValue({ status: "available", connected: false }),
@@ -148,6 +150,8 @@ vi.mock("@/hooks/useTools", () => ({
     config_fields: tool.config_fields,
     helper_text: tool.helper_text,
     docs_url: tool.docs_url,
+    oauth_fallback_fields: tool.oauth_fallback_fields,
+    manual_auth_configured: tool.manual_auth_configured,
   }),
 }));
 
@@ -201,6 +205,7 @@ vi.mock("./integrations/index", () => ({
       return {
         integration: this.integration,
         onAction: () => mockGenericOAuthOnAction(this.providerId),
+        onDisconnect: () => mockGenericOAuthOnDisconnect(this.providerId),
       };
     }
 
@@ -368,6 +373,7 @@ describe("Integrations", () => {
     mockPlexOnAction.mockResolvedValue(undefined);
     mockPlexOnDisconnect.mockResolvedValue(undefined);
     mockGenericOAuthOnAction.mockResolvedValue(undefined);
+    mockGenericOAuthOnDisconnect.mockResolvedValue(undefined);
     mockEnhancedConfigDialogProps.mockClear();
     mockGenericOAuthLoadStatus.mockResolvedValue({
       status: "available",
@@ -1454,6 +1460,136 @@ describe("Integrations", () => {
     expect(
       screen.queryByText(/Connect acme_drive first/i),
     ).not.toBeInTheDocument();
+  });
+
+  it("offers OAuth and manual credentials for providers with a fallback", async () => {
+    mockUseTools.mockReturnValue({
+      tools: [
+        {
+          name: "github",
+          display_name: "GitHub",
+          description: "Manage GitHub repositories",
+          icon: "SiGithub",
+          icon_color: null,
+          category: "developer",
+          status: "requires_config",
+          setup_type: "oauth",
+          auth_provider: "github",
+          config_fields: [
+            {
+              name: "access_token",
+              label: "Access Token",
+              type: "password",
+              required: false,
+            },
+            {
+              name: "base_url",
+              label: "Base URL",
+              type: "url",
+              required: false,
+            },
+          ],
+          oauth_fallback_fields: ["access_token"],
+          manual_auth_configured: false,
+          helper_text: null,
+          docs_url: null,
+          dependencies: null,
+        },
+      ],
+      loading: false,
+      refetch: vi.fn(),
+      statusAuthoritative: true,
+    });
+
+    render(<Integrations />);
+
+    const githubCard = await waitFor(() => {
+      const card = screen.getByText("GitHub").closest(".h-full");
+      expect(card).toBeInstanceOf(HTMLElement);
+      return card as HTMLElement;
+    });
+    expect(
+      within(githubCard).getByRole("button", { name: "Connect with GitHub" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(githubCard).getByRole("button", { name: "Use access token" }),
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Enhanced Config Dialog")).toBeInTheDocument();
+      expect(screen.getByText("Service: github")).toBeInTheDocument();
+    });
+    expect(mockGenericOAuthOnAction).not.toHaveBeenCalled();
+  });
+
+  it("edits and removes a configured OAuth fallback without disconnecting OAuth", async () => {
+    const refetch = vi.fn();
+    mockUseTools.mockReturnValue({
+      tools: [
+        {
+          name: "github",
+          display_name: "GitHub",
+          description: "Manage GitHub repositories",
+          icon: "SiGithub",
+          icon_color: null,
+          category: "developer",
+          status: "available",
+          setup_type: "oauth",
+          auth_provider: "github",
+          config_fields: [
+            {
+              name: "access_token",
+              label: "Access Token",
+              type: "password",
+              required: false,
+            },
+            {
+              name: "base_url",
+              label: "Base URL",
+              type: "url",
+              required: false,
+            },
+          ],
+          oauth_fallback_fields: ["access_token"],
+          manual_auth_configured: true,
+          helper_text: null,
+          docs_url: null,
+          dependencies: null,
+        },
+      ],
+      loading: false,
+      refetch,
+      statusAuthoritative: true,
+    });
+    global.fetch = vi.fn().mockResolvedValue({ ok: true });
+
+    render(<Integrations />);
+
+    const githubCard = await waitFor(() => {
+      const card = screen.getByText("GitHub").closest(".h-full");
+      expect(card).toBeInstanceOf(HTMLElement);
+      return card as HTMLElement;
+    });
+    expect(within(githubCard).getByText("Access Token")).toBeInTheDocument();
+    expect(
+      within(githubCard).getByRole("button", { name: "Edit access token" }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(
+      within(githubCard).getByRole("button", { name: "Remove access token" }),
+    );
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "http://localhost:8080/api/credentials/github",
+        {
+          method: "DELETE",
+        },
+      );
+      expect(refetch).toHaveBeenCalledTimes(1);
+    });
+    expect(mockGenericOAuthOnDisconnect).not.toHaveBeenCalled();
   });
 
   it("ignores stale shared-scope reloads after switching scope mid-action", async () => {

--- a/frontend/src/components/Integrations/Integrations.tsx
+++ b/frontend/src/components/Integrations/Integrations.tsx
@@ -62,9 +62,31 @@ const titleFromProviderId = (providerId: string) =>
     .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
     .join(" ");
 
+const oauthProviderDisplayName = (
+  providerId: string,
+  providerTool?: ToolInfo,
+) =>
+  providerTool?.display_name.replace(/\s+Tool$/, "") ??
+  titleFromProviderId(providerId);
+
 const oauthRedirectPlaceholderOrigin = () =>
   new URL(API_BASE_URL || window.location.origin, window.location.origin)
     .origin;
+
+const hasManualOAuthFallback = (integration: Integration) =>
+  integration.setup_type === "oauth" &&
+  Boolean(integration.oauth_fallback_fields?.length);
+
+const manualOAuthFallbackLabel = (integration: Integration) => {
+  const fallbackFields = integration.oauth_fallback_fields ?? [];
+  if (fallbackFields.length !== 1) {
+    return "Manual credentials";
+  }
+  return (
+    integration.config_fields?.find((field) => field.name === fallbackFields[0])
+      ?.label ?? "Manual credentials"
+  );
+};
 
 export function Integrations() {
   const { agents, agentPoliciesByAgent } = useConfigStore();
@@ -234,8 +256,6 @@ export function Integrations() {
           config_fields:
             providerTool?.config_fields ?? config.integration.config_fields,
           docs_url: providerTool?.docs_url ?? config.integration.docs_url,
-          helper_text:
-            providerTool?.helper_text ?? config.integration.helper_text,
           dependencies:
             providerTool?.dependencies ?? config.integration.dependencies,
           icon_color: providerTool?.icon_color ?? config.integration.icon_color,
@@ -245,7 +265,26 @@ export function Integrations() {
           execution_scope_supported:
             providerTool?.execution_scope_supported ??
             config.integration.execution_scope_supported,
+          oauth_fallback_fields: providerTool?.oauth_fallback_fields,
+          manual_auth_configured: providerTool?.manual_auth_configured,
           ...status,
+          status:
+            providerTool?.manual_auth_configured === true
+              ? "connected"
+              : (status.status ?? config.integration.status),
+          connected:
+            providerTool?.manual_auth_configured === true ||
+            status.connected === true,
+          status_error:
+            providerTool?.manual_auth_configured === true
+              ? undefined
+              : status.status_error,
+          helper_text:
+            providerTool?.manual_auth_configured === true
+              ? providerTool.helper_text
+              : (status.helper_text ??
+                providerTool?.helper_text ??
+                config.integration.helper_text),
           config_service:
             providerTool?.name ??
             status.config_service ??
@@ -267,10 +306,14 @@ export function Integrations() {
         const providerTool = backendTools.find(
           (tool) => tool.auth_provider === providerId,
         );
+        const providerDisplayName = oauthProviderDisplayName(
+          providerId,
+          providerTool,
+        );
         const integration: Integration = {
           id: providerId,
-          name: titleFromProviderId(providerId),
-          description: `Connect ${titleFromProviderId(providerId)} OAuth for ${providerTool?.display_name ?? "this tool"}.`,
+          name: providerDisplayName,
+          description: `Connect ${providerDisplayName} OAuth for ${providerTool?.display_name ?? "this tool"}.`,
           category: providerTool?.category ?? "productivity",
           icon: getIconForTool(
             providerTool?.icon ?? null,
@@ -289,6 +332,8 @@ export function Integrations() {
           dashboard_configuration_supported:
             providerTool?.dashboard_configuration_supported,
           execution_scope_supported: providerTool?.execution_scope_supported,
+          oauth_fallback_fields: providerTool?.oauth_fallback_fields,
+          manual_auth_configured: providerTool?.manual_auth_configured,
         };
         const provider = new GenericOAuthIntegrationProvider(
           integration,
@@ -298,6 +343,21 @@ export function Integrations() {
         loadedIntegrations.push({
           ...integration,
           ...status,
+          status:
+            providerTool?.manual_auth_configured === true
+              ? "connected"
+              : (status?.status ?? integration.status),
+          connected:
+            providerTool?.manual_auth_configured === true ||
+            status?.connected === true,
+          status_error:
+            providerTool?.manual_auth_configured === true
+              ? undefined
+              : status?.status_error,
+          helper_text:
+            providerTool?.manual_auth_configured === true
+              ? providerTool.helper_text
+              : (status?.helper_text ?? integration.helper_text),
           config_service:
             providerTool?.name ??
             status?.config_service ??
@@ -332,6 +392,8 @@ export function Integrations() {
                 : mapped.status,
             auth_provider: tool.auth_provider ?? undefined,
             config_service: tool.name,
+            oauth_fallback_fields: tool.oauth_fallback_fields,
+            manual_auth_configured: tool.manual_auth_configured,
           } as Integration & { auth_provider?: string };
         });
 
@@ -408,7 +470,7 @@ export function Integrations() {
         label: "Client ID",
         type: "text",
         required: true,
-        placeholder: "your-client-id.apps.googleusercontent.com",
+        placeholder: "OAuth app client ID",
         description: "OAuth app client ID",
       },
       {
@@ -555,14 +617,17 @@ export function Integrations() {
 
     setLoading(true);
     try {
-      if (provider?.getConfig(scope).onDisconnect) {
+      if (
+        integration.manual_auth_configured !== true &&
+        provider?.getConfig(scope).onDisconnect
+      ) {
         // Use provider's disconnect method if available
         await provider.getConfig(scope).onDisconnect!(integration.id);
       } else {
         // For generic tools, delete credentials via API
         const response = await fetch(
           withAgentExecutionScope(
-            `${API_BASE_URL}/api/credentials/${integration.id}`,
+            `${API_BASE_URL}/api/credentials/${integration.config_service ?? integration.id}`,
             effectiveScopeAgentName,
             selectedExecutionScope,
           ),
@@ -640,6 +705,21 @@ export function Integrations() {
           : "Use custom client"}
       </Button>
     ) : null;
+    const manualFallbackAvailable = hasManualOAuthFallback(integration);
+    const manualFallbackLabel = manualOAuthFallbackLabel(integration);
+    const manualFallbackActionLabel = manualFallbackLabel.toLocaleLowerCase();
+    const manualFallbackButton =
+      manualFallbackAvailable && integration.manual_auth_configured !== true ? (
+        <Button
+          onClick={() => openToolConfigDialog(integration)}
+          disabled={loading}
+          variant="outline"
+          size="sm"
+        >
+          <Key className="h-4 w-4 mr-1" />
+          Use {manualFallbackActionLabel}
+        </Button>
+      ) : null;
 
     // Handle tools with delegated authentication
     const tool = integration;
@@ -772,6 +852,37 @@ export function Integrations() {
       }
     }
 
+    if (
+      manualFallbackAvailable &&
+      integration.manual_auth_configured === true
+    ) {
+      return (
+        <div className="flex gap-2 items-center">
+          <Badge className="bg-green-500/10 dark:bg-green-500/20 text-green-700 dark:text-green-300">
+            <Key className="h-3 w-3 mr-1" />
+            {manualFallbackLabel}
+          </Badge>
+          <Button
+            onClick={() => openToolConfigDialog(integration)}
+            disabled={loading}
+            variant="outline"
+            size="sm"
+          >
+            Edit {manualFallbackActionLabel}
+          </Button>
+          {oauthClientConfigButton}
+          <Button
+            onClick={() => handleDisconnect(integration)}
+            disabled={loading}
+            variant="destructive"
+            size="sm"
+          >
+            Remove {manualFallbackActionLabel}
+          </Button>
+        </div>
+      );
+    }
+
     if (integration.setup_type === "oauth" && integration.status_error) {
       return (
         <div className="flex gap-2 items-center">
@@ -779,6 +890,7 @@ export function Integrations() {
             Status unavailable
           </Button>
           {oauthClientConfigButton}
+          {manualFallbackButton}
           <Button
             onClick={() => void loadIntegrations(false)}
             disabled={loading}
@@ -809,9 +921,12 @@ export function Integrations() {
             ) : (
               <ExternalLink className="h-4 w-4" />
             )}
-            Connect
+            {manualFallbackAvailable
+              ? `Connect with ${integration.name}`
+              : "Connect"}
           </Button>
           {oauthClientConfigButton}
+          {manualFallbackButton}
         </div>
       );
     }
@@ -822,14 +937,34 @@ export function Integrations() {
       integration.oauth_service_account_configured !== true
     ) {
       return (
-        <Button
-          onClick={() => handleIntegrationAction(integration)}
-          disabled={loading || !integration.oauth_client_config_service}
-          variant="outline"
-          size="sm"
-        >
-          Configure client
-        </Button>
+        <div className="flex gap-2 items-center">
+          <Button
+            onClick={() => handleIntegrationAction(integration)}
+            disabled={loading || !integration.oauth_client_config_service}
+            variant="outline"
+            size="sm"
+          >
+            Configure client
+          </Button>
+          {manualFallbackButton}
+        </div>
+      );
+    }
+
+    if (integration.status === "connected" && manualFallbackAvailable) {
+      return (
+        <div className="flex gap-2">
+          {manualFallbackButton}
+          {oauthClientConfigButton}
+          <Button
+            onClick={() => handleDisconnect(integration)}
+            disabled={loading}
+            variant="destructive"
+            size="sm"
+          >
+            Disconnect
+          </Button>
+        </div>
       );
     }
 
@@ -874,7 +1009,7 @@ export function Integrations() {
         <Key className="h-4 w-4" />
       );
 
-    return (
+    const actionButton = (
       <Button
         onClick={() => handleIntegrationAction(integration)}
         disabled={loading}
@@ -882,8 +1017,19 @@ export function Integrations() {
         className="flex items-center gap-2"
       >
         {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : icon}
-        {buttonText}
+        {manualFallbackAvailable
+          ? `Connect with ${integration.name}`
+          : buttonText}
       </Button>
+    );
+
+    return manualFallbackButton ? (
+      <div className="flex gap-2 items-center">
+        {actionButton}
+        {manualFallbackButton}
+      </div>
+    ) : (
+      actionButton
     );
   };
 

--- a/frontend/src/components/Integrations/Integrations.tsx
+++ b/frontend/src/components/Integrations/Integrations.tsx
@@ -77,6 +77,13 @@ const hasManualOAuthFallback = (integration: Integration) =>
   integration.setup_type === "oauth" &&
   Boolean(integration.oauth_fallback_fields?.length);
 
+const hasConfiguredOAuthFallback = (integration?: {
+  manual_auth_configured?: boolean;
+  environment_auth_configured?: boolean;
+}) =>
+  integration?.manual_auth_configured === true ||
+  integration?.environment_auth_configured === true;
+
 const manualOAuthFallbackLabel = (integration: Integration) => {
   const fallbackFields = integration.oauth_fallback_fields ?? [];
   if (fallbackFields.length !== 1) {
@@ -251,6 +258,7 @@ export function Integrations() {
         const status = provider.loadStatus
           ? await provider.loadStatus(scope)
           : {};
+        const fallbackConfigured = hasConfiguredOAuthFallback(providerTool);
         loadedIntegrations.push({
           ...config.integration,
           config_fields:
@@ -267,24 +275,19 @@ export function Integrations() {
             config.integration.execution_scope_supported,
           oauth_fallback_fields: providerTool?.oauth_fallback_fields,
           manual_auth_configured: providerTool?.manual_auth_configured,
+          environment_auth_configured:
+            providerTool?.environment_auth_configured,
           ...status,
-          status:
-            providerTool?.manual_auth_configured === true
-              ? "connected"
-              : (status.status ?? config.integration.status),
-          connected:
-            providerTool?.manual_auth_configured === true ||
-            status.connected === true,
-          status_error:
-            providerTool?.manual_auth_configured === true
-              ? undefined
-              : status.status_error,
-          helper_text:
-            providerTool?.manual_auth_configured === true
-              ? providerTool.helper_text
-              : (status.helper_text ??
-                providerTool?.helper_text ??
-                config.integration.helper_text),
+          status: fallbackConfigured
+            ? "connected"
+            : (status.status ?? config.integration.status),
+          connected: fallbackConfigured || status.connected === true,
+          status_error: fallbackConfigured ? undefined : status.status_error,
+          helper_text: fallbackConfigured
+            ? providerTool?.helper_text
+            : (status.helper_text ??
+              providerTool?.helper_text ??
+              config.integration.helper_text),
           config_service:
             providerTool?.name ??
             status.config_service ??
@@ -334,30 +337,26 @@ export function Integrations() {
           execution_scope_supported: providerTool?.execution_scope_supported,
           oauth_fallback_fields: providerTool?.oauth_fallback_fields,
           manual_auth_configured: providerTool?.manual_auth_configured,
+          environment_auth_configured:
+            providerTool?.environment_auth_configured,
         };
         const provider = new GenericOAuthIntegrationProvider(
           integration,
           providerId,
         );
         const status = await provider.loadStatus?.(scope);
+        const fallbackConfigured = hasConfiguredOAuthFallback(providerTool);
         loadedIntegrations.push({
           ...integration,
           ...status,
-          status:
-            providerTool?.manual_auth_configured === true
-              ? "connected"
-              : (status?.status ?? integration.status),
-          connected:
-            providerTool?.manual_auth_configured === true ||
-            status?.connected === true,
-          status_error:
-            providerTool?.manual_auth_configured === true
-              ? undefined
-              : status?.status_error,
-          helper_text:
-            providerTool?.manual_auth_configured === true
-              ? providerTool.helper_text
-              : (status?.helper_text ?? integration.helper_text),
+          status: fallbackConfigured
+            ? "connected"
+            : (status?.status ?? integration.status),
+          connected: fallbackConfigured || status?.connected === true,
+          status_error: fallbackConfigured ? undefined : status?.status_error,
+          helper_text: fallbackConfigured
+            ? providerTool?.helper_text
+            : (status?.helper_text ?? integration.helper_text),
           config_service:
             providerTool?.name ??
             status?.config_service ??
@@ -709,7 +708,7 @@ export function Integrations() {
     const manualFallbackLabel = manualOAuthFallbackLabel(integration);
     const manualFallbackActionLabel = manualFallbackLabel.toLocaleLowerCase();
     const manualFallbackButton =
-      manualFallbackAvailable && integration.manual_auth_configured !== true ? (
+      manualFallbackAvailable && !hasConfiguredOAuthFallback(integration) ? (
         <Button
           onClick={() => openToolConfigDialog(integration)}
           disabled={loading}
@@ -850,6 +849,30 @@ export function Integrations() {
           </Badge>
         );
       }
+    }
+
+    if (
+      manualFallbackAvailable &&
+      integration.environment_auth_configured === true &&
+      integration.manual_auth_configured !== true
+    ) {
+      return (
+        <div className="flex gap-2 items-center">
+          <Badge className="bg-green-500/10 dark:bg-green-500/20 text-green-700 dark:text-green-300">
+            <Key className="h-3 w-3 mr-1" />
+            Environment {manualFallbackLabel}
+          </Badge>
+          <Button
+            onClick={() => openToolConfigDialog(integration)}
+            disabled={loading}
+            variant="outline"
+            size="sm"
+          >
+            Configure
+          </Button>
+          {oauthClientConfigButton}
+        </div>
+      );
     }
 
     if (
@@ -1294,8 +1317,8 @@ export function Integrations() {
               <AlertDescription className="mt-2">
                 Home Assistant and Spotify remain shared-only unless the agent
                 has an effective shared runtime scope (
-                <code>worker_scope=shared</code>). OAuth-backed Google
-                integrations can be connected for this selected agent.
+                <code>worker_scope=shared</code>). OAuth-backed integrations can
+                be connected for this selected agent.
               </AlertDescription>
             </Alert>
           )}

--- a/frontend/src/components/Integrations/integrations/types/index.ts
+++ b/frontend/src/components/Integrations/integrations/types/index.ts
@@ -34,6 +34,7 @@ export interface Integration {
   config_service?: string;
   oauth_fallback_fields?: string[];
   manual_auth_configured?: boolean;
+  environment_auth_configured?: boolean;
 }
 
 export interface IntegrationScope {

--- a/frontend/src/components/Integrations/integrations/types/index.ts
+++ b/frontend/src/components/Integrations/integrations/types/index.ts
@@ -32,6 +32,8 @@ export interface Integration {
   oauth_service_account_configured?: boolean;
   status_error?: string;
   config_service?: string;
+  oauth_fallback_fields?: string[];
+  manual_auth_configured?: boolean;
 }
 
 export interface IntegrationScope {

--- a/frontend/src/hooks/useTools.ts
+++ b/frontend/src/hooks/useTools.ts
@@ -36,6 +36,8 @@ export interface ToolInfo {
   function_names?: string[] | null;
   dashboard_configuration_supported?: boolean;
   execution_scope_supported?: boolean;
+  oauth_fallback_fields?: string[];
+  manual_auth_configured?: boolean;
 }
 
 export interface ToolsResponse {
@@ -123,5 +125,7 @@ export function mapToolToIntegration(tool: ToolInfo) {
     dependencies: tool.dependencies,
     docs_url: tool.docs_url,
     helper_text: tool.helper_text,
+    oauth_fallback_fields: tool.oauth_fallback_fields,
+    manual_auth_configured: tool.manual_auth_configured,
   };
 }

--- a/frontend/src/hooks/useTools.ts
+++ b/frontend/src/hooks/useTools.ts
@@ -38,6 +38,7 @@ export interface ToolInfo {
   execution_scope_supported?: boolean;
   oauth_fallback_fields?: string[];
   manual_auth_configured?: boolean;
+  environment_auth_configured?: boolean;
 }
 
 export interface ToolsResponse {
@@ -127,5 +128,6 @@ export function mapToolToIntegration(tool: ToolInfo) {
     helper_text: tool.helper_text,
     oauth_fallback_fields: tool.oauth_fallback_fields,
     manual_auth_configured: tool.manual_auth_configured,
+    environment_auth_configured: tool.environment_auth_configured,
   };
 }

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2035,7 +2035,7 @@ Adding or removing tools via chat does not discard existing per-agent overrides 
 `worker_tools` decides which tools run in the sandbox proxy instead of the main MindRoom process.
 When omitted, MindRoom routes `coding`, `docker`, `file`, `python`, and `shell` through the proxy by default.
 Registry-backed tools can be listed in `worker_tools`, and MindRoom will attempt to route them through the worker runtime.
-Some local-only tools stay in the primary runtime even when listed: `attachments`, `desktop`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, `google_sheets`, and `homeassistant`.
+Some local-only tools stay in the primary runtime even when listed: `attachments`, `desktop`, `github`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, `google_sheets`, and `homeassistant`.
 Dedicated Docker workers also receive a projected read-only config snapshot so config-relative plugins, knowledge bases, and other worker-safe assets remain available without exposing unrelated primary-runtime state.
 Agent-scoped workers snapshot only that agent's projected context files and assigned knowledge bases, while scopes that intentionally share one worker across multiple agents keep the broader shared projection for that worker.
 Writable file-memory paths are rewritten into worker-owned state instead of being mounted from the host config tree.
@@ -2046,7 +2046,7 @@ Some integrations require `worker_scope` unset or `shared` because their credent
 That list includes `spotify`, `homeassistant`, and non-OAuth configured `mcp_<server_id>` tools.
 OAuth-backed remote MCP tools use requester-scoped OAuth credentials and can be used with `worker_scope: user` or `worker_scope: user_agent`.
 Among those shared-scope integrations, `homeassistant` always stays local regardless of `worker_tools` and is never proxied to the sandbox.
-`gmail`, `google_calendar`, `google_docs`, `google_drive`, and `google_sheets` also always stay local.
+`github`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, and `google_sheets` also always stay local.
 `spotify` can still be proxied through the sandbox.
 The built-in `memory`, `delegate`, and `self_config` tools are also created directly in the primary runtime today and are not routed through `worker_tools`.
 
@@ -2094,8 +2094,9 @@ Workers mount those canonical private-instance roots.
 They do not own them.
 
 The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-OAuth providers that support scoped dashboard flows, such as the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the Google tools still execute in the primary MindRoom runtime.
+OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
+For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
 Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime instead.
 
 For more details on storage layout and isolation, see [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/).
@@ -8613,6 +8614,7 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 Choose **Connect with GitHub** on the Tools dashboard to use requester-scoped GitHub App user OAuth.
 For a self-hosted installation, configure the GitHub App client ID and client secret under the `github_oauth_client` credential service and register `/api/oauth/github/callback` on the installation's public URL as the callback URL.
 MindRoom requests no classic OAuth scopes because GitHub App user tokens use the app's fine-grained permissions.
+Managed GitHub credentials follow the requester independently of the agent's worker scope and stay in the primary MindRoom runtime.
 When a requester has not connected GitHub, tool calls return a structured `OAuthConnectionRequired` result containing that requester's connect URL.
 MindRoom refreshes expiring access tokens through the existing scoped OAuth refresh flow and persists rotated access and refresh tokens.
 
@@ -12977,7 +12979,7 @@ To adopt hooks:
 # OAuth Integration Framework
 
 MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account.
-Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, optional PKCE requirements, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
+Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, optional PKCE requirements, requester-only credential placement, explicitly permitted manual fallback fields and runtime environment names, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
 
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/status`, and `/api/oauth/{provider}/disconnect`.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
@@ -13002,16 +13004,16 @@ Plugins can use `OAuthDiscoveryConfig` with `oauth_runtime_bootstrapper()` to re
 Automatic discovery first checks protected-resource metadata at the resource origin and path, then uses the advertised authorization server or falls back to authorization-server metadata at the resource origin.
 Dynamic client registration requires a provider-specific `client_config_services` entry and stores generated client configuration only in the primary runtime.
 
-OAuth token writes always go through `resolve_request_credentials_target()` and `save_scoped_credentials()`.
-For private agents, the target worker key is derived from the authenticated requester and the agent's saved `worker_scope`, so a user-owned OAuth token lands under the same scope normal tools will read at runtime.
-For shared-scope agents, OAuth tokens land in a per-agent primary-runtime store, so a connection made for one agent never becomes visible to other agents.
-Only agents without any worker scope share OAuth tokens through the global credential store.
+OAuth token writes always go through the provider's credential-target resolver and `save_scoped_credentials()`.
+Providers can declare that credentials follow the requester independently of agent worker reuse.
+GitHub uses that policy, so its managed token always lands in the requester's `user` scope and can never fall back to a shared or global token store.
+For providers without that policy, private-agent tokens follow the authenticated requester and the agent's saved `worker_scope`, shared-scope agent tokens use a per-agent primary-runtime store, and unscoped agents use the global credential store.
 If MindRoom cannot resolve the authenticated dashboard user to the requester carried by a conversation-issued link, the link fails closed and no credential is saved.
 Credential placement and visibility policy is centralized in `src/mindroom/credential_policy.py`.
 That module owns service classification, OAuth token field filtering, local-only credential service names, and worker-grantable rejections.
 Storage, API routing, OAuth provider loading, and worker identity derivation stay in their existing modules.
 Tools should declare `auth_provider` and, when credentials are missing, return a concise connect instruction that points at the generic `authorize` route for the provider and agent.
-Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need Google OAuth client config or user refresh tokens.
+GitHub and Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need OAuth client config or user refresh tokens.
 OAuth token documents and editable tool setting documents should be separate services.
 The OAuth callback writes only the provider's `credential_service`, while dashboard configuration reads and writes the provider's `tool_config_service` when one is declared.
 OAuth app client config is stored separately from both of those services.
@@ -13036,6 +13038,7 @@ Identity restrictions are provider settings, not MindRoom policy.
 Providers can enforce allowed email domains, allowed hosted-domain claims, and custom claim validators.
 If a configured restriction cannot be checked from verified provider claims, the callback fails closed and no credential is saved.
 
+The built-in GitHub provider uses the generic framework for GitHub App user tokens, requests no classic OAuth scopes, and requires S256 PKCE.
 Built-in Google providers use the generic framework for Drive, Docs, Calendar, Sheets, and Gmail.
 Each provider has minimal service-specific scopes, stores OAuth tokens under its own `*_oauth` service, stores editable tool settings separately, and uses `/api/oauth/*`.
 Each provider first checks its provider-specific client config service, then the shared `google_oauth_client` service.
@@ -18385,8 +18388,9 @@ With `MINDROOM_WORKER_BACKEND=docker` or `MINDROOM_WORKER_BACKEND=kubernetes`, M
 - `worker_scope` does **not** change where agent data is stored.
   All scopes read and write the same agent storage directory (`agents/<name>/`).
 - The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-  OAuth providers that support scoped dashboard flows, such as the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-  For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the Google tools still execute in the primary MindRoom runtime.
+  OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
+  For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+  GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
   Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime.
 - `user` mode shares one runtime across multiple agents for a single user, so agents in that runtime can access each other's files.
   Use `user_agent` for per-agent isolation.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -8584,7 +8584,7 @@ Use these tools when you need repository context, issue tracking, documentation 
 
 The `todo` tool is available without credentials.
 The other tools on this page are registered as `status=requires_config`, so they stay unavailable in the dashboard until their required credentials or connection fields are present.
-None of these tools declare an `auth_provider`, and `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes, so project-management tools are configured through stored tool credentials or environment variables rather than a dedicated dashboard OAuth flow.
+GitHub supports requester-scoped OAuth through MindRoom's built-in `github` provider, while the remaining project-management tools use stored tool credentials or environment variables.
 Password and token fields should be stored through the dashboard or credential store instead of inline YAML.
 Most upstream SDKs also read environment variables, including `GITHUB_ACCESS_TOKEN`, `BITBUCKET_USERNAME`, `BITBUCKET_PASSWORD`, `BITBUCKET_TOKEN`, `JIRA_SERVER_URL`, `JIRA_USERNAME`, `JIRA_PASSWORD`, `JIRA_TOKEN`, `LINEAR_API_KEY`, `CLICKUP_API_KEY`, `MASTER_SPACE_ID`, `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, `CONFLUENCE_API_KEY`, `CONFLUENCE_PASSWORD`, `NOTION_API_KEY`, `NOTION_DATABASE_ID`, `TRELLO_API_KEY`, `TRELLO_API_SECRET`, `TRELLO_TOKEN`, `TODOIST_API_TOKEN`, `ZENDESK_USERNAME`, `ZENDESK_PASSWORD`, and `ZENDESK_COMPANY_NAME`.
 Several registry fields on this page are marked optional in metadata even though the upstream tool effectively requires them at runtime, so the notes below call out the practical requirement level for each tool.
@@ -8605,8 +8605,19 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 
 | Option | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
-| `access_token` | `password` | `no` | `null` | GitHub personal access token or GitHub App token. |
+| `access_token` | `password` | `no` | `null` | Optional explicit GitHub access token; takes precedence over OAuth when set. |
 | `base_url` | `url` | `no` | `null` | Optional GitHub Enterprise API base URL such as `https://github.example.com/api/v3`. |
+
+### OAuth Setup
+
+Choose **Connect with GitHub** on the Tools dashboard to use requester-scoped GitHub App user OAuth.
+For a self-hosted installation, configure the GitHub App client ID and client secret under the `github_oauth_client` credential service and register `/api/oauth/github/callback` on the installation's public URL as the callback URL.
+MindRoom requests no classic OAuth scopes because GitHub App user tokens use the app's fine-grained permissions.
+When a requester has not connected GitHub, tool calls return a structured `OAuthConnectionRequired` result containing that requester's connect URL.
+MindRoom refreshes expiring access tokens through the existing scoped OAuth refresh flow and persists rotated access and refresh tokens.
+
+Choose **Use access token** instead to save an explicit token, or set `GITHUB_ACCESS_TOKEN` in the runtime environment.
+An explicit token always takes precedence over requester-scoped OAuth credentials.
 
 ### Example
 
@@ -8626,7 +8637,7 @@ get_pull_request("mindroom-ai/mindroom", 123)
 
 ### Notes
 
-- `access_token` is marked optional in MindRoom metadata, but the upstream client raises at startup if neither `access_token` nor `GITHUB_ACCESS_TOKEN` is present.
+- The tool can start without credentials; its functions return a requester-bound OAuth connection link until GitHub is connected or an explicit token is configured.
 - Use `base_url` only for GitHub Enterprise, and set it to the API endpoint such as `/api/v3` rather than the human-facing site root.
 - `github` is the best fit on this page when you need repository file operations or rich pull-request inspection in addition to issue tracking.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2094,8 +2094,7 @@ Workers mount those canonical private-instance roots.
 They do not own them.
 
 The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+The Google Drive, Docs, Gmail, Calendar, and Sheets OAuth providers are an exception: the dashboard can connect scoped `user` and `user_agent` credentials, while the tools still execute in the primary MindRoom runtime.
 GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
 Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime instead.
 
@@ -8606,7 +8605,7 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 
 | Option | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
-| `access_token` | `password` | `no` | `null` | Optional explicit GitHub access token; takes precedence over OAuth when set. |
+| `access_token` | `password` | `no` | `null` | Optional explicit GitHub access token; takes precedence over OAuth when non-blank. |
 | `base_url` | `url` | `no` | `null` | Optional GitHub Enterprise API base URL such as `https://github.example.com/api/v3`. |
 
 ### OAuth Setup
@@ -8619,7 +8618,8 @@ When a requester has not connected GitHub, tool calls return a structured `OAuth
 MindRoom refreshes expiring access tokens through the existing scoped OAuth refresh flow and persists rotated access and refresh tokens.
 
 Choose **Use access token** instead to save an explicit token, or set `GITHUB_ACCESS_TOKEN` in the runtime environment.
-An explicit token always takes precedence over requester-scoped OAuth credentials.
+A non-blank saved `access_token` takes precedence over a non-blank `GITHUB_ACCESS_TOKEN`, which takes precedence over requester-scoped OAuth credentials.
+Whitespace-only token values are treated as absent.
 
 ### Example
 
@@ -18388,8 +18388,7 @@ With `MINDROOM_WORKER_BACKEND=docker` or `MINDROOM_WORKER_BACKEND=kubernetes`, M
 - `worker_scope` does **not** change where agent data is stored.
   All scopes read and write the same agent storage directory (`agents/<name>/`).
 - The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-  OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-  For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+  The Google Drive, Docs, Gmail, Calendar, and Sheets OAuth providers are an exception: the dashboard can connect scoped `user` and `user_agent` credentials, while the tools still execute in the primary MindRoom runtime.
   GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
   Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime.
 - `user` mode shares one runtime across multiple agents for a single user, so agents in that runtime can access each other's files.

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -361,7 +361,7 @@ Adding or removing tools via chat does not discard existing per-agent overrides 
 `worker_tools` decides which tools run in the sandbox proxy instead of the main MindRoom process.
 When omitted, MindRoom routes `coding`, `docker`, `file`, `python`, and `shell` through the proxy by default.
 Registry-backed tools can be listed in `worker_tools`, and MindRoom will attempt to route them through the worker runtime.
-Some local-only tools stay in the primary runtime even when listed: `attachments`, `desktop`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, `google_sheets`, and `homeassistant`.
+Some local-only tools stay in the primary runtime even when listed: `attachments`, `desktop`, `github`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, `google_sheets`, and `homeassistant`.
 Dedicated Docker workers also receive a projected read-only config snapshot so config-relative plugins, knowledge bases, and other worker-safe assets remain available without exposing unrelated primary-runtime state.
 Agent-scoped workers snapshot only that agent's projected context files and assigned knowledge bases, while scopes that intentionally share one worker across multiple agents keep the broader shared projection for that worker.
 Writable file-memory paths are rewritten into worker-owned state instead of being mounted from the host config tree.
@@ -372,7 +372,7 @@ Some integrations require `worker_scope` unset or `shared` because their credent
 That list includes `spotify`, `homeassistant`, and non-OAuth configured `mcp_<server_id>` tools.
 OAuth-backed remote MCP tools use requester-scoped OAuth credentials and can be used with `worker_scope: user` or `worker_scope: user_agent`.
 Among those shared-scope integrations, `homeassistant` always stays local regardless of `worker_tools` and is never proxied to the sandbox.
-`gmail`, `google_calendar`, `google_docs`, `google_drive`, and `google_sheets` also always stay local.
+`github`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, and `google_sheets` also always stay local.
 `spotify` can still be proxied through the sandbox.
 The built-in `memory`, `delegate`, and `self_config` tools are also created directly in the primary runtime today and are not routed through `worker_tools`.
 
@@ -420,8 +420,9 @@ Workers mount those canonical private-instance roots.
 They do not own them.
 
 The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-OAuth providers that support scoped dashboard flows, such as the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the Google tools still execute in the primary MindRoom runtime.
+OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
+For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
 Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime instead.
 
 For more details on storage layout and isolation, see [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-proxy/).

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -420,8 +420,7 @@ Workers mount those canonical private-instance roots.
 They do not own them.
 
 The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+The Google Drive, Docs, Gmail, Calendar, and Sheets OAuth providers are an exception: the dashboard can connect scoped `user` and `user_agent` credentials, while the tools still execute in the primary MindRoom runtime.
 GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
 Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime instead.
 

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -641,8 +641,7 @@ With `MINDROOM_WORKER_BACKEND=docker` or `MINDROOM_WORKER_BACKEND=kubernetes`, M
 - `worker_scope` does **not** change where agent data is stored.
   All scopes read and write the same agent storage directory (`agents/<name>/`).
 - The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-  OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-  For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+  The Google Drive, Docs, Gmail, Calendar, and Sheets OAuth providers are an exception: the dashboard can connect scoped `user` and `user_agent` credentials, while the tools still execute in the primary MindRoom runtime.
   GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
   Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime.
 - `user` mode shares one runtime across multiple agents for a single user, so agents in that runtime can access each other's files.

--- a/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
+++ b/skills/mindroom-docs/references/page__deployment__sandbox-proxy__index.md
@@ -641,8 +641,9 @@ With `MINDROOM_WORKER_BACKEND=docker` or `MINDROOM_WORKER_BACKEND=kubernetes`, M
 - `worker_scope` does **not** change where agent data is stored.
   All scopes read and write the same agent storage directory (`agents/<name>/`).
 - The dashboard's generic credential forms only work for unscoped agents and agents with `worker_scope=shared`.
-  OAuth providers that support scoped dashboard flows, such as the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
-  For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the Google tools still execute in the primary MindRoom runtime.
+  OAuth providers that support scoped dashboard flows, such as GitHub and the Google Drive, Docs, Gmail, Calendar, and Sheets providers, are the exception.
+  For those providers, the dashboard can connect scoped `user` and `user_agent` credentials, but the tools still execute in the primary MindRoom runtime.
+  GitHub managed OAuth credentials always use the requester's `user` scope, independently of the agent's `worker_scope`.
   Tools without a scoped OAuth provider still manage `user` and `user_agent` credentials through their worker runtime.
 - `user` mode shares one runtime across multiple agents for a single user, so agents in that runtime can access each other's files.
   Use `user_agent` for per-agent isolation.

--- a/skills/mindroom-docs/references/page__oauth-framework__index.md
+++ b/skills/mindroom-docs/references/page__oauth-framework__index.md
@@ -1,7 +1,7 @@
 # OAuth Integration Framework
 
 MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account.
-Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, optional PKCE requirements, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
+Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, optional PKCE requirements, requester-only credential placement, explicitly permitted manual fallback fields and runtime environment names, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
 
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/status`, and `/api/oauth/{provider}/disconnect`.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
@@ -26,16 +26,16 @@ Plugins can use `OAuthDiscoveryConfig` with `oauth_runtime_bootstrapper()` to re
 Automatic discovery first checks protected-resource metadata at the resource origin and path, then uses the advertised authorization server or falls back to authorization-server metadata at the resource origin.
 Dynamic client registration requires a provider-specific `client_config_services` entry and stores generated client configuration only in the primary runtime.
 
-OAuth token writes always go through `resolve_request_credentials_target()` and `save_scoped_credentials()`.
-For private agents, the target worker key is derived from the authenticated requester and the agent's saved `worker_scope`, so a user-owned OAuth token lands under the same scope normal tools will read at runtime.
-For shared-scope agents, OAuth tokens land in a per-agent primary-runtime store, so a connection made for one agent never becomes visible to other agents.
-Only agents without any worker scope share OAuth tokens through the global credential store.
+OAuth token writes always go through the provider's credential-target resolver and `save_scoped_credentials()`.
+Providers can declare that credentials follow the requester independently of agent worker reuse.
+GitHub uses that policy, so its managed token always lands in the requester's `user` scope and can never fall back to a shared or global token store.
+For providers without that policy, private-agent tokens follow the authenticated requester and the agent's saved `worker_scope`, shared-scope agent tokens use a per-agent primary-runtime store, and unscoped agents use the global credential store.
 If MindRoom cannot resolve the authenticated dashboard user to the requester carried by a conversation-issued link, the link fails closed and no credential is saved.
 Credential placement and visibility policy is centralized in `src/mindroom/credential_policy.py`.
 That module owns service classification, OAuth token field filtering, local-only credential service names, and worker-grantable rejections.
 Storage, API routing, OAuth provider loading, and worker identity derivation stay in their existing modules.
 Tools should declare `auth_provider` and, when credentials are missing, return a concise connect instruction that points at the generic `authorize` route for the provider and agent.
-Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need Google OAuth client config or user refresh tokens.
+GitHub and Google OAuth tools always execute in the primary MindRoom runtime so worker runtimes never need OAuth client config or user refresh tokens.
 OAuth token documents and editable tool setting documents should be separate services.
 The OAuth callback writes only the provider's `credential_service`, while dashboard configuration reads and writes the provider's `tool_config_service` when one is declared.
 OAuth app client config is stored separately from both of those services.
@@ -60,6 +60,7 @@ Identity restrictions are provider settings, not MindRoom policy.
 Providers can enforce allowed email domains, allowed hosted-domain claims, and custom claim validators.
 If a configured restriction cannot be checked from verified provider claims, the callback fails closed and no credential is saved.
 
+The built-in GitHub provider uses the generic framework for GitHub App user tokens, requests no classic OAuth scopes, and requires S256 PKCE.
 Built-in Google providers use the generic framework for Drive, Docs, Calendar, Sheets, and Gmail.
 Each provider has minimal service-specific scopes, stores OAuth tokens under its own `*_oauth` service, stores editable tool settings separately, and uses `/api/oauth/*`.
 Each provider first checks its provider-specific client config service, then the shared `google_oauth_client` service.

--- a/skills/mindroom-docs/references/page__tools__project-management__index.md
+++ b/skills/mindroom-docs/references/page__tools__project-management__index.md
@@ -46,7 +46,7 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 
 | Option | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
-| `access_token` | `password` | `no` | `null` | Optional explicit GitHub access token; takes precedence over OAuth when set. |
+| `access_token` | `password` | `no` | `null` | Optional explicit GitHub access token; takes precedence over OAuth when non-blank. |
 | `base_url` | `url` | `no` | `null` | Optional GitHub Enterprise API base URL such as `https://github.example.com/api/v3`. |
 
 ### OAuth Setup
@@ -59,7 +59,8 @@ When a requester has not connected GitHub, tool calls return a structured `OAuth
 MindRoom refreshes expiring access tokens through the existing scoped OAuth refresh flow and persists rotated access and refresh tokens.
 
 Choose **Use access token** instead to save an explicit token, or set `GITHUB_ACCESS_TOKEN` in the runtime environment.
-An explicit token always takes precedence over requester-scoped OAuth credentials.
+A non-blank saved `access_token` takes precedence over a non-blank `GITHUB_ACCESS_TOKEN`, which takes precedence over requester-scoped OAuth credentials.
+Whitespace-only token values are treated as absent.
 
 ### Example
 

--- a/skills/mindroom-docs/references/page__tools__project-management__index.md
+++ b/skills/mindroom-docs/references/page__tools__project-management__index.md
@@ -54,6 +54,7 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 Choose **Connect with GitHub** on the Tools dashboard to use requester-scoped GitHub App user OAuth.
 For a self-hosted installation, configure the GitHub App client ID and client secret under the `github_oauth_client` credential service and register `/api/oauth/github/callback` on the installation's public URL as the callback URL.
 MindRoom requests no classic OAuth scopes because GitHub App user tokens use the app's fine-grained permissions.
+Managed GitHub credentials follow the requester independently of the agent's worker scope and stay in the primary MindRoom runtime.
 When a requester has not connected GitHub, tool calls return a structured `OAuthConnectionRequired` result containing that requester's connect URL.
 MindRoom refreshes expiring access tokens through the existing scoped OAuth refresh flow and persists rotated access and refresh tokens.
 

--- a/skills/mindroom-docs/references/page__tools__project-management__index.md
+++ b/skills/mindroom-docs/references/page__tools__project-management__index.md
@@ -25,7 +25,7 @@ Use these tools when you need repository context, issue tracking, documentation 
 
 The `todo` tool is available without credentials.
 The other tools on this page are registered as `status=requires_config`, so they stay unavailable in the dashboard until their required credentials or connection fields are present.
-None of these tools declare an `auth_provider`, and `src/mindroom/api/integrations.py` currently only exposes Spotify OAuth routes, so project-management tools are configured through stored tool credentials or environment variables rather than a dedicated dashboard OAuth flow.
+GitHub supports requester-scoped OAuth through MindRoom's built-in `github` provider, while the remaining project-management tools use stored tool credentials or environment variables.
 Password and token fields should be stored through the dashboard or credential store instead of inline YAML.
 Most upstream SDKs also read environment variables, including `GITHUB_ACCESS_TOKEN`, `BITBUCKET_USERNAME`, `BITBUCKET_PASSWORD`, `BITBUCKET_TOKEN`, `JIRA_SERVER_URL`, `JIRA_USERNAME`, `JIRA_PASSWORD`, `JIRA_TOKEN`, `LINEAR_API_KEY`, `CLICKUP_API_KEY`, `MASTER_SPACE_ID`, `CONFLUENCE_URL`, `CONFLUENCE_USERNAME`, `CONFLUENCE_API_KEY`, `CONFLUENCE_PASSWORD`, `NOTION_API_KEY`, `NOTION_DATABASE_ID`, `TRELLO_API_KEY`, `TRELLO_API_SECRET`, `TRELLO_TOKEN`, `TODOIST_API_TOKEN`, `ZENDESK_USERNAME`, `ZENDESK_PASSWORD`, and `ZENDESK_COMPANY_NAME`.
 Several registry fields on this page are marked optional in metadata even though the upstream tool effectively requires them at runtime, so the notes below call out the practical requirement level for each tool.
@@ -46,8 +46,19 @@ The file-management surface includes `create_file()`, `get_file_content()`, `upd
 
 | Option | Type | Required | Default | Notes |
 | --- | --- | --- | --- | --- |
-| `access_token` | `password` | `no` | `null` | GitHub personal access token or GitHub App token. |
+| `access_token` | `password` | `no` | `null` | Optional explicit GitHub access token; takes precedence over OAuth when set. |
 | `base_url` | `url` | `no` | `null` | Optional GitHub Enterprise API base URL such as `https://github.example.com/api/v3`. |
+
+### OAuth Setup
+
+Choose **Connect with GitHub** on the Tools dashboard to use requester-scoped GitHub App user OAuth.
+For a self-hosted installation, configure the GitHub App client ID and client secret under the `github_oauth_client` credential service and register `/api/oauth/github/callback` on the installation's public URL as the callback URL.
+MindRoom requests no classic OAuth scopes because GitHub App user tokens use the app's fine-grained permissions.
+When a requester has not connected GitHub, tool calls return a structured `OAuthConnectionRequired` result containing that requester's connect URL.
+MindRoom refreshes expiring access tokens through the existing scoped OAuth refresh flow and persists rotated access and refresh tokens.
+
+Choose **Use access token** instead to save an explicit token, or set `GITHUB_ACCESS_TOKEN` in the runtime environment.
+An explicit token always takes precedence over requester-scoped OAuth credentials.
 
 ### Example
 
@@ -67,7 +78,7 @@ get_pull_request("mindroom-ai/mindroom", 123)
 
 ### Notes
 
-- `access_token` is marked optional in MindRoom metadata, but the upstream client raises at startup if neither `access_token` nor `GITHUB_ACCESS_TOKEN` is present.
+- The tool can start without credentials; its functions return a requester-bound OAuth connection link until GitHub is connected or an explicit token is configured.
 - Use `base_url` only for GitHub Enterprise, and set it to the API endpoint such as `/api/v3` rather than the human-facing site root.
 - `github` is the best fit on this page when you need repository file operations or rich pull-request inspection in addition to issue tracking.
 

--- a/src/mindroom/api/credential_responses.py
+++ b/src/mindroom/api/credential_responses.py
@@ -13,12 +13,21 @@ def _filter_internal_keys(credentials: dict[str, Any]) -> dict[str, Any]:
     return {k: v for k, v in credentials.items() if not k.startswith("_")}
 
 
-def filter_credentials_for_response(credentials: dict[str, Any], *, is_oauth_service: bool) -> dict[str, Any]:
+def filter_credentials_for_response(
+    credentials: dict[str, Any],
+    *,
+    is_oauth_service: bool,
+    oauth_fallback_fields: frozenset[str] = frozenset(),
+) -> dict[str, Any]:
     """Return credentials safe for dashboard config responses."""
     filtered = _filter_internal_keys(credentials)
     if not is_oauth_service and not looks_like_oauth_credentials(credentials):
         return filtered
-    return filter_oauth_credential_fields(filtered)
+    safe_credentials = filter_oauth_credential_fields(filtered)
+    safe_credentials.update(
+        {field_name: filtered[field_name] for field_name in oauth_fallback_fields if field_name in filtered},
+    )
+    return safe_credentials
 
 
 def filter_oauth_client_config_for_response(credentials: dict[str, Any]) -> dict[str, Any]:

--- a/src/mindroom/api/credentials.py
+++ b/src/mindroom/api/credentials.py
@@ -160,11 +160,13 @@ class _DashboardCredentialAccess:
 
     def response_credentials(self, service: str, credentials: dict[str, Any]) -> dict[str, Any]:
         """Return credentials filtered for dashboard responses."""
-        if is_client_config_service(service, self.match(service)):
+        match = self.match(service)
+        if is_client_config_service(service, match):
             return filter_oauth_client_config_for_response(credentials)
         return filter_credentials_for_response(
             credentials,
-            is_oauth_service=dashboard_may_edit_oauth_match(self.match(service)),
+            is_oauth_service=dashboard_may_edit_oauth_match(match),
+            oauth_fallback_fields=match.oauth_fallback_fields if match is not None else frozenset(),
         )
 
     def credentials_for_save(self, service: str, config_values: dict[str, Any]) -> dict[str, Any]:
@@ -173,6 +175,7 @@ class _DashboardCredentialAccess:
         credentials = dashboard_credentials_for_save(
             config_values,
             strip_oauth_fields=dashboard_may_edit_oauth_match(match) and not is_client_config_service(service, match),
+            oauth_fallback_fields=match.oauth_fallback_fields if match is not None else frozenset(),
         )
         if is_client_config_service(service, match):
             validate_oauth_client_config_fields(credentials)

--- a/src/mindroom/api/credentials_oauth_policy.py
+++ b/src/mindroom/api/credentials_oauth_policy.py
@@ -39,6 +39,7 @@ class OAuthCredentialServiceMatch:
     token_service: bool
     tool_config_service: bool
     client_config_service: bool
+    oauth_fallback_fields: frozenset[str]
 
 
 @dataclass(frozen=True)
@@ -59,6 +60,9 @@ class OAuthCredentialServices:
                     token_service=token_service,
                     tool_config_service=tool_config_service,
                     client_config_service=client_config_service,
+                    oauth_fallback_fields=(
+                        frozenset(provider.tool_config_oauth_fallback_fields) if tool_config_service else frozenset()
+                    ),
                 )
         return None
 
@@ -187,11 +191,19 @@ def dashboard_credentials_for_save(
     config_values: dict[str, Any],
     *,
     strip_oauth_fields: bool,
+    oauth_fallback_fields: frozenset[str] = frozenset(),
 ) -> dict[str, Any]:
     """Return user-submitted credentials normalized for dashboard storage."""
     credentials = dict(config_values)
     if strip_oauth_fields:
         credentials = filter_oauth_credential_fields(credentials)
+        credentials.update(
+            {
+                field_name: config_values[field_name]
+                for field_name in oauth_fallback_fields
+                if field_name in config_values
+            },
+        )
     credentials["_source"] = "ui"
     return credentials
 

--- a/src/mindroom/api/credentials_target.py
+++ b/src/mindroom/api/credentials_target.py
@@ -10,6 +10,7 @@ from fastapi import HTTPException, Request
 from mindroom.agent_policy import dashboard_credentials_supported_for_scope
 from mindroom.api import config_lifecycle
 from mindroom.api.dashboard_credential_scope import (
+    build_dashboard_execution_identity,
     dashboard_scope_label,
     reject_unbound_private_dashboard_requester,
     require_agent_credential_management_authorized,
@@ -192,6 +193,44 @@ def resolve_request_credentials_target(
         agent_name=scope_request.agent_name,
         execution_identity=execution_identity,
         allowed_shared_services=config.get_worker_grantable_credentials(),
+    )
+
+
+def resolve_requester_credentials_target(
+    request: Request,
+    *,
+    agent_name: str | None,
+    service_names: tuple[str, ...] = (),
+) -> RequestCredentialsTarget:
+    """Resolve credentials that must follow the authenticated requester, independent of worker reuse."""
+    base_target = resolve_request_credentials_target(
+        request,
+        agent_name=agent_name,
+        service_names=service_names,
+        execution_scope_override_provided=False,
+        execution_scope_override=None,
+        allow_private_scopes=True,
+    )
+    execution_identity = build_dashboard_execution_identity(
+        request,
+        agent_name or "oauth",
+        runtime_paths=base_target.runtime_paths,
+    )
+    reject_unbound_private_dashboard_requester("user", execution_identity)
+    worker_key = require_worker_key_for_scope(
+        "user",
+        execution_identity=execution_identity,
+        agent_name=agent_name,
+        failure_message="Could not resolve requester-scoped OAuth credentials.",
+    )
+    return RequestCredentialsTarget(
+        runtime_paths=base_target.runtime_paths,
+        base_manager=base_target.base_manager,
+        target_manager=base_target.base_manager.for_worker(worker_key),
+        worker_scope="user",
+        agent_name=agent_name,
+        execution_identity=execution_identity,
+        allowed_shared_services=base_target.allowed_shared_services,
     )
 
 

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -138,6 +138,7 @@ def _resolve_oauth_credentials_target(
     execution_scope_override: WorkerScope | None = None,
 ) -> RequestCredentialsTarget:
     if provider.requester_scoped_credentials:
+        # Requester-scoped providers always bind to the user's store, so agent scope overrides cannot change it.
         return resolve_requester_credentials_target(
             request,
             agent_name=agent_name,

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -14,7 +14,11 @@ from pydantic import BaseModel, Field
 from mindroom.api import config_lifecycle
 from mindroom.api.auth import login_redirect_for_request, verify_user
 from mindroom.api.credentials_oauth_flows import consume_pending_oauth_request, issue_pending_oauth_state
-from mindroom.api.credentials_target import resolve_request_credentials_target, worker_target_for_credentials_target
+from mindroom.api.credentials_target import (
+    resolve_request_credentials_target,
+    resolve_requester_credentials_target,
+    worker_target_for_credentials_target,
+)
 from mindroom.api.dashboard_credential_scope import build_dashboard_execution_identity
 from mindroom.credentials import delete_scoped_credentials, load_scoped_credentials, save_scoped_credentials
 from mindroom.logging_config import get_logger
@@ -42,6 +46,7 @@ from mindroom.oauth.service import (
 if TYPE_CHECKING:
     from mindroom.api.credentials_target import RequestCredentialsTarget
     from mindroom.constants import RuntimePaths
+    from mindroom.tool_system.worker_routing import WorkerScope
 
 router = APIRouter(prefix="/api/oauth", tags=["oauth"])
 logger = get_logger(__name__)
@@ -124,6 +129,30 @@ async def _client_config_resolution_for_request(
     return None
 
 
+def _resolve_oauth_credentials_target(
+    request: Request,
+    provider: OAuthProvider,
+    *,
+    agent_name: str | None,
+    execution_scope_override_provided: bool | None = None,
+    execution_scope_override: WorkerScope | None = None,
+) -> RequestCredentialsTarget:
+    if provider.requester_scoped_credentials:
+        return resolve_requester_credentials_target(
+            request,
+            agent_name=agent_name,
+            service_names=(provider.credential_service,),
+        )
+    return resolve_request_credentials_target(
+        request,
+        agent_name=agent_name,
+        service_names=(provider.credential_service,),
+        execution_scope_override_provided=execution_scope_override_provided,
+        execution_scope_override=execution_scope_override,
+        allow_private_scopes=True,
+    )
+
+
 async def _issue_authorization_url(
     request: Request,
     provider: OAuthProvider,
@@ -145,11 +174,10 @@ async def _issue_authorization_url(
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         _verify_connect_target_authorized(request, connect_target, runtime_paths)
         _verify_connect_target_query(connect_target, agent_name, request.query_params.get("execution_scope"))
-        target = resolve_request_credentials_target(
+        target = _resolve_oauth_credentials_target(
             request,
+            provider,
             agent_name=agent_name,
-            service_names=(provider.credential_service,),
-            allow_private_scopes=True,
         )
         _verify_connect_target_binding(provider, connect_target, target)
         code_verifier = provider.issue_pkce_code_verifier()
@@ -178,11 +206,10 @@ async def _issue_authorization_url(
             completion_origin=_oauth_success_origin(provider, runtime_paths),
         )
 
-    target = resolve_request_credentials_target(
+    target = _resolve_oauth_credentials_target(
         request,
+        provider,
         agent_name=agent_name,
-        service_names=(provider.credential_service,),
-        allow_private_scopes=True,
     )
     try:
         code_verifier = provider.issue_pkce_code_verifier()
@@ -393,13 +420,12 @@ async def callback(provider_id: str, request: Request) -> RedirectResponse:
     await _require_oauth_api_user(request)
     provider, runtime_paths = _load_provider(request, provider_id)
     pending = consume_pending_oauth_request(request, provider.id, state)
-    target = resolve_request_credentials_target(
+    target = _resolve_oauth_credentials_target(
         request,
+        provider,
         agent_name=pending.agent_name,
-        service_names=(provider.credential_service,),
         execution_scope_override_provided=pending.execution_scope_override_provided,
         execution_scope_override=pending.execution_scope_override,
-        allow_private_scopes=True,
     )
     _verify_pending_target_binding(provider, pending.payload, target)
 
@@ -446,11 +472,10 @@ async def status(provider_id: str, request: Request, agent_name: str | None = No
     """Return scoped connection status for one provider."""
     await _require_oauth_api_user(request)
     provider, runtime_paths = _load_provider(request, provider_id)
-    target = resolve_request_credentials_target(
+    target = _resolve_oauth_credentials_target(
         request,
+        provider,
         agent_name=agent_name,
-        service_names=(provider.credential_service,),
-        allow_private_scopes=True,
     )
     worker_target = worker_target_for_credentials_target(target)
     credentials = (
@@ -525,11 +550,10 @@ async def disconnect(provider_id: str, request: Request, agent_name: str | None 
     """Remove scoped OAuth credentials for one provider while preserving tool settings."""
     await _require_oauth_api_user(request)
     provider, _runtime_paths = _load_provider(request, provider_id)
-    target = resolve_request_credentials_target(
+    target = _resolve_oauth_credentials_target(
         request,
+        provider,
         agent_name=agent_name,
-        service_names=(provider.credential_service,),
-        allow_private_scopes=True,
     )
     worker_target = worker_target_for_credentials_target(target)
     delete_scoped_credentials(

--- a/src/mindroom/api/tools.py
+++ b/src/mindroom/api/tools.py
@@ -24,7 +24,11 @@ from mindroom.credentials import (
     load_worker_grantable_shared_credentials,
 )
 from mindroom.oauth.registry import load_oauth_providers
-from mindroom.oauth.service import oauth_credentials_usable, oauth_provider_service_account_configured
+from mindroom.oauth.service import (
+    oauth_credentials_usable,
+    oauth_credentials_worker_target,
+    oauth_provider_service_account_configured,
+)
 from mindroom.tool_system.catalog import export_tools_metadata, resolved_tool_metadata_for_runtime
 from mindroom.tool_system.worker_routing import (
     WorkerScope,
@@ -133,6 +137,19 @@ def _check_manual_oauth_fallback_configured(
         if value is None or (isinstance(value, str) and not value.strip()):
             return False
     return True
+
+
+def _check_environment_oauth_fallback_configured(
+    provider: OAuthProvider | None,
+    runtime_paths: RuntimePaths,
+) -> bool:
+    """Return whether a provider's complete runtime fallback is present without exposing values."""
+    if provider is None:
+        return False
+    env_vars = provider.tool_config_oauth_fallback_env_vars
+    return bool(env_vars) and all(
+        isinstance(value := runtime_paths.env_value(env_var), str) and bool(value.strip()) for env_var in env_vars
+    )
 
 
 def _append_config_only_presets(tools: list[dict[str, Any]]) -> None:
@@ -244,9 +261,7 @@ def _resolve_tool_availability_context(
         else None
     )
     execution_identity = (
-        authorized_identity
-        if status_authoritative and scope_request.agent_name is not None and execution_scope is not None
-        else None
+        authorized_identity if not scope_request.draft_scope_preview and scope_request.agent_name is not None else None
     )
     worker_target = (
         build_worker_target_from_runtime_env(
@@ -255,7 +270,8 @@ def _resolve_tool_availability_context(
             execution_identity=execution_identity,
             runtime_paths=runtime_paths,
         )
-        if status_authoritative and (scope_request.agent_name is not None or execution_scope is not None)
+        if not scope_request.draft_scope_preview
+        and (scope_request.agent_name is not None or execution_scope is not None)
         else None
     )
     oauth_providers = load_oauth_providers(config, runtime_paths)
@@ -284,25 +300,31 @@ def _update_tools_statuses(
     context: _ResolvedToolAvailabilityContext,
 ) -> None:
     """Update tool runtime availability using the resolved credential context."""
-    credentials_cache: dict[str, dict[str, Any] | None] = {}
+    credentials_cache: dict[tuple[str, str | None, bool], dict[str, Any] | None] = {}
 
-    def get_credentials(service: str) -> dict[str, Any] | None:
-        if service not in credentials_cache:
+    def get_credentials(
+        service: str,
+        *,
+        worker_target: ResolvedWorkerTarget | None = context.worker_target,
+        use_request_target: bool = False,
+    ) -> dict[str, Any] | None:
+        cache_key = (service, worker_target.worker_key if worker_target is not None else None, use_request_target)
+        if cache_key not in credentials_cache:
             allowed_shared_services = _effective_allowed_shared_services(service, context)
-            if context.status_authoritative:
-                credentials_cache[service] = load_scoped_credentials(
+            if context.status_authoritative or use_request_target:
+                credentials_cache[cache_key] = load_scoped_credentials(
                     service,
                     credentials_manager=context.credentials_manager,
-                    worker_target=context.worker_target,
+                    worker_target=worker_target,
                     allowed_shared_services=allowed_shared_services,
                 )
             else:
-                credentials_cache[service] = _load_shared_preview_credentials(
+                credentials_cache[cache_key] = _load_shared_preview_credentials(
                     service,
                     credentials_manager=context.credentials_manager,
                     allowed_shared_services=allowed_shared_services,
                 )
-        return credentials_cache[service]
+        return credentials_cache[cache_key]
 
     for tool in tools:
         tool_name = tool["name"]
@@ -311,19 +333,47 @@ def _update_tools_statuses(
 
         auth_provider = tool.get("auth_provider")
         if auth_provider:
+            provider = context.oauth_providers.get(auth_provider)
+            use_request_target = provider is not None and context.worker_target is not None
             manual_auth_configured = _check_manual_oauth_fallback_configured(
                 tool,
-                get_credentials(tool_name) if tool.get("oauth_fallback_fields") else None,
+                (
+                    get_credentials(tool_name, use_request_target=use_request_target)
+                    if tool.get("oauth_fallback_fields")
+                    else None
+                ),
             )
             if tool.get("oauth_fallback_fields"):
                 tool["manual_auth_configured"] = manual_auth_configured
+            environment_auth_configured = _check_environment_oauth_fallback_configured(
+                provider,
+                context.runtime_paths,
+            )
+            tool["environment_auth_configured"] = environment_auth_configured
             credential_service = context.auth_provider_credential_services.get(auth_provider, auth_provider)
-            provider_creds = get_credentials(credential_service)
-            if manual_auth_configured or _check_auth_provider_configured(
-                tool,
-                provider_creds,
-                provider=context.oauth_providers.get(auth_provider),
-                runtime_paths=context.runtime_paths,
+            provider_target = (
+                oauth_credentials_worker_target(provider, context.worker_target)
+                if provider is not None
+                else context.worker_target
+            )
+            provider_creds = (
+                get_credentials(
+                    credential_service,
+                    worker_target=provider_target,
+                    use_request_target=use_request_target,
+                )
+                if provider is None or not provider.requester_scoped_credentials or provider_target is not None
+                else None
+            )
+            if (
+                manual_auth_configured
+                or environment_auth_configured
+                or _check_auth_provider_configured(
+                    tool,
+                    provider_creds,
+                    provider=provider,
+                    runtime_paths=context.runtime_paths,
+                )
             ):
                 tool["status"] = "available"
             continue

--- a/src/mindroom/api/tools.py
+++ b/src/mindroom/api/tools.py
@@ -334,7 +334,9 @@ def _update_tools_statuses(
         auth_provider = tool.get("auth_provider")
         if auth_provider:
             provider = context.oauth_providers.get(auth_provider)
-            use_request_target = provider is not None and context.worker_target is not None
+            use_request_target = (
+                provider is not None and provider.requester_scoped_credentials and context.worker_target is not None
+            )
             manual_auth_configured = _check_manual_oauth_fallback_configured(
                 tool,
                 (

--- a/src/mindroom/api/tools.py
+++ b/src/mindroom/api/tools.py
@@ -118,6 +118,23 @@ def _check_auth_provider_configured(
     return oauth_credentials_usable(provider, runtime_paths, credentials)
 
 
+def _check_manual_oauth_fallback_configured(
+    tool: dict[str, Any],
+    credentials: dict[str, Any] | None,
+) -> bool:
+    """Return whether all declared manual OAuth fallback fields are configured."""
+    fallback_fields = tool.get("oauth_fallback_fields")
+    if not isinstance(fallback_fields, list | tuple) or not fallback_fields or not credentials:
+        return False
+    for field_name in fallback_fields:
+        if not isinstance(field_name, str):
+            return False
+        value = credentials.get(field_name)
+        if value is None or (isinstance(value, str) and not value.strip()):
+            return False
+    return True
+
+
 def _append_config_only_presets(tools: list[dict[str, Any]]) -> None:
     """Append config-only tool presets so the dashboard can display them."""
     existing_tool_names = {tool.get("name") for tool in tools}
@@ -294,9 +311,15 @@ def _update_tools_statuses(
 
         auth_provider = tool.get("auth_provider")
         if auth_provider:
+            manual_auth_configured = _check_manual_oauth_fallback_configured(
+                tool,
+                get_credentials(tool_name) if tool.get("oauth_fallback_fields") else None,
+            )
+            if tool.get("oauth_fallback_fields"):
+                tool["manual_auth_configured"] = manual_auth_configured
             credential_service = context.auth_provider_credential_services.get(auth_provider, auth_provider)
             provider_creds = get_credentials(credential_service)
-            if _check_auth_provider_configured(
+            if manual_auth_configured or _check_auth_provider_configured(
                 tool,
                 provider_creds,
                 provider=context.oauth_providers.get(auth_provider),

--- a/src/mindroom/custom_tools/github.py
+++ b/src/mindroom/custom_tools/github.py
@@ -1,0 +1,141 @@
+"""Requester-scoped OAuth wrapper for Agno's GitHub toolkit."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from functools import wraps
+from typing import TYPE_CHECKING
+
+from agno.tools.github import GithubTools as AgnoGithubTools
+from github import Auth, Github
+
+from mindroom.credentials import load_scoped_credentials
+from mindroom.logging_config import get_logger
+from mindroom.oauth.github import github_oauth_provider
+from mindroom.oauth.providers import OAuthConnectionRequired, OAuthProviderError, oauth_connection_required_payload
+from mindroom.oauth.service import (
+    build_oauth_connect_instruction,
+    oauth_connect_url,
+    oauth_credentials_usable,
+    refresh_scoped_oauth_credentials,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from mindroom.constants import RuntimePaths
+    from mindroom.credentials import CredentialsManager
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+
+logger = get_logger(__name__)
+_PENDING_ACCESS_TOKEN = "mindroom-oauth-connection-pending"  # noqa: S105
+
+
+class GithubTools(AgnoGithubTools):
+    """Agno GitHub tools authenticated by explicit or requester-scoped credentials."""
+
+    def __init__(
+        self,
+        access_token: str | None = None,
+        base_url: str | None = None,
+        *,
+        runtime_paths: RuntimePaths,
+        credentials_manager: CredentialsManager,
+        worker_target: ResolvedWorkerTarget | None,
+        **kwargs: object,
+    ) -> None:
+        self._runtime_paths = runtime_paths
+        self._credentials_manager = credentials_manager
+        self._worker_target = worker_target
+        self._oauth_provider = github_oauth_provider()
+        explicit_access_token = access_token or runtime_paths.env_value("GITHUB_ACCESS_TOKEN")
+        self._explicit_access_token = bool(explicit_access_token)
+        initial_access_token = explicit_access_token or self._stored_access_token() or _PENDING_ACCESS_TOKEN
+        self._active_access_token = initial_access_token
+        super().__init__(access_token=initial_access_token, base_url=base_url, **kwargs)
+        self._wrap_oauth_function_entrypoints()
+
+    def _stored_access_token(self) -> str | None:
+        credentials = load_scoped_credentials(
+            self._oauth_provider.credential_service,
+            credentials_manager=self._credentials_manager,
+            worker_target=self._worker_target,
+        )
+        if credentials is None:
+            return None
+        token = credentials.get("token") or credentials.get("access_token")
+        return token if isinstance(token, str) and token else None
+
+    def _connection_required(self) -> OAuthConnectionRequired:
+        connect_url = oauth_connect_url(
+            self._oauth_provider,
+            self._runtime_paths,
+            worker_target=self._worker_target,
+        )
+        return OAuthConnectionRequired(
+            build_oauth_connect_instruction(self._oauth_provider, connect_url),
+            provider_id=self._oauth_provider.id,
+            connect_url=connect_url,
+        )
+
+    def _refresh_oauth_credentials(self) -> dict[str, object] | None:
+        return asyncio.run(
+            refresh_scoped_oauth_credentials(
+                self._oauth_provider,
+                self._runtime_paths,
+                credentials_manager=self._credentials_manager,
+                worker_target=self._worker_target,
+            ),
+        )
+
+    def _ensure_authenticated(self) -> None:
+        if self._explicit_access_token:
+            return
+        try:
+            credentials = self._refresh_oauth_credentials()
+        except OAuthProviderError as exc:
+            logger.warning(
+                "github_oauth_refresh_failed",
+                provider_id=self._oauth_provider.id,
+                error_type=type(exc).__name__,
+            )
+            raise self._connection_required() from exc
+        if not oauth_credentials_usable(self._oauth_provider, self._runtime_paths, credentials):
+            raise self._connection_required()
+        token = (credentials or {}).get("token") or (credentials or {}).get("access_token")
+        if not isinstance(token, str) or not token:
+            raise self._connection_required()
+        if token == self._active_access_token:
+            return
+        self.access_token = token
+        self._active_access_token = token
+        self.g = self.authenticate()
+
+    def _wrap_oauth_function_entrypoints(self) -> None:
+        for function in self.functions.values():
+            entrypoint = function.entrypoint
+            if entrypoint is None:
+                continue
+
+            @wraps(entrypoint)
+            def oauth_entrypoint(
+                *args: object,
+                _entrypoint: Callable[..., object] = entrypoint,
+                **kwargs: object,
+            ) -> object:
+                try:
+                    self._ensure_authenticated()
+                except OAuthConnectionRequired as exc:
+                    return json.dumps(oauth_connection_required_payload(exc))
+                return _entrypoint(*args, **kwargs)
+
+            function.entrypoint = oauth_entrypoint
+            setattr(self, function.name, oauth_entrypoint)
+
+    def authenticate(self) -> Github:
+        """Build the PyGithub client without logging credential values."""
+        auth = Auth.Token(self.access_token)
+        if self.base_url:
+            return Github(base_url=self.base_url, auth=auth)
+        return Github(auth=auth)

--- a/src/mindroom/custom_tools/github.py
+++ b/src/mindroom/custom_tools/github.py
@@ -134,6 +134,8 @@ class GithubTools(AgnoGithubTools):
 
     def authenticate(self) -> Github:
         """Build the PyGithub client without logging credential values."""
+        if not self.access_token:
+            raise self._connection_required()
         auth = Auth.Token(self.access_token)
         if self.base_url:
             return Github(base_url=self.base_url, auth=auth)

--- a/src/mindroom/custom_tools/github.py
+++ b/src/mindroom/custom_tools/github.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 from agno.tools.github import GithubTools as AgnoGithubTools
 from github import Auth, Github
 
-from mindroom.credentials import load_scoped_credentials
+from mindroom.credentials import CredentialsManager, load_scoped_credentials
 from mindroom.logging_config import get_logger
 from mindroom.oauth.github import github_oauth_provider
 from mindroom.oauth.providers import OAuthConnectionRequired, OAuthProviderError, oauth_connection_required_payload
@@ -25,7 +25,6 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from mindroom.constants import RuntimePaths
-    from mindroom.credentials import CredentialsManager
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
 
 logger = get_logger(__name__)

--- a/src/mindroom/custom_tools/github.py
+++ b/src/mindroom/custom_tools/github.py
@@ -20,8 +20,10 @@ from mindroom.oauth.service import (
     build_oauth_connect_instruction,
     oauth_connect_url,
     oauth_credentials_usable,
+    oauth_credentials_worker_target,
     refresh_scoped_oauth_credentials,
 )
+from mindroom.tool_system.worker_routing import active_tool_execution_identity
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -31,6 +33,26 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _PENDING_ACCESS_TOKEN = "mindroom-oauth-connection-pending"  # noqa: S105
+
+
+def _normalized_access_token(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _is_github_authentication_error(result: object) -> bool:
+    if not isinstance(result, str):
+        return False
+    try:
+        payload = json.loads(result)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(payload, dict):
+        return False
+    error = payload.get("error")
+    return isinstance(error, str) and error.lstrip().startswith("401 ")
 
 
 class GithubTools(AgnoGithubTools):
@@ -50,7 +72,9 @@ class GithubTools(AgnoGithubTools):
         self._credentials_manager = credentials_manager
         self._worker_target = worker_target
         self._oauth_provider = github_oauth_provider()
-        explicit_access_token = access_token or runtime_paths.env_value("GITHUB_ACCESS_TOKEN")
+        explicit_access_token = _normalized_access_token(access_token) or _normalized_access_token(
+            runtime_paths.env_value("GITHUB_ACCESS_TOKEN"),
+        )
         self._explicit_access_token = bool(explicit_access_token)
         initial_access_token = explicit_access_token or self._stored_access_token() or _PENDING_ACCESS_TOKEN
         self._active_access_token = initial_access_token
@@ -58,21 +82,34 @@ class GithubTools(AgnoGithubTools):
         self._wrap_oauth_function_entrypoints()
 
     def _stored_access_token(self) -> str | None:
+        worker_target = self._oauth_credentials_worker_target()
+        if self._oauth_provider.requester_scoped_credentials and worker_target is None:
+            return None
         credentials = load_scoped_credentials(
             self._oauth_provider.credential_service,
             credentials_manager=self._credentials_manager,
-            worker_target=self._worker_target,
+            worker_target=worker_target,
         )
         if credentials is None:
             return None
         token = credentials.get("token") or credentials.get("access_token")
-        return token if isinstance(token, str) and token else None
+        return _normalized_access_token(token)
+
+    def _oauth_credentials_worker_target(self) -> ResolvedWorkerTarget | None:
+        execution_identity = active_tool_execution_identity(None)
+        if execution_identity is None and self._worker_target is not None:
+            execution_identity = self._worker_target.execution_identity
+        return oauth_credentials_worker_target(
+            self._oauth_provider,
+            self._worker_target,
+            execution_identity=execution_identity,
+        )
 
     def _connection_required(self) -> OAuthConnectionRequired:
         connect_url = oauth_connect_url(
             self._oauth_provider,
             self._runtime_paths,
-            worker_target=self._worker_target,
+            worker_target=self._oauth_credentials_worker_target(),
         )
         return OAuthConnectionRequired(
             build_oauth_connect_instruction(self._oauth_provider, connect_url),
@@ -81,11 +118,14 @@ class GithubTools(AgnoGithubTools):
         )
 
     def _refresh_oauth_credentials(self) -> dict[str, object] | None:
+        worker_target = self._oauth_credentials_worker_target()
+        if self._oauth_provider.requester_scoped_credentials and worker_target is None:
+            return None
         refresh = refresh_scoped_oauth_credentials(
             self._oauth_provider,
             self._runtime_paths,
             credentials_manager=self._credentials_manager,
-            worker_target=self._worker_target,
+            worker_target=worker_target,
         )
         try:
             asyncio.get_running_loop()
@@ -124,8 +164,10 @@ class GithubTools(AgnoGithubTools):
             raise self._connection_required() from exc
         if not oauth_credentials_usable(self._oauth_provider, self._runtime_paths, credentials):
             raise self._connection_required()
-        token = (credentials or {}).get("token") or (credentials or {}).get("access_token")
-        if not isinstance(token, str) or not token:
+        token = _normalized_access_token(
+            (credentials or {}).get("token") or (credentials or {}).get("access_token"),
+        )
+        if token is None:
             raise self._connection_required()
         if token == self._active_access_token:
             return
@@ -149,7 +191,10 @@ class GithubTools(AgnoGithubTools):
                     self._ensure_authenticated()
                 except OAuthConnectionRequired as exc:
                     return json.dumps(oauth_connection_required_payload(exc))
-                return _entrypoint(*args, **kwargs)
+                result = _entrypoint(*args, **kwargs)
+                if not self._explicit_access_token and _is_github_authentication_error(result):
+                    return json.dumps(oauth_connection_required_payload(self._connection_required()))
+                return result
 
             function.entrypoint = oauth_entrypoint
             setattr(self, function.name, oauth_entrypoint)

--- a/src/mindroom/custom_tools/github.py
+++ b/src/mindroom/custom_tools/github.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
+from contextvars import copy_context
 from functools import wraps
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from agno.tools.github import GithubTools as AgnoGithubTools
 from github import Auth, Github
@@ -79,14 +81,34 @@ class GithubTools(AgnoGithubTools):
         )
 
     def _refresh_oauth_credentials(self) -> dict[str, object] | None:
-        return asyncio.run(
-            refresh_scoped_oauth_credentials(
-                self._oauth_provider,
-                self._runtime_paths,
-                credentials_manager=self._credentials_manager,
-                worker_target=self._worker_target,
-            ),
+        refresh = refresh_scoped_oauth_credentials(
+            self._oauth_provider,
+            self._runtime_paths,
+            credentials_manager=self._credentials_manager,
+            worker_target=self._worker_target,
         )
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return asyncio.run(refresh)
+
+        result: list[dict[str, object] | None] = []
+        errors: list[BaseException] = []
+        context = copy_context()
+
+        def run_refresh() -> None:
+            try:
+                refreshed = context.run(asyncio.run, refresh)
+                result.append(cast("dict[str, object] | None", refreshed))
+            except BaseException as exc:
+                errors.append(exc)
+
+        thread = threading.Thread(target=run_refresh, name="mindroom-github-oauth-refresh")
+        thread.start()
+        thread.join()
+        if errors:
+            raise errors[0]
+        return result[0]
 
     def _ensure_authenticated(self) -> None:
         if self._explicit_access_token:

--- a/src/mindroom/oauth/github.py
+++ b/src/mindroom/oauth/github.py
@@ -19,4 +19,7 @@ def github_oauth_provider() -> OAuthProvider:
         client_config_services=("github_oauth_client",),
         default_redirect_path="/api/oauth/github/callback",
         pkce_code_challenge_method="S256",
+        requester_scoped_credentials=True,
+        tool_config_oauth_fallback_fields=("access_token",),
+        tool_config_oauth_fallback_env_vars=("GITHUB_ACCESS_TOKEN",),
     )

--- a/src/mindroom/oauth/github.py
+++ b/src/mindroom/oauth/github.py
@@ -1,0 +1,22 @@
+"""Built-in GitHub App user OAuth provider."""
+
+from __future__ import annotations
+
+from mindroom.oauth.providers import OAuthProvider
+
+
+def github_oauth_provider() -> OAuthProvider:
+    """Return the built-in GitHub App user OAuth provider definition."""
+    return OAuthProvider(
+        id="github",
+        display_name="GitHub",
+        authorization_url="https://github.com/login/oauth/authorize",
+        token_url="https://github.com/login/oauth/access_token",  # noqa: S106
+        scopes=(),
+        allow_empty_scopes=True,
+        credential_service="github_oauth",
+        tool_config_service="github",
+        client_config_services=("github_oauth_client",),
+        default_redirect_path="/api/oauth/github/callback",
+        pkce_code_challenge_method="S256",
+    )

--- a/src/mindroom/oauth/providers.py
+++ b/src/mindroom/oauth/providers.py
@@ -397,6 +397,9 @@ class OAuthProvider:
     token_endpoint_auth_method: _TokenEndpointAuthMethod = _DEFAULT_TOKEN_ENDPOINT_AUTH_METHOD
     pkce_code_challenge_method: _PKCECodeChallengeMethod | None = None
     allow_empty_scopes: bool = False
+    requester_scoped_credentials: bool = False
+    tool_config_oauth_fallback_fields: tuple[str, ...] = ()
+    tool_config_oauth_fallback_env_vars: tuple[str, ...] = ()
     allowed_email_domains: tuple[str, ...] = ()
     allowed_hosted_domains: tuple[str, ...] = ()
     allowed_email_domains_env: str | Sequence[str] | None = None

--- a/src/mindroom/oauth/registry.py
+++ b/src/mindroom/oauth/registry.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any
 from mindroom.config.main import Config
 from mindroom.logging_config import get_logger
 from mindroom.mcp.oauth import mcp_oauth_providers_for_config
+from mindroom.oauth.github import github_oauth_provider
 from mindroom.oauth.google_calendar import google_calendar_oauth_provider
 from mindroom.oauth.google_docs import google_docs_oauth_provider
 from mindroom.oauth.google_drive import google_drive_oauth_provider
@@ -46,6 +47,7 @@ def clear_oauth_provider_cache() -> None:
 
 def _builtin_oauth_providers() -> tuple[OAuthProvider, ...]:
     return (
+        github_oauth_provider(),
         google_calendar_oauth_provider(),
         google_docs_oauth_provider(),
         google_drive_oauth_provider(),

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -18,6 +18,7 @@ from mindroom.oauth.providers import (
     oauth_connect_url_requires_host_browser,
 )
 from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_state, read_opaque_oauth_state
+from mindroom.tool_system.worker_routing import resolve_worker_target
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Mapping
@@ -26,7 +27,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.credentials import CredentialsManager
     from mindroom.oauth.providers import OAuthClientConfig, OAuthProvider
-    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, ToolExecutionIdentity
 
 _OAUTH_CONNECT_TOKEN_TTL_SECONDS = 600
 _OAUTH_CONNECT_TOKEN_KIND = "conversation_oauth_connect"  # noqa: S105
@@ -83,6 +84,7 @@ __all__ = [
     "oauth_credentials_match_client_id",
     "oauth_credentials_satisfy_identity_policy",
     "oauth_credentials_usable",
+    "oauth_credentials_worker_target",
     "oauth_provider_service_account_configured",
     "oauth_success_redirect_url",
     "refresh_scoped_oauth_credentials",
@@ -111,6 +113,28 @@ class OAuthCredentialsRefreshResult:
     credentials: dict[str, Any] | None
     refreshed: bool
     stale_retry_used: bool = False
+
+
+def oauth_credentials_worker_target(
+    provider: OAuthProvider,
+    worker_target: ResolvedWorkerTarget | None,
+    *,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> ResolvedWorkerTarget | None:
+    """Return the credential target required by one provider's identity policy."""
+    if not provider.requester_scoped_credentials:
+        return worker_target
+    identity = execution_identity or (worker_target.execution_identity if worker_target is not None else None)
+    if identity is None or not identity.requester_id:
+        return None
+    return resolve_worker_target(
+        "user",
+        worker_target.routing_agent_name if worker_target is not None else identity.agent_name,
+        execution_identity=identity,
+        tenant_id=worker_target.tenant_id if worker_target is not None else None,
+        account_id=worker_target.account_id if worker_target is not None else None,
+        private_agent_names=worker_target.private_agent_names if worker_target is not None else None,
+    )
 
 
 def scoped_oauth_credentials_refresh_lock_path(

--- a/src/mindroom/tool_system/declarations.py
+++ b/src/mindroom/tool_system/declarations.py
@@ -116,6 +116,7 @@ class ToolMetadata:
     authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT
     dependencies: list[str] | None = None
     auth_provider: str | None = None
+    oauth_fallback_fields: tuple[str, ...] = ()
     docs_url: str | None = None
     helper_text: str | None = None
     function_names: tuple[str, ...] = ()

--- a/src/mindroom/tool_system/metadata.py
+++ b/src/mindroom/tool_system/metadata.py
@@ -1318,6 +1318,10 @@ def export_tools_metadata(tool_metadata: dict[str, ToolMetadata] | None = None) 
         tool_dict["status"] = metadata.status.value
         tool_dict["setup_type"] = metadata.setup_type.value
         tool_dict["default_execution_target"] = metadata.default_execution_target.value
+        if metadata.oauth_fallback_fields:
+            tool_dict["oauth_fallback_fields"] = list(metadata.oauth_fallback_fields)
+        else:
+            tool_dict.pop("oauth_fallback_fields", None)
         tool_dict.pop("authored_override_validator", None)
         tool_dict.pop("managed_init_args", None)
         tool_dict.pop("supports_toolkit_filters", None)

--- a/src/mindroom/tool_system/registration.py
+++ b/src/mindroom/tool_system/registration.py
@@ -43,6 +43,7 @@ def register_tool_with_metadata(
     authored_override_validator: ToolAuthoredOverrideValidator = ToolAuthoredOverrideValidator.DEFAULT,
     dependencies: list[str] | None = None,
     auth_provider: str | None = None,
+    oauth_fallback_fields: tuple[str, ...] = (),
     docs_url: str | None = None,
     helper_text: str | None = None,
     function_names: tuple[str, ...] = (),
@@ -50,6 +51,15 @@ def register_tool_with_metadata(
     supports_toolkit_filters: bool = True,
 ) -> Callable[[Callable[[], type]], Callable[[], type]]:
     """Register a tool factory and its declarative metadata."""
+    if oauth_fallback_fields:
+        if setup_type != SetupType.OAUTH:
+            msg = "OAuth fallback fields require setup_type=oauth"
+            raise ValueError(msg)
+        config_field_names = {field.name for field in config_fields or ()}
+        missing_fields = sorted(set(oauth_fallback_fields) - config_field_names)
+        if missing_fields:
+            msg = f"OAuth fallback fields must reference config fields: {', '.join(missing_fields)}"
+            raise ValueError(msg)
 
     def decorator(factory: Callable[[], type]) -> Callable[[], type]:
         metadata = ToolMetadata(
@@ -69,6 +79,7 @@ def register_tool_with_metadata(
             authored_override_validator=authored_override_validator,
             dependencies=dependencies,
             auth_provider=auth_provider,
+            oauth_fallback_fields=oauth_fallback_fields,
             docs_url=docs_url,
             helper_text=helper_text,
             function_names=function_names,

--- a/src/mindroom/tool_system/worker_routing.py
+++ b/src/mindroom/tool_system/worker_routing.py
@@ -41,6 +41,7 @@ _LOCAL_ONLY_SHARED_INTEGRATION_TOOL_NAMES = frozenset(
         "callback_manager",
         "desktop",
         "external_trigger_manager",
+        "github",
         "gmail",
         "google_calendar",
         "google_docs",

--- a/src/mindroom/tools/github.py
+++ b/src/mindroom/tools/github.py
@@ -12,7 +12,7 @@ from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCatego
 from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
-    from agno.tools.github import GithubTools
+    from mindroom.custom_tools.github import GithubTools
 
 
 @register_tool_with_metadata(
@@ -86,6 +86,6 @@ if TYPE_CHECKING:
 )
 def github_tools() -> type[GithubTools]:
     """Return GitHub tools for repository management."""
-    from agno.tools.github import GithubTools
+    from mindroom.custom_tools.github import GithubTools
 
     return GithubTools

--- a/src/mindroom/tools/github.py
+++ b/src/mindroom/tools/github.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolStatus
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolManagedInitArg, ToolStatus
 from mindroom.tool_system.registration import register_tool_with_metadata
 
 if TYPE_CHECKING:
@@ -21,7 +21,8 @@ if TYPE_CHECKING:
     description="Repository and issue management",
     category=ToolCategory.DEVELOPMENT,
     status=ToolStatus.REQUIRES_CONFIG,
-    setup_type=SetupType.API_KEY,
+    setup_type=SetupType.OAUTH,
+    auth_provider="github",
     icon="SiGithub",
     icon_color="text-gray-800",  # GitHub black
     config_fields=[
@@ -41,6 +42,12 @@ if TYPE_CHECKING:
         ),
     ],
     dependencies=["PyGithub"],
+    oauth_fallback_fields=("access_token",),
+    managed_init_args=(
+        ToolManagedInitArg.RUNTIME_PATHS,
+        ToolManagedInitArg.CREDENTIALS_MANAGER,
+        ToolManagedInitArg.WORKER_TARGET,
+    ),
     docs_url="https://docs.agno.com/tools/toolkits/others/github",
     function_names=(
         "assign_issue",

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -3663,7 +3663,7 @@
     },
     {
       "agent_override_fields": null,
-      "auth_provider": null,
+      "auth_provider": "github",
       "category": "development",
       "config_fields": [
         {
@@ -3744,8 +3744,11 @@
       "icon": "SiGithub",
       "icon_color": "text-gray-800",
       "name": "github",
+      "oauth_fallback_fields": [
+        "access_token"
+      ],
       "requires_room_context": false,
-      "setup_type": "api_key",
+      "setup_type": "oauth",
       "status": "requires_config"
     },
     {

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -1,6 +1,7 @@
 """Tests for the dashboard backend API endpoints."""
 
 import asyncio
+import copy
 import json
 import os
 import threading
@@ -1940,6 +1941,77 @@ def test_get_tools_requires_oauth_token_for_generic_auth_provider(test_client: T
     assert connected_tool["status"] == "available"
 
 
+def test_get_tools_non_requester_oauth_keeps_non_authoritative_shared_preview(
+    test_client: TestClient,
+) -> None:
+    """Existing OAuth providers must not expose requester stores through non-authoritative status."""
+    runtime_paths = use_trusted_upstream_runtime(main.app)
+    config = _config_with_worker_scope(
+        "user",
+        authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "google_drive_oauth_client",
+        {"client_id": "client-id", "client_secret": "client-secret"},
+    )
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id=None,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    oauth_target = resolve_worker_target("user", "general", execution_identity=identity)
+    save_scoped_credentials(
+        "google_drive_oauth",
+        {
+            "token": "drive-token",
+            "refresh_token": "drive-refresh-token",
+            "client_id": "client-id",
+            "scopes": [
+                "openid",
+                "https://www.googleapis.com/auth/userinfo.email",
+                "https://www.googleapis.com/auth/userinfo.profile",
+                "https://www.googleapis.com/auth/drive",
+            ],
+            "_source": "oauth",
+            "_oauth_provider": "google_drive",
+        },
+        credentials_manager=manager,
+        worker_target=oauth_target,
+    )
+    tools = [
+        {
+            "name": "google_drive",
+            "display_name": "Google Drive",
+            "description": "Drive access",
+            "category": "productivity",
+            "status": "requires_config",
+            "setup_type": "oauth",
+            "auth_provider": "google_drive",
+            "config_fields": [],
+        },
+    ]
+    headers = trusted_upstream_headers(
+        user_id="alice",
+        email="alice@example.org",
+        matrix_user_id="@alice:example.org",
+    )
+
+    with (
+        patch("mindroom.api.tools._read_tools_runtime_config", return_value=(config, runtime_paths)),
+        patch("mindroom.api.tools.export_tools_metadata", return_value=tools),
+    ):
+        response = test_client.get("/api/tools/?agent_name=general", headers=headers)
+
+    assert response.status_code == 200
+    assert response.json()["status_authoritative"] is False
+    assert response.json()["tools"][0]["status"] == "requires_config"
+
+
 def test_get_tools_marks_google_oauth_tool_available_with_service_account(
     test_client: TestClient,
     tmp_path: Path,
@@ -2077,11 +2149,9 @@ def test_get_tools_reports_requester_scoped_github_manual_fallback(test_client: 
 
     with (
         patch("mindroom.api.tools._read_tools_runtime_config", return_value=(config, runtime_paths)),
-        patch("mindroom.api.tools.export_tools_metadata", return_value=tools),
+        patch("mindroom.api.tools.export_tools_metadata", side_effect=lambda *_: copy.deepcopy(tools)),
     ):
         alice_response = test_client.get("/api/tools/?agent_name=general", headers=alice_headers)
-        tools[0]["status"] = "requires_config"
-        tools[0].pop("manual_auth_configured", None)
         bob_response = test_client.get("/api/tools/?agent_name=general", headers=bob_headers)
 
     assert alice_response.status_code == 200

--- a/tests/api/test_api.py
+++ b/tests/api/test_api.py
@@ -36,7 +36,7 @@ from mindroom.matrix.decrypt_failure import e2ee_stats
 from mindroom.matrix.health import mark_matrix_sync_loop_started, mark_matrix_sync_success, reset_matrix_sync_health
 from mindroom.matrix.state import MatrixState
 from mindroom.runtime_state import reset_runtime_state, set_runtime_ready, set_runtime_starting
-from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_key
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_key, resolve_worker_target
 from mindroom.workers.models import WorkerHandle, WorkerMaintenanceResult
 from tests.api.conftest import trusted_upstream_headers, use_trusted_upstream_runtime
 
@@ -2017,6 +2017,153 @@ def test_get_tools_does_not_treat_scoped_credentials_as_dashboard_truth(
     assert tool["status"] == "requires_config"
     assert tool["dashboard_configuration_supported"] is False
     mock_load_scoped_credentials.assert_not_called()
+
+
+def test_get_tools_reports_requester_scoped_github_manual_fallback(test_client: TestClient) -> None:
+    """GitHub manual auth status should use the authenticated requester's persisted agent target."""
+    runtime_paths = use_trusted_upstream_runtime(main.app)
+    config = _config_with_worker_scope(
+        "user_agent",
+        authorization={
+            "agent_reply_permissions": {
+                "general": ["@alice:example.org", "@bob:example.org"],
+            },
+        },
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+    alice_identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id=None,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    alice_target = resolve_worker_target("user_agent", "general", execution_identity=alice_identity)
+    manual_secret = "github-manual-secret"  # noqa: S105
+    save_scoped_credentials(
+        "github",
+        {"access_token": manual_secret, "base_url": "https://api.github.com"},
+        credentials_manager=manager,
+        worker_target=alice_target,
+    )
+    tools = [
+        {
+            "name": "github",
+            "display_name": "GitHub",
+            "description": "GitHub access",
+            "category": "development",
+            "status": "requires_config",
+            "setup_type": "oauth",
+            "auth_provider": "github",
+            "config_fields": [
+                {"name": "access_token", "required": False},
+                {"name": "base_url", "required": False},
+            ],
+            "oauth_fallback_fields": ["access_token"],
+        },
+    ]
+    alice_headers = trusted_upstream_headers(
+        user_id="alice",
+        email="alice@example.org",
+        matrix_user_id="@alice:example.org",
+    )
+    bob_headers = trusted_upstream_headers(
+        user_id="bob",
+        email="bob@example.org",
+        matrix_user_id="@bob:example.org",
+    )
+
+    with (
+        patch("mindroom.api.tools._read_tools_runtime_config", return_value=(config, runtime_paths)),
+        patch("mindroom.api.tools.export_tools_metadata", return_value=tools),
+    ):
+        alice_response = test_client.get("/api/tools/?agent_name=general", headers=alice_headers)
+        tools[0]["status"] = "requires_config"
+        tools[0].pop("manual_auth_configured", None)
+        bob_response = test_client.get("/api/tools/?agent_name=general", headers=bob_headers)
+
+    assert alice_response.status_code == 200
+    assert alice_response.json()["status_authoritative"] is False
+    alice_tool = alice_response.json()["tools"][0]
+    assert alice_tool["status"] == "available"
+    assert alice_tool["manual_auth_configured"] is True
+    assert manual_secret not in alice_response.text
+
+    assert bob_response.status_code == 200
+    bob_tool = bob_response.json()["tools"][0]
+    assert bob_tool["status"] == "requires_config"
+    assert bob_tool["manual_auth_configured"] is False
+
+
+def test_get_tools_reports_requester_scoped_github_oauth_for_unscoped_agent(test_client: TestClient) -> None:
+    """An unscoped agent should inspect the authenticated requester's GitHub OAuth store."""
+    runtime_paths = use_trusted_upstream_runtime(main.app)
+    config = _config_with_worker_scope(
+        None,
+        authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "github_oauth_client",
+        {"client_id": "github-client-id", "client_secret": "github-client-secret"},
+    )
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id=None,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    oauth_target = resolve_worker_target("user", "general", execution_identity=identity)
+    oauth_secret = "github-oauth-secret"  # noqa: S105
+    save_scoped_credentials(
+        "github_oauth",
+        {
+            "token": oauth_secret,
+            "refresh_token": "github-refresh-secret",
+            "client_id": "github-client-id",
+            "scopes": [],
+            "expires_at": 4_102_444_800.0,
+            "_source": "oauth",
+            "_oauth_provider": "github",
+        },
+        credentials_manager=manager,
+        worker_target=oauth_target,
+    )
+    tools = [
+        {
+            "name": "github",
+            "display_name": "GitHub",
+            "description": "GitHub access",
+            "category": "development",
+            "status": "requires_config",
+            "setup_type": "oauth",
+            "auth_provider": "github",
+            "config_fields": [{"name": "access_token", "required": False}],
+            "oauth_fallback_fields": ["access_token"],
+        },
+    ]
+
+    with (
+        patch("mindroom.api.tools._read_tools_runtime_config", return_value=(config, runtime_paths)),
+        patch("mindroom.api.tools.export_tools_metadata", return_value=tools),
+    ):
+        response = test_client.get(
+            "/api/tools/?agent_name=general",
+            headers=trusted_upstream_headers(
+                user_id="alice",
+                email="alice@example.org",
+                matrix_user_id="@alice:example.org",
+            ),
+        )
+
+    assert response.status_code == 200
+    assert response.json()["tools"][0]["status"] == "available"
+    assert oauth_secret not in response.text
 
 
 def test_get_tools_uses_one_runtime_snapshot(

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -464,6 +464,40 @@ class TestCredentialsAPI:
             "_source": "ui",
         }
 
+    def test_github_manual_access_token_round_trips_through_tool_config(
+        self,
+        client: TestClient,
+    ) -> None:
+        """The OAuth tool-config boundary must preserve declared manual fallbacks."""
+        runtime_paths = main._app_runtime_paths(client.app)
+        manager = get_runtime_credentials_manager(runtime_paths)
+
+        response = client.post(
+            "/api/credentials/github",
+            json={
+                "credentials": {
+                    "access_token": "github-manual-token",
+                    "base_url": "https://github.example.test/api/v3",
+                },
+            },
+        )
+        get_response = client.get("/api/credentials/github")
+
+        assert response.status_code == 200
+        assert manager.load_credentials("github") == {
+            "access_token": "github-manual-token",
+            "base_url": "https://github.example.test/api/v3",
+            "_source": "ui",
+        }
+        assert get_response.status_code == 200
+        assert get_response.json() == {
+            "service": "github",
+            "credentials": {
+                "access_token": "github-manual-token",
+                "base_url": "https://github.example.test/api/v3",
+            },
+        }
+
     def test_get_oauth_credentials_filters_token_fields(
         self,
         client: TestClient,

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -81,7 +81,7 @@ def _runtime_paths(tmp_path: Path, process_env: dict[str, str] | None = None) ->
 
 
 def _config_payload(
-    worker_scope: str = "user_agent",
+    worker_scope: str | None = "user_agent",
     *,
     authorization: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -182,6 +182,7 @@ def _fake_provider(
     scopes: tuple[str, ...] = ("scope.read",),
     client_config_services: tuple[str, ...] = ("test_drive_oauth_client",),
     shared_client_config_services: tuple[str, ...] = (),
+    requester_scoped_credentials: bool = False,
 ) -> OAuthProvider:
     async def _exchange(
         provider: OAuthProvider,
@@ -228,6 +229,7 @@ def _fake_provider(
         allowed_hosted_domains=allowed_hosted_domains,
         status_capabilities=("Test files",),
         token_exchanger=_exchange,
+        requester_scoped_credentials=requester_scoped_credentials,
     )
 
 
@@ -2081,6 +2083,115 @@ def test_shared_scope_oauth_token_uses_agent_store_not_shared_or_worker_path(tmp
     assert manager.shared_manager().load_credentials(provider.credential_service) is None
     assert manager.for_primary_runtime_agent_scope("other").load_credentials(provider.credential_service) is None
     assert manager.for_worker(worker_key).load_credentials(provider.credential_service) is None
+
+
+@pytest.mark.parametrize(
+    ("worker_scope", "agent_query"),
+    [
+        (None, ""),
+        ("shared", "?agent_name=general"),
+    ],
+)
+def test_requester_scoped_provider_uses_user_store_for_non_private_agent_runtime(
+    tmp_path: Path,
+    worker_scope: str | None,
+    agent_query: str,
+) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+            constants.OWNER_MATRIX_USER_ID_ENV: "@alice:example.org",
+        },
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope=worker_scope))
+    provider = _fake_provider(
+        provider_id="github",
+        credential_service="github_oauth",
+        requester_scoped_credentials=True,
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            _login(client)
+            connect_response = client.post(f"/api/oauth/{provider.id}/connect{agent_query}")
+            state = _state_from_auth_url(connect_response.json()["auth_url"])
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                follow_redirects=False,
+            )
+
+    assert callback_response.status_code == 307
+    user_credentials = manager.for_primary_runtime_scope("@alice:example.org", None).load_credentials(
+        provider.credential_service,
+    )
+    assert user_credentials is not None
+    assert user_credentials["token"] == "github-access-token"
+    assert manager.shared_manager().load_credentials(provider.credential_service) is None
+    assert manager.for_primary_runtime_agent_scope("general").load_credentials(provider.credential_service) is None
+
+
+def test_requester_scoped_conversation_link_for_user_agent_uses_user_store(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(
+            worker_scope="user_agent",
+            authorization={"agent_reply_permissions": {"general": ["@alice:example.org"]}},
+        ),
+    )
+    _use_runtime_auth_settings(api_app)
+    provider = _fake_provider(
+        provider_id="github",
+        credential_service="github_oauth",
+        requester_scoped_credentials=True,
+    )
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    runtime_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    oauth_target = oauth_service.oauth_credentials_worker_target(provider, runtime_target)
+    assert oauth_target is not None
+    assert oauth_target.worker_scope == "user"
+    connect_url = urlparse(oauth_service.oauth_connect_url(provider, runtime_paths, worker_target=oauth_target))
+    authorize_path = f"{connect_url.path}?{connect_url.query}"
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            authorize_response = client.get(
+                authorize_path,
+                headers=trusted_upstream_headers(),
+                follow_redirects=False,
+            )
+            state = _state_from_auth_url(authorize_response.headers["location"])
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                headers=trusted_upstream_headers(),
+                follow_redirects=False,
+            )
+
+    assert authorize_response.status_code == 307
+    assert callback_response.status_code == 307
+    manager = get_runtime_credentials_manager(runtime_paths)
+    user_credentials = manager.for_primary_runtime_scope("@alice:example.org", None).load_credentials(
+        provider.credential_service,
+    )
+    assert user_credentials is not None
+    assert user_credentials["token"] == "github-access-token"
+    assert (
+        manager.for_primary_runtime_scope("@alice:example.org", "general").load_credentials(
+            provider.credential_service,
+        )
+        is None
+    )
 
 
 def test_shared_scope_plugin_oauth_token_uses_agent_store_not_shared_or_worker_path(tmp_path: Path) -> None:

--- a/tests/api/test_tools_oauth_fallback.py
+++ b/tests/api/test_tools_oauth_fallback.py
@@ -1,0 +1,117 @@
+"""Tests for manual credential fallbacks on OAuth-backed tools."""
+
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.api import tools as tools_api
+from mindroom.constants import resolve_runtime_paths
+from mindroom.credentials import get_runtime_credentials_manager, save_scoped_credentials
+from mindroom.oauth.github import github_oauth_provider
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.constants import RuntimePaths
+    from mindroom.credentials import CredentialsManager
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+
+
+def _runtime_paths(tmp_path: Path) -> RuntimePaths:
+    return resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={},
+    )
+
+
+def _worker_target(requester_id: str) -> ResolvedWorkerTarget:
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="code",
+        requester_id=requester_id,
+        room_id="!room:example.test",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        session_id=None,
+    )
+    return resolve_worker_target("user_agent", "code", execution_identity=identity)
+
+
+def _context(
+    runtime_paths: RuntimePaths,
+    credentials_manager: CredentialsManager,
+    worker_target: ResolvedWorkerTarget,
+) -> tools_api._ResolvedToolAvailabilityContext:
+    provider = github_oauth_provider()
+    return tools_api._ResolvedToolAvailabilityContext(
+        execution_scope="user_agent",
+        dashboard_configuration_supported=True,
+        status_authoritative=True,
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+        allowed_shared_services=None,
+        auth_provider_credential_services={"github": provider.credential_service},
+        oauth_providers={"github": provider},
+        runtime_paths=runtime_paths,
+    )
+
+
+def _github_tool() -> dict[str, object]:
+    return {
+        "name": "github",
+        "status": "requires_config",
+        "setup_type": "oauth",
+        "auth_provider": "github",
+        "config_fields": [
+            {"name": "access_token", "required": False},
+            {"name": "base_url", "required": False},
+        ],
+        "oauth_fallback_fields": ["access_token"],
+    }
+
+
+def test_manual_oauth_fallback_status_is_requester_scoped_and_secret_free(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = get_runtime_credentials_manager(runtime_paths)
+    alice_target = _worker_target("@alice:example.test")
+    bob_target = _worker_target("@bob:example.test")
+    manual_secret = "github-manual-secret"  # noqa: S105
+    save_scoped_credentials(
+        "github",
+        {"access_token": manual_secret, "base_url": "https://api.github.com"},
+        credentials_manager=manager,
+        worker_target=alice_target,
+    )
+    alice_tool = _github_tool()
+    bob_tool = _github_tool()
+
+    tools_api._update_tools_statuses([alice_tool], _context(runtime_paths, manager, alice_target))
+    tools_api._update_tools_statuses([bob_tool], _context(runtime_paths, manager, bob_target))
+
+    assert alice_tool["status"] == "available"
+    assert alice_tool["manual_auth_configured"] is True
+    assert bob_tool["status"] == "requires_config"
+    assert bob_tool["manual_auth_configured"] is False
+    assert manual_secret not in repr(alice_tool)
+
+
+def test_blank_manual_oauth_fallback_does_not_mark_tool_available(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = get_runtime_credentials_manager(runtime_paths)
+    target = _worker_target("@alice:example.test")
+    save_scoped_credentials(
+        "github",
+        {"access_token": "   ", "base_url": "https://api.github.com"},
+        credentials_manager=manager,
+        worker_target=target,
+    )
+    tool = _github_tool()
+
+    tools_api._update_tools_statuses([tool], _context(runtime_paths, manager, target))
+
+    assert tool["status"] == "requires_config"
+    assert tool["manual_auth_configured"] is False

--- a/tests/api/test_tools_oauth_fallback.py
+++ b/tests/api/test_tools_oauth_fallback.py
@@ -115,3 +115,22 @@ def test_blank_manual_oauth_fallback_does_not_mark_tool_available(tmp_path: Path
 
     assert tool["status"] == "requires_config"
     assert tool["manual_auth_configured"] is False
+
+
+def test_environment_oauth_fallback_status_is_available_and_secret_free(tmp_path: Path) -> None:
+    environment_secret = "github-environment-secret"  # noqa: S105
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={"GITHUB_ACCESS_TOKEN": f"  {environment_secret}  "},
+    )
+    manager = get_runtime_credentials_manager(runtime_paths)
+    target = _worker_target("@alice:example.test")
+    tool = _github_tool()
+
+    tools_api._update_tools_statuses([tool], _context(runtime_paths, manager, target))
+
+    assert tool["status"] == "available"
+    assert tool["manual_auth_configured"] is False
+    assert tool["environment_auth_configured"] is True
+    assert environment_secret not in repr(tool)

--- a/tests/test_github_oauth_provider.py
+++ b/tests/test_github_oauth_provider.py
@@ -1,0 +1,160 @@
+"""Tests for the built-in GitHub App OAuth provider."""
+
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import importlib.util
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+from urllib.parse import parse_qs, urlparse
+
+from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.credentials import get_runtime_credentials_manager
+from mindroom.oauth.service import refresh_scoped_oauth_credentials
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.oauth.providers import OAuthProvider
+
+
+def _runtime_paths(tmp_path: Path) -> RuntimePaths:
+    return resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={"MINDROOM_PUBLIC_URL": "https://mindroom.example.test"},
+    )
+
+
+def _provider() -> OAuthProvider:
+    spec = importlib.util.find_spec("mindroom.oauth.github")
+    assert spec is not None, "the built-in GitHub OAuth provider module is missing"
+    module = importlib.import_module("mindroom.oauth.github")
+    return module.github_oauth_provider()
+
+
+def _save_client_config(runtime_paths: RuntimePaths) -> None:
+    get_runtime_credentials_manager(runtime_paths).save_credentials(
+        "github_oauth_client",
+        {
+            "client_id": "github-client-id",
+            "client_secret": "github-client-secret",
+        },
+    )
+
+
+def test_github_provider_declares_github_app_user_oauth_contract() -> None:
+    provider = _provider()
+
+    assert provider.id == "github"
+    assert provider.display_name == "GitHub"
+    assert provider.authorization_url == "https://github.com/login/oauth/authorize"
+    assert provider.token_url == "https://github.com/login/oauth/access_token"  # noqa: S105
+    assert provider.scopes == ()
+    assert provider.allow_empty_scopes is True
+    assert provider.pkce_code_challenge_method == "S256"
+    assert provider.credential_service == "github_oauth"
+    assert provider.tool_config_service == "github"
+    assert provider.client_config_services == ("github_oauth_client",)
+    assert provider.redirect_path == "/api/oauth/github/callback"
+
+
+def test_github_authorization_url_omits_classic_oauth_scope(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    _save_client_config(runtime_paths)
+
+    authorization_url = asyncio.run(
+        _provider().authorization_uri_async(
+            runtime_paths,
+            state="opaque-state",
+            code_verifier="v" * 64,
+        ),
+    )
+    query = parse_qs(urlparse(authorization_url).query, keep_blank_values=True)
+
+    assert query["client_id"] == ["github-client-id"]
+    assert query["state"] == ["opaque-state"]
+    assert query["code_challenge_method"] == ["S256"]
+    assert "scope" not in query
+
+
+def test_github_token_exchange_normalizes_rotating_user_token(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    _save_client_config(runtime_paths)
+    token_response = {
+        "access_token": "github-user-access",
+        "refresh_token": "github-user-refresh",
+        "expires_in": 28_800,
+        "refresh_token_expires_in": 15_897_600,
+        "scope": "",
+        "token_type": "bearer",
+    }
+
+    with patch(
+        "mindroom.oauth.providers.AsyncOAuth2Client.fetch_token",
+        new=AsyncMock(return_value=token_response),
+    ):
+        result = asyncio.run(
+            _provider().exchange_code(
+                "authorization-code",
+                runtime_paths,
+                code_verifier="v" * 64,
+            ),
+        )
+
+    assert result.token_data["token"] == "github-user-access"  # noqa: S105
+    assert result.token_data["refresh_token"] == "github-user-refresh"  # noqa: S105
+    assert result.token_data["client_id"] == "github-client-id"
+    assert result.token_data["scopes"] == []
+    assert result.token_data["token_type"] == "bearer"  # noqa: S105
+    assert result.token_data["expires_at"] > time.time()
+    assert result.token_data["_oauth_provider"] == "github"
+
+
+def test_github_refresh_persists_rotated_access_and_refresh_tokens(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    _save_client_config(runtime_paths)
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    credentials_manager.save_credentials(
+        "github_oauth",
+        {
+            "token": "old-access",
+            "refresh_token": "old-refresh",
+            "client_id": "github-client-id",
+            "scopes": [],
+            "expires_at": 1.0,
+            "_source": "oauth",
+            "_oauth_provider": "github",
+        },
+    )
+    refresh_response = {
+        "access_token": "rotated-access",
+        "refresh_token": "rotated-refresh",
+        "expires_in": 28_800,
+        "refresh_token_expires_in": 15_897_600,
+        "scope": "",
+        "token_type": "bearer",
+    }
+
+    with patch(
+        "mindroom.oauth.providers.AsyncOAuth2Client.refresh_token",
+        new=AsyncMock(return_value=refresh_response),
+    ):
+        refreshed = asyncio.run(
+            refresh_scoped_oauth_credentials(
+                _provider(),
+                runtime_paths,
+                credentials_manager=credentials_manager,
+                worker_target=None,
+            ),
+        )
+
+    stored = credentials_manager.load_credentials("github_oauth")
+    assert refreshed is not None
+    assert refreshed["token"] == "rotated-access"  # noqa: S105
+    assert refreshed["refresh_token"] == "rotated-refresh"  # noqa: S105
+    assert stored == refreshed

--- a/tests/test_github_oauth_provider.py
+++ b/tests/test_github_oauth_provider.py
@@ -5,8 +5,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
-import importlib.util
 import time
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
@@ -14,6 +12,7 @@ from urllib.parse import parse_qs, urlparse
 
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.credentials import get_runtime_credentials_manager
+from mindroom.oauth.github import github_oauth_provider
 from mindroom.oauth.service import refresh_scoped_oauth_credentials
 
 if TYPE_CHECKING:
@@ -31,10 +30,7 @@ def _runtime_paths(tmp_path: Path) -> RuntimePaths:
 
 
 def _provider() -> OAuthProvider:
-    spec = importlib.util.find_spec("mindroom.oauth.github")
-    assert spec is not None, "the built-in GitHub OAuth provider module is missing"
-    module = importlib.import_module("mindroom.oauth.github")
-    return module.github_oauth_provider()
+    return github_oauth_provider()
 
 
 def _save_client_config(runtime_paths: RuntimePaths) -> None:

--- a/tests/test_github_oauth_provider.py
+++ b/tests/test_github_oauth_provider.py
@@ -61,6 +61,9 @@ def test_github_provider_declares_github_app_user_oauth_contract() -> None:
     assert provider.tool_config_service == "github"
     assert provider.client_config_services == ("github_oauth_client",)
     assert provider.redirect_path == "/api/oauth/github/callback"
+    assert provider.requester_scoped_credentials is True
+    assert provider.tool_config_oauth_fallback_fields == ("access_token",)
+    assert provider.tool_config_oauth_fallback_env_vars == ("GITHUB_ACCESS_TOKEN",)
 
 
 def test_github_authorization_url_omits_classic_oauth_scope(tmp_path: Path) -> None:

--- a/tests/test_github_oauth_tool.py
+++ b/tests/test_github_oauth_tool.py
@@ -1,0 +1,314 @@
+"""Tests for the requester-scoped GitHub OAuth toolkit."""
+
+# ruff: noqa: D103
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+from mindroom.constants import RuntimePaths, resolve_runtime_paths
+from mindroom.credentials import (
+    CredentialsManager,
+    get_runtime_credentials_manager,
+    load_scoped_credentials,
+    save_scoped_credentials,
+)
+from mindroom.oauth.providers import OAuthRefreshRejectedError
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+
+DEFAULT_REFRESH_TOKEN = "github-refresh"  # noqa: S105
+MANUAL_ACCESS_TOKEN = "manual-access"  # noqa: S105
+OLD_REFRESH_TOKEN = "old-refresh"  # noqa: S105
+ROTATED_REFRESH_TOKEN = "rotated-refresh"  # noqa: S105
+ENV_ACCESS_TOKEN = "environment-access"  # noqa: S105
+
+
+@dataclass(frozen=True)
+class _FakeRepo:
+    full_name: str
+
+
+class _FakeUser:
+    def get_repos(self) -> list[_FakeRepo]:
+        return [_FakeRepo("example/project")]
+
+
+class _FakeGithub:
+    def get_user(self) -> _FakeUser:
+        return _FakeUser()
+
+
+class _CapturingLogger:
+    def __init__(self) -> None:
+        self.warning_calls: list[tuple[str, dict[str, object]]] = []
+
+    def warning(self, event: str, **kwargs: object) -> None:
+        self.warning_calls.append((event, kwargs))
+
+
+def _runtime_paths(tmp_path: Path, extra_env: dict[str, str] | None = None) -> RuntimePaths:
+    return resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "mindroom_data",
+        process_env={
+            "MINDROOM_PUBLIC_URL": "https://mindroom.example.test",
+            **(extra_env or {}),
+        },
+    )
+
+
+def _worker_target(requester_id: str) -> ResolvedWorkerTarget:
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="code",
+        requester_id=requester_id,
+        room_id="!room:example.test",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        session_id=None,
+    )
+    return resolve_worker_target("user_agent", "code", execution_identity=identity)
+
+
+def _tool_class() -> type[Any]:
+    spec = importlib.util.find_spec("mindroom.custom_tools.github")
+    assert spec is not None, "the MindRoom GitHub wrapper module is missing"
+    module = importlib.import_module("mindroom.custom_tools.github")
+    return module.GithubTools
+
+
+def _save_client_config(runtime_paths: RuntimePaths) -> CredentialsManager:
+    manager = get_runtime_credentials_manager(runtime_paths)
+    manager.save_credentials(
+        "github_oauth_client",
+        {
+            "client_id": "github-client-id",
+            "client_secret": "github-client-secret",
+        },
+    )
+    return manager
+
+
+def _oauth_credentials(
+    token: str,
+    *,
+    refresh_token: str = DEFAULT_REFRESH_TOKEN,
+    expires_at: float = 4_102_444_800.0,
+) -> dict[str, object]:
+    return {
+        "token": token,
+        "refresh_token": refresh_token,
+        "client_id": "github-client-id",
+        "scopes": [],
+        "expires_at": expires_at,
+        "_source": "oauth",
+        "_oauth_provider": "github",
+    }
+
+
+def _build_tool(
+    runtime_paths: RuntimePaths,
+    manager: CredentialsManager,
+    worker_target: ResolvedWorkerTarget,
+    *,
+    access_token: str | None = None,
+    base_url: str | None = None,
+) -> Any:  # noqa: ANN401
+    return _tool_class()(
+        access_token=access_token,
+        base_url=base_url,
+        runtime_paths=runtime_paths,
+        credentials_manager=manager,
+        worker_target=worker_target,
+    )
+
+
+def test_missing_credentials_return_requester_bound_connection_links(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    alice = _build_tool(runtime_paths, manager, _worker_target("@alice:example.test"))
+    bob = _build_tool(runtime_paths, manager, _worker_target("@bob:example.test"))
+
+    alice_result = json.loads(alice.list_repositories())
+    bob_result = json.loads(bob.list_repositories())
+
+    assert alice_result["oauth_connection_required"] is True
+    assert alice_result["provider"] == "github"
+    assert "/api/oauth/github/authorize?connect_token=" in alice_result["connect_url"]
+    assert bob_result["connect_url"] != alice_result["connect_url"]
+    assert "@alice:example.test" not in json.dumps(alice_result)
+    assert "@bob:example.test" not in json.dumps(bob_result)
+
+
+def test_requesters_cannot_use_each_others_github_oauth_credentials(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    alice_target = _worker_target("@alice:example.test")
+    bob_target = _worker_target("@bob:example.test")
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials("alice-access"),
+        credentials_manager=manager,
+        worker_target=alice_target,
+    )
+    alice = _build_tool(runtime_paths, manager, alice_target)
+    alice.g = _FakeGithub()
+    bob = _build_tool(runtime_paths, manager, bob_target)
+
+    assert json.loads(alice.list_repositories()) == ["example/project"]
+    assert json.loads(bob.list_repositories())["oauth_connection_required"] is True
+
+
+def test_explicit_access_token_takes_precedence_over_scoped_oauth(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    target = _worker_target("@alice:example.test")
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials("oauth-access", expires_at=1.0),
+        credentials_manager=manager,
+        worker_target=target,
+    )
+    tool = _build_tool(runtime_paths, manager, target, access_token=MANUAL_ACCESS_TOKEN)
+    tool.g = _FakeGithub()
+
+    assert json.loads(tool.list_repositories()) == ["example/project"]
+    assert tool.access_token == MANUAL_ACCESS_TOKEN
+
+
+def test_environment_access_token_remains_an_explicit_fallback(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path, {"GITHUB_ACCESS_TOKEN": ENV_ACCESS_TOKEN})
+    manager = _save_client_config(runtime_paths)
+    tool = _build_tool(runtime_paths, manager, _worker_target("@alice:example.test"))
+    tool.g = _FakeGithub()
+
+    assert json.loads(tool.list_repositories()) == ["example/project"]
+    assert tool.access_token == ENV_ACCESS_TOKEN
+
+
+def test_base_url_is_forwarded_to_pygithub(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool_class = _tool_class()
+    captured: dict[str, object] = {}
+
+    def github_factory(**kwargs: object) -> _FakeGithub:
+        captured.update(kwargs)
+        return _FakeGithub()
+
+    with patch("mindroom.custom_tools.github.Github", side_effect=github_factory):
+        tool = tool_class(
+            access_token=MANUAL_ACCESS_TOKEN,
+            base_url="https://github.example.test/api/v3",
+            runtime_paths=runtime_paths,
+            credentials_manager=manager,
+            worker_target=_worker_target("@alice:example.test"),
+        )
+
+    assert json.loads(tool.list_repositories()) == ["example/project"]
+    assert captured["base_url"] == "https://github.example.test/api/v3"
+
+
+def test_expired_oauth_credentials_refresh_and_persist_rotation(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool_class = _tool_class()
+    target = _worker_target("@alice:example.test")
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials("old-access", refresh_token=OLD_REFRESH_TOKEN, expires_at=1.0),
+        credentials_manager=manager,
+        worker_target=target,
+    )
+    refreshed = _oauth_credentials("rotated-access", refresh_token=ROTATED_REFRESH_TOKEN)
+
+    async def refresh_credentials(*_args: object, **_kwargs: object) -> dict[str, object]:
+        save_scoped_credentials(
+            "github_oauth",
+            refreshed,
+            credentials_manager=manager,
+            worker_target=target,
+        )
+        return refreshed
+
+    with (
+        patch("mindroom.custom_tools.github.refresh_scoped_oauth_credentials", side_effect=refresh_credentials),
+        patch("mindroom.custom_tools.github.Github", return_value=_FakeGithub()),
+    ):
+        tool = tool_class(
+            runtime_paths=runtime_paths,
+            credentials_manager=manager,
+            worker_target=target,
+        )
+        result = json.loads(tool.list_repositories())
+
+    stored = load_scoped_credentials(
+        "github_oauth",
+        credentials_manager=manager,
+        worker_target=target,
+    )
+    assert result == ["example/project"]
+    assert stored is not None
+    assert stored["token"] == "rotated-access"  # noqa: S105
+    assert stored["refresh_token"] == "rotated-refresh"  # noqa: S105
+
+
+def test_terminal_refresh_failure_returns_safe_connection_payload(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool_class = _tool_class()
+    target = _worker_target("@alice:example.test")
+    leaked_secret = "refresh-secret-that-must-not-leak"  # noqa: S105
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials("old-access", refresh_token=leaked_secret, expires_at=1.0),
+        credentials_manager=manager,
+        worker_target=target,
+    )
+    logger = _CapturingLogger()
+
+    async def reject_refresh(*_args: object, **_kwargs: object) -> None:
+        msg = f"OAuth token refresh failed: invalid_grant {leaked_secret}"
+        raise OAuthRefreshRejectedError(msg, oauth_error="invalid_grant")
+
+    with (
+        patch("mindroom.custom_tools.github.refresh_scoped_oauth_credentials", side_effect=reject_refresh),
+        patch("mindroom.custom_tools.github.logger", logger),
+    ):
+        result = tool_class(
+            runtime_paths=runtime_paths,
+            credentials_manager=manager,
+            worker_target=target,
+        ).list_repositories()
+
+    payload = json.loads(result)
+    assert payload["oauth_connection_required"] is True
+    assert payload["provider"] == "github"
+    assert leaked_secret not in result
+    assert leaked_secret not in repr(logger.warning_calls)
+
+
+def test_wrapper_preserves_all_registered_github_function_names(tmp_path: Path) -> None:
+    from mindroom import tools as _mindroom_tools  # noqa: F401, PLC0415
+    from mindroom.tool_system.catalog import TOOL_METADATA  # noqa: PLC0415
+
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target("@alice:example.test"),
+        access_token=MANUAL_ACCESS_TOKEN,
+    )
+
+    assert set(tool.functions) == set(TOOL_METADATA["github"].function_names)

--- a/tests/test_github_oauth_tool.py
+++ b/tests/test_github_oauth_tool.py
@@ -5,8 +5,6 @@
 from __future__ import annotations
 
 import asyncio
-import importlib
-import importlib.util
 import json
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -22,6 +20,7 @@ from mindroom.credentials import (
     load_scoped_credentials,
     save_scoped_credentials,
 )
+from mindroom.custom_tools.github import GithubTools
 from mindroom.oauth.providers import OAuthRefreshRejectedError
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target, tool_execution_identity
 
@@ -101,10 +100,7 @@ def _oauth_target(requester_id: str) -> ResolvedWorkerTarget:
 
 
 def _tool_class() -> type[Any]:
-    spec = importlib.util.find_spec("mindroom.custom_tools.github")
-    assert spec is not None, "the MindRoom GitHub wrapper module is missing"
-    module = importlib.import_module("mindroom.custom_tools.github")
-    return module.GithubTools
+    return GithubTools
 
 
 def _save_client_config(runtime_paths: RuntimePaths) -> CredentialsManager:

--- a/tests/test_github_oauth_tool.py
+++ b/tests/test_github_oauth_tool.py
@@ -12,6 +12,9 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
+import pytest
+from github import BadCredentialsException
+
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.credentials import (
     CredentialsManager,
@@ -20,12 +23,12 @@ from mindroom.credentials import (
     save_scoped_credentials,
 )
 from mindroom.oauth.providers import OAuthRefreshRejectedError
-from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target, tool_execution_identity
 
 if TYPE_CHECKING:
     from pathlib import Path
 
-    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, WorkerScope
 
 DEFAULT_REFRESH_TOKEN = "github-refresh"  # noqa: S105
 MANUAL_ACCESS_TOKEN = "manual-access"  # noqa: S105
@@ -49,6 +52,11 @@ class _FakeGithub:
         return _FakeUser()
 
 
+class _RevokedTokenGithub:
+    def get_user(self) -> _FakeUser:
+        raise BadCredentialsException(401, {"message": "Bad credentials"})
+
+
 class _CapturingLogger:
     def __init__(self) -> None:
         self.warning_calls: list[tuple[str, dict[str, object]]] = []
@@ -68,7 +76,10 @@ def _runtime_paths(tmp_path: Path, extra_env: dict[str, str] | None = None) -> R
     )
 
 
-def _worker_target(requester_id: str) -> ResolvedWorkerTarget:
+def _worker_target_for_scope(
+    requester_id: str,
+    worker_scope: WorkerScope | None,
+) -> ResolvedWorkerTarget:
     identity = ToolExecutionIdentity(
         channel="matrix",
         agent_name="code",
@@ -78,7 +89,15 @@ def _worker_target(requester_id: str) -> ResolvedWorkerTarget:
         resolved_thread_id="$thread",
         session_id=None,
     )
-    return resolve_worker_target("user_agent", "code", execution_identity=identity)
+    return resolve_worker_target(worker_scope, "code", execution_identity=identity)
+
+
+def _worker_target(requester_id: str) -> ResolvedWorkerTarget:
+    return _worker_target_for_scope(requester_id, "user_agent")
+
+
+def _oauth_target(requester_id: str) -> ResolvedWorkerTarget:
+    return _worker_target_for_scope(requester_id, "user")
 
 
 def _tool_class() -> type[Any]:
@@ -160,7 +179,7 @@ def test_requesters_cannot_use_each_others_github_oauth_credentials(tmp_path: Pa
         "github_oauth",
         _oauth_credentials("alice-access"),
         credentials_manager=manager,
-        worker_target=alice_target,
+        worker_target=_oauth_target("@alice:example.test"),
     )
     alice = _build_tool(runtime_paths, manager, alice_target)
     alice.g = _FakeGithub()
@@ -168,6 +187,73 @@ def test_requesters_cannot_use_each_others_github_oauth_credentials(tmp_path: Pa
 
     assert json.loads(alice.list_repositories()) == ["example/project"]
     assert json.loads(bob.list_repositories())["oauth_connection_required"] is True
+
+
+def test_active_requester_overrides_tool_construction_identity(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    alice_target = _worker_target("@alice:example.test")
+    bob_target = _worker_target("@bob:example.test")
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials("alice-access"),
+        credentials_manager=manager,
+        worker_target=_oauth_target("@alice:example.test"),
+    )
+    tool = _build_tool(runtime_paths, manager, alice_target)
+    tool.g = _FakeGithub()
+
+    with tool_execution_identity(bob_target.execution_identity):
+        result = json.loads(tool.list_repositories())
+
+    assert result["oauth_connection_required"] is True
+    assert result["provider"] == "github"
+
+
+@pytest.mark.parametrize("worker_scope", [None, "shared", "user_agent"])
+def test_github_oauth_is_requester_scoped_when_agent_runtime_is_not(
+    tmp_path: Path,
+    worker_scope: WorkerScope | None,
+) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    alice_target = _worker_target_for_scope("@alice:example.test", worker_scope)
+    bob_target = _worker_target_for_scope("@bob:example.test", worker_scope)
+    alice_oauth_target = _oauth_target("@alice:example.test")
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials("alice-access"),
+        credentials_manager=manager,
+        worker_target=alice_oauth_target,
+    )
+    alice = _build_tool(runtime_paths, manager, alice_target)
+    alice.g = _FakeGithub()
+    bob = _build_tool(runtime_paths, manager, bob_target)
+    bob.g = _FakeGithub()
+
+    assert json.loads(alice.list_repositories()) == ["example/project"]
+    assert json.loads(bob.list_repositories())["oauth_connection_required"] is True
+
+
+def test_unscoped_agent_connection_links_are_requester_bound(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    alice = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target_for_scope("@alice:example.test", None),
+    )
+    bob = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target_for_scope("@bob:example.test", None),
+    )
+
+    alice_result = json.loads(alice.list_repositories())
+    bob_result = json.loads(bob.list_repositories())
+
+    assert "/api/oauth/github/authorize?connect_token=" in alice_result["connect_url"]
+    assert bob_result["connect_url"] != alice_result["connect_url"]
 
 
 def test_explicit_access_token_takes_precedence_over_scoped_oauth(tmp_path: Path) -> None:
@@ -178,7 +264,7 @@ def test_explicit_access_token_takes_precedence_over_scoped_oauth(tmp_path: Path
         "github_oauth",
         _oauth_credentials("oauth-access", expires_at=1.0),
         credentials_manager=manager,
-        worker_target=target,
+        worker_target=_oauth_target("@alice:example.test"),
     )
     tool = _build_tool(runtime_paths, manager, target, access_token=MANUAL_ACCESS_TOKEN)
     tool.g = _FakeGithub()
@@ -195,6 +281,52 @@ def test_environment_access_token_remains_an_explicit_fallback(tmp_path: Path) -
 
     assert json.loads(tool.list_repositories()) == ["example/project"]
     assert tool.access_token == ENV_ACCESS_TOKEN
+
+
+@pytest.mark.parametrize(
+    ("access_token", "extra_env"),
+    [
+        ("   ", None),
+        (None, {"GITHUB_ACCESS_TOKEN": "   "}),
+    ],
+)
+def test_whitespace_explicit_tokens_fall_back_to_scoped_oauth(
+    tmp_path: Path,
+    access_token: str | None,
+    extra_env: dict[str, str] | None,
+) -> None:
+    runtime_paths = _runtime_paths(tmp_path, extra_env)
+    manager = _save_client_config(runtime_paths)
+    target = _worker_target("@alice:example.test")
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials("oauth-access"),
+        credentials_manager=manager,
+        worker_target=_oauth_target("@alice:example.test"),
+    )
+
+    tool = _build_tool(runtime_paths, manager, target, access_token=access_token)
+    tool.g = _FakeGithub()
+
+    assert json.loads(tool.list_repositories()) == ["example/project"]
+    assert tool.access_token == "oauth-access"  # noqa: S105
+
+
+def test_whitespace_stored_oauth_token_requires_connection(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    target = _worker_target("@alice:example.test")
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials("   ", refresh_token=""),
+        credentials_manager=manager,
+        worker_target=_oauth_target("@alice:example.test"),
+    )
+
+    result = json.loads(_build_tool(runtime_paths, manager, target).list_repositories())
+
+    assert result["oauth_connection_required"] is True
+    assert result["provider"] == "github"
 
 
 def test_base_url_is_forwarded_to_pygithub(tmp_path: Path) -> None:
@@ -225,11 +357,12 @@ def test_expired_oauth_credentials_refresh_and_persist_rotation(tmp_path: Path) 
     manager = _save_client_config(runtime_paths)
     tool_class = _tool_class()
     target = _worker_target("@alice:example.test")
+    oauth_target = _oauth_target("@alice:example.test")
     save_scoped_credentials(
         "github_oauth",
         _oauth_credentials("old-access", refresh_token=OLD_REFRESH_TOKEN, expires_at=1.0),
         credentials_manager=manager,
-        worker_target=target,
+        worker_target=oauth_target,
     )
     refreshed = _oauth_credentials("rotated-access", refresh_token=ROTATED_REFRESH_TOKEN)
 
@@ -238,7 +371,7 @@ def test_expired_oauth_credentials_refresh_and_persist_rotation(tmp_path: Path) 
             "github_oauth",
             refreshed,
             credentials_manager=manager,
-            worker_target=target,
+            worker_target=oauth_target,
         )
         return refreshed
 
@@ -256,7 +389,7 @@ def test_expired_oauth_credentials_refresh_and_persist_rotation(tmp_path: Path) 
     stored = load_scoped_credentials(
         "github_oauth",
         credentials_manager=manager,
-        worker_target=target,
+        worker_target=oauth_target,
     )
     assert result == ["example/project"]
     assert stored is not None
@@ -272,7 +405,7 @@ def test_oauth_refresh_works_when_agno_calls_sync_tool_on_running_loop(tmp_path:
         "github_oauth",
         _oauth_credentials("oauth-access"),
         credentials_manager=manager,
-        worker_target=target,
+        worker_target=_oauth_target("@alice:example.test"),
     )
     tool = _build_tool(runtime_paths, manager, target)
     tool.g = _FakeGithub()
@@ -295,7 +428,7 @@ def test_terminal_refresh_failure_returns_safe_connection_payload(tmp_path: Path
         "github_oauth",
         _oauth_credentials("old-access", refresh_token=leaked_secret, expires_at=1.0),
         credentials_manager=manager,
-        worker_target=target,
+        worker_target=_oauth_target("@alice:example.test"),
     )
     logger = _CapturingLogger()
 
@@ -318,6 +451,29 @@ def test_terminal_refresh_failure_returns_safe_connection_payload(tmp_path: Path
     assert payload["provider"] == "github"
     assert leaked_secret not in result
     assert leaked_secret not in repr(logger.warning_calls)
+
+
+def test_revoked_unexpired_oauth_token_returns_connection_payload(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    target = _worker_target("@alice:example.test")
+    revoked_token = "revoked-access-that-must-not-leak"  # noqa: S105
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials(revoked_token),
+        credentials_manager=manager,
+        worker_target=_oauth_target("@alice:example.test"),
+    )
+    tool = _build_tool(runtime_paths, manager, target)
+    tool.g = _RevokedTokenGithub()
+
+    result = tool.list_repositories()
+    payload = json.loads(result)
+
+    assert payload["oauth_connection_required"] is True
+    assert payload["provider"] == "github"
+    assert "/api/oauth/github/authorize?connect_token=" in payload["connect_url"]
+    assert revoked_token not in result
 
 
 def test_wrapper_preserves_all_registered_github_function_names(tmp_path: Path) -> None:

--- a/tests/test_github_oauth_tool.py
+++ b/tests/test_github_oauth_tool.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 import importlib.util
 import json
@@ -261,6 +262,27 @@ def test_expired_oauth_credentials_refresh_and_persist_rotation(tmp_path: Path) 
     assert stored is not None
     assert stored["token"] == "rotated-access"  # noqa: S105
     assert stored["refresh_token"] == "rotated-refresh"  # noqa: S105
+
+
+def test_oauth_refresh_works_when_agno_calls_sync_tool_on_running_loop(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    target = _worker_target("@alice:example.test")
+    save_scoped_credentials(
+        "github_oauth",
+        _oauth_credentials("oauth-access"),
+        credentials_manager=manager,
+        worker_target=target,
+    )
+    tool = _build_tool(runtime_paths, manager, target)
+    tool.g = _FakeGithub()
+
+    async def call_sync_tool_entrypoint() -> str:
+        return tool.list_repositories()
+
+    result = asyncio.run(call_sync_tool_entrypoint())
+
+    assert json.loads(result) == ["example/project"]
 
 
 def test_terminal_refresh_failure_returns_safe_connection_payload(tmp_path: Path) -> None:

--- a/tests/test_oauth_registry.py
+++ b/tests/test_oauth_registry.py
@@ -50,6 +50,14 @@ def test_builtin_oauth_registry_includes_google_docs() -> None:
     assert providers["google_drive"].scopes[-1] == "https://www.googleapis.com/auth/drive"
 
 
+def test_builtin_oauth_registry_includes_github() -> None:
+    """GitHub should participate in built-in discovery and service-collision checks."""
+    providers = {provider.id: provider for provider in oauth_registry._builtin_oauth_providers()}
+
+    assert providers["github"].credential_service == "github_oauth"
+    assert providers["github"].tool_config_service == "github"
+
+
 def test_load_oauth_provider_registry_caches_loaded_registry(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -158,6 +158,20 @@ def test_approved_egress_tool_stays_primary_even_when_sandbox_mode_all(tmp_path:
     )
 
 
+def test_github_oauth_tool_stays_primary_when_worker_routing_is_requested(tmp_path: Path) -> None:
+    """Requester OAuth credentials must remain in the primary runtime credential boundary."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        process_env={},
+    )
+
+    assert not sandbox_proxy_module.sandbox_proxy_enabled_for_tool(
+        "github",
+        runtime_paths=runtime_paths,
+        worker_tools_override=["github"],
+    )
+
+
 def test_attachment_save_protocol_payload_fields_round_trip() -> None:
     """Attachment save payload helpers should preserve the current wire fields."""
     payload_bytes = b"attachment-bytes"

--- a/tests/test_tools_metadata.py
+++ b/tests/test_tools_metadata.py
@@ -23,6 +23,7 @@ from mindroom.constants import resolve_runtime_paths
 from mindroom.redaction import REDACTED
 from mindroom.server_fetch_url import ServerFetchUrlError
 from mindroom.tool_system.bootstrap import ensure_tool_registry_loaded
+from mindroom.tool_system.declarations import SetupType
 from mindroom.tool_system.metadata import (
     _AUTHORED_OVERRIDE_INHERIT,
     ConfigField,
@@ -496,6 +497,42 @@ def test_tool_metadata_consistency() -> None:
                 f"{tool_name} is metadata-only and should not declare managed init args: "
                 f"{[managed_arg.value for managed_arg in metadata.managed_init_args]}"
             )
+
+
+def test_github_metadata_declares_oauth_and_manual_token_fallback() -> None:
+    """GitHub metadata should describe both managed OAuth and manual-token construction."""
+    metadata = TOOL_METADATA["github"]
+
+    assert metadata.setup_type == SetupType.OAUTH
+    assert metadata.auth_provider == "github"
+    assert metadata.oauth_fallback_fields == ("access_token",)
+    assert metadata.managed_init_args == (
+        ToolManagedInitArg.RUNTIME_PATHS,
+        ToolManagedInitArg.CREDENTIALS_MANAGER,
+        ToolManagedInitArg.WORKER_TARGET,
+    )
+    assert {field.name for field in metadata.config_fields or []} == {"access_token", "base_url"}
+
+    exported = next(tool for tool in export_tools_metadata() if tool["name"] == "github")
+    assert exported["oauth_fallback_fields"] == ["access_token"]
+    assert "managed_init_args" not in exported
+
+
+def test_registration_rejects_missing_oauth_fallback_config_field() -> None:
+    """Fallback metadata should never reference a field the dashboard cannot configure."""
+    with pytest.raises(ValueError, match="missing_field"):
+
+        @register_tool_with_metadata(
+            name="invalid_oauth_fallback",
+            display_name="Invalid OAuth Fallback",
+            description="Invalid test metadata.",
+            category=ToolCategory.DEVELOPMENT,
+            setup_type=SetupType.OAUTH,
+            config_fields=[],
+            oauth_fallback_fields=("missing_field",),
+        )
+        def _invalid_oauth_fallback() -> type[Toolkit]:
+            return Toolkit
 
 
 def test_dynamic_tools_is_durable_metadata_only_builtin(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add the built-in `github` OAuth provider for requester-scoped GitHub App user tokens
- authenticate the existing GitHub toolkit through scoped OAuth refresh and rotation while preserving explicit `access_token` and `GITHUB_ACCESS_TOKEN` precedence
- expose OAuth and manual token setup as parallel dashboard options without changing GitHub tool function names or approval handling
- preserve GitHub Enterprise `base_url` support and document both setup paths

## Verification

- full Python test suite
- frontend test suite: 511 passed, 1 skipped
- all repository pre-commit hooks
- `git diff --check`

## Summary by Sourcery

Introduce requester-scoped GitHub App OAuth for the GitHub toolkit, with a manual access-token fallback and corresponding dashboard, backend, and documentation updates.

New Features:
- Add a built-in GitHub OAuth provider and requester-scoped GitHub App user token flow integrated with the existing OAuth registry.
- Expose GitHub as an OAuth-backed tool while preserving support for explicit access tokens and GitHub Enterprise base URLs.
- Surface parallel OAuth and manual credential setup paths for OAuth-backed tools in the dashboard UI, including GitHub.

Enhancements:
- Track and expose per-requester manual OAuth fallback configuration status for tools with declared fallback fields.
- Ensure OAuth-backed tools can mark themselves as connected based on either OAuth credentials or manual fallback credentials, without leaking secrets in status payloads.
- Validate at registration time that declared OAuth fallback fields correspond to actual configurable fields in tool metadata.
- Export OAuth fallback field metadata for tools while omitting internal managed-init arguments from the public metadata surface.
- Adjust integration disconnect behavior to avoid invoking provider disconnect handlers when only manual credentials are being removed.

Documentation:
- Document GitHub’s requester-scoped OAuth setup, token precedence rules, and Enterprise base URL handling in project-management tool docs and agent configuration docs.

Tests:
- Add comprehensive tests for the GitHub OAuth toolkit wrapper, including token precedence, refresh, rotation persistence, and function coverage.
- Add tests for the built-in GitHub OAuth provider’s contract, token exchange, and refresh behavior.
- Add API tests covering manual OAuth fallback handling and requester scoping for tools like GitHub.
- Extend frontend integration tests to cover dual OAuth/manual flows, configuration, and removal behavior for GitHub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub OAuth integration with requester-scoped credentials, token refresh, and secure connection flows.
  * Added access-token fallback configuration, including manual and environment-provided credentials.
  * GitHub authentication status and setup options are now reflected in the Integrations interface.
  * GitHub remains available in the primary runtime when worker routing is enabled.

* **Documentation**
  * Updated GitHub setup, OAuth, credential-scope, and worker-routing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->