### PR TITLE
Fix legacy interactive question schema upgrades

### DIFF
--- a/src/mindroom/event_journal/postgres_backend.py
+++ b/src/mindroom/event_journal/postgres_backend.py
@@ -16,7 +16,7 @@ from psycopg.rows import dict_row
 
 from .offloading import ThreadOffload
 from .schema import POSTGRES_DIALECT, render, schema_statements
-from .schema_migrations import migration_statements, validate_interactive_question_columns
+from .schema_migrations import migration_statements, pre_schema_migration_statements
 
 # An arbitrary constant that only this schema setup uses, so the lock it
 # takes cannot collide with an application advisory lock.
@@ -125,9 +125,11 @@ class PostgresBackend:
                   AND table_name = 'interactive_questions'
                 """,
             )
-            validate_interactive_question_columns(
-                frozenset(str(row["column_name"]) for row in cursor.fetchall()),
-            )
+            interactive_question_columns = frozenset(str(row["column_name"]) for row in cursor.fetchall())
+            for statement in pre_schema_migration_statements(
+                interactive_question_columns=interactive_question_columns,
+            ):
+                cursor.execute(cast("LiteralString", statement))
             for statement in schema_statements(POSTGRES_DIALECT):
                 cursor.execute(cast("LiteralString", statement))
             for statement in migration_statements(POSTGRES_DIALECT):

--- a/src/mindroom/event_journal/schema_migrations.py
+++ b/src/mindroom/event_journal/schema_migrations.py
@@ -11,15 +11,17 @@ _APPROVAL_CARD_NATIVE_IDENTITY_COLUMNS = (
 )
 
 
-def validate_interactive_question_columns(existing_columns: frozenset[str]) -> None:
-    """Refuse the old question-claim schema instead of guessing its ownership."""
-    if "claimed_source_event_id" not in existing_columns:
-        return
-    msg = (
-        "This event journal uses the incompatible pre-selection schema; "
-        "recreate the event journal database before starting MindRoom"
+def pre_schema_migration_statements(
+    *,
+    interactive_question_columns: frozenset[str] = frozenset(),
+) -> tuple[str, ...]:
+    """Archive the obsolete derived-prompt table before creating its replacement."""
+    if "claimed_source_event_id" not in interactive_question_columns:
+        return ()
+    return (
+        "CREATE TABLE interactive_questions_pre_selection AS SELECT * FROM interactive_questions",
+        "DROP TABLE interactive_questions",
     )
-    raise RuntimeError(msg)
 
 
 def migration_statements(

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -37,7 +37,7 @@ from mindroom.logging_config import get_logger
 
 from .offloading import ThreadOffload, settled
 from .schema import SQLITE_DIALECT, render, schema_statements
-from .schema_migrations import migration_statements, validate_interactive_question_columns
+from .schema_migrations import migration_statements, pre_schema_migration_statements
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -202,26 +202,29 @@ class SqliteBackend:
         # gap the certifier can see. Readers commit nothing, so this is the
         # writer's cost alone.
         _configure(connection, synchronous="FULL")
-        interactive_question_columns = frozenset(
-            str(row[1]) for row in connection.execute("PRAGMA table_info(interactive_questions)")
-        )
+        connection.execute("BEGIN IMMEDIATE")
         try:
-            validate_interactive_question_columns(interactive_question_columns)
-        except RuntimeError:
+            interactive_question_columns = frozenset(
+                str(row[1]) for row in connection.execute("PRAGMA table_info(interactive_questions)")
+            )
+            for statement in pre_schema_migration_statements(
+                interactive_question_columns=interactive_question_columns,
+            ):
+                connection.execute(statement)
+            for statement in schema_statements(SQLITE_DIALECT):
+                connection.execute(statement)
+            approval_card_columns = frozenset(
+                str(row[1]) for row in connection.execute("PRAGMA table_info(approval_cards)")
+            )
+            for statement in migration_statements(
+                SQLITE_DIALECT,
+                approval_card_columns=approval_card_columns,
+            ):
+                connection.execute(statement)
+            connection.execute("COMMIT")
+        except BaseException:
             connection.close()
             raise
-        connection.execute("BEGIN IMMEDIATE")
-        for statement in schema_statements(SQLITE_DIALECT):
-            connection.execute(statement)
-        approval_card_columns = frozenset(
-            str(row[1]) for row in connection.execute("PRAGMA table_info(approval_cards)")
-        )
-        for statement in migration_statements(
-            SQLITE_DIALECT,
-            approval_card_columns=approval_card_columns,
-        ):
-            connection.execute(statement)
-        connection.execute("COMMIT")
         return connection
 
     def _reader(self) -> sqlite3.Connection:

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -2726,46 +2726,6 @@ class TestInteractiveQuestionConsumption:
         assert await _interactive_selection_rows(journal_store) == []
 
 
-class TestIncompatibleInteractiveSchemaRefusal:
-    """An old question-claim shape must not be read under new ownership semantics."""
-
-    async def test_sqlite_refuses_the_legacy_claim_column(self, tmp_path: Path) -> None:
-        """SQLite fails loudly instead of treating an owned question as active."""
-        database_path = tmp_path / "legacy.db"
-        with sqlite3.connect(database_path) as database:
-            database.execute(
-                """
-                CREATE TABLE interactive_questions (
-                    principal_id TEXT NOT NULL,
-                    question_event_id TEXT NOT NULL,
-                    claimed_source_event_id TEXT
-                )
-                """,
-            )
-
-        with pytest.raises(RuntimeError, match="incompatible pre-selection schema"):
-            EventJournalStore.open_sqlite(database_path)
-
-    async def test_postgres_refuses_the_legacy_claim_column(self, postgres_journal_url: str) -> None:
-        """PostgreSQL applies the same explicit schema boundary as SQLite."""
-        import psycopg  # noqa: PLC0415
-
-        database_url = postgres_journal_schema_url(postgres_journal_url)
-        with psycopg.connect(database_url, autocommit=True) as database:
-            database.execute(
-                """
-                CREATE TABLE interactive_questions (
-                    principal_id TEXT NOT NULL,
-                    question_event_id TEXT NOT NULL,
-                    claimed_source_event_id TEXT
-                )
-                """,
-            )
-
-        with pytest.raises(RuntimeError, match="incompatible pre-selection schema"):
-            EventJournalStore.open_postgres(database_url)
-
-
 class TestDeliveryIsScopedToTheMembershipThatAuthorizedIt:
     """A turn that outlived its membership must not answer into the next one.
 
@@ -5857,6 +5817,196 @@ class TestConnectionSecretsStayOutOfLogs:
 
 class TestSchemaUpgrades:
     """Opening the journal preserves old rows and enables current writes."""
+
+    @staticmethod
+    async def _assert_legacy_questions_are_archived(backend: Backend) -> None:
+        archived = await backend.read(
+            lambda transaction: transaction.fetchall(
+                """
+                SELECT question_event_id, claimed_source_event_id
+                FROM interactive_questions_pre_selection
+                ORDER BY question_event_id
+                """,
+            ),
+        )
+        assert [(row["question_event_id"], row["claimed_source_event_id"]) for row in archived] == [
+            ("$claimed", "$selection"),
+            ("$open", None),
+        ]
+
+    @staticmethod
+    async def _assert_current_questions_work(backend: Backend) -> None:
+        journal = EventJournalStore(backend)
+        assert await _interactive_question_rows(journal) == []
+
+        alice = journal.principal("agent@alice")
+        await admit(alice, "$turn")
+        await _activate_interactive_question(alice, "$current")
+
+        current = await _interactive_question_rows(journal)
+        assert [row["question_event_id"] for row in current] == ["$current"]
+
+    @staticmethod
+    def _create_legacy_questions_sqlite(database: sqlite3.Connection) -> None:
+        database.execute(
+            """
+            CREATE TABLE interactive_questions (
+                principal_id TEXT NOT NULL,
+                question_event_id TEXT NOT NULL,
+                room_id TEXT NOT NULL,
+                thread_id TEXT NOT NULL,
+                creator_agent TEXT NOT NULL,
+                question_json TEXT NOT NULL,
+                membership_epoch BIGINT NOT NULL,
+                claimed_source_event_id TEXT,
+                created_at_ns BIGINT NOT NULL,
+                PRIMARY KEY (principal_id, question_event_id),
+                UNIQUE (principal_id, claimed_source_event_id)
+            )
+            """,
+        )
+        database.execute(
+            """
+            CREATE INDEX interactive_questions_active
+            ON interactive_questions (
+                principal_id, room_id, thread_id, creator_agent,
+                created_at_ns, question_event_id
+            )
+            WHERE claimed_source_event_id IS NULL
+            """,
+        )
+        database.executemany(
+            """
+            INSERT INTO interactive_questions (
+                principal_id, question_event_id, room_id, thread_id,
+                creator_agent, question_json, membership_epoch,
+                claimed_source_event_id, created_at_ns
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                ("agent@alice", "$open", ROOM, "$thread", "agent", '{"question_text":"Open"}', 0, None, 1),
+                (
+                    "agent@alice",
+                    "$claimed",
+                    ROOM,
+                    "$thread",
+                    "agent",
+                    '{"question_text":"Claimed"}',
+                    0,
+                    "$selection",
+                    2,
+                ),
+            ),
+        )
+
+    async def test_sqlite_archives_the_previous_question_schema_and_reopens(self, tmp_path: Path) -> None:
+        """SQLite keeps legacy prompts inert while the current projection remains writable."""
+        database_path = tmp_path / "previous-questions.db"
+        with sqlite3.connect(database_path) as database:
+            self._create_legacy_questions_sqlite(database)
+
+        backend = SqliteBackend.open(database_path)
+        try:
+            await self._assert_legacy_questions_are_archived(backend)
+            await self._assert_current_questions_work(backend)
+        finally:
+            await backend.close()
+
+        reopened = SqliteBackend.open(database_path)
+        try:
+            await self._assert_legacy_questions_are_archived(reopened)
+            current = await _interactive_question_rows(EventJournalStore(reopened))
+            assert [row["question_event_id"] for row in current] == ["$current"]
+        finally:
+            await reopened.close()
+
+    async def test_postgres_archives_the_previous_question_schema_and_reopens(
+        self,
+        postgres_journal_url: str,
+    ) -> None:
+        """PostgreSQL applies the same inert archival upgrade under its schema lock."""
+        import psycopg  # noqa: PLC0415 - optional backend exercised only by this test
+
+        from mindroom.event_journal.postgres_backend import PostgresBackend  # noqa: PLC0415
+
+        database_url = postgres_journal_schema_url(postgres_journal_url)
+        with psycopg.connect(database_url) as database:
+            database.execute(
+                """
+                CREATE TABLE interactive_questions (
+                    principal_id TEXT NOT NULL,
+                    question_event_id TEXT NOT NULL,
+                    room_id TEXT NOT NULL,
+                    thread_id TEXT NOT NULL,
+                    creator_agent TEXT NOT NULL,
+                    question_json TEXT NOT NULL,
+                    membership_epoch BIGINT NOT NULL,
+                    claimed_source_event_id TEXT,
+                    created_at_ns BIGINT NOT NULL,
+                    PRIMARY KEY (principal_id, question_event_id),
+                    UNIQUE (principal_id, claimed_source_event_id)
+                )
+                """,
+            )
+            database.execute(
+                """
+                CREATE INDEX interactive_questions_active
+                ON interactive_questions (
+                    principal_id, room_id, thread_id, creator_agent,
+                    created_at_ns, question_event_id
+                )
+                WHERE claimed_source_event_id IS NULL
+                """,
+            )
+            with database.cursor() as cursor:
+                cursor.executemany(
+                    """
+                    INSERT INTO interactive_questions (
+                        principal_id, question_event_id, room_id, thread_id,
+                        creator_agent, question_json, membership_epoch,
+                        claimed_source_event_id, created_at_ns
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    (
+                        (
+                            "agent@alice",
+                            "$open",
+                            ROOM,
+                            "$thread",
+                            "agent",
+                            '{"question_text":"Open"}',
+                            0,
+                            None,
+                            1,
+                        ),
+                        (
+                            "agent@alice",
+                            "$claimed",
+                            ROOM,
+                            "$thread",
+                            "agent",
+                            '{"question_text":"Claimed"}',
+                            0,
+                            "$selection",
+                            2,
+                        ),
+                    ),
+                )
+
+        backend = PostgresBackend.open(database_url)
+        try:
+            await self._assert_legacy_questions_are_archived(backend)
+            await self._assert_current_questions_work(backend)
+        finally:
+            await backend.close()
+
+        reopened = PostgresBackend.open(database_url)
+        try:
+            await self._assert_legacy_questions_are_archived(reopened)
+            current = await _interactive_question_rows(EventJournalStore(reopened))
+            assert [row["question_event_id"] for row in current] == ["$current"]
+        finally:
+            await reopened.close()
 
     @staticmethod
     async def _assert_old_row_is_inert_and_new_card_works(backend: Backend) -> None:


### PR DESCRIPTION
## Summary

- archive the pre-selection `interactive_questions` table before creating the projection-owned replacement
- keep claimed and unclaimed legacy prompt rows inert without recreating the whole event journal
- apply the same transactional upgrade under SQLite locking and the PostgreSQL schema advisory lock
- verify current prompt writes and idempotent reopen on both backends

## Safety

The migration runs only when the shipped legacy `claimed_source_event_id` column is present.
Old derived prompt rows remain available in `interactive_questions_pre_selection`, but are never interpreted under current ownership semantics.
All unrelated journal tables, generation metadata, pending work, approvals, deduplication, and recovery state remain in place.

## Verification

- `uv run pytest tests/test_event_journal_store.py::TestSchemaUpgrades -q -n 0 --no-cov --disable-warnings --maxfail=1`
- `uv run pytest tests/test_event_journal_store.py -q -n auto --no-cov --disable-warnings --maxfail=1`
- `uv run pytest -q --no-cov --disable-warnings --maxfail=1`
- `uv run pre-commit run --all-files`
- `git diff --check origin/main..HEAD`

Follow-up to #1828 and #1838.

## Summary by Sourcery

Archive legacy interactive question tables into a separate pre-selection table during schema setup so that legacy data remains inert while enabling the current projection schema on both SQLite and PostgreSQL.

Enhancements:
- Introduce a pre-schema migration step that archives legacy interactive_questions rows into an interactive_questions_pre_selection table before recreating the projection-owned table on SQLite and PostgreSQL.
- Perform the legacy table archival and schema creation inside the existing SQLite transaction and PostgreSQL schema advisory lock to keep upgrades atomic.

Tests:
- Replace legacy-schema refusal tests with backend-specific upgrade tests that seed a legacy interactive_questions table, verify archival into interactive_questions_pre_selection, and confirm current interactive questions can be written and survive reopen on both SQLite and PostgreSQL.