### PR TITLE
Keep routine logs content-safe

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import logging
 from collections.abc import Mapping
 from contextlib import aclosing
 from copy import deepcopy
@@ -124,7 +123,6 @@ if TYPE_CHECKING:
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 logger = get_logger(__name__)
-_stdlib_logger = logging.getLogger(__name__)
 
 __all__ = [
     "AIStreamChunk",
@@ -1280,12 +1278,11 @@ async def _prepare_agent_and_prompt(
         message_count=len(run_messages),
         unseen_event_count=len(unseen_event_ids),
     )
-    if _stdlib_logger.isEnabledFor(logging.DEBUG):
-        logger.debug(
-            "Prepared agent full prompt",
-            agent=agent_name,
-            full_prompt=render_prepared_messages_text(run_messages),
-        )
+    logger.debug(
+        "Prepared agent full prompt",
+        agent=agent_name,
+        full_prompt=render_prepared_messages_text(run_messages),
+    )
     return _PreparedAgentRun(
         agent=agent,
         messages=run_messages,

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Mapping
 from contextlib import aclosing
 from copy import deepcopy
@@ -123,6 +124,7 @@ if TYPE_CHECKING:
     from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 
 logger = get_logger(__name__)
+_stdlib_logger = logging.getLogger(__name__)
 
 __all__ = [
     "AIStreamChunk",
@@ -1271,13 +1273,19 @@ async def _prepare_agent_and_prompt(
     unseen_event_ids = prepared_execution.unseen_event_ids
     run_messages = prepared_execution.messages
 
-    # Routine logs stay content-safe; full request text belongs only in opt-in request logging.
+    # Routine logs stay content-safe; detailed prompt text is emitted separately only at DEBUG.
     logger.info(
         "Preparing agent and prompt",
         agent=agent_name,
         message_count=len(run_messages),
         unseen_event_count=len(unseen_event_ids),
     )
+    if _stdlib_logger.isEnabledFor(logging.DEBUG):
+        logger.debug(
+            "Prepared agent full prompt",
+            agent=agent_name,
+            full_prompt=render_prepared_messages_text(run_messages),
+        )
     return _PreparedAgentRun(
         agent=agent,
         messages=run_messages,

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1271,10 +1271,12 @@ async def _prepare_agent_and_prompt(
     unseen_event_ids = prepared_execution.unseen_event_ids
     run_messages = prepared_execution.messages
 
+    # Routine logs stay content-safe; full request text belongs only in opt-in request logging.
     logger.info(
         "Preparing agent and prompt",
         agent=agent_name,
-        full_prompt=render_prepared_messages_text(run_messages),
+        message_count=len(run_messages),
+        unseen_event_count=len(unseen_event_ids),
     )
     return _PreparedAgentRun(
         agent=agent,

--- a/src/mindroom/tool_system/output_files.py
+++ b/src/mindroom/tool_system/output_files.py
@@ -743,7 +743,7 @@ def wrap_function_for_output_files(function: Function, policy: ToolOutputFilePol
     if function.entrypoint is None or getattr(function.entrypoint, _WRAPPED_ATTR, False):
         return function
     if _has_output_path_argument(function):
-        logger.warning(
+        logger.debug(
             "tool_output_path_argument_collision",
             function_name=function.name,
             argument_name=OUTPUT_PATH_ARGUMENT,

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -31,6 +31,7 @@ from agno.run.agent import (
 from agno.run.base import RunStatus
 from agno.run.requirement import RunRequirement
 from agno.tools.function import Function
+from structlog.testing import capture_logs
 
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.ai import (
@@ -705,6 +706,55 @@ class TestUserIdPassthrough:
         assert prepared_history.replay_plan.mode == "configured"
         assert "runtime_paths" not in mock_create_agent.call_args.kwargs
         assert mock_create_agent.call_args.kwargs["supports_native_tool_approval"] is True
+
+    @pytest.mark.asyncio
+    async def test_prepare_agent_and_prompt_logs_only_safe_metadata(self, tmp_path: Path) -> None:
+        """Routine preparation logs must not include prepared message contents."""
+        sensitive_marker = "sensitive prompt marker"
+        config = _config()
+        runtime_paths = _runtime_paths(tmp_path)
+        persist_entity_accounts(config, runtime_paths)
+        mock_agent = MagicMock()
+        prepared_execution = _PreparedExecutionContext(
+            messages=(
+                Message(role="system", content=sensitive_marker),
+                Message(role="user", content="current request"),
+            ),
+            unseen_event_ids=["event-one", "event-two"],
+            prepared_history=PreparedHistoryState(),
+        )
+
+        with (
+            patch(
+                "mindroom.ai.build_memory_prompt_parts",
+                new_callable=AsyncMock,
+                return_value=MemoryPromptParts(),
+            ),
+            patch("mindroom.ai.create_agent", return_value=mock_agent),
+            patch(
+                "mindroom.ai.prepare_agent_execution_context",
+                new=AsyncMock(return_value=prepared_execution),
+            ),
+            capture_logs() as logs,
+        ):
+            await _prepare_agent_and_prompt(
+                make_turn_context("general"),
+                prompt="current request",
+                runtime_paths=runtime_paths,
+                config=config,
+            )
+
+        preparation_logs = [log for log in logs if log.get("event") == "Preparing agent and prompt"]
+        assert preparation_logs == [
+            {
+                "agent": "general",
+                "event": "Preparing agent and prompt",
+                "log_level": "info",
+                "message_count": 2,
+                "unseen_event_count": 2,
+            },
+        ]
+        assert sensitive_marker not in repr(logs)
 
     @pytest.mark.asyncio
     async def test_prepare_agent_and_prompt_uses_raw_prompt_for_memory_and_appends_additional_context(

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 from contextvars import Context
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -708,8 +709,12 @@ class TestUserIdPassthrough:
         assert mock_create_agent.call_args.kwargs["supports_native_tool_approval"] is True
 
     @pytest.mark.asyncio
-    async def test_prepare_agent_and_prompt_logs_only_safe_metadata(self, tmp_path: Path) -> None:
-        """Routine preparation logs must not include prepared message contents."""
+    async def test_prepare_agent_and_prompt_logs_full_prompt_only_at_debug(
+        self,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Routine logs stay content-safe while debug logs retain the prepared prompt."""
         sensitive_marker = "sensitive prompt marker"
         config = _config()
         runtime_paths = _runtime_paths(tmp_path)
@@ -724,37 +729,51 @@ class TestUserIdPassthrough:
             prepared_history=PreparedHistoryState(),
         )
 
-        with (
-            patch(
-                "mindroom.ai.build_memory_prompt_parts",
-                new_callable=AsyncMock,
-                return_value=MemoryPromptParts(),
-            ),
-            patch("mindroom.ai.create_agent", return_value=mock_agent),
-            patch(
-                "mindroom.ai.prepare_agent_execution_context",
-                new=AsyncMock(return_value=prepared_execution),
-            ),
-            capture_logs() as logs,
-        ):
-            await _prepare_agent_and_prompt(
-                make_turn_context("general"),
-                prompt="current request",
-                runtime_paths=runtime_paths,
-                config=config,
-            )
+        async def prepare_with_debug(*, enabled: bool) -> list[dict[str, object]]:
+            level = logging.DEBUG if enabled else logging.INFO
+            with (
+                caplog.at_level(level, logger="mindroom.ai"),
+                patch(
+                    "mindroom.ai.build_memory_prompt_parts",
+                    new_callable=AsyncMock,
+                    return_value=MemoryPromptParts(),
+                ),
+                patch("mindroom.ai.create_agent", return_value=mock_agent),
+                patch(
+                    "mindroom.ai.prepare_agent_execution_context",
+                    new=AsyncMock(return_value=prepared_execution),
+                ),
+                capture_logs() as logs,
+            ):
+                await _prepare_agent_and_prompt(
+                    make_turn_context("general"),
+                    prompt="current request",
+                    runtime_paths=runtime_paths,
+                    config=config,
+                )
+            return logs
 
-        preparation_logs = [log for log in logs if log.get("event") == "Preparing agent and prompt"]
-        assert preparation_logs == [
+        safe_log = {
+            "agent": "general",
+            "event": "Preparing agent and prompt",
+            "log_level": "info",
+            "message_count": 2,
+            "unseen_event_count": 2,
+        }
+        normal_logs = await prepare_with_debug(enabled=False)
+        assert normal_logs == [safe_log]
+        assert sensitive_marker not in repr(normal_logs)
+
+        debug_logs = await prepare_with_debug(enabled=True)
+        assert debug_logs == [
+            safe_log,
             {
                 "agent": "general",
-                "event": "Preparing agent and prompt",
-                "log_level": "info",
-                "message_count": 2,
-                "unseen_event_count": 2,
+                "event": "Prepared agent full prompt",
+                "full_prompt": "sensitive prompt marker\n\ncurrent request",
+                "log_level": "debug",
             },
         ]
-        assert sensitive_marker not in repr(logs)
 
     @pytest.mark.asyncio
     async def test_prepare_agent_and_prompt_uses_raw_prompt_for_memory_and_appends_additional_context(

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import logging
 from contextvars import Context
 from typing import TYPE_CHECKING, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -709,11 +708,7 @@ class TestUserIdPassthrough:
         assert mock_create_agent.call_args.kwargs["supports_native_tool_approval"] is True
 
     @pytest.mark.asyncio
-    async def test_prepare_agent_and_prompt_logs_full_prompt_only_at_debug(
-        self,
-        tmp_path: Path,
-        caplog: pytest.LogCaptureFixture,
-    ) -> None:
+    async def test_prepare_agent_and_prompt_logs_full_prompt_at_debug(self, tmp_path: Path) -> None:
         """Routine logs stay content-safe while debug logs retain the prepared prompt."""
         sensitive_marker = "sensitive prompt marker"
         config = _config()
@@ -729,29 +724,25 @@ class TestUserIdPassthrough:
             prepared_history=PreparedHistoryState(),
         )
 
-        async def prepare_with_debug(*, enabled: bool) -> list[dict[str, object]]:
-            level = logging.DEBUG if enabled else logging.INFO
-            with (
-                caplog.at_level(level, logger="mindroom.ai"),
-                patch(
-                    "mindroom.ai.build_memory_prompt_parts",
-                    new_callable=AsyncMock,
-                    return_value=MemoryPromptParts(),
-                ),
-                patch("mindroom.ai.create_agent", return_value=mock_agent),
-                patch(
-                    "mindroom.ai.prepare_agent_execution_context",
-                    new=AsyncMock(return_value=prepared_execution),
-                ),
-                capture_logs() as logs,
-            ):
-                await _prepare_agent_and_prompt(
-                    make_turn_context("general"),
-                    prompt="current request",
-                    runtime_paths=runtime_paths,
-                    config=config,
-                )
-            return logs
+        with (
+            patch(
+                "mindroom.ai.build_memory_prompt_parts",
+                new_callable=AsyncMock,
+                return_value=MemoryPromptParts(),
+            ),
+            patch("mindroom.ai.create_agent", return_value=mock_agent),
+            patch(
+                "mindroom.ai.prepare_agent_execution_context",
+                new=AsyncMock(return_value=prepared_execution),
+            ),
+            capture_logs() as logs,
+        ):
+            await _prepare_agent_and_prompt(
+                make_turn_context("general"),
+                prompt="current request",
+                runtime_paths=runtime_paths,
+                config=config,
+            )
 
         safe_log = {
             "agent": "general",
@@ -760,12 +751,7 @@ class TestUserIdPassthrough:
             "message_count": 2,
             "unseen_event_count": 2,
         }
-        normal_logs = await prepare_with_debug(enabled=False)
-        assert normal_logs == [safe_log]
-        assert sensitive_marker not in repr(normal_logs)
-
-        debug_logs = await prepare_with_debug(enabled=True)
-        assert debug_logs == [
+        assert logs == [
             safe_log,
             {
                 "agent": "general",

--- a/tests/test_tool_output_files.py
+++ b/tests/test_tool_output_files.py
@@ -15,6 +15,7 @@ from agno.models.openai.chat import OpenAIChat
 from agno.tools import Toolkit
 from agno.tools.function import Function, FunctionCall, ToolResult
 from pydantic import BaseModel
+from structlog.testing import capture_logs
 
 from mindroom.config.plugin import PluginEntryConfig
 from mindroom.constants import resolve_runtime_paths
@@ -348,15 +349,22 @@ def test_no_workspace_root_leaves_schema_unmodified() -> None:
     assert OUTPUT_PATH_ARGUMENT not in function.parameters["properties"]
 
 
-def test_function_with_existing_mindroom_output_path_is_skipped_with_warning(tmp_path: Path) -> None:
+def test_function_with_existing_mindroom_output_path_is_skipped_with_debug(tmp_path: Path) -> None:
     def existing(mindroom_output_path: str) -> str:
         return mindroom_output_path
 
     function = Function(name="existing", entrypoint=existing)
-    with patch("mindroom.tool_system.output_files.logger.warning") as warning:
+    with capture_logs() as logs:
         wrap_function_for_output_files(function, _policy(tmp_path))
 
-    warning.assert_called_once()
+    assert logs == [
+        {
+            "argument_name": OUTPUT_PATH_ARGUMENT,
+            "event": "tool_output_path_argument_collision",
+            "function_name": "existing",
+            "log_level": "debug",
+        },
+    ]
     result = FunctionCall(
         function=function,
         arguments={OUTPUT_PATH_ARGUMENT: "not-redirected"},


### PR DESCRIPTION
## Summary

- replace prepared message contents in routine info logs with message and unseen-event counts
- retain the complete prepared prompt in a debug event and let the logging configuration control emission
- log expected native output-path handling at debug level instead of warning
- add regressions for both logging contracts

## Tests

- `uv run pytest -q`
- `uv run pre-commit run --files src/mindroom/ai.py src/mindroom/tool_system/output_files.py tests/test_ai_user_id.py tests/test_tool_output_files.py`

## Summary by Sourcery

Make routine logging content-safe while preserving detailed diagnostics at debug level.

Bug Fixes:
- Keep routine agent-preparation logs content-safe by reporting message and unseen-event counts instead of prompt contents.

Enhancements:
- Retain the complete prepared prompt in a DEBUG-only log entry.
- Downgrade expected native output-path argument collisions from warnings to debug logs.

Tests:
- Add regressions covering content-safe routine logging, DEBUG prompt retention, and debug-level output-path collision logging.