### PR TITLE
Preserve hook-created invited rooms during cleanup

### DIFF
--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -205,6 +205,14 @@ class BotRoomLifecycle:
             return set()
         return load_invited_rooms(self._invited_rooms_file_path())
 
+    def _refresh_invited_rooms(self) -> None:
+        """Merge durable rooms written by other runtime components into memory."""
+        if not self._should_persist_invited_rooms():
+            return
+        room_ids = load_invited_rooms(self._invited_rooms_file_path()) | self.invited_rooms
+        room_ids.difference_update(self._pending_forgotten_invited_rooms)
+        self.invited_rooms = room_ids
+
     def forget_invited_room(self, room_id: str) -> None:
         """Stop preserving an ad-hoc room after this bot leaves it."""
         if not self._should_persist_invited_rooms():
@@ -287,6 +295,7 @@ class BotRoomLifecycle:
         current_rooms = set(joined_rooms)
         configured_rooms = set(self.deps.get_configured_rooms())
         if self._should_persist_invited_rooms():
+            self._refresh_invited_rooms()
             configured_rooms.update(self.invited_rooms)
         if self.deps.agent_name == ROUTER_AGENT_NAME:
             root_space_id = matrix_state_for_runtime(self.deps.runtime_paths).space_room_id

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -205,11 +205,12 @@ class BotRoomLifecycle:
             return set()
         return load_invited_rooms(self._invited_rooms_file_path())
 
-    def _refresh_invited_rooms(self) -> None:
+    async def _refresh_invited_rooms(self) -> None:
         """Merge durable rooms written by other runtime components into memory."""
         if not self._should_persist_invited_rooms():
             return
-        room_ids = load_invited_rooms(self._invited_rooms_file_path()) | self.invited_rooms
+        durable_rooms = await asyncio.to_thread(load_invited_rooms, self._invited_rooms_file_path())
+        room_ids = durable_rooms | self.invited_rooms
         room_ids.difference_update(self._pending_forgotten_invited_rooms)
         self.invited_rooms = room_ids
 
@@ -295,7 +296,7 @@ class BotRoomLifecycle:
         current_rooms = set(joined_rooms)
         configured_rooms = set(self.deps.get_configured_rooms())
         if self._should_persist_invited_rooms():
-            self._refresh_invited_rooms()
+            await self._refresh_invited_rooms()
             configured_rooms.update(self.invited_rooms)
         if self.deps.agent_name == ROUTER_AGENT_NAME:
             root_space_id = matrix_state_for_runtime(self.deps.runtime_paths).space_room_id

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -7,6 +7,7 @@ memberships. This test module verifies that behavior.
 from __future__ import annotations
 
 import asyncio
+import threading
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
@@ -23,7 +24,7 @@ from mindroom.config.models import RouterConfig
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.hooks.matrix_admin import build_hook_matrix_admin
 from mindroom.matrix.client_room_admin import RoomJoinOutcome
-from mindroom.matrix.invited_rooms_store import invited_rooms_path, save_invited_rooms
+from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms, save_invited_rooms
 from mindroom.matrix.room_cleanup import cleanup_all_orphaned_bots
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser
@@ -685,6 +686,42 @@ async def test_router_cleanup_preserves_room_created_after_lifecycle_loaded(
 
     assert bot._room_lifecycle.invited_rooms == {"!hook-created:localhost"}
     assert left_room_ids == ["!stale:localhost"]
+
+
+@pytest.mark.asyncio
+async def test_router_cleanup_loads_invited_rooms_off_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Durable refresh must not perform file I/O on the event-loop thread."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot.client = AsyncMock()
+    event_loop_thread_id = threading.get_ident()
+    load_thread_ids: list[int] = []
+
+    def record_load_thread(path: Path) -> set[str]:
+        load_thread_ids.append(threading.get_ident())
+        return load_invited_rooms(path)
+
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.load_invited_rooms", record_load_thread)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.get_joined_rooms", AsyncMock(return_value=[]))
+    monkeypatch.setattr(
+        "mindroom.bot_room_lifecycle.matrix_state_for_runtime",
+        lambda *_args, **_kwargs: MatrixState(),
+    )
+
+    assert await bot._room_lifecycle._rooms_to_leave() == []
+    assert len(load_thread_ids) == 1
+    assert load_thread_ids[0] != event_loop_thread_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -624,6 +624,70 @@ async def test_router_invite_preserves_room_created_after_lifecycle_loaded(
 
 
 @pytest.mark.asyncio
+async def test_router_cleanup_preserves_room_created_after_lifecycle_loaded(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cleanup must refresh rooms persisted by hooks after lifecycle construction."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = AgentBot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    install_runtime_journal_support(bot)
+    bot.client = AsyncMock()
+
+    creator_client = AsyncMock(spec=nio.AsyncClient)
+    creator_client.homeserver = "http://localhost:8008"
+    creator_client.user_id = bot.agent_user.user_id
+    with monkeypatch.context() as patch_context:
+        patch_context.setattr(
+            "mindroom.hooks.matrix_admin.create_room",
+            AsyncMock(return_value="!hook-created:localhost"),
+        )
+        admin = build_hook_matrix_admin(
+            creator_client,
+            runtime_paths_for(config),
+            config=config,
+        )
+        await admin.create_room(name="Hook-created room")
+
+    assert bot._room_lifecycle.invited_rooms == set()
+
+    left_room_ids: list[str] = []
+
+    async def record_rooms_to_leave(
+        _client: AsyncMock,
+        room_ids: list[str],
+        *,
+        on_room_left: Callable[[str], Awaitable[None]],
+    ) -> list[str]:
+        del on_room_left
+        left_room_ids.extend(room_ids)
+        return room_ids
+
+    monkeypatch.setattr(
+        "mindroom.bot_room_lifecycle.get_joined_rooms",
+        AsyncMock(return_value=["!hook-created:localhost", "!stale:localhost"]),
+    )
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.leave_non_dm_rooms", record_rooms_to_leave)
+    monkeypatch.setattr(
+        "mindroom.bot_room_lifecycle.matrix_state_for_runtime",
+        lambda *_args, **_kwargs: MatrixState(),
+    )
+
+    await bot.leave_unconfigured_rooms()
+
+    assert bot._room_lifecycle.invited_rooms == {"!hook-created:localhost"}
+    assert left_room_ids == ["!stale:localhost"]
+
+
+@pytest.mark.asyncio
 async def test_router_invite_keeps_memory_after_transient_persistence_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -869,6 +933,44 @@ def test_agent_retries_failed_persisted_invited_room_forget(
         runtime_paths=runtime_paths_for(config),
     )
     assert restarted._room_lifecycle.invited_rooms == set()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_does_not_resurrect_room_pending_durable_forget(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed durable forget must still make the departed room eligible for cleanup."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    invited_path = _invited_rooms_path(config, ROUTER_AGENT_NAME)
+    invited_path.parent.mkdir(parents=True, exist_ok=True)
+    invited_path.write_text('[\n  "!departed:localhost"\n]\n', encoding="utf-8")
+    bot = AgentBot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot.client = AsyncMock()
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.save_invited_rooms", lambda *_args: False)
+
+    with pytest.raises(OSError, match="Failed to forget invited room"):
+        bot._room_lifecycle.forget_invited_room("!departed:localhost")
+
+    monkeypatch.setattr(
+        "mindroom.bot_room_lifecycle.get_joined_rooms",
+        AsyncMock(return_value=["!departed:localhost"]),
+    )
+    monkeypatch.setattr(
+        "mindroom.bot_room_lifecycle.matrix_state_for_runtime",
+        lambda *_args, **_kwargs: MatrixState(),
+    )
+
+    assert await bot._room_lifecycle._rooms_to_leave() == ["!departed:localhost"]
+    assert bot._room_lifecycle.invited_rooms == set()
 
 
 def test_nonpersisting_agent_forget_clears_in_memory_room(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- refresh persisted invited-room state before destructive membership cleanup
- keep pending durable forgets excluded while merging fresh state
- cover rooms persisted by hooks after lifecycle construction

## Root cause

Room lifecycle state was loaded once during bot construction. A hook could persist a newly created room afterward, leaving cleanup with a stale in-memory set and allowing it to leave a room that had already been recorded for preservation.

## Verification

- red-green regression for hook-created rooms
- pending durable-forget regression
- `uv run pytest tests/test_room_invites.py -q`
- `uv run pre-commit run --files src/mindroom/bot_room_lifecycle.py tests/test_room_invites.py`
- `uv run pytest -q --timeout=120`

## Summary by Sourcery

Ensure room cleanup respects invited rooms persisted after lifecycle initialization and handles rooms pending durable forget correctly.

New Features:
- Support refreshing in-memory invited-room state from durable storage before membership cleanup.

Bug Fixes:
- Prevent cleanup from leaving rooms that were newly persisted for preservation by hooks after lifecycle construction.
- Ensure rooms that failed durable forget remain eligible for cleanup instead of being resurrected as preserved rooms.

Tests:
- Add regression tests covering hook-created rooms persisted after lifecycle load and rooms pending durable forget during cleanup.