### PR TITLE
Preserve partial approval responses after restart

### DIFF
--- a/src/mindroom/approval_response.py
+++ b/src/mindroom/approval_response.py
@@ -394,8 +394,15 @@ class ApprovalResponseCoordinator:
         continuation = await self.store.approval_continuation(approval_id)
         return None if continuation is None else await self.request_failure(continuation, reason)
 
-    async def settle_failure(self, continuation: ApprovalContinuation, reason: str) -> bool:
-        """Settle cards and one durable failure edit from the owning source worker."""
+    async def settle_failure(
+        self,
+        continuation: ApprovalContinuation,
+        reason: str,
+        *,
+        visible_text: str | None = None,
+        stream_status: str = STREAM_STATUS_COMPLETED,
+    ) -> bool:
+        """Settle cards and the failure outcome from the owning source worker."""
         current = await self.store.approval_continuation(continuation.approval_id)
         if current is None:
             return True
@@ -411,14 +418,14 @@ class ApprovalResponseCoordinator:
         failed_delivery = await self.final_delivery(current)
         if failed_delivery is not None and failed_delivery.permanently_failed:
             return await self.store.finish_approval_continuation(current.approval_id)
-        visible_reason = _USER_STOP_VISIBLE_NOTE if reason == _USER_STOP_FAILURE_REASON else reason
+        visible_reason = visible_text or (_USER_STOP_VISIBLE_NOTE if reason == _USER_STOP_FAILURE_REASON else reason)
         target = continuation_target(current)
         delivered = await self.delivery_gateway.edit_text(
             EditTextRequest(
                 target=target,
                 event_id=current.response_event_id,
                 new_text=visible_reason,
-                extra_content={STREAM_STATUS_KEY: STREAM_STATUS_COMPLETED},
+                extra_content={STREAM_STATUS_KEY: stream_status},
                 delivery_turn_id=current.source_event_ids[0],
                 defer_source_handoff=True,
             ),

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -250,6 +250,17 @@ async def extract_visible_edit_body(
     )
 
 
+def _is_replacement_for_event(
+    event_source: dict[str, Any],
+    *,
+    sender: str,
+    event_id: str,
+) -> bool:
+    """Return whether one replacement belongs to the event being recovered."""
+    event_info = EventInfo.from_event(event_source)
+    return event_source.get("sender") == sender and event_info.is_edit and event_info.original_event_id == event_id
+
+
 async def _latest_relation_or_original_body(
     client: nio.AsyncClient,
     *,
@@ -269,6 +280,8 @@ async def _latest_relation_or_original_body(
     )
     async with contextlib.aclosing(relations):
         async for candidate in relations:
+            if candidate.sender != event.sender:
+                continue
             replacement = candidate
             if isinstance(replacement, nio.MegolmEvent):
                 if client.olm is None:
@@ -279,7 +292,11 @@ async def _latest_relation_or_original_body(
                     return None
             if not is_visible_room_message(replacement):
                 return None
-            if replacement.sender != event.sender:
+            if not _is_replacement_for_event(
+                replacement.source,
+                sender=event.sender,
+                event_id=event_id,
+            ):
                 continue
             body, _content = await extract_visible_edit_body(
                 replacement.source,
@@ -321,9 +338,15 @@ async def fetch_latest_visible_body(
     if event_source is None:
         return None
     replacements = bundled_replacement_candidates(event_source)
-    if replacements:
+    for replacement in replacements:
+        if not _is_replacement_for_event(
+            replacement,
+            sender=event.sender,
+            event_id=event_id,
+        ):
+            continue
         body, _content = await extract_visible_edit_body(
-            replacements[0],
+            replacement,
             client,
             config=config,
             runtime_paths=runtime_paths,

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 from collections.abc import Collection, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any
 
 import nio
+from nio.api import RelationshipType
 from typing_extensions import TypeIs
 
 from mindroom.constants import STREAM_STATUS_KEY
@@ -248,7 +250,58 @@ async def extract_visible_edit_body(
     )
 
 
-async def fetch_latest_bundled_edit_body(
+async def _latest_relation_or_original_body(
+    client: nio.AsyncClient,
+    *,
+    room_id: str,
+    event_id: str,
+    event: VisibleRoomMessage,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    trusted_sender_ids: Collection[str] | None,
+) -> str | None:
+    """Read the newest valid replacement relation, or the original body."""
+    relations = client.room_get_event_relations(
+        room_id,
+        event_id,
+        RelationshipType.replacement,
+        direction=nio.MessageDirection.back,
+    )
+    async with contextlib.aclosing(relations):
+        async for candidate in relations:
+            replacement = candidate
+            if isinstance(replacement, nio.MegolmEvent):
+                if client.olm is None:
+                    return None
+                try:
+                    replacement = client.decrypt_event(replacement)
+                except nio.EncryptionError:
+                    return None
+            if not is_visible_room_message(replacement):
+                return None
+            if replacement.sender != event.sender:
+                continue
+            body, _content = await extract_visible_edit_body(
+                replacement.source,
+                client,
+                config=config,
+                runtime_paths=runtime_paths,
+                trusted_sender_ids=trusted_sender_ids,
+            )
+            return body
+
+    _resolved_source, body = await resolve_visible_event_source(
+        event.source,
+        client,
+        fallback_body=room_message_fallback_body(event),
+        config=config,
+        runtime_paths=runtime_paths,
+        trusted_sender_ids=trusted_sender_ids,
+    )
+    return body
+
+
+async def fetch_latest_visible_body(
     client: nio.AsyncClient,
     *,
     room_id: str,
@@ -257,32 +310,36 @@ async def fetch_latest_bundled_edit_body(
     runtime_paths: RuntimePaths,
     trusted_sender_ids: Collection[str] | None = None,
 ) -> str | None:
-    """Fetch an event's authoritative bundled edit body, failing closed."""
+    """Fetch an event's authoritative latest visible body, failing closed."""
     response = await client.room_get_event(room_id, event_id)
     if not isinstance(response, nio.RoomGetEventResponse):
         return None
-    event_source = response.event.source if isinstance(response.event.source, dict) else None
+    event = response.event
+    if not is_visible_room_message(event):
+        return None
+    event_source = event.source if isinstance(event.source, dict) else None
     if event_source is None:
         return None
     replacements = bundled_replacement_candidates(event_source)
-    if not replacements:
-        _resolved_source, body = await resolve_visible_event_source(
-            event_source,
+    if replacements:
+        body, _content = await extract_visible_edit_body(
+            replacements[0],
             client,
-            fallback_body=room_message_fallback_body(response.event),
             config=config,
             runtime_paths=runtime_paths,
             trusted_sender_ids=trusted_sender_ids,
         )
         return body
-    body, _content = await extract_visible_edit_body(
-        replacements[0],
+
+    return await _latest_relation_or_original_body(
         client,
+        room_id=room_id,
+        event_id=event_id,
+        event=event,
         config=config,
         runtime_paths=runtime_paths,
         trusted_sender_ids=trusted_sender_ids,
     )
-    return body
 
 
 async def resolve_visible_event_source(
@@ -685,7 +742,7 @@ __all__ = [
     "bundled_replacement_candidates",
     "extract_visible_edit_body",
     "extract_visible_message",
-    "fetch_latest_bundled_edit_body",
+    "fetch_latest_visible_body",
     "is_visible_room_message",
     "message_preview",
     "replace_visible_message",

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -248,6 +248,35 @@ async def extract_visible_edit_body(
     )
 
 
+async def fetch_latest_bundled_edit_body(
+    client: nio.AsyncClient,
+    *,
+    room_id: str,
+    event_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    trusted_sender_ids: Collection[str] | None = None,
+) -> str | None:
+    """Fetch an event's authoritative bundled edit body, failing closed."""
+    response = await client.room_get_event(room_id, event_id)
+    if not isinstance(response, nio.RoomGetEventResponse):
+        return None
+    event_source = response.event.source if isinstance(response.event.source, dict) else None
+    if event_source is None:
+        return None
+    replacements = bundled_replacement_candidates(event_source)
+    if not replacements:
+        return None
+    body, _content = await extract_visible_edit_body(
+        replacements[0],
+        client,
+        config=config,
+        runtime_paths=runtime_paths,
+        trusted_sender_ids=trusted_sender_ids,
+    )
+    return body
+
+
 async def resolve_visible_event_source(
     event_source: Mapping[str, Any],
     client: nio.AsyncClient | None = None,
@@ -648,6 +677,7 @@ __all__ = [
     "bundled_replacement_candidates",
     "extract_visible_edit_body",
     "extract_visible_message",
+    "fetch_latest_bundled_edit_body",
     "is_visible_room_message",
     "message_preview",
     "replace_visible_message",

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -21,6 +21,7 @@ from mindroom.matrix.message_content import (
     extract_edit_body,
     resolve_event_source_content,
 )
+from mindroom.matrix.sidecar_content import holds_unresolved_sidecar
 from mindroom.matrix.visible_body import bundled_visible_body_preview, visible_body_from_event_source
 
 if TYPE_CHECKING:
@@ -243,11 +244,14 @@ async def extract_visible_edit_body(
     trusted_sender_ids: Collection[str] | None = None,
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Extract one visible edit body using runtime-derived sender trust."""
-    return await extract_edit_body(
+    body, content = await extract_edit_body(
         event_source,
         client,
         trusted_sender_ids=_resolved_trusted_sender_ids(config, runtime_paths, trusted_sender_ids),
     )
+    if content is not None and holds_unresolved_sidecar(content):
+        return None, None
+    return body, content
 
 
 def _is_replacement_for_event(
@@ -290,6 +294,8 @@ async def _latest_relation_or_original_body(
                     replacement = client.decrypt_event(replacement)
                 except nio.EncryptionError:
                     return None
+            if isinstance(replacement, nio.RedactedEvent):
+                continue
             if not is_visible_room_message(replacement):
                 return None
             if not _is_replacement_for_event(
@@ -307,7 +313,7 @@ async def _latest_relation_or_original_body(
             )
             return body
 
-    _resolved_source, body = await resolve_visible_event_source(
+    resolved_source, body = await resolve_visible_event_source(
         event.source,
         client,
         fallback_body=room_message_fallback_body(event),
@@ -315,6 +321,9 @@ async def _latest_relation_or_original_body(
         runtime_paths=runtime_paths,
         trusted_sender_ids=trusted_sender_ids,
     )
+    resolved_content = resolved_source.get("content")
+    if not isinstance(resolved_content, Mapping) or holds_unresolved_sidecar(resolved_content):
+        return None
     return body
 
 

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -266,7 +266,15 @@ async def fetch_latest_bundled_edit_body(
         return None
     replacements = bundled_replacement_candidates(event_source)
     if not replacements:
-        return None
+        _resolved_source, body = await resolve_visible_event_source(
+            event_source,
+            client,
+            fallback_body=room_message_fallback_body(response.event),
+            config=config,
+            runtime_paths=runtime_paths,
+            trusted_sender_ids=trusted_sender_ids,
+        )
+        return body
     body, _content = await extract_visible_edit_body(
         replacements[0],
         client,

--- a/src/mindroom/matrix/client_visible_messages.py
+++ b/src/mindroom/matrix/client_visible_messages.py
@@ -244,14 +244,11 @@ async def extract_visible_edit_body(
     trusted_sender_ids: Collection[str] | None = None,
 ) -> tuple[str | None, dict[str, Any] | None]:
     """Extract one visible edit body using runtime-derived sender trust."""
-    body, content = await extract_edit_body(
+    return await extract_edit_body(
         event_source,
         client,
         trusted_sender_ids=_resolved_trusted_sender_ids(config, runtime_paths, trusted_sender_ids),
     )
-    if content is not None and holds_unresolved_sidecar(content):
-        return None, None
-    return body, content
 
 
 def _is_replacement_for_event(
@@ -304,14 +301,14 @@ async def _latest_relation_or_original_body(
                 event_id=event_id,
             ):
                 continue
-            body, _content = await extract_visible_edit_body(
+            body, content = await extract_visible_edit_body(
                 replacement.source,
                 client,
                 config=config,
                 runtime_paths=runtime_paths,
                 trusted_sender_ids=trusted_sender_ids,
             )
-            return body
+            return None if content is not None and holds_unresolved_sidecar(content) else body
 
     resolved_source, body = await resolve_visible_event_source(
         event.source,
@@ -354,14 +351,14 @@ async def fetch_latest_visible_body(
             event_id=event_id,
         ):
             continue
-        body, _content = await extract_visible_edit_body(
+        body, content = await extract_visible_edit_body(
             replacement,
             client,
             config=config,
             runtime_paths=runtime_paths,
             trusted_sender_ids=trusted_sender_ids,
         )
-        return body
+        return None if content is not None and holds_unresolved_sidecar(content) else body
 
     return await _latest_relation_or_original_body(
         client,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -2273,7 +2273,7 @@ class ResponseRunner:
             if await self._approval_responses.successful_final_delivery(owned, recover=True) is not None:
                 owns_final, event_id = await self._recover_frozen_approval_final(owned, target=target)
                 return True, event_id if owns_final else None
-            reason = owned.failure_reason or "Tool approval continuation was interrupted and denied safely."
+            reason = owned.failure_reason or "Tool approval continuation failed safely."
             cancel_source = _approval_interruption_cancel_source(reason)
             settled = (
                 await self._settle_interrupted_approval_recovery(

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -1168,8 +1168,8 @@ class ResponseRunner:
     ) -> None:
         """Preserve partial text for interrupted continuations, but not explicit stops."""
         reason = outcome.failure_reason or "Tool approval continuation failed safely."
-        cancel_source = cancel_source_from_failure_reason(reason)
-        if outcome.terminal_status == "cancelled" and cancel_source != "user_stop":
+        cancel_source = _approval_interruption_cancel_source(reason)
+        if outcome.terminal_status == "cancelled" and cancel_source is not None:
             await self._settle_interrupted_approval_recovery(
                 continuation,
                 reason=cancel_failure_reason(cancel_source),
@@ -2141,12 +2141,13 @@ class ResponseRunner:
     ) -> str | None:
         try:
             outcome = await self._run_claimed_approval_lifecycle(claimed, target=target)
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as error:
+            reason = cancel_failure_reason(classify_cancel_source(error))
             owns_final, event_id, _failing = await run_coroutine_until_complete(
                 self._recover_or_request_claimed_failure(
                     claimed,
                     target=target,
-                    reason="Tool approval continuation was interrupted and denied safely.",
+                    reason=reason,
                 ),
             )
             if owns_final:

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -55,7 +55,7 @@ from mindroom.hooks import EnrichmentItem, MessageEnvelope
 from mindroom.interactive import InteractiveMetadata
 from mindroom.matrix.client_visible_messages import (
     ResolvedVisibleMessage,
-    fetch_latest_bundled_edit_body,
+    fetch_latest_visible_body,
     replace_visible_message,
 )
 from mindroom.matrix.presence import should_use_streaming
@@ -90,7 +90,7 @@ from mindroom.streaming import (
     ReplacementStreamingResponse,
     StreamingDeliveryError,
     StreamingResponse,
-    build_restart_interrupted_body,
+    build_cancelled_response_update,
     clean_partial_reply_text,
     strip_visible_tool_markers,
 )
@@ -142,6 +142,17 @@ from .response_lifecycle import (
 _INTERRUPTED_APPROVAL_RECOVERY_REASON = (
     "Tool approval continuation was interrupted before final delivery and denied safely."
 )
+
+
+def _approval_interruption_cancel_source(reason: str) -> Literal["sync_restart", "interrupted"] | None:
+    """Recover the cancellation provenance persisted for an interrupted approval."""
+    if reason == _INTERRUPTED_APPROVAL_RECOVERY_REASON:
+        return "sync_restart"
+    cancel_source = cancel_source_from_failure_reason(reason)
+    if cancel_source == "user_stop" or cancel_failure_reason(cancel_source) != reason:
+        return None
+    return cancel_source
+
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Awaitable, Callable, Coroutine, Mapping, Sequence
@@ -1157,8 +1168,13 @@ class ResponseRunner:
     ) -> None:
         """Preserve partial text for interrupted continuations, but not explicit stops."""
         reason = outcome.failure_reason or "Tool approval continuation failed safely."
-        if outcome.terminal_status == "cancelled" and cancel_source_from_failure_reason(reason) != "user_stop":
-            await self._settle_interrupted_approval_recovery(continuation)
+        cancel_source = cancel_source_from_failure_reason(reason)
+        if outcome.terminal_status == "cancelled" and cancel_source != "user_stop":
+            await self._settle_interrupted_approval_recovery(
+                continuation,
+                reason=cancel_failure_reason(cancel_source),
+                cancel_source=cancel_source,
+            )
         else:
             await self._approval_responses.settle_failure(continuation, reason)
 
@@ -1210,38 +1226,49 @@ class ResponseRunner:
                 _INTERRUPTED_APPROVAL_RECOVERY_REASON,
             )
             return claimed.response_event_id if settled else None
-        settled = await self._settle_interrupted_approval_recovery(claimed)
+        settled = await self._settle_interrupted_approval_recovery(
+            claimed,
+            reason=_INTERRUPTED_APPROVAL_RECOVERY_REASON,
+            cancel_source="sync_restart",
+        )
         return claimed.response_event_id if settled else None
 
-    async def _settle_interrupted_approval_recovery(self, continuation: ApprovalContinuation) -> bool:
+    async def _settle_interrupted_approval_recovery(
+        self,
+        continuation: ApprovalContinuation,
+        *,
+        reason: str,
+        cancel_source: Literal["sync_restart", "interrupted"],
+    ) -> bool:
         """Fence an uncertain stale claim and settle it with the committed visible body."""
         failing = continuation
         if failing.state != "failing":
             requested = await self._approval_responses.request_failure(
                 failing,
-                _INTERRUPTED_APPROVAL_RECOVERY_REASON,
+                reason,
             )
             if requested is None:
                 return False
             failing = requested
-        update = await self._approval_restart_interruption_update(failing)
+        update = await self._approval_interruption_update(failing, cancel_source=cancel_source)
         if update is None:
             return False
-        visible_text = update
         return await self._approval_responses.settle_failure(
             failing,
-            _INTERRUPTED_APPROVAL_RECOVERY_REASON,
-            visible_text=visible_text,
+            reason,
+            visible_text=update,
             stream_status=STREAM_STATUS_ERROR,
         )
 
-    async def _approval_restart_interruption_update(
+    async def _approval_interruption_update(
         self,
         continuation: ApprovalContinuation,
+        *,
+        cancel_source: Literal["sync_restart", "interrupted"],
     ) -> str | None:
-        """Read the latest committed edit and build its restart terminalization."""
+        """Read the latest committed edit and build its interruption terminalization."""
         try:
-            body = await fetch_latest_bundled_edit_body(
+            body = await fetch_latest_visible_body(
                 self._client(),
                 room_id=continuation.room_id,
                 event_id=continuation.response_event_id,
@@ -1261,8 +1288,11 @@ class ResponseRunner:
                 error=str(error),
             )
             return None
+        note = RESTART_INTERRUPTED_RESPONSE_NOTE if cancel_source == "sync_restart" else INTERRUPTED_RESPONSE_NOTE
         return (
-            body if body.rstrip().endswith(RESTART_INTERRUPTED_RESPONSE_NOTE) else build_restart_interrupted_body(body)
+            body
+            if body.rstrip().endswith(note)
+            else build_cancelled_response_update(body, cancel_source=cancel_source)[0]
         )
 
     async def _recover_frozen_approval_final(
@@ -2243,9 +2273,14 @@ class ResponseRunner:
                 owns_final, event_id = await self._recover_frozen_approval_final(owned, target=target)
                 return True, event_id if owns_final else None
             reason = owned.failure_reason or "Tool approval continuation was interrupted and denied safely."
+            cancel_source = _approval_interruption_cancel_source(reason)
             settled = (
-                await self._settle_interrupted_approval_recovery(owned)
-                if reason == _INTERRUPTED_APPROVAL_RECOVERY_REASON
+                await self._settle_interrupted_approval_recovery(
+                    owned,
+                    reason=reason,
+                    cancel_source=cancel_source,
+                )
+                if cancel_source is not None
                 else await self._approval_responses.settle_failure(owned, reason)
             )
             return True, owned.response_event_id if settled else None

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -34,6 +34,7 @@ from mindroom.constants import (
     ROUTER_AGENT_NAME,
     STREAM_STATUS_APPROVAL_PENDING,
     STREAM_STATUS_COMPLETED,
+    STREAM_STATUS_ERROR,
     STREAM_STATUS_KEY,
     STREAM_STATUS_PENDING,
 )
@@ -52,7 +53,11 @@ from mindroom.history.storage import has_pending_force_compaction_scope, read_sc
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.hooks import EnrichmentItem, MessageEnvelope
 from mindroom.interactive import InteractiveMetadata
-from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage, replace_visible_message
+from mindroom.matrix.client_visible_messages import (
+    ResolvedVisibleMessage,
+    fetch_latest_bundled_edit_body,
+    replace_visible_message,
+)
 from mindroom.matrix.presence import should_use_streaming
 from mindroom.matrix.typing import typing_indicator
 from mindroom.memory import (
@@ -63,6 +68,7 @@ from mindroom.memory import (
 )
 from mindroom.orchestration.runtime import (
     cancel_failure_reason,
+    cancel_source_from_failure_reason,
     classify_cancel_source,
     log_cancelled_response,
     log_cancelled_response_source,
@@ -84,6 +90,7 @@ from mindroom.streaming import (
     ReplacementStreamingResponse,
     StreamingDeliveryError,
     StreamingResponse,
+    build_restart_interrupted_body,
     clean_partial_reply_text,
     strip_visible_tool_markers,
 )
@@ -130,6 +137,10 @@ from .response_lifecycle import (
     ResponseLifecycleCoordinator,
     ResponseLifecycleDeps,
     ResponseLifecycleReservation,
+)
+
+_INTERRUPTED_APPROVAL_RECOVERY_REASON = (
+    "Tool approval continuation was interrupted before final delivery and denied safely."
 )
 
 if TYPE_CHECKING:
@@ -1060,6 +1071,7 @@ class ResponseRunner:
         """Run one claimed pause through the normal stoppable response lifecycle."""
         request = self._approval_response_request(claimed, target=target)
         progress = _DeliveryProgress(tracked_event_id=claimed.response_event_id)
+        progress.note_delivery_started(claimed.response_event_id)
         lifecycle = self._build_lifecycle(
             identity=self._response_identity(
                 request,
@@ -1135,9 +1147,20 @@ class ResponseRunner:
                 msg = "Approval continuation final delivery was not durably acknowledged"
                 raise RuntimeError(msg)
         elif outcome.terminal_status != "suspended":
-            reason = outcome.failure_reason or "Tool approval continuation failed safely."
-            await self._approval_responses.settle_failure(post_effect_continuation, reason)
+            await self._settle_failed_approval_outcome(post_effect_continuation, outcome)
         return outcome
+
+    async def _settle_failed_approval_outcome(
+        self,
+        continuation: ApprovalContinuation,
+        outcome: FinalDeliveryOutcome,
+    ) -> None:
+        """Preserve partial text for interrupted continuations, but not explicit stops."""
+        reason = outcome.failure_reason or "Tool approval continuation failed safely."
+        if outcome.terminal_status == "cancelled" and cancel_source_from_failure_reason(reason) != "user_stop":
+            await self._settle_interrupted_approval_recovery(continuation)
+        else:
+            await self._approval_responses.settle_failure(continuation, reason)
 
     @staticmethod
     def _approval_outcome_from_delivery(delivery: MatrixDelivery) -> FinalDeliveryOutcome:
@@ -1180,9 +1203,67 @@ class ResponseRunner:
         owns_final, event_id = await self._recover_frozen_approval_final(claimed, target=target)
         if owns_final:
             return event_id
-        reason = "Tool approval continuation was interrupted before final delivery and denied safely."
-        settled = await self._approval_responses.settle_failure(claimed, reason)
+        final_delivery = await self._approval_responses.final_delivery(claimed)
+        if final_delivery is not None and final_delivery.permanently_failed:
+            settled = await self._approval_responses.settle_failure(
+                claimed,
+                _INTERRUPTED_APPROVAL_RECOVERY_REASON,
+            )
+            return claimed.response_event_id if settled else None
+        settled = await self._settle_interrupted_approval_recovery(claimed)
         return claimed.response_event_id if settled else None
+
+    async def _settle_interrupted_approval_recovery(self, continuation: ApprovalContinuation) -> bool:
+        """Fence an uncertain stale claim and settle it with the committed visible body."""
+        failing = continuation
+        if failing.state != "failing":
+            requested = await self._approval_responses.request_failure(
+                failing,
+                _INTERRUPTED_APPROVAL_RECOVERY_REASON,
+            )
+            if requested is None:
+                return False
+            failing = requested
+        update = await self._approval_restart_interruption_update(failing)
+        if update is None:
+            return False
+        visible_text = update
+        return await self._approval_responses.settle_failure(
+            failing,
+            _INTERRUPTED_APPROVAL_RECOVERY_REASON,
+            visible_text=visible_text,
+            stream_status=STREAM_STATUS_ERROR,
+        )
+
+    async def _approval_restart_interruption_update(
+        self,
+        continuation: ApprovalContinuation,
+    ) -> str | None:
+        """Read the latest committed edit and build its restart terminalization."""
+        try:
+            body = await fetch_latest_bundled_edit_body(
+                self._client(),
+                room_id=continuation.room_id,
+                event_id=continuation.response_event_id,
+                config=self.deps.runtime.config,
+                runtime_paths=self.deps.runtime_paths,
+                trusted_sender_ids=current_internal_sender_ids(
+                    self.deps.runtime.config,
+                    self.deps.runtime_paths,
+                ),
+            )
+            if body is None:
+                return None
+        except Exception as error:
+            self.deps.logger.warning(
+                "approval_restart_interruption_read_failed",
+                approval_id=continuation.approval_id,
+                error=str(error),
+            )
+            return None
+        return (
+            body if body.rstrip().endswith(RESTART_INTERRUPTED_RESPONSE_NOTE) else build_restart_interrupted_body(body)
+        )
 
     async def _recover_frozen_approval_final(
         self,
@@ -2162,7 +2243,11 @@ class ResponseRunner:
                 owns_final, event_id = await self._recover_frozen_approval_final(owned, target=target)
                 return True, event_id if owns_final else None
             reason = owned.failure_reason or "Tool approval continuation was interrupted and denied safely."
-            settled = await self._approval_responses.settle_failure(owned, reason)
+            settled = (
+                await self._settle_interrupted_approval_recovery(owned)
+                if reason == _INTERRUPTED_APPROVAL_RECOVERY_REASON
+                else await self._approval_responses.settle_failure(owned, reason)
+            )
             return True, owned.response_event_id if settled else None
         return False, None
 

--- a/tach.toml
+++ b/tach.toml
@@ -4341,6 +4341,7 @@ expose = [
     "bundled_replacement_candidates",
     "extract_visible_edit_body",
     "extract_visible_message",
+    "fetch_latest_bundled_edit_body",
     "is_visible_room_message",
     "message_preview",
     "room_message_fallback_body",

--- a/tach.toml
+++ b/tach.toml
@@ -2536,6 +2536,7 @@ depends_on = [
     "mindroom.matrix.event_info",
     "mindroom.matrix.identity",
     "mindroom.matrix.message_content",
+    "mindroom.matrix.sidecar_content",
     "mindroom.matrix.visible_body",
 ]
 visibility = [
@@ -4187,6 +4188,7 @@ expose = ["holds_unresolved_sidecar", "sidecar_content_to_resolve", "sidecar_mxc
 from = ["mindroom.matrix.sidecar_content"]
 visibility = [
     "mindroom.event_journal",
+    "mindroom.matrix.client_visible_messages",
     "mindroom.matrix.conversation_hydration",
     "mindroom.matrix.message_content",
 ]

--- a/tach.toml
+++ b/tach.toml
@@ -4341,7 +4341,7 @@ expose = [
     "bundled_replacement_candidates",
     "extract_visible_edit_body",
     "extract_visible_message",
-    "fetch_latest_bundled_edit_body",
+    "fetch_latest_visible_body",
     "is_visible_room_message",
     "message_preview",
     "room_message_fallback_body",

--- a/tests/test_edit_response_regeneration.py
+++ b/tests/test_edit_response_regeneration.py
@@ -478,8 +478,18 @@ async def test_bot_regenerates_response_on_edit(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_bot_edit_hooks_see_hydrated_sidecar_edit_body(tmp_path: Path) -> None:
-    """Edit regeneration should use the resolved edited body from a v2 sidecar."""
+@pytest.mark.parametrize(
+    ("download_succeeds", "expected_body"),
+    [(True, "@test_agent what is 99+1?"), (False, "Preview edit")],
+    ids=("hydrated", "preview_fallback"),
+)
+async def test_bot_edit_hooks_see_best_available_sidecar_edit_body(
+    tmp_path: Path,
+    *,
+    download_succeeds: bool,
+    expected_body: str,
+) -> None:
+    """Edit regeneration should keep the preview when a v2 sidecar cannot be hydrated."""
     agent_user = AgentMatrixUser(
         agent_name="test_agent",
         user_id="@mindroom_test_agent:example.com",
@@ -495,8 +505,8 @@ async def test_bot_edit_hooks_see_hydrated_sidecar_edit_body(tmp_path: Path) -> 
         rooms=["!test:example.com"],
     )
     bot.client = make_matrix_client_mock(user_id="@mindroom_test_agent:example.com")
-    bot.client.download = AsyncMock(
-        return_value=MagicMock(
+    download_response = (
+        MagicMock(
             spec=nio.DownloadResponse,
             body=json.dumps(
                 {
@@ -512,8 +522,11 @@ async def test_bot_edit_hooks_see_hydrated_sidecar_edit_body(tmp_path: Path) -> 
                     },
                 },
             ).encode("utf-8"),
-        ),
+        )
+        if download_succeeds
+        else nio.DownloadError("missing")
     )
+    bot.client.download = AsyncMock(return_value=download_response)
     replace_edit_regenerator_deps(bot)
     bot.logger = MagicMock()
 
@@ -581,7 +594,7 @@ async def test_bot_edit_hooks_see_hydrated_sidecar_edit_body(tmp_path: Path) -> 
         await bot._on_message(room, edit_event)
 
     emitted_envelope = mock_emit_hooks.await_args.kwargs["envelope"]
-    assert emitted_envelope.body == "@test_agent what is 99+1?"
+    assert emitted_envelope.body == expected_body
 
 
 @pytest.mark.asyncio

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -39,6 +39,7 @@ from mindroom.config.models import ModelConfig
 from mindroom.constants import (
     DURABLE_FINAL_OUTCOME_KEY,
     STREAM_STATUS_APPROVAL_PENDING,
+    STREAM_STATUS_ERROR,
     STREAM_STATUS_KEY,
     STREAM_STATUS_PENDING,
 )
@@ -68,6 +69,7 @@ from mindroom.handled_turns import TurnRecord
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client import DeliveredMatrixEvent
+from mindroom.matrix.client_visible_messages import fetch_latest_bundled_edit_body
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.thread_history_result import ThreadHistoryResult
 from mindroom.message_target import MessageTarget, ResponseLifecycleKey
@@ -1152,6 +1154,133 @@ async def test_failing_continuation_recovers_frozen_success_before_failure_settl
     assert event_id == "$waiting"
     lifecycle.finalize.assert_awaited_once()
     assert await store.approval_continuation(continuation.approval_id) is None
+
+
+@pytest.mark.asyncio
+async def test_stale_claim_recovery_preserves_visible_partial_reply(tmp_path: Path) -> None:
+    """Restart recovery retires an uncertain claim without replacing its streamed body."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    store = runner.deps.approval_store
+    await _admit_approval_source(store)
+    continuation = ApprovalContinuation(
+        approval_id="approval-stale-claim",
+        run_id="run-1",
+        session_id="session-1",
+        entity_kind="agent",
+        entity_name="general",
+        room_id="!room:localhost",
+        thread_id="$thread",
+        requester_id="@user:localhost",
+        response_event_id="$waiting",
+        source_event_ids=("$source",),
+        calls=(),
+        state="ready",
+    )
+    assert await store.create_approval_continuation(continuation) == continuation
+    claimed = await store.claim_approval_continuation(
+        continuation.approval_id,
+        runtime_generation="previous-runtime",
+    )
+    assert claimed is not None
+    interrupted_body = f"committed partial\n\n{RESTART_INTERRUPTED_RESPONSE_NOTE}"
+
+    async def acknowledge_interruption_edit(request: EditTextRequest) -> bool:
+        await store.enqueue_matrix_delivery(
+            delivery_id="$source",
+            stage=DeliveryStage.FINAL,
+            room_id="!room:localhost",
+            thread_id="$thread",
+            payload={"body": request.new_text},
+            edits_event_id="$waiting",
+        )
+        assert await store.claim_matrix_delivery(delivery_id="$source", stage=DeliveryStage.FINAL) is not None
+        await store.acknowledge_matrix_delivery(
+            delivery_id="$source",
+            stage=DeliveryStage.FINAL,
+            event_id="$waiting",
+            delivered_projections=(),
+        )
+        return True
+
+    edit_text = AsyncMock(side_effect=acknowledge_interruption_edit)
+
+    with (
+        patch.object(DeliveryGateway, "edit_text", new=edit_text),
+        patch(
+            "mindroom.response_runner.fetch_latest_bundled_edit_body",
+            new=AsyncMock(return_value="committed partial"),
+        ),
+        patch(
+            "mindroom.approval_response.approval_manager.get_approval_store",
+            return_value=MagicMock(cards=None, expire_continuation_cards=AsyncMock(return_value=True)),
+        ),
+    ):
+        event_id = await runner._recover_claimed_approval_lifecycle(
+            claimed,
+            target=_target(thread_id="$thread", reply_to_event_id="$source"),
+        )
+
+    assert event_id == "$waiting"
+    edit_request = edit_text.await_args.args[0]
+    assert edit_request.new_text == interrupted_body
+    assert edit_request.extra_content == {
+        STREAM_STATUS_KEY: STREAM_STATUS_ERROR,
+    }
+    assert await store.approval_continuation(continuation.approval_id) is None
+    assert not await store.is_pending("$source")
+
+
+@pytest.mark.asyncio
+async def test_claimed_approval_user_stop_keeps_user_stop_settlement(tmp_path: Path) -> None:
+    """Explicit user cancellation must not be relabeled as a service restart."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    continuation = MagicMock(spec=ApprovalContinuation)
+    settle_failure = AsyncMock()
+    restart_recovery = AsyncMock()
+    outcome = FinalDeliveryOutcome(
+        terminal_status="cancelled",
+        event_id="$waiting",
+        failure_reason="cancelled_by_user",
+        is_visible_response=True,
+    )
+
+    with (
+        patch.object(runner._approval_responses, "settle_failure", new=settle_failure),
+        patch.object(runner, "_settle_interrupted_approval_recovery", new=restart_recovery),
+    ):
+        await runner._settle_failed_approval_outcome(continuation, outcome)
+
+    settle_failure.assert_awaited_once_with(continuation, "cancelled_by_user")
+    restart_recovery.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_restart_recovery_does_not_fall_back_from_unreadable_latest_edit(tmp_path: Path) -> None:
+    """An unreadable authoritative edit is retryable, not permission to use stale text."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    response = nio.RoomGetEventResponse()
+    response.event = MagicMock(source={})
+    client = runner._client()
+    client.room_get_event = AsyncMock(return_value=response)
+    extract_body = AsyncMock(side_effect=[(None, None), ("older partial", {})])
+
+    with (
+        patch(
+            "mindroom.matrix.client_visible_messages.bundled_replacement_candidates",
+            return_value=[{"new": 1}, {"old": 1}],
+        ),
+        patch("mindroom.matrix.client_visible_messages.extract_visible_edit_body", new=extract_body),
+    ):
+        update = await fetch_latest_bundled_edit_body(
+            client,
+            room_id="!room:localhost",
+            event_id="$waiting",
+            config=runner.deps.runtime.config,
+            runtime_paths=runner.deps.runtime_paths,
+        )
+
+    assert update is None
+    assert extract_body.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1231,8 +1231,59 @@ async def test_stale_claim_recovery_preserves_visible_partial_reply(tmp_path: Pa
 
 
 @pytest.mark.asyncio
-async def test_claimed_approval_user_stop_keeps_user_stop_settlement(tmp_path: Path) -> None:
-    """Explicit user cancellation must not be relabeled as a service restart."""
+async def test_claimed_approval_restart_persists_canonical_failure_reason(tmp_path: Path) -> None:
+    """A restart cancellation stays recognizable after the claim is fenced."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    store = runner.deps.approval_store
+    await _admit_approval_source(store)
+    continuation = ApprovalContinuation(
+        approval_id="approval-restart-cancelled",
+        run_id="run-1",
+        session_id="session-1",
+        entity_kind="agent",
+        entity_name="general",
+        room_id="!room:localhost",
+        thread_id="$thread",
+        requester_id="@user:localhost",
+        response_event_id="$waiting",
+        source_event_ids=("$source",),
+        calls=(),
+        state="ready",
+    )
+    assert await store.create_approval_continuation(continuation) == continuation
+    claimed = await store.claim_approval_continuation(
+        continuation.approval_id,
+        runtime_generation="current-runtime",
+    )
+    assert claimed is not None
+
+    with (
+        patch.object(
+            runner,
+            "_run_claimed_approval_lifecycle",
+            new=AsyncMock(side_effect=asyncio.CancelledError("sync_restart")),
+        ),
+        patch.object(runner, "_recover_frozen_approval_final", new=AsyncMock(return_value=(False, None))),
+        pytest.raises(asyncio.CancelledError),
+    ):
+        await runner._run_owned_approval_continuation(
+            claimed,
+            target=_target(thread_id="$thread", reply_to_event_id="$source"),
+        )
+
+    failing = await store.approval_continuation(continuation.approval_id)
+    assert failing is not None
+    assert failing.state == "failing"
+    assert failing.failure_reason == "sync_restart_cancelled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_reason", ["cancelled_by_user", "suppressed_by_hook"])
+async def test_claimed_approval_non_interruption_uses_ordinary_settlement(
+    tmp_path: Path,
+    failure_reason: str,
+) -> None:
+    """User stops and hook suppression must not be relabeled as interruptions."""
     runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
     continuation = MagicMock(spec=ApprovalContinuation)
     settle_failure = AsyncMock()
@@ -1240,7 +1291,7 @@ async def test_claimed_approval_user_stop_keeps_user_stop_settlement(tmp_path: P
     outcome = FinalDeliveryOutcome(
         terminal_status="cancelled",
         event_id="$waiting",
-        failure_reason="cancelled_by_user",
+        failure_reason=failure_reason,
         is_visible_response=True,
     )
 
@@ -1250,7 +1301,7 @@ async def test_claimed_approval_user_stop_keeps_user_stop_settlement(tmp_path: P
     ):
         await runner._settle_failed_approval_outcome(continuation, outcome)
 
-    settle_failure.assert_awaited_once_with(continuation, "cancelled_by_user")
+    settle_failure.assert_awaited_once_with(continuation, failure_reason)
     restart_recovery.assert_not_awaited()
 
 

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -69,7 +69,7 @@ from mindroom.handled_turns import TurnRecord
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.logging_config import get_logger
 from mindroom.matrix.client import DeliveredMatrixEvent
-from mindroom.matrix.client_visible_messages import fetch_latest_bundled_edit_body
+from mindroom.matrix.client_visible_messages import fetch_latest_visible_body
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.thread_history_result import ThreadHistoryResult
 from mindroom.message_target import MessageTarget, ResponseLifecycleKey
@@ -1207,7 +1207,7 @@ async def test_stale_claim_recovery_preserves_visible_partial_reply(tmp_path: Pa
     with (
         patch.object(DeliveryGateway, "edit_text", new=edit_text),
         patch(
-            "mindroom.response_runner.fetch_latest_bundled_edit_body",
+            "mindroom.response_runner.fetch_latest_visible_body",
             new=AsyncMock(return_value="committed partial"),
         ),
         patch(
@@ -1255,11 +1255,153 @@ async def test_claimed_approval_user_stop_keeps_user_stop_settlement(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_claimed_approval_generic_interruption_keeps_generic_marker(tmp_path: Path) -> None:
+    """A generic cancellation preserves its provenance instead of claiming a restart."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    store = runner.deps.approval_store
+    await _admit_approval_source(store)
+    continuation = ApprovalContinuation(
+        approval_id="approval-interrupted",
+        run_id="run-1",
+        session_id="session-1",
+        entity_kind="agent",
+        entity_name="general",
+        room_id="!room:localhost",
+        thread_id="$thread",
+        requester_id="@user:localhost",
+        response_event_id="$waiting",
+        source_event_ids=("$source",),
+        calls=(),
+        state="ready",
+    )
+    assert await store.create_approval_continuation(continuation) == continuation
+    claimed = await store.claim_approval_continuation(
+        continuation.approval_id,
+        runtime_generation="current-runtime",
+    )
+    assert claimed is not None
+
+    async def acknowledge_interruption_edit(request: EditTextRequest) -> bool:
+        await store.enqueue_matrix_delivery(
+            delivery_id="$source",
+            stage=DeliveryStage.FINAL,
+            room_id="!room:localhost",
+            thread_id="$thread",
+            payload={"body": request.new_text},
+            edits_event_id="$waiting",
+        )
+        assert await store.claim_matrix_delivery(delivery_id="$source", stage=DeliveryStage.FINAL) is not None
+        await store.acknowledge_matrix_delivery(
+            delivery_id="$source",
+            stage=DeliveryStage.FINAL,
+            event_id="$waiting",
+            delivered_projections=(),
+        )
+        return True
+
+    edit_text = AsyncMock(side_effect=acknowledge_interruption_edit)
+    outcome = FinalDeliveryOutcome(
+        terminal_status="cancelled",
+        event_id="$waiting",
+        failure_reason="interrupted",
+        is_visible_response=True,
+    )
+
+    fetch_body = AsyncMock(side_effect=[None, "committed partial"])
+    with (
+        patch.object(DeliveryGateway, "edit_text", new=edit_text),
+        patch(
+            "mindroom.response_runner.fetch_latest_visible_body",
+            new=fetch_body,
+        ),
+        patch(
+            "mindroom.approval_response.approval_manager.get_approval_store",
+            return_value=MagicMock(cards=None, expire_continuation_cards=AsyncMock(return_value=True)),
+        ),
+    ):
+        await runner._settle_failed_approval_outcome(claimed, outcome)
+        failing = await store.approval_continuation(continuation.approval_id)
+        assert failing is not None
+        handled, event_id = await runner._recover_nonready_approval(
+            failing,
+            target=_target(thread_id="$thread", reply_to_event_id="$source"),
+        )
+
+    assert handled
+    assert event_id == "$waiting"
+    assert fetch_body.await_count == 2
+    edit_request = edit_text.await_args.args[0]
+    assert edit_request.new_text == f"committed partial\n\n{INTERRUPTED_RESPONSE_NOTE}"
+    assert edit_request.extra_content == {STREAM_STATUS_KEY: STREAM_STATUS_ERROR}
+
+
+def _visible_event_response(*, sender: str, body: str) -> nio.RoomGetEventResponse:
+    """Return one complete visible Matrix event response."""
+    response = nio.RoomGetEventResponse.from_dict(
+        {
+            "event_id": "$waiting",
+            "sender": sender,
+            "origin_server_ts": 1_000,
+            "type": "m.room.message",
+            "content": {"msgtype": "m.text", "body": body},
+        },
+    )
+    assert isinstance(response, nio.RoomGetEventResponse)
+    return response
+
+
+def _encrypted_event(*, sender: str, event_id: str = "$edit") -> nio.MegolmEvent:
+    """Return one encrypted Matrix event."""
+    event = nio.MegolmEvent.from_dict(
+        {
+            "event_id": event_id,
+            "sender": sender,
+            "origin_server_ts": 2_000,
+            "type": "m.room.encrypted",
+            "content": {
+                "algorithm": "m.megolm.v1.aes-sha2",
+                "ciphertext": "ciphertext",
+                "device_id": "DEVICE",
+                "sender_key": "sender-key",
+                "session_id": "session",
+            },
+        },
+    )
+    assert isinstance(event, nio.MegolmEvent)
+    return event
+
+
+def _decrypted_edit(*, sender: str) -> nio.RoomMessage:
+    """Return the visible edit corresponding to `_encrypted_event`."""
+    event = nio.Event.parse_event(
+        {
+            "event_id": "$edit",
+            "sender": sender,
+            "origin_server_ts": 2_000,
+            "type": "m.room.message",
+            "content": {
+                "msgtype": "m.text",
+                "body": "latest partial",
+                "m.new_content": {"msgtype": "m.text", "body": "latest partial"},
+                "m.relates_to": {"rel_type": "m.replace", "event_id": "$waiting"},
+            },
+        },
+    )
+    assert isinstance(event, nio.RoomMessage)
+    return event
+
+
+async def _relations(*events: nio.Event) -> AsyncIterator[nio.Event]:
+    """Yield relation fixtures in server order."""
+    for event in events:
+        yield event
+
+
+@pytest.mark.asyncio
 async def test_restart_recovery_does_not_fall_back_from_unreadable_latest_edit(tmp_path: Path) -> None:
     """An unreadable authoritative edit is retryable, not permission to use stale text."""
     runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
-    response = nio.RoomGetEventResponse()
-    response.event = MagicMock(source={})
+    response = _visible_event_response(sender=runner.deps.matrix_full_id, body="original partial")
     client = runner._client()
     client.room_get_event = AsyncMock(return_value=response)
     extract_body = AsyncMock(side_effect=[(None, None), ("older partial", {})])
@@ -1271,7 +1413,7 @@ async def test_restart_recovery_does_not_fall_back_from_unreadable_latest_edit(t
         ),
         patch("mindroom.matrix.client_visible_messages.extract_visible_edit_body", new=extract_body),
     ):
-        update = await fetch_latest_bundled_edit_body(
+        update = await fetch_latest_visible_body(
             client,
             room_id="!room:localhost",
             event_id="$waiting",
@@ -1284,21 +1426,71 @@ async def test_restart_recovery_does_not_fall_back_from_unreadable_latest_edit(t
 
 
 @pytest.mark.asyncio
-async def test_restart_recovery_uses_original_body_when_no_edit_exists(tmp_path: Path) -> None:
-    """A verified unedited response still has an authoritative visible body."""
+@pytest.mark.parametrize(
+    ("decryptable", "expected_body"),
+    [(True, "latest partial"), (False, None)],
+    ids=("decrypted", "unreadable"),
+)
+async def test_restart_recovery_uses_only_decryptable_latest_relation(
+    tmp_path: Path,
+    *,
+    decryptable: bool,
+    expected_body: str | None,
+) -> None:
+    """A missing bundle resolves its encrypted relation without stale fallback."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    sender = runner.deps.matrix_full_id
+    client = runner._client()
+    client.room_get_event = AsyncMock(return_value=_visible_event_response(sender=sender, body="original partial"))
+    client.room_get_event_relations = MagicMock(return_value=_relations(_encrypted_event(sender=sender)))
+    client.olm = MagicMock()
+    client.decrypt_event = (
+        MagicMock(return_value=_decrypted_edit(sender=sender))
+        if decryptable
+        else MagicMock(side_effect=nio.EncryptionError("missing session"))
+    )
+
+    body = await fetch_latest_visible_body(
+        client,
+        room_id="!room:localhost",
+        event_id="$waiting",
+        config=runner.deps.runtime.config,
+        runtime_paths=runner.deps.runtime_paths,
+    )
+
+    assert body == expected_body
+
+
+@pytest.mark.asyncio
+async def test_restart_recovery_retries_when_original_cannot_decrypt(tmp_path: Path) -> None:
+    """An undecryptable original event cannot become a marker-only replacement."""
     runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
     response = nio.RoomGetEventResponse()
-    response.event = MagicMock(
-        source={
-            "type": "m.room.message",
-            "sender": runner.deps.matrix_full_id,
-            "content": {"msgtype": "m.text", "body": "original partial"},
-        },
-    )
+    response.event = _encrypted_event(sender=runner.deps.matrix_full_id, event_id="$waiting")
     client = runner._client()
     client.room_get_event = AsyncMock(return_value=response)
 
-    body = await fetch_latest_bundled_edit_body(
+    body = await fetch_latest_visible_body(
+        client,
+        room_id="!room:localhost",
+        event_id="$waiting",
+        config=runner.deps.runtime.config,
+        runtime_paths=runner.deps.runtime_paths,
+    )
+
+    assert body is None
+
+
+@pytest.mark.asyncio
+async def test_restart_recovery_uses_original_body_when_no_edit_exists(tmp_path: Path) -> None:
+    """A verified unedited response still has an authoritative visible body."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    client = runner._client()
+    client.room_get_event = AsyncMock(
+        return_value=_visible_event_response(sender=runner.deps.matrix_full_id, body="original partial"),
+    )
+
+    body = await fetch_latest_visible_body(
         client,
         room_id="!room:localhost",
         event_id="$waiting",

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1284,6 +1284,32 @@ async def test_restart_recovery_does_not_fall_back_from_unreadable_latest_edit(t
 
 
 @pytest.mark.asyncio
+async def test_restart_recovery_uses_original_body_when_no_edit_exists(tmp_path: Path) -> None:
+    """A verified unedited response still has an authoritative visible body."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    response = nio.RoomGetEventResponse()
+    response.event = MagicMock(
+        source={
+            "type": "m.room.message",
+            "sender": runner.deps.matrix_full_id,
+            "content": {"msgtype": "m.text", "body": "original partial"},
+        },
+    )
+    client = runner._client()
+    client.room_get_event = AsyncMock(return_value=response)
+
+    body = await fetch_latest_bundled_edit_body(
+        client,
+        room_id="!room:localhost",
+        event_id="$waiting",
+        config=runner.deps.runtime.config,
+        runtime_paths=runner.deps.runtime_paths,
+    )
+
+    assert body == "original partial"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("cancelled", [False, True], ids=("error", "cancellation"))
 async def test_final_recovery_error_fences_current_claim(tmp_path: Path, *, cancelled: bool) -> None:
     """A failed outbox read cannot hide a same-runtime claim until restart."""

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1442,6 +1442,30 @@ def _decrypted_edit(*, sender: str, target_event_id: str = "$waiting") -> nio.Ro
     return event
 
 
+def _sidecar_preview_content() -> dict[str, Any]:
+    """Return one unresolved v2 long-text preview."""
+    return {
+        "msgtype": "m.file",
+        "body": "Preview partial...",
+        "info": {"mimetype": "application/json"},
+        "io.mindroom.long_text": {
+            "version": 2,
+            "encoding": "matrix_event_content_json",
+        },
+        "url": "mxc://server/recovery-sidecar",
+    }
+
+
+def _sidecar_edit(*, sender: str) -> nio.RoomMessage:
+    """Return one replacement whose full body lives in a v2 sidecar."""
+    source = _decrypted_edit(sender=sender).source
+    source["content"]["body"] = "* Preview partial..."
+    source["content"]["m.new_content"] = _sidecar_preview_content()
+    event = nio.Event.parse_event(source)
+    assert isinstance(event, nio.RoomMessage)
+    return event
+
+
 async def _relations(*events: nio.Event) -> AsyncIterator[nio.Event]:
     """Yield relation fixtures in server order."""
     for event in events:
@@ -1620,6 +1644,89 @@ async def test_restart_recovery_uses_original_body_when_no_edit_exists(tmp_path:
     )
 
     assert body == "original partial"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("source_kind", ["original", "bundled", "relation"])
+async def test_restart_recovery_waits_for_unresolved_long_text(
+    tmp_path: Path,
+    source_kind: str,
+) -> None:
+    """A failed sidecar fetch cannot replace the committed full response with its preview."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    sender = runner.deps.matrix_full_id
+    response = _visible_event_response(sender=sender, body="original partial")
+    replacement = _sidecar_edit(sender=sender)
+    relations: tuple[nio.Event, ...] = ()
+    if source_kind == "original":
+        response = nio.RoomGetEventResponse.from_dict(
+            {
+                "event_id": "$waiting",
+                "sender": sender,
+                "origin_server_ts": 1_000,
+                "type": "m.room.message",
+                "content": _sidecar_preview_content(),
+            },
+        )
+        assert isinstance(response, nio.RoomGetEventResponse)
+    elif source_kind == "bundled":
+        response.event.source["unsigned"] = {
+            "m.relations": {"m.replace": {"latest_event": replacement.source}},
+        }
+    else:
+        relations = (replacement,)
+    client = runner._client()
+    client.room_get_event = AsyncMock(return_value=response)
+    client.room_get_event_relations = MagicMock(return_value=_relations(*relations))
+    client.download = AsyncMock(return_value=nio.DownloadError("missing"))
+
+    body = await fetch_latest_visible_body(
+        client,
+        room_id="!room:localhost",
+        event_id="$waiting",
+        config=runner.deps.runtime.config,
+        runtime_paths=runner.deps.runtime_paths,
+    )
+
+    assert body is None
+
+
+@pytest.mark.asyncio
+async def test_restart_recovery_skips_redacted_replacement(tmp_path: Path) -> None:
+    """A redacted latest edit cannot permanently hide an older visible edit."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    sender = runner.deps.matrix_full_id
+    redacted = nio.Event.parse_event(
+        {
+            "event_id": "$redacted-edit",
+            "sender": sender,
+            "origin_server_ts": 3_000,
+            "type": "m.room.message",
+            "content": {},
+            "unsigned": {
+                "redacted_because": {
+                    "sender": "@moderator:localhost",
+                    "content": {},
+                },
+            },
+        },
+    )
+    assert isinstance(redacted, nio.RedactedEvent)
+    client = runner._client()
+    client.room_get_event = AsyncMock(return_value=_visible_event_response(sender=sender, body="original partial"))
+    client.room_get_event_relations = MagicMock(
+        return_value=_relations(redacted, _decrypted_edit(sender=sender)),
+    )
+
+    body = await fetch_latest_visible_body(
+        client,
+        room_id="!room:localhost",
+        event_id="$waiting",
+        config=runner.deps.runtime.config,
+        runtime_paths=runner.deps.runtime_paths,
+    )
+
+    assert body == "latest partial"
 
 
 @pytest.mark.asyncio

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -1371,7 +1371,7 @@ def _encrypted_event(*, sender: str, event_id: str = "$edit") -> nio.MegolmEvent
     return event
 
 
-def _decrypted_edit(*, sender: str) -> nio.RoomMessage:
+def _decrypted_edit(*, sender: str, target_event_id: str = "$waiting") -> nio.RoomMessage:
     """Return the visible edit corresponding to `_encrypted_event`."""
     event = nio.Event.parse_event(
         {
@@ -1383,7 +1383,7 @@ def _decrypted_edit(*, sender: str) -> nio.RoomMessage:
                 "msgtype": "m.text",
                 "body": "latest partial",
                 "m.new_content": {"msgtype": "m.text", "body": "latest partial"},
-                "m.relates_to": {"rel_type": "m.replace", "event_id": "$waiting"},
+                "m.relates_to": {"rel_type": "m.replace", "event_id": target_event_id},
             },
         },
     )
@@ -1401,15 +1401,17 @@ async def _relations(*events: nio.Event) -> AsyncIterator[nio.Event]:
 async def test_restart_recovery_does_not_fall_back_from_unreadable_latest_edit(tmp_path: Path) -> None:
     """An unreadable authoritative edit is retryable, not permission to use stale text."""
     runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
-    response = _visible_event_response(sender=runner.deps.matrix_full_id, body="original partial")
+    sender = runner.deps.matrix_full_id
+    response = _visible_event_response(sender=sender, body="original partial")
     client = runner._client()
     client.room_get_event = AsyncMock(return_value=response)
     extract_body = AsyncMock(side_effect=[(None, None), ("older partial", {})])
+    replacement = _decrypted_edit(sender=sender).source
 
     with (
         patch(
             "mindroom.matrix.client_visible_messages.bundled_replacement_candidates",
-            return_value=[{"new": 1}, {"old": 1}],
+            return_value=[replacement, replacement],
         ),
         patch("mindroom.matrix.client_visible_messages.extract_visible_edit_body", new=extract_body),
     ):
@@ -1423,6 +1425,74 @@ async def test_restart_recovery_does_not_fall_back_from_unreadable_latest_edit(t
 
     assert update is None
     assert extract_body.await_count == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("replacement_sender", "target_event_id"),
+    [
+        ("@other:localhost", "$waiting"),
+        (None, "$other"),
+    ],
+    ids=("foreign-sender", "wrong-target"),
+)
+async def test_restart_recovery_ignores_unrelated_bundled_replacement(
+    tmp_path: Path,
+    *,
+    replacement_sender: str | None,
+    target_event_id: str,
+) -> None:
+    """A bundled edit cannot replace a different sender's event or target."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    sender = runner.deps.matrix_full_id
+    response = _visible_event_response(sender=sender, body="original partial")
+    response.event.source["unsigned"] = {
+        "m.relations": {
+            "m.replace": {
+                "latest_event": _decrypted_edit(
+                    sender=replacement_sender or sender,
+                    target_event_id=target_event_id,
+                ).source,
+            },
+        },
+    }
+    client = runner._client()
+    client.room_get_event = AsyncMock(return_value=response)
+    client.room_get_event_relations = MagicMock(return_value=_relations())
+
+    body = await fetch_latest_visible_body(
+        client,
+        room_id="!room:localhost",
+        event_id="$waiting",
+        config=runner.deps.runtime.config,
+        runtime_paths=runner.deps.runtime_paths,
+    )
+
+    assert body == "original partial"
+
+
+@pytest.mark.asyncio
+async def test_restart_recovery_ignores_unreadable_foreign_relation(tmp_path: Path) -> None:
+    """An unreadable relation from another sender cannot block the original body."""
+    runner = unwrap_extracted_collaborator(_bot(tmp_path)._response_runner)
+    sender = runner.deps.matrix_full_id
+    client = runner._client()
+    client.room_get_event = AsyncMock(return_value=_visible_event_response(sender=sender, body="original partial"))
+    client.room_get_event_relations = MagicMock(
+        return_value=_relations(_encrypted_event(sender="@other:localhost")),
+    )
+    client.olm = MagicMock()
+    client.decrypt_event = MagicMock(side_effect=nio.EncryptionError("missing session"))
+
+    body = await fetch_latest_visible_body(
+        client,
+        room_id="!room:localhost",
+        event_id="$waiting",
+        config=runner.deps.runtime.config,
+        runtime_paths=runner.deps.runtime_paths,
+    )
+
+    assert body == "original partial"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- preserve the latest committed partial response when an approval continuation is interrupted
- append the existing restart marker through durable final delivery instead of replacing visible text
- retain explicit user-cancellation behavior and retry when the latest edit cannot be read safely

## Regression cause

This regressed in #1807, when approval continuations moved to durable lifecycle ownership. During restart recovery, a claimed continuation without an acknowledged final delivery was routed through `ApprovalResponseCoordinator.settle_failure`. That method used the interruption reason as the entire replacement body, so it overwrote any text already committed by the stream.

The earlier generic stale-stream recovery preserved the existing body and appended a restart marker. Once the approval journal became the durable owner of these responses, that generic path no longer handled this case, exposing the overwrite behavior.

This change keeps the durable ownership model but reads the authoritative latest edit, appends the existing marker, and delivers that combined body through the durable final-delivery path. If the latest edit cannot be read safely, recovery remains pending instead of falling back to older visible text.

## Testing

- `uv run pytest -q`
- `uv run pre-commit run --files tach.toml src/mindroom/approval_response.py src/mindroom/matrix/client_visible_messages.py src/mindroom/response_runner.py tests/test_response_runner_focused.py`

## Summary by Sourcery

Preserve committed approval response text during interruption recovery while failing closed when the authoritative Matrix content cannot be safely resolved.

Bug Fixes:
- Preserve the latest committed partial approval response when restart or interruption recovery completes a failed continuation.
- Retry recovery when the authoritative Matrix response or edit cannot be read safely instead of overwriting it with stale or marker-only text.
- Keep explicit user cancellation and hook suppression behavior distinct from restart interruptions.

Enhancements:
- Route interrupted approval recovery through durable final delivery while retaining the existing visible response and appending the appropriate interruption marker.
- Validate replacement ownership, decryption, redaction, and long-text sidecar resolution when determining the authoritative visible response body.

Tests:
- Add regression coverage for partial-response preservation, cancellation provenance, unreadable or unrelated edits, encrypted relations, redactions, and unresolved long-text sidecars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery when approved responses are interrupted, cancelled, or fail during delivery.
  - Preserves displayed reply text and adds the appropriate interruption notice only when needed.
  - Safely validates message edits, including encrypted or unreadable updates, and prevents invalid replacements from being shown.
  - Falls back to the original message content when no valid replacement is available.
  - Reports interrupted approval failures with the correct error status.

- **Tests**
  - Added coverage for interruption recovery, cancellation sources, encrypted edits, invalid replacements, and message-content fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->