### PR TITLE
Fix oversized file edit fallback validation

### DIFF
--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -67,6 +67,7 @@ _SIDECAR_ONLY_MINDROOM_KEYS = frozenset(
         STREAM_VISIBLE_BODY_KEY,
     },
 )
+_FILE_FALLBACK_KEYS = ("url", "file", "filename", "info")
 _NONTERMINAL_STREAM_STATUSES = frozenset({STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING})
 _NONTERMINAL_STREAM_PREVIEW_BYTES = 12000
 _MATRIX_EVENT_HARD_LIMIT = 64000
@@ -99,6 +100,33 @@ def _copy_edit_wrapper_metadata(source_content: dict[str, Any], target_content: 
     target_content.update(
         {key: value for key, value in source_content.items() if _is_passthrough_edit_wrapper_key(key)},
     )
+
+
+def _copy_file_edit_fallback_fields(source_content: dict[str, Any], target_content: dict[str, Any]) -> None:
+    """Keep the outer fallback independently valid when an edit replaces a file."""
+    target_content.update({key: source_content[key] for key in _FILE_FALLBACK_KEYS if key in source_content})
+
+
+def _wrap_large_edit(
+    content: dict[str, Any],
+    source_content: dict[str, Any],
+    replacement_content: dict[str, Any],
+) -> dict[str, Any]:
+    """Build a compact edit wrapper whose fallback is valid on its own."""
+    source_msgtype = source_content.get("msgtype", "m.text")
+    wrapper_msgtype = (
+        replacement_content.get("msgtype", source_msgtype) if source_msgtype == "m.file" else source_msgtype
+    )
+    wrapper = {
+        "msgtype": wrapper_msgtype,
+        "body": f"* {replacement_content['body']}",
+        "m.new_content": replacement_content,
+        "m.relates_to": content.get("m.relates_to", {}),
+    }
+    if source_msgtype == "m.file":
+        _copy_file_edit_fallback_fields(replacement_content, wrapper)
+    _copy_edit_wrapper_metadata(source_content, wrapper)
+    return wrapper
 
 
 def _copy_inline_streaming_preview_metadata(source_content: dict[str, Any], target_content: dict[str, Any]) -> None:
@@ -633,13 +661,7 @@ async def prepare_large_message(
         modified_content["m.relates_to"] = content["m.relates_to"]
 
     if is_edit and "m.new_content" in content:
-        modified_content = {
-            "msgtype": source_content.get("msgtype", "m.text"),
-            "body": f"* {modified_content['body']}",
-            "m.new_content": modified_content,
-            "m.relates_to": content.get("m.relates_to", {}),
-        }
-        _copy_edit_wrapper_metadata(source_content, modified_content)
+        modified_content = _wrap_large_edit(content, source_content, modified_content)
 
     final_size = _calculate_event_size(modified_content)
     if final_size > 64000:

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -729,8 +729,11 @@ async def test_prepare_oversized_encrypted_file_edit_remains_parseable(
     assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
 
 
+@pytest.mark.parametrize("room_encrypted", [False, True])
 @pytest.mark.asyncio
-async def test_prepare_oversized_file_edit_upload_failure_uses_parseable_text_fallback() -> None:
+async def test_prepare_oversized_file_edit_upload_failure_uses_parseable_text_fallback(
+    room_encrypted: bool,
+) -> None:
     """A failed replacement sidecar upload must not leave an invalid file wrapper."""
     client = _UploadClient(RuntimeError("upload failed"))
     text = "updated file fallback " * 3000
@@ -750,7 +753,12 @@ async def test_prepare_oversized_file_edit_upload_failure_uses_parseable_text_fa
         "url": "mxc://server/previous-sidecar",
     }
 
-    prepared = await prepare_large_message(client, "!room:server", edit_content)
+    prepared = await prepare_large_message(
+        client,
+        "!room:server",
+        edit_content,
+        room_encrypted=room_encrypted,
+    )
 
     for event_id, fallback in (("$replacement", prepared), ("$new-content", prepared["m.new_content"])):
         parsed = nio.Event.parse_event(

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -659,6 +659,8 @@ async def test_prepare_oversized_file_edit_remains_parseable() -> None:
 
     assert isinstance(parsed, nio.RoomMessageFile)
     assert prepared["url"] == prepared["m.new_content"]["url"]
+    assert prepared["filename"] == prepared["m.new_content"]["filename"]
+    assert prepared["info"] == prepared["m.new_content"]["info"]
     assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
 
 
@@ -722,6 +724,49 @@ async def test_prepare_oversized_encrypted_file_edit_remains_parseable(
 
     assert isinstance(parsed, nio.RoomEncryptedFile)
     assert prepared["file"] == prepared["m.new_content"]["file"]
+    assert prepared["filename"] == prepared["m.new_content"]["filename"]
+    assert prepared["info"] == prepared["m.new_content"]["info"]
+    assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_prepare_oversized_file_edit_upload_failure_uses_parseable_text_fallback() -> None:
+    """A failed replacement sidecar upload must not leave an invalid file wrapper."""
+    client = _UploadClient(RuntimeError("upload failed"))
+    text = "updated file fallback " * 3000
+    edit_content = {
+        "body": f"* {text}",
+        "filename": "previous-message-content.json",
+        "info": {"mimetype": "application/json", "size": 123},
+        "m.new_content": {
+            "body": text,
+            "filename": "previous-message-content.json",
+            "info": {"mimetype": "application/json", "size": 123},
+            "msgtype": "m.file",
+            "url": "mxc://server/previous-sidecar",
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$original"},
+        "msgtype": "m.file",
+        "url": "mxc://server/previous-sidecar",
+    }
+
+    prepared = await prepare_large_message(client, "!room:server", edit_content)
+
+    for event_id, fallback in (("$replacement", prepared), ("$new-content", prepared["m.new_content"])):
+        parsed = nio.Event.parse_event(
+            {
+                "content": fallback,
+                "event_id": event_id,
+                "sender": "@agent:server",
+                "origin_server_ts": 123,
+                "type": "m.room.message",
+            },
+        )
+        assert isinstance(parsed, nio.RoomMessageText)
+        assert fallback["msgtype"] == "m.text"
+        for media_key in ("url", "file", "filename", "info"):
+            assert media_key not in fallback
+
     assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
 
 

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -32,6 +32,7 @@ from mindroom.matrix.large_messages import (
     prepare_large_message,
     should_send_oversized_nonterminal_streaming_edit,
 )
+from mindroom.matrix.media import parse_matrix_media_event_source
 from mindroom.matrix.message_content import extract_and_resolve_message
 from mindroom.tool_system.events import _TOOL_TRACE_KEY
 
@@ -622,6 +623,106 @@ async def test_prepare_edit_message() -> None:
     assert result["m.new_content"]["io.mindroom.long_text"]["version"] == 2
     assert client.uploaded_data is not None
     assert json.loads(client.uploaded_data.decode("utf-8")) == edit_content
+
+
+@pytest.mark.asyncio
+async def test_prepare_oversized_file_edit_remains_parseable() -> None:
+    """A sidecar-backed file edit must carry a valid outer fallback event."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/replacement-sidecar"))
+    text = "updated file preview " * 3000
+    edit_content = {
+        "body": f"* {text}",
+        "filename": "previous-message-content.json",
+        "info": {"mimetype": "application/json", "size": 123},
+        "m.new_content": {
+            "body": text,
+            "filename": "previous-message-content.json",
+            "info": {"mimetype": "application/json", "size": 123},
+            "msgtype": "m.file",
+            "url": "mxc://server/previous-sidecar",
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$original"},
+        "msgtype": "m.file",
+        "url": "mxc://server/previous-sidecar",
+    }
+
+    prepared = await prepare_large_message(client, "!room:server", edit_content)
+    parsed = nio.Event.parse_event(
+        {
+            "content": prepared,
+            "event_id": "$replacement",
+            "sender": "@agent:server",
+            "origin_server_ts": 123,
+            "type": "m.room.message",
+        },
+    )
+
+    assert isinstance(parsed, nio.RoomMessageFile)
+    assert prepared["url"] == prepared["m.new_content"]["url"]
+    assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_prepare_oversized_encrypted_file_edit_remains_parseable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Encrypted sidecar edits must carry their file descriptor on the fallback."""
+    encrypted_file = {
+        "url": "mxc://server/replacement-sidecar",
+        "key": {
+            "alg": "A256CTR",
+            "ext": True,
+            "key_ops": ["encrypt", "decrypt"],
+            "kty": "oct",
+            "k": "synthetic-key",
+        },
+        "iv": "synthetic-iv",
+        "hashes": {"sha256": "synthetic-hash"},
+        "v": "v2",
+        "mimetype": "application/json",
+        "size": 123,
+    }
+
+    async def upload_sidecar(*_args: object, **_kwargs: object) -> tuple[str, dict[str, object]]:
+        return "mxc://server/replacement-sidecar", encrypted_file
+
+    monkeypatch.setattr("mindroom.matrix.large_messages.upload_json_sidecar", upload_sidecar)
+    text = "updated encrypted file preview " * 3000
+    edit_content = {
+        "body": f"* {text}",
+        "file": {**encrypted_file, "url": "mxc://server/previous-sidecar"},
+        "filename": "previous-message-content.json",
+        "info": {"mimetype": "application/json", "size": 123},
+        "m.new_content": {
+            "body": text,
+            "file": {**encrypted_file, "url": "mxc://server/previous-sidecar"},
+            "filename": "previous-message-content.json",
+            "info": {"mimetype": "application/json", "size": 123},
+            "msgtype": "m.file",
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$original"},
+        "msgtype": "m.file",
+    }
+
+    prepared = await prepare_large_message(
+        _UploadClient(nio.UploadResponse("mxc://server/unused")),
+        "!room:server",
+        edit_content,
+        room_encrypted=True,
+    )
+    parsed = parse_matrix_media_event_source(
+        {
+            "content": prepared,
+            "event_id": "$replacement",
+            "sender": "@agent:server",
+            "origin_server_ts": 123,
+            "type": "m.room.message",
+        },
+    )
+
+    assert isinstance(parsed, nio.RoomEncryptedFile)
+    assert prepared["file"] == prepared["m.new_content"]["file"]
+    assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep the outer fallback of oversized file replacements independently valid
- preserve plaintext and encrypted sidecar locators with compact file metadata
- cover successful and failed sidecar uploads with strict parser regressions

## Root cause
Oversized replacement content was converted to a sidecar and then wrapped in a compact `m.replace` envelope containing only the original message type, body, and relation. When the replacement was already an `m.file`, the new sidecar locator existed only in `m.new_content`. Strict clients validate the outer fallback independently, so the missing `url` or encrypted `file` field made the persisted event unreadable.

## Prevention
- mirror the generated replacement locator, filename, and info onto file-shaped outer fallbacks
- adopt the generated text message type when a sidecar upload fails
- parse complete plaintext and encrypted events in regression tests
- enforce the hard event-size limit in every new regression

## Test plan
- `uv run pre-commit run --all-files`
- `uv run pytest`
- `uv run pytest tests/test_large_messages.py -q -n 0 --no-cov`
- `uv run pytest tests/test_matrix_media_event_parsing.py -q -n 0 --no-cov`

## Summary by Sourcery

Ensure oversized file edit fallbacks remain valid and parseable across successful and failed sidecar uploads.

Bug Fixes:
- Keep oversized file replacement edits independently parseable by preserving generated plaintext or encrypted file metadata on the outer fallback.
- Fall back to parseable text edits when replacement sidecar uploads fail.

Enhancements:
- Centralize large edit wrapper construction and fallback metadata handling.

Tests:
- Add strict plaintext and encrypted media parsing regressions for successful and failed oversized file edit sidecar uploads, including hard event-size limit checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of oversized file edits so media metadata is preserved correctly.
  - Ensured encrypted and unencrypted file edits remain parseable and within Matrix message limits.
  - Added a text fallback when media upload fails, preventing malformed events.

- **Tests**
  - Added coverage for file metadata preservation, encrypted media, upload failures, and message-size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->