### PR TITLE
Detach delivery recovery from sync request context

### DIFF
--- a/src/mindroom/background_tasks.py
+++ b/src/mindroom/background_tasks.py
@@ -89,7 +89,8 @@ def create_background_task(
         error_handler: Optional error handler function
         owner: Optional logical owner used for scoped shutdown waits
         log_exceptions: Whether unhandled task exceptions should be logged automatically
-        context: Optional context in which to run the task
+        context: Execution context for the task. ``None`` preserves asyncio's normal
+            caller-context inheritance.
 
     Returns:
         The created task

--- a/src/mindroom/background_tasks.py
+++ b/src/mindroom/background_tasks.py
@@ -11,6 +11,7 @@ from mindroom.runtime_shutdown import GENERIC_SHUTDOWN, RuntimeShutdownIntent
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
+    from contextvars import Context
 
 logger = get_logger(__name__)
 _MAX_BACKGROUND_TASK_CANCEL_ROUNDS = 3
@@ -78,6 +79,7 @@ def create_background_task(
     *,
     owner: object | None = None,
     log_exceptions: bool = True,
+    context: Context | None = None,
 ) -> asyncio.Task[Any]:
     """Create a background task that won't block the main execution.
 
@@ -87,12 +89,13 @@ def create_background_task(
         error_handler: Optional error handler function
         owner: Optional logical owner used for scoped shutdown waits
         log_exceptions: Whether unhandled task exceptions should be logged automatically
+        context: Optional context in which to run the task
 
     Returns:
         The created task
 
     """
-    task: asyncio.Task[Any] = asyncio.create_task(coro)
+    task: asyncio.Task[Any] = asyncio.create_task(coro, context=context)
     if name:
         task.set_name(name)
 

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from contextvars import Context
 from dataclasses import dataclass, replace
 from functools import cached_property, partial
 from typing import TYPE_CHECKING, Any, cast
@@ -1683,6 +1684,7 @@ class AgentBot:
             self._run_scheduled_delivery_recovery(),
             name=f"delivery_recovery_{self.agent_name}",
             owner=self._runtime_view,
+            context=Context(),
         )
 
     async def _run_scheduled_delivery_recovery(self) -> None:

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1684,6 +1684,7 @@ class AgentBot:
             self._run_scheduled_delivery_recovery(),
             name=f"delivery_recovery_{self.agent_name}",
             owner=self._runtime_view,
+            # Recovery outlives the sync request generation, so it must not inherit that context.
             context=Context(),
         )
 

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -1601,6 +1601,114 @@ async def test_delivery_recovery_asks_the_outbox_on_every_sync_response(
 
 
 @pytest.mark.asyncio
+async def test_delivery_recovery_drops_sync_request_context_before_transport(
+    tmp_path: Path,
+) -> None:
+    """A detached recovery worker must not retain its spawning sync generation."""
+    bot = _sliding_response_bot(tmp_path)
+    client = nio.AsyncClient(
+        "https://localhost",
+        "@code:localhost",
+        config=nio.AsyncClientConfig(
+            encryption_enabled=False,
+            store_sync_tokens=False,
+            backfill_limited_timelines=True,
+            backfill_persist_recovery=False,
+        ),
+    )
+    client.restore_login("@code:localhost", "DEVICEID", "token")
+    bot.client = client
+
+    recovery_started = asyncio.Event()
+    allow_recovery_request = asyncio.Event()
+    request_reached_transport = asyncio.Event()
+
+    async def request(*_args: object, **_kwargs: object) -> object:
+        request_reached_transport.set()
+        return object()
+
+    session = MagicMock()
+    session.request = AsyncMock(side_effect=request)
+    session.close = AsyncMock()
+    client.client_session = session
+
+    async def recover_deliveries() -> RecoveryOutcome:
+        recovery_started.set()
+        await allow_recovery_request.wait()
+        try:
+            await client.send("GET", "/_matrix/client/versions")
+        finally:
+            bot._sync_shutting_down = True
+            bot._delivery_recovery_wake.set()
+        return RecoveryOutcome(recovered=0, failed=0)
+
+    async def schedule_recovery_from_sync(
+        _room: nio.MatrixRoom,
+        _event: nio.RoomMessageText,
+    ) -> None:
+        bot._schedule_delivery_recovery()
+
+    room_id = "!room:localhost"
+    event = nio.RoomMessageText.from_dict(
+        {
+            "content": {"body": "hello", "msgtype": "m.text"},
+            "event_id": "$message:localhost",
+            "origin_server_ts": 1,
+            "room_id": room_id,
+            "sender": "@alice:localhost",
+            "type": "m.room.message",
+        },
+    )
+    response = nio.SyncResponse(
+        next_batch="s_after",
+        rooms=nio.Rooms(
+            invite={},
+            join={
+                room_id: nio.RoomInfo(
+                    timeline=nio.Timeline(events=[event], limited=False, prev_batch=None),
+                    state=[],
+                    ephemeral=[],
+                    account_data=[],
+                ),
+            },
+            leave={},
+        ),
+        device_key_count=nio.DeviceOneTimeKeyCount(curve25519=0, signed_curve25519=0),
+        device_list=nio.DeviceList(changed=[], left=[]),
+        to_device_events=[],
+        presence_events=[],
+        account_data_events=[],
+    )
+
+    async def receive_sync_response(*_args: object, **_kwargs: object) -> nio.SyncResponse:
+        await client.receive_response(response)
+        return response
+
+    client.add_event_callback(schedule_recovery_from_sync, nio.RoomMessageText)
+    try:
+        with (
+            patch.object(client, "_send", new=receive_sync_response),
+            patch.object(
+                bot,
+                "_delivery_gateway",
+                new=SimpleNamespace(recover_deliveries=recover_deliveries),
+            ),
+        ):
+            await client.sync(timeout=0)
+            await asyncio.wait_for(recovery_started.wait(), timeout=1)
+            await client.reset_classic_sync_state()
+            allow_recovery_request.set()
+            assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+    finally:
+        bot._sync_shutting_down = True
+        allow_recovery_request.set()
+        await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+        await client.close()
+
+    assert request_reached_transport.is_set()
+
+
+@pytest.mark.asyncio
 async def test_sync_response_returns_while_delivery_recovery_waits_for_the_next_response(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
- run detached delivery recovery in a fresh context
- preserve shared task ownership and exception handling
- cover a Classic client generation reset at the mocked transport boundary

## Testing
- `uv run pytest`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Run detached delivery recovery in an independent context so it remains valid across sync request generation resets.

Bug Fixes:
- Prevent detached delivery recovery from retaining stale sync-request context after a Classic client generation reset.

Enhancements:
- Allow background tasks to run with an explicitly supplied execution context while preserving task ownership and exception handling.

Tests:
- Add coverage for delivery recovery reaching the transport after the spawning sync context is reset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved delivery-recovery task handling so it remains reliable after a sync reset.
  * Prevented detached recovery work from retaining outdated request context.

* **Tests**
  * Added coverage verifying recovery reaches the transport successfully and background tasks complete cleanly after a sync reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->