### PR TITLE
Fix scheduled todo poke sender selection

### DIFF
--- a/src/mindroom/custom_tools/todo_poke.py
+++ b/src/mindroom/custom_tools/todo_poke.py
@@ -43,7 +43,7 @@ __all__ = [
 ]
 
 type _TodoScheduleQuery = Callable[[str, tuple[str, ...]], Awaitable[frozenset[str | None] | None]]
-type _TodoPokeSender = Callable[[str, str, str, str | None], Awaitable[str | None]]
+type _TodoPokeSender = Callable[[tuple[str, ...], str, str, str | None], Awaitable[str | None]]
 type _StateWarningKey = tuple[str, str]
 
 _VALID_STATUSES = {"open", *TERMINAL_STATUSES}
@@ -536,14 +536,11 @@ def _period_elapsed(now_timestamp: float, previous_timestamp: float, period_seco
 async def _pending_schedules_by_room(
     scopes: list[_TodoPokeScope],
     schedule_query: _TodoScheduleQuery,
-) -> dict[str, frozenset[str | None]] | None:
+) -> dict[str, frozenset[str | None]]:
     pending_by_room: dict[str, frozenset[str | None]] = {}
-    query_agents_by_room: dict[str, set[str]] = {}
-    for scope in scopes:
-        query_agents_by_room.setdefault(scope.room_id, set()).add(scope.assigned_agent)
-    for room_id, agent_names in sorted(query_agents_by_room.items()):
+    for room_id, agent_names in sorted(_agent_names_by_room(scopes).items()):
         try:
-            pending_threads = await schedule_query(room_id, tuple(sorted(agent_names)))
+            pending_threads = await schedule_query(room_id, agent_names)
         except Exception as exc:
             logger.warning(
                 "todo_poke_schedule_query_failed",
@@ -554,9 +551,16 @@ async def _pending_schedules_by_room(
             pending_threads = frozenset()
         if pending_threads is None:
             logger.debug("todo_poke_scan_skipped_runtime_unavailable", room_id=room_id)
-            return None
+            continue
         pending_by_room[room_id] = pending_threads
     return pending_by_room
+
+
+def _agent_names_by_room(scopes: list[_TodoPokeScope]) -> dict[str, tuple[str, ...]]:
+    names_by_room: dict[str, set[str]] = {}
+    for scope in scopes:
+        names_by_room.setdefault(scope.room_id, set()).add(scope.assigned_agent)
+    return {room_id: tuple(sorted(agent_names)) for room_id, agent_names in names_by_room.items()}
 
 
 def _dedup_allows_poke(
@@ -619,19 +623,21 @@ async def _deliver_pokes(
     delivered = 0
     attempts = 0
     poked_agents: set[str] = set()
+    agent_names_by_room = _agent_names_by_room(scopes)
     for scope in scopes:
         if attempts >= policy.max_pokes_per_scan:
             break
         if scope.assigned_agent in poked_agents:
             continue
-        if scope.thread_id in pending_by_room[scope.room_id]:
+        pending_threads = pending_by_room.get(scope.room_id)
+        if pending_threads is None or scope.thread_id in pending_threads:
             continue
 
         attempts += 1
         scope_key = _scope_key(scope)
         previous = session_poke_records.get(scope_key) or _poke_record(poke_state, scope)
         event_id = await deps.sender(
-            scope.assigned_agent,
+            agent_names_by_room[scope.room_id],
             scope.room_id,
             _format_poke_message(scope),
             scope.thread_id,
@@ -686,8 +692,6 @@ async def scan_todo_pokes(
         return 0
 
     pending_by_room = await _pending_schedules_by_room(scopes, deps.schedule_query)
-    if pending_by_room is None:
-        return 0
 
     return await _deliver_pokes(
         scopes,

--- a/src/mindroom/custom_tools/todo_poke.py
+++ b/src/mindroom/custom_tools/todo_poke.py
@@ -42,7 +42,7 @@ __all__ = [
     "todo_poke_policy",
 ]
 
-type _TodoScheduleQuery = Callable[[str, str], Awaitable[frozenset[str | None] | None]]
+type _TodoScheduleQuery = Callable[[str, tuple[str, ...]], Awaitable[frozenset[str | None] | None]]
 type _TodoPokeSender = Callable[[str, str, str, str | None], Awaitable[str | None]]
 type _StateWarningKey = tuple[str, str]
 
@@ -538,12 +538,12 @@ async def _pending_schedules_by_room(
     schedule_query: _TodoScheduleQuery,
 ) -> dict[str, frozenset[str | None]] | None:
     pending_by_room: dict[str, frozenset[str | None]] = {}
-    query_agent_by_room: dict[str, str] = {}
+    query_agents_by_room: dict[str, set[str]] = {}
     for scope in scopes:
-        query_agent_by_room.setdefault(scope.room_id, scope.assigned_agent)
-    for room_id, agent_name in sorted(query_agent_by_room.items()):
+        query_agents_by_room.setdefault(scope.room_id, set()).add(scope.assigned_agent)
+    for room_id, agent_names in sorted(query_agents_by_room.items()):
         try:
-            pending_threads = await schedule_query(agent_name, room_id)
+            pending_threads = await schedule_query(room_id, tuple(sorted(agent_names)))
         except Exception as exc:
             logger.warning(
                 "todo_poke_schedule_query_failed",

--- a/src/mindroom/custom_tools/todo_poke.py
+++ b/src/mindroom/custom_tools/todo_poke.py
@@ -42,8 +42,8 @@ __all__ = [
     "todo_poke_policy",
 ]
 
-type _TodoScheduleQuery = Callable[[str], Awaitable[frozenset[str | None] | None]]
-type _TodoPokeSender = Callable[[str, str, str | None], Awaitable[str | None]]
+type _TodoScheduleQuery = Callable[[str, str], Awaitable[frozenset[str | None] | None]]
+type _TodoPokeSender = Callable[[str, str, str, str | None], Awaitable[str | None]]
 type _StateWarningKey = tuple[str, str]
 
 _VALID_STATUSES = {"open", *TERMINAL_STATUSES}
@@ -538,9 +538,12 @@ async def _pending_schedules_by_room(
     schedule_query: _TodoScheduleQuery,
 ) -> dict[str, frozenset[str | None]] | None:
     pending_by_room: dict[str, frozenset[str | None]] = {}
-    for room_id in sorted({scope.room_id for scope in scopes}):
+    query_agent_by_room: dict[str, str] = {}
+    for scope in scopes:
+        query_agent_by_room.setdefault(scope.room_id, scope.assigned_agent)
+    for room_id, agent_name in sorted(query_agent_by_room.items()):
         try:
-            pending_threads = await schedule_query(room_id)
+            pending_threads = await schedule_query(agent_name, room_id)
         except Exception as exc:
             logger.warning(
                 "todo_poke_schedule_query_failed",
@@ -628,6 +631,7 @@ async def _deliver_pokes(
         scope_key = _scope_key(scope)
         previous = session_poke_records.get(scope_key) or _poke_record(poke_state, scope)
         event_id = await deps.sender(
+            scope.assigned_agent,
             scope.room_id,
             _format_poke_message(scope),
             scope.thread_id,

--- a/src/mindroom/custom_tools/todo_poke.py
+++ b/src/mindroom/custom_tools/todo_poke.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 __all__ = [
+    "TodoPokeDeliveryUnavailableError",
     "TodoPokeDeps",
     "TodoPokePolicy",
     "TodoPokeWorker",
@@ -43,7 +44,7 @@ __all__ = [
 ]
 
 type _TodoScheduleQuery = Callable[[str, tuple[str, ...]], Awaitable[frozenset[str | None] | None]]
-type _TodoPokeSender = Callable[[tuple[str, ...], str, str, str | None], Awaitable[str | None]]
+type _TodoPokeSender = Callable[[str, str, str, str | None], Awaitable[str | None]]
 type _StateWarningKey = tuple[str, str]
 
 _VALID_STATUSES = {"open", *TERMINAL_STATUSES}
@@ -53,6 +54,10 @@ _POKE_STATE_FILENAME = "poke_state.json"
 _VISIBLE_ITEM_LIMIT = 5
 _RETRY_BACKSTOP_SECONDS = 60 * 60
 _MAX_UNCHANGED_REPOKES = 3
+
+
+class TodoPokeDeliveryUnavailableError(RuntimeError):
+    """Signal that the runtime could not attempt a todo poke delivery."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -623,7 +628,6 @@ async def _deliver_pokes(
     delivered = 0
     attempts = 0
     poked_agents: set[str] = set()
-    agent_names_by_room = _agent_names_by_room(scopes)
     for scope in scopes:
         if attempts >= policy.max_pokes_per_scan:
             break
@@ -633,15 +637,23 @@ async def _deliver_pokes(
         if pending_threads is None or scope.thread_id in pending_threads:
             continue
 
-        attempts += 1
         scope_key = _scope_key(scope)
         previous = session_poke_records.get(scope_key) or _poke_record(poke_state, scope)
-        event_id = await deps.sender(
-            agent_names_by_room[scope.room_id],
-            scope.room_id,
-            _format_poke_message(scope),
-            scope.thread_id,
-        )
+        try:
+            event_id = await deps.sender(
+                scope.assigned_agent,
+                scope.room_id,
+                _format_poke_message(scope),
+                scope.thread_id,
+            )
+        except TodoPokeDeliveryUnavailableError:
+            logger.debug(
+                "todo_poke_delivery_skipped_runtime_unavailable",
+                assigned_agent=scope.assigned_agent,
+                room_id=scope.room_id,
+            )
+            continue
+        attempts += 1
         outcome_timestamp = deps.clock().astimezone(UTC).timestamp()
         record = _record_after_attempt(scope, previous, outcome_timestamp, delivered=event_id is not None)
         session_poke_records[scope_key] = record

--- a/src/mindroom/orchestration/todo_poke_runtime.py
+++ b/src/mindroom/orchestration/todo_poke_runtime.py
@@ -16,6 +16,7 @@ from mindroom.custom_tools.todo_poke import (
 )
 from mindroom.custom_tools.todo_state import state_root as todo_state_root
 from mindroom.entity_resolution import mindroom_user_id
+from mindroom.matrix.client_room_admin import get_joined_rooms
 from mindroom.scheduling import get_pending_schedule_thread_ids_for_room
 
 if TYPE_CHECKING:
@@ -96,18 +97,21 @@ class TodoPokeRuntimeCoordinator:
             return None
         return agent_bot
 
-    def _joined_agent_bot(
+    async def _joined_agent_bot(
         self,
         room_id: str,
         agent_names: tuple[str, ...],
     ) -> AgentBot | TeamBot | None:
-        """Return the first ready candidate bot joined to the target room."""
+        """Return the first ready candidate with authoritative membership in the target room."""
         for agent_name in agent_names:
             agent_bot = self._agent_bot(agent_name)
             if agent_bot is None:
                 continue
             client = agent_bot.client
-            if client is not None and room_id in client.rooms:
+            if client is None:
+                continue
+            joined_room_ids = await get_joined_rooms(client)
+            if joined_room_ids is not None and room_id in joined_room_ids:
                 return agent_bot
         return None
 
@@ -117,7 +121,7 @@ class TodoPokeRuntimeCoordinator:
         agent_names: tuple[str, ...],
     ) -> frozenset[str | None] | None:
         """Return pending schedule scopes through one assigned agent joined to the room."""
-        agent_bot = self._joined_agent_bot(room_id, agent_names)
+        agent_bot = await self._joined_agent_bot(room_id, agent_names)
         if agent_bot is None or agent_bot.client is None:
             return None
         return await get_pending_schedule_thread_ids_for_room(agent_bot.client, room_id)
@@ -130,9 +134,11 @@ class TodoPokeRuntimeCoordinator:
         thread_id: str | None,
     ) -> str | None:
         """Send one assigned-agent todo poke that enters normal dispatch."""
-        agent_bot = self._agent_bot(agent_name)
         config = self.config_provider()
-        if agent_bot is None or config is None or agent_bot.client is None or room_id not in agent_bot.client.rooms:
+        if config is None:
+            raise TodoPokeDeliveryUnavailableError
+        agent_bot = await self._joined_agent_bot(room_id, (agent_name,))
+        if agent_bot is None or agent_bot.client is None:
             raise TodoPokeDeliveryUnavailableError
 
         original_sender = mindroom_user_id(config, self.runtime_paths)

--- a/src/mindroom/orchestration/todo_poke_runtime.py
+++ b/src/mindroom/orchestration/todo_poke_runtime.py
@@ -16,6 +16,7 @@ from mindroom.custom_tools.todo_poke import (
 )
 from mindroom.custom_tools.todo_state import state_root as todo_state_root
 from mindroom.entity_resolution import mindroom_user_id
+from mindroom.logging_config import get_logger
 from mindroom.matrix.client_room_admin import get_joined_rooms
 from mindroom.scheduling import get_pending_schedule_thread_ids_for_room
 
@@ -25,6 +26,9 @@ if TYPE_CHECKING:
     from mindroom.bot import AgentBot, TeamBot
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
+
+
+logger = get_logger(__name__)
 
 
 @dataclass
@@ -110,7 +114,19 @@ class TodoPokeRuntimeCoordinator:
             client = agent_bot.client
             if client is None:
                 continue
-            joined_room_ids = await get_joined_rooms(client)
+            try:
+                joined_room_ids = await get_joined_rooms(client)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "todo_poke_membership_query_failed",
+                    assigned_agent=agent_name,
+                    room_id=room_id,
+                    error=str(exc),
+                    exc_info=True,
+                )
+                continue
             if joined_room_ids is not None and room_id in joined_room_ids:
                 return agent_bot
         return None

--- a/src/mindroom/orchestration/todo_poke_runtime.py
+++ b/src/mindroom/orchestration/todo_poke_runtime.py
@@ -8,7 +8,12 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
 from mindroom.constants import ORIGINAL_SENDER_KEY
-from mindroom.custom_tools.todo_poke import TodoPokeDeps, TodoPokeWorker, todo_poke_policy
+from mindroom.custom_tools.todo_poke import (
+    TodoPokeDeliveryUnavailableError,
+    TodoPokeDeps,
+    TodoPokeWorker,
+    todo_poke_policy,
+)
 from mindroom.custom_tools.todo_state import state_root as todo_state_root
 from mindroom.entity_resolution import mindroom_user_id
 from mindroom.scheduling import get_pending_schedule_thread_ids_for_room
@@ -119,16 +124,16 @@ class TodoPokeRuntimeCoordinator:
 
     async def _send_poke(
         self,
-        agent_names: tuple[str, ...],
+        agent_name: str,
         room_id: str,
         body: str,
         thread_id: str | None,
     ) -> str | None:
-        """Send one todo poke through a joined candidate into normal dispatch."""
-        agent_bot = self._joined_agent_bot(room_id, agent_names)
+        """Send one assigned-agent todo poke that enters normal dispatch."""
+        agent_bot = self._agent_bot(agent_name)
         config = self.config_provider()
-        if agent_bot is None or config is None:
-            return None
+        if agent_bot is None or config is None or agent_bot.client is None or room_id not in agent_bot.client.rooms:
+            raise TodoPokeDeliveryUnavailableError
 
         original_sender = mindroom_user_id(config, self.runtime_paths)
         extra_content = {ORIGINAL_SENDER_KEY: original_sender} if original_sender is not None else None

--- a/src/mindroom/orchestration/todo_poke_runtime.py
+++ b/src/mindroom/orchestration/todo_poke_runtime.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from mindroom.constants import ORIGINAL_SENDER_KEY, ROUTER_AGENT_NAME
+from mindroom.constants import ORIGINAL_SENDER_KEY
 from mindroom.custom_tools.todo_poke import TodoPokeDeps, TodoPokeWorker, todo_poke_policy
 from mindroom.custom_tools.todo_state import state_root as todo_state_root
 from mindroom.entity_resolution import mindroom_user_id
@@ -84,38 +84,39 @@ class TodoPokeRuntimeCoordinator:
                 return False
         return True
 
-    def _router(self) -> AgentBot | TeamBot | None:
-        """Return the running router bot when todo poke I/O is ready."""
-        router_bot = self.bot_provider(ROUTER_AGENT_NAME)
-        if router_bot is None or not router_bot.running or router_bot.client is None:
+    def _agent_bot(self, agent_name: str) -> AgentBot | TeamBot | None:
+        """Return the assigned agent bot when todo poke I/O is ready."""
+        agent_bot = self.bot_provider(agent_name)
+        if agent_bot is None or not agent_bot.running or agent_bot.client is None:
             return None
-        return router_bot
+        return agent_bot
 
-    async def _schedule_query(self, room_id: str) -> frozenset[str | None] | None:
-        """Return pending schedule scopes, or None while router I/O is unavailable."""
-        router_bot = self._router()
-        if router_bot is None:
+    async def _schedule_query(self, agent_name: str, room_id: str) -> frozenset[str | None] | None:
+        """Return pending schedule scopes, or None while assigned-agent I/O is unavailable."""
+        agent_bot = self._agent_bot(agent_name)
+        if agent_bot is None:
             return None
-        client = router_bot.client
+        client = agent_bot.client
         if client is None:
             return None
         return await get_pending_schedule_thread_ids_for_room(client, room_id)
 
     async def _send_poke(
         self,
+        agent_name: str,
         room_id: str,
         body: str,
         thread_id: str | None,
     ) -> str | None:
-        """Send one router-originated todo poke that enters normal dispatch."""
-        router_bot = self._router()
+        """Send one assigned-agent todo poke that enters normal dispatch."""
+        agent_bot = self._agent_bot(agent_name)
         config = self.config_provider()
-        if router_bot is None or config is None:
+        if agent_bot is None or config is None:
             return None
 
         original_sender = mindroom_user_id(config, self.runtime_paths)
         extra_content = {ORIGINAL_SENDER_KEY: original_sender} if original_sender is not None else None
-        return await router_bot._hook_send_message(
+        return await agent_bot._hook_send_message(
             room_id,
             body,
             thread_id,

--- a/src/mindroom/orchestration/todo_poke_runtime.py
+++ b/src/mindroom/orchestration/todo_poke_runtime.py
@@ -91,15 +91,20 @@ class TodoPokeRuntimeCoordinator:
             return None
         return agent_bot
 
-    async def _schedule_query(self, agent_name: str, room_id: str) -> frozenset[str | None] | None:
-        """Return pending schedule scopes, or None while assigned-agent I/O is unavailable."""
-        agent_bot = self._agent_bot(agent_name)
-        if agent_bot is None:
-            return None
-        client = agent_bot.client
-        if client is None:
-            return None
-        return await get_pending_schedule_thread_ids_for_room(client, room_id)
+    async def _schedule_query(
+        self,
+        room_id: str,
+        agent_names: tuple[str, ...],
+    ) -> frozenset[str | None] | None:
+        """Return pending schedule scopes through one assigned agent joined to the room."""
+        for agent_name in agent_names:
+            agent_bot = self._agent_bot(agent_name)
+            if agent_bot is None:
+                continue
+            client = agent_bot.client
+            if client is not None and room_id in client.rooms:
+                return await get_pending_schedule_thread_ids_for_room(client, room_id)
+        return None
 
     async def _send_poke(
         self,

--- a/src/mindroom/orchestration/todo_poke_runtime.py
+++ b/src/mindroom/orchestration/todo_poke_runtime.py
@@ -91,30 +91,41 @@ class TodoPokeRuntimeCoordinator:
             return None
         return agent_bot
 
-    async def _schedule_query(
+    def _joined_agent_bot(
         self,
         room_id: str,
         agent_names: tuple[str, ...],
-    ) -> frozenset[str | None] | None:
-        """Return pending schedule scopes through one assigned agent joined to the room."""
+    ) -> AgentBot | TeamBot | None:
+        """Return the first ready candidate bot joined to the target room."""
         for agent_name in agent_names:
             agent_bot = self._agent_bot(agent_name)
             if agent_bot is None:
                 continue
             client = agent_bot.client
             if client is not None and room_id in client.rooms:
-                return await get_pending_schedule_thread_ids_for_room(client, room_id)
+                return agent_bot
         return None
+
+    async def _schedule_query(
+        self,
+        room_id: str,
+        agent_names: tuple[str, ...],
+    ) -> frozenset[str | None] | None:
+        """Return pending schedule scopes through one assigned agent joined to the room."""
+        agent_bot = self._joined_agent_bot(room_id, agent_names)
+        if agent_bot is None or agent_bot.client is None:
+            return None
+        return await get_pending_schedule_thread_ids_for_room(agent_bot.client, room_id)
 
     async def _send_poke(
         self,
-        agent_name: str,
+        agent_names: tuple[str, ...],
         room_id: str,
         body: str,
         thread_id: str | None,
     ) -> str | None:
-        """Send one assigned-agent todo poke that enters normal dispatch."""
-        agent_bot = self._agent_bot(agent_name)
+        """Send one todo poke through a joined candidate into normal dispatch."""
+        agent_bot = self._joined_agent_bot(room_id, agent_names)
         config = self.config_provider()
         if agent_bot is None or config is None:
             return None

--- a/tach.toml
+++ b/tach.toml
@@ -1576,6 +1576,7 @@ depends_on = [
     "mindroom.custom_tools.todo_poke",
     "mindroom.custom_tools.todo_state",
     "mindroom.entity_resolution",
+    "mindroom.matrix.client_room_admin",
     "mindroom.scheduling",
 ]
 
@@ -2214,6 +2215,7 @@ visibility = [
     "mindroom.matrix.rooms",
     "mindroom.matrix.stale_stream_cleanup",
     "mindroom.orchestration.external_trigger_runtime",
+    "mindroom.orchestration.todo_poke_runtime",
     "mindroom.orchestrator",
 ]
 

--- a/tach.toml
+++ b/tach.toml
@@ -1576,6 +1576,7 @@ depends_on = [
     "mindroom.custom_tools.todo_poke",
     "mindroom.custom_tools.todo_state",
     "mindroom.entity_resolution",
+    "mindroom.logging_config",
     "mindroom.matrix.client_room_admin",
     "mindroom.scheduling",
 ]

--- a/tests/test_todo_poke.py
+++ b/tests/test_todo_poke.py
@@ -100,7 +100,12 @@ def _deps(
             raise schedule_error
         return schedule_result
 
-    async def sender(_agent_name: str, room_id: str, body: str, thread_id: str | None) -> str | None:
+    async def sender(
+        _agent_names: tuple[str, ...],
+        room_id: str,
+        body: str,
+        thread_id: str | None,
+    ) -> str | None:
         sent.append((room_id, body, thread_id))
         if remaining_results:
             return remaining_results.pop(0)
@@ -159,7 +164,7 @@ async def test_scan_skips_malformed_unassigned_and_unconfigured_items(tmp_path: 
 
 
 @pytest.mark.asyncio
-async def test_scan_routes_schedule_reads_and_delivery_through_assigned_agent(tmp_path: Path) -> None:
+async def test_scan_routes_room_io_through_assigned_candidates(tmp_path: Path) -> None:
     """One room query gets every assignee candidate while each poke keeps its owner."""
     todo_root = tmp_path / "todo"
     _write_thread(
@@ -171,19 +176,19 @@ async def test_scan_routes_schedule_reads_and_delivery_through_assigned_agent(tm
         ],
     )
     schedule_calls: list[tuple[str, tuple[str, ...]]] = []
-    send_calls: list[tuple[str, str, str, str | None]] = []
+    send_calls: list[tuple[tuple[str, ...], str, str, str | None]] = []
 
     async def schedule_query(room_id: str, agent_names: tuple[str, ...]) -> frozenset[str | None]:
         schedule_calls.append((room_id, agent_names))
         return frozenset()
 
     async def sender(
-        agent_name: str,
+        agent_names: tuple[str, ...],
         room_id: str,
         body: str,
         thread_id: str | None,
     ) -> str:
-        send_calls.append((agent_name, room_id, body, thread_id))
+        send_calls.append((agent_names, room_id, body, thread_id))
         return "$event"
 
     deps = TodoPokeDeps(
@@ -196,10 +201,54 @@ async def test_scan_routes_schedule_reads_and_delivery_through_assigned_agent(tm
 
     assert await scan_todo_pokes(TodoPokePolicy(quiet_seconds=0), deps) == 2
     assert schedule_calls == [("!room:localhost", ("code", "reviewer"))]
-    assert [(agent, room, thread) for agent, room, _body, thread in send_calls] == [
-        ("code", "!room:localhost", "$thread"),
-        ("reviewer", "!room:localhost", "$thread"),
+    assert [(agents, room, thread) for agents, room, _body, thread in send_calls] == [
+        (("code", "reviewer"), "!room:localhost", "$thread"),
+        (("code", "reviewer"), "!room:localhost", "$thread"),
     ]
+    assert "@code Todo work is ready" in send_calls[0][2]
+    assert "@reviewer Todo work is ready" in send_calls[1][2]
+
+
+@pytest.mark.asyncio
+async def test_scan_skips_only_room_without_joined_candidate(tmp_path: Path) -> None:
+    """Room-local I/O unavailability must not suppress another deliverable room."""
+    todo_root = tmp_path / "todo"
+    _write_thread(
+        todo_root,
+        "a-unavailable",
+        room_id="!unavailable:localhost",
+        items=[_item("unavailable", assigned_agent="code")],
+    )
+    _write_thread(
+        todo_root,
+        "b-ready",
+        room_id="!ready:localhost",
+        items=[_item("ready", assigned_agent="reviewer")],
+    )
+    send_calls: list[tuple[tuple[str, ...], str]] = []
+
+    async def schedule_query(room_id: str, _agent_names: tuple[str, ...]) -> frozenset[str | None] | None:
+        return None if room_id == "!unavailable:localhost" else frozenset()
+
+    async def sender(
+        agent_names: tuple[str, ...],
+        room_id: str,
+        _body: str,
+        _thread_id: str | None,
+    ) -> str:
+        send_calls.append((agent_names, room_id))
+        return "$event"
+
+    deps = TodoPokeDeps(
+        state_root=todo_root,
+        schedule_query=schedule_query,
+        idle_check=lambda _agent_name: True,
+        sender=sender,
+        clock=lambda: _NOW,
+    )
+
+    assert await scan_todo_pokes(TodoPokePolicy(quiet_seconds=0), deps) == 1
+    assert send_calls == [(("reviewer",), "!ready:localhost")]
 
 
 @pytest.mark.asyncio
@@ -506,13 +555,13 @@ async def test_delivery_outcome_time_owns_cooldown_and_backstop_windows(tmp_path
         return await base_deps.schedule_query(room_id, agent_names)
 
     async def delayed_sender(
-        agent_name: str,
+        agent_names: tuple[str, ...],
         room_id: str,
         body: str,
         thread_id: str | None,
     ) -> str | None:
         current_time[0] += timedelta(minutes=20)
-        return await base_deps.sender(agent_name, room_id, body, thread_id)
+        return await base_deps.sender(agent_names, room_id, body, thread_id)
 
     deps = replace(
         base_deps,

--- a/tests/test_todo_poke.py
+++ b/tests/test_todo_poke.py
@@ -15,6 +15,7 @@ from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.custom_tools import todo_poke as todo_poke_module
 from mindroom.custom_tools.todo_poke import (
+    TodoPokeDeliveryUnavailableError,
     TodoPokeDeps,
     TodoPokePolicy,
     TodoPokeWorker,
@@ -101,7 +102,7 @@ def _deps(
         return schedule_result
 
     async def sender(
-        _agent_names: tuple[str, ...],
+        _agent_name: str,
         room_id: str,
         body: str,
         thread_id: str | None,
@@ -176,19 +177,19 @@ async def test_scan_routes_room_io_through_assigned_candidates(tmp_path: Path) -
         ],
     )
     schedule_calls: list[tuple[str, tuple[str, ...]]] = []
-    send_calls: list[tuple[tuple[str, ...], str, str, str | None]] = []
+    send_calls: list[tuple[str, str, str, str | None]] = []
 
     async def schedule_query(room_id: str, agent_names: tuple[str, ...]) -> frozenset[str | None]:
         schedule_calls.append((room_id, agent_names))
         return frozenset()
 
     async def sender(
-        agent_names: tuple[str, ...],
+        agent_name: str,
         room_id: str,
         body: str,
         thread_id: str | None,
     ) -> str:
-        send_calls.append((agent_names, room_id, body, thread_id))
+        send_calls.append((agent_name, room_id, body, thread_id))
         return "$event"
 
     deps = TodoPokeDeps(
@@ -201,9 +202,9 @@ async def test_scan_routes_room_io_through_assigned_candidates(tmp_path: Path) -
 
     assert await scan_todo_pokes(TodoPokePolicy(quiet_seconds=0), deps) == 2
     assert schedule_calls == [("!room:localhost", ("code", "reviewer"))]
-    assert [(agents, room, thread) for agents, room, _body, thread in send_calls] == [
-        (("code", "reviewer"), "!room:localhost", "$thread"),
-        (("code", "reviewer"), "!room:localhost", "$thread"),
+    assert [(agent, room, thread) for agent, room, _body, thread in send_calls] == [
+        ("code", "!room:localhost", "$thread"),
+        ("reviewer", "!room:localhost", "$thread"),
     ]
     assert "@code Todo work is ready" in send_calls[0][2]
     assert "@reviewer Todo work is ready" in send_calls[1][2]
@@ -225,18 +226,18 @@ async def test_scan_skips_only_room_without_joined_candidate(tmp_path: Path) -> 
         room_id="!ready:localhost",
         items=[_item("ready", assigned_agent="reviewer")],
     )
-    send_calls: list[tuple[tuple[str, ...], str]] = []
+    send_calls: list[tuple[str, str]] = []
 
     async def schedule_query(room_id: str, _agent_names: tuple[str, ...]) -> frozenset[str | None] | None:
         return None if room_id == "!unavailable:localhost" else frozenset()
 
     async def sender(
-        agent_names: tuple[str, ...],
+        agent_name: str,
         room_id: str,
         _body: str,
         _thread_id: str | None,
     ) -> str:
-        send_calls.append((agent_names, room_id))
+        send_calls.append((agent_name, room_id))
         return "$event"
 
     deps = TodoPokeDeps(
@@ -248,7 +249,49 @@ async def test_scan_skips_only_room_without_joined_candidate(tmp_path: Path) -> 
     )
 
     assert await scan_todo_pokes(TodoPokePolicy(quiet_seconds=0), deps) == 1
-    assert send_calls == [(("reviewer",), "!ready:localhost")]
+    assert send_calls == [("reviewer", "!ready:localhost")]
+
+
+@pytest.mark.asyncio
+async def test_unavailable_delivery_does_not_consume_attempt_or_cooldown(tmp_path: Path) -> None:
+    """An unjoined owner is skipped while a later deliverable owner uses the attempt budget."""
+    todo_root = tmp_path / "todo"
+    _write_thread(
+        todo_root,
+        "scope",
+        items=[
+            _item("unavailable", assigned_agent="code"),
+            _item("ready", assigned_agent="reviewer"),
+        ],
+    )
+    sender_calls: list[str] = []
+
+    async def schedule_query(_room_id: str, _agent_names: tuple[str, ...]) -> frozenset[str | None]:
+        return frozenset()
+
+    async def sender(
+        agent_name: str,
+        _room_id: str,
+        _body: str,
+        _thread_id: str | None,
+    ) -> str:
+        sender_calls.append(agent_name)
+        if agent_name == "code":
+            raise TodoPokeDeliveryUnavailableError
+        return "$event"
+
+    deps = TodoPokeDeps(
+        state_root=todo_root,
+        schedule_query=schedule_query,
+        idle_check=lambda _agent_name: True,
+        sender=sender,
+        clock=lambda: _NOW,
+    )
+
+    assert await scan_todo_pokes(TodoPokePolicy(quiet_seconds=0, max_pokes_per_scan=1), deps) == 1
+    assert sender_calls == ["code", "reviewer"]
+    poke_state = json.loads((todo_root / "poke_state.json").read_text(encoding="utf-8"))
+    assert len(poke_state["scopes"]) == 1
 
 
 @pytest.mark.asyncio
@@ -555,13 +598,13 @@ async def test_delivery_outcome_time_owns_cooldown_and_backstop_windows(tmp_path
         return await base_deps.schedule_query(room_id, agent_names)
 
     async def delayed_sender(
-        agent_names: tuple[str, ...],
+        agent_name: str,
         room_id: str,
         body: str,
         thread_id: str | None,
     ) -> str | None:
         current_time[0] += timedelta(minutes=20)
-        return await base_deps.sender(agent_names, room_id, body, thread_id)
+        return await base_deps.sender(agent_name, room_id, body, thread_id)
 
     deps = replace(
         base_deps,

--- a/tests/test_todo_poke.py
+++ b/tests/test_todo_poke.py
@@ -94,13 +94,13 @@ def _deps(
     sent: list[tuple[str, str, str | None]] = []
     remaining_results = list(send_results) if send_results is not None else []
 
-    async def schedule_query(room_id: str) -> frozenset[str | None] | None:
+    async def schedule_query(_agent_name: str, room_id: str) -> frozenset[str | None] | None:
         queried_rooms.append(room_id)
         if schedule_error is not None:
             raise schedule_error
         return schedule_result
 
-    async def sender(room_id: str, body: str, thread_id: str | None) -> str | None:
+    async def sender(_agent_name: str, room_id: str, body: str, thread_id: str | None) -> str | None:
         sent.append((room_id, body, thread_id))
         if remaining_results:
             return remaining_results.pop(0)
@@ -156,6 +156,42 @@ async def test_scan_skips_malformed_unassigned_and_unconfigured_items(tmp_path: 
     assert "`ready` [medium]" in sent[0][1]
     assert "blocked" not in sent[0][1]
     assert "removed" in idle_checks
+
+
+@pytest.mark.asyncio
+async def test_scan_routes_schedule_reads_and_delivery_through_assigned_agent(tmp_path: Path) -> None:
+    """Each poke carries its assignee to I/O so room membership is resolved by the owning bot."""
+    todo_root = tmp_path / "todo"
+    _write_thread(todo_root, "scope", items=[_item("ready", assigned_agent="code")])
+    schedule_calls: list[tuple[str, str]] = []
+    send_calls: list[tuple[str, str, str, str | None]] = []
+
+    async def schedule_query(agent_name: str, room_id: str) -> frozenset[str | None]:
+        schedule_calls.append((agent_name, room_id))
+        return frozenset()
+
+    async def sender(
+        agent_name: str,
+        room_id: str,
+        body: str,
+        thread_id: str | None,
+    ) -> str:
+        send_calls.append((agent_name, room_id, body, thread_id))
+        return "$event"
+
+    deps = TodoPokeDeps(
+        state_root=todo_root,
+        schedule_query=schedule_query,
+        idle_check=lambda _agent_name: True,
+        sender=sender,
+        clock=lambda: _NOW,
+    )
+
+    assert await scan_todo_pokes(TodoPokePolicy(quiet_seconds=0), deps) == 1
+    assert schedule_calls == [("code", "!room:localhost")]
+    assert [(agent, room, thread) for agent, room, _body, thread in send_calls] == [
+        ("code", "!room:localhost", "$thread"),
+    ]
 
 
 @pytest.mark.asyncio
@@ -454,13 +490,18 @@ async def test_delivery_outcome_time_owns_cooldown_and_backstop_windows(tmp_path
     current_time = [_NOW]
     base_deps, queried_rooms, sent = _deps(todo_root, clock=lambda: current_time[0])
 
-    async def delayed_schedule_query(room_id: str) -> frozenset[str | None] | None:
+    async def delayed_schedule_query(agent_name: str, room_id: str) -> frozenset[str | None] | None:
         current_time[0] += timedelta(minutes=10)
-        return await base_deps.schedule_query(room_id)
+        return await base_deps.schedule_query(agent_name, room_id)
 
-    async def delayed_sender(room_id: str, body: str, thread_id: str | None) -> str | None:
+    async def delayed_sender(
+        agent_name: str,
+        room_id: str,
+        body: str,
+        thread_id: str | None,
+    ) -> str | None:
         current_time[0] += timedelta(minutes=20)
-        return await base_deps.sender(room_id, body, thread_id)
+        return await base_deps.sender(agent_name, room_id, body, thread_id)
 
     deps = replace(
         base_deps,

--- a/tests/test_todo_poke.py
+++ b/tests/test_todo_poke.py
@@ -94,7 +94,7 @@ def _deps(
     sent: list[tuple[str, str, str | None]] = []
     remaining_results = list(send_results) if send_results is not None else []
 
-    async def schedule_query(_agent_name: str, room_id: str) -> frozenset[str | None] | None:
+    async def schedule_query(room_id: str, _agent_names: tuple[str, ...]) -> frozenset[str | None] | None:
         queried_rooms.append(room_id)
         if schedule_error is not None:
             raise schedule_error
@@ -160,14 +160,21 @@ async def test_scan_skips_malformed_unassigned_and_unconfigured_items(tmp_path: 
 
 @pytest.mark.asyncio
 async def test_scan_routes_schedule_reads_and_delivery_through_assigned_agent(tmp_path: Path) -> None:
-    """Each poke carries its assignee to I/O so room membership is resolved by the owning bot."""
+    """One room query gets every assignee candidate while each poke keeps its owner."""
     todo_root = tmp_path / "todo"
-    _write_thread(todo_root, "scope", items=[_item("ready", assigned_agent="code")])
-    schedule_calls: list[tuple[str, str]] = []
+    _write_thread(
+        todo_root,
+        "scope",
+        items=[
+            _item("ready", assigned_agent="code"),
+            _item("review", assigned_agent="reviewer"),
+        ],
+    )
+    schedule_calls: list[tuple[str, tuple[str, ...]]] = []
     send_calls: list[tuple[str, str, str, str | None]] = []
 
-    async def schedule_query(agent_name: str, room_id: str) -> frozenset[str | None]:
-        schedule_calls.append((agent_name, room_id))
+    async def schedule_query(room_id: str, agent_names: tuple[str, ...]) -> frozenset[str | None]:
+        schedule_calls.append((room_id, agent_names))
         return frozenset()
 
     async def sender(
@@ -187,10 +194,11 @@ async def test_scan_routes_schedule_reads_and_delivery_through_assigned_agent(tm
         clock=lambda: _NOW,
     )
 
-    assert await scan_todo_pokes(TodoPokePolicy(quiet_seconds=0), deps) == 1
-    assert schedule_calls == [("code", "!room:localhost")]
+    assert await scan_todo_pokes(TodoPokePolicy(quiet_seconds=0), deps) == 2
+    assert schedule_calls == [("!room:localhost", ("code", "reviewer"))]
     assert [(agent, room, thread) for agent, room, _body, thread in send_calls] == [
         ("code", "!room:localhost", "$thread"),
+        ("reviewer", "!room:localhost", "$thread"),
     ]
 
 
@@ -490,9 +498,12 @@ async def test_delivery_outcome_time_owns_cooldown_and_backstop_windows(tmp_path
     current_time = [_NOW]
     base_deps, queried_rooms, sent = _deps(todo_root, clock=lambda: current_time[0])
 
-    async def delayed_schedule_query(agent_name: str, room_id: str) -> frozenset[str | None] | None:
+    async def delayed_schedule_query(
+        room_id: str,
+        agent_names: tuple[str, ...],
+    ) -> frozenset[str | None] | None:
         current_time[0] += timedelta(minutes=10)
-        return await base_deps.schedule_query(agent_name, room_id)
+        return await base_deps.schedule_query(room_id, agent_names)
 
     async def delayed_sender(
         agent_name: str,

--- a/tests/test_todo_poke_runtime_binding.py
+++ b/tests/test_todo_poke_runtime_binding.py
@@ -11,6 +11,7 @@ import pytest
 from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.constants import ORIGINAL_SENDER_KEY
+from mindroom.custom_tools.todo_poke import TodoPokeDeliveryUnavailableError
 from mindroom.orchestration.todo_poke_runtime import TodoPokeRuntimeCoordinator
 from mindroom.orchestrator import _MultiAgentOrchestrator
 from tests.conftest import bind_runtime_paths, test_runtime_paths
@@ -112,7 +113,7 @@ async def test_assigned_agent_query_and_send_wiring(tmp_path: Path) -> None:
     ):
         pending = await coordinator._schedule_query("!room:localhost", ("code",))
         event_id = await coordinator._send_poke(
-            ("code",),
+            "code",
             "!room:localhost",
             "@code Todo work is ready.",
             "$thread",
@@ -162,8 +163,8 @@ async def test_schedule_query_uses_joined_candidate_for_shared_room(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_send_uses_joined_candidate_for_unjoined_todo_owner(tmp_path: Path) -> None:
-    """A joined same-room assignee transports a poke that targets an unjoined owner."""
+async def test_send_skips_unjoined_todo_owner_without_using_other_candidate(tmp_path: Path) -> None:
+    """Only the todo owner may transport its poke, and it must be joined."""
     unjoined_client = MagicMock()
     unjoined_client.rooms = {}
     joined_client = MagicMock()
@@ -178,20 +179,22 @@ async def test_send_uses_joined_candidate_for_unjoined_todo_owner(tmp_path: Path
         {"code": unjoined_bot, "reviewer": joined_bot},
     )
 
-    with patch(
-        "mindroom.orchestration.todo_poke_runtime.mindroom_user_id",
-        return_value="@mindroom_user:localhost",
+    with (
+        patch(
+            "mindroom.orchestration.todo_poke_runtime.mindroom_user_id",
+            return_value="@mindroom_user:localhost",
+        ),
+        pytest.raises(TodoPokeDeliveryUnavailableError),
     ):
-        event_id = await coordinator._send_poke(
-            ("code", "reviewer"),
+        await coordinator._send_poke(
+            "code",
             "!room:localhost",
             "@code Todo work is ready.",
             "$thread",
         )
 
-    assert event_id == "$event"
     unjoined_bot._hook_send_message.assert_not_awaited()
-    joined_bot._hook_send_message.assert_awaited_once()
+    joined_bot._hook_send_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -201,15 +204,13 @@ async def test_adapters_skip_when_runtime_is_unavailable(tmp_path: Path) -> None
 
     assert coordinator._agent_is_idle("code") is False
     assert await coordinator._schedule_query("!room:localhost", ("code",)) is None
-    assert (
+    with pytest.raises(TodoPokeDeliveryUnavailableError):
         await coordinator._send_poke(
-            ("code",),
+            "code",
             "!room:localhost",
             "@code Todo work is ready.",
             "$thread",
         )
-        is None
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_todo_poke_runtime_binding.py
+++ b/tests/test_todo_poke_runtime_binding.py
@@ -84,14 +84,16 @@ def test_idle_check_includes_direct_and_running_team_bots(tmp_path: Path) -> Non
 
 
 @pytest.mark.asyncio
-async def test_router_query_and_send_wiring(tmp_path: Path) -> None:
-    """Router I/O supplies schedule scopes and dispatches with the internal requester."""
+async def test_assigned_agent_query_and_send_wiring(tmp_path: Path) -> None:
+    """Todo poke I/O uses the assigned agent that owns membership in the target room."""
     router_bot = _bot()
     router_bot._hook_send_message = AsyncMock(return_value="$event")
+    agent_bot = _bot()
+    agent_bot._hook_send_message = AsyncMock(return_value="$event")
     coordinator = _coordinator(
         test_runtime_paths(tmp_path),
         _config(tmp_path),
-        {"router": router_bot},
+        {"router": router_bot, "code": agent_bot},
     )
 
     with (
@@ -104,17 +106,18 @@ async def test_router_query_and_send_wiring(tmp_path: Path) -> None:
             return_value="@mindroom_user:localhost",
         ),
     ):
-        pending = await coordinator._schedule_query("!room:localhost")
+        pending = await coordinator._schedule_query("code", "!room:localhost")
         event_id = await coordinator._send_poke(
+            "code",
             "!room:localhost",
             "@code Todo work is ready.",
             "$thread",
         )
 
     assert pending == frozenset({"$scheduled"})
-    schedule_query.assert_awaited_once_with(router_bot.client, "!room:localhost")
+    schedule_query.assert_awaited_once_with(agent_bot.client, "!room:localhost")
     assert event_id == "$event"
-    router_bot._hook_send_message.assert_awaited_once_with(
+    agent_bot._hook_send_message.assert_awaited_once_with(
         "!room:localhost",
         "@code Todo work is ready.",
         "$thread",
@@ -122,6 +125,7 @@ async def test_router_query_and_send_wiring(tmp_path: Path) -> None:
         {ORIGINAL_SENDER_KEY: "@mindroom_user:localhost"},
         trigger_dispatch=True,
     )
+    router_bot._hook_send_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -130,9 +134,10 @@ async def test_adapters_skip_when_runtime_is_unavailable(tmp_path: Path) -> None
     coordinator = _coordinator(test_runtime_paths(tmp_path), _config(tmp_path), {})
 
     assert coordinator._agent_is_idle("code") is False
-    assert await coordinator._schedule_query("!room:localhost") is None
+    assert await coordinator._schedule_query("code", "!room:localhost") is None
     assert (
         await coordinator._send_poke(
+            "code",
             "!room:localhost",
             "@code Todo work is ready.",
             "$thread",
@@ -147,7 +152,7 @@ async def test_schedule_adapter_preserves_read_errors(tmp_path: Path) -> None:
     coordinator = _coordinator(
         test_runtime_paths(tmp_path),
         _config(tmp_path),
-        {"router": _bot()},
+        {"code": _bot()},
     )
 
     with (
@@ -157,7 +162,7 @@ async def test_schedule_adapter_preserves_read_errors(tmp_path: Path) -> None:
         ),
         pytest.raises(RuntimeError, match="state unavailable"),
     ):
-        await coordinator._schedule_query("!room:localhost")
+        await coordinator._schedule_query("code", "!room:localhost")
 
 
 @pytest.mark.asyncio

--- a/tests/test_todo_poke_runtime_binding.py
+++ b/tests/test_todo_poke_runtime_binding.py
@@ -6,6 +6,7 @@ from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import nio
 import pytest
 
 from mindroom.config.agent import AgentConfig, TeamConfig
@@ -52,14 +53,26 @@ def _coordinator(
     )
 
 
+def _client(
+    *joined_room_ids: str,
+    cached_room_ids: tuple[str, ...] | None = None,
+) -> MagicMock:
+    client = MagicMock()
+    cached_ids = joined_room_ids if cached_room_ids is None else cached_room_ids
+    client.rooms = {room_id: MagicMock() for room_id in cached_ids}
+    client.joined_rooms = AsyncMock(
+        return_value=nio.JoinedRoomsResponse(rooms=list(joined_room_ids)),
+    )
+    return client
+
+
 def _bot(**overrides: object) -> MagicMock:
     bot = MagicMock()
     bot.running = overrides.get("running", True)
     if "client" in overrides:
         bot.client = overrides["client"]
     else:
-        bot.client = MagicMock()
-        bot.client.rooms = {"!room:localhost": MagicMock()}
+        bot.client = _client("!room:localhost")
     bot.in_flight_response_count = overrides.get("in_flight_response_count", 0)
     return bot
 
@@ -136,10 +149,8 @@ async def test_assigned_agent_query_and_send_wiring(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_schedule_query_uses_joined_candidate_for_shared_room(tmp_path: Path) -> None:
     """A same-room assignee without membership must not hide a later joined assignee."""
-    unjoined_client = MagicMock()
-    unjoined_client.rooms = {}
-    joined_client = MagicMock()
-    joined_client.rooms = {"!room:localhost": MagicMock()}
+    unjoined_client = _client()
+    joined_client = _client("!room:localhost")
     coordinator = _coordinator(
         test_runtime_paths(tmp_path),
         _config(tmp_path),
@@ -165,10 +176,8 @@ async def test_schedule_query_uses_joined_candidate_for_shared_room(tmp_path: Pa
 @pytest.mark.asyncio
 async def test_send_skips_unjoined_todo_owner_without_using_other_candidate(tmp_path: Path) -> None:
     """Only the todo owner may transport its poke, and it must be joined."""
-    unjoined_client = MagicMock()
-    unjoined_client.rooms = {}
-    joined_client = MagicMock()
-    joined_client.rooms = {"!room:localhost": MagicMock()}
+    unjoined_client = _client()
+    joined_client = _client("!room:localhost")
     unjoined_bot = _bot(client=unjoined_client)
     unjoined_bot._hook_send_message = AsyncMock(return_value="$wrong")
     joined_bot = _bot(client=joined_client)
@@ -195,6 +204,49 @@ async def test_send_skips_unjoined_todo_owner_without_using_other_candidate(tmp_
 
     unjoined_bot._hook_send_message.assert_not_awaited()
     joined_bot._hook_send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_schedule_query_rejects_stale_joined_room_cache(tmp_path: Path) -> None:
+    """Cached room state must not authorize a schedule read after membership ended."""
+    stale_client = _client(cached_room_ids=("!room:localhost",))
+    coordinator = _coordinator(
+        test_runtime_paths(tmp_path),
+        _config(tmp_path),
+        {"code": _bot(client=stale_client)},
+    )
+
+    with patch(
+        "mindroom.orchestration.todo_poke_runtime.get_pending_schedule_thread_ids_for_room",
+        new=AsyncMock(return_value=frozenset({"$scheduled"})),
+    ) as schedule_query:
+        pending = await coordinator._schedule_query("!room:localhost", ("code",))
+
+    assert pending is None
+    schedule_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_rejects_stale_joined_room_cache(tmp_path: Path) -> None:
+    """Cached room state must not authorize delivery after membership ended."""
+    stale_client = _client(cached_room_ids=("!room:localhost",))
+    stale_bot = _bot(client=stale_client)
+    stale_bot._hook_send_message = AsyncMock(return_value="$wrong")
+    coordinator = _coordinator(
+        test_runtime_paths(tmp_path),
+        _config(tmp_path),
+        {"code": stale_bot},
+    )
+
+    with pytest.raises(TodoPokeDeliveryUnavailableError):
+        await coordinator._send_poke(
+            "code",
+            "!room:localhost",
+            "@code Todo work is ready.",
+            "$thread",
+        )
+
+    stale_bot._hook_send_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_todo_poke_runtime_binding.py
+++ b/tests/test_todo_poke_runtime_binding.py
@@ -112,7 +112,7 @@ async def test_assigned_agent_query_and_send_wiring(tmp_path: Path) -> None:
     ):
         pending = await coordinator._schedule_query("!room:localhost", ("code",))
         event_id = await coordinator._send_poke(
-            "code",
+            ("code",),
             "!room:localhost",
             "@code Todo work is ready.",
             "$thread",
@@ -162,6 +162,39 @@ async def test_schedule_query_uses_joined_candidate_for_shared_room(tmp_path: Pa
 
 
 @pytest.mark.asyncio
+async def test_send_uses_joined_candidate_for_unjoined_todo_owner(tmp_path: Path) -> None:
+    """A joined same-room assignee transports a poke that targets an unjoined owner."""
+    unjoined_client = MagicMock()
+    unjoined_client.rooms = {}
+    joined_client = MagicMock()
+    joined_client.rooms = {"!room:localhost": MagicMock()}
+    unjoined_bot = _bot(client=unjoined_client)
+    unjoined_bot._hook_send_message = AsyncMock(return_value="$wrong")
+    joined_bot = _bot(client=joined_client)
+    joined_bot._hook_send_message = AsyncMock(return_value="$event")
+    coordinator = _coordinator(
+        test_runtime_paths(tmp_path),
+        _config(tmp_path),
+        {"code": unjoined_bot, "reviewer": joined_bot},
+    )
+
+    with patch(
+        "mindroom.orchestration.todo_poke_runtime.mindroom_user_id",
+        return_value="@mindroom_user:localhost",
+    ):
+        event_id = await coordinator._send_poke(
+            ("code", "reviewer"),
+            "!room:localhost",
+            "@code Todo work is ready.",
+            "$thread",
+        )
+
+    assert event_id == "$event"
+    unjoined_bot._hook_send_message.assert_not_awaited()
+    joined_bot._hook_send_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_adapters_skip_when_runtime_is_unavailable(tmp_path: Path) -> None:
     """Unavailable idle, schedule, and sender adapters conservatively skip the tick."""
     coordinator = _coordinator(test_runtime_paths(tmp_path), _config(tmp_path), {})
@@ -170,7 +203,7 @@ async def test_adapters_skip_when_runtime_is_unavailable(tmp_path: Path) -> None
     assert await coordinator._schedule_query("!room:localhost", ("code",)) is None
     assert (
         await coordinator._send_poke(
-            "code",
+            ("code",),
             "!room:localhost",
             "@code Todo work is ready.",
             "$thread",

--- a/tests/test_todo_poke_runtime_binding.py
+++ b/tests/test_todo_poke_runtime_binding.py
@@ -54,7 +54,11 @@ def _coordinator(
 def _bot(**overrides: object) -> MagicMock:
     bot = MagicMock()
     bot.running = overrides.get("running", True)
-    bot.client = overrides.get("client", object())
+    if "client" in overrides:
+        bot.client = overrides["client"]
+    else:
+        bot.client = MagicMock()
+        bot.client.rooms = {"!room:localhost": MagicMock()}
     bot.in_flight_response_count = overrides.get("in_flight_response_count", 0)
     return bot
 
@@ -106,7 +110,7 @@ async def test_assigned_agent_query_and_send_wiring(tmp_path: Path) -> None:
             return_value="@mindroom_user:localhost",
         ),
     ):
-        pending = await coordinator._schedule_query("code", "!room:localhost")
+        pending = await coordinator._schedule_query("!room:localhost", ("code",))
         event_id = await coordinator._send_poke(
             "code",
             "!room:localhost",
@@ -129,12 +133,41 @@ async def test_assigned_agent_query_and_send_wiring(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_schedule_query_uses_joined_candidate_for_shared_room(tmp_path: Path) -> None:
+    """A same-room assignee without membership must not hide a later joined assignee."""
+    unjoined_client = MagicMock()
+    unjoined_client.rooms = {}
+    joined_client = MagicMock()
+    joined_client.rooms = {"!room:localhost": MagicMock()}
+    coordinator = _coordinator(
+        test_runtime_paths(tmp_path),
+        _config(tmp_path),
+        {
+            "code": _bot(client=unjoined_client),
+            "reviewer": _bot(client=joined_client),
+        },
+    )
+
+    with patch(
+        "mindroom.orchestration.todo_poke_runtime.get_pending_schedule_thread_ids_for_room",
+        new=AsyncMock(return_value=frozenset({"$scheduled"})),
+    ) as schedule_query:
+        pending = await coordinator._schedule_query(
+            "!room:localhost",
+            ("code", "reviewer"),
+        )
+
+    assert pending == frozenset({"$scheduled"})
+    schedule_query.assert_awaited_once_with(joined_client, "!room:localhost")
+
+
+@pytest.mark.asyncio
 async def test_adapters_skip_when_runtime_is_unavailable(tmp_path: Path) -> None:
     """Unavailable idle, schedule, and sender adapters conservatively skip the tick."""
     coordinator = _coordinator(test_runtime_paths(tmp_path), _config(tmp_path), {})
 
     assert coordinator._agent_is_idle("code") is False
-    assert await coordinator._schedule_query("code", "!room:localhost") is None
+    assert await coordinator._schedule_query("!room:localhost", ("code",)) is None
     assert (
         await coordinator._send_poke(
             "code",
@@ -162,7 +195,7 @@ async def test_schedule_adapter_preserves_read_errors(tmp_path: Path) -> None:
         ),
         pytest.raises(RuntimeError, match="state unavailable"),
     ):
-        await coordinator._schedule_query("code", "!room:localhost")
+        await coordinator._schedule_query("!room:localhost", ("code",))
 
 
 @pytest.mark.asyncio

--- a/tests/test_todo_poke_runtime_binding.py
+++ b/tests/test_todo_poke_runtime_binding.py
@@ -227,6 +227,34 @@ async def test_schedule_query_rejects_stale_joined_room_cache(tmp_path: Path) ->
 
 
 @pytest.mark.asyncio
+async def test_schedule_query_continues_after_candidate_membership_probe_failure(tmp_path: Path) -> None:
+    """One failed membership probe must not hide a later joined candidate."""
+    failing_client = _client()
+    failing_client.joined_rooms = AsyncMock(side_effect=RuntimeError("membership unavailable"))
+    joined_client = _client("!room:localhost")
+    coordinator = _coordinator(
+        test_runtime_paths(tmp_path),
+        _config(tmp_path),
+        {
+            "code": _bot(client=failing_client),
+            "reviewer": _bot(client=joined_client),
+        },
+    )
+
+    with patch(
+        "mindroom.orchestration.todo_poke_runtime.get_pending_schedule_thread_ids_for_room",
+        new=AsyncMock(return_value=frozenset({"$scheduled"})),
+    ) as schedule_query:
+        pending = await coordinator._schedule_query(
+            "!room:localhost",
+            ("code", "reviewer"),
+        )
+
+    assert pending == frozenset({"$scheduled"})
+    schedule_query.assert_awaited_once_with(joined_client, "!room:localhost")
+
+
+@pytest.mark.asyncio
 async def test_send_rejects_stale_joined_room_cache(tmp_path: Path) -> None:
     """Cached room state must not authorize delivery after membership ended."""
     stale_client = _client(cached_room_ids=("!room:localhost",))
@@ -247,6 +275,30 @@ async def test_send_rejects_stale_joined_room_cache(tmp_path: Path) -> None:
         )
 
     stale_bot._hook_send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_maps_membership_probe_failure_to_delivery_unavailable(tmp_path: Path) -> None:
+    """A failed membership probe must remain a no-attempt delivery outcome."""
+    failing_client = _client()
+    failing_client.joined_rooms = AsyncMock(side_effect=RuntimeError("membership unavailable"))
+    failing_bot = _bot(client=failing_client)
+    failing_bot._hook_send_message = AsyncMock(return_value="$wrong")
+    coordinator = _coordinator(
+        test_runtime_paths(tmp_path),
+        _config(tmp_path),
+        {"code": failing_bot},
+    )
+
+    with pytest.raises(TodoPokeDeliveryUnavailableError):
+        await coordinator._send_poke(
+            "code",
+            "!room:localhost",
+            "@code Todo work is ready.",
+            "$thread",
+        )
+
+    failing_bot._hook_send_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Deliver scheduled todo pokes through each todo's assigned agent.
- Read room schedule state through one joined assigned-agent client while preserving one query per room.
- Skip unavailable rooms without aborting delivery for other rooms.
- Do not consume retry budget or persist cooldown when the assigned agent cannot attempt delivery.
- Preserve existing retry, deduplication, and dispatch behavior for actual send attempts.

## Root cause

Todo discovery retained the assigned agent, but the runtime used a central router for Matrix I/O. When that router was not joined to a target room, schedule queries and message delivery failed even though the assigned agent was joined.

Using an arbitrary joined agent for delivery is also unsafe: the send may succeed, but the assigned agent may never observe its poke. Delivery therefore remains bound to the actual todo owner.

## Tests

- Added coverage for multiple assignees when the first schedule-query candidate is not joined.
- Added coverage proving one unavailable room does not suppress another room.
- Added coverage proving an unavailable owner is not bypassed through another agent.
- Added coverage proving an unavailable owner consumes neither retry budget nor cooldown.
- Retained coverage for normal failed-send retry and deduplication behavior.
- Passed focused todo-poke tests and all-file pre-commit checks.
- Passed full GitHub pytest and smoke-stack checks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Todo reminders now route schedule checks and delivery through eligible assigned agents.
  * Rooms with unavailable schedules are skipped without stopping the full scan.
  * Failed deliveries no longer consume reminder attempts or cooldowns.
  * Pokes now identify the assigned agent.

* **Reliability**
  * Delivery requires the assigned agent to be available and joined to the room.
  * Unavailable rooms and delivery conditions are handled gracefully while other rooms continue processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->