### PR TITLE
Handle encryption changes during large-message preparation

### DIFF
--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -104,6 +104,15 @@ if TYPE_CHECKING:
     from mindroom.timing import DispatchPipelineTiming
     from mindroom.tool_system.events import ToolTraceEntry
 
+
+def _permanent_delivery_failure_payload() -> dict[str, str]:
+    """Return a bounded wire-shaped tombstone for a preflight refusal."""
+    return {
+        "msgtype": "m.notice",
+        "body": "Message delivery failed before it could be sent.",
+    }
+
+
 _PLACEHOLDER_DELIVERY_FAILURE_TEXT = "Response delivery failed. Please retry."
 _PLACEHOLDER_DELIVERY_FAILURE_REASONS = frozenset(
     {
@@ -887,6 +896,7 @@ class DeliveryGateway:
             if prepared.kind is not MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
                 return prepared
             preparation_failure: MatrixDeliveryFailure | None = prepared
+            content = _permanent_delivery_failure_payload()
         else:
             preparation_failure = None
             content = prepared
@@ -1058,6 +1068,7 @@ class DeliveryGateway:
             if prepared.kind is not MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
                 return prepared
             preparation_failure = prepared
+            envelope = _permanent_delivery_failure_payload()
         else:
             preparation_failure = None
             envelope = prepared
@@ -1712,6 +1723,7 @@ class DeliveryGateway:
                 room_id,
                 wire_content,
                 room_encrypted=encryption_outcome,
+                fit_for_encrypted_delivery=True,
             )
         except MatrixEventTooLargeError as error:
             return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -104,15 +104,6 @@ if TYPE_CHECKING:
     from mindroom.timing import DispatchPipelineTiming
     from mindroom.tool_system.events import ToolTraceEntry
 
-
-def _permanent_delivery_failure_payload() -> dict[str, str]:
-    """Return a bounded wire-shaped tombstone for a preflight refusal."""
-    return {
-        "msgtype": "m.notice",
-        "body": "Message delivery failed before it could be sent.",
-    }
-
-
 _PLACEHOLDER_DELIVERY_FAILURE_TEXT = "Response delivery failed. Please retry."
 _PLACEHOLDER_DELIVERY_FAILURE_REASONS = frozenset(
     {
@@ -896,7 +887,6 @@ class DeliveryGateway:
             if prepared.kind is not MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
                 return prepared
             preparation_failure: MatrixDeliveryFailure | None = prepared
-            content = _permanent_delivery_failure_payload()
         else:
             preparation_failure = None
             content = prepared
@@ -1068,7 +1058,6 @@ class DeliveryGateway:
             if prepared.kind is not MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
                 return prepared
             preparation_failure = prepared
-            envelope = _permanent_delivery_failure_payload()
         else:
             preparation_failure = None
             envelope = prepared
@@ -1696,9 +1685,11 @@ class DeliveryGateway:
         nothing can ever reference -- or fail before the durable payload gets
         another chance to reach Matrix.
 
-        Preparation uses the currently observed room encryption state. Once
-        attempted, retries and startup recovery send the same frozen bytes
-        without uploading or rebuilding anything.
+        A durable row may be replayed after room encryption is enabled, and an
+        attempted row cannot be rebuilt. Durable sidecars therefore use the
+        encrypted form before the payload is frozen, even while the room is
+        currently plaintext. Direct sends keep standard plaintext sidecars and
+        rebuild only if encryption changes during their upload.
         """
         existing = await self.deps.outbox.load_matrix_delivery(delivery_id=turn_id, stage=stage)
         if existing is not None and existing.attempted:
@@ -1723,7 +1714,7 @@ class DeliveryGateway:
                 room_id,
                 wire_content,
                 room_encrypted=encryption_outcome,
-                fit_for_encrypted_delivery=True,
+                prepare_for_encrypted_delivery=True,
             )
         except MatrixEventTooLargeError as error:
             return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -16,7 +16,11 @@ from nio.api import Api
 from nio.exceptions import OlmTrustError
 
 from mindroom.logging_config import get_logger
-from mindroom.matrix.large_messages import MatrixEventTooLargeError, prepare_large_message
+from mindroom.matrix.large_messages import (
+    MatrixEventTooLargeError,
+    ensure_prepared_message_fits_delivery,
+    prepare_large_message,
+)
 from mindroom.matrix.media import upload_content_uri, upload_media_bytes
 from mindroom.matrix.message_builder import build_matrix_edit_content
 from mindroom.timing import emit_timing_event
@@ -63,6 +67,14 @@ class MatrixDeliveryFailure:
 
 
 type MatrixSendOutcome = DeliveredMatrixEvent | MatrixDeliveryFailure
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedMatrixMessage:
+    """Validated content plus the transport path that must send it."""
+
+    content: dict[str, Any]
+    cache_bypass: bool
 
 
 def _sanitized_delivery_error_message(error: Exception) -> str:
@@ -342,6 +354,63 @@ async def send_room_event_result(
     return cast("nio.RoomSendResponse | nio.RoomSendError | None", response)
 
 
+async def _prepare_matrix_message(
+    client: nio.AsyncClient,
+    room_id: str,
+    content: dict[str, Any],
+    *,
+    operation: str,
+    content_is_prepared: bool,
+) -> _PreparedMatrixMessage | MatrixDeliveryFailure:
+    """Prepare or revalidate one message against its latest delivery envelope."""
+    rooms = client.rooms
+    room = rooms.get(room_id)
+    encryption_outcome = await resolve_room_encryption_outcome(
+        client,
+        room_id,
+        operation=operation,
+    )
+    if isinstance(encryption_outcome, MatrixDeliveryFailure):
+        return encryption_outcome
+    room_encrypted = encryption_outcome
+    cache_bypass = room is None and not room_encrypted
+
+    content_sent = content
+    if not content_is_prepared:
+        try:
+            content_sent = await prepare_large_message(
+                client,
+                room_id,
+                content,
+                room_encrypted=room_encrypted,
+                fit_for_encrypted_delivery=True,
+            )
+        except MatrixEventTooLargeError as error:
+            return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
+        current_room = rooms.get(room_id)
+        if current_room is not None:
+            encryption_outcome = await resolve_room_encryption_outcome(
+                client,
+                room_id,
+                operation=operation,
+            )
+            if isinstance(encryption_outcome, MatrixDeliveryFailure):
+                return encryption_outcome
+            room_encrypted = encryption_outcome
+            cache_bypass = False
+
+    try:
+        ensure_prepared_message_fits_delivery(
+            client,
+            room_id,
+            content_sent,
+            room_encrypted=room_encrypted,
+        )
+    except MatrixEventTooLargeError as error:
+        return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
+    return _PreparedMatrixMessage(content_sent, cache_bypass)
+
+
 async def send_message_outcome(
     client: nio.AsyncClient,
     room_id: str,
@@ -364,19 +433,6 @@ async def send_message_outcome(
             "encrypted delivery rejected by local trust policy",
         )
 
-    rooms = client.rooms
-    cache_bypass = False
-    room = rooms.get(room_id)
-    encryption_outcome = await resolve_room_encryption_outcome(
-        client,
-        room_id,
-        operation=operation,
-    )
-    if isinstance(encryption_outcome, MatrixDeliveryFailure):
-        return encryption_outcome
-    room_encryption_override = encryption_outcome
-    cache_bypass = room is None and not room_encryption_override
-
     message_type = "m.room.message"
     emit_timing_event(
         "Matrix send timing",
@@ -384,17 +440,17 @@ async def send_message_outcome(
         room_id=room_id,
         message_type=message_type,
     )
-    content_sent = content
-    if not content_is_prepared:
-        try:
-            content_sent = await prepare_large_message(
-                client,
-                room_id,
-                content,
-                room_encrypted=room_encryption_override,
-            )
-        except MatrixEventTooLargeError as error:
-            return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
+    prepared = await _prepare_matrix_message(
+        client,
+        room_id,
+        content,
+        operation=operation,
+        content_is_prepared=content_is_prepared,
+    )
+    if isinstance(prepared, MatrixDeliveryFailure):
+        return prepared
+    content_sent = prepared.content
+    cache_bypass = prepared.cache_bypass
     emit_timing_event(
         "Matrix send timing",
         phase="prepare_finish",

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -16,11 +16,7 @@ from nio.api import Api
 from nio.exceptions import OlmTrustError
 
 from mindroom.logging_config import get_logger
-from mindroom.matrix.large_messages import (
-    MatrixEventTooLargeError,
-    ensure_prepared_message_fits_delivery,
-    prepare_large_message,
-)
+from mindroom.matrix.large_messages import MatrixEventTooLargeError, prepare_large_message
 from mindroom.matrix.media import upload_content_uri, upload_media_bytes
 from mindroom.matrix.message_builder import build_matrix_edit_content
 from mindroom.timing import emit_timing_event
@@ -71,7 +67,7 @@ type MatrixSendOutcome = DeliveredMatrixEvent | MatrixDeliveryFailure
 
 @dataclass(frozen=True, slots=True)
 class _PreparedMatrixMessage:
-    """Validated content plus the transport path that must send it."""
+    """Prepared content plus the transport path that must send it."""
 
     content: dict[str, Any]
     cache_bypass: bool
@@ -362,7 +358,7 @@ async def _prepare_matrix_message(
     operation: str,
     content_is_prepared: bool,
 ) -> _PreparedMatrixMessage | MatrixDeliveryFailure:
-    """Prepare or revalidate one message against its latest delivery envelope."""
+    """Prepare one message, rebuilding once if encryption turns on while yielding."""
     rooms = client.rooms
     room = rooms.get(room_id)
     encryption_outcome = await resolve_room_encryption_outcome(
@@ -383,29 +379,37 @@ async def _prepare_matrix_message(
                 room_id,
                 content,
                 room_encrypted=room_encrypted,
-                fit_for_encrypted_delivery=True,
             )
         except MatrixEventTooLargeError as error:
             return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
-        encryption_outcome = await resolve_room_encryption_outcome(
-            client,
-            room_id,
-            operation=operation,
-        )
-        if isinstance(encryption_outcome, MatrixDeliveryFailure):
-            return encryption_outcome
-        room_encrypted = encryption_outcome
-        cache_bypass = rooms.get(room_id) is None and not room_encrypted
 
-    try:
-        ensure_prepared_message_fits_delivery(
-            client,
-            room_id,
-            content_sent,
-            room_encrypted=room_encrypted,
-        )
-    except MatrixEventTooLargeError as error:
-        return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
+        # An unchanged return means preparation did not yield, so room state
+        # could not have changed within this task. A changed plaintext payload
+        # may contain a sidecar uploaded across an await. Recheck only then.
+        # If encryption became enabled, rebuild from the semantic source once:
+        # the first upload remains unreferenced and the sent event points only
+        # at encrypted bytes. Matrix room encryption cannot later be disabled.
+        if not room_encrypted and content_sent is not content:
+            encryption_outcome = await resolve_room_encryption_outcome(
+                client,
+                room_id,
+                operation=operation,
+            )
+            if isinstance(encryption_outcome, MatrixDeliveryFailure):
+                return encryption_outcome
+            room_encrypted = encryption_outcome
+            cache_bypass = rooms.get(room_id) is None and not room_encrypted
+            if room_encrypted:
+                try:
+                    content_sent = await prepare_large_message(
+                        client,
+                        room_id,
+                        content,
+                        room_encrypted=True,
+                    )
+                except MatrixEventTooLargeError as error:
+                    return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
+
     return _PreparedMatrixMessage(content_sent, cache_bypass)
 
 

--- a/src/mindroom/matrix/client_delivery.py
+++ b/src/mindroom/matrix/client_delivery.py
@@ -387,17 +387,15 @@ async def _prepare_matrix_message(
             )
         except MatrixEventTooLargeError as error:
             return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
-        current_room = rooms.get(room_id)
-        if current_room is not None:
-            encryption_outcome = await resolve_room_encryption_outcome(
-                client,
-                room_id,
-                operation=operation,
-            )
-            if isinstance(encryption_outcome, MatrixDeliveryFailure):
-                return encryption_outcome
-            room_encrypted = encryption_outcome
-            cache_bypass = False
+        encryption_outcome = await resolve_room_encryption_outcome(
+            client,
+            room_id,
+            operation=operation,
+        )
+        if isinstance(encryption_outcome, MatrixDeliveryFailure):
+            return encryption_outcome
+        room_encrypted = encryption_outcome
+        cache_bypass = rooms.get(room_id) is None and not room_encrypted
 
     try:
         ensure_prepared_message_fits_delivery(

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -81,6 +81,9 @@ _MEGOLM_AES_BLOCK_BYTES = 16
 _MEGOLM_MAX_MESSAGE_INDEX_VARINT_BYTES = 5
 _MEGOLM_BASE64_KEY_LENGTH = 43
 _UNREPRESENTABLE_MESSAGE_ERROR = "Large message cannot fit within the Matrix event limit after sidecar preparation"
+_PREPARED_MESSAGE_TOO_LARGE_ERROR = (
+    "Prepared Matrix event exceeds the hard size limit under the current delivery envelope"
+)
 _OVERSIZED_NONTERMINAL_STREAMING_EDIT_MIN_INTERVAL_SECONDS = 5.0
 _oversized_nonterminal_streaming_edit_sent_at: dict[tuple[str, str], float] = {}
 
@@ -286,7 +289,9 @@ def _delivery_event_size_calculator(
     """Bind the currently observed delivery fields for size estimation."""
     device_id: str | None = None
     if room_encrypted:
-        device_id = client.olm.device_id if client.olm is not None else client.device_id
+        olm = getattr(client, "olm", None)
+        raw_device_id = getattr(olm, "device_id", None) if olm is not None else getattr(client, "device_id", None)
+        device_id = raw_device_id if isinstance(raw_device_id, str) else None
 
     def calculate(candidate: dict[str, Any]) -> int:
         return _calculate_delivery_event_size(
@@ -297,6 +302,23 @@ def _delivery_event_size_calculator(
         )
 
     return calculate
+
+
+def ensure_prepared_message_fits_delivery(
+    client: nio.AsyncClient,
+    room_id: str,
+    content: dict[str, Any],
+    *,
+    room_encrypted: bool,
+) -> None:
+    """Reject prepared content that cannot fit its current wire envelope."""
+    calculate_delivery_event_size = _delivery_event_size_calculator(
+        client,
+        room_id=room_id,
+        room_encrypted=room_encrypted,
+    )
+    if calculate_delivery_event_size(content) > _MATRIX_EVENT_HARD_LIMIT:
+        raise MatrixEventTooLargeError(_PREPARED_MESSAGE_TOO_LARGE_ERROR)
 
 
 def _is_edit_message(content: dict[str, Any]) -> bool:
@@ -878,6 +900,7 @@ async def prepare_large_message(
     content: dict[str, Any],
     *,
     room_encrypted: bool | None = None,
+    fit_for_encrypted_delivery: bool = False,
 ) -> dict[str, Any]:
     """Check if message is too large and prepare it if needed.
 
@@ -892,6 +915,7 @@ async def prepare_large_message(
         room_id: The room to send to
         content: The message content dictionary
         room_encrypted: Authoritative encryption state when the room cache is unavailable
+        fit_for_encrypted_delivery: Keep the prepared bytes valid if delivery becomes encrypted
 
     Returns:
         Original content (if small) or modified content with preview and MXC reference
@@ -905,7 +929,7 @@ async def prepare_large_message(
     calculate_delivery_event_size = _delivery_event_size_calculator(
         client,
         room_id=room_id,
-        room_encrypted=room_encrypted,
+        room_encrypted=room_encrypted or fit_for_encrypted_delivery,
     )
     current_size = _calculate_event_size(content)
     if current_size <= size_limit and calculate_delivery_event_size(content) <= _MATRIX_EVENT_HARD_LIMIT:

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -915,7 +915,7 @@ async def prepare_large_message(
         room_id: The room to send to
         content: The message content dictionary
         room_encrypted: Authoritative encryption state when the room cache is unavailable
-        fit_for_encrypted_delivery: Keep the prepared bytes valid if delivery becomes encrypted
+        fit_for_encrypted_delivery: Encrypt sidecars and fit bytes for a possible encrypted delivery
 
     Returns:
         Original content (if small) or modified content with preview and MXC reference
@@ -926,10 +926,11 @@ async def prepare_large_message(
     size_limit = _EDIT_MESSAGE_LIMIT if is_edit else _NORMAL_MESSAGE_LIMIT
     if room_encrypted is None:
         room_encrypted = _room_is_encrypted(client, room_id)
+    encrypted_delivery_safe = room_encrypted or fit_for_encrypted_delivery
     calculate_delivery_event_size = _delivery_event_size_calculator(
         client,
         room_id=room_id,
-        room_encrypted=room_encrypted or fit_for_encrypted_delivery,
+        room_encrypted=encrypted_delivery_safe,
     )
     current_size = _calculate_event_size(content)
     if current_size <= size_limit and calculate_delivery_event_size(content) <= _MATRIX_EVENT_HARD_LIMIT:
@@ -954,12 +955,12 @@ async def prepare_large_message(
             client,
             room_id,
             content,
-            room_encrypted=room_encrypted,
+            room_encrypted=encrypted_delivery_safe,
         )
         if not sidecar_upload_is_usable(
             mxc_uri,
             file_info,
-            room_encrypted=room_encrypted,
+            room_encrypted=encrypted_delivery_safe,
         ):
             logger.warning(
                 "large_message_sidecar_unavailable_using_inline_preview",
@@ -975,7 +976,7 @@ async def prepare_large_message(
             content,
             source_content,
             preview_text,
-            room_encrypted=room_encrypted,
+            room_encrypted=encrypted_delivery_safe,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=current_size,
@@ -1006,19 +1007,19 @@ async def prepare_large_message(
         content,
         preview_text,
         size_limit,
-        room_encrypted=room_encrypted,
+        room_encrypted=encrypted_delivery_safe,
     )
 
     sidecar_usable = sidecar_upload_is_usable(
         mxc_uri,
         file_info,
-        room_encrypted=room_encrypted,
+        room_encrypted=encrypted_delivery_safe,
     )
     if sidecar_usable:
         _copy_preview_metadata(source_content, modified_content)
         _add_sidecar_metadata(
             modified_content,
-            room_encrypted=room_encrypted,
+            room_encrypted=encrypted_delivery_safe,
             mxc_uri=mxc_uri,
             file_info=file_info,
             original_size=current_size,

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -81,9 +81,6 @@ _MEGOLM_AES_BLOCK_BYTES = 16
 _MEGOLM_MAX_MESSAGE_INDEX_VARINT_BYTES = 5
 _MEGOLM_BASE64_KEY_LENGTH = 43
 _UNREPRESENTABLE_MESSAGE_ERROR = "Large message cannot fit within the Matrix event limit after sidecar preparation"
-_PREPARED_MESSAGE_TOO_LARGE_ERROR = (
-    "Prepared Matrix event exceeds the hard size limit under the current delivery envelope"
-)
 _OVERSIZED_NONTERMINAL_STREAMING_EDIT_MIN_INTERVAL_SECONDS = 5.0
 _oversized_nonterminal_streaming_edit_sent_at: dict[tuple[str, str], float] = {}
 
@@ -302,23 +299,6 @@ def _delivery_event_size_calculator(
         )
 
     return calculate
-
-
-def ensure_prepared_message_fits_delivery(
-    client: nio.AsyncClient,
-    room_id: str,
-    content: dict[str, Any],
-    *,
-    room_encrypted: bool,
-) -> None:
-    """Reject prepared content that cannot fit its current wire envelope."""
-    calculate_delivery_event_size = _delivery_event_size_calculator(
-        client,
-        room_id=room_id,
-        room_encrypted=room_encrypted,
-    )
-    if calculate_delivery_event_size(content) > _MATRIX_EVENT_HARD_LIMIT:
-        raise MatrixEventTooLargeError(_PREPARED_MESSAGE_TOO_LARGE_ERROR)
 
 
 def _is_edit_message(content: dict[str, Any]) -> bool:
@@ -900,7 +880,7 @@ async def prepare_large_message(
     content: dict[str, Any],
     *,
     room_encrypted: bool | None = None,
-    fit_for_encrypted_delivery: bool = False,
+    prepare_for_encrypted_delivery: bool = False,
 ) -> dict[str, Any]:
     """Check if message is too large and prepare it if needed.
 
@@ -915,10 +895,13 @@ async def prepare_large_message(
         room_id: The room to send to
         content: The message content dictionary
         room_encrypted: Authoritative encryption state when the room cache is unavailable
-        fit_for_encrypted_delivery: Encrypt sidecars and fit bytes for a possible encrypted delivery
+        prepare_for_encrypted_delivery: Encrypt sidecars and fit a durable payload for later encrypted delivery
 
     Returns:
-        Original content (if small) or modified content with preview and MXC reference
+        The original content object when no preparation is needed, otherwise
+        modified content with a preview and MXC reference. The identity
+        guarantee lets the delivery boundary avoid a redundant state lookup
+        when this coroutine completed without yielding.
 
     """
     content = _without_local_recovery_data(content)
@@ -926,7 +909,7 @@ async def prepare_large_message(
     size_limit = _EDIT_MESSAGE_LIMIT if is_edit else _NORMAL_MESSAGE_LIMIT
     if room_encrypted is None:
         room_encrypted = _room_is_encrypted(client, room_id)
-    encrypted_delivery_safe = room_encrypted or fit_for_encrypted_delivery
+    encrypted_delivery_safe = room_encrypted or prepare_for_encrypted_delivery
     calculate_delivery_event_size = _delivery_event_size_calculator(
         client,
         room_id=room_id,

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -289,8 +289,8 @@ def _delivery_event_size_calculator(
     """Bind the currently observed delivery fields for size estimation."""
     device_id: str | None = None
     if room_encrypted:
-        olm = getattr(client, "olm", None)
-        raw_device_id = getattr(olm, "device_id", None) if olm is not None else getattr(client, "device_id", None)
+        olm = client.olm
+        raw_device_id = olm.device_id if olm is not None else client.device_id
         device_id = raw_device_id if isinstance(raw_device_id, str) else None
 
     def calculate(candidate: dict[str, Any]) -> int:

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -10,6 +10,7 @@ import nio
 import pytest
 from agno.models.response import ToolExecution
 from agno.run.agent import ToolCallCompletedEvent, ToolCallStartedEvent
+from nio import crypto
 
 from mindroom.config.models import DefaultsConfig
 from mindroom.constants import (
@@ -147,9 +148,12 @@ async def test_regular_message_over_limit() -> None:
     assert sent_content["io.mindroom.long_text"]["encoding"] == "matrix_event_content_json"
     assert sent_content["io.mindroom.long_text"]["is_complete_content"] is True
 
-    # Should have file URL
-    assert sent_content["url"].startswith("mxc://server/")
-    assert "file" not in sent_content
+    # Transition-safe sends encrypt the sidecar even while the room is plaintext.
+    assert sent_content["file"]["url"].startswith("mxc://server/")
+    assert sent_content["file"]["key"]
+    assert sent_content["file"]["iv"]
+    assert sent_content["file"]["hashes"]
+    assert "url" not in sent_content
 
 
 @pytest.mark.asyncio
@@ -202,7 +206,15 @@ async def test_large_edit_preserves_mindroom_metadata_in_both_payload_layers() -
         assert sent_content[key] == value
         assert sent_content["m.new_content"][key] == value
 
-    uploaded_payload = json.loads(client.uploads[0]["data"].read())
+    encrypted_file = sent_content["m.new_content"]["file"]
+    uploaded_payload = json.loads(
+        crypto.attachments.decrypt_attachment(
+            client.uploads[0]["data"].read(),
+            encrypted_file["key"]["k"],
+            encrypted_file["hashes"]["sha256"],
+            encrypted_file["iv"],
+        ),
+    )
     for key, value in extra_content.items():
         assert uploaded_payload["m.new_content"][key] == value
 

--- a/tests/test_large_messages_integration.py
+++ b/tests/test_large_messages_integration.py
@@ -10,7 +10,6 @@ import nio
 import pytest
 from agno.models.response import ToolExecution
 from agno.run.agent import ToolCallCompletedEvent, ToolCallStartedEvent
-from nio import crypto
 
 from mindroom.config.models import DefaultsConfig
 from mindroom.constants import (
@@ -117,6 +116,7 @@ async def test_regular_message_under_limit() -> None:
 
     assert len(client.messages_sent) == 1
     sent_content = client.messages_sent[0][2]
+    assert sent_content is content
     assert sent_content["body"] == "Hello world"
     assert "io.mindroom.long_text" not in sent_content
 
@@ -148,12 +148,9 @@ async def test_regular_message_over_limit() -> None:
     assert sent_content["io.mindroom.long_text"]["encoding"] == "matrix_event_content_json"
     assert sent_content["io.mindroom.long_text"]["is_complete_content"] is True
 
-    # Transition-safe sends encrypt the sidecar even while the room is plaintext.
-    assert sent_content["file"]["url"].startswith("mxc://server/")
-    assert sent_content["file"]["key"]
-    assert sent_content["file"]["iv"]
-    assert sent_content["file"]["hashes"]
-    assert "url" not in sent_content
+    # A room that stays plaintext keeps standard Matrix m.file semantics.
+    assert sent_content["url"].startswith("mxc://server/")
+    assert "file" not in sent_content
 
 
 @pytest.mark.asyncio
@@ -206,15 +203,7 @@ async def test_large_edit_preserves_mindroom_metadata_in_both_payload_layers() -
         assert sent_content[key] == value
         assert sent_content["m.new_content"][key] == value
 
-    encrypted_file = sent_content["m.new_content"]["file"]
-    uploaded_payload = json.loads(
-        crypto.attachments.decrypt_attachment(
-            client.uploads[0]["data"].read(),
-            encrypted_file["key"]["k"],
-            encrypted_file["hashes"]["sha256"],
-            encrypted_file["iv"],
-        ),
-    )
+    uploaded_payload = json.loads(client.uploads[0]["data"].read())
     for key, value in extra_content.items():
         assert uploaded_payload["m.new_content"][key] == value
 

--- a/tests/test_matrix_delivery.py
+++ b/tests/test_matrix_delivery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import ast
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import nio
@@ -22,6 +23,11 @@ from mindroom.matrix.client_delivery import (
     send_message_result,
     send_room_event_result,
 )
+from mindroom.matrix.large_messages import _MATRIX_EVENT_HARD_LIMIT, _calculate_delivery_event_size
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from io import BytesIO
 
 
 def _mock_client(*, encrypted: bool = False) -> AsyncMock:
@@ -395,6 +401,78 @@ async def test_send_message_outcome_success_returns_delivered_event() -> None:
     assert isinstance(outcome, DeliveredMatrixEvent)
     assert outcome.event_id == "$event:localhost"
     assert outcome.content_sent == content
+
+
+@pytest.mark.asyncio
+async def test_send_message_outcome_fits_for_encryption_enabled_during_sidecar_upload() -> None:
+    """A state change while preparation yields must not make the event oversized."""
+    client = _mock_client()
+    client.device_id = "D"
+
+    async def upload_and_enable_encryption(**kwargs: object) -> tuple[nio.UploadResponse, None]:
+        data_provider = cast("Callable[[object, object], BytesIO]", kwargs["data_provider"])
+        data_provider(None, None).read()
+        client.rooms["!room:localhost"].encrypted = True
+        client.olm = MagicMock()
+        client.olm.device_id = "D"
+        return nio.UploadResponse("mxc://server/direct-sidecar"), None
+
+    client.upload.side_effect = upload_and_enable_encryption
+
+    outcome = await send_message_outcome(
+        client,
+        "!room:localhost",
+        {"body": "x" * 100_000, "msgtype": "m.text"},
+    )
+
+    assert isinstance(outcome, DeliveredMatrixEvent)
+    assert (
+        _calculate_delivery_event_size(
+            outcome.content_sent,
+            room_id="!room:localhost",
+            room_encrypted=True,
+            device_id="D",
+        )
+        <= _MATRIX_EVENT_HARD_LIMIT
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_message_outcome_rejects_a_frozen_event_that_no_longer_fits() -> None:
+    """Recovery must validate the current encrypted envelope before network I/O."""
+    client = _mock_client(encrypted=True)
+    client.olm.device_id = "😀" * 512
+    frozen = {"body": "x" * 45_000, "msgtype": "m.text"}
+
+    assert (
+        _calculate_delivery_event_size(
+            frozen,
+            room_id="!room:localhost",
+            room_encrypted=True,
+            device_id="D",
+        )
+        <= _MATRIX_EVENT_HARD_LIMIT
+    )
+    assert (
+        _calculate_delivery_event_size(
+            frozen,
+            room_id="!room:localhost",
+            room_encrypted=True,
+            device_id=client.olm.device_id,
+        )
+        > _MATRIX_EVENT_HARD_LIMIT
+    )
+
+    outcome = await send_message_outcome(
+        client,
+        "!room:localhost",
+        frozen,
+        content_is_prepared=True,
+    )
+
+    assert isinstance(outcome, MatrixDeliveryFailure)
+    assert outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE
+    client.room_send.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_delivery.py
+++ b/tests/test_matrix_delivery.py
@@ -460,18 +460,33 @@ async def test_uncached_room_encryption_enabled_during_upload_avoids_raw_send() 
     )
     client.upload.return_value = nio.UploadResponse("mxc://server/uncached-sidecar"), None
     client._send.return_value = nio.RoomSendResponse("$raw", "!room:localhost")
-    client.room_send.return_value = nio.RoomSendResponse("$encrypted", "!room:localhost")
+    client.room_send.side_effect = [
+        nio.SendRetryError("Classic Sync room state is being rebuilt."),
+        nio.RoomSendResponse("$encrypted", "!room:localhost"),
+    ]
 
-    outcome = await send_message_outcome(
-        client,
-        "!room:localhost",
-        {"body": "x" * 100_000, "msgtype": "m.text"},
-    )
+    async def restore_encrypted_room(_delay: float) -> None:
+        room = MagicMock()
+        room.encrypted = True
+        client.rooms["!room:localhost"] = room
+
+    with patch("mindroom.matrix.client_delivery.asyncio.sleep", new=restore_encrypted_room):
+        outcome = await send_message_outcome(
+            client,
+            "!room:localhost",
+            {"body": "x" * 100_000, "msgtype": "m.text"},
+        )
 
     assert isinstance(outcome, DeliveredMatrixEvent)
     assert outcome.event_id == "$encrypted"
+    encrypted_file = cast("dict[str, object]", outcome.content_sent["file"])
+    assert encrypted_file["url"] == "mxc://server/uncached-sidecar"
+    assert encrypted_file["key"]
+    assert encrypted_file["iv"]
+    assert encrypted_file["hashes"]
+    assert "url" not in outcome.content_sent
     assert client.room_get_state_event.await_count == 2
-    client.room_send.assert_awaited_once()
+    assert client.room_send.await_count == 2
     client._send.assert_not_awaited()
 
 

--- a/tests/test_matrix_delivery.py
+++ b/tests/test_matrix_delivery.py
@@ -406,17 +406,22 @@ async def test_send_message_outcome_success_returns_delivered_event() -> None:
 
 @pytest.mark.asyncio
 async def test_send_message_outcome_fits_for_encryption_enabled_during_sidecar_upload() -> None:
-    """A state change while preparation yields must not make the event oversized."""
+    """A direct plaintext sidecar is rebuilt if encryption turns on during upload."""
     client = _mock_client()
     client.device_id = "D"
+    upload_requests: list[tuple[str, str]] = []
 
     async def upload_and_enable_encryption(**kwargs: object) -> tuple[nio.UploadResponse, None]:
         data_provider = cast("Callable[[object, object], BytesIO]", kwargs["data_provider"])
         data_provider(None, None).read()
-        client.rooms["!room:localhost"].encrypted = True
-        client.olm = MagicMock()
-        client.olm.device_id = "D"
-        return nio.UploadResponse("mxc://server/direct-sidecar"), None
+        content_type = cast("str", kwargs["content_type"])
+        filename = cast("str", kwargs["filename"])
+        upload_requests.append((content_type, filename))
+        if len(upload_requests) == 1:
+            client.rooms["!room:localhost"].encrypted = True
+            client.olm = MagicMock()
+            client.olm.device_id = "D"
+        return nio.UploadResponse(f"mxc://server/direct-sidecar-{len(upload_requests)}"), None
 
     client.upload.side_effect = upload_and_enable_encryption
 
@@ -427,6 +432,16 @@ async def test_send_message_outcome_fits_for_encryption_enabled_during_sidecar_u
     )
 
     assert isinstance(outcome, DeliveredMatrixEvent)
+    assert upload_requests == [
+        ("application/json", "message-content.json"),
+        ("application/octet-stream", "message-content.json.enc"),
+    ]
+    encrypted_file = cast("dict[str, object]", outcome.content_sent["file"])
+    assert encrypted_file["url"] == "mxc://server/direct-sidecar-2"
+    assert encrypted_file["key"]
+    assert encrypted_file["iv"]
+    assert encrypted_file["hashes"]
+    assert "url" not in outcome.content_sent
     assert (
         _calculate_delivery_event_size(
             outcome.content_sent,
@@ -458,7 +473,10 @@ async def test_uncached_room_encryption_enabled_during_upload_avoids_raw_send() 
             ),
         ],
     )
-    client.upload.return_value = nio.UploadResponse("mxc://server/uncached-sidecar"), None
+    client.upload.side_effect = [
+        (nio.UploadResponse("mxc://server/uncached-sidecar-1"), None),
+        (nio.UploadResponse("mxc://server/uncached-sidecar-2"), None),
+    ]
     client._send.return_value = nio.RoomSendResponse("$raw", "!room:localhost")
     client.room_send.side_effect = [
         nio.SendRetryError("Classic Sync room state is being rebuilt."),
@@ -480,52 +498,22 @@ async def test_uncached_room_encryption_enabled_during_upload_avoids_raw_send() 
     assert isinstance(outcome, DeliveredMatrixEvent)
     assert outcome.event_id == "$encrypted"
     encrypted_file = cast("dict[str, object]", outcome.content_sent["file"])
-    assert encrypted_file["url"] == "mxc://server/uncached-sidecar"
+    assert encrypted_file["url"] == "mxc://server/uncached-sidecar-2"
     assert encrypted_file["key"]
     assert encrypted_file["iv"]
     assert encrypted_file["hashes"]
     assert "url" not in outcome.content_sent
+    assert [call.kwargs["content_type"] for call in client.upload.await_args_list] == [
+        "application/json",
+        "application/octet-stream",
+    ]
+    assert [call.kwargs["filename"] for call in client.upload.await_args_list] == [
+        "message-content.json",
+        "message-content.json.enc",
+    ]
     assert client.room_get_state_event.await_count == 2
     assert client.room_send.await_count == 2
     client._send.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_send_message_outcome_rejects_a_frozen_event_that_no_longer_fits() -> None:
-    """Recovery must validate the current encrypted envelope before network I/O."""
-    client = _mock_client(encrypted=True)
-    client.olm.device_id = "😀" * 512
-    frozen = {"body": "x" * 45_000, "msgtype": "m.text"}
-
-    assert (
-        _calculate_delivery_event_size(
-            frozen,
-            room_id="!room:localhost",
-            room_encrypted=True,
-            device_id="D",
-        )
-        <= _MATRIX_EVENT_HARD_LIMIT
-    )
-    assert (
-        _calculate_delivery_event_size(
-            frozen,
-            room_id="!room:localhost",
-            room_encrypted=True,
-            device_id=client.olm.device_id,
-        )
-        > _MATRIX_EVENT_HARD_LIMIT
-    )
-
-    outcome = await send_message_outcome(
-        client,
-        "!room:localhost",
-        frozen,
-        content_is_prepared=True,
-    )
-
-    assert isinstance(outcome, MatrixDeliveryFailure)
-    assert outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE
-    client.room_send.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_delivery.py
+++ b/tests/test_matrix_delivery.py
@@ -37,6 +37,7 @@ def _mock_client(*, encrypted: bool = False) -> AsyncMock:
     room.encrypted = encrypted
     client.rooms = {"!room:localhost": room}
     client.olm = MagicMock() if encrypted else None
+    client.device_id = "DEVICE"
     if client.olm is not None:
         client.olm.device_id = "DEVICE"
     client.room_send.return_value = nio.RoomSendResponse(event_id="$event:localhost", room_id="!room:localhost")
@@ -435,6 +436,43 @@ async def test_send_message_outcome_fits_for_encryption_enabled_during_sidecar_u
         )
         <= _MATRIX_EVENT_HARD_LIMIT
     )
+
+
+@pytest.mark.asyncio
+async def test_uncached_room_encryption_enabled_during_upload_avoids_raw_send() -> None:
+    """An uncached room enabling encryption during upload must not use the plaintext fallback."""
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.rooms = {}
+    client.olm = MagicMock()
+    client.olm.device_id = "D"
+    client.device_id = "D"
+    client.access_token = "token"  # noqa: S105
+    client.room_get_state_event = AsyncMock(
+        side_effect=[
+            nio.RoomGetStateEventError("not found", status_code="M_NOT_FOUND"),
+            nio.RoomGetStateEventResponse(
+                {"algorithm": "m.megolm.v1.aes-sha2"},
+                "m.room.encryption",
+                "",
+                "!room:localhost",
+            ),
+        ],
+    )
+    client.upload.return_value = nio.UploadResponse("mxc://server/uncached-sidecar"), None
+    client._send.return_value = nio.RoomSendResponse("$raw", "!room:localhost")
+    client.room_send.return_value = nio.RoomSendResponse("$encrypted", "!room:localhost")
+
+    outcome = await send_message_outcome(
+        client,
+        "!room:localhost",
+        {"body": "x" * 100_000, "msgtype": "m.text"},
+    )
+
+    assert isinstance(outcome, DeliveredMatrixEvent)
+    assert outcome.event_id == "$encrypted"
+    assert client.room_get_state_event.await_count == 2
+    client.room_send.assert_awaited_once()
+    client._send.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -837,6 +837,8 @@ class TestTurnDeliveryGoesThroughTheOutbox:
 
         assert outcome.terminal_status == "completed"
         frozen = outbox.rows["$cause", "final"].payload
+        assert frozen["file"]["url"] == "mxc://localhost/transition-sidecar"
+        assert "url" not in frozen
         assert (
             _calculate_delivery_event_size(
                 frozen,
@@ -911,17 +913,6 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert not failed.attempted
         assert failed.edits_event_id == existing_event_id
         assert failed == frozen
-        assert _calculate_event_size(dict(failed.payload)) <= _MATRIX_EVENT_HARD_LIMIT
-        assert (
-            _calculate_delivery_event_size(
-                dict(failed.payload),
-                room_id=_ROOM_ID,
-                room_encrypted=True,
-                device_id="DEVICE",
-            )
-            <= _MATRIX_EVENT_HARD_LIMIT
-        )
-        assert "io.mindroom.required_metadata" not in failed.payload
         client.upload.assert_not_awaited()
         client.room_send.assert_not_awaited()
 

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -805,6 +805,48 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         )
         client.room_get_state_event.assert_awaited_once_with(_ROOM_ID, "m.room.encryption")
 
+    async def test_plaintext_durable_payload_is_fitted_for_a_later_encrypted_send(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Persistence must freeze bytes that remain valid if encryption is enabled."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.user_id = _AGENT_USER_ID
+        client.device_id = "DEVICE"
+        client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
+        room = MagicMock()
+        room.encrypted = False
+        client.rooms = {_ROOM_ID: room}
+        client.olm = None
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/transition-sidecar"}),
+            None,
+        )
+        client.room_send.return_value = nio.RoomSendResponse(event_id="$edit", room_id=_ROOM_ID)
+        gateway.deps.runtime.client = client
+
+        outcome = await gateway.deliver_final(
+            replace(
+                self._final_request("x" * 100_000),
+                defer_source_handoff=True,
+            ),
+        )
+
+        assert outcome.terminal_status == "completed"
+        frozen = outbox.rows["$cause", "final"].payload
+        assert (
+            _calculate_delivery_event_size(
+                frozen,
+                room_id=_ROOM_ID,
+                room_encrypted=True,
+                device_id="DEVICE",
+            )
+            <= _MATRIX_EVENT_HARD_LIMIT
+        )
+
     async def test_unknown_uncached_room_encryption_fails_before_durable_enqueue(
         self,
         tmp_path: Path,
@@ -869,6 +911,17 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert not failed.attempted
         assert failed.edits_event_id == existing_event_id
         assert failed == frozen
+        assert _calculate_event_size(dict(failed.payload)) <= _MATRIX_EVENT_HARD_LIMIT
+        assert (
+            _calculate_delivery_event_size(
+                dict(failed.payload),
+                room_id=_ROOM_ID,
+                room_encrypted=True,
+                device_id="DEVICE",
+            )
+            <= _MATRIX_EVENT_HARD_LIMIT
+        )
+        assert "io.mindroom.required_metadata" not in failed.payload
         client.upload.assert_not_awaited()
         client.room_send.assert_not_awaited()
 

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -711,7 +711,6 @@ class TestSendAudioMessage:
         client = AsyncMock(spec=nio.AsyncClient)
         client.rooms = {}
         client.olm = None
-        client.device_id = "DEVICE"
         client.access_token = "token"  # noqa: S105
         client.upload.return_value = (_upload_response("mxc://localhost/voice"), {})
         client.room_get_state_event.return_value = nio.RoomGetStateEventError(
@@ -731,7 +730,7 @@ class TestSendAudioMessage:
         )
 
         assert event_id == "$voice:localhost"
-        assert client.room_get_state_event.await_count == 3
+        assert client.room_get_state_event.await_count == 2
         client.room_send.assert_not_awaited()
         client._send.assert_awaited_once()
 
@@ -791,26 +790,25 @@ class TestSendMessageResult:
         )
         client._send.return_value = nio.RoomSendResponse("$evt:localhost", "!room:localhost")
 
-        prepared_content = {"body": "hello", "msgtype": "m.text"}
+        content = {"body": "hello", "msgtype": "m.text"}
         with patch("mindroom.matrix.client_delivery.prepare_large_message", new_callable=AsyncMock) as mock_prepare:
-            mock_prepare.return_value = prepared_content
+            mock_prepare.return_value = content
             result = await send_message_result(
                 client,
                 "!room:localhost",
-                {"body": "hello", "msgtype": "m.text"},
+                content,
             )
 
         assert result is not None
         assert result.event_id == "$evt:localhost"
-        assert result.content_sent == prepared_content
+        assert result.content_sent is content
         mock_prepare.assert_awaited_once_with(
             client,
             "!room:localhost",
-            {"body": "hello", "msgtype": "m.text"},
+            content,
             room_encrypted=False,
-            fit_for_encrypted_delivery=True,
         )
-        assert client.room_get_state_event.await_count == 2
+        client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
         client.room_send.assert_not_awaited()
         client._send.assert_awaited_once()
 
@@ -971,16 +969,10 @@ class TestSendMessageResult:
         assert client.room_send.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_encrypted_sidecar_refreshes_state_across_cache_reset_race(self) -> None:
-        """A cache reset after inspection must refresh encryption before delivery."""
+    async def test_encrypted_sidecar_keeps_cached_state_across_reset_race(self) -> None:
+        """A cache reset after inspection cannot downgrade sidecar encryption."""
         client = _mock_client(encrypted=True)
         room = client.rooms["!room:localhost"]
-        client.room_get_state_event.return_value = nio.RoomGetStateEventResponse(
-            {"algorithm": "m.megolm.v1.aes-sha2"},
-            "m.room.encryption",
-            "",
-            "!room:localhost",
-        )
         client.room_send.side_effect = [
             nio.SendRetryError("Classic Sync room state is being rebuilt."),
             nio.RoomSendResponse("$evt:localhost", "!room:localhost"),
@@ -992,10 +984,8 @@ class TestSendMessageResult:
             _content: dict[str, object],
             *,
             room_encrypted: bool | None,
-            fit_for_encrypted_delivery: bool,
         ) -> dict[str, str]:
             assert room_encrypted is True
-            assert fit_for_encrypted_delivery is True
             client.rooms.clear()
             return {"body": "prepared", "msgtype": "m.text"}
 
@@ -1014,7 +1004,6 @@ class TestSendMessageResult:
 
         assert result is not None
         assert result.event_id == "$evt:localhost"
-        client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
 
     @pytest.mark.parametrize("is_edit", [False, True], ids=["send", "edit"])
     @pytest.mark.asyncio

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -711,6 +711,7 @@ class TestSendAudioMessage:
         client = AsyncMock(spec=nio.AsyncClient)
         client.rooms = {}
         client.olm = None
+        client.device_id = "DEVICE"
         client.access_token = "token"  # noqa: S105
         client.upload.return_value = (_upload_response("mxc://localhost/voice"), {})
         client.room_get_state_event.return_value = nio.RoomGetStateEventError(
@@ -730,7 +731,7 @@ class TestSendAudioMessage:
         )
 
         assert event_id == "$voice:localhost"
-        assert client.room_get_state_event.await_count == 2
+        assert client.room_get_state_event.await_count == 3
         client.room_send.assert_not_awaited()
         client._send.assert_awaited_once()
 
@@ -809,7 +810,7 @@ class TestSendMessageResult:
             room_encrypted=False,
             fit_for_encrypted_delivery=True,
         )
-        client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
+        assert client.room_get_state_event.await_count == 2
         client.room_send.assert_not_awaited()
         client._send.assert_awaited_once()
 
@@ -970,10 +971,16 @@ class TestSendMessageResult:
         assert client.room_send.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_encrypted_sidecar_keeps_cached_state_across_reset_race(self) -> None:
-        """A cache reset after inspection cannot downgrade sidecar encryption."""
+    async def test_encrypted_sidecar_refreshes_state_across_cache_reset_race(self) -> None:
+        """A cache reset after inspection must refresh encryption before delivery."""
         client = _mock_client(encrypted=True)
         room = client.rooms["!room:localhost"]
+        client.room_get_state_event.return_value = nio.RoomGetStateEventResponse(
+            {"algorithm": "m.megolm.v1.aes-sha2"},
+            "m.room.encryption",
+            "",
+            "!room:localhost",
+        )
         client.room_send.side_effect = [
             nio.SendRetryError("Classic Sync room state is being rebuilt."),
             nio.RoomSendResponse("$evt:localhost", "!room:localhost"),
@@ -1007,6 +1014,7 @@ class TestSendMessageResult:
 
         assert result is not None
         assert result.event_id == "$evt:localhost"
+        client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
 
     @pytest.mark.parametrize("is_edit", [False, True], ids=["send", "edit"])
     @pytest.mark.asyncio

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -807,6 +807,7 @@ class TestSendMessageResult:
             "!room:localhost",
             {"body": "hello", "msgtype": "m.text"},
             room_encrypted=False,
+            fit_for_encrypted_delivery=True,
         )
         client.room_get_state_event.assert_awaited_once_with("!room:localhost", "m.room.encryption")
         client.room_send.assert_not_awaited()
@@ -984,8 +985,10 @@ class TestSendMessageResult:
             _content: dict[str, object],
             *,
             room_encrypted: bool | None,
+            fit_for_encrypted_delivery: bool,
         ) -> dict[str, str]:
             assert room_encrypted is True
+            assert fit_for_encrypted_delivery is True
             client.rooms.clear()
             return {"body": "prepared", "msgtype": "m.text"}
 

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -267,8 +267,6 @@ async def _run_cleanup(
     terminal_interrupted_only: bool = False,
 ) -> tuple[int, list[InterruptedThread]]:
     client.user_id = BOT_USER_ID
-    client.device_id = "TESTDEVICE"
-    client.olm = None
     assert joined_rooms == [ROOM_ID]
     with patch("mindroom.matrix.stale_stream_cleanup.time.time", return_value=now_ms / 1000):
         return await cleanup_stale_streaming_room(

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -267,6 +267,8 @@ async def _run_cleanup(
     terminal_interrupted_only: bool = False,
 ) -> tuple[int, list[InterruptedThread]]:
     client.user_id = BOT_USER_ID
+    client.device_id = "TESTDEVICE"
+    client.olm = None
     assert joined_rooms == [ROOM_ID]
     with patch("mindroom.matrix.stale_stream_cleanup.time.time", return_value=now_ms / 1000):
         return await cleanup_stale_streaming_room(


### PR DESCRIPTION
## Summary

- keep standard plaintext m.file sidecars for direct sends when room state stays plaintext
- if encryption is enabled while a direct sidecar upload yields, rebuild once from the original content with encrypted attachment metadata
- prepare durable outbox sidecars for encrypted delivery before freezing them, because attempted recovery payloads must remain byte-for-byte stable
- let existing permanent M_TOO_LARGE handling stop retries if a later device envelope is still rejected, instead of predicting future device IDs

## Regression coverage

- direct large plaintext messages retain standard url attachment semantics
- cached and uncached encryption transitions produce encrypted file references
- an uncached encryption transition never uses the raw-send path
- plaintext durable payloads are bounded for later encrypted delivery
- small uncached messages do not perform an extra state lookup
- irreducible pre-enqueue failures retain their original inspectable payload

## Tests

- uv run pytest
- uv run pre-commit run --all-files
