### PR TITLE
Fix merged room invite tests

### DIFF
--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -633,7 +633,7 @@ async def test_router_cleanup_preserves_room_created_after_lifecycle_loaded(
         Config(router=RouterConfig(model="default", accept_invites=True)),
         test_runtime_paths(tmp_path),
     )
-    bot = AgentBot(
+    bot = make_test_agent_bot(
         agent_user=_router_user(),
         storage_path=tmp_path,
         config=config,
@@ -697,7 +697,7 @@ async def test_router_cleanup_loads_invited_rooms_off_event_loop(
         Config(router=RouterConfig(model="default", accept_invites=True)),
         test_runtime_paths(tmp_path),
     )
-    bot = AgentBot(
+    bot = make_test_agent_bot(
         agent_user=_router_user(),
         storage_path=tmp_path,
         config=config,
@@ -990,7 +990,7 @@ async def test_cleanup_does_not_resurrect_room_pending_durable_forget(
     invited_path = _invited_rooms_path(config, ROUTER_AGENT_NAME)
     invited_path.parent.mkdir(parents=True, exist_ok=True)
     invited_path.write_text('[\n  "!departed:localhost"\n]\n', encoding="utf-8")
-    bot = AgentBot(
+    bot = make_test_agent_bot(
         agent_user=_router_user(),
         storage_path=tmp_path,
         config=config,


### PR DESCRIPTION
## Summary

- switch three newly merged room-invite tests to the canonical `make_test_agent_bot` helper
- preserve all test behavior and assertions
- avoid restoring the direct `AgentBot` import removed from `main`

## Cause

PR #1848's own head passed CI. Its squash merge landed after `main` removed the old direct `AgentBot` test import, while three new tests still constructed `AgentBot` directly. This is a merge-only test integration bug, not evidence of a runtime failure.

Deployment remains gated on staging validation.

## Verification

- red: three focused tests failed with `NameError: name 'AgentBot' is not defined`
- green: same three focused tests passed
- `uv run pre-commit run --all-files`
- `uv run pytest -m "not requires_matrix" -q`

## Summary by Sourcery

Tests:
- Update three room invite tests to construct bots via make_test_agent_bot instead of direct AgentBot instantiation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated room-invite test setup to use the standard test bot creation process.
  * No user-facing behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->