### PR TITLE
fix: preserve Docker worker retirement ownership

### DIFF
--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -9,7 +9,7 @@ import os
 import threading
 import time
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Protocol, cast
 
 import httpx
@@ -826,17 +826,19 @@ class DockerWorkerBackend:
             container = None
 
         if container is None:
+            volumes = self._container_volumes(
+                paths,
+                worker_key=metadata.worker_key,
+                private_agent_names=private_agent_names,
+            )
+            self._prepare_nested_storage_mount_targets(paths, volumes)
             container = self._client.containers.run(
                 launch_config.image_reference,
                 command=["/app/run-sandbox-runner.sh"],
                 name=metadata.container_name,
                 detach=True,
                 environment=self._container_env(metadata.worker_key),
-                volumes=self._container_volumes(
-                    paths,
-                    worker_key=metadata.worker_key,
-                    private_agent_names=private_agent_names,
-                ),
+                volumes=volumes,
                 ports={f"{self.config.worker_port}/tcp": (self.config.publish_host, None)},
                 labels=self._container_labels(
                     metadata,
@@ -1079,6 +1081,29 @@ class DockerWorkerBackend:
                 "mode": "ro" if read_only else "rw",
             }
         return volumes
+
+    def _prepare_nested_storage_mount_targets(
+        self,
+        paths: LocalWorkerStatePaths,
+        volumes: dict[str, dict[str, str]],
+    ) -> None:
+        """Create nested bind targets before the Docker daemon can create them as root."""
+        storage_root = PurePosixPath(self.config.storage_mount_path)
+        for mount in volumes.values():
+            container_path = PurePosixPath(mount["bind"])
+            if container_path == storage_root or storage_root not in container_path.parents:
+                continue
+            relative_path = container_path.relative_to(storage_root)
+            if ".." in relative_path.parts:
+                msg = f"Docker worker mount target escapes the worker storage root: {container_path}"
+                raise WorkerBackendError(msg)
+            current = paths.root
+            for segment in relative_path.parts:
+                current /= segment
+                if current.is_symlink() or (current.exists() and not current.is_dir()):
+                    msg = f"Docker worker mount target must be a real directory: {current}"
+                    raise WorkerBackendError(msg)
+                current.mkdir(exist_ok=True)
 
     def _scoped_storage_mount_specs(
         self,

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -3632,6 +3632,29 @@ def test_docker_backend_projects_shared_agent_for_narrower_user_agent_worker(
     assert str(agent_state_root_path(tmp_path, "alpha")) in volumes
 
 
+def test_docker_backend_precreates_nested_storage_mount_targets(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Docker must not create nested worker mount targets with daemon ownership."""
+    config_text, _projected_paths = _multi_agent_projected_config_fixture(tmp_path)
+    backend, fake_client, _sync_calls = _backend(monkeypatch, tmp_path, config_text=config_text)
+    worker_key = "v1:default:user_agent:@alice:example.org:alpha"
+
+    backend.ensure_worker(
+        WorkerSpec(worker_key, private_agent_names=frozenset()),
+        now=10.0,
+    )
+
+    worker_root = worker_root_path(tmp_path, worker_key)
+    assert (worker_root / "agents" / "alpha").is_dir()
+    assert len(fake_client.containers.run_calls) == 1
+
+    backend.retire_worker(worker_key)
+
+    assert not worker_root.exists()
+
+
 def test_docker_backend_rejects_ambiguous_normalized_user_agent_key(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -3640,13 +3640,20 @@ def test_docker_backend_precreates_nested_storage_mount_targets(
     config_text, _projected_paths = _multi_agent_projected_config_fixture(tmp_path)
     backend, fake_client, _sync_calls = _backend(monkeypatch, tmp_path, config_text=config_text)
     worker_key = "v1:default:user_agent:@alice:example.org:alpha"
+    worker_root = worker_root_path(tmp_path, worker_key)
+    original_run = fake_client.containers.run
+
+    def run_after_asserting_mount_target(image: str, **kwargs: object) -> _FakeContainer:
+        assert (worker_root / "agents" / "alpha").is_dir()
+        return original_run(image, **kwargs)
+
+    monkeypatch.setattr(fake_client.containers, "run", run_after_asserting_mount_target)
 
     backend.ensure_worker(
         WorkerSpec(worker_key, private_agent_names=frozenset()),
         now=10.0,
     )
 
-    worker_root = worker_root_path(tmp_path, worker_key)
     assert (worker_root / "agents" / "alpha").is_dir()
     assert len(fake_client.containers.run_calls) == 1
 


### PR DESCRIPTION
## Summary

- Precreate nested Docker bind-mount targets under the host runtime user before container launch.
- Prevent the Docker daemon from leaving root-owned mount-point parents inside disposable worker roots.
- Keep per-run worker retirement unattended and sudo-free.

## Root cause

Docker creates missing nested bind-mount targets before the configured container user starts, so setting the container user does not control those host-path owners.

## Verification

- Real Docker worker: container user and nested target owner both matched the host UID/GID, and exact worker retirement removed the worker root.
- `uv run pytest -q -n 0 tests/test_docker_worker_backend.py::test_docker_backend_precreates_nested_storage_mount_targets --no-cov`
- `uv run pre-commit run --all-files`
- `uv run pytest -q`

## Summary by Sourcery

Preserve host runtime ownership of nested Docker worker mount targets and ensure clean worker retirement.

Bug Fixes:
- Prevent Docker from creating nested worker bind-mount targets with daemon-owned permissions.

Enhancements:
- Validate and precreate nested storage mount directories within each worker root before launching containers, preserving unattended worker retirement without elevated privileges.

Tests:
- Add coverage confirming nested mount targets exist before container launch and are removed during worker retirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Nested Docker worker storage directories are now created before containers start.
  - Improved validation prevents mounts from escaping the worker storage area or targeting invalid paths.
  - Prevents Docker from creating nested mount targets with unintended ownership.

- **Tests**
  - Added coverage confirming nested mount directories are prepared correctly and cleaned up when workers retire.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->