### PR TITLE
Make config hot reload selective

### DIFF
--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -86,7 +86,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
 1. On a config change, `ConfigReloadLifecycle.request_reload()` queues a debounced reload.
 2. On an MCP catalog change, the orchestrator returns immediately when no configured entity references that server, while still clearing the worker validation snapshot cache.
    The dependent-entity check runs again under the config update lock immediately before replacement.
-3. `ConfigReloadLifecycle.apply_with_response_admission()` serializes config reloads and MCP catalog replacements behind one global admission owner.
+3. Config reloads and MCP catalog replacements serialize behind one global admission owner; MCP replacements enter through `ConfigReloadLifecycle.apply_with_response_admission()`.
 4. Sampling the in-flight count and closing the shared `ResponseAdmissionGate` happen atomically, so a new response cannot race the decision to apply.
    The gate covers Matrix-driven response lifecycles, external-trigger delivery, call admission, and requester-driven call operations.
    Text and router planning, commands, edit regeneration, interactive selections, visible router voice echoes, calls, and external triggers perform their final reply-policy check after admission and retain the slot through their direct side effect or response-runner handoff.
@@ -104,6 +104,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
 8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations after the gate closes.
 9. The orchestrator applies the resulting plan: changed entities are replaced, unchanged bots receive the new config, and room-only changes reconcile memberships in place while restarting only sliding receive loops to refresh their subscriptions.
+   Call-enabled agents are conservatively replaced after any authored config change because active call tooling captures the full authored config snapshot.
 10. Removed entities run `cleanup()` to leave rooms and stop the bot.
 11. New and restarted bots go through room setup.
 12. The gate reopens once the apply finishes, whether it succeeded, failed, or was cancelled, and deferred responses may then start.

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -91,8 +91,8 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    The gate covers Matrix-driven response lifecycles, external-trigger delivery, call admission, and requester-driven call operations.
    Text and router planning, commands, edit regeneration, interactive selections, visible router voice echoes, calls, and external triggers perform their final reply-policy check after admission and retain the slot through their direct side effect or response-runner handoff.
    The OpenAI-compatible API in `mindroom.api.openai_compat` remains outside this gate because it does not use Matrix reply authorization.
-   The gate stays closed, but is not held, across config loading and plan application.
-   Holding it would stall the apply against itself: applying the plan stops bots, and stopping a bot drains its detached responses.
+   Config loading and diff planning keep response admission open; only publication closes the gate after current responses drain.
+   Holding the gate while loading would block responses for validation work that cannot affect the live runtime.
 5. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
    The gate is global and covers the whole apply window regardless of how narrow the plan turns out to be.
    When the apply finishes, responses owned by unchanged or replacement runtimes compete for admission normally.
@@ -102,8 +102,8 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped.
 7. If responses never drain, either replacement flow stops deferring after 600 seconds and closes the gate over still-running responses.
    This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
-8. For config reloads, `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`.
-9. The orchestrator applies the resulting plan: affected entities are stopped, recreated, and restarted.
+8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations.
+9. The orchestrator applies the resulting plan: changed entities are replaced, unchanged bots receive the new config, and room-only changes reconcile memberships in place while restarting only sliding receive loops to refresh their subscriptions.
 10. Removed entities run `cleanup()` to leave rooms and stop the bot.
 11. New and restarted bots go through room setup.
 12. The gate reopens once the apply finishes, whether it succeeded, failed, or was cancelled, and deferred responses may then start.

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -91,7 +91,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    The gate covers Matrix-driven response lifecycles, external-trigger delivery, call admission, and requester-driven call operations.
    Text and router planning, commands, edit regeneration, interactive selections, visible router voice echoes, calls, and external triggers perform their final reply-policy check after admission and retain the slot through their direct side effect or response-runner handoff.
    The OpenAI-compatible API in `mindroom.api.openai_compat` remains outside this gate because it does not use Matrix reply authorization.
-   Config loading and diff planning keep response admission open; only publication closes the gate after current responses drain.
+   Config loading keeps response admission open; after current responses drain, the gate closes for diff planning and publication.
    Holding the gate while loading would block responses for validation work that cannot affect the live runtime.
 5. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
    The gate is global and covers the whole apply window regardless of how narrow the plan turns out to be.
@@ -102,7 +102,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped.
 7. If responses never drain, either replacement flow stops deferring after 600 seconds and closes the gate over still-running responses.
    This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
-8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations.
+8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations after the gate closes.
 9. The orchestrator applies the resulting plan: changed entities are replaced, unchanged bots receive the new config, and room-only changes reconcile memberships in place while restarting only sliding receive loops to refresh their subscriptions.
 10. Removed entities run `cleanup()` to leave rooms and stop the bot.
 11. New and restarted bots go through room setup.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17156,8 +17156,8 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    The gate covers Matrix-driven response lifecycles, external-trigger delivery, call admission, and requester-driven call operations.
    Text and router planning, commands, edit regeneration, interactive selections, visible router voice echoes, calls, and external triggers perform their final reply-policy check after admission and retain the slot through their direct side effect or response-runner handoff.
    The OpenAI-compatible API in `mindroom.api.openai_compat` remains outside this gate because it does not use Matrix reply authorization.
-   The gate stays closed, but is not held, across config loading and plan application.
-   Holding it would stall the apply against itself: applying the plan stops bots, and stopping a bot drains its detached responses.
+   Config loading and diff planning keep response admission open; only publication closes the gate after current responses drain.
+   Holding the gate while loading would block responses for validation work that cannot affect the live runtime.
 5. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
    The gate is global and covers the whole apply window regardless of how narrow the plan turns out to be.
    When the apply finishes, responses owned by unchanged or replacement runtimes compete for admission normally.
@@ -17167,8 +17167,8 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped.
 7. If responses never drain, either replacement flow stops deferring after 600 seconds and closes the gate over still-running responses.
    This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
-8. For config reloads, `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`.
-9. The orchestrator applies the resulting plan: affected entities are stopped, recreated, and restarted.
+8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations.
+9. The orchestrator applies the resulting plan: changed entities are replaced, unchanged bots receive the new config, and room-only changes reconcile memberships in place while restarting only sliding receive loops to refresh their subscriptions.
 10. Removed entities run `cleanup()` to leave rooms and stop the bot.
 11. New and restarted bots go through room setup.
 12. The gate reopens once the apply finishes, whether it succeeded, failed, or was cancelled, and deferred responses may then start.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17151,7 +17151,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
 1. On a config change, `ConfigReloadLifecycle.request_reload()` queues a debounced reload.
 2. On an MCP catalog change, the orchestrator returns immediately when no configured entity references that server, while still clearing the worker validation snapshot cache.
    The dependent-entity check runs again under the config update lock immediately before replacement.
-3. `ConfigReloadLifecycle.apply_with_response_admission()` serializes config reloads and MCP catalog replacements behind one global admission owner.
+3. Config reloads and MCP catalog replacements serialize behind one global admission owner; MCP replacements enter through `ConfigReloadLifecycle.apply_with_response_admission()`.
 4. Sampling the in-flight count and closing the shared `ResponseAdmissionGate` happen atomically, so a new response cannot race the decision to apply.
    The gate covers Matrix-driven response lifecycles, external-trigger delivery, call admission, and requester-driven call operations.
    Text and router planning, commands, edit regeneration, interactive selections, visible router voice echoes, calls, and external triggers perform their final reply-policy check after admission and retain the slot through their direct side effect or response-runner handoff.
@@ -17169,6 +17169,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
 8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations after the gate closes.
 9. The orchestrator applies the resulting plan: changed entities are replaced, unchanged bots receive the new config, and room-only changes reconcile memberships in place while restarting only sliding receive loops to refresh their subscriptions.
+   Call-enabled agents are conservatively replaced after any authored config change because active call tooling captures the full authored config snapshot.
 10. Removed entities run `cleanup()` to leave rooms and stop the bot.
 11. New and restarted bots go through room setup.
 12. The gate reopens once the apply finishes, whether it succeeded, failed, or was cancelled, and deferred responses may then start.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17156,7 +17156,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    The gate covers Matrix-driven response lifecycles, external-trigger delivery, call admission, and requester-driven call operations.
    Text and router planning, commands, edit regeneration, interactive selections, visible router voice echoes, calls, and external triggers perform their final reply-policy check after admission and retain the slot through their direct side effect or response-runner handoff.
    The OpenAI-compatible API in `mindroom.api.openai_compat` remains outside this gate because it does not use Matrix reply authorization.
-   Config loading and diff planning keep response admission open; only publication closes the gate after current responses drain.
+   Config loading keeps response admission open; after current responses drain, the gate closes for diff planning and publication.
    Holding the gate while loading would block responses for validation work that cannot affect the live runtime.
 5. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
    The gate is global and covers the whole apply window regardless of how narrow the plan turns out to be.
@@ -17167,7 +17167,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped.
 7. If responses never drain, either replacement flow stops deferring after 600 seconds and closes the gate over still-running responses.
    This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
-8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations.
+8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations after the gate closes.
 9. The orchestrator applies the resulting plan: changed entities are replaced, unchanged bots receive the new config, and room-only changes reconcile memberships in place while restarting only sliding receive loops to refresh their subscriptions.
 10. Removed entities run `cleanup()` to leave rooms and stop the bot.
 11. New and restarted bots go through room setup.

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -87,8 +87,8 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    The gate covers Matrix-driven response lifecycles, external-trigger delivery, call admission, and requester-driven call operations.
    Text and router planning, commands, edit regeneration, interactive selections, visible router voice echoes, calls, and external triggers perform their final reply-policy check after admission and retain the slot through their direct side effect or response-runner handoff.
    The OpenAI-compatible API in `mindroom.api.openai_compat` remains outside this gate because it does not use Matrix reply authorization.
-   The gate stays closed, but is not held, across config loading and plan application.
-   Holding it would stall the apply against itself: applying the plan stops bots, and stopping a bot drains its detached responses.
+   Config loading and diff planning keep response admission open; only publication closes the gate after current responses drain.
+   Holding the gate while loading would block responses for validation work that cannot affect the live runtime.
 5. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
    The gate is global and covers the whole apply window regardless of how narrow the plan turns out to be.
    When the apply finishes, responses owned by unchanged or replacement runtimes compete for admission normally.
@@ -98,8 +98,8 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped.
 7. If responses never drain, either replacement flow stops deferring after 600 seconds and closes the gate over still-running responses.
    This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
-8. For config reloads, `ConfigReloadLifecycle.update_config()` loads the new config and `_identify_entities_to_restart()` computes the diff using `model_dump(exclude_none=True)`.
-9. The orchestrator applies the resulting plan: affected entities are stopped, recreated, and restarted.
+8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations.
+9. The orchestrator applies the resulting plan: changed entities are replaced, unchanged bots receive the new config, and room-only changes reconcile memberships in place while restarting only sliding receive loops to refresh their subscriptions.
 10. Removed entities run `cleanup()` to leave rooms and stop the bot.
 11. New and restarted bots go through room setup.
 12. The gate reopens once the apply finishes, whether it succeeded, failed, or was cancelled, and deferred responses may then start.

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -87,7 +87,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    The gate covers Matrix-driven response lifecycles, external-trigger delivery, call admission, and requester-driven call operations.
    Text and router planning, commands, edit regeneration, interactive selections, visible router voice echoes, calls, and external triggers perform their final reply-policy check after admission and retain the slot through their direct side effect or response-runner handoff.
    The OpenAI-compatible API in `mindroom.api.openai_compat` remains outside this gate because it does not use Matrix reply authorization.
-   Config loading and diff planning keep response admission open; only publication closes the gate after current responses drain.
+   Config loading keeps response admission open; after current responses drain, the gate closes for diff planning and publication.
    Holding the gate while loading would block responses for validation work that cannot affect the live runtime.
 5. While the gate is closed, a response waits before taking a lifecycle lock, incrementing the in-flight count, or publishing a placeholder.
    The gate is global and covers the whole apply window regardless of how narrow the plan turns out to be.
@@ -98,7 +98,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    Auto-resume messages received by replacement bots during the apply wait for the gate to reopen instead of being dropped.
 7. If responses never drain, either replacement flow stops deferring after 600 seconds and closes the gate over still-running responses.
    This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
-8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations.
+8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations after the gate closes.
 9. The orchestrator applies the resulting plan: changed entities are replaced, unchanged bots receive the new config, and room-only changes reconcile memberships in place while restarting only sliding receive loops to refresh their subscriptions.
 10. Removed entities run `cleanup()` to leave rooms and stop the bot.
 11. New and restarted bots go through room setup.

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -82,7 +82,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
 1. On a config change, `ConfigReloadLifecycle.request_reload()` queues a debounced reload.
 2. On an MCP catalog change, the orchestrator returns immediately when no configured entity references that server, while still clearing the worker validation snapshot cache.
    The dependent-entity check runs again under the config update lock immediately before replacement.
-3. `ConfigReloadLifecycle.apply_with_response_admission()` serializes config reloads and MCP catalog replacements behind one global admission owner.
+3. Config reloads and MCP catalog replacements serialize behind one global admission owner; MCP replacements enter through `ConfigReloadLifecycle.apply_with_response_admission()`.
 4. Sampling the in-flight count and closing the shared `ResponseAdmissionGate` happen atomically, so a new response cannot race the decision to apply.
    The gate covers Matrix-driven response lifecycles, external-trigger delivery, call admission, and requester-driven call operations.
    Text and router planning, commands, edit regeneration, interactive selections, visible router voice echoes, calls, and external triggers perform their final reply-policy check after admission and retain the slot through their direct side effect or response-runner handoff.
@@ -100,6 +100,7 @@ The MCP manager callback schedules an orchestrator-owned background task so the 
    This bounded forced apply prevents a busy install from starving config or MCP replacement forever.
 8. For config reloads, `ConfigReloadLifecycle._update_config()` loads and validates the new config while admission remains open, then `build_config_update_plan()` computes targeted restarts and in-place reconciliations after the gate closes.
 9. The orchestrator applies the resulting plan: changed entities are replaced, unchanged bots receive the new config, and room-only changes reconcile memberships in place while restarting only sliding receive loops to refresh their subscriptions.
+   Call-enabled agents are conservatively replaced after any authored config change because active call tooling captures the full authored config snapshot.
 10. Removed entities run `cleanup()` to leave rooms and stop the bot.
 11. New and restarted bots go through room setup.
 12. The gate reopens once the apply finishes, whether it succeeded, failed, or was cancelled, and deferred responses may then start.

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -139,9 +139,9 @@ class ConfigReloadLifecycle:
         self._requested_at = None
         await cancel_logged_task(task)
 
-    async def _update_config(self) -> bool:
-        """Reload configuration from disk and dispatch the resulting update plan."""
-        async with self._response_admission_apply_lock, self.config_update_lock:
+    async def _update_config(self) -> bool | None:
+        """Reload config, returning whether agents changed or ``None`` when superseded."""
+        async with self._response_admission_apply_lock:
             # Config validation executes plugin modules and walks the filesystem;
             # keep it off the event loop (#1260). Admission stays open because
             # nothing is published until loading and planning both succeed.
@@ -155,14 +155,15 @@ class ConfigReloadLifecycle:
 
                 async def load_initial_config() -> None:
                     nonlocal updated
-                    updated = await self.load_initial_config(new_config)
+                    async with self.config_update_lock:
+                        updated = await self.load_initial_config(new_config)
 
-                await self._apply_after_response_drain(
+                applied = await self._apply_after_response_drain(
                     load_initial_config,
                     operation_name="configuration reload",
                     request_is_current=self._reload_publication_is_current,
                 )
-                return updated
+                return updated if applied else None
 
             if pending_event_journal_restart(new_config, self.runtime_paths):
                 # Adopted, not refused: the store was opened once at startup and
@@ -195,14 +196,15 @@ class ConfigReloadLifecycle:
 
             async def apply_update_plan() -> None:
                 nonlocal updated
-                updated = await self.apply_update_plan(current_config, plan, plugin_changes)
+                async with self.config_update_lock:
+                    updated = await self.apply_update_plan(current_config, plan, plugin_changes)
 
-            await self._apply_after_response_drain(
+            applied = await self._apply_after_response_drain(
                 apply_update_plan,
                 operation_name="configuration reload",
                 request_is_current=self._reload_publication_is_current,
             )
-            return updated
+            return updated if applied else None
 
     def _reload_publication_is_current(self) -> bool:
         """Allow direct updates, but skip queued snapshots superseded before publication."""
@@ -328,8 +330,8 @@ class ConfigReloadLifecycle:
         *,
         operation_name: str,
         request_is_current: Callable[[], bool],
-    ) -> None:
-        """Drain responses and apply while the caller owns replacement serialization."""
+    ) -> bool:
+        """Drain responses and report whether the serialized operation was applied."""
         loop = asyncio.get_running_loop()
         drain_state = _ReplacementDrainState()
         while request_is_current():
@@ -350,9 +352,10 @@ class ConfigReloadLifecycle:
             self.response_admission_gate.close()
             break
         else:
-            return
+            return False
 
         await self._apply_with_closed_admission(operation)
+        return True
 
     async def _apply_queued_config_reload(self) -> None:
         """Apply one queued config reload attempt and log the result."""
@@ -369,7 +372,9 @@ class ConfigReloadLifecycle:
             if failed_files is not None:
                 self.failed_reload_source_files = failed_files
             return
-        if updated:
+        if updated is None:
+            logger.info("Configuration reload superseded before publication; skipping")
+        elif updated:
             logger.info("Configuration update applied to affected agents")
         else:
             logger.info("No agent changes detected in configuration update")

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -374,10 +374,11 @@ class ConfigReloadLifecycle:
     ) -> None:
         """Run one global serialized replacement after a bounded response drain.
 
-        Config reloads call this from their debounced task. MCP catalog changes
-        call it from an orchestrator-owned background task so an admitted tool
-        call cannot wait on its own slot. The drain defers for at most 600
-        seconds before closing admission over a forced apply.
+        Config reloads acquire the same serialization lock from their debounced
+        task and use the same drain helper. MCP catalog changes call this from
+        an orchestrator-owned background task so an admitted tool call cannot
+        wait on its own slot. The drain defers for at most 600 seconds before
+        closing admission over a forced apply.
         """
         async with self._response_admission_apply_lock:
             await self._apply_after_response_drain(

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -115,6 +115,8 @@ class ConfigReloadLifecycle:
     # Source topology from the latest config that loaded successfully, even
     # when its effective authored content did not require publication.
     loaded_source_files: frozenset[Path] | None = field(default=None, init=False)
+    # The last config whose complete update plan returned successfully.
+    _fully_applied_config: Config | None = field(default=None, init=False, repr=False)
 
     def request_reload(self) -> None:
         """Queue a debounced config reload for the running orchestrator."""
@@ -145,9 +147,17 @@ class ConfigReloadLifecycle:
             # Config validation executes plugin modules and walks the filesystem;
             # keep it off the event loop (#1260). Admission stays open because
             # nothing is published until loading and planning both succeed.
-            new_config = await asyncio.to_thread(load_config, self.runtime_paths, tolerate_plugin_load_errors=True)
+            async with self.config_update_lock:
+                new_config = await asyncio.to_thread(
+                    load_config,
+                    self.runtime_paths,
+                    tolerate_plugin_load_errors=True,
+                )
             self.loaded_source_files = new_config.source_files
-            current_config = self.current_config()
+            runtime_config = self.current_config()
+            if self._fully_applied_config is None:
+                self._fully_applied_config = runtime_config
+            current_config = self._fully_applied_config
             self.failed_reload_source_files = None
 
             if current_config is None:
@@ -157,6 +167,7 @@ class ConfigReloadLifecycle:
                     nonlocal updated
                     async with self.config_update_lock:
                         updated = await self.load_initial_config(new_config)
+                        self._fully_applied_config = new_config
 
                 applied = await self._apply_after_response_drain(
                     load_initial_config,
@@ -198,6 +209,7 @@ class ConfigReloadLifecycle:
                 nonlocal updated
                 async with self.config_update_lock:
                     updated = await self.apply_update_plan(current_config, plan, plugin_changes)
+                    self._fully_applied_config = new_config
 
             applied = await self._apply_after_response_drain(
                 apply_update_plan,

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -117,6 +117,8 @@ class ConfigReloadLifecycle:
     loaded_source_files: frozenset[Path] | None = field(default=None, init=False)
     # The last config whose complete update plan returned successfully.
     _fully_applied_config: Config | None = field(default=None, init=False, repr=False)
+    # A transition target that may have published only part of its runtime state.
+    _incomplete_config: Config | None = field(default=None, init=False, repr=False)
 
     def request_reload(self) -> None:
         """Queue a debounced config reload for the running orchestrator."""
@@ -190,14 +192,19 @@ class ConfigReloadLifecycle:
             current_authored_config = current_config.authored_model_dump()
             new_authored_config = new_config.authored_model_dump()
             runtime_authored_config = runtime_config.authored_model_dump() if runtime_config is not None else None
-            if current_authored_config == new_authored_config == runtime_authored_config:
+            if (
+                self._incomplete_config is None
+                and current_authored_config == new_authored_config == runtime_authored_config
+            ):
                 logger.info("Configuration content unchanged; skipping publication")
                 return False
-            repair_config = (
-                runtime_config
-                if runtime_config is not None and runtime_authored_config != current_authored_config
-                else None
-            )
+            repair_config = self._incomplete_config
+            if (
+                repair_config is None
+                and runtime_config is not None
+                and runtime_authored_config != current_authored_config
+            ):
+                repair_config = runtime_config
             if repair_config is not None:
                 logger.warning(
                     "config_reload_repairing_partial_publication",
@@ -232,10 +239,14 @@ class ConfigReloadLifecycle:
         updated = False
         async with self.config_update_lock:
             if repair_config is not None:
+                self._incomplete_config = repair_config
                 updated = await self._apply_config_transition(repair_config, fully_applied_config)
+                self._incomplete_config = None
             if fully_applied_config.authored_model_dump() != requested_config.authored_model_dump():
+                self._incomplete_config = requested_config
                 requested_updated = await self._apply_config_transition(fully_applied_config, requested_config)
                 updated = updated or requested_updated
+                self._incomplete_config = None
             self._fully_applied_config = requested_config
         return updated
 

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -193,39 +193,69 @@ class ConfigReloadLifecycle:
             if current_authored_config == new_authored_config == runtime_authored_config:
                 logger.info("Configuration content unchanged; skipping publication")
                 return False
-            repairing_partial_publication = current_authored_config == new_authored_config
-            if repairing_partial_publication:
-                logger.warning("config_reload_repairing_partial_publication")
-            plan_base_config = (
-                runtime_config if repairing_partial_publication and runtime_config is not None else current_config
+            repair_config = (
+                runtime_config
+                if runtime_config is not None and runtime_authored_config != current_authored_config
+                else None
             )
-
-            agent_bots = self.agent_bots()
-            plugin_changes = plugin_change_paths(plan_base_config, new_config)
-            plan = build_config_update_plan(
-                current_config=plan_base_config,
-                new_config=new_config,
-                configured_entities=set(configured_entity_names(new_config)),
-                existing_entities=set(agent_bots.keys()),
-                agent_bots=agent_bots,
-            )
-            if plugin_changes:
-                plan = replace(plan, entities_to_restart=plan.entities_to_restart | set(agent_bots))
+            if repair_config is not None:
+                logger.warning(
+                    "config_reload_repairing_partial_publication",
+                    action="restore last successful config before applying requested config",
+                )
 
             updated = False
 
-            async def apply_update_plan() -> None:
+            async def apply_update_steps() -> None:
                 nonlocal updated
-                async with self.config_update_lock:
-                    updated = await self.apply_update_plan(plan_base_config, plan, plugin_changes)
-                    self._fully_applied_config = new_config
+                updated = await self._apply_config_update_steps(
+                    fully_applied_config=current_config,
+                    requested_config=new_config,
+                    repair_config=repair_config,
+                )
 
             applied = await self._apply_after_response_drain(
-                apply_update_plan,
+                apply_update_steps,
                 operation_name="configuration reload",
                 request_is_current=self._reload_publication_is_current,
             )
             return updated if applied else None
+
+    async def _apply_config_update_steps(
+        self,
+        *,
+        fully_applied_config: Config,
+        requested_config: Config,
+        repair_config: Config | None,
+    ) -> bool:
+        """Restore the last-good state when needed, then apply the requested config."""
+        updated = False
+        async with self.config_update_lock:
+            if repair_config is not None:
+                updated = await self._apply_config_transition(repair_config, fully_applied_config)
+            if fully_applied_config.authored_model_dump() != requested_config.authored_model_dump():
+                requested_updated = await self._apply_config_transition(fully_applied_config, requested_config)
+                updated = updated or requested_updated
+            self._fully_applied_config = requested_config
+        return updated
+
+    async def _apply_config_transition(self, current_config: Config, new_config: Config) -> bool:
+        """Build and apply one normal config transition against the current bot inventory."""
+        agent_bots = self.agent_bots()
+        plugin_changes = plugin_change_paths(current_config, new_config)
+        plan = build_config_update_plan(
+            current_config=current_config,
+            new_config=new_config,
+            configured_entities=set(configured_entity_names(new_config)),
+            existing_entities=set(agent_bots.keys()),
+            agent_bots=agent_bots,
+        )
+        if plugin_changes:
+            plan = replace(
+                plan,
+                entities_to_restart=plan.entities_to_restart | set(agent_bots),
+            )
+        return await self.apply_update_plan(current_config, plan, plugin_changes)
 
     def _reload_publication_is_current(self) -> bool:
         """Allow direct updates, but skip queued snapshots superseded before publication."""

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -187,14 +187,23 @@ class ConfigReloadLifecycle:
                     requested=describe_event_journal(new_config.event_journal, self.runtime_paths),
                 )
 
-            if current_config.authored_model_dump() == new_config.authored_model_dump():
+            current_authored_config = current_config.authored_model_dump()
+            new_authored_config = new_config.authored_model_dump()
+            runtime_authored_config = runtime_config.authored_model_dump() if runtime_config is not None else None
+            if current_authored_config == new_authored_config == runtime_authored_config:
                 logger.info("Configuration content unchanged; skipping publication")
                 return False
+            repairing_partial_publication = current_authored_config == new_authored_config
+            if repairing_partial_publication:
+                logger.warning("config_reload_repairing_partial_publication")
+            plan_base_config = (
+                runtime_config if repairing_partial_publication and runtime_config is not None else current_config
+            )
 
             agent_bots = self.agent_bots()
-            plugin_changes = plugin_change_paths(current_config, new_config)
+            plugin_changes = plugin_change_paths(plan_base_config, new_config)
             plan = build_config_update_plan(
-                current_config=current_config,
+                current_config=plan_base_config,
                 new_config=new_config,
                 configured_entities=set(configured_entity_names(new_config)),
                 existing_entities=set(agent_bots.keys()),
@@ -208,7 +217,7 @@ class ConfigReloadLifecycle:
             async def apply_update_plan() -> None:
                 nonlocal updated
                 async with self.config_update_lock:
-                    updated = await self.apply_update_plan(current_config, plan, plugin_changes)
+                    updated = await self.apply_update_plan(plan_base_config, plan, plugin_changes)
                     self._fully_applied_config = new_config
 
             applied = await self._apply_after_response_drain(

--- a/src/mindroom/orchestration/config_lifecycle.py
+++ b/src/mindroom/orchestration/config_lifecycle.py
@@ -112,6 +112,9 @@ class ConfigReloadLifecycle:
     # Owned by ``_update_config``, which is the only place that knows whether
     # an attempt was adopted.
     failed_reload_source_files: frozenset[Path] | None = field(default=None, init=False)
+    # Source topology from the latest config that loaded successfully, even
+    # when its effective authored content did not require publication.
+    loaded_source_files: frozenset[Path] | None = field(default=None, init=False)
 
     def request_reload(self) -> None:
         """Queue a debounced config reload for the running orchestrator."""
@@ -138,15 +141,29 @@ class ConfigReloadLifecycle:
 
     async def _update_config(self) -> bool:
         """Reload configuration from disk and dispatch the resulting update plan."""
-        async with self.config_update_lock:
+        async with self._response_admission_apply_lock, self.config_update_lock:
             # Config validation executes plugin modules and walks the filesystem;
-            # keep it off the event loop (#1260).
+            # keep it off the event loop (#1260). Admission stays open because
+            # nothing is published until loading and planning both succeed.
             new_config = await asyncio.to_thread(load_config, self.runtime_paths, tolerate_plugin_load_errors=True)
+            self.loaded_source_files = new_config.source_files
             current_config = self.current_config()
-            if current_config is None:
-                self.failed_reload_source_files = None
-                return await self.load_initial_config(new_config)
             self.failed_reload_source_files = None
+
+            if current_config is None:
+                updated = False
+
+                async def load_initial_config() -> None:
+                    nonlocal updated
+                    updated = await self.load_initial_config(new_config)
+
+                await self._apply_after_response_drain(
+                    load_initial_config,
+                    operation_name="configuration reload",
+                    request_is_current=self._reload_publication_is_current,
+                )
+                return updated
+
             if pending_event_journal_restart(new_config, self.runtime_paths):
                 # Adopted, not refused: the store was opened once at startup and
                 # every bot borrows that one, so no reload can move it and the
@@ -157,6 +174,10 @@ class ConfigReloadLifecycle:
                     reason="the event journal in force was opened at startup and cannot change until restart",
                     requested=describe_event_journal(new_config.event_journal, self.runtime_paths),
                 )
+
+            if current_config.authored_model_dump() == new_config.authored_model_dump():
+                logger.info("Configuration content unchanged; skipping publication")
+                return False
 
             agent_bots = self.agent_bots()
             plugin_changes = plugin_change_paths(current_config, new_config)
@@ -169,7 +190,25 @@ class ConfigReloadLifecycle:
             )
             if plugin_changes:
                 plan = replace(plan, entities_to_restart=plan.entities_to_restart | set(agent_bots))
-            return await self.apply_update_plan(current_config, plan, plugin_changes)
+
+            updated = False
+
+            async def apply_update_plan() -> None:
+                nonlocal updated
+                updated = await self.apply_update_plan(current_config, plan, plugin_changes)
+
+            await self._apply_after_response_drain(
+                apply_update_plan,
+                operation_name="configuration reload",
+                request_is_current=self._reload_publication_is_current,
+            )
+            return updated
+
+    def _reload_publication_is_current(self) -> bool:
+        """Allow direct updates, but skip queued snapshots superseded before publication."""
+        if asyncio.current_task() is not self._reload_task:
+            return True
+        return self.is_running() and self._requested_at is None
 
     async def _wait_for_reload_debounce(
         self,
@@ -276,30 +315,44 @@ class ConfigReloadLifecycle:
         call cannot wait on its own slot. The drain defers for at most 600
         seconds before closing admission over a forced apply.
         """
+        async with self._response_admission_apply_lock:
+            await self._apply_after_response_drain(
+                operation,
+                operation_name=operation_name,
+                request_is_current=request_is_current,
+            )
+
+    async def _apply_after_response_drain(
+        self,
+        operation: Callable[[], Awaitable[None]],
+        *,
+        operation_name: str,
+        request_is_current: Callable[[], bool],
+    ) -> None:
+        """Drain responses and apply while the caller owns replacement serialization."""
         loop = asyncio.get_running_loop()
         drain_state = _ReplacementDrainState()
-        async with self._response_admission_apply_lock:
-            while request_is_current():
-                if self.response_admission_gate.close_if_idle():
-                    if drain_state.waiting_for_idle:
-                        logger.info(
-                            "Active responses finished; applying replacement",
-                            operation=operation_name,
-                        )
-                    break
-                if await self._should_defer_replacement_for_active_responses(
-                    drain_state=drain_state,
-                    active_response_count=self.response_admission_gate.in_flight_response_count,
-                    loop=loop,
-                    operation_name=operation_name,
-                ):
-                    continue
-                self.response_admission_gate.close()
+        while request_is_current():
+            if self.response_admission_gate.close_if_idle():
+                if drain_state.waiting_for_idle:
+                    logger.info(
+                        "Active responses finished; applying replacement",
+                        operation=operation_name,
+                    )
                 break
-            else:
-                return
+            if await self._should_defer_replacement_for_active_responses(
+                drain_state=drain_state,
+                active_response_count=self.response_admission_gate.in_flight_response_count,
+                loop=loop,
+                operation_name=operation_name,
+            ):
+                continue
+            self.response_admission_gate.close()
+            break
+        else:
+            return
 
-            await self._apply_with_closed_admission(operation)
+        await self._apply_with_closed_admission(operation)
 
     async def _apply_queued_config_reload(self) -> None:
         """Apply one queued config reload attempt and log the result."""
@@ -334,11 +387,7 @@ class ConfigReloadLifecycle:
                     # A newer config change superseded the current one.
                     continue
 
-                await self.apply_with_response_admission(
-                    self._apply_queued_config_reload,
-                    operation_name="configuration reload",
-                    request_is_current=lambda requested_at=requested_at: self._requested_at == requested_at,
-                )
+                await self._apply_queued_config_reload()
         finally:
             if self._reload_task is current_task:
                 self._reload_task = None

--- a/src/mindroom/orchestration/config_updates.py
+++ b/src/mindroom/orchestration/config_updates.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from mindroom.constants import ROUTER_AGENT_NAME
+from mindroom.entity_rooms import get_rooms_for_entity
 from mindroom.logging_config import get_logger
 from mindroom.mcp.registry import mcp_tool_name
 
@@ -57,11 +58,14 @@ class ConfigUpdatePlan:
     authorization_changed: bool
     room_metadata_changed: bool = False
     added_entities: set[str] = field(default_factory=set)
+    entities_to_reconcile_rooms: set[str] = field(default_factory=set)
 
     @property
     def _has_entity_changes(self) -> bool:
-        """Return whether any bots must be created, restarted, or removed."""
-        return bool(self.entities_to_restart or self.new_entities or self.removed_entities)
+        """Return whether any bots must be created, restarted, removed, or reconciled."""
+        return bool(
+            self.entities_to_restart or self.new_entities or self.removed_entities or self.entities_to_reconcile_rooms,
+        )
 
     @property
     def only_support_service_changes(self) -> bool:
@@ -91,11 +95,19 @@ def plugin_change_paths(current_config: Config, new_config: Config) -> tuple[str
     return tuple(sorted(changed_paths))
 
 
-def _config_entries_differ(old_entry: BaseModel | None, new_entry: BaseModel | None) -> bool:
+def _config_entries_differ(
+    old_entry: BaseModel | None,
+    new_entry: BaseModel | None,
+    *,
+    exclude: set[str] | None = None,
+) -> bool:
     """Compare optional config models using the same shape as persisted YAML."""
     if old_entry is None or new_entry is None:
         return old_entry != new_entry
-    return old_entry.model_dump(exclude_none=True) != new_entry.model_dump(exclude_none=True)
+    return old_entry.model_dump(exclude_none=True, exclude=exclude) != new_entry.model_dump(
+        exclude_none=True,
+        exclude=exclude,
+    )
 
 
 def _identify_entities_to_restart(
@@ -113,19 +125,63 @@ def _identify_entities_to_restart(
     if changed_mcp_servers:
         entities_to_restart |= _entities_referencing_mcp_servers(config, new_config, changed_mcp_servers)
 
-    if _router_needs_restart(config, new_config):
-        entities_to_restart.add("router")
-
     return entities_to_restart
 
 
 def _call_agents_to_restart(config: Config | None, new_config: Config) -> set[str]:
-    """Return call agents whose managers captured an obsolete config snapshot."""
-    if config is None or config.authored_model_dump() == new_config.authored_model_dump():
+    """Return call agents whose effective call-manager configuration changed."""
+    if config is None:
         return set()
     old_agents = set(config.calls.agents) if config.calls.enabled else set()
     new_agents = set(new_config.calls.agents) if new_config.calls.enabled else set()
-    return old_agents | new_agents
+    return {
+        agent_name
+        for agent_name in old_agents | new_agents
+        if _call_manager_signature(config, agent_name) != _call_manager_signature(new_config, agent_name)
+    }
+
+
+def _call_manager_signature(config: Config, agent_name: str) -> tuple[object, ...] | None:
+    """Return config captured by one call manager and its active call tooling."""
+    if not config.calls.enabled or agent_name not in config.calls.agents:
+        return None
+    call_config = config.calls.resolve_agent_config(agent_name)
+    agent_config = config.get_agent(agent_name)
+    entity_view = config.resolve_entity(agent_name)
+    configured_worker_tools = agent_config.worker_tools
+    if configured_worker_tools is None:
+        configured_worker_tools = config.defaults.worker_tools
+    effective_worker_tools = (
+        None if configured_worker_tools is None else tuple(config.expand_tool_names(configured_worker_tools))
+    )
+    effective_worker_scope = entity_view.execution_scope
+    effective_allow_self_config = (
+        agent_config.allow_self_config
+        if agent_config.allow_self_config is not None
+        else config.defaults.allow_self_config
+    )
+    call_agent_model_signature: object
+    if call_config.backend == "cascaded" and call_config.model is not None:
+        call_agent_model_signature = ("explicit", call_config.model, config.models[call_config.model])
+    else:
+        call_agent_model_signature = (
+            "dynamic",
+            entity_view.model_name,
+            tuple(sorted(config.room_models.items())),
+            tuple(sorted(config.models.items())),
+        )
+    return (
+        call_config,
+        config.calls.livekit_service_url,
+        call_agent_model_signature,
+        tuple(entity_view.tool_configs),
+        effective_worker_tools,
+        effective_worker_scope,
+        config.get_worker_grantable_credentials() if effective_worker_scope is not None else None,
+        effective_allow_self_config,
+        config.authorization,
+        config.tool_approval,
+    )
 
 
 def _get_changed_agents(
@@ -144,7 +200,7 @@ def _get_changed_agents(
         old_agent = config.agents.get(agent_name)
         new_agent = new_config.agents.get(agent_name)
 
-        agents_differ = _config_entries_differ(old_agent, new_agent)
+        agents_differ = _config_entries_differ(old_agent, new_agent, exclude={"rooms"})
         old_culture = _culture_signature_for_agent(agent_name, config) if old_agent else None
         new_culture = _culture_signature_for_agent(agent_name, new_config) if new_agent else None
         culture_differ = old_culture != new_culture
@@ -188,7 +244,7 @@ def _get_changed_teams(
     for team_name in all_teams:
         old_team = config.teams.get(team_name)
         new_team = new_config.teams.get(team_name)
-        teams_differ = _config_entries_differ(old_team, new_team)
+        teams_differ = _config_entries_differ(old_team, new_team, exclude={"rooms"})
 
         if teams_differ and (team_name in agent_bots or new_team is not None):
             changed.add(team_name)
@@ -196,14 +252,19 @@ def _get_changed_teams(
     return changed
 
 
-def _router_needs_restart(config: Config | None, new_config: Config) -> bool:
-    """Check if router needs restart due to room changes."""
-    if not config:
-        return False
-
-    old_rooms = config.get_all_configured_rooms()
-    new_rooms = new_config.get_all_configured_rooms()
-    return old_rooms != new_rooms
+def _entities_with_room_changes(
+    config: Config,
+    new_config: Config,
+    *,
+    configured_entities: set[str],
+    existing_entities: set[str],
+) -> set[str]:
+    """Return live entities whose desired Matrix room memberships changed."""
+    return {
+        entity_name
+        for entity_name in configured_entities & existing_entities
+        if set(get_rooms_for_entity(entity_name, config)) != set(get_rooms_for_entity(entity_name, new_config))
+    }
 
 
 def _room_metadata_changed(config: Config, new_config: Config) -> bool:
@@ -307,6 +368,16 @@ def build_config_update_plan(
             )
         entities_to_restart |= sync_affected_entities
 
+    entities_to_reconcile_rooms = (
+        _entities_with_room_changes(
+            current_config,
+            new_config,
+            configured_entities=configured_entities,
+            existing_entities=existing_entities,
+        )
+        - entities_to_restart
+    )
+
     added_entities = configured_entities - existing_entities
     new_entities = added_entities - entities_to_restart
 
@@ -323,4 +394,5 @@ def build_config_update_plan(
         authorization_changed=current_config.authorization != new_config.authorization,
         room_metadata_changed=_room_metadata_changed(current_config, new_config),
         added_entities=added_entities,
+        entities_to_reconcile_rooms=entities_to_reconcile_rooms,
     )

--- a/src/mindroom/orchestration/config_updates.py
+++ b/src/mindroom/orchestration/config_updates.py
@@ -143,59 +143,16 @@ def _call_agents_to_restart(config: Config | None, new_config: Config) -> set[st
         logger.info(
             "call_manager_configuration_changed_restart_required",
             agents=sorted(changed_agents),
+            reason="active call tooling captures the authored configuration snapshot",
         )
     return changed_agents
 
 
-def _call_manager_signature(config: Config, agent_name: str) -> tuple[object, ...] | None:
-    """Return config captured by one call manager and its active call tooling."""
+def _call_manager_signature(config: Config, agent_name: str) -> object | None:
+    """Return the authored config captured by one active call agent."""
     if not config.calls.enabled or agent_name not in config.calls.agents:
         return None
-    call_config = config.calls.resolve_agent_config(agent_name)
-    agent_config = config.get_agent(agent_name)
-    entity_view = config.resolve_entity(agent_name)
-    configured_worker_tools = agent_config.worker_tools
-    if configured_worker_tools is None:
-        configured_worker_tools = config.defaults.worker_tools
-    effective_worker_tools = (
-        None if configured_worker_tools is None else tuple(config.expand_tool_names(configured_worker_tools))
-    )
-    effective_worker_scope = entity_view.execution_scope
-    effective_allow_self_config = (
-        agent_config.allow_self_config
-        if agent_config.allow_self_config is not None
-        else config.defaults.allow_self_config
-    )
-    call_agent_model_signature: object
-    if call_config.backend == "cascaded" and call_config.model is not None:
-        call_agent_model_signature = ("explicit", call_config.model, config.models[call_config.model])
-    else:
-        call_agent_model_signature = (
-            "dynamic",
-            entity_view.model_name,
-            tuple(sorted(config.room_models.items())),
-            tuple(sorted(config.models.items())),
-        )
-    return (
-        call_config,
-        config.calls.livekit_service_url,
-        call_agent_model_signature,
-        tuple(entity_view.tool_configs),
-        effective_worker_tools,
-        effective_worker_scope,
-        config.get_worker_grantable_credentials() if effective_worker_scope is not None else None,
-        effective_allow_self_config,
-        config.authorization,
-        config.tool_approval,
-        config.matrix_room_access.encrypt_managed_rooms,
-        tuple(
-            sorted(
-                (room_name, room_config.encrypted)
-                for room_name, room_config in config.rooms.items()
-                if room_config.encrypted is not None
-            ),
-        ),
-    )
+    return config.authored_model_dump()
 
 
 def _get_changed_agents(

--- a/src/mindroom/orchestration/config_updates.py
+++ b/src/mindroom/orchestration/config_updates.py
@@ -134,11 +134,17 @@ def _call_agents_to_restart(config: Config | None, new_config: Config) -> set[st
         return set()
     old_agents = set(config.calls.agents) if config.calls.enabled else set()
     new_agents = set(new_config.calls.agents) if new_config.calls.enabled else set()
-    return {
+    changed_agents = {
         agent_name
         for agent_name in old_agents | new_agents
         if _call_manager_signature(config, agent_name) != _call_manager_signature(new_config, agent_name)
     }
+    if changed_agents:
+        logger.info(
+            "call_manager_configuration_changed_restart_required",
+            agents=sorted(changed_agents),
+        )
+    return changed_agents
 
 
 def _call_manager_signature(config: Config, agent_name: str) -> tuple[object, ...] | None:
@@ -181,6 +187,14 @@ def _call_manager_signature(config: Config, agent_name: str) -> tuple[object, ..
         effective_allow_self_config,
         config.authorization,
         config.tool_approval,
+        config.matrix_room_access.encrypt_managed_rooms,
+        tuple(
+            sorted(
+                (room_name, room_config.encrypted)
+                for room_name, room_config in config.rooms.items()
+                if room_config.encrypted is not None
+            ),
+        ),
     )
 
 

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1753,6 +1753,7 @@ class _MultiAgentOrchestrator:
                 room_count=len(bot.rooms),
             )
             await cancel_sync_task(bot.agent_name, self._sync_tasks)
+            bot.preserve_reply_memberships_on_next_sync_start()
             self._start_sync_task(bot.agent_name, bot)
         if plan.matrix_space_changed or plan.room_metadata_changed:
             room_ids = await self._ensure_rooms_exist()

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1740,9 +1740,20 @@ class _MultiAgentOrchestrator:
         changed_entities: set[str],
     ) -> None:
         """Reconcile rooms and memberships after entity/config updates."""
+        room_reconciled_bots = self._running_bots_for_entities(plan.entities_to_reconcile_rooms)
         bots_to_setup = self._running_bots_for_entities(changed_entities | plan.entities_to_reconcile_rooms)
         if bots_to_setup or plan.mindroom_user_changed or plan.matrix_room_access_changed or plan.authorization_changed:
             await self._setup_rooms_and_memberships(bots_to_setup)
+        for bot in room_reconciled_bots:
+            if bot.config.matrix_sync.mode != "sliding":
+                continue
+            logger.info(
+                "restarting_sliding_sync_after_room_reconciliation",
+                agent=bot.agent_name,
+                room_count=len(bot.rooms),
+            )
+            await cancel_sync_task(bot.agent_name, self._sync_tasks)
+            self._start_sync_task(bot.agent_name, bot)
         if plan.matrix_space_changed or plan.room_metadata_changed:
             room_ids = await self._ensure_rooms_exist()
             await self._ensure_root_space(room_ids)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1740,7 +1740,7 @@ class _MultiAgentOrchestrator:
         changed_entities: set[str],
     ) -> None:
         """Reconcile rooms and memberships after entity/config updates."""
-        bots_to_setup = self._running_bots_for_entities(changed_entities)
+        bots_to_setup = self._running_bots_for_entities(changed_entities | plan.entities_to_reconcile_rooms)
         if bots_to_setup or plan.mindroom_user_changed or plan.matrix_room_access_changed or plan.authorization_changed:
             await self._setup_rooms_and_memberships(bots_to_setup)
         if plan.matrix_space_changed or plan.room_metadata_changed:
@@ -2259,7 +2259,10 @@ async def _watch_config_task(config_path: Path, orchestrator: _MultiAgentOrchest
     def config_source_paths() -> Iterable[Path]:
         config = orchestrator.config
         watched: set[Path] = {config_path}
-        if config is not None and config.source_files:
+        loaded_source_files = orchestrator.config_reload.loaded_source_files
+        if loaded_source_files is not None:
+            watched.update(loaded_source_files)
+        elif config is not None and config.source_files:
             watched.update(config.source_files)
         # A failed reload's own source set covers include files the last good
         # config never referenced, so fixing them still triggers a retry.

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -791,6 +791,50 @@ async def test_failed_partial_publication_retries_from_last_successful_config(
 
 
 @pytest.mark.asyncio
+async def test_failed_partial_publication_allows_rollback_to_last_successful_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Restoring the last-good file must repair a partially published runtime."""
+    current_config = Config()
+    failed_config = Config(defaults={"enable_streaming": False})
+    loaded_config = failed_config
+    live_config = current_config
+    applied_from: list[Config] = []
+    applied_configs: list[Config] = []
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle.load_config",
+        lambda *_args, **_kwargs: loaded_config,
+    )
+    lifecycle = _make_lifecycle(tmp_path, current_config=current_config)
+    lifecycle.current_config = lambda: live_config
+
+    async def apply_plan(
+        applied_config: Config,
+        plan: ConfigUpdatePlan,
+        _plugin_changes: tuple[str, ...],
+    ) -> bool:
+        nonlocal live_config
+        applied_from.append(applied_config)
+        applied_configs.append(plan.new_config)
+        live_config = plan.new_config
+        if len(applied_configs) == 1:
+            msg = "failed after config publication"
+            raise RuntimeError(msg)
+        return True
+
+    lifecycle.apply_update_plan = AsyncMock(side_effect=apply_plan)
+
+    with pytest.raises(RuntimeError, match="failed after config publication"):
+        await lifecycle._update_config()
+
+    loaded_config = current_config
+    assert await lifecycle._update_config() is True
+    assert applied_from == [current_config, failed_config]
+    assert applied_configs == [failed_config, current_config]
+
+
+@pytest.mark.asyncio
 async def test_update_config_plugin_changes_restart_all_bots(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -760,7 +760,7 @@ async def test_failed_partial_publication_retries_from_last_successful_config(
     current_config = Config()
     new_config = Config(defaults={"enable_streaming": False})
     live_config = current_config
-    applied_from: list[Config] = []
+    applied_steps: list[tuple[Config, Config]] = []
     monkeypatch.setattr(
         "mindroom.orchestration.config_lifecycle.load_config",
         lambda *_args, **_kwargs: new_config,
@@ -770,13 +770,13 @@ async def test_failed_partial_publication_retries_from_last_successful_config(
 
     async def apply_plan(
         applied_config: Config,
-        _plan: ConfigUpdatePlan,
+        plan: ConfigUpdatePlan,
         _plugin_changes: tuple[str, ...],
     ) -> bool:
         nonlocal live_config
-        applied_from.append(applied_config)
-        live_config = new_config
-        if len(applied_from) == 1:
+        applied_steps.append((applied_config, plan.new_config))
+        live_config = plan.new_config
+        if len(applied_steps) == 1:
             msg = "failed after config publication"
             raise RuntimeError(msg)
         return True
@@ -787,7 +787,11 @@ async def test_failed_partial_publication_retries_from_last_successful_config(
         await lifecycle._update_config()
 
     assert await lifecycle._update_config() is True
-    assert applied_from == [current_config, current_config]
+    assert applied_steps == [
+        (current_config, new_config),
+        (new_config, current_config),
+        (current_config, new_config),
+    ]
 
 
 @pytest.mark.asyncio
@@ -832,6 +836,55 @@ async def test_failed_partial_publication_allows_rollback_to_last_successful_con
     assert await lifecycle._update_config() is True
     assert applied_from == [current_config, failed_config]
     assert applied_configs == [failed_config, current_config]
+
+
+@pytest.mark.asyncio
+async def test_failed_partial_publication_repairs_before_applying_corrected_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A corrected third snapshot must apply only after restoring the last-good state."""
+    current_config = Config(agents={"agent1": AgentConfig(display_name="Agent 1", rooms=["lobby"])})
+    failed_config = Config(agents={"agent1": AgentConfig(display_name="Agent 1", rooms=["project"])})
+    corrected_config = Config(
+        agents={"agent1": AgentConfig(display_name="Agent 1", rooms=["lobby"])},
+        defaults={"enable_streaming": False},
+    )
+    loaded_config = failed_config
+    live_config = current_config
+    applied_steps: list[tuple[Config, Config]] = []
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle.load_config",
+        lambda *_args, **_kwargs: loaded_config,
+    )
+    lifecycle = _make_lifecycle(tmp_path, current_config=current_config)
+    lifecycle.current_config = lambda: live_config
+
+    async def apply_plan(
+        applied_config: Config,
+        plan: ConfigUpdatePlan,
+        _plugin_changes: tuple[str, ...],
+    ) -> bool:
+        nonlocal live_config
+        applied_steps.append((applied_config, plan.new_config))
+        live_config = plan.new_config
+        if len(applied_steps) == 1:
+            msg = "failed after config publication"
+            raise RuntimeError(msg)
+        return True
+
+    lifecycle.apply_update_plan = AsyncMock(side_effect=apply_plan)
+
+    with pytest.raises(RuntimeError, match="failed after config publication"):
+        await lifecycle._update_config()
+
+    loaded_config = corrected_config
+    assert await lifecycle._update_config() is True
+    assert applied_steps == [
+        (current_config, failed_config),
+        (failed_config, current_config),
+        (current_config, corrected_config),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -822,8 +822,12 @@ async def test_failed_partial_publication_allows_rollback_to_last_successful_con
         applied_from.append(applied_config)
         applied_configs.append(plan.new_config)
         live_config = plan.new_config
-        if len(applied_configs) == 1:
-            msg = "failed after config publication"
+        if len(applied_configs) <= 2:
+            msg = (
+                "failed after config publication"
+                if len(applied_configs) == 1
+                else "failed during partial-publication repair"
+            )
             raise RuntimeError(msg)
         return True
 
@@ -833,9 +837,12 @@ async def test_failed_partial_publication_allows_rollback_to_last_successful_con
         await lifecycle._update_config()
 
     loaded_config = current_config
+    with pytest.raises(RuntimeError, match="failed during partial-publication repair"):
+        await lifecycle._update_config()
+
     assert await lifecycle._update_config() is True
-    assert applied_from == [current_config, failed_config]
-    assert applied_configs == [failed_config, current_config]
+    assert applied_from == [current_config, failed_config, failed_config]
+    assert applied_configs == [failed_config, current_config, current_config]
 
 
 @pytest.mark.asyncio

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -172,6 +172,43 @@ async def test_reload_drains_active_responses_before_applying(
 
 
 @pytest.mark.asyncio
+async def test_reload_does_not_hold_config_lock_while_draining_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Response drain must not block unrelated config-lock owners."""
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
+    gate = ResponseAdmissionGate()
+    assert gate.admit()
+    current_config = Config()
+    new_config = Config(defaults={"enable_streaming": False})
+    load_started = threading.Event()
+
+    def observed_load_config(*_args: object, **_kwargs: object) -> Config:
+        load_started.set()
+        return new_config
+
+    load_config_mock = MagicMock(side_effect=observed_load_config)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle.load_config", load_config_mock)
+    lifecycle = _make_lifecycle(
+        tmp_path,
+        current_config=current_config,
+        response_admission_gate=gate,
+    )
+
+    update_task = asyncio.create_task(lifecycle._update_config())
+    assert await asyncio.to_thread(load_started.wait, 1)
+    await asyncio.sleep(0.02)
+
+    await asyncio.wait_for(lifecycle.config_update_lock.acquire(), timeout=0.1)
+    lifecycle.config_update_lock.release()
+    lifecycle.apply_update_plan.assert_not_awaited()
+
+    gate.release()
+    assert await asyncio.wait_for(update_task, timeout=1) is True
+
+
+@pytest.mark.asyncio
 async def test_semantic_noop_reload_does_not_wait_for_active_responses(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -357,6 +394,8 @@ async def test_new_request_during_drain_keeps_waiting_for_idle(
     """A newer config change should not make an active response reload early."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0.01)
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.005)
+    logger_mock = MagicMock()
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle.logger", logger_mock)
     gate = ResponseAdmissionGate()
     assert gate.admit()
     current_config = Config()
@@ -383,6 +422,7 @@ async def test_new_request_during_drain_keeps_waiting_for_idle(
     await asyncio.wait_for(task, timeout=1)
 
     lifecycle.apply_update_plan.assert_awaited_once()
+    logger_mock.info.assert_any_call("Configuration reload superseded before publication; skipping")
 
 
 @pytest.mark.asyncio
@@ -791,11 +831,11 @@ async def test_update_config_loads_config_off_event_loop(
 
 
 @pytest.mark.asyncio
-async def test_update_config_waits_for_lock_before_loading(
+async def test_update_config_loads_before_waiting_for_publication_lock(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Config loading must not start until the shared update lock is available."""
+    """Config loading may proceed while another shared-lock owner is active."""
     lock = asyncio.Lock()
     current_config = Config()
     new_config = Config(defaults={"enable_streaming": False})
@@ -814,11 +854,11 @@ async def test_update_config_waits_for_lock_before_loading(
 
     await lock.acquire()
     update_task = asyncio.create_task(lifecycle._update_config())
-    await asyncio.sleep(0)
-    assert not to_thread_started.is_set()
+    await asyncio.wait_for(to_thread_started.wait(), timeout=1.0)
+    assert not update_task.done()
+    lifecycle.apply_update_plan.assert_not_awaited()
 
     lock.release()
-    await asyncio.wait_for(to_thread_started.wait(), timeout=1.0)
     assert await update_task is True
     load_config_mock.assert_called_once()
     lifecycle.apply_update_plan.assert_awaited_once()

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -11,7 +11,7 @@ import pytest
 
 import mindroom.orchestration.config_lifecycle as lifecycle_module
 from mindroom.config.agent import AgentConfig
-from mindroom.config.main import Config
+from mindroom.config.main import Config, load_config
 from mindroom.orchestration.config_lifecycle import ConfigReloadLifecycle, _ReplacementDrainState
 from mindroom.orchestration.config_updates import ConfigUpdatePlan
 from mindroom.orchestration.runtime import create_logged_task
@@ -147,20 +147,89 @@ async def test_reload_drains_active_responses_before_applying(
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
     gate = ResponseAdmissionGate()
     assert gate.admit()
-    lifecycle = _make_lifecycle(tmp_path, response_admission_gate=gate)
-    lifecycle._update_config = AsyncMock(return_value=True)
+    current_config = Config()
+    new_config = Config(defaults={"enable_streaming": False})
+    load_config_mock = MagicMock(return_value=new_config)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle.load_config", load_config_mock)
+    lifecycle = _make_lifecycle(
+        tmp_path,
+        current_config=current_config,
+        response_admission_gate=gate,
+    )
 
     lifecycle.request_reload()
     task = lifecycle._reload_task
     assert task is not None
 
     await asyncio.sleep(0.05)
-    lifecycle._update_config.assert_not_awaited()
+    load_config_mock.assert_called_once()
+    lifecycle.apply_update_plan.assert_not_awaited()
 
     gate.release()
     await asyncio.wait_for(task, timeout=1)
-    lifecycle._update_config.assert_awaited_once()
+    lifecycle.apply_update_plan.assert_awaited_once()
     assert gate.closed is False
+
+
+@pytest.mark.asyncio
+async def test_semantic_noop_reload_does_not_wait_for_active_responses(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A comment-only or formatting-only save must not close response admission."""
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0)
+    gate = ResponseAdmissionGate()
+    assert gate.admit()
+    current_config = Config()
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle.load_config",
+        lambda *_args, **_kwargs: Config(),
+    )
+    lifecycle = _make_lifecycle(
+        tmp_path,
+        current_config=current_config,
+        response_admission_gate=gate,
+    )
+
+    lifecycle.request_reload()
+    task = lifecycle._reload_task
+    assert task is not None
+
+    try:
+        await asyncio.wait_for(asyncio.shield(task), timeout=0.2)
+    finally:
+        gate.release()
+        await asyncio.gather(task, return_exceptions=True)
+
+    lifecycle.apply_update_plan.assert_not_awaited()
+    assert gate.closed is False
+
+
+@pytest.mark.asyncio
+async def test_semantic_noop_reload_records_new_include_sources(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Equivalent config moved into an include must make that include watchable."""
+    runtime_paths = test_runtime_paths(tmp_path)
+    runtime_paths.config_path.write_text("defaults:\n  enable_streaming: true\n", encoding="utf-8")
+    current_config = load_config(runtime_paths)
+    included_defaults = tmp_path / "defaults.yaml"
+    included_defaults.write_text("enable_streaming: true\n", encoding="utf-8")
+    runtime_paths.config_path.write_text("defaults: !include defaults.yaml\n", encoding="utf-8")
+    reloaded_config = load_config(runtime_paths)
+    assert current_config.authored_model_dump() == reloaded_config.authored_model_dump()
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle.load_config",
+        lambda *_args, **_kwargs: reloaded_config,
+    )
+    lifecycle = _make_lifecycle(tmp_path, current_config=current_config)
+
+    assert await lifecycle._update_config() is False
+
+    assert lifecycle.loaded_source_files == reloaded_config.source_files
+    assert included_defaults.resolve() in lifecycle.loaded_source_files
+    lifecycle.apply_update_plan.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -290,9 +359,15 @@ async def test_new_request_during_drain_keeps_waiting_for_idle(
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.005)
     gate = ResponseAdmissionGate()
     assert gate.admit()
-    lifecycle = _make_lifecycle(tmp_path, response_admission_gate=gate)
-
-    lifecycle._update_config = AsyncMock(return_value=True)
+    current_config = Config()
+    new_config = Config(defaults={"enable_streaming": False})
+    load_config_mock = MagicMock(return_value=new_config)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle.load_config", load_config_mock)
+    lifecycle = _make_lifecycle(
+        tmp_path,
+        current_config=current_config,
+        response_admission_gate=gate,
+    )
 
     lifecycle.request_reload()
     await asyncio.sleep(0.06)
@@ -301,12 +376,13 @@ async def test_new_request_during_drain_keeps_waiting_for_idle(
 
     task = lifecycle._reload_task
     assert task is not None
-    lifecycle._update_config.assert_not_awaited()
+    assert load_config_mock.call_count == 2
+    lifecycle.apply_update_plan.assert_not_awaited()
 
     gate.release()
     await asyncio.wait_for(task, timeout=1)
 
-    lifecycle._update_config.assert_awaited_once()
+    lifecycle.apply_update_plan.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -418,8 +494,15 @@ async def test_cancel_clears_queued_reload(
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
     busy_gate = ResponseAdmissionGate()
     assert busy_gate.admit()
-    lifecycle = _make_lifecycle(tmp_path, response_admission_gate=busy_gate)
-    lifecycle._update_config = AsyncMock(return_value=True)
+    current_config = Config()
+    new_config = Config(defaults={"enable_streaming": False})
+    load_config_mock = MagicMock(return_value=new_config)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle.load_config", load_config_mock)
+    lifecycle = _make_lifecycle(
+        tmp_path,
+        current_config=current_config,
+        response_admission_gate=busy_gate,
+    )
 
     lifecycle.request_reload()
     task = lifecycle._reload_task
@@ -431,22 +514,24 @@ async def test_cancel_clears_queued_reload(
     assert lifecycle._reload_task is None
     assert lifecycle._requested_at is None
     assert task.done()
-    lifecycle._update_config.assert_not_awaited()
+    load_config_mock.assert_called_once()
+    lifecycle.apply_update_plan.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_response_start_during_config_load_waits_until_apply_finishes(
+async def test_config_load_stays_open_then_apply_waits_for_active_responses(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A response racing blocked config loading must be refused until apply finishes."""
+    """Loading and planning stay live, while publication still drains active responses."""
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0)
     load_started = threading.Event()
     release_load = threading.Event()
     observed_apply_counts: list[int] = []
     gate = ResponseAdmissionGate()
+    assert gate.admit()
     current_config = Config()
-    new_config = Config()
+    new_config = Config(defaults={"enable_streaming": False})
 
     def blocked_load(*_args: object, **_kwargs: object) -> Config:
         load_started.set()
@@ -469,14 +554,19 @@ async def test_response_start_during_config_load_waits_until_apply_finishes(
     lifecycle.request_reload()
     reload_task = lifecycle._reload_task
     assert reload_task is not None
-    assert await asyncio.to_thread(load_started.wait, 1)
 
     try:
-        # Admission is already closed while the apply is in progress, and asking
-        # never blocks on the applier, so the response is refused immediately.
-        assert gate.admit() is False
+        assert await asyncio.to_thread(load_started.wait, 1)
+        # Loading and validation do not publish anything, so responses may keep
+        # entering on the current config snapshot.
+        assert gate.admit() is True
+        gate.release()
 
         release_load.set()
+        await asyncio.sleep(0.05)
+        lifecycle.apply_update_plan.assert_not_awaited()
+
+        gate.release()
         await asyncio.wait_for(reload_task, timeout=1)
 
         lifecycle.apply_update_plan.assert_awaited_once()
@@ -486,6 +576,8 @@ async def test_response_start_during_config_load_waits_until_apply_finishes(
         gate.release()
     finally:
         release_load.set()
+        while gate.in_flight_response_count:
+            gate.release()
         await asyncio.gather(reload_task, return_exceptions=True)
 
 
@@ -503,7 +595,10 @@ async def test_apply_does_not_block_response_drain_started_by_the_apply(
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._CONFIG_RELOAD_DEBOUNCE_SECONDS", 0)
     gate = ResponseAdmissionGate()
     lifecycle = _make_lifecycle(tmp_path, current_config=Config(), response_admission_gate=gate)
-    monkeypatch.setattr("mindroom.orchestration.config_lifecycle.load_config", lambda *_a, **_k: Config())
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle.load_config",
+        lambda *_a, **_k: Config(defaults={"enable_streaming": False}),
+    )
 
     async def response_lifecycle() -> str:
         if not gate.admit():
@@ -542,15 +637,24 @@ async def test_drain_applies_reload_after_force_timeout(
     gate = ResponseAdmissionGate()
     # A response that never finishes, so the gate is never idle.
     assert gate.admit()
-    lifecycle = _make_lifecycle(tmp_path, response_admission_gate=gate)
-    lifecycle._update_config = AsyncMock(return_value=True)
+    current_config = Config()
+    new_config = Config(defaults={"enable_streaming": False})
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle.load_config",
+        lambda *_args, **_kwargs: new_config,
+    )
+    lifecycle = _make_lifecycle(
+        tmp_path,
+        current_config=current_config,
+        response_admission_gate=gate,
+    )
 
     lifecycle.request_reload()
     task = lifecycle._reload_task
     assert task is not None
     await asyncio.wait_for(task, timeout=2)
 
-    lifecycle._update_config.assert_awaited_once()
+    lifecycle.apply_update_plan.assert_awaited_once()
     # Admission reopens even though the forced apply ran over a live response.
     assert gate.closed is False
 
@@ -614,7 +718,7 @@ async def test_update_config_plugin_changes_restart_all_bots(
 ) -> None:
     """Plugin entry changes should expand the plan to restart every managed bot."""
     current_config = Config()
-    new_config = Config()
+    new_config = Config(plugins=["plugins/demo"])
     plan = ConfigUpdatePlan(
         new_config=new_config,
         changed_mcp_servers=set(),
@@ -693,7 +797,8 @@ async def test_update_config_waits_for_lock_before_loading(
 ) -> None:
     """Config loading must not start until the shared update lock is available."""
     lock = asyncio.Lock()
-    config = Config()
+    current_config = Config()
+    new_config = Config(defaults={"enable_streaming": False})
     to_thread_started = asyncio.Event()
     real_to_thread = asyncio.to_thread
 
@@ -702,9 +807,9 @@ async def test_update_config_waits_for_lock_before_loading(
         return await real_to_thread(*args, **kwargs)
 
     monkeypatch.setattr(lifecycle_module.asyncio, "to_thread", observed_to_thread)
-    load_config_mock = MagicMock(return_value=config)
+    load_config_mock = MagicMock(return_value=new_config)
     monkeypatch.setattr(lifecycle_module, "load_config", load_config_mock)
-    lifecycle = _make_lifecycle(tmp_path, current_config=config)
+    lifecycle = _make_lifecycle(tmp_path, current_config=current_config)
     lifecycle.config_update_lock = lock
 
     await lock.acquire()

--- a/tests/test_config_lifecycle.py
+++ b/tests/test_config_lifecycle.py
@@ -752,6 +752,45 @@ async def test_update_config_builds_plan_and_dispatches(
 
 
 @pytest.mark.asyncio
+async def test_failed_partial_publication_retries_from_last_successful_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A partially published config must not make its retry look unchanged."""
+    current_config = Config()
+    new_config = Config(defaults={"enable_streaming": False})
+    live_config = current_config
+    applied_from: list[Config] = []
+    monkeypatch.setattr(
+        "mindroom.orchestration.config_lifecycle.load_config",
+        lambda *_args, **_kwargs: new_config,
+    )
+    lifecycle = _make_lifecycle(tmp_path, current_config=current_config)
+    lifecycle.current_config = lambda: live_config
+
+    async def apply_plan(
+        applied_config: Config,
+        _plan: ConfigUpdatePlan,
+        _plugin_changes: tuple[str, ...],
+    ) -> bool:
+        nonlocal live_config
+        applied_from.append(applied_config)
+        live_config = new_config
+        if len(applied_from) == 1:
+            msg = "failed after config publication"
+            raise RuntimeError(msg)
+        return True
+
+    lifecycle.apply_update_plan = AsyncMock(side_effect=apply_plan)
+
+    with pytest.raises(RuntimeError, match="failed after config publication"):
+        await lifecycle._update_config()
+
+    assert await lifecycle._update_config() is True
+    assert applied_from == [current_config, current_config]
+
+
+@pytest.mark.asyncio
 async def test_update_config_plugin_changes_restart_all_bots(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -831,11 +870,11 @@ async def test_update_config_loads_config_off_event_loop(
 
 
 @pytest.mark.asyncio
-async def test_update_config_loads_before_waiting_for_publication_lock(
+async def test_update_config_waits_for_shared_lock_before_plugin_aware_loading(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Config loading may proceed while another shared-lock owner is active."""
+    """Config loading must not overlap another plugin/config publication owner."""
     lock = asyncio.Lock()
     current_config = Config()
     new_config = Config(defaults={"enable_streaming": False})
@@ -854,11 +893,13 @@ async def test_update_config_loads_before_waiting_for_publication_lock(
 
     await lock.acquire()
     update_task = asyncio.create_task(lifecycle._update_config())
-    await asyncio.wait_for(to_thread_started.wait(), timeout=1.0)
-    assert not update_task.done()
-    lifecycle.apply_update_plan.assert_not_awaited()
-
-    lock.release()
+    await asyncio.sleep(0)
+    try:
+        assert not to_thread_started.is_set()
+        assert not update_task.done()
+        lifecycle.apply_update_plan.assert_not_awaited()
+    finally:
+        lock.release()
     assert await update_task is True
     load_config_mock.assert_called_once()
     lifecycle.apply_update_plan.assert_awaited_once()

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -2240,6 +2240,45 @@ def test_config_update_plan_restarts_implicit_cascaded_call_agent_when_room_mode
     assert plan.entities_to_restart == {"general"}
 
 
+@pytest.mark.parametrize(
+    "encryption_config",
+    [
+        {"matrix_room_access": {"encrypt_managed_rooms": True}},
+        {"rooms": {"lobby": {"encrypted": True}}},
+    ],
+)
+def test_config_update_plan_restarts_call_agents_when_room_encryption_policy_changes(
+    encryption_config: dict[str, object],
+) -> None:
+    """Call sessions must rebuild when their rooms switch to encrypted media."""
+    old_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent", rooms=["lobby"])},
+            calls=_calls_for("general"),
+            router=RouterConfig(model="default"),
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent", rooms=["lobby"])},
+            calls=_calls_for("general"),
+            router=RouterConfig(model="default"),
+            **encryption_config,
+        ),
+    )
+    running_entities = {ROUTER_AGENT_NAME, "general"}
+
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == {"general"}
+
+
 def test_config_update_plan_reconciles_agent_and_router_room_changes_without_restarts() -> None:
     """Room-list edits should update memberships without replacing Matrix clients."""
     old_config = _runtime_bound_config(

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -19,9 +19,10 @@ import mindroom.orchestrator as orchestrator_module
 import mindroom.tool_system.plugin_imports as plugin_module
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig, CultureConfig, RoomConfig, TeamConfig
-from mindroom.config.calls import CallsConfig, RealtimeCallProfile
+from mindroom.config.calls import CallsConfig, CascadedCallProfile, RealtimeCallProfile
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
+from mindroom.config.voice import SpeechServiceConfig
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.delivery_gateway import SendTextRequest
 from mindroom.file_watcher import _tree_snapshot
@@ -76,6 +77,26 @@ def _calls_for(
                 model=model,
                 credentials_service="openai",
                 voice=voice,
+            ),
+        },
+        agents={agent_name: "voice"},
+    )
+
+
+def _cascaded_calls_for(agent_name: str, *, model: str | None) -> CallsConfig:
+    speech_service = SpeechServiceConfig(
+        provider="openai_compatible",
+        model="local-speech",
+        host="http://127.0.0.1:9000",
+    )
+    return CallsConfig(
+        enabled=True,
+        profiles={
+            "voice": CascadedCallProfile(
+                backend="cascaded",
+                model=model,
+                stt=speech_service,
+                tts=speech_service,
             ),
         },
         agents={agent_name: "voice"},
@@ -1523,6 +1544,14 @@ async def test_config_update_serializes_manual_plugin_reload_and_mcp_catalog_cha
     orchestrator = _MultiAgentOrchestrator(runtime_paths_for(config))
     orchestrator.config = config
     orchestrator.running = True
+    reloaded_config = _runtime_bound_config(
+        Config(
+            agents={"agent1": AgentConfig(display_name="Agent 1", tools=["mcp_demo"])},
+            mcp_servers={"demo": {"transport": "stdio", "command": "npx"}},
+            defaults={"enable_streaming": False},
+        ),
+        tmp_path,
+    )
     apply_started = asyncio.Event()
     finish_apply = asyncio.Event()
 
@@ -1537,7 +1566,7 @@ async def test_config_update_serializes_manual_plugin_reload_and_mcp_catalog_cha
 
     reload_result = PluginReloadResult(HookRegistry.empty(), (), 0)
     with (
-        patch("mindroom.orchestration.config_lifecycle.load_config", return_value=config),
+        patch("mindroom.orchestration.config_lifecycle.load_config", return_value=reloaded_config),
         patch.object(orchestrator.config_reload, "apply_update_plan", new=apply_update_plan),
         patch("mindroom.orchestrator.reload_plugins", return_value=reload_result) as reload_plugins_mock,
     ):
@@ -1619,11 +1648,18 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
         )
 
     orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
+    orchestrator.config = config
     orchestrator.running = True
     orchestrator.agent_bots["agent1"] = bot
     # The orchestrator owns one shared gate that every managed bot admits through.
     bot.admission_gate = orchestrator.config_reload.response_admission_gate
-    orchestrator.config_reload._update_config = AsyncMock(return_value=True)
+    reloaded_config = _runtime_bound_config(
+        config.model_copy(update={"defaults": config.defaults.model_copy(update={"enable_streaming": False})}),
+        tmp_path,
+    )
+    load_config_mock = MagicMock(return_value=reloaded_config)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle.load_config", load_config_mock)
+    orchestrator.config_reload.apply_update_plan = AsyncMock(return_value=True)
 
     response_task = asyncio.create_task(
         runner._run_locked_response_lifecycle(
@@ -1642,13 +1678,14 @@ async def test_queued_config_reload_waits_for_in_flight_response_without_event_i
         assert task is not None
 
         await asyncio.sleep(0.05)
-        orchestrator.config_reload._update_config.assert_not_awaited()
+        load_config_mock.assert_called_once()
+        orchestrator.config_reload.apply_update_plan.assert_not_awaited()
 
         release_response.set()
         await asyncio.wait_for(response_task, timeout=1)
         await asyncio.wait_for(task, timeout=1)
 
-        orchestrator.config_reload._update_config.assert_awaited_once()
+        orchestrator.config_reload.apply_update_plan.assert_awaited_once()
     finally:
         release_response.set()
         await asyncio.gather(response_task, return_exceptions=True)
@@ -1975,7 +2012,7 @@ def test_config_update_plan_restarts_call_agent_when_profile_voice_changes() -> 
 
 
 def test_config_update_plan_restarts_call_agents_when_authorization_changes() -> None:
-    """Call managers restart so admission uses the current authorization rules."""
+    """Call tool contexts rebuild so authorization changes cannot leave stale policy."""
     old_config = _runtime_bound_config(
         Config(
             agents={"general": AgentConfig(display_name="General Agent")},
@@ -2006,7 +2043,7 @@ def test_config_update_plan_restarts_call_agents_when_authorization_changes() ->
 
 
 def test_config_update_plan_restarts_call_agents_for_captured_policy_changes() -> None:
-    """Call tool closures are rebuilt when any captured config policy changes."""
+    """Active call tool closures are rebuilt when their approval policy changes."""
     old_config = _runtime_bound_config(
         Config(
             agents={"general": AgentConfig(display_name="General Agent")},
@@ -2033,6 +2070,225 @@ def test_config_update_plan_restarts_call_agents_for_captured_policy_changes() -
     )
 
     assert plan.entities_to_restart == {"general"}
+
+
+def test_config_update_plan_restarts_call_agent_when_inherited_tools_change() -> None:
+    """An active call rebuilds when its effective default-provided tool surface changes."""
+    old_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            calls=_calls_for("general"),
+            defaults={"tools": ["shell"]},
+            router=RouterConfig(model="default"),
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            calls=_calls_for("general"),
+            defaults={"tools": []},
+            router=RouterConfig(model="default"),
+        ),
+    )
+    running_entities = {ROUTER_AGENT_NAME, "general"}
+
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == {"general"}
+
+
+def test_config_update_plan_restarts_call_agent_when_worker_routing_changes() -> None:
+    """An active call rebuilds when inherited worker routing changes for its tools."""
+    old_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            calls=_calls_for("general"),
+            defaults={"tools": ["shell"], "worker_tools": ["shell"]},
+            router=RouterConfig(model="default"),
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            calls=_calls_for("general"),
+            defaults={"tools": ["shell"], "worker_tools": []},
+            router=RouterConfig(model="default"),
+        ),
+    )
+    running_entities = {ROUTER_AGENT_NAME, "general"}
+
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == {"general"}
+
+
+def test_config_update_plan_restarts_cascaded_call_agent_when_referenced_model_changes() -> None:
+    """An active cascaded call rebuilds when its named model definition changes."""
+    old_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            models={
+                "default": ModelConfig(provider="openai", id="default-model"),
+                "call": ModelConfig(provider="openai", id="old-model"),
+            },
+            calls=_cascaded_calls_for("general", model="call"),
+            router=RouterConfig(model="default"),
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            models={
+                "default": ModelConfig(provider="openai", id="default-model"),
+                "call": ModelConfig(provider="openai", id="new-model"),
+            },
+            calls=_cascaded_calls_for("general", model="call"),
+            router=RouterConfig(model="default"),
+        ),
+    )
+    running_entities = {ROUTER_AGENT_NAME, "general"}
+
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == {"general"}
+
+
+def test_config_update_plan_restarts_realtime_call_agent_when_agent_model_changes() -> None:
+    """Realtime call tooling rebuilds when the normal agent's model definition changes."""
+    old_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            models={"default": ModelConfig(provider="openai", id="old-model")},
+            calls=_calls_for("general"),
+            router=RouterConfig(model="default"),
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            models={"default": ModelConfig(provider="openai", id="new-model")},
+            calls=_calls_for("general"),
+            router=RouterConfig(model="default"),
+        ),
+    )
+    running_entities = {ROUTER_AGENT_NAME, "general"}
+
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == {"general"}
+
+
+def test_config_update_plan_restarts_implicit_cascaded_call_agent_when_room_model_changes() -> None:
+    """Implicit cascaded model selection rebuilds when configured room routing changes."""
+    models = {
+        "default": ModelConfig(provider="openai", id="default-model"),
+        "focused": ModelConfig(provider="openai", id="focused-model"),
+        "fast": ModelConfig(provider="openai", id="fast-model"),
+    }
+    old_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent", rooms=["lobby"])},
+            models=models,
+            room_models={"lobby": "focused"},
+            calls=_cascaded_calls_for("general", model=None),
+            router=RouterConfig(model="default"),
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent", rooms=["lobby"])},
+            models=models,
+            room_models={"lobby": "fast"},
+            calls=_cascaded_calls_for("general", model=None),
+            router=RouterConfig(model="default"),
+        ),
+    )
+    running_entities = {ROUTER_AGENT_NAME, "general"}
+
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == {"general"}
+
+
+def test_config_update_plan_reconciles_agent_and_router_room_changes_without_restarts() -> None:
+    """Room-list edits should update memberships without replacing Matrix clients."""
+    old_config = _runtime_bound_config(
+        Config(
+            agents={
+                "general": AgentConfig(display_name="General Agent", rooms=["lobby"]),
+                "writer": AgentConfig(display_name="Writer Agent", rooms=["writers"]),
+            },
+            teams={
+                "editors": TeamConfig(
+                    display_name="Editors",
+                    role="Edit documents",
+                    agents=["writer"],
+                    rooms=["reviews"],
+                ),
+            },
+            router=RouterConfig(model="default"),
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            agents={
+                "general": AgentConfig(display_name="General Agent", rooms=["project"]),
+                "writer": AgentConfig(display_name="Writer Agent", rooms=["writers"]),
+            },
+            teams={
+                "editors": TeamConfig(
+                    display_name="Editors",
+                    role="Edit documents",
+                    agents=["writer"],
+                    rooms=["published"],
+                ),
+            },
+            router=RouterConfig(model="default"),
+        ),
+    )
+    running_entities = {ROUTER_AGENT_NAME, "general", "writer", "editors"}
+
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == set()
+    assert plan.entities_to_reconcile_rooms == {ROUTER_AGENT_NAME, "general", "editors"}
+    assert plan.only_support_service_changes is False
 
 
 def test_config_update_plan_stops_call_agents_when_calls_are_disabled() -> None:
@@ -3079,6 +3335,9 @@ async def test_shutdown_during_active_drain_cancels_reload(
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle._REPLACEMENT_DRAIN_IDLE_POLL_SECONDS", 0.01)
 
     orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
+    current_config = _runtime_bound_config(Config(), tmp_path)
+    reloaded_config = _runtime_bound_config(Config(defaults={"enable_streaming": False}), tmp_path)
+    orchestrator.config = current_config
     orchestrator.running = True
 
     mock_bot = MagicMock(spec=AgentBot)
@@ -3086,18 +3345,21 @@ async def test_shutdown_during_active_drain_cancels_reload(
     orchestrator.agent_bots["agent1"] = mock_bot
     # An admitted response that never finishes, so the drain never goes idle.
     assert orchestrator.config_reload.response_admission_gate.admit()
-    orchestrator.config_reload._update_config = AsyncMock(return_value=True)
+    load_config_mock = MagicMock(return_value=reloaded_config)
+    monkeypatch.setattr("mindroom.orchestration.config_lifecycle.load_config", load_config_mock)
+    orchestrator.config_reload.apply_update_plan = AsyncMock(return_value=True)
     orchestrator.config_reload.request_reload()
     task = orchestrator.config_reload._reload_task
     assert task is not None
 
     # Let the drain loop start polling
     await asyncio.sleep(0.05)
-    orchestrator.config_reload._update_config.assert_not_awaited()
+    load_config_mock.assert_called_once()
+    orchestrator.config_reload.apply_update_plan.assert_not_awaited()
 
     # Shutdown
     await orchestrator.stop()
 
     # The reload task should have been cancelled
     assert task.done()
-    orchestrator.config_reload._update_config.assert_not_awaited()
+    orchestrator.config_reload.apply_update_plan.assert_not_awaited()

--- a/tests/test_config_reload.py
+++ b/tests/test_config_reload.py
@@ -20,6 +20,7 @@ import mindroom.tool_system.plugin_imports as plugin_module
 from mindroom.bot import AgentBot
 from mindroom.config.agent import AgentConfig, CultureConfig, RoomConfig, TeamConfig
 from mindroom.config.calls import CallsConfig, CascadedCallProfile, RealtimeCallProfile
+from mindroom.config.knowledge import KnowledgeBaseConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig, RouterConfig
 from mindroom.config.voice import SpeechServiceConfig
@@ -2277,6 +2278,73 @@ def test_config_update_plan_restarts_call_agents_when_room_encryption_policy_cha
     )
 
     assert plan.entities_to_restart == {"general"}
+
+
+def test_config_update_plan_restarts_call_agent_when_knowledge_definition_changes() -> None:
+    """Active call tooling must not keep a captured stale knowledge definition."""
+    common = {
+        "agents": {
+            "general": AgentConfig(
+                display_name="General Agent",
+                knowledge_bases=["docs"],
+            ),
+        },
+        "calls": _calls_for("general"),
+        "router": RouterConfig(model="default"),
+    }
+    old_config = _runtime_bound_config(
+        Config(
+            **common,
+            knowledge_bases={"docs": KnowledgeBaseConfig(path="./old-docs")},
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            **common,
+            knowledge_bases={"docs": KnowledgeBaseConfig(path="./new-docs")},
+        ),
+    )
+    running_entities = {ROUTER_AGENT_NAME, "general"}
+
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == {"general"}
+
+
+def test_config_update_plan_restarts_call_agent_when_its_rooms_change() -> None:
+    """Replacing a call agent must terminate sessions in rooms it leaves."""
+    old_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent", rooms=["lobby"])},
+            calls=_calls_for("general"),
+            router=RouterConfig(model="default"),
+        ),
+    )
+    new_config = _runtime_bound_config(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent", rooms=["project"])},
+            calls=_calls_for("general"),
+            router=RouterConfig(model="default"),
+        ),
+    )
+    running_entities = {ROUTER_AGENT_NAME, "general"}
+
+    plan = build_config_update_plan(
+        current_config=old_config,
+        new_config=new_config,
+        configured_entities=running_entities,
+        existing_entities=running_entities,
+        agent_bots={entity: AsyncMock() for entity in running_entities},
+    )
+
+    assert plan.entities_to_restart == {"general"}
+    assert plan.entities_to_reconcile_rooms == {ROUTER_AGENT_NAME}
 
 
 def test_config_update_plan_reconciles_agent_and_router_room_changes_without_restarts() -> None:

--- a/tests/test_config_yaml_includes.py
+++ b/tests/test_config_yaml_includes.py
@@ -6,6 +6,7 @@ import asyncio
 import os
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -19,6 +20,7 @@ from mindroom.config.main import Config, load_config
 from mindroom.config.yaml_includes import ConfigIncludeError, load_yaml_config_source, partial_source_files
 from mindroom.constants import resolve_runtime_paths
 from mindroom.orchestration.config_lifecycle import ConfigReloadLifecycle
+from mindroom.orchestrator import _watch_config_task
 from mindroom.response_admission import ResponseAdmissionGate
 
 if TYPE_CHECKING:
@@ -714,6 +716,34 @@ class TestFailedReloadWatchSet:
         await lifecycle._apply_queued_config_reload()
 
         assert lifecycle.failed_reload_source_files is None
+
+    @pytest.mark.asyncio
+    async def test_config_watcher_uses_sources_from_a_successful_noop_reload(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The dynamic watcher should replace stale include topology after an equal reload."""
+        config_path = (tmp_path / "config.yaml").resolve()
+        old_include = (tmp_path / "old.yaml").resolve()
+        new_include = (tmp_path / "new.yaml").resolve()
+        orchestrator = SimpleNamespace(
+            config=SimpleNamespace(source_files=frozenset({config_path, old_include})),
+            config_reload=SimpleNamespace(
+                loaded_source_files=frozenset({config_path, new_include}),
+                failed_reload_source_files=None,
+            ),
+        )
+        watched: set[Path] = set()
+
+        async def capture_paths(paths_provider: Callable[[], set[Path]], _callback: object) -> None:
+            watched.update(paths_provider())
+
+        monkeypatch.setattr(file_watcher, "watch_paths", capture_paths)
+
+        await _watch_config_task(config_path, orchestrator)  # type: ignore[arg-type]
+
+        assert watched == {config_path, new_include}
 
     @pytest.mark.asyncio
     async def test_broken_new_include_file_stays_watched_until_fixed(self, tmp_path: Path) -> None:

--- a/tests/test_dynamic_config_update.py
+++ b/tests/test_dynamic_config_update.py
@@ -19,7 +19,6 @@ from mindroom.constants import ROUTER_AGENT_NAME, resolve_runtime_paths
 from mindroom.matrix.client import PermanentMatrixStartupError
 from mindroom.matrix.identity import MatrixID
 from mindroom.matrix.state import MatrixState
-from mindroom.orchestration.runtime import EntityStartResults
 from mindroom.orchestrator import _MultiAgentOrchestrator
 from mindroom.scheduling import CronSchedule, ScheduledWorkflow, _parse_workflow_schedule
 from tests.conftest import orchestrator_runtime_paths
@@ -589,11 +588,11 @@ class TestDynamicConfigUpdate:
         assert membership_client.joined_members.await_count == 1
 
     @pytest.mark.asyncio
-    async def test_failed_router_replacement_invalidates_ready_reply_memberships(
+    async def test_room_only_update_keeps_ready_reply_memberships_without_router_replacement(
         self,
         orchestrator_factory: Callable[[], _MultiAgentOrchestrator],
     ) -> None:
-        """A stopped control client cannot leave its old grant snapshot authoritative."""
+        """Live room reconciliation should preserve grants without replacing the router."""
         authorization = {
             "global_users": ["@alice:example.com"],
             "agent_reply_permissions": {
@@ -649,21 +648,23 @@ class TestDynamicConfigUpdate:
         with (
             patch("mindroom.orchestration.config_lifecycle.load_config", return_value=updated_config),
             patch.object(orchestrator, "_prepare_accounts_for_config_update", new=AsyncMock()),
-            patch("mindroom.orchestrator.stop_entities", new=AsyncMock()),
             patch.object(
                 orchestrator,
-                "_create_and_start_entities",
-                new=AsyncMock(return_value=EntityStartResults(retryable_entities=[ROUTER_AGENT_NAME])),
-            ),
-            patch.object(orchestrator, "_reconcile_post_update_rooms", new=AsyncMock()),
-            patch.object(orchestrator, "_schedule_bot_start_retry", new=AsyncMock()),
+                "_restart_changed_entities",
+                new=AsyncMock(return_value=(set(), [], [])),
+            ) as restart_entities,
+            patch.object(orchestrator, "_reconcile_post_update_rooms", new=AsyncMock()) as reconcile_rooms,
             patch.object(orchestrator, "_finalize_config_reload", new=AsyncMock()),
         ):
             updated = await orchestrator.config_reload._update_config()
 
         assert updated is True
-        assert orchestrator.agent_reply_memberships.needs_refresh(updated_config.authorization)
-        assert not orchestrator.agent_reply_memberships.is_allowed(
+        plan = restart_entities.await_args.args[0]
+        assert plan.entities_to_restart == set()
+        assert plan.entities_to_reconcile_rooms == {ROUTER_AGENT_NAME, "general"}
+        reconcile_rooms.assert_awaited_once_with(plan, set())
+        assert not orchestrator.agent_reply_memberships.needs_refresh(updated_config.authorization)
+        assert orchestrator.agent_reply_memberships.is_allowed(
             "@alice:example.com",
             ["lobby"],
             updated_config.authorization,

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -1759,6 +1759,41 @@ class TestMultiAgentOrchestrator:
         assert set(setup_rooms.await_args.args[0]) == {router_bot, general_bot}
 
     @pytest.mark.asyncio
+    async def test_reconcile_post_update_rooms_restarts_sliding_subscriptions(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Room-only edits must refresh explicit sliding-sync subscriptions."""
+        config = _runtime_bound_config(Config(matrix_sync={"mode": "sliding"}), tmp_path)
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
+        orchestrator.config = config
+        general_bot = MagicMock(agent_name="general", config=config, running=True)
+        orchestrator.agent_bots = {"general": general_bot}
+        plan = ConfigUpdatePlan(
+            new_config=config,
+            changed_mcp_servers=set(),
+            configured_entities={"general"},
+            entities_to_restart=set(),
+            new_entities=set(),
+            removed_entities=set(),
+            mindroom_user_changed=False,
+            matrix_room_access_changed=False,
+            matrix_space_changed=False,
+            authorization_changed=False,
+            entities_to_reconcile_rooms={"general"},
+        )
+
+        with (
+            patch.object(orchestrator, "_setup_rooms_and_memberships", new=AsyncMock()),
+            patch("mindroom.orchestrator.cancel_sync_task", new=AsyncMock()) as cancel_sync,
+            patch.object(orchestrator, "_start_sync_task") as start_sync,
+        ):
+            await orchestrator._reconcile_post_update_rooms(plan, changed_entities=set())
+
+        cancel_sync.assert_awaited_once_with("general", orchestrator._sync_tasks)
+        start_sync.assert_called_once_with("general", general_bot)
+
+    @pytest.mark.asyncio
     @pytest.mark.requires_matrix  # Requires real Matrix server for orchestrator initialization
     @pytest.mark.timeout(10)  # Add timeout to prevent hanging on real server connection
     @patch("mindroom.orchestrator.load_config")

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -1724,6 +1724,41 @@ class TestMultiAgentOrchestrator:
         ensure_space.assert_awaited_once_with({"lobby": "!room1:localhost"})
 
     @pytest.mark.asyncio
+    async def test_reconcile_post_update_rooms_sets_up_live_room_changes(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Room-only edits should reconcile the affected live bots without replacement."""
+        config = _runtime_bound_config(Config(), tmp_path)
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
+        orchestrator.config = config
+        router_bot = MagicMock(running=True)
+        general_bot = MagicMock(running=True)
+        orchestrator.agent_bots = {
+            ROUTER_AGENT_NAME: router_bot,
+            "general": general_bot,
+        }
+        plan = ConfigUpdatePlan(
+            new_config=config,
+            changed_mcp_servers=set(),
+            configured_entities={ROUTER_AGENT_NAME, "general"},
+            entities_to_restart=set(),
+            new_entities=set(),
+            removed_entities=set(),
+            mindroom_user_changed=False,
+            matrix_room_access_changed=False,
+            matrix_space_changed=False,
+            authorization_changed=False,
+            entities_to_reconcile_rooms={ROUTER_AGENT_NAME, "general"},
+        )
+
+        with patch.object(orchestrator, "_setup_rooms_and_memberships", new=AsyncMock()) as setup_rooms:
+            await orchestrator._reconcile_post_update_rooms(plan, changed_entities=set())
+
+        setup_rooms.assert_awaited_once()
+        assert set(setup_rooms.await_args.args[0]) == {router_bot, general_bot}
+
+    @pytest.mark.asyncio
     @pytest.mark.requires_matrix  # Requires real Matrix server for orchestrator initialization
     @pytest.mark.timeout(10)  # Add timeout to prevent hanging on real server connection
     @patch("mindroom.orchestrator.load_config")
@@ -3692,31 +3727,19 @@ class TestMultiAgentOrchestrator:
     async def test_update_config_syncs_runtime_services_when_running(self, tmp_path: Path) -> None:
         """Hot reload should sync runtime services without global knowledge refresh work."""
         orchestrator = _MultiAgentOrchestrator(runtime_paths=TestAgentBot._runtime_paths(tmp_path))
-
-        config = MagicMock()
-        config.agents = {}
-        config.teams = {}
-        config.mindroom_user = None
-        config.matrix_room_access = MagicMock()
-        config.authorization = MagicMock()
-        config.event_journal = MagicMock()
-        config.defaults.enable_streaming = True
-
-        orchestrator.config = config
+        current_config = _runtime_bound_config(Config(defaults={"enable_streaming": True}), tmp_path)
+        new_config = _runtime_bound_config(Config(defaults={"enable_streaming": False}), tmp_path)
+        orchestrator.config = current_config
         orchestrator.running = True
         router_bot = MagicMock()
-        router_bot.config = config
+        router_bot.config = current_config
         router_bot.enable_streaming = True
         router_bot._set_presence_with_model_info = AsyncMock()
         orchestrator.agent_bots = {"router": router_bot}
 
         with (
-            patch("mindroom.orchestration.config_lifecycle.load_config", return_value=config),
+            patch("mindroom.orchestration.config_lifecycle.load_config", return_value=new_config),
             patch("mindroom.orchestrator.load_plugins"),
-            patch(
-                "mindroom.orchestration.config_updates._identify_entities_to_restart",
-                return_value=set(),
-            ),
             patch.object(orchestrator._external_trigger_runtime, "sync_api_config_snapshot", new=AsyncMock()),
             patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()) as mock_sync_runtime,
         ):
@@ -3724,9 +3747,9 @@ class TestMultiAgentOrchestrator:
 
         assert updated is False
         mock_sync_runtime.assert_awaited_once_with(
-            config,
+            new_config,
             start_watcher=True,
-            previous_config=config,
+            previous_config=current_config,
         )
         assert not hasattr(orchestrator, "_schedule_knowledge_refresh")
 

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -1759,20 +1759,20 @@ class TestMultiAgentOrchestrator:
         assert set(setup_rooms.await_args.args[0]) == {router_bot, general_bot}
 
     @pytest.mark.asyncio
-    async def test_reconcile_post_update_rooms_restarts_sliding_subscriptions(
+    async def test_reconcile_post_update_rooms_preserves_router_grants_before_sliding_restart(
         self,
         tmp_path: Path,
     ) -> None:
-        """Room-only edits must refresh explicit sliding-sync subscriptions."""
+        """Room-only edits must preserve refreshed router grants across subscription restart."""
         config = _runtime_bound_config(Config(matrix_sync={"mode": "sliding"}), tmp_path)
         orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
         orchestrator.config = config
-        general_bot = MagicMock(agent_name="general", config=config, running=True)
-        orchestrator.agent_bots = {"general": general_bot}
+        router_bot = MagicMock(agent_name=ROUTER_AGENT_NAME, config=config, running=True)
+        orchestrator.agent_bots = {ROUTER_AGENT_NAME: router_bot}
         plan = ConfigUpdatePlan(
             new_config=config,
             changed_mcp_servers=set(),
-            configured_entities={"general"},
+            configured_entities={ROUTER_AGENT_NAME},
             entities_to_restart=set(),
             new_entities=set(),
             removed_entities=set(),
@@ -1780,7 +1780,7 @@ class TestMultiAgentOrchestrator:
             matrix_room_access_changed=False,
             matrix_space_changed=False,
             authorization_changed=False,
-            entities_to_reconcile_rooms={"general"},
+            entities_to_reconcile_rooms={ROUTER_AGENT_NAME},
         )
 
         with (
@@ -1790,8 +1790,9 @@ class TestMultiAgentOrchestrator:
         ):
             await orchestrator._reconcile_post_update_rooms(plan, changed_entities=set())
 
-        cancel_sync.assert_awaited_once_with("general", orchestrator._sync_tasks)
-        start_sync.assert_called_once_with("general", general_bot)
+        cancel_sync.assert_awaited_once_with(ROUTER_AGENT_NAME, orchestrator._sync_tasks)
+        router_bot.preserve_reply_memberships_on_next_sync_start.assert_called_once_with()
+        start_sync.assert_called_once_with(ROUTER_AGENT_NAME, router_bot)
 
     @pytest.mark.asyncio
     @pytest.mark.requires_matrix  # Requires real Matrix server for orchestrator initialization

--- a/tests/test_router_rooms.py
+++ b/tests/test_router_rooms.py
@@ -326,7 +326,10 @@ async def test_orchestrator_creates_router_with_all_rooms(
 @pytest.mark.asyncio
 @pytest.mark.requires_matrix  # Requires real Matrix server for router room updates
 @pytest.mark.timeout(10)  # Add timeout to prevent hanging on real server connection
-async def test_router_updates_rooms_on_config_change(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+async def test_router_updates_rooms_on_config_change(  # noqa: PLR0915
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
     """Test that the router updates its room list when config changes."""
     # Initial config with some rooms
     initial_config = Config(
@@ -376,7 +379,8 @@ async def test_router_updates_rooms_on_config_change(monkeypatch: pytest.MonkeyP
     monkeypatch.setattr("mindroom.orchestrator.load_config", mock_load_config)
     monkeypatch.setattr("mindroom.orchestration.config_lifecycle.load_config", mock_load_config)
     monkeypatch.setattr("mindroom.orchestrator._MultiAgentOrchestrator._ensure_user_account", AsyncMock())
-    monkeypatch.setattr("mindroom.orchestrator._MultiAgentOrchestrator._setup_rooms_and_memberships", AsyncMock())
+    setup_rooms = AsyncMock()
+    monkeypatch.setattr("mindroom.orchestrator._MultiAgentOrchestrator._setup_rooms_and_memberships", setup_rooms)
 
     # Create orchestrator with initial config
     # Mock start/sync_forever at class level so newly created bots in update_config don't perform real login/sync
@@ -396,7 +400,14 @@ async def test_router_updates_rooms_on_config_change(monkeypatch: pytest.MonkeyP
 
         # Check initial router rooms
         router_bot = orchestrator.agent_bots[ROUTER_AGENT_NAME]
+        agent1_bot = orchestrator.agent_bots["agent1"]
         assert set(router_bot.rooms) == {"room1"}
+
+        async def reconcile_room_aliases(bots: list[object]) -> None:
+            orchestrator._resolve_bot_room_aliases(bots, orchestrator._require_config())  # type: ignore[arg-type]
+
+        setup_rooms.reset_mock()
+        setup_rooms.side_effect = reconcile_room_aliases
 
         # Mock bot operations using monkeypatch to avoid method assignment errors
         async def mock_stop(*, shutdown_intent: object | None = None) -> None:
@@ -419,10 +430,13 @@ async def test_router_updates_rooms_on_config_change(monkeypatch: pytest.MonkeyP
 
         # Update config
         updated = await orchestrator.config_reload._update_config()
-        assert updated  # Should return True since router needs restart
+        assert updated
 
-        # Router should be recreated with new rooms
+        # Existing clients stay alive while their desired room lists change.
         new_router_bot = orchestrator.agent_bots[ROUTER_AGENT_NAME]
+        assert new_router_bot is router_bot
+        assert orchestrator.agent_bots["agent1"] is agent1_bot
         assert set(new_router_bot.rooms) == {"room1", "room2", "room3"}
+        setup_rooms.assert_awaited_once()
     finally:
         await orchestrator.stop()

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -2722,10 +2722,10 @@ async def test_startup_membership_publication_serializes_config_reload(
         if entity_name == ROUTER_AGENT_NAME:
             router_sync_started.set()
 
-    async def blocked_reload() -> bool:
+    async def blocked_config_load(*_args: object, **_kwargs: object) -> Config:
         reload_started.set()
         await reload_can_finish.wait()
-        return True
+        return orchestrator.config
 
     with (
         patch("mindroom.orchestrator.wait_for_matrix_homeserver", new=AsyncMock()),
@@ -2740,7 +2740,7 @@ async def test_startup_membership_publication_serializes_config_reload(
         patch.object(orchestrator, "_sync_runtime_support_services", new=AsyncMock()),
         patch.object(orchestrator._approval_transport, "handle_bot_ready", new=AsyncMock()),
         patch.object(orchestrator, "_start_sync_task", side_effect=start_sync_task),
-        patch.object(orchestrator.config_reload, "_update_config", side_effect=blocked_reload),
+        patch("mindroom.orchestration.config_lifecycle.asyncio.to_thread", side_effect=blocked_config_load),
         patch("mindroom.orchestrator.set_runtime_ready", side_effect=runtime_ready.set),
     ):
         runtime_task = asyncio.create_task(orchestrator._start_runtime())
@@ -2760,7 +2760,7 @@ async def test_startup_membership_publication_serializes_config_reload(
             await orchestrator.handle_bot_ready(router_bot)
             await asyncio.wait_for(runtime_ready.wait(), timeout=1.0)
             await asyncio.wait_for(reload_started.wait(), timeout=1.0)
-            assert orchestrator._response_admission_gate.closed
+            assert not orchestrator._response_admission_gate.closed
 
             reload_can_finish.set()
             await asyncio.wait_for(reload_task, timeout=1.0)
@@ -2784,7 +2784,7 @@ async def test_update_config_replays_cancelled_startup_maintenance_and_runs_appr
     """Hot reload during startup maintenance must not lose one-shot restart cleanup."""
     orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
     current_config = Config()
-    new_config = Config()
+    new_config = Config(defaults={"enable_streaming": False})
 
     plan = ConfigUpdatePlan(
         new_config=new_config,

--- a/tests/test_team_room_updates.py
+++ b/tests/test_team_room_updates.py
@@ -9,18 +9,37 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from mindroom.config.main import Config
+from mindroom.entity_rooms import get_rooms_for_entity
 from mindroom.orchestrator import _MultiAgentOrchestrator
 from tests.conftest import orchestrator_runtime_paths
+
+
+def _mock_running_bot(entity_name: str, agent_user: object, config: Config) -> MagicMock:
+    """Return one distinct running bot double with its configured rooms."""
+    bot = MagicMock()
+    bot.agent_name = entity_name
+    bot.agent_user = agent_user
+    bot.config = config
+    bot.rooms = get_rooms_for_entity(entity_name, config)
+    bot.running = True
+    bot.start = AsyncMock()
+    bot.stop = AsyncMock()
+    bot.sync_forever = AsyncMock()
+    bot.try_start = AsyncMock(return_value=True)
+    bot.prepare_for_sync_shutdown = AsyncMock()
+    bot._set_presence_with_model_info = AsyncMock()
+    bot.mark_sync_loop_started = MagicMock()
+    bot.reset_watchdog_clock = MagicMock()
+    return bot
 
 
 class TestTeamRoomUpdates:
     """Test team room configuration updates."""
 
     @pytest.mark.asyncio
-    @pytest.mark.requires_matrix  # Requires real Matrix server for team room management
     @pytest.mark.timeout(10)  # Add timeout to prevent hanging on real server connection
-    async def test_team_room_change_triggers_restart(self, tmp_path: Path) -> None:
-        """Test that changing a team's room configuration triggers a restart."""
+    async def test_team_room_change_reconciles_live_bot(self, tmp_path: Path) -> None:
+        """Changing a team's rooms should preserve bots and reconcile memberships live."""
         # Create initial config
         initial_config_data: dict[str, Any] = {
             "agents": {
@@ -74,28 +93,44 @@ class TestTeamRoomUpdates:
                     patch("mindroom.topic_generator.generate_room_topic_ai", mock_generate_room_topic_ai),
                     patch("mindroom.matrix.rooms.generate_room_topic_ai", mock_generate_room_topic_ai),
                     patch("mindroom.orchestrator._MultiAgentOrchestrator._ensure_user_account", new=AsyncMock()),
+                    patch("mindroom.orchestrator._MultiAgentOrchestrator._validate_entity_accounts"),
                     patch(
                         "mindroom.orchestrator._MultiAgentOrchestrator._setup_rooms_and_memberships",
                         new=AsyncMock(),
-                    ),
+                    ) as setup_rooms,
                 ):
                     orchestrator = _MultiAgentOrchestrator(runtime_paths=orchestrator_runtime_paths(tmp_path))
 
                     with patch("mindroom.orchestrator.create_bot_for_entity") as mock_create_bot:
-                        mock_bot = MagicMock()
-                        mock_bot.start = AsyncMock()
-                        mock_bot.stop = AsyncMock()
-                        mock_bot.sync_forever = AsyncMock()
-                        mock_bot.try_start = AsyncMock(return_value=True)
-                        mock_bot.prepare_for_sync_shutdown = AsyncMock()
-                        mock_bot._set_presence_with_model_info = AsyncMock()
-                        mock_bot.mark_sync_loop_started = MagicMock()
-                        mock_bot.reset_watchdog_clock = MagicMock()
-                        mock_create_bot.return_value = mock_bot
+                        created_bots: dict[str, MagicMock] = {}
+
+                        def create_mock_bot(
+                            entity_name: str,
+                            agent_user: object,
+                            config: Config,
+                            *_args: object,
+                            **_kwargs: object,
+                        ) -> MagicMock:
+                            bot = _mock_running_bot(entity_name, agent_user, config)
+                            created_bots[entity_name] = bot
+                            return bot
+
+                        mock_create_bot.side_effect = create_mock_bot
 
                         try:
                             await orchestrator.initialize()
                             orchestrator.running = True
+                            original_bots = dict(orchestrator.agent_bots)
+
+                            async def reconcile_rooms(bots: list[MagicMock]) -> None:
+                                active_config = orchestrator._require_config()
+                                for bot in bots:
+                                    bot.rooms = get_rooms_for_entity(bot.agent_name, active_config)
+
+                            setup_rooms.side_effect = reconcile_rooms
+                            setup_rooms.reset_mock()
+                            for bot in created_bots.values():
+                                bot.stop.reset_mock()
 
                             # Update config with different rooms for the team
                             updated_config_data = initial_config_data.copy()
@@ -106,13 +141,23 @@ class TestTeamRoomUpdates:
                             # Update config
                             updated = await orchestrator.config_reload._update_config()
 
-                            # Verify the team was restarted
+                            # Verify the existing team and router bots were reconciled in place.
                             assert updated is True
-                            assert mock_bot.stop.called
-
-                            # Should create: agent1 + team1 + router on init, team1 + router on update
-                            # (router gets recreated when teams change)
-                            assert mock_create_bot.call_count == 5
+                            assert orchestrator.agent_bots == original_bots
+                            assert orchestrator.agent_bots["agent1"].rooms == ["room1"]
+                            assert orchestrator.agent_bots["team1"].rooms == ["room2", "room3", "room4"]
+                            assert set(orchestrator.agent_bots["router"].rooms) == {
+                                "room1",
+                                "room2",
+                                "room3",
+                                "room4",
+                            }
+                            for bot in created_bots.values():
+                                bot.stop.assert_not_awaited()
+                            assert mock_create_bot.call_count == 3
+                            setup_rooms.assert_awaited_once()
+                            reconciled_bots = setup_rooms.await_args.args[0]
+                            assert {bot.agent_name for bot in reconciled_bots} == {"router", "team1"}
                         finally:
                             await orchestrator.stop()
 


### PR DESCRIPTION
## Summary

- parse and diff configuration before closing response admission, and skip semantic no-op publication
- reconcile room-only membership changes without replacing live bots
- restart call-enabled agents only when captured call/runtime dependencies change
- retain successfully loaded include-source topology for watcher updates

## Testing

- `uv run pytest -n 0 -q`
- targeted pre-commit hooks for all changed files
- `git diff --check`

## Summary by Sourcery

Make configuration hot reload selective while preserving runtime continuity and safely coordinating published changes with active responses.

Bug Fixes:
- Preserve successfully loaded include-file topology so configuration watchers continue detecting changes after semantically equivalent reloads.
- Recover from partially published configuration updates by restoring the last fully applied configuration before applying a subsequent update.

Enhancements:
- Make configuration hot reload selective by skipping semantic no-ops, reconciling room membership changes in place, and limiting bot replacement to entities whose effective runtime dependencies changed.
- Keep response admission open during configuration loading and validation, closing it only for publication after active responses drain.
- Restart call-enabled agents only when their captured configuration or runtime dependencies change, while preserving live bots for room-only updates.

Documentation:
- Update orchestration documentation to describe selective reload planning, response-admission timing, in-place room reconciliation, and call-agent restart behavior.

Tests:
- Expand lifecycle, room reconciliation, call dependency, include watching, and response-admission coverage for selective hot reload behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration updates now reconcile agent, team, and router room memberships without restarting active bots.
  * Configuration reloads track included source files for more accurate file watching.
  * Reloads skip unnecessary work when configuration content is unchanged.
  * Call-related services restart only when relevant settings change.

* **Bug Fixes**
  * Improved reload serialization, cancellation handling, and coalescing of queued updates.
  * Preserved active bot connections and reply memberships during room-only changes.
  * Added recovery for partially applied configurations, including rollback before retrying updates.
  * Improved reload handling for staged or interrupted configuration updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->