### PR TITLE
Prevent unverifiable legacy approval actions from poisoning event-journal lanes

### DIFF
--- a/src/mindroom/approval_manager.py
+++ b/src/mindroom/approval_manager.py
@@ -64,11 +64,15 @@ logger = get_logger(__name__)
 
 
 class ToolApprovalTransportError(RuntimeError):
-    """One actionable reason an approval card cannot be delivered."""
+    """One actionable reason an approval card cannot be transported or verified."""
 
     def __init__(self, reason: str) -> None:
         super().__init__(reason)
         self.reason = reason
+
+
+class UnverifiableApprovalCardError(ToolApprovalTransportError):
+    """A legacy approval action target cannot be authenticated by Matrix."""
 
 
 def _utcnow() -> datetime:
@@ -361,11 +365,22 @@ class _ApprovalManager:
                 card_event_id=card_event_id,
             )
             if not terminal and cards is not None and self.resolve_action_delivery is not None:
-                stored = await self._bind_action_delivery(
-                    cards,
-                    room_id=room_id,
-                    card_event_id=card_event_id,
-                )
+                try:
+                    stored = await self._bind_action_delivery(
+                        cards,
+                        room_id=room_id,
+                        card_event_id=card_event_id,
+                    )
+                except UnverifiableApprovalCardError as exc:
+                    if before_consume is not None:
+                        await before_consume()
+                    logger.warning(
+                        "unverifiable_legacy_approval_action_ignored",
+                        room_id=room_id,
+                        card_event_id=card_event_id,
+                        transport_reason=exc.reason,
+                    )
+                    return ApprovalActionResult(consumed=True, resolved=False, card_event_id=card_event_id)
                 terminal = stored is None and await cards.is_terminal_approval_card(
                     room_id=room_id,
                     card_event_id=card_event_id,

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -408,8 +408,14 @@ class ApprovalMatrixTransport:
 
     async def resolve_approval_action_delivery(self, room_id: str, card_event_id: str) -> str | None:
         """Return the generic delivery ID carried by one exact visible card."""
-        bot = self.transport_bot(room_id)
-        if bot is None or bot.client is None:
+        bot = self.bot_provider(ROUTER_AGENT_NAME)
+        if bot is None:
+            msg = f"Router approval transport cannot read {room_id} to verify a card action"
+            raise approval_manager.UnverifiableApprovalCardError(msg)
+        if not bot.running or bot.client is None:
+            msg = f"Router approval transport is not ready to verify a card action in {room_id}"
+            raise ToolApprovalTransportError(msg)
+        if room_id not in bot.approval_room_ids:
             msg = f"Router approval transport cannot read {room_id} to verify a card action"
             raise approval_manager.UnverifiableApprovalCardError(msg)
         response = await bot.client.room_get_event(room_id, card_event_id)

--- a/src/mindroom/approval_transport.py
+++ b/src/mindroom/approval_transport.py
@@ -411,8 +411,14 @@ class ApprovalMatrixTransport:
         bot = self.transport_bot(room_id)
         if bot is None or bot.client is None:
             msg = f"Router approval transport cannot read {room_id} to verify a card action"
-            raise ToolApprovalTransportError(msg)
+            raise approval_manager.UnverifiableApprovalCardError(msg)
         response = await bot.client.room_get_event(room_id, card_event_id)
+        if isinstance(response, nio.RoomGetEventError) and response.status_code in {
+            "M_FORBIDDEN",
+            "M_NOT_FOUND",
+        }:
+            msg = f"Matrix cannot verify approval card {card_event_id!r}: {response}"
+            raise approval_manager.UnverifiableApprovalCardError(msg)
         if not isinstance(response, nio.RoomGetEventResponse):
             msg = f"Matrix could not verify approval card {card_event_id!r}: {response}"
             raise ToolApprovalTransportError(msg)

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -19,7 +19,7 @@ from agno.run.agent import RunOutput
 from agno.run.base import RunStatus
 from agno.tools.function import Function
 
-from mindroom import interactive
+from mindroom import approval_manager, approval_transport, interactive
 from mindroom.approval_manager import (
     initialize_approval_store,
 )
@@ -137,6 +137,23 @@ def _approval_reply_event(event_id: str = "$approval-reply") -> nio.RoomMessageT
         },
     )
     assert isinstance(event, nio.RoomMessageText)
+    return event
+
+
+def _approval_action_event(event_id: str, *, status: str) -> nio.UnknownEvent:
+    event = nio.UnknownEvent.from_dict(
+        {
+            "type": "io.mindroom.tool_approval_response",
+            "sender": "@user:localhost",
+            "event_id": event_id,
+            "origin_server_ts": 1,
+            "content": {
+                "status": status,
+                "m.relates_to": {"m.in_reply_to": {"event_id": "$approval"}},
+            },
+        },
+    )
+    assert isinstance(event, nio.UnknownEvent)
     return event
 
 
@@ -1809,6 +1826,67 @@ class TestAgentBot(AgentBotTestBase):
             await bot._on_unknown_event(room, event)
 
         handle_matrix_approval_action.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unverifiable_legacy_approval_action_does_not_block_later_room_events(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A terminal ignored legacy action settles before the room lane advances."""
+        config = self._config_for_storage(tmp_path)
+        runtime_paths = runtime_paths_for(config)
+        bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        room = nio.MatrixRoom("!test:localhost", bot.matrix_id.full_id)
+        cards = bot._journal_store.principal("router@shared")
+        transport = approval_transport.ApprovalMatrixTransport(
+            runtime_paths=runtime_paths,
+            bot_provider=lambda _name: None,
+            cards_provider=lambda: cards,
+        )
+        manager = initialize_approval_store(
+            runtime_paths,
+            cards=cards,
+            resolve_action_delivery=transport.resolve_approval_action_delivery,
+        )
+        dispatched: list[str] = []
+        on_approval = bot._journal_dispatcher.callbacks.on_approval
+
+        async def record_dispatch(dispatch_room: nio.MatrixRoom, event: nio.UnknownEvent) -> None:
+            dispatched.append(event.event_id)
+            await on_approval(dispatch_room, event)
+
+        bot._journal_dispatcher.callbacks = replace(
+            bot._journal_dispatcher.callbacks,
+            on_approval=record_dispatch,
+        )
+        ignored = _approval_action_event("$legacy-action", status="approved")
+        later = _approval_action_event("$later-action", status="invalid")
+
+        try:
+            with patch.object(approval_manager.logger, "warning") as warning:
+                await bot._journal_dispatcher.admit_out_of_band(
+                    room,
+                    ignored,
+                    EventKind.APPROVAL,
+                    EventClass.ACTIONABLE,
+                )
+                await bot._journal_dispatcher.admit_out_of_band(
+                    room,
+                    later,
+                    EventKind.APPROVAL,
+                    EventClass.ACTIONABLE,
+                )
+                await bot._journal_dispatcher.drain_once()
+            await _cancel_dispatch_retry(bot)
+        finally:
+            await manager.shutdown()
+            await shutdown_approval_runtime()
+
+        assert dispatched == [ignored.event_id, later.event_id]
+        assert await bot._journal_dispatcher.store.pending() == ()
+        warning.assert_called_once()
+        assert warning.call_args.args == ("unverifiable_legacy_approval_action_ignored",)
 
     @pytest.mark.asyncio
     async def test_interrupted_approval_reply_replay_cannot_become_ai_input(

--- a/tests/test_bot_reactions_approvals.py
+++ b/tests/test_bot_reactions_approvals.py
@@ -1838,32 +1838,32 @@ class TestAgentBot(AgentBotTestBase):
         runtime_paths = runtime_paths_for(config)
         bot = AgentBot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
         room = nio.MatrixRoom("!test:localhost", bot.matrix_id.full_id)
-        cards = bot._journal_store.principal("router@shared")
-        transport = approval_transport.ApprovalMatrixTransport(
-            runtime_paths=runtime_paths,
-            bot_provider=lambda _name: None,
-            cards_provider=lambda: cards,
-        )
-        manager = initialize_approval_store(
-            runtime_paths,
-            cards=cards,
-            resolve_action_delivery=transport.resolve_approval_action_delivery,
-        )
         dispatched: list[str] = []
-        on_approval = bot._journal_dispatcher.callbacks.on_approval
-
-        async def record_dispatch(dispatch_room: nio.MatrixRoom, event: nio.UnknownEvent) -> None:
-            dispatched.append(event.event_id)
-            await on_approval(dispatch_room, event)
-
-        bot._journal_dispatcher.callbacks = replace(
-            bot._journal_dispatcher.callbacks,
-            on_approval=record_dispatch,
-        )
-        ignored = _approval_action_event("$legacy-action", status="approved")
-        later = _approval_action_event("$later-action", status="invalid")
 
         try:
+            cards = bot._journal_store.principal("router@shared")
+            transport = approval_transport.ApprovalMatrixTransport(
+                runtime_paths=runtime_paths,
+                bot_provider=lambda _name: None,
+                cards_provider=lambda: cards,
+            )
+            initialize_approval_store(
+                runtime_paths,
+                cards=cards,
+                resolve_action_delivery=transport.resolve_approval_action_delivery,
+            )
+            on_approval = bot._journal_dispatcher.callbacks.on_approval
+
+            async def record_dispatch(dispatch_room: nio.MatrixRoom, event: nio.UnknownEvent) -> None:
+                dispatched.append(event.event_id)
+                await on_approval(dispatch_room, event)
+
+            bot._journal_dispatcher.callbacks = replace(
+                bot._journal_dispatcher.callbacks,
+                on_approval=record_dispatch,
+            )
+            ignored = _approval_action_event("$legacy-action", status="approved")
+            later = _approval_action_event("$later-action", status="invalid")
             with patch.object(approval_manager.logger, "warning") as warning:
                 await bot._journal_dispatcher.admit_out_of_band(
                     room,
@@ -1878,10 +1878,11 @@ class TestAgentBot(AgentBotTestBase):
                     EventClass.ACTIONABLE,
                 )
                 await bot._journal_dispatcher.drain_once()
-            await _cancel_dispatch_retry(bot)
         finally:
-            await manager.shutdown()
-            await shutdown_approval_runtime()
+            try:
+                await _cancel_dispatch_retry(bot)
+            finally:
+                await shutdown_approval_runtime()
 
         assert dispatched == [ignored.event_id, later.event_id]
         assert await bot._journal_dispatcher.store.pending() == ()

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -383,6 +383,54 @@ async def test_legacy_action_without_router_transport_is_ignored(tmp_path: Path)
     }
 
 
+@pytest.mark.asyncio
+async def test_legacy_action_retries_while_router_transport_is_starting(tmp_path: Path) -> None:
+    """An existing router without a live client is not a terminal verification result."""
+    cards = MagicMock()
+    cards.pending_approval_card = AsyncMock(return_value=None)
+    cards.is_terminal_approval_card = AsyncMock(return_value=False)
+    cards.resolve_continuation_approval_card = AsyncMock()
+    cards.acknowledge_matrix_delivery = AsyncMock()
+    router = MagicMock(
+        agent_name="router",
+        running=False,
+        client=None,
+        approval_room_ids=frozenset({"!room:localhost"}),
+    )
+    transport = approval_transport.ApprovalMatrixTransport(
+        runtime_paths=test_runtime_paths(tmp_path),
+        bot_provider=lambda name: router if name == "router" else None,
+        cards_provider=lambda: cards,
+    )
+    manager = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        cards=cards,
+        resolve_action_delivery=transport.resolve_approval_action_delivery,
+    )
+    before_consume = AsyncMock()
+
+    try:
+        with (
+            patch("mindroom.approval_manager.logger.warning") as warning,
+            pytest.raises(ToolApprovalTransportError, match="not ready"),
+        ):
+            await manager.handle_card_response(
+                room_id="!room:localhost",
+                sender_id="@approver:localhost",
+                card_event_id="$approval",
+                status="approved",
+                reason=None,
+                before_consume=before_consume,
+            )
+    finally:
+        await manager.shutdown()
+
+    before_consume.assert_not_awaited()
+    cards.resolve_continuation_approval_card.assert_not_awaited()
+    cards.acknowledge_matrix_delivery.assert_not_awaited()
+    warning.assert_not_called()
+
+
 @pytest.mark.parametrize("error_code", ["M_FORBIDDEN", "M_NOT_FOUND"])
 @pytest.mark.asyncio
 async def test_legacy_action_for_unreadable_room_is_ignored(tmp_path: Path, error_code: str) -> None:

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -383,8 +383,9 @@ async def test_legacy_action_without_router_transport_is_ignored(tmp_path: Path)
     }
 
 
+@pytest.mark.parametrize("error_code", ["M_FORBIDDEN", "M_NOT_FOUND"])
 @pytest.mark.asyncio
-async def test_legacy_action_for_unreadable_room_is_ignored(tmp_path: Path) -> None:
+async def test_legacy_action_for_unreadable_room_is_ignored(tmp_path: Path, error_code: str) -> None:
     """A definitive Matrix refusal cannot make an unregistered action retry forever."""
     cards = MagicMock()
     cards.pending_approval_card = AsyncMock(return_value=None)
@@ -394,7 +395,7 @@ async def test_legacy_action_for_unreadable_room_is_ignored(tmp_path: Path) -> N
     client = MagicMock(
         user_id="@mindroom_router:localhost",
         room_get_event=AsyncMock(
-            return_value=nio.RoomGetEventError("not joined", status_code="M_FORBIDDEN"),
+            return_value=nio.RoomGetEventError("unavailable", status_code=error_code),
         ),
     )
     router = MagicMock(
@@ -437,7 +438,7 @@ async def test_legacy_action_for_unreadable_room_is_ignored(tmp_path: Path) -> N
     assert warning.call_args.args == ("unverifiable_legacy_approval_action_ignored",)
     assert warning.call_args.kwargs["room_id"] == "!room:localhost"
     assert warning.call_args.kwargs["card_event_id"] == "$approval"
-    assert "M_FORBIDDEN" in warning.call_args.kwargs["transport_reason"]
+    assert error_code in warning.call_args.kwargs["transport_reason"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_approval.py
+++ b/tests/test_tool_approval.py
@@ -47,6 +47,7 @@ from mindroom.matrix.message_builder import build_message_content
 from mindroom.tool_approval import (
     MatrixApprovalAction,
     ToolApprovalScriptError,
+    ToolApprovalTransportError,
     evaluate_tool_approval,
     handle_matrix_approval_action,
     resolve_tool_approval_approver,
@@ -333,6 +334,168 @@ async def test_action_delivery_resolver_retries_an_unreadable_exact_card(tmp_pat
 
     with pytest.raises(approval_transport.ToolApprovalTransportError, match="could not verify"):
         await transport.resolve_approval_action_delivery("!room:localhost", "$approval")
+
+
+@pytest.mark.asyncio
+async def test_legacy_action_without_router_transport_is_ignored(tmp_path: Path) -> None:
+    """An unverifiable pre-registry card cannot retain an event-journal lane forever."""
+    cards = MagicMock()
+    cards.pending_approval_card = AsyncMock(return_value=None)
+    cards.is_terminal_approval_card = AsyncMock(return_value=False)
+    cards.resolve_continuation_approval_card = AsyncMock()
+    cards.acknowledge_matrix_delivery = AsyncMock()
+    transport = approval_transport.ApprovalMatrixTransport(
+        runtime_paths=test_runtime_paths(tmp_path),
+        bot_provider=lambda _name: None,
+        cards_provider=lambda: cards,
+    )
+    manager = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        cards=cards,
+        resolve_action_delivery=transport.resolve_approval_action_delivery,
+    )
+    before_consume = AsyncMock()
+
+    try:
+        with patch("mindroom.approval_manager.logger.warning") as warning:
+            result = await manager.handle_card_response(
+                room_id="!room:localhost",
+                sender_id="@approver:localhost",
+                card_event_id="$approval",
+                status="approved",
+                reason=None,
+                before_consume=before_consume,
+            )
+    finally:
+        await manager.shutdown()
+
+    assert result.consumed is True
+    assert result.resolved is False
+    before_consume.assert_awaited_once_with()
+    cards.resolve_continuation_approval_card.assert_not_awaited()
+    cards.acknowledge_matrix_delivery.assert_not_awaited()
+    warning.assert_called_once()
+    assert warning.call_args.args == ("unverifiable_legacy_approval_action_ignored",)
+    assert warning.call_args.kwargs == {
+        "room_id": "!room:localhost",
+        "card_event_id": "$approval",
+        "transport_reason": "Router approval transport cannot read !room:localhost to verify a card action",
+    }
+
+
+@pytest.mark.asyncio
+async def test_legacy_action_for_unreadable_room_is_ignored(tmp_path: Path) -> None:
+    """A definitive Matrix refusal cannot make an unregistered action retry forever."""
+    cards = MagicMock()
+    cards.pending_approval_card = AsyncMock(return_value=None)
+    cards.is_terminal_approval_card = AsyncMock(return_value=False)
+    cards.resolve_continuation_approval_card = AsyncMock()
+    cards.acknowledge_matrix_delivery = AsyncMock()
+    client = MagicMock(
+        user_id="@mindroom_router:localhost",
+        room_get_event=AsyncMock(
+            return_value=nio.RoomGetEventError("not joined", status_code="M_FORBIDDEN"),
+        ),
+    )
+    router = MagicMock(
+        agent_name="router",
+        running=True,
+        client=client,
+        approval_room_ids=frozenset({"!room:localhost"}),
+    )
+    transport = approval_transport.ApprovalMatrixTransport(
+        runtime_paths=test_runtime_paths(tmp_path),
+        bot_provider=lambda name: router if name == "router" else None,
+        cards_provider=lambda: cards,
+    )
+    manager = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        cards=cards,
+        resolve_action_delivery=transport.resolve_approval_action_delivery,
+    )
+    before_consume = AsyncMock()
+
+    try:
+        with patch("mindroom.approval_manager.logger.warning") as warning:
+            result = await manager.handle_card_response(
+                room_id="!room:localhost",
+                sender_id="@approver:localhost",
+                card_event_id="$approval",
+                status="denied",
+                reason="No",
+                before_consume=before_consume,
+            )
+    finally:
+        await manager.shutdown()
+
+    assert result.consumed is True
+    assert result.resolved is False
+    before_consume.assert_awaited_once_with()
+    cards.resolve_continuation_approval_card.assert_not_awaited()
+    cards.acknowledge_matrix_delivery.assert_not_awaited()
+    warning.assert_called_once()
+    assert warning.call_args.args == ("unverifiable_legacy_approval_action_ignored",)
+    assert warning.call_args.kwargs["room_id"] == "!room:localhost"
+    assert warning.call_args.kwargs["card_event_id"] == "$approval"
+    assert "M_FORBIDDEN" in warning.call_args.kwargs["transport_reason"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_action_retries_a_transient_transport_failure(tmp_path: Path) -> None:
+    """A temporary Matrix read failure must leave the source available for replay."""
+    cards = MagicMock()
+    cards.pending_approval_card = AsyncMock(return_value=None)
+    cards.is_terminal_approval_card = AsyncMock(return_value=False)
+    cards.resolve_continuation_approval_card = AsyncMock()
+    cards.acknowledge_matrix_delivery = AsyncMock()
+    client = MagicMock(
+        user_id="@mindroom_router:localhost",
+        room_get_event=AsyncMock(
+            return_value=nio.RoomGetEventError(
+                "temporarily unavailable",
+                status_code="M_LIMIT_EXCEEDED",
+                retry_after_ms=1_000,
+            ),
+        ),
+    )
+    router = MagicMock(
+        agent_name="router",
+        running=True,
+        client=client,
+        approval_room_ids=frozenset({"!room:localhost"}),
+    )
+    transport = approval_transport.ApprovalMatrixTransport(
+        runtime_paths=test_runtime_paths(tmp_path),
+        bot_provider=lambda name: router if name == "router" else None,
+        cards_provider=lambda: cards,
+    )
+    manager = _ApprovalManager(
+        test_runtime_paths(tmp_path),
+        cards=cards,
+        resolve_action_delivery=transport.resolve_approval_action_delivery,
+    )
+    before_consume = AsyncMock()
+
+    try:
+        with (
+            patch("mindroom.approval_manager.logger.warning") as warning,
+            pytest.raises(ToolApprovalTransportError, match="could not verify"),
+        ):
+            await manager.handle_card_response(
+                room_id="!room:localhost",
+                sender_id="@approver:localhost",
+                card_event_id="$approval",
+                status="approved",
+                reason=None,
+                before_consume=before_consume,
+            )
+    finally:
+        await manager.shutdown()
+
+    before_consume.assert_not_awaited()
+    cards.resolve_continuation_approval_card.assert_not_awaited()
+    cards.acknowledge_matrix_delivery.assert_not_awaited()
+    warning.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- distinguish terminal legacy-card verification failures from retryable transport failures
- consume unverifiable unregistered actions without applying an approval decision
- emit one structured warning and allow later journal work to continue
- preserve registered-card behavior and transient retries

## Root cause

Legacy action recovery attempted to bind a visible card to durable delivery state before deciding it.
When the card had no durable record and Matrix could not verify the target, the generic transport error escaped the completing journal callback and kept the lane pending.

## Verification

- focused legacy-action manager regressions
- journal-lane settlement and later-dispatch regression
- full approval manager and bot suites
- full journal ingress and store suites
- repository pre-commit hooks

## Summary by Sourcery

Prevent unverifiable legacy approval actions from blocking event-journal lanes by correctly classifying Matrix transport failures and handling unverifiable legacy cards as ignorable terminal cases.

Bug Fixes:
- Ensure legacy approval actions without a verifiable Matrix card do not keep journal lanes pending indefinitely.
- Treat definitive Matrix refusals for unreadable or missing rooms as terminal unverifiable legacy actions instead of retryable transport errors.
- Preserve retry behavior for transient Matrix transport failures while avoiding lane poisoning for legacy actions.

Enhancements:
- Introduce a dedicated error type for unverifiable approval cards to distinguish them from generic transport failures.
- Log a structured warning when a legacy approval action is ignored so later journal work can safely continue.

Tests:
- Add approval manager tests covering ignored unverifiable legacy actions, transient transport retry behavior, and associated logging.
- Add bot reaction tests to verify that ignored legacy approval actions settle cleanly and do not block subsequent room events from being dispatched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy approval actions with unverifiable cards are now safely consumed without blocking subsequent approval events.
  * Definitive verification failures are logged and handled without incorrectly resolving or acknowledging approval cards.
  * Transient transport failures remain retryable.
* **Tests**
  * Added regression coverage for unverifiable approval cards, event processing, pending entries, logging, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->