### PR TITLE
Keep large final edits within Matrix event limits

### DIFF
--- a/src/mindroom/approval_response.py
+++ b/src/mindroom/approval_response.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING, cast
 
 from mindroom import approval_manager
 from mindroom.constants import (
-    DURABLE_FINAL_OUTCOME_KEY,
     STREAM_STATUS_APPROVAL_PENDING,
     STREAM_STATUS_COMPLETED,
     STREAM_STATUS_KEY,
@@ -433,14 +432,7 @@ class ApprovalResponseCoordinator:
         delivery = await self.final_delivery(continuation, recover=recover)
         if delivery is None:
             return None
-        payload = delivery.payload
-        nested = payload.get("m.new_content")
-        semantic = (
-            next((value for key, value in nested.items() if key == DURABLE_FINAL_OUTCOME_KEY), None)
-            if isinstance(nested, dict)
-            else payload.get(DURABLE_FINAL_OUTCOME_KEY)
-        )
-        return delivery if isinstance(semantic, dict) else None
+        return delivery if delivery.result is not None else None
 
     async def final_delivery(
         self,

--- a/src/mindroom/approval_response.py
+++ b/src/mindroom/approval_response.py
@@ -408,6 +408,9 @@ class ApprovalResponseCoordinator:
         manager = approval_manager.get_approval_store()
         if manager is None or not await manager.expire_continuation_cards(current.approval_id):
             return False
+        failed_delivery = await self.final_delivery(current)
+        if failed_delivery is not None and failed_delivery.permanently_failed:
+            return await self.store.finish_approval_continuation(current.approval_id)
         visible_reason = _USER_STOP_VISIBLE_NOTE if reason == _USER_STOP_FAILURE_REASON else reason
         target = continuation_target(current)
         delivered = await self.delivery_gateway.edit_text(
@@ -432,7 +435,7 @@ class ApprovalResponseCoordinator:
         delivery = await self.final_delivery(continuation, recover=recover)
         if delivery is None:
             return None
-        return delivery if delivery.result is not None else None
+        return delivery if delivery.result is not None and not delivery.permanently_failed else None
 
     async def final_delivery(
         self,

--- a/src/mindroom/constants.py
+++ b/src/mindroom/constants.py
@@ -1074,6 +1074,7 @@ MINDROOM_MATRIX_HISTORY_METADATA_KEY = "mindroom_matrix_history"
 COMPACTION_NOTICE_CONTENT_KEY = "io.mindroom.compaction"
 STREAM_STATUS_KEY = "io.mindroom.stream_status"
 DURABLE_FINAL_OUTCOME_KEY = "io.mindroom.final_delivery"
+DURABLE_FINAL_OUTCOME_VERSION = 2
 STREAM_VISIBLE_BODY_KEY = "io.mindroom.visible_body"
 STREAM_WARMUP_SUFFIX_KEY = "io.mindroom.warmup_suffix"
 TOOL_TRACE_CONTENT_KEY = "io.mindroom.tool_trace"

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -1668,9 +1668,11 @@ class DeliveryGateway:
 
         A durable row can also outlive the room state observed here. Size it for
         encrypted delivery even when the room is currently unencrypted, so
-        enabling encryption cannot make the frozen event too large. The sidecar
-        remains shaped for the current room: a plaintext ``m.file`` stays valid
-        inside a later encrypted event and is parseable before the transition too.
+        enabling encryption cannot make the frozen event too large. Encrypt the
+        sidecar immediately and carry its descriptor on a normal text preview
+        while the room is still plaintext. That preview is parseable in either
+        room state, and a later encrypted send does not expose plaintext sidecar
+        bytes to the homeserver.
         This conservative work happens once per durable row, before enqueue;
         retries and startup recovery send the same frozen bytes without repeating it.
         """

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -14,12 +14,13 @@ import nio
 from nio.exceptions import SendRetryError
 
 from mindroom import constants, interactive
-from mindroom.constants import SKIP_MENTIONS_KEY
+from mindroom.constants import DURABLE_FINAL_OUTCOME_KEY, DURABLE_FINAL_OUTCOME_VERSION, SKIP_MENTIONS_KEY
 from mindroom.event_journal import (
     MatrixDelivery,
     MatrixDeliveryView,
     ProjectedEvent,
     TerminalTurnWrite,
+    matrix_delivery_payload,
     replacement_target,
     thread_root,
 )
@@ -1229,6 +1230,10 @@ class DeliveryGateway:
         delivery_result: dict[str, object] | None = None
         if request.defer_source_handoff:
             metadata = interactive_response.interactive_metadata
+            # Older readers recognize any mapping here as a successful FINAL.
+            # Keep that rolling-read signal bounded; the complete result is
+            # local outbox state and cannot make the Matrix event impossible.
+            delivery_extra_content[DURABLE_FINAL_OUTCOME_KEY] = {"version": DURABLE_FINAL_OUTCOME_VERSION}
             delivery_result = {
                 "body": display_text,
                 "interactive": metadata.to_metadata() if metadata is not None else None,
@@ -1655,7 +1660,13 @@ class DeliveryGateway:
         existing = await self.deps.outbox.load_matrix_delivery(delivery_id=turn_id, stage=stage)
         if existing is not None and existing.attempted:
             return content
-        return await prepare_large_message(self._client(), room_id, content)
+        wire_content = matrix_delivery_payload(
+            self.deps.outbox.principal_id,
+            turn_id,
+            stage,
+            content,
+        )
+        return await prepare_large_message(self._client(), room_id, wire_content)
 
     def _final_text_transform(self, identity: ResponseIdentity) -> FinalTextTransform:
         """Return the hook that shapes the answer before its terminal payload is built.

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -55,7 +55,7 @@ from mindroom.matrix.client_delivery import (
     send_message_outcome,
     send_message_result,
 )
-from mindroom.matrix.large_messages import prepare_large_message
+from mindroom.matrix.large_messages import MatrixEventTooLargeError, prepare_large_message
 from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_message_content
 from mindroom.matrix.room_history_reads import (
@@ -412,6 +412,7 @@ class DeliveryGatewayDeps:
 _MATRIX_DELIVERY_FAILURE_REASONS: dict[MatrixDeliveryFailureKind, str] = {
     MatrixDeliveryFailureKind.ENCRYPTION_GUARD: "encrypted delivery rejected by local trust policy",
     MatrixDeliveryFailureKind.UNKNOWN_ENCRYPTION_STATE: "room encryption state unknown",
+    MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE: "matrix event exceeds the hard size limit",
     MatrixDeliveryFailureKind.SEND_EXCEPTION: "matrix delivery raised a local exception",
     MatrixDeliveryFailureKind.UNEXPECTED_RESPONSE: "matrix delivery returned an unexpected response",
 }
@@ -863,12 +864,15 @@ class DeliveryGateway:
         # homeserver had already accepted. An attempted row is already frozen,
         # so preparation is skipped and `enqueue` leaves that stored payload
         # untouched for the claimed send below.
-        content = await self._prepared_for_the_wire(
-            room_id,
-            content,
-            turn_id=request.delivery_turn_id,
-            stage=request.delivery_stage,
-        )
+        try:
+            content = await self._prepared_for_the_wire(
+                room_id,
+                content,
+                turn_id=request.delivery_turn_id,
+                stage=request.delivery_stage,
+            )
+        except MatrixEventTooLargeError as error:
+            return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
         requested_delivery: DeliveredMatrixEvent | None = None
 
         async def send(claimed: MatrixDelivery) -> str:
@@ -1004,12 +1008,15 @@ class DeliveryGateway:
         # upload again under a transaction ID already accepted. An attempted
         # row is already frozen, so preparation is skipped and
         # `enqueue` leaves that stored envelope untouched for the claimed send.
-        envelope = await self._prepared_for_the_wire(
-            room_id,
-            envelope,
-            turn_id=request.delivery_turn_id,
-            stage=DeliveryStage.FINAL,
-        )
+        try:
+            envelope = await self._prepared_for_the_wire(
+                room_id,
+                envelope,
+                turn_id=request.delivery_turn_id,
+                stage=DeliveryStage.FINAL,
+            )
+        except MatrixEventTooLargeError as error:
+            return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
         delivered: DeliveredMatrixEvent | None = None
 
         async def send(claimed: MatrixDelivery) -> str:

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -14,7 +14,7 @@ import nio
 from nio.exceptions import SendRetryError
 
 from mindroom import constants, interactive
-from mindroom.constants import DURABLE_FINAL_OUTCOME_KEY, SKIP_MENTIONS_KEY
+from mindroom.constants import SKIP_MENTIONS_KEY
 from mindroom.event_journal import (
     MatrixDelivery,
     MatrixDeliveryView,
@@ -257,6 +257,7 @@ class SendTextRequest:  # noqa: D101
     # whose duplication a reader would see, and it is the initial stage.
     delivery_stage: DeliveryStage = DeliveryStage.FINAL
     defer_source_handoff: bool = False
+    delivery_result: dict[str, object] | None = None
 
 
 @dataclass(frozen=True)
@@ -272,6 +273,7 @@ class EditTextRequest:  # noqa: D101
     # whose loss leaves a user looking at "Thinking..." for good.
     delivery_turn_id: str | None = None
     defer_source_handoff: bool = False
+    delivery_result: dict[str, object] | None = None
 
 
 @dataclass(frozen=True)
@@ -883,6 +885,7 @@ class DeliveryGateway:
                 room_id=room_id,
                 thread_id=request.target.resolved_thread_id,
                 payload=content,
+                result=request.delivery_result,
             )
         except _DeliveryRefusedError:
             return None
@@ -1041,6 +1044,7 @@ class DeliveryGateway:
                 room_id=room_id,
                 thread_id=request.target.resolved_thread_id,
                 payload=envelope,
+                result=request.delivery_result,
                 edits_event_id=request.event_id,
             )
         except _DeliveryRefusedError:
@@ -1222,9 +1226,10 @@ class DeliveryGateway:
                     source_event_id=request.identity.response_envelope.source_event_id,
                 ),
             )
+        delivery_result: dict[str, object] | None = None
         if request.defer_source_handoff:
             metadata = interactive_response.interactive_metadata
-            delivery_extra_content[DURABLE_FINAL_OUTCOME_KEY] = {
+            delivery_result = {
                 "body": display_text,
                 "interactive": metadata.to_metadata() if metadata is not None else None,
             }
@@ -1240,6 +1245,7 @@ class DeliveryGateway:
                     delivery_turn_id=request.identity.response_envelope.source_event_id,
                     retry_sync_recovery=True,
                     defer_source_handoff=request.defer_source_handoff,
+                    delivery_result=delivery_result,
                 ),
             )
             if edited:
@@ -1286,6 +1292,7 @@ class DeliveryGateway:
                 # value after a restart, which a generated ID would not.
                 delivery_turn_id=request.identity.response_envelope.source_event_id,
                 defer_source_handoff=request.defer_source_handoff,
+                delivery_result=delivery_result,
             ),
         )
         if event_id is None:

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -1671,7 +1671,7 @@ class DeliveryGateway:
             return content
         client = self._client()
         room_encrypted: bool | None = None
-        if isinstance(getattr(client, "rooms", None), Mapping):
+        if isinstance(client.rooms, Mapping):
             encryption_outcome = await resolve_room_encryption_outcome(
                 client,
                 room_id,

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -1665,6 +1665,14 @@ class DeliveryGateway:
         refuses to overwrite it, so preparing again would upload an attachment
         nothing can ever reference -- or fail before the durable payload gets
         another chance to reach Matrix.
+
+        A durable row can also outlive the room state observed here. Size it for
+        encrypted delivery even when the room is currently unencrypted, so
+        enabling encryption cannot make the frozen event too large. The sidecar
+        remains shaped for the current room: a plaintext ``m.file`` stays valid
+        inside a later encrypted event and is parseable before the transition too.
+        This conservative work happens once per durable row, before enqueue;
+        retries and startup recovery send the same frozen bytes without repeating it.
         """
         existing = await self.deps.outbox.load_matrix_delivery(delivery_id=turn_id, stage=stage)
         if existing is not None and existing.attempted:
@@ -1692,6 +1700,7 @@ class DeliveryGateway:
                 room_id,
                 wire_content,
                 room_encrypted=room_encrypted,
+                transition_safe=True,
             )
         except MatrixEventTooLargeError as error:
             return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -860,6 +860,15 @@ class DeliveryGateway:
                 content,
                 retry_sync_recovery=request.retry_sync_recovery,
             )
+        requested_delivery: DeliveredMatrixEvent | None = None
+
+        async def send(claimed: MatrixDelivery) -> str:
+            nonlocal requested_delivery
+            delivered = await self._send_claimed(claimed, retry_sync_recovery=request.retry_sync_recovery)
+            if claimed.stage is request.delivery_stage:
+                requested_delivery = delivered
+            return delivered.event_id
+
         # Prepared before the row is written, so the frozen payload is the one
         # that goes on the wire. Uploading the sidecar after the claim left the
         # row holding the oversized original while Matrix received an MXC
@@ -875,16 +884,12 @@ class DeliveryGateway:
             stage=request.delivery_stage,
         )
         if isinstance(prepared, MatrixDeliveryFailure):
-            return prepared
-        content = prepared
-        requested_delivery: DeliveredMatrixEvent | None = None
-
-        async def send(claimed: MatrixDelivery) -> str:
-            nonlocal requested_delivery
-            delivered = await self._send_claimed(claimed, retry_sync_recovery=request.retry_sync_recovery)
-            if claimed.stage is request.delivery_stage:
-                requested_delivery = delivered
-            return delivered.event_id
+            if prepared.kind is not MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
+                return prepared
+            preparation_failure: MatrixDeliveryFailure | None = prepared
+        else:
+            preparation_failure = None
+            content = prepared
 
         try:
             handoff = None if request.defer_source_handoff else self.deps.turn_handoff
@@ -895,13 +900,16 @@ class DeliveryGateway:
                 thread_id=request.target.resolved_thread_id,
                 payload=content,
                 result=request.delivery_result,
+                permanent_failure_reason=(
+                    _matrix_delivery_failure_reason(preparation_failure) if preparation_failure is not None else None
+                ),
             )
         except _DeliveryRefusedError:
             return None
         if event_id is None:
             # The delivery was withdrawn by membership or ended in an explicit
             # permanent failure, so there is nothing left for recovery to send.
-            return None
+            return preparation_failure
         if requested_delivery is not None and requested_delivery.event_id == event_id:
             return requested_delivery
         # The delivery was already acknowledged, so nothing was sent and the
@@ -993,33 +1001,6 @@ class DeliveryGateway:
                 request.new_text,
                 retry_sync_recovery=request.retry_sync_recovery,
             )
-        # What is stored is the finished wire event, not the text it was built
-        # from. Recovery sends the row exactly as frozen and has no request to
-        # rebuild from, so anything reconstructed at send time -- the replace
-        # envelope, the fallback body -- would be missing on the one path that
-        # matters, and the answer would come back as a second message with the
-        # placeholder still above it.
-        envelope = build_edit_event_content(
-            event_id=request.event_id,
-            new_content=content,
-            new_text=request.new_text,
-        )
-        # Prepared before the row is written, for the same reason the envelope
-        # is built here: the row has to hold the finished wire event. A sidecar
-        # uploaded after the claim would leave the row holding the oversized
-        # original while Matrix received an MXC reference, and a resend would
-        # upload again under a transaction ID already accepted. An attempted
-        # row is already frozen, so preparation is skipped and
-        # `enqueue` leaves that stored envelope untouched for the claimed send.
-        prepared = await self._prepared_for_the_wire(
-            room_id,
-            envelope,
-            turn_id=request.delivery_turn_id,
-            stage=DeliveryStage.FINAL,
-        )
-        if isinstance(prepared, MatrixDeliveryFailure):
-            return prepared
-        envelope = prepared
         delivered: DeliveredMatrixEvent | None = None
 
         async def send(claimed: MatrixDelivery) -> str:
@@ -1049,6 +1030,38 @@ class DeliveryGateway:
             delivered = outcome
             return outcome.event_id
 
+        # What is stored is the finished wire event, not the text it was built
+        # from. Recovery sends the row exactly as frozen and has no request to
+        # rebuild from, so anything reconstructed at send time -- the replace
+        # envelope, the fallback body -- would be missing on the one path that
+        # matters, and the answer would come back as a second message with the
+        # placeholder still above it.
+        envelope = build_edit_event_content(
+            event_id=request.event_id,
+            new_content=content,
+            new_text=request.new_text,
+        )
+        # Prepared before the row is written, for the same reason the envelope
+        # is built here: the row has to hold the finished wire event. A sidecar
+        # uploaded after the claim would leave the row holding the oversized
+        # original while Matrix received an MXC reference, and a resend would
+        # upload again under a transaction ID already accepted. An attempted
+        # row is already frozen, so preparation is skipped and
+        # `enqueue` leaves that stored envelope untouched for the claimed send.
+        prepared = await self._prepared_for_the_wire(
+            room_id,
+            envelope,
+            turn_id=request.delivery_turn_id,
+            stage=DeliveryStage.FINAL,
+        )
+        if isinstance(prepared, MatrixDeliveryFailure):
+            if prepared.kind is not MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
+                return prepared
+            preparation_failure = prepared
+        else:
+            preparation_failure = None
+            envelope = prepared
+
         try:
             handoff = None if request.defer_source_handoff else self.deps.turn_handoff
             event_id = await self._response_delivery(send, handoff=handoff).deliver(
@@ -1059,13 +1072,16 @@ class DeliveryGateway:
                 payload=envelope,
                 result=request.delivery_result,
                 edits_event_id=request.event_id,
+                permanent_failure_reason=(
+                    _matrix_delivery_failure_reason(preparation_failure) if preparation_failure is not None else None
+                ),
             )
         except _DeliveryRefusedError:
             return None
         if event_id is None:
             # The delivery was withdrawn by membership or ended in an explicit
             # permanent failure, so there is nothing left for recovery to send.
-            return None
+            return preparation_failure
         if delivered is not None:
             return delivered
         # Already acknowledged: this turn's answer reached the room on an

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from html import escape as html_escape
@@ -66,6 +65,7 @@ from mindroom.matrix.room_history_reads import (
 from mindroom.matrix_delivery import (
     DeliveryStage,
     MatrixDeliveryWorker,
+    PermanentDeliveryError,
     RecoveryOutcome,
     SendDelivery,
     TurnHandoff,
@@ -683,6 +683,8 @@ class DeliveryGateway:
         )
         if isinstance(outcome, MatrixDeliveryFailure):
             detail = _matrix_delivery_failure_reason(outcome)
+            if outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
+                raise PermanentDeliveryError(detail)
             msg = f"Matrix refused delivery for turn {claimed.delivery_id!r} stage {claimed.stage.value!r}: {detail}"
             raise _DeliveryRefusedError(msg)
         return outcome
@@ -897,9 +899,8 @@ class DeliveryGateway:
         except _DeliveryRefusedError:
             return None
         if event_id is None:
-            # The membership this turn answered has ended. The room it was
-            # answering is not the room the bot is in now, so there is nothing
-            # to send and nothing to recover.
+            # The delivery was withdrawn by membership or ended in an explicit
+            # permanent failure, so there is nothing left for recovery to send.
             return None
         if requested_delivery is not None and requested_delivery.event_id == event_id:
             return requested_delivery
@@ -1041,6 +1042,8 @@ class DeliveryGateway:
             )
             if isinstance(outcome, MatrixDeliveryFailure):
                 detail = _matrix_delivery_failure_reason(outcome)
+                if outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
+                    raise PermanentDeliveryError(detail)
                 msg = f"Matrix refused the final edit for turn {claimed.delivery_id!r}: {detail}"
                 raise _DeliveryRefusedError(msg)
             delivered = outcome
@@ -1060,8 +1063,8 @@ class DeliveryGateway:
         except _DeliveryRefusedError:
             return None
         if event_id is None:
-            # The membership this turn answered has ended, so its answer is
-            # not this bot's to give in the room it is in now.
+            # The delivery was withdrawn by membership or ended in an explicit
+            # permanent failure, so there is nothing left for recovery to send.
             return None
         if delivered is not None:
             return delivered
@@ -1666,30 +1669,21 @@ class DeliveryGateway:
         nothing can ever reference -- or fail before the durable payload gets
         another chance to reach Matrix.
 
-        A durable row can also outlive the room state observed here. Size it for
-        encrypted delivery even when the room is currently unencrypted, so
-        enabling encryption cannot make the frozen event too large. Encrypt the
-        sidecar immediately and carry its descriptor on a normal text preview
-        while the room is still plaintext. That preview is parseable in either
-        room state, and a later encrypted send does not expose plaintext sidecar
-        bytes to the homeserver.
-        This conservative work happens once per durable row, before enqueue;
-        retries and startup recovery send the same frozen bytes without repeating it.
+        Preparation uses the currently observed room encryption state. Once
+        attempted, retries and startup recovery send the same frozen bytes
+        without uploading or rebuilding anything.
         """
         existing = await self.deps.outbox.load_matrix_delivery(delivery_id=turn_id, stage=stage)
         if existing is not None and existing.attempted:
             return content
         client = self._client()
-        room_encrypted: bool | None = None
-        if isinstance(client.rooms, Mapping):
-            encryption_outcome = await resolve_room_encryption_outcome(
-                client,
-                room_id,
-                operation="prepare_durable_delivery",
-            )
-            if isinstance(encryption_outcome, MatrixDeliveryFailure):
-                return encryption_outcome
-            room_encrypted = encryption_outcome
+        encryption_outcome = await resolve_room_encryption_outcome(
+            client,
+            room_id,
+            operation="prepare_durable_delivery",
+        )
+        if isinstance(encryption_outcome, MatrixDeliveryFailure):
+            return encryption_outcome
         wire_content = matrix_delivery_payload(
             self.deps.outbox.principal_id,
             turn_id,
@@ -1701,8 +1695,7 @@ class DeliveryGateway:
                 client,
                 room_id,
                 wire_content,
-                room_encrypted=room_encrypted,
-                transition_safe=True,
+                room_encrypted=encryption_outcome,
             )
         except MatrixEventTooLargeError as error:
             return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from html import escape as html_escape
@@ -52,6 +53,7 @@ from mindroom.matrix.client_delivery import (
     build_edit_event_content,
     edit_message_outcome,
     edit_message_result,
+    resolve_room_encryption_outcome,
     send_message_outcome,
     send_message_result,
 )
@@ -864,15 +866,15 @@ class DeliveryGateway:
         # homeserver had already accepted. An attempted row is already frozen,
         # so preparation is skipped and `enqueue` leaves that stored payload
         # untouched for the claimed send below.
-        try:
-            content = await self._prepared_for_the_wire(
-                room_id,
-                content,
-                turn_id=request.delivery_turn_id,
-                stage=request.delivery_stage,
-            )
-        except MatrixEventTooLargeError as error:
-            return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
+        prepared = await self._prepared_for_the_wire(
+            room_id,
+            content,
+            turn_id=request.delivery_turn_id,
+            stage=request.delivery_stage,
+        )
+        if isinstance(prepared, MatrixDeliveryFailure):
+            return prepared
+        content = prepared
         requested_delivery: DeliveredMatrixEvent | None = None
 
         async def send(claimed: MatrixDelivery) -> str:
@@ -1008,15 +1010,15 @@ class DeliveryGateway:
         # upload again under a transaction ID already accepted. An attempted
         # row is already frozen, so preparation is skipped and
         # `enqueue` leaves that stored envelope untouched for the claimed send.
-        try:
-            envelope = await self._prepared_for_the_wire(
-                room_id,
-                envelope,
-                turn_id=request.delivery_turn_id,
-                stage=DeliveryStage.FINAL,
-            )
-        except MatrixEventTooLargeError as error:
-            return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
+        prepared = await self._prepared_for_the_wire(
+            room_id,
+            envelope,
+            turn_id=request.delivery_turn_id,
+            stage=DeliveryStage.FINAL,
+        )
+        if isinstance(prepared, MatrixDeliveryFailure):
+            return prepared
+        envelope = prepared
         delivered: DeliveredMatrixEvent | None = None
 
         async def send(claimed: MatrixDelivery) -> str:
@@ -1655,7 +1657,7 @@ class DeliveryGateway:
         *,
         turn_id: str,
         stage: DeliveryStage,
-    ) -> dict[str, Any]:
+    ) -> dict[str, Any] | MatrixDeliveryFailure:
         """Prepare a payload for the wire, unless a frozen one already exists.
 
         Preparation can upload a sidecar, so it must not run for a turn whose
@@ -1667,13 +1669,32 @@ class DeliveryGateway:
         existing = await self.deps.outbox.load_matrix_delivery(delivery_id=turn_id, stage=stage)
         if existing is not None and existing.attempted:
             return content
+        client = self._client()
+        room_encrypted: bool | None = None
+        if isinstance(getattr(client, "rooms", None), Mapping):
+            encryption_outcome = await resolve_room_encryption_outcome(
+                client,
+                room_id,
+                operation="prepare_durable_delivery",
+            )
+            if isinstance(encryption_outcome, MatrixDeliveryFailure):
+                return encryption_outcome
+            room_encrypted = encryption_outcome
         wire_content = matrix_delivery_payload(
             self.deps.outbox.principal_id,
             turn_id,
             stage,
             content,
         )
-        return await prepare_large_message(self._client(), room_id, wire_content)
+        try:
+            return await prepare_large_message(
+                client,
+                room_id,
+                wire_content,
+                room_encrypted=room_encrypted,
+            )
+        except MatrixEventTooLargeError as error:
+            return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
 
     def _final_text_transform(self, identity: ResponseIdentity) -> FinalTextTransform:
         """Return the hook that shapes the answer before its terminal payload is built.

--- a/src/mindroom/event_journal/__init__.py
+++ b/src/mindroom/event_journal/__init__.py
@@ -53,6 +53,7 @@ from .models import (
     UnreadableMatrixDelivery,
     VisibleMessage,
 )
+from .outbox import matrix_delivery_payload
 from .projection import ProjectedEvent, replacement_target, thread_root, visible_content
 from .store import EventJournalStore, PrincipalStore, TurnRecordStore
 from .views import (
@@ -123,6 +124,7 @@ __all__ = [
     "decode_thread_id",
     "delivery_transaction_id",
     "encode_thread_id",
+    "matrix_delivery_payload",
     "replacement_target",
     "thread_root",
     "visible_content",

--- a/src/mindroom/event_journal/approval_continuations.py
+++ b/src/mindroom/event_journal/approval_continuations.py
@@ -702,6 +702,7 @@ def request_failure(
                   AND source.source_ordinal = 0
               )
               AND final.stage = 'final'
+              AND final.permanent_failure_reason IS NULL
           )
         RETURNING approval_id
         """,
@@ -723,7 +724,7 @@ def finish(
     *,
     approval_id: str,
 ) -> bool:
-    """Release sources only after the continuation's FINAL delivery is acknowledged."""
+    """Release sources after the continuation's FINAL reaches a terminal outcome."""
     continuation = _get_locked(transaction, principal_id, approval_id=approval_id)
     if continuation is None:
         return False
@@ -731,7 +732,7 @@ def finish(
         """
         SELECT 1 AS present FROM matrix_delivery_outbox
         WHERE principal_id = ? AND delivery_id = ? AND stage = ?
-          AND acknowledged_event_id IS NOT NULL
+          AND (acknowledged_event_id IS NOT NULL OR permanent_failure_reason IS NOT NULL)
         """,
         (principal_id, continuation.source_event_ids[0], DeliveryStage.FINAL.value),
     )

--- a/src/mindroom/event_journal/models.py
+++ b/src/mindroom/event_journal/models.py
@@ -335,6 +335,9 @@ class MatrixDelivery:
     # The scan key recovery pages on. Without it a pass that fails a whole page
     # re-reads the same page forever and never reaches what is behind it.
     created_at_ns: int
+    # Semantic facts retained locally for post-acknowledgement recovery. They
+    # are intentionally separate from ``payload``, which is Matrix wire data.
+    result: Mapping[str, object] | None = None
     event_type: str = "m.room.message"
     # Whether this row has already been offered to the homeserver. Together
     # with the device below it answers the only question a resend needs: can

--- a/src/mindroom/event_journal/models.py
+++ b/src/mindroom/event_journal/models.py
@@ -347,11 +347,19 @@ class MatrixDelivery:
     # An obsolete delivery stays as an identity tombstone so late work cannot
     # cross into a newer membership, but recovery never sends it again.
     retired: bool = False
+    # A definitive refusal of this immutable payload. Unlike retirement, this
+    # records a delivery failure rather than an obsolete membership identity.
+    permanent_failure_reason: str | None = None
     # The device that offered it, or None when none is recorded. A Matrix
     # transaction ID deduplicates within one device, so a row attempted by a
     # device this process is no longer logged in as carries an ID the
     # homeserver would accept as new.
     sending_device_id: str | None = None
+
+    @property
+    def permanently_failed(self) -> bool:
+        """Return whether this immutable payload has a terminal refusal."""
+        return self.permanent_failure_reason is not None
 
     @property
     def has_interactive_prompt(self) -> bool:

--- a/src/mindroom/event_journal/outbox.py
+++ b/src/mindroom/event_journal/outbox.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 _OUTBOX_COLUMNS = """
     delivery_id, stage, event_type, room_id, membership_epoch, thread_id, transaction_id,
     payload_json, result_json, edits_event_id, acknowledged_event_id, created_at_ns,
-    attempted, retired, sending_device_id
+    attempted, retired, permanent_failure_reason, sending_device_id
 """
 _DELIVERY_STAGE_VALUES = frozenset(item.value for item in DeliveryStage)
 _LEGACY_FINAL_OUTCOME_KEY = "io.mindroom.final_delivery"
@@ -272,12 +272,13 @@ def claim(
     _lock_delivery_stages(transaction, principal_id, delivery_id)
     current = transaction.fetchone(
         """
-        SELECT attempted, retired, edits_event_id, edit_target_pending FROM matrix_delivery_outbox
+        SELECT attempted, retired, permanent_failure_reason, edits_event_id, edit_target_pending
+        FROM matrix_delivery_outbox
         WHERE principal_id = ? AND delivery_id = ? AND stage = ?
         """,
         (principal_id, delivery_id, stage.value),
     )
-    if current is None or bool(current["retired"]):
+    if current is None or bool(current["retired"]) or current["permanent_failure_reason"] is not None:
         return None
     if stage is DeliveryStage.INITIAL and not bool(current["attempted"]):
         final = transaction.fetchone(
@@ -409,7 +410,8 @@ def acknowledge(
     """
     bound = transaction.fetchone(
         """
-        UPDATE matrix_delivery_outbox SET acknowledged_event_id = ?
+        UPDATE matrix_delivery_outbox
+        SET acknowledged_event_id = ?, permanent_failure_reason = NULL
         WHERE principal_id = ? AND delivery_id = ? AND stage = ? AND acknowledged_event_id IS NULL
         RETURNING delivery_id
         """,
@@ -427,6 +429,39 @@ def acknowledge(
             (event_id, principal_id, delivery_id, DeliveryStage.FINAL.value),
         )
     return bound is not None
+
+
+def record_permanent_failure(
+    transaction: Transaction,
+    principal_id: str,
+    *,
+    delivery_id: str,
+    stage: DeliveryStage,
+    reason: str,
+) -> str | None:
+    """Stop retrying one refused immutable payload, or return its concurrent ACK."""
+    if not reason:
+        msg = "A permanent Matrix delivery failure requires a reason"
+        raise ValueError(msg)
+    transaction.execute(
+        """
+        UPDATE matrix_delivery_outbox SET permanent_failure_reason = ?
+        WHERE principal_id = ? AND delivery_id = ? AND stage = ?
+          AND acknowledged_event_id IS NULL AND retired = 0
+          AND permanent_failure_reason IS NULL
+        """,
+        (reason, principal_id, delivery_id, stage.value),
+    )
+    row = transaction.fetchone(
+        """
+        SELECT acknowledged_event_id FROM matrix_delivery_outbox
+        WHERE principal_id = ? AND delivery_id = ? AND stage = ?
+        """,
+        (principal_id, delivery_id, stage.value),
+    )
+    if row is None or row["acknowledged_event_id"] is None:
+        return None
+    return str(row["acknowledged_event_id"])
 
 
 def delivery_ownership(
@@ -608,7 +643,8 @@ def unacknowledged(
         f"""
         SELECT {_OUTBOX_COLUMNS} FROM matrix_delivery_outbox
         WHERE principal_id = ? AND event_type = ?
-          AND acknowledged_event_id IS NULL AND retired = 0{cursor_clause}
+          AND acknowledged_event_id IS NULL AND retired = 0
+          AND permanent_failure_reason IS NULL{cursor_clause}
         ORDER BY created_at_ns, delivery_id/*bytes*/, stage/*bytes*/
         LIMIT ?
         """,  # noqa: S608 - a fixed column list and a fixed clause, not input
@@ -631,6 +667,7 @@ def has_attempted_unacknowledged_prompt_delivery(
         WHERE principal_id = ? AND room_id = ? AND membership_epoch = ?
           AND event_type = 'm.room.message'
           AND attempted = 1 AND retired = 0 AND acknowledged_event_id IS NULL
+          AND permanent_failure_reason IS NULL
           AND (
               edits_event_id IS NOT NULL
               OR payload_json LIKE ?
@@ -726,6 +763,7 @@ def _delivery(row: Row) -> MatrixDelivery:
         result=result,
         attempted=bool(row["attempted"]),
         retired=bool(row["retired"]),
+        permanent_failure_reason=row["permanent_failure_reason"],
         sending_device_id=row["sending_device_id"],
     )
 

--- a/src/mindroom/event_journal/outbox.py
+++ b/src/mindroom/event_journal/outbox.py
@@ -40,10 +40,11 @@ if TYPE_CHECKING:
 
 _OUTBOX_COLUMNS = """
     delivery_id, stage, event_type, room_id, membership_epoch, thread_id, transaction_id,
-    payload_json, edits_event_id, acknowledged_event_id, created_at_ns,
+    payload_json, result_json, edits_event_id, acknowledged_event_id, created_at_ns,
     attempted, retired, sending_device_id
 """
 _DELIVERY_STAGE_VALUES = frozenset(item.value for item in DeliveryStage)
+_LEGACY_FINAL_OUTCOME_KEY = "io.mindroom.final_delivery"
 
 
 def _delivery_payload(
@@ -81,6 +82,13 @@ def delivery_payload_json(
         separators=(",", ":"),
         sort_keys=True,
     )
+
+
+def _delivery_result_json(result: Mapping[str, object] | None) -> str | None:
+    """Return canonical local result JSON without mixing it into wire content."""
+    if result is None:
+        return None
+    return json.dumps(dict(result), ensure_ascii=True, separators=(",", ":"), sort_keys=True)
 
 
 def _delivery_identity(content: Mapping[str, object] | None) -> tuple[str, str, DeliveryStage] | None:
@@ -129,6 +137,7 @@ def enqueue(
     thread_id: str | None,
     payload: Mapping[str, object],
     edits_event_id: str | None,
+    result: Mapping[str, object] | None = None,
     edit_target_pending: bool = False,
 ) -> str | None:
     """Record delivery intent without changing its durable membership owner."""
@@ -163,15 +172,16 @@ def enqueue(
         """
         INSERT INTO matrix_delivery_outbox (
             principal_id, delivery_id, stage, event_type, room_id, membership_epoch,
-            thread_id, transaction_id, payload_json, edits_event_id,
+            thread_id, transaction_id, payload_json, result_json, edits_event_id,
             edit_target_pending, attempted, created_at_ns
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
         ON CONFLICT (principal_id, delivery_id, stage) DO UPDATE SET
             room_id = excluded.room_id,
             membership_epoch = excluded.membership_epoch,
             thread_id = excluded.thread_id,
             event_type = excluded.event_type,
             payload_json = excluded.payload_json,
+            result_json = excluded.result_json,
             edits_event_id = excluded.edits_event_id,
             edit_target_pending = excluded.edit_target_pending
         WHERE matrix_delivery_outbox.attempted = 0
@@ -186,6 +196,7 @@ def enqueue(
             encode_thread_id(thread_id),
             transaction_id,
             delivery_payload_json(principal_id, delivery_id, stage, payload),
+            _delivery_result_json(result),
             edits_event_id,
             int(edit_target_pending),
             time.time_ns(),
@@ -673,6 +684,21 @@ def _delivery(row: Row) -> MatrixDelivery:
     if not isinstance(payload, dict):
         msg = f"Outbox payload for delivery {row['delivery_id']!r} is not an object"
         raise TypeError(msg)
+    raw_result = row["result_json"]
+    if raw_result is None:
+        replacement = payload.get("m.new_content")
+        legacy_result = (
+            replacement.get(_LEGACY_FINAL_OUTCOME_KEY)
+            if isinstance(replacement, dict)
+            else payload.get(_LEGACY_FINAL_OUTCOME_KEY)
+        )
+        result = dict(legacy_result) if isinstance(legacy_result, dict) else None
+    else:
+        decoded_result = json.loads(raw_result)
+        if not isinstance(decoded_result, dict):
+            msg = f"Outbox result for delivery {row['delivery_id']!r} is not an object"
+            raise TypeError(msg)
+        result = decoded_result
     return MatrixDelivery(
         delivery_id=row["delivery_id"],
         stage=DeliveryStage(row["stage"]),
@@ -685,6 +711,7 @@ def _delivery(row: Row) -> MatrixDelivery:
         edits_event_id=row["edits_event_id"],
         acknowledged_event_id=row["acknowledged_event_id"],
         created_at_ns=int(row["created_at_ns"]),
+        result=result,
         attempted=bool(row["attempted"]),
         retired=bool(row["retired"]),
         sending_device_id=row["sending_device_id"],

--- a/src/mindroom/event_journal/outbox.py
+++ b/src/mindroom/event_journal/outbox.py
@@ -45,9 +45,13 @@ _OUTBOX_COLUMNS = """
 """
 _DELIVERY_STAGE_VALUES = frozenset(item.value for item in DeliveryStage)
 _LEGACY_FINAL_OUTCOME_KEY = "io.mindroom.final_delivery"
+# New writers retain only this old-reader success signal on the wire. Any
+# richer value came from a legacy writer and is the semantic result belonging
+# to that writer's current payload, even when a stale result_json also exists.
+_LOCAL_RESULT_COMPATIBILITY_MARKER = {"version": 2}
 
 
-def _delivery_payload(
+def matrix_delivery_payload(
     principal_id: str,
     delivery_id: str,
     stage: DeliveryStage,
@@ -77,7 +81,7 @@ def delivery_payload_json(
 ) -> str:
     """Return the canonical stored Matrix payload, including its identity."""
     return json.dumps(
-        _delivery_payload(principal_id, delivery_id, stage, payload),
+        matrix_delivery_payload(principal_id, delivery_id, stage, payload),
         ensure_ascii=True,
         separators=(",", ":"),
         sort_keys=True,
@@ -695,9 +699,10 @@ def _delivery(row: Row) -> MatrixDelivery:
     if not isinstance(payload, dict):
         msg = f"Outbox payload for delivery {row['delivery_id']!r} is not an object"
         raise TypeError(msg)
+    legacy_result = _legacy_delivery_result(payload)
     raw_result = row["result_json"]
-    if raw_result is None:
-        result = _legacy_delivery_result(payload)
+    if (legacy_result is not None and legacy_result != _LOCAL_RESULT_COMPATIBILITY_MARKER) or raw_result is None:
+        result = legacy_result
     else:
         decoded_result = json.loads(raw_result)
         if not isinstance(decoded_result, dict):

--- a/src/mindroom/event_journal/outbox.py
+++ b/src/mindroom/event_journal/outbox.py
@@ -158,6 +158,7 @@ def enqueue(
     edit_target_pending: bool = False,
 ) -> str | None:
     """Record delivery intent without changing its durable membership owner."""
+    permanent_failure_reason: str | None = None
     _lock_delivery_stages(transaction, principal_id, delivery_id)
     existing_owner = transaction.fetchone(
         """
@@ -176,7 +177,7 @@ def enqueue(
     if stage is DeliveryStage.FINAL and edit_target_pending:
         initial = transaction.fetchone(
             """
-            SELECT acknowledged_event_id FROM matrix_delivery_outbox
+            SELECT acknowledged_event_id, permanent_failure_reason FROM matrix_delivery_outbox
             WHERE principal_id = ? AND delivery_id = ? AND stage = ?
             """,
             (principal_id, delivery_id, DeliveryStage.INITIAL.value),
@@ -184,14 +185,18 @@ def enqueue(
         if initial is not None and initial["acknowledged_event_id"] is not None:
             edits_event_id = str(initial["acknowledged_event_id"])
             edit_target_pending = False
+        elif initial is not None and initial["permanent_failure_reason"] is not None:
+            permanent_failure_reason = "required edit target was permanently refused: " + str(
+                initial["permanent_failure_reason"],
+            )
     transaction_id = delivery_transaction_id(principal_id, delivery_id, stage.value)
     transaction.execute(
         """
         INSERT INTO matrix_delivery_outbox (
             principal_id, delivery_id, stage, event_type, room_id, membership_epoch,
             thread_id, transaction_id, payload_json, result_json, edits_event_id,
-            edit_target_pending, attempted, created_at_ns
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
+            edit_target_pending, attempted, permanent_failure_reason, created_at_ns
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?)
         ON CONFLICT (principal_id, delivery_id, stage) DO UPDATE SET
             room_id = excluded.room_id,
             membership_epoch = excluded.membership_epoch,
@@ -200,7 +205,8 @@ def enqueue(
             payload_json = excluded.payload_json,
             result_json = excluded.result_json,
             edits_event_id = excluded.edits_event_id,
-            edit_target_pending = excluded.edit_target_pending
+            edit_target_pending = excluded.edit_target_pending,
+            permanent_failure_reason = excluded.permanent_failure_reason
         WHERE matrix_delivery_outbox.attempted = 0
         """,
         (
@@ -216,6 +222,7 @@ def enqueue(
             _delivery_result_json(result),
             edits_event_id,
             int(edit_target_pending),
+            permanent_failure_reason,
             time.time_ns(),
         ),
     )
@@ -323,7 +330,7 @@ def claim(
             SELECT 1 AS present FROM matrix_delivery_outbox
             WHERE principal_id = ? AND delivery_id = ? AND stage = ?
               AND attempted = 1 AND acknowledged_event_id IS NULL
-              AND retired = 0
+              AND retired = 0 AND permanent_failure_reason IS NULL
             """,
             (principal_id, delivery_id, DeliveryStage.INITIAL.value),
         )
@@ -421,7 +428,7 @@ def acknowledge(
         transaction.execute(
             """
             UPDATE matrix_delivery_outbox
-            SET edits_event_id = ?, edit_target_pending = 0
+            SET edits_event_id = ?, edit_target_pending = 0, permanent_failure_reason = NULL
             WHERE principal_id = ? AND delivery_id = ? AND stage = ?
               AND attempted = 0
               AND edit_target_pending = 1
@@ -443,15 +450,32 @@ def record_permanent_failure(
     if not reason:
         msg = "A permanent Matrix delivery failure requires a reason"
         raise ValueError(msg)
-    transaction.execute(
+    failed = transaction.fetchone(
         """
         UPDATE matrix_delivery_outbox SET permanent_failure_reason = ?
         WHERE principal_id = ? AND delivery_id = ? AND stage = ?
           AND acknowledged_event_id IS NULL AND retired = 0
           AND permanent_failure_reason IS NULL
+        RETURNING delivery_id
         """,
         (reason, principal_id, delivery_id, stage.value),
     )
+    if failed is not None and stage is DeliveryStage.INITIAL:
+        transaction.execute(
+            """
+            UPDATE matrix_delivery_outbox
+            SET permanent_failure_reason = ?
+            WHERE principal_id = ? AND delivery_id = ? AND stage = ?
+              AND acknowledged_event_id IS NULL AND retired = 0
+              AND edit_target_pending = 1 AND permanent_failure_reason IS NULL
+            """,
+            (
+                f"required edit target was permanently refused: {reason}",
+                principal_id,
+                delivery_id,
+                DeliveryStage.FINAL.value,
+            ),
+        )
     row = transaction.fetchone(
         """
         SELECT acknowledged_event_id FROM matrix_delivery_outbox

--- a/src/mindroom/event_journal/outbox.py
+++ b/src/mindroom/event_journal/outbox.py
@@ -91,6 +91,17 @@ def _delivery_result_json(result: Mapping[str, object] | None) -> str | None:
     return json.dumps(dict(result), ensure_ascii=True, separators=(",", ":"), sort_keys=True)
 
 
+def _legacy_delivery_result(payload: Mapping[str, object]) -> dict[str, object] | None:
+    """Read the local result older writers placed inside Matrix content."""
+    replacement = payload.get("m.new_content")
+    legacy_result = (
+        cast("Mapping[str, object]", replacement).get(_LEGACY_FINAL_OUTCOME_KEY)
+        if isinstance(replacement, dict)
+        else payload.get(_LEGACY_FINAL_OUTCOME_KEY)
+    )
+    return dict(cast("Mapping[str, object]", legacy_result)) if isinstance(legacy_result, dict) else None
+
+
 def _delivery_identity(content: Mapping[str, object] | None) -> tuple[str, str, DeliveryStage] | None:
     """Return the stable outbox identity carried by one Matrix payload."""
     if content is None:
@@ -686,13 +697,7 @@ def _delivery(row: Row) -> MatrixDelivery:
         raise TypeError(msg)
     raw_result = row["result_json"]
     if raw_result is None:
-        replacement = payload.get("m.new_content")
-        legacy_result = (
-            replacement.get(_LEGACY_FINAL_OUTCOME_KEY)
-            if isinstance(replacement, dict)
-            else payload.get(_LEGACY_FINAL_OUTCOME_KEY)
-        )
-        result = dict(legacy_result) if isinstance(legacy_result, dict) else None
+        result = _legacy_delivery_result(payload)
     else:
         decoded_result = json.loads(raw_result)
         if not isinstance(decoded_result, dict):

--- a/src/mindroom/event_journal/outbox.py
+++ b/src/mindroom/event_journal/outbox.py
@@ -156,9 +156,12 @@ def enqueue(
     edits_event_id: str | None,
     result: Mapping[str, object] | None = None,
     edit_target_pending: bool = False,
+    permanent_failure_reason: str | None = None,
 ) -> str | None:
     """Record delivery intent without changing its durable membership owner."""
-    permanent_failure_reason: str | None = None
+    if permanent_failure_reason is not None and not permanent_failure_reason:
+        msg = "A permanent Matrix delivery failure requires a reason"
+        raise ValueError(msg)
     _lock_delivery_stages(transaction, principal_id, delivery_id)
     existing_owner = transaction.fetchone(
         """
@@ -185,7 +188,9 @@ def enqueue(
         if initial is not None and initial["acknowledged_event_id"] is not None:
             edits_event_id = str(initial["acknowledged_event_id"])
             edit_target_pending = False
-        elif initial is not None and initial["permanent_failure_reason"] is not None:
+        elif (
+            permanent_failure_reason is None and initial is not None and initial["permanent_failure_reason"] is not None
+        ):
             permanent_failure_reason = "required edit target was permanently refused: " + str(
                 initial["permanent_failure_reason"],
             )
@@ -208,6 +213,7 @@ def enqueue(
             edit_target_pending = excluded.edit_target_pending,
             permanent_failure_reason = excluded.permanent_failure_reason
         WHERE matrix_delivery_outbox.attempted = 0
+          AND matrix_delivery_outbox.permanent_failure_reason IS NULL
         """,
         (
             principal_id,

--- a/src/mindroom/event_journal/postgres_backend.py
+++ b/src/mindroom/event_journal/postgres_backend.py
@@ -123,7 +123,11 @@ class PostgresBackend:
                 SELECT table_name, column_name
                 FROM information_schema.columns
                 WHERE table_schema = current_schema()
-                  AND table_name IN ('approval_continuation_calls', 'interactive_questions')
+                  AND table_name IN (
+                      'approval_continuation_calls',
+                      'interactive_questions',
+                      'matrix_delivery_outbox'
+                  )
                 """,
             )
             existing_columns = cursor.fetchall()
@@ -135,9 +139,13 @@ class PostgresBackend:
             interactive_question_columns = frozenset(
                 str(row["column_name"]) for row in existing_columns if row["table_name"] == "interactive_questions"
             )
+            matrix_delivery_outbox_columns = frozenset(
+                str(row["column_name"]) for row in existing_columns if row["table_name"] == "matrix_delivery_outbox"
+            )
             for statement in pre_schema_migration_statements(
                 approval_continuation_call_columns=approval_continuation_call_columns,
                 interactive_question_columns=interactive_question_columns,
+                matrix_delivery_outbox_columns=matrix_delivery_outbox_columns,
             ):
                 cursor.execute(cast("LiteralString", statement))
             transaction = _PostgresTransaction(cursor)

--- a/src/mindroom/event_journal/schema.py
+++ b/src/mindroom/event_journal/schema.py
@@ -233,6 +233,9 @@ _TABLES = (
         thread_id TEXT NOT NULL,
         transaction_id TEXT NOT NULL,
         payload_json TEXT NOT NULL,
+        -- Local semantic facts needed after acknowledgement. These are not
+        -- Matrix event content and are never sent by the delivery worker.
+        result_json TEXT,
         edits_event_id TEXT,
         -- A durable edit can be reserved before the INITIAL event ID exists.
         -- Its claim waits until INITIAL acknowledgement fills the target.

--- a/src/mindroom/event_journal/schema.py
+++ b/src/mindroom/event_journal/schema.py
@@ -242,6 +242,7 @@ _TABLES = (
         edit_target_pending INTEGER NOT NULL DEFAULT 0,
         attempted INTEGER NOT NULL DEFAULT 0,
         retired INTEGER NOT NULL DEFAULT 0,
+        permanent_failure_reason TEXT,
         -- The device whose transaction ID the homeserver may already hold. A
         -- transaction ID deduplicates within one device, so a row attempted by
         -- a device this process is no longer logged in as carries an ID that

--- a/src/mindroom/event_journal/schema_migrations.py
+++ b/src/mindroom/event_journal/schema_migrations.py
@@ -7,6 +7,7 @@ def pre_schema_migration_statements(
     *,
     approval_continuation_call_columns: frozenset[str] = frozenset(),
     interactive_question_columns: frozenset[str] = frozenset(),
+    matrix_delivery_outbox_columns: frozenset[str] = frozenset(),
 ) -> tuple[str, ...]:
     """Return upgrades that must run before installing the current schema."""
     statements: list[str] = []
@@ -14,6 +15,8 @@ def pre_schema_migration_statements(
         statements.append(
             "ALTER TABLE approval_continuation_calls ADD COLUMN human_approval_required BOOLEAN",
         )
+    if matrix_delivery_outbox_columns and "result_json" not in matrix_delivery_outbox_columns:
+        statements.append("ALTER TABLE matrix_delivery_outbox ADD COLUMN result_json TEXT")
     if "claimed_source_event_id" in interactive_question_columns:
         statements.extend(
             (

--- a/src/mindroom/event_journal/schema_migrations.py
+++ b/src/mindroom/event_journal/schema_migrations.py
@@ -17,6 +17,8 @@ def pre_schema_migration_statements(
         )
     if matrix_delivery_outbox_columns and "result_json" not in matrix_delivery_outbox_columns:
         statements.append("ALTER TABLE matrix_delivery_outbox ADD COLUMN result_json TEXT")
+    if matrix_delivery_outbox_columns and "permanent_failure_reason" not in matrix_delivery_outbox_columns:
+        statements.append("ALTER TABLE matrix_delivery_outbox ADD COLUMN permanent_failure_reason TEXT")
     if "claimed_source_event_id" in interactive_question_columns:
         statements.extend(
             (

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -211,9 +211,13 @@ class SqliteBackend:
             approval_continuation_call_columns = frozenset(
                 str(row[1]) for row in connection.execute("PRAGMA table_info(approval_continuation_calls)")
             )
+            matrix_delivery_outbox_columns = frozenset(
+                str(row[1]) for row in connection.execute("PRAGMA table_info(matrix_delivery_outbox)")
+            )
             for statement in pre_schema_migration_statements(
                 approval_continuation_call_columns=approval_continuation_call_columns,
                 interactive_question_columns=interactive_question_columns,
+                matrix_delivery_outbox_columns=matrix_delivery_outbox_columns,
             ):
                 connection.execute(statement)
             transaction = _SqliteTransaction(connection)

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -1091,7 +1091,7 @@ class PrincipalStore:
         )
 
     async def finish_approval_continuation(self, approval_id: str) -> bool:
-        """Settle one paused run only after its FINAL delivery is acknowledged."""
+        """Settle one paused run after its FINAL delivery reaches a terminal outcome."""
         return await self._backend.write(
             lambda transaction: approval_continuations.finish(
                 transaction,

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -666,6 +666,24 @@ class PrincipalStore:
             ),
         )
 
+    async def record_permanent_matrix_delivery_failure(
+        self,
+        *,
+        delivery_id: str,
+        stage: DeliveryStage,
+        reason: str,
+    ) -> str | None:
+        """Stop retrying one definitively refused immutable payload, or return its ACK."""
+        return await self._backend.write(
+            lambda transaction: outbox.record_permanent_failure(
+                transaction,
+                self._principal_id,
+                delivery_id=delivery_id,
+                stage=stage,
+                reason=reason,
+            ),
+        )
+
     async def retire_matrix_delivery(
         self,
         *,

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -576,6 +576,7 @@ class PrincipalStore:
         event_type: str = "m.room.message",
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),
+        permanent_failure_reason: str | None = None,
     ) -> str | None:
         """Record delivery intent, or refuse it as an answer to a membership that ended.
 
@@ -605,6 +606,7 @@ class PrincipalStore:
                 result=result,
                 edits_event_id=edits_event_id,
                 settle_source_event_ids=settle_source_event_ids,
+                permanent_failure_reason=permanent_failure_reason,
             ),
         )
 
@@ -1204,6 +1206,7 @@ def _enqueue_matrix_delivery(
     result: Mapping[str, object] | None,
     edits_event_id: str | None,
     settle_source_event_ids: tuple[str, ...],
+    permanent_failure_reason: str | None,
 ) -> str | None:
     """Record delivery intent unless the membership that authorized it has ended.
 
@@ -1277,6 +1280,7 @@ def _enqueue_matrix_delivery(
         payload=payload,
         result=result,
         edits_event_id=edits_event_id,
+        permanent_failure_reason=permanent_failure_reason,
     )
     if transaction_id is None:
         return None

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -572,6 +572,7 @@ class PrincipalStore:
         room_id: str,
         thread_id: str | None,
         payload: Mapping[str, object],
+        result: Mapping[str, object] | None = None,
         event_type: str = "m.room.message",
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),
@@ -601,6 +602,7 @@ class PrincipalStore:
                 room_id=room_id,
                 thread_id=thread_id,
                 payload=payload,
+                result=result,
                 edits_event_id=edits_event_id,
                 settle_source_event_ids=settle_source_event_ids,
             ),
@@ -1181,6 +1183,7 @@ def _enqueue_matrix_delivery(
     room_id: str,
     thread_id: str | None,
     payload: Mapping[str, object],
+    result: Mapping[str, object] | None,
     edits_event_id: str | None,
     settle_source_event_ids: tuple[str, ...],
 ) -> str | None:
@@ -1254,6 +1257,7 @@ def _enqueue_matrix_delivery(
         membership_epoch=membership_epoch,
         thread_id=thread_id,
         payload=payload,
+        result=result,
         edits_event_id=edits_event_id,
     )
     if transaction_id is None:

--- a/src/mindroom/event_journal/views.py
+++ b/src/mindroom/event_journal/views.py
@@ -314,6 +314,7 @@ class MatrixDeliveryView(Protocol):
         event_type: str = "m.room.message",
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),
+        permanent_failure_reason: str | None = None,
     ) -> str | None:
         """Record delivery intent and settle what it answers, or refuse both."""
         ...

--- a/src/mindroom/event_journal/views.py
+++ b/src/mindroom/event_journal/views.py
@@ -293,6 +293,11 @@ class MatrixDeliveryView(Protocol):
     delivery accounts for.
     """
 
+    @property
+    def principal_id(self) -> str:
+        """Return the principal whose delivery rows this view owns."""
+        ...
+
     async def membership_epoch(self, room_id: str) -> int:
         """Return the current membership epoch for one room."""
         ...

--- a/src/mindroom/event_journal/views.py
+++ b/src/mindroom/event_journal/views.py
@@ -346,6 +346,16 @@ class MatrixDeliveryView(Protocol):
         """Return one delivery without claiming it."""
         ...
 
+    async def record_permanent_matrix_delivery_failure(
+        self,
+        *,
+        delivery_id: str,
+        stage: DeliveryStage,
+        reason: str,
+    ) -> str | None:
+        """Stop retrying one definitively refused immutable payload, or return its ACK."""
+        ...
+
     async def retire_matrix_delivery(
         self,
         *,

--- a/src/mindroom/event_journal/views.py
+++ b/src/mindroom/event_journal/views.py
@@ -305,6 +305,7 @@ class MatrixDeliveryView(Protocol):
         room_id: str,
         thread_id: str | None,
         payload: Mapping[str, object],
+        result: Mapping[str, object] | None = None,
         event_type: str = "m.room.message",
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -266,7 +266,7 @@ def _can_send_to_encrypted_room(client: nio.AsyncClient, room_id: str, *, operat
     )
 
 
-async def _resolve_room_encryption_outcome(
+async def resolve_room_encryption_outcome(
     client: nio.AsyncClient,
     room_id: str,
     *,
@@ -313,7 +313,7 @@ async def resolve_room_encryption_for_delivery(
     operation: str,
 ) -> bool | None:
     """Return authoritative room encryption state for safe outbound preparation."""
-    outcome = await _resolve_room_encryption_outcome(client, room_id, operation=operation)
+    outcome = await resolve_room_encryption_outcome(client, room_id, operation=operation)
     return outcome if isinstance(outcome, bool) else None
 
 
@@ -374,7 +374,7 @@ async def send_message_outcome(
     room_encryption_override: bool | None = None
     if isinstance(rooms, Mapping):
         room = rooms.get(room_id)
-        encryption_outcome = await _resolve_room_encryption_outcome(
+        encryption_outcome = await resolve_room_encryption_outcome(
             client,
             room_id,
             operation=operation,
@@ -855,6 +855,7 @@ __all__ = [
     "edit_message_outcome",
     "edit_message_result",
     "resolve_room_encryption_for_delivery",
+    "resolve_room_encryption_outcome",
     "send_audio_message",
     "send_file_message",
     "send_message_outcome",

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -399,6 +399,7 @@ async def send_message_outcome(
                 room_id,
                 content,
                 room_encrypted=room_encryption_override,
+                transition_safe=True,
             )
         except MatrixEventTooLargeError as error:
             return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -17,7 +17,7 @@ from nio.api import Api
 from nio.exceptions import OlmTrustError
 
 from mindroom.logging_config import get_logger
-from mindroom.matrix.large_messages import prepare_large_message
+from mindroom.matrix.large_messages import MatrixEventTooLargeError, prepare_large_message
 from mindroom.matrix.media import upload_content_uri, upload_media_bytes
 from mindroom.matrix.message_builder import build_matrix_edit_content
 from mindroom.timing import emit_timing_event
@@ -48,6 +48,7 @@ class MatrixDeliveryFailureKind(enum.Enum):
 
     ENCRYPTION_GUARD = "encryption_guard"
     UNKNOWN_ENCRYPTION_STATE = "unknown_encryption_state"
+    PAYLOAD_TOO_LARGE = "payload_too_large"
     SEND_EXCEPTION = "send_exception"
     UNEXPECTED_RESPONSE = "unexpected_response"
 
@@ -392,12 +393,15 @@ async def send_message_outcome(
     )
     content_sent = content
     if not content_is_prepared:
-        content_sent = await prepare_large_message(
-            client,
-            room_id,
-            content,
-            room_encrypted=room_encryption_override,
-        )
+        try:
+            content_sent = await prepare_large_message(
+                client,
+                room_id,
+                content,
+                room_encrypted=room_encryption_override,
+            )
+        except MatrixEventTooLargeError as error:
+            return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
     emit_timing_event(
         "Matrix send timing",
         phase="prepare_finish",

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import enum
 import mimetypes
-from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -23,6 +22,8 @@ from mindroom.matrix.message_builder import build_matrix_edit_content
 from mindroom.timing import emit_timing_event
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable, Sequence
+
     from mindroom.matrix.runtime_media import RuntimeEncryptedMediaAttachment
 
 logger = get_logger(__name__)
@@ -225,13 +226,7 @@ async def _send_prepared_room_message(
 
 def cached_room(client: nio.AsyncClient, room_id: str) -> nio.MatrixRoom | None:
     """Return one room from nio's in-memory room cache if present."""
-    return _cached_rooms(client).get(room_id)
-
-
-def _cached_rooms(client: nio.AsyncClient) -> Mapping[str, nio.MatrixRoom]:
-    """Return the client room cache when nio has initialized it."""
-    rooms = client.rooms
-    return rooms if isinstance(rooms, Mapping) else {}
+    return client.rooms.get(room_id)
 
 
 def _has_encrypted_delivery_support(
@@ -371,18 +366,16 @@ async def send_message_outcome(
 
     rooms = client.rooms
     cache_bypass = False
-    room_encryption_override: bool | None = None
-    if isinstance(rooms, Mapping):
-        room = rooms.get(room_id)
-        encryption_outcome = await resolve_room_encryption_outcome(
-            client,
-            room_id,
-            operation=operation,
-        )
-        if isinstance(encryption_outcome, MatrixDeliveryFailure):
-            return encryption_outcome
-        room_encryption_override = encryption_outcome
-        cache_bypass = room is None and not room_encryption_override
+    room = rooms.get(room_id)
+    encryption_outcome = await resolve_room_encryption_outcome(
+        client,
+        room_id,
+        operation=operation,
+    )
+    if isinstance(encryption_outcome, MatrixDeliveryFailure):
+        return encryption_outcome
+    room_encryption_override = encryption_outcome
+    cache_bypass = room is None and not room_encryption_override
 
     message_type = "m.room.message"
     emit_timing_event(
@@ -399,7 +392,6 @@ async def send_message_outcome(
                 room_id,
                 content,
                 room_encrypted=room_encryption_override,
-                transition_safe=True,
             )
         except MatrixEventTooLargeError as error:
             return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
@@ -454,6 +446,11 @@ async def send_message_outcome(
             cache_bypass=cache_bypass,
         )
         return DeliveredMatrixEvent(event_id=str(response.event_id), content_sent=content_sent)
+    failure_kind = MatrixDeliveryFailureKind.UNEXPECTED_RESPONSE
+    failure_detail = str(response)
+    if isinstance(response, nio.RoomSendError) and response.status_code == "M_TOO_LARGE":
+        failure_kind = MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE
+        failure_detail = response.message
     emit_timing_event(
         "Matrix send timing",
         phase="send_finish",
@@ -469,7 +466,10 @@ async def send_message_outcome(
         error=str(response),
         cache_bypass=cache_bypass,
     )
-    return MatrixDeliveryFailure(MatrixDeliveryFailureKind.UNEXPECTED_RESPONSE, str(response))
+    return MatrixDeliveryFailure(
+        failure_kind,
+        failure_detail,
+    )
 
 
 async def send_message_result(

--- a/src/mindroom/matrix/client_session.py
+++ b/src/mindroom/matrix/client_session.py
@@ -13,14 +13,12 @@ import nio
 
 from mindroom.constants import (
     CLASSIC_SYNC_TIMELINE_LIMIT,
-    CONFIG_CONFIRMATION_REACTION_KEY,
-    STREAM_STATUS_KEY,
-    VISIBLE_ROUTER_VOICE_ECHO_KEY,
     RuntimePaths,
     encryption_keys_dir,
     runtime_matrix_ssl_verify,
 )
 from mindroom.logging_config import get_logger
+from mindroom.matrix.encrypted_event_metadata import encryption_visible_metadata
 from mindroom.matrix.event_types import CALL_ENCRYPTION_KEYS_EVENT_TYPE
 from mindroom.matrix.to_device import AuthenticatedToDeviceEvent
 from mindroom.startup_errors import PermanentStartupError
@@ -122,14 +120,7 @@ class _MindRoomAsyncClient(nio.AsyncClient):
     ) -> tuple[str, dict[str, Any]]:
         """Expose coarse delivery markers needed without decrypting room history."""
         encrypted_message_type, encrypted_content = super().encrypt(room_id, message_type, content)
-        stream_status = content.get(STREAM_STATUS_KEY)
-        if isinstance(stream_status, str):
-            encrypted_content[STREAM_STATUS_KEY] = stream_status
-        if content.get(VISIBLE_ROUTER_VOICE_ECHO_KEY) is True:
-            encrypted_content[VISIBLE_ROUTER_VOICE_ECHO_KEY] = True
-        config_reaction_id = content.get(CONFIG_CONFIRMATION_REACTION_KEY)
-        if isinstance(config_reaction_id, str):
-            encrypted_content[CONFIG_CONFIRMATION_REACTION_KEY] = config_reaction_id
+        encrypted_content.update(encryption_visible_metadata(content))
         return encrypted_message_type, encrypted_content
 
     def _handle_olm_events(self, response: nio.SyncResponse | nio.SlidingSyncResponse) -> None:

--- a/src/mindroom/matrix/encrypted_event_metadata.py
+++ b/src/mindroom/matrix/encrypted_event_metadata.py
@@ -1,0 +1,29 @@
+"""Cleartext metadata intentionally exposed on encrypted Matrix events."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from mindroom.constants import (
+    CONFIG_CONFIRMATION_REACTION_KEY,
+    STREAM_STATUS_KEY,
+    VISIBLE_ROUTER_VOICE_ECHO_KEY,
+)
+
+
+def encryption_visible_metadata(content: Mapping[Any, Any]) -> dict[str, str | bool]:
+    """Return metadata copied outside the encrypted event payload.
+
+    This is the single source of truth for both real encryption and preflight
+    size estimation. Keeping the allowlist here prevents durable payloads from
+    passing preparation with an envelope smaller than the one sent on the wire.
+    """
+    visible_metadata: dict[str, str | bool] = {}
+    stream_status = content.get(STREAM_STATUS_KEY)
+    if isinstance(stream_status, str):
+        visible_metadata[STREAM_STATUS_KEY] = stream_status
+    if content.get(VISIBLE_ROUTER_VOICE_ECHO_KEY) is True:
+        visible_metadata[VISIBLE_ROUTER_VOICE_ECHO_KEY] = True
+    config_reaction_id = content.get(CONFIG_CONFIRMATION_REACTION_KEY)
+    if isinstance(config_reaction_id, str):
+        visible_metadata[CONFIG_CONFIRMATION_REACTION_KEY] = config_reaction_id
+    return visible_metadata

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -179,8 +179,7 @@ def _without_local_recovery_data(content: dict[str, Any]) -> dict[str, Any]:
 
 
 def _room_is_encrypted(client: nio.AsyncClient, room_id: str | None) -> bool:
-    rooms = getattr(client, "rooms", {})
-    return bool(room_id and isinstance(rooms, dict) and room_id in rooms and rooms[room_id].encrypted)
+    return bool(room_id and room_id in client.rooms and client.rooms[room_id].encrypted)
 
 
 def _add_sidecar_metadata(
@@ -276,11 +275,10 @@ def _delivery_event_size_calculator(
     room_encrypted: bool,
 ) -> Callable[[dict[str, Any]], int]:
     """Bind the delivery-specific fields needed by repeated preview fitting."""
-    olm = getattr(client, "olm", None)
-    raw_device_id = getattr(olm, "device_id", None)
-    if not isinstance(raw_device_id, str):
-        raw_device_id = getattr(client, "device_id", None)
-    device_id = raw_device_id if isinstance(raw_device_id, str) else None
+    device_id: str | None = None
+    if room_encrypted:
+        raw_device_id = client.olm.device_id if client.olm is not None else client.device_id
+        device_id = raw_device_id if isinstance(raw_device_id, str) else None
 
     def calculate(candidate: dict[str, Any]) -> int:
         return _calculate_delivery_event_size(

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -16,6 +16,7 @@ from nio import crypto
 from mindroom.constants import (
     AI_RUN_METADATA_KEY,
     ATTACHMENT_IDS_KEY,
+    DURABLE_FINAL_OUTCOME_KEY,
     HOOK_MESSAGE_RECEIVED_DEPTH_KEY,
     HOOK_SOURCE_KEY,
     ORIGINAL_SENDER_KEY,
@@ -70,6 +71,7 @@ _SIDECAR_ONLY_MINDROOM_KEYS = frozenset(
 _NONTERMINAL_STREAM_STATUSES = frozenset({STREAM_STATUS_PENDING, STREAM_STATUS_STREAMING})
 _NONTERMINAL_STREAM_PREVIEW_BYTES = 12000
 _MATRIX_EVENT_HARD_LIMIT = 64000
+_UNREPRESENTABLE_MESSAGE_ERROR = "Large message cannot fit within the Matrix event limit after sidecar preparation"
 _OVERSIZED_NONTERMINAL_STREAMING_EDIT_MIN_INTERVAL_SECONDS = 5.0
 _oversized_nonterminal_streaming_edit_sent_at: dict[tuple[str, str], float] = {}
 
@@ -86,7 +88,12 @@ def _is_passthrough_preview_key(key: object) -> bool:
 
 def _is_passthrough_edit_wrapper_key(key: object) -> bool:
     """Return whether one source key should be mirrored onto the edit wrapper."""
-    return isinstance(key, str) and key.startswith("io.mindroom.") and key not in _SIDECAR_ONLY_MINDROOM_KEYS
+    return (
+        isinstance(key, str)
+        and key.startswith("io.mindroom.")
+        and key not in _SIDECAR_ONLY_MINDROOM_KEYS
+        and key != DURABLE_FINAL_OUTCOME_KEY
+    )
 
 
 def _copy_preview_metadata(source_content: dict[str, Any], target_content: dict[str, Any]) -> None:
@@ -247,6 +254,66 @@ def _build_nonterminal_streaming_edit_preview(
             break
         preview_limit = max(0, preview_limit // 2)
     return None
+
+
+def _build_terminal_edit_preview(
+    content: dict[str, Any],
+    source_content: dict[str, Any],
+    preview_content: dict[str, Any],
+    preview_text: str,
+    *,
+    continuation_indicator: str,
+) -> dict[str, Any]:
+    """Fit a terminal edit after all replacement and wrapper metadata is present."""
+    preview_body = preview_content.get("body")
+    if not isinstance(preview_body, str):
+        msg = "Large-message preview body must be text"
+        raise TypeError(msg)
+
+    inner_limit = len(preview_body.encode("utf-8"))
+    while True:
+        inner_content = dict(preview_content)
+        inner_content["body"] = _create_preview(
+            preview_text,
+            inner_limit,
+            continuation_indicator=continuation_indicator,
+        )
+        outer_limit = len(inner_content["body"].encode("utf-8"))
+        while True:
+            outer_preview = _create_preview(
+                preview_text,
+                outer_limit,
+                continuation_indicator=continuation_indicator,
+            )
+            modified_content: dict[str, Any] = {
+                "msgtype": source_content.get("msgtype", "m.text"),
+                "body": f"* {outer_preview}",
+                "m.new_content": inner_content,
+                "m.relates_to": content.get("m.relates_to", {}),
+            }
+            _copy_edit_wrapper_metadata(source_content, modified_content)
+            if _calculate_event_size(modified_content) <= _MATRIX_EVENT_HARD_LIMIT:
+                return modified_content
+            if outer_limit == 0:
+                break
+            outer_limit = max(0, outer_limit // 2)
+        if inner_limit == 0:
+            raise ValueError(_UNREPRESENTABLE_MESSAGE_ERROR)
+        inner_limit = max(0, inner_limit // 2)
+
+
+def _ensure_event_fits(content: dict[str, Any], *, room_id: str) -> None:
+    """Reject any prepared payload that still exceeds the Matrix event limit."""
+    final_size = _calculate_event_size(content)
+    if final_size <= _MATRIX_EVENT_HARD_LIMIT:
+        return
+    logger.error(
+        "large_message_cannot_fit_event_limit",
+        room_id=room_id,
+        final_size_bytes=final_size,
+        size_limit_bytes=_MATRIX_EVENT_HARD_LIMIT,
+    )
+    raise ValueError(_UNREPRESENTABLE_MESSAGE_ERROR)
 
 
 def _prefix_by_bytes(text: str, max_bytes: int) -> str:
@@ -609,7 +676,8 @@ async def prepare_large_message(
         room_encrypted=room_encrypted,
     )
 
-    if sidecar_upload_is_usable(mxc_uri, file_info, room_encrypted=room_encrypted):
+    sidecar_usable = sidecar_upload_is_usable(mxc_uri, file_info, room_encrypted=room_encrypted)
+    if sidecar_usable:
         _copy_preview_metadata(source_content, modified_content)
         _add_sidecar_metadata(
             modified_content,
@@ -633,22 +701,15 @@ async def prepare_large_message(
         modified_content["m.relates_to"] = content["m.relates_to"]
 
     if is_edit and "m.new_content" in content:
-        modified_content = {
-            "msgtype": source_content.get("msgtype", "m.text"),
-            "body": f"* {modified_content['body']}",
-            "m.new_content": modified_content,
-            "m.relates_to": content.get("m.relates_to", {}),
-        }
-        _copy_edit_wrapper_metadata(source_content, modified_content)
-
-    final_size = _calculate_event_size(modified_content)
-    if final_size > 64000:
-        logger.warning(
-            "large_message_still_exceeds_limit",
-            room_id=room_id,
-            final_size_bytes=final_size,
-            size_limit_bytes=64000,
+        modified_content = _build_terminal_edit_preview(
+            content,
+            source_content,
+            modified_content,
+            preview_text,
+            continuation_indicator=(_CONTINUATION_INDICATOR if sidecar_usable else _SIDECAR_UPLOAD_FALLBACK_INDICATOR),
         )
+
+    _ensure_event_fits(modified_content, room_id=room_id)
 
     new_content = modified_content.get("m.new_content")
     inner = new_content if isinstance(new_content, dict) else modified_content

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 from time import monotonic
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import nio
 from nio import crypto
@@ -36,6 +36,9 @@ from mindroom.constants import (
 from mindroom.logging_config import get_logger
 from mindroom.matrix.media import upload_content_uri, upload_media_bytes
 from mindroom.matrix.message_builder import markdown_to_html
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 logger = get_logger(__name__)
 
@@ -270,8 +273,7 @@ def _build_terminal_edit_preview(
         msg = "Large-message preview body must be text"
         raise TypeError(msg)
 
-    inner_limit = len(preview_body.encode("utf-8"))
-    while True:
+    def build_inner(inner_limit: int) -> dict[str, Any]:
         inner_content = dict(preview_content)
         inner_content["body"] = (
             _create_preview(
@@ -287,28 +289,59 @@ def _build_terminal_edit_preview(
             sidecar_metadata = dict(sidecar_metadata)
             sidecar_metadata["preview_size"] = len(inner_content["body"])
             inner_content["io.mindroom.long_text"] = sidecar_metadata
-        outer_limit = len(inner_content["body"].encode("utf-8"))
-        while True:
-            outer_body = (
-                f"* {_create_preview(preview_text, outer_limit, continuation_indicator=continuation_indicator)}"
-                if outer_limit > 0
-                else ""
-            )
-            modified_content: dict[str, Any] = {
-                "msgtype": source_content.get("msgtype", "m.text"),
-                "body": outer_body,
-                "m.new_content": inner_content,
-                "m.relates_to": content.get("m.relates_to", {}),
-            }
-            _copy_edit_wrapper_metadata(source_content, modified_content)
-            if _calculate_event_size(modified_content) <= _MATRIX_EVENT_HARD_LIMIT:
-                return modified_content
-            if outer_limit == 0:
-                break
-            outer_limit = max(0, outer_limit // 2)
-        if inner_limit == 0:
-            raise ValueError(_UNREPRESENTABLE_MESSAGE_ERROR)
-        inner_limit = max(0, inner_limit // 2)
+        return inner_content
+
+    def build_event(inner_content: dict[str, Any], outer_limit: int) -> dict[str, Any]:
+        outer_body = (
+            f"* {_create_preview(preview_text, outer_limit, continuation_indicator=continuation_indicator)}"
+            if outer_limit > 0
+            else ""
+        )
+        modified_content: dict[str, Any] = {
+            "msgtype": source_content.get("msgtype", "m.text"),
+            "body": outer_body,
+            "m.new_content": inner_content,
+            "m.relates_to": content.get("m.relates_to", {}),
+        }
+        _copy_edit_wrapper_metadata(source_content, modified_content)
+        return modified_content
+
+    def fits(inner_content: dict[str, Any], outer_limit: int) -> bool:
+        return _calculate_event_size(build_event(inner_content, outer_limit)) <= _MATRIX_EVENT_HARD_LIMIT
+
+    empty_inner = build_inner(0)
+    if not fits(empty_inner, 0):
+        raise ValueError(_UNREPRESENTABLE_MESSAGE_ERROR)
+
+    maximum_inner_limit = len(preview_body.encode("utf-8"))
+    full_inner = build_inner(maximum_inner_limit)
+    if fits(full_inner, 0):
+        fitted_inner = full_inner
+    else:
+        inner_limit = _largest_fitting_limit(
+            maximum_inner_limit,
+            lambda candidate_limit: fits(build_inner(candidate_limit), 0),
+        )
+        fitted_inner = build_inner(inner_limit)
+
+    outer_limit = _largest_fitting_limit(
+        len(fitted_inner["body"].encode("utf-8")),
+        lambda candidate_limit: fits(fitted_inner, candidate_limit),
+    )
+    return build_event(fitted_inner, outer_limit)
+
+
+def _largest_fitting_limit(maximum: int, fits: Callable[[int], bool]) -> int:
+    """Return the greatest monotonic byte limit accepted by ``fits``."""
+    lower = 0
+    upper = maximum
+    while lower < upper:
+        candidate = (lower + upper + 1) // 2
+        if fits(candidate):
+            lower = candidate
+        else:
+            upper = candidate - 1
+    return lower
 
 
 def _ensure_event_fits(content: dict[str, Any], *, room_id: str) -> None:

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -80,6 +80,14 @@ _MATRIX_EVENT_HARD_LIMIT = 64000
 _MEGOLM_AES_BLOCK_BYTES = 16
 _MEGOLM_MAX_MESSAGE_INDEX_VARINT_BYTES = 5
 _MEGOLM_BASE64_KEY_LENGTH = 43
+# A transition-safe payload may be encrypted by a different device after recovery.
+# Matrix leaves device IDs opaque, so fitting to the current ID would put a
+# mutable envelope field exactly on the event boundary. Budget 1 KiB for its
+# canonical JSON value and use an even larger current value verbatim. This
+# keeps ordinary device rotation from invalidating frozen bytes without
+# shrinking typical previews by more than a small fraction. It is deliberately
+# recovery headroom, not a claimed protocol maximum.
+_RECOVERY_DEVICE_ID_JSON_RESERVE_BYTES = 1024
 _UNREPRESENTABLE_MESSAGE_ERROR = "Large message cannot fit within the Matrix event limit after sidecar preparation"
 _OVERSIZED_NONTERMINAL_STREAMING_EDIT_MIN_INTERVAL_SECONDS = 5.0
 _oversized_nonterminal_streaming_edit_sent_at: dict[tuple[str, str], float] = {}
@@ -186,7 +194,7 @@ def _room_is_encrypted(client: nio.AsyncClient, room_id: str | None) -> bool:
 def _add_sidecar_metadata(
     target_content: dict[str, Any],
     *,
-    room_encrypted: bool,
+    sidecar_encrypted: bool,
     mxc_uri: str | None,
     file_info: dict[str, Any] | None,
     original_size: int,
@@ -194,7 +202,7 @@ def _add_sidecar_metadata(
     if mxc_uri is None or file_info is None:
         return
 
-    if room_encrypted:
+    if sidecar_encrypted:
         target_content["file"] = file_info
     else:
         target_content["url"] = mxc_uri
@@ -282,12 +290,18 @@ def _delivery_event_size_calculator(
     *,
     room_id: str,
     room_encrypted: bool,
+    recovery_safe: bool,
 ) -> Callable[[dict[str, Any]], int]:
-    """Bind the delivery-specific fields needed by repeated preview fitting."""
+    """Bind delivery fields while reserving mutable recovery-envelope space."""
     device_id: str | None = None
     if room_encrypted:
-        raw_device_id = client.olm.device_id if client.olm is not None else client.device_id
+        olm = getattr(client, "olm", None)
+        raw_device_id = getattr(olm, "device_id", None) if olm is not None else getattr(client, "device_id", None)
         device_id = raw_device_id if isinstance(raw_device_id, str) else None
+        device_id_json_bytes = len(json.dumps(device_id).encode("utf-8")) if device_id is not None else 0
+        if recovery_safe and device_id_json_bytes < _RECOVERY_DEVICE_ID_JSON_RESERVE_BYTES:
+            # Quotes occupy two bytes in the serialized JSON value.
+            device_id = "d" * (_RECOVERY_DEVICE_ID_JSON_RESERVE_BYTES - 2)
 
     def calculate(candidate: dict[str, Any]) -> int:
         return _calculate_delivery_event_size(
@@ -353,7 +367,7 @@ def _build_nonterminal_streaming_edit_preview(
     source_content: dict[str, Any],
     preview_text: str,
     *,
-    room_encrypted: bool,
+    sidecar_encrypted: bool,
     mxc_uri: str | None,
     file_info: dict[str, Any] | None,
     original_size: int,
@@ -377,7 +391,7 @@ def _build_nonterminal_streaming_edit_preview(
         _copy_inline_streaming_preview_metadata(source_content, preview_content)
         _add_sidecar_metadata(
             preview_content,
-            room_encrypted=room_encrypted,
+            sidecar_encrypted=sidecar_encrypted,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=original_size,
@@ -692,26 +706,31 @@ async def _build_file_content(
     preview_text: str,
     size_limit: int,
     *,
-    room_encrypted: bool,
+    sidecar_encrypted: bool,
+    use_file_message: bool,
+    preview_msgtype: str,
 ) -> tuple[str | None, dict[str, Any] | None, dict[str, Any]]:
-    """Upload full original content JSON and build preview ``m.file`` event."""
+    """Upload full original content JSON and build its parseable preview."""
     mxc_uri, file_info = await upload_json_sidecar(
         client,
         room_id,
         full_content,
-        room_encrypted=room_encrypted,
+        room_encrypted=sidecar_encrypted,
     )
 
     available = size_limit - _LARGE_MESSAGE_PREVIEW_OVERHEAD_BYTES
     preview = _create_preview(preview_text, available)
 
-    modified_content: dict[str, Any] = {
-        "msgtype": "m.file",
-        "body": preview,
-        "filename": "message-content.json",
-    }
-    if file_info is not None:
-        modified_content["info"] = file_info
+    modified_content: dict[str, Any] = {"msgtype": preview_msgtype, "body": preview}
+    if use_file_message:
+        modified_content.update(
+            {
+                "msgtype": "m.file",
+                "filename": "message-content.json",
+            },
+        )
+        if file_info is not None:
+            modified_content["info"] = file_info
 
     return mxc_uri, file_info, modified_content
 
@@ -894,14 +913,15 @@ async def prepare_large_message(
         room_id: The room to send to
         content: The message content dictionary
         room_encrypted: Authoritative encryption state when the room cache is unavailable
-        transition_safe: Size for the strongest room state the payload may encounter
+        transition_safe: Prepare for the strongest room state the payload may encounter
 
-            Durable payloads can outlive the room state observed during preparation, while
-            room encryption can later change from disabled to enabled. Encrypted-envelope
-            sizing keeps their exact frozen bytes valid after that transition. The sidecar
-            still follows the current room state: a plaintext ``m.file`` remains valid inside
-            a later encrypted event, while an encrypted-file-only event cannot be parsed in a
-            plaintext room. Direct sends retain the default and use only the current state.
+            Durable payloads can outlive the observed room state, and a direct send can yield
+            during its sidecar upload while encryption changes from disabled to enabled.
+            Encrypted-envelope sizing and recovery-device headroom keep the prepared bytes
+            valid after that transition. Sidecars are encrypted up front. In a currently
+            plaintext room, the encrypted descriptor lives on a normal text preview: that
+            event parses before or after the transition, while an encrypted-file-only
+            ``m.file`` does not parse as a plaintext event.
 
     Returns:
         Original content (if small) or modified content with preview and MXC reference
@@ -917,7 +937,9 @@ async def prepare_large_message(
         client,
         room_id=room_id,
         room_encrypted=size_for_encrypted_delivery,
+        recovery_safe=transition_safe,
     )
+    sidecar_encrypted = room_encrypted or transition_safe
 
     current_size = _calculate_event_size(content)
     if current_size <= size_limit and calculate_delivery_event_size(content) <= _MATRIX_EVENT_HARD_LIMIT:
@@ -942,12 +964,12 @@ async def prepare_large_message(
             client,
             room_id,
             content,
-            room_encrypted=room_encrypted,
+            room_encrypted=sidecar_encrypted,
         )
         if not sidecar_upload_is_usable(
             mxc_uri,
             file_info,
-            room_encrypted=room_encrypted,
+            room_encrypted=sidecar_encrypted,
         ):
             logger.warning(
                 "large_message_sidecar_unavailable_using_inline_preview",
@@ -963,7 +985,7 @@ async def prepare_large_message(
             content,
             source_content,
             preview_text,
-            room_encrypted=room_encrypted,
+            sidecar_encrypted=sidecar_encrypted,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=current_size,
@@ -994,19 +1016,21 @@ async def prepare_large_message(
         content,
         preview_text,
         size_limit,
-        room_encrypted=room_encrypted,
+        sidecar_encrypted=sidecar_encrypted,
+        use_file_message=room_encrypted or not transition_safe,
+        preview_msgtype=("m.notice" if source_content.get("msgtype") == "m.notice" else "m.text"),
     )
 
     sidecar_usable = sidecar_upload_is_usable(
         mxc_uri,
         file_info,
-        room_encrypted=room_encrypted,
+        room_encrypted=sidecar_encrypted,
     )
     if sidecar_usable:
         _copy_preview_metadata(source_content, modified_content)
         _add_sidecar_metadata(
             modified_content,
-            room_encrypted=room_encrypted,
+            sidecar_encrypted=sidecar_encrypted,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=current_size,

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -273,21 +273,30 @@ def _build_terminal_edit_preview(
     inner_limit = len(preview_body.encode("utf-8"))
     while True:
         inner_content = dict(preview_content)
-        inner_content["body"] = _create_preview(
-            preview_text,
-            inner_limit,
-            continuation_indicator=continuation_indicator,
+        inner_content["body"] = (
+            _create_preview(
+                preview_text,
+                inner_limit,
+                continuation_indicator=continuation_indicator,
+            )
+            if inner_limit > 0
+            else ""
         )
+        sidecar_metadata = inner_content.get("io.mindroom.long_text")
+        if isinstance(sidecar_metadata, dict):
+            sidecar_metadata = dict(sidecar_metadata)
+            sidecar_metadata["preview_size"] = len(inner_content["body"])
+            inner_content["io.mindroom.long_text"] = sidecar_metadata
         outer_limit = len(inner_content["body"].encode("utf-8"))
         while True:
-            outer_preview = _create_preview(
-                preview_text,
-                outer_limit,
-                continuation_indicator=continuation_indicator,
+            outer_body = (
+                f"* {_create_preview(preview_text, outer_limit, continuation_indicator=continuation_indicator)}"
+                if outer_limit > 0
+                else ""
             )
             modified_content: dict[str, Any] = {
                 "msgtype": source_content.get("msgtype", "m.text"),
-                "body": f"* {outer_preview}",
+                "body": outer_body,
                 "m.new_content": inner_content,
                 "m.relates_to": content.get("m.relates_to", {}),
             }

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -800,12 +800,77 @@ def _build_text_fallback_content(
         preview_limit = max(0, preview_limit // 2)
 
 
+def _ensure_minimum_preview_can_fit(
+    content: dict[str, Any],
+    source_content: dict[str, Any],
+    *,
+    is_edit: bool,
+    room_id: str,
+    calculate_event_size: Callable[[dict[str, Any]], int],
+) -> None:
+    """Reject fixed metadata that cannot fit even with an empty text preview.
+
+    This is deliberately a lower-bound check before any sidecar upload. If the
+    smallest possible fallback cannot fit, uploading cannot make the event
+    deliverable and would only leave an unreferenced attachment behind.
+    """
+    preview_msgtype = "m.notice" if source_content.get("msgtype") == "m.notice" else "m.text"
+    minimum_preview: dict[str, Any] = {"msgtype": preview_msgtype, "body": ""}
+    _copy_preview_metadata(source_content, minimum_preview)
+
+    if is_edit:
+        minimum_event = _wrap_large_edit(content, source_content, minimum_preview)
+        minimum_event["body"] = ""
+    else:
+        minimum_event = minimum_preview
+        if "m.relates_to" in content:
+            minimum_event["m.relates_to"] = content["m.relates_to"]
+
+    _ensure_event_fits(
+        minimum_event,
+        room_id=room_id,
+        calculate_event_size=calculate_event_size,
+    )
+
+
+def _fit_large_message_preview(
+    content: dict[str, Any],
+    source_content: dict[str, Any],
+    preview_content: dict[str, Any],
+    preview_text: str,
+    *,
+    is_edit: bool,
+    continuation_indicator: str,
+    calculate_event_size: Callable[[dict[str, Any]], int],
+) -> dict[str, Any]:
+    """Attach relations and fit one regular or replacement preview."""
+    if "m.relates_to" in content:
+        preview_content["m.relates_to"] = content["m.relates_to"]
+
+    if is_edit and "m.new_content" in content:
+        return _build_terminal_edit_preview(
+            content,
+            source_content,
+            preview_content,
+            preview_text,
+            continuation_indicator=continuation_indicator,
+            calculate_event_size=calculate_event_size,
+        )
+    return _fit_regular_preview(
+        preview_content,
+        preview_text,
+        continuation_indicator=continuation_indicator,
+        calculate_event_size=calculate_event_size,
+    )
+
+
 async def prepare_large_message(
     client: nio.AsyncClient,
     room_id: str,
     content: dict[str, Any],
     *,
     room_encrypted: bool | None = None,
+    transition_safe: bool = False,
 ) -> dict[str, Any]:
     """Check if message is too large and prepare it if needed.
 
@@ -820,6 +885,14 @@ async def prepare_large_message(
         room_id: The room to send to
         content: The message content dictionary
         room_encrypted: Authoritative encryption state when the room cache is unavailable
+        transition_safe: Size for the strongest room state the payload may encounter
+
+            Durable payloads can outlive the room state observed during preparation, while
+            room encryption can later change from disabled to enabled. Encrypted-envelope
+            sizing keeps their exact frozen bytes valid after that transition. The sidecar
+            still follows the current room state: a plaintext ``m.file`` remains valid inside
+            a later encrypted event, while an encrypted-file-only event cannot be parsed in a
+            plaintext room. Direct sends retain the default and use only the current state.
 
     Returns:
         Original content (if small) or modified content with preview and MXC reference
@@ -830,10 +903,11 @@ async def prepare_large_message(
     size_limit = _EDIT_MESSAGE_LIMIT if is_edit else _NORMAL_MESSAGE_LIMIT
     if room_encrypted is None:
         room_encrypted = _room_is_encrypted(client, room_id)
+    size_for_encrypted_delivery = room_encrypted or transition_safe
     calculate_delivery_event_size = _delivery_event_size_calculator(
         client,
         room_id=room_id,
-        room_encrypted=room_encrypted,
+        room_encrypted=size_for_encrypted_delivery,
     )
 
     current_size = _calculate_event_size(content)
@@ -842,6 +916,13 @@ async def prepare_large_message(
 
     source_content = content["m.new_content"] if is_edit and "m.new_content" in content else content
     preview_text = source_content["body"]
+    _ensure_minimum_preview_can_fit(
+        content,
+        source_content,
+        is_edit=is_edit,
+        room_id=room_id,
+        calculate_event_size=calculate_delivery_event_size,
+    )
     if is_edit and _is_nonterminal_stream_content(source_content):
         logger.info(
             "large_streaming_edit_sidecar_upload_started",
@@ -854,7 +935,11 @@ async def prepare_large_message(
             content,
             room_encrypted=room_encrypted,
         )
-        if not sidecar_upload_is_usable(mxc_uri, file_info, room_encrypted=room_encrypted):
+        if not sidecar_upload_is_usable(
+            mxc_uri,
+            file_info,
+            room_encrypted=room_encrypted,
+        ):
             logger.warning(
                 "large_message_sidecar_unavailable_using_inline_preview",
                 room_id=room_id,
@@ -903,7 +988,11 @@ async def prepare_large_message(
         room_encrypted=room_encrypted,
     )
 
-    sidecar_usable = sidecar_upload_is_usable(mxc_uri, file_info, room_encrypted=room_encrypted)
+    sidecar_usable = sidecar_upload_is_usable(
+        mxc_uri,
+        file_info,
+        room_encrypted=room_encrypted,
+    )
     if sidecar_usable:
         _copy_preview_metadata(source_content, modified_content)
         _add_sidecar_metadata(
@@ -924,23 +1013,36 @@ async def prepare_large_message(
         )
         modified_content = _build_text_fallback_content(source_content, preview_text, size_limit)
 
-    if "m.relates_to" in content:
-        modified_content["m.relates_to"] = content["m.relates_to"]
-
-    if is_edit and "m.new_content" in content:
-        modified_content = _build_terminal_edit_preview(
+    try:
+        modified_content = _fit_large_message_preview(
             content,
             source_content,
             modified_content,
             preview_text,
+            is_edit=is_edit,
             continuation_indicator=(_CONTINUATION_INDICATOR if sidecar_usable else _SIDECAR_UPLOAD_FALLBACK_INDICATOR),
             calculate_event_size=calculate_delivery_event_size,
         )
-    else:
-        modified_content = _fit_regular_preview(
-            modified_content,
+    except MatrixEventTooLargeError:
+        if not sidecar_usable:
+            raise
+        # The server chooses the final MXC URI, so its exact sidecar envelope
+        # cannot be proven before upload. The empty text envelope was proven
+        # above; fall back to it instead of failing and uploading again on the
+        # next delivery attempt.
+        logger.warning(
+            "large_message_sidecar_envelope_too_large_using_text_fallback",
+            room_id=room_id,
+            original_size_bytes=current_size,
+            is_edit=is_edit,
+        )
+        modified_content = _fit_large_message_preview(
+            content,
+            source_content,
+            _build_text_fallback_content(source_content, preview_text, size_limit),
             preview_text,
-            continuation_indicator=(_CONTINUATION_INDICATOR if sidecar_usable else _SIDECAR_UPLOAD_FALLBACK_INDICATOR),
+            is_edit=is_edit,
+            continuation_indicator=_SIDECAR_UPLOAD_FALLBACK_INDICATOR,
             calculate_event_size=calculate_delivery_event_size,
         )
 

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -80,14 +80,6 @@ _MATRIX_EVENT_HARD_LIMIT = 64000
 _MEGOLM_AES_BLOCK_BYTES = 16
 _MEGOLM_MAX_MESSAGE_INDEX_VARINT_BYTES = 5
 _MEGOLM_BASE64_KEY_LENGTH = 43
-# A transition-safe payload may be encrypted by a different device after recovery.
-# Matrix leaves device IDs opaque, so fitting to the current ID would put a
-# mutable envelope field exactly on the event boundary. Budget 1 KiB for its
-# canonical JSON value and use an even larger current value verbatim. This
-# keeps ordinary device rotation from invalidating frozen bytes without
-# shrinking typical previews by more than a small fraction. It is deliberately
-# recovery headroom, not a claimed protocol maximum.
-_RECOVERY_DEVICE_ID_JSON_RESERVE_BYTES = 1024
 _UNREPRESENTABLE_MESSAGE_ERROR = "Large message cannot fit within the Matrix event limit after sidecar preparation"
 _OVERSIZED_NONTERMINAL_STREAMING_EDIT_MIN_INTERVAL_SECONDS = 5.0
 _oversized_nonterminal_streaming_edit_sent_at: dict[tuple[str, str], float] = {}
@@ -194,7 +186,7 @@ def _room_is_encrypted(client: nio.AsyncClient, room_id: str | None) -> bool:
 def _add_sidecar_metadata(
     target_content: dict[str, Any],
     *,
-    sidecar_encrypted: bool,
+    room_encrypted: bool,
     mxc_uri: str | None,
     file_info: dict[str, Any] | None,
     original_size: int,
@@ -202,7 +194,7 @@ def _add_sidecar_metadata(
     if mxc_uri is None or file_info is None:
         return
 
-    if sidecar_encrypted:
+    if room_encrypted:
         target_content["file"] = file_info
     else:
         target_content["url"] = mxc_uri
@@ -290,18 +282,11 @@ def _delivery_event_size_calculator(
     *,
     room_id: str,
     room_encrypted: bool,
-    recovery_safe: bool,
 ) -> Callable[[dict[str, Any]], int]:
-    """Bind delivery fields while reserving mutable recovery-envelope space."""
+    """Bind the currently observed delivery fields for size estimation."""
     device_id: str | None = None
     if room_encrypted:
-        olm = getattr(client, "olm", None)
-        raw_device_id = getattr(olm, "device_id", None) if olm is not None else getattr(client, "device_id", None)
-        device_id = raw_device_id if isinstance(raw_device_id, str) else None
-        device_id_json_bytes = len(json.dumps(device_id).encode("utf-8")) if device_id is not None else 0
-        if recovery_safe and device_id_json_bytes < _RECOVERY_DEVICE_ID_JSON_RESERVE_BYTES:
-            # Quotes occupy two bytes in the serialized JSON value.
-            device_id = "d" * (_RECOVERY_DEVICE_ID_JSON_RESERVE_BYTES - 2)
+        device_id = client.olm.device_id if client.olm is not None else client.device_id
 
     def calculate(candidate: dict[str, Any]) -> int:
         return _calculate_delivery_event_size(
@@ -367,7 +352,7 @@ def _build_nonterminal_streaming_edit_preview(
     source_content: dict[str, Any],
     preview_text: str,
     *,
-    sidecar_encrypted: bool,
+    room_encrypted: bool,
     mxc_uri: str | None,
     file_info: dict[str, Any] | None,
     original_size: int,
@@ -391,7 +376,7 @@ def _build_nonterminal_streaming_edit_preview(
         _copy_inline_streaming_preview_metadata(source_content, preview_content)
         _add_sidecar_metadata(
             preview_content,
-            sidecar_encrypted=sidecar_encrypted,
+            room_encrypted=room_encrypted,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=original_size,
@@ -706,31 +691,26 @@ async def _build_file_content(
     preview_text: str,
     size_limit: int,
     *,
-    sidecar_encrypted: bool,
-    use_file_message: bool,
-    preview_msgtype: str,
+    room_encrypted: bool,
 ) -> tuple[str | None, dict[str, Any] | None, dict[str, Any]]:
-    """Upload full original content JSON and build its parseable preview."""
+    """Upload full original content JSON and build preview ``m.file`` event."""
     mxc_uri, file_info = await upload_json_sidecar(
         client,
         room_id,
         full_content,
-        room_encrypted=sidecar_encrypted,
+        room_encrypted=room_encrypted,
     )
 
     available = size_limit - _LARGE_MESSAGE_PREVIEW_OVERHEAD_BYTES
     preview = _create_preview(preview_text, available)
 
-    modified_content: dict[str, Any] = {"msgtype": preview_msgtype, "body": preview}
-    if use_file_message:
-        modified_content.update(
-            {
-                "msgtype": "m.file",
-                "filename": "message-content.json",
-            },
-        )
-        if file_info is not None:
-            modified_content["info"] = file_info
+    modified_content: dict[str, Any] = {
+        "msgtype": "m.file",
+        "body": preview,
+        "filename": "message-content.json",
+    }
+    if file_info is not None:
+        modified_content["info"] = file_info
 
     return mxc_uri, file_info, modified_content
 
@@ -898,7 +878,6 @@ async def prepare_large_message(
     content: dict[str, Any],
     *,
     room_encrypted: bool | None = None,
-    transition_safe: bool = False,
 ) -> dict[str, Any]:
     """Check if message is too large and prepare it if needed.
 
@@ -913,15 +892,6 @@ async def prepare_large_message(
         room_id: The room to send to
         content: The message content dictionary
         room_encrypted: Authoritative encryption state when the room cache is unavailable
-        transition_safe: Prepare for the strongest room state the payload may encounter
-
-            Durable payloads can outlive the observed room state, and a direct send can yield
-            during its sidecar upload while encryption changes from disabled to enabled.
-            Encrypted-envelope sizing and recovery-device headroom keep the prepared bytes
-            valid after that transition. Sidecars are encrypted up front. In a currently
-            plaintext room, the encrypted descriptor lives on a normal text preview: that
-            event parses before or after the transition, while an encrypted-file-only
-            ``m.file`` does not parse as a plaintext event.
 
     Returns:
         Original content (if small) or modified content with preview and MXC reference
@@ -932,15 +902,11 @@ async def prepare_large_message(
     size_limit = _EDIT_MESSAGE_LIMIT if is_edit else _NORMAL_MESSAGE_LIMIT
     if room_encrypted is None:
         room_encrypted = _room_is_encrypted(client, room_id)
-    size_for_encrypted_delivery = room_encrypted or transition_safe
     calculate_delivery_event_size = _delivery_event_size_calculator(
         client,
         room_id=room_id,
-        room_encrypted=size_for_encrypted_delivery,
-        recovery_safe=transition_safe,
+        room_encrypted=room_encrypted,
     )
-    sidecar_encrypted = room_encrypted or transition_safe
-
     current_size = _calculate_event_size(content)
     if current_size <= size_limit and calculate_delivery_event_size(content) <= _MATRIX_EVENT_HARD_LIMIT:
         return content
@@ -964,12 +930,12 @@ async def prepare_large_message(
             client,
             room_id,
             content,
-            room_encrypted=sidecar_encrypted,
+            room_encrypted=room_encrypted,
         )
         if not sidecar_upload_is_usable(
             mxc_uri,
             file_info,
-            room_encrypted=sidecar_encrypted,
+            room_encrypted=room_encrypted,
         ):
             logger.warning(
                 "large_message_sidecar_unavailable_using_inline_preview",
@@ -985,7 +951,7 @@ async def prepare_large_message(
             content,
             source_content,
             preview_text,
-            sidecar_encrypted=sidecar_encrypted,
+            room_encrypted=room_encrypted,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=current_size,
@@ -1016,21 +982,19 @@ async def prepare_large_message(
         content,
         preview_text,
         size_limit,
-        sidecar_encrypted=sidecar_encrypted,
-        use_file_message=room_encrypted or not transition_safe,
-        preview_msgtype=("m.notice" if source_content.get("msgtype") == "m.notice" else "m.text"),
+        room_encrypted=room_encrypted,
     )
 
     sidecar_usable = sidecar_upload_is_usable(
         mxc_uri,
         file_info,
-        room_encrypted=sidecar_encrypted,
+        room_encrypted=room_encrypted,
     )
     if sidecar_usable:
         _copy_preview_metadata(source_content, modified_content)
         _add_sidecar_metadata(
             modified_content,
-            sidecar_encrypted=sidecar_encrypted,
+            room_encrypted=room_encrypted,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=current_size,

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -16,6 +16,7 @@ from nio import crypto
 from mindroom.constants import (
     AI_RUN_METADATA_KEY,
     ATTACHMENT_IDS_KEY,
+    CONFIG_CONFIRMATION_REACTION_KEY,
     DURABLE_FINAL_OUTCOME_KEY,
     DURABLE_FINAL_OUTCOME_VERSION,
     HOOK_MESSAGE_RECEIVED_DEPTH_KEY,
@@ -31,6 +32,7 @@ from mindroom.constants import (
     STREAM_VISIBLE_BODY_KEY,
     STREAM_WARMUP_SUFFIX_KEY,
     TOOL_TRACE_CONTENT_KEY,
+    VISIBLE_ROUTER_VOICE_ECHO_KEY,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
     VOICE_TRANSCRIPT_KEY,
 )
@@ -230,7 +232,13 @@ def _calculate_delivery_event_size(
     room_encrypted: bool,
     device_id: str | None,
 ) -> int:
-    """Estimate the complete event size after nio's optional Megolm wrapping."""
+    """Estimate the complete event size after nio's optional Megolm wrapping.
+
+    The custom client copies a small recovery-metadata allowlist onto the
+    encrypted envelope after Megolm encryption. Those outer fields are wire
+    bytes too, so this estimate must mirror ``_MindRoomAsyncClient.encrypt``;
+    omitting them would let a boundary payload fail identically on every replay.
+    """
     if not room_encrypted:
         return _calculate_event_size(content)
 
@@ -265,6 +273,14 @@ def _calculate_delivery_event_size(
     relation = content.get("m.relates_to")
     if isinstance(relation, dict):
         estimated_content["m.relates_to"] = relation
+    stream_status = content.get(STREAM_STATUS_KEY)
+    if isinstance(stream_status, str):
+        estimated_content[STREAM_STATUS_KEY] = stream_status
+    if content.get(VISIBLE_ROUTER_VOICE_ECHO_KEY) is True:
+        estimated_content[VISIBLE_ROUTER_VOICE_ECHO_KEY] = True
+    config_reaction_id = content.get(CONFIG_CONFIRMATION_REACTION_KEY)
+    if isinstance(config_reaction_id, str):
+        estimated_content[CONFIG_CONFIRMATION_REACTION_KEY] = config_reaction_id
     return _calculate_event_size(estimated_content)
 
 

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -80,6 +80,10 @@ _OVERSIZED_NONTERMINAL_STREAMING_EDIT_MIN_INTERVAL_SECONDS = 5.0
 _oversized_nonterminal_streaming_edit_sent_at: dict[tuple[str, str], float] = {}
 
 
+class MatrixEventTooLargeError(ValueError):
+    """The complete Matrix event cannot fit even after sidecar preparation."""
+
+
 def _is_passthrough_preview_key(key: object) -> bool:
     """Return whether one source key should stay on the preview event."""
     if not isinstance(key, str):
@@ -338,7 +342,7 @@ def _build_terminal_edit_preview(
 
     empty_inner = build_inner(0)
     if not fits(empty_inner, 0):
-        raise ValueError(_UNREPRESENTABLE_MESSAGE_ERROR)
+        raise MatrixEventTooLargeError(_UNREPRESENTABLE_MESSAGE_ERROR)
 
     maximum_inner_limit = len(preview_body.encode("utf-8"))
     full_inner = build_inner(maximum_inner_limit)
@@ -382,7 +386,7 @@ def _ensure_event_fits(content: dict[str, Any], *, room_id: str) -> None:
         final_size_bytes=final_size,
         size_limit_bytes=_MATRIX_EVENT_HARD_LIMIT,
     )
-    raise ValueError(_UNREPRESENTABLE_MESSAGE_ERROR)
+    raise MatrixEventTooLargeError(_UNREPRESENTABLE_MESSAGE_ERROR)
 
 
 def _prefix_by_bytes(text: str, max_bytes: int) -> str:

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -16,7 +16,6 @@ from nio import crypto
 from mindroom.constants import (
     AI_RUN_METADATA_KEY,
     ATTACHMENT_IDS_KEY,
-    CONFIG_CONFIRMATION_REACTION_KEY,
     DURABLE_FINAL_OUTCOME_KEY,
     DURABLE_FINAL_OUTCOME_VERSION,
     HOOK_MESSAGE_RECEIVED_DEPTH_KEY,
@@ -32,11 +31,11 @@ from mindroom.constants import (
     STREAM_VISIBLE_BODY_KEY,
     STREAM_WARMUP_SUFFIX_KEY,
     TOOL_TRACE_CONTENT_KEY,
-    VISIBLE_ROUTER_VOICE_ECHO_KEY,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
     VOICE_TRANSCRIPT_KEY,
 )
 from mindroom.logging_config import get_logger
+from mindroom.matrix.encrypted_event_metadata import encryption_visible_metadata
 from mindroom.matrix.media import upload_content_uri, upload_media_bytes
 from mindroom.matrix.message_builder import markdown_to_html
 
@@ -236,8 +235,9 @@ def _calculate_delivery_event_size(
 
     The custom client copies a small recovery-metadata allowlist onto the
     encrypted envelope after Megolm encryption. Those outer fields are wire
-    bytes too, so this estimate must mirror ``_MindRoomAsyncClient.encrypt``;
-    omitting them would let a boundary payload fail identically on every replay.
+    bytes too. Real encryption and this estimate therefore share
+    ``encryption_visible_metadata``; letting the contracts drift would make a
+    boundary payload fail identically on every replay.
     """
     if not room_encrypted:
         return _calculate_event_size(content)
@@ -273,14 +273,7 @@ def _calculate_delivery_event_size(
     relation = content.get("m.relates_to")
     if isinstance(relation, dict):
         estimated_content["m.relates_to"] = relation
-    stream_status = content.get(STREAM_STATUS_KEY)
-    if isinstance(stream_status, str):
-        estimated_content[STREAM_STATUS_KEY] = stream_status
-    if content.get(VISIBLE_ROUTER_VOICE_ECHO_KEY) is True:
-        estimated_content[VISIBLE_ROUTER_VOICE_ECHO_KEY] = True
-    config_reaction_id = content.get(CONFIG_CONFIRMATION_REACTION_KEY)
-    if isinstance(config_reaction_id, str):
-        estimated_content[CONFIG_CONFIRMATION_REACTION_KEY] = config_reaction_id
+    estimated_content.update(encryption_visible_metadata(content))
     return _calculate_event_size(estimated_content)
 
 

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -17,6 +17,7 @@ from mindroom.constants import (
     AI_RUN_METADATA_KEY,
     ATTACHMENT_IDS_KEY,
     DURABLE_FINAL_OUTCOME_KEY,
+    DURABLE_FINAL_OUTCOME_VERSION,
     HOOK_MESSAGE_RECEIVED_DEPTH_KEY,
     HOOK_SOURCE_KEY,
     ORIGINAL_SENDER_KEY,
@@ -114,6 +115,32 @@ def _copy_edit_wrapper_metadata(source_content: dict[str, Any], target_content: 
 def _copy_inline_streaming_preview_metadata(source_content: dict[str, Any], target_content: dict[str, Any]) -> None:
     """Copy metadata that should remain inline on rich streaming previews."""
     _copy_preview_metadata(source_content, target_content)
+
+
+def _without_local_recovery_data(content: dict[str, Any]) -> dict[str, Any]:
+    """Return event content without semantic results that belong only in the outbox."""
+    replacement = content.get("m.new_content")
+    compatibility_marker = {"version": DURABLE_FINAL_OUTCOME_VERSION}
+    outer_has_result = (
+        DURABLE_FINAL_OUTCOME_KEY in content and content[DURABLE_FINAL_OUTCOME_KEY] != compatibility_marker
+    )
+    nested_has_result = (
+        isinstance(replacement, dict)
+        and DURABLE_FINAL_OUTCOME_KEY in replacement
+        and replacement[DURABLE_FINAL_OUTCOME_KEY] != compatibility_marker
+    )
+    if not outer_has_result and not nested_has_result:
+        return content
+
+    sanitized = dict(content)
+    if outer_has_result:
+        sanitized.pop(DURABLE_FINAL_OUTCOME_KEY, None)
+    if isinstance(replacement, dict):
+        sanitized_replacement = dict(replacement)
+        if nested_has_result:
+            sanitized_replacement.pop(DURABLE_FINAL_OUTCOME_KEY, None)
+        sanitized["m.new_content"] = sanitized_replacement
+    return sanitized
 
 
 def _room_is_encrypted(client: nio.AsyncClient, room_id: str | None) -> bool:
@@ -647,6 +674,7 @@ async def prepare_large_message(
         Original content (if small) or modified content with preview and MXC reference
 
     """
+    content = _without_local_recovery_data(content)
     is_edit = _is_edit_message(content)
     size_limit = _EDIT_MESSAGE_LIMIT if is_edit else _NORMAL_MESSAGE_LIMIT
 

--- a/src/mindroom/matrix_delivery.py
+++ b/src/mindroom/matrix_delivery.py
@@ -29,6 +29,11 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+
+class PermanentDeliveryError(RuntimeError):
+    """A definitive refusal that must not remain ordinary recovery work."""
+
+
 type SendDelivery = Callable[[MatrixDelivery], Awaitable[str]]
 type _ObserveDelivered = Callable[[MatrixDelivery, str], Awaitable[tuple[ProjectedEvent, ...]]]
 
@@ -315,7 +320,12 @@ class MatrixDeliveryWorker:
                 if stage is DeliveryStage.FINAL
                 else None
             )
-            blocked_final = stage is DeliveryStage.FINAL and stored is not None and not stored.retired
+            blocked_final = (
+                stage is DeliveryStage.FINAL
+                and stored is not None
+                and not stored.retired
+                and not stored.permanently_failed
+            )
             logger.info(
                 "matrix_delivery_stage_blocked" if blocked_final else "matrix_delivery_row_withdrawn",
                 delivery_id=delivery_id,
@@ -391,7 +401,15 @@ class MatrixDeliveryWorker:
             stage=claimed.stage,
             device_id=self.sending_device_id,
         )
-        event_id = await self.send(claimed)
+        try:
+            event_id = await self.send(claimed)
+        except PermanentDeliveryError as error:
+            acknowledged_event_id = await self.store.record_permanent_matrix_delivery_failure(
+                delivery_id=claimed.delivery_id,
+                stage=claimed.stage,
+                reason=str(error),
+            )
+            return _FlushOutcome(event_id=acknowledged_event_id)
         return await self._acknowledge(claimed, event_id)
 
     async def _acknowledge(self, claimed: MatrixDelivery, event_id: str) -> _FlushOutcome:
@@ -585,8 +603,8 @@ class MatrixDeliveryWorker:
                     if outcome.retry_required:
                         failed_deliveries.add((delivery.delivery_id, delivery.stage))
                         continue
-                    # The row was retired, or a FINAL superseded this INITIAL.
-                    # Nothing is owed and nothing failed.
+                    # The row was retired, permanently failed, or superseded.
+                    # Nothing remains for a later recovery pass.
                     continue
                 recovered += 1
 
@@ -594,6 +612,7 @@ class MatrixDeliveryWorker:
 __all__ = [
     "DeliveryStage",
     "MatrixDeliveryWorker",
+    "PermanentDeliveryError",
     "RecoveryOutcome",
     "ResolveDelivered",
     "SendDelivery",

--- a/src/mindroom/matrix_delivery.py
+++ b/src/mindroom/matrix_delivery.py
@@ -152,6 +152,7 @@ class MatrixDeliveryWorker:
         payload: Mapping[str, object],
         result: Mapping[str, object] | None = None,
         edits_event_id: str | None = None,
+        permanent_failure_reason: str | None = None,
     ) -> str | None:
         """Enqueue, claim, send, and acknowledge one delivery.
 
@@ -188,6 +189,7 @@ class MatrixDeliveryWorker:
                 payload=payload,
                 result=result,
                 edits_event_id=edits_event_id,
+                permanent_failure_reason=permanent_failure_reason,
             )
         return await self._finish_flush(delivery_id, outcome)
 
@@ -201,6 +203,7 @@ class MatrixDeliveryWorker:
         payload: Mapping[str, object],
         result: Mapping[str, object] | None,
         edits_event_id: str | None,
+        permanent_failure_reason: str | None,
     ) -> _FlushOutcome:
         """Finish a delivery whose durable handoff may already have committed."""
         completed: _FlushOutcome | None = None
@@ -219,6 +222,7 @@ class MatrixDeliveryWorker:
                 result=result,
                 edits_event_id=edits_event_id,
                 settle_source_event_ids=handed_over,
+                permanent_failure_reason=permanent_failure_reason,
             )
             if transaction_id is None:
                 logger.info("matrix_delivery_refused_for_ended_membership", delivery_id=delivery_id, stage=stage.value)

--- a/src/mindroom/matrix_delivery.py
+++ b/src/mindroom/matrix_delivery.py
@@ -145,6 +145,7 @@ class MatrixDeliveryWorker:
         room_id: str,
         thread_id: str | None,
         payload: Mapping[str, object],
+        result: Mapping[str, object] | None = None,
         edits_event_id: str | None = None,
     ) -> str | None:
         """Enqueue, claim, send, and acknowledge one delivery.
@@ -180,6 +181,7 @@ class MatrixDeliveryWorker:
                 room_id=room_id,
                 thread_id=thread_id,
                 payload=payload,
+                result=result,
                 edits_event_id=edits_event_id,
             )
         return await self._finish_flush(delivery_id, outcome)
@@ -192,6 +194,7 @@ class MatrixDeliveryWorker:
         room_id: str,
         thread_id: str | None,
         payload: Mapping[str, object],
+        result: Mapping[str, object] | None,
         edits_event_id: str | None,
     ) -> _FlushOutcome:
         """Finish a delivery whose durable handoff may already have committed."""
@@ -208,6 +211,7 @@ class MatrixDeliveryWorker:
                 room_id=room_id,
                 thread_id=thread_id,
                 payload=payload,
+                result=result,
                 edits_event_id=edits_event_id,
                 settle_source_event_ids=handed_over,
             )

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -28,7 +28,6 @@ from mindroom.authorization import is_sender_allowed_for_entity_replies_in_room
 from mindroom.background_tasks import create_background_task, run_coroutine_until_complete
 from mindroom.constants import (
     ATTACHMENT_IDS_KEY,
-    DURABLE_FINAL_OUTCOME_KEY,
     MATRIX_MESSAGE_TARGET_ENRICHMENT_KEY,
     MATRIX_SOURCE_EVENT_IDS_METADATA_KEY,
     ORIGINAL_SENDER_KEY,
@@ -1151,7 +1150,7 @@ class ResponseRunner:
         payload = dict(delivery.payload)
         nested = payload.get("m.new_content")
         visible = cast("dict[str, Any]", nested) if isinstance(nested, dict) else payload
-        semantic = visible.get(DURABLE_FINAL_OUTCOME_KEY)
+        semantic = delivery.result
         semantic_body: object = None
         interactive_metadata = None
         if isinstance(semantic, dict):

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1194,6 +1194,8 @@ class ResponseRunner:
         delivery = await self._approval_responses.final_delivery(claimed, recover=True)
         if delivery is None:
             return False, None
+        if delivery.permanently_failed:
+            return False, None
         if delivery.acknowledged_event_id is None:
             return True, None
         recovered_outcome = self._approval_outcome_from_delivery(delivery)
@@ -2115,7 +2117,12 @@ class ResponseRunner:
 
         async def recover(_target: MessageTarget) -> bool:
             delivery = await self._approval_responses.final_delivery(continuation, recover=True)
-            if delivery is None or delivery.acknowledged_event_id is None:
+            if delivery is None:
+                return False
+            if delivery.permanently_failed:
+                reason = delivery.permanent_failure_reason or "Final Matrix delivery was permanently refused."
+                return await self._approval_responses.settle_failure(continuation, reason)
+            if delivery.acknowledged_event_id is None:
                 return False
             if await self._approval_responses.successful_final_delivery(continuation) is None:
                 return await self.deps.approval_store.finish_approval_continuation(continuation.approval_id)

--- a/tach.toml
+++ b/tach.toml
@@ -4316,6 +4316,7 @@ expose = [
     "edit_message_outcome",
     "edit_message_result",
     "resolve_room_encryption_for_delivery",
+    "resolve_room_encryption_outcome",
     "send_audio_message",
     "send_file_message",
     "send_message_outcome",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1394,7 +1394,7 @@ class FakeOutbox:
         """
         key = (delivery_id, stage.value)
         row = self.rows.get(key)
-        if row is None or row.retired:
+        if row is None or row.retired or row.permanently_failed:
             return None
         if (
             stage is DeliveryStage.INITIAL
@@ -1435,6 +1435,25 @@ class FakeOutbox:
     async def load_matrix_delivery(self, *, delivery_id: str, stage: DeliveryStage) -> MatrixDelivery | None:
         """Return one delivery without claiming it."""
         return self.rows.get((delivery_id, stage.value))
+
+    async def record_permanent_matrix_delivery_failure(
+        self,
+        *,
+        delivery_id: str,
+        stage: DeliveryStage,
+        reason: str,
+    ) -> str | None:
+        """Stop retrying one definitively refused immutable payload, or return its ACK."""
+        if not reason:
+            msg = "A permanent Matrix delivery failure requires a reason"
+            raise ValueError(msg)
+        key = (delivery_id, stage.value)
+        row = self.rows.get(key)
+        if row is None or row.acknowledged_event_id is not None:
+            return None if row is None else row.acknowledged_event_id
+        if not row.retired and not row.permanently_failed:
+            self.rows[key] = replace(row, permanent_failure_reason=reason)
+        return None
 
     async def retire_matrix_delivery(
         self,
@@ -1477,7 +1496,11 @@ class FakeOutbox:
             # the row already names rather than its own, and told it bound
             # nothing -- which stays true even when the two events are equal.
             return DeliveryAcknowledgement(settled_event_id=already, bound=False)
-        self.rows[key] = replace(self.rows[key], acknowledged_event_id=event_id)
+        self.rows[key] = replace(
+            self.rows[key],
+            acknowledged_event_id=event_id,
+            permanent_failure_reason=None,
+        )
         self.acknowledged_terminal_turns.append((delivery_id, terminal_turn))
         self.acknowledged_projections.append(delivered_projections)
         return DeliveryAcknowledgement(settled_event_id=event_id, bound=True)
@@ -1500,7 +1523,12 @@ class FakeOutbox:
             (
                 row
                 for row in self.rows.values()
-                if row.event_type == event_type and row.acknowledged_event_id is None and not row.retired
+                if (
+                    row.event_type == event_type
+                    and row.acknowledged_event_id is None
+                    and not row.retired
+                    and not row.permanently_failed
+                )
             ),
             key=lambda row: (row.created_at_ns, row.delivery_id, row.stage.value),
         )
@@ -1635,6 +1663,20 @@ class DiesAfterAcknowledgement:
     async def load_matrix_delivery(self, *, delivery_id: str, stage: DeliveryStage) -> MatrixDelivery | None:
         """Return one delivery without claiming it."""
         return await self.inner.load_matrix_delivery(delivery_id=delivery_id, stage=stage)
+
+    async def record_permanent_matrix_delivery_failure(
+        self,
+        *,
+        delivery_id: str,
+        stage: DeliveryStage,
+        reason: str,
+    ) -> str | None:
+        """Stop retrying one definitively refused immutable payload, or return its ACK."""
+        return await self.inner.record_permanent_matrix_delivery_failure(
+            delivery_id=delivery_id,
+            stage=stage,
+            reason=reason,
+        )
 
     async def retire_matrix_delivery(
         self,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,6 +84,7 @@ from mindroom.event_journal import (
 from mindroom.event_journal import reads as journal_reads
 from mindroom.event_journal.outbox import (
     _delivery_payload,
+    _legacy_delivery_result,
 )
 from mindroom.final_delivery import FinalDeliveryOutcome
 from mindroom.handled_turns import _reset_handled_turn_ledger_runtime
@@ -1306,6 +1307,7 @@ class FakeOutbox:
         room_id: str,
         thread_id: str | None,
         payload: Mapping[str, object],
+        result: Mapping[str, object] | None = None,
         event_type: str = "m.room.message",
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),
@@ -1356,6 +1358,7 @@ class FakeOutbox:
                 room_id=room_id,
                 thread_id=thread_id,
                 payload=_delivery_payload(self.principal_id, delivery_id, stage, payload),
+                result=dict(result) if result is not None else _legacy_delivery_result(payload),
                 event_type=event_type,
                 edits_event_id=edits_event_id,
             )
@@ -1372,6 +1375,7 @@ class FakeOutbox:
             thread_id=thread_id,
             transaction_id=transaction_id,
             payload=_delivery_payload(self.principal_id, delivery_id, stage, payload),
+            result=dict(result) if result is not None else _legacy_delivery_result(payload),
             edits_event_id=edits_event_id,
             acknowledged_event_id=None,
             created_at_ns=len(self.rows),
@@ -1580,6 +1584,7 @@ class DiesAfterAcknowledgement:
         room_id: str,
         thread_id: str | None,
         payload: Mapping[str, object],
+        result: Mapping[str, object] | None = None,
         event_type: str = "m.room.message",
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),
@@ -1591,6 +1596,7 @@ class DiesAfterAcknowledgement:
             room_id=room_id,
             thread_id=thread_id,
             payload=payload,
+            result=result,
             event_type=event_type,
             edits_event_id=edits_event_id,
             settle_source_event_ids=settle_source_event_ids,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1309,6 +1309,7 @@ class FakeOutbox:
         event_type: str = "m.room.message",
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),
+        permanent_failure_reason: str | None = None,
     ) -> str | None:
         """Record intent, leaving an already-attempted row's payload alone.
 
@@ -1349,7 +1350,7 @@ class FakeOutbox:
         key = (delivery_id, stage.value)
         existing = self.rows.get(key)
         if existing is not None:
-            if key in self.attempted:
+            if key in self.attempted or existing.permanently_failed:
                 return existing.transaction_id
             self.rows[key] = replace(
                 existing,
@@ -1359,6 +1360,7 @@ class FakeOutbox:
                 result=dict(result) if result is not None else _legacy_delivery_result(payload),
                 event_type=event_type,
                 edits_event_id=edits_event_id,
+                permanent_failure_reason=permanent_failure_reason,
             )
             return existing.transaction_id
         if delivery_id in self.ended_membership_turn_ids:
@@ -1377,6 +1379,7 @@ class FakeOutbox:
             edits_event_id=edits_event_id,
             acknowledged_event_id=None,
             created_at_ns=len(self.rows),
+            permanent_failure_reason=permanent_failure_reason,
         )
         return transaction_id
 
@@ -1614,6 +1617,7 @@ class DiesAfterAcknowledgement:
         event_type: str = "m.room.message",
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),
+        permanent_failure_reason: str | None = None,
     ) -> str | None:
         """Record delivery intent."""
         return await self.inner.enqueue_matrix_delivery(
@@ -1626,6 +1630,7 @@ class DiesAfterAcknowledgement:
             event_type=event_type,
             edits_event_id=edits_event_id,
             settle_source_event_ids=settle_source_event_ids,
+            permanent_failure_reason=permanent_failure_reason,
         )
 
     async def turn_membership_is_current(self, *, turn_id: str, room_id: str) -> bool:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,10 +82,7 @@ from mindroom.event_journal import (
     VisibleMessage,
 )
 from mindroom.event_journal import reads as journal_reads
-from mindroom.event_journal.outbox import (
-    _delivery_payload,
-    _legacy_delivery_result,
-)
+from mindroom.event_journal.outbox import _legacy_delivery_result, matrix_delivery_payload
 from mindroom.final_delivery import FinalDeliveryOutcome
 from mindroom.handled_turns import _reset_handled_turn_ledger_runtime
 from mindroom.history.runtime import (
@@ -1357,7 +1354,7 @@ class FakeOutbox:
                 existing,
                 room_id=room_id,
                 thread_id=thread_id,
-                payload=_delivery_payload(self.principal_id, delivery_id, stage, payload),
+                payload=matrix_delivery_payload(self.principal_id, delivery_id, stage, payload),
                 result=dict(result) if result is not None else _legacy_delivery_result(payload),
                 event_type=event_type,
                 edits_event_id=edits_event_id,
@@ -1374,7 +1371,7 @@ class FakeOutbox:
             membership_epoch=membership_epoch,
             thread_id=thread_id,
             transaction_id=transaction_id,
-            payload=_delivery_payload(self.principal_id, delivery_id, stage, payload),
+            payload=matrix_delivery_payload(self.principal_id, delivery_id, stage, payload),
             result=dict(result) if result is not None else _legacy_delivery_result(payload),
             edits_event_id=edits_event_id,
             acknowledged_event_id=None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1146,6 +1146,7 @@ def make_matrix_client_mock(*, user_id: str = "@mindroom_test:example.com") -> A
     # A logged-in client always has one, and delivery records it on every claim
     # so a resend can tell whether its frozen transaction ID still deduplicates.
     client.device_id = "TESTDEVICE"
+    client.olm = None
     client.rooms = _AutoRoomCache(user_id)
     client.next_batch = "s_test_token"
     client.loaded_sync_token = ""

--- a/tests/test_config_commands.py
+++ b/tests/test_config_commands.py
@@ -47,7 +47,7 @@ from mindroom.tool_system.plugins import PluginReloadResult
 from tests.authorization_helpers import (
     make_test_command_handler_context,
 )
-from tests.conftest import make_conversation_reader_mock, write_config_yaml
+from tests.conftest import make_conversation_reader_mock, make_matrix_client_mock, write_config_yaml
 
 
 def _runtime_paths_for_config(config_path: Path) -> constants_mod.RuntimePaths:
@@ -157,7 +157,7 @@ def test_validate_and_persist_config_payload_rejects_without_overwriting(tmp_pat
 @pytest.mark.asyncio
 async def test_add_confirmation_reactions_sends_confirm_and_cancel_annotations() -> None:
     """Config confirmation should add canonical Matrix annotation reactions."""
-    client = AsyncMock()
+    client = make_matrix_client_mock()
     response = MagicMock(spec=nio.RoomSendResponse)
     client.room_send.return_value = response
     await _add_confirmation_reactions(client, "!room:example.org", "$preview")
@@ -195,7 +195,7 @@ async def test_confirmation_setup_errors_remain_retryable() -> None:
     with pytest.raises(RuntimeError, match="Failed to store pending config change"):
         await config_confirmation._store_pending_change_in_matrix(state_client, "$preview", pending_change)
 
-    reaction_client = AsyncMock()
+    reaction_client = make_matrix_client_mock()
     reaction_client.room_send.return_value = nio.RoomSendError.from_dict(
         {"errcode": "M_LIMIT_EXCEEDED", "error": "Slow down"},
         "!room:example.org",
@@ -207,7 +207,7 @@ async def test_confirmation_setup_errors_remain_retryable() -> None:
 @pytest.mark.asyncio
 async def test_confirmation_setup_adopts_existing_duplicate_reaction() -> None:
     """A replayed setup should accept the homeserver's duplicate-annotation proof."""
-    client = AsyncMock()
+    client = make_matrix_client_mock()
     client.room_send.side_effect = [
         nio.RoomSendError("already exists", "M_DUPLICATE_ANNOTATION"),
         nio.RoomSendResponse("$cancel-reaction", "!room:example.org"),

--- a/tests/test_continuation_delivery_invariant.py
+++ b/tests/test_continuation_delivery_invariant.py
@@ -166,6 +166,20 @@ class _WatchedOutbox:
         """Return one delivery without claiming it."""
         return await self.inner.load_matrix_delivery(delivery_id=delivery_id, stage=stage)
 
+    async def record_permanent_matrix_delivery_failure(
+        self,
+        *,
+        delivery_id: str,
+        stage: DeliveryStage,
+        reason: str,
+    ) -> str | None:
+        """Stop retrying one definitively refused immutable payload, or return its ACK."""
+        return await self.inner.record_permanent_matrix_delivery_failure(
+            delivery_id=delivery_id,
+            stage=stage,
+            reason=reason,
+        )
+
     async def retire_matrix_delivery(
         self,
         *,

--- a/tests/test_continuation_delivery_invariant.py
+++ b/tests/test_continuation_delivery_invariant.py
@@ -111,6 +111,7 @@ class _WatchedOutbox:
         result: Mapping[str, object] | None = None,
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),
+        permanent_failure_reason: str | None = None,
     ) -> str | None:
         """Record intent, noting the stage on the timeline first."""
         self.timeline.append(f"enqueue:{stage.value}")
@@ -124,6 +125,7 @@ class _WatchedOutbox:
             result=result,
             edits_event_id=edits_event_id,
             settle_source_event_ids=settle_source_event_ids,
+            permanent_failure_reason=permanent_failure_reason,
         )
 
     async def claim_matrix_delivery(

--- a/tests/test_continuation_delivery_invariant.py
+++ b/tests/test_continuation_delivery_invariant.py
@@ -108,6 +108,7 @@ class _WatchedOutbox:
         room_id: str,
         thread_id: str | None,
         payload: Mapping[str, object],
+        result: Mapping[str, object] | None = None,
         edits_event_id: str | None = None,
         settle_source_event_ids: tuple[str, ...] = (),
     ) -> str | None:
@@ -120,6 +121,7 @@ class _WatchedOutbox:
             room_id=room_id,
             thread_id=thread_id,
             payload=payload,
+            result=result,
             edits_event_id=edits_event_id,
             settle_source_event_ids=settle_source_event_ids,
         )

--- a/tests/test_event_journal_schema_migrations.py
+++ b/tests/test_event_journal_schema_migrations.py
@@ -14,7 +14,10 @@ def test_pre_schema_migrations_add_missing_delivery_result_column() -> None:
     """An existing outbox gains storage that is never part of its wire payload."""
     assert pre_schema_migration_statements(
         matrix_delivery_outbox_columns=frozenset({"payload_json"}),
-    ) == ("ALTER TABLE matrix_delivery_outbox ADD COLUMN result_json TEXT",)
+    ) == (
+        "ALTER TABLE matrix_delivery_outbox ADD COLUMN result_json TEXT",
+        "ALTER TABLE matrix_delivery_outbox ADD COLUMN permanent_failure_reason TEXT",
+    )
 
 
 def test_pre_schema_migrations_skip_absent_or_current_approval_table() -> None:
@@ -23,7 +26,9 @@ def test_pre_schema_migrations_skip_absent_or_current_approval_table() -> None:
     assert (
         pre_schema_migration_statements(
             approval_continuation_call_columns=frozenset({"tool_call_id", "human_approval_required"}),
-            matrix_delivery_outbox_columns=frozenset({"payload_json", "result_json"}),
+            matrix_delivery_outbox_columns=frozenset(
+                {"payload_json", "result_json", "permanent_failure_reason"},
+            ),
         )
         == ()
     )
@@ -38,6 +43,7 @@ def test_pre_schema_migrations_compose_independent_upgrades() -> None:
     ) == (
         "ALTER TABLE approval_continuation_calls ADD COLUMN human_approval_required BOOLEAN",
         "ALTER TABLE matrix_delivery_outbox ADD COLUMN result_json TEXT",
+        "ALTER TABLE matrix_delivery_outbox ADD COLUMN permanent_failure_reason TEXT",
         "CREATE TABLE interactive_questions_pre_selection AS SELECT * FROM interactive_questions",
         "DROP TABLE interactive_questions",
     )

--- a/tests/test_event_journal_schema_migrations.py
+++ b/tests/test_event_journal_schema_migrations.py
@@ -10,12 +10,20 @@ def test_pre_schema_migrations_add_missing_approval_provenance_column() -> None:
     ) == ("ALTER TABLE approval_continuation_calls ADD COLUMN human_approval_required BOOLEAN",)
 
 
+def test_pre_schema_migrations_add_missing_delivery_result_column() -> None:
+    """An existing outbox gains storage that is never part of its wire payload."""
+    assert pre_schema_migration_statements(
+        matrix_delivery_outbox_columns=frozenset({"payload_json"}),
+    ) == ("ALTER TABLE matrix_delivery_outbox ADD COLUMN result_json TEXT",)
+
+
 def test_pre_schema_migrations_skip_absent_or_current_approval_table() -> None:
     """The approval upgrade is a no-op without a legacy table needing it."""
     assert pre_schema_migration_statements() == ()
     assert (
         pre_schema_migration_statements(
             approval_continuation_call_columns=frozenset({"tool_call_id", "human_approval_required"}),
+            matrix_delivery_outbox_columns=frozenset({"payload_json", "result_json"}),
         )
         == ()
     )
@@ -26,8 +34,10 @@ def test_pre_schema_migrations_compose_independent_upgrades() -> None:
     assert pre_schema_migration_statements(
         approval_continuation_call_columns=frozenset({"tool_call_id"}),
         interactive_question_columns=frozenset({"claimed_source_event_id"}),
+        matrix_delivery_outbox_columns=frozenset({"payload_json"}),
     ) == (
         "ALTER TABLE approval_continuation_calls ADD COLUMN human_approval_required BOOLEAN",
+        "ALTER TABLE matrix_delivery_outbox ADD COLUMN result_json TEXT",
         "CREATE TABLE interactive_questions_pre_selection AS SELECT * FROM interactive_questions",
         "DROP TABLE interactive_questions",
     )

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -5620,8 +5620,11 @@ class TestOutbox:
         assert stored is not None
         assert stored.result == {"body": "full result", "interactive": None}
 
-    async def test_claiming_freezes_the_payload(self, alice: PrincipalStore) -> None:
-        """Claiming freezes the payload.
+    async def test_claiming_freezes_the_payload_and_rejects_a_late_preflight_failure(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """Claiming freezes the payload and its live delivery state.
 
         The case this closes: Matrix accepted the old text, and the regenerated
         text could never become visible under the same transaction ID.
@@ -5641,11 +5644,13 @@ class TestOutbox:
             room_id=ROOM,
             thread_id=None,
             payload=text("regenerated"),
+            permanent_failure_reason="regenerated payload cannot fit",
         )
 
         stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
         assert stored is not None
         assert stored.payload["body"] == "sent"
+        assert not stored.permanently_failed
 
     async def test_claiming_freezes_the_local_result_with_the_payload(self, alice: PrincipalStore) -> None:
         """A regenerated turn cannot pair old wire bytes with new recovery facts."""
@@ -5818,6 +5823,45 @@ class TestOutbox:
         assert stored.permanent_failure_reason == "matrix event exceeds the hard size limit"
         assert await alice.unacknowledged_matrix_deliveries() == ()
         assert await alice.claim_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL) is None
+
+    async def test_preflight_failure_atomically_hands_sources_to_terminal_state(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """A locally impossible payload and its source ownership commit together."""
+        await admit(alice, "$turn")
+
+        transaction_id = await alice.enqueue_matrix_delivery(
+            delivery_id="$turn",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("unrepresentable"),
+            settle_source_event_ids=("$turn",),
+            permanent_failure_reason="matrix event exceeds the hard size limit",
+        )
+
+        stored = await alice.load_matrix_delivery(delivery_id="$turn", stage=DeliveryStage.FINAL)
+        assert transaction_id is not None
+        assert stored is not None
+        assert stored.permanent_failure_reason == "matrix event exceeds the hard size limit"
+        assert not stored.attempted
+        assert not await alice.is_pending("$turn")
+        assert await alice.unacknowledged_matrix_deliveries() == ()
+        assert await alice.claim_matrix_delivery(delivery_id="$turn", stage=DeliveryStage.FINAL) is None
+
+        await alice.enqueue_matrix_delivery(
+            delivery_id="$turn",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("regenerated"),
+        )
+
+        retained = await alice.load_matrix_delivery(delivery_id="$turn", stage=DeliveryStage.FINAL)
+        assert retained is not None
+        assert retained.payload["body"] == "unrepresentable"
+        assert retained.permanent_failure_reason == "matrix event exceeds the hard size limit"
 
     async def test_permanently_failed_initial_does_not_block_standalone_final(
         self,

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 import pytest
 import pytest_asyncio
 
+from mindroom.constants import DURABLE_FINAL_OUTCOME_KEY
 from mindroom.event_journal import (
     AdmissionResult,
     ApprovalCall,
@@ -110,6 +111,18 @@ CREATE TABLE matrix_delivery_outbox (
     edits_event_id TEXT, edit_target_pending INTEGER NOT NULL DEFAULT 0,
     attempted INTEGER NOT NULL DEFAULT 0, sending_device_id TEXT,
     acknowledged_event_id TEXT, created_at_ns BIGINT NOT NULL,
+    PRIMARY KEY (principal_id, delivery_id, stage)
+)
+"""
+_CURRENT_MATRIX_DELIVERY_OUTBOX_WITHOUT_RESULT_DDL = """
+CREATE TABLE matrix_delivery_outbox (
+    principal_id TEXT NOT NULL, delivery_id TEXT NOT NULL,
+    stage TEXT NOT NULL, event_type TEXT NOT NULL, room_id TEXT NOT NULL,
+    membership_epoch BIGINT NOT NULL, thread_id TEXT NOT NULL,
+    transaction_id TEXT NOT NULL, payload_json TEXT NOT NULL,
+    edits_event_id TEXT, edit_target_pending INTEGER NOT NULL DEFAULT 0,
+    attempted INTEGER NOT NULL DEFAULT 0, retired INTEGER NOT NULL DEFAULT 0,
+    sending_device_id TEXT, acknowledged_event_id TEXT, created_at_ns BIGINT NOT NULL,
     PRIMARY KEY (principal_id, delivery_id, stage)
 )
 """
@@ -5557,6 +5570,31 @@ class TestOutbox:
         assert claimed is not None
         assert claimed.payload["body"] == "final"
 
+    async def test_an_unattempted_delivery_replaces_its_local_result(self, alice: PrincipalStore) -> None:
+        """Wire content and its local semantic result change atomically before claim."""
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("draft preview"),
+            result={"body": "draft full result"},
+        )
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("final preview"),
+            result={"body": "final full result"},
+        )
+
+        claimed = await alice.claim_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+
+        assert claimed is not None
+        assert claimed.payload["body"] == "final preview"
+        assert claimed.result == {"body": "final full result"}
+
     async def test_claiming_freezes_the_payload(self, alice: PrincipalStore) -> None:
         """Claiming freezes the payload.
 
@@ -5583,6 +5621,57 @@ class TestOutbox:
         stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
         assert stored is not None
         assert stored.payload["body"] == "sent"
+
+    async def test_claiming_freezes_the_local_result_with_the_payload(self, alice: PrincipalStore) -> None:
+        """A regenerated turn cannot pair old wire bytes with new recovery facts."""
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("sent preview"),
+            result={"body": "sent full result"},
+        )
+        await alice.claim_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("regenerated preview"),
+            result={"body": "regenerated full result"},
+        )
+
+        stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+        assert stored is not None
+        assert stored.payload["body"] == "sent preview"
+        assert stored.result == {"body": "sent full result"}
+
+    async def test_legacy_inline_final_result_remains_recoverable(self, alice: PrincipalStore) -> None:
+        """Rows written before local result storage retain their semantic outcome."""
+        legacy_result = {"body": "legacy full result", "interactive": None}
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload={
+                "msgtype": "m.text",
+                "body": "* legacy preview",
+                "m.new_content": {
+                    "msgtype": "m.text",
+                    "body": "legacy preview",
+                    DURABLE_FINAL_OUTCOME_KEY: legacy_result,
+                },
+                "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
+            },
+        )
+
+        stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+
+        assert stored is not None
+        assert stored.result == legacy_result
 
     async def test_reclaiming_sends_the_identical_delivery(self, alice: PrincipalStore) -> None:
         """Everything that goes on the wire is frozen; the claim state is not.
@@ -8161,6 +8250,19 @@ class TestConnectionSecretsStayOutOfLogs:
 
 class TestSchemaUpgrades:
     """Opening the journal preserves old rows and enables current writes."""
+
+    async def test_sqlite_adds_local_results_to_an_existing_delivery_outbox(self, tmp_path: Path) -> None:
+        """A shipped outbox gains local result storage without rebuilding its wire rows."""
+        database_path = tmp_path / "delivery-result-upgrade.db"
+        with sqlite3.connect(database_path) as connection:
+            connection.execute(_CURRENT_MATRIX_DELIVERY_OUTBOX_WITHOUT_RESULT_DDL)
+
+        store = EventJournalStore.open_sqlite(database_path)
+        await store.close()
+
+        with sqlite3.connect(database_path) as connection:
+            columns = {str(row[1]) for row in connection.execute("PRAGMA table_info(matrix_delivery_outbox)")}
+        assert "result_json" in columns
 
     @staticmethod
     async def _assert_legacy_approval_call_provenance_is_unknown(backend: Backend) -> None:

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -5595,6 +5595,29 @@ class TestOutbox:
         assert claimed.payload["body"] == "final preview"
         assert claimed.result == {"body": "final full result"}
 
+    async def test_a_compatibility_marker_does_not_replace_the_local_result(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """The bounded old-reader sentinel is not itself the semantic result."""
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload={
+                "msgtype": "m.text",
+                "body": "preview",
+                DURABLE_FINAL_OUTCOME_KEY: {"version": 2},
+            },
+            result={"body": "full result", "interactive": None},
+        )
+
+        stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+
+        assert stored is not None
+        assert stored.result == {"body": "full result", "interactive": None}
+
     async def test_claiming_freezes_the_payload(self, alice: PrincipalStore) -> None:
         """Claiming freezes the payload.
 
@@ -5671,6 +5694,43 @@ class TestOutbox:
         stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
 
         assert stored is not None
+        assert stored.result == legacy_result
+
+    async def test_a_legacy_reenqueue_replaces_a_new_writers_local_result(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """The result read after a rolling-version rewrite belongs to its payload."""
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("new-writer preview"),
+            result={"body": "new-writer full result", "interactive": None},
+        )
+        legacy_result = {"body": "legacy-writer full result", "interactive": None}
+        legacy_payload = {
+            "msgtype": "m.text",
+            "body": "legacy-writer preview",
+            DURABLE_FINAL_OUTCOME_KEY: legacy_result,
+        }
+
+        await alice._backend.write(
+            lambda transaction: transaction.execute(
+                """
+                UPDATE matrix_delivery_outbox
+                SET payload_json = ?
+                WHERE principal_id = ? AND delivery_id = ? AND stage = ?
+                """,
+                (json.dumps(legacy_payload), "agent@alice", "turn-1", "final"),
+            ),
+        )
+
+        stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+
+        assert stored is not None
+        assert stored.payload["body"] == "legacy-writer preview"
         assert stored.result == legacy_result
 
     async def test_reclaiming_sends_the_identical_delivery(self, alice: PrincipalStore) -> None:
@@ -8263,6 +8323,32 @@ class TestSchemaUpgrades:
         with sqlite3.connect(database_path) as connection:
             columns = {str(row[1]) for row in connection.execute("PRAGMA table_info(matrix_delivery_outbox)")}
         assert "result_json" in columns
+
+    async def test_postgres_adds_local_results_to_an_existing_delivery_outbox(
+        self,
+        postgres_journal_url: str,
+    ) -> None:
+        """PostgreSQL discovers and upgrades the same shipped outbox schema."""
+        import psycopg  # noqa: PLC0415 - optional backend exercised explicitly
+
+        database_url = postgres_journal_schema_url(postgres_journal_url)
+        with psycopg.connect(database_url) as connection:
+            connection.execute(_CURRENT_MATRIX_DELIVERY_OUTBOX_WITHOUT_RESULT_DDL)
+            connection.commit()
+
+        store = EventJournalStore.open_postgres(database_url)
+        await store.close()
+
+        with psycopg.connect(database_url) as connection:
+            rows = connection.execute(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = current_schema()
+                  AND table_name = 'matrix_delivery_outbox'
+                """,
+            ).fetchall()
+        assert "result_json" in {str(row[0]) for row in rows}
 
     @staticmethod
     async def _assert_legacy_approval_call_provenance_is_unknown(backend: Backend) -> None:

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -5795,6 +5795,58 @@ class TestOutbox:
 
         assert await alice.unacknowledged_matrix_deliveries() == ()
 
+    async def test_permanently_failed_matrix_delivery_is_not_replayable(self, alice: PrincipalStore) -> None:
+        """A deterministic refusal remains inspectable without becoming recovery work."""
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("sent"),
+        )
+        await alice.claim_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+
+        acknowledged_event_id = await alice.record_permanent_matrix_delivery_failure(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            reason="matrix event exceeds the hard size limit",
+        )
+
+        stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+        assert acknowledged_event_id is None
+        assert stored is not None
+        assert stored.permanent_failure_reason == "matrix event exceeds the hard size limit"
+        assert await alice.unacknowledged_matrix_deliveries() == ()
+        assert await alice.claim_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL) is None
+
+    async def test_acknowledgement_supersedes_a_concurrent_permanent_failure(self, alice: PrincipalStore) -> None:
+        """A visible event is stronger evidence than a racing refusal."""
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("sent"),
+        )
+        await alice.claim_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+        await alice.record_permanent_matrix_delivery_failure(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            reason="matrix event exceeds the hard size limit",
+        )
+
+        await alice.acknowledge_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            event_id="$sent",
+            delivered_projections=(),
+        )
+
+        stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+        assert stored is not None
+        assert stored.acknowledged_event_id == "$sent"
+        assert stored.permanent_failure_reason is None
+
     async def test_acknowledgement_keeps_the_first_event_id(self, alice: PrincipalStore) -> None:
         """Acknowledgement keeps the first event id."""
         await alice.enqueue_matrix_delivery(
@@ -8325,6 +8377,7 @@ class TestSchemaUpgrades:
         with sqlite3.connect(database_path) as connection:
             columns = {str(row[1]) for row in connection.execute("PRAGMA table_info(matrix_delivery_outbox)")}
         assert "result_json" in columns
+        assert "permanent_failure_reason" in columns
 
     async def test_postgres_adds_local_results_to_an_existing_delivery_outbox(
         self,
@@ -8350,7 +8403,9 @@ class TestSchemaUpgrades:
                   AND table_name = 'matrix_delivery_outbox'
                 """,
             ).fetchall()
-        assert "result_json" in {str(row[0]) for row in rows}
+        columns = {str(row[0]) for row in rows}
+        assert "result_json" in columns
+        assert "permanent_failure_reason" in columns
 
     @staticmethod
     async def _assert_legacy_approval_call_provenance_is_unknown(backend: Backend) -> None:

--- a/tests/test_event_journal_store.py
+++ b/tests/test_event_journal_store.py
@@ -5819,6 +5819,37 @@ class TestOutbox:
         assert await alice.unacknowledged_matrix_deliveries() == ()
         assert await alice.claim_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL) is None
 
+    async def test_permanently_failed_initial_does_not_block_standalone_final(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """A refused placeholder cannot strand a final that does not need it."""
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.INITIAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("Thinking..."),
+        )
+        await alice.claim_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.INITIAL)
+        await alice.record_permanent_matrix_delivery_failure(
+            delivery_id="turn-1",
+            stage=DeliveryStage.INITIAL,
+            reason="matrix event exceeds the hard size limit",
+        )
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id=None,
+            payload=text("finished"),
+        )
+
+        final = await alice.claim_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+
+        assert final is not None
+        assert final.edits_event_id is None
+
     async def test_acknowledgement_supersedes_a_concurrent_permanent_failure(self, alice: PrincipalStore) -> None:
         """A visible event is stronger evidence than a racing refusal."""
         await alice.enqueue_matrix_delivery(
@@ -6729,6 +6760,41 @@ class TestApprovalContinuations:
         assert retained is not None
         assert retained.state == "claimed"
 
+    async def test_permanently_failed_final_can_settle_approval_ownership(self, alice: PrincipalStore) -> None:
+        """A definitive Matrix refusal is terminal for its paused-run owner too."""
+        await self.admit_sources(alice)
+        await alice.create_approval_continuation(self.continuation())
+        claimed = await alice.claim_approval_continuation("approval-1", runtime_generation="runtime-a")
+        assert claimed is not None
+        await alice.enqueue_matrix_delivery(
+            delivery_id="$source-1",
+            stage=DeliveryStage.FINAL,
+            room_id=ROOM,
+            thread_id="$thread",
+            payload={"msgtype": "m.text", "body": "finished"},
+        )
+        await alice.claim_matrix_delivery(delivery_id="$source-1", stage=DeliveryStage.FINAL)
+        await alice.record_permanent_matrix_delivery_failure(
+            delivery_id="$source-1",
+            stage=DeliveryStage.FINAL,
+            reason="matrix event exceeds the hard size limit",
+        )
+
+        failing = await alice.request_approval_failure(
+            "approval-1",
+            "final Matrix delivery was permanently refused",
+            expected_state="claimed",
+            expected_generation=claimed.generation,
+            expected_runtime_generation="runtime-a",
+        )
+
+        assert failing is not None
+        assert failing.state == "failing"
+        assert await alice.finish_approval_continuation("approval-1")
+        assert await alice.approval_continuation("approval-1") is None
+        assert not await alice.is_pending("$source-1")
+        assert not await alice.is_pending("$source-2")
+
     async def test_card_decision_atomically_readies_the_exact_call(self, alice: PrincipalStore) -> None:
         """The card and final call decision become durable in one transaction."""
         await self.admit_sources(alice)
@@ -7634,12 +7700,12 @@ class TestApprovalContinuations:
             is None
         )
 
-    async def test_initial_acknowledgement_binds_a_precommitted_terminal_edit(
+    async def test_initial_acknowledgement_revives_a_target_dependent_final(
         self,
         journal_store: EventJournalStore,
         alice: PrincipalStore,
     ) -> None:
-        """A decision committed during an unknown send outcome still edits that exact card."""
+        """A late visible card outranks its refusal and restores its terminal edit."""
         router = journal_store.principal("router@shared")
         await self.admit_sources(alice)
         await alice.create_approval_continuation(
@@ -7674,6 +7740,11 @@ class TestApprovalContinuations:
             stage=DeliveryStage.INITIAL,
             device_id=DEVICE,
         )
+        await router.record_permanent_matrix_delivery_failure(
+            delivery_id="approval-card-1",
+            stage=DeliveryStage.INITIAL,
+            reason="matrix event exceeds the hard size limit",
+        )
 
         await alice.fence_departure(ROOM, source=DepartureSource.REPORTED)
 
@@ -7683,6 +7754,14 @@ class TestApprovalContinuations:
         )
         assert terminal is not None
         assert terminal.edits_event_id is None
+        assert terminal.permanently_failed
+        assert (
+            await router.claim_matrix_delivery(
+                delivery_id="approval-card-1",
+                stage=DeliveryStage.FINAL,
+            )
+            is None
+        )
 
         await router.acknowledge_matrix_delivery(
             delivery_id="approval-card-1",
@@ -7697,6 +7776,11 @@ class TestApprovalContinuations:
         )
         assert bound is not None
         assert bound.edits_event_id == "$approval"
+        assert not bound.permanently_failed
+        assert await router.claim_matrix_delivery(
+            delivery_id="approval-card-1",
+            stage=DeliveryStage.FINAL,
+        )
 
     async def test_router_departure_wakes_the_responder_continuation_to_fail_closed(
         self,

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -8,12 +8,13 @@ import nio
 import pytest
 
 from mindroom import interactive
+from tests.conftest import make_matrix_client_mock
 
 
 @pytest.fixture
 def mock_client() -> AsyncMock:
     """Create a mock Matrix client."""
-    client = AsyncMock()
+    client = make_matrix_client_mock()
     client.user_id = "@mindroom_test:localhost"
     return client
 

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -1,7 +1,7 @@
 """Tests for large message handling."""
 
 import json
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import nio
 import pytest
@@ -725,6 +725,64 @@ async def test_prepare_large_message_never_returns_an_unrepresentable_payload() 
 
     with pytest.raises(ValueError, match="cannot fit within the Matrix event limit"):
         await prepare_large_message(client, "!room:server", edit_content)
+
+
+@pytest.mark.asyncio
+async def test_prepare_terminal_edit_keeps_the_largest_outer_preview_that_fits() -> None:
+    """A small overflow must trim only the bytes the finished envelope cannot carry."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/maximal-preview"))
+    text = "x" * 20_500
+    metadata = "m" * 10_500
+    edit_content = {
+        "body": f"* {text}",
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.text",
+            "io.mindroom.test_metadata": metadata,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
+        "msgtype": "m.text",
+        "io.mindroom.test_metadata": metadata,
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    assert result["m.new_content"]["body"] == text
+    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+    outer_preview = result["body"][2:]
+    assert outer_preview.endswith("[Message continues in attached file]")
+    visible_prefix_length = len(outer_preview) - len("\n\n[Message continues in attached file]")
+    one_more_byte = dict(result)
+    one_more_byte["body"] = f"* {text[: visible_prefix_length + 1]}\n\n[Message continues in attached file]"
+    assert _calculate_event_size(one_more_byte) > _MATRIX_EVENT_HARD_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_prepare_terminal_edit_rejects_irreducible_metadata_before_repeated_fitting() -> None:
+    """An impossible envelope is detected from its empty-preview form."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/impossible-metadata"))
+    text = "x" * 30_000
+    edit_content = {
+        "body": f"* {text}",
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.text",
+            "io.mindroom.required_metadata": "m" * 70_000,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
+        "msgtype": "m.text",
+    }
+
+    with (
+        patch(
+            "mindroom.matrix.large_messages._calculate_event_size",
+            wraps=_calculate_event_size,
+        ) as calculate_size,
+        pytest.raises(ValueError, match="cannot fit within the Matrix event limit"),
+    ):
+        await prepare_large_message(client, "!room:server", edit_content)
+
+    assert calculate_size.call_count <= 3
 
 
 @pytest.mark.asyncio

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -883,6 +883,52 @@ async def test_prepare_terminal_edit_rejects_irreducible_metadata_before_repeate
 
 
 @pytest.mark.asyncio
+async def test_sidecar_locator_overflow_falls_back_without_repreparing() -> None:
+    """An unexpectedly large MXC URI must not turn preparation into a retry loop."""
+    huge_mxc_uri = f"mxc://server/{'x' * 70_000}"
+    encrypted_file = {
+        "url": huge_mxc_uri,
+        "key": {"kty": "oct", "k": "key"},
+        "iv": "iv",
+        "hashes": {"sha256": "hash"},
+        "v": "v2",
+        "mimetype": "application/json",
+        "size": 70_000,
+    }
+    upload_count = 0
+
+    async def upload_sidecar(*_args: object, **_kwargs: object) -> tuple[str, dict[str, object]]:
+        nonlocal upload_count
+        upload_count += 1
+        return huge_mxc_uri, encrypted_file
+
+    content = {"msgtype": "m.text", "body": "x" * 70_000}
+    with patch("mindroom.matrix.large_messages.upload_json_sidecar", new=upload_sidecar):
+        result = await prepare_large_message(
+            _UploadClient(nio.UploadResponse("mxc://server/unused")),
+            "!room:server",
+            content,
+            room_encrypted=False,
+            transition_safe=True,
+        )
+
+    assert upload_count == 1
+    assert result["msgtype"] == "m.text"
+    assert _SIDECAR_UPLOAD_FALLBACK_TEXT in result["body"]
+    for sidecar_key in ("url", "file", "filename", "info", "io.mindroom.long_text"):
+        assert sidecar_key not in result
+    assert (
+        _calculate_delivery_event_size(
+            result,
+            room_id="!room:server",
+            room_encrypted=True,
+            device_id="DEVICE",
+        )
+        <= _MATRIX_EVENT_HARD_LIMIT
+    )
+
+
+@pytest.mark.asyncio
 async def test_prepare_oversized_file_edit_remains_parseable() -> None:
     """A sidecar-backed file edit must carry a valid outer fallback event."""
     client = _UploadClient(nio.UploadResponse("mxc://server/replacement-sidecar"))

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -9,6 +9,7 @@ import pytest
 from mindroom.constants import (
     AI_RUN_METADATA_KEY,
     ATTACHMENT_IDS_KEY,
+    DURABLE_FINAL_OUTCOME_KEY,
     HOOK_MESSAGE_RECEIVED_DEPTH_KEY,
     ORIGINAL_SENDER_KEY,
     PER_FIRE_THREAD_ROOT_EVENT_ID_KEY,
@@ -622,6 +623,55 @@ async def test_prepare_edit_message() -> None:
     assert result["m.new_content"]["io.mindroom.long_text"]["version"] == 2
     assert client.uploaded_data is not None
     assert json.loads(client.uploaded_data.decode("utf-8")) == edit_content
+
+
+@pytest.mark.asyncio
+async def test_prepare_terminal_edit_with_durable_outcome_fits_hard_limit() -> None:
+    """A deferred final edit must not freeze a payload Matrix will always reject."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/final-edit"))
+    text = "final answer " + ("x" * 20_000)
+    semantic_outcome = {"body": text, "interactive": None}
+    edit_content = {
+        "body": f"* {text}",
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.text",
+            DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
+        "msgtype": "m.text",
+        DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+    assert DURABLE_FINAL_OUTCOME_KEY not in result
+    assert result["m.new_content"][DURABLE_FINAL_OUTCOME_KEY] == semantic_outcome
+    assert client.uploaded_data is not None
+    assert json.loads(client.uploaded_data.decode("utf-8")) == edit_content
+
+
+@pytest.mark.asyncio
+async def test_prepare_large_message_never_returns_an_unrepresentable_payload() -> None:
+    """Metadata that cannot fit even without a preview must fail before delivery."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/unrepresentable-edit"))
+    text = "final answer " + ("x" * 70_000)
+    semantic_outcome = {"body": text, "interactive": None}
+    edit_content = {
+        "body": f"* {text}",
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.text",
+            DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
+        "msgtype": "m.text",
+        DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+    }
+
+    with pytest.raises(ValueError, match="cannot fit within the Matrix event limit"):
+        await prepare_large_message(client, "!room:server", edit_content)
 
 
 @pytest.mark.asyncio

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -10,6 +10,7 @@ from nio.crypto import OutboundGroupSession
 from mindroom.constants import (
     AI_RUN_METADATA_KEY,
     ATTACHMENT_IDS_KEY,
+    CONFIG_CONFIRMATION_REACTION_KEY,
     DURABLE_FINAL_OUTCOME_KEY,
     HOOK_MESSAGE_RECEIVED_DEPTH_KEY,
     ORIGINAL_SENDER_KEY,
@@ -20,6 +21,7 @@ from mindroom.constants import (
     STREAM_STATUS_KEY,
     STREAM_STATUS_STREAMING,
     STREAM_WARMUP_SUFFIX_KEY,
+    VISIBLE_ROUTER_VOICE_ECHO_KEY,
     VOICE_RAW_AUDIO_FALLBACK_KEY,
 )
 from mindroom.interactive import parse_and_format_interactive
@@ -86,15 +88,26 @@ def _actual_encrypted_event_size(content: dict[str, object], *, room_id: str) ->
     relation = content.get("m.relates_to")
     if isinstance(relation, dict):
         encrypted_content["m.relates_to"] = relation
+    stream_status = content.get(STREAM_STATUS_KEY)
+    if isinstance(stream_status, str):
+        encrypted_content[STREAM_STATUS_KEY] = stream_status
+    if content.get(VISIBLE_ROUTER_VOICE_ECHO_KEY) is True:
+        encrypted_content[VISIBLE_ROUTER_VOICE_ECHO_KEY] = True
+    config_reaction_id = content.get(CONFIG_CONFIRMATION_REACTION_KEY)
+    if isinstance(config_reaction_id, str):
+        encrypted_content[CONFIG_CONFIRMATION_REACTION_KEY] = config_reaction_id
     return _calculate_event_size(encrypted_content)
 
 
 def test_encrypted_event_size_estimate_bounds_real_megolm_output() -> None:
     """The delivery estimate must include Megolm expansion without consuming a live session."""
     content: dict[str, object] = {
-        "body": "x" * 45_000,
+        "body": "x" * 45_750,
         "msgtype": "m.text",
         "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
+        STREAM_STATUS_KEY: "completed",
+        VISIBLE_ROUTER_VOICE_ECHO_KEY: True,
+        CONFIG_CONFIRMATION_REACTION_KEY: "$reaction",
     }
 
     estimated = _calculate_delivery_event_size(
@@ -105,6 +118,7 @@ def test_encrypted_event_size_estimate_bounds_real_megolm_output() -> None:
     )
     actual = _actual_encrypted_event_size(content, room_id="!room:server")
 
+    assert _MATRIX_EVENT_HARD_LIMIT - 256 <= actual <= _MATRIX_EVENT_HARD_LIMIT
     assert actual <= estimated <= actual + 16
 
 

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -626,8 +626,8 @@ async def test_prepare_edit_message() -> None:
 
 
 @pytest.mark.asyncio
-async def test_prepare_terminal_edit_with_durable_outcome_fits_hard_limit() -> None:
-    """A deferred final edit must not freeze a payload Matrix will always reject."""
+async def test_prepare_terminal_edit_keeps_local_recovery_data_off_the_wire() -> None:
+    """Local recovery facts belong in the outbox, not its event or sidecar."""
     client = _UploadClient(nio.UploadResponse("mxc://server/final-edit"))
     text = "final answer " + ("x" * 20_000)
     semantic_outcome = {"body": text, "interactive": None}
@@ -647,9 +647,35 @@ async def test_prepare_terminal_edit_with_durable_outcome_fits_hard_limit() -> N
 
     assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
     assert DURABLE_FINAL_OUTCOME_KEY not in result
-    assert result["m.new_content"][DURABLE_FINAL_OUTCOME_KEY] == semantic_outcome
+    assert DURABLE_FINAL_OUTCOME_KEY not in result["m.new_content"]
     assert client.uploaded_data is not None
-    assert json.loads(client.uploaded_data.decode("utf-8")) == edit_content
+    uploaded = json.loads(client.uploaded_data.decode("utf-8"))
+    assert DURABLE_FINAL_OUTCOME_KEY not in uploaded
+    assert DURABLE_FINAL_OUTCOME_KEY not in uploaded["m.new_content"]
+
+
+@pytest.mark.asyncio
+async def test_prepare_terminal_edit_preserves_bounded_result_compatibility_marker() -> None:
+    """A version marker remains visible to older readers without carrying the result."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/final-edit-compatibility"))
+    text = "final answer " + ("x" * 20_000)
+    marker = {"version": 2}
+    edit_content = {
+        "body": f"* {text}",
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.text",
+            DURABLE_FINAL_OUTCOME_KEY: marker,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
+        "msgtype": "m.text",
+        DURABLE_FINAL_OUTCOME_KEY: marker,
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    assert result["m.new_content"][DURABLE_FINAL_OUTCOME_KEY] == {"version": 2}
+    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -657,17 +683,17 @@ async def test_prepare_terminal_edit_updates_sidecar_size_after_inner_preview_sh
     """Fitting the replacement body must keep its sidecar metadata truthful."""
     client = _UploadClient(nio.UploadResponse("mxc://server/fitted-final-edit"))
     text = "final answer " + ("x" * 50_000)
-    semantic_outcome = {"body": text, "interactive": None}
+    metadata = "m" * 20_000
     edit_content = {
         "body": f"* {text}",
         "m.new_content": {
             "body": text,
             "msgtype": "m.text",
-            DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+            "io.mindroom.required_metadata": metadata,
         },
         "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
         "msgtype": "m.text",
-        DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+        "io.mindroom.required_metadata": metadata,
     }
 
     result = await prepare_large_message(client, "!room:server", edit_content)
@@ -675,7 +701,7 @@ async def test_prepare_terminal_edit_updates_sidecar_size_after_inner_preview_sh
     inner = result["m.new_content"]
     assert len(inner["body"]) < 22_000
     assert inner["io.mindroom.long_text"]["preview_size"] == len(inner["body"])
-    assert inner[DURABLE_FINAL_OUTCOME_KEY] == semantic_outcome
+    assert inner["io.mindroom.required_metadata"] == metadata
     assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
 
 
@@ -684,47 +710,25 @@ async def test_prepare_terminal_edit_uses_empty_previews_at_the_metadata_boundar
     """Mandatory metadata may consume the final bytes without making the edit impossible."""
     client = _UploadClient(nio.UploadResponse("mxc://server/boundary-final-edit"))
     text = "x" * 61_400
-    semantic_outcome = {"body": text, "interactive": None}
+    metadata = "m" * 30_706
     edit_content = {
         "body": f"* {text}",
         "m.new_content": {
             "body": text,
             "msgtype": "m.text",
-            DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+            "io.mindroom.required_metadata": metadata,
         },
         "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
         "msgtype": "m.text",
-        DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+        "io.mindroom.required_metadata": metadata,
     }
 
     result = await prepare_large_message(client, "!room:server", edit_content)
 
     assert result["body"] == ""
     assert result["m.new_content"]["body"] == ""
-    assert result["m.new_content"][DURABLE_FINAL_OUTCOME_KEY] == semantic_outcome
-    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
-
-
-@pytest.mark.asyncio
-async def test_prepare_large_message_never_returns_an_unrepresentable_payload() -> None:
-    """Metadata that cannot fit even without a preview must fail before delivery."""
-    client = _UploadClient(nio.UploadResponse("mxc://server/unrepresentable-edit"))
-    text = "final answer " + ("x" * 70_000)
-    semantic_outcome = {"body": text, "interactive": None}
-    edit_content = {
-        "body": f"* {text}",
-        "m.new_content": {
-            "body": text,
-            "msgtype": "m.text",
-            DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
-        },
-        "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
-        "msgtype": "m.text",
-        DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
-    }
-
-    with pytest.raises(ValueError, match="cannot fit within the Matrix event limit"):
-        await prepare_large_message(client, "!room:server", edit_content)
+    assert result["m.new_content"]["io.mindroom.required_metadata"] == metadata
+    assert _calculate_event_size(result) == _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -23,11 +23,11 @@ from mindroom.constants import (
     VOICE_RAW_AUDIO_FALLBACK_KEY,
 )
 from mindroom.interactive import parse_and_format_interactive
-from mindroom.matrix import large_messages
 from mindroom.matrix.large_messages import (
     _MATRIX_EVENT_HARD_LIMIT,
     _NORMAL_MESSAGE_LIMIT,
     _SIDECAR_UPLOAD_FALLBACK_INDICATOR,
+    _calculate_delivery_event_size,
     _calculate_event_size,
     _create_preview,
     _is_edit_message,
@@ -44,6 +44,7 @@ _SIDECAR_UPLOAD_FALLBACK_TEXT = _SIDECAR_UPLOAD_FALLBACK_INDICATOR.strip()
 
 class _UploadClient:
     rooms: dict = {}  # noqa: RUF012
+    olm = None
     device_id = "DEVICE"
 
     def __init__(self, upload_result: object | BaseException) -> None:
@@ -90,15 +91,13 @@ def _actual_encrypted_event_size(content: dict[str, object], *, room_id: str) ->
 
 def test_encrypted_event_size_estimate_bounds_real_megolm_output() -> None:
     """The delivery estimate must include Megolm expansion without consuming a live session."""
-    estimator = getattr(large_messages, "_calculate_delivery_event_size", None)
-    assert callable(estimator)
     content: dict[str, object] = {
         "body": "x" * 45_000,
         "msgtype": "m.text",
         "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
     }
 
-    estimated = estimator(
+    estimated = _calculate_delivery_event_size(
         content,
         room_id="!room:server",
         room_encrypted=True,

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -653,6 +653,59 @@ async def test_prepare_terminal_edit_with_durable_outcome_fits_hard_limit() -> N
 
 
 @pytest.mark.asyncio
+async def test_prepare_terminal_edit_updates_sidecar_size_after_inner_preview_shrinks() -> None:
+    """Fitting the replacement body must keep its sidecar metadata truthful."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/fitted-final-edit"))
+    text = "final answer " + ("x" * 50_000)
+    semantic_outcome = {"body": text, "interactive": None}
+    edit_content = {
+        "body": f"* {text}",
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.text",
+            DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
+        "msgtype": "m.text",
+        DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    inner = result["m.new_content"]
+    assert len(inner["body"]) < 22_000
+    assert inner["io.mindroom.long_text"]["preview_size"] == len(inner["body"])
+    assert inner[DURABLE_FINAL_OUTCOME_KEY] == semantic_outcome
+    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_prepare_terminal_edit_uses_empty_previews_at_the_metadata_boundary() -> None:
+    """Mandatory metadata may consume the final bytes without making the edit impossible."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/boundary-final-edit"))
+    text = "x" * 61_400
+    semantic_outcome = {"body": text, "interactive": None}
+    edit_content = {
+        "body": f"* {text}",
+        "m.new_content": {
+            "body": text,
+            "msgtype": "m.text",
+            DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+        },
+        "m.relates_to": {"rel_type": "m.replace", "event_id": "$target"},
+        "msgtype": "m.text",
+        DURABLE_FINAL_OUTCOME_KEY: semantic_outcome,
+    }
+
+    result = await prepare_large_message(client, "!room:server", edit_content)
+
+    assert result["body"] == ""
+    assert result["m.new_content"]["body"] == ""
+    assert result["m.new_content"][DURABLE_FINAL_OUTCOME_KEY] == semantic_outcome
+    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+
+
+@pytest.mark.asyncio
 async def test_prepare_large_message_never_returns_an_unrepresentable_payload() -> None:
     """Metadata that cannot fit even without a preview must fail before delivery."""
     client = _UploadClient(nio.UploadResponse("mxc://server/unrepresentable-edit"))

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, patch
 
 import nio
 import pytest
-from nio import crypto
 from nio.crypto import OutboundGroupSession
 
 from mindroom.constants import (
@@ -143,67 +142,6 @@ async def test_prepare_encrypted_normal_message_fits_after_megolm_encryption() -
     assert prepared["msgtype"] == "m.file"
     assert prepared["file"]["url"] == "mxc://server/encrypted-normal-sidecar"
     assert _actual_encrypted_event_size(prepared, room_id="!room:server") <= _MATRIX_EVENT_HARD_LIMIT
-
-
-@pytest.mark.asyncio
-async def test_transition_safe_plaintext_room_uses_an_encrypted_parseable_sidecar() -> None:
-    """A room transition must not expose sidecar bytes or invalidate the frozen preview."""
-    content = {"body": "x" * 100_000, "msgtype": "m.text"}
-    client = _UploadClient(nio.UploadResponse("mxc://server/transition-safe-sidecar"))
-
-    prepared = await prepare_large_message(
-        client,
-        "!room:server",
-        content,
-        room_encrypted=False,
-        transition_safe=True,
-    )
-
-    assert prepared["msgtype"] == "m.text"
-    assert "url" not in prepared
-    assert prepared["file"]["url"] == "mxc://server/transition-safe-sidecar"
-    event_source = {
-        "content": prepared,
-        "event_id": "$transition-safe",
-        "sender": "@agent:server",
-        "origin_server_ts": 123,
-        "type": "m.room.message",
-    }
-    assert isinstance(nio.Event.parse_event(event_source), nio.RoomMessageText)
-    assert isinstance(nio.RoomMessage.parse_decrypted_event(event_source), nio.RoomMessageText)
-    assert client.uploaded_data is not None
-    encrypted_file = prepared["file"]
-    decrypted = crypto.attachments.decrypt_attachment(
-        client.uploaded_data,
-        encrypted_file["key"]["k"],
-        encrypted_file["hashes"]["sha256"],
-        encrypted_file["iv"],
-    )
-    assert json.loads(decrypted) == content
-
-
-@pytest.mark.asyncio
-async def test_encrypted_fitting_reserves_for_a_longer_recovery_device_id() -> None:
-    """A frozen payload fitted on one device must remain sendable after device recovery."""
-    client = _UploadClient(nio.UploadResponse("mxc://server/recovery-sidecar"))
-    client.device_id = "D"
-
-    prepared = await prepare_large_message(
-        client,
-        "!room:server",
-        {"body": "x" * 100_000, "msgtype": "m.text"},
-        room_encrypted=True,
-        transition_safe=True,
-    )
-
-    assert (
-        _actual_encrypted_event_size(
-            prepared,
-            room_id="!room:server",
-            device_id="R" * 255,
-        )
-        <= _MATRIX_EVENT_HARD_LIMIT
-    )
 
 
 @pytest.mark.parametrize("is_edit", [False, True])
@@ -990,7 +928,6 @@ async def test_sidecar_locator_overflow_falls_back_without_repreparing() -> None
             "!room:server",
             content,
             room_encrypted=False,
-            transition_safe=True,
         )
 
     assert upload_count == 1
@@ -1002,8 +939,8 @@ async def test_sidecar_locator_overflow_falls_back_without_repreparing() -> None
         _calculate_delivery_event_size(
             result,
             room_id="!room:server",
-            room_encrypted=True,
-            device_id="DEVICE",
+            room_encrypted=False,
+            device_id=None,
         )
         <= _MATRIX_EVENT_HARD_LIMIT
     )

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 
 import nio
 import pytest
+from nio import crypto
 from nio.crypto import OutboundGroupSession
 
 from mindroom.constants import (
@@ -67,7 +68,12 @@ def _large_text_content(prefix: str) -> dict[str, str]:
     return {"body": prefix + ("x" * 100000), "msgtype": "m.text"}
 
 
-def _actual_encrypted_event_size(content: dict[str, object], *, room_id: str) -> int:
+def _actual_encrypted_event_size(
+    content: dict[str, object],
+    *,
+    room_id: str,
+    device_id: str = "DEVICE",
+) -> int:
     """Encrypt one event with Megolm and measure the resulting content envelope."""
     session = OutboundGroupSession()
     session.shared = True
@@ -83,7 +89,7 @@ def _actual_encrypted_event_size(content: dict[str, object], *, room_id: str) ->
         "sender_key": "s" * 43,
         "ciphertext": session.encrypt(plaintext),
         "session_id": "i" * 43,
-        "device_id": "DEVICE",
+        "device_id": device_id,
     }
     relation = content.get("m.relates_to")
     if isinstance(relation, dict):
@@ -137,6 +143,67 @@ async def test_prepare_encrypted_normal_message_fits_after_megolm_encryption() -
     assert prepared["msgtype"] == "m.file"
     assert prepared["file"]["url"] == "mxc://server/encrypted-normal-sidecar"
     assert _actual_encrypted_event_size(prepared, room_id="!room:server") <= _MATRIX_EVENT_HARD_LIMIT
+
+
+@pytest.mark.asyncio
+async def test_transition_safe_plaintext_room_uses_an_encrypted_parseable_sidecar() -> None:
+    """A room transition must not expose sidecar bytes or invalidate the frozen preview."""
+    content = {"body": "x" * 100_000, "msgtype": "m.text"}
+    client = _UploadClient(nio.UploadResponse("mxc://server/transition-safe-sidecar"))
+
+    prepared = await prepare_large_message(
+        client,
+        "!room:server",
+        content,
+        room_encrypted=False,
+        transition_safe=True,
+    )
+
+    assert prepared["msgtype"] == "m.text"
+    assert "url" not in prepared
+    assert prepared["file"]["url"] == "mxc://server/transition-safe-sidecar"
+    event_source = {
+        "content": prepared,
+        "event_id": "$transition-safe",
+        "sender": "@agent:server",
+        "origin_server_ts": 123,
+        "type": "m.room.message",
+    }
+    assert isinstance(nio.Event.parse_event(event_source), nio.RoomMessageText)
+    assert isinstance(nio.RoomMessage.parse_decrypted_event(event_source), nio.RoomMessageText)
+    assert client.uploaded_data is not None
+    encrypted_file = prepared["file"]
+    decrypted = crypto.attachments.decrypt_attachment(
+        client.uploaded_data,
+        encrypted_file["key"]["k"],
+        encrypted_file["hashes"]["sha256"],
+        encrypted_file["iv"],
+    )
+    assert json.loads(decrypted) == content
+
+
+@pytest.mark.asyncio
+async def test_encrypted_fitting_reserves_for_a_longer_recovery_device_id() -> None:
+    """A frozen payload fitted on one device must remain sendable after device recovery."""
+    client = _UploadClient(nio.UploadResponse("mxc://server/recovery-sidecar"))
+    client.device_id = "D"
+
+    prepared = await prepare_large_message(
+        client,
+        "!room:server",
+        {"body": "x" * 100_000, "msgtype": "m.text"},
+        room_encrypted=True,
+        transition_safe=True,
+    )
+
+    assert (
+        _actual_encrypted_event_size(
+            prepared,
+            room_id="!room:server",
+            device_id="R" * 255,
+        )
+        <= _MATRIX_EVENT_HARD_LIMIT
+    )
 
 
 @pytest.mark.parametrize("is_edit", [False, True])

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -10,6 +10,7 @@ import nio
 import pytest
 from agno.models.response import ToolExecution
 from agno.run.agent import ToolCallCompletedEvent, ToolCallStartedEvent
+from nio import crypto
 
 from mindroom.config.models import DefaultsConfig
 from mindroom.constants import (
@@ -132,9 +133,10 @@ async def test_regular_message_over_limit() -> None:
     assert len(client.messages_sent) == 1
     sent_content = client.messages_sent[0][2]
 
-    # Should be an m.file message
-    assert sent_content["msgtype"] == "m.file"
-    assert sent_content["filename"] == "message-content.json"
+    # A direct send can cross into encryption while its upload yields, so its
+    # frozen sidecar is encrypted and carried by a parseable text preview.
+    assert sent_content["msgtype"] == "m.text"
+    assert "filename" not in sent_content
 
     # Should have truncated body preview
     assert len(sent_content["body"]) < len(large_text)
@@ -147,7 +149,8 @@ async def test_regular_message_over_limit() -> None:
     assert sent_content["io.mindroom.long_text"]["is_complete_content"] is True
 
     # Should have file URL
-    assert "url" in sent_content or "file" in sent_content
+    assert "url" not in sent_content
+    assert sent_content["file"]["url"].startswith("mxc://server/")
 
 
 @pytest.mark.asyncio
@@ -167,7 +170,7 @@ async def test_edit_message_with_lower_threshold() -> None:
     # Should be truncated due to edit limit
     # For edits, check m.new_content
     assert "m.new_content" in sent_content
-    assert sent_content["m.new_content"]["msgtype"] == "m.file"
+    assert sent_content["m.new_content"]["msgtype"] == "m.text"
     assert "io.mindroom.long_text" in sent_content["m.new_content"]
     assert len(sent_content["m.new_content"]["body"]) < len(text)
 
@@ -195,12 +198,20 @@ async def test_large_edit_preserves_mindroom_metadata_in_both_payload_layers() -
     assert len(client.messages_sent) == 1
     sent_content = client.messages_sent[0][2]
     assert "m.new_content" in sent_content
-    assert sent_content["m.new_content"]["msgtype"] == "m.file"
+    assert sent_content["m.new_content"]["msgtype"] == "m.text"
     for key, value in extra_content.items():
         assert sent_content[key] == value
         assert sent_content["m.new_content"][key] == value
 
-    uploaded_payload = json.loads(client.uploads[0]["data"].read().decode("utf-8"))
+    encrypted_file = sent_content["m.new_content"]["file"]
+    uploaded_payload = json.loads(
+        crypto.attachments.decrypt_attachment(
+            client.uploads[0]["data"].read(),
+            encrypted_file["key"]["k"],
+            encrypted_file["hashes"]["sha256"],
+            encrypted_file["iv"],
+        ),
+    )
     for key, value in extra_content.items():
         assert uploaded_payload["m.new_content"][key] == value
 
@@ -285,7 +296,7 @@ async def test_streaming_initial_message_over_limit() -> None:
     # Should have sent with large message handling
     assert len(client.messages_sent) == 1
     sent_content = client.messages_sent[0][2]
-    assert sent_content["msgtype"] == "m.file"
+    assert sent_content["msgtype"] == "m.text"
     assert len(sent_content["body"]) < 60000
     assert "io.mindroom.long_text" in sent_content
 
@@ -324,7 +335,7 @@ async def test_streaming_edit_grows_over_limit() -> None:
 
     # Edit should have large message handling
     assert "m.new_content" in edit_content
-    assert edit_content["m.new_content"]["msgtype"] == "m.file"
+    assert edit_content["m.new_content"]["msgtype"] == "m.text"
     assert "io.mindroom.long_text" in edit_content["m.new_content"]
     assert len(edit_content["m.new_content"]["body"]) < 35000
 
@@ -376,7 +387,7 @@ async def test_streaming_multiple_edits_with_growth(monkeypatch: pytest.MonkeyPa
     assert nonterminal_large_edit["m.new_content"]["io.mindroom.long_text"]["encoding"] == "matrix_event_content_json"
 
     terminal_large_edit = client.messages_sent[-1][2]
-    assert terminal_large_edit["m.new_content"]["msgtype"] == "m.file"
+    assert terminal_large_edit["m.new_content"]["msgtype"] == "m.text"
     assert "io.mindroom.long_text" in terminal_large_edit["m.new_content"]
 
 
@@ -408,7 +419,7 @@ async def test_streaming_with_thread_context() -> None:
     assert relates_to.get("event_id") == "$thread_root" or relates_to.get("rel_type") == "m.thread"
 
     # Should have large message handling
-    assert sent_content["msgtype"] == "m.file"
+    assert sent_content["msgtype"] == "m.text"
     assert "io.mindroom.long_text" in sent_content
 
 
@@ -552,7 +563,7 @@ async def test_streaming_finalize() -> None:
     sent_content = client.messages_sent[0][2]
 
     # Should have large message handling
-    assert sent_content["msgtype"] == "m.file"
+    assert sent_content["msgtype"] == "m.text"
     assert "io.mindroom.long_text" in sent_content
     # Should not have in-progress marker in final
     assert "⋯" not in sent_content["body"]

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -10,7 +10,6 @@ import nio
 import pytest
 from agno.models.response import ToolExecution
 from agno.run.agent import ToolCallCompletedEvent, ToolCallStartedEvent
-from nio import crypto
 
 from mindroom.config.models import DefaultsConfig
 from mindroom.constants import (
@@ -49,6 +48,8 @@ class MockClient:
         self.messages_sent = []
         self.uploads: list[dict] = []
         self.should_upload_succeed = should_upload_succeed
+        self.olm = None
+        self.device_id = "DEVICE"
 
     async def room_send(
         self,
@@ -133,10 +134,8 @@ async def test_regular_message_over_limit() -> None:
     assert len(client.messages_sent) == 1
     sent_content = client.messages_sent[0][2]
 
-    # A direct send can cross into encryption while its upload yields, so its
-    # frozen sidecar is encrypted and carried by a parseable text preview.
-    assert sent_content["msgtype"] == "m.text"
-    assert "filename" not in sent_content
+    assert sent_content["msgtype"] == "m.file"
+    assert sent_content["filename"] == "message-content.json"
 
     # Should have truncated body preview
     assert len(sent_content["body"]) < len(large_text)
@@ -149,8 +148,8 @@ async def test_regular_message_over_limit() -> None:
     assert sent_content["io.mindroom.long_text"]["is_complete_content"] is True
 
     # Should have file URL
-    assert "url" not in sent_content
-    assert sent_content["file"]["url"].startswith("mxc://server/")
+    assert sent_content["url"].startswith("mxc://server/")
+    assert "file" not in sent_content
 
 
 @pytest.mark.asyncio
@@ -170,7 +169,7 @@ async def test_edit_message_with_lower_threshold() -> None:
     # Should be truncated due to edit limit
     # For edits, check m.new_content
     assert "m.new_content" in sent_content
-    assert sent_content["m.new_content"]["msgtype"] == "m.text"
+    assert sent_content["m.new_content"]["msgtype"] == "m.file"
     assert "io.mindroom.long_text" in sent_content["m.new_content"]
     assert len(sent_content["m.new_content"]["body"]) < len(text)
 
@@ -198,20 +197,12 @@ async def test_large_edit_preserves_mindroom_metadata_in_both_payload_layers() -
     assert len(client.messages_sent) == 1
     sent_content = client.messages_sent[0][2]
     assert "m.new_content" in sent_content
-    assert sent_content["m.new_content"]["msgtype"] == "m.text"
+    assert sent_content["m.new_content"]["msgtype"] == "m.file"
     for key, value in extra_content.items():
         assert sent_content[key] == value
         assert sent_content["m.new_content"][key] == value
 
-    encrypted_file = sent_content["m.new_content"]["file"]
-    uploaded_payload = json.loads(
-        crypto.attachments.decrypt_attachment(
-            client.uploads[0]["data"].read(),
-            encrypted_file["key"]["k"],
-            encrypted_file["hashes"]["sha256"],
-            encrypted_file["iv"],
-        ),
-    )
+    uploaded_payload = json.loads(client.uploads[0]["data"].read())
     for key, value in extra_content.items():
         assert uploaded_payload["m.new_content"][key] == value
 
@@ -296,7 +287,7 @@ async def test_streaming_initial_message_over_limit() -> None:
     # Should have sent with large message handling
     assert len(client.messages_sent) == 1
     sent_content = client.messages_sent[0][2]
-    assert sent_content["msgtype"] == "m.text"
+    assert sent_content["msgtype"] == "m.file"
     assert len(sent_content["body"]) < 60000
     assert "io.mindroom.long_text" in sent_content
 
@@ -335,7 +326,7 @@ async def test_streaming_edit_grows_over_limit() -> None:
 
     # Edit should have large message handling
     assert "m.new_content" in edit_content
-    assert edit_content["m.new_content"]["msgtype"] == "m.text"
+    assert edit_content["m.new_content"]["msgtype"] == "m.file"
     assert "io.mindroom.long_text" in edit_content["m.new_content"]
     assert len(edit_content["m.new_content"]["body"]) < 35000
 
@@ -387,7 +378,7 @@ async def test_streaming_multiple_edits_with_growth(monkeypatch: pytest.MonkeyPa
     assert nonterminal_large_edit["m.new_content"]["io.mindroom.long_text"]["encoding"] == "matrix_event_content_json"
 
     terminal_large_edit = client.messages_sent[-1][2]
-    assert terminal_large_edit["m.new_content"]["msgtype"] == "m.text"
+    assert terminal_large_edit["m.new_content"]["msgtype"] == "m.file"
     assert "io.mindroom.long_text" in terminal_large_edit["m.new_content"]
 
 
@@ -419,7 +410,7 @@ async def test_streaming_with_thread_context() -> None:
     assert relates_to.get("event_id") == "$thread_root" or relates_to.get("rel_type") == "m.thread"
 
     # Should have large message handling
-    assert sent_content["msgtype"] == "m.text"
+    assert sent_content["msgtype"] == "m.file"
     assert "io.mindroom.long_text" in sent_content
 
 
@@ -563,7 +554,7 @@ async def test_streaming_finalize() -> None:
     sent_content = client.messages_sent[0][2]
 
     # Should have large message handling
-    assert sent_content["msgtype"] == "m.text"
+    assert sent_content["msgtype"] == "m.file"
     assert "io.mindroom.long_text" in sent_content
     # Should not have in-progress marker in final
     assert "⋯" not in sent_content["body"]

--- a/tests/test_matrix_delivery.py
+++ b/tests/test_matrix_delivery.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -23,11 +22,6 @@ from mindroom.matrix.client_delivery import (
     send_message_result,
     send_room_event_result,
 )
-from mindroom.matrix.large_messages import _MATRIX_EVENT_HARD_LIMIT, _calculate_delivery_event_size
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from io import BytesIO
 
 
 def _mock_client(*, encrypted: bool = False) -> AsyncMock:
@@ -347,6 +341,50 @@ async def test_send_message_outcome_maps_unexpected_response() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_message_outcome_maps_server_too_large_response() -> None:
+    """A definite homeserver size refusal is distinguishable from retryable failures."""
+    client = _mock_client()
+    client.room_send.return_value = nio.RoomSendError(
+        message="event too large",
+        status_code="M_TOO_LARGE",
+        room_id="!room:localhost",
+    )
+
+    outcome = await send_message_outcome(
+        client,
+        "!room:localhost",
+        {"body": "already prepared", "msgtype": "m.text"},
+        content_is_prepared=True,
+    )
+
+    assert outcome == MatrixDeliveryFailure(
+        MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE,
+        "event too large",
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_outcome_keeps_other_server_refusals_retryable() -> None:
+    """A server refusal is not permanent merely because it is a client error."""
+    client = _mock_client()
+    client.room_send.return_value = nio.RoomSendError(
+        message="forbidden",
+        status_code="M_FORBIDDEN",
+        room_id="!room:localhost",
+    )
+
+    outcome = await send_message_outcome(
+        client,
+        "!room:localhost",
+        {"body": "already prepared", "msgtype": "m.text"},
+        content_is_prepared=True,
+    )
+
+    assert isinstance(outcome, MatrixDeliveryFailure)
+    assert outcome.kind is MatrixDeliveryFailureKind.UNEXPECTED_RESPONSE
+
+
+@pytest.mark.asyncio
 async def test_send_message_outcome_success_returns_delivered_event() -> None:
     """Successful sends keep returning the delivered event id and sent content."""
     client = _mock_client(encrypted=True)
@@ -357,46 +395,6 @@ async def test_send_message_outcome_success_returns_delivered_event() -> None:
     assert isinstance(outcome, DeliveredMatrixEvent)
     assert outcome.event_id == "$event:localhost"
     assert outcome.content_sent == content
-
-
-@pytest.mark.asyncio
-async def test_direct_send_survives_room_encryption_being_enabled_during_sidecar_upload() -> None:
-    """Direct preparation must be valid if room encryption changes while upload yields."""
-    client = _mock_client()
-    client.device_id = "D"
-    uploaded_data: bytes | None = None
-
-    async def upload_and_enable_encryption(**kwargs: object) -> tuple[nio.UploadResponse, None]:
-        nonlocal uploaded_data
-        data_provider = cast("Callable[[object, object], BytesIO]", kwargs["data_provider"])
-        uploaded_data = data_provider(None, None).read()
-        client.rooms["!room:localhost"].encrypted = True
-        client.olm = MagicMock()
-        client.olm.device_id = "RECOVERY-DEVICE"
-        return nio.UploadResponse("mxc://server/direct-sidecar"), None
-
-    client.upload.side_effect = upload_and_enable_encryption
-
-    outcome = await send_message_outcome(
-        client,
-        "!room:localhost",
-        {"body": "x" * 56_000, "msgtype": "m.text"},
-    )
-
-    assert isinstance(outcome, DeliveredMatrixEvent)
-    assert uploaded_data is not None
-    assert not uploaded_data.startswith(b"{")
-    assert "url" not in outcome.content_sent
-    assert outcome.content_sent["file"]["url"] == "mxc://server/direct-sidecar"
-    assert (
-        _calculate_delivery_event_size(
-            outcome.content_sent,
-            room_id="!room:localhost",
-            room_encrypted=True,
-            device_id="RECOVERY-DEVICE",
-        )
-        <= _MATRIX_EVENT_HARD_LIMIT
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_delivery.py
+++ b/tests/test_matrix_delivery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -22,6 +23,11 @@ from mindroom.matrix.client_delivery import (
     send_message_result,
     send_room_event_result,
 )
+from mindroom.matrix.large_messages import _MATRIX_EVENT_HARD_LIMIT, _calculate_delivery_event_size
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from io import BytesIO
 
 
 def _mock_client(*, encrypted: bool = False) -> AsyncMock:
@@ -351,6 +357,46 @@ async def test_send_message_outcome_success_returns_delivered_event() -> None:
     assert isinstance(outcome, DeliveredMatrixEvent)
     assert outcome.event_id == "$event:localhost"
     assert outcome.content_sent == content
+
+
+@pytest.mark.asyncio
+async def test_direct_send_survives_room_encryption_being_enabled_during_sidecar_upload() -> None:
+    """Direct preparation must be valid if room encryption changes while upload yields."""
+    client = _mock_client()
+    client.device_id = "D"
+    uploaded_data: bytes | None = None
+
+    async def upload_and_enable_encryption(**kwargs: object) -> tuple[nio.UploadResponse, None]:
+        nonlocal uploaded_data
+        data_provider = cast("Callable[[object, object], BytesIO]", kwargs["data_provider"])
+        uploaded_data = data_provider(None, None).read()
+        client.rooms["!room:localhost"].encrypted = True
+        client.olm = MagicMock()
+        client.olm.device_id = "RECOVERY-DEVICE"
+        return nio.UploadResponse("mxc://server/direct-sidecar"), None
+
+    client.upload.side_effect = upload_and_enable_encryption
+
+    outcome = await send_message_outcome(
+        client,
+        "!room:localhost",
+        {"body": "x" * 56_000, "msgtype": "m.text"},
+    )
+
+    assert isinstance(outcome, DeliveredMatrixEvent)
+    assert uploaded_data is not None
+    assert not uploaded_data.startswith(b"{")
+    assert "url" not in outcome.content_sent
+    assert outcome.content_sent["file"]["url"] == "mxc://server/direct-sidecar"
+    assert (
+        _calculate_delivery_event_size(
+            outcome.content_sent,
+            room_id="!room:localhost",
+            room_encrypted=True,
+            device_id="RECOVERY-DEVICE",
+        )
+        <= _MATRIX_EVENT_HARD_LIMIT
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_delivery.py
+++ b/tests/test_matrix_delivery.py
@@ -304,6 +304,27 @@ async def test_send_message_outcome_maps_send_exception() -> None:
 
 
 @pytest.mark.asyncio
+async def test_send_message_outcome_maps_an_unrepresentable_payload() -> None:
+    """Irreducible metadata is a typed refusal and never reaches Matrix."""
+    client = _mock_client()
+    client.upload.return_value = (
+        nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/impossible-message"}),
+        None,
+    )
+    content = {
+        "body": "x" * 70_000,
+        "msgtype": "m.text",
+        "io.mindroom.required_metadata": "m" * 70_000,
+    }
+
+    outcome = await send_message_outcome(client, "!room:localhost", content)
+
+    assert isinstance(outcome, MatrixDeliveryFailure)
+    assert outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE
+    client.room_send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_send_message_outcome_maps_unexpected_response() -> None:
     """A non-send response maps to the unexpected-response kind."""
     client = _mock_client()

--- a/tests/test_matrix_delivery.py
+++ b/tests/test_matrix_delivery.py
@@ -31,6 +31,8 @@ def _mock_client(*, encrypted: bool = False) -> AsyncMock:
     room.encrypted = encrypted
     client.rooms = {"!room:localhost": room}
     client.olm = MagicMock() if encrypted else None
+    if client.olm is not None:
+        client.olm.device_id = "DEVICE"
     client.room_send.return_value = nio.RoomSendResponse(event_id="$event:localhost", room_id="!room:localhost")
     return client
 
@@ -251,6 +253,8 @@ def _cache_bypass_client(*, encrypted: bool | None) -> AsyncMock:
         encryption_state.status_code = "M_NOT_FOUND"
     client.room_get_state_event = AsyncMock(return_value=encryption_state)
     client.olm = MagicMock() if encrypted else None
+    if client.olm is not None:
+        client.olm.device_id = "DEVICE"
     client.room_send.return_value = nio.RoomSendResponse(event_id="$event:localhost", room_id="!room:localhost")
     return client
 

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -19,6 +19,7 @@ import pytest
 
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
+from mindroom.constants import DURABLE_FINAL_OUTCOME_KEY
 from mindroom.delivery_gateway import (
     CancelledVisibleNoteRequest,
     DeliveryGateway,
@@ -33,6 +34,7 @@ from mindroom.event_journal import DepartureSource
 from mindroom.handled_turns import TurnRecord, _reset_handled_turn_ledger_runtime
 from mindroom.hooks.context import ResponseDraft
 from mindroom.matrix.client_delivery import DeliveredMatrixEvent, MatrixDeliveryFailure, MatrixDeliveryFailureKind
+from mindroom.matrix.large_messages import _MATRIX_EVENT_HARD_LIMIT, _calculate_event_size
 from mindroom.matrix_delivery import MatrixDeliveryWorker, RecoveryOutcome
 from mindroom.message_target import MessageTarget
 from mindroom.streaming import PROGRESS_PLACEHOLDER
@@ -679,6 +681,44 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert semantic["body"] == outcome.final_visible_body
         assert semantic["interactive"]["question_text"] == "Pick"
         assert semantic["interactive"]["option_map"] == {"1": "yes", "✅": "yes"}
+
+    async def test_large_deferred_final_edit_freezes_a_sendable_semantic_payload(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A recoverable final edit must not leave an impossible outbox retry."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.user_id = _AGENT_USER_ID
+        client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
+        room = MagicMock()
+        room.encrypted = False
+        client.rooms = {_ROOM_ID: room}
+        client.olm = None
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/final-edit"}),
+            None,
+        )
+        client.room_send.return_value = nio.RoomSendResponse(event_id="$edit", room_id=_ROOM_ID)
+        gateway.deps.runtime.client = client
+        answer = "final answer " + ("x" * 20_000)
+
+        outcome = await gateway.deliver_final(
+            replace(
+                self._final_request(answer),
+                existing_event_id="$placeholder",
+                defer_source_handoff=True,
+            ),
+        )
+
+        assert outcome.terminal_status == "completed"
+        frozen = outbox.rows["$cause", "final"].payload
+        assert _calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
+        assert DURABLE_FINAL_OUTCOME_KEY not in frozen
+        assert frozen["m.new_content"][DURABLE_FINAL_OUTCOME_KEY]["body"] == answer
+        assert client.room_send.await_args.kwargs["content"] == frozen
 
     async def test_a_regenerated_answer_cannot_go_out_under_a_frozen_edit(
         self,

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -34,7 +34,11 @@ from mindroom.event_journal import DepartureSource
 from mindroom.handled_turns import TurnRecord, _reset_handled_turn_ledger_runtime
 from mindroom.hooks.context import ResponseDraft
 from mindroom.matrix.client_delivery import DeliveredMatrixEvent, MatrixDeliveryFailure, MatrixDeliveryFailureKind
-from mindroom.matrix.large_messages import _MATRIX_EVENT_HARD_LIMIT, _calculate_event_size
+from mindroom.matrix.large_messages import (
+    _MATRIX_EVENT_HARD_LIMIT,
+    _calculate_delivery_event_size,
+    _calculate_event_size,
+)
 from mindroom.matrix_delivery import MatrixDeliveryWorker, RecoveryOutcome
 from mindroom.message_target import MessageTarget
 from mindroom.streaming import PROGRESS_PLACEHOLDER
@@ -135,7 +139,10 @@ def _gateway(
     )
     client = AsyncMock()
     client.user_id = _AGENT_USER_ID
-
+    room = MagicMock()
+    room.encrypted = False
+    client.rooms = {_ROOM_ID: room}
+    client.olm = None
     client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
     return DeliveryGateway(
         DeliveryGatewayDeps(
@@ -758,6 +765,66 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         frozen = outbox.rows["$cause", "final"].payload
         assert _calculate_event_size(frozen) <= 64_000
         assert client.room_send.await_args.kwargs["content"] == frozen
+
+    async def test_uncached_encrypted_room_is_fitted_before_durable_enqueue(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Remote encryption state must shape the payload before the outbox freezes it."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.rooms = {}
+        client.olm = MagicMock()
+        client.olm.device_id = "DEVICE"
+        client.room_get_state_event.return_value = MagicMock(spec=nio.RoomGetStateEventResponse)
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/encrypted-sidecar"}),
+            None,
+        )
+        gateway.deps.runtime.client = client
+        delivered = DeliveredMatrixEvent("$sent", {"msgtype": "m.text", "body": "preview"})
+
+        with patch("mindroom.delivery_gateway.send_message_outcome", AsyncMock(return_value=delivered)):
+            outcome = await gateway.deliver_final(self._final_request("x" * 50_000))
+
+        assert outcome.event_id == "$sent"
+        frozen = outbox.rows["$cause", "final"].payload
+        assert frozen["msgtype"] == "m.file"
+        assert (
+            _calculate_delivery_event_size(
+                frozen,
+                room_id=_ROOM_ID,
+                room_encrypted=True,
+                device_id="DEVICE",
+            )
+            <= _MATRIX_EVENT_HARD_LIMIT
+        )
+        client.room_get_state_event.assert_awaited_once_with(_ROOM_ID, "m.room.encryption")
+
+    async def test_unknown_uncached_room_encryption_fails_before_durable_enqueue(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """An unknown encryption state must not leave an ambiguously sized outbox row."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.rooms = {}
+        client.olm = MagicMock()
+        encryption_error = MagicMock(spec=nio.RoomGetStateEventError)
+        encryption_error.status_code = "M_FORBIDDEN"
+        client.room_get_state_event.return_value = encryption_error
+        gateway.deps.runtime.client = client
+
+        outcome = await gateway.deliver_final(self._final_request("answer"))
+
+        assert outcome.terminal_status == "error"
+        assert outbox.rows == {}
+        client.upload.assert_not_awaited()
+        client.room_send.assert_not_awaited()
 
     async def test_an_unrepresentable_final_is_refused_before_enqueue_or_send(
         self,

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -828,11 +828,13 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         client.upload.assert_not_awaited()
         client.room_send.assert_not_awaited()
 
-    async def test_an_unrepresentable_final_is_refused_before_enqueue_or_send(
+    @pytest.mark.parametrize("existing_event_id", [None, "$placeholder"], ids=("send", "edit"))
+    async def test_an_unrepresentable_final_is_recorded_without_a_send(
         self,
         tmp_path: Path,
+        existing_event_id: str | None,
     ) -> None:
-        """Irreducible metadata fails through the normal delivery outcome."""
+        """Irreducible metadata becomes durable terminal state without network I/O."""
         outbox = FakeOutbox()
         gateway = _gateway(tmp_path, outbox)
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
@@ -850,16 +852,23 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         gateway.deps.runtime.client = client
         request = replace(
             self._final_request("x" * 70_000),
-            existing_event_id="$placeholder",
+            existing_event_id=existing_event_id,
             defer_source_handoff=True,
             extra_content={"io.mindroom.required_metadata": "m" * 70_000},
         )
 
         outcome = await gateway.deliver_final(request)
+        frozen = outbox.rows["$cause", "final"]
+        repeated = await gateway.deliver_final(request)
 
         assert outcome.terminal_status == "error"
         assert outcome.failure_reason == "delivery_failed"
-        assert outbox.rows == {}
+        assert repeated.terminal_status == "error"
+        failed = outbox.rows["$cause", "final"]
+        assert failed.permanently_failed
+        assert not failed.attempted
+        assert failed.edits_event_id == existing_event_id
+        assert failed == frozen
         client.upload.assert_not_awaited()
         client.room_send.assert_not_awaited()
 
@@ -2807,6 +2816,7 @@ class TestTurnDeliverySerialization:
             result: Mapping[str, object] | None = None,
             edits_event_id: str | None = None,
             settle_source_event_ids: tuple[str, ...] = (),
+            permanent_failure_reason: str | None = None,
         ) -> str | None:
             transaction_id = await original_enqueue(
                 delivery_id=delivery_id,
@@ -2818,6 +2828,7 @@ class TestTurnDeliverySerialization:
                 result=result,
                 edits_event_id=edits_event_id,
                 settle_source_event_ids=settle_source_event_ids,
+                permanent_failure_reason=permanent_failure_reason,
             )
             enqueue_committed.set()
             await return_from_enqueue.wait()

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -39,7 +39,7 @@ from mindroom.matrix.large_messages import (
     _calculate_delivery_event_size,
     _calculate_event_size,
 )
-from mindroom.matrix_delivery import MatrixDeliveryWorker, RecoveryOutcome
+from mindroom.matrix_delivery import MatrixDeliveryWorker, PermanentDeliveryError, RecoveryOutcome
 from mindroom.message_target import MessageTarget
 from mindroom.streaming import PROGRESS_PLACEHOLDER
 from tests.conftest import (
@@ -805,68 +805,6 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         )
         client.room_get_state_event.assert_awaited_once_with(_ROOM_ID, "m.room.encryption")
 
-    async def test_unencrypted_durable_payload_remains_valid_after_encryption_is_enabled(
-        self,
-        tmp_path: Path,
-    ) -> None:
-        """A frozen payload must fit the stronger state a room can enter later."""
-        outbox = FakeOutbox()
-        gateway = _gateway(tmp_path, outbox)
-        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
-        client = AsyncMock(spec=nio.AsyncClient)
-        client.user_id = _AGENT_USER_ID
-        client.device_id = "DEVICE"
-        client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
-        room = MagicMock()
-        room.encrypted = False
-        client.rooms = {_ROOM_ID: room}
-        client.olm = None
-        client.upload.return_value = (
-            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/transition-safe-sidecar"}),
-            None,
-        )
-        client.room_send.side_effect = (
-            nio.RoomSendError(message="temporary refusal"),
-            nio.RoomSendResponse(event_id="$sent", room_id=_ROOM_ID),
-        )
-        gateway.deps.runtime.client = client
-        request = self._final_request("x" * 25_000)
-
-        first = await gateway.deliver_final(request)
-
-        assert first.terminal_status == "error"
-        frozen = dict(outbox.rows["$cause", "final"].payload)
-        assert frozen["msgtype"] == "m.text"
-        assert "url" not in frozen
-        assert frozen["file"]["url"] == "mxc://localhost/transition-safe-sidecar"
-        event_source = {
-            "content": frozen,
-            "event_id": "$transition-safe",
-            "sender": _AGENT_USER_ID,
-            "origin_server_ts": 1,
-            "type": "m.room.message",
-        }
-        assert isinstance(nio.Event.parse_event(event_source), nio.RoomMessageText)
-        assert isinstance(nio.RoomMessage.parse_decrypted_event(event_source), nio.RoomMessageText)
-        assert (
-            _calculate_delivery_event_size(
-                frozen,
-                room_id=_ROOM_ID,
-                room_encrypted=True,
-                device_id="DEVICE",
-            )
-            <= _MATRIX_EVENT_HARD_LIMIT
-        )
-        room.encrypted = True
-        client.olm = MagicMock()
-        client.olm.device_id = "DEVICE"
-
-        replay = await gateway.deliver_final(request)
-
-        assert replay.terminal_status == "completed"
-        assert client.upload.await_count == 1
-        assert [call.kwargs["content"] for call in client.room_send.await_args_list] == [frozen, frozen]
-
     async def test_unknown_uncached_room_encryption_fails_before_durable_enqueue(
         self,
         tmp_path: Path,
@@ -1184,6 +1122,53 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert delivered is not None
         assert client.upload.await_count == 1
         assert client.room_send.await_args.kwargs["content"] == frozen
+
+    async def test_a_definitive_oversized_refusal_stops_recovery(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The server's size refusal is inspectable and never replayed forever."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.user_id = _AGENT_USER_ID
+        client.device_id = "DEVICE"
+        client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
+        room = MagicMock()
+        room.encrypted = False
+        client.rooms = {_ROOM_ID: room}
+        client.olm = None
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/sidecar"}),
+            None,
+        )
+        client.room_send.return_value = nio.RoomSendError(
+            message="event too large",
+            status_code="M_TOO_LARGE",
+            room_id=_ROOM_ID,
+        )
+        gateway.deps.runtime.client = client
+        terminal = gateway._durable_terminal_edit(
+            "$cause",
+            MessageTarget.resolve(_ROOM_ID, None, None, room_mode=True),
+        )
+        assert terminal is not None
+        answer = "x" * 125_000
+        content = {
+            "msgtype": "m.text",
+            "body": answer,
+            "io.mindroom.stream_status": "completed",
+        }
+
+        first = await terminal(client, _ROOM_ID, "$streamed", content, answer)
+        second = await terminal(client, _ROOM_ID, "$streamed", content, answer)
+
+        stored = outbox.rows["$cause", "final"]
+        assert first is None
+        assert second is None
+        assert stored.permanent_failure_reason is not None
+        assert client.room_send.await_count == 1
+        assert client.upload.await_count == 1
 
     async def test_a_streamed_terminal_edit_freezes_its_fallback_body_too(
         self,
@@ -2628,6 +2613,32 @@ class TestGenericDeliveryDeviceChangePolicy:
         send.assert_awaited_once()
         assert stored is not None
         assert stored.acknowledged_event_id == "$replacement"
+
+    async def test_permanent_refusal_is_not_returned_to_recovery(self, alice: PrincipalStore) -> None:
+        """A definitive refusal is terminal state, not another failed recovery pass."""
+        await alice.enqueue_matrix_delivery(
+            delivery_id="turn-1",
+            stage=DeliveryStage.FINAL,
+            room_id=_ROOM_ID,
+            thread_id=None,
+            payload={"msgtype": "m.text", "body": "frozen"},
+        )
+        send = AsyncMock(side_effect=PermanentDeliveryError("matrix event exceeds the hard size limit"))
+        worker = MatrixDeliveryWorker(
+            store=alice,
+            send=send,
+            sending_device_id="DEVICE",
+        )
+
+        first = await worker.recover()
+        second = await worker.recover()
+
+        stored = await alice.load_matrix_delivery(delivery_id="turn-1", stage=DeliveryStage.FINAL)
+        assert first == RecoveryOutcome(recovered=0, failed=0)
+        assert second == RecoveryOutcome(recovered=0, failed=0)
+        send.assert_awaited_once()
+        assert stored is not None
+        assert stored.permanent_failure_reason == "matrix event exceeds the hard size limit"
 
 
 class TestTurnDeliverySerialization:

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -702,6 +702,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID
+        client.device_id = "DEVICE"
         client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
         room = MagicMock()
         room.encrypted = False
@@ -741,6 +742,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID
+        client.device_id = "DEVICE"
         client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
         room = MagicMock()
         room.encrypted = False
@@ -803,6 +805,68 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         )
         client.room_get_state_event.assert_awaited_once_with(_ROOM_ID, "m.room.encryption")
 
+    async def test_unencrypted_durable_payload_remains_valid_after_encryption_is_enabled(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A frozen payload must fit the stronger state a room can enter later."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.user_id = _AGENT_USER_ID
+        client.device_id = "DEVICE"
+        client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
+        room = MagicMock()
+        room.encrypted = False
+        client.rooms = {_ROOM_ID: room}
+        client.olm = None
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/transition-safe-sidecar"}),
+            None,
+        )
+        client.room_send.side_effect = (
+            nio.RoomSendError(message="temporary refusal"),
+            nio.RoomSendResponse(event_id="$sent", room_id=_ROOM_ID),
+        )
+        gateway.deps.runtime.client = client
+        request = self._final_request("x" * 25_000)
+
+        first = await gateway.deliver_final(request)
+
+        assert first.terminal_status == "error"
+        frozen = dict(outbox.rows["$cause", "final"].payload)
+        assert frozen["msgtype"] == "m.file"
+        assert "url" in frozen
+        assert "file" not in frozen
+        event_source = {
+            "content": frozen,
+            "event_id": "$transition-safe",
+            "sender": _AGENT_USER_ID,
+            "origin_server_ts": 1,
+            "type": "m.room.message",
+        }
+        assert isinstance(nio.Event.parse_event(event_source), nio.RoomMessageFile)
+        assert isinstance(nio.RoomMessage.parse_decrypted_event(event_source), nio.RoomMessageFile)
+        assert (
+            _calculate_delivery_event_size(
+                frozen,
+                room_id=_ROOM_ID,
+                room_encrypted=True,
+                device_id="DEVICE",
+            )
+            <= _MATRIX_EVENT_HARD_LIMIT
+        )
+        room.encrypted = True
+        client.olm = MagicMock()
+        client.olm.device_id = "DEVICE"
+
+        replay = await gateway.deliver_final(request)
+
+        assert replay.terminal_status == "completed"
+        assert client.upload.await_count == 1
+        assert [call.kwargs["content"] for call in client.room_send.await_args_list] == [frozen, frozen]
+
     async def test_unknown_uncached_room_encryption_fails_before_durable_enqueue(
         self,
         tmp_path: Path,
@@ -836,6 +900,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID
+        client.device_id = "DEVICE"
         room = MagicMock()
         room.encrypted = False
         client.rooms = {_ROOM_ID: room}
@@ -857,6 +922,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert outcome.terminal_status == "error"
         assert outcome.failure_reason == "delivery_failed"
         assert outbox.rows == {}
+        client.upload.assert_not_awaited()
         client.room_send.assert_not_awaited()
 
     async def test_a_regenerated_answer_cannot_go_out_under_a_frozen_edit(
@@ -1019,6 +1085,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         gateway = _gateway(tmp_path, outbox)
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID
+        client.device_id = "DEVICE"
         client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
         room = MagicMock()
         room.encrypted = False
@@ -1080,6 +1147,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         gateway = _gateway(tmp_path, outbox)
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID
+        client.device_id = "DEVICE"
         client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
         room = MagicMock()
         room.encrypted = False

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -678,8 +678,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         prompt = new_content["io.mindroom.interactive"]
         assert prompt["question_text"] == "Pick"
         assert prompt["options"] == {"1": "yes", "✅": "yes"}
-        assert DURABLE_FINAL_OUTCOME_KEY not in frozen
-        assert DURABLE_FINAL_OUTCOME_KEY not in new_content
+        assert new_content[DURABLE_FINAL_OUTCOME_KEY] == {"version": 2}
         semantic = delivery.result
         assert semantic is not None
         assert semantic["body"] == outcome.final_visible_body
@@ -721,9 +720,43 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         delivery = outbox.rows["$cause", "final"]
         frozen = delivery.payload
         assert _calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
-        assert DURABLE_FINAL_OUTCOME_KEY not in frozen
-        assert DURABLE_FINAL_OUTCOME_KEY not in frozen["m.new_content"]
+        assert frozen["m.new_content"][DURABLE_FINAL_OUTCOME_KEY] == {"version": 2}
         assert delivery.result == {"body": answer, "interactive": None}
+        assert client.room_send.await_args.kwargs["content"] == frozen
+
+    async def test_delivery_identity_is_included_in_the_validated_event_size(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The exact persisted and sent event must fit after identity is attached."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.user_id = _AGENT_USER_ID
+        client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
+        room = MagicMock()
+        room.encrypted = False
+        client.rooms = {_ROOM_ID: room}
+        client.olm = None
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/identity-sized-edit"}),
+            None,
+        )
+        client.room_send.return_value = nio.RoomSendResponse(event_id="$edit", room_id=_ROOM_ID)
+        gateway.deps.runtime.client = client
+        request = replace(
+            self._final_request("x" * 20_500),
+            existing_event_id="$placeholder",
+            defer_source_handoff=True,
+            extra_content={"io.mindroom.test_metadata": "m" * 10_500},
+        )
+
+        outcome = await gateway.deliver_final(request)
+
+        assert outcome.terminal_status == "completed"
+        frozen = outbox.rows["$cause", "final"].payload
+        assert _calculate_event_size(frozen) <= 64_000
         assert client.room_send.await_args.kwargs["content"] == frozen
 
     async def test_a_regenerated_answer_cannot_go_out_under_a_frozen_edit(

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -836,9 +836,9 @@ class TestTurnDeliveryGoesThroughTheOutbox:
 
         assert first.terminal_status == "error"
         frozen = dict(outbox.rows["$cause", "final"].payload)
-        assert frozen["msgtype"] == "m.file"
-        assert "url" in frozen
-        assert "file" not in frozen
+        assert frozen["msgtype"] == "m.text"
+        assert "url" not in frozen
+        assert frozen["file"]["url"] == "mxc://localhost/transition-safe-sidecar"
         event_source = {
             "content": frozen,
             "event_id": "$transition-safe",
@@ -846,8 +846,8 @@ class TestTurnDeliveryGoesThroughTheOutbox:
             "origin_server_ts": 1,
             "type": "m.room.message",
         }
-        assert isinstance(nio.Event.parse_event(event_source), nio.RoomMessageFile)
-        assert isinstance(nio.RoomMessage.parse_decrypted_event(event_source), nio.RoomMessageFile)
+        assert isinstance(nio.Event.parse_event(event_source), nio.RoomMessageText)
+        assert isinstance(nio.RoomMessage.parse_decrypted_event(event_source), nio.RoomMessageText)
         assert (
             _calculate_delivery_event_size(
                 frozen,

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -672,12 +672,16 @@ class TestTurnDeliveryGoesThroughTheOutbox:
                 ),
             )
 
-        frozen = outbox.rows["$cause", "final"].payload
+        delivery = outbox.rows["$cause", "final"]
+        frozen = delivery.payload
         new_content = frozen["m.new_content"]
         prompt = new_content["io.mindroom.interactive"]
         assert prompt["question_text"] == "Pick"
         assert prompt["options"] == {"1": "yes", "✅": "yes"}
-        semantic = new_content["io.mindroom.final_delivery"]
+        assert DURABLE_FINAL_OUTCOME_KEY not in frozen
+        assert DURABLE_FINAL_OUTCOME_KEY not in new_content
+        semantic = delivery.result
+        assert semantic is not None
         assert semantic["body"] == outcome.final_visible_body
         assert semantic["interactive"]["question_text"] == "Pick"
         assert semantic["interactive"]["option_map"] == {"1": "yes", "✅": "yes"}
@@ -703,7 +707,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         )
         client.room_send.return_value = nio.RoomSendResponse(event_id="$edit", room_id=_ROOM_ID)
         gateway.deps.runtime.client = client
-        answer = "final answer " + ("x" * 20_000)
+        answer = "final answer " + ("x" * 100_000)
 
         outcome = await gateway.deliver_final(
             replace(
@@ -714,10 +718,12 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         )
 
         assert outcome.terminal_status == "completed"
-        frozen = outbox.rows["$cause", "final"].payload
+        delivery = outbox.rows["$cause", "final"]
+        frozen = delivery.payload
         assert _calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
         assert DURABLE_FINAL_OUTCOME_KEY not in frozen
-        assert frozen["m.new_content"][DURABLE_FINAL_OUTCOME_KEY]["body"] == answer
+        assert DURABLE_FINAL_OUTCOME_KEY not in frozen["m.new_content"]
+        assert delivery.result == {"body": answer, "interactive": None}
         assert client.room_send.await_args.kwargs["content"] == frozen
 
     async def test_a_regenerated_answer_cannot_go_out_under_a_frozen_edit(
@@ -2586,6 +2592,7 @@ class TestTurnDeliverySerialization:
             room_id: str,
             thread_id: str | None,
             payload: Mapping[str, object],
+            result: Mapping[str, object] | None = None,
             edits_event_id: str | None = None,
             settle_source_event_ids: tuple[str, ...] = (),
         ) -> str | None:
@@ -2596,6 +2603,7 @@ class TestTurnDeliverySerialization:
                 room_id=room_id,
                 thread_id=thread_id,
                 payload=payload,
+                result=result,
                 edits_event_id=edits_event_id,
                 settle_source_event_ids=settle_source_event_ids,
             )

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -763,7 +763,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
 
         assert outcome.terminal_status == "completed"
         frozen = outbox.rows["$cause", "final"].payload
-        assert _calculate_event_size(frozen) <= 64_000
+        assert _calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
         assert client.room_send.await_args.kwargs["content"] == frozen
 
     async def test_uncached_encrypted_room_is_fitted_before_durable_enqueue(

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -759,6 +759,39 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert _calculate_event_size(frozen) <= 64_000
         assert client.room_send.await_args.kwargs["content"] == frozen
 
+    async def test_an_unrepresentable_final_is_refused_before_enqueue_or_send(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Irreducible metadata fails through the normal delivery outcome."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.user_id = _AGENT_USER_ID
+        room = MagicMock()
+        room.encrypted = False
+        client.rooms = {_ROOM_ID: room}
+        client.olm = None
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/impossible-edit"}),
+            None,
+        )
+        gateway.deps.runtime.client = client
+        request = replace(
+            self._final_request("x" * 70_000),
+            existing_event_id="$placeholder",
+            defer_source_handoff=True,
+            extra_content={"io.mindroom.required_metadata": "m" * 70_000},
+        )
+
+        outcome = await gateway.deliver_final(request)
+
+        assert outcome.terminal_status == "error"
+        assert outcome.failure_reason == "delivery_failed"
+        assert outbox.rows == {}
+        client.room_send.assert_not_awaited()
+
     async def test_a_regenerated_answer_cannot_go_out_under_a_frozen_edit(
         self,
         tmp_path: Path,

--- a/tests/test_response_runner_agent.py
+++ b/tests/test_response_runner_agent.py
@@ -497,7 +497,7 @@ class TestAgentBot(AgentBotTestBase):
         """Non-streaming responses should persist attachment IDs in message metadata."""
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
 
@@ -857,7 +857,7 @@ class TestAgentBot(AgentBotTestBase):
         config = self._config_for_storage(tmp_path)
         config.defaults.show_stop_button = False
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
         bot.hook_registry = HookRegistry.from_plugins([_hook_plugin("hooked", [before_hook, after_hook])])
@@ -897,7 +897,7 @@ class TestAgentBot(AgentBotTestBase):
 
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
 
@@ -1581,7 +1581,7 @@ class TestAgentBot(AgentBotTestBase):
             tmp_path,
         )
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
 
@@ -1647,7 +1647,7 @@ class TestAgentBot(AgentBotTestBase):
             tmp_path,
         )
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot.client.room_send.return_value = _room_send_response("$response")
         _set_knowledge_for_agent(bot, MagicMock(return_value=None))
 
@@ -1730,7 +1730,7 @@ class TestAgentBot(AgentBotTestBase):
         config = self._config_for_storage(tmp_path)
         config.timezone = "America/Los_Angeles"
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         prior_user_time = datetime(2026, 3, 10, 8, 10, tzinfo=ZoneInfo("America/Los_Angeles"))
         prior_agent_time = datetime(2026, 3, 10, 8, 12, tzinfo=ZoneInfo("America/Los_Angeles"))
@@ -1845,7 +1845,7 @@ class TestAgentBot(AgentBotTestBase):
         config.memory.backend = "mem0"
         config.timezone = "America/Los_Angeles"
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         bob_time = datetime(2026, 3, 10, 8, 10, tzinfo=ZoneInfo("America/Los_Angeles"))
         alice_time = datetime(2026, 3, 10, 8, 12, tzinfo=ZoneInfo("America/Los_Angeles"))
@@ -1970,7 +1970,7 @@ class TestAgentBot(AgentBotTestBase):
 
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         with (
             patch.object(
@@ -2067,7 +2067,7 @@ class TestAgentBot(AgentBotTestBase):
 
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         async def cached_history_refresh(
             _room_id: str,
@@ -2169,7 +2169,7 @@ class TestAgentBot(AgentBotTestBase):
 
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         envelope = MessageEnvelope(
             source_event_id="$reply_plain:localhost",
             target=MessageTarget.resolve(
@@ -2591,7 +2591,7 @@ class TestAgentBot(AgentBotTestBase):
 
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
 
         with (
             patch.object(

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -3459,6 +3459,71 @@ async def test_original_owner_recovery_retires_acknowledged_failure_without_succ
 
 
 @pytest.mark.asyncio
+async def test_permanently_refused_approval_final_releases_its_sources(tmp_path: Path) -> None:
+    """An oversized frozen FINAL is terminal failure, not immortal approval debt."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    store = runner.deps.approval_store
+    await _admit_approval_source(store)
+    continuation = ApprovalContinuation(
+        approval_id="approval-oversized-final",
+        run_id="run-1",
+        session_id="session-1",
+        entity_kind="agent",
+        entity_name="general",
+        room_id="!room:localhost",
+        thread_id="$thread",
+        requester_id="@user:localhost",
+        response_event_id="$waiting",
+        calls=(),
+        execution_identity={},
+        source_event_ids=("$source",),
+        state="ready",
+    )
+    assert await store.create_approval_continuation(continuation) == continuation
+    claimed = await store.claim_approval_continuation(
+        continuation.approval_id,
+        runtime_generation=runner.deps.approval_runtime_generation,
+    )
+    assert claimed is not None
+    await store.enqueue_matrix_delivery(
+        delivery_id="$source",
+        stage=DeliveryStage.FINAL,
+        room_id="!room:localhost",
+        thread_id="$thread",
+        payload={"body": "oversized final"},
+        result={"body": "oversized final"},
+        edits_event_id="$waiting",
+    )
+    assert await store.claim_matrix_delivery(delivery_id="$source", stage=DeliveryStage.FINAL) is not None
+    await store.record_permanent_matrix_delivery_failure(
+        delivery_id="$source",
+        stage=DeliveryStage.FINAL,
+        reason="matrix event exceeds the hard size limit",
+    )
+    edit_text = AsyncMock(side_effect=AssertionError("a failed frozen row must not be reused"))
+
+    with (
+        patch.object(DeliveryGateway, "edit_text", new=edit_text),
+        patch(
+            "mindroom.approval_response.approval_manager.get_approval_store",
+            return_value=MagicMock(cards=None, expire_continuation_cards=AsyncMock(return_value=True)),
+        ),
+    ):
+        event_id = await runner._recover_claimed_approval_lifecycle(
+            claimed,
+            target=_target(thread_id="$thread", reply_to_event_id="$source"),
+        )
+
+    assert event_id == "$waiting"
+    edit_text.assert_not_awaited()
+    assert await store.approval_continuation(continuation.approval_id) is None
+    assert not await store.is_pending("$source")
+    failed = await store.load_matrix_delivery(delivery_id="$source", stage=DeliveryStage.FINAL)
+    assert failed is not None
+    assert failed.permanently_failed
+
+
+@pytest.mark.asyncio
 async def test_acknowledged_final_wins_cancellation_before_delivery_returns(tmp_path: Path) -> None:
     """A visible successful FINAL must complete even if the live caller is cancelled afterward."""
     runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -3376,14 +3376,14 @@ async def test_recovered_claim_restores_plain_body_and_interactive_metadata(tmp_
         payload={
             "body": "plain fallback",
             "formatted_body": "<strong>rendered html</strong>",
-            "io.mindroom.final_delivery": {
-                "body": "plain final",
-                "interactive": {
-                    "question_text": "Pick",
-                    "option_map": {"1": "yes", "✅": "yes"},
-                    "option_labels": {"1": "Yes", "✅": "Yes"},
-                    "options_list": [{"emoji": "✅", "label": "Yes", "value": "yes"}],
-                },
+        },
+        result={
+            "body": "plain final",
+            "interactive": {
+                "question_text": "Pick",
+                "option_map": {"1": "yes", "✅": "yes"},
+                "option_labels": {"1": "Yes", "✅": "Yes"},
+                "options_list": [{"emoji": "✅", "label": "Yes", "value": "yes"}],
             },
         },
         edits_event_id="$waiting",

--- a/tests/test_response_tracking_regression.py
+++ b/tests/test_response_tracking_regression.py
@@ -28,6 +28,7 @@ from tests.conftest import (
     drain_coalescing,
     install_runtime_journal_support,
     install_send_response_mock,
+    make_matrix_client_mock,
     runtime_paths_for,
     test_runtime_paths,
     wrap_extracted_collaborators,
@@ -90,7 +91,7 @@ class TestResponseTrackingRegression:
             rooms=[test_room_id],
         )
         wrap_extracted_collaborators(bot)
-        bot.client = AsyncMock()
+        bot.client = make_matrix_client_mock(user_id=mock_router_agent.user_id)
         bot.client.user_id = mock_router_agent.user_id
         install_runtime_journal_support(bot)
 
@@ -263,7 +264,7 @@ class TestResponseTrackingRegression:
             rooms=[test_room_id],
         )
         wrap_extracted_collaborators(bot)
-        bot.client = AsyncMock()
+        bot.client = make_matrix_client_mock(user_id=mock_router_agent.user_id)
         bot.client.user_id = mock_router_agent.user_id
         install_runtime_journal_support(bot)
 

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -804,6 +804,7 @@ class TestSendMessageResult:
             "!room:localhost",
             {"body": "hello", "msgtype": "m.text"},
             room_encrypted=False,
+            transition_safe=True,
         )
         client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
         client.room_send.assert_not_awaited()
@@ -1002,8 +1003,10 @@ class TestSendMessageResult:
             _content: dict[str, object],
             *,
             room_encrypted: bool | None,
+            transition_safe: bool,
         ) -> dict[str, str]:
             assert room_encrypted is True
+            assert transition_safe is True
             client.rooms.clear()
             return {"body": "prepared", "msgtype": "m.text"}
 

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -38,6 +38,9 @@ def _mock_client(*, encrypted: bool = False) -> AsyncMock:
     room.encrypted = encrypted
     client.rooms = {"!room:localhost": room}
     client.olm = MagicMock() if encrypted else None
+    client.device_id = "DEVICE"
+    if client.olm is not None:
+        client.olm.device_id = "DEVICE"
     return client
 
 
@@ -804,7 +807,6 @@ class TestSendMessageResult:
             "!room:localhost",
             {"body": "hello", "msgtype": "m.text"},
             room_encrypted=False,
-            transition_safe=True,
         )
         client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
         client.room_send.assert_not_awaited()
@@ -839,27 +841,6 @@ class TestSendMessageResult:
         client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
         client.room_send.assert_not_awaited()
         client._send.assert_not_awaited()
-
-    @pytest.mark.asyncio
-    async def test_treats_non_dict_room_cache_as_unknown_room(self) -> None:
-        """Non-dict room caches should be treated as empty for plain sends."""
-        client = AsyncMock(spec=nio.AsyncClient)
-        client.rooms = AsyncMock()
-        client.room_send.return_value = nio.RoomSendResponse("$evt:localhost", "!room:localhost")
-
-        with patch(
-            "mindroom.matrix.client_delivery.prepare_large_message",
-            new=AsyncMock(side_effect=lambda *_, **__: {"body": "hello", "msgtype": "m.text"}),
-        ):
-            result = await send_message_result(
-                client,
-                "!room:localhost",
-                {"body": "hello", "msgtype": "m.text"},
-            )
-
-        assert result is not None
-        assert result.event_id == "$evt:localhost"
-        client.room_send.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_returns_none_when_room_send_raises_unverified_device_error(self) -> None:
@@ -1003,10 +984,8 @@ class TestSendMessageResult:
             _content: dict[str, object],
             *,
             room_encrypted: bool | None,
-            transition_safe: bool,
         ) -> dict[str, str]:
             assert room_encrypted is True
-            assert transition_safe is True
             client.rooms.clear()
             return {"body": "prepared", "msgtype": "m.text"}
 

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -35,7 +35,12 @@ from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtim
 from tests.authorization_helpers import (
     make_test_tool_runtime_context,
 )
-from tests.conftest import delivered_matrix_side_effect, make_conversation_reader_mock, make_relation_lookup
+from tests.conftest import (
+    delivered_matrix_side_effect,
+    make_conversation_reader_mock,
+    make_matrix_client_mock,
+    make_relation_lookup,
+)
 from tests.identity_helpers import actual_entity_usernames, persist_entity_accounts
 
 if TYPE_CHECKING:
@@ -123,7 +128,7 @@ def _make_context(
             reply_to_event_id=None,
         ),
         requester_id=requester_id,
-        client=MagicMock(),
+        client=make_matrix_client_mock(),
         config=effective_config,
         runtime_paths=runtime_paths,
         relations=make_relation_lookup(),

--- a/tests/test_team_scheduler_context.py
+++ b/tests/test_team_scheduler_context.py
@@ -30,6 +30,7 @@ from tests.conftest import (
     TEST_PASSWORD,
     bind_runtime_paths,
     install_runtime_journal_support,
+    make_matrix_client_mock,
     message_origin,
     patch_response_runner_module,
     runtime_paths_for,
@@ -95,9 +96,7 @@ def _make_bot(tmp_path: Path) -> AgentBot:
         runtime_paths=runtime_paths_for(config),
         rooms=["!team:localhost"],
     )
-    bot.client = AsyncMock()
-    bot.client.user_id = agent_user.user_id
-    bot.client.rooms = {"!team:localhost": MagicMock(room_id="!team:localhost")}
+    bot.client = make_matrix_client_mock(user_id=agent_user.user_id)
     bot.orchestrator = MagicMock(config=config)
     return install_runtime_journal_support(bot)
 

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -550,7 +550,7 @@ class TestAgentBot(AgentBotTestBase):
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         _wrap_extracted_collaborators(bot)
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
         event = MagicMock(spec=nio.RoomMessageText)
@@ -2760,7 +2760,7 @@ class TestAgentBot(AgentBotTestBase):
         """Incomplete placeholder cleanup should leave the source event retryable."""
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         tracker = _set_turn_store_tracker(bot, MagicMock())
         bot.logger = MagicMock()
         _replace_turn_policy_deps(bot, logger=bot.logger)
@@ -3100,7 +3100,7 @@ class TestAgentBot(AgentBotTestBase):
         """Failed edits of an existing visible response must keep the prior event visible but retryable."""
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = MagicMock()
+        bot.client = _make_matrix_client_mock()
         response_envelope = _hook_envelope(body="hello", source_event_id="$event123")
         gateway = replace_delivery_gateway_deps(
             bot,

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -377,6 +377,8 @@ class TestAgentBot(AgentBotTestBase):
             rejection_message="Rejected request",
         )
         bot.client = AsyncMock(spec=nio.AsyncClient)
+        bot.client.device_id = "DEVICE"
+        bot.client.olm = None
         cached_room = MagicMock()
         cached_room.encrypted = False
         bot.client.rooms = {room.room_id: cached_room}

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -377,6 +377,9 @@ class TestAgentBot(AgentBotTestBase):
             rejection_message="Rejected request",
         )
         bot.client = AsyncMock(spec=nio.AsyncClient)
+        cached_room = MagicMock()
+        cached_room.encrypted = False
+        bot.client.rooms = {room.room_id: cached_room}
 
         with (
             patch(


### PR DESCRIPTION
## Summary

- assemble the complete identity-bearing Matrix event before size fitting, persistence, and sending
- account for Megolm ciphertext expansion and resolve uncached-room encryption before durable enqueue
- store full semantic recovery results in local outbox state with additive SQLite and PostgreSQL migrations
- retain only a bounded old-reader success marker on the wire and handle mixed-version writer rewrites safely
- preserve valid file-edit fallbacks while fitting terminal previews to the final envelope
- reject irreducible oversized or ambiguously encrypted payloads through typed failures before enqueue

## Tests

- `uv run pytest -qq` (14,585 passed, 24 skipped)
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Keep large final Matrix deliveries within event limits by validating the complete sendable envelope before persistence and sending.

New Features:
- Fit large Matrix messages and terminal edits against the complete final event envelope, including encrypted Megolm delivery overhead.
- Persist full semantic final-delivery results separately from Matrix wire payloads for durable recovery.

Bug Fixes:
- Prevent oversized or ambiguously encrypted payloads from being enqueued or sent by returning typed delivery failures.
- Preserve valid plaintext file-edit fallbacks and avoid repeated sidecar uploads when the final envelope cannot fit.
- Maintain compatibility with older readers and legacy outbox rows during final-result migration.

Enhancements:
- Resolve uncached room encryption before durable preparation and conservatively size durable payloads for future encryption transitions.
- Add bounded preview fitting that accounts for relations, metadata, sidecars, and nested edit content.

Tests:
- Add coverage for encrypted event sizing, terminal edit fitting, durable semantic-result recovery, encryption-state transitions, migration upgrades, and irreducible payload failures.

Chores:
- Add additive SQLite and PostgreSQL outbox migrations for locally stored delivery results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling of large Matrix messages, including encrypted messages and file edits.
  * Added clearer payload-size failure reporting when content cannot be delivered.
  * Final delivery results are now preserved reliably for recovery and follow-up processing.

* **Bug Fixes**
  * Prevented local recovery data from appearing in sent messages.
  * Added fallbacks for oversized file edits and failed sidecar previews.
  * Preserved compatibility with previously stored delivery results.

* **Chores**
  * Added database migration support for storing delivery results separately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->