### PR TITLE
Fix offline OAuth scope validation

### DIFF
--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -576,8 +576,7 @@ def oauth_credentials_have_scopes(
 def oauth_credentials_have_required_scopes(provider: OAuthProvider, credentials: dict[str, object]) -> bool:
     """Return whether stored credentials include every provider-required scope."""
     required_scopes = set(provider.scopes)
-    refresh_token = credentials.get("refresh_token")
-    if isinstance(refresh_token, str) and refresh_token:
+    if _refresh_token_value(credentials) is not None:
         required_scopes.discard("offline_access")
     return oauth_credentials_have_scopes(credentials, required_scopes)
 

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -575,7 +575,11 @@ def oauth_credentials_have_scopes(
 
 def oauth_credentials_have_required_scopes(provider: OAuthProvider, credentials: dict[str, object]) -> bool:
     """Return whether stored credentials include every provider-required scope."""
-    return oauth_credentials_have_scopes(credentials, provider.scopes)
+    required_scopes = set(provider.scopes)
+    refresh_token = credentials.get("refresh_token")
+    if isinstance(refresh_token, str) and refresh_token:
+        required_scopes.discard("offline_access")
+    return oauth_credentials_have_scopes(credentials, required_scopes)
 
 
 def oauth_credentials_satisfy_identity_policy(

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -4299,3 +4299,11 @@ def test_required_scope_check_accepts_refresh_token_for_offline_access() -> None
         provider,
         {"scopes": ["scope.read"]},
     )
+    assert not oauth_service.oauth_credentials_have_required_scopes(
+        provider,
+        {"refresh_token": "refresh-token"},
+    )
+    assert not oauth_service.oauth_credentials_have_required_scopes(
+        provider,
+        {"scopes": ["scope.read"], "refresh_token": ""},
+    )

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -4286,3 +4286,16 @@ def test_required_scope_check_accepts_google_scope_supersets() -> None:
         sheets_provider,
         {"scope": "https://www.googleapis.com/auth/spreadsheets"},
     )
+
+
+def test_required_scope_check_accepts_refresh_token_for_offline_access() -> None:
+    provider = _fake_provider(scopes=("scope.read", "offline_access"))
+
+    assert oauth_service.oauth_credentials_have_required_scopes(
+        provider,
+        {"scopes": ["scope.read"], "refresh_token": "refresh-token"},
+    )
+    assert not oauth_service.oauth_credentials_have_required_scopes(
+        provider,
+        {"scopes": ["scope.read"]},
+    )


### PR DESCRIPTION
## Summary

- treat a non-empty refresh token as satisfying the OAuth `offline_access` pseudo-scope
- preserve strict validation for all provider resource scopes
- add regression coverage for tokens that omit `offline_access` from the echoed scope list

## Verification

- `uv run pytest tests/api/test_oauth_api.py -q`
- `uv run pre-commit run --files src/mindroom/oauth/service.py tests/api/test_oauth_api.py`

## Summary by Sourcery

Adjust OAuth required scope checking to treat a non-empty refresh token as satisfying offline access while preserving other scope validations.

Bug Fixes:
- Fix offline OAuth scope validation so credentials with a refresh token are accepted even when offline_access is not present in the echoed scopes list.

Tests:
- Add regression test ensuring offline access is considered satisfied when a refresh token is present and rejected when it is absent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth credentials with a valid refresh token are now accepted without requiring the `offline_access` scope.
  * Scope validation continues to require `offline_access` when no refresh token is available.

* **Tests**
  * Added coverage for OAuth scope validation with and without a refresh token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->