### PR TITLE
Expose room admins to hook-created rooms

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -573,7 +573,8 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Provides a narrow Matrix admin facade when MindRoom has a router-backed admin client available for the current hook context.
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
-The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=..., admin_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+Room creation grants `power_user_ids` power level 50 and `admin_user_ids` power level 100 in the initial room state.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -12912,7 +12912,8 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Provides a narrow Matrix admin facade when MindRoom has a router-backed admin client available for the current hook context.
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
-The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=..., admin_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+Room creation grants `power_user_ids` power level 50 and `admin_user_ids` power level 100 in the initial room state.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.

--- a/skills/mindroom-docs/references/page__hooks__index.md
+++ b/skills/mindroom-docs/references/page__hooks__index.md
@@ -569,7 +569,8 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Provides a narrow Matrix admin facade when MindRoom has a router-backed admin client available for the current hook context.
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
-The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=..., admin_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+Room creation grants `power_user_ids` power level 50 and `admin_user_ids` power level 100 in the initial room state.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -48,6 +48,7 @@ class _BoundHookMatrixAdmin:
         alias_localpart: str | None = None,
         topic: str | None = None,
         power_user_ids: list[str] | None = None,
+        admin_user_ids: list[str] | None = None,
     ) -> str | None:
         """Create one room and record it so lifecycle cleanup preserves it for the creator."""
         room_id = await create_room(
@@ -56,6 +57,7 @@ class _BoundHookMatrixAdmin:
             alias=alias_localpart,
             topic=topic,
             power_users=power_user_ids,
+            admin_users=admin_user_ids,
         )
         if room_id is not None:
             self._persist_created_room_for_creator(room_id)

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -127,6 +127,7 @@ class HookMatrixAdmin(Protocol):
         alias_localpart: str | None = None,
         topic: str | None = None,
         power_user_ids: list[str] | None = None,
+        admin_user_ids: list[str] | None = None,
     ) -> str | None:
         """Create one room and return the room ID on success."""
 

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -181,7 +181,12 @@ async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path:
     ):
         admin = module.build_hook_matrix_admin(client, runtime_paths=runtime_paths)
 
-        room_id = await admin.create_room(name="Personal Room", alias_localpart="personal-user", topic="Hello")
+        room_id = await admin.create_room(
+            name="Personal Room",
+            alias_localpart="personal-user",
+            topic="Hello",
+            admin_user_ids=["@user:localhost"],
+        )
         invited = await admin.invite_user("!created:localhost", "@user:localhost")
         client.room_kick.return_value = nio.RoomKickResponse()
         kicked = await admin.kick_user(
@@ -214,6 +219,7 @@ async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path:
         alias="personal-user",
         topic="Hello",
         power_users=None,
+        admin_users=["@user:localhost"],
     )
     mock_invite.assert_awaited_once_with(client, "!created:localhost", "@user:localhost")
     client.room_kick.assert_awaited_once_with(


### PR DESCRIPTION
## Summary

- expose optional `admin_user_ids` on hook-created rooms
- assign those users power level 100 in the room initial state
- document the hook API and its power-level semantics

## Why

Personal Mind room owners need room-admin rights to use commands such as `!room_model`.

## Testing

- full Python test suite
- pre-commit on all changed files
- 62 targeted hook and room-access tests

## Summary by Sourcery

Expose an optional admin_user_ids parameter on hook-created Matrix rooms and ensure those users receive admin-level power in the initial room state.

New Features:
- Allow hooks to specify admin_user_ids when creating Matrix rooms so designated users are recorded as room admins.

Documentation:
- Document the matrix_admin hook facade to include the new admin_user_ids parameter and clarify the power-level semantics for power_user_ids and admin_user_ids.

Tests:
- Extend hook Matrix admin tests to cover room creation with admin_user_ids and the corresponding admin user configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Room creation now supports specifying administrators separately from power users.
  - Administrators receive the highest room permissions, while power users receive elevated permissions.

- **Documentation**
  - Updated the Matrix administration API documentation to include the new administrator option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->