### PR TITLE
Fix paused runs in shared conversation sessions

### DIFF
--- a/src/mindroom/agent_storage.py
+++ b/src/mindroom/agent_storage.py
@@ -88,7 +88,7 @@ def _create_sqlite_state_storage(
     db_file = str(db_dir / f"{storage_name}.db")
     engine = _state_engine(db_file)
     if prompt_roles is not None:
-        return _PromptSanitizingSqliteDb(
+        return _ConversationSqliteDb(
             prompt_roles=prompt_roles,
             session_table=session_table,
             db_file=db_file,
@@ -142,8 +142,8 @@ def _create_agent_session_db(
     )
 
 
-class _PromptSanitizingSqliteDb(SqliteDb):
-    """SQLite session DB that strips prompt messages before durable persistence."""
+class _ConversationSqliteDb(SqliteDb):
+    """SQLite session DB with conversation-specific persistence semantics."""
 
     def __init__(
         self,
@@ -155,6 +155,22 @@ class _PromptSanitizingSqliteDb(SqliteDb):
     ) -> None:
         super().__init__(session_table=session_table, db_file=db_file, db_engine=db_engine)
         self._prompt_roles = prompt_roles
+
+    def get_session(
+        self,
+        session_id: str,
+        session_type: SessionType | None = None,
+        user_id: str | None = None,
+        deserialize: bool | None = True,
+    ) -> Session | dict[str, Any] | None:
+        """Read a canonical conversation session without treating its requester as its owner."""
+        _ = user_id
+        return super().get_session(
+            session_id=session_id,
+            session_type=session_type,
+            user_id=None,
+            deserialize=deserialize,
+        )
 
     def upsert_session(
         self,

--- a/tests/test_history_scope_state.py
+++ b/tests/test_history_scope_state.py
@@ -54,6 +54,26 @@ from tests.history_helpers import (  # noqa: F401
 )
 
 
+def _shared_session(*, is_team: bool) -> AgentSession | TeamSession:
+    if is_team:
+        return TeamSession(
+            session_id="session-1",
+            team_id="test_agent",
+            user_id="@history-owner:localhost",
+            runs=[],
+            created_at=1,
+            updated_at=1,
+        )
+    return AgentSession(
+        session_id="session-1",
+        agent_id="test_agent",
+        user_id="@history-owner:localhost",
+        runs=[],
+        created_at=1,
+        updated_at=1,
+    )
+
+
 def test_scope_seen_event_ids_survive_scope_state_writes(tmp_path: Path) -> None:
     _config, _runtime_paths_value = _make_config(tmp_path)
     scope = HistoryScope(kind="team", scope_id="team-123")
@@ -186,11 +206,11 @@ def test_seen_event_ids_match_model_history_visibility(is_team: bool) -> None:
 
 @pytest.mark.parametrize("is_team", [False, True], ids=["agent", "team"])
 @pytest.mark.asyncio
-async def test_paused_run_preserves_prompt_roles_until_continuation_completes(
+async def test_shared_session_paused_run_preserves_prompt_roles_until_continuation_completes(
     tmp_path: Path,
     is_team: bool,
 ) -> None:
-    """A fresh Agno runtime must see the persisted system prompt only while continuing a pause."""
+    """A fresh runtime must resume a paused run in a session shared by multiple requesters."""
     config, runtime_paths = _make_config(tmp_path)
     executed: list[list[str]] = []
 
@@ -224,11 +244,13 @@ async def test_paused_run_preserves_prompt_roles_until_continuation_completes(
         return entity, model
 
     first_storage = create_session_storage("test_agent", config, runtime_paths, execution_identity=None)
+    assert first_storage.upsert_session(_shared_session(is_team=is_team)) is not None
+
     first, _first_model = runtime(first_storage)
     paused = await first.arun(
         "exercise the tool",
         session_id="session-1",
-        user_id="@user:localhost",
+        user_id="@requester:localhost",
         stream=False,
     )
     assert paused.status is RunStatus.paused
@@ -240,11 +262,14 @@ async def test_paused_run_preserves_prompt_roles_until_continuation_completes(
     try:
         session = await resumed.aget_session(
             session_id="session-1",
-            user_id="@user:localhost",
+            user_id="@requester:localhost",
         )
+        assert session is not None
+        assert session.user_id == "@history-owner:localhost"
         persisted = session.get_run(paused.run_id)
         assert persisted is not None
         assert persisted.status == RunStatus.paused
+        assert persisted.user_id == "@requester:localhost"
         assert [message.role for message in persisted.messages or ()][:2] == ["system", "user"]
         requirements = deepcopy(persisted.requirements or [])
         assert len(requirements) == 1
@@ -256,7 +281,7 @@ async def test_paused_run_preserves_prompt_roles_until_continuation_completes(
                     run_response=persisted,
                     requirements=requirements,
                     session_id="session-1",
-                    user_id="@user:localhost",
+                    user_id="@requester:localhost",
                     stream=False,
                 )
             else:
@@ -264,7 +289,7 @@ async def test_paused_run_preserves_prompt_roles_until_continuation_completes(
                     run_id=paused.run_id,
                     requirements=requirements,
                     session_id="session-1",
-                    user_id="@user:localhost",
+                    user_id="@requester:localhost",
                     stream=False,
                 )
 
@@ -276,10 +301,13 @@ async def test_paused_run_preserves_prompt_roles_until_continuation_completes(
 
         completed_session = await resumed.aget_session(
             session_id="session-1",
-            user_id="@user:localhost",
+            user_id="@requester:localhost",
         )
+        assert completed_session is not None
+        assert completed_session.user_id == "@history-owner:localhost"
         completed_run = completed_session.get_run(paused.run_id)
         assert completed_run is not None
+        assert completed_run.user_id == "@requester:localhost"
         assert all(message.role not in {"system", "developer"} for message in completed_run.messages or ())
     finally:
         resumed_storage.close()


### PR DESCRIPTION
## Summary

- resolve canonical conversation sessions by session ID instead of treating the requester as the session owner
- preserve requester identity on individual run records
- cover agent and team paused-run continuation across participants

## Testing

- `uv run pytest tests/test_history_scope_state.py -n 0 --no-cov -q`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Fix shared-session paused-run continuation so canonical session ownership and per-run requester identity remain distinct.

Bug Fixes:
- Allow paused agent and team runs to resume correctly when different requesters access the same shared conversation session.

Enhancements:
- Resolve shared conversation sessions by their session ID while preserving the requester identity on individual runs.
- Retain prompt-role history during paused-run continuation and remove it after completion.

Tests:
- Add coverage for paused-run continuation across participants in shared agent and team sessions.