### PR TITLE
Fix GitHub repository stats and search qualifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,7 +203,8 @@ giphy = [
   "httpx>=0.27",
 ]
 github = [
-  "pygithub>=2.5",
+  # PyGithub 2.9 injects URL metadata into dictionary responses, breaking Agno's numeric language parser.
+  "pygithub>=2.5,<2.9",
 ]
 gmail = [
   "google-api-python-client>=2.178",

--- a/src/mindroom/custom_tools/github.py
+++ b/src/mindroom/custom_tools/github.py
@@ -7,6 +7,7 @@ import json
 import threading
 from contextvars import copy_context
 from functools import wraps
+from html import unescape
 from typing import TYPE_CHECKING, cast
 
 from agno.tools.github import GithubTools as AgnoGithubTools
@@ -198,6 +199,34 @@ class GithubTools(AgnoGithubTools):
 
             function.entrypoint = oauth_entrypoint
             setattr(self, function.name, oauth_entrypoint)
+
+    @wraps(AgnoGithubTools.search_issues_and_prs)
+    def search_issues_and_prs(
+        self,
+        query: str,
+        state: str | None = None,
+        type_filter: str | None = None,
+        repo: str | None = None,
+        user: str | None = None,
+        label: str | None = None,
+        sort: str = "created",
+        order: str = "desc",
+        page: int = 1,
+        per_page: int = 30,
+    ) -> str:
+        """Search for issues and pull requests while restoring escaped operators."""
+        return super().search_issues_and_prs(
+            query=unescape(query),
+            state=state,
+            type_filter=type_filter,
+            repo=repo,
+            user=user,
+            label=label,
+            sort=sort,
+            order=order,
+            page=page,
+            per_page=per_page,
+        )
 
     def authenticate(self) -> Github:
         """Build the PyGithub client without logging credential values."""

--- a/tests/test_github_oauth_tool.py
+++ b/tests/test_github_oauth_tool.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 import pytest
-from github import BadCredentialsException
+from github import BadCredentialsException, Github
 
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.credentials import (
@@ -49,6 +49,25 @@ class _FakeUser:
 class _FakeGithub:
     def get_user(self) -> _FakeUser:
         return _FakeUser()
+
+
+class _FakeIssueSearchResults:
+    totalCount = 0  # noqa: N815
+
+    def get_page(self, page: int) -> list[object]:
+        assert page == 0
+        return []
+
+
+class _SearchGithub:
+    def __init__(self) -> None:
+        self.queries: list[str] = []
+
+    def search_issues(self, query: str, *, sort: str, order: str) -> _FakeIssueSearchResults:
+        assert sort == "created"
+        assert order == "desc"
+        self.queries.append(query)
+        return _FakeIssueSearchResults()
 
 
 class _RevokedTokenGithub:
@@ -346,6 +365,38 @@ def test_base_url_is_forwarded_to_pygithub(tmp_path: Path) -> None:
 
     assert json.loads(tool.list_repositories()) == ["example/project"]
     assert captured["base_url"] == "https://github.example.test/api/v3"
+
+
+def test_pygithub_language_payload_remains_numeric_for_agno_stats() -> None:
+    client = Github(lazy=True)
+    try:
+        repo = client.get_repo("example/project", lazy=True)
+        with patch.object(
+            repo._requester,
+            "requestJson",
+            return_value=(200, {}, '{"Python": 123}'),
+        ):
+            assert repo.get_languages() == {"Python": 123}
+    finally:
+        client.close()
+
+
+def test_issue_search_decodes_html_escaped_comparison_operators(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target("@alice:example.test"),
+        access_token=MANUAL_ACCESS_TOKEN,
+    )
+    github = _SearchGithub()
+    tool.g = github
+
+    result = json.loads(tool.search_issues_and_prs("created:&gt;=2026-08-07"))
+
+    assert github.queries == ["created:>=2026-08-07"]
+    assert result["query"] == "created:>=2026-08-07"
 
 
 def test_expired_oauth_credentials_refresh_and_persist_rotation(tmp_path: Path) -> None:

--- a/tests/test_github_oauth_tool.py
+++ b/tests/test_github_oauth_tool.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import asyncio
 import json
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
@@ -25,6 +26,7 @@ from mindroom.oauth.providers import OAuthRefreshRejectedError
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target, tool_execution_identity
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
 
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, WorkerScope
@@ -68,6 +70,71 @@ class _SearchGithub:
         assert order == "desc"
         self.queries.append(query)
         return _FakeIssueSearchResults()
+
+
+class _FakePaginatedItems:
+    totalCount = 0  # noqa: N815
+
+    def __iter__(self) -> Iterator[object]:
+        return iter(())
+
+
+@dataclass(frozen=True)
+class _FakeRepoOwner:
+    login: str
+
+
+class _FakeRepositoryStats:
+    id = 1
+    name = "project"
+    full_name = "example/project"
+    owner = _FakeRepoOwner("example")
+    description = "Example repository"
+    html_url = "https://github.example.test/example/project"
+    homepage = None
+    language = "Python"
+    created_at = datetime(2026, 1, 1, tzinfo=UTC)
+    updated_at = datetime(2026, 1, 2, tzinfo=UTC)
+    pushed_at = datetime(2026, 1, 3, tzinfo=UTC)
+    size = 123
+    stargazers_count = 4
+    watchers_count = 5
+    forks_count = 6
+    open_issues_count = 7
+    default_branch = "main"
+    license = None
+    private = False
+    archived = False
+
+    def get_topics(self) -> list[str]:
+        return ["example"]
+
+    def get_languages(self) -> dict[str, int]:
+        return {"Python": 123}
+
+    def get_issues(self, *, state: str) -> list[object]:
+        assert state == "open"
+        return []
+
+    def get_pulls(
+        self,
+        *,
+        state: str,
+        sort: str | None = None,
+        direction: str | None = None,
+    ) -> _FakePaginatedItems:
+        assert state in {"all", "open"}
+        assert (sort, direction) in {(None, None), ("created", "desc")}
+        return _FakePaginatedItems()
+
+    def get_contributors(self) -> list[object]:
+        return []
+
+
+class _StatsGithub:
+    def get_repo(self, repo_name: str) -> _FakeRepositoryStats:
+        assert repo_name == "example/project"
+        return _FakeRepositoryStats()
 
 
 class _RevokedTokenGithub:
@@ -379,6 +446,30 @@ def test_pygithub_language_payload_remains_numeric_for_agno_stats() -> None:
             assert repo.get_languages() == {"Python": 123}
     finally:
         client.close()
+
+
+def test_repository_stats_consumes_numeric_language_payload(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target("@alice:example.test"),
+        access_token=MANUAL_ACCESS_TOKEN,
+    )
+    tool.g = _StatsGithub()
+
+    result = json.loads(tool.get_repository_with_stats("example/project"))
+
+    assert result["languages"] == {"Python": 123}
+    assert result["stargazers_count"] == 4
+    assert result["open_pr_count"] == 0
+    assert result["pr_metrics"] == {
+        "total_prs": 0,
+        "merged_prs": 0,
+        "acceptance_rate": 0,
+        "avg_time_to_merge": None,
+    }
 
 
 def test_issue_search_decodes_html_escaped_comparison_operators(tmp_path: Path) -> None:

--- a/tests/test_memory_chroma_scores.py
+++ b/tests/test_memory_chroma_scores.py
@@ -18,8 +18,8 @@ def _chroma_store() -> ChromaDB:
     store.insert(
         vectors=[[1.0, 0.0, 0.0], [0.8, 0.6, 0.0], [0.0, 0.0, 1.0]],
         payloads=[
-            {"data": "IonQ MindRoom COI lawyer review", "user_id": "agent_general"},
-            {"data": "IonQ hardware notes", "user_id": "agent_general"},
+            {"data": "PR review", "user_id": "agent_general"},
+            {"data": "Hardware notes", "user_id": "agent_general"},
             {"data": "unrelated grocery list", "user_id": "agent_general"},
         ],
         ids=["verbatim", "related", "unrelated"],

--- a/uv.lock
+++ b/uv.lock
@@ -4542,7 +4542,7 @@ requires-dist = [
     { name = "pydantic", marker = "extra == 'jina'", specifier = ">=2" },
     { name = "pydantic", marker = "extra == 'self-config'", specifier = ">=2" },
     { name = "pydantic-settings", specifier = ">=2.10.1" },
-    { name = "pygithub", marker = "extra == 'github'", specifier = ">=2.5" },
+    { name = "pygithub", marker = "extra == 'github'", specifier = ">=2.5,<2.9" },
     { name = "pygments", specifier = ">=2.20" },
     { name = "pyjwt", specifier = ">=2.8" },
     { name = "pyobjc-framework-applicationservices", marker = "sys_platform == 'darwin' and extra == 'desktop'", specifier = ">=12.2.1" },
@@ -7060,7 +7060,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/e1/70/c7a4f46dbf06048c6
 
 [[package]]
 name = "pygithub"
-version = "2.9.1"
+version = "2.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pyjwt", extra = ["crypto"] },
@@ -7069,9 +7069,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/c3/8465a311197e16cf5ab68789fe689535e90f6b61ab524cc32a39e67237ae/pygithub-2.9.1.tar.gz", hash = "sha256:59771d7ff63d54d427be2e7d0dad2208dfffc2b0a045fec959263787739b611c", size = 2594989, upload-time = "2026-04-14T07:26:13.622Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c1/74/e560bdeffea72ecb26cff27f0fad548bbff5ecc51d6a155311ea7f9e4c4c/pygithub-2.8.1.tar.gz", hash = "sha256:341b7c78521cb07324ff670afd1baa2bf5c286f8d9fd302c1798ba594a5400c9", size = 2246994, upload-time = "2025-09-02T17:41:54.674Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/aa/81a5506f089a26338bff17535e4339b3b22049ebd1bcdeff756c4d7a7559/pygithub-2.9.1-py3-none-any.whl", hash = "sha256:2ec78fca30092d51a42d76f4ddb02131b6f0c666a35dfdf364cf302cdda115b9", size = 449710, upload-time = "2026-04-14T07:26:12.382Z" },
+    { url = "https://files.pythonhosted.org/packages/07/ba/7049ce39f653f6140aac4beb53a5aaf08b4407b6a3019aae394c1c5244ff/pygithub-2.8.1-py3-none-any.whl", hash = "sha256:23a0a5bca93baef082e03411bf0ce27204c32be8bfa7abc92fe4a3e132936df0", size = 432709, upload-time = "2025-09-02T17:41:52.947Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- keep PyGithub on a compatible version so repository language counts remain numeric for Agno statistics
- restore HTML-escaped comparison operators before issue and pull-request searches
- add regressions for dependency response shape, repository statistics, and search qualifiers

## Testing

- uv run pytest tests/test_github_oauth_tool.py -q -n 0 --no-cov
- uv run pre-commit run --all-files
- full pytest suite: 13,780 passed; four unrelated parallel timing failures passed on serial rerun

## Summary by Sourcery

Constrain the GitHub client dependency and adjust the custom GitHub tool to keep repository stats numeric and restore proper search query operators.

New Features:
- Override the GitHub search issues and pull requests helper to decode HTML-escaped comparison operators before executing searches.

Bug Fixes:
- Ensure PyGithub version remains compatible with Agno so repository language statistics are parsed as numeric values.
- Correct issue and pull-request search behavior by unescaping HTML-escaped comparison operators in queries.
- Fix repository statistics aggregation to consume numeric language payloads without breaking derived metrics.

Build:
- Pin the PyGithub dependency below version 2.9 to avoid breaking changes in dictionary response metadata.

Tests:
- Add regression tests covering PyGithub language payload shape for Agno statistics, repository statistics consumption, and search query operator decoding.