### PR TITLE
Fix GitHub write tool result handling

### DIFF
--- a/src/mindroom/custom_tools/github.py
+++ b/src/mindroom/custom_tools/github.py
@@ -8,10 +8,10 @@ import threading
 from contextvars import copy_context
 from functools import wraps
 from html import unescape
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Protocol, cast
 
 from agno.tools.github import GithubTools as AgnoGithubTools
-from github import Auth, Github
+from github import Auth, Github, GithubException
 
 from mindroom.credentials import CredentialsManager, load_scoped_credentials
 from mindroom.logging_config import get_logger
@@ -34,6 +34,17 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 _PENDING_ACCESS_TOKEN = "mindroom-oauth-connection-pending"  # noqa: S105
+
+
+class _ContentWriteResult(Protocol):
+    path: str
+    sha: str
+    html_url: str
+
+
+class _CommitWriteResult(Protocol):
+    sha: str
+    html_url: str
 
 
 def _normalized_access_token(value: object) -> str | None:
@@ -199,6 +210,142 @@ class GithubTools(AgnoGithubTools):
 
             function.entrypoint = oauth_entrypoint
             setattr(self, function.name, oauth_entrypoint)
+
+    @wraps(AgnoGithubTools.update_file)
+    def update_file(
+        self,
+        repo_name: str,
+        path: str,
+        content: str,
+        message: str,
+        sha: str,
+        branch: str | None = None,
+    ) -> str:
+        """Update a file without requiring nested commit details in the response."""
+        try:
+            repo = self.g.get_repo(repo_name)
+            if branch is None:
+                result = repo.update_file(
+                    path=path,
+                    message=message,
+                    content=content.encode("utf-8"),
+                    sha=sha,
+                )
+            else:
+                result = repo.update_file(
+                    path=path,
+                    message=message,
+                    content=content.encode("utf-8"),
+                    sha=sha,
+                    branch=branch,
+                )
+        except GithubException as exc:
+            logger.exception("github_file_update_failed", repo_name=repo_name, path=path)
+            return json.dumps({"error": str(exc)})
+
+        content_result = cast(_ContentWriteResult, result["content"])  # noqa: TC006
+        commit_result = cast(_CommitWriteResult, result["commit"])  # noqa: TC006
+        return json.dumps(
+            {
+                "path": content_result.path,
+                "sha": content_result.sha,
+                "url": content_result.html_url,
+                "commit": {
+                    "sha": commit_result.sha,
+                    "message": message,
+                    "url": commit_result.html_url,
+                },
+            },
+            indent=2,
+        )
+
+    @wraps(AgnoGithubTools.delete_file)
+    def delete_file(
+        self,
+        repo_name: str,
+        path: str,
+        message: str,
+        sha: str,
+        branch: str | None = None,
+    ) -> str:
+        """Delete a file without requiring nested commit details in the response."""
+        try:
+            repo = self.g.get_repo(repo_name)
+            if branch is None:
+                result = repo.delete_file(path=path, message=message, sha=sha)
+            else:
+                result = repo.delete_file(path=path, message=message, sha=sha, branch=branch)
+        except GithubException as exc:
+            logger.exception("github_file_delete_failed", repo_name=repo_name, path=path)
+            return json.dumps({"error": str(exc)})
+
+        commit_result = cast(_CommitWriteResult, result["commit"])  # noqa: TC006
+        return json.dumps(
+            {
+                "message": f"File {path} deleted successfully",
+                "commit": {
+                    "sha": commit_result.sha,
+                    "message": message,
+                    "url": commit_result.html_url,
+                },
+            },
+            indent=2,
+        )
+
+    @wraps(AgnoGithubTools.edit_issue)
+    def edit_issue(
+        self,
+        repo_name: str,
+        issue_number: int,
+        title: str | None = None,
+        body: str | None = None,
+    ) -> str:
+        """Edit only explicitly supplied issue fields."""
+        if title is None and body is None:
+            return json.dumps({"error": f"Provide a title or body to update issue #{issue_number}."})
+
+        try:
+            issue = self.g.get_repo(repo_name).get_issue(number=issue_number)
+            if title is None:
+                assert body is not None
+                issue.edit(body=body)
+            elif body is None:
+                issue.edit(title=title)
+            else:
+                issue.edit(title=title, body=body)
+        except GithubException as exc:
+            logger.exception("github_issue_edit_failed", repo_name=repo_name, issue_number=issue_number)
+            return json.dumps({"error": str(exc)})
+        return json.dumps({"message": f"Issue #{issue_number} updated."}, indent=2)
+
+    @wraps(AgnoGithubTools.get_pull_request_count)
+    def get_pull_request_count(
+        self,
+        repo_name: str,
+        state: str = "all",
+        author: str | None = None,
+        base: str | None = None,
+        head: str | None = None,
+    ) -> str:
+        """Count pull requests even when PyGithub omits the aggregate count."""
+        filters = {"state": state}
+        if base is not None:
+            filters["base"] = base
+        if head is not None:
+            filters["head"] = head
+
+        try:
+            pulls = self.g.get_repo(repo_name).get_pulls(**filters)
+            if author is not None:
+                count = sum(1 for pull in pulls if pull.user.login == author and state in ("all", pull.state))
+            else:
+                count = pulls.totalCount
+                if count is None:
+                    count = sum(1 for _pull in pulls)
+        except GithubException as exc:
+            logger.exception("github_pull_request_count_failed", repo_name=repo_name)
+            return json.dumps({"error": str(exc)})
+        return json.dumps({"count": count}, indent=2)
 
     @wraps(AgnoGithubTools.search_issues_and_prs)
     def search_issues_and_prs(

--- a/tests/test_github_oauth_tool.py
+++ b/tests/test_github_oauth_tool.py
@@ -137,6 +137,104 @@ class _StatsGithub:
         return _FakeRepositoryStats()
 
 
+@dataclass(frozen=True)
+class _FakeContentWriteResult:
+    path: str = "notes.txt"
+    sha: str = "content-sha"
+    html_url: str = "https://github.example.test/example/project/blob/main/notes.txt"
+
+
+@dataclass(frozen=True)
+class _FakeCommitWriteResult:
+    sha: str = "commit-sha"
+    html_url: str = "https://github.example.test/example/project/commit/commit-sha"
+    commit: None = None
+
+
+class _FakeWriteRepository:
+    def __init__(self) -> None:
+        self.update_calls: list[dict[str, object]] = []
+        self.delete_calls: list[dict[str, object]] = []
+
+    def update_file(self, **kwargs: object) -> dict[str, object]:
+        self.update_calls.append(kwargs)
+        return {
+            "content": _FakeContentWriteResult(),
+            "commit": _FakeCommitWriteResult(),
+        }
+
+    def delete_file(self, **kwargs: object) -> dict[str, object]:
+        self.delete_calls.append(kwargs)
+        return {
+            "content": None,
+            "commit": _FakeCommitWriteResult(),
+        }
+
+
+class _WriteGithub:
+    def __init__(self) -> None:
+        self.repo = _FakeWriteRepository()
+
+    def get_repo(self, repo_name: str) -> _FakeWriteRepository:
+        assert repo_name == "example/project"
+        return self.repo
+
+
+class _FakeEditableIssue:
+    def __init__(self) -> None:
+        self.edit_calls: list[dict[str, object]] = []
+
+    def edit(self, **kwargs: object) -> None:
+        self.edit_calls.append(kwargs)
+
+
+@dataclass(frozen=True)
+class _FakePullUser:
+    login: str
+
+
+@dataclass(frozen=True)
+class _FakePull:
+    user: _FakePullUser
+    state: str
+
+
+class _FakePullsWithoutTotal:
+    totalCount = None  # noqa: N815
+
+    def __init__(self) -> None:
+        self.items = [
+            _FakePull(user=_FakePullUser("alice"), state="open"),
+            _FakePull(user=_FakePullUser("bob"), state="open"),
+        ]
+
+    def __iter__(self) -> Iterator[_FakePull]:
+        return iter(self.items)
+
+
+class _FakeIssueAndPullRepository:
+    def __init__(self) -> None:
+        self.issue = _FakeEditableIssue()
+        self.pull_calls: list[dict[str, object]] = []
+
+    def get_issue(self, *, number: int) -> _FakeEditableIssue:
+        assert number == 7
+        return self.issue
+
+    def get_pulls(self, **kwargs: object) -> _FakePullsWithoutTotal:
+        self.pull_calls.append(kwargs)
+        return _FakePullsWithoutTotal()
+
+
+class _IssueAndPullGithub:
+    def __init__(self) -> None:
+        self.repo = _FakeIssueAndPullRepository()
+
+    def get_repo(self, repo_name: str) -> _FakeIssueAndPullRepository:
+        assert repo_name == "example/project"
+        return self.repo
+
+
 class _RevokedTokenGithub:
     def get_user(self) -> _FakeUser:
         raise BadCredentialsException(401, {"message": "Bad credentials"})
@@ -488,6 +586,150 @@ def test_issue_search_decodes_html_escaped_comparison_operators(tmp_path: Path) 
 
     assert github.queries == ["created:>=2026-08-07"]
     assert result["query"] == "created:>=2026-08-07"
+
+
+def test_update_file_reports_success_without_refetching_commit_details(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target("@alice:example.test"),
+        access_token=MANUAL_ACCESS_TOKEN,
+    )
+    github = _WriteGithub()
+    tool.g = github
+
+    result = json.loads(
+        tool.update_file(
+            repo_name="example/project",
+            path="notes.txt",
+            content="updated notes",
+            message="Update notes",
+            sha="old-content-sha",
+            branch="main",
+        ),
+    )
+
+    assert github.repo.update_calls == [
+        {
+            "path": "notes.txt",
+            "message": "Update notes",
+            "content": b"updated notes",
+            "sha": "old-content-sha",
+            "branch": "main",
+        },
+    ]
+    assert result == {
+        "path": "notes.txt",
+        "sha": "content-sha",
+        "url": "https://github.example.test/example/project/blob/main/notes.txt",
+        "commit": {
+            "sha": "commit-sha",
+            "message": "Update notes",
+            "url": "https://github.example.test/example/project/commit/commit-sha",
+        },
+    }
+
+
+def test_delete_file_reports_success_without_refetching_commit_details(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target("@alice:example.test"),
+        access_token=MANUAL_ACCESS_TOKEN,
+    )
+    github = _WriteGithub()
+    tool.g = github
+
+    result = json.loads(
+        tool.delete_file(
+            repo_name="example/project",
+            path="notes.txt",
+            message="Delete notes",
+            sha="content-sha",
+            branch="main",
+        ),
+    )
+
+    assert github.repo.delete_calls == [
+        {
+            "path": "notes.txt",
+            "message": "Delete notes",
+            "sha": "content-sha",
+            "branch": "main",
+        },
+    ]
+    assert result == {
+        "message": "File notes.txt deleted successfully",
+        "commit": {
+            "sha": "commit-sha",
+            "message": "Delete notes",
+            "url": "https://github.example.test/example/project/commit/commit-sha",
+        },
+    }
+
+
+def test_edit_issue_omits_unspecified_fields(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target("@alice:example.test"),
+        access_token=MANUAL_ACCESS_TOKEN,
+    )
+    github = _IssueAndPullGithub()
+    tool.g = github
+
+    result = json.loads(
+        tool.edit_issue(
+            repo_name="example/project",
+            issue_number=7,
+            title="Updated title",
+        ),
+    )
+
+    assert github.repo.issue.edit_calls == [{"title": "Updated title"}]
+    assert result == {"message": "Issue #7 updated."}
+
+
+def test_edit_issue_rejects_empty_update(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target("@alice:example.test"),
+        access_token=MANUAL_ACCESS_TOKEN,
+    )
+    github = _IssueAndPullGithub()
+    tool.g = github
+
+    result = json.loads(tool.edit_issue(repo_name="example/project", issue_number=7))
+
+    assert result == {"error": "Provide a title or body to update issue #7."}
+    assert github.repo.issue.edit_calls == []
+
+
+def test_pull_request_count_falls_back_when_total_count_is_missing(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = _save_client_config(runtime_paths)
+    tool = _build_tool(
+        runtime_paths,
+        manager,
+        _worker_target("@alice:example.test"),
+        access_token=MANUAL_ACCESS_TOKEN,
+    )
+    github = _IssueAndPullGithub()
+    tool.g = github
+
+    result = json.loads(tool.get_pull_request_count("example/project", state="open"))
+
+    assert result == {"count": 2}
+    assert github.repo.pull_calls == [{"state": "open"}]
 
 
 def test_expired_oauth_credentials_refresh_and_persist_rotation(tmp_path: Path) -> None:

--- a/tests/test_memory_chroma_scores.py
+++ b/tests/test_memory_chroma_scores.py
@@ -30,7 +30,7 @@ def _chroma_store() -> ChromaDB:
 def _rank_with_mem0(store: ChromaDB) -> list[dict[str, object]]:
     """Run mem0's real semantic scoring gate over one verbatim-overlap query."""
     hits = store.search(
-        query="IonQ COI lawyer review",
+        query="PR review",
         vectors=[1.0, 0.0, 0.0],
         top_k=3,
         filters=_SCOPE_FILTER,
@@ -72,7 +72,7 @@ def test_wrapped_chroma_scores_return_the_verbatim_match_first() -> None:
     _install_chroma_similarity_scores(store)
 
     hits = store.search(
-        query="IonQ COI lawyer review",
+        query="PR review",
         vectors=[1.0, 0.0, 0.0],
         top_k=3,
         filters=_SCOPE_FILTER,
@@ -83,7 +83,7 @@ def test_wrapped_chroma_scores_return_the_verbatim_match_first() -> None:
 
     ranked = _rank_with_mem0(store)
     assert [entry["id"] for entry in ranked] == ["verbatim", "related"]
-    assert ranked[0]["payload"]["data"] == "IonQ MindRoom COI lawyer review"
+    assert ranked[0]["payload"]["data"] == "PR review"
 
 
 def test_install_ignores_non_chroma_stores() -> None:


### PR DESCRIPTION
## Summary

- return successful GitHub file update and delete results without dereferencing unavailable nested commit details
- omit unspecified issue fields, reject empty edits, and fall back to counting pull requests when aggregate totals are unavailable
- keep the Chroma score regression fixture and assertion consistent

## Testing

- `uv run pytest -m "not requires_matrix"` (13,745 passed, 41 skipped)
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Improve GitHub custom tools' handling of write operations and counts, and align Chroma score tests with updated query data.

Bug Fixes:
- Return successful GitHub file update and delete results without relying on nested commit details that may be unavailable.
- Ensure issue edits only update explicitly provided fields and reject empty updates with a clear error.
- Compute pull request counts robustly by falling back to iterating results when aggregate totals are missing.

Enhancements:
- Add explicit wrappers around GitHub tools for file writes, issue editing, and pull request counting with structured JSON responses.
- Introduce protocol types for GitHub write results to simplify response mapping.

Tests:
- Add unit tests covering GitHub file update/delete behavior, selective issue editing, and pull request count fallback when totals are absent.
- Update Chroma score regression fixtures and assertions to use a simpler "PR review" query and corresponding payload data.