### PR TITLE
Preserve approval tool markers and refresh subprocess PATH

### DIFF
--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -161,6 +161,7 @@ async def refresh_knowledge_binding_in_subprocess(
         force_reindex=force_reindex,
     )
     env = dict(runtime_env_values(runtime_paths))
+    env.setdefault("PATH", os.environ.get("PATH") or os.defpath)
     env.update(_REFRESH_SUBPROCESS_THREAD_ENV)
     env["MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"] = "1"
     # Resolved before the spawn so a malformed window rejects the refresh

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -99,6 +99,7 @@ from mindroom.teams import (
 from mindroom.thread_summary import thread_summary_message_count_hint
 from mindroom.timing import DispatchPipelineTiming, timed
 from mindroom.tool_system.dynamic_toolkits import visible_tool_surface
+from mindroom.tool_system.events import format_tool_trace_markers
 from mindroom.tool_system.runtime_context import ToolDispatchContext, runtime_context_from_dispatch_context
 from mindroom.tool_system.worker_routing import (
     parse_tool_execution_identity_payload,
@@ -956,18 +957,26 @@ class ResponseRunner:
         )
         if isinstance(result, CompletedApprovalRun):
             current = await self.deps.approval_store.approval_continuation(claimed.approval_id) or claimed
+            show_tool_calls = self._show_tool_calls()
+            visible_tool_trace = tool_trace if show_tool_calls else []
+            tool_markers = format_tool_trace_markers(visible_tool_trace)
+            response_text = (
+                f"{tool_markers}\n\n{result.response_text}"
+                if tool_markers and result.response_text
+                else tool_markers or result.response_text
+            )
             return (
                 await self.deps.delivery_gateway.deliver_final(
                     FinalDeliveryRequest(
                         target=target,
                         existing_event_id=claimed.response_event_id,
                         existing_event_is_placeholder=False,
-                        response_text=result.response_text,
+                        response_text=response_text,
                         identity=self._response_identity(
                             request,
                             response_kind="team" if claimed.entity_kind == "team" else "ai",
                         ),
-                        tool_trace=tool_trace if self._show_tool_calls() else None,
+                        tool_trace=visible_tool_trace if show_tool_calls else None,
                         extra_content=_merge_response_extra_content(
                             {**result.metadata_content, STREAM_STATUS_KEY: STREAM_STATUS_COMPLETED},
                             claimed.attachment_ids,

--- a/src/mindroom/tool_system/events.py
+++ b/src/mindroom/tool_system/events.py
@@ -447,6 +447,18 @@ def _format_tool_marker(tool_name: str, tool_index: int | None, *, pending: bool
     return f"\n\n{_tool_marker_line(tool_name, tool_index, pending=pending)}\n\n"
 
 
+def format_tool_trace_markers(tool_trace: Sequence[ToolTraceEntry]) -> str:
+    """Render indexed visible anchors for structured tool-trace entries."""
+    return "\n\n".join(
+        _tool_marker_line(
+            trace_entry.tool_name,
+            tool_index,
+            pending=trace_entry.type == "tool_call_started",
+        )
+        for tool_index, trace_entry in enumerate(tool_trace, start=1)
+    )
+
+
 def _format_tool_args(tool_args: dict[str, object]) -> tuple[str, bool]:
     parts: list[str] = []
     truncated = False

--- a/tach.toml
+++ b/tach.toml
@@ -4791,6 +4791,7 @@ expose = [
     "format_tool_combined",
     "format_tool_completed_event",
     "format_tool_started_event",
+    "format_tool_trace_markers",
     "render_tool_trace_for_context",
 ]
 from = ["mindroom.tool_system.events"]

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -5690,7 +5690,9 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The subprocess helper sends the scheduled config snapshot via stdin."""
+    """The subprocess gets its config snapshot and the launcher's executable path."""
+    launcher_bin = tmp_path / "nix-profile" / "bin"
+    monkeypatch.setenv("PATH", str(launcher_bin))
     docs_path = tmp_path / "docs"
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     config.knowledge_bases["docs"].chunk_size = 1234
@@ -5752,6 +5754,7 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     assert captured_args[:3] == (sys.executable, "-m", "mindroom.knowledge_refresh_runner")
     assert "--request-path" not in captured_args
     assert captured_env["MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"] == "1"
+    assert captured_env["PATH"] == str(launcher_bin)
     assert captured_stdin is not None
     captured_request.update(json.loads(bytes(captured_stdin.payload).decode()))
     assert captured_request["base_id"] == "docs"

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -5686,17 +5686,25 @@ async def test_refresh_scheduler_refresh_now_runs_directly_with_force_reindex(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("explicit_runtime_path", [False, True], ids=["launcher-fallback", "runtime-override"])
 async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    explicit_runtime_path: bool,
 ) -> None:
-    """The subprocess gets its config snapshot and the launcher's executable path."""
+    """The subprocess gets its config snapshot and the correct executable path."""
     launcher_bin = tmp_path / "nix-profile" / "bin"
+    runtime_bin = tmp_path / "runtime-bin"
     monkeypatch.setenv("PATH", str(launcher_bin))
     docs_path = tmp_path / "docs"
     config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
     config.knowledge_bases["docs"].chunk_size = 1234
     runtime_paths = runtime_paths_for(config)
+    path_overrides = ({}, {"PATH": str(runtime_bin)})[explicit_runtime_path]
+    runtime_paths = replace(
+        runtime_paths,
+        process_env={**runtime_paths.process_env, **path_overrides},
+    )
     captured_request: dict[str, object] = {}
     captured_args: tuple[object, ...] = ()
     captured_env: dict[str, str] = {}
@@ -5754,7 +5762,7 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     assert captured_args[:3] == (sys.executable, "-m", "mindroom.knowledge_refresh_runner")
     assert "--request-path" not in captured_args
     assert captured_env["MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"] == "1"
-    assert captured_env["PATH"] == str(launcher_bin)
+    assert captured_env["PATH"] == str((launcher_bin, runtime_bin)[explicit_runtime_path])
     assert captured_stdin is not None
     captured_request.update(json.loads(bytes(captured_stdin.payload).decode()))
     assert captured_request["base_id"] == "docs"

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -98,6 +98,7 @@ from mindroom.synthetic_model import SyntheticModel
 from mindroom.thread_summary import thread_summary_message_count_hint
 from mindroom.timing import DispatchPipelineTiming
 from mindroom.tool_system.approval_exemptions import register_tool_approval_exemption
+from mindroom.tool_system.events import ToolTraceEntry
 from mindroom.tool_system.runtime_context import ToolDispatchContext
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 from mindroom.turn_policy import PreparedDispatch
@@ -2323,6 +2324,63 @@ async def test_automatic_pause_without_visible_event_sends_neutral_placeholder(t
     assert outcome.final_visible_body == "Thinking..."
     assert outcome.delivery_kind == "sent"
     assert outcome.extra_content == {STREAM_STATUS_KEY: STREAM_STATUS_PENDING}
+
+
+@pytest.mark.asyncio
+async def test_completed_approval_continuation_materializes_tool_markers_in_final_body(tmp_path: Path) -> None:
+    """A resumed final answer must retain visible anchors for its structured tool trace."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    target = _target(thread_id="$thread")
+    request = _plain_request(target, source_event_id="$source")
+    continuation = ApprovalContinuation(
+        approval_id="approval-visible-tools",
+        run_id="run-1",
+        session_id="session-1",
+        entity_kind="agent",
+        entity_name="general",
+        room_id=target.room_id,
+        thread_id=target.resolved_thread_id,
+        requester_id="@user:localhost",
+        response_event_id="$thinking",
+        source_event_ids=("$source",),
+        calls=(),
+        state="claimed",
+    )
+    trace = [
+        ToolTraceEntry(type="tool_call_completed", tool_name="fetch_report"),
+        ToolTraceEntry(type="tool_call_completed", tool_name="save_report"),
+    ]
+
+    async def continue_call(
+        *_args: object,
+        tool_trace_collector: list[ToolTraceEntry],
+        **_kwargs: object,
+    ) -> CompletedApprovalRun:
+        tool_trace_collector.extend(trace)
+        return CompletedApprovalRun(response_text="Final answer.", metadata_content={})
+
+    deliver_final = AsyncMock(
+        return_value=FinalDeliveryOutcome(
+            terminal_status="completed",
+            event_id="$thinking",
+            is_visible_response=True,
+            final_visible_body="Final answer.",
+            delivery_kind="edited",
+        ),
+    )
+    with (
+        patch.object(runner, "_continue_entity_call", new=continue_call),
+        patch.object(DeliveryGateway, "deliver_final", new=deliver_final),
+    ):
+        await runner._execute_claimed_approval(
+            continuation,
+            request=request,
+            target=target,
+        )
+
+    final_request = deliver_final.await_args.args[0]
+    assert final_request.response_text == ("🔧 `fetch_report` [1]\n\n🔧 `save_report` [2]\n\nFinal answer.")
+    assert final_request.tool_trace == trace
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- materialize indexed tool markers when an approval continuation completes, keeping the visible body aligned with structured trace metadata
- preserve the launcher PATH for knowledge refresh subprocesses when the runtime snapshot omits it, while respecting an explicit runtime PATH
- add regression coverage for both paths

## Why

Approval continuations completed through non-streaming final delivery could retain structured tool metadata without emitting visible marker anchors. Separately, refresh children without PATH fell back to conventional system directories, breaking executable discovery on systems with nonstandard tool locations.

## Testing

- `uv run pytest -n auto --no-cov -q`
- `uv run pre-commit run --all-files`
- `uv run tach check --dependencies --interfaces`

## Summary by Sourcery

Preserve tool-trace visibility and executable discovery across approval continuations and knowledge refresh subprocesses.

Bug Fixes:
- Preserve visible indexed tool markers when delivering completed approval continuations with structured tool traces.
- Ensure knowledge refresh subprocesses retain the launcher PATH when no runtime override is provided, while honoring explicit runtime PATH values.

Tests:
- Add regression coverage for approval continuation tool markers and refresh subprocess PATH propagation.