### PR TITLE
Fix router reinvite after kick

### DIFF
--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -93,12 +93,6 @@ class BotRoomLifecycle:
             locks[room_id] = lock
         return lock
 
-    def _client_has_joined_room(self, room_id: str) -> bool:
-        rooms = self._client().rooms
-        if not isinstance(rooms, Mapping):
-            return False
-        return any(joined_room_id == room_id for joined_room_id in rooms)
-
     def _client(self) -> nio.AsyncClient:
         client = self.deps.runtime.client
         if client is None:
@@ -422,7 +416,7 @@ class BotRoomLifecycle:
             return
 
         async with self._lock_for_room(self._invite_join_locks, room.room_id):
-            if room.room_id in self._handled_invite_room_ids or self._client_has_joined_room(room.room_id):
+            if room.room_id in self._handled_invite_room_ids:
                 self._logger().debug("Invite already handled", room_id=room.room_id, sender=event.sender)
                 await self.deps.on_room_joined(room.room_id)
                 self._remember_invited_room(room.room_id)

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -847,7 +847,7 @@ async def test_router_departure_allows_fresh_reinvite(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A room departure must not let old invite and welcome markers suppress rejoining."""
+    """A room departure must rejoin even when nio keeps the old room cached."""
     config = bind_runtime_paths(
         Config(
             router=RouterConfig(model="default", accept_invites=True),
@@ -882,6 +882,7 @@ async def test_router_departure_allows_fresh_reinvite(
     install_send_response_mock(bot, send_response)
 
     await bot._on_invite(room, event)
+    bot.client.rooms[room_id] = MagicMock()
     bot._room_lifecycle.forget_invited_room(room_id)
     await bot._on_invite(room, event)
 


### PR DESCRIPTION
## Summary

- Rejoin an invited room even when matrix-nio retains a stale joined-room cache entry after a kick.
- Cover the kick and reinvite path with a stale-cache regression test.

## Root cause

Receiving an invite proves the current membership is invite, but the invite handler treated presence in `client.rooms` as proof that the bot was already joined. matrix-nio can retain departed rooms in that cache, so the handler skipped `room_join` and the router remained invited instead of joining.

## Testing

- `uv run pytest tests/test_room_invites.py tests/test_invite_router_tool.py -q` (57 passed)
- `uv run pre-commit run --files src/mindroom/bot_room_lifecycle.py tests/test_room_invites.py`
- `git diff --check`

## Known local suite issue

`uv run pytest -m "not requires_matrix"` completed with 14,048 passed, 41 skipped, and one unrelated failure in `test_direct_refresh_timeout_drains_git_descendants_before_releasing_source_lock`. The failure reproduces in untouched knowledge-refresh code because its final Git checkout inherits a one-second test timeout; CI on the exact base SHA is green.

## Summary by Sourcery

Ensure the invite router rejoins rooms after being kicked even if the Matrix client retains a stale joined-room cache entry.

Bug Fixes:
- Prevent invites from being ignored due to stale joined-room entries in the Matrix client cache after a departure.

Tests:
- Extend invite router tests to cover the kick-and-reinvite flow with a simulated stale client room cache.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed room rejoining after an invite is received again.
  * Ensured stale cached room information no longer prevents successful re-entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->