### PR TITLE
Add runtime room model defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,7 @@ Matrix sync callback
 | `thread_utils.py` | Thread analysis and agent detection |
 | `session_ids.py` | Leaf helpers for the canonical persisted room/thread session ID |
 | `thread_models.py` | Durable per-thread model overrides backing `!model` and the `thread_model` tool |
+| `room_model_overrides.py` | Durable per-room runtime model defaults backing `!room_model` |
 | `file_watcher.py` | File change detection for config hot-reload |
 | `interactive.py` | Interactive Q&A system via Matrix reactions |
 | `stop.py` | StopManager for cancelling in-progress responses |

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Plain replies that never reach threaded context still stay plain replies.
 - `!config <operation>` - Manage configuration
 - `!desktop [setup|status|confirm|rotate|disconnect]` - Manage your Desktop target
 - `!model [name|list|reset]` - Show or switch the model used in the current thread
-- `!room_model [name|list|reset]` - Show or switch the default model used in the current room (room admin only)
+- `!room_model [name|list|reset]` - Show the room model default or switch it (set/reset require a room admin)
 - `!thread_mode [room|thread|reset|show]` - Show or switch the thread mode used in the current room (room admin only)
 - `!encrypt [confirm]` - Enable end-to-end encryption for this room (irreversible, room admin only)
 - `!e2ee` - Show encryption diagnostics for this room

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ https://github.com/user-attachments/assets/1f121c89-5418-4f42-bdfe-fb9de0fecd03
 - **100+ tool integrations** — Gmail, GitHub, Google Docs, Google Drive, Home Assistant, shell, Python, web search, and more, plus native Matrix tools and a per-thread `todo` planner, with sandboxed execution and per-tool approval rules.
 - **Knowledge bases (RAG)** — point an agent at a folder of files; MindRoom indexes it and can watch it for changes.
 - **Scheduling & automation** — cron or natural-language scheduled tasks (`!schedule`), background work with human escalation.
-- **Model routing** — a different model per agent, room, or thread (`!model`); route sensitive rooms to local Ollama and everything else to a cloud model.
+- **Model routing** — a different model per agent, room, or thread (`!model` and `!room_model`); route sensitive rooms to local Ollama and everything else to a cloud model.
 - **Voice** — transcription of Matrix voice messages, and text-to-speech tools via OpenAI, Groq, ElevenLabs, and Cartesia.
 - **Streaming responses** — agents type into the room with progressive edits, visible tool traces, and cancellation.
 - **Plugins & hooks** — drop-in [plugins](docs/plugins.md) add custom tools, skills, and OAuth providers, and a typed [event-hook system](docs/hooks.md) (per-hook timeouts, fault isolation) lets them observe and transform messages; reload plugins at runtime with `!reload-plugins`.
@@ -190,6 +190,7 @@ Plain replies that never reach threaded context still stay plain replies.
 - `!config <operation>` - Manage configuration
 - `!desktop [setup|status|confirm|rotate|disconnect]` - Manage your Desktop target
 - `!model [name|list|reset]` - Show or switch the model used in the current thread
+- `!room_model [name|list|reset]` - Show or switch the default model used in the current room (room admin only)
 - `!thread_mode [room|thread|reset|show]` - Show or switch the thread mode used in the current room (room admin only)
 - `!encrypt [confirm]` - Enable end-to-end encryption for this room (irreversible, room admin only)
 - `!e2ee` - Show encryption diagnostics for this room

--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -207,7 +207,7 @@ Show or switch the model that every agent, team, and the router uses in the curr
 `!model` and `!model list` show the current override and the available model names.
 Model names come from the `models:` section of `config.yaml`.
 The override applies from the next message in the thread and survives restarts.
-Other threads and rooms keep their configured models.
+Other threads keep their own thread override when present and otherwise use their room's effective default; other rooms remain independent.
 Use `!room_model` for a durable runtime room default or `room_models` in `config.yaml` for an authored room default.
 Agents can also switch the thread model themselves when they have the `thread_model` tool.
 

--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -224,6 +224,7 @@ Show or switch the model that every agent, team, and the router uses by default 
 
 `!room_model` and `!room_model list` show the current runtime override and available model names.
 `!room_model opus` stores a durable room override without modifying `config.yaml`.
+The new default applies to subsequent turns; an in-progress or approval-paused turn keeps the model choices it started with.
 `!room_model reset` removes the runtime override so the configured `room_models` choice or each entity's configured model applies again.
 Thread-level `!model` overrides and explicit per-run model choices take precedence over the room default.
 Set and reset are Matrix room-admin-only actions, while status is available to authorized room members.

--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -20,7 +20,7 @@ Commands start with `!` and are normally handled by the router agent.
 | `!edit_schedule <id> <task>` | Edit an existing scheduled task |
 | `!desktop [setup\|status\|confirm\|rotate\|disconnect]` | Manage your Desktop target for one agent |
 | `!model [name\|list\|reset]` | Show or switch the model used in the current thread |
-| `!room_model [name\|list\|reset]` | Show or switch the default model used in the current room |
+| `!room_model [name\|list\|reset]` | Show the room model default or switch it (set/reset require a room admin) |
 | `!thread_mode [room\|thread\|reset\|show]` | Show or switch the thread mode used in the current room |
 | `!encrypt [confirm]` | Enable end-to-end encryption for this room (irreversible, room admin only) |
 | `!e2ee` | Show encryption diagnostics for this room |

--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -20,6 +20,7 @@ Commands start with `!` and are normally handled by the router agent.
 | `!edit_schedule <id> <task>` | Edit an existing scheduled task |
 | `!desktop [setup\|status\|confirm\|rotate\|disconnect]` | Manage your Desktop target for one agent |
 | `!model [name\|list\|reset]` | Show or switch the model used in the current thread |
+| `!room_model [name\|list\|reset]` | Show or switch the default model used in the current room |
 | `!thread_mode [room\|thread\|reset\|show]` | Show or switch the thread mode used in the current room |
 | `!encrypt [confirm]` | Enable end-to-end encryption for this room (irreversible, room admin only) |
 | `!e2ee` | Show encryption diagnostics for this room |
@@ -60,7 +61,7 @@ Display available commands or get detailed help on a specific topic.
 !help edit_schedule
 ```
 
-**Topics:** `schedule`, `config`, `model`, `thread_mode`, `thread-mode`, `threadmode`, `list_schedules`, `inspect_schedules`, `cancel`, `cancel_schedule`, `edit`, `edit_schedule`, `reload-plugins`, `reload_plugins`, `encrypt`, `e2ee`, `encryption`
+**Topics:** `schedule`, `config`, `model`, `room_model`, `room-model`, `roommodel`, `thread_mode`, `thread-mode`, `threadmode`, `list_schedules`, `inspect_schedules`, `cancel`, `cancel_schedule`, `edit`, `edit_schedule`, `reload-plugins`, `reload_plugins`, `encrypt`, `e2ee`, `encryption`
 
 ### `!hi`
 
@@ -206,8 +207,27 @@ Show or switch the model that every agent, team, and the router uses in the curr
 `!model` and `!model list` show the current override and the available model names.
 Model names come from the `models:` section of `config.yaml`.
 The override applies from the next message in the thread and survives restarts.
-Other threads and rooms keep their configured models; room-wide overrides are configured via `room_models` in `config.yaml`.
+Other threads and rooms keep their configured models.
+Use `!room_model` for a durable runtime room default or `room_models` in `config.yaml` for an authored room default.
 Agents can also switch the thread model themselves when they have the `thread_model` tool.
+
+### `!room_model`
+
+Show or switch the model that every agent, team, and the router uses by default in the current room.
+
+```
+!room_model
+!room_model list
+!room_model opus
+!room_model reset
+```
+
+`!room_model` and `!room_model list` show the current runtime override and available model names.
+`!room_model opus` stores a durable room override without modifying `config.yaml`.
+`!room_model reset` removes the runtime override so the configured `room_models` choice or each entity's configured model applies again.
+Thread-level `!model` overrides and explicit per-run model choices take precedence over the room default.
+Set and reset are Matrix room-admin-only actions, while status is available to authorized room members.
+The override is keyed by Matrix room ID and stored under `mindroom_data/tracking`, so it survives restarts and room-alias changes.
 
 ### `!thread_mode`
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -597,6 +597,9 @@ rooms:
 # Example: room_models: {dev: sonnet, lobby: gpt4o}
 room_models: {}
 
+# Room admins can override this authored choice at runtime with !room_model.
+# Runtime overrides are stored under mindroom_data/tracking and do not modify this file.
+
 # Room-specific automatic thread summary model overrides (optional)
 # Keys are room aliases or raw Matrix room IDs, values are model names from the models section.
 # Example: room_thread_summary_models: {lobby: haiku}

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -61,6 +61,7 @@ A requester-scoped `!desktop` command may instead be owned by an eligible privat
 - `!config <operation>` - Manage configuration when explicitly enabled for global admins
 - `!desktop [setup|status|confirm|rotate|disconnect]` - Manage the requester's Desktop target
 - `!model [name|list|reset]` - Show or switch the current thread model
+- `!room_model [name|list|reset]` - Show or switch the current room's runtime model default
 - `!thread_mode [room|thread|reset|show]` - Manage room thread mode (room admin only)
 - `!encrypt [confirm]` - Enable room encryption (irreversible, room admin only)
 - `!e2ee` - Show room encryption diagnostics

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -61,7 +61,7 @@ A requester-scoped `!desktop` command may instead be owned by an eligible privat
 - `!config <operation>` - Manage configuration when explicitly enabled for global admins
 - `!desktop [setup|status|confirm|rotate|disconnect]` - Manage the requester's Desktop target
 - `!model [name|list|reset]` - Show or switch the current thread model
-- `!room_model [name|list|reset]` - Show or switch the current room's runtime model default
+- `!room_model [name|list|reset]` - Show the current room model default or switch it (set/reset require a room admin)
 - `!thread_mode [room|thread|reset|show]` - Manage room thread mode (room admin only)
 - `!encrypt [confirm]` - Enable room encryption (irreversible, room admin only)
 - `!e2ee` - Show room encryption diagnostics

--- a/docs/index.md
+++ b/docs/index.md
@@ -171,7 +171,7 @@ mindroom run
 | **Authorization** | Fine-grained user and room access control |
 | **OpenAI-Compatible API** | Use agents from LibreChat, Open WebUI, or any OpenAI client |
 | **Streaming** | Progressive message edits with presence-based gating and tool-call markers |
-| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
+| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!room_model [name\|list\|reset]`, `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
 | **Hot Reload** | Config changes are detected and agents restart automatically |
 
 ## Architecture
@@ -213,7 +213,7 @@ mindroom run
 - [Image Messages](images.md) - Image analysis with vision models
 - [File & Video Attachments](attachments.md) - Context-scoped file and video handling
 - [Streaming Responses](streaming.md) - Progressive message edits with presence-based gating
-- [Chat Commands](chat-commands.md) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
+- [Chat Commands](chat-commands.md) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!room_model [name|list|reset]`, `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
 - [Interactive Q&A](interactive.md) - Clickable multiple-choice questions via Matrix reactions
 - [Authorization](authorization.md) - User and room access control
 - [Matrix Space](matrix-space.md) - Optional root Matrix Space for grouping managed rooms

--- a/docs/index.md
+++ b/docs/index.md
@@ -171,7 +171,7 @@ mindroom run
 | **Authorization** | Fine-grained user and room access control |
 | **OpenAI-Compatible API** | Use agents from LibreChat, Open WebUI, or any OpenAI client |
 | **Streaming** | Progressive message edits with presence-based gating and tool-call markers |
-| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!room_model [name\|list\|reset]`, `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
+| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!room_model [name\|list\|reset]` (set/reset require a room admin), `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
 | **Hot Reload** | Config changes are detected and agents restart automatically |
 
 ## Architecture
@@ -213,7 +213,7 @@ mindroom run
 - [Image Messages](images.md) - Image analysis with vision models
 - [File & Video Attachments](attachments.md) - Context-scoped file and video handling
 - [Streaming Responses](streaming.md) - Progressive message edits with presence-based gating
-- [Chat Commands](chat-commands.md) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!room_model [name|list|reset]`, `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
+- [Chat Commands](chat-commands.md) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!room_model [name|list|reset]` (set/reset require a room admin), `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
 - [Interactive Q&A](interactive.md) - Clickable multiple-choice questions via Matrix reactions
 - [Authorization](authorization.md) - User and room access control
 - [Matrix Space](matrix-space.md) - Optional root Matrix Space for grouping managed rooms

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -350,7 +350,7 @@ reset_thread_model()
 
 - The override is stored per thread root in `mindroom_data/tracking/thread_models.json`.
 - Users can manage the same override with the `!model` chat command; see [Chat Commands](../chat-commands.md).
-- An explicit `active_model_name` (for example a delegated child run) still beats the thread override, and the thread override beats `room_models` and the authored entity model.
+- An explicit `active_model_name` (for example a delegated child run) still beats the thread override, and the thread override beats the runtime `!room_model` choice, configured `room_models`, and the authored entity model.
 
 ## [`matrix_api`]
 

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -325,7 +325,7 @@ All three functions require an active thread context and return an error outside
 The override applies to all agents and teams in the thread, persists across restarts, and takes effect from the next message; the current response keeps the model it started with.
 `get_thread_model` returns the active override and the available model names.
 When a stored override names a model that has been removed from `config.models`, runtime resolution ignores it, and `get_thread_model` reports `override: null` plus a `stale_override` field instead of an active override.
-`reset_thread_model` removes the override so agents use their configured models again.
+`reset_thread_model` removes the thread override so room-level model selection applies: an active runtime `!room_model` override, then configured `room_models`, then each entity's configured model.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -173,7 +173,7 @@ mindroom run
 | **Authorization** | Fine-grained user and room access control |
 | **OpenAI-Compatible API** | Use agents from LibreChat, Open WebUI, or any OpenAI client |
 | **Streaming** | Progressive message edits with presence-based gating and tool-call markers |
-| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
+| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!room_model [name\|list\|reset]`, `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
 | **Hot Reload** | Config changes are detected and agents restart automatically |
 
 ## Architecture
@@ -215,7 +215,7 @@ mindroom run
 - [Image Messages](https://docs.mindroom.chat/images/) - Image analysis with vision models
 - [File & Video Attachments](https://docs.mindroom.chat/attachments/) - Context-scoped file and video handling
 - [Streaming Responses](https://docs.mindroom.chat/streaming/) - Progressive message edits with presence-based gating
-- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
+- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!room_model [name|list|reset]`, `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
 - [Interactive Q&A](https://docs.mindroom.chat/interactive/) - Clickable multiple-choice questions via Matrix reactions
 - [Authorization](https://docs.mindroom.chat/authorization/) - User and room access control
 - [Matrix Space](https://docs.mindroom.chat/matrix-space/) - Optional root Matrix Space for grouping managed rooms
@@ -1480,6 +1480,9 @@ rooms:
 # Keys are room aliases, values are model names from the models section.
 # Example: room_models: {dev: sonnet, lobby: gpt4o}
 room_models: {}
+
+# Room admins can override this authored choice at runtime with !room_model.
+# Runtime overrides are stored under mindroom_data/tracking and do not modify this file.
 
 # Room-specific automatic thread summary model overrides (optional)
 # Keys are room aliases or raw Matrix room IDs, values are model names from the models section.
@@ -3090,6 +3093,7 @@ A requester-scoped `!desktop` command may instead be owned by an eligible privat
 - `!config <operation>` - Manage configuration when explicitly enabled for global admins
 - `!desktop [setup|status|confirm|rotate|disconnect]` - Manage the requester's Desktop target
 - `!model [name|list|reset]` - Show or switch the current thread model
+- `!room_model [name|list|reset]` - Show or switch the current room's runtime model default
 - `!thread_mode [room|thread|reset|show]` - Manage room thread mode (room admin only)
 - `!encrypt [confirm]` - Enable room encryption (irreversible, room admin only)
 - `!e2ee` - Show room encryption diagnostics
@@ -7442,7 +7446,7 @@ reset_thread_model()
 
 - The override is stored per thread root in `mindroom_data/tracking/thread_models.json`.
 - Users can manage the same override with the `!model` chat command; see [Chat Commands](https://docs.mindroom.chat/chat-commands/).
-- An explicit `active_model_name` (for example a delegated child run) still beats the thread override, and the thread override beats `room_models` and the authored entity model.
+- An explicit `active_model_name` (for example a delegated child run) still beats the thread override, and the thread override beats the runtime `!room_model` choice, configured `room_models`, and the authored entity model.
 
 ## [`matrix_api`]
 
@@ -14771,6 +14775,7 @@ Commands start with `!` and are normally handled by the router agent.
 | `!edit_schedule <id> <task>` | Edit an existing scheduled task |
 | `!desktop [setup\|status\|confirm\|rotate\|disconnect]` | Manage your Desktop target for one agent |
 | `!model [name\|list\|reset]` | Show or switch the model used in the current thread |
+| `!room_model [name\|list\|reset]` | Show or switch the default model used in the current room |
 | `!thread_mode [room\|thread\|reset\|show]` | Show or switch the thread mode used in the current room |
 | `!encrypt [confirm]` | Enable end-to-end encryption for this room (irreversible, room admin only) |
 | `!e2ee` | Show encryption diagnostics for this room |
@@ -14811,7 +14816,7 @@ Display available commands or get detailed help on a specific topic.
 !help edit_schedule
 ```
 
-**Topics:** `schedule`, `config`, `model`, `thread_mode`, `thread-mode`, `threadmode`, `list_schedules`, `inspect_schedules`, `cancel`, `cancel_schedule`, `edit`, `edit_schedule`, `reload-plugins`, `reload_plugins`, `encrypt`, `e2ee`, `encryption`
+**Topics:** `schedule`, `config`, `model`, `room_model`, `room-model`, `roommodel`, `thread_mode`, `thread-mode`, `threadmode`, `list_schedules`, `inspect_schedules`, `cancel`, `cancel_schedule`, `edit`, `edit_schedule`, `reload-plugins`, `reload_plugins`, `encrypt`, `e2ee`, `encryption`
 
 ### `!hi`
 
@@ -14957,8 +14962,27 @@ Show or switch the model that every agent, team, and the router uses in the curr
 `!model` and `!model list` show the current override and the available model names.
 Model names come from the `models:` section of `config.yaml`.
 The override applies from the next message in the thread and survives restarts.
-Other threads and rooms keep their configured models; room-wide overrides are configured via `room_models` in `config.yaml`.
+Other threads and rooms keep their configured models.
+Use `!room_model` for a durable runtime room default or `room_models` in `config.yaml` for an authored room default.
 Agents can also switch the thread model themselves when they have the `thread_model` tool.
+
+### `!room_model`
+
+Show or switch the model that every agent, team, and the router uses by default in the current room.
+
+```
+!room_model
+!room_model list
+!room_model opus
+!room_model reset
+```
+
+`!room_model` and `!room_model list` show the current runtime override and available model names.
+`!room_model opus` stores a durable room override without modifying `config.yaml`.
+`!room_model reset` removes the runtime override so the configured `room_models` choice or each entity's configured model applies again.
+Thread-level `!model` overrides and explicit per-run model choices take precedence over the room default.
+Set and reset are Matrix room-admin-only actions, while status is available to authorized room members.
+The override is keyed by Matrix room ID and stored under `mindroom_data/tracking`, so it survives restarts and room-alias changes.
 
 ### `!thread_mode`
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -173,7 +173,7 @@ mindroom run
 | **Authorization** | Fine-grained user and room access control |
 | **OpenAI-Compatible API** | Use agents from LibreChat, Open WebUI, or any OpenAI client |
 | **Streaming** | Progressive message edits with presence-based gating and tool-call markers |
-| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!room_model [name\|list\|reset]`, `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
+| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!room_model [name\|list\|reset]` (set/reset require a room admin), `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
 | **Hot Reload** | Config changes are detected and agents restart automatically |
 
 ## Architecture
@@ -215,7 +215,7 @@ mindroom run
 - [Image Messages](https://docs.mindroom.chat/images/) - Image analysis with vision models
 - [File & Video Attachments](https://docs.mindroom.chat/attachments/) - Context-scoped file and video handling
 - [Streaming Responses](https://docs.mindroom.chat/streaming/) - Progressive message edits with presence-based gating
-- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!room_model [name|list|reset]`, `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
+- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!room_model [name|list|reset]` (set/reset require a room admin), `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
 - [Interactive Q&A](https://docs.mindroom.chat/interactive/) - Clickable multiple-choice questions via Matrix reactions
 - [Authorization](https://docs.mindroom.chat/authorization/) - User and room access control
 - [Matrix Space](https://docs.mindroom.chat/matrix-space/) - Optional root Matrix Space for grouping managed rooms
@@ -3093,7 +3093,7 @@ A requester-scoped `!desktop` command may instead be owned by an eligible privat
 - `!config <operation>` - Manage configuration when explicitly enabled for global admins
 - `!desktop [setup|status|confirm|rotate|disconnect]` - Manage the requester's Desktop target
 - `!model [name|list|reset]` - Show or switch the current thread model
-- `!room_model [name|list|reset]` - Show or switch the current room's runtime model default
+- `!room_model [name|list|reset]` - Show the current room model default or switch it (set/reset require a room admin)
 - `!thread_mode [room|thread|reset|show]` - Manage room thread mode (room admin only)
 - `!encrypt [confirm]` - Enable room encryption (irreversible, room admin only)
 - `!e2ee` - Show room encryption diagnostics
@@ -14962,7 +14962,7 @@ Show or switch the model that every agent, team, and the router uses in the curr
 `!model` and `!model list` show the current override and the available model names.
 Model names come from the `models:` section of `config.yaml`.
 The override applies from the next message in the thread and survives restarts.
-Other threads and rooms keep their configured models.
+Other threads keep their own thread override when present and otherwise use their room's effective default; other rooms remain independent.
 Use `!room_model` for a durable runtime room default or `room_models` in `config.yaml` for an authored room default.
 Agents can also switch the thread model themselves when they have the `thread_model` tool.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14775,7 +14775,7 @@ Commands start with `!` and are normally handled by the router agent.
 | `!edit_schedule <id> <task>` | Edit an existing scheduled task |
 | `!desktop [setup\|status\|confirm\|rotate\|disconnect]` | Manage your Desktop target for one agent |
 | `!model [name\|list\|reset]` | Show or switch the model used in the current thread |
-| `!room_model [name\|list\|reset]` | Show or switch the default model used in the current room |
+| `!room_model [name\|list\|reset]` | Show the room model default or switch it (set/reset require a room admin) |
 | `!thread_mode [room\|thread\|reset\|show]` | Show or switch the thread mode used in the current room |
 | `!encrypt [confirm]` | Enable end-to-end encryption for this room (irreversible, room admin only) |
 | `!e2ee` | Show encryption diagnostics for this room |

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7421,7 +7421,7 @@ All three functions require an active thread context and return an error outside
 The override applies to all agents and teams in the thread, persists across restarts, and takes effect from the next message; the current response keeps the model it started with.
 `get_thread_model` returns the active override and the available model names.
 When a stored override names a model that has been removed from `config.models`, runtime resolution ignores it, and `get_thread_model` reports `override: null` plus a `stale_override` field instead of an active override.
-`reset_thread_model` removes the override so agents use their configured models again.
+`reset_thread_model` removes the thread override so room-level model selection applies: an active runtime `!room_model` override, then configured `room_models`, then each entity's configured model.
 
 ### Configuration
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14979,6 +14979,7 @@ Show or switch the model that every agent, team, and the router uses by default 
 
 `!room_model` and `!room_model list` show the current runtime override and available model names.
 `!room_model opus` stores a durable room override without modifying `config.yaml`.
+The new default applies to subsequent turns; an in-progress or approval-paused turn keeps the model choices it started with.
 `!room_model reset` removes the runtime override so the configured `room_models` choice or each entity's configured model applies again.
 Thread-level `!model` overrides and explicit per-run model choices take precedence over the room default.
 Set and reset are Matrix room-admin-only actions, while status is available to authorized room members.

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -203,7 +203,7 @@ Show or switch the model that every agent, team, and the router uses in the curr
 `!model` and `!model list` show the current override and the available model names.
 Model names come from the `models:` section of `config.yaml`.
 The override applies from the next message in the thread and survives restarts.
-Other threads and rooms keep their configured models.
+Other threads keep their own thread override when present and otherwise use their room's effective default; other rooms remain independent.
 Use `!room_model` for a durable runtime room default or `room_models` in `config.yaml` for an authored room default.
 Agents can also switch the thread model themselves when they have the `thread_model` tool.
 

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -220,6 +220,7 @@ Show or switch the model that every agent, team, and the router uses by default 
 
 `!room_model` and `!room_model list` show the current runtime override and available model names.
 `!room_model opus` stores a durable room override without modifying `config.yaml`.
+The new default applies to subsequent turns; an in-progress or approval-paused turn keeps the model choices it started with.
 `!room_model reset` removes the runtime override so the configured `room_models` choice or each entity's configured model applies again.
 Thread-level `!model` overrides and explicit per-run model choices take precedence over the room default.
 Set and reset are Matrix room-admin-only actions, while status is available to authorized room members.

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -16,6 +16,7 @@ Commands start with `!` and are normally handled by the router agent.
 | `!edit_schedule <id> <task>` | Edit an existing scheduled task |
 | `!desktop [setup\|status\|confirm\|rotate\|disconnect]` | Manage your Desktop target for one agent |
 | `!model [name\|list\|reset]` | Show or switch the model used in the current thread |
+| `!room_model [name\|list\|reset]` | Show or switch the default model used in the current room |
 | `!thread_mode [room\|thread\|reset\|show]` | Show or switch the thread mode used in the current room |
 | `!encrypt [confirm]` | Enable end-to-end encryption for this room (irreversible, room admin only) |
 | `!e2ee` | Show encryption diagnostics for this room |
@@ -56,7 +57,7 @@ Display available commands or get detailed help on a specific topic.
 !help edit_schedule
 ```
 
-**Topics:** `schedule`, `config`, `model`, `thread_mode`, `thread-mode`, `threadmode`, `list_schedules`, `inspect_schedules`, `cancel`, `cancel_schedule`, `edit`, `edit_schedule`, `reload-plugins`, `reload_plugins`, `encrypt`, `e2ee`, `encryption`
+**Topics:** `schedule`, `config`, `model`, `room_model`, `room-model`, `roommodel`, `thread_mode`, `thread-mode`, `threadmode`, `list_schedules`, `inspect_schedules`, `cancel`, `cancel_schedule`, `edit`, `edit_schedule`, `reload-plugins`, `reload_plugins`, `encrypt`, `e2ee`, `encryption`
 
 ### `!hi`
 
@@ -202,8 +203,27 @@ Show or switch the model that every agent, team, and the router uses in the curr
 `!model` and `!model list` show the current override and the available model names.
 Model names come from the `models:` section of `config.yaml`.
 The override applies from the next message in the thread and survives restarts.
-Other threads and rooms keep their configured models; room-wide overrides are configured via `room_models` in `config.yaml`.
+Other threads and rooms keep their configured models.
+Use `!room_model` for a durable runtime room default or `room_models` in `config.yaml` for an authored room default.
 Agents can also switch the thread model themselves when they have the `thread_model` tool.
+
+### `!room_model`
+
+Show or switch the model that every agent, team, and the router uses by default in the current room.
+
+```
+!room_model
+!room_model list
+!room_model opus
+!room_model reset
+```
+
+`!room_model` and `!room_model list` show the current runtime override and available model names.
+`!room_model opus` stores a durable room override without modifying `config.yaml`.
+`!room_model reset` removes the runtime override so the configured `room_models` choice or each entity's configured model applies again.
+Thread-level `!model` overrides and explicit per-run model choices take precedence over the room default.
+Set and reset are Matrix room-admin-only actions, while status is available to authorized room members.
+The override is keyed by Matrix room ID and stored under `mindroom_data/tracking`, so it survives restarts and room-alias changes.
 
 ### `!thread_mode`
 

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -16,7 +16,7 @@ Commands start with `!` and are normally handled by the router agent.
 | `!edit_schedule <id> <task>` | Edit an existing scheduled task |
 | `!desktop [setup\|status\|confirm\|rotate\|disconnect]` | Manage your Desktop target for one agent |
 | `!model [name\|list\|reset]` | Show or switch the model used in the current thread |
-| `!room_model [name\|list\|reset]` | Show or switch the default model used in the current room |
+| `!room_model [name\|list\|reset]` | Show the room model default or switch it (set/reset require a room admin) |
 | `!thread_mode [room\|thread\|reset\|show]` | Show or switch the thread mode used in the current room |
 | `!encrypt [confirm]` | Enable end-to-end encryption for this room (irreversible, room admin only) |
 | `!e2ee` | Show encryption diagnostics for this room |

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -593,6 +593,9 @@ rooms:
 # Example: room_models: {dev: sonnet, lobby: gpt4o}
 room_models: {}
 
+# Room admins can override this authored choice at runtime with !room_model.
+# Runtime overrides are stored under mindroom_data/tracking and do not modify this file.
+
 # Room-specific automatic thread summary model overrides (optional)
 # Keys are room aliases or raw Matrix room IDs, values are model names from the models section.
 # Example: room_thread_summary_models: {lobby: haiku}

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -57,7 +57,7 @@ A requester-scoped `!desktop` command may instead be owned by an eligible privat
 - `!config <operation>` - Manage configuration when explicitly enabled for global admins
 - `!desktop [setup|status|confirm|rotate|disconnect]` - Manage the requester's Desktop target
 - `!model [name|list|reset]` - Show or switch the current thread model
-- `!room_model [name|list|reset]` - Show or switch the current room's runtime model default
+- `!room_model [name|list|reset]` - Show the current room model default or switch it (set/reset require a room admin)
 - `!thread_mode [room|thread|reset|show]` - Manage room thread mode (room admin only)
 - `!encrypt [confirm]` - Enable room encryption (irreversible, room admin only)
 - `!e2ee` - Show room encryption diagnostics

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -57,6 +57,7 @@ A requester-scoped `!desktop` command may instead be owned by an eligible privat
 - `!config <operation>` - Manage configuration when explicitly enabled for global admins
 - `!desktop [setup|status|confirm|rotate|disconnect]` - Manage the requester's Desktop target
 - `!model [name|list|reset]` - Show or switch the current thread model
+- `!room_model [name|list|reset]` - Show or switch the current room's runtime model default
 - `!thread_mode [room|thread|reset|show]` - Manage room thread mode (room admin only)
 - `!encrypt [confirm]` - Enable room encryption (irreversible, room admin only)
 - `!e2ee` - Show room encryption diagnostics

--- a/skills/mindroom-docs/references/page__index.md
+++ b/skills/mindroom-docs/references/page__index.md
@@ -167,7 +167,7 @@ mindroom run
 | **Authorization** | Fine-grained user and room access control |
 | **OpenAI-Compatible API** | Use agents from LibreChat, Open WebUI, or any OpenAI client |
 | **Streaming** | Progressive message edits with presence-based gating and tool-call markers |
-| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
+| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!room_model [name\|list\|reset]`, `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
 | **Hot Reload** | Config changes are detected and agents restart automatically |
 
 ## Architecture
@@ -209,7 +209,7 @@ mindroom run
 - [Image Messages](https://docs.mindroom.chat/images/) - Image analysis with vision models
 - [File & Video Attachments](https://docs.mindroom.chat/attachments/) - Context-scoped file and video handling
 - [Streaming Responses](https://docs.mindroom.chat/streaming/) - Progressive message edits with presence-based gating
-- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
+- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!room_model [name|list|reset]`, `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
 - [Interactive Q&A](https://docs.mindroom.chat/interactive/) - Clickable multiple-choice questions via Matrix reactions
 - [Authorization](https://docs.mindroom.chat/authorization/) - User and room access control
 - [Matrix Space](https://docs.mindroom.chat/matrix-space/) - Optional root Matrix Space for grouping managed rooms

--- a/skills/mindroom-docs/references/page__index.md
+++ b/skills/mindroom-docs/references/page__index.md
@@ -167,7 +167,7 @@ mindroom run
 | **Authorization** | Fine-grained user and room access control |
 | **OpenAI-Compatible API** | Use agents from LibreChat, Open WebUI, or any OpenAI client |
 | **Streaming** | Progressive message edits with presence-based gating and tool-call markers |
-| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!room_model [name\|list\|reset]`, `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
+| **Chat Commands** | Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup\|status\|confirm\|rotate\|disconnect]`, `!model [name\|list\|reset]`, `!room_model [name\|list\|reset]` (set/reset require a room admin), `!thread_mode [room\|thread\|reset\|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi`; commands are normally handled by the router, while a Desktop-enabled agent can handle `!desktop` directly in a room containing only it and the requester |
 | **Hot Reload** | Config changes are detected and agents restart automatically |
 
 ## Architecture
@@ -209,7 +209,7 @@ mindroom run
 - [Image Messages](https://docs.mindroom.chat/images/) - Image analysis with vision models
 - [File & Video Attachments](https://docs.mindroom.chat/attachments/) - Context-scoped file and video handling
 - [Streaming Responses](https://docs.mindroom.chat/streaming/) - Progressive message edits with presence-based gating
-- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!room_model [name|list|reset]`, `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
+- [Chat Commands](https://docs.mindroom.chat/chat-commands/) - Built-in `!schedule <task>`, `!list_schedules`, `!cancel_schedule <id>`, `!edit_schedule <id> <task>`, `!desktop [setup|status|confirm|rotate|disconnect]`, `!model [name|list|reset]`, `!room_model [name|list|reset]` (set/reset require a room admin), `!thread_mode [room|thread|reset|show]`, `!encrypt [confirm]`, `!e2ee`, `!help [topic]`, admin `!reload-plugins`, opt-in admin `!config <operation>`, and `!hi` commands
 - [Interactive Q&A](https://docs.mindroom.chat/interactive/) - Clickable multiple-choice questions via Matrix reactions
 - [Authorization](https://docs.mindroom.chat/authorization/) - User and room access control
 - [Matrix Space](https://docs.mindroom.chat/matrix-space/) - Optional root Matrix Space for grouping managed rooms

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -346,7 +346,7 @@ reset_thread_model()
 
 - The override is stored per thread root in `mindroom_data/tracking/thread_models.json`.
 - Users can manage the same override with the `!model` chat command; see [Chat Commands](https://docs.mindroom.chat/chat-commands/).
-- An explicit `active_model_name` (for example a delegated child run) still beats the thread override, and the thread override beats `room_models` and the authored entity model.
+- An explicit `active_model_name` (for example a delegated child run) still beats the thread override, and the thread override beats the runtime `!room_model` choice, configured `room_models`, and the authored entity model.
 
 ## [`matrix_api`]
 

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -321,7 +321,7 @@ All three functions require an active thread context and return an error outside
 The override applies to all agents and teams in the thread, persists across restarts, and takes effect from the next message; the current response keeps the model it started with.
 `get_thread_model` returns the active override and the available model names.
 When a stored override names a model that has been removed from `config.models`, runtime resolution ignores it, and `get_thread_model` reports `override: null` plus a `stale_override` field instead of an active override.
-`reset_thread_model` removes the override so agents use their configured models again.
+`reset_thread_model` removes the thread override so room-level model selection applies: an active runtime `!room_model` override, then configured `room_models`, then each entity's configured model.
 
 ### Configuration
 

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -16,6 +16,7 @@ from mindroom.commands.desktop_commands import (
 from mindroom.commands.encryption_commands import handle_e2ee_command, handle_encrypt_command
 from mindroom.commands.model_commands import handle_model_command
 from mindroom.commands.parsing import Command, CommandType, get_command_help, get_compact_command_entries
+from mindroom.commands.room_model_commands import handle_room_model_command
 from mindroom.commands.thread_mode_commands import handle_thread_mode_command
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.entity_resolution import configured_routable_entity_ids_for_room, entity_identity_registry
@@ -56,6 +57,7 @@ COMMAND_TYPES_WITH_SIDE_EFFECTS = frozenset(
         CommandType.EDIT_SCHEDULE,
         CommandType.DESKTOP,
         CommandType.MODEL,
+        CommandType.ROOM_MODEL,
         CommandType.THREAD_MODE,
         CommandType.ENCRYPT,
     },
@@ -456,6 +458,17 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
             room_id=room.room_id,
             thread_id=effective_thread_id,
             requester_user_id=requester_user_id,
+        )
+
+    elif command.type == CommandType.ROOM_MODEL:
+        response_text = await handle_room_model_command(
+            command.args.get("args_text", ""),
+            client=context.client,
+            config=context.config,
+            runtime_paths=context.runtime_paths,
+            room_id=room.room_id,
+            requester_user_id=requester_user_id,
+            sender_user_id=event.sender,
         )
 
     elif command.type == CommandType.THREAD_MODE:

--- a/src/mindroom/commands/model_commands.py
+++ b/src/mindroom/commands/model_commands.py
@@ -31,7 +31,7 @@ def _show_thread_model(config: Config, runtime_paths: RuntimePaths, thread_id: s
         model = config.models[override]
         current = f"This thread uses the `{override}` override ({model.provider} {model.id})."
     else:
-        current = "No thread model override is set; agents use their configured models."
+        current = "No thread model override is set; room-level model selection applies."
     return (
         f"{current}\n\n**Available models:**\n{_available_models_text(config)}\n\n"
         "Use `!model <name>` inside a thread to switch it, or `!model reset` to remove the override."
@@ -58,7 +58,7 @@ def handle_model_command(  # noqa: PLR0911
             return _THREAD_REQUIRED_MESSAGE
         if requested.lower() in _RESET_ARGUMENTS:
             if clear_thread_model_override(runtime_paths, thread_id):
-                return "✅ Thread model override removed. Agents use their configured models again."
+                return "✅ Thread model override removed; room-level model selection applies again."
             return "This thread has no model override."
         return f"❌ Unknown model `{requested}`. Available models:\n{_available_models_text(config)}"
     if thread_id is None:
@@ -73,5 +73,5 @@ def handle_model_command(  # noqa: PLR0911
     model = config.models[requested]
     return (
         f"✅ This thread now uses `{requested}` ({model.provider} {model.id}) for all agents and teams.\n"
-        "Use `!model reset` to restore the configured models."
+        "Use `!model reset` to restore room-level model selection."
     )

--- a/src/mindroom/commands/parsing.py
+++ b/src/mindroom/commands/parsing.py
@@ -25,6 +25,7 @@ class CommandType(Enum):
     CONFIG = "config"  # Configuration command
     DESKTOP = "desktop"  # Requester-scoped Desktop pairing
     MODEL = "model"  # Per-thread model override command
+    ROOM_MODEL = "room_model"  # Room-level model override command
     THREAD_MODE = "thread_mode"  # Room-level thread mode override command
     ENCRYPT = "encrypt"  # Room encryption enablement command
     E2EE = "e2ee"  # Encryption diagnostics command
@@ -43,6 +44,10 @@ _COMMAND_DOCS = {
     CommandType.CONFIG: ("!config <operation>", "Manage configuration"),
     CommandType.DESKTOP: ("!desktop [setup|status|confirm|rotate|disconnect]", "Manage your Desktop target"),
     CommandType.MODEL: ("!model [name|list|reset]", "Show or switch the model used in the current thread"),
+    CommandType.ROOM_MODEL: (
+        "!room_model [name|list|reset]",
+        "Show or switch the default model used in the current room (room admin only)",
+    ),
     CommandType.THREAD_MODE: (
         "!thread_mode [room|thread|reset|show]",
         "Show or switch the thread mode used in the current room (room admin only)",
@@ -121,6 +126,7 @@ class _CommandParser:
     CONFIG_PATTERN = re.compile(r"^!config(?:\s+(.+))?$", re.IGNORECASE)
     DESKTOP_PATTERN = re.compile(r"^!desktop(?:\s+(.+))?$", re.IGNORECASE)
     MODEL_PATTERN = re.compile(r"^!model(?:\s+(.+))?$", re.IGNORECASE)
+    ROOM_MODEL_PATTERN = re.compile(r"^!room[_-]?model(?:\s+(.+))?$", re.IGNORECASE)
     THREAD_MODE_PATTERN = re.compile(r"^!thread[_-]?mode(?:\s+(.+))?$", re.IGNORECASE)
     ENCRYPT_PATTERN = re.compile(r"^!encrypt(?:\s+(.+))?$", re.IGNORECASE)
     E2EE_PATTERN = re.compile(r"^!e2ee$", re.IGNORECASE)
@@ -224,6 +230,15 @@ class _CommandParser:
                 raw_text=message,
             )
 
+        match = self.ROOM_MODEL_PATTERN.match(message)
+        if match:
+            args_text = match.group(1).strip() if match.group(1) else ""
+            return Command(
+                type=CommandType.ROOM_MODEL,
+                args={"args_text": args_text},
+                raw_text=message,
+            )
+
         match = self.THREAD_MODE_PATTERN.match(message)
         if match:
             args_text = match.group(1).strip() if match.group(1) else ""
@@ -253,7 +268,7 @@ class _CommandParser:
         )
 
 
-def get_command_help(topic: str | None = None) -> str:  # noqa: PLR0911
+def get_command_help(topic: str | None = None) -> str:  # noqa: C901, PLR0911
     """Get help text for commands.
 
     Args:
@@ -399,7 +414,23 @@ How it works:
 - The override applies to all agents, teams, and the router from the next message in the thread
 - Model names come from the `models:` section of config.yaml
 - The override is scoped to one thread and survives restarts; other threads and rooms are unaffected
-- Room-wide overrides are configured separately via `room_models` in config.yaml"""
+- Use `!room_model` for a runtime room default, or `room_models` in config.yaml for an authored room default"""
+
+    if topic in {"room_model", "room-model", "roommodel"}:
+        return """**Room Model Command**
+
+Usage: `!room_model [name|list|reset]` - Show or switch the default model used in the current room
+
+**Examples:**
+- `!room_model` or `!room_model list` - Show the current room override and available models
+- `!room_model opus` - Make `opus` the default for every agent, team, and the router in this room
+- `!room_model reset` - Remove the runtime override and restore configured room or entity models
+
+How it works:
+- The override applies from the next model run and survives restarts without changing config.yaml
+- Thread overrides take precedence over this room default
+- The runtime room override takes precedence over `room_models` in config.yaml
+- Only Matrix room admins can set or reset the override"""
 
     if topic in {"encrypt", "e2ee", "encryption"}:
         return """**Encryption Commands**

--- a/src/mindroom/commands/parsing.py
+++ b/src/mindroom/commands/parsing.py
@@ -46,7 +46,7 @@ _COMMAND_DOCS = {
     CommandType.MODEL: ("!model [name|list|reset]", "Show or switch the model used in the current thread"),
     CommandType.ROOM_MODEL: (
         "!room_model [name|list|reset]",
-        "Show or switch the default model used in the current room (room admin only)",
+        "Show the room model default or switch it (set/reset require a room admin)",
     ),
     CommandType.THREAD_MODE: (
         "!thread_mode [room|thread|reset|show]",

--- a/src/mindroom/commands/parsing.py
+++ b/src/mindroom/commands/parsing.py
@@ -408,7 +408,7 @@ Usage: `!model [name|list|reset]` - Show or switch the model used in the current
 **Examples:**
 - `!model` or `!model list` - Show the current thread's model override and the available models
 - `!model opus` - Make every agent and team in this thread use the `opus` model
-- `!model reset` - Remove the override so agents use their configured models again
+- `!model reset` - Remove the override so room-level model selection applies again
 
 How it works:
 - The override applies to all agents, teams, and the router from the next message in the thread
@@ -424,7 +424,7 @@ Usage: `!room_model [name|list|reset]` - Show or switch the default model used i
 **Examples:**
 - `!room_model` or `!room_model list` - Show the current room override and available models
 - `!room_model opus` - Make `opus` the default for every agent, team, and the router in this room
-- `!room_model reset` - Remove the runtime override and restore configured room or entity models
+- `!room_model reset` - Remove the runtime override so the room default returns to configured room or entity models
 
 How it works:
 - The override applies from the next model run and survives restarts without changing config.yaml

--- a/src/mindroom/commands/room_model_commands.py
+++ b/src/mindroom/commands/room_model_commands.py
@@ -33,7 +33,10 @@ def _show_room_model(config: Config, runtime_paths: RuntimePaths, room_id: str) 
     elif state.stale is not None:
         current = f"Stored room model override `{state.stale}` is unavailable and ignored."
     else:
-        current = "No room model override is set; agents use configured room or entity models."
+        current = (
+            "No room model override is set; configured room or entity models define the room default. "
+            "Thread model overrides still take precedence."
+        )
     return (
         f"{current}\n\n**Available models:**\n{_available_models_text(config)}\n\n"
         "Use `!room_model <name>` to switch this room, or `!room_model reset` to remove the override."
@@ -64,7 +67,10 @@ async def handle_room_model_command(
 
     if requested not in config.models:
         if clear_room_model_override(runtime_paths, room_id):
-            return "✅ Room model override removed. Agents use their configured room or entity models again."
+            return (
+                "✅ Room model override removed. Room default returns to configured room or entity models. "
+                "Thread model overrides still take precedence."
+            )
         return "This room has no model override."
 
     set_room_model_override(

--- a/src/mindroom/commands/room_model_commands.py
+++ b/src/mindroom/commands/room_model_commands.py
@@ -1,0 +1,80 @@
+"""Chat-based room model override handling for the `!room_model` command."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.matrix.client_room_admin import room_admin_power_user
+from mindroom.room_model_overrides import (
+    clear_room_model_override,
+    resolve_room_model_override,
+    set_room_model_override,
+)
+
+if TYPE_CHECKING:
+    import nio
+
+    from mindroom.config.main import Config
+    from mindroom.constants import RuntimePaths
+
+_RESET_ARGUMENTS = frozenset({"reset", "clear"})
+_LIST_ARGUMENTS = frozenset({"list", "show", "status"})
+
+
+def _available_models_text(config: Config) -> str:
+    return "\n".join(f"- `{name}` ({model.provider} {model.id})" for name, model in config.models.items())
+
+
+def _show_room_model(config: Config, runtime_paths: RuntimePaths, room_id: str) -> str:
+    state = resolve_room_model_override(runtime_paths, room_id, configured_models=config.models)
+    if state.active is not None:
+        model = config.models[state.active]
+        current = f"This room uses the `{state.active}` override ({model.provider} {model.id})."
+    elif state.stale is not None:
+        current = f"Stored room model override `{state.stale}` is unavailable and ignored."
+    else:
+        current = "No room model override is set; agents use configured room or entity models."
+    return (
+        f"{current}\n\n**Available models:**\n{_available_models_text(config)}\n\n"
+        "Use `!room_model <name>` to switch this room, or `!room_model reset` to remove the override."
+    )
+
+
+async def handle_room_model_command(
+    args_text: str,
+    *,
+    client: nio.AsyncClient,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    room_id: str,
+    requester_user_id: str,
+    sender_user_id: str,
+) -> str:
+    """Set or clear one room's runtime model override."""
+    requested = args_text.strip()
+    if requested not in config.models:
+        if not requested or requested.lower() in _LIST_ARGUMENTS:
+            return _show_room_model(config, runtime_paths, room_id)
+        if requested.lower() not in _RESET_ARGUMENTS:
+            return f"❌ Unknown model `{requested}`. Available models:\n{_available_models_text(config)}"
+
+    admin_user_id = await room_admin_power_user(client, room_id, (requester_user_id, sender_user_id))
+    if admin_user_id is None:
+        return "❌ Room admin only."
+
+    if requested not in config.models:
+        if clear_room_model_override(runtime_paths, room_id):
+            return "✅ Room model override removed. Agents use their configured room or entity models again."
+        return "This room has no model override."
+
+    set_room_model_override(
+        runtime_paths,
+        room_id=room_id,
+        model_name=requested,
+        set_by=admin_user_id,
+    )
+    model = config.models[requested]
+    return (
+        f"✅ This room now uses `{requested}` ({model.provider} {model.id}) as its model default.\n"
+        "Thread model overrides still take precedence."
+    )

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -84,6 +84,7 @@ from mindroom.matrix_identifiers import (
 from mindroom.mcp.config import MCPServerConfig, normalize_mcp_server_id
 from mindroom.prompt_templates import render_prompt_template, validate_prompt_template_fields
 from mindroom.prompts import PROMPT_DEFAULT_NAMES, PROMPT_DEFAULTS
+from mindroom.room_model_overrides import resolve_room_model_override
 from mindroom.room_thread_modes import resolve_room_thread_mode_override
 from mindroom.runtime_env_policy import SANDBOX_RUNTIME_ENV_BY_KEY
 from mindroom.thread_models import resolve_thread_model_override
@@ -1881,8 +1882,8 @@ class Config(BaseModel):
     ) -> ResolvedRuntimeModel:
         """Resolve the active runtime model plus its configured context window.
 
-        Precedence: explicit `active_model_name`, then a persisted per-thread
-        override, then the room override, then the entity's authored model.
+        Precedence: explicit `active_model_name`, persisted thread override,
+        persisted room override, configured room override, then authored entity model.
         """
         resolved_model_name = active_model_name
         if resolved_model_name is None and thread_id is not None:
@@ -1903,9 +1904,17 @@ class Config(BaseModel):
                 if runtime_paths is None:
                     msg = "runtime_paths are required to resolve a room-specific runtime model"
                     raise ValueError(msg)
-                from mindroom.entity_resolution import effective_entity_model_name  # noqa: PLC0415
+                room_override = resolve_room_model_override(
+                    runtime_paths,
+                    room_id,
+                    configured_models=self.models,
+                ).active
+                if room_override is not None:
+                    resolved_model_name = room_override
+                else:
+                    from mindroom.entity_resolution import effective_entity_model_name  # noqa: PLC0415
 
-                resolved_model_name = effective_entity_model_name(self, entity_name, room_id, runtime_paths)
+                    resolved_model_name = effective_entity_model_name(self, entity_name, room_id, runtime_paths)
             else:
                 resolved_model_name = self._entity_model_name(entity_name)
 

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -150,12 +150,21 @@ class DelegateTools(Toolkit):
                 runtime_context=runtime_context,
                 execution_identity=execution_identity,
             )
+            thread_id = _resolve_delegated_thread_id(
+                runtime_context=runtime_context,
+                execution_identity=execution_identity,
+            )
+            active_model_name = active_config.resolve_runtime_model(
+                entity_name=agent_name,
+                room_id=room_id,
+                thread_id=thread_id,
+                runtime_paths=self._runtime_paths,
+            ).model_name
             delegated_runtime_context = self._build_delegated_runtime_context(
                 agent_name=agent_name,
                 session_id=session_id,
-                room_id=room_id,
                 runtime_context=runtime_context,
-                config=active_config,
+                active_model_name=active_model_name,
             )
             delegated_correlation_id = (
                 delegated_runtime_context.correlation_id if delegated_runtime_context is not None else None
@@ -167,9 +176,10 @@ class DelegateTools(Toolkit):
                 correlation_id=delegated_correlation_id or uuid4().hex,
                 reply_to_event_id=None,
                 room_id=room_id,
-                thread_id=None,
+                thread_id=thread_id,
                 requester_id=execution_identity.requester_id if execution_identity is not None else None,
                 matrix_run_metadata=None,
+                active_model_name=active_model_name,
                 transient_enrichment_items=tuple(transient_enrichment_items),
             )
             with tool_runtime_context(delegated_runtime_context):
@@ -203,23 +213,16 @@ class DelegateTools(Toolkit):
         *,
         agent_name: str,
         session_id: str,
-        room_id: str | None,
         runtime_context: ToolRuntimeContext | None,
-        config: Config,
+        active_model_name: str,
     ) -> ToolRuntimeContext | None:
         """Return the child tool runtime context for one delegated run."""
         if runtime_context is None:
             return None
-        runtime_model = config.resolve_runtime_model(
-            entity_name=agent_name,
-            room_id=room_id,
-            thread_id=runtime_context.resolved_thread_id,
-            runtime_paths=self._runtime_paths,
-        )
         return replace(
             runtime_context,
             agent_name=agent_name,
-            active_model_name=runtime_model.model_name,
+            active_model_name=active_model_name,
             target=replace(runtime_context.target, session_id=session_id),
         )
 
@@ -234,4 +237,17 @@ def _resolve_delegated_room_id(
         return runtime_context.room_id
     if execution_identity is not None:
         return execution_identity.room_id
+    return None
+
+
+def _resolve_delegated_thread_id(
+    *,
+    runtime_context: ToolRuntimeContext | None,
+    execution_identity: ToolExecutionIdentity | None,
+) -> str | None:
+    """Resolve the thread context that should apply to a delegated child run."""
+    if runtime_context is not None:
+        return runtime_context.resolved_thread_id
+    if execution_identity is not None:
+        return execution_identity.resolved_thread_id
     return None

--- a/src/mindroom/custom_tools/thread_model.py
+++ b/src/mindroom/custom_tools/thread_model.py
@@ -50,7 +50,7 @@ class ThreadModelTools(Toolkit):
         if override.stale is not None:
             stale_fields["stale_override"] = override.stale
             stale_fields["note"] = (
-                "The stored override names a model that is no longer configured, so agents use their configured models."
+                "The stored override names a model that is no longer configured, so room-level model selection applies."
             )
         return self._payload(
             "ok",
@@ -103,7 +103,7 @@ class ThreadModelTools(Toolkit):
         )
 
     async def reset_thread_model(self) -> str:
-        """Remove the model override for the current thread, restoring configured models."""
+        """Remove the thread override, restoring room-level model selection."""
         resolved = self._thread_context()
         if isinstance(resolved, str):
             return resolved

--- a/src/mindroom/durable_write.py
+++ b/src/mindroom/durable_write.py
@@ -100,6 +100,11 @@ def write_bounded_override_records(
     if len(records) > max_records:
         newest = sorted(records.items(), key=lambda item: item[1].get("set_at", ""), reverse=True)
         records = dict(newest[:max_records])
+    write_override_records(path, records)
+
+
+def write_override_records(path: Path, records: dict[str, OverrideRecord]) -> None:
+    """Durably replace one override record file without evicting active records."""
     write_json_file_durable(path, records, indent=2, sort_keys=True)
     _override_load_cache.pop(path, None)
 

--- a/src/mindroom/event_journal/approval_continuations.py
+++ b/src/mindroom/event_journal/approval_continuations.py
@@ -146,6 +146,7 @@ class ApprovalContinuation:
     execution_identity: dict[str, object] = field(default_factory=dict)
     runtime_model_name: str | None = None
     team_member_names: tuple[str, ...] = ()
+    team_member_model_names: tuple[tuple[str, str], ...] = ()
     team_mode: str | None = None
     request_body: str = ""
     transport_sender_id: str | None = None
@@ -179,6 +180,7 @@ def _context(continuation: ApprovalContinuation) -> dict[str, object]:
         "execution_identity": continuation.execution_identity,
         "runtime_model_name": continuation.runtime_model_name,
         "team_member_names": list(continuation.team_member_names),
+        "team_member_model_names": [list(item) for item in continuation.team_member_model_names],
         "team_mode": continuation.team_mode,
         "request_body": continuation.request_body,
         "transport_sender_id": continuation.transport_sender_id,
@@ -283,6 +285,11 @@ def _from_rows(
         execution_identity=cast("dict[str, object]", stored.get("execution_identity", {})),
         runtime_model_name=cast("str | None", stored.get("runtime_model_name")),
         team_member_names=tuple(cast("list[str]", stored.get("team_member_names", []))),
+        team_member_model_names=tuple(
+            (str(item[0]), str(item[1]))
+            for item in cast("list[list[str]]", stored.get("team_member_model_names", []))
+            if len(item) == 2
+        ),
         team_mode=cast("str | None", stored.get("team_mode")),
         request_body=cast("str", stored.get("request_body", "")),
         transport_sender_id=cast("str | None", stored.get("transport_sender_id")),

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -91,6 +91,7 @@ from mindroom.sync_restart_retry import interrupted_source_needs_retry
 from mindroom.teams import (
     TeamMode,
     continue_paused_team_run,
+    resolve_team_turn_models,
     select_model_for_team,
     team_response,
     team_response_stream,
@@ -3016,13 +3017,16 @@ class ResponseRunner:
                 model_prompt=request.model_prompt,
             )
         )
-        model_name = select_model_for_team(
+        turn_models = resolve_team_turn_models(
             self.deps.agent_name,
+            agent_names,
             request.room_id,
             self.deps.runtime.config,
             self.deps.runtime_paths,
             thread_id=resolved_target.resolved_thread_id,
         )
+        model_name = turn_models.team_model_name
+        member_model_names = turn_models.member_model_names
         use_streaming = await should_use_streaming(
             self._client(),
             request.room_id,
@@ -3180,6 +3184,7 @@ class ResponseRunner:
                             mode=mode,
                             thread_history=model_thread_history,
                             model_name=model_name,
+                            member_model_names=member_model_names,
                             media=resolved_request.media,
                             show_tool_calls=show_tool_calls,
                             run_id_callback=_note_attempt_run_id,
@@ -3275,6 +3280,7 @@ class ResponseRunner:
                                     ctx=team_turn_ctx,
                                     thread_history=model_thread_history,
                                     model_name=model_name,
+                                    member_model_names=member_model_names,
                                     media=resolved_request.media,
                                     run_id_callback=_note_attempt_run_id,
                                     user_id=requester_user_id,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -386,6 +386,13 @@ class ResponseRequest:
         return self.response_envelope.target.resolved_thread_id
 
 
+def _response_thread_id(request: ResponseRequest, resolved_target: MessageTarget) -> str | None:
+    """Return the thread root used for this response's model and delivery context."""
+    if request.existing_event_id and not request.existing_event_is_placeholder:
+        return request.thread_id
+    return resolved_target.resolved_thread_id
+
+
 class PostLockRequestPreparationError(RuntimeError):
     """Raised when post-lock request preparation fails before generation starts."""
 
@@ -2964,6 +2971,18 @@ class ResponseRunner:
                 execution_identity=retry_execution_identity,
                 reply_entity_names=tuple(agent_names),
             )
+        turn_models = (
+            None
+            if team_request.resolution_reason is not None
+            else resolve_team_turn_models(
+                self.deps.agent_name,
+                agent_names,
+                request.room_id,
+                self.deps.runtime.config,
+                self.deps.runtime_paths,
+                thread_id=resolved_target.resolved_thread_id,
+            )
+        )
         prepared_request = await self._begin_locked_turn(
             request,
             resolved_target=resolved_target,
@@ -3019,14 +3038,7 @@ class ResponseRunner:
                 model_prompt=request.model_prompt,
             )
         )
-        turn_models = resolve_team_turn_models(
-            self.deps.agent_name,
-            agent_names,
-            request.room_id,
-            self.deps.runtime.config,
-            self.deps.runtime_paths,
-            thread_id=resolved_target.resolved_thread_id,
-        )
+        assert turn_models is not None
         model_name = turn_models.team_model_name
         member_model_names = turn_models.member_model_names
         use_streaming = await should_use_streaming(
@@ -3494,28 +3506,27 @@ class ResponseRunner:
     async def prepare_response_runtime(
         self,
         request: ResponseRequest,
+        *,
+        active_model_name: str | None = None,
     ) -> _PreparedResponseRuntime:
         """Resolve shared runtime context for one streaming or non-streaming response."""
         resolved_target = request.response_envelope.target
-        response_thread_id = (
-            request.thread_id
-            if request.existing_event_id and not request.existing_event_is_placeholder
-            else request.response_envelope.target.resolved_thread_id
-        )
+        response_thread_id = _response_thread_id(request, resolved_target)
         resolved_target = resolved_target.with_thread_root(response_thread_id)
         media_inputs = request.media or MediaInputs()
         session_id = resolved_target.session_id
         resolved_model_prompt = request.model_prompt or request.prompt
-        runtime_model = self.deps.runtime.config.resolve_runtime_model(
-            entity_name=self.deps.agent_name,
-            room_id=resolved_target.room_id,
-            thread_id=response_thread_id,
-            runtime_paths=self.deps.runtime_paths,
-        )
+        if active_model_name is None:
+            active_model_name = self.deps.runtime.config.resolve_runtime_model(
+                entity_name=self.deps.agent_name,
+                room_id=resolved_target.room_id,
+                thread_id=response_thread_id,
+                runtime_paths=self.deps.runtime_paths,
+            ).model_name
         tool_dispatch = self.deps.tool_runtime.build_dispatch_context(
             resolved_target,
             user_id=request.user_id,
-            active_model_name=runtime_model.model_name,
+            active_model_name=active_model_name,
             attachment_ids=request.attachment_ids,
             correlation_id=request.correlation_id,
             source_envelope=request.response_envelope,
@@ -3526,7 +3537,7 @@ class ResponseRunner:
             media_inputs=media_inputs,
             session_id=session_id,
             model_prompt=resolved_model_prompt,
-            active_model_name=runtime_model.model_name,
+            active_model_name=active_model_name,
             tool_dispatch=tool_dispatch,
         )
 
@@ -4081,6 +4092,13 @@ class ResponseRunner:
                 history_scope=history_scope,
                 execution_identity=execution_identity,
             )
+        response_thread_id = _response_thread_id(request, resolved_target)
+        active_model_name = self.deps.runtime.config.resolve_runtime_model(
+            entity_name=self.deps.agent_name,
+            room_id=resolved_target.room_id,
+            thread_id=response_thread_id,
+            runtime_paths=self.deps.runtime_paths,
+        ).model_name
         prepared_request = await self._begin_locked_turn(
             request,
             resolved_target=resolved_target,
@@ -4120,7 +4138,10 @@ class ResponseRunner:
 
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_start")
-        runtime = await self.prepare_response_runtime(normalized_request)
+        runtime = await self.prepare_response_runtime(
+            normalized_request,
+            active_model_name=active_model_name,
+        )
         if request.pipeline_timing is not None:
             request.pipeline_timing.mark("response_runtime_ready")
         use_streaming = await should_use_streaming(

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -870,6 +870,7 @@ class ResponseRunner:
                     execution_identity=serialize_tool_execution_identity(execution_identity),
                     runtime_model_name=paused.runtime_model_name,
                     team_member_names=team_member_names,
+                    team_member_model_names=paused.team_member_model_names,
                     team_mode=team_mode,
                     request_body=request.response_envelope.body,
                     transport_sender_id=request.response_envelope.sender_id,
@@ -1416,6 +1417,7 @@ class ResponseRunner:
                         decisions=decisions,
                         denial_reasons=denial_reasons,
                         refresh_scheduler=self._knowledge_refresh_scheduler(),
+                        member_model_names=dict(continuation.team_member_model_names) or None,
                         history_scope=continuation.history_scope,
                         tool_trace_collector=tool_trace_collector,
                     )

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -517,6 +517,7 @@ class _PreparedResponseRuntime:
     media_inputs: MediaInputs
     session_id: str
     model_prompt: str
+    active_model_name: str
     tool_dispatch: ToolDispatchContext
 
 
@@ -2360,6 +2361,7 @@ class ResponseRunner:
             thread_id=runtime.resolved_target.resolved_thread_id,
             requester_id=request.user_id,
             matrix_run_metadata=_materialize_matrix_run_metadata(request.matrix_run_metadata),
+            active_model_name=runtime.active_model_name,
             active_event_ids=frozenset(active_event_ids),
             transient_enrichment_items=_with_matrix_message_target(
                 transient_enrichment_items,
@@ -3524,6 +3526,7 @@ class ResponseRunner:
             media_inputs=media_inputs,
             session_id=session_id,
             model_prompt=resolved_model_prompt,
+            active_model_name=runtime_model.model_name,
             tool_dispatch=tool_dispatch,
         )
 
@@ -3745,13 +3748,15 @@ class ResponseRunner:
         response_kind: str = "ai",
         on_delivery_started: Callable[[str | None], None] | None = None,
         attempt_run_id_collector: list[str] | None = None,
+        runtime: _PreparedResponseRuntime | None = None,
     ) -> _ResponseGenerationOutcome:
         """Process a message and send a response without streaming."""
-        if request.pipeline_timing is not None:
-            request.pipeline_timing.mark("response_runtime_start")
-        runtime = await self.prepare_response_runtime(request)
-        if request.pipeline_timing is not None:
-            request.pipeline_timing.mark("response_runtime_ready")
+        if runtime is None:
+            if request.pipeline_timing is not None:
+                request.pipeline_timing.mark("response_runtime_start")
+            runtime = await self.prepare_response_runtime(request)
+            if request.pipeline_timing is not None:
+                request.pipeline_timing.mark("response_runtime_ready")
         request = self._request_with_locked_target(request, runtime.resolved_target)
         response_identity = self._response_identity(request, response_kind=response_kind)
         lifecycle = self._build_lifecycle(
@@ -3867,13 +3872,15 @@ class ResponseRunner:
         response_kind: str = "ai",
         on_delivery_started: Callable[[str | None], None] | None = None,
         attempt_run_id_collector: list[str] | None = None,
+        runtime: _PreparedResponseRuntime | None = None,
     ) -> _ResponseGenerationOutcome:
         """Process a message and send a streamed response."""
-        if request.pipeline_timing is not None:
-            request.pipeline_timing.mark("response_runtime_start")
-        runtime = await self.prepare_response_runtime(request)
-        if request.pipeline_timing is not None:
-            request.pipeline_timing.mark("response_runtime_ready")
+        if runtime is None:
+            if request.pipeline_timing is not None:
+                request.pipeline_timing.mark("response_runtime_start")
+            runtime = await self.prepare_response_runtime(request)
+            if request.pipeline_timing is not None:
+                request.pipeline_timing.mark("response_runtime_ready")
         request = self._request_with_locked_target(request, runtime.resolved_target)
         response_identity = self._response_identity(request, response_kind=response_kind)
         lifecycle = self._build_lifecycle(
@@ -4111,6 +4118,11 @@ class ResponseRunner:
             execution_identity=execution_identity,
         )
 
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("response_runtime_start")
+        runtime = await self.prepare_response_runtime(normalized_request)
+        if request.pipeline_timing is not None:
+            request.pipeline_timing.mark("response_runtime_ready")
         use_streaming = await should_use_streaming(
             self._client(),
             request.room_id,
@@ -4153,6 +4165,7 @@ class ResponseRunner:
                     run_id=response_run_id,
                     on_delivery_started=progress.note_delivery_started,
                     attempt_run_id_collector=attempt_run_ids,
+                    runtime=runtime,
                 )
             else:
                 generation = await self._process_and_respond(
@@ -4160,6 +4173,7 @@ class ResponseRunner:
                     run_id=response_run_id,
                     on_delivery_started=progress.note_delivery_started,
                     attempt_run_id_collector=attempt_run_ids,
+                    runtime=runtime,
                 )
             progress.settle(generation.delivery)
 

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -361,6 +361,7 @@ class PausedAttempt:
     tools: tuple[ToolExecution, ...]
     requirements: tuple[RunRequirement, ...] = ()
     runtime_model_name: str | None = None
+    team_member_model_names: tuple[tuple[str, str], ...] = ()
 
 
 class ResponsePausedForApproval(StreamingLifecycleSuspensionError):  # noqa: N818

--- a/src/mindroom/room_model_overrides.py
+++ b/src/mindroom/room_model_overrides.py
@@ -1,0 +1,99 @@
+"""Durable room-level model overrides controlled from chat."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from mindroom.constants import tracking_dir
+from mindroom.durable_write import (
+    OverrideRecord,
+    load_cached_override_records,
+    write_bounded_override_records,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Container
+    from pathlib import Path
+
+    from mindroom.constants import RuntimePaths
+
+_ROOM_MODEL_OVERRIDES_FILENAME = "room_model_overrides.json"
+_MAX_TRACKED_ROOMS = 1000
+
+
+def _store_path(runtime_paths: RuntimePaths) -> Path:
+    return tracking_dir(runtime_paths) / _ROOM_MODEL_OVERRIDES_FILENAME
+
+
+def _is_valid_override(_room_id: str, record: dict[object, object]) -> bool:
+    """Return whether one persisted room-model record has the required shape."""
+    return isinstance(record.get("model"), str) and isinstance(record.get("set_at", ""), str)
+
+
+def _load_overrides(path: Path) -> dict[str, OverrideRecord]:
+    """Load persisted overrides, treating a missing or unreadable file as empty."""
+    return load_cached_override_records(path, _is_valid_override)
+
+
+def _save_overrides(path: Path, overrides: dict[str, OverrideRecord]) -> None:
+    write_bounded_override_records(path, overrides, max_records=_MAX_TRACKED_ROOMS)
+
+
+@dataclass(frozen=True)
+class _RoomModelOverrideState:
+    """One room's stored override split into active and stale model names."""
+
+    active: str | None
+    stale: str | None
+    set_by: str | None = None
+    set_at: str | None = None
+
+
+def resolve_room_model_override(
+    runtime_paths: RuntimePaths,
+    room_id: str | None,
+    *,
+    configured_models: Container[str],
+) -> _RoomModelOverrideState:
+    """Classify one room's stored override against configured model names."""
+    if room_id is None:
+        return _RoomModelOverrideState(active=None, stale=None)
+    record = _load_overrides(_store_path(runtime_paths)).get(room_id)
+    if record is None:
+        return _RoomModelOverrideState(active=None, stale=None)
+    model_name = record["model"]
+    metadata = {"set_by": record.get("set_by"), "set_at": record.get("set_at")}
+    if model_name in configured_models:
+        return _RoomModelOverrideState(active=model_name, stale=None, **metadata)
+    return _RoomModelOverrideState(active=None, stale=model_name, **metadata)
+
+
+def set_room_model_override(
+    runtime_paths: RuntimePaths,
+    *,
+    room_id: str,
+    model_name: str,
+    set_by: str,
+) -> None:
+    """Persist one room's model override, replacing any previous one."""
+    path = _store_path(runtime_paths)
+    overrides = _load_overrides(path)
+    overrides[room_id] = {
+        "model": model_name,
+        "set_by": set_by,
+        "set_at": datetime.now(UTC).isoformat(),
+    }
+    _save_overrides(path, overrides)
+
+
+def clear_room_model_override(runtime_paths: RuntimePaths, room_id: str) -> bool:
+    """Remove one room's model override; return whether one was present."""
+    path = _store_path(runtime_paths)
+    overrides = _load_overrides(path)
+    if room_id not in overrides:
+        return False
+    del overrides[room_id]
+    _save_overrides(path, overrides)
+    return True

--- a/src/mindroom/room_model_overrides.py
+++ b/src/mindroom/room_model_overrides.py
@@ -10,7 +10,7 @@ from mindroom.constants import tracking_dir
 from mindroom.durable_write import (
     OverrideRecord,
     load_cached_override_records,
-    write_bounded_override_records,
+    write_override_records,
 )
 
 if TYPE_CHECKING:
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
 
 _ROOM_MODEL_OVERRIDES_FILENAME = "room_model_overrides.json"
-_MAX_TRACKED_ROOMS = 1000
 
 
 def _store_path(runtime_paths: RuntimePaths) -> Path:
@@ -38,7 +37,7 @@ def _load_overrides(path: Path) -> dict[str, OverrideRecord]:
 
 
 def _save_overrides(path: Path, overrides: dict[str, OverrideRecord]) -> None:
-    write_bounded_override_records(path, overrides, max_records=_MAX_TRACKED_ROOMS)
+    write_override_records(path, overrides)
 
 
 @dataclass(frozen=True)

--- a/src/mindroom/router_relay.py
+++ b/src/mindroom/router_relay.py
@@ -290,6 +290,8 @@ async def execute_router_relay(
                 deps.runtime.config,
                 deps.runtime_paths,
                 thread_history,
+                room_id=room.room_id,
+                thread_id=thread_id,
             )
 
     target_resolution = _resolve_router_target(

--- a/src/mindroom/routing.py
+++ b/src/mindroom/routing.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from mindroom import model_loading
 from mindroom.agent_descriptions import describe_agent
+from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage, replace_visible_message
@@ -38,6 +39,9 @@ async def suggest_responder(
     config: Config,
     runtime_paths: RuntimePaths,
     thread_context: Sequence[ResolvedVisibleMessage] | None = None,
+    *,
+    room_id: str | None = None,
+    thread_id: str | None = None,
 ) -> str | None:
     """Use AI to suggest which configured responder should answer a message.
 
@@ -50,6 +54,8 @@ async def suggest_responder(
         runtime_paths: Explicit runtime context for model and Matrix identity resolution.
         thread_context: Optional recent messages for context.
             Each message should expose visible sender/body fields.
+        room_id: Optional Matrix room whose runtime model default applies.
+        thread_id: Optional Matrix thread whose model override takes precedence.
 
     Returns:
         The suggested responder name, or None if routing fails.
@@ -77,7 +83,12 @@ async def suggest_responder(
                 context += f"{sender}: {body}\n"
             prompt = context + "\n" + prompt
 
-        router_model_name = config.router.model
+        router_model_name = config.resolve_runtime_model(
+            entity_name=ROUTER_AGENT_NAME,
+            room_id=room_id,
+            thread_id=thread_id,
+            runtime_paths=runtime_paths,
+        ).model_name
 
         model = model_loading.get_model_instance(config, runtime_paths, router_model_name)
         logger.info(
@@ -128,6 +139,9 @@ async def suggest_responder_for_message(
     config: Config,
     runtime_paths: RuntimePaths,
     thread_context: Sequence[ResolvedVisibleMessage] | None = None,
+    *,
+    room_id: str | None = None,
+    thread_id: str | None = None,
 ) -> str | None:
     """Use AI to suggest which configured responder should answer a message.
 
@@ -153,7 +167,15 @@ async def suggest_responder_for_message(
                 sender = sender_name if sender_name is not None else MatrixID.parse(sender).domain
             resolved_context.append(replace_visible_message(msg, sender=sender))
 
-    return await suggest_responder(message, entity_names, config, runtime_paths, resolved_context)
+    return await suggest_responder(
+        message,
+        entity_names,
+        config,
+        runtime_paths,
+        resolved_context,
+        room_id=room_id,
+        thread_id=thread_id,
+    )
 
 
 __all__ = [

--- a/src/mindroom/team_exact_members.py
+++ b/src/mindroom/team_exact_members.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, cast
 
 from mindroom.constants import ROUTER_AGENT_NAME
@@ -29,6 +29,7 @@ class ResolvedExactTeamMembers:
     display_names: list[str]
     materialized_agent_names: set[str]
     failed_agent_names: list[str]
+    model_names: dict[str, str] = field(default_factory=dict)
 
 
 def resolve_live_shared_agent_names(

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1785,15 +1785,16 @@ def select_model_for_team(
 
     Priority:
     1. Thread-specific model override
-    2. Room-specific model from room_models
-    3. Team's configured model
-    4. Global default model
+    2. Persisted runtime room override
+    3. Room-specific model from room_models
+    4. Team's configured model
+    5. Global default model
 
     Args:
         team_name: Name of the team
         room_id: Matrix room ID
         config: Application configuration
-        runtime_paths: Explicit runtime context for room alias resolution
+        runtime_paths: Explicit runtime context for persisted overrides and room alias resolution
         thread_id: Optional resolved Matrix thread root for thread model overrides
 
     Returns:

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1496,6 +1496,14 @@ class _TeamTurnHolder:
     tool_tracker: StreamingToolTracker = field(default_factory=StreamingToolTracker)  # streaming turns only
 
 
+@dataclass(frozen=True)
+class TeamTurnModelSelection:
+    """Model aliases frozen together for one team turn."""
+
+    team_model_name: str
+    member_model_names: dict[str, str]
+
+
 def _build_team_runtime_db_callbacks(
     holder: _TeamTurnHolder,
 ) -> tuple[Callable[[ScopeSessionContext | None], None], Callable[[ScopeSessionContext | None], None]]:
@@ -1622,6 +1630,26 @@ def materialize_exact_team_members(
 def _requested_team_agent_names(agent_names: list[str]) -> list[str]:
     """Return the requested team members, excluding router placeholders."""
     return [name for name in agent_names if name != ROUTER_AGENT_NAME]
+
+
+def resolve_team_member_model_names(
+    agent_names: Sequence[str],
+    room_id: str | None,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    *,
+    thread_id: str | None = None,
+) -> dict[str, str]:
+    """Resolve every exact team member's model alias without yielding control."""
+    return {
+        agent_name: config.resolve_runtime_model(
+            entity_name=agent_name,
+            room_id=room_id,
+            thread_id=thread_id,
+            runtime_paths=runtime_paths,
+        ).model_name
+        for agent_name in _requested_team_agent_names(list(agent_names))
+    }
 
 
 def _materialize_team_members(
@@ -1821,6 +1849,34 @@ def select_model_for_team(
     ).model_name
     logger.info("selected_team_model", team_name=team_name, model_name=model_name)
     return model_name
+
+
+def resolve_team_turn_models(
+    team_name: str,
+    member_names: Sequence[str],
+    room_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    *,
+    thread_id: str | None = None,
+) -> TeamTurnModelSelection:
+    """Freeze the coordinator and member model aliases in one synchronous snapshot."""
+    return TeamTurnModelSelection(
+        team_model_name=select_model_for_team(
+            team_name,
+            room_id,
+            config,
+            runtime_paths,
+            thread_id=thread_id,
+        ),
+        member_model_names=resolve_team_member_model_names(
+            member_names,
+            room_id,
+            config,
+            runtime_paths,
+            thread_id=thread_id,
+        ),
+    )
 
 
 def build_materialized_team_instance(
@@ -2082,6 +2138,7 @@ async def team_response(  # noqa: C901, PLR0915
     *,
     turn_recorder: TurnRecorder,
     reason_prefix: str = "Team request",
+    member_model_names: Mapping[str, str] | None = None,
 ) -> str:
     """Create a team and execute response.
 
@@ -2099,6 +2156,17 @@ async def team_response(  # noqa: C901, PLR0915
         requested_agent_names,
         allow_direct_private_agents=allow_direct_private_agents,
     )
+    active_member_model_names = (
+        dict(member_model_names)
+        if member_model_names is not None
+        else resolve_team_member_model_names(
+            requested_agent_names,
+            ctx.room_id,
+            orchestrator.config,
+            orchestrator.runtime_paths,
+            thread_id=ctx.thread_id,
+        )
+    )
     unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
     try:
         # Member agent builds walk the filesystem (workspace scaffolding,
@@ -2112,6 +2180,7 @@ async def team_response(  # noqa: C901, PLR0915
             unavailable_bases=unavailable_bases,
             reason_prefix=reason_prefix,
             configured_team_name=configured_team_name,
+            active_model_names=active_member_model_names,
         )
     except ValueError as exc:
         return str(exc)
@@ -2567,6 +2636,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
     *,
     turn_recorder: TurnRecorder,
     reason_prefix: str = "Team request",
+    member_model_names: Mapping[str, str] | None = None,
 ) -> AsyncIterator[_TeamStreamChunk]:
     """Aggregate team streaming into a non-stream-style document, live.
 
@@ -2589,6 +2659,17 @@ async def team_response_stream(  # noqa: C901, PLR0915
         requested_agent_names,
         allow_direct_private_agents=allow_direct_private_agents,
     )
+    active_member_model_names = (
+        dict(member_model_names)
+        if member_model_names is not None
+        else resolve_team_member_model_names(
+            requested_agent_names,
+            ctx.room_id,
+            orchestrator.config,
+            orchestrator.runtime_paths,
+            thread_id=ctx.thread_id,
+        )
+    )
     unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
     try:
         # Member agent builds walk the filesystem (workspace scaffolding,
@@ -2602,6 +2683,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
             unavailable_bases=unavailable_bases,
             reason_prefix=reason_prefix,
             configured_team_name=configured_team_name,
+            active_model_names=active_member_model_names,
         )
     except ValueError as exc:
         yield str(exc)
@@ -3386,6 +3468,7 @@ __all__ = [
     "TeamOutcome",
     "TeamResolution",
     "TeamResolutionMember",
+    "TeamTurnModelSelection",
     "build_materialized_team_instance",
     "continue_paused_team_run",
     "decide_team_formation",
@@ -3396,6 +3479,8 @@ __all__ = [
     "prepare_materialized_team_execution",
     "resolve_configured_team",
     "resolve_live_shared_agent_names",
+    "resolve_team_member_model_names",
+    "resolve_team_turn_models",
     "select_ad_hoc_team_mode",
     "select_model_for_team",
     "team_response",

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -1567,6 +1567,12 @@ def materialize_exact_team_members(
         )
         if unavailable_bases is not None:
             unavailable_bases.update(knowledge_resolution.unavailable)
+        runtime_model = config.resolve_runtime_model(
+            entity_name=agent_name,
+            room_id=execution_identity.room_id if execution_identity is not None else None,
+            thread_id=execution_identity.resolved_thread_id if execution_identity is not None else None,
+            runtime_paths=runtime_paths,
+        )
         return create_agent(
             agent_name,
             config,
@@ -1577,6 +1583,7 @@ def materialize_exact_team_members(
             else execution_identity.session_id
             if execution_identity
             else None,
+            active_model_name=runtime_model.model_name,
             knowledge=knowledge_resolution.knowledge,
             include_interactive_questions=False,
             include_openai_compat_guidance=include_openai_compat_guidance,

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -117,7 +117,7 @@ from mindroom.tool_system.events import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
+    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping, Sequence
 
     import nio
     from agno.db.base import BaseDb
@@ -1434,6 +1434,7 @@ async def _ensure_attempt_team_members(
             session_id=session_id,
             reason_prefix=reason_prefix,
             configured_team_name=configured_team_name,
+            active_model_names=holder.member_model_names,
         )
         holder.team_members = members
     return members
@@ -1488,6 +1489,7 @@ class _TeamTurnHolder:
 
     team: Team | None = None
     team_members: ResolvedExactTeamMembers | None = None
+    member_model_names: dict[str, str] = field(default_factory=dict)
     attempt_started: bool = False
     attempt_run_id: str | None = None
     render_partial: Callable[[], str] = _empty_partial_text  # streaming turns only
@@ -1546,6 +1548,7 @@ def materialize_exact_team_members(
     reason_prefix: str = "Team request",
     dynamic_tool_continuation: bool = False,
     supports_native_tool_approval: bool = False,
+    active_model_names: Mapping[str, str] | None = None,
 ) -> ResolvedExactTeamMembers:
     """Materialize the exact team-member set without silent fallback.
 
@@ -1557,6 +1560,8 @@ def materialize_exact_team_members(
     if not requested_agent_names:
         raise ValueError(_NO_AGENTS_RESPONSE)
 
+    selected_model_names: dict[str, str] = {}
+
     def _build_member(agent_name: str) -> Agent:
         knowledge_resolution = resolve_agent_knowledge_access(
             agent_name,
@@ -1567,12 +1572,17 @@ def materialize_exact_team_members(
         )
         if unavailable_bases is not None:
             unavailable_bases.update(knowledge_resolution.unavailable)
-        runtime_model = config.resolve_runtime_model(
-            entity_name=agent_name,
-            room_id=execution_identity.room_id if execution_identity is not None else None,
-            thread_id=execution_identity.resolved_thread_id if execution_identity is not None else None,
-            runtime_paths=runtime_paths,
+        model_name = (
+            active_model_names[agent_name]
+            if active_model_names is not None
+            else config.resolve_runtime_model(
+                entity_name=agent_name,
+                room_id=execution_identity.room_id if execution_identity is not None else None,
+                thread_id=execution_identity.resolved_thread_id if execution_identity is not None else None,
+                runtime_paths=runtime_paths,
+            ).model_name
         )
+        selected_model_names[agent_name] = model_name
         return create_agent(
             agent_name,
             config,
@@ -1583,7 +1593,7 @@ def materialize_exact_team_members(
             else execution_identity.session_id
             if execution_identity
             else None,
-            active_model_name=runtime_model.model_name,
+            active_model_name=model_name,
             knowledge=knowledge_resolution.knowledge,
             include_interactive_questions=False,
             include_openai_compat_guidance=include_openai_compat_guidance,
@@ -1606,7 +1616,7 @@ def materialize_exact_team_members(
         raise ValueError(
             _not_materializable_team_agents_message(team_members.failed_agent_names, prefix=reason_prefix),
         )
-    return team_members
+    return replace(team_members, model_names=selected_model_names)
 
 
 def _requested_team_agent_names(agent_names: list[str]) -> list[str]:
@@ -1623,6 +1633,7 @@ def _materialize_team_members(
     configured_team_name: str | None = None,
     unavailable_bases: dict[str, KnowledgeAvailabilityDetail] | None = None,
     reason_prefix: str = "Team request",
+    active_model_names: Mapping[str, str] | None = None,
 ) -> ResolvedExactTeamMembers:
     """Materialize the exact requested team-member set without silent fallback."""
     requested_agent_names = _requested_team_agent_names(agent_names)
@@ -1647,6 +1658,7 @@ def _materialize_team_members(
         refresh_scheduler=orchestrator.knowledge_refresh_scheduler,
         dynamic_tool_continuation=True,
         supports_native_tool_approval=True,
+        active_model_names=active_model_names,
         reason_prefix=reason_prefix,
     )
 
@@ -1853,6 +1865,7 @@ async def continue_paused_team_run(
     decisions: dict[str, bool],
     denial_reasons: dict[str, str | None],
     refresh_scheduler: KnowledgeRefreshScheduler | None,
+    member_model_names: Mapping[str, str] | None = None,
     history_scope: HistoryScope | None = None,
     tool_trace_collector: list[ToolTraceEntry] | None = None,
 ) -> CompletedApprovalRun | PausedAttempt:
@@ -1867,6 +1880,7 @@ async def continue_paused_team_run(
         refresh_scheduler=refresh_scheduler,
         dynamic_tool_continuation=True,
         supports_native_tool_approval=True,
+        active_model_names=member_model_names,
     )
     for member in members.agents:
         if member.model is not None:
@@ -2115,7 +2129,10 @@ async def team_response(  # noqa: C901, PLR0915
     )
     base_media_inputs = media or MediaInputs()
     config = orchestrator.config
-    holder = _TeamTurnHolder(team_members=team_members)
+    holder = _TeamTurnHolder(
+        team_members=team_members,
+        member_model_names=team_members.model_names,
+    )
 
     async def _run_team_attempt(  # noqa: C901, PLR0912, PLR0915
         run: TurnRunState,
@@ -2327,7 +2344,11 @@ async def team_response(  # noqa: C901, PLR0915
                 fallback_run_id=attempt_run_id,
             )
             if paused_attempt is not None:
-                return replace(paused_attempt, runtime_model_name=prepared_execution.runtime_model_name)
+                return replace(
+                    paused_attempt,
+                    runtime_model_name=prepared_execution.runtime_model_name,
+                    team_member_model_names=tuple(sorted(holder.member_model_names.items())),
+                )
             original_status = response.status if isinstance(response.status, RunStatus) else RunStatus.error
             partial_text = _extract_interrupted_team_partial_text(response)
             completed_tools, interrupted_tools = _extract_cancelled_team_tool_trace(response)
@@ -2598,7 +2619,10 @@ async def team_response_stream(  # noqa: C901, PLR0915
     )
     base_media_inputs = media or MediaInputs()
     config = orchestrator.config
-    holder = _TeamTurnHolder(team_members=team_members)
+    holder = _TeamTurnHolder(
+        team_members=team_members,
+        member_model_names=team_members.model_names,
+    )
 
     async def _run_team_stream_attempt(  # noqa: C901, PLR0911, PLR0912, PLR0915
         run: TurnRunState,
@@ -3140,7 +3164,11 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     )
                     if paused_attempt is not None:
                         yield AttemptResolved(
-                            replace(paused_attempt, runtime_model_name=prepared_execution.runtime_model_name),
+                            replace(
+                                paused_attempt,
+                                runtime_model_name=prepared_execution.runtime_model_name,
+                                team_member_model_names=tuple(sorted(holder.member_model_names.items())),
+                            ),
                         )
                         return
                     yield AttemptResolved(

--- a/tach.toml
+++ b/tach.toml
@@ -1731,6 +1731,7 @@ visibility = [
 path = "mindroom.routing"
 depends_on = [
     "mindroom.agent_descriptions",
+    "mindroom.constants",
     "mindroom.entity_resolution",
     "mindroom.logging_config",
     "mindroom.matrix.client_visible_messages",

--- a/tach.toml
+++ b/tach.toml
@@ -1815,6 +1815,7 @@ depends_on = [
     "mindroom.mcp.config",
     "mindroom.prompt_templates",
     "mindroom.prompts",
+    "mindroom.room_model_overrides",
     "mindroom.room_thread_modes",
     "mindroom.thread_models",
     "mindroom.tool_system.catalog",
@@ -2208,6 +2209,7 @@ visibility = [
     "mindroom.bot",
     "mindroom.bot_room_lifecycle",
     "mindroom.commands.encryption_commands",
+    "mindroom.commands.room_model_commands",
     "mindroom.commands.thread_mode_commands",
     "mindroom.external_triggers.executor",
     "mindroom.hooks.matrix_admin",
@@ -2626,6 +2628,13 @@ depends_on = [
 
 [[modules]]
 path = "mindroom.thread_models"
+depends_on = [
+    "mindroom.constants",
+    "mindroom.durable_write",
+]
+
+[[modules]]
+path = "mindroom.room_model_overrides"
 depends_on = [
     "mindroom.constants",
     "mindroom.durable_write",
@@ -3101,6 +3110,14 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.commands.room_model_commands"
+depends_on = [
+    "mindroom.matrix.client_room_admin",
+    "mindroom.room_model_overrides",
+]
+visibility = ["mindroom.commands.handler"]
+
+[[modules]]
 path = "mindroom.commands.thread_mode_commands"
 depends_on = [
     "mindroom.matrix.client_room_admin",
@@ -3134,6 +3151,7 @@ depends_on = [
     "mindroom.commands.encryption_commands",
     "mindroom.commands.model_commands",
     "mindroom.commands.parsing",
+    "mindroom.commands.room_model_commands",
     "mindroom.commands.thread_mode_commands",
     "mindroom.constants",
     "mindroom.entity_resolution",

--- a/tach.toml
+++ b/tach.toml
@@ -3941,6 +3941,7 @@ expose = [
     "format_team_response",
     "is_cancelled_run_output",
     "is_errored_run_output",
+    "resolve_team_turn_models",
     "select_model_for_team",
     "team_response",
     "team_response_stream",

--- a/tests/test_delegate_tools.py
+++ b/tests/test_delegate_tools.py
@@ -23,6 +23,7 @@ from mindroom.knowledge.indexing_config import IndexingSettings
 from mindroom.knowledge.utils import _KnowledgeResolution
 from mindroom.matrix.state import MatrixState
 from mindroom.message_target import MessageTarget
+from mindroom.thread_models import set_thread_model_override
 from mindroom.tool_schema_cache import cached_processed_schema
 from mindroom.tool_system.metadata import TOOL_METADATA
 from mindroom.tool_system.runtime_context import get_tool_runtime_context, tool_runtime_context
@@ -753,12 +754,18 @@ class TestDelegateKnowledge:
         assert result == "done"
 
     @pytest.mark.asyncio
-    async def test_delegation_rebinds_room_resolved_model_for_child_agent(
+    @pytest.mark.parametrize(
+        ("thread_model_name", "expected_model_name"),
+        [(None, "large"), ("default", "default")],
+    )
+    async def test_delegation_rebinds_resolved_model_for_child_agent(
         self,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
+        thread_model_name: str | None,
+        expected_model_name: str,
     ) -> None:
-        """Delegated child tools should see the child's room-resolved runtime model."""
+        """Delegated child and its tools must share thread-over-room model precedence."""
         config = Config(
             agents={
                 "leader": AgentConfig(
@@ -783,6 +790,14 @@ class TestDelegateKnowledge:
         config = _bind_runtime_paths(config, tmp_path)
         runtime_paths = resolve_runtime_paths(config_path=tmp_path / "config.yaml", storage_path=tmp_path)
         monkeypatch.setattr("mindroom.matrix.state.get_room_alias_from_id", lambda *_args: "lobby")
+        if thread_model_name is not None:
+            set_thread_model_override(
+                runtime_paths,
+                thread_id="$thread",
+                model_name=thread_model_name,
+                room_id="!room:example.org",
+                set_by="@alice:example.org",
+            )
         execution_identity = ToolExecutionIdentity(
             channel="matrix",
             agent_name="leader",
@@ -823,8 +838,10 @@ class TestDelegateKnowledge:
             assert context is not None
             assert context.agent_name == "worker"
             assert context.room_id == "!room:example.org"
-            assert context.active_model_name == "large"
+            assert context.active_model_name == expected_model_name
             assert ctx.room_id == "!room:example.org"
+            assert ctx.thread_id == "$thread"
+            assert ctx.active_model_name == expected_model_name
             return "done"
 
         with (

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -3544,6 +3544,54 @@ async def test_non_streaming_response_reuses_prepared_room_model_after_override_
 
 
 @pytest.mark.asyncio
+async def test_agent_model_snapshot_precedes_locked_turn_preparation(tmp_path: Path) -> None:
+    """A room-default change during locked preparation must wait for the next turn."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    config = coordinator.deps.runtime.config
+    config.models["large"] = ModelConfig(provider="test", id="large-model")
+    set_room_model_override(
+        coordinator.deps.runtime_paths,
+        room_id="!room:localhost",
+        model_name="large",
+        set_by="@admin:localhost",
+    )
+    original_begin_locked_turn = coordinator._begin_locked_turn
+    active_models: list[str | None] = []
+
+    async def change_room_default_during_preparation(*args: object, **kwargs: object) -> ResponseRequest | None:
+        set_room_model_override(
+            coordinator.deps.runtime_paths,
+            room_id="!room:localhost",
+            model_name="default",
+            set_by="@admin:localhost",
+        )
+        return await original_begin_locked_turn(*args, **kwargs)  # type: ignore[arg-type]
+
+    async def fake_ai_response(ctx: ResponseTurnContext, **_kwargs: object) -> str:
+        active_models.append(ctx.active_model_name)
+        return "final text"
+
+    with (
+        patch.object(coordinator, "_begin_locked_turn", new=change_room_default_during_preparation),
+        patch.object(DeliveryGateway, "send_text", new=AsyncMock(return_value="$placeholder")),
+        patch.object(
+            DeliveryGateway,
+            "deliver_final",
+            new=AsyncMock(return_value=_completed_outcome("$response", body="final text")),
+        ),
+        patch_response_runner_module(
+            ai_response=fake_ai_response,
+            should_use_streaming=AsyncMock(return_value=False),
+            typing_indicator=_noop_typing,
+        ),
+    ):
+        await coordinator.generate_response(_plain_request(_target()))
+
+    assert active_models == ["large"]
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_invisible_delivery_does_not_mark_substantive_reply(tmp_path: Path) -> None:
     """A failed final delivery must not turn a thinking placeholder into a substantive reply."""
     bot = _bot(tmp_path)

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -34,6 +34,7 @@ from mindroom.background_tasks import wait_for_background_tasks
 from mindroom.cancellation import request_task_cancel
 from mindroom.config.approval import ApprovalRuleConfig
 from mindroom.config.auth import AgentReplyPermission, AuthorizationConfig
+from mindroom.config.models import ModelConfig
 from mindroom.constants import (
     DURABLE_FINAL_OUTCOME_KEY,
     STREAM_STATUS_APPROVAL_PENDING,
@@ -46,6 +47,7 @@ from mindroom.delivery_gateway import (
     EditTextRequest,
     FinalizeStreamedResponseRequest,
     SendTextRequest,
+    StreamingDeliveryRequest,
 )
 from mindroom.dispatch_source import ScheduledHistoryBudget
 from mindroom.entity_resolution import current_internal_sender_ids
@@ -83,7 +85,8 @@ from mindroom.response_runner import (
     _ResponseGenerationOutcome,
     prepare_memory_and_model_context,
 )
-from mindroom.response_turn import CompletedApprovalRun, PausedAttempt, ResponsePausedForApproval
+from mindroom.response_turn import CompletedApprovalRun, PausedAttempt, ResponsePausedForApproval, ResponseTurnContext
+from mindroom.room_model_overrides import set_room_model_override
 from mindroom.stop import StopManager
 from mindroom.streaming import (
     INTERRUPTED_RESPONSE_NOTE,
@@ -3498,6 +3501,49 @@ async def test_non_streaming_response_delivers_through_deliver_final(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_response_reuses_prepared_room_model_after_override_change(tmp_path: Path) -> None:
+    """A blocking agent turn must not re-read a changed room default during execution."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    config = coordinator.deps.runtime.config
+    config.models["large"] = ModelConfig(provider="test", id="large-model")
+    set_room_model_override(
+        coordinator.deps.runtime_paths,
+        room_id="!room:localhost",
+        model_name="large",
+        set_by="@admin:localhost",
+    )
+    request = _plain_request(_target())
+    runtime = await coordinator.prepare_response_runtime(request)
+    set_room_model_override(
+        coordinator.deps.runtime_paths,
+        room_id="!room:localhost",
+        model_name="default",
+        set_by="@admin:localhost",
+    )
+    active_models: list[str | None] = []
+
+    async def fake_ai_response(ctx: ResponseTurnContext, **_kwargs: object) -> str:
+        active_models.append(ctx.active_model_name)
+        return "final text"
+
+    with (
+        patch.object(
+            DeliveryGateway,
+            "deliver_final",
+            new=AsyncMock(return_value=_completed_outcome("$response", body="final text")),
+        ),
+        patch_response_runner_module(
+            ai_response=fake_ai_response,
+            typing_indicator=_noop_typing,
+        ),
+    ):
+        await coordinator._process_and_respond(request, runtime=runtime)
+
+    assert active_models == ["large"]
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_invisible_delivery_does_not_mark_substantive_reply(tmp_path: Path) -> None:
     """A failed final delivery must not turn a thinking placeholder into a substantive reply."""
     bot = _bot(tmp_path)
@@ -3595,6 +3641,61 @@ async def test_streaming_response_streams_then_finalizes_through_gateway(tmp_pat
     assert finalize_request.stream_transport_outcome is transport
     assert finalize_request.initial_delivery_kind == "sent"
     assert finalize_request.identity.response_kind == "ai"
+
+
+@pytest.mark.asyncio
+async def test_streaming_response_reuses_prepared_room_model_after_override_change(tmp_path: Path) -> None:
+    """A streaming agent turn must not re-read a changed room default during execution."""
+    bot = _bot(tmp_path)
+    coordinator = unwrap_extracted_collaborator(bot._response_runner)
+    config = coordinator.deps.runtime.config
+    config.models["large"] = ModelConfig(provider="test", id="large-model")
+    set_room_model_override(
+        coordinator.deps.runtime_paths,
+        room_id="!room:localhost",
+        model_name="large",
+        set_by="@admin:localhost",
+    )
+    request = _plain_request(_target())
+    runtime = await coordinator.prepare_response_runtime(request)
+    set_room_model_override(
+        coordinator.deps.runtime_paths,
+        room_id="!room:localhost",
+        model_name="default",
+        set_by="@admin:localhost",
+    )
+    active_models: list[str | None] = []
+    transport = StreamTransportOutcome(
+        last_physical_stream_event_id="$stream",
+        terminal_status="completed",
+        rendered_body="streamed body",
+        visible_body_state="visible_body",
+    )
+
+    async def fake_stream(ctx: ResponseTurnContext, **_kwargs: object) -> AsyncIterator[str]:
+        active_models.append(ctx.active_model_name)
+        yield "chunk"
+
+    async def consume_stream(delivery_request: StreamingDeliveryRequest) -> StreamTransportOutcome:
+        async for _chunk in delivery_request.response_stream:
+            pass
+        return transport
+
+    with (
+        patch.object(DeliveryGateway, "deliver_stream", new=AsyncMock(side_effect=consume_stream)),
+        patch.object(
+            DeliveryGateway,
+            "finalize_streamed_response",
+            new=AsyncMock(return_value=_completed_outcome("$stream", body="streamed body")),
+        ),
+        patch_response_runner_module(
+            stream_agent_response=fake_stream,
+            typing_indicator=_noop_typing,
+        ),
+    ):
+        await coordinator._process_and_respond_streaming(request, runtime=runtime)
+
+    assert active_models == ["large"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1648,6 +1648,52 @@ async def test_waiting_message_without_continuation_replays_the_safe_paused_turn
     assert [event.event_id for event in pending] == ["$source"]
 
 
+@pytest.mark.asyncio
+async def test_team_approval_persists_pinned_member_models(tmp_path: Path) -> None:
+    """Approval pause must retain the member aliases selected at turn start."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    request = _plain_request(_target(thread_id="$thread"), source_event_id="$source")
+    await _admit_approval_source(runner.deps.approval_store)
+    paused = PausedAttempt(
+        session_id="session-1",
+        run_id="run-paused",
+        tools=(ToolExecution(tool_call_id="call-1", tool_name="dangerous", requires_confirmation=True),),
+        runtime_model_name="large",
+        team_member_model_names=(("general", "large"),),
+    )
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@user:localhost",
+        room_id=request.room_id,
+        thread_id=request.thread_id,
+        resolved_thread_id=request.response_envelope.target.resolved_thread_id,
+        session_id=paused.session_id,
+    )
+
+    with (
+        patch.object(DeliveryGateway, "send_text", new=AsyncMock(return_value="$waiting")),
+        patch("mindroom.response_runner.uuid4", return_value=MagicMock(hex="approval-team-models")),
+        patch("mindroom.approval_response.resolve_tool_approval_approver", return_value="@user:localhost"),
+        patch("mindroom.approval_response.evaluate_tool_approval", new=AsyncMock(return_value=(True, 60.0))),
+    ):
+        await runner._suspend_for_approval(
+            paused,
+            request=request,
+            target=request.response_envelope.target,
+            progress=response_runner._DeliveryProgress(),
+            execution_identity=identity,
+            entity_kind="team",
+            history_scope=runner.deps.state_writer.history_scope(),
+            team_member_names=("general",),
+            team_mode="coordinate",
+        )
+
+    continuation = await runner.deps.approval_store.approval_continuation("approval-team-models")
+    assert continuation is not None
+    assert continuation.team_member_model_names == (("general", "large"),)
+
+
 @pytest.mark.parametrize(("approved", "reason"), [(True, None), (False, "too dangerous")])
 @pytest.mark.asyncio
 async def test_agent_continuation_executes_real_agno_confirmation(
@@ -2966,6 +3012,62 @@ async def test_continuation_rejects_missing_persisted_execution_identity(tmp_pat
             target=_target(),
             tool_trace_collector=[],
         )
+
+
+@pytest.mark.asyncio
+async def test_team_approval_resume_reuses_persisted_member_models(tmp_path: Path) -> None:
+    """A resumed team must rebuild members from the turn's pinned aliases."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    target = _target(thread_id="$thread")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@user:localhost",
+        room_id=target.room_id,
+        thread_id=target.resolved_thread_id,
+        resolved_thread_id=target.resolved_thread_id,
+        session_id="session-1",
+    )
+    continuation = ApprovalContinuation(
+        approval_id="approval-team-model-resume",
+        run_id="run-paused",
+        session_id="session-1",
+        entity_kind="team",
+        entity_name="general",
+        room_id=target.room_id,
+        thread_id=target.resolved_thread_id,
+        requester_id="@user:localhost",
+        response_event_id="$waiting",
+        source_event_ids=("$source",),
+        calls=(),
+        state="claimed",
+        execution_identity={},
+        runtime_model_name="large",
+        team_member_names=("general",),
+        team_member_model_names=(("general", "large"),),
+        team_mode="coordinate",
+    )
+    continued = AsyncMock(return_value=CompletedApprovalRun(response_text="done", metadata_content={}))
+
+    with (
+        patch("mindroom.response_runner.parse_tool_execution_identity_payload", return_value=identity),
+        patch.object(
+            runner.deps.tool_runtime,
+            "build_dispatch_context",
+            return_value=ToolDispatchContext(execution_identity=identity),
+        ),
+        patch("mindroom.response_runner.continue_paused_team_run", new=continued),
+        patch("mindroom.response_runner.typing_indicator", _noop_typing),
+    ):
+        result = await runner._continue_entity_call(
+            continuation,
+            request=_plain_request(target, source_event_id="$source"),
+            target=target,
+            tool_trace_collector=[],
+        )
+
+    assert isinstance(result, CompletedApprovalRun)
+    assert continued.await_args.kwargs.get("member_model_names") == {"general": "large"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_response_runner_team.py
+++ b/tests/test_response_runner_team.py
@@ -85,6 +85,68 @@ class TestAgentBot(AgentBotTestBase):
     """Bot behavior tests moved verbatim from tests/test_multi_agent_bot.py."""
 
     @pytest.mark.asyncio
+    async def test_team_model_snapshot_precedes_locked_turn_preparation(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A room-default change during locked preparation must wait for the next team turn."""
+        config = self._config_for_storage(tmp_path)
+        config.defaults.show_stop_button = False
+        config.models["large"] = ModelConfig(provider="test", id="large-model")
+        runtime_paths = runtime_paths_for(config)
+        set_room_model_override(
+            runtime_paths,
+            room_id="!test:localhost",
+            model_name="large",
+            set_by="@admin:localhost",
+        )
+        bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        bot.client = _make_matrix_client_mock()
+        bot.orchestrator = MagicMock(current_config=config, config=config, runtime_paths=runtime_paths)
+        coordinator = unwrap_extracted_collaborator(bot._response_runner)
+        original_begin_locked_turn = coordinator._begin_locked_turn
+        matrix_ids = entity_ids(config, runtime_paths)
+        mock_team_response = AsyncMock(return_value="Team reply")
+
+        async def change_room_default_during_preparation(*args: object, **kwargs: object) -> ResponseRequest | None:
+            set_room_model_override(
+                runtime_paths,
+                room_id="!test:localhost",
+                model_name="default",
+                set_by="@admin:localhost",
+            )
+            return await original_begin_locked_turn(*args, **kwargs)  # type: ignore[arg-type]
+
+        with (
+            patch.object(coordinator, "_begin_locked_turn", new=change_room_default_during_preparation),
+            patch(
+                "mindroom.delivery_gateway.send_message_outcome",
+                new=AsyncMock(side_effect=delivered_matrix_side_effect("$team")),
+            ),
+            patch_response_runner_module(
+                typing_indicator=_noop_typing_indicator,
+                should_use_streaming=AsyncMock(return_value=False),
+                team_response=mock_team_response,
+            ),
+        ):
+            await coordinator.generate_team_response_helper(
+                ResponseRequest(
+                    thread_history=[],
+                    user_id="@user:localhost",
+                    prompt="team prompt",
+                    response_envelope=_hook_envelope(body="team prompt", source_event_id="$team-root"),
+                    correlation_id="corr-team",
+                ),
+                team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
+                team_mode="collaborate",
+            )
+
+        response_kwargs = mock_team_response.await_args.kwargs
+        assert response_kwargs["model_name"] == "large"
+        assert response_kwargs["member_model_names"] == {"calculator": "large", "general": "large"}
+
+    @pytest.mark.asyncio
     async def test_team_model_snapshot_is_complete_before_streaming_check_yields(
         self,
         mock_agent_user: AgentMatrixUser,

--- a/tests/test_response_runner_team.py
+++ b/tests/test_response_runner_team.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from mindroom.config.models import ModelConfig
 from mindroom.dispatch_source import (
     MESSAGE_SOURCE_KIND,
 )
@@ -29,6 +30,7 @@ from mindroom.response_runner import (
     ResponseRequest,
     ResponseRunner,
 )
+from mindroom.room_model_overrides import set_room_model_override
 from mindroom.teams import TeamIntent, TeamMemberStatus, TeamMode, TeamOutcome, TeamResolution, TeamResolutionMember
 from mindroom.thread_summary import thread_summary_message_count_hint
 from mindroom.turn_policy import _ResponderAvailability
@@ -81,6 +83,65 @@ def mock_agent_user() -> AgentMatrixUser:
 
 class TestAgentBot(AgentBotTestBase):
     """Bot behavior tests moved verbatim from tests/test_multi_agent_bot.py."""
+
+    @pytest.mark.asyncio
+    async def test_team_model_snapshot_is_complete_before_streaming_check_yields(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """One room-default change must not split a turn across model aliases."""
+        config = self._config_for_storage(tmp_path)
+        config.defaults.show_stop_button = False
+        config.models["large"] = ModelConfig(provider="test", id="large-model")
+        runtime_paths = runtime_paths_for(config)
+        set_room_model_override(
+            runtime_paths,
+            room_id="!test:localhost",
+            model_name="large",
+            set_by="@admin:localhost",
+        )
+        bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        bot.client = _make_matrix_client_mock()
+        bot.orchestrator = MagicMock(current_config=config, config=config, runtime_paths=runtime_paths)
+        matrix_ids = entity_ids(config, runtime_paths)
+        mock_team_response = AsyncMock(return_value="Team reply")
+
+        async def change_room_default(*_args: object, **_kwargs: object) -> bool:
+            set_room_model_override(
+                runtime_paths,
+                room_id="!test:localhost",
+                model_name="default",
+                set_by="@admin:localhost",
+            )
+            return False
+
+        with (
+            patch(
+                "mindroom.delivery_gateway.send_message_outcome",
+                new=AsyncMock(side_effect=delivered_matrix_side_effect("$team")),
+            ),
+            patch_response_runner_module(
+                typing_indicator=_noop_typing_indicator,
+                should_use_streaming=AsyncMock(side_effect=change_room_default),
+                team_response=mock_team_response,
+            ),
+        ):
+            await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    thread_history=[],
+                    user_id="@user:localhost",
+                    prompt="team prompt",
+                    response_envelope=_hook_envelope(body="team prompt", source_event_id="$team-root"),
+                    correlation_id="corr-team",
+                ),
+                team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
+                team_mode="collaborate",
+            )
+
+        response_kwargs = mock_team_response.await_args.kwargs
+        assert response_kwargs["model_name"] == "large"
+        assert response_kwargs["member_model_names"] == {"calculator": "large", "general": "large"}
 
     @pytest.mark.asyncio
     async def test_generate_team_response_helper_applies_hooks_to_final_team_message(

--- a/tests/test_room_models.py
+++ b/tests/test_room_models.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import json
 from dataclasses import dataclass
-from pathlib import Path
 from types import SimpleNamespace
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import nio
@@ -16,6 +16,7 @@ from mindroom.commands.parsing import Command, CommandType, command_parser, get_
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
+from mindroom.history.runtime import close_team_runtime_state_dbs
 from mindroom.message_target import MessageTarget
 from mindroom.room_model_overrides import (
     _store_path,
@@ -23,9 +24,14 @@ from mindroom.room_model_overrides import (
     resolve_room_model_override,
     set_room_model_override,
 )
+from mindroom.teams import materialize_exact_team_members
 from mindroom.thread_models import set_thread_model_override
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 from tests.authorization_helpers import make_test_command_handler_context
 from tests.conftest import bind_runtime_paths, make_conversation_reader_mock, runtime_paths_for, test_runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 ROOM_ID = "!room:localhost"
 
@@ -318,6 +324,65 @@ def test_runtime_room_override_precedence(tmp_path: Path, monkeypatch: pytest.Mo
         ).model_name
         == "large"
     )
+
+
+def test_runtime_model_precedence_applies_to_materialized_team_members(tmp_path: Path) -> None:
+    """Team members must use room defaults while retaining higher-priority thread choices."""
+    context = _room_model_context(tmp_path, AsyncMock())
+    set_room_model_override(
+        context.runtime_paths,
+        room_id=ROOM_ID,
+        model_name="large",
+        set_by="@admin:localhost",
+    )
+
+    members = materialize_exact_team_members(
+        ["assistant"],
+        config=context.config,
+        runtime_paths=context.runtime_paths,
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="team",
+            requester_id="@user:localhost",
+            room_id=ROOM_ID,
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+        ),
+    )
+    try:
+        assert members.agents[0].model is not None
+        assert members.agents[0].model.id == "large-model"
+    finally:
+        close_team_runtime_state_dbs(agents=members.agents, team_db=None)
+
+    thread_id = "$thread:localhost"
+    set_thread_model_override(
+        context.runtime_paths,
+        thread_id=thread_id,
+        model_name="default",
+        room_id=ROOM_ID,
+        set_by="@user:localhost",
+    )
+    thread_members = materialize_exact_team_members(
+        ["assistant"],
+        config=context.config,
+        runtime_paths=context.runtime_paths,
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="team",
+            requester_id="@user:localhost",
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            resolved_thread_id=thread_id,
+            session_id=f"{ROOM_ID}:{thread_id}",
+        ),
+    )
+    try:
+        assert thread_members.agents[0].model is not None
+        assert thread_members.agents[0].model.id == "default-model"
+    finally:
+        close_team_runtime_state_dbs(agents=thread_members.agents, team_db=None)
 
 
 def test_stale_runtime_room_override_falls_back_to_static_room_model(

--- a/tests/test_room_models.py
+++ b/tests/test_room_models.py
@@ -1,0 +1,484 @@
+"""Tests for durable room-level model overrides."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import nio
+import pytest
+
+from mindroom.commands.handler import CommandHandlerContext, handle_command
+from mindroom.commands.parsing import Command, CommandType, command_parser, get_command_help
+from mindroom.config.agent import AgentConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.message_target import MessageTarget
+from mindroom.room_model_overrides import (
+    _store_path,
+    clear_room_model_override,
+    resolve_room_model_override,
+    set_room_model_override,
+)
+from mindroom.thread_models import set_thread_model_override
+from tests.authorization_helpers import make_test_command_handler_context
+from tests.conftest import bind_runtime_paths, make_conversation_reader_mock, runtime_paths_for, test_runtime_paths
+
+ROOM_ID = "!room:localhost"
+
+
+@dataclass(frozen=True)
+class _RoomModelEvent:
+    sender: str
+    event_id: str
+    body: str
+    source: dict[str, dict[str, str]]
+
+
+def _power_levels_response(*, users: dict[str, int]) -> nio.RoomGetStateEventResponse:
+    return nio.RoomGetStateEventResponse(
+        content={"users": users, "users_default": 0},
+        event_type="m.room.power_levels",
+        state_key="",
+        room_id=ROOM_ID,
+    )
+
+
+def _room_model_context(
+    tmp_path: Path,
+    client: AsyncMock,
+    *,
+    models: dict[str, ModelConfig] | None = None,
+) -> CommandHandlerContext:
+    config = bind_runtime_paths(
+        Config(
+            agents={"assistant": AgentConfig(display_name="Assistant", model="default")},
+            models=models
+            or {
+                "default": ModelConfig(provider="openai", id="default-model"),
+                "large": ModelConfig(provider="openai", id="large-model", context_window=32_000),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    return make_test_command_handler_context(
+        client=client,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        logger=MagicMock(),
+        conversation_reader=make_conversation_reader_mock(),
+        stable_target=MessageTarget.resolve(ROOM_ID, None, "$event"),
+        record_handled_turn=AsyncMock(),
+        record_command_result=AsyncMock(),
+        send_response=AsyncMock(return_value="$reply"),
+    )
+
+
+def _room_model_event(sender: str, body: str) -> _RoomModelEvent:
+    return _RoomModelEvent(
+        sender=sender,
+        event_id="$event",
+        body=body,
+        source={"content": {"body": body}},
+    )
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_args"),
+    [
+        ("!room_model", ""),
+        ("!room-model large", "large"),
+        ("!roommodel reset", "reset"),
+    ],
+)
+def test_room_model_command_parses_supported_spellings(message: str, expected_args: str) -> None:
+    """Missing room-model parser support must not route valid commands as unknown."""
+    command = command_parser.parse(message)
+
+    assert command is not None
+    assert command.type.value == "room_model"
+    assert command.args["args_text"] == expected_args
+
+
+@pytest.mark.parametrize("topic", ["room_model", "room-model", "roommodel"])
+def test_room_model_help_accepts_supported_spellings(topic: str) -> None:
+    """Missing help routing must not hide room-model scope and permissions."""
+    help_text = get_command_help(topic)
+
+    assert "**Room Model Command**" in help_text
+    assert "room admin" in help_text.lower()
+    assert "Thread overrides take precedence" in help_text
+
+
+@pytest.mark.asyncio
+async def test_room_model_command_sets_runtime_default_without_writing_config(tmp_path: Path) -> None:
+    """Missing room state must not leave future room turns on entity config."""
+    client = AsyncMock()
+    client.room_get_state_event.return_value = _power_levels_response(users={"@admin:localhost": 100})
+    context = _room_model_context(tmp_path, client)
+    config_before = context.runtime_paths.config_path.read_text(encoding="utf-8")
+    command = Command(type=CommandType.ROOM_MODEL, args={"args_text": "large"}, raw_text="!room_model large")
+
+    await handle_command(
+        context=context,
+        room=SimpleNamespace(room_id=ROOM_ID),
+        event=_room_model_event("@admin:localhost", "!room_model large"),
+        command=command,
+        requester_user_id="@admin:localhost",
+    )
+
+    runtime_model = context.config.resolve_runtime_model(
+        entity_name="assistant",
+        room_id=ROOM_ID,
+        runtime_paths=context.runtime_paths,
+    )
+    assert runtime_model.model_name == "large"
+    assert runtime_model.context_window == 32_000
+    assert context.runtime_paths.config_path.read_text(encoding="utf-8") == config_before
+
+
+@pytest.mark.asyncio
+async def test_room_model_command_reset_restores_configured_default(tmp_path: Path) -> None:
+    """Missing reset support must not leave a removed room choice active."""
+    client = AsyncMock()
+    client.room_get_state_event.return_value = _power_levels_response(users={"@admin:localhost": 100})
+    context = _room_model_context(tmp_path, client)
+
+    await handle_command(
+        context=context,
+        room=SimpleNamespace(room_id=ROOM_ID),
+        event=_room_model_event("@admin:localhost", "!room_model large"),
+        command=Command(
+            type=CommandType.ROOM_MODEL,
+            args={"args_text": "large"},
+            raw_text="!room_model large",
+        ),
+        requester_user_id="@admin:localhost",
+    )
+    await handle_command(
+        context=context,
+        room=SimpleNamespace(room_id=ROOM_ID),
+        event=_room_model_event("@admin:localhost", "!room_model reset"),
+        command=Command(
+            type=CommandType.ROOM_MODEL,
+            args={"args_text": "reset"},
+            raw_text="!room_model reset",
+        ),
+        requester_user_id="@admin:localhost",
+    )
+
+    runtime_model = context.config.resolve_runtime_model(
+        entity_name="assistant",
+        room_id=ROOM_ID,
+        runtime_paths=context.runtime_paths,
+    )
+    assert runtime_model.model_name == "default"
+    assert "override removed" in context.send_response.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_room_model_command_show_lists_state_and_available_models(tmp_path: Path) -> None:
+    """Missing status support must not hide room state or valid model choices."""
+    client = AsyncMock()
+    context = _room_model_context(tmp_path, client)
+
+    await handle_command(
+        context=context,
+        room=SimpleNamespace(room_id=ROOM_ID),
+        event=_room_model_event("@user:localhost", "!room_model"),
+        command=Command(type=CommandType.ROOM_MODEL, args={"args_text": ""}, raw_text="!room_model"),
+        requester_user_id="@user:localhost",
+    )
+
+    response = context.send_response.await_args.args[0]
+    assert "No room model override" in response
+    assert "`default` (openai default-model)" in response
+    assert "`large` (openai large-model)" in response
+
+
+def test_room_model_store_scopes_records_by_room_and_preserves_audit_metadata(tmp_path: Path) -> None:
+    """A room override must not leak into another room or lose its author."""
+    runtime_paths = test_runtime_paths(tmp_path)
+
+    set_room_model_override(
+        runtime_paths,
+        room_id=ROOM_ID,
+        model_name="large",
+        set_by="@admin:localhost",
+    )
+
+    state = resolve_room_model_override(runtime_paths, ROOM_ID, configured_models={"default", "large"})
+    other_state = resolve_room_model_override(
+        runtime_paths,
+        "!other:localhost",
+        configured_models={"default", "large"},
+    )
+    assert state.active == "large"
+    assert state.stale is None
+    assert state.set_by == "@admin:localhost"
+    assert state.set_at is not None
+    assert other_state.active is None
+    assert clear_room_model_override(runtime_paths, ROOM_ID) is True
+    assert clear_room_model_override(runtime_paths, ROOM_ID) is False
+
+
+def test_room_model_store_ignores_corrupt_records_and_classifies_removed_models(tmp_path: Path) -> None:
+    """Malformed or removed model names must never become active runtime choices."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    path = _store_path(runtime_paths)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            {
+                ROOM_ID: {"model": [], "set_at": "2026-08-15T00:00:00+00:00"},
+                "!bad-time:localhost": {"model": "large", "set_at": 12345},
+                "!removed:localhost": {"model": "removed", "set_at": "2026-08-15T00:00:00+00:00"},
+            },
+        ),
+        encoding="utf-8",
+    )
+
+    invalid = resolve_room_model_override(runtime_paths, ROOM_ID, configured_models={"default", "large"})
+    invalid_time = resolve_room_model_override(
+        runtime_paths,
+        "!bad-time:localhost",
+        configured_models={"default", "large"},
+    )
+    stale = resolve_room_model_override(
+        runtime_paths,
+        "!removed:localhost",
+        configured_models={"default", "large"},
+    )
+    assert invalid.active is None
+    assert invalid.stale is None
+    assert invalid_time.active is None
+    assert invalid_time.stale is None
+    assert stale.active is None
+    assert stale.stale == "removed"
+
+
+def test_runtime_room_override_precedence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Room runtime state must beat static room config while thread and explicit choices still win."""
+    config = bind_runtime_paths(
+        Config(
+            agents={"assistant": AgentConfig(display_name="Assistant", model="default")},
+            room_models={"lobby": "default"},
+            models={
+                "default": ModelConfig(provider="openai", id="default-model"),
+                "large": ModelConfig(provider="openai", id="large-model", context_window=32_000),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    runtime_paths = runtime_paths_for(config)
+    monkeypatch.setattr("mindroom.matrix.state.get_room_alias_from_id", lambda *_args: "lobby")
+    set_room_model_override(
+        runtime_paths,
+        room_id=ROOM_ID,
+        model_name="large",
+        set_by="@admin:localhost",
+    )
+
+    assert (
+        config.resolve_runtime_model(
+            entity_name="assistant",
+            room_id=ROOM_ID,
+            runtime_paths=runtime_paths,
+        ).model_name
+        == "large"
+    )
+
+    thread_id = "$thread:localhost"
+    set_thread_model_override(
+        runtime_paths,
+        thread_id=thread_id,
+        model_name="default",
+        room_id=ROOM_ID,
+        set_by="@user:localhost",
+    )
+    assert (
+        config.resolve_runtime_model(
+            entity_name="assistant",
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            runtime_paths=runtime_paths,
+        ).model_name
+        == "default"
+    )
+    assert (
+        config.resolve_runtime_model(
+            entity_name="assistant",
+            active_model_name="large",
+            room_id=ROOM_ID,
+            thread_id=thread_id,
+            runtime_paths=runtime_paths,
+        ).model_name
+        == "large"
+    )
+
+
+def test_stale_runtime_room_override_falls_back_to_static_room_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Removed runtime aliases must not mask a still-valid static room model."""
+    config = bind_runtime_paths(
+        Config(
+            agents={"assistant": AgentConfig(display_name="Assistant", model="large")},
+            room_models={"lobby": "default"},
+            models={
+                "default": ModelConfig(provider="openai", id="default-model"),
+                "large": ModelConfig(provider="openai", id="large-model"),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    runtime_paths = runtime_paths_for(config)
+    monkeypatch.setattr("mindroom.matrix.state.get_room_alias_from_id", lambda *_args: "lobby")
+    set_room_model_override(
+        runtime_paths,
+        room_id=ROOM_ID,
+        model_name="removed",
+        set_by="@admin:localhost",
+    )
+
+    runtime_model = config.resolve_runtime_model(
+        entity_name="assistant",
+        room_id=ROOM_ID,
+        runtime_paths=runtime_paths,
+    )
+    assert runtime_model.model_name == "default"
+
+
+@pytest.mark.asyncio
+async def test_room_model_command_rejects_non_admin_without_changing_state(tmp_path: Path) -> None:
+    """A regular room member must not change defaults for every conversation."""
+    client = AsyncMock()
+    client.room_get_state_event.return_value = _power_levels_response(users={"@admin:localhost": 100})
+    context = _room_model_context(tmp_path, client)
+
+    await handle_command(
+        context=context,
+        room=SimpleNamespace(room_id=ROOM_ID),
+        event=_room_model_event("@user:localhost", "!room_model large"),
+        command=Command(
+            type=CommandType.ROOM_MODEL,
+            args={"args_text": "large"},
+            raw_text="!room_model large",
+        ),
+        requester_user_id="@user:localhost",
+    )
+
+    state = resolve_room_model_override(context.runtime_paths, ROOM_ID, configured_models=context.config.models)
+    assert state.active is None
+    assert context.send_response.await_args.args[0] == "❌ Room admin only."
+
+
+@pytest.mark.asyncio
+async def test_room_model_command_records_authorizing_sender(tmp_path: Path) -> None:
+    """Bridge-mediated commands must audit the Matrix user satisfying the admin check."""
+    client = AsyncMock()
+    client.room_get_state_event.return_value = _power_levels_response(users={"@bridge-admin:localhost": 100})
+    context = _room_model_context(tmp_path, client)
+
+    await handle_command(
+        context=context,
+        room=SimpleNamespace(room_id=ROOM_ID),
+        event=_room_model_event("@bridge-admin:localhost", "!room_model large"),
+        command=Command(
+            type=CommandType.ROOM_MODEL,
+            args={"args_text": "large"},
+            raw_text="!room_model large",
+        ),
+        requester_user_id="@puppet-user:localhost",
+    )
+
+    state = resolve_room_model_override(context.runtime_paths, ROOM_ID, configured_models=context.config.models)
+    assert state.active == "large"
+    assert state.set_by == "@bridge-admin:localhost"
+
+
+@pytest.mark.asyncio
+async def test_room_model_command_reports_stale_override(tmp_path: Path) -> None:
+    """Status must distinguish an ignored removed alias from no stored choice."""
+    client = AsyncMock()
+    context = _room_model_context(tmp_path, client)
+    set_room_model_override(
+        context.runtime_paths,
+        room_id=ROOM_ID,
+        model_name="removed",
+        set_by="@admin:localhost",
+    )
+
+    await handle_command(
+        context=context,
+        room=SimpleNamespace(room_id=ROOM_ID),
+        event=_room_model_event("@user:localhost", "!room_model status"),
+        command=Command(
+            type=CommandType.ROOM_MODEL,
+            args={"args_text": "status"},
+            raw_text="!room_model status",
+        ),
+        requester_user_id="@user:localhost",
+    )
+
+    assert "Stored room model override `removed` is unavailable and ignored" in context.send_response.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_room_model_command_configured_reset_name_sets_model(tmp_path: Path) -> None:
+    """A configured model named reset must remain selectable instead of clearing state."""
+    client = AsyncMock()
+    client.room_get_state_event.return_value = _power_levels_response(users={"@admin:localhost": 100})
+    context = _room_model_context(
+        tmp_path,
+        client,
+        models={
+            "default": ModelConfig(provider="openai", id="default-model"),
+            "reset": ModelConfig(provider="openai", id="reset-model"),
+        },
+    )
+
+    await handle_command(
+        context=context,
+        room=SimpleNamespace(room_id=ROOM_ID),
+        event=_room_model_event("@admin:localhost", "!room_model reset"),
+        command=Command(
+            type=CommandType.ROOM_MODEL,
+            args={"args_text": "reset"},
+            raw_text="!room_model reset",
+        ),
+        requester_user_id="@admin:localhost",
+    )
+
+    state = resolve_room_model_override(context.runtime_paths, ROOM_ID, configured_models=context.config.models)
+    assert state.active == "reset"
+
+
+@pytest.mark.asyncio
+async def test_room_model_command_unknown_name_lists_available_models(tmp_path: Path) -> None:
+    """An invalid choice must leave state unchanged and provide actionable choices."""
+    client = AsyncMock()
+    context = _room_model_context(tmp_path, client)
+
+    await handle_command(
+        context=context,
+        room=SimpleNamespace(room_id=ROOM_ID),
+        event=_room_model_event("@user:localhost", "!room_model missing"),
+        command=Command(
+            type=CommandType.ROOM_MODEL,
+            args={"args_text": "missing"},
+            raw_text="!room_model missing",
+        ),
+        requester_user_id="@user:localhost",
+    )
+
+    response = context.send_response.await_args.args[0]
+    state = resolve_room_model_override(context.runtime_paths, ROOM_ID, configured_models=context.config.models)
+    assert state.active is None
+    assert "Unknown model `missing`" in response
+    assert "`default` (openai default-model)" in response
+    assert "`large` (openai large-model)" in response

--- a/tests/test_room_models.py
+++ b/tests/test_room_models.py
@@ -117,6 +117,7 @@ def test_room_model_help_accepts_supported_spellings(topic: str) -> None:
 
     assert "**Room Model Command**" in help_text
     assert "room admin" in help_text.lower()
+    assert "room default returns to configured room or entity models" in help_text.lower()
     assert "Thread overrides take precedence" in help_text
 
 
@@ -183,7 +184,10 @@ async def test_room_model_command_reset_restores_configured_default(tmp_path: Pa
         runtime_paths=context.runtime_paths,
     )
     assert runtime_model.model_name == "default"
-    assert "override removed" in context.send_response.await_args.args[0]
+    response = context.send_response.await_args.args[0]
+    assert "override removed" in response
+    assert "Room default returns to configured room or entity models" in response
+    assert "Thread model overrides still take precedence" in response
 
 
 @pytest.mark.asyncio
@@ -202,6 +206,8 @@ async def test_room_model_command_show_lists_state_and_available_models(tmp_path
 
     response = context.send_response.await_args.args[0]
     assert "No room model override" in response
+    assert "configured room or entity models define the room default" in response
+    assert "Thread model overrides still take precedence" in response
     assert "`default` (openai default-model)" in response
     assert "`large` (openai large-model)" in response
 

--- a/tests/test_room_models.py
+++ b/tests/test_room_models.py
@@ -232,6 +232,26 @@ def test_room_model_store_scopes_records_by_room_and_preserves_audit_metadata(tm
     assert clear_room_model_override(runtime_paths, ROOM_ID) is False
 
 
+def test_room_model_overrides_do_not_silently_evict_active_rooms(tmp_path: Path) -> None:
+    """A durable room default must remain until reset, even after many other rooms are set."""
+    context = _room_model_context(tmp_path, AsyncMock())
+    for index in range(1001):
+        set_room_model_override(
+            context.runtime_paths,
+            room_id=f"!room-{index}:localhost",
+            model_name="large",
+            set_by="@admin:localhost",
+        )
+
+    oldest = resolve_room_model_override(
+        context.runtime_paths,
+        "!room-0:localhost",
+        configured_models=context.config.models,
+    )
+
+    assert oldest.active == "large"
+
+
 def test_room_model_store_ignores_corrupt_records_and_classifies_removed_models(tmp_path: Path) -> None:
     """Malformed or removed model names must never become active runtime choices."""
     runtime_paths = test_runtime_paths(tmp_path)

--- a/tests/test_room_models.py
+++ b/tests/test_room_models.py
@@ -6,11 +6,12 @@ import json
 from dataclasses import dataclass
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
 import pytest
 
+import mindroom.routing
 from mindroom.commands.handler import CommandHandlerContext, handle_command
 from mindroom.commands.parsing import Command, CommandType, command_parser, get_command_help
 from mindroom.config.agent import AgentConfig
@@ -324,6 +325,42 @@ def test_runtime_room_override_precedence(tmp_path: Path, monkeypatch: pytest.Mo
         ).model_name
         == "large"
     )
+
+
+@pytest.mark.asyncio
+async def test_runtime_room_override_selects_router_model(tmp_path: Path) -> None:
+    """Router selection must not bypass the room's runtime model default."""
+    context = _room_model_context(tmp_path, AsyncMock())
+    set_room_model_override(
+        context.runtime_paths,
+        room_id=ROOM_ID,
+        model_name="large",
+        set_by="@admin:localhost",
+    )
+    selected_models: list[str] = []
+
+    def load_model(_config: Config, _runtime_paths: object, model_name: str) -> MagicMock:
+        selected_models.append(model_name)
+        return MagicMock(id=f"{model_name}-model")
+
+    router = AsyncMock()
+    router.arun.return_value = SimpleNamespace(
+        content={"entity_name": "assistant", "reasoning": "Only candidate"},
+    )
+    with (
+        patch("mindroom.routing.model_loading.get_model_instance", side_effect=load_model),
+        patch("mindroom.routing.Agent", return_value=router),
+    ):
+        result = await mindroom.routing.suggest_responder(
+            "Help me",
+            ["assistant"],
+            context.config,
+            context.runtime_paths,
+            room_id=ROOM_ID,
+        )
+
+    assert result == "assistant"
+    assert selected_models == ["large"]
 
 
 def test_runtime_model_precedence_applies_to_materialized_team_members(tmp_path: Path) -> None:

--- a/tests/test_routing_regression.py
+++ b/tests/test_routing_regression.py
@@ -1797,6 +1797,7 @@ class TestRoutingRegression:
         }
         mock_orchestrator.current_config = mock_config
         mock_orchestrator.config = mock_config  # This is what teams.py uses
+        mock_orchestrator.runtime_paths = runtime_paths_for(mock_config)
 
         # Set the orchestrator on both bots
         research_bot.orchestrator = mock_orchestrator

--- a/tests/test_team_dynamic_continuation.py
+++ b/tests/test_team_dynamic_continuation.py
@@ -14,9 +14,11 @@ from agno.run.agent import ToolCallCompletedEvent as AgentToolCallCompletedEvent
 from agno.run.team import TeamRunOutput
 
 from mindroom import teams as teams_module
+from mindroom.config.models import ModelConfig
 from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.knowledge.utils import _KnowledgeResolution
+from mindroom.room_model_overrides import set_room_model_override
 from mindroom.team_exact_members import ResolvedExactTeamMembers
 from mindroom.teams import (
     TeamMode,
@@ -27,6 +29,7 @@ from mindroom.teams import (
     team_response,
     team_response_stream,
 )
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 from tests.conftest import make_turn_context, runtime_paths_for
 from tests.identity_helpers import entity_ids
 from tests.test_team_media_fallback import _build_test_config, _make_test_agent, _make_test_team
@@ -115,6 +118,65 @@ async def test_team_response_continues_after_member_dynamic_tool_load() -> None:
     assert "Used the loaded tool." in recorder.assistant_text
     # The turn-level trace still carries the first attempt's dynamic tool call.
     assert any(entry.tool_name == "load_tool" for entry in recorder.completed_tools)
+
+
+@pytest.mark.asyncio
+async def test_team_dynamic_continuation_pins_member_model_for_whole_turn() -> None:
+    """A room-default change mid-turn must not switch rebuilt team members."""
+    orchestrator, config = _make_orchestrator()
+    config.models["large"] = ModelConfig(provider="openai", id="large-model")
+    runtime_paths = runtime_paths_for(config)
+    room_id = "!room:localhost"
+    set_room_model_override(
+        runtime_paths,
+        room_id=room_id,
+        model_name="large",
+        set_by="@admin:localhost",
+    )
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@user:localhost",
+        room_id=room_id,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    attempt = 0
+
+    async def run_team(_prompt: object, **_kwargs: object) -> TeamRunOutput:
+        nonlocal attempt
+        attempt += 1
+        if attempt == 1:
+            set_room_model_override(
+                runtime_paths,
+                room_id=room_id,
+                model_name="default",
+                set_by="@admin:localhost",
+            )
+            return _dynamic_tool_team_output()
+        return TeamRunOutput(content="Used the loaded tool.")
+
+    mock_team = _make_test_team()
+    mock_team.arun = AsyncMock(side_effect=run_team)
+    fake_agent = _make_test_agent("GeneralAgent")
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent) as mock_create,
+        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+        patch("mindroom.teams._create_team_instance", return_value=mock_team),
+    ):
+        response = await team_response(
+            agent_names=["general"],
+            mode=TeamMode.COORDINATE,
+            message="Load the sleep tool and use it.",
+            turn_recorder=TurnRecorder(user_message="Load the sleep tool and use it."),
+            orchestrator=orchestrator,
+            execution_identity=identity,
+            ctx=make_turn_context(session_id=None, room_id=room_id),
+        )
+
+    assert "Used the loaded tool." in response
+    assert [call.kwargs["active_model_name"] for call in mock_create.call_args_list] == ["large", "large"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_team_media_fallback.py
+++ b/tests/test_team_media_fallback.py
@@ -2764,6 +2764,7 @@ async def test_team_response_stream_suspends_for_confirmation_pause_event() -> N
         display_names=["GeneralAgent"],
         materialized_agent_names={"general"},
         failed_agent_names=[],
+        model_names={"general": "large"},
     )
     tool = ToolExecution(
         tool_call_id="call-team-stream-approval",
@@ -2811,6 +2812,7 @@ async def test_team_response_stream_suspends_for_confirmation_pause_event() -> N
 
     assert raised.value.paused.run_id == "run-paused"
     assert raised.value.paused.tools == (tool,)
+    assert raised.value.paused.team_member_model_names == (("general", "large"),)
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_models.py
+++ b/tests/test_thread_models.py
@@ -13,13 +13,14 @@ import pytest
 import mindroom.tools  # noqa: F401
 from mindroom.ai_run_metadata import build_ai_run_metadata_content
 from mindroom.commands.model_commands import handle_model_command
-from mindroom.commands.parsing import CommandType, command_parser
+from mindroom.commands.parsing import CommandType, command_parser, get_command_help
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.constants import AI_RUN_METADATA_KEY
 from mindroom.custom_tools.thread_model import ThreadModelTools
 from mindroom.message_target import MessageTarget
+from mindroom.room_model_overrides import set_room_model_override
 from mindroom.thread_models import (
     _get_thread_model_override,
     _store_path,
@@ -310,7 +311,15 @@ def test_model_command_set_and_reset(tmp_path: Path) -> None:
     )
     assert "✅" in response
     assert "`large`" in response
+    assert "room-level model selection" in response
     assert _get_thread_model_override(runtime_paths, THREAD_ID) == "large"
+
+    set_room_model_override(
+        runtime_paths,
+        room_id=ROOM_ID,
+        model_name="large",
+        set_by="@admin:localhost",
+    )
 
     response = handle_model_command(
         "reset",
@@ -321,7 +330,17 @@ def test_model_command_set_and_reset(tmp_path: Path) -> None:
         requester_user_id="@user:localhost",
     )
     assert "✅" in response
+    assert "room-level model selection" in response
     assert _get_thread_model_override(runtime_paths, THREAD_ID) is None
+    assert (
+        config.resolve_runtime_model(
+            entity_name="test_agent",
+            room_id=ROOM_ID,
+            thread_id=THREAD_ID,
+            runtime_paths=runtime_paths,
+        ).model_name
+        == "large"
+    )
 
     response = handle_model_command(
         "reset",
@@ -348,6 +367,7 @@ def test_model_command_show(tmp_path: Path) -> None:
         requester_user_id="@user:localhost",
     )
     assert "No thread model override" in response
+    assert "room-level model selection" in response
     assert "`default`" in response
     assert "`large`" in response
 
@@ -367,6 +387,13 @@ def test_model_command_show(tmp_path: Path) -> None:
         requester_user_id="@user:localhost",
     )
     assert "`large` override" in response
+
+
+def test_model_help_describes_room_level_fallback() -> None:
+    """Reset help must describe the room-level fallback that actually runs."""
+    help_text = get_command_help("model")
+
+    assert "room-level model selection" in help_text
 
 
 def test_model_command_list_alias_shows_models(tmp_path: Path) -> None:
@@ -566,6 +593,12 @@ async def test_thread_model_tool_reports_stale_override_as_inactive() -> None:
         room_id=ROOM_ID,
         set_by="@user:localhost",
     )
+    set_room_model_override(
+        context.runtime_paths,
+        room_id=ROOM_ID,
+        model_name="large",
+        set_by="@admin:localhost",
+    )
 
     with tool_runtime_context(context):
         payload = json.loads(await ThreadModelTools().get_thread_model())
@@ -574,6 +607,16 @@ async def test_thread_model_tool_reports_stale_override_as_inactive() -> None:
     assert payload["override"] is None
     assert payload["stale_override"] == "removed-model"
     assert "no longer configured" in payload["note"]
+    assert "room-level model selection" in payload["note"]
+    assert (
+        context.config.resolve_runtime_model(
+            entity_name="test_agent",
+            room_id=ROOM_ID,
+            thread_id=THREAD_ID,
+            runtime_paths=context.runtime_paths,
+        ).model_name
+        == "large"
+    )
 
 
 def test_ai_run_metadata_uses_preparation_time_model(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add `!room_model` for durable room-scoped runtime defaults without modifying `config.yaml`
- persist overrides by Matrix room ID under tracking state, with room-admin-only set/reset and member-readable status
- enforce explicit > thread > runtime room > configured room > entity precedence across the router, agents, teams, and delegated child runs
- freeze agent, team-leader, and team-member aliases at turn start; persist team member aliases across retries and approval continuation
- preserve all active room overrides without silent record eviction and document command, persistence, precedence, and turn semantics

## Verification

- `uv run pre-commit run --all-files`
- affected room/thread/routing/response/team/delegation/import suites passed locally
- GitHub Python 3.13, image build, smoke, docs, security, plugin, markdown, and Tach checks passed
- Greptile passed; CodeRabbit was rate-limited on the follow-up commit
- no unresolved review threads