### PR TITLE
Fix MCP OAuth credential scope ownership

### DIFF
--- a/docs/configuration/agents.md
+++ b/docs/configuration/agents.md
@@ -376,8 +376,8 @@ A filtered public startup-runtime env payload can still propagate from exported 
 `worker_scope` controls how those sandbox runtimes are reused between calls.
 Some integrations require `worker_scope` unset or `shared` because their credentials or sessions are shared at runtime.
 That list includes `spotify` and `homeassistant`.
-Configured `mcp_<server_id>` tools work on every worker scope: generated OAuth providers always use requester-scoped `user` credentials and sessions, while non-OAuth servers use the shared MCP session without requester credentials.
-`worker_scope` controls worker-runtime reuse but does not change generated MCP OAuth credential identity.
+Configured `mcp_<server_id>` tools work on every worker scope: generated OAuth providers follow the selected agent's effective credential scope, while non-OAuth servers use the shared MCP session without requester credentials.
+For OAuth-backed MCP, `shared` uses one agent-owned connection, `user` reuses one requester-owned connection across agents, `user_agent` isolates each requester-agent pair, and unscoped uses one installation-level connection.
 Among those shared-scope integrations, `homeassistant` always stays local regardless of `worker_tools` and is never proxied to the sandbox.
 `github`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, `google_sheets`, and `oauth_connections` also always stay local.
 `spotify` can still be proxied through the sandbox.

--- a/docs/dev/oauth-credential-lifecycle-design.md
+++ b/docs/dev/oauth-credential-lifecycle-design.md
@@ -66,7 +66,7 @@ Synchronous provider work runs in a worker thread while the owner loop retains t
 
 `src/mindroom/mcp/manager.py` treats the credential revision and token hash as an authorization lease.
 It revalidates that lease before publishing a session catalog and before admitting a remote tool call.
-Requester sessions are fenced during reset so captured stale state cannot reconnect before the SQLite reset commits.
+Credential-scope sessions are fenced during reset so captured stale state cannot reconnect before the SQLite reset commits.
 
 ### Browser reset
 

--- a/docs/dev/oauth-credential-lifecycle-design.md
+++ b/docs/dev/oauth-credential-lifecycle-design.md
@@ -37,7 +37,7 @@ This makes the local state transition atomic instead of reconstructing it after 
 21. The reset tool is non-destructive and only issues a requester-bound browser confirmation URL.
 22. The authenticated browser POST is the reset execution boundary.
 23. MCP retirement completes before the credential transaction commits a reset.
-24. A same-generation HTTP bearer rejection retires the exact MCP requester session without replaying the remote call.
+24. A same-generation HTTP bearer rejection retires the exact MCP credential-scope session without replaying the remote call.
 
 ## Ownership
 
@@ -103,7 +103,7 @@ Later same-scope callers observe the committed rotation and do not consume the s
 
 1. Revalidate the requester, provider, agent, scope, worker key, and confirmed connection generation.
 2. Return a completed stable operation before MCP retirement.
-3. Fence and retire every cached MCP requester session for the credential key.
+3. Fence and retire every cached MCP credential-scope session for the credential key.
 4. Enter the SQLite transaction.
 5. Recheck the stable receipt and connection generation.
 6. Clear the payload, advance both revisions, and insert the permanent receipt in one commit.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -454,5 +454,6 @@ It waits up to 600 seconds for active Matrix responses to drain, then force-appl
 - Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
 - OAuth-backed remote MCP credentials and sessions follow the selected agent's effective execution scope.
 - OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the active credential target.
+- Agent-initiated `reset_oauth_connection()` supports `user` and `user_agent` MCP credential scopes; reset shared or installation-level MCP connections from the authenticated dashboard.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -93,7 +93,8 @@ For `streamable-http` servers, `url` is required.
 `env` and `headers` values support `${ENV_VAR}` interpolation.
 MindRoom resolves those placeholders from the current runtime environment when it opens the MCP transport.
 Static `headers` are process-global and shared by every requester.
-Use the OAuth `auth` block plus `worker_scope: user` or `worker_scope: user_agent` for remote MCP servers that need a different bearer token per requester.
+Use the OAuth `auth` block plus `worker_scope: user` or `worker_scope: user_agent` for remote MCP servers that need different bearer tokens by requester.
+Use `worker_scope: shared` when one connected account belongs to the agent and every authorized caller should use it.
 
 ## Per-Server Options
 
@@ -164,13 +165,19 @@ They are useful when one server exposes many tools but one agent should see only
 
 MCP tools are available on every worker scope, including private per-user agents.
 Non-OAuth `mcp_<server_id>` tools always execute through the shared MCP server session; requester identity and requester credentials are never passed to the server.
-OAuth-backed remote MCP servers resolve credentials against the effective requester's canonical `user` scope at tool-call time, independent of the agent's configured worker scope.
-They keep one session per canonical requester credential target and server configuration generation.
-Agent execution still follows the configured worker scope, but MCP OAuth credential and session ownership remains requester-isolated.
+OAuth-backed remote MCP servers resolve credentials against the selected agent's effective execution scope at tool-call time.
+They keep one session per canonical credential target and server configuration generation.
+With `shared`, one connection belongs to the selected agent and is used by every authorized caller.
+With `user`, one connection belongs to the requester and is reused across that requester's agents.
+With `user_agent`, each requester and agent pair has its own connection, so one requester can connect different accounts for different agents.
+With no execution scope, one installation-level connection is used.
+Private agents derive this same ownership from `private.per`.
+Changing an agent's effective scope changes its OAuth credential owner, and MindRoom never copies a credential from another scope into the new target.
+If the new target has no credential, reconnect it explicitly.
 
 ## OAuth-Backed Remote MCP
 
-Use `auth.type: oauth` for a remote MCP server that requires an OAuth bearer token resolved for the effective requester's canonical `user` credential scope.
+Use `auth.type: oauth` for a remote MCP server that requires an OAuth bearer token resolved for the selected agent's effective credential scope.
 OAuth-backed MCP requires `sse` or `streamable-http`; `stdio` servers cannot use this mode.
 
 ```yaml
@@ -212,12 +219,12 @@ OAuth-backed MCP servers always expose a stable bridge surface:
 - `<prefix>_list_tools`
 - `<prefix>_call_tool`
 
-The bridge functions let an agent trigger the normal MindRoom OAuth connect flow before the remote server has revealed a requester-scoped tool catalog.
+The bridge functions let an agent trigger the normal MindRoom OAuth connect flow before the remote server has revealed a catalog for the active credential scope.
 When credentials are missing, the bridge returns the same structured OAuth-required payload used by built-in OAuth tools.
-Until the effective requester connects, the bridge functions are the only model-visible surface for the server, and their generic descriptions say nothing about what the server offers.
+Until the active credential scope is connected, the bridge functions are the only model-visible surface for the server, and their generic descriptions say nothing about what the server offers.
 Set the per-server `description` option to tell the model what connecting would unlock; it is appended to all three bridge tool descriptions.
-After the user connects, `list_tools` returns the remote catalog and `call_tool` sends the access token resolved for the effective requester's canonical `user` credential scope to the MCP server.
-After MindRoom has cached a requester-scoped catalog, the toolkit also exposes typed `<prefix>_<remote_tool_name>` functions for that requester in addition to the bridge functions.
+After the connection is established, `list_tools` returns the remote catalog and `call_tool` sends the access token resolved for the active credential scope to the MCP server.
+After MindRoom has cached a scoped catalog, the toolkit also exposes typed `<prefix>_<remote_tool_name>` functions for that credential scope in addition to the bridge functions.
 
 `discovery: auto` performs protected-resource metadata discovery from the configured `resource` or server `url`, then resolves authorization-server metadata.
 MindRoom tries `/.well-known/oauth-protected-resource` at the resource origin and at the resource path.
@@ -419,10 +426,10 @@ If a server fails to start, initialize, or publish a valid tool catalog, MindRoo
 
 By default a failed server degrades gracefully: agents and teams that reference `mcp_<server_id>` still start, with that server's tools omitted from their tool schema.
 For servers without OAuth, MindRoom keeps retrying transport and discovery failures in the background with exponential backoff, and restarts the affected agents and teams once the server recovers so they pick up its tools.
-OAuth-backed servers retry discovery lazily on the next requester call instead of scheduling a background refresh.
+OAuth-backed servers retry discovery lazily on the next scoped call instead of scheduling a background refresh.
 Function-name collisions remain failed because retrying the same invalid catalog cannot recover; after fixing the remote catalog or configured prefixes, reload `config.yaml` or restart MindRoom to retry those servers.
 Collision invalidation is symmetric and atomic.
-If a requester-scoped OAuth catalog collides with a shared non-OAuth catalog visible to the same agent, MindRoom marks both catalogs failed regardless of which catalog was published first.
+If a scoped OAuth catalog collides with a shared non-OAuth catalog visible to the same agent, MindRoom marks both catalogs failed regardless of which catalog was published first.
 Because the non-OAuth catalog is shared, it remains unavailable to every agent until the collision is fixed and `config.yaml` is reloaded or MindRoom restarts.
 Set `required: true` on a server to restore hard-fail behavior, where dependent agents and teams stay blocked from starting until the server is available.
 
@@ -445,7 +452,7 @@ It waits up to 600 seconds for active Matrix responses to drain, then force-appl
 - Phase 1 supports MCP tools only.
 - MCP resources and prompts are not exposed in MindRoom yet.
 - Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
-- OAuth-backed remote MCP credentials and sessions are always isolated by the effective requester in canonical `user` scope, independent of the agent's configured worker scope.
-- OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the effective requester's canonical credential target.
+- OAuth-backed remote MCP credentials and sessions follow the selected agent's effective execution scope.
+- OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the active credential target.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.

--- a/docs/oauth-framework.md
+++ b/docs/oauth-framework.md
@@ -83,8 +83,9 @@ MindRoom synthesizes an OAuth provider from each `mcp_servers.*.auth.type: oauth
 Generated MCP OAuth token services use the `<provider_id>_oauth` naming pattern; the default provider ID is already `mcp_<server_id>`.
 Custom provider IDs that do not start with `mcp_` get an `mcp_` credential-service prefix.
 These token services stay in the primary runtime credential store.
-The matching MCP toolkit always loads the token for the current canonical requester from a `user` credential scope before opening the remote MCP transport.
-Generated MCP OAuth credentials and sessions remain requester-isolated even when the agent's execution worker uses `shared` or `user_agent`; `worker_scope` still controls worker-runtime reuse, not the MCP OAuth credential identity.
+The matching MCP toolkit loads the token from the selected agent's effective credential scope before opening the remote MCP transport.
+Generated MCP OAuth credentials and sessions follow the same `shared`, `user`, `user_agent`, or unscoped ownership policy as other OAuth providers that do not declare requester-only credentials.
+Private agents derive the corresponding credential scope from `private.per`.
 Generated MCP OAuth providers can use public clients with `token_endpoint_auth_method: none`, PKCE, and empty scope lists.
 Generated MCP OAuth providers can also discover protected-resource metadata and authorization-server metadata lazily when the first OAuth flow starts.
 If the authorization server advertises dynamic client registration and no client config is stored yet, MindRoom registers a public client and persists the returned registration metadata in the generated OAuth client config service.

--- a/docs/tools/agent-orchestration.md
+++ b/docs/tools/agent-orchestration.md
@@ -48,7 +48,7 @@ For [`openclaw_compat`], that means `matrix_message` is added directly and `atta
 The toolkit exposes only `reset_oauth_connection(provider_id)`.
 The provider must back one of the current agent's configured tools through that tool's `auth_provider` metadata.
 The call returns a time-limited, retryable, requester-bound browser link and does not change credentials itself.
-The authenticated browser confirmation retires the matching requester-scoped MCP OAuth session when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
+The authenticated browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
 The reset does not revoke the grant at the external provider.
 Opening the link without confirming is non-destructive.
 Confirming when no local credential exists is safe and still continues to provider authorization.
@@ -77,7 +77,8 @@ The browser page is the human approval boundary: its GET only displays the actio
 The link freezes the provider, credential service, invoking agent, canonical requester, credential scope, worker key, connection generation, and a stable reset operation ID.
 Only the original authenticated human requester can open and confirm the link.
 Both link issuance and confirmation apply `authorization.agent_reply_permissions` for the current agent, including configured sender aliases.
-The resolved credential scope must be `user` or `user_agent`; shared credentials are refused.
+The resolved credential scope must be `user` or `user_agent`; shared and unscoped credentials are refused.
+Use the authenticated dashboard connection controls to disconnect and reconnect shared or installation-level credentials.
 A `user` reset affects the current requester across agents, while a `user_agent` reset affects only the current requester and current agent.
 Providers that define requester-scoped credentials, such as GitHub, may resolve to `user` scope independently of the agent's `worker_scope`.
 

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -126,8 +126,8 @@ Use [Sandbox Proxy Isolation](../deployment/sandbox-proxy.md) for deployment det
 
 Some dashboard integrations are restricted to shared or unscoped execution and cannot be used by agents with isolating worker scopes.
 The current shared-only integrations are `spotify` and `homeassistant`.
-MCP `mcp_<server_id>` tools work on every worker scope: OAuth credentials and sessions are always isolated to the canonical requester, while non-OAuth servers always call through the shared server session without requester credentials.
-Worker scope controls execution placement and reuse, not MCP OAuth credential ownership.
+MCP `mcp_<server_id>` tools work on every worker scope: OAuth credentials and sessions follow the selected agent's effective execution scope, while non-OAuth servers always call through the shared server session without requester credentials.
+For OAuth-backed MCP, `shared` belongs to the agent, `user` belongs to the requester across agents, `user_agent` belongs to one requester-agent pair, and unscoped belongs to the installation.
 
 ## Automatic Dependency Installation
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -2071,8 +2071,8 @@ A filtered public startup-runtime env payload can still propagate from exported 
 `worker_scope` controls how those sandbox runtimes are reused between calls.
 Some integrations require `worker_scope` unset or `shared` because their credentials or sessions are shared at runtime.
 That list includes `spotify` and `homeassistant`.
-Configured `mcp_<server_id>` tools work on every worker scope: generated OAuth providers always use requester-scoped `user` credentials and sessions, while non-OAuth servers use the shared MCP session without requester credentials.
-`worker_scope` controls worker-runtime reuse but does not change generated MCP OAuth credential identity.
+Configured `mcp_<server_id>` tools work on every worker scope: generated OAuth providers follow the selected agent's effective credential scope, while non-OAuth servers use the shared MCP session without requester credentials.
+For OAuth-backed MCP, `shared` uses one agent-owned connection, `user` reuses one requester-owned connection across agents, `user_agent` isolates each requester-agent pair, and unscoped uses one installation-level connection.
 Among those shared-scope integrations, `homeassistant` always stays local regardless of `worker_tools` and is never proxied to the sandbox.
 `github`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, `google_sheets`, and `oauth_connections` also always stay local.
 `spotify` can still be proxied through the sandbox.
@@ -3349,8 +3349,8 @@ Use [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-prox
 
 Some dashboard integrations are restricted to shared or unscoped execution and cannot be used by agents with isolating worker scopes.
 The current shared-only integrations are `spotify` and `homeassistant`.
-MCP `mcp_<server_id>` tools work on every worker scope: OAuth credentials and sessions are always isolated to the canonical requester, while non-OAuth servers always call through the shared server session without requester credentials.
-Worker scope controls execution placement and reuse, not MCP OAuth credential ownership.
+MCP `mcp_<server_id>` tools work on every worker scope: OAuth credentials and sessions follow the selected agent's effective execution scope, while non-OAuth servers always call through the shared server session without requester credentials.
+For OAuth-backed MCP, `shared` belongs to the agent, `user` belongs to the requester across agents, `user_agent` belongs to one requester-agent pair, and unscoped belongs to the installation.
 
 ## Automatic Dependency Installation
 
@@ -11050,7 +11050,8 @@ For `streamable-http` servers, `url` is required.
 `env` and `headers` values support `${ENV_VAR}` interpolation.
 MindRoom resolves those placeholders from the current runtime environment when it opens the MCP transport.
 Static `headers` are process-global and shared by every requester.
-Use the OAuth `auth` block plus `worker_scope: user` or `worker_scope: user_agent` for remote MCP servers that need a different bearer token per requester.
+Use the OAuth `auth` block plus `worker_scope: user` or `worker_scope: user_agent` for remote MCP servers that need different bearer tokens by requester.
+Use `worker_scope: shared` when one connected account belongs to the agent and every authorized caller should use it.
 
 ## Per-Server Options
 
@@ -11121,13 +11122,19 @@ They are useful when one server exposes many tools but one agent should see only
 
 MCP tools are available on every worker scope, including private per-user agents.
 Non-OAuth `mcp_<server_id>` tools always execute through the shared MCP server session; requester identity and requester credentials are never passed to the server.
-OAuth-backed remote MCP servers resolve credentials against the effective requester's canonical `user` scope at tool-call time, independent of the agent's configured worker scope.
-They keep one session per canonical requester credential target and server configuration generation.
-Agent execution still follows the configured worker scope, but MCP OAuth credential and session ownership remains requester-isolated.
+OAuth-backed remote MCP servers resolve credentials against the selected agent's effective execution scope at tool-call time.
+They keep one session per canonical credential target and server configuration generation.
+With `shared`, one connection belongs to the selected agent and is used by every authorized caller.
+With `user`, one connection belongs to the requester and is reused across that requester's agents.
+With `user_agent`, each requester and agent pair has its own connection, so one requester can connect different accounts for different agents.
+With no execution scope, one installation-level connection is used.
+Private agents derive this same ownership from `private.per`.
+Changing an agent's effective scope changes its OAuth credential owner, and MindRoom never copies a credential from another scope into the new target.
+If the new target has no credential, reconnect it explicitly.
 
 ## OAuth-Backed Remote MCP
 
-Use `auth.type: oauth` for a remote MCP server that requires an OAuth bearer token resolved for the effective requester's canonical `user` credential scope.
+Use `auth.type: oauth` for a remote MCP server that requires an OAuth bearer token resolved for the selected agent's effective credential scope.
 OAuth-backed MCP requires `sse` or `streamable-http`; `stdio` servers cannot use this mode.
 
 ```yaml
@@ -11169,12 +11176,12 @@ OAuth-backed MCP servers always expose a stable bridge surface:
 - `<prefix>_list_tools`
 - `<prefix>_call_tool`
 
-The bridge functions let an agent trigger the normal MindRoom OAuth connect flow before the remote server has revealed a requester-scoped tool catalog.
+The bridge functions let an agent trigger the normal MindRoom OAuth connect flow before the remote server has revealed a catalog for the active credential scope.
 When credentials are missing, the bridge returns the same structured OAuth-required payload used by built-in OAuth tools.
-Until the effective requester connects, the bridge functions are the only model-visible surface for the server, and their generic descriptions say nothing about what the server offers.
+Until the active credential scope is connected, the bridge functions are the only model-visible surface for the server, and their generic descriptions say nothing about what the server offers.
 Set the per-server `description` option to tell the model what connecting would unlock; it is appended to all three bridge tool descriptions.
-After the user connects, `list_tools` returns the remote catalog and `call_tool` sends the access token resolved for the effective requester's canonical `user` credential scope to the MCP server.
-After MindRoom has cached a requester-scoped catalog, the toolkit also exposes typed `<prefix>_<remote_tool_name>` functions for that requester in addition to the bridge functions.
+After the connection is established, `list_tools` returns the remote catalog and `call_tool` sends the access token resolved for the active credential scope to the MCP server.
+After MindRoom has cached a scoped catalog, the toolkit also exposes typed `<prefix>_<remote_tool_name>` functions for that credential scope in addition to the bridge functions.
 
 `discovery: auto` performs protected-resource metadata discovery from the configured `resource` or server `url`, then resolves authorization-server metadata.
 MindRoom tries `/.well-known/oauth-protected-resource` at the resource origin and at the resource path.
@@ -11376,10 +11383,10 @@ If a server fails to start, initialize, or publish a valid tool catalog, MindRoo
 
 By default a failed server degrades gracefully: agents and teams that reference `mcp_<server_id>` still start, with that server's tools omitted from their tool schema.
 For servers without OAuth, MindRoom keeps retrying transport and discovery failures in the background with exponential backoff, and restarts the affected agents and teams once the server recovers so they pick up its tools.
-OAuth-backed servers retry discovery lazily on the next requester call instead of scheduling a background refresh.
+OAuth-backed servers retry discovery lazily on the next scoped call instead of scheduling a background refresh.
 Function-name collisions remain failed because retrying the same invalid catalog cannot recover; after fixing the remote catalog or configured prefixes, reload `config.yaml` or restart MindRoom to retry those servers.
 Collision invalidation is symmetric and atomic.
-If a requester-scoped OAuth catalog collides with a shared non-OAuth catalog visible to the same agent, MindRoom marks both catalogs failed regardless of which catalog was published first.
+If a scoped OAuth catalog collides with a shared non-OAuth catalog visible to the same agent, MindRoom marks both catalogs failed regardless of which catalog was published first.
 Because the non-OAuth catalog is shared, it remains unavailable to every agent until the collision is fixed and `config.yaml` is reloaded or MindRoom restarts.
 Set `required: true` on a server to restore hard-fail behavior, where dependent agents and teams stay blocked from starting until the server is available.
 
@@ -11402,8 +11409,8 @@ It waits up to 600 seconds for active Matrix responses to drain, then force-appl
 - Phase 1 supports MCP tools only.
 - MCP resources and prompts are not exposed in MindRoom yet.
 - Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
-- OAuth-backed remote MCP credentials and sessions are always isolated by the effective requester in canonical `user` scope, independent of the agent's configured worker scope.
-- OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the effective requester's canonical credential target.
+- OAuth-backed remote MCP credentials and sessions follow the selected agent's effective execution scope.
+- OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the active credential target.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.
 
@@ -13315,8 +13322,9 @@ MindRoom synthesizes an OAuth provider from each `mcp_servers.*.auth.type: oauth
 Generated MCP OAuth token services use the `<provider_id>_oauth` naming pattern; the default provider ID is already `mcp_<server_id>`.
 Custom provider IDs that do not start with `mcp_` get an `mcp_` credential-service prefix.
 These token services stay in the primary runtime credential store.
-The matching MCP toolkit always loads the token for the current canonical requester from a `user` credential scope before opening the remote MCP transport.
-Generated MCP OAuth credentials and sessions remain requester-isolated even when the agent's execution worker uses `shared` or `user_agent`; `worker_scope` still controls worker-runtime reuse, not the MCP OAuth credential identity.
+The matching MCP toolkit loads the token from the selected agent's effective credential scope before opening the remote MCP transport.
+Generated MCP OAuth credentials and sessions follow the same `shared`, `user`, `user_agent`, or unscoped ownership policy as other OAuth providers that do not declare requester-only credentials.
+Private agents derive the corresponding credential scope from `private.per`.
 Generated MCP OAuth providers can use public clients with `token_endpoint_auth_method: none`, PKCE, and empty scope lists.
 Generated MCP OAuth providers can also discover protected-resource metadata and authorization-server metadata lazily when the first OAuth flow starts.
 If the authorization server advertises dynamic client registration and no client config is stored yet, MindRoom registers a public client and persists the returned registration metadata in the generated OAuth client config service.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9672,7 +9672,7 @@ For [`openclaw_compat`], that means `matrix_message` is added directly and `atta
 The toolkit exposes only `reset_oauth_connection(provider_id)`.
 The provider must back one of the current agent's configured tools through that tool's `auth_provider` metadata.
 The call returns a time-limited, retryable, requester-bound browser link and does not change credentials itself.
-The authenticated browser confirmation retires the matching requester-scoped MCP OAuth session when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
+The authenticated browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
 The reset does not revoke the grant at the external provider.
 Opening the link without confirming is non-destructive.
 Confirming when no local credential exists is safe and still continues to provider authorization.
@@ -9701,7 +9701,8 @@ The browser page is the human approval boundary: its GET only displays the actio
 The link freezes the provider, credential service, invoking agent, canonical requester, credential scope, worker key, connection generation, and a stable reset operation ID.
 Only the original authenticated human requester can open and confirm the link.
 Both link issuance and confirmation apply `authorization.agent_reply_permissions` for the current agent, including configured sender aliases.
-The resolved credential scope must be `user` or `user_agent`; shared credentials are refused.
+The resolved credential scope must be `user` or `user_agent`; shared and unscoped credentials are refused.
+Use the authenticated dashboard connection controls to disconnect and reconnect shared or installation-level credentials.
 A `user` reset affects the current requester across agents, while a `user_agent` reset affects only the current requester and current agent.
 Providers that define requester-scoped credentials, such as GitHub, may resolve to `user` scope independently of the agent's `worker_scope`.
 
@@ -11411,6 +11412,7 @@ It waits up to 600 seconds for active Matrix responses to drain, then force-appl
 - Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
 - OAuth-backed remote MCP credentials and sessions follow the selected agent's effective execution scope.
 - OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the active credential target.
+- Agent-initiated `reset_oauth_connection()` supports `user` and `user_agent` MCP credential scopes; reset shared or installation-level MCP connections from the authenticated dashboard.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.
 

--- a/skills/mindroom-docs/references/page__configuration__agents__index.md
+++ b/skills/mindroom-docs/references/page__configuration__agents__index.md
@@ -372,8 +372,8 @@ A filtered public startup-runtime env payload can still propagate from exported 
 `worker_scope` controls how those sandbox runtimes are reused between calls.
 Some integrations require `worker_scope` unset or `shared` because their credentials or sessions are shared at runtime.
 That list includes `spotify` and `homeassistant`.
-Configured `mcp_<server_id>` tools work on every worker scope: generated OAuth providers always use requester-scoped `user` credentials and sessions, while non-OAuth servers use the shared MCP session without requester credentials.
-`worker_scope` controls worker-runtime reuse but does not change generated MCP OAuth credential identity.
+Configured `mcp_<server_id>` tools work on every worker scope: generated OAuth providers follow the selected agent's effective credential scope, while non-OAuth servers use the shared MCP session without requester credentials.
+For OAuth-backed MCP, `shared` uses one agent-owned connection, `user` reuses one requester-owned connection across agents, `user_agent` isolates each requester-agent pair, and unscoped uses one installation-level connection.
 Among those shared-scope integrations, `homeassistant` always stays local regardless of `worker_tools` and is never proxied to the sandbox.
 `github`, `gmail`, `google_calendar`, `google_docs`, `google_drive`, `google_sheets`, and `oauth_connections` also always stay local.
 `spotify` can still be proxied through the sandbox.

--- a/skills/mindroom-docs/references/page__mcp__index.md
+++ b/skills/mindroom-docs/references/page__mcp__index.md
@@ -89,7 +89,8 @@ For `streamable-http` servers, `url` is required.
 `env` and `headers` values support `${ENV_VAR}` interpolation.
 MindRoom resolves those placeholders from the current runtime environment when it opens the MCP transport.
 Static `headers` are process-global and shared by every requester.
-Use the OAuth `auth` block plus `worker_scope: user` or `worker_scope: user_agent` for remote MCP servers that need a different bearer token per requester.
+Use the OAuth `auth` block plus `worker_scope: user` or `worker_scope: user_agent` for remote MCP servers that need different bearer tokens by requester.
+Use `worker_scope: shared` when one connected account belongs to the agent and every authorized caller should use it.
 
 ## Per-Server Options
 
@@ -160,13 +161,19 @@ They are useful when one server exposes many tools but one agent should see only
 
 MCP tools are available on every worker scope, including private per-user agents.
 Non-OAuth `mcp_<server_id>` tools always execute through the shared MCP server session; requester identity and requester credentials are never passed to the server.
-OAuth-backed remote MCP servers resolve credentials against the effective requester's canonical `user` scope at tool-call time, independent of the agent's configured worker scope.
-They keep one session per canonical requester credential target and server configuration generation.
-Agent execution still follows the configured worker scope, but MCP OAuth credential and session ownership remains requester-isolated.
+OAuth-backed remote MCP servers resolve credentials against the selected agent's effective execution scope at tool-call time.
+They keep one session per canonical credential target and server configuration generation.
+With `shared`, one connection belongs to the selected agent and is used by every authorized caller.
+With `user`, one connection belongs to the requester and is reused across that requester's agents.
+With `user_agent`, each requester and agent pair has its own connection, so one requester can connect different accounts for different agents.
+With no execution scope, one installation-level connection is used.
+Private agents derive this same ownership from `private.per`.
+Changing an agent's effective scope changes its OAuth credential owner, and MindRoom never copies a credential from another scope into the new target.
+If the new target has no credential, reconnect it explicitly.
 
 ## OAuth-Backed Remote MCP
 
-Use `auth.type: oauth` for a remote MCP server that requires an OAuth bearer token resolved for the effective requester's canonical `user` credential scope.
+Use `auth.type: oauth` for a remote MCP server that requires an OAuth bearer token resolved for the selected agent's effective credential scope.
 OAuth-backed MCP requires `sse` or `streamable-http`; `stdio` servers cannot use this mode.
 
 ```yaml
@@ -208,12 +215,12 @@ OAuth-backed MCP servers always expose a stable bridge surface:
 - `<prefix>_list_tools`
 - `<prefix>_call_tool`
 
-The bridge functions let an agent trigger the normal MindRoom OAuth connect flow before the remote server has revealed a requester-scoped tool catalog.
+The bridge functions let an agent trigger the normal MindRoom OAuth connect flow before the remote server has revealed a catalog for the active credential scope.
 When credentials are missing, the bridge returns the same structured OAuth-required payload used by built-in OAuth tools.
-Until the effective requester connects, the bridge functions are the only model-visible surface for the server, and their generic descriptions say nothing about what the server offers.
+Until the active credential scope is connected, the bridge functions are the only model-visible surface for the server, and their generic descriptions say nothing about what the server offers.
 Set the per-server `description` option to tell the model what connecting would unlock; it is appended to all three bridge tool descriptions.
-After the user connects, `list_tools` returns the remote catalog and `call_tool` sends the access token resolved for the effective requester's canonical `user` credential scope to the MCP server.
-After MindRoom has cached a requester-scoped catalog, the toolkit also exposes typed `<prefix>_<remote_tool_name>` functions for that requester in addition to the bridge functions.
+After the connection is established, `list_tools` returns the remote catalog and `call_tool` sends the access token resolved for the active credential scope to the MCP server.
+After MindRoom has cached a scoped catalog, the toolkit also exposes typed `<prefix>_<remote_tool_name>` functions for that credential scope in addition to the bridge functions.
 
 `discovery: auto` performs protected-resource metadata discovery from the configured `resource` or server `url`, then resolves authorization-server metadata.
 MindRoom tries `/.well-known/oauth-protected-resource` at the resource origin and at the resource path.
@@ -415,10 +422,10 @@ If a server fails to start, initialize, or publish a valid tool catalog, MindRoo
 
 By default a failed server degrades gracefully: agents and teams that reference `mcp_<server_id>` still start, with that server's tools omitted from their tool schema.
 For servers without OAuth, MindRoom keeps retrying transport and discovery failures in the background with exponential backoff, and restarts the affected agents and teams once the server recovers so they pick up its tools.
-OAuth-backed servers retry discovery lazily on the next requester call instead of scheduling a background refresh.
+OAuth-backed servers retry discovery lazily on the next scoped call instead of scheduling a background refresh.
 Function-name collisions remain failed because retrying the same invalid catalog cannot recover; after fixing the remote catalog or configured prefixes, reload `config.yaml` or restart MindRoom to retry those servers.
 Collision invalidation is symmetric and atomic.
-If a requester-scoped OAuth catalog collides with a shared non-OAuth catalog visible to the same agent, MindRoom marks both catalogs failed regardless of which catalog was published first.
+If a scoped OAuth catalog collides with a shared non-OAuth catalog visible to the same agent, MindRoom marks both catalogs failed regardless of which catalog was published first.
 Because the non-OAuth catalog is shared, it remains unavailable to every agent until the collision is fixed and `config.yaml` is reloaded or MindRoom restarts.
 Set `required: true` on a server to restore hard-fail behavior, where dependent agents and teams stay blocked from starting until the server is available.
 
@@ -441,7 +448,7 @@ It waits up to 600 seconds for active Matrix responses to drain, then force-appl
 - Phase 1 supports MCP tools only.
 - MCP resources and prompts are not exposed in MindRoom yet.
 - Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
-- OAuth-backed remote MCP credentials and sessions are always isolated by the effective requester in canonical `user` scope, independent of the agent's configured worker scope.
-- OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the effective requester's canonical credential target.
+- OAuth-backed remote MCP credentials and sessions follow the selected agent's effective execution scope.
+- OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the active credential target.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.

--- a/skills/mindroom-docs/references/page__mcp__index.md
+++ b/skills/mindroom-docs/references/page__mcp__index.md
@@ -450,5 +450,6 @@ It waits up to 600 seconds for active Matrix responses to drain, then force-appl
 - Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
 - OAuth-backed remote MCP credentials and sessions follow the selected agent's effective execution scope.
 - OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the active credential target.
+- Agent-initiated `reset_oauth_connection()` supports `user` and `user_agent` MCP credential scopes; reset shared or installation-level MCP connections from the authenticated dashboard.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.

--- a/skills/mindroom-docs/references/page__oauth-framework__index.md
+++ b/skills/mindroom-docs/references/page__oauth-framework__index.md
@@ -79,8 +79,9 @@ MindRoom synthesizes an OAuth provider from each `mcp_servers.*.auth.type: oauth
 Generated MCP OAuth token services use the `<provider_id>_oauth` naming pattern; the default provider ID is already `mcp_<server_id>`.
 Custom provider IDs that do not start with `mcp_` get an `mcp_` credential-service prefix.
 These token services stay in the primary runtime credential store.
-The matching MCP toolkit always loads the token for the current canonical requester from a `user` credential scope before opening the remote MCP transport.
-Generated MCP OAuth credentials and sessions remain requester-isolated even when the agent's execution worker uses `shared` or `user_agent`; `worker_scope` still controls worker-runtime reuse, not the MCP OAuth credential identity.
+The matching MCP toolkit loads the token from the selected agent's effective credential scope before opening the remote MCP transport.
+Generated MCP OAuth credentials and sessions follow the same `shared`, `user`, `user_agent`, or unscoped ownership policy as other OAuth providers that do not declare requester-only credentials.
+Private agents derive the corresponding credential scope from `private.per`.
 Generated MCP OAuth providers can use public clients with `token_endpoint_auth_method: none`, PKCE, and empty scope lists.
 Generated MCP OAuth providers can also discover protected-resource metadata and authorization-server metadata lazily when the first OAuth flow starts.
 If the authorization server advertises dynamic client registration and no client config is stored yet, MindRoom registers a public client and persists the returned registration metadata in the generated OAuth client config service.

--- a/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
+++ b/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
@@ -44,7 +44,7 @@ For [`openclaw_compat`], that means `matrix_message` is added directly and `atta
 The toolkit exposes only `reset_oauth_connection(provider_id)`.
 The provider must back one of the current agent's configured tools through that tool's `auth_provider` metadata.
 The call returns a time-limited, retryable, requester-bound browser link and does not change credentials itself.
-The authenticated browser confirmation retires the matching requester-scoped MCP OAuth session when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
+The authenticated browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
 The reset does not revoke the grant at the external provider.
 Opening the link without confirming is non-destructive.
 Confirming when no local credential exists is safe and still continues to provider authorization.
@@ -73,7 +73,8 @@ The browser page is the human approval boundary: its GET only displays the actio
 The link freezes the provider, credential service, invoking agent, canonical requester, credential scope, worker key, connection generation, and a stable reset operation ID.
 Only the original authenticated human requester can open and confirm the link.
 Both link issuance and confirmation apply `authorization.agent_reply_permissions` for the current agent, including configured sender aliases.
-The resolved credential scope must be `user` or `user_agent`; shared credentials are refused.
+The resolved credential scope must be `user` or `user_agent`; shared and unscoped credentials are refused.
+Use the authenticated dashboard connection controls to disconnect and reconnect shared or installation-level credentials.
 A `user` reset affects the current requester across agents, while a `user_agent` reset affects only the current requester and current agent.
 Providers that define requester-scoped credentials, such as GitHub, may resolve to `user` scope independently of the agent's `worker_scope`.
 

--- a/skills/mindroom-docs/references/page__tools__index.md
+++ b/skills/mindroom-docs/references/page__tools__index.md
@@ -122,8 +122,8 @@ Use [Sandbox Proxy Isolation](https://docs.mindroom.chat/deployment/sandbox-prox
 
 Some dashboard integrations are restricted to shared or unscoped execution and cannot be used by agents with isolating worker scopes.
 The current shared-only integrations are `spotify` and `homeassistant`.
-MCP `mcp_<server_id>` tools work on every worker scope: OAuth credentials and sessions are always isolated to the canonical requester, while non-OAuth servers always call through the shared server session without requester credentials.
-Worker scope controls execution placement and reuse, not MCP OAuth credential ownership.
+MCP `mcp_<server_id>` tools work on every worker scope: OAuth credentials and sessions follow the selected agent's effective execution scope, while non-OAuth servers always call through the shared server session without requester credentials.
+For OAuth-backed MCP, `shared` belongs to the agent, `user` belongs to the requester across agents, `user_agent` belongs to one requester-agent pair, and unscoped belongs to the installation.
 
 ## Automatic Dependency Installation
 

--- a/src/mindroom/config/main.py
+++ b/src/mindroom/config/main.py
@@ -1302,6 +1302,19 @@ class Config(BaseModel):
         )
         return policy.effective_execution_scope
 
+    def agent_has_tool_at_execution_scope(
+        self,
+        agent_name: str,
+        tool_name: str,
+        execution_scope: WorkerScope | None,
+    ) -> bool:
+        """Return whether one agent can still reach a tool at an exact execution scope."""
+        return (
+            agent_name in self.agents
+            and tool_name in self.resolve_entity(agent_name).available_tools
+            and self._agent_execution_scope(agent_name) == execution_scope
+        )
+
     def _agent_scope_label(self, agent_name: str) -> str:
         """Return the user-facing authored scope label for one agent.
 

--- a/src/mindroom/mcp/function_surface.py
+++ b/src/mindroom/mcp/function_surface.py
@@ -5,9 +5,16 @@ Static discovery invalidates conflicting catalogs, dynamic loading rejects the n
 construction hides any collision that appears between those validation boundaries.
 """
 
+from __future__ import annotations
+
 from collections import Counter
-from collections.abc import Collection
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Collection
+
+    from mindroom.mcp.types import MCPOAuthCredentialScope
 
 __all__ = [
     "MCPFunctionCollisionReport",
@@ -22,7 +29,7 @@ class MCPFunctionSurfaceSnapshot:
     """One agent and credential surface prepared by the MCP manager."""
 
     agent_name: str
-    credential_surface: tuple[str, str] | None
+    credential_surface: MCPOAuthCredentialScope | None
     local_function_names: frozenset[str]
     server_function_sources: tuple[tuple[str, tuple[frozenset[str], ...]], ...]
 
@@ -32,7 +39,7 @@ class MCPFunctionCollisionReport:
     """Collisions owned by one server on one agent and credential surface."""
 
     agent_name: str
-    credential_surface: tuple[str, str] | None
+    credential_surface: MCPOAuthCredentialScope | None
     server_id: str
     function_name_collisions: tuple[tuple[str, str], ...]
 

--- a/src/mindroom/mcp/function_surface.py
+++ b/src/mindroom/mcp/function_surface.py
@@ -19,20 +19,20 @@ __all__ = [
 
 @dataclass(frozen=True, slots=True)
 class MCPFunctionSurfaceSnapshot:
-    """One agent and requester surface prepared by the MCP manager."""
+    """One agent and credential surface prepared by the MCP manager."""
 
     agent_name: str
-    requester_surface: tuple[str, str] | None
+    credential_surface: tuple[str, str] | None
     local_function_names: frozenset[str]
     server_function_sources: tuple[tuple[str, tuple[frozenset[str], ...]], ...]
 
 
 @dataclass(frozen=True, slots=True)
 class MCPFunctionCollisionReport:
-    """Collisions owned by one server on one agent and requester surface."""
+    """Collisions owned by one server on one agent and credential surface."""
 
     agent_name: str
-    requester_surface: tuple[str, str] | None
+    credential_surface: tuple[str, str] | None
     server_id: str
     function_name_collisions: tuple[tuple[str, str], ...]
 
@@ -87,7 +87,7 @@ def analyze_mcp_function_collisions(
         reports.extend(
             MCPFunctionCollisionReport(
                 agent_name=snapshot.agent_name,
-                requester_surface=snapshot.requester_surface,
+                credential_surface=snapshot.credential_surface,
                 server_id=server_id,
                 function_name_collisions=tuple(sorted(collisions)),
             )

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -520,9 +520,16 @@ class MCPServerManager:
                 base_state,
                 worker_target=worker_target,
             )
+            credential_target = credential_context.worker_target
+            if (
+                credential_target is not None
+                and credential_target.worker_scope is not None
+                and not credential_target.worker_key
+            ):
+                return None
             key = self._scope_session_key(
                 base_state,
-                credential_context.worker_target,
+                credential_target,
                 provider_id=credential_context.provider.id,
             )
         except OAuthConnectionRequired:
@@ -769,6 +776,7 @@ class MCPServerManager:
                     oauth_provider_id=key.provider_id,
                     oauth_authorization=base_state.oauth_authorization,
                     oauth_credential_scope=(key.worker_scope, key.worker_key),
+                    oauth_routing_agent_name=(worker_target.routing_agent_name if worker_target is not None else None),
                 )
                 self._scoped_states[key] = state
 

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -98,8 +98,8 @@ def _discovery_retry_delay_seconds(consecutive_failures: int) -> float:
 
 
 @dataclass(frozen=True)
-class _MCPOAuthRequestKey:
-    """Provider and requester identity shared across server config generations."""
+class _MCPOAuthScopeKey:
+    """Provider and credential scope shared across server config generations."""
 
     provider_id: str
     worker_scope: str
@@ -108,7 +108,7 @@ class _MCPOAuthRequestKey:
 
 @dataclass(frozen=True)
 class _MCPSessionKey:
-    """Requester-scoped MCP session cache key."""
+    """Credential-scoped MCP session cache key."""
 
     server_id: str
     config_generation: int
@@ -117,9 +117,9 @@ class _MCPSessionKey:
     worker_key: str
 
     @property
-    def oauth_request_key(self) -> _MCPOAuthRequestKey:
-        """Return the provider/requester identity used by reset retirement."""
-        return _MCPOAuthRequestKey(
+    def oauth_scope_key(self) -> _MCPOAuthScopeKey:
+        """Return the provider and credential scope used by reset retirement."""
+        return _MCPOAuthScopeKey(
             provider_id=self.provider_id,
             worker_scope=self.worker_scope,
             worker_key=self.worker_key,
@@ -128,7 +128,7 @@ class _MCPSessionKey:
 
 @dataclass(frozen=True)
 class _MCPAuthorizationLease:
-    """Authorization material and identity for one requester operation."""
+    """Authorization material and identity for one credential-scoped operation."""
 
     headers: Mapping[str, str]
     version: MCPOAuthLeaseVersion
@@ -137,11 +137,11 @@ class _MCPAuthorizationLease:
 
 
 class _MCPAuthorizationChangedError(RuntimeError):
-    """Signal that a requester must reacquire authoritative authorization."""
+    """Signal that an operation must reacquire authoritative authorization."""
 
 
 class _MCPConfigurationChangedError(RuntimeError):
-    """Signal that a requester resolved against a retired config generation."""
+    """Signal that an operation resolved against a retired config generation."""
 
 
 class _MCPFunctionValidationError(MCPProtocolError):
@@ -155,6 +155,26 @@ class _MCPFunctionValidationError(MCPProtocolError):
     ) -> None:
         super().__init__(server_id, message)
         self.invalid_states = invalid_states
+
+
+def _resolved_oauth_scope(
+    worker_target: ResolvedWorkerTarget | None,
+    *,
+    provider_id: str,
+) -> tuple[str, str]:
+    """Return the canonical credential scope used to key one MCP OAuth session."""
+    if worker_target is None or worker_target.worker_scope is None:
+        return "unscoped", "global"
+    worker_scope = worker_target.worker_scope
+    worker_key = worker_target.worker_key
+    if not worker_key:
+        msg = f"MCP OAuth provider '{provider_id}' requires a complete credential target"
+        raise OAuthProviderError(msg)
+    identity = worker_target.execution_identity
+    if worker_scope in {"user", "user_agent"} and (identity is None or not identity.requester_id):
+        msg = f"MCP OAuth provider '{provider_id}' requires a requester identity"
+        raise OAuthConnectionRequired(msg, provider_id=provider_id)
+    return worker_scope, worker_key
 
 
 @dataclass(frozen=True, slots=True)
@@ -189,8 +209,8 @@ class MCPServerManager:
         self._states: dict[str, MCPServerState] = {}
         self._scoped_states: dict[_MCPSessionKey, MCPServerState] = {}
         self._retiring_states: dict[int, MCPServerState] = {}
-        self._request_retirement_locks: WeakValueDictionary[_MCPOAuthRequestKey, asyncio.Lock] = WeakValueDictionary()
-        self._retired_request_keys: set[_MCPOAuthRequestKey] = set()
+        self._scope_retirement_locks: WeakValueDictionary[_MCPOAuthScopeKey, asyncio.Lock] = WeakValueDictionary()
+        self._retired_scope_keys: set[_MCPOAuthScopeKey] = set()
         self._catalog_validation_lock = asyncio.Lock()
         self._state_lifecycle_lock = asyncio.Lock()
         self._sync_lock = asyncio.Lock()
@@ -381,8 +401,8 @@ class MCPServerManager:
                 self._states.clear()
                 self._scoped_states.clear()
                 self._retiring_states.clear()
-                self._request_retirement_locks.clear()
-                self._retired_request_keys.clear()
+                self._scope_retirement_locks.clear()
+                self._retired_scope_keys.clear()
                 self._shutdown_complete.set()
 
     async def call_tool(
@@ -453,7 +473,7 @@ class MCPServerManager:
         credentials_manager: CredentialsManager | None,
         worker_target: ResolvedWorkerTarget | None,
     ) -> MCPServerCatalog:
-        """Return a requester-scoped catalog for one OAuth-backed MCP server."""
+        """Return the catalog for one OAuth-backed MCP credential scope."""
         for _attempt in range(_MAX_REQUEST_STATE_RETRIES):
             state, authorization_lease = await self._request_state_and_headers(
                 server_id,
@@ -479,7 +499,7 @@ class MCPServerManager:
                 if rejection is None:
                     raise
                 await run_coroutine_until_complete(
-                    self._disconnect_rejected_oauth_request_state(authorization_lease.session_key, state),
+                    self._disconnect_rejected_oauth_scope_state(authorization_lease.session_key, state),
                 )
                 raise rejection from exc
         msg = f"MCP server '{server_id}' authorization changed repeatedly during catalog resolution"
@@ -500,7 +520,7 @@ class MCPServerManager:
                 base_state,
                 worker_target=worker_target,
             )
-            key = self._request_session_key(
+            key = self._scope_session_key(
                 base_state,
                 credential_context.worker_target,
                 provider_id=credential_context.provider.id,
@@ -513,23 +533,27 @@ class MCPServerManager:
         return state.catalog
 
     @asynccontextmanager
-    async def retire_request_session(
+    async def retire_oauth_scope_session(
         self,
         *,
         credential_context: OAuthCredentialContext,
         expected_connection_generation: str | None = None,
     ) -> AsyncIterator[None]:
-        """Fence one provider/requester lineage across every server config generation."""
+        """Fence one provider credential lineage across every server config generation."""
         worker_target = credential_context.worker_target
-        request_key = _MCPOAuthRequestKey(
+        worker_scope, worker_key = _resolved_oauth_scope(
+            worker_target,
             provider_id=credential_context.provider.id,
-            worker_scope=(worker_target.worker_scope if worker_target is not None else None) or "unscoped",
-            worker_key=(worker_target.worker_key if worker_target is not None else None) or "global",
+        )
+        scope_key = _MCPOAuthScopeKey(
+            provider_id=credential_context.provider.id,
+            worker_scope=worker_scope,
+            worker_key=worker_key,
         )
         async with self._state_lifecycle_lock:
-            retirement_lock = self._request_retirement_locks.setdefault(request_key, asyncio.Lock())
+            retirement_lock = self._scope_retirement_locks.setdefault(scope_key, asyncio.Lock())
         async with retirement_lock:
-            self._retired_request_keys.add(request_key)
+            self._retired_scope_keys.add(scope_key)
             try:
                 connection_generation = await load_oauth_reset_connection_generation(credential_context)
                 if (
@@ -542,7 +566,7 @@ class MCPServerManager:
                     states: list[MCPServerState] = []
                     seen_state_ids: set[int] = set()
                     for key, state in tuple(self._scoped_states.items()):
-                        if key.oauth_request_key != request_key:
+                        if key.oauth_scope_key != scope_key:
                             continue
                         self._scoped_states.pop(key)
                         state.retired = True
@@ -552,17 +576,17 @@ class MCPServerManager:
                     for state in self._retiring_states.values():
                         if (
                             id(state) in seen_state_ids
-                            or state.oauth_provider_id != request_key.provider_id
-                            or state.oauth_request_scope != (request_key.worker_scope, request_key.worker_key)
+                            or state.oauth_provider_id != scope_key.provider_id
+                            or state.oauth_credential_scope != (scope_key.worker_scope, scope_key.worker_key)
                         ):
                             continue
                         state.retired = True
                         states.append(state)
                         seen_state_ids.add(id(state))
-                await run_coroutine_until_complete(self._drain_retired_request_states(tuple(states)))
+                await run_coroutine_until_complete(self._drain_retired_oauth_scope_states(tuple(states)))
                 yield
             finally:
-                self._retired_request_keys.discard(request_key)
+                self._retired_scope_keys.discard(scope_key)
 
     def _oauth_credential_context(
         self,
@@ -579,24 +603,17 @@ class MCPServerManager:
             authorization=state.oauth_authorization,
         )
 
-    def _request_session_key(
+    def _scope_session_key(
         self,
         state: MCPServerState,
         worker_target: ResolvedWorkerTarget | None,
         *,
         provider_id: str,
     ) -> _MCPSessionKey:
-        worker_scope = worker_target.worker_scope if worker_target is not None else None
-        worker_key = worker_target.worker_key if worker_target is not None else None
-        identity = worker_target.execution_identity if worker_target is not None else None
-        if (
-            worker_scope not in {"user", "user_agent"}
-            or not worker_key
-            or identity is None
-            or not identity.requester_id
-        ):
-            msg = f"MCP OAuth provider '{provider_id}' requires a requester identity"
-            raise OAuthConnectionRequired(msg, provider_id=provider_id)
+        worker_scope, worker_key = _resolved_oauth_scope(
+            worker_target,
+            provider_id=provider_id,
+        )
         return _MCPSessionKey(
             server_id=state.server_id,
             config_generation=state.config_generation,
@@ -711,7 +728,7 @@ class MCPServerManager:
         credentials_manager: CredentialsManager | None,
         worker_target: ResolvedWorkerTarget | None,
     ) -> tuple[MCPServerState, _MCPAuthorizationLease]:
-        """Resolve one requester session against an exact published config generation."""
+        """Resolve one credential-scoped session against an exact config generation."""
         base_state = self._require_state(server_id)
         if base_state.config.auth is None:
             msg = f"MCP server '{server_id}' is not OAuth-backed"
@@ -724,12 +741,12 @@ class MCPServerManager:
             credentials_manager=credentials_manager,
         )
         worker_target = credential_context.worker_target
-        key = self._request_session_key(
+        key = self._scope_session_key(
             base_state,
             worker_target,
             provider_id=credential_context.provider.id,
         )
-        request_key = key.oauth_request_key
+        scope_key = key.oauth_scope_key
         async with self._state_lifecycle_lock:
             if self._shutdown:
                 msg = f"MCP server manager shut down while resolving '{server_id}'"
@@ -741,7 +758,7 @@ class MCPServerManager:
                 or base_state.retired
             ):
                 raise _MCPConfigurationChangedError
-            if request_key in self._retired_request_keys:
+            if scope_key in self._retired_scope_keys:
                 raise oauth_connection_required(credential_context)
             state = self._scoped_states.get(key)
             if state is None:
@@ -751,7 +768,7 @@ class MCPServerManager:
                     config_generation=key.config_generation,
                     oauth_provider_id=key.provider_id,
                     oauth_authorization=base_state.oauth_authorization,
-                    oauth_request_scope=(key.worker_scope, key.worker_key),
+                    oauth_credential_scope=(key.worker_scope, key.worker_key),
                 )
                 self._scoped_states[key] = state
 
@@ -783,7 +800,7 @@ class MCPServerManager:
                         state.stale = True
                         state.oauth_lease_version = lease_version
         except OAuthConnectionRequired:
-            await run_coroutine_until_complete(self._disconnect_rejected_oauth_request_state(key, state))
+            await run_coroutine_until_complete(self._disconnect_rejected_oauth_scope_state(key, state))
             raise
         return state, _MCPAuthorizationLease(
             headers={"Authorization": f"Bearer {access_token}"},
@@ -800,12 +817,12 @@ class MCPServerManager:
         credential_context: OAuthCredentialContext,
     ) -> None:
         """Distinguish reset retirement from ordinary config-generation replacement."""
-        if key.oauth_request_key in self._retired_request_keys:
+        if key.oauth_scope_key in self._retired_scope_keys:
             raise oauth_connection_required(credential_context)
         if state.retired or self._scoped_states.get(key) is not state:
             raise _MCPConfigurationChangedError
 
-    async def _disconnect_rejected_oauth_request_state(
+    async def _disconnect_rejected_oauth_scope_state(
         self,
         key: _MCPSessionKey,
         state: MCPServerState,
@@ -865,7 +882,7 @@ class MCPServerManager:
             rejection = await self._oauth_transport_rejection(state, authorization_lease)
             if rejection is not None:
                 await run_coroutine_until_complete(
-                    self._disconnect_rejected_oauth_request_state(authorization_lease.session_key, state),
+                    self._disconnect_rejected_oauth_scope_state(authorization_lease.session_key, state),
                 )
                 raise rejection
         refresh_revision = state.refresh_revision
@@ -891,7 +908,7 @@ class MCPServerManager:
                 )
                 if rejection is not None:
                     await run_coroutine_until_complete(
-                        self._disconnect_rejected_oauth_request_state(
+                        self._disconnect_rejected_oauth_scope_state(
                             authorization_lease.session_key,
                             state,
                         ),
@@ -1102,7 +1119,7 @@ class MCPServerManager:
         if outcome.discovery_rejection is not None:
             rejection = outcome.discovery_rejection
             await run_coroutine_until_complete(
-                self._disconnect_rejected_oauth_request_state(
+                self._disconnect_rejected_oauth_scope_state(
                     rejection.authorization_lease.session_key,
                     state,
                 ),
@@ -1436,8 +1453,8 @@ class MCPServerManager:
             async with self._state_lifecycle_lock:
                 self._retiring_states.pop(id(state), None)
 
-    async def _drain_retired_request_states(self, states: tuple[MCPServerState, ...]) -> None:
-        """Close requester states before reset, failing closed on teardown errors."""
+    async def _drain_retired_oauth_scope_states(self, states: tuple[MCPServerState, ...]) -> None:
+        """Close credential-scoped states before reset, failing closed on teardown errors."""
         first_error: BaseException | None = None
         first_error_state: MCPServerState | None = None
         for state in states:
@@ -1449,7 +1466,7 @@ class MCPServerManager:
                 first_error = first_error or exc
                 first_error_state = first_error_state or state
                 logger.warning(
-                    "MCP requester-state refresh cleanup failed",
+                    "MCP credential-scope refresh cleanup failed",
                     server_id=state.server_id,
                     error_type=type(exc).__name__,
                 )
@@ -1461,7 +1478,7 @@ class MCPServerManager:
                 first_error = first_error or exc
                 first_error_state = first_error_state or state
                 logger.warning(
-                    "MCP requester-state session cleanup failed",
+                    "MCP credential-scope session cleanup failed",
                     server_id=state.server_id,
                     error_type=type(exc).__name__,
                 )
@@ -1472,7 +1489,7 @@ class MCPServerManager:
             if isinstance(first_error, asyncio.CancelledError | MCPError):
                 raise first_error
             assert first_error_state is not None
-            msg = f"MCP requester session cleanup failed for server '{first_error_state.server_id}'"
+            msg = f"MCP credential-scope session cleanup failed for server '{first_error_state.server_id}'"
             raise MCPConnectionError(first_error_state.server_id, msg) from first_error
 
     async def _clear_function_validation_errors(self) -> None:
@@ -1583,13 +1600,13 @@ class MCPServerManager:
             or state.oauth_lease_version != authorization_lease.version
             or state.config_generation != authorization_lease.session_key.config_generation
             or state.oauth_provider_id != authorization_lease.session_key.provider_id
-            or state.oauth_request_scope
+            or state.oauth_credential_scope
             != (
                 authorization_lease.session_key.worker_scope,
                 authorization_lease.session_key.worker_key,
             )
             or self._scoped_states.get(authorization_lease.session_key) is not state
-            or authorization_lease.session_key.oauth_request_key in self._retired_request_keys
+            or authorization_lease.session_key.oauth_scope_key in self._retired_scope_keys
         ):
             raise _MCPAuthorizationChangedError
 
@@ -1630,7 +1647,7 @@ class MCPServerManager:
     @staticmethod
     def _require_active_state(state: MCPServerState) -> None:
         if state.retired:
-            msg = f"MCP server '{state.server_id}' requester session generation is retired"
+            msg = f"MCP server '{state.server_id}' credential-scope session generation is retired"
             raise MCPConnectionError(state.server_id, msg)
 
     def _function_surface_context(self) -> MCPFunctionSurfaceContext | None:
@@ -1644,7 +1661,7 @@ class MCPServerManager:
             states=self._states,
             scoped_states=tuple(
                 MCPScopedFunctionState(
-                    requester_surface=(key.worker_scope, key.worker_key),
+                    credential_surface=(key.worker_scope, key.worker_key),
                     state=state,
                 )
                 for key, state in self._scoped_states.items()
@@ -1669,7 +1686,7 @@ class MCPServerManager:
         ):
             for state in self._function_validation_states_for_surface(
                 report.server_id,
-                report.requester_surface,
+                report.credential_surface,
             ):
                 entry = errors_by_state.setdefault(id(state), (state, set()))
                 entry[1].update(message for _function_name, message in report.function_name_collisions)
@@ -1714,17 +1731,17 @@ class MCPServerManager:
     def _function_validation_states_for_surface(
         self,
         server_id: str,
-        requester_surface: tuple[str, str] | None,
+        credential_surface: tuple[str, str] | None,
     ) -> tuple[MCPServerState, ...]:
         """Return only states whose visible function surface owns one collision."""
         base_state = self._states.get(server_id)
-        if requester_surface is None:
+        if credential_surface is None:
             return (base_state,) if base_state is not None else ()
         states = [base_state] if base_state is not None and base_state.config.auth is None else []
         states.extend(
             state
             for key, state in self._scoped_states.items()
-            if key.server_id == server_id and (key.worker_scope, key.worker_key) == requester_surface
+            if key.server_id == server_id and (key.worker_scope, key.worker_key) == credential_surface
         )
         return tuple(states)
 
@@ -1771,10 +1788,8 @@ class MCPServerManager:
         context = self._function_surface_context()
         if context is None:
             return []
-        requester_surfaces: set[tuple[str, str]] = set()
+        credential_surfaces: set[tuple[str, str]] = set()
         if worker_target is not None:
-            # Generated MCP OAuth providers are requester-scoped, so every
-            # configured agent worker scope canonicalizes to one user surface.
             for server_id in sorted(self._states):
                 state = self._states[server_id]
                 if state.config.auth is None:
@@ -1783,17 +1798,17 @@ class MCPServerManager:
                     state,
                     worker_target=worker_target,
                 ).worker_target
-                if (
-                    canonical_target is not None
-                    and canonical_target.worker_scope is not None
-                    and canonical_target.worker_key is not None
-                ):
-                    requester_surfaces.add((canonical_target.worker_scope, canonical_target.worker_key))
+                credential_surfaces.add(
+                    _resolved_oauth_scope(
+                        canonical_target,
+                        provider_id=state.oauth_provider_id or server_id,
+                    ),
+                )
         return function_collision_messages(
             context,
             agent_name,
             loaded_tools,
-            requester_surfaces=requester_surfaces,
+            credential_surfaces=credential_surfaces,
         )
 
     @classmethod

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -165,14 +165,14 @@ def _resolved_oauth_scope(
     if worker_target is None or worker_target.worker_scope is None:
         return MCPOAuthCredentialScope(worker_scope="unscoped", worker_key="global")
     worker_scope = worker_target.worker_scope
-    worker_key = worker_target.worker_key
-    if not worker_key:
-        msg = f"MCP OAuth provider '{provider_id}' requires a complete credential target"
-        raise OAuthProviderError(msg)
     identity = worker_target.execution_identity
     if worker_scope in {"user", "user_agent"} and (identity is None or not identity.requester_id):
         msg = f"MCP OAuth provider '{provider_id}' requires a requester identity"
         raise OAuthConnectionRequired(msg, provider_id=provider_id)
+    worker_key = worker_target.worker_key
+    if not worker_key:
+        msg = f"MCP OAuth provider '{provider_id}' requires a complete credential target"
+        raise OAuthProviderError(msg)
     routing_agent_name = worker_target.routing_agent_name if worker_scope in {"shared", "user_agent"} else None
     if worker_scope in {"shared", "user_agent"} and not routing_agent_name:
         msg = f"MCP OAuth provider '{provider_id}' requires an agent identity"
@@ -1829,12 +1829,14 @@ class MCPServerManager:
                     state,
                     worker_target=worker_target,
                 ).worker_target
-                credential_surfaces.add(
-                    _resolved_oauth_scope(
+                try:
+                    credential_surface = _resolved_oauth_scope(
                         canonical_target,
                         provider_id=state.oauth_provider_id or server_id,
-                    ),
-                )
+                    )
+                except OAuthConnectionRequired:
+                    continue
+                credential_surfaces.add(credential_surface)
         return function_collision_messages(
             context,
             agent_name,

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -550,16 +550,9 @@ class MCPServerManager:
                 base_state,
                 worker_target=worker_target,
             )
-            credential_target = credential_context.worker_target
-            if (
-                credential_target is not None
-                and credential_target.worker_scope is not None
-                and not credential_target.worker_key
-            ):
-                return None
             key = self._scope_session_key(
                 base_state,
-                credential_target,
+                credential_context.worker_target,
                 provider_id=credential_context.provider.id,
             )
         except OAuthConnectionRequired:

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -40,6 +40,7 @@ from mindroom.mcp.surface_projection import (
     function_collision_messages,
     function_collision_reports,
     mcp_tool_unavailable_messages,
+    scoped_oauth_state_has_configured_agent,
 )
 from mindroom.mcp.transports import build_transport_handle
 from mindroom.mcp.types import (
@@ -290,6 +291,34 @@ class MCPServerManager:
             changed_server_ids.difference_update(self.failed_server_ids())
             return changed_server_ids
 
+    def _track_retiring_state(
+        self,
+        state: MCPServerState,
+        retired_states: list[MCPServerState],
+    ) -> None:
+        """Detach one state into the manager-owned retirement set."""
+        if state.retired:
+            return
+        state.retired = True
+        self._retiring_states[id(state)] = state
+        retired_states.append(state)
+
+    def _retire_unreachable_scoped_states(
+        self,
+        config: Config,
+        retired_states: list[MCPServerState],
+    ) -> None:
+        """Detach scoped OAuth states with no agent access in the published config."""
+        for key, scoped_state in tuple(self._scoped_states.items()):
+            scoped = MCPScopedFunctionState(
+                credential_surface=(key.worker_scope, key.worker_key),
+                state=scoped_state,
+            )
+            if scoped_oauth_state_has_configured_agent(config, scoped):
+                continue
+            self._scoped_states.pop(key)
+            self._track_retiring_state(scoped_state, retired_states)
+
     async def _publish_server_config(
         self,
         config: Config,
@@ -297,13 +326,6 @@ class MCPServerManager:
     ) -> list[MCPServerState] | None:
         """Atomically replace changed base generations and detach their scoped sessions."""
         retired_states: list[MCPServerState] = []
-
-        def retire_state(state: MCPServerState) -> None:
-            if state.retired:
-                return
-            state.retired = True
-            self._retiring_states[id(state)] = state
-            retired_states.append(state)
 
         async with self._state_lifecycle_lock:
             if self._shutdown:
@@ -323,11 +345,12 @@ class MCPServerManager:
                 ):
                     continue
                 self._states.pop(server_id)
-                retire_state(state)
+                self._track_retiring_state(state, retired_states)
                 for key, scoped_state in tuple(self._scoped_states.items()):
                     if key.server_id == server_id:
                         self._scoped_states.pop(key)
-                        retire_state(scoped_state)
+                        self._track_retiring_state(scoped_state, retired_states)
+            self._retire_unreachable_scoped_states(config, retired_states)
             for server_id, server_config in desired_servers.items():
                 if server_id in self._states:
                     continue

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -45,6 +45,7 @@ from mindroom.mcp.surface_projection import (
 from mindroom.mcp.transports import build_transport_handle
 from mindroom.mcp.types import (
     MCPDiscoveredTool,
+    MCPOAuthCredentialScope,
     MCPOAuthLeaseVersion,
     MCPServerCatalog,
     MCPServerState,
@@ -103,8 +104,7 @@ class _MCPOAuthScopeKey:
     """Provider and credential scope shared across server config generations."""
 
     provider_id: str
-    worker_scope: str
-    worker_key: str
+    credential_scope: MCPOAuthCredentialScope
 
 
 @dataclass(frozen=True)
@@ -114,16 +114,14 @@ class _MCPSessionKey:
     server_id: str
     config_generation: int
     provider_id: str
-    worker_scope: str
-    worker_key: str
+    credential_scope: MCPOAuthCredentialScope
 
     @property
     def oauth_scope_key(self) -> _MCPOAuthScopeKey:
         """Return the provider and credential scope used by reset retirement."""
         return _MCPOAuthScopeKey(
             provider_id=self.provider_id,
-            worker_scope=self.worker_scope,
-            worker_key=self.worker_key,
+            credential_scope=self.credential_scope,
         )
 
 
@@ -162,10 +160,10 @@ def _resolved_oauth_scope(
     worker_target: ResolvedWorkerTarget | None,
     *,
     provider_id: str,
-) -> tuple[str, str]:
+) -> MCPOAuthCredentialScope:
     """Return the canonical credential scope used to key one MCP OAuth session."""
     if worker_target is None or worker_target.worker_scope is None:
-        return "unscoped", "global"
+        return MCPOAuthCredentialScope(worker_scope="unscoped", worker_key="global")
     worker_scope = worker_target.worker_scope
     worker_key = worker_target.worker_key
     if not worker_key:
@@ -175,7 +173,16 @@ def _resolved_oauth_scope(
     if worker_scope in {"user", "user_agent"} and (identity is None or not identity.requester_id):
         msg = f"MCP OAuth provider '{provider_id}' requires a requester identity"
         raise OAuthConnectionRequired(msg, provider_id=provider_id)
-    return worker_scope, worker_key
+    routing_agent_name = worker_target.routing_agent_name if worker_scope in {"shared", "user_agent"} else None
+    if worker_scope in {"shared", "user_agent"} and not routing_agent_name:
+        msg = f"MCP OAuth provider '{provider_id}' requires an agent identity"
+        raise OAuthProviderError(msg)
+    return MCPOAuthCredentialScope(
+        worker_scope=worker_scope,
+        worker_key=worker_key,
+        requester_id=identity.requester_id if identity is not None and worker_scope in {"user", "user_agent"} else None,
+        routing_agent_name=routing_agent_name,
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -311,7 +318,7 @@ class MCPServerManager:
         """Detach scoped OAuth states with no agent access in the published config."""
         for key, scoped_state in tuple(self._scoped_states.items()):
             scoped = MCPScopedFunctionState(
-                credential_surface=(key.worker_scope, key.worker_key),
+                credential_surface=key.credential_scope,
                 state=scoped_state,
             )
             if scoped_oauth_state_has_configured_agent(config, scoped):
@@ -571,14 +578,13 @@ class MCPServerManager:
     ) -> AsyncIterator[None]:
         """Fence one provider credential lineage across every server config generation."""
         worker_target = credential_context.worker_target
-        worker_scope, worker_key = _resolved_oauth_scope(
+        credential_scope = _resolved_oauth_scope(
             worker_target,
             provider_id=credential_context.provider.id,
         )
         scope_key = _MCPOAuthScopeKey(
             provider_id=credential_context.provider.id,
-            worker_scope=worker_scope,
-            worker_key=worker_key,
+            credential_scope=credential_scope,
         )
         async with self._state_lifecycle_lock:
             retirement_lock = self._scope_retirement_locks.setdefault(scope_key, asyncio.Lock())
@@ -607,7 +613,7 @@ class MCPServerManager:
                         if (
                             id(state) in seen_state_ids
                             or state.oauth_provider_id != scope_key.provider_id
-                            or state.oauth_credential_scope != (scope_key.worker_scope, scope_key.worker_key)
+                            or state.oauth_credential_scope != scope_key.credential_scope
                         ):
                             continue
                         state.retired = True
@@ -640,7 +646,7 @@ class MCPServerManager:
         *,
         provider_id: str,
     ) -> _MCPSessionKey:
-        worker_scope, worker_key = _resolved_oauth_scope(
+        credential_scope = _resolved_oauth_scope(
             worker_target,
             provider_id=provider_id,
         )
@@ -648,8 +654,7 @@ class MCPServerManager:
             server_id=state.server_id,
             config_generation=state.config_generation,
             provider_id=provider_id,
-            worker_scope=worker_scope,
-            worker_key=worker_key,
+            credential_scope=credential_scope,
         )
 
     def _log_oauth_refresh_failure(
@@ -798,8 +803,7 @@ class MCPServerManager:
                     config_generation=key.config_generation,
                     oauth_provider_id=key.provider_id,
                     oauth_authorization=base_state.oauth_authorization,
-                    oauth_credential_scope=(key.worker_scope, key.worker_key),
-                    oauth_routing_agent_name=(worker_target.routing_agent_name if worker_target is not None else None),
+                    oauth_credential_scope=key.credential_scope,
                 )
                 self._scoped_states[key] = state
 
@@ -1631,11 +1635,7 @@ class MCPServerManager:
             or state.oauth_lease_version != authorization_lease.version
             or state.config_generation != authorization_lease.session_key.config_generation
             or state.oauth_provider_id != authorization_lease.session_key.provider_id
-            or state.oauth_credential_scope
-            != (
-                authorization_lease.session_key.worker_scope,
-                authorization_lease.session_key.worker_key,
-            )
+            or state.oauth_credential_scope != authorization_lease.session_key.credential_scope
             or self._scoped_states.get(authorization_lease.session_key) is not state
             or authorization_lease.session_key.oauth_scope_key in self._retired_scope_keys
         ):
@@ -1692,7 +1692,7 @@ class MCPServerManager:
             states=self._states,
             scoped_states=tuple(
                 MCPScopedFunctionState(
-                    credential_surface=(key.worker_scope, key.worker_key),
+                    credential_surface=key.credential_scope,
                     state=state,
                 )
                 for key, state in self._scoped_states.items()
@@ -1762,7 +1762,7 @@ class MCPServerManager:
     def _function_validation_states_for_surface(
         self,
         server_id: str,
-        credential_surface: tuple[str, str] | None,
+        credential_surface: MCPOAuthCredentialScope | None,
     ) -> tuple[MCPServerState, ...]:
         """Return only states whose visible function surface owns one collision."""
         base_state = self._states.get(server_id)
@@ -1772,7 +1772,7 @@ class MCPServerManager:
         states.extend(
             state
             for key, state in self._scoped_states.items()
-            if key.server_id == server_id and (key.worker_scope, key.worker_key) == credential_surface
+            if key.server_id == server_id and key.credential_scope == credential_surface
         )
         return tuple(states)
 
@@ -1819,7 +1819,7 @@ class MCPServerManager:
         context = self._function_surface_context()
         if context is None:
             return []
-        credential_surfaces: set[tuple[str, str]] = set()
+        credential_surfaces: set[MCPOAuthCredentialScope] = set()
         if worker_target is not None:
             for server_id in sorted(self._states):
                 state = self._states[server_id]

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -172,7 +172,7 @@ def _resolved_oauth_scope(
     worker_key = worker_target.worker_key
     if not worker_key:
         msg = f"MCP OAuth provider '{provider_id}' requires a complete credential target"
-        raise OAuthProviderError(msg)
+        raise OAuthConnectionRequired(msg, provider_id=provider_id)
     routing_agent_name = worker_target.routing_agent_name if worker_scope in {"shared", "user_agent"} else None
     if worker_scope in {"shared", "user_agent"} and not routing_agent_name:
         msg = f"MCP OAuth provider '{provider_id}' requires an agent identity"

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -550,12 +550,13 @@ class MCPServerManager:
                 base_state,
                 worker_target=worker_target,
             )
+            self._require_configured_oauth_target(server_id, credential_context.worker_target)
             key = self._scope_session_key(
                 base_state,
                 credential_context.worker_target,
                 provider_id=credential_context.provider.id,
             )
-        except OAuthConnectionRequired:
+        except (MCPConnectionError, OAuthConnectionRequired):
             return None
         state = self._scoped_states.get(key)
         if state is None or state.retired or state.catalog is None or state.stale or state.last_error is not None:
@@ -649,6 +650,25 @@ class MCPServerManager:
             provider_id=provider_id,
             credential_scope=credential_scope,
         )
+
+    def _require_configured_oauth_target(
+        self,
+        server_id: str,
+        worker_target: ResolvedWorkerTarget | None,
+    ) -> None:
+        """Reject a stale toolkit whose agent, tool, or execution scope was reconfigured."""
+        if worker_target is None or worker_target.routing_agent_name is None:
+            return
+        agent_name = worker_target.routing_agent_name
+        config = self._config
+        if config is not None and config.agent_has_tool_at_execution_scope(
+            agent_name,
+            mcp_tool_name(server_id),
+            worker_target.worker_scope,
+        ):
+            return
+        msg = f"MCP server '{server_id}' credential target is no longer configured"
+        raise MCPConnectionError(server_id, msg)
 
     def _log_oauth_refresh_failure(
         self,
@@ -786,6 +806,7 @@ class MCPServerManager:
                 or base_state.retired
             ):
                 raise _MCPConfigurationChangedError
+            self._require_configured_oauth_target(server_id, worker_target)
             if scope_key in self._retired_scope_keys:
                 raise oauth_connection_required(credential_context)
             state = self._scoped_states.get(key)

--- a/src/mindroom/mcp/oauth.py
+++ b/src/mindroom/mcp/oauth.py
@@ -55,19 +55,19 @@ def _mcp_oauth_provider_is_configured(
 
 
 @asynccontextmanager
-async def retire_mcp_oauth_request_session(
+async def retire_mcp_oauth_scope_session(
     mcp_servers: dict[str, MCPServerConfig],
     provider_id: str,
     *,
     credential_context: OAuthCredentialContext,
     expected_connection_generation: str | None = None,
 ) -> AsyncIterator[None]:
-    """Fence a generated provider's requester session for an OAuth reset transaction."""
+    """Fence a generated provider's credential-scoped session for an OAuth reset transaction."""
     manager = require_mcp_server_manager() if _mcp_oauth_provider_is_configured(mcp_servers, provider_id) else None
     if manager is None:
         yield
         return
-    async with manager.retire_request_session(
+    async with manager.retire_oauth_scope_session(
         credential_context=credential_context,
         expected_connection_generation=expected_connection_generation,
     ):
@@ -146,7 +146,6 @@ def mcp_oauth_provider(server_id: str, server_config: MCPServerConfig) -> OAuthP
         token_endpoint_auth_method=auth_config.token_endpoint_auth_method,
         pkce_code_challenge_method=auth_config.pkce_code_challenge_method,
         allow_empty_scopes=True,
-        requester_scoped_credentials=True,
         status_capabilities=(f"{_display_name(server_id, auth_config)} MCP access",),
         runtime_bootstrapper=oauth_runtime_bootstrapper(_oauth_discovery_config(server_config)),
     )

--- a/src/mindroom/mcp/surface_projection.py
+++ b/src/mindroom/mcp/surface_projection.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from mindroom.config.main import Config
     from mindroom.config.models import EffectiveToolConfig
     from mindroom.constants import RuntimePaths
-    from mindroom.mcp.types import MCPServerCatalog, MCPServerState
+    from mindroom.mcp.types import MCPOAuthCredentialScope, MCPServerCatalog, MCPServerState
 
 type _LoadedToolNames = list[str] | tuple[str, ...] | set[str] | frozenset[str]
 
@@ -47,7 +47,7 @@ logger = get_logger(__name__)
 class MCPScopedFunctionState:
     """One credential surface and the MCP state that can publish onto it."""
 
-    credential_surface: tuple[str, str]
+    credential_surface: MCPOAuthCredentialScope
     state: MCPServerState
 
 
@@ -94,11 +94,11 @@ def _scoped_state_is_visible_to_agent(
     agent_execution_scope: str | None,
 ) -> bool:
     """Return whether one credential-scoped catalog belongs on an agent surface."""
-    worker_scope, _worker_key = scoped.credential_surface
+    worker_scope = scoped.credential_surface.worker_scope
     credential_execution_scope = None if worker_scope == "unscoped" else worker_scope
     if credential_execution_scope != agent_execution_scope:
         return False
-    return worker_scope not in {"shared", "user_agent"} or scoped.state.oauth_routing_agent_name == agent_name
+    return worker_scope not in {"shared", "user_agent"} or scoped.credential_surface.routing_agent_name == agent_name
 
 
 def scoped_oauth_state_has_configured_agent(
@@ -240,7 +240,7 @@ def _agent_function_surface_snapshot(
     agent_name: str,
     *,
     loaded_tools: _LoadedToolNames | None,
-    credential_surface: tuple[str, str] | None,
+    credential_surface: MCPOAuthCredentialScope | None,
     candidate_state: MCPServerState | None = None,
     candidate_catalog: MCPServerCatalog | None = None,
     configured_surface: tuple[set[str], dict[str, tuple[EffectiveToolConfig, ...]]] | None = None,
@@ -357,7 +357,7 @@ def function_collision_messages(
     agent_name: str,
     loaded_tools: _LoadedToolNames,
     *,
-    credential_surfaces: set[tuple[str, str]],
+    credential_surfaces: set[MCPOAuthCredentialScope],
 ) -> list[str]:
     """Return collision messages for one candidate dynamic-tool surface."""
     active_states = (*context.states.values(), *(scoped.state for scoped in context.scoped_states))

--- a/src/mindroom/mcp/surface_projection.py
+++ b/src/mindroom/mcp/surface_projection.py
@@ -107,15 +107,16 @@ def scoped_oauth_state_has_configured_agent(
 ) -> bool:
     """Return whether any configured agent can still reach one scoped OAuth state."""
     tool_name = mcp_tool_name(scoped.state.server_id)
+    worker_scope = scoped.credential_surface.worker_scope
+    credential_execution_scope = None if worker_scope == "unscoped" else worker_scope
     for agent_name in config.agents:
-        entity = config.resolve_entity(agent_name)
-        if tool_name not in entity.available_tools:
-            continue
-        if _scoped_state_is_visible_to_agent(
-            scoped,
+        if not config.agent_has_tool_at_execution_scope(
             agent_name,
-            agent_execution_scope=entity.execution_scope,
+            tool_name,
+            credential_execution_scope,
         ):
+            continue
+        if worker_scope not in {"shared", "user_agent"} or scoped.credential_surface.routing_agent_name == agent_name:
             return True
     return False
 

--- a/src/mindroom/mcp/surface_projection.py
+++ b/src/mindroom/mcp/surface_projection.py
@@ -86,9 +86,17 @@ def _catalog_function_names_for_tool_config(
     }
 
 
-def _scoped_state_is_visible_to_agent(scoped: MCPScopedFunctionState, agent_name: str) -> bool:
+def _scoped_state_is_visible_to_agent(
+    scoped: MCPScopedFunctionState,
+    agent_name: str,
+    *,
+    agent_execution_scope: str | None,
+) -> bool:
     """Return whether one credential-scoped catalog belongs on an agent surface."""
     worker_scope, _worker_key = scoped.credential_surface
+    credential_execution_scope = None if worker_scope == "unscoped" else worker_scope
+    if credential_execution_scope != agent_execution_scope:
+        return False
     return worker_scope not in {"shared", "user_agent"} or scoped.state.oauth_routing_agent_name == agent_name
 
 
@@ -218,6 +226,7 @@ def _agent_function_surface_snapshot(
     configured_surface: tuple[set[str], dict[str, tuple[EffectiveToolConfig, ...]]] | None = None,
 ) -> MCPFunctionSurfaceSnapshot:
     """Snapshot one configured agent and credential surface from supplied runtime state."""
+    agent_execution_scope = context.config.resolve_entity(agent_name).execution_scope
     local_function_names, configured_mcp_tool_configs = configured_surface or _configured_function_surface(
         context,
         agent_name,
@@ -238,7 +247,11 @@ def _agent_function_surface_snapshot(
             if scoped.state.server_id == server_id
             and credential_surface is not None
             and scoped.credential_surface == credential_surface
-            and _scoped_state_is_visible_to_agent(scoped, agent_name)
+            and _scoped_state_is_visible_to_agent(
+                scoped,
+                agent_name,
+                agent_execution_scope=agent_execution_scope,
+            )
             and (scoped.state.last_error is None or scoped.state is candidate_state)
         )
         function_sources.extend(

--- a/src/mindroom/mcp/surface_projection.py
+++ b/src/mindroom/mcp/surface_projection.py
@@ -44,9 +44,9 @@ logger = get_logger(__name__)
 
 @dataclass(frozen=True, slots=True)
 class MCPScopedFunctionState:
-    """One requester surface and the MCP state that can publish onto it."""
+    """One credential surface and the MCP state that can publish onto it."""
 
-    requester_surface: tuple[str, str]
+    credential_surface: tuple[str, str]
     state: MCPServerState
 
 
@@ -206,12 +206,12 @@ def _agent_function_surface_snapshot(
     agent_name: str,
     *,
     loaded_tools: _LoadedToolNames | None,
-    requester_surface: tuple[str, str] | None,
+    credential_surface: tuple[str, str] | None,
     candidate_state: MCPServerState | None = None,
     candidate_catalog: MCPServerCatalog | None = None,
     configured_surface: tuple[set[str], dict[str, tuple[EffectiveToolConfig, ...]]] | None = None,
 ) -> MCPFunctionSurfaceSnapshot:
-    """Snapshot one configured agent/requester surface from supplied runtime state."""
+    """Snapshot one configured agent and credential surface from supplied runtime state."""
     local_function_names, configured_mcp_tool_configs = configured_surface or _configured_function_surface(
         context,
         agent_name,
@@ -230,8 +230,8 @@ def _agent_function_surface_snapshot(
             candidate_catalog if scoped.state is candidate_state else scoped.state.catalog
             for scoped in context.scoped_states
             if scoped.state.server_id == server_id
-            and requester_surface is not None
-            and scoped.requester_surface == requester_surface
+            and credential_surface is not None
+            and scoped.credential_surface == credential_surface
             and (scoped.state.last_error is None or scoped.state is candidate_state)
         )
         function_sources.extend(
@@ -246,7 +246,7 @@ def _agent_function_surface_snapshot(
         server_function_sources.append((server_id, tuple(function_sources)))
     return MCPFunctionSurfaceSnapshot(
         agent_name=agent_name,
-        requester_surface=requester_surface,
+        credential_surface=credential_surface,
         local_function_names=frozenset(local_function_names),
         server_function_sources=tuple(server_function_sources),
     )
@@ -259,12 +259,12 @@ def function_collision_reports(
     candidate_catalog: MCPServerCatalog | None = None,
 ) -> tuple[MCPFunctionCollisionReport, ...]:
     """Project all active surfaces and return their collision reports."""
-    requester_surface = candidate_state.oauth_request_scope if candidate_state is not None else None
-    requester_surfaces = {
-        scoped.requester_surface
+    credential_surface = candidate_state.oauth_credential_scope if candidate_state is not None else None
+    credential_surfaces = {
+        scoped.credential_surface
         for scoped in context.scoped_states
         if scoped.state.catalog is not None and scoped.state.last_error is None
-    } | ({requester_surface} if requester_surface is not None else set())
+    } | ({credential_surface} if credential_surface is not None else set())
     configured_surfaces = {
         agent_name: _configured_function_surface(context, agent_name, loaded_tools=[])
         for agent_name in sorted(context.config.agents)
@@ -274,12 +274,12 @@ def function_collision_reports(
             context,
             agent_name,
             loaded_tools=[],
-            requester_surface=surface,
+            credential_surface=surface,
             candidate_state=candidate_state,
             candidate_catalog=candidate_catalog,
             configured_surface=configured_surfaces[agent_name],
         )
-        for surface in (None, *sorted(requester_surfaces))
+        for surface in (None, *sorted(credential_surfaces))
         for agent_name in sorted(context.config.agents)
     )
     return analyze_mcp_function_collisions(snapshots)
@@ -317,13 +317,13 @@ def function_collision_messages(
     agent_name: str,
     loaded_tools: _LoadedToolNames,
     *,
-    requester_surfaces: set[tuple[str, str]],
+    credential_surfaces: set[tuple[str, str]],
 ) -> list[str]:
     """Return collision messages for one candidate dynamic-tool surface."""
     active_states = (*context.states.values(), *(scoped.state for scoped in context.scoped_states))
     if not any(
         state.last_error is None
-        and (state.catalog is not None or (state.oauth_request_scope is None and state.config.auth is not None))
+        and (state.catalog is not None or (state.oauth_credential_scope is None and state.config.auth is not None))
         for state in active_states
     ):
         return []
@@ -333,10 +333,10 @@ def function_collision_messages(
             context,
             agent_name,
             loaded_tools=loaded_tools,
-            requester_surface=requester_surface,
+            credential_surface=credential_surface,
             configured_surface=configured_surface,
         )
-        for requester_surface in (sorted(requester_surfaces) or [None])
+        for credential_surface in (sorted(credential_surfaces) or [None])
     )
     return sorted(
         {

--- a/src/mindroom/mcp/surface_projection.py
+++ b/src/mindroom/mcp/surface_projection.py
@@ -86,6 +86,12 @@ def _catalog_function_names_for_tool_config(
     }
 
 
+def _scoped_state_is_visible_to_agent(scoped: MCPScopedFunctionState, agent_name: str) -> bool:
+    """Return whether one credential-scoped catalog belongs on an agent surface."""
+    worker_scope, _worker_key = scoped.credential_surface
+    return worker_scope not in {"shared", "user_agent"} or scoped.state.oauth_routing_agent_name == agent_name
+
+
 def _configured_tool_configs(
     context: MCPFunctionSurfaceContext,
     agent_name: str,
@@ -232,6 +238,7 @@ def _agent_function_surface_snapshot(
             if scoped.state.server_id == server_id
             and credential_surface is not None
             and scoped.credential_surface == credential_surface
+            and _scoped_state_is_visible_to_agent(scoped, agent_name)
             and (scoped.state.last_error is None or scoped.state is candidate_state)
         )
         function_sources.extend(

--- a/src/mindroom/mcp/surface_projection.py
+++ b/src/mindroom/mcp/surface_projection.py
@@ -37,6 +37,7 @@ __all__ = [
     "function_collision_messages",
     "function_collision_reports",
     "mcp_tool_unavailable_messages",
+    "scoped_oauth_state_has_configured_agent",
 ]
 
 logger = get_logger(__name__)
@@ -98,6 +99,25 @@ def _scoped_state_is_visible_to_agent(
     if credential_execution_scope != agent_execution_scope:
         return False
     return worker_scope not in {"shared", "user_agent"} or scoped.state.oauth_routing_agent_name == agent_name
+
+
+def scoped_oauth_state_has_configured_agent(
+    config: Config,
+    scoped: MCPScopedFunctionState,
+) -> bool:
+    """Return whether any configured agent can still reach one scoped OAuth state."""
+    tool_name = mcp_tool_name(scoped.state.server_id)
+    for agent_name in config.agents:
+        entity = config.resolve_entity(agent_name)
+        if tool_name not in entity.available_tools:
+            continue
+        if _scoped_state_is_visible_to_agent(
+            scoped,
+            agent_name,
+            agent_execution_scope=entity.execution_scope,
+        ):
+            return True
+    return False
 
 
 def _configured_tool_configs(

--- a/src/mindroom/mcp/toolkit.py
+++ b/src/mindroom/mcp/toolkit.py
@@ -165,27 +165,27 @@ class MindRoomMCPToolkit(Toolkit):
         if self.server_config is None:
             return
         tool_prefix = resolved_mcp_tool_prefix(self.server_id, self.server_config)
-        # Before the requester signs in, these bridge functions are the only
+        # Before the credential scope is connected, these bridge functions are the only
         # model-visible surface for the server, so the configured description
         # is the model's only hint about what connecting would unlock.
         suffix = f" {self.server_config.description}" if self.server_config.description else ""
         self.async_functions[f"{tool_prefix}_connection_status"] = Function(
             name=f"{tool_prefix}_connection_status",
-            description=f"Check whether MCP server '{self.server_id}' is connected for the current requester.{suffix}",
+            description=f"Check whether MCP server '{self.server_id}' is connected for this agent's credential scope.{suffix}",
             parameters={"type": "object", "properties": {}},
             entrypoint=self._oauth_connection_status,
             skip_entrypoint_processing=True,
         )
         self.async_functions[f"{tool_prefix}_list_tools"] = Function(
             name=f"{tool_prefix}_list_tools",
-            description=f"List remote tools exposed by MCP server '{self.server_id}' for the current requester.{suffix}",
+            description=f"List remote tools exposed by MCP server '{self.server_id}' for this agent's credential scope.{suffix}",
             parameters={"type": "object", "properties": {}},
             entrypoint=self._oauth_list_tools,
             skip_entrypoint_processing=True,
         )
         self.async_functions[f"{tool_prefix}_call_tool"] = Function(
             name=f"{tool_prefix}_call_tool",
-            description=f"Call one remote tool on MCP server '{self.server_id}' for the current requester.{suffix}",
+            description=f"Call one remote tool on MCP server '{self.server_id}' for this agent's credential scope.{suffix}",
             parameters={
                 "type": "object",
                 "properties": {

--- a/src/mindroom/mcp/types.py
+++ b/src/mindroom/mcp/types.py
@@ -103,7 +103,7 @@ class MCPServerState:
     config_generation: int = 0
     oauth_provider_id: str | None = None
     oauth_authorization: AuthorizationConfig | None = None
-    oauth_request_scope: tuple[str, str] | None = None
+    oauth_credential_scope: tuple[str, str] | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     call_lock: _AsyncReadWriteLock = field(default_factory=_AsyncReadWriteLock)
     catalog: MCPServerCatalog | None = None

--- a/src/mindroom/mcp/types.py
+++ b/src/mindroom/mcp/types.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from mindroom.config.auth import AuthorizationConfig
     from mindroom.mcp.config import MCPServerConfig
     from mindroom.mcp.errors import MCPError
+    from mindroom.tool_system.worker_routing import ResolvedWorkerKeyScope
 
 
 class _AsyncReadWriteLock:
@@ -94,6 +95,16 @@ class MCPOAuthLeaseVersion:
     credential_generation: str
 
 
+@dataclass(frozen=True, order=True, slots=True)
+class MCPOAuthCredentialScope:
+    """Lossless identity of one OAuth credential store used by MCP."""
+
+    worker_scope: ResolvedWorkerKeyScope
+    worker_key: str
+    requester_id: str | None = None
+    routing_agent_name: str | None = None
+
+
 @dataclass
 class MCPServerState:
     """Live connection state for one configured server."""
@@ -103,8 +114,7 @@ class MCPServerState:
     config_generation: int = 0
     oauth_provider_id: str | None = None
     oauth_authorization: AuthorizationConfig | None = None
-    oauth_credential_scope: tuple[str, str] | None = None
-    oauth_routing_agent_name: str | None = None
+    oauth_credential_scope: MCPOAuthCredentialScope | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     call_lock: _AsyncReadWriteLock = field(default_factory=_AsyncReadWriteLock)
     catalog: MCPServerCatalog | None = None

--- a/src/mindroom/mcp/types.py
+++ b/src/mindroom/mcp/types.py
@@ -104,6 +104,7 @@ class MCPServerState:
     oauth_provider_id: str | None = None
     oauth_authorization: AuthorizationConfig | None = None
     oauth_credential_scope: tuple[str, str] | None = None
+    oauth_routing_agent_name: str | None = None
     lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     call_lock: _AsyncReadWriteLock = field(default_factory=_AsyncReadWriteLock)
     catalog: MCPServerCatalog | None = None

--- a/src/mindroom/oauth/reset_execution.py
+++ b/src/mindroom/oauth/reset_execution.py
@@ -1,11 +1,11 @@
-"""Single execution owner for requester-scoped OAuth connection reset."""
+"""Single execution owner for scoped OAuth connection reset."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
 from mindroom.mcp.errors import MCPError
-from mindroom.mcp.oauth import retire_mcp_oauth_request_session
+from mindroom.mcp.oauth import retire_mcp_oauth_scope_session
 from mindroom.oauth.credential_lifecycle import oauth_reset_operation_result, reset_oauth_credentials
 from mindroom.oauth.providers import OAuthProviderError
 
@@ -38,7 +38,7 @@ async def retire_and_reset_oauth_credentials(
             return completed
     reset_started = False
     try:
-        async with retire_mcp_oauth_request_session(
+        async with retire_mcp_oauth_scope_session(
             dict(mcp_servers),
             context.provider.id,
             credential_context=context,

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -2523,7 +2523,6 @@ def test_generated_mcp_oauth_routes_follow_agent_scope_for_connect_status_and_di
     config = main._app_context(api_app).runtime_config
     assert config is not None
     generated_provider = load_oauth_providers(config, runtime_paths)["mcp_demo"]
-    scope_following_provider = replace(generated_provider, requester_scoped_credentials=False)
 
     with TestClient(api_app) as client:
         _login(client)
@@ -2535,7 +2534,7 @@ def test_generated_mcp_oauth_routes_follow_agent_scope_for_connect_status_and_di
         )
         status_response = client.get("/api/oauth/mcp_demo/status?agent_name=general")
         connected_credentials = _stored_oauth_credentials(
-            scope_following_provider,
+            generated_provider,
             runtime_paths,
             worker_scope=expected_scope,
         )
@@ -2562,7 +2561,7 @@ def test_generated_mcp_oauth_routes_follow_agent_scope_for_connect_status_and_di
     assert disconnected_status_response.json()["connected"] is False
     assert (
         _stored_oauth_credentials(
-            scope_following_provider,
+            generated_provider,
             runtime_paths,
             worker_scope=expected_scope,
         )

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -150,7 +150,7 @@ def _config_payload(
     return payload
 
 
-def _mcp_oauth_config_payload(worker_scope: str = "user_agent") -> dict[str, Any]:
+def _mcp_oauth_config_payload(worker_scope: str | None = "user_agent") -> dict[str, Any]:
     return {
         "models": {"default": {"provider": "openai", "id": "gpt-5.4"}},
         "router": {"model": "default"},
@@ -2265,7 +2265,7 @@ def test_disconnect_deletes_mcp_credentials_encrypted_with_unreadable_key(tmp_pa
     )
     api_app = _make_test_app(runtime_paths, _mcp_oauth_config_payload())
     credentials_manager = get_runtime_credentials_manager(runtime_paths)
-    scoped_manager = credentials_manager.for_primary_runtime_scope("@alice:example.org", None)
+    scoped_manager = credentials_manager.for_primary_runtime_scope("@alice:example.org", "general")
     wrong_key_manager = CredentialsManager(
         scoped_manager.base_path,
         shared_base_path=scoped_manager.shared_base_path,
@@ -2460,15 +2460,33 @@ async def test_callback_hides_provider_controlled_exchange_error(
     assert "provider-controlled-callback-secret" not in str(raised.value.detail)
 
 
-def test_generated_mcp_oauth_routes_store_status_and_disconnect_scoped_credentials(
+@pytest.mark.parametrize(
+    ("authored_worker_scope", "private_scope", "expected_scope"),
+    [
+        pytest.param(None, None, None, id="unscoped"),
+        pytest.param("shared", None, "shared", id="shared"),
+        pytest.param("user", None, "user", id="user"),
+        pytest.param("user_agent", None, "user_agent", id="user-agent"),
+        pytest.param(None, "user_agent", "user_agent", id="private-per-user-agent"),
+    ],
+)
+def test_generated_mcp_oauth_routes_follow_agent_scope_for_connect_status_and_disconnect(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    authored_worker_scope: WorkerScope | None,
+    private_scope: WorkerScope | None,
+    expected_scope: WorkerScope | None,
 ) -> None:
     runtime_paths = _runtime_paths(
         tmp_path,
         {constants.OWNER_MATRIX_USER_ID_ENV: "@alice:example.org"},
     )
-    api_app = _make_test_app(runtime_paths, _mcp_oauth_config_payload(worker_scope="user_agent"))
+    config_payload = _mcp_oauth_config_payload(worker_scope=authored_worker_scope)
+    if private_scope is not None:
+        agent_payload = config_payload["agents"]["general"]
+        agent_payload.pop("worker_scope")
+        agent_payload["private"] = {"per": private_scope}
+    api_app = _make_test_app(runtime_paths, config_payload)
     manager = get_runtime_credentials_manager(runtime_paths)
     manager.save_credentials(
         "mcp_demo_oauth_client",
@@ -2502,6 +2520,10 @@ def test_generated_mcp_oauth_routes_store_status_and_disconnect_scoped_credentia
             }
 
     monkeypatch.setattr("mindroom.oauth.providers.AsyncOAuth2Client", FakeOAuth2Client)
+    config = main._app_context(api_app).runtime_config
+    assert config is not None
+    generated_provider = load_oauth_providers(config, runtime_paths)["mcp_demo"]
+    scope_following_provider = replace(generated_provider, requester_scoped_credentials=False)
 
     with TestClient(api_app) as client:
         _login(client)
@@ -2512,6 +2534,11 @@ def test_generated_mcp_oauth_routes_store_status_and_disconnect_scoped_credentia
             follow_redirects=False,
         )
         status_response = client.get("/api/oauth/mcp_demo/status?agent_name=general")
+        connected_credentials = _stored_oauth_credentials(
+            scope_following_provider,
+            runtime_paths,
+            worker_scope=expected_scope,
+        )
         disconnect_response = client.post("/api/oauth/mcp_demo/disconnect?agent_name=general")
         disconnected_status_response = client.get("/api/oauth/mcp_demo/status?agent_name=general")
 
@@ -2528,13 +2555,19 @@ def test_generated_mcp_oauth_routes_store_status_and_disconnect_scoped_credentia
     assert fetch_kwargs["code_verifier"]
     assert status_response.status_code == 200
     assert status_response.json()["connected"] is True
+    assert connected_credentials is not None
+    assert connected_credentials["token"] == "mcp-access-token"
     assert disconnect_response.status_code == 200
     assert disconnected_status_response.status_code == 200
     assert disconnected_status_response.json()["connected"] is False
-    scoped_credentials = manager.for_primary_runtime_scope("@alice:example.org", "general").load_credentials(
-        "mcp_demo_oauth",
+    assert (
+        _stored_oauth_credentials(
+            scope_following_provider,
+            runtime_paths,
+            worker_scope=expected_scope,
+        )
+        is None
     )
-    assert scoped_credentials is None
 
 
 @pytest.mark.parametrize("existing_token_client_id", ["old-client-id", None], ids=["previous-client", "unknown-client"])
@@ -3238,7 +3271,7 @@ def test_disconnect_cleanup_failure_preserves_credentials(tmp_path: Path, monkey
         raise MCPConnectionError(server_id, message)
         yield
 
-    monkeypatch.setattr(oauth_reset_execution, "retire_mcp_oauth_request_session", failed_retirement)
+    monkeypatch.setattr(oauth_reset_execution, "retire_mcp_oauth_scope_session", failed_retirement)
 
     with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
         with TestClient(api_app) as client:

--- a/tests/test_config_manager_consolidated.py
+++ b/tests/test_config_manager_consolidated.py
@@ -916,8 +916,8 @@ class TestConsolidatedConfigManager:
         assert "connect_url" not in result
         assert "MindRoom-managed OAuth" not in result
 
-    def test_manage_agent_returns_target_link_for_oauth_mcp_tool(self, tmp_path: Path) -> None:
-        """Requester-scoped MCP OAuth links must target the canonical user credential scope."""
+    def test_manage_agent_returns_agent_scope_link_for_oauth_mcp_tool(self, tmp_path: Path) -> None:
+        """MCP OAuth links must target the created agent's effective credential scope."""
         mcp_server = MCPServerConfig(
             transport="streamable-http",
             url="https://mcp.example.test/mcp",
@@ -950,7 +950,7 @@ class TestConsolidatedConfigManager:
 
         query = parse_qs(urlparse(_connect_url_from_result(result)).query)
         assert query["agent_name"] == ["research"]
-        assert query["execution_scope"] == ["user"]
+        assert query["execution_scope"] == ["user_agent"]
         assert "/api/oauth/mcp_demo/authorize" in result
 
     def test_manage_agent_oauth_link_failure_does_not_mask_saved_update(self, tmp_path: Path) -> None:

--- a/tests/test_mcp_function_surface.py
+++ b/tests/test_mcp_function_surface.py
@@ -5,12 +5,21 @@ from mindroom.mcp.function_surface import (
     MCPFunctionSurfaceSnapshot,
     analyze_mcp_function_collisions,
 )
+from mindroom.mcp.types import MCPOAuthCredentialScope
+
+
+def _user_credential_scope(requester_id: str) -> MCPOAuthCredentialScope:
+    return MCPOAuthCredentialScope(
+        worker_scope="user",
+        worker_key=f"v1:tenant:user:{requester_id}",
+        requester_id=requester_id,
+    )
 
 
 def _snapshot(
     *,
     agent_name: str = "code",
-    credential_surface: tuple[str, str] | None = None,
+    credential_surface: MCPOAuthCredentialScope | None = None,
     local_function_names: tuple[str, ...] = (),
     server_function_sources: tuple[tuple[str, tuple[tuple[str, ...], ...]], ...],
 ) -> MCPFunctionSurfaceSnapshot:
@@ -69,11 +78,11 @@ def test_reports_every_server_owning_cross_server_collision() -> None:
 def test_same_function_on_distinct_credential_surfaces_does_not_collide() -> None:
     """Function ownership on distinct credential surfaces remains isolated."""
     alice = _snapshot(
-        credential_surface=("user", "@alice:example.test"),
+        credential_surface=_user_credential_scope("@alice:example.test"),
         server_function_sources=(("alpha", (("shared",),)),),
     )
     bob = _snapshot(
-        credential_surface=("user", "@bob:example.test"),
+        credential_surface=_user_credential_scope("@bob:example.test"),
         server_function_sources=(("beta", (("shared",),)),),
     )
 
@@ -83,7 +92,7 @@ def test_same_function_on_distinct_credential_surfaces_does_not_collide() -> Non
 def test_reports_duplicate_function_across_same_server_catalogs() -> None:
     """Duplicate names from two same-scope catalogs implicate that server."""
     snapshot = _snapshot(
-        credential_surface=("user", "@alice:example.test"),
+        credential_surface=_user_credential_scope("@alice:example.test"),
         server_function_sources=(("demo", (("echo", "first_only"), ("echo", "second_only"))),),
     )
 
@@ -92,7 +101,7 @@ def test_reports_duplicate_function_across_same_server_catalogs() -> None:
     assert reports == (
         MCPFunctionCollisionReport(
             agent_name="code",
-            credential_surface=("user", "@alice:example.test"),
+            credential_surface=_user_credential_scope("@alice:example.test"),
             server_id="demo",
             function_name_collisions=(("echo", "MCP function name 'echo' collides within server 'demo'"),),
         ),

--- a/tests/test_mcp_function_surface.py
+++ b/tests/test_mcp_function_surface.py
@@ -10,13 +10,13 @@ from mindroom.mcp.function_surface import (
 def _snapshot(
     *,
     agent_name: str = "code",
-    requester_surface: tuple[str, str] | None = None,
+    credential_surface: tuple[str, str] | None = None,
     local_function_names: tuple[str, ...] = (),
     server_function_sources: tuple[tuple[str, tuple[tuple[str, ...], ...]], ...],
 ) -> MCPFunctionSurfaceSnapshot:
     return MCPFunctionSurfaceSnapshot(
         agent_name=agent_name,
-        requester_surface=requester_surface,
+        credential_surface=credential_surface,
         local_function_names=frozenset(local_function_names),
         server_function_sources=tuple(
             (server_id, tuple(frozenset(source) for source in sources))
@@ -37,7 +37,7 @@ def test_reports_local_function_collision_for_owning_server() -> None:
     assert reports == (
         MCPFunctionCollisionReport(
             agent_name="code",
-            requester_surface=None,
+            credential_surface=None,
             server_id="demo",
             function_name_collisions=(
                 (
@@ -66,14 +66,14 @@ def test_reports_every_server_owning_cross_server_collision() -> None:
     }
 
 
-def test_same_function_on_distinct_requester_surfaces_does_not_collide() -> None:
-    """Function ownership on distinct requester surfaces remains isolated."""
+def test_same_function_on_distinct_credential_surfaces_does_not_collide() -> None:
+    """Function ownership on distinct credential surfaces remains isolated."""
     alice = _snapshot(
-        requester_surface=("user", "@alice:example.test"),
+        credential_surface=("user", "@alice:example.test"),
         server_function_sources=(("alpha", (("shared",),)),),
     )
     bob = _snapshot(
-        requester_surface=("user", "@bob:example.test"),
+        credential_surface=("user", "@bob:example.test"),
         server_function_sources=(("beta", (("shared",),)),),
     )
 
@@ -81,9 +81,9 @@ def test_same_function_on_distinct_requester_surfaces_does_not_collide() -> None
 
 
 def test_reports_duplicate_function_across_same_server_catalogs() -> None:
-    """Duplicate names from two same-requester catalogs implicate that server."""
+    """Duplicate names from two same-scope catalogs implicate that server."""
     snapshot = _snapshot(
-        requester_surface=("user", "@alice:example.test"),
+        credential_surface=("user", "@alice:example.test"),
         server_function_sources=(("demo", (("echo", "first_only"), ("echo", "second_only"))),),
     )
 
@@ -92,7 +92,7 @@ def test_reports_duplicate_function_across_same_server_catalogs() -> None:
     assert reports == (
         MCPFunctionCollisionReport(
             agent_name="code",
-            requester_surface=("user", "@alice:example.test"),
+            credential_surface=("user", "@alice:example.test"),
             server_id="demo",
             function_name_collisions=(("echo", "MCP function name 'echo' collides within server 'demo'"),),
         ),

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -143,6 +143,14 @@ class _ConfigStub:
     def get_entities_referencing_tools(self, _tool_names: set[str]) -> set[str]:
         return set()
 
+    @staticmethod
+    def agent_has_tool_at_execution_scope(
+        _agent_name: str,
+        _tool_name: str,
+        _execution_scope: WorkerScope | None,
+    ) -> bool:
+        return True
+
 
 class _FakeClientSession:
     sessions: ClassVar[list[_FakeClientSession]] = []
@@ -3211,6 +3219,17 @@ async def test_mcp_config_reload_retires_unreachable_oauth_scope(
         assert manager._retiring_states == {}
         assert scoped_state.retired is True
         assert session.closed is True
+        transport_count = len(_FakeClientSession.transport_extra_headers)
+
+        with pytest.raises(MCPConnectionError, match="credential target is no longer configured"):
+            await manager.get_request_catalog(
+                "demo",
+                credentials_manager=credentials_manager,
+                worker_target=worker_target,
+            )
+
+        assert manager._scoped_states == {}
+        assert len(_FakeClientSession.transport_extra_headers) == transport_count
     finally:
         await manager.shutdown()
 
@@ -3246,11 +3265,12 @@ async def test_mcp_config_reload_keeps_user_scope_reachable_from_another_agent(
 
     worker_target = _worker_target("@alice:example.test", agent_name="code")
     _save_mcp_oauth_credentials(runtime_paths, worker_target, "alice-token")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
     manager = MCPServerManager(runtime_paths)
     await manager.sync_servers(config_for_agents(("code", "research")))
     await manager.get_request_catalog(
         "demo",
-        credentials_manager=get_runtime_credentials_manager(runtime_paths),
+        credentials_manager=credentials_manager,
         worker_target=worker_target,
     )
     scoped_state = next(iter(manager._scoped_states.values()))
@@ -3262,6 +3282,26 @@ async def test_mcp_config_reload_keeps_user_scope_reachable_from_another_agent(
 
         assert tuple(manager._scoped_states.values()) == (scoped_state,)
         assert scoped_state.retired is False
+        assert session.closed is False
+        assert manager.cached_request_catalog("demo", worker_target=worker_target) is None
+
+        with pytest.raises(MCPConnectionError, match="credential target is no longer configured"):
+            await manager.get_request_catalog(
+                "demo",
+                credentials_manager=credentials_manager,
+                worker_target=worker_target,
+            )
+
+        research_target = _worker_target("@alice:example.test", agent_name="research")
+        assert manager.cached_request_catalog("demo", worker_target=research_target) is scoped_state.catalog
+        assert (
+            await manager.get_request_catalog(
+                "demo",
+                credentials_manager=credentials_manager,
+                worker_target=research_target,
+            )
+        ).server_id == "demo"
+        assert tuple(manager._scoped_states.values()) == (scoped_state,)
         assert session.closed is False
     finally:
         await manager.shutdown()

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -448,6 +448,10 @@ def _save_mcp_oauth_credentials(
     )
 
 
+def _scoped_worker_keys(manager: MCPServerManager) -> set[tuple[str, str]]:
+    return {(key.credential_scope.worker_scope, key.credential_scope.worker_key) for key in manager._scoped_states}
+
+
 def _save_expiring_mcp_oauth_credentials(
     runtime_paths: RuntimePaths,
     worker_target: ResolvedWorkerTarget,
@@ -694,7 +698,7 @@ async def test_unscoped_mcp_oauth_uses_installation_credential_and_session(
     )
 
     assert _FakeClientSession.transport_extra_headers == [{"Authorization": "Bearer installation-token"}]
-    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {("unscoped", "global")}
+    assert _scoped_worker_keys(manager) == {("unscoped", "global")}
 
 
 @pytest.mark.asyncio
@@ -1777,7 +1781,7 @@ async def test_mcp_manager_resolves_oauth_alias_context_once(tmp_path: Path) -> 
 
     assert lease.headers == {"Authorization": "Bearer canonical-a-token"}
     assert next(iter(manager._scoped_states.values())) is state
-    assert next(iter(manager._scoped_states)).worker_key == canonical_a_target.worker_key
+    assert next(iter(manager._scoped_states)).credential_scope.worker_key == canonical_a_target.worker_key
 
 
 @pytest.mark.asyncio
@@ -1832,7 +1836,7 @@ async def test_mcp_alias_reload_retires_sessions_and_uses_published_identity_pol
     )
 
     assert lease.headers == {"Authorization": "Bearer canonical-b-token"}
-    assert lease.session_key.worker_key == canonical_b_target.worker_key
+    assert lease.session_key.credential_scope.worker_key == canonical_b_target.worker_key
 
 
 @pytest.mark.asyncio
@@ -1982,7 +1986,7 @@ async def test_oauth_mcp_shared_agent_reuses_agent_bearer_across_requesters(
     )
 
     assert _FakeClientSession.transport_extra_headers == [{"Authorization": "Bearer agent-token"}]
-    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+    assert _scoped_worker_keys(manager) == {
         ("shared", alice_request_target.worker_key),
     }
 
@@ -1996,10 +2000,11 @@ async def test_oauth_mcp_shared_scope_keeps_accounts_separate_per_agent(
     _patch_manager(monkeypatch)
     _FakeClientSession.tool_list = [_tool("echo")]
     runtime_paths = _runtime_paths(tmp_path)
-    first_target = _shared_worker_target("@alice:example.test", agent_name="code")
-    second_target = _shared_worker_target("@alice:example.test", agent_name="research")
-    _save_mcp_oauth_credentials(runtime_paths, first_target, "code-token")
-    _save_mcp_oauth_credentials(runtime_paths, second_target, "research-token")
+    first_target = _shared_worker_target("@alice:example.test", agent_name="foo")
+    second_target = _shared_worker_target("@alice:example.test", agent_name="_foo_")
+    assert first_target.worker_key == second_target.worker_key
+    _save_mcp_oauth_credentials(runtime_paths, first_target, "foo-token")
+    _save_mcp_oauth_credentials(runtime_paths, second_target, "underscored-token")
     credentials_manager = get_runtime_credentials_manager(runtime_paths)
     manager = MCPServerManager(runtime_paths)
     await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
@@ -2016,13 +2021,84 @@ async def test_oauth_mcp_shared_scope_keeps_accounts_separate_per_agent(
     )
 
     assert _FakeClientSession.transport_extra_headers == [
-        {"Authorization": "Bearer code-token"},
-        {"Authorization": "Bearer research-token"},
+        {"Authorization": "Bearer foo-token"},
+        {"Authorization": "Bearer underscored-token"},
     ]
-    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+    assert len(manager._scoped_states) == 2
+    assert _scoped_worker_keys(manager) == {
         ("shared", first_target.worker_key),
-        ("shared", second_target.worker_key),
     }
+
+
+@pytest.mark.asyncio
+async def test_oauth_mcp_collision_failure_does_not_cross_distinct_raw_agent_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A colliding agent name must not make another credential scope lose its catalog."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    runtime_paths = _runtime_paths(tmp_path)
+    first_target = _shared_worker_target("@alice:example.test", agent_name="foo")
+    second_target = _shared_worker_target("@alice:example.test", agent_name="_foo_")
+    assert first_target.worker_key == second_target.worker_key
+    _save_mcp_oauth_credentials(runtime_paths, first_target, "foo-token")
+    _save_mcp_oauth_credentials(runtime_paths, second_target, "underscored-token")
+
+    class _FakeToolkit:
+        def __init__(self, tool_name: str) -> None:
+            self.functions = {"demo_echo": object()} if tool_name == "shell" else {}
+            self.async_functions = {}
+            self.tools = ()
+
+    monkeypatch.setattr(
+        "mindroom.mcp.surface_projection.get_tool_by_name",
+        lambda tool_name, *_args, **_kwargs: _FakeToolkit(tool_name),
+    )
+    config = Config.validate_with_runtime(
+        {
+            "defaults": {"tools": []},
+            "mcp_servers": {"demo": _oauth_mcp_config().model_dump(exclude_none=True)},
+            "agents": {
+                "foo": {
+                    "display_name": "Foo",
+                    "role": "Use MCP",
+                    "tools": ["mcp_demo"],
+                    "worker_scope": "shared",
+                },
+                "_foo_": {
+                    "display_name": "Underscored Foo",
+                    "role": "Use local and MCP tools",
+                    "tools": ["shell", "mcp_demo"],
+                    "worker_scope": "shared",
+                },
+            },
+        },
+        runtime_paths,
+    )
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(config)
+
+    try:
+        await manager.get_request_catalog(
+            "demo",
+            credentials_manager=credentials_manager,
+            worker_target=first_target,
+        )
+        first_state = next(iter(manager._scoped_states.values()))
+
+        with pytest.raises(MCPProtocolError, match="demo_echo"):
+            await manager.get_request_catalog(
+                "demo",
+                credentials_manager=credentials_manager,
+                worker_target=second_target,
+            )
+
+        assert first_state.catalog is not None
+        assert first_state.last_error is None
+    finally:
+        await manager.shutdown()
 
 
 @pytest.mark.asyncio
@@ -2085,7 +2161,7 @@ async def test_oauth_mcp_user_scope_reuses_account_across_agents(
     )
 
     assert _FakeClientSession.transport_extra_headers == [{"Authorization": "Bearer alice-token"}]
-    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+    assert _scoped_worker_keys(manager) == {
         ("user", first_target.worker_key),
     }
 
@@ -2102,15 +2178,16 @@ async def test_oauth_mcp_user_agent_scope_keeps_accounts_separate_per_agent(
     first_target = _worker_target(
         "@alice:example.test",
         worker_scope="user_agent",
-        agent_name="code",
+        agent_name="foo",
     )
     second_target = _worker_target(
         "@alice:example.test",
         worker_scope="user_agent",
-        agent_name="research",
+        agent_name="_foo_",
     )
-    _save_mcp_oauth_credentials(runtime_paths, first_target, "code-token")
-    _save_mcp_oauth_credentials(runtime_paths, second_target, "research-token")
+    assert first_target.worker_key == second_target.worker_key
+    _save_mcp_oauth_credentials(runtime_paths, first_target, "foo-token")
+    _save_mcp_oauth_credentials(runtime_paths, second_target, "underscored-token")
     credentials_manager = get_runtime_credentials_manager(runtime_paths)
     manager = MCPServerManager(runtime_paths)
     await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
@@ -2127,12 +2204,12 @@ async def test_oauth_mcp_user_agent_scope_keeps_accounts_separate_per_agent(
     )
 
     assert _FakeClientSession.transport_extra_headers == [
-        {"Authorization": "Bearer code-token"},
-        {"Authorization": "Bearer research-token"},
+        {"Authorization": "Bearer foo-token"},
+        {"Authorization": "Bearer underscored-token"},
     ]
-    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+    assert len(manager._scoped_states) == 2
+    assert _scoped_worker_keys(manager) == {
         ("user_agent", first_target.worker_key),
-        ("user_agent", second_target.worker_key),
     }
 
 
@@ -2388,10 +2465,11 @@ async def test_mcp_manager_retires_shared_agent_session_without_touching_other_a
     _patch_manager(monkeypatch)
     _FakeClientSession.tool_list = [_tool("echo")]
     runtime_paths = _runtime_paths(tmp_path)
-    code_target = _shared_worker_target("@alice:example.test", agent_name="code")
-    research_target = _shared_worker_target("@alice:example.test", agent_name="research")
-    _save_mcp_oauth_credentials(runtime_paths, code_target, "code-token")
-    _save_mcp_oauth_credentials(runtime_paths, research_target, "research-token")
+    code_target = _shared_worker_target("@alice:example.test", agent_name="foo")
+    research_target = _shared_worker_target("@alice:example.test", agent_name="_foo_")
+    assert code_target.worker_key == research_target.worker_key
+    _save_mcp_oauth_credentials(runtime_paths, code_target, "foo-token")
+    _save_mcp_oauth_credentials(runtime_paths, research_target, "underscored-token")
     credentials_manager = get_runtime_credentials_manager(runtime_paths)
     manager = MCPServerManager(runtime_paths)
     await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
@@ -2414,7 +2492,7 @@ async def test_mcp_manager_retires_shared_agent_session_without_touching_other_a
 
     assert code_session.closed is True
     assert research_session.closed is False
-    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+    assert _scoped_worker_keys(manager) == {
         ("shared", research_target.worker_key),
     }
 

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -2133,6 +2133,89 @@ async def test_requestless_scoped_oauth_mcp_toolkit_keeps_bridge_surface(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("worker_scope", ["user", "user_agent"])
+async def test_requestless_requester_scoped_oauth_mcp_bridges_return_connection_required(
+    tmp_path: Path,
+    worker_scope: WorkerScope,
+) -> None:
+    """Requester-scoped bridge calls without a requester must return their structured recovery payload."""
+    runtime_paths = _runtime_paths(tmp_path)
+    server_config = _oauth_mcp_config()
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": server_config}))
+    toolkit = MindRoomMCPToolkit(
+        server_id="demo",
+        manager=manager,
+        catalog=None,
+        server_config=server_config,
+        runtime_paths=runtime_paths,
+        credentials_manager=get_runtime_credentials_manager(runtime_paths),
+        worker_target=resolve_worker_target(worker_scope, "code", None),
+    )
+    calls = {
+        "demo_call_tool": {"tool_name": "echo", "arguments": {}},
+        "demo_connection_status": {},
+        "demo_list_tools": {},
+    }
+    try:
+        for function_name, kwargs in calls.items():
+            payload = json.loads(await toolkit.get_async_functions()[function_name].entrypoint(**kwargs))
+            assert payload == {
+                "error": "MCP OAuth provider 'mcp_demo' requires a requester identity",
+                "oauth_connection_required": True,
+                "provider": "mcp_demo",
+                "connect_url": None,
+            }
+    finally:
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("worker_scope", ["user", "user_agent"])
+async def test_requestless_oauth_scope_does_not_block_unrelated_dynamic_tool_load(
+    tmp_path: Path,
+    worker_scope: WorkerScope,
+) -> None:
+    """An unavailable requester scope must not make unrelated deferred tools unloadable."""
+    runtime_paths = _runtime_paths(tmp_path)
+    config = Config.validate_with_runtime(
+        {
+            "mcp_servers": {
+                "demo": _oauth_mcp_config().model_dump(exclude_none=True),
+            },
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Use local and MCP tools",
+                    "tools": ["mcp_demo", {"shell": {"defer": True}}],
+                    "worker_scope": worker_scope,
+                },
+            },
+        },
+        runtime_paths,
+    )
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(config)
+    worker_target = resolve_worker_target(worker_scope, "code", None)
+    toolkit = DynamicToolsToolkit(
+        agent_name="code",
+        config=config,
+        session_id="thread-a",
+        worker_target=worker_target,
+    )
+
+    bind_mcp_server_manager(manager)
+    try:
+        payload = json.loads(toolkit.load_tool("shell"))
+    finally:
+        await manager.shutdown()
+        bind_mcp_server_manager(None)
+
+    assert payload["status"] == "loaded"
+    assert payload["loaded_tools"] == ["shell"]
+
+
+@pytest.mark.asyncio
 async def test_oauth_mcp_user_scope_reuses_account_across_agents(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -2133,12 +2133,32 @@ async def test_requestless_scoped_oauth_mcp_toolkit_keeps_bridge_surface(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("worker_scope", ["user", "user_agent"])
-async def test_requestless_requester_scoped_oauth_mcp_bridges_return_connection_required(
+@pytest.mark.parametrize(
+    ("worker_scope", "expected_error"),
+    [
+        pytest.param(
+            "shared",
+            "MCP OAuth provider 'mcp_demo' requires a complete credential target",
+            id="shared",
+        ),
+        pytest.param(
+            "user",
+            "MCP OAuth provider 'mcp_demo' requires a requester identity",
+            id="user",
+        ),
+        pytest.param(
+            "user_agent",
+            "MCP OAuth provider 'mcp_demo' requires a requester identity",
+            id="user-agent",
+        ),
+    ],
+)
+async def test_requestless_incomplete_oauth_mcp_bridges_return_connection_required(
     tmp_path: Path,
     worker_scope: WorkerScope,
+    expected_error: str,
 ) -> None:
-    """Requester-scoped bridge calls without a requester must return their structured recovery payload."""
+    """Bridge calls without a complete scope target must return their structured recovery payload."""
     runtime_paths = _runtime_paths(tmp_path)
     server_config = _oauth_mcp_config()
     manager = MCPServerManager(runtime_paths)
@@ -2161,7 +2181,7 @@ async def test_requestless_requester_scoped_oauth_mcp_bridges_return_connection_
         for function_name, kwargs in calls.items():
             payload = json.loads(await toolkit.get_async_functions()[function_name].entrypoint(**kwargs))
             assert payload == {
-                "error": "MCP OAuth provider 'mcp_demo' requires a requester identity",
+                "error": expected_error,
                 "oauth_connection_required": True,
                 "provider": "mcp_demo",
                 "connect_url": None,
@@ -2171,7 +2191,7 @@ async def test_requestless_requester_scoped_oauth_mcp_bridges_return_connection_
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("worker_scope", ["user", "user_agent"])
+@pytest.mark.parametrize("worker_scope", ["shared", "user", "user_agent"])
 async def test_requestless_oauth_scope_does_not_block_unrelated_dynamic_tool_load(
     tmp_path: Path,
     worker_scope: WorkerScope,

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -4645,22 +4645,46 @@ async def test_mcp_manager_allows_local_function_name_collisions_on_other_agents
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("worker_scope", ["shared", "user_agent"])
-async def test_agent_owned_oauth_catalog_ignores_local_collisions_on_other_agents(
+@pytest.mark.parametrize(
+    ("catalog_scope", "other_agent_scope"),
+    [
+        pytest.param("shared", "shared", id="shared-owner"),
+        pytest.param("user_agent", "user_agent", id="user-agent-owner"),
+        pytest.param("user", "shared", id="user-vs-shared"),
+        pytest.param(None, "user", id="unscoped-vs-user"),
+    ],
+)
+async def test_oauth_catalog_ignores_unreachable_local_collisions(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    worker_scope: WorkerScope,
+    catalog_scope: WorkerScope | None,
+    other_agent_scope: WorkerScope,
 ) -> None:
-    """An agent-owned OAuth catalog should be projected only onto its owning agent."""
+    """An OAuth catalog should be projected only onto agents that can reach its scope."""
     _patch_manager(monkeypatch)
     _FakeClientSession.tool_list = [_tool("echo")]
     runtime_paths = _runtime_paths(tmp_path)
-    worker_target = _worker_target(
-        "@alice:example.test",
-        worker_scope=worker_scope,
-        agent_name="code",
-    )
-    _save_mcp_oauth_credentials(runtime_paths, worker_target, "code-token")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    if catalog_scope is None:
+        worker_target = None
+        credentials_manager.save_credentials("mcp_demo_oauth_client", {"client_id": "public-client"})
+        credentials_manager.save_credentials(
+            "mcp_demo_oauth",
+            {
+                "token": "installation-token",
+                "client_id": "public-client",
+                "scopes": [],
+                "_source": "oauth",
+                "_oauth_provider": "mcp_demo",
+            },
+        )
+    else:
+        worker_target = _worker_target(
+            "@alice:example.test",
+            worker_scope=catalog_scope,
+            agent_name="code",
+        )
+        _save_mcp_oauth_credentials(runtime_paths, worker_target, "code-token")
 
     class _FakeToolkit:
         def __init__(self, tool_name: str) -> None:
@@ -4683,13 +4707,13 @@ async def test_agent_owned_oauth_catalog_ignores_local_collisions_on_other_agent
                     "display_name": "Code",
                     "role": "Use MCP",
                     "tools": ["mcp_demo"],
-                    "worker_scope": worker_scope,
+                    "worker_scope": catalog_scope,
                 },
                 "research": {
                     "display_name": "Research",
                     "role": "Use local and MCP tools",
                     "tools": ["shell", "mcp_demo"],
-                    "worker_scope": worker_scope,
+                    "worker_scope": other_agent_scope,
                 },
             },
         },
@@ -4700,7 +4724,7 @@ async def test_agent_owned_oauth_catalog_ignores_local_collisions_on_other_agent
 
     catalog = await manager.get_request_catalog(
         "demo",
-        credentials_manager=get_runtime_credentials_manager(runtime_paths),
+        credentials_manager=credentials_manager,
         worker_target=worker_target,
     )
 

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -2026,6 +2026,37 @@ async def test_oauth_mcp_shared_scope_keeps_accounts_separate_per_agent(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("worker_scope", ["shared", "user", "user_agent"])
+async def test_requestless_scoped_oauth_mcp_toolkit_keeps_bridge_surface(
+    tmp_path: Path,
+    worker_scope: WorkerScope,
+) -> None:
+    """A scoped OAuth MCP toolkit without request identity should remain constructible."""
+    runtime_paths = _runtime_paths(tmp_path)
+    server_config = _oauth_mcp_config()
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": server_config}))
+    worker_target = resolve_worker_target(worker_scope, "code", None)
+    assert worker_target.worker_key is None
+
+    toolkit = MindRoomMCPToolkit(
+        server_id="demo",
+        manager=manager,
+        catalog=None,
+        server_config=server_config,
+        runtime_paths=runtime_paths,
+        credentials_manager=get_runtime_credentials_manager(runtime_paths),
+        worker_target=worker_target,
+    )
+
+    assert set(toolkit.get_async_functions()) == {
+        "demo_call_tool",
+        "demo_connection_status",
+        "demo_list_tools",
+    }
+
+
+@pytest.mark.asyncio
 async def test_oauth_mcp_user_scope_reuses_account_across_agents(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -4611,6 +4642,70 @@ async def test_mcp_manager_allows_local_function_name_collisions_on_other_agents
 
     assert changed == {"demo"}
     assert manager.failed_server_ids() == set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("worker_scope", ["shared", "user_agent"])
+async def test_agent_owned_oauth_catalog_ignores_local_collisions_on_other_agents(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    worker_scope: WorkerScope,
+) -> None:
+    """An agent-owned OAuth catalog should be projected only onto its owning agent."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _worker_target(
+        "@alice:example.test",
+        worker_scope=worker_scope,
+        agent_name="code",
+    )
+    _save_mcp_oauth_credentials(runtime_paths, worker_target, "code-token")
+
+    class _FakeToolkit:
+        def __init__(self, tool_name: str) -> None:
+            self.functions = {"demo_echo": object()} if tool_name == "shell" else {}
+            self.async_functions = {}
+            self.tools = ()
+
+    monkeypatch.setattr(
+        "mindroom.mcp.surface_projection.get_tool_by_name",
+        lambda tool_name, *_args, **_kwargs: _FakeToolkit(tool_name),
+    )
+    config = Config.validate_with_runtime(
+        {
+            "defaults": {"tools": []},
+            "mcp_servers": {
+                "demo": _oauth_mcp_config().model_dump(exclude_none=True),
+            },
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Use MCP",
+                    "tools": ["mcp_demo"],
+                    "worker_scope": worker_scope,
+                },
+                "research": {
+                    "display_name": "Research",
+                    "role": "Use local and MCP tools",
+                    "tools": ["shell", "mcp_demo"],
+                    "worker_scope": worker_scope,
+                },
+            },
+        },
+        runtime_paths,
+    )
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(config)
+
+    catalog = await manager.get_request_catalog(
+        "demo",
+        credentials_manager=get_runtime_credentials_manager(runtime_paths),
+        worker_target=worker_target,
+    )
+
+    assert [tool.function_name for tool in catalog.tools] == ["demo_echo"]
+    assert next(iter(manager._scoped_states.values())).last_error is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -2960,6 +2960,133 @@ async def test_mcp_manager_shutdown_is_terminal_for_later_sync(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("reload_kind", ["agent_removed", "tool_removed", "scope_changed"])
+async def test_mcp_config_reload_retires_unreachable_oauth_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    reload_kind: str,
+) -> None:
+    """Hot reload should close a scoped OAuth session after its configured access disappears."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    runtime_paths = _runtime_paths(tmp_path)
+    server_config = _oauth_mcp_config()
+    initial_config = Config.validate_with_runtime(
+        {
+            "defaults": {"tools": []},
+            "mcp_servers": {"demo": server_config.model_dump(exclude_none=True)},
+            "agents": {
+                "code": {
+                    "display_name": "Code",
+                    "role": "Use MCP",
+                    "tools": ["mcp_demo"],
+                    "worker_scope": "shared",
+                },
+            },
+        },
+        runtime_paths,
+    )
+    worker_target = _shared_worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(runtime_paths, worker_target, "code-token")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(initial_config)
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    base_state = manager._states["demo"]
+    scoped_state = next(iter(manager._scoped_states.values()))
+    session = scoped_state.session
+    assert isinstance(session, _FakeClientSession)
+
+    reloaded_agents: dict[str, object]
+    if reload_kind == "agent_removed":
+        reloaded_agents = {}
+    else:
+        reloaded_agents = {
+            "code": {
+                "display_name": "Code",
+                "role": "Use MCP",
+                "tools": [] if reload_kind == "tool_removed" else ["mcp_demo"],
+                "worker_scope": "shared" if reload_kind == "tool_removed" else "user",
+            },
+        }
+    reloaded_config = Config.validate_with_runtime(
+        {
+            "defaults": {"tools": []},
+            "mcp_servers": {"demo": server_config.model_dump(exclude_none=True)},
+            "agents": reloaded_agents,
+        },
+        runtime_paths,
+    )
+
+    try:
+        await manager.sync_servers(reloaded_config)
+
+        assert manager._states["demo"] is base_state
+        assert manager._scoped_states == {}
+        assert manager._retiring_states == {}
+        assert scoped_state.retired is True
+        assert session.closed is True
+    finally:
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_mcp_config_reload_keeps_user_scope_reachable_from_another_agent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A requester-wide session should survive while another user-scoped agent can use it."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    runtime_paths = _runtime_paths(tmp_path)
+    server_config = _oauth_mcp_config()
+
+    def config_for_agents(agent_names: tuple[str, ...]) -> Config:
+        return Config.validate_with_runtime(
+            {
+                "defaults": {"tools": []},
+                "mcp_servers": {"demo": server_config.model_dump(exclude_none=True)},
+                "agents": {
+                    agent_name: {
+                        "display_name": agent_name.title(),
+                        "role": "Use MCP",
+                        "tools": ["mcp_demo"],
+                        "worker_scope": "user",
+                    }
+                    for agent_name in agent_names
+                },
+            },
+            runtime_paths,
+        )
+
+    worker_target = _worker_target("@alice:example.test", agent_name="code")
+    _save_mcp_oauth_credentials(runtime_paths, worker_target, "alice-token")
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(config_for_agents(("code", "research")))
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=get_runtime_credentials_manager(runtime_paths),
+        worker_target=worker_target,
+    )
+    scoped_state = next(iter(manager._scoped_states.values()))
+    session = scoped_state.session
+    assert isinstance(session, _FakeClientSession)
+
+    try:
+        await manager.sync_servers(config_for_agents(("research",)))
+
+        assert tuple(manager._scoped_states.values()) == (scoped_state,)
+        assert scoped_state.retired is False
+        assert session.closed is False
+    finally:
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_mcp_manager_shutdown_drains_every_state_when_one_close_fails(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -384,10 +384,15 @@ def _oauth_non_oauth_collision_config(runtime_paths: RuntimePaths) -> Config:
     )
 
 
-def _worker_target(requester_id: str, *, worker_scope: WorkerScope = "user") -> ResolvedWorkerTarget:
+def _worker_target(
+    requester_id: str,
+    *,
+    worker_scope: WorkerScope = "user",
+    agent_name: str = "code",
+) -> ResolvedWorkerTarget:
     identity = ToolExecutionIdentity(
         channel="matrix",
-        agent_name="code",
+        agent_name=agent_name,
         requester_id=requester_id,
         room_id="!room:example.test",
         thread_id="$thread",
@@ -396,7 +401,7 @@ def _worker_target(requester_id: str, *, worker_scope: WorkerScope = "user") -> 
         tenant_id="tenant",
         account_id=None,
     )
-    return resolve_worker_target(worker_scope, "code", identity)
+    return resolve_worker_target(worker_scope, agent_name, identity)
 
 
 def _shared_worker_target(requester_id: str, *, agent_name: str = "code") -> ResolvedWorkerTarget:
@@ -659,11 +664,11 @@ async def test_mcp_manager_uses_requester_oauth_bearer_token(
 
 
 @pytest.mark.asyncio
-async def test_requester_scoped_mcp_oauth_rejects_missing_identity_before_credential_load(
+async def test_unscoped_mcp_oauth_uses_installation_credential_and_session(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Identity-less MCP calls cannot fall back to a legacy global bearer or session key."""
+    """An unscoped MCP server adopts and uses its installation-level OAuth credential."""
     _patch_manager(monkeypatch)
     _FakeClientSession.tool_list = [_tool("echo")]
     runtime_paths = _runtime_paths(tmp_path)
@@ -672,7 +677,7 @@ async def test_requester_scoped_mcp_oauth_rejects_missing_identity_before_creden
     credentials_manager.save_credentials(
         "mcp_demo_oauth",
         {
-            "token": "legacy-global-token",
+            "token": "installation-token",
             "client_id": "public-client",
             "scopes": [],
             "_source": "oauth",
@@ -682,16 +687,14 @@ async def test_requester_scoped_mcp_oauth_rejects_missing_identity_before_creden
     manager = MCPServerManager(runtime_paths)
     await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
 
-    with pytest.raises(OAuthConnectionRequired, match="requester identity") as exc_info:
-        await manager.get_request_catalog(
-            "demo",
-            credentials_manager=credentials_manager,
-            worker_target=None,
-        )
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=None,
+    )
 
-    assert exc_info.value.connect_url is None
-    assert manager._scoped_states == {}
-    assert _FakeClientSession.transport_extra_headers == []
+    assert _FakeClientSession.transport_extra_headers == [{"Authorization": "Bearer installation-token"}]
+    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {("unscoped", "global")}
 
 
 @pytest.mark.asyncio
@@ -1952,20 +1955,17 @@ async def test_mcp_manager_allows_same_oauth_typed_tools_for_multiple_requesters
 
 
 @pytest.mark.asyncio
-async def test_oauth_mcp_shared_agent_still_isolates_requester_bearers(
+async def test_oauth_mcp_shared_agent_reuses_agent_bearer_across_requesters(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Shared worker reuse must not turn requester-owned MCP OAuth into an agent-global token."""
+    """A shared agent owns one MCP OAuth account used by every authorized requester."""
     _patch_manager(monkeypatch)
     _FakeClientSession.tool_list = [_tool("echo")]
     runtime_paths = _runtime_paths(tmp_path)
     alice_request_target = _shared_worker_target("@alice:example.test")
     bob_request_target = _shared_worker_target("@bob:example.test")
-    alice_credential_target = _worker_target("@alice:example.test", worker_scope="user")
-    bob_credential_target = _worker_target("@bob:example.test", worker_scope="user")
-    _save_mcp_oauth_credentials(runtime_paths, alice_credential_target, "alice-token")
-    _save_mcp_oauth_credentials(runtime_paths, bob_credential_target, "bob-token")
+    _save_mcp_oauth_credentials(runtime_paths, alice_request_target, "agent-token")
     credentials_manager = get_runtime_credentials_manager(runtime_paths)
     manager = MCPServerManager(runtime_paths)
     await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
@@ -1981,13 +1981,127 @@ async def test_oauth_mcp_shared_agent_still_isolates_requester_bearers(
         worker_target=bob_request_target,
     )
 
+    assert _FakeClientSession.transport_extra_headers == [{"Authorization": "Bearer agent-token"}]
+    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+        ("shared", alice_request_target.worker_key),
+    }
+
+
+@pytest.mark.asyncio
+async def test_oauth_mcp_shared_scope_keeps_accounts_separate_per_agent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Distinct shared agents can own different MCP OAuth accounts."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    runtime_paths = _runtime_paths(tmp_path)
+    first_target = _shared_worker_target("@alice:example.test", agent_name="code")
+    second_target = _shared_worker_target("@alice:example.test", agent_name="research")
+    _save_mcp_oauth_credentials(runtime_paths, first_target, "code-token")
+    _save_mcp_oauth_credentials(runtime_paths, second_target, "research-token")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=first_target,
+    )
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=second_target,
+    )
+
     assert _FakeClientSession.transport_extra_headers == [
-        {"Authorization": "Bearer alice-token"},
-        {"Authorization": "Bearer bob-token"},
+        {"Authorization": "Bearer code-token"},
+        {"Authorization": "Bearer research-token"},
     ]
-    assert {key.worker_key for key in manager._scoped_states} == {
-        alice_credential_target.worker_key,
-        bob_credential_target.worker_key,
+    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+        ("shared", first_target.worker_key),
+        ("shared", second_target.worker_key),
+    }
+
+
+@pytest.mark.asyncio
+async def test_oauth_mcp_user_scope_reuses_account_across_agents(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A user-scoped MCP OAuth account is shared across that requester's agents."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    runtime_paths = _runtime_paths(tmp_path)
+    first_target = _worker_target("@alice:example.test", agent_name="code")
+    second_target = _worker_target("@alice:example.test", agent_name="research")
+    assert first_target.worker_key == second_target.worker_key
+    _save_mcp_oauth_credentials(runtime_paths, first_target, "alice-token")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=first_target,
+    )
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=second_target,
+    )
+
+    assert _FakeClientSession.transport_extra_headers == [{"Authorization": "Bearer alice-token"}]
+    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+        ("user", first_target.worker_key),
+    }
+
+
+@pytest.mark.asyncio
+async def test_oauth_mcp_user_agent_scope_keeps_accounts_separate_per_agent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """One requester can connect distinct MCP OAuth accounts for different agents."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    runtime_paths = _runtime_paths(tmp_path)
+    first_target = _worker_target(
+        "@alice:example.test",
+        worker_scope="user_agent",
+        agent_name="code",
+    )
+    second_target = _worker_target(
+        "@alice:example.test",
+        worker_scope="user_agent",
+        agent_name="research",
+    )
+    _save_mcp_oauth_credentials(runtime_paths, first_target, "code-token")
+    _save_mcp_oauth_credentials(runtime_paths, second_target, "research-token")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=first_target,
+    )
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=second_target,
+    )
+
+    assert _FakeClientSession.transport_extra_headers == [
+        {"Authorization": "Bearer code-token"},
+        {"Authorization": "Bearer research-token"},
+    ]
+    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+        ("user_agent", first_target.worker_key),
+        ("user_agent", second_target.worker_key),
     }
 
 
@@ -2192,7 +2306,7 @@ async def test_mcp_provider_move_retires_current_provider_owner_not_old_server_i
     assert replacement_session is not None
     assert shared_session is not None
 
-    async with manager.retire_request_session(credential_context=old_context):
+    async with manager.retire_oauth_scope_session(credential_context=old_context):
         assert replacement_key in manager._scoped_states
         assert shared_key not in manager._scoped_states
 
@@ -2226,12 +2340,52 @@ async def test_mcp_manager_retires_requester_oauth_session(
         credentials_manager=credentials_manager,
     )
 
-    async with manager.retire_request_session(credential_context=credential_context):
+    async with manager.retire_oauth_scope_session(credential_context=credential_context):
         pass
 
     assert alice_session.closed is True
     assert bob_session.closed is False
     assert len(manager._scoped_states) == 1
+
+
+@pytest.mark.asyncio
+async def test_mcp_manager_retires_shared_agent_session_without_touching_other_agent(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Reset retirement follows the shared agent credential owner."""
+    _patch_manager(monkeypatch)
+    _FakeClientSession.tool_list = [_tool("echo")]
+    runtime_paths = _runtime_paths(tmp_path)
+    code_target = _shared_worker_target("@alice:example.test", agent_name="code")
+    research_target = _shared_worker_target("@alice:example.test", agent_name="research")
+    _save_mcp_oauth_credentials(runtime_paths, code_target, "code-token")
+    _save_mcp_oauth_credentials(runtime_paths, research_target, "research-token")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    await manager.get_request_catalog("demo", credentials_manager=credentials_manager, worker_target=code_target)
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=research_target,
+    )
+    code_session = _FakeClientSession.sessions[0]
+    research_session = _FakeClientSession.sessions[1]
+    credential_context = manager._oauth_credential_context(
+        manager._states["demo"],
+        worker_target=code_target,
+        credentials_manager=credentials_manager,
+    )
+
+    async with manager.retire_oauth_scope_session(credential_context=credential_context):
+        pass
+
+    assert code_session.closed is True
+    assert research_session.closed is False
+    assert {(key.worker_scope, key.worker_key) for key in manager._scoped_states} == {
+        ("shared", research_target.worker_key),
+    }
 
 
 @pytest.mark.asyncio
@@ -2267,7 +2421,7 @@ async def test_mcp_manager_retirement_waits_for_in_flight_requester_call(
     retirement_entered = asyncio.Event()
 
     async def retire() -> None:
-        async with manager.retire_request_session(credential_context=credential_context):
+        async with manager.retire_oauth_scope_session(credential_context=credential_context):
             retirement_entered.set()
 
     call_task = asyncio.create_task(
@@ -2327,7 +2481,7 @@ async def test_mcp_manager_retirement_fences_captured_state_and_new_requesters(
         credentials_manager=credentials_manager,
     )
 
-    async with manager.retire_request_session(credential_context=credential_context):
+    async with manager.retire_oauth_scope_session(credential_context=credential_context):
         assert captured_state.retired is True
         with pytest.raises(_MCPAuthorizationChangedError):
             await manager._refresh_server_catalog(
@@ -2377,7 +2531,7 @@ async def test_mcp_manager_retirement_allows_new_catalog_after_cancellation(
     finish_body = asyncio.Event()
 
     async def retire() -> None:
-        async with manager.retire_request_session(credential_context=credential_context):
+        async with manager.retire_oauth_scope_session(credential_context=credential_context):
             body_entered.set()
             await finish_body.wait()
 
@@ -2425,11 +2579,11 @@ async def test_mcp_manager_retirement_finishes_pre_yield_cleanup_before_cancella
         worker_target=worker_target,
         credentials_manager=credentials_manager,
     )
-    request_key = manager._request_session_key(
+    request_key = manager._scope_session_key(
         base_state,
         credential_context.worker_target,
         provider_id=credential_context.provider.id,
-    ).oauth_request_key
+    ).oauth_scope_key
     cleanup_started = asyncio.Event()
     allow_cleanup = asyncio.Event()
     cancellation_turn = asyncio.Event()
@@ -2443,7 +2597,7 @@ async def test_mcp_manager_retirement_finishes_pre_yield_cleanup_before_cancella
 
     async def retire() -> None:
         nonlocal body_entered
-        async with manager.retire_request_session(credential_context=credential_context):
+        async with manager.retire_oauth_scope_session(credential_context=credential_context):
             body_entered = True
 
     monkeypatch.setattr(manager, "_disconnect_state_when_idle", delayed_disconnect)
@@ -2456,7 +2610,7 @@ async def test_mcp_manager_retirement_finishes_pre_yield_cleanup_before_cancella
     assert retirement.done() is False
     assert manager._scoped_states == {}
     assert manager._retiring_states == {id(state): state}
-    assert request_key in manager._retired_request_keys
+    assert request_key in manager._retired_scope_keys
     with pytest.raises(OAuthConnectionRequired):
         await manager.get_request_catalog(
             "demo",
@@ -2472,7 +2626,7 @@ async def test_mcp_manager_retirement_finishes_pre_yield_cleanup_before_cancella
     assert body_entered is False
     assert session.closed is True
     assert manager._retiring_states == {}
-    assert request_key not in manager._retired_request_keys
+    assert request_key not in manager._retired_scope_keys
 
 
 @pytest.mark.asyncio
@@ -2508,7 +2662,7 @@ async def test_mcp_manager_retires_stale_cached_session_for_current_connection_g
         credential_generation="stale-cached-generation",
     )
 
-    async with manager.retire_request_session(
+    async with manager.retire_oauth_scope_session(
         credential_context=credential_context,
         expected_connection_generation=approved_connection_generation,
     ):
@@ -2546,7 +2700,7 @@ async def test_mcp_manager_does_not_retire_session_from_later_connection_generat
         credentials_manager=credentials_manager,
     )
 
-    async with manager.retire_request_session(
+    async with manager.retire_oauth_scope_session(
         credential_context=credential_context,
         expected_connection_generation="older-approved-connection-generation",
     ):
@@ -2846,8 +3000,8 @@ async def test_request_retirement_drains_later_states_before_propagating_cleanup
 
     monkeypatch.setattr(manager, "_disconnect_state_when_idle", disconnect)
 
-    with pytest.raises(MCPConnectionError, match="requester session cleanup failed"):
-        await manager._drain_retired_request_states((first, second))
+    with pytest.raises(MCPConnectionError, match="credential-scope session cleanup failed"):
+        await manager._drain_retired_oauth_scope_states((first, second))
 
     assert drained == ["first", "second"]
     assert manager._retiring_states == {id(first): first}
@@ -3924,19 +4078,19 @@ async def test_mcp_manager_ignores_deferred_unloaded_local_function_collisions_a
         ),
     ],
 )
-async def test_dynamic_load_rejects_requester_scoped_oauth_mcp_function_collision(
+async def test_dynamic_load_rejects_scoped_oauth_mcp_function_collision(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     worker_scope: WorkerScope,
     requester_id: str,
     authorization: dict[str, object],
 ) -> None:
-    """Deferred tools should collide with the active requester's discovered OAuth MCP catalog."""
+    """Deferred tools should collide with the active credential scope's discovered OAuth MCP catalog."""
     _patch_manager(monkeypatch)
     _FakeClientSession.tool_list = [_tool("shell_command")]
     runtime_paths = _runtime_paths(tmp_path)
     worker_target = _worker_target(requester_id, worker_scope=worker_scope)
-    credential_target = _worker_target("@alice:example.test")
+    credential_target = _worker_target("@alice:example.test", worker_scope=worker_scope)
     _save_mcp_oauth_credentials(runtime_paths, credential_target, "alice-token")
     config = Config.validate_with_runtime(
         {

--- a/tests/test_mcp_oauth.py
+++ b/tests/test_mcp_oauth.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import subprocess
 import sys
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, ClassVar
 from urllib.parse import parse_qs, urlparse
 
@@ -13,7 +14,7 @@ import pytest
 from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
 from mindroom.credential_policy import RUNTIME_BOOTSTRAPPED_CLIENT_CONFIG_KEY, credential_service_policy
-from mindroom.credentials import get_runtime_credentials_manager, save_scoped_credentials
+from mindroom.credentials import get_runtime_credentials_manager, save_scoped_credentials, scoped_credentials_path
 from mindroom.mcp.config import MCPServerConfig
 from mindroom.mcp.oauth import (
     _mcp_oauth_provider_is_configured,
@@ -21,6 +22,7 @@ from mindroom.mcp.oauth import (
     mcp_oauth_provider,
     mcp_oauth_provider_id,
 )
+from mindroom.oauth.credential_lifecycle import load_oauth_credentials_snapshot, resolve_oauth_credential_context
 from mindroom.oauth.discovery import (
     _DISCOVERY_CACHE,
     _DYNAMIC_CLIENT_REGISTRATION_LOCKS,
@@ -28,7 +30,7 @@ from mindroom.oauth.discovery import (
 )
 from mindroom.oauth.providers import OAuthProvider, OAuthProviderError
 from mindroom.oauth.registry import clear_oauth_provider_cache, load_oauth_providers
-from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_worker_target
+from mindroom.tool_system.worker_routing import ToolExecutionIdentity, WorkerScope, resolve_worker_target
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
@@ -209,7 +211,7 @@ class _InvalidJsonDiscoveryResponse(_FakeDiscoveryResponse):
 
 
 def test_mcp_oauth_provider_defaults_to_mcp_server_provider_id() -> None:
-    """Generated MCP OAuth providers use deterministic services and public-client defaults."""
+    """Generated MCP OAuth providers use deterministic services and follow the agent credential scope."""
     provider = mcp_oauth_provider("demo", _oauth_mcp_server_config())
 
     assert provider.id == "mcp_demo"
@@ -224,7 +226,7 @@ def test_mcp_oauth_provider_defaults_to_mcp_server_provider_id() -> None:
     assert provider.pkce_code_challenge_method == "S256"
     assert provider.extra_auth_params == {"audience": "example"}
     assert provider.extra_token_params == {"resource": "https://mcp.example.test/mcp"}
-    assert provider.requester_scoped_credentials is True
+    assert provider.requester_scoped_credentials is False
 
 
 def test_custom_mcp_oauth_provider_id_keeps_generated_credential_services_mcp_scoped() -> None:
@@ -573,3 +575,63 @@ def test_mcp_oauth_credentials_are_primary_runtime_scoped_for_user_agents(tmp_pa
 
     assert manager.load_credentials("mcp_demo_oauth") is None
     assert manager.for_worker(worker_target.worker_key).load_credentials("mcp_demo_oauth") is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("worker_scope", ["shared", "user_agent"])
+async def test_mcp_oauth_scope_policy_recovers_legacy_credentials_after_empty_requester_store(
+    tmp_path: Path,
+    worker_scope: WorkerScope,
+) -> None:
+    """Correct-scope legacy credentials remain adoptable after a requester store was created."""
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = get_runtime_credentials_manager(runtime_paths)
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="code",
+        requester_id="@alice:example.test",
+        room_id="!room:example.test",
+        thread_id="$thread",
+        resolved_thread_id="$thread",
+        session_id=None,
+        tenant_id="tenant",
+        account_id=None,
+    )
+    worker_target = resolve_worker_target(worker_scope, "code", identity)
+    provider = mcp_oauth_provider("demo", _oauth_mcp_server_config())
+    legacy_credentials = {
+        "token": "legacy-token",
+        "_source": "oauth",
+        "_oauth_provider": provider.id,
+    }
+    save_scoped_credentials(
+        provider.credential_service,
+        legacy_credentials,
+        credentials_manager=manager,
+        worker_target=worker_target,
+    )
+    legacy_path = scoped_credentials_path(
+        provider.credential_service,
+        credentials_manager=manager,
+        worker_target=worker_target,
+    )
+
+    requester_only_context = resolve_oauth_credential_context(
+        replace(provider, requester_scoped_credentials=True),
+        runtime_paths,
+        manager,
+        worker_target,
+    )
+    assert (await load_oauth_credentials_snapshot(requester_only_context)).credentials is None
+
+    scope_context = resolve_oauth_credential_context(
+        provider,
+        runtime_paths,
+        manager,
+        worker_target,
+    )
+    snapshot = await load_oauth_credentials_snapshot(scope_context)
+
+    assert scope_context.worker_target == worker_target
+    assert snapshot.credentials == legacy_credentials
+    assert not legacy_path.exists()

--- a/tests/test_mcp_toolkit.py
+++ b/tests/test_mcp_toolkit.py
@@ -295,13 +295,13 @@ async def test_oauth_mcp_toolkit_bridge_descriptions_without_server_description(
     )
 
     assert toolkit.async_functions["demo_connection_status"].description == (
-        "Check whether MCP server 'demo' is connected for the current requester."
+        "Check whether MCP server 'demo' is connected for this agent's credential scope."
     )
     assert toolkit.async_functions["demo_list_tools"].description == (
-        "List remote tools exposed by MCP server 'demo' for the current requester."
+        "List remote tools exposed by MCP server 'demo' for this agent's credential scope."
     )
     assert toolkit.async_functions["demo_call_tool"].description == (
-        "Call one remote tool on MCP server 'demo' for the current requester."
+        "Call one remote tool on MCP server 'demo' for this agent's credential scope."
     )
 
 

--- a/tests/test_oauth_service.py
+++ b/tests/test_oauth_service.py
@@ -792,7 +792,7 @@ async def test_completed_browser_reset_replay_skips_mcp_retirement(
         retirement_entered = True
         yield
 
-    monkeypatch.setattr(reset_execution, "retire_mcp_oauth_request_session", retirement)
+    monkeypatch.setattr(reset_execution, "retire_mcp_oauth_scope_session", retirement)
 
     deleted = await reset_execution.retire_and_reset_oauth_credentials(
         context,


### PR DESCRIPTION
## Summary

- Make generated MCP OAuth providers follow the selected agent's effective credential scope.
- Key MCP catalogs, sessions, reset retirement, and collision surfaces by the canonical credential target.
- Preserve safe upgrades by adopting legacy credentials already stored at the correct target without reassigning ambiguous cross-scope accounts.
- Document and test shared, user, user-agent, private-agent, and unscoped ownership.

## Validation

- `uv run pytest tests/test_agents.py tests/test_config_manager_consolidated.py tests/test_dynamic_toolkits.py tests/test_generate_skill_references.py tests/test_import_graph.py tests/test_mcp_config.py tests/test_mcp_function_surface.py tests/test_mcp_manager.py tests/test_mcp_oauth.py tests/test_mcp_orchestrator.py tests/test_mcp_registry.py tests/test_mcp_results.py tests/test_mcp_toolkit.py tests/test_mcp_transports.py tests/test_oauth_credential_store.py tests/test_oauth_service.py tests/test_resolve_tool_worker_target.py tests/api/test_oauth_api.py -x -n 0 --no-cov -q`
- `uv run pre-commit run --files $(git diff --name-only origin/main..HEAD)`
- `uv run ty check src tests`
- `uv run tach check --dependencies --interfaces`

## Summary by Sourcery

Make generated MCP OAuth providers follow the selected agent's effective credential scope and isolate connection state by canonical ownership.

Bug Fixes:
- Align generated MCP OAuth credentials, sessions, catalogs, reset handling, and collision detection with each agent's effective credential scope.
- Preserve compatible legacy MCP OAuth credentials at their canonical scope without adopting ambiguous credentials from other scopes.

Enhancements:
- Support shared, user, user-agent, private-agent, and unscoped ownership for MCP OAuth connections, including scope-aware configuration reload and session retirement.

Documentation:
- Document MCP OAuth ownership, connection reuse, reset behavior, and scope-specific access across configuration and OAuth guidance.

Tests:
- Expand MCP OAuth, catalog, collision, reset, reload, credential lifecycle, and API coverage across all supported credential scopes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP OAuth credentials and sessions now follow the selected agent’s effective execution scope.
  * Supports shared, user, user-agent, private-agent, and installation-wide credential ownership.
  * Scoped catalogs, tool visibility, and collision handling now reflect credential ownership.

* **Bug Fixes**
  * Improved OAuth session cleanup, reset handling, and stale-session protection across credential scopes.
  * Non-OAuth MCP servers continue using shared sessions.

* **Documentation**
  * Updated MCP and OAuth guidance to explain scope-based credentials, reconnection, retries, reset limitations, and dashboard controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->