### PR TITLE
Avoid blocking dynamic tool reads during validation

### DIFF
--- a/src/mindroom/tool_system/dynamic_toolkits.py
+++ b/src/mindroom/tool_system/dynamic_toolkits.py
@@ -35,7 +35,7 @@ class VisibleToolSurface:
 
 @dataclass(frozen=True)
 class LoadToolResult:
-    """Result of one locked dynamic-tool load attempt."""
+    """Result of one dynamic-tool load attempt."""
 
     status: str
     loaded_tools: tuple[str, ...]
@@ -479,6 +479,7 @@ def load_tool_for_session(
             candidate_loaded_tools = _ordered_deferred_tools(deferred_tool_names, [*loaded_tools, tool_name])
             state_snapshot = tuple(_loaded_tools[key]) if key in _loaded_tools else None
 
+        # Validation may be slow, so run it unlocked; retry if same-session state changes.
         validation_failure = (
             validate_loaded_tools(candidate_loaded_tools) if validate_loaded_tools is not None else None
         )

--- a/src/mindroom/tool_system/dynamic_toolkits.py
+++ b/src/mindroom/tool_system/dynamic_toolkits.py
@@ -395,6 +395,27 @@ def get_loaded_tools_for_session(
         return list(loaded_tools)
 
 
+def _load_validation_result(
+    validation_failure: LoadToolValidationFailure | None,
+    loaded_tools: list[str],
+) -> LoadToolResult | None:
+    if validation_failure is None:
+        return None
+    if validation_failure.status == "function_name_collision":
+        return LoadToolResult(
+            status="function_name_collision",
+            loaded_tools=tuple(loaded_tools),
+            collision_messages=tuple(sorted(validation_failure.messages)),
+        )
+    if validation_failure.status == "tool_unavailable":
+        return LoadToolResult(
+            status="tool_unavailable",
+            loaded_tools=tuple(loaded_tools),
+            unavailable_messages=tuple(sorted(validation_failure.messages)),
+        )
+    return None
+
+
 def load_tool_for_session(
     *,
     agent_name: str,
@@ -410,69 +431,73 @@ def load_tool_for_session(
         return LoadToolResult(status="error", loaded_tools=tuple(loaded_tools))
 
     key = _state_key(agent_name, session_id)
-    with _loaded_tools_lock:
-        raw_loaded_tools = _loaded_tools.get(key)
-        if raw_loaded_tools is None:
-            raw_loaded_tools = _initial_loaded_tools(config, agent_name)
-        else:
-            raw_loaded_tools = _coerce_loaded_tools(raw_loaded_tools)
-
-        loaded_tools, invalid_tools = _sanitize_loaded_tools_with_current_initials(config, agent_name, raw_loaded_tools)
-        if invalid_tools:
-            logger.warning(
-                "Dropping invalid dynamic tools from in-memory session state",
-                agent=agent_name,
-                session_id=session_id,
-                scope_key=key[1],
-                invalid_tools=invalid_tools,
-            )
-            save_loaded_tools_for_session(
-                agent_name=agent_name,
-                session_id=session_id,
-                loaded_tools=loaded_tools,
-                config=config,
-            )
-
-        if tool_name not in deferred_tool_names:
-            result = LoadToolResult(
-                status="unknown",
-                loaded_tools=tuple(loaded_tools),
-                available_tools=tuple(deferred_tool_names),
-            )
-        elif incompatible_tools := config.resolve_entity(agent_name).deferred_tool_scope_incompatible_tools(tool_name):
-            result = LoadToolResult(
-                status="scope_incompatible",
-                loaded_tools=tuple(loaded_tools),
-                unsupported_tools=tuple(incompatible_tools),
-            )
-        elif tool_name in loaded_tools:
-            result = LoadToolResult(status="already_loaded", loaded_tools=tuple(loaded_tools))
-        else:
-            candidate_loaded_tools = _ordered_deferred_tools(deferred_tool_names, [*loaded_tools, tool_name])
-            validation_failure = (
-                validate_loaded_tools(candidate_loaded_tools) if validate_loaded_tools is not None else None
-            )
-            if validation_failure is not None and validation_failure.status == "function_name_collision":
-                result = LoadToolResult(
-                    status="function_name_collision",
-                    loaded_tools=tuple(loaded_tools),
-                    collision_messages=tuple(sorted(validation_failure.messages)),
-                )
-            elif validation_failure is not None and validation_failure.status == "tool_unavailable":
-                result = LoadToolResult(
-                    status="tool_unavailable",
-                    loaded_tools=tuple(loaded_tools),
-                    unavailable_messages=tuple(sorted(validation_failure.messages)),
-                )
+    while True:
+        with _loaded_tools_lock:
+            raw_loaded_tools = _loaded_tools.get(key)
+            if raw_loaded_tools is None:
+                raw_loaded_tools = _initial_loaded_tools(config, agent_name)
             else:
+                raw_loaded_tools = _coerce_loaded_tools(raw_loaded_tools)
+
+            loaded_tools, invalid_tools = _sanitize_loaded_tools_with_current_initials(
+                config,
+                agent_name,
+                raw_loaded_tools,
+            )
+            if invalid_tools:
+                logger.warning(
+                    "Dropping invalid dynamic tools from in-memory session state",
+                    agent=agent_name,
+                    session_id=session_id,
+                    scope_key=key[1],
+                    invalid_tools=invalid_tools,
+                )
                 save_loaded_tools_for_session(
                     agent_name=agent_name,
                     session_id=session_id,
-                    loaded_tools=candidate_loaded_tools,
+                    loaded_tools=loaded_tools,
                     config=config,
                 )
-                result = LoadToolResult(status="loaded", loaded_tools=tuple(candidate_loaded_tools))
-        return result
+
+            if tool_name not in deferred_tool_names:
+                return LoadToolResult(
+                    status="unknown",
+                    loaded_tools=tuple(loaded_tools),
+                    available_tools=tuple(deferred_tool_names),
+                )
+            if incompatible_tools := config.resolve_entity(agent_name).deferred_tool_scope_incompatible_tools(
+                tool_name,
+            ):
+                return LoadToolResult(
+                    status="scope_incompatible",
+                    loaded_tools=tuple(loaded_tools),
+                    unsupported_tools=tuple(incompatible_tools),
+                )
+            if tool_name in loaded_tools:
+                return LoadToolResult(status="already_loaded", loaded_tools=tuple(loaded_tools))
+
+            candidate_loaded_tools = _ordered_deferred_tools(deferred_tool_names, [*loaded_tools, tool_name])
+            state_snapshot = tuple(_loaded_tools[key]) if key in _loaded_tools else None
+
+        validation_failure = (
+            validate_loaded_tools(candidate_loaded_tools) if validate_loaded_tools is not None else None
+        )
+
+        with _loaded_tools_lock:
+            current_state = tuple(_loaded_tools[key]) if key in _loaded_tools else None
+            if current_state != state_snapshot:
+                continue
+
+            if validation_result := _load_validation_result(validation_failure, loaded_tools):
+                return validation_result
+
+            save_loaded_tools_for_session(
+                agent_name=agent_name,
+                session_id=session_id,
+                loaded_tools=candidate_loaded_tools,
+                config=config,
+            )
+            return LoadToolResult(status="loaded", loaded_tools=tuple(candidate_loaded_tools))
 
 
 def unload_tool_for_session(

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -978,7 +978,7 @@ def test_blocked_load_validation_does_not_block_visible_tool_surface(tmp_path: P
 
     def blocked_validator(_loaded_tools: list[str]) -> None:
         validation_started.set()
-        assert continue_validation.wait(timeout=5)
+        assert continue_validation.wait(timeout=30)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         load_future = executor.submit(
@@ -989,7 +989,7 @@ def test_blocked_load_validation_does_not_block_visible_tool_surface(tmp_path: P
             tool_name="shell",
             validate_loaded_tools=blocked_validator,
         )
-        assert validation_started.wait(timeout=5)
+        assert validation_started.wait(timeout=10)
         try:
             surface_future = executor.submit(
                 visible_tool_surface,
@@ -997,11 +997,11 @@ def test_blocked_load_validation_does_not_block_visible_tool_surface(tmp_path: P
                 config=config,
                 session_id="thread-a",
             )
-            surface = surface_future.result(timeout=1)
+            surface = surface_future.result(timeout=10)
         finally:
             continue_validation.set()
 
-        result = load_future.result(timeout=5)
+        result = load_future.result(timeout=30)
 
     assert surface.loaded_tools == ()
     assert result.status == "loaded"
@@ -1024,7 +1024,7 @@ def test_load_revalidates_after_concurrent_session_mutation(tmp_path: Path) -> N
         validated_candidates.append(candidate)
         if candidate == ("shell",) and not continue_first_validation.is_set():
             first_validation_started.set()
-            assert continue_first_validation.wait(timeout=5)
+            assert continue_first_validation.wait(timeout=30)
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         shell_future = executor.submit(
@@ -1035,7 +1035,7 @@ def test_load_revalidates_after_concurrent_session_mutation(tmp_path: Path) -> N
             tool_name="shell",
             validate_loaded_tools=validator,
         )
-        assert first_validation_started.wait(timeout=5)
+        assert first_validation_started.wait(timeout=10)
         try:
             sleep_future = executor.submit(
                 load_tool_for_session,
@@ -1045,11 +1045,11 @@ def test_load_revalidates_after_concurrent_session_mutation(tmp_path: Path) -> N
                 tool_name="sleep",
                 validate_loaded_tools=validator,
             )
-            sleep_result = sleep_future.result(timeout=1)
+            sleep_result = sleep_future.result(timeout=10)
         finally:
             continue_first_validation.set()
 
-        shell_result = shell_future.result(timeout=5)
+        shell_result = shell_future.result(timeout=30)
 
     assert shell_result.status == "loaded"
     assert sleep_result.status == "loaded"

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from concurrent.futures import ThreadPoolExecutor
-from threading import Barrier
+from threading import Barrier, Event
 from typing import TYPE_CHECKING
 
 import pytest
@@ -41,6 +41,7 @@ from mindroom.response_runner import _agent_has_matrix_messaging_tool
 from mindroom.tool_system import dynamic_toolkits as dynamic_toolkits_module
 from mindroom.tool_system.dynamic_toolkits import (
     get_loaded_tools_for_session,
+    load_tool_for_session,
     save_loaded_tools_for_session,
     suppress_fully_deferred_toolkit_instructions,
     visible_tool_surface,
@@ -965,6 +966,98 @@ def test_dynamic_tools_manager_concurrent_load_collision_uses_latest_state(tmp_p
         ["mcp_demo"],
         ["shell"],
     )
+
+
+def test_blocked_load_validation_does_not_block_visible_tool_surface(tmp_path: Path) -> None:
+    """Reading visible tools should not wait for an in-progress load validation."""
+    raw = _base_config_data()
+    raw["agents"]["code"]["tools"] = [{"shell": {"defer": True}}]  # type: ignore[index]
+    config = _validated_config(tmp_path, raw)
+    validation_started = Event()
+    continue_validation = Event()
+
+    def blocked_validator(_loaded_tools: list[str]) -> None:
+        validation_started.set()
+        assert continue_validation.wait(timeout=5)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        load_future = executor.submit(
+            load_tool_for_session,
+            agent_name="code",
+            config=config,
+            session_id="thread-a",
+            tool_name="shell",
+            validate_loaded_tools=blocked_validator,
+        )
+        assert validation_started.wait(timeout=5)
+        try:
+            surface_future = executor.submit(
+                visible_tool_surface,
+                agent_name="code",
+                config=config,
+                session_id="thread-a",
+            )
+            surface = surface_future.result(timeout=1)
+        finally:
+            continue_validation.set()
+
+        result = load_future.result(timeout=5)
+
+    assert surface.loaded_tools == ()
+    assert result.status == "loaded"
+
+
+def test_load_revalidates_after_concurrent_session_mutation(tmp_path: Path) -> None:
+    """A load should merge with state committed while its first validation is blocked."""
+    raw = _base_config_data()
+    raw["agents"]["code"]["tools"] = [  # type: ignore[index]
+        {"shell": {"defer": True}},
+        {"sleep": {"defer": True}},
+    ]
+    config = _validated_config(tmp_path, raw)
+    first_validation_started = Event()
+    continue_first_validation = Event()
+    validated_candidates: list[tuple[str, ...]] = []
+
+    def validator(loaded_tools: list[str]) -> None:
+        candidate = tuple(loaded_tools)
+        validated_candidates.append(candidate)
+        if candidate == ("shell",) and not continue_first_validation.is_set():
+            first_validation_started.set()
+            assert continue_first_validation.wait(timeout=5)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        shell_future = executor.submit(
+            load_tool_for_session,
+            agent_name="code",
+            config=config,
+            session_id="thread-a",
+            tool_name="shell",
+            validate_loaded_tools=validator,
+        )
+        assert first_validation_started.wait(timeout=5)
+        try:
+            sleep_future = executor.submit(
+                load_tool_for_session,
+                agent_name="code",
+                config=config,
+                session_id="thread-a",
+                tool_name="sleep",
+                validate_loaded_tools=validator,
+            )
+            sleep_result = sleep_future.result(timeout=1)
+        finally:
+            continue_first_validation.set()
+
+        shell_result = shell_future.result(timeout=5)
+
+    assert shell_result.status == "loaded"
+    assert sleep_result.status == "loaded"
+    assert ("shell", "sleep") in validated_candidates
+    assert get_loaded_tools_for_session(agent_name="code", config=config, session_id="thread-a") == [
+        "shell",
+        "sleep",
+    ]
 
 
 def test_scope_incompatible_deferred_tools_reject_at_config_and_runtime(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- validate dynamic tool candidates outside the shared-state lock
- retry against concurrent session changes before committing
- add deterministic coverage for read progress and stale-state protection

## Testing

- `uv run pytest tests/test_dynamic_toolkits.py -n 0 --no-cov -q`
- `uv run pytest -n auto --no-cov -q`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Allow dynamic-tool validation to run without holding shared session state locks while preserving correct concurrent updates.

Bug Fixes:
- Prevent dynamic-tool validation from blocking concurrent reads of a session’s visible tool surface.
- Protect dynamic-tool loads from overwriting changes committed concurrently by retrying validation against the latest session state.

Tests:
- Add deterministic concurrency tests covering non-blocking reads and stale-state protection during dynamic-tool loads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool loading reliability when multiple session changes occur concurrently.
  * Prevented failed, incompatible, duplicate, conflicting, or unavailable loads from modifying session state.
  * Ensured successful tool loads are saved only after the latest session state is confirmed.
  * Improved responsiveness by allowing tool-surface reads during load validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->