### PR TITLE
Support isolated Kubernetes background scripts

### DIFF
--- a/cluster/k8s/runtime/templates/deployment.yaml
+++ b/cluster/k8s/runtime/templates/deployment.yaml
@@ -291,6 +291,10 @@ spec:
               value: {{ .Values.workers.kubernetes.resources.requests.cpu | quote }}
             - name: MINDROOM_KUBERNETES_WORKER_CPU_LIMIT
               value: {{ .Values.workers.kubernetes.resources.limits.cpu | quote }}
+            - name: MINDROOM_KUBERNETES_DEFAULT_SCRIPT_RESOURCE_PROFILE
+              value: {{ .Values.workers.kubernetes.scriptResources.defaultProfile | quote }}
+            - name: MINDROOM_KUBERNETES_SCRIPT_RESOURCE_PROFILES_JSON
+              value: {{ toJson .Values.workers.kubernetes.scriptResources.profiles | quote }}
             {{- if .Values.workers.kubernetes.nodeName }}
             - name: MINDROOM_KUBERNETES_WORKER_NODE_NAME
               value: {{ .Values.workers.kubernetes.nodeName | quote }}

--- a/cluster/k8s/runtime/values.yaml
+++ b/cluster/k8s/runtime/values.yaml
@@ -359,6 +359,30 @@ workers:
       limits:
         cpu: 500m
         memory: 1Gi
+    scriptResources:
+      defaultProfile: small
+      profiles:
+        small:
+          requests:
+            cpu: 100m
+            memory: 256Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+        standard:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+        large:
+          requests:
+            cpu: 500m
+            memory: 2Gi
+          limits:
+            cpu: "2"
+            memory: 8Gi
     # Per-worker Agent Vault egress. When enabled, each dedicated worker pod
     # gets an init container that mints a proxy-role Agent Vault token for that
     # worker's vault into an in-pod volume; the sandbox runner composes

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -215,7 +215,8 @@ Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 | `MINDROOM_MATRIX_HOMESERVER_STARTUP_TIMEOUT_SECONDS` | Seconds to wait for the homeserver to return a valid `/_matrix/client/versions` response at startup (`0` = wait indefinitely); MindRoom polls at a fixed interval until success or the deadline | _(wait indefinitely)_ |
 | `MINDROOM_MATRIX_SYNC_STARTUP_TIMEOUT_SECONDS` | Positive seconds allowed for the first Matrix sync response | `600` |
 | `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` | Finite positive seconds the sync watchdog and `/api/health` may wait for one active durable sync-cache phase before treating it as wedged | `600` |
-| `MINDROOM_SCRIPT_GATEWAY_URL` | Complete worker-reachable background-script gateway base URL, including `/api/script-gateway`; required for dedicated Docker worker mode unless a reachable `MINDROOM_PUBLIC_URL` is configured | _(none)_ |
+| `MINDROOM_SCRIPT_GATEWAY_URL` | Complete worker-reachable background-script gateway base URL, including `/api/script-gateway`; required for Kubernetes and for Docker unless a reachable `MINDROOM_PUBLIC_URL` is configured | _(none)_ |
+| `MINDROOM_SCRIPT_GATEWAY_ISOLATED` | Operator attestation that the Kubernetes worker's configured script-gateway listener exposes only `/api/script-gateway`; required to admit Kubernetes background scripts and does not create network isolation itself | `false` |
 | `MINDROOM_SCRIPT_RETENTION_SECONDS` | Finite positive seconds to retain terminal background-script runs, tool-call receipts, approval rows, and durable approval records before lifecycle pruning | `2592000` (30 days) |
 | `MINDROOM_WORKER_BACKEND` | Worker backend for tool execution (`static_runner`, `docker`, or `kubernetes`) | `static_runner` |
 

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -217,6 +217,8 @@ Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 | `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` | Finite positive seconds the sync watchdog and `/api/health` may wait for one active durable sync-cache phase before treating it as wedged | `600` |
 | `MINDROOM_SCRIPT_GATEWAY_URL` | Complete worker-reachable background-script gateway base URL, including `/api/script-gateway`; required for Kubernetes and for Docker unless a reachable `MINDROOM_PUBLIC_URL` is configured | _(none)_ |
 | `MINDROOM_SCRIPT_GATEWAY_ISOLATED` | Operator attestation that the Kubernetes worker's configured script-gateway listener exposes only `/api/script-gateway`; required to admit Kubernetes background scripts and does not create network isolation itself | `false` |
+| `MINDROOM_KUBERNETES_DEFAULT_SCRIPT_RESOURCE_PROFILE` | Default Kubernetes background-script profile (`small`, `standard`, or `large`) when `start_script` omits `resource_profile` | `small` |
+| `MINDROOM_KUBERNETES_SCRIPT_RESOURCE_PROFILES_JSON` | JSON object defining exact CPU and memory requests and limits for the fixed `small`, `standard`, and `large` background-script profiles | Built-in bounded profiles |
 | `MINDROOM_SCRIPT_RETENTION_SECONDS` | Finite positive seconds to retain terminal background-script runs, tool-call receipts, approval rows, and durable approval records before lifecycle pruning | `2592000` (30 days) |
 | `MINDROOM_WORKER_BACKEND` | Worker backend for tool execution (`static_runner`, `docker`, or `kubernetes`) | `static_runner` |
 

--- a/docs/tools/background-scripts.md
+++ b/docs/tools/background-scripts.md
@@ -61,10 +61,16 @@ The limits are captured with each run.
 
 ## Control Functions
 
-The agent receives four control functions.
+The agent receives five control functions.
 
 ```text
-start_script(source: str | None = None, path: str | None = None, name: str | None = None)
+start_script(
+    source: str | None = None,
+    path: str | None = None,
+    name: str | None = None,
+    resource_profile: Literal["small", "standard", "large"] | None = None,
+)
+get_script_resource_profiles()
 get_script(run_id: str)
 cancel_script(run_id: str, force: bool = False)
 list_scripts(include_finished: bool = True)
@@ -75,6 +81,11 @@ list_scripts(include_finished: bool = True)
 `path` must be relative to the agent workspace, and MindRoom snapshots the file before launch so later edits do not change the running program.
 Source is limited to 128 KiB.
 `name` is an optional short label shown in status and list results.
+On Kubernetes, `resource_profile` selects one of three administrator-bounded profiles.
+Omitting it uses the configured default.
+Call `get_script_resource_profiles` first to see the live default and exact CPU and memory requests and limits.
+The selected profile and its exact quantities are also returned by start, status, and list operations.
+An explicit profile fails when the active worker backend cannot enforce resource profiles.
 
 `get_script` returns durable run state plus the supervisor's recent process output when it is available.
 `list_scripts` returns only runs owned by the current requester and agent.

--- a/docs/tools/background-scripts.md
+++ b/docs/tools/background-scripts.md
@@ -178,11 +178,12 @@ Cancellation, expiry, agent removal, and orphan recovery settle pending cards wi
 
 ## Worker And Network Requirements
 
-The supported safe deployment uses the dedicated Docker backend described in [Sandbox Proxy](../deployment/sandbox-proxy.md).
+The supported safe deployment uses a dedicated Docker or Kubernetes worker backend as described in [Sandbox Proxy](../deployment/sandbox-proxy.md).
 The worker must run the same MindRoom revision as the primary runtime and must be able to read the staged script snapshot from its configured dedicated worker state root.
 The worker must also reach the primary script gateway over an authenticated network path.
-Kubernetes background scripts currently return an error because the primary Kubernetes Service exposes more than the capability-gated script gateway on one listener.
-They will remain disabled until the chart provides a gateway-only listener and NetworkPolicy target.
+Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
+They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
+Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 Alternatively, set `MINDROOM_PUBLIC_URL` to the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.
@@ -196,6 +197,14 @@ export MINDROOM_SANDBOX_PROXY_TOKEN=replace-with-a-long-random-token
 export MINDROOM_SCRIPT_GATEWAY_URL=https://mindroom.example.org/api/script-gateway
 ```
 
+For Kubernetes, configure the dedicated backend and isolated gateway attestation instead:
+
+```bash
+export MINDROOM_WORKER_BACKEND=kubernetes
+export MINDROOM_SCRIPT_GATEWAY_URL=https://script-gateway.example.org/api/script-gateway
+export MINDROOM_SCRIPT_GATEWAY_ISOLATED=true
+```
+
 Build the worker image from the same source checkout when testing unreleased code.
 
 ```bash
@@ -203,7 +212,6 @@ docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.mindroom .
 ```
 
 Every non-local script run receives its own dedicated worker process and worker filesystem root, even when another run belongs to the same requester and agent.
-Dedicated-worker script launch currently rejects private agents because their canonical private workspace cannot be projected into a run-specific worker without weakening isolation.
 The run-specific worker key extends the canonical requester-and-agent key while keeping the agent name as its final component.
 The worker receives its run snapshot plus the canonical requester-and-agent scoped workspace and state projections used by that worker scope.
 The script can read and modify files visible through that scoped worker filesystem and can read operator-authored worker environment values, including backend `extra_env` and workspace environment overlays.

--- a/docs/tools/background-scripts.md
+++ b/docs/tools/background-scripts.md
@@ -179,14 +179,15 @@ Cancellation, expiry, agent removal, and orphan recovery settle pending cards wi
 ## Worker And Network Requirements
 
 The supported safe deployment uses a dedicated Docker or Kubernetes worker backend as described in [Sandbox Proxy](../deployment/sandbox-proxy.md).
-The worker must run the same MindRoom revision as the primary runtime and must be able to read the staged script snapshot from its configured dedicated worker state root.
+The worker must run the same MindRoom revision as the primary runtime and must be able to read the staged script snapshot from its configured worker-state root.
 The worker must also reach the primary script gateway over an authenticated network path.
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
-Alternatively, set `MINDROOM_PUBLIC_URL` to the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.
+For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.
+Kubernetes always requires an explicit `MINDROOM_SCRIPT_GATEWAY_URL` naming its gateway-only listener.
 Worker mode rejects missing, malformed, credential-bearing, unresolved, unspecified, or loopback gateway addresses.
 A query string or fragment is also rejected because the SDK appends receipt endpoint paths to this base.
 

--- a/docs/tools/background-scripts.md
+++ b/docs/tools/background-scripts.md
@@ -214,6 +214,7 @@ docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.mindroom .
 
 Every non-local script run receives its own dedicated worker process and worker filesystem root, even when another run belongs to the same requester and agent.
 The run-specific worker key extends the canonical requester-and-agent key while keeping the agent name as its final component.
+Private agents are supported in worker mode when they use `private.per: user_agent`; broader requester-wide private scopes remain unavailable to background-script workers.
 The worker receives its run snapshot plus the canonical requester-and-agent scoped workspace and state projections used by that worker scope.
 The script can read and modify files visible through that scoped worker filesystem and can read operator-authored worker environment values, including backend `extra_env` and workspace environment overlays.
 MindRoom does not automatically mirror global worker-grantable credentials into a script-specific worker; governed SDK calls obtain their normal authority through the primary gateway.

--- a/docs/tools/background-scripts.md
+++ b/docs/tools/background-scripts.md
@@ -42,7 +42,7 @@ defaults:
 ```
 
 `allowed_tools` contains toolkit names, not function names.
-Unknown or unavailable toolkit names, including `*`, reject the launch with a clear error.
+Unknown or ineligible toolkit names, including `*`, reject the launch with a clear error.
 It limits calls made through `MindRoomTools`; it does not restrict Python imports, filesystem access, operating-system calls, subprocesses, or direct network clients in the script source.
 Treat `script` as trusted arbitrary code with authority comparable to `python` or `shell` inside its selected execution runtime.
 MindRoom captures the configured `allowed_tools` value when the script launches.
@@ -184,6 +184,7 @@ The worker must also reach the primary script gateway over an authenticated netw
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
+Kubernetes background scripts are not supported while `MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED=true` because run-specific external vault identities cannot yet be retired exactly.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1099,7 +1099,8 @@ Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 | `MINDROOM_MATRIX_HOMESERVER_STARTUP_TIMEOUT_SECONDS` | Seconds to wait for the homeserver to return a valid `/_matrix/client/versions` response at startup (`0` = wait indefinitely); MindRoom polls at a fixed interval until success or the deadline | _(wait indefinitely)_ |
 | `MINDROOM_MATRIX_SYNC_STARTUP_TIMEOUT_SECONDS` | Positive seconds allowed for the first Matrix sync response | `600` |
 | `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` | Finite positive seconds the sync watchdog and `/api/health` may wait for one active durable sync-cache phase before treating it as wedged | `600` |
-| `MINDROOM_SCRIPT_GATEWAY_URL` | Complete worker-reachable background-script gateway base URL, including `/api/script-gateway`; required for dedicated Docker worker mode unless a reachable `MINDROOM_PUBLIC_URL` is configured | _(none)_ |
+| `MINDROOM_SCRIPT_GATEWAY_URL` | Complete worker-reachable background-script gateway base URL, including `/api/script-gateway`; required for Kubernetes and for Docker unless a reachable `MINDROOM_PUBLIC_URL` is configured | _(none)_ |
+| `MINDROOM_SCRIPT_GATEWAY_ISOLATED` | Operator attestation that the Kubernetes worker's configured script-gateway listener exposes only `/api/script-gateway`; required to admit Kubernetes background scripts and does not create network isolation itself | `false` |
 | `MINDROOM_SCRIPT_RETENTION_SECONDS` | Finite positive seconds to retain terminal background-script runs, tool-call receipts, approval rows, and durable approval records before lifecycle pruning | `2592000` (30 days) |
 | `MINDROOM_WORKER_BACKEND` | Worker backend for tool execution (`static_runner`, `docker`, or `kubernetes`) | `static_runner` |
 
@@ -10500,11 +10501,12 @@ Cancellation, expiry, agent removal, and orphan recovery settle pending cards wi
 
 ## Worker And Network Requirements
 
-The supported safe deployment uses the dedicated Docker backend described in [Sandbox Proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/).
+The supported safe deployment uses a dedicated Docker or Kubernetes worker backend as described in [Sandbox Proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/).
 The worker must run the same MindRoom revision as the primary runtime and must be able to read the staged script snapshot from its configured dedicated worker state root.
 The worker must also reach the primary script gateway over an authenticated network path.
-Kubernetes background scripts currently return an error because the primary Kubernetes Service exposes more than the capability-gated script gateway on one listener.
-They will remain disabled until the chart provides a gateway-only listener and NetworkPolicy target.
+Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
+They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
+Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 Alternatively, set `MINDROOM_PUBLIC_URL` to the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.
@@ -10518,6 +10520,14 @@ export MINDROOM_SANDBOX_PROXY_TOKEN=replace-with-a-long-random-token
 export MINDROOM_SCRIPT_GATEWAY_URL=https://mindroom.example.org/api/script-gateway
 ```
 
+For Kubernetes, configure the dedicated backend and isolated gateway attestation instead:
+
+```bash
+export MINDROOM_WORKER_BACKEND=kubernetes
+export MINDROOM_SCRIPT_GATEWAY_URL=https://script-gateway.example.org/api/script-gateway
+export MINDROOM_SCRIPT_GATEWAY_ISOLATED=true
+```
+
 Build the worker image from the same source checkout when testing unreleased code.
 
 ```bash
@@ -10525,7 +10535,6 @@ docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.mindroom .
 ```
 
 Every non-local script run receives its own dedicated worker process and worker filesystem root, even when another run belongs to the same requester and agent.
-Dedicated-worker script launch currently rejects private agents because their canonical private workspace cannot be projected into a run-specific worker without weakening isolation.
 The run-specific worker key extends the canonical requester-and-agent key while keeping the agent name as its final component.
 The worker receives its run snapshot plus the canonical requester-and-agent scoped workspace and state projections used by that worker scope.
 The script can read and modify files visible through that scoped worker filesystem and can read operator-authored worker environment values, including backend `extra_env` and workspace environment overlays.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -10537,6 +10537,7 @@ docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.mindroom .
 
 Every non-local script run receives its own dedicated worker process and worker filesystem root, even when another run belongs to the same requester and agent.
 The run-specific worker key extends the canonical requester-and-agent key while keeping the agent name as its final component.
+Private agents are supported in worker mode when they use `private.per: user_agent`; broader requester-wide private scopes remain unavailable to background-script workers.
 The worker receives its run snapshot plus the canonical requester-and-agent scoped workspace and state projections used by that worker scope.
 The script can read and modify files visible through that scoped worker filesystem and can read operator-authored worker environment values, including backend `extra_env` and workspace environment overlays.
 MindRoom does not automatically mirror global worker-grantable credentials into a script-specific worker; governed SDK calls obtain their normal authority through the primary gateway.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1101,6 +1101,8 @@ Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 | `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` | Finite positive seconds the sync watchdog and `/api/health` may wait for one active durable sync-cache phase before treating it as wedged | `600` |
 | `MINDROOM_SCRIPT_GATEWAY_URL` | Complete worker-reachable background-script gateway base URL, including `/api/script-gateway`; required for Kubernetes and for Docker unless a reachable `MINDROOM_PUBLIC_URL` is configured | _(none)_ |
 | `MINDROOM_SCRIPT_GATEWAY_ISOLATED` | Operator attestation that the Kubernetes worker's configured script-gateway listener exposes only `/api/script-gateway`; required to admit Kubernetes background scripts and does not create network isolation itself | `false` |
+| `MINDROOM_KUBERNETES_DEFAULT_SCRIPT_RESOURCE_PROFILE` | Default Kubernetes background-script profile (`small`, `standard`, or `large`) when `start_script` omits `resource_profile` | `small` |
+| `MINDROOM_KUBERNETES_SCRIPT_RESOURCE_PROFILES_JSON` | JSON object defining exact CPU and memory requests and limits for the fixed `small`, `standard`, and `large` background-script profiles | Built-in bounded profiles |
 | `MINDROOM_SCRIPT_RETENTION_SECONDS` | Finite positive seconds to retain terminal background-script runs, tool-call receipts, approval rows, and durable approval records before lifecycle pruning | `2592000` (30 days) |
 | `MINDROOM_WORKER_BACKEND` | Worker backend for tool execution (`static_runner`, `docker`, or `kubernetes`) | `static_runner` |
 
@@ -10384,10 +10386,16 @@ The limits are captured with each run.
 
 ## Control Functions
 
-The agent receives four control functions.
+The agent receives five control functions.
 
 ```text
-start_script(source: str | None = None, path: str | None = None, name: str | None = None)
+start_script(
+    source: str | None = None,
+    path: str | None = None,
+    name: str | None = None,
+    resource_profile: Literal["small", "standard", "large"] | None = None,
+)
+get_script_resource_profiles()
 get_script(run_id: str)
 cancel_script(run_id: str, force: bool = False)
 list_scripts(include_finished: bool = True)
@@ -10398,6 +10406,11 @@ list_scripts(include_finished: bool = True)
 `path` must be relative to the agent workspace, and MindRoom snapshots the file before launch so later edits do not change the running program.
 Source is limited to 128 KiB.
 `name` is an optional short label shown in status and list results.
+On Kubernetes, `resource_profile` selects one of three administrator-bounded profiles.
+Omitting it uses the configured default.
+Call `get_script_resource_profiles` first to see the live default and exact CPU and memory requests and limits.
+The selected profile and its exact quantities are also returned by start, status, and list operations.
+An explicit profile fails when the active worker backend cannot enforce resource profiles.
 
 `get_script` returns durable run state plus the supervisor's recent process output when it is available.
 `list_scripts` returns only runs owned by the current requester and agent.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -10365,7 +10365,7 @@ defaults:
 ```
 
 `allowed_tools` contains toolkit names, not function names.
-Unknown or unavailable toolkit names, including `*`, reject the launch with a clear error.
+Unknown or ineligible toolkit names, including `*`, reject the launch with a clear error.
 It limits calls made through `MindRoomTools`; it does not restrict Python imports, filesystem access, operating-system calls, subprocesses, or direct network clients in the script source.
 Treat `script` as trusted arbitrary code with authority comparable to `python` or `shell` inside its selected execution runtime.
 MindRoom captures the configured `allowed_tools` value when the script launches.
@@ -10507,6 +10507,7 @@ The worker must also reach the primary script gateway over an authenticated netw
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
+Kubernetes background scripts are not supported while `MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED=true` because run-specific external vault identities cannot yet be retired exactly.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -10502,14 +10502,15 @@ Cancellation, expiry, agent removal, and orphan recovery settle pending cards wi
 ## Worker And Network Requirements
 
 The supported safe deployment uses a dedicated Docker or Kubernetes worker backend as described in [Sandbox Proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/).
-The worker must run the same MindRoom revision as the primary runtime and must be able to read the staged script snapshot from its configured dedicated worker state root.
+The worker must run the same MindRoom revision as the primary runtime and must be able to read the staged script snapshot from its configured worker-state root.
 The worker must also reach the primary script gateway over an authenticated network path.
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
-Alternatively, set `MINDROOM_PUBLIC_URL` to the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.
+For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.
+Kubernetes always requires an explicit `MINDROOM_SCRIPT_GATEWAY_URL` naming its gateway-only listener.
 Worker mode rejects missing, malformed, credential-bearing, unresolved, unspecified, or loopback gateway addresses.
 A query string or fragment is also rejected because the SDK appends receipt endpoint paths to this base.
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -213,6 +213,8 @@ Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 | `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` | Finite positive seconds the sync watchdog and `/api/health` may wait for one active durable sync-cache phase before treating it as wedged | `600` |
 | `MINDROOM_SCRIPT_GATEWAY_URL` | Complete worker-reachable background-script gateway base URL, including `/api/script-gateway`; required for Kubernetes and for Docker unless a reachable `MINDROOM_PUBLIC_URL` is configured | _(none)_ |
 | `MINDROOM_SCRIPT_GATEWAY_ISOLATED` | Operator attestation that the Kubernetes worker's configured script-gateway listener exposes only `/api/script-gateway`; required to admit Kubernetes background scripts and does not create network isolation itself | `false` |
+| `MINDROOM_KUBERNETES_DEFAULT_SCRIPT_RESOURCE_PROFILE` | Default Kubernetes background-script profile (`small`, `standard`, or `large`) when `start_script` omits `resource_profile` | `small` |
+| `MINDROOM_KUBERNETES_SCRIPT_RESOURCE_PROFILES_JSON` | JSON object defining exact CPU and memory requests and limits for the fixed `small`, `standard`, and `large` background-script profiles | Built-in bounded profiles |
 | `MINDROOM_SCRIPT_RETENTION_SECONDS` | Finite positive seconds to retain terminal background-script runs, tool-call receipts, approval rows, and durable approval records before lifecycle pruning | `2592000` (30 days) |
 | `MINDROOM_WORKER_BACKEND` | Worker backend for tool execution (`static_runner`, `docker`, or `kubernetes`) | `static_runner` |
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -211,7 +211,8 @@ Set `CODEX_HOME` only if your Codex CLI state lives outside `~/.codex`.
 | `MINDROOM_MATRIX_HOMESERVER_STARTUP_TIMEOUT_SECONDS` | Seconds to wait for the homeserver to return a valid `/_matrix/client/versions` response at startup (`0` = wait indefinitely); MindRoom polls at a fixed interval until success or the deadline | _(wait indefinitely)_ |
 | `MINDROOM_MATRIX_SYNC_STARTUP_TIMEOUT_SECONDS` | Positive seconds allowed for the first Matrix sync response | `600` |
 | `MINDROOM_MATRIX_SYNC_CACHE_WRITE_GRACE_SECONDS` | Finite positive seconds the sync watchdog and `/api/health` may wait for one active durable sync-cache phase before treating it as wedged | `600` |
-| `MINDROOM_SCRIPT_GATEWAY_URL` | Complete worker-reachable background-script gateway base URL, including `/api/script-gateway`; required for dedicated Docker worker mode unless a reachable `MINDROOM_PUBLIC_URL` is configured | _(none)_ |
+| `MINDROOM_SCRIPT_GATEWAY_URL` | Complete worker-reachable background-script gateway base URL, including `/api/script-gateway`; required for Kubernetes and for Docker unless a reachable `MINDROOM_PUBLIC_URL` is configured | _(none)_ |
+| `MINDROOM_SCRIPT_GATEWAY_ISOLATED` | Operator attestation that the Kubernetes worker's configured script-gateway listener exposes only `/api/script-gateway`; required to admit Kubernetes background scripts and does not create network isolation itself | `false` |
 | `MINDROOM_SCRIPT_RETENTION_SECONDS` | Finite positive seconds to retain terminal background-script runs, tool-call receipts, approval rows, and durable approval records before lifecycle pruning | `2592000` (30 days) |
 | `MINDROOM_WORKER_BACKEND` | Worker backend for tool execution (`static_runner`, `docker`, or `kubernetes`) | `static_runner` |
 

--- a/skills/mindroom-docs/references/page__tools__background-scripts__index.md
+++ b/skills/mindroom-docs/references/page__tools__background-scripts__index.md
@@ -175,14 +175,15 @@ Cancellation, expiry, agent removal, and orphan recovery settle pending cards wi
 ## Worker And Network Requirements
 
 The supported safe deployment uses a dedicated Docker or Kubernetes worker backend as described in [Sandbox Proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/).
-The worker must run the same MindRoom revision as the primary runtime and must be able to read the staged script snapshot from its configured dedicated worker state root.
+The worker must run the same MindRoom revision as the primary runtime and must be able to read the staged script snapshot from its configured worker-state root.
 The worker must also reach the primary script gateway over an authenticated network path.
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
-Alternatively, set `MINDROOM_PUBLIC_URL` to the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.
+For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.
+Kubernetes always requires an explicit `MINDROOM_SCRIPT_GATEWAY_URL` naming its gateway-only listener.
 Worker mode rejects missing, malformed, credential-bearing, unresolved, unspecified, or loopback gateway addresses.
 A query string or fragment is also rejected because the SDK appends receipt endpoint paths to this base.
 

--- a/skills/mindroom-docs/references/page__tools__background-scripts__index.md
+++ b/skills/mindroom-docs/references/page__tools__background-scripts__index.md
@@ -57,10 +57,16 @@ The limits are captured with each run.
 
 ## Control Functions
 
-The agent receives four control functions.
+The agent receives five control functions.
 
 ```text
-start_script(source: str | None = None, path: str | None = None, name: str | None = None)
+start_script(
+    source: str | None = None,
+    path: str | None = None,
+    name: str | None = None,
+    resource_profile: Literal["small", "standard", "large"] | None = None,
+)
+get_script_resource_profiles()
 get_script(run_id: str)
 cancel_script(run_id: str, force: bool = False)
 list_scripts(include_finished: bool = True)
@@ -71,6 +77,11 @@ list_scripts(include_finished: bool = True)
 `path` must be relative to the agent workspace, and MindRoom snapshots the file before launch so later edits do not change the running program.
 Source is limited to 128 KiB.
 `name` is an optional short label shown in status and list results.
+On Kubernetes, `resource_profile` selects one of three administrator-bounded profiles.
+Omitting it uses the configured default.
+Call `get_script_resource_profiles` first to see the live default and exact CPU and memory requests and limits.
+The selected profile and its exact quantities are also returned by start, status, and list operations.
+An explicit profile fails when the active worker backend cannot enforce resource profiles.
 
 `get_script` returns durable run state plus the supervisor's recent process output when it is available.
 `list_scripts` returns only runs owned by the current requester and agent.

--- a/skills/mindroom-docs/references/page__tools__background-scripts__index.md
+++ b/skills/mindroom-docs/references/page__tools__background-scripts__index.md
@@ -38,7 +38,7 @@ defaults:
 ```
 
 `allowed_tools` contains toolkit names, not function names.
-Unknown or unavailable toolkit names, including `*`, reject the launch with a clear error.
+Unknown or ineligible toolkit names, including `*`, reject the launch with a clear error.
 It limits calls made through `MindRoomTools`; it does not restrict Python imports, filesystem access, operating-system calls, subprocesses, or direct network clients in the script source.
 Treat `script` as trusted arbitrary code with authority comparable to `python` or `shell` inside its selected execution runtime.
 MindRoom captures the configured `allowed_tools` value when the script launches.
@@ -180,6 +180,7 @@ The worker must also reach the primary script gateway over an authenticated netw
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
+Kubernetes background scripts are not supported while `MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED=true` because run-specific external vault identities cannot yet be retired exactly.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.

--- a/skills/mindroom-docs/references/page__tools__background-scripts__index.md
+++ b/skills/mindroom-docs/references/page__tools__background-scripts__index.md
@@ -174,11 +174,12 @@ Cancellation, expiry, agent removal, and orphan recovery settle pending cards wi
 
 ## Worker And Network Requirements
 
-The supported safe deployment uses the dedicated Docker backend described in [Sandbox Proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/).
+The supported safe deployment uses a dedicated Docker or Kubernetes worker backend as described in [Sandbox Proxy](https://docs.mindroom.chat/deployment/sandbox-proxy/).
 The worker must run the same MindRoom revision as the primary runtime and must be able to read the staged script snapshot from its configured dedicated worker state root.
 The worker must also reach the primary script gateway over an authenticated network path.
-Kubernetes background scripts currently return an error because the primary Kubernetes Service exposes more than the capability-gated script gateway on one listener.
-They will remain disabled until the chart provides a gateway-only listener and NetworkPolicy target.
+Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
+They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
+Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 Alternatively, set `MINDROOM_PUBLIC_URL` to the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.
@@ -192,6 +193,14 @@ export MINDROOM_SANDBOX_PROXY_TOKEN=replace-with-a-long-random-token
 export MINDROOM_SCRIPT_GATEWAY_URL=https://mindroom.example.org/api/script-gateway
 ```
 
+For Kubernetes, configure the dedicated backend and isolated gateway attestation instead:
+
+```bash
+export MINDROOM_WORKER_BACKEND=kubernetes
+export MINDROOM_SCRIPT_GATEWAY_URL=https://script-gateway.example.org/api/script-gateway
+export MINDROOM_SCRIPT_GATEWAY_ISOLATED=true
+```
+
 Build the worker image from the same source checkout when testing unreleased code.
 
 ```bash
@@ -199,7 +208,6 @@ docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.mindroom .
 ```
 
 Every non-local script run receives its own dedicated worker process and worker filesystem root, even when another run belongs to the same requester and agent.
-Dedicated-worker script launch currently rejects private agents because their canonical private workspace cannot be projected into a run-specific worker without weakening isolation.
 The run-specific worker key extends the canonical requester-and-agent key while keeping the agent name as its final component.
 The worker receives its run snapshot plus the canonical requester-and-agent scoped workspace and state projections used by that worker scope.
 The script can read and modify files visible through that scoped worker filesystem and can read operator-authored worker environment values, including backend `extra_env` and workspace environment overlays.

--- a/skills/mindroom-docs/references/page__tools__background-scripts__index.md
+++ b/skills/mindroom-docs/references/page__tools__background-scripts__index.md
@@ -210,6 +210,7 @@ docker build -t mindroom:dev -f local/instances/deploy/Dockerfile.mindroom .
 
 Every non-local script run receives its own dedicated worker process and worker filesystem root, even when another run belongs to the same requester and agent.
 The run-specific worker key extends the canonical requester-and-agent key while keeping the agent name as its final component.
+Private agents are supported in worker mode when they use `private.per: user_agent`; broader requester-wide private scopes remain unavailable to background-script workers.
 The worker receives its run snapshot plus the canonical requester-and-agent scoped workspace and state projections used by that worker scope.
 The script can read and modify files visible through that scoped worker filesystem and can read operator-authored worker environment values, including backend `extra_env` and workspace environment overlays.
 MindRoom does not automatically mirror global worker-grantable credentials into a script-specific worker; governed SDK calls obtain their normal authority through the primary gateway.

--- a/src/mindroom/api/sandbox_runner.py
+++ b/src/mindroom/api/sandbox_runner.py
@@ -69,8 +69,10 @@ from mindroom.tool_system.worker_routing import (
     build_worker_target_from_runtime_env,
     resolved_worker_key_scope,
     tool_execution_identity,
+    visible_state_roots_for_worker_key,
 )
 from mindroom.workers.backends.local import get_local_worker_manager
+from mindroom.workspaces import resolve_agent_workspace_from_state_path
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -558,6 +560,48 @@ def app_runtime_paths(app: FastAPI) -> RuntimePaths:
 def app_runtime_config(app: FastAPI) -> Config:
     """Return sandbox runner config stored on the FastAPI app."""
     return _app_context(app).config
+
+
+def resolve_script_state_workspace(
+    app: FastAPI,
+    *,
+    state_scope_worker_key: str,
+    agent_name: str,
+    private_agent_names: frozenset[str],
+) -> Path:
+    """Resolve the canonical agent workspace projected into one script worker."""
+    runtime_paths = app_runtime_paths(app)
+    config = app_runtime_config(app)
+    agent_config = config.agents.get(agent_name)
+    if agent_config is None:
+        msg = "Script state scope does not resolve an agent workspace."
+        raise ValueError(msg)
+    is_private = agent_config.private is not None
+    if (agent_name in private_agent_names) != is_private:
+        msg = "Script state scope does not match private-agent visibility."
+        raise ValueError(msg)
+    state_roots = visible_state_roots_for_worker_key(
+        sandbox_exec.runner_storage_root(runtime_paths),
+        state_scope_worker_key,
+        private_agent_names=private_agent_names,
+    )
+    if len(state_roots) != 1:
+        msg = "Script state scope does not resolve one agent workspace."
+        raise ValueError(msg)
+    state_root = state_roots[0].resolve()
+    resolved_workspace = resolve_agent_workspace_from_state_path(
+        agent_name,
+        config,
+        runtime_paths=runtime_paths,
+        state_storage_path=state_root,
+        use_state_storage_path=is_private,
+    )
+    workspace = (resolved_workspace.root if resolved_workspace is not None else state_root / "workspace").resolve()
+    if not workspace.is_relative_to(state_root):
+        msg = "Script workspace escapes its mounted state scope."
+        raise ValueError(msg)
+    workspace.mkdir(parents=True, exist_ok=True)
+    return workspace
 
 
 def _app_tool_metadata(app: FastAPI) -> dict[str, Any]:

--- a/src/mindroom/api/sandbox_runner_scripts.py
+++ b/src/mindroom/api/sandbox_runner_scripts.py
@@ -16,9 +16,14 @@ from fastapi.routing import APIRoute
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field
 
 from mindroom.api import sandbox_env_assembly, sandbox_exec, sandbox_worker_prep
-from mindroom.api.sandbox_runner import app_runner_token, app_runtime_paths, validate_runner_token
+from mindroom.api.sandbox_runner import (
+    app_runner_token,
+    app_runtime_paths,
+    resolve_script_state_workspace,
+    validate_runner_token,
+)
 from mindroom.constants import CONTROL_STATE_PATH_ENV
-from mindroom.script_runs.models import supervisor_handle_for_run
+from mindroom.script_runs.models import script_worker_key_for_run, supervisor_handle_for_run
 from mindroom.shell_supervisor import (
     ShellSupervisorStartupError,
     background_script_supervision_supported,
@@ -125,6 +130,7 @@ class SandboxScriptRunRequest(BaseModel):
 
     run_id: _RunId
     worker_key: str = Field(min_length=1, max_length=1024)
+    state_scope_worker_key: str | None = Field(default=None, min_length=1, max_length=1024)
     source_digest: str = Field(min_length=64, max_length=64, pattern=r"[0-9a-f]{64}")
     gateway_url: str = Field(min_length=1, max_length=2048)
     private_agent_names: list[str] | None = Field(default=None, max_length=128)
@@ -254,7 +260,40 @@ def _script_snapshot_paths(workspace: Path, run_id: str) -> tuple[Path, Path]:
     )
 
 
-def _script_environment(payload: SandboxScriptRunRequest, *, workspace: Path, token_path: Path) -> dict[str, str]:
+def _script_execution_workspace(
+    request: Request,
+    payload: SandboxScriptRunRequest,
+    *,
+    snapshot_workspace: Path,
+) -> Path:
+    state_scope_worker_key = payload.state_scope_worker_key
+    if state_scope_worker_key is None:
+        return snapshot_workspace
+    try:
+        expected_worker_key = script_worker_key_for_run(state_scope_worker_key, payload.run_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Script state scope is invalid for this run.") from exc
+    if not secrets.compare_digest(expected_worker_key, payload.worker_key):
+        raise HTTPException(status_code=400, detail="Script state scope does not own this run worker.")
+
+    try:
+        return resolve_script_state_workspace(
+            request.app,
+            state_scope_worker_key=state_scope_worker_key,
+            agent_name=state_scope_worker_key.rsplit(":", maxsplit=1)[-1],
+            private_agent_names=frozenset(payload.private_agent_names or ()),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+
+def _script_environment(
+    payload: SandboxScriptRunRequest,
+    *,
+    workspace: Path,
+    snapshot_workspace: Path,
+    token_path: Path,
+) -> dict[str, str]:
     parsed_url = urlsplit(payload.gateway_url)
     if (
         parsed_url.scheme not in {"http", "https"}
@@ -267,6 +306,7 @@ def _script_environment(payload: SandboxScriptRunRequest, *, workspace: Path, to
         "MINDROOM_SCRIPT_GATEWAY_URL": payload.gateway_url.rstrip("/"),
         "MINDROOM_SCRIPT_RUN_ID": payload.run_id,
         "MINDROOM_SCRIPT_SOURCE_DIGEST": payload.source_digest,
+        "MINDROOM_SCRIPT_SNAPSHOT_ROOT": str(snapshot_workspace),
         "MINDROOM_SCRIPT_TOKEN_PATH": str(token_path),
         "MINDROOM_SCRIPT_WORKSPACE_ROOT": str(workspace),
     }
@@ -330,10 +370,16 @@ async def run_script_in_worker(request: Request, payload: SandboxScriptRunReques
         worker_key=payload.worker_key,
         private_agent_names=payload.private_agent_names,
     )
-    workspace = prepared.paths.workspace.resolve()
-    source_path, token_path = _script_snapshot_paths(workspace, payload.run_id)
+    snapshot_workspace = prepared.paths.workspace.resolve()
+    source_path, token_path = _script_snapshot_paths(snapshot_workspace, payload.run_id)
     _validate_source_digest(source_path, payload.source_digest)
-    script_environment = _script_environment(payload, workspace=workspace, token_path=token_path)
+    workspace = _script_execution_workspace(request, payload, snapshot_workspace=snapshot_workspace)
+    script_environment = _script_environment(
+        payload,
+        workspace=workspace,
+        snapshot_workspace=snapshot_workspace,
+        token_path=token_path,
+    )
     python_executable, base_environment, _cwd = sandbox_exec.resolve_subprocess_worker_context(prepared.paths)
     if python_executable is None or base_environment is None:
         return SandboxScriptRunResponse(ok=False, error="Worker Python runtime is unavailable.", failure_kind="worker")

--- a/src/mindroom/custom_tools/script.py
+++ b/src/mindroom/custom_tools/script.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from agno.tools import Toolkit
 
@@ -44,14 +44,29 @@ class ScriptTools(Toolkit):
         )
         super().__init__(
             name="script",
-            tools=[self.start_script, self.get_script, self.cancel_script, self.list_scripts],
+            tools=[
+                self.start_script,
+                self.get_script_resource_profiles,
+                self.get_script,
+                self.cancel_script,
+                self.list_scripts,
+            ],
         )
+
+    async def get_script_resource_profiles(self) -> str:
+        """Return the exact CPU and memory reservations available to background scripts."""
+        resolved = _runtime()
+        if isinstance(resolved, str):
+            return resolved
+        manager, context = resolved
+        return _payload("ok", action="resource_profiles", **manager.resource_profiles(context))
 
     async def start_script(
         self,
         source: str | None = None,
         path: str | None = None,
         name: str | None = None,
+        resource_profile: Literal["small", "standard", "large"] | None = None,
     ) -> str:
         """Run a Python script in the background.
 
@@ -62,6 +77,8 @@ class ScriptTools(Toolkit):
             source: Inline Python source code.
             path: Workspace-relative path to a Python source file.
             name: Optional short label shown by status and list operations.
+            resource_profile: Optional bounded Kubernetes profile. Call get_script_resource_profiles to inspect the
+                exact resources, or omit it to use the configured default.
 
         """
         resolved = _runtime()
@@ -69,7 +86,14 @@ class ScriptTools(Toolkit):
             return resolved
         manager, context = resolved
         try:
-            run = await manager.run(context, source=source, path=path, name=name, limits=self.limits)
+            run = await manager.run(
+                context,
+                source=source,
+                path=path,
+                name=name,
+                resource_profile=resource_profile,
+                limits=self.limits,
+            )
         except ScriptRunManagerError as exc:
             return _payload("error", message=str(exc))
         return _payload("ok", action="run", run=_public_run(run))
@@ -145,6 +169,9 @@ def _public_run(run: ScriptRunRecord) -> dict[str, object]:
         "state": run.state.value,
         "execution_mode": "unsafe_local" if run.local_unsafe else "worker",
         "local_unsafe": run.local_unsafe,
+        "resource_profile": run.resource_profile,
+        "resource_requests": dict(run.resource_requests),
+        "resource_limits": dict(run.resource_limits),
         "created_at": run.created_at,
         "started_at": run.started_at,
         "finished_at": run.finished_at,

--- a/src/mindroom/runtime_env_policy.py
+++ b/src/mindroom/runtime_env_policy.py
@@ -166,6 +166,8 @@ KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY: Mapping[str, str] = MappingProxyTyp
         "memory_limit": "MINDROOM_KUBERNETES_WORKER_MEMORY_LIMIT",
         "cpu_request": "MINDROOM_KUBERNETES_WORKER_CPU_REQUEST",
         "cpu_limit": "MINDROOM_KUBERNETES_WORKER_CPU_LIMIT",
+        "script_resource_profiles_json": "MINDROOM_KUBERNETES_SCRIPT_RESOURCE_PROFILES_JSON",
+        "default_script_resource_profile": "MINDROOM_KUBERNETES_DEFAULT_SCRIPT_RESOURCE_PROFILE",
         "enable_service_links": "MINDROOM_KUBERNETES_WORKER_ENABLE_SERVICE_LINKS",
         "auth_secret_name": "MINDROOM_KUBERNETES_WORKER_AUTH_SECRET_NAME",
         "agent_vault_enabled": "MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED",

--- a/src/mindroom/script_runs/manager.py
+++ b/src/mindroom/script_runs/manager.py
@@ -14,7 +14,7 @@ from contextlib import suppress
 from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol, runtime_checkable
+from typing import TYPE_CHECKING, Protocol, TypedDict, cast, runtime_checkable
 from weakref import WeakValueDictionary
 
 from mindroom.background_tasks import run_blocking_until_complete, run_coroutine_until_complete
@@ -56,7 +56,7 @@ from mindroom.tool_system.worker_routing import (
     serialize_tool_execution_identity,
 )
 from mindroom.workers.backends.static_runner import StaticSandboxRunnerBackend
-from mindroom.workers.models import WorkerHandle, WorkerSpec
+from mindroom.workers.models import ScriptResourceProfileName, WorkerHandle, WorkerSpec
 from mindroom.workers.worker_retirement import remove_directory_tree_at
 from mindroom.workspaces import resolve_workspace_relative_path
 
@@ -91,6 +91,7 @@ _TERMINAL_STATES = frozenset(
         ScriptRunState.INTERRUPTED,
     },
 )
+_SCRIPT_RESOURCE_PROFILE_NAMES = frozenset({"small", "standard", "large"})
 
 
 class ScriptRunManagerError(ValueError):
@@ -108,6 +109,22 @@ class _AmbiguousLaunchError(Exception):
 class _ScriptBroker(Protocol):
     async def cancel_run(self, run_id: str) -> None:
         """Cancel in-process broker executions for one revoked run."""
+
+
+@runtime_checkable
+class _ScriptResourceProfileBackend(Protocol):
+    def script_resource_profiles(self) -> dict[str, object] | None:
+        """Return the bounded resource profiles this backend can enforce."""
+
+
+class _ScriptResourceProfile(TypedDict):
+    requests: dict[str, str]
+    limits: dict[str, str]
+
+
+class _ScriptResourceProfilesPayload(TypedDict):
+    default_profile: ScriptResourceProfileName
+    profiles: dict[str, _ScriptResourceProfile]
 
 
 @runtime_checkable
@@ -204,6 +221,17 @@ class ScriptRunManager:
         """Mark the empty admission set as drained before any launch begins."""
         self._launches_drained.set()
 
+    def resource_profiles(self, context: ToolRuntimeContext) -> dict[str, object]:
+        """Return the exact bounded profiles available for this runtime."""
+        del context
+        payload = _validated_script_resource_profiles(self._worker_backend_for(None))
+        if payload is None:
+            return {"default_profile": None, "profiles": {}}
+        return {
+            "default_profile": payload["default_profile"],
+            "profiles": payload["profiles"],
+        }
+
     async def begin_shutdown(self) -> None:
         """Permanently reject new launches and drain every already-admitted launch."""
         async with self._launch_admission_lock:
@@ -270,6 +298,7 @@ class ScriptRunManager:
         source: str | None = None,
         path: str | None = None,
         name: str | None = None,
+        resource_profile: ScriptResourceProfileName | None = None,
         limits: ScriptRunLimits | None = None,
     ) -> ScriptRunRecord:
         """Snapshot and launch one Python source under its resolved execution scope."""
@@ -295,6 +324,9 @@ class ScriptRunManager:
                 msg = "Background-script workers require MINDROOM_SCRIPT_GATEWAY_URL or MINDROOM_PUBLIC_URL."
                 raise ScriptRunManagerError(msg)
             worker_backend = _require_script_launch_backend(worker_backend, context.runtime_paths)
+            selected_profile = None
+            resource_requests: dict[str, str] = {}
+            resource_limits: dict[str, str] = {}
             if worker_target.worker_key is None:
                 msg = "Background script worker scope could not be resolved for this requester."
                 raise ScriptRunManagerError(msg)
@@ -302,12 +334,18 @@ class ScriptRunManager:
             worker_key = script_worker_key_for_run(worker_target.worker_key, run_id)
             local_unsafe = False
         elif execution_mode in _LOCAL_EXECUTION_MODES:
+            if resource_profile is not None:
+                msg = "Resource profiles require a worker backend that advertises enforceable profiles."
+                raise ScriptRunManagerError(msg)
             if not background_script_supervision_supported():
                 msg = "Background scripts require Linux process-group containment."
                 raise ScriptRunManagerError(msg)
             run_id = f"script-{uuid.uuid4().hex}"
             worker_key = None
             local_unsafe = True
+            selected_profile = None
+            resource_requests = {}
+            resource_limits = {}
         else:
             msg = "Background scripts require a worker or an explicitly disabled sandbox."
             raise ScriptRunManagerError(msg)
@@ -329,6 +367,9 @@ class ScriptRunManager:
             worker_backend_locator=None,
             name=_validated_name(name),
             local_unsafe=local_unsafe,
+            resource_profile=selected_profile,
+            resource_requests=resource_requests,
+            resource_limits=resource_limits,
             max_tool_calls_per_minute=effective_limits.max_tool_calls_per_minute,
             max_runtime_seconds=max(1, round(effective_limits.max_runtime_hours * 60 * 60)),
         )
@@ -340,6 +381,7 @@ class ScriptRunManager:
                 private_agent_names=worker_target.private_agent_names,
                 mirrored_credential_services=frozenset(),
                 state_scope_worker_key=worker_target.worker_key,
+                resource_profile=selected_profile,
             )
         )
         await self._admit_launch()
@@ -353,8 +395,12 @@ class ScriptRunManager:
                     max_concurrent_runs=effective_limits.max_concurrent_runs,
                     worker_spec=worker_spec,
                 )
-            admitted_backend = _require_script_launch_backend(self._worker_backend_for(None), context.runtime_paths)
-            run = replace(run, worker_backend_locator=admitted_backend.cleanup_locator)
+            run, worker_spec = self._bind_admitted_worker_profile(
+                context,
+                run=run,
+                worker_spec=_require_worker_spec(worker_spec),
+                requested_profile=resource_profile,
+            )
             return await self._create_and_launch(
                 context,
                 run=run,
@@ -365,6 +411,28 @@ class ScriptRunManager:
             )
         finally:
             await self._release_launch_admission()
+
+    def _bind_admitted_worker_profile(
+        self,
+        context: ToolRuntimeContext,
+        *,
+        run: ScriptRunRecord,
+        worker_spec: WorkerSpec,
+        requested_profile: ScriptResourceProfileName | None,
+    ) -> tuple[ScriptRunRecord, WorkerSpec]:
+        """Bind persisted quantities to the same refreshed backend that creates the worker."""
+        backend = _require_script_launch_backend(self._worker_backend_for(None), context.runtime_paths)
+        profile, requests, limits = _resolve_script_resource_profile(backend, requested_profile)
+        return (
+            replace(
+                run,
+                worker_backend_locator=backend.cleanup_locator,
+                resource_profile=profile,
+                resource_requests=requests,
+                resource_limits=limits,
+            ),
+            replace(worker_spec, resource_profile=profile),
+        )
 
     async def _create_and_launch(
         self,
@@ -1122,6 +1190,71 @@ def _require_supported_private_script_worker_scope(context: ToolRuntimeContext) 
     ):
         msg = "Background-script workers for private agents require private.per=user_agent."
         raise ScriptRunManagerError(msg)
+
+
+def _validated_script_resource_profiles(backend: object | None) -> _ScriptResourceProfilesPayload | None:
+    if backend is None or not isinstance(backend, _ScriptResourceProfileBackend):
+        return None
+    raw = backend.script_resource_profiles()
+    if raw is None:
+        return None
+    default_profile = raw.get("default_profile")
+    profiles = raw.get("profiles")
+    if (
+        not isinstance(default_profile, str)
+        or default_profile not in _SCRIPT_RESOURCE_PROFILE_NAMES
+        or not isinstance(profiles, dict)
+        or set(profiles) != _SCRIPT_RESOURCE_PROFILE_NAMES
+    ):
+        msg = "Background script resource profiles must define small, standard, and large with a valid default."
+        raise ScriptRunManagerError(msg)
+    profiles_mapping = cast("dict[str, object]", profiles)
+    normalized: dict[str, _ScriptResourceProfile] = {}
+    for profile_name in sorted(_SCRIPT_RESOURCE_PROFILE_NAMES):
+        profile = profiles_mapping[profile_name]
+        if not isinstance(profile, dict):
+            msg = f"Background script resource profile '{profile_name}' must be an object."
+            raise ScriptRunManagerError(msg)
+        profile_mapping = cast("dict[str, object]", profile)
+        requests = profile_mapping.get("requests")
+        limits = profile_mapping.get("limits")
+        if not _valid_resource_quantities(requests) or not _valid_resource_quantities(limits):
+            msg = f"Background script resource profile '{profile_name}' must define CPU and memory requests and limits."
+            raise ScriptRunManagerError(msg)
+        normalized[profile_name] = {
+            "requests": dict(cast("dict[str, str]", requests)),
+            "limits": dict(cast("dict[str, str]", limits)),
+        }
+    return {
+        "default_profile": cast("ScriptResourceProfileName", default_profile),
+        "profiles": normalized,
+    }
+
+
+def _valid_resource_quantities(value: object) -> bool:
+    return (
+        isinstance(value, dict)
+        and set(value) == {"cpu", "memory"}
+        and all(isinstance(quantity, str) and quantity.strip() for quantity in value.values())
+    )
+
+
+def _resolve_script_resource_profile(
+    backend: object,
+    requested_profile: ScriptResourceProfileName | None,
+) -> tuple[ScriptResourceProfileName | None, dict[str, str], dict[str, str]]:
+    payload = _validated_script_resource_profiles(backend)
+    if payload is None:
+        if requested_profile is not None:
+            msg = "Resource profiles require a worker backend that advertises enforceable profiles."
+            raise ScriptRunManagerError(msg)
+        return None, {}, {}
+    selected = requested_profile or payload["default_profile"]
+    profiles = payload["profiles"]
+    profile = profiles[selected]
+    requests = profile["requests"]
+    limits = profile["limits"]
+    return selected, dict(requests), dict(limits)
 
 
 def _worker_workspace(context: ToolRuntimeContext, worker: WorkerHandle) -> Path:

--- a/src/mindroom/script_runs/manager.py
+++ b/src/mindroom/script_runs/manager.py
@@ -29,7 +29,7 @@ from mindroom.script_runs.models import (
     script_worker_key_for_run,
     supervisor_handle_for_run,
 )
-from mindroom.script_runs.policy import resolve_script_launch_grants
+from mindroom.script_runs.policy import resolve_script_launch_grants, resolve_script_launch_toolkit_names
 from mindroom.script_runs.reasons import (
     AMBIGUOUS_LAUNCH,
     INTERRUPTION_REASONS,
@@ -184,6 +184,7 @@ class ScriptRunManager:
     worker_backend: WorkerBackend | None
     gateway_url: str
     grant_resolver: Callable[[ToolRuntimeContext], tuple[ScriptToolGrant, ...]] = resolve_script_launch_grants
+    toolkit_name_resolver: Callable[[ToolRuntimeContext], frozenset[str]] = resolve_script_launch_toolkit_names
     cancellation_grace_seconds: float = 2.0
     cancellation_poll_interval_seconds: float = 0.05
     _launch_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
@@ -243,6 +244,24 @@ class ScriptRunManager:
             if self._launches_in_progress == 0:
                 self._launches_drained.set()
 
+    async def _resolve_launch_grants(
+        self,
+        context: ToolRuntimeContext,
+        limits: ScriptRunLimits,
+    ) -> tuple[ScriptToolGrant, ...]:
+        """Resolve one launch snapshot and apply its authored toolkit allowlist."""
+        launch_grants = await asyncio.to_thread(self.grant_resolver, context)
+        if limits.allowed_tools is None:
+            return launch_grants
+        allowed_tools = frozenset(limits.allowed_tools)
+        eligible_toolkits = await asyncio.to_thread(self.toolkit_name_resolver, context)
+        unknown_toolkits = allowed_tools - eligible_toolkits
+        if unknown_toolkits:
+            names = ", ".join(sorted(unknown_toolkits))
+            msg = f"Background script allowed_tools contains unknown or ineligible toolkit names: {names}."
+            raise ScriptRunManagerError(msg)
+        return tuple(grant for grant in launch_grants if grant.toolkit_name in allowed_tools)
+
     async def run(
         self,
         context: ToolRuntimeContext,
@@ -292,17 +311,7 @@ class ScriptRunManager:
             msg = "Background scripts require a worker or an explicitly disabled sandbox."
             raise ScriptRunManagerError(msg)
 
-        launch_grants = await asyncio.to_thread(self.grant_resolver, context)
-        if effective_limits.allowed_tools is not None:
-            allowed_tools = frozenset(effective_limits.allowed_tools)
-            unknown_toolkits = allowed_tools - {grant.toolkit_name for grant in launch_grants}
-            if unknown_toolkits:
-                names = ", ".join(sorted(unknown_toolkits))
-                msg = (
-                    f"Background script allowed_tools contains unknown toolkit names or unavailable toolkits: {names}."
-                )
-                raise ScriptRunManagerError(msg)
-            launch_grants = tuple(grant for grant in launch_grants if grant.toolkit_name in allowed_tools)
+        launch_grants = await self._resolve_launch_grants(context, effective_limits)
         token, token_hash = mint_script_capability()
         run = ScriptRunRecord(
             run_id=run_id,

--- a/src/mindroom/script_runs/manager.py
+++ b/src/mindroom/script_runs/manager.py
@@ -243,7 +243,7 @@ class ScriptRunManager:
             if self._launches_in_progress == 0:
                 self._launches_drained.set()
 
-    async def run(  # noqa: PLR0915
+    async def run(
         self,
         context: ToolRuntimeContext,
         *,
@@ -273,12 +273,9 @@ class ScriptRunManager:
             if not self.gateway_url:
                 msg = "Background-script workers require MINDROOM_SCRIPT_GATEWAY_URL or MINDROOM_PUBLIC_URL."
                 raise ScriptRunManagerError(msg)
-            worker_backend = _require_script_worker_backend(worker_backend)
+            worker_backend = _require_script_launch_backend(worker_backend, context.runtime_paths)
             if worker_target.worker_key is None:
                 msg = "Background script worker scope could not be resolved for this requester."
-                raise ScriptRunManagerError(msg)
-            if worker_target.private_agent_names:
-                msg = "Background scripts in dedicated workers are not supported for private agents."
                 raise ScriptRunManagerError(msg)
             run_id = f"script-{uuid.uuid4().hex}"
             worker_key = script_worker_key_for_run(worker_target.worker_key, run_id)
@@ -331,6 +328,7 @@ class ScriptRunManager:
                 worker_key=_require_worker_key(worker_key),
                 private_agent_names=worker_target.private_agent_names,
                 mirrored_credential_services=frozenset(),
+                state_scope_worker_key=worker_target.worker_key,
             )
         )
         await self._admit_launch()
@@ -344,7 +342,7 @@ class ScriptRunManager:
                     max_concurrent_runs=effective_limits.max_concurrent_runs,
                     worker_spec=worker_spec,
                 )
-            admitted_backend = _require_script_worker_backend(self._worker_backend_for(None))
+            admitted_backend = _require_script_launch_backend(self._worker_backend_for(None), context.runtime_paths)
             run = replace(run, worker_backend_locator=admitted_backend.cleanup_locator)
             return await self._create_and_launch(
                 context,
@@ -1302,7 +1300,9 @@ def _raise_concurrent_run_limit() -> None:
     raise ScriptRunManagerError(msg)
 
 
-def _require_script_worker_backend(backend: WorkerBackend | None) -> _RetiringWorkerBackend:
+def _require_script_worker_backend(
+    backend: WorkerBackend | None,
+) -> _RetiringWorkerBackend:
     if backend is None:
         msg = "Background script worker backend is unavailable."
         raise ScriptRunManagerError(msg)
@@ -1312,12 +1312,6 @@ def _require_script_worker_backend(backend: WorkerBackend | None) -> _RetiringWo
             "unsafe-local mode or a Docker worker backend."
         )
         raise ScriptRunManagerError(msg)
-    if backend.backend_name == "kubernetes":
-        msg = (
-            "Kubernetes background scripts require a gateway-only listener; "
-            "use Docker or explicit unsafe-local mode until that boundary is configured."
-        )
-        raise ScriptRunManagerError(msg)
     if backend.cleanup_locator is None:
         msg = "Background script worker backend has no durable cleanup locator."
         raise ScriptRunManagerError(msg)
@@ -1325,6 +1319,23 @@ def _require_script_worker_backend(backend: WorkerBackend | None) -> _RetiringWo
         msg = "Background script worker backend does not support exact worker retirement."
         raise ScriptRunManagerError(msg)
     return backend
+
+
+def _require_script_launch_backend(
+    backend: WorkerBackend | None,
+    runtime_paths: RuntimePaths,
+) -> _RetiringWorkerBackend:
+    admitted_backend = _require_script_worker_backend(backend)
+    isolated_kubernetes_gateway = runtime_paths.env_flag(
+        "MINDROOM_SCRIPT_GATEWAY_ISOLATED",
+    ) and bool((runtime_paths.env_value("MINDROOM_SCRIPT_GATEWAY_URL") or "").strip())
+    if admitted_backend.backend_name == "kubernetes" and not isolated_kubernetes_gateway:
+        msg = (
+            "Kubernetes background scripts require a gateway-only listener; "
+            "use Docker or explicit unsafe-local mode until that boundary is configured."
+        )
+        raise ScriptRunManagerError(msg)
+    return admitted_backend
 
 
 def _terminal_state_for(run: ScriptRunRecord) -> ScriptRunState:

--- a/src/mindroom/script_runs/manager.py
+++ b/src/mindroom/script_runs/manager.py
@@ -270,6 +270,7 @@ class ScriptRunManager:
             context.runtime_paths,
             worker_backend_configured=worker_backend is not None,
         ):
+            _require_supported_private_script_worker_scope(context)
             if not self.gateway_url:
                 msg = "Background-script workers require MINDROOM_SCRIPT_GATEWAY_URL or MINDROOM_PUBLIC_URL."
                 raise ScriptRunManagerError(msg)
@@ -675,6 +676,7 @@ class ScriptRunManager:
                 run_id=run.run_id,
                 source_digest=run.source_digest,
                 gateway_url=self.gateway_url,
+                state_scope_worker_key=worker_spec.state_scope_worker_key,
                 private_agent_names=(
                     tuple(sorted(worker_spec.private_agent_names))
                     if worker_spec.private_agent_names is not None
@@ -777,6 +779,7 @@ class ScriptRunManager:
                 "MINDROOM_SCRIPT_GATEWAY_URL": self.gateway_url.rstrip("/"),
                 "MINDROOM_SCRIPT_RUN_ID": run.run_id,
                 "MINDROOM_SCRIPT_SOURCE_DIGEST": run.source_digest,
+                "MINDROOM_SCRIPT_SNAPSHOT_ROOT": str(workspace),
                 "MINDROOM_SCRIPT_TOKEN_PATH": str(token_path),
                 "MINDROOM_SCRIPT_WORKSPACE_ROOT": str(workspace),
             },
@@ -1100,6 +1103,15 @@ def _agent_workspace(context: ToolRuntimeContext) -> Path:
     )
     workspace.mkdir(parents=True, exist_ok=True)
     return workspace.resolve()
+
+
+def _require_supported_private_script_worker_scope(context: ToolRuntimeContext) -> None:
+    agent_config = context.config.get_agent(context.agent_name)
+    if agent_config.private is not None and context.config.resolve_entity(context.agent_name).execution_scope != (
+        "user_agent"
+    ):
+        msg = "Background-script workers for private agents require private.per=user_agent."
+        raise ScriptRunManagerError(msg)
 
 
 def _worker_workspace(context: ToolRuntimeContext, worker: WorkerHandle) -> Path:

--- a/src/mindroom/script_runs/manager.py
+++ b/src/mindroom/script_runs/manager.py
@@ -20,6 +20,7 @@ from weakref import WeakValueDictionary
 from mindroom.background_tasks import run_blocking_until_complete, run_coroutine_until_complete
 from mindroom.constants import CONTROL_STATE_PATH_ENV
 from mindroom.logging_config import get_logger
+from mindroom.runtime_env_policy import KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY
 from mindroom.runtime_resolution import resolve_agent_runtime
 from mindroom.script_runs.models import (
     ScriptRunRecord,
@@ -1330,7 +1331,7 @@ def _require_script_worker_backend(
     if isinstance(backend, StaticSandboxRunnerBackend):
         msg = (
             "Background scripts cannot use the shared static sandbox runner; configure explicit "
-            "unsafe-local mode or a Docker worker backend."
+            "unsafe-local mode or a dedicated Docker or isolated Kubernetes worker backend."
         )
         raise ScriptRunManagerError(msg)
     if backend.cleanup_locator is None:
@@ -1355,6 +1356,11 @@ def _require_script_launch_backend(
             "Kubernetes background scripts require a gateway-only listener; "
             "use Docker or explicit unsafe-local mode until that boundary is configured."
         )
+        raise ScriptRunManagerError(msg)
+    if admitted_backend.backend_name == "kubernetes" and runtime_paths.env_flag(
+        KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["agent_vault_enabled"],
+    ):
+        msg = "Kubernetes background scripts are not supported while Agent Vault is enabled."
         raise ScriptRunManagerError(msg)
     return admitted_backend
 

--- a/src/mindroom/script_runs/models.py
+++ b/src/mindroom/script_runs/models.py
@@ -56,6 +56,9 @@ class ScriptRunRecord:
     snapshot_locator: str | None = None
     name: str | None = None
     local_unsafe: bool = False
+    resource_profile: str | None = None
+    resource_requests: dict[str, str] = field(default_factory=dict)
+    resource_limits: dict[str, str] = field(default_factory=dict)
     max_tool_calls_per_minute: int = 30
     max_runtime_seconds: int = 24 * 60 * 60
     state: ScriptRunState = ScriptRunState.STARTING

--- a/src/mindroom/script_runs/policy.py
+++ b/src/mindroom/script_runs/policy.py
@@ -18,7 +18,11 @@ if TYPE_CHECKING:
     from mindroom.config.models import EffectiveToolConfig
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
 
-__all__ = ["resolve_current_script_tool", "resolve_script_launch_grants"]
+__all__ = [
+    "resolve_current_script_tool",
+    "resolve_script_launch_grants",
+    "resolve_script_launch_toolkit_names",
+]
 
 
 _SCRIPT_RESTRICTED_TOOLKITS = frozenset(
@@ -34,6 +38,11 @@ def resolve_script_launch_grants(context: ToolRuntimeContext) -> tuple[ScriptToo
         for toolkit_name, toolkit in toolkits.items()
         for function_name in _visible_function_names(context, toolkit)
     )
+
+
+def resolve_script_launch_toolkit_names(context: ToolRuntimeContext) -> frozenset[str]:
+    """Resolve eligible toolkit names independently of their current function catalogs."""
+    return frozenset(entry.name for entry in _visible_script_tool_entries(context, context.config))
 
 
 def resolve_current_script_tool(

--- a/src/mindroom/script_runs/shim.py
+++ b/src/mindroom/script_runs/shim.py
@@ -13,6 +13,7 @@ from pathlib import Path
 
 _CONTROL_STATE_PATH_ENV = "MINDROOM_CONTROL_STATE_PATH"
 _SOURCE_DIGEST_ENV = "MINDROOM_SCRIPT_SOURCE_DIGEST"
+_SNAPSHOT_ROOT_ENV = "MINDROOM_SCRIPT_SNAPSHOT_ROOT"
 _TOKEN_PATH_ENV = "MINDROOM_SCRIPT_TOKEN_PATH"  # noqa: S105 - this names a path, not a token.
 _WORKSPACE_ROOT_ENV = "MINDROOM_SCRIPT_WORKSPACE_ROOT"
 _MAX_SOURCE_BYTES = 128 * 1024
@@ -91,17 +92,22 @@ def _main(argv: list[str]) -> int:
         msg = f"{_WORKSPACE_ROOT_ENV} must be set for a supervised script run."
         raise ValueError(msg)
     workspace_root = Path(raw_workspace_root).resolve(strict=True)
-    token_entry = _trusted_token_entry(argv[2], workspace_root=workspace_root)
+    if not workspace_root.is_dir():
+        msg = f"{_WORKSPACE_ROOT_ENV} must name a directory."
+        raise ValueError(msg)
+    raw_snapshot_root = os.environ.get(_SNAPSHOT_ROOT_ENV, "").strip() or raw_workspace_root
+    snapshot_root = Path(raw_snapshot_root).resolve(strict=True)
+    token_entry = _trusted_token_entry(argv[2], workspace_root=snapshot_root)
     try:
         token_path = _validated_file(
             argv[2],
-            workspace_root=workspace_root,
+            workspace_root=snapshot_root,
             label="Script capability file",
             byte_limit=_MAX_TOKEN_BYTES,
         )
         source_path = _validated_file(
             argv[1],
-            workspace_root=workspace_root,
+            workspace_root=snapshot_root,
             label="Script source",
             byte_limit=_MAX_SOURCE_BYTES,
         )
@@ -115,7 +121,7 @@ def _main(argv: list[str]) -> int:
     finally:
         sys.stdout.flush()
         sys.stderr.flush()
-        _remove_token_entry(token_entry, workspace_root=workspace_root)
+        _remove_token_entry(token_entry, workspace_root=snapshot_root)
     return 0
 
 

--- a/src/mindroom/script_runs/store.py
+++ b/src/mindroom/script_runs/store.py
@@ -147,10 +147,11 @@ class ScriptRunStore:
                         execution_identity_json, source_digest, grants_json, token_hash, preapprove_launch_grants,
                         worker_key, worker_id, worker_backend_locator,
                         snapshot_locator, name, local_unsafe,
+                        resource_profile, resource_requests_json, resource_limits_json,
                         max_tool_calls_per_minute, max_runtime_seconds, state, created_at,
                         started_at, finished_at, exit_code, error, output,
                         cancel_requested_at, cancellation_reason
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     _run_values(run),
                 )
@@ -612,6 +613,12 @@ class ScriptRunStore:
         with self._write_transaction() as connection:
             for statement in _SCHEMA_STATEMENTS:
                 connection.execute(statement)
+            existing_columns = {
+                str(row["name"]) for row in connection.execute("PRAGMA table_info(script_runs)").fetchall()
+            }
+            for column_name, statement in _SCRIPT_RUN_COLUMN_MIGRATIONS:
+                if column_name not in existing_columns:
+                    connection.execute(statement)
 
     @contextmanager
     def _read_connection(self) -> Iterator[sqlite3.Connection]:
@@ -656,6 +663,9 @@ _SCHEMA_STATEMENTS = (
                     snapshot_locator TEXT,
                     name TEXT,
                     local_unsafe INTEGER NOT NULL,
+                    resource_profile TEXT,
+                    resource_requests_json TEXT NOT NULL DEFAULT '{}',
+                    resource_limits_json TEXT NOT NULL DEFAULT '{}',
                     max_tool_calls_per_minute INTEGER NOT NULL,
                     max_runtime_seconds INTEGER NOT NULL,
                     state TEXT NOT NULL,
@@ -690,6 +700,18 @@ _SCHEMA_STATEMENTS = (
                 CREATE INDEX IF NOT EXISTS script_calls_run_created_idx
                     ON script_calls(run_id, created_at)
                 """,
+)
+
+_SCRIPT_RUN_COLUMN_MIGRATIONS = (
+    ("resource_profile", "ALTER TABLE script_runs ADD COLUMN resource_profile TEXT"),
+    (
+        "resource_requests_json",
+        "ALTER TABLE script_runs ADD COLUMN resource_requests_json TEXT NOT NULL DEFAULT '{}'",
+    ),
+    (
+        "resource_limits_json",
+        "ALTER TABLE script_runs ADD COLUMN resource_limits_json TEXT NOT NULL DEFAULT '{}'",
+    ),
 )
 
 
@@ -728,6 +750,9 @@ def _run_values(run: ScriptRunRecord) -> tuple[object, ...]:
         run.snapshot_locator,
         run.name,
         int(run.local_unsafe),
+        run.resource_profile,
+        json.dumps(run.resource_requests, separators=(",", ":"), sort_keys=True),
+        json.dumps(run.resource_limits, separators=(",", ":"), sort_keys=True),
         run.max_tool_calls_per_minute,
         run.max_runtime_seconds,
         run.state.value,
@@ -761,6 +786,9 @@ def _run_from_row(row: sqlite3.Row) -> ScriptRunRecord:
         snapshot_locator=_nullable_string(row["snapshot_locator"]),
         name=_nullable_string(row["name"]),
         local_unsafe=bool(row["local_unsafe"]),
+        resource_profile=_nullable_string(row["resource_profile"]),
+        resource_requests=cast("dict[str, str]", json.loads(str(row["resource_requests_json"]))),
+        resource_limits=cast("dict[str, str]", json.loads(str(row["resource_limits_json"]))),
         max_tool_calls_per_minute=int(row["max_tool_calls_per_minute"]),
         max_runtime_seconds=int(row["max_runtime_seconds"]),
         state=ScriptRunState(str(row["state"])),

--- a/src/mindroom/script_runs/worker_client.py
+++ b/src/mindroom/script_runs/worker_client.py
@@ -66,6 +66,7 @@ class ScriptWorkerClient:
         run_id: str,
         source_digest: str,
         gateway_url: str,
+        state_scope_worker_key: str | None = None,
         private_agent_names: tuple[str, ...] | None = None,
     ) -> None:
         """Launch the run's fixed source snapshot under its derived handle."""
@@ -76,6 +77,7 @@ class ScriptWorkerClient:
             json={
                 "run_id": run_id,
                 "worker_key": worker.worker_key,
+                "state_scope_worker_key": state_scope_worker_key,
                 "source_digest": source_digest,
                 "gateway_url": gateway_url,
                 "private_agent_names": list(private_agent_names) if private_agent_names is not None else None,

--- a/src/mindroom/tools/script.py
+++ b/src/mindroom/tools/script.py
@@ -70,7 +70,13 @@ if TYPE_CHECKING:
     ],
     dependencies=["agno"],
     requires_room_context=True,
-    function_names=("start_script", "get_script", "cancel_script", "list_scripts"),
+    function_names=(
+        "start_script",
+        "get_script_resource_profiles",
+        "get_script",
+        "cancel_script",
+        "list_scripts",
+    ),
     supports_toolkit_filters=False,
 )
 def script_tools() -> type[ScriptTools]:

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -5868,6 +5868,7 @@
       "docs_url": null,
       "function_names": [
         "start_script",
+        "get_script_resource_profiles",
         "get_script",
         "cancel_script",
         "list_scripts"

--- a/src/mindroom/workers/backends/_dedicated_worker_common.py
+++ b/src/mindroom/workers/backends/_dedicated_worker_common.py
@@ -29,6 +29,7 @@ __all__ = [
     "build_backend_config_signature",
     "build_dedicated_worker_runtime_paths",
     "plan_scoped_visible_state_roots",
+    "resolve_state_scope_worker_key",
     "resolved_agent_policies_from_config_data",
     "stable_signature_json",
     "validate_dedicated_worker_extra_env",
@@ -60,6 +61,22 @@ class ScopedVisibleStateRoot:
 
     local_path: Path
     worker_visible_path: Path
+
+
+def resolve_state_scope_worker_key(worker_key: str, state_scope_worker_key: str | None) -> str:
+    """Resolve a narrower run key to the durable worker scope it is allowed to mount."""
+    if state_scope_worker_key is None or state_scope_worker_key == worker_key:
+        return worker_key
+    worker_parts = worker_key.split(":")
+    state_scope_parts = state_scope_worker_key.split(":")
+    if (
+        len(worker_parts) == len(state_scope_parts) + 1
+        and worker_parts[:-2] == state_scope_parts[:-1]
+        and worker_parts[-1] == state_scope_parts[-1]
+    ):
+        return state_scope_worker_key
+    msg = f"Worker state scope does not own the requested worker key: {worker_key}"
+    raise WorkerBackendError(msg)
 
 
 def validate_private_user_agent_visibility(

--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -34,6 +34,7 @@ from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends._dedicated_worker_common import (
     build_dedicated_worker_runtime_paths,
     plan_scoped_visible_state_roots,
+    resolve_state_scope_worker_key,
     validate_dedicated_worker_extra_env,
     validate_unique_worker_visible_paths,
 )
@@ -454,6 +455,7 @@ class DockerWorkerBackend:
                 metadata,
                 paths,
                 private_agent_names=spec.private_agent_names,
+                state_scope_worker_key=spec.state_scope_worker_key,
             )
             lifecycle_state = prepare_worker_ensure_lifecycle(
                 read_lifecycle_state(metadata),
@@ -481,6 +483,7 @@ class DockerWorkerBackend:
                     metadata,
                     paths,
                     private_agent_names=spec.private_agent_names,
+                    state_scope_worker_key=spec.state_scope_worker_key,
                     launch_config=launch_config,
                 )
                 try:
@@ -501,6 +504,7 @@ class DockerWorkerBackend:
                         metadata,
                         paths,
                         private_agent_names=spec.private_agent_names,
+                        state_scope_worker_key=spec.state_scope_worker_key,
                         stale_error=stale_error,
                     )
                     endpoint = self._wait_for_ready(container)
@@ -751,6 +755,7 @@ class DockerWorkerBackend:
         paths: LocalWorkerStatePaths,
         *,
         private_agent_names: frozenset[str] | None,
+        state_scope_worker_key: str | None,
     ) -> bool:
         container = self._read_container(metadata.container_name)
         if metadata.status == "failed":
@@ -762,6 +767,7 @@ class DockerWorkerBackend:
             container,
             paths,
             private_agent_names=private_agent_names,
+            state_scope_worker_key=state_scope_worker_key,
         ):
             return True
         return not self._container_is_running(container)
@@ -773,6 +779,7 @@ class DockerWorkerBackend:
         paths: LocalWorkerStatePaths,
         *,
         private_agent_names: frozenset[str] | None,
+        state_scope_worker_key: str | None,
     ) -> bool:
         compatible_launch_config_hashes = self._compatible_launch_config_hashes(container)
         if metadata.launch_config_hash not in compatible_launch_config_hashes:
@@ -801,6 +808,7 @@ class DockerWorkerBackend:
             self._scoped_storage_mount_specs(
                 metadata.worker_key,
                 private_agent_names=private_agent_names,
+                state_scope_worker_key=state_scope_worker_key,
             ),
         )
         mount_checks.extend(config_mount_specs)
@@ -812,6 +820,7 @@ class DockerWorkerBackend:
         paths: LocalWorkerStatePaths,
         *,
         private_agent_names: frozenset[str] | None,
+        state_scope_worker_key: str | None,
         launch_config: _DockerLaunchConfig,
     ) -> _DockerContainer:
         paths.root.mkdir(parents=True, exist_ok=True)
@@ -821,6 +830,7 @@ class DockerWorkerBackend:
             container,
             paths,
             private_agent_names=private_agent_names,
+            state_scope_worker_key=state_scope_worker_key,
         ):
             self._remove_container(container)
             container = None
@@ -830,6 +840,7 @@ class DockerWorkerBackend:
                 paths,
                 worker_key=metadata.worker_key,
                 private_agent_names=private_agent_names,
+                state_scope_worker_key=state_scope_worker_key,
             )
             self._prepare_nested_storage_mount_targets(paths, volumes)
             container = self._client.containers.run(
@@ -865,6 +876,7 @@ class DockerWorkerBackend:
         paths: LocalWorkerStatePaths,
         *,
         private_agent_names: frozenset[str] | None,
+        state_scope_worker_key: str | None,
         stale_error: WorkerBackendError,
     ) -> tuple[_DockerContainer, _DockerLaunchConfig]:
         """Pull the configured image once and relaunch after a protocol mismatch.
@@ -892,6 +904,7 @@ class DockerWorkerBackend:
                 metadata,
                 paths,
                 private_agent_names=private_agent_names,
+                state_scope_worker_key=state_scope_worker_key,
                 launch_config=launch_config,
             ),
             launch_config,
@@ -1058,6 +1071,7 @@ class DockerWorkerBackend:
         *,
         worker_key: str | None = None,
         private_agent_names: frozenset[str] | None = None,
+        state_scope_worker_key: str | None = None,
     ) -> dict[str, dict[str, str]]:
         volumes = {
             str(paths.root): {"bind": self.config.storage_mount_path, "mode": "rw"},
@@ -1066,6 +1080,7 @@ class DockerWorkerBackend:
             for host_path, container_path, read_only in self._scoped_storage_mount_specs(
                 worker_key,
                 private_agent_names=private_agent_names,
+                state_scope_worker_key=state_scope_worker_key,
             ):
                 volumes[str(host_path)] = {
                     "bind": container_path,
@@ -1110,11 +1125,12 @@ class DockerWorkerBackend:
         worker_key: str,
         *,
         private_agent_names: frozenset[str] | None,
+        state_scope_worker_key: str | None = None,
     ) -> list[tuple[Path, str, bool]]:
         mount_specs = [
             (planned_root.local_path, str(planned_root.worker_visible_path), False)
             for planned_root in plan_scoped_visible_state_roots(
-                worker_key=worker_key,
+                worker_key=resolve_state_scope_worker_key(worker_key, state_scope_worker_key),
                 local_shared_storage_root=self._storage_path,
                 worker_visible_shared_storage_root=Path(self.config.storage_mount_path),
                 private_agent_names=private_agent_names,

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -275,6 +275,20 @@ class KubernetesWorkerBackend:
     """Kubernetes-backed worker provider for dedicated worker pods."""
 
     backend_name = "kubernetes"
+
+    def script_resource_profiles(self) -> dict[str, object]:
+        """Return the fixed profile names and exact configured quantities."""
+        return {
+            "default_profile": self.config.default_script_resource_profile,
+            "profiles": {
+                name: {
+                    "requests": dict(profile["requests"]),
+                    "limits": dict(profile["limits"]),
+                }
+                for name, profile in self.config.script_resource_profiles.items()
+            },
+        }
+
     cleanup_locator: str | None = None
 
     def __init__(
@@ -445,6 +459,7 @@ class KubernetesWorkerBackend:
                         replicas=1,
                         private_agent_names=spec.private_agent_names,
                         state_scope_worker_key=spec.state_scope_worker_key,
+                        resource_profile=spec.resource_profile,
                     )
                     startup_triggered = should_restart or deployment_apply.recreated
                     destructive_failure_allowed = destructive_failure_allowed or startup_triggered
@@ -694,6 +709,7 @@ class KubernetesWorkerBackend:
         annotations = dict(deployment.metadata.annotations or {})
         private_agent_names = resources.parse_private_agent_names_annotation(annotations)
         state_scope_worker_key = resources.parse_state_scope_worker_key_annotation(annotations)
+        resource_profile = resources.parse_resource_profile_annotation(annotations)
         if private_agent_names is None and resolved_worker_key_scope(handle.worker_key) == "user_agent":
             # Deployments created before visibility persistence cannot be rebuilt
             # deterministically; the ensure-time hash check recreates them on next use.
@@ -710,6 +726,7 @@ class KubernetesWorkerBackend:
                 state_subpath=self._state_subpath(handle.worker_key),
                 private_agent_names=private_agent_names,
                 state_scope_worker_key=state_scope_worker_key,
+                resource_profile=resource_profile,
             )
         except WorkerBackendError:
             logger.warning("Skipping pod-template reconciliation for worker %r", handle.worker_key, exc_info=True)
@@ -737,6 +754,7 @@ class KubernetesWorkerBackend:
                 replicas=0,
                 private_agent_names=resources.parse_private_agent_names_annotation(annotations),
                 state_scope_worker_key=resources.parse_state_scope_worker_key_annotation(annotations),
+                resource_profile=resources.parse_resource_profile_annotation(annotations),
             )
         except WorkerBackendError:
             logger.warning("Skipping pod-template reconciliation for worker %r", live_handle.worker_key, exc_info=True)

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -442,6 +442,7 @@ class KubernetesWorkerBackend:
                         annotations=annotations,
                         replicas=1,
                         private_agent_names=spec.private_agent_names,
+                        state_scope_worker_key=spec.state_scope_worker_key,
                     )
                     startup_triggered = should_restart or deployment_apply.recreated
                     destructive_failure_allowed = destructive_failure_allowed or startup_triggered
@@ -645,6 +646,7 @@ class KubernetesWorkerBackend:
             return False
         annotations = dict(deployment.metadata.annotations or {})
         private_agent_names = resources.parse_private_agent_names_annotation(annotations)
+        state_scope_worker_key = resources.parse_state_scope_worker_key_annotation(annotations)
         if private_agent_names is None and resolved_worker_key_scope(handle.worker_key) == "user_agent":
             # Deployments created before visibility persistence cannot be rebuilt
             # deterministically; the ensure-time hash check recreates them on next use.
@@ -660,6 +662,7 @@ class KubernetesWorkerBackend:
                 worker_id=handle.worker_id,
                 state_subpath=self._state_subpath(handle.worker_key),
                 private_agent_names=private_agent_names,
+                state_scope_worker_key=state_scope_worker_key,
             )
         except WorkerBackendError:
             logger.warning("Skipping pod-template reconciliation for worker %r", handle.worker_key, exc_info=True)
@@ -686,6 +689,7 @@ class KubernetesWorkerBackend:
                 annotations=annotations,
                 replicas=0,
                 private_agent_names=resources.parse_private_agent_names_annotation(annotations),
+                state_scope_worker_key=resources.parse_state_scope_worker_key_annotation(annotations),
             )
         except WorkerBackendError:
             logger.warning("Skipping pod-template reconciliation for worker %r", live_handle.worker_key, exc_info=True)

--- a/src/mindroom/workers/backends/kubernetes.py
+++ b/src/mindroom/workers/backends/kubernetes.py
@@ -12,6 +12,7 @@ from mindroom.credential_policy import credential_service_policy
 from mindroom.credentials import get_runtime_credentials_manager, sync_shared_credentials_to_worker
 from mindroom.runtime_env_policy import (
     CREDENTIALS_ENCRYPTION_KEY_ENV,
+    SANDBOX_RUNTIME_ENV_BY_KEY,
     credentials_encryption_key_value,
 )
 from mindroom.tool_system.worker_routing import resolved_worker_key_scope, worker_dir_name, worker_id_for_key
@@ -30,6 +31,7 @@ from mindroom.workers.models import (
     WorkerSpec,
     WorkerStatus,
 )
+from mindroom.workers.worker_retirement import open_worker_state_root
 
 from . import kubernetes_resources as resources
 from .kubernetes_config import (
@@ -554,6 +556,51 @@ class KubernetesWorkerBackend:
         """Scale idle workers to zero while retaining their state."""
         timestamp = time.time() if now is None else now
         return self._cleanup_idle_deployments(self._resources.list_deployments(), now=timestamp)
+
+    def retire_worker(self, worker_key: str) -> None:
+        """Remove one exact Kubernetes worker and all backend-owned state."""
+        with self._worker_lock(worker_key):
+            worker_id = self._worker_id(worker_key)
+            state_subpath = self._state_subpath(worker_key)
+            state_parts = tuple(part for part in state_subpath.split("/") if part)
+            if not state_parts:
+                msg = f"Kubernetes worker state path is invalid for retirement: {state_subpath!r}."
+                raise WorkerBackendError(msg)
+            deployment = self._resources.read_deployment(worker_id)
+            if deployment is not None:
+                annotations = dict(deployment.metadata.annotations or {})
+                if annotations.get(resources.ANNOTATION_WORKER_KEY) != worker_key:
+                    msg = f"Kubernetes worker Deployment does not match retirement key '{worker_key}'."
+                    raise WorkerBackendError(msg)
+                if annotations.get(resources.ANNOTATION_STATE_SUBPATH) != state_subpath:
+                    msg = f"Kubernetes worker Deployment does not match retirement state for '{worker_key}'."
+                    raise WorkerBackendError(msg)
+            try:
+                with open_worker_state_root(
+                    self.storage_root,
+                    workers_subpath=state_parts[:-1],
+                    worker_name=state_parts[-1],
+                    expected_worker_key=worker_key,
+                    identity_path=(".runtime", "startup_manifest.json"),
+                    identity_field_path=(
+                        "runtime_paths",
+                        "process_env",
+                        SANDBOX_RUNTIME_ENV_BY_KEY["dedicated_worker_key"],
+                    ),
+                ) as state:
+                    self._invalidate_ready_worker(worker_key)
+                    self._resources.delete_service(worker_id)
+                    self._resources.delete_deployment(
+                        worker_id,
+                        timeout_seconds=self.config.ready_timeout_seconds,
+                    )
+                    self._resources.delete_secret(worker_id)
+                    state.remove()
+            except WorkerBackendError:
+                raise
+            except (OSError, RecursionError, TypeError, ValueError) as exc:
+                msg = f"Failed to retire Kubernetes worker '{worker_key}': {exc}"
+                raise WorkerBackendError(msg) from exc
 
     def _cleanup_idle_deployments(
         self,

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -543,9 +543,10 @@ def _kubernetes_cleanup_client_identity(runtime_paths: RuntimePaths) -> str:
     context = contexts.get(current_context or "")
     cluster_name = context.get("cluster") if context is not None else None
     cluster = clusters.get(cluster_name) if isinstance(cluster_name, str) else None
-    if cluster is None:
+    cluster_server = cluster.get("server") if cluster is not None else None
+    if not isinstance(cluster_server, str) or not cluster_server:
         return _kubernetes_client_identity(runtime_paths)
-    return "kubeconfig-cluster:" + stable_signature_json(cluster)
+    return "kubeconfig-cluster:" + stable_signature_json({"server": cluster_server})
 
 
 def _merge_named_kubeconfig_entries(

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
+from mindroom import yaml_io
 from mindroom.constants import runtime_env_values
 from mindroom.runtime_env_policy import (
     CREDENTIALS_ENCRYPTION_KEY_ENV,
@@ -415,9 +416,59 @@ def kubernetes_backend_cleanup_signature(
         config.storage_pvc_name,
         config.storage_subpath_prefix,
         config.auth_secret_name or "",
-        _kubernetes_client_identity(runtime_paths),
+        _kubernetes_cleanup_client_identity(runtime_paths),
         str(storage_root.expanduser().resolve()) if storage_root is not None else "",
     )
+
+
+def _kubernetes_cleanup_client_identity(runtime_paths: RuntimePaths) -> str:
+    """Return a Kubernetes cleanup identity that ignores mutable user credentials."""
+    env = runtime_env_values(runtime_paths)
+    service_host = env.get("KUBERNETES_SERVICE_HOST")
+    service_port = env.get("KUBERNETES_SERVICE_PORT")
+    if service_host and service_port:
+        return f"in-cluster:{service_host}:{service_port}"
+
+    contexts: dict[str, dict[str, object]] = {}
+    clusters: dict[str, dict[str, object]] = {}
+    current_context: str | None = None
+    for kubeconfig_path in resolve_kubeconfig_paths(runtime_paths):
+        try:
+            document = yaml_io.safe_load(kubeconfig_path.read_bytes())
+        except OSError:
+            continue
+        if not isinstance(document, dict):
+            continue
+        configured_context = document.get("current-context")
+        if isinstance(configured_context, str):
+            current_context = configured_context
+        _merge_named_kubeconfig_entries(contexts, document.get("contexts"), "context")
+        _merge_named_kubeconfig_entries(clusters, document.get("clusters"), "cluster")
+
+    context = contexts.get(current_context or "")
+    cluster_name = context.get("cluster") if context is not None else None
+    cluster = clusters.get(cluster_name) if isinstance(cluster_name, str) else None
+    if cluster is None:
+        return _kubernetes_client_identity(runtime_paths)
+    return "kubeconfig-cluster:" + stable_signature_json(cluster)
+
+
+def _merge_named_kubeconfig_entries(
+    destination: dict[str, dict[str, object]],
+    entries: object,
+    value_key: str,
+) -> None:
+    """Merge named kubeconfig entries with the client's first-name-wins semantics."""
+    if not isinstance(entries, list):
+        return
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_mapping = cast("dict[str, object]", entry)
+        name = entry_mapping.get("name")
+        value = entry_mapping.get(value_key)
+        if isinstance(name, str) and isinstance(value, dict) and name not in destination:
+            destination[name] = cast("dict[str, object]", value)
 
 
 def _kubernetes_client_identity(runtime_paths: RuntimePaths) -> str:

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 
@@ -50,6 +51,8 @@ _DEFAULT_MEMORY_REQUEST = "256Mi"
 _DEFAULT_MEMORY_LIMIT = "1Gi"
 _DEFAULT_CPU_REQUEST = "100m"
 _DEFAULT_CPU_LIMIT = "500m"
+_SCRIPT_RESOURCE_PROFILE_NAMES = frozenset({"small", "standard", "large"})
+_DEFAULT_SCRIPT_RESOURCE_PROFILE = "small"
 
 _DEFAULT_AGENT_VAULT_VAULT_NAME_PREFIX = "agent-vault"
 _DEFAULT_AGENT_VAULT_API_URL = "http://agent-vault:14321"
@@ -84,6 +87,8 @@ _MEMORY_REQUEST_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["memory_reques
 _MEMORY_LIMIT_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["memory_limit"]
 _CPU_REQUEST_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["cpu_request"]
 _CPU_LIMIT_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["cpu_limit"]
+_SCRIPT_RESOURCE_PROFILES_JSON_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["script_resource_profiles_json"]
+_DEFAULT_SCRIPT_RESOURCE_PROFILE_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["default_script_resource_profile"]
 _ENABLE_SERVICE_LINKS_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["enable_service_links"]
 _AUTH_SECRET_NAME_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["auth_secret_name"]
 _AGENT_VAULT_ENABLED_ENV = KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["agent_vault_enabled"]
@@ -115,6 +120,65 @@ _EXTRA_CONTAINER_ALLOWED_KEYS = frozenset(
 )
 _EXTRA_VOLUME_SOURCE_KEYS = frozenset({"secret", "configMap", "emptyDir", "projected"})
 _EXTRA_VOLUME_ALLOWED_KEYS = frozenset({"name", *_EXTRA_VOLUME_SOURCE_KEYS})
+
+
+def _default_script_resource_profiles() -> dict[str, dict[str, dict[str, str]]]:
+    return {
+        "small": {
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+            "limits": {"cpu": "500m", "memory": "1Gi"},
+        },
+        "standard": {
+            "requests": {"cpu": "250m", "memory": "512Mi"},
+            "limits": {"cpu": "1", "memory": "2Gi"},
+        },
+        "large": {
+            "requests": {"cpu": "500m", "memory": "2Gi"},
+            "limits": {"cpu": "2", "memory": "8Gi"},
+        },
+    }
+
+
+def _normalized_script_resource_profiles(value: object) -> dict[str, dict[str, dict[str, str]]]:
+    if not isinstance(value, dict) or set(value) != _SCRIPT_RESOURCE_PROFILE_NAMES:
+        msg = f"{_SCRIPT_RESOURCE_PROFILES_JSON_ENV} must define exactly small, standard, and large."
+        raise WorkerBackendError(msg)
+    value_mapping = cast("dict[str, object]", value)
+    normalized: dict[str, dict[str, dict[str, str]]] = {}
+    for profile_name in sorted(_SCRIPT_RESOURCE_PROFILE_NAMES):
+        profile = value_mapping[profile_name]
+        if not isinstance(profile, dict) or set(profile) != {"requests", "limits"}:
+            msg = f"{_SCRIPT_RESOURCE_PROFILES_JSON_ENV}.{profile_name} must define requests and limits."
+            raise WorkerBackendError(msg)
+        profile_mapping = cast("dict[str, object]", profile)
+        normalized_profile: dict[str, dict[str, str]] = {}
+        for resource_kind in ("requests", "limits"):
+            quantities = profile_mapping[resource_kind]
+            if (
+                not isinstance(quantities, dict)
+                or set(quantities) != {"cpu", "memory"}
+                or any(not isinstance(quantity, str) or not quantity.strip() for quantity in quantities.values())
+            ):
+                msg = (
+                    f"{_SCRIPT_RESOURCE_PROFILES_JSON_ENV}.{profile_name}.{resource_kind} "
+                    "must define non-empty cpu and memory quantities."
+                )
+                raise WorkerBackendError(msg)
+            normalized_profile[resource_kind] = dict(cast("dict[str, str]", quantities))
+        normalized[profile_name] = normalized_profile
+    return normalized
+
+
+def _read_script_resource_profiles_env(env: Mapping[str, str]) -> dict[str, dict[str, dict[str, str]]]:
+    raw = read_env(env, _SCRIPT_RESOURCE_PROFILES_JSON_ENV)
+    if not raw:
+        return _default_script_resource_profiles()
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        msg = f"{_SCRIPT_RESOURCE_PROFILES_JSON_ENV} must contain a JSON object."
+        raise WorkerBackendError(msg) from exc
+    return _normalized_script_resource_profiles(parsed)
 
 
 def is_kubernetes_worker_backend_config_env_name(name: str) -> bool:
@@ -271,6 +335,10 @@ class KubernetesWorkerBackendConfig:
     resource_limits: dict[str, str]
     enable_service_links: bool
     auth_secret_name: str | None
+    script_resource_profiles: dict[str, dict[str, dict[str, str]]] = field(
+        default_factory=_default_script_resource_profiles,
+    )
+    default_script_resource_profile: str = _DEFAULT_SCRIPT_RESOURCE_PROFILE
     reconcile_pod_templates: bool = True
     agent_vault: KubernetesAgentVaultConfig | None = None
     extra_containers: tuple[dict[str, object], ...] = ()
@@ -286,6 +354,21 @@ class KubernetesWorkerBackendConfig:
         ):
             msg = f"{_STORAGE_SUBPATH_PREFIX_ENV} must be a relative path without traversal segments."
             raise WorkerBackendError(msg)
+        normalized_profiles = _normalized_script_resource_profiles(self.script_resource_profiles)
+        if self.default_script_resource_profile not in normalized_profiles:
+            msg = f"{_DEFAULT_SCRIPT_RESOURCE_PROFILE_ENV} must be one of: small, standard, large."
+            raise WorkerBackendError(msg)
+        object.__setattr__(self, "script_resource_profiles", normalized_profiles)
+
+    def resources_for_profile(self, profile_name: str | None) -> tuple[dict[str, str], dict[str, str]]:
+        """Return main-worker resources or one bounded script profile."""
+        if profile_name is None:
+            return dict(self.resource_requests), dict(self.resource_limits)
+        profile = self.script_resource_profiles.get(profile_name)
+        if profile is None:
+            msg = "Worker resource profile must be one of: small, standard, large."
+            raise WorkerBackendError(msg)
+        return dict(profile["requests"]), dict(profile["limits"])
 
     @classmethod
     def from_runtime(cls, runtime_paths: RuntimePaths) -> KubernetesWorkerBackendConfig:
@@ -342,6 +425,15 @@ class KubernetesWorkerBackendConfig:
             resource_limits=resource_limits,
             enable_service_links=read_bool_env(env, _ENABLE_SERVICE_LINKS_ENV, default=False),
             auth_secret_name=read_env(env, _AUTH_SECRET_NAME_ENV) or None,
+            script_resource_profiles=_read_script_resource_profiles_env(env),
+            default_script_resource_profile=(
+                read_env(
+                    env,
+                    _DEFAULT_SCRIPT_RESOURCE_PROFILE_ENV,
+                    _DEFAULT_SCRIPT_RESOURCE_PROFILE,
+                )
+                or _DEFAULT_SCRIPT_RESOURCE_PROFILE
+            ),
             reconcile_pod_templates=read_bool_env(env, _RECONCILE_POD_TEMPLATES_ENV, default=True),
             agent_vault=KubernetesAgentVaultConfig.from_env(env),
         )
@@ -364,6 +456,7 @@ def kubernetes_backend_config_signature(
     extra_volumes_json = stable_signature_json(config.extra_volumes)
     resource_requests_json = stable_signature_json(config.resource_requests)
     resource_limits_json = stable_signature_json(config.resource_limits)
+    script_resource_profiles_json = stable_signature_json(config.script_resource_profiles)
     client_identity = _kubernetes_client_identity(runtime_paths)
     return (
         "kubernetes",
@@ -392,6 +485,8 @@ def kubernetes_backend_config_signature(
         config.owner_deployment_name or "",
         resource_requests_json,
         resource_limits_json,
+        script_resource_profiles_json,
+        config.default_script_resource_profile,
         str(config.enable_service_links),
         config.auth_secret_name or "",
         str(config.reconcile_pod_templates),

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -53,6 +53,8 @@ _DEFAULT_CPU_REQUEST = "100m"
 _DEFAULT_CPU_LIMIT = "500m"
 _SCRIPT_RESOURCE_PROFILE_NAMES = frozenset({"small", "standard", "large"})
 _DEFAULT_SCRIPT_RESOURCE_PROFILE = "small"
+_IN_CLUSTER_TOKEN_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+_IN_CLUSTER_CERT_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 
 _DEFAULT_AGENT_VAULT_VAULT_NAME_PREFIX = "agent-vault"
 _DEFAULT_AGENT_VAULT_API_URL = "http://agent-vault:14321"
@@ -518,11 +520,9 @@ def kubernetes_backend_cleanup_signature(
 
 def _kubernetes_cleanup_client_identity(runtime_paths: RuntimePaths) -> str:
     """Return a Kubernetes cleanup identity that ignores mutable user credentials."""
-    env = runtime_env_values(runtime_paths)
-    service_host = env.get("KUBERNETES_SERVICE_HOST")
-    service_port = env.get("KUBERNETES_SERVICE_PORT")
-    if service_host and service_port:
-        return f"in-cluster:{service_host}:{service_port}"
+    in_cluster_identity = _in_cluster_client_identity(runtime_paths)
+    if in_cluster_identity is not None:
+        return in_cluster_identity
 
     contexts: dict[str, dict[str, object]] = {}
     clusters: dict[str, dict[str, object]] = {}
@@ -568,11 +568,9 @@ def _merge_named_kubeconfig_entries(
 
 def _kubernetes_client_identity(runtime_paths: RuntimePaths) -> str:
     """Return a non-secret cache fingerprint for the selected Kubernetes control plane."""
-    env = runtime_env_values(runtime_paths)
-    service_host = env.get("KUBERNETES_SERVICE_HOST")
-    service_port = env.get("KUBERNETES_SERVICE_PORT")
-    if service_host and service_port:
-        return f"in-cluster:{service_host}:{service_port}"
+    in_cluster_identity = _in_cluster_client_identity(runtime_paths)
+    if in_cluster_identity is not None:
+        return in_cluster_identity
     identities: list[str] = []
     for kubeconfig_path in resolve_kubeconfig_paths(runtime_paths):
         try:
@@ -581,6 +579,28 @@ def _kubernetes_client_identity(runtime_paths: RuntimePaths) -> str:
             kubeconfig_digest = "unavailable"
         identities.append(f"{kubeconfig_path}:{kubeconfig_digest}")
     return "kubeconfig:" + os.pathsep.join(identities)
+
+
+def _in_cluster_client_identity(runtime_paths: RuntimePaths) -> str | None:
+    """Return the in-cluster identity only when its required credentials are available."""
+    env = runtime_env_values(runtime_paths)
+    service_host = env.get("KUBERNETES_SERVICE_HOST")
+    service_port = env.get("KUBERNETES_SERVICE_PORT")
+    if service_host and service_port and _in_cluster_credentials_available():
+        return f"in-cluster:{service_host}:{service_port}"
+    return None
+
+
+def _in_cluster_credentials_available() -> bool:
+    """Return whether the Kubernetes client can read its required service-account files."""
+    try:
+        for path in (_IN_CLUSTER_TOKEN_PATH, _IN_CLUSTER_CERT_PATH):
+            with path.open("rb") as credential_file:
+                if not credential_file.read(1):
+                    return False
+    except OSError:
+        return False
+    return True
 
 
 def resolve_kubeconfig_paths(runtime_paths: RuntimePaths) -> tuple[Path, ...]:

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -401,6 +401,25 @@ def kubernetes_backend_config_signature(
     )
 
 
+def kubernetes_backend_cleanup_signature(
+    runtime_paths: RuntimePaths,
+    *,
+    storage_root: Path | None = None,
+) -> tuple[str, ...]:
+    """Return the stable fields needed to find and retire an existing Kubernetes worker."""
+    config = KubernetesWorkerBackendConfig.from_runtime(runtime_paths)
+    return (
+        "kubernetes",
+        config.namespace,
+        config.name_prefix,
+        config.storage_pvc_name,
+        config.storage_subpath_prefix,
+        config.auth_secret_name or "",
+        _kubernetes_client_identity(runtime_paths),
+        str(storage_root.expanduser().resolve()) if storage_root is not None else "",
+    )
+
+
 def _kubernetes_client_identity(runtime_paths: RuntimePaths) -> str:
     """Return a non-secret cache fingerprint for the selected Kubernetes control plane."""
     env = runtime_env_values(runtime_paths)

--- a/src/mindroom/workers/backends/kubernetes_config.py
+++ b/src/mindroom/workers/backends/kubernetes_config.py
@@ -520,7 +520,7 @@ def kubernetes_backend_cleanup_signature(
 
 def _kubernetes_cleanup_client_identity(runtime_paths: RuntimePaths) -> str:
     """Return a Kubernetes cleanup identity that ignores mutable user credentials."""
-    in_cluster_identity = _in_cluster_client_identity(runtime_paths)
+    in_cluster_identity = _in_cluster_client_identity()
     if in_cluster_identity is not None:
         return in_cluster_identity
 
@@ -568,7 +568,7 @@ def _merge_named_kubeconfig_entries(
 
 def _kubernetes_client_identity(runtime_paths: RuntimePaths) -> str:
     """Return a non-secret cache fingerprint for the selected Kubernetes control plane."""
-    in_cluster_identity = _in_cluster_client_identity(runtime_paths)
+    in_cluster_identity = _in_cluster_client_identity()
     if in_cluster_identity is not None:
         return in_cluster_identity
     identities: list[str] = []
@@ -581,11 +581,10 @@ def _kubernetes_client_identity(runtime_paths: RuntimePaths) -> str:
     return "kubeconfig:" + os.pathsep.join(identities)
 
 
-def _in_cluster_client_identity(runtime_paths: RuntimePaths) -> str | None:
+def _in_cluster_client_identity() -> str | None:
     """Return the in-cluster identity only when its required credentials are available."""
-    env = runtime_env_values(runtime_paths)
-    service_host = env.get("KUBERNETES_SERVICE_HOST")
-    service_port = env.get("KUBERNETES_SERVICE_PORT")
+    service_host = os.environ.get("KUBERNETES_SERVICE_HOST")
+    service_port = os.environ.get("KUBERNETES_SERVICE_PORT")
     if service_host and service_port and _in_cluster_credentials_available():
         return f"in-cluster:{service_host}:{service_port}"
     return None

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -291,7 +291,12 @@ class _AppsApiProtocol(Protocol):
         body: dict[str, object],
     ) -> KubernetesDeployment: ...
 
-    def delete_namespaced_deployment(self, name: str, namespace: str) -> None: ...
+    def delete_namespaced_deployment(
+        self,
+        name: str,
+        namespace: str,
+        **kwargs: str,
+    ) -> None: ...
 
     def list_namespaced_deployment(
         self,
@@ -868,7 +873,20 @@ class KubernetesResourceManager:
 
     def _delete_deployment(self, deployment_name: str) -> None:
         """Delete one worker Deployment, ignoring 404s."""
-        self._delete_object(self._apps.delete_namespaced_deployment, deployment_name)
+        try:
+            self._apps.delete_namespaced_deployment(
+                deployment_name,
+                self.config.namespace,
+                propagation_policy="Foreground",
+            )
+        except self._api_exception as exc:
+            if exc.status != 404:
+                raise
+
+    def delete_deployment(self, deployment_name: str, *, timeout_seconds: float) -> None:
+        """Delete one worker Deployment after its dependent pods terminate."""
+        self._delete_deployment(deployment_name)
+        self._wait_for_deployment_absent(deployment_name, timeout_seconds=timeout_seconds)
 
     def delete_service(self, service_name: str) -> None:
         """Delete one worker Service, ignoring 404s."""

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -96,6 +96,7 @@ _ANNOTATION_CREDENTIALS_ENCRYPTION_KEY_HASH = "mindroom.ai/credentials-encryptio
 _ANNOTATION_TEMPLATE_HASH = "mindroom.ai/template-hash"
 _ANNOTATION_PRIVATE_AGENT_NAMES = "mindroom.ai/private-agent-names"
 _ANNOTATION_STATE_SCOPE_WORKER_KEY = "mindroom.ai/state-scope-worker-key"
+_ANNOTATION_RESOURCE_PROFILE = "mindroom.ai/resource-profile"
 
 _LABEL_COMPONENT = "mindroom.ai/component"
 _LABEL_COMPONENT_VALUE = "worker"
@@ -493,6 +494,12 @@ def parse_state_scope_worker_key_annotation(annotations: dict[str, str]) -> str 
     return value or None
 
 
+def parse_resource_profile_annotation(annotations: dict[str, str]) -> str | None:
+    """Parse the persisted bounded resource profile, ``None`` for ordinary workers."""
+    value = annotations.get(_ANNOTATION_RESOURCE_PROFILE)
+    return value or None
+
+
 def _labels(*, extra_labels: dict[str, str], worker_id: str) -> dict[str, str]:
     labels = {
         _LABEL_COMPONENT: _LABEL_COMPONENT_VALUE,
@@ -811,6 +818,7 @@ class KubernetesResourceManager:
         replicas: int,
         private_agent_names: frozenset[str] | None = None,
         state_scope_worker_key: str | None = None,
+        resource_profile: str | None = None,
     ) -> DeploymentApplyResult:
         """Create-or-patch one worker Deployment."""
         manifest = self._deployment_manifest(
@@ -821,6 +829,7 @@ class KubernetesResourceManager:
             replicas=replicas,
             private_agent_names=private_agent_names,
             state_scope_worker_key=state_scope_worker_key,
+            resource_profile=resource_profile,
         )
         existing = self.read_deployment(worker_id)
         if existing is not None:
@@ -1224,6 +1233,7 @@ class KubernetesResourceManager:
         state_subpath: str,
         private_agent_names: frozenset[str] | None,
         state_scope_worker_key: str | None = None,
+        resource_profile: str | None = None,
     ) -> bool:
         """Return whether one Deployment's recorded pod template differs from current config."""
         startup_manifest_path, startup_manifest_hash = self._startup_manifest_path_and_hash(
@@ -1238,6 +1248,7 @@ class KubernetesResourceManager:
             startup_manifest_hash=startup_manifest_hash,
             private_agent_names=private_agent_names,
             state_scope_worker_key=state_scope_worker_key,
+            resource_profile=resource_profile,
         )
         recorded_hash = dict(deployment.metadata.annotations or {}).get(_ANNOTATION_TEMPLATE_HASH)
         return recorded_hash != _template_hash(template)
@@ -1252,7 +1263,9 @@ class KubernetesResourceManager:
         startup_manifest_hash: str,
         private_agent_names: frozenset[str] | None,
         state_scope_worker_key: str | None = None,
+        resource_profile: str | None = None,
     ) -> dict[str, object]:
+        resource_requests, resource_limits = self.config.resources_for_profile(resource_profile)
         worker_labels = _labels(extra_labels=self.config.extra_labels, worker_id=worker_id)
         template_annotations = dict(self.config.extra_annotations)
         template_annotations[ANNOTATION_WORKER_KEY] = worker_key
@@ -1312,8 +1325,8 @@ class KubernetesResourceManager:
                         "failureThreshold": 6,
                     },
                     "resources": {
-                        "requests": dict(self.config.resource_requests),
-                        "limits": dict(self.config.resource_limits),
+                        "requests": resource_requests,
+                        "limits": resource_limits,
                     },
                     "securityContext": {
                         "allowPrivilegeEscalation": False,
@@ -1352,6 +1365,7 @@ class KubernetesResourceManager:
         replicas: int,
         private_agent_names: frozenset[str] | None = None,
         state_scope_worker_key: str | None = None,
+        resource_profile: str | None = None,
     ) -> dict[str, object]:
         worker_labels = _labels(extra_labels=self.config.extra_labels, worker_id=worker_id)
         startup_manifest_path, startup_manifest_hash = self._write_startup_manifest(
@@ -1367,6 +1381,7 @@ class KubernetesResourceManager:
             startup_manifest_hash=startup_manifest_hash,
             private_agent_names=private_agent_names,
             state_scope_worker_key=state_scope_worker_key,
+            resource_profile=resource_profile,
         )
         metadata: dict[str, object] = {
             "name": worker_id,
@@ -1387,6 +1402,10 @@ class KubernetesResourceManager:
             desired_annotations[_ANNOTATION_STATE_SCOPE_WORKER_KEY] = state_scope_worker_key
         else:
             desired_annotations.pop(_ANNOTATION_STATE_SCOPE_WORKER_KEY, None)
+        if resource_profile is not None:
+            desired_annotations[_ANNOTATION_RESOURCE_PROFILE] = resource_profile
+        else:
+            desired_annotations.pop(_ANNOTATION_RESOURCE_PROFILE, None)
         metadata["annotations"] = desired_annotations
 
         return {

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -49,6 +49,7 @@ from mindroom.tool_system.worker_routing import (
 from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends._dedicated_worker_common import (
     plan_scoped_visible_state_roots,
+    resolve_state_scope_worker_key,
     resolved_agent_policies_from_config_data,
     validate_unique_worker_visible_paths,
 )
@@ -94,6 +95,7 @@ _ANNOTATION_RUNNER_TOKEN_HASH = "mindroom.ai/runner-token-hash"  # noqa: S105
 _ANNOTATION_CREDENTIALS_ENCRYPTION_KEY_HASH = "mindroom.ai/credentials-encryption-key-hash"
 _ANNOTATION_TEMPLATE_HASH = "mindroom.ai/template-hash"
 _ANNOTATION_PRIVATE_AGENT_NAMES = "mindroom.ai/private-agent-names"
+_ANNOTATION_STATE_SCOPE_WORKER_KEY = "mindroom.ai/state-scope-worker-key"
 
 _LABEL_COMPONENT = "mindroom.ai/component"
 _LABEL_COMPONENT_VALUE = "worker"
@@ -480,6 +482,12 @@ def parse_private_agent_names_annotation(annotations: dict[str, str]) -> frozens
     return frozenset(name for name in parsed if isinstance(name, str))
 
 
+def parse_state_scope_worker_key_annotation(annotations: dict[str, str]) -> str | None:
+    """Parse the persisted state-scope worker key, ``None`` when absent."""
+    value = annotations.get(_ANNOTATION_STATE_SCOPE_WORKER_KEY)
+    return value or None
+
+
 def _labels(*, extra_labels: dict[str, str], worker_id: str) -> dict[str, str]:
     labels = {
         _LABEL_COMPONENT: _LABEL_COMPONENT_VALUE,
@@ -797,6 +805,7 @@ class KubernetesResourceManager:
         annotations: dict[str, str],
         replicas: int,
         private_agent_names: frozenset[str] | None = None,
+        state_scope_worker_key: str | None = None,
     ) -> DeploymentApplyResult:
         """Create-or-patch one worker Deployment."""
         manifest = self._deployment_manifest(
@@ -806,6 +815,7 @@ class KubernetesResourceManager:
             annotations=annotations,
             replicas=replicas,
             private_agent_names=private_agent_names,
+            state_scope_worker_key=state_scope_worker_key,
         )
         existing = self.read_deployment(worker_id)
         if existing is not None:
@@ -1195,6 +1205,7 @@ class KubernetesResourceManager:
         worker_id: str,
         state_subpath: str,
         private_agent_names: frozenset[str] | None,
+        state_scope_worker_key: str | None = None,
     ) -> bool:
         """Return whether one Deployment's recorded pod template differs from current config."""
         startup_manifest_path, startup_manifest_hash = self._startup_manifest_path_and_hash(
@@ -1208,6 +1219,7 @@ class KubernetesResourceManager:
             startup_manifest_path=startup_manifest_path,
             startup_manifest_hash=startup_manifest_hash,
             private_agent_names=private_agent_names,
+            state_scope_worker_key=state_scope_worker_key,
         )
         recorded_hash = dict(deployment.metadata.annotations or {}).get(_ANNOTATION_TEMPLATE_HASH)
         return recorded_hash != _template_hash(template)
@@ -1221,6 +1233,7 @@ class KubernetesResourceManager:
         startup_manifest_path: str,
         startup_manifest_hash: str,
         private_agent_names: frozenset[str] | None,
+        state_scope_worker_key: str | None = None,
     ) -> dict[str, object]:
         worker_labels = _labels(extra_labels=self.config.extra_labels, worker_id=worker_id)
         template_annotations = dict(self.config.extra_annotations)
@@ -1259,7 +1272,12 @@ class KubernetesResourceManager:
                         state_subpath=state_subpath,
                         startup_manifest_path=startup_manifest_path,
                     ),
-                    "volumeMounts": self._volume_mounts(worker_key, state_subpath, private_agent_names),
+                    "volumeMounts": self._volume_mounts(
+                        worker_key,
+                        state_subpath,
+                        private_agent_names,
+                        state_scope_worker_key=state_scope_worker_key,
+                    ),
                     "readinessProbe": {
                         "httpGet": {"path": "/healthz", "port": "api"},
                         "periodSeconds": 5,
@@ -1315,6 +1333,7 @@ class KubernetesResourceManager:
         annotations: dict[str, str],
         replicas: int,
         private_agent_names: frozenset[str] | None = None,
+        state_scope_worker_key: str | None = None,
     ) -> dict[str, object]:
         worker_labels = _labels(extra_labels=self.config.extra_labels, worker_id=worker_id)
         startup_manifest_path, startup_manifest_hash = self._write_startup_manifest(
@@ -1329,6 +1348,7 @@ class KubernetesResourceManager:
             startup_manifest_path=startup_manifest_path,
             startup_manifest_hash=startup_manifest_hash,
             private_agent_names=private_agent_names,
+            state_scope_worker_key=state_scope_worker_key,
         )
         metadata: dict[str, object] = {
             "name": worker_id,
@@ -1345,6 +1365,10 @@ class KubernetesResourceManager:
                 sorted(private_agent_names),
                 separators=(",", ":"),
             )
+        if state_scope_worker_key is not None:
+            desired_annotations[_ANNOTATION_STATE_SCOPE_WORKER_KEY] = state_scope_worker_key
+        else:
+            desired_annotations.pop(_ANNOTATION_STATE_SCOPE_WORKER_KEY, None)
         metadata["annotations"] = desired_annotations
 
         return {
@@ -1525,11 +1549,14 @@ class KubernetesResourceManager:
         worker_key: str,
         state_subpath: str,
         private_agent_names: frozenset[str] | None,
+        *,
+        state_scope_worker_key: str | None = None,
     ) -> list[dict[str, object]]:
         mounts = self._scoped_storage_mounts(
             worker_key,
             state_subpath,
             private_agent_names=private_agent_names,
+            state_scope_worker_key=state_scope_worker_key,
         )
         if self.config.config_map_name is None:
             mounts.extend(self._file_config_storage_mounts())
@@ -1694,6 +1721,7 @@ class KubernetesResourceManager:
         state_subpath: str,
         *,
         private_agent_names: frozenset[str] | None,
+        state_scope_worker_key: str | None = None,
     ) -> list[dict[str, object]]:
         mounted_storage_root = Path(self.config.storage_mount_path)
         mounts: list[dict[str, object]] = [
@@ -1703,7 +1731,7 @@ class KubernetesResourceManager:
                 "subPath": str(planned_root.worker_visible_path.relative_to(mounted_storage_root)),
             }
             for planned_root in plan_scoped_visible_state_roots(
-                worker_key=worker_key,
+                worker_key=resolve_state_scope_worker_key(worker_key, state_scope_worker_key),
                 local_shared_storage_root=self.storage_root,
                 worker_visible_shared_storage_root=mounted_storage_root,
                 private_agent_names=private_agent_names,

--- a/src/mindroom/workers/models.py
+++ b/src/mindroom/workers/models.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 WorkerStatus = Literal["starting", "ready", "idle", "failed"]
 WorkerReadyPhase = Literal["cold_start", "waiting", "ready", "failed"]
+ScriptResourceProfileName = Literal["small", "standard", "large"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -18,6 +19,7 @@ class WorkerSpec:
     private_agent_names: frozenset[str] | None = None
     mirrored_credential_services: frozenset[str] | None = None
     state_scope_worker_key: str | None = None
+    resource_profile: ScriptResourceProfileName | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/workers/models.py
+++ b/src/mindroom/workers/models.py
@@ -17,6 +17,7 @@ class WorkerSpec:
     worker_key: str
     private_agent_names: frozenset[str] | None = None
     mirrored_credential_services: frozenset[str] | None = None
+    state_scope_worker_key: str | None = None
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -19,7 +19,11 @@ from mindroom.workers.backends.docker_config import (
     docker_backend_cleanup_signature,
     docker_backend_config_signature,
 )
-from mindroom.workers.backends.kubernetes import KubernetesWorkerBackend, kubernetes_backend_config_signature
+from mindroom.workers.backends.kubernetes import KubernetesWorkerBackend
+from mindroom.workers.backends.kubernetes_config import (
+    kubernetes_backend_cleanup_signature,
+    kubernetes_backend_config_signature,
+)
 from mindroom.workers.backends.static_runner import StaticSandboxRunnerBackend, normalize_static_runner_api_root
 
 if TYPE_CHECKING:
@@ -443,6 +447,11 @@ def _primary_worker_backend_cleanup_signature(
         return docker_backend_cleanup_signature(
             runtime_paths,
             storage_path=(storage_root or runtime_paths.storage_root).expanduser().resolve(),
+        )
+    if primary_worker_backend_name(runtime_paths) == "kubernetes":
+        return kubernetes_backend_cleanup_signature(
+            runtime_paths,
+            storage_root=(storage_root or runtime_paths.storage_root).expanduser().resolve(),
         )
     return config_signature
 

--- a/tests/api/test_sandbox_runner_scripts.py
+++ b/tests/api/test_sandbox_runner_scripts.py
@@ -23,7 +23,9 @@ from mindroom.api.sandbox_runner_scripts import router as sandbox_runner_scripts
 from mindroom.api.sandbox_worker_prep import prepare_worker_request
 from mindroom.constants import resolve_runtime_paths
 from mindroom.runtime_env_policy import SANDBOX_RUNTIME_ENV_BY_KEY
+from mindroom.script_runs.models import script_worker_key_for_run
 from mindroom.shell_supervisor import ShellSupervisorStartupError, _ShellSupervisorManager
+from mindroom.tool_system.worker_routing import _private_instance_state_root_path
 from mindroom.workers.backends import local as local_workers_module
 
 if TYPE_CHECKING:
@@ -293,6 +295,128 @@ def test_worker_script_endpoint_applies_workspace_environment_overlay(
     assert status.json()["exit_code"] == 0
     assert "overlay=from-hook" in status.json()["output"]
     assert f"run_id={run_id}" in status.json()["output"]
+
+
+def test_private_worker_script_executes_in_canonical_requester_workspace(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A private script uses its mounted requester workspace, not the run snapshot scratch directory."""
+    run_id = f"script-{'a' * 32}"
+    state_scope_worker_key = "v1:test:user_agent:@alice:example.test:watcher"
+    worker_key = script_worker_key_for_run(state_scope_worker_key, run_id)
+    shared_storage_root = tmp_path / "storage"
+    dedicated_root = tmp_path / "dedicated-worker"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+agents:
+  watcher:
+    display_name: Watcher
+    role: Watch for changes.
+    model: default
+    private:
+      per: user_agent
+      root: private-workspace
+models:
+  default:
+    provider: openai
+    id: gpt-5.4
+router:
+  model: default
+""".lstrip(),
+        encoding="utf-8",
+    )
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=dedicated_root,
+        process_env={
+            SANDBOX_RUNTIME_ENV_BY_KEY["dedicated_worker_key"]: worker_key,
+            SANDBOX_RUNTIME_ENV_BY_KEY["dedicated_worker_root"]: str(dedicated_root),
+            SANDBOX_RUNTIME_ENV_BY_KEY["shared_storage_root"]: str(shared_storage_root),
+        },
+    )
+    monkeypatch.setattr(local_workers_module.venv.EnvBuilder, "create", _fake_local_worker_venv_create)
+    monkeypatch.setattr(local_workers_module, "_local_worker_manager", None)
+    monkeypatch.setattr(local_workers_module, "_local_worker_manager_config", None)
+    app = FastAPI()
+    app.include_router(sandbox_runner_scripts_router)
+    sandbox_runner_module.initialize_sandbox_runner_app(
+        app,
+        runtime_paths,
+        config=sandbox_runner_module._runtime_config_or_empty(runtime_paths),
+        runner_token=_TOKEN,
+    )
+    prepared = prepare_worker_request(
+        worker_key=worker_key,
+        tool_init_overrides={},
+        runtime_paths=runtime_paths,
+        private_agent_names=frozenset({"watcher"}),
+        runner_token=_TOKEN,
+    )
+    private_workspace = (
+        _private_instance_state_root_path(
+            shared_storage_root,
+            worker_key=state_scope_worker_key,
+            agent_name="watcher",
+        )
+        / "private-workspace"
+    )
+    private_workspace.mkdir(parents=True)
+    hook_path = private_workspace / ".mindroom" / "worker-env.sh"
+    hook_path.parent.mkdir(parents=True)
+    hook_path.write_text("export SCRIPT_TEST_OVERLAY=private-workspace\n", encoding="utf-8")
+    source = (
+        "import os\n"
+        "from pathlib import Path\n"
+        "workspace = Path(os.environ['MINDROOM_SCRIPT_WORKSPACE_ROOT'])\n"
+        "workspace.joinpath('script-result.txt').write_text(\n"
+        "    f\"{os.environ['SCRIPT_TEST_OVERLAY']}|{Path.cwd()}\",\n"
+        "    encoding='utf-8',\n"
+        ")\n"
+    )
+    _source_path, _token_path, source_digest = _write_run_files(prepared.paths.workspace, run_id, source)
+    supervisor = _ShellSupervisorManager()
+    monkeypatch.setattr(shell_supervisor_module, "_manager", supervisor)
+    try:
+        client = TestClient(app)
+        response = client.post(
+            "/api/sandbox-runner/scripts/run",
+            headers=_HEADERS,
+            json={
+                "run_id": run_id,
+                "worker_key": worker_key,
+                "state_scope_worker_key": state_scope_worker_key,
+                "source_digest": source_digest,
+                "gateway_url": "http://primary:8765/api/script-gateway",
+                "private_agent_names": ["watcher"],
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["ok"] is True
+
+        deadline = time.monotonic() + 5
+        status = client.get(
+            f"/api/sandbox-runner/scripts/{run_id}",
+            headers=_HEADERS,
+            params={"worker_key": worker_key},
+        )
+        while status.json()["state"] == "running" and time.monotonic() < deadline:
+            time.sleep(0.01)
+            status = client.get(
+                f"/api/sandbox-runner/scripts/{run_id}",
+                headers=_HEADERS,
+                params={"worker_key": worker_key},
+            )
+
+        assert status.json()["state"] == "exited"
+        assert status.json()["exit_code"] == 0
+        assert (private_workspace / "script-result.txt").read_text(encoding="utf-8") == (
+            f"private-workspace|{private_workspace}"
+        )
+        assert not (prepared.paths.workspace / "script-result.txt").exists()
+    finally:
+        supervisor.shutdown()
 
 
 def test_worker_script_endpoint_rejects_source_digest_mismatch(

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -3848,6 +3848,39 @@ def test_docker_backend_user_agent_mounts_private_root_from_worker_spec(
     assert env["HOME"] == "/app/worker"
 
 
+def test_docker_script_worker_mounts_the_owning_private_state_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A unique script worker must not derive a fresh private root from its run ID."""
+    config_text, _projected_paths = _private_user_agent_projected_config_fixture(tmp_path)
+    backend, fake_client, _sync_calls = _backend(monkeypatch, tmp_path, config_text=config_text)
+    state_scope_worker_key = "v1:tenant-123:user_agent:@alice:example.org:alpha"
+    worker_key = script_worker_key_for_run(state_scope_worker_key, f"script-{'a' * 32}")
+
+    backend.ensure_worker(
+        WorkerSpec(
+            worker_key,
+            private_agent_names=frozenset({"alpha"}),
+            state_scope_worker_key=state_scope_worker_key,
+        ),
+        now=10.0,
+    )
+
+    volumes = fake_client.containers.run_calls[0]["volumes"]
+    assert isinstance(volumes, dict)
+    expected_private_root = (
+        tmp_path / "private_instances" / worker_dir_name(state_scope_worker_key) / "alpha"
+    ).resolve()
+    expected_run_root = worker_root_path(tmp_path, worker_key)
+    assert volumes[str(expected_private_root)] == {
+        "bind": f"/app/worker/private_instances/{worker_dir_name(state_scope_worker_key)}/alpha",
+        "mode": "rw",
+    }
+    assert str(expected_run_root) in volumes
+    assert str(tmp_path / "private_instances" / worker_dir_name(worker_key) / "alpha") not in volumes
+
+
 def test_docker_backend_rejects_private_user_agent_container_without_target_visibility(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_helm_instance_worker_isolation.py
+++ b/tests/test_helm_instance_worker_isolation.py
@@ -79,6 +79,28 @@ def _render_runtime_chart() -> list[dict[str, Any]]:
     )
 
 
+def test_runtime_chart_exposes_exact_script_resource_profiles_to_primary() -> None:
+    """The primary receives the same three bounded quantities configured in Helm values."""
+    deployment = _resource(_render_runtime_chart(), "Deployment", "mindroom-runtime")
+    env = _env_by_name(_container(deployment, "mindroom"))
+
+    assert env["MINDROOM_KUBERNETES_DEFAULT_SCRIPT_RESOURCE_PROFILE"]["value"] == "small"
+    assert json.loads(env["MINDROOM_KUBERNETES_SCRIPT_RESOURCE_PROFILES_JSON"]["value"]) == {
+        "small": {
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+            "limits": {"cpu": "500m", "memory": "1Gi"},
+        },
+        "standard": {
+            "requests": {"cpu": "250m", "memory": "512Mi"},
+            "limits": {"cpu": "1", "memory": "2Gi"},
+        },
+        "large": {
+            "requests": {"cpu": "500m", "memory": "2Gi"},
+            "limits": {"cpu": "2", "memory": "8Gi"},
+        },
+    }
+
+
 def _render_runtime_chart_with_separate_worker_namespace() -> list[dict[str, Any]]:
     return _render_chart(
         Path("cluster/k8s/runtime"),

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -480,6 +480,8 @@ def _backend(
     worker_grantable_credentials: frozenset[str] = DEFAULT_WORKER_GRANTABLE_CREDENTIALS,
     resource_requests: dict[str, str] | None = None,
     resource_limits: dict[str, str] | None = None,
+    script_resource_profiles: dict[str, dict[str, dict[str, str]]] | None = None,
+    default_script_resource_profile: str = "small",
     extra_env: dict[str, str] | None = None,
     extra_annotations: dict[str, str] | None = None,
     enable_service_links: bool = False,
@@ -488,6 +490,12 @@ def _backend(
     agent_vault: KubernetesAgentVaultConfig | None = None,
     config_snapshot: dict[str, object] | None = None,
 ) -> tuple[KubernetesWorkerBackend, _FakeAppsApi, _FakeCoreApi]:
+    profile_config: dict[str, object] = {}
+    if script_resource_profiles is not None:
+        profile_config = {
+            "script_resource_profiles": script_resource_profiles,
+            "default_script_resource_profile": default_script_resource_profile,
+        }
     config = KubernetesWorkerBackendConfig(
         namespace="chat",
         image="ghcr.io/mindroom-ai/mindroom:latest",
@@ -511,6 +519,7 @@ def _backend(
         owner_deployment_name=owner_deployment_name,
         resource_requests=resource_requests if resource_requests is not None else {"memory": "256Mi", "cpu": "100m"},
         resource_limits=resource_limits if resource_limits is not None else {"memory": "1Gi", "cpu": "500m"},
+        **profile_config,
         enable_service_links=enable_service_links,
         auth_secret_name=auth_secret_name,
         reconcile_pod_templates=reconcile_pod_templates,
@@ -1616,6 +1625,63 @@ def test_kubernetes_backend_config_resources_default_when_env_unset(tmp_path: Pa
     assert config.enable_service_links is False
 
 
+def test_kubernetes_backend_config_reads_all_three_script_resource_profiles(tmp_path: Path) -> None:
+    """Runtime configuration carries exact administrator-owned quantities and the selected default."""
+    profiles = {
+        "small": {
+            "requests": {"cpu": "50m", "memory": "128Mi"},
+            "limits": {"cpu": "250m", "memory": "512Mi"},
+        },
+        "standard": {
+            "requests": {"cpu": "200m", "memory": "512Mi"},
+            "limits": {"cpu": "1", "memory": "2Gi"},
+        },
+        "large": {
+            "requests": {"cpu": "750m", "memory": "2Gi"},
+            "limits": {"cpu": "3", "memory": "10Gi"},
+        },
+    }
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.yaml"
+    config_path.write_text("agents: {}\n", encoding="utf-8")
+    (config_dir / ".env").write_text(
+        "\n".join(
+            (
+                "MINDROOM_WORKER_BACKEND=kubernetes",
+                "MINDROOM_KUBERNETES_WORKER_IMAGE=test-image",
+                "MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME=test-pvc",
+                "MINDROOM_KUBERNETES_DEFAULT_SCRIPT_RESOURCE_PROFILE=standard",
+                f"MINDROOM_KUBERNETES_SCRIPT_RESOURCE_PROFILES_JSON={json.dumps(profiles)}",
+            ),
+        ),
+        encoding="utf-8",
+    )
+
+    config = KubernetesWorkerBackendConfig.from_runtime(resolve_primary_runtime_paths(config_path=config_path))
+
+    assert config.default_script_resource_profile == "standard"
+    assert config.script_resource_profiles == profiles
+
+
+def test_kubernetes_backend_config_rejects_partial_script_resource_profiles(tmp_path: Path) -> None:
+    """Operators cannot accidentally expose a profile name without bounded quantities."""
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir(parents=True)
+    config_path = config_dir / "config.yaml"
+    config_path.write_text("agents: {}\n", encoding="utf-8")
+    (config_dir / ".env").write_text(
+        "MINDROOM_WORKER_BACKEND=kubernetes\n"
+        "MINDROOM_KUBERNETES_WORKER_IMAGE=test-image\n"
+        "MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME=test-pvc\n"
+        'MINDROOM_KUBERNETES_SCRIPT_RESOURCE_PROFILES_JSON={"small": {}}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(WorkerBackendError, match="exactly small, standard, and large"):
+        KubernetesWorkerBackendConfig.from_runtime(resolve_primary_runtime_paths(config_path=config_path))
+
+
 def test_kubernetes_backend_config_allows_service_links_override(tmp_path: Path) -> None:
     """Worker service-link env injection remains opt-in."""
     config_dir = tmp_path / "cfg"
@@ -1658,6 +1724,43 @@ def test_kubernetes_backend_renders_configured_resources_on_worker_container(tmp
     container = apps_api.created_bodies[0]["spec"]["template"]["spec"]["containers"][0]
     assert container["resources"]["requests"] == {"memory": "2Gi", "cpu": "500m"}
     assert container["resources"]["limits"] == {"memory": "8Gi", "cpu": "2"}
+
+
+def test_kubernetes_script_worker_uses_selected_bounded_resource_profile(tmp_path: Path) -> None:
+    """A script profile selects configured quantities without accepting quantities from the agent."""
+    profiles = {
+        "small": {
+            "requests": {"cpu": "100m", "memory": "256Mi"},
+            "limits": {"cpu": "500m", "memory": "1Gi"},
+        },
+        "standard": {
+            "requests": {"cpu": "250m", "memory": "512Mi"},
+            "limits": {"cpu": "1", "memory": "2Gi"},
+        },
+        "large": {
+            "requests": {"cpu": "500m", "memory": "2Gi"},
+            "limits": {"cpu": "2", "memory": "8Gi"},
+        },
+    }
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, _core_api = _backend(
+        runtime_paths=runtime_paths,
+        script_resource_profiles=profiles,
+    )
+
+    backend.ensure_worker(WorkerSpec(_TEST_SCOPED_WORKER_KEY_A, resource_profile="large"), now=10.0)
+
+    deployment = apps_api.created_bodies[0]
+    container = deployment["spec"]["template"]["spec"]["containers"][0]
+    assert container["resources"] == profiles["large"]
+    assert deployment["metadata"]["annotations"]["mindroom.ai/resource-profile"] == "large"
+    assert backend.script_resource_profiles() == {
+        "default_profile": "small",
+        "profiles": profiles,
+    }
 
 
 def test_kubernetes_backend_renders_service_links_override_in_worker_template() -> None:

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -27,6 +27,7 @@ from mindroom.constants import (
     startup_manifest_sha256,
 )
 from mindroom.runtime_env_policy import CREDENTIALS_ENCRYPTION_KEY_ENV
+from mindroom.script_runs.models import script_worker_key_for_run
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
     _private_instance_state_root_path,
@@ -49,6 +50,7 @@ from mindroom.workers.backends.kubernetes_resources import (
     _ANNOTATION_PRIVATE_AGENT_NAMES,
     _ANNOTATION_RUNNER_TOKEN_HASH,
     _ANNOTATION_STARTUP_MANIFEST_HASH,
+    _ANNOTATION_STATE_SCOPE_WORKER_KEY,
     _ANNOTATION_TEMPLATE_HASH,
     ANNOTATION_WORKER_KEY,
     worker_auth_token,
@@ -2502,6 +2504,60 @@ def test_kubernetes_backend_user_agent_mounts_private_root_from_worker_spec() ->
     assert f"/app/worker/private_instances/{worker_dir_name(worker_key)}" not in mount_paths
 
 
+def test_kubernetes_script_worker_mounts_the_owning_private_state_scope() -> None:
+    """A unique script worker must not derive a fresh private root from its run ID."""
+    backend, apps_api, _core_api = _backend()
+    state_scope_worker_key = "v1:tenant-123:user_agent:@alice:example.org:mind"
+    run_id = f"script-{'a' * 32}"
+    worker_key = script_worker_key_for_run(state_scope_worker_key, run_id)
+
+    backend.ensure_worker(
+        WorkerSpec(
+            worker_key,
+            private_agent_names=frozenset({"mind"}),
+            state_scope_worker_key=state_scope_worker_key,
+        ),
+        now=10.0,
+    )
+
+    deployment = apps_api.created_bodies[0]
+    volume_mounts = deployment["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+    mount_paths = {mount["mountPath"]: mount.get("subPath") for mount in volume_mounts}
+    expected_private_root = str(
+        _private_instance_state_root_path(
+            Path("/app/worker"),
+            worker_key=state_scope_worker_key,
+            agent_name="mind",
+        ),
+    )
+    expected_private_subpath = f"private_instances/{worker_dir_name(state_scope_worker_key)}/mind"
+    expected_run_root = f"/app/worker/workers/{worker_dir_name(worker_key)}"
+
+    assert deployment["metadata"]["annotations"][_ANNOTATION_STATE_SCOPE_WORKER_KEY] == state_scope_worker_key
+    assert mount_paths[expected_private_root] == expected_private_subpath
+    assert mount_paths[expected_run_root] == f"workers/{worker_dir_name(worker_key)}"
+    assert f"private_instances/{worker_dir_name(worker_key)}/mind" not in set(mount_paths.values())
+
+
+def test_kubernetes_script_worker_rejects_an_unrelated_state_scope() -> None:
+    """A worker spec cannot use the state-scope field to mount another identity's files."""
+    backend, apps_api, _core_api = _backend()
+    state_scope_worker_key = "v1:tenant-123:user_agent:@alice:example.org:mind"
+    worker_key = script_worker_key_for_run(state_scope_worker_key, f"script-{'a' * 32}")
+
+    with pytest.raises(WorkerBackendError, match="does not own the requested worker key"):
+        backend.ensure_worker(
+            WorkerSpec(
+                worker_key,
+                private_agent_names=frozenset({"mind"}),
+                state_scope_worker_key="v1:tenant-123:user_agent:@mallory:example.org:mind",
+            ),
+            now=10.0,
+        )
+
+    assert apps_api.created_bodies == []
+
+
 def test_kubernetes_backend_recreates_user_agent_deployment_when_private_visibility_changes() -> None:
     """Changing private visibility should recreate the Deployment instead of relying on patch semantics."""
     backend, apps_api, _core_api = _backend()
@@ -3059,6 +3115,46 @@ def test_kubernetes_backend_reconcile_uses_persisted_private_visibility(tmp_path
         _private_instance_state_root_path(
             Path("/app/worker"),
             worker_key=worker_key,
+            agent_name="mind",
+        ),
+    )
+    assert expected_private_root in mount_paths
+
+
+def test_kubernetes_backend_reconcile_uses_persisted_script_state_scope(tmp_path: Path) -> None:
+    """Template reconciliation must preserve a script worker's canonical private workspace mount."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    state_scope_worker_key = "v1:tenant-123:user_agent:@alice:example.org:mind"
+    worker_key = script_worker_key_for_run(state_scope_worker_key, f"script-{'a' * 32}")
+    backend.ensure_worker(
+        WorkerSpec(
+            worker_key,
+            private_agent_names=frozenset({"mind"}),
+            state_scope_worker_key=state_scope_worker_key,
+        ),
+        now=0.0,
+    )
+    backend.cleanup_idle_workers(now=80.0)
+
+    updated_backend, _, _ = _backend(runtime_paths=runtime_paths, resource_limits={"memory": "2Gi", "cpu": "1"})
+    _wire_fake_apis(updated_backend, apps_api, core_api)
+
+    reconciled = updated_backend.maintain_workers(now=100.0).reconciled
+
+    assert [worker.worker_key for worker in reconciled] == [worker_key]
+    recreated = apps_api.created_bodies[-1]
+    assert recreated["metadata"]["annotations"][_ANNOTATION_STATE_SCOPE_WORKER_KEY] == state_scope_worker_key
+    mount_paths = {
+        mount["mountPath"] for mount in recreated["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
+    }
+    expected_private_root = str(
+        _private_instance_state_root_path(
+            Path("/app/worker"),
+            worker_key=state_scope_worker_key,
             agent_name="mind",
         ),
     )

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -184,6 +184,7 @@ class _FakeAppsApi:
         self.created_bodies: list[dict[str, object]] = []
         self.patched_bodies: list[tuple[str, dict[str, object]]] = []
         self.deleted_names: list[str] = []
+        self.deleted_propagation_policies: list[str | None] = []
         self.list_label_selectors: list[str] = []
         self.raw_list_count = 0
         self.delete_read_lag_by_name: dict[str, int] = {}
@@ -237,9 +238,16 @@ class _FakeAppsApi:
         deployment.status.observed_generation = deployment.metadata.generation
         return deployment
 
-    def delete_namespaced_deployment(self, name: str, namespace: str) -> None:
+    def delete_namespaced_deployment(
+        self,
+        name: str,
+        namespace: str,
+        *,
+        propagation_policy: str | None = None,
+    ) -> None:
         _ = namespace
         self.deleted_names.append(name)
+        self.deleted_propagation_policies.append(propagation_policy)
         if self.delete_read_lag_by_name.get(name, 0) > 0:
             self._active_delete_read_lag_by_name[name] = self.delete_read_lag_by_name[name]
             return
@@ -1015,6 +1023,83 @@ def test_kubernetes_backend_cleanup_removes_only_own_key_from_tenant_auth_secret
     assert handle.worker_id not in tenant_secret.data
     assert f"{handle.worker_id}.credentials-encryption-key" not in tenant_secret.data
     assert tenant_secret.data[other_worker_id] == "preexisting"
+
+
+def test_kubernetes_backend_retires_only_one_exact_run_worker_idempotently(tmp_path: Path) -> None:
+    """Script retirement removes one run worker while preserving its canonical worker."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    base_key = "v1:test:user_agent:@alice:example.test:watcher"
+    run_key = script_worker_key_for_run(base_key, f"script-{'c' * 32}")
+    ordinary = backend.ensure_worker(WorkerSpec(base_key, private_agent_names=frozenset()), now=1.0)
+    retired = backend.ensure_worker(WorkerSpec(run_key, private_agent_names=frozenset()), now=1.0)
+    ordinary_root = backend.storage_root / backend._state_subpath(base_key)
+    retired_root = backend.storage_root / backend._state_subpath(run_key)
+
+    backend.retire_worker(run_key)
+    backend.retire_worker(run_key)
+
+    assert retired.worker_id not in apps_api.deployments
+    assert retired.worker_id not in core_api.services
+    assert retired.worker_id not in core_api.secrets
+    assert retired_root.exists() is False
+    assert apps_api.deleted_propagation_policies[-2:] == ["Foreground", "Foreground"]
+    assert ordinary.worker_id in apps_api.deployments
+    assert ordinary.worker_id in core_api.services
+    assert ordinary.worker_id in core_api.secrets
+    assert ordinary_root.is_dir()
+    assert [handle.worker_key for handle in backend.list_workers()] == [base_key]
+
+
+def test_kubernetes_backend_refuses_retirement_when_deployment_key_mismatches(tmp_path: Path) -> None:
+    """A colliding Deployment name cannot authorize deletion for another worker key."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    run_key = script_worker_key_for_run(
+        "v1:test:user_agent:@alice:example.test:watcher",
+        f"script-{'d' * 32}",
+    )
+    handle = backend.ensure_worker(WorkerSpec(run_key, private_agent_names=frozenset()), now=1.0)
+    apps_api.deployments[handle.worker_id].metadata.annotations[ANNOTATION_WORKER_KEY] = "another-worker"
+    state_root = backend.storage_root / backend._state_subpath(run_key)
+
+    with pytest.raises(WorkerBackendError, match="does not match retirement key"):
+        backend.retire_worker(run_key)
+
+    assert handle.worker_id in apps_api.deployments
+    assert handle.worker_id in core_api.services
+    assert handle.worker_id in core_api.secrets
+    assert state_root.is_dir()
+
+
+def test_kubernetes_backend_refuses_retirement_without_exact_state_identity(tmp_path: Path) -> None:
+    """Run state must identify its exact worker key before recursive deletion."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, core_api = _backend(runtime_paths=runtime_paths)
+    run_key = script_worker_key_for_run(
+        "v1:test:user_agent:@alice:example.test:watcher",
+        f"script-{'e' * 32}",
+    )
+    handle = backend.ensure_worker(WorkerSpec(run_key, private_agent_names=frozenset()), now=1.0)
+    state_root = backend.storage_root / backend._state_subpath(run_key)
+    sandbox_startup_manifest_path(state_root).write_text("{}", encoding="utf-8")
+
+    with pytest.raises(WorkerBackendError, match="exact worker key"):
+        backend.retire_worker(run_key)
+
+    assert handle.worker_id in apps_api.deployments
+    assert handle.worker_id in core_api.services
+    assert handle.worker_id in core_api.secrets
+    assert state_root.is_dir()
 
 
 def test_kubernetes_backend_reapply_without_encryption_removes_worker_secret_key(tmp_path: Path) -> None:

--- a/tests/test_script_docs.py
+++ b/tests/test_script_docs.py
@@ -18,6 +18,7 @@ def test_background_script_docs_cover_security_and_lifecycle() -> None:
         "interrupted",
         "indeterminate",
         "MINDROOM_SCRIPT_GATEWAY_URL",
+        "MINDROOM_SCRIPT_GATEWAY_ISOLATED",
         "MINDROOM_SCRIPT_RETENTION_SECONDS",
         "local execution",
     ):
@@ -25,6 +26,7 @@ def test_background_script_docs_cover_security_and_lifecycle() -> None:
 
     environment_reference = Path("docs/configuration/index.md").read_text(encoding="utf-8")
     assert "MINDROOM_SCRIPT_GATEWAY_URL" in environment_reference
+    assert "MINDROOM_SCRIPT_GATEWAY_ISOLATED" in environment_reference
     assert "MINDROOM_SCRIPT_RETENTION_SECONDS" in environment_reference
 
     generated_reference = Path("skills/mindroom-docs/references/page__tools__background-scripts__index.md")

--- a/tests/test_script_docs.py
+++ b/tests/test_script_docs.py
@@ -30,4 +30,9 @@ def test_background_script_docs_cover_security_and_lifecycle() -> None:
     assert "MINDROOM_SCRIPT_RETENTION_SECONDS" in environment_reference
 
     generated_reference = Path("skills/mindroom-docs/references/page__tools__background-scripts__index.md")
-    assert generated_reference.read_text(encoding="utf-8").startswith("# Background Python Scripts")
+    generated_text = generated_reference.read_text(encoding="utf-8")
+    assert generated_text.startswith("# Background Python Scripts")
+    assert "MINDROOM_SCRIPT_GATEWAY_ISOLATED" in generated_text
+
+    generated_configuration = Path("skills/mindroom-docs/references/page__configuration__index.md")
+    assert "MINDROOM_SCRIPT_GATEWAY_ISOLATED" in generated_configuration.read_text(encoding="utf-8")

--- a/tests/test_script_run_manager.py
+++ b/tests/test_script_run_manager.py
@@ -464,7 +464,7 @@ async def test_static_worker_backend_rejects_script_before_creating_any_state(tm
     )
     manager.worker_backend = static_backend
 
-    with pytest.raises(ScriptRunManagerError, match="unsafe-local mode or a Docker worker"):
+    with pytest.raises(ScriptRunManagerError, match="dedicated Docker or isolated Kubernetes worker backend"):
         await manager.run(_context(tmp_path, backend="static"), source="print('unavailable')\n")
 
     assert manager.store.list_runs() == []
@@ -515,6 +515,39 @@ async def test_kubernetes_worker_accepts_scripts_with_an_explicit_isolated_gatew
         ),
     ]
     assert len(client.requested_handles) == 1
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_worker_rejects_scripts_when_agent_vault_is_enabled(tmp_path: Path) -> None:
+    """Run-specific workers must not create external identities that exact retirement cannot delete."""
+    manager, backend, client = _manager(
+        tmp_path,
+        backend="kubernetes",
+        isolated_script_gateway=True,
+    )
+    backend.backend_name = "kubernetes"
+    context = _context(
+        tmp_path,
+        backend="kubernetes",
+        isolated_script_gateway=True,
+    )
+    context = replace(
+        context,
+        runtime_paths=replace(
+            context.runtime_paths,
+            process_env={
+                **context.runtime_paths.process_env,
+                "MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED": "true",
+            },
+        ),
+    )
+
+    with pytest.raises(ScriptRunManagerError, match="Agent Vault"):
+        await manager.run(context, source="print('ok')\n")
+
+    assert manager.store.list_runs() == []
+    assert backend.specs == []
+    assert client.requested_handles == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_script_run_manager.py
+++ b/tests/test_script_run_manager.py
@@ -80,6 +80,7 @@ def _context(
     requester_id: str = "@alice:example.test",
     mode: str | None = "all",
     private: bool = False,
+    private_scope: str = "user_agent",
     worker_scope: str = "user_agent",
     backend: str | None = None,
     isolated_script_gateway: bool = False,
@@ -97,7 +98,7 @@ def _context(
     }
     if private:
         watcher.pop("worker_scope")
-        watcher["private"] = {"per": "user_agent", "root": "private/watcher"}
+        watcher["private"] = {"per": private_scope, "root": "private/watcher"}
     config = Config(
         agents={
             "watcher": watcher,
@@ -215,6 +216,7 @@ class _WorkerBackend:
 class _WorkerClient:
     store: ScriptRunStore
     launch_paths: dict[str, tuple[Path, Path]] = field(default_factory=dict)
+    launch_state_scope_worker_keys: list[str | None] = field(default_factory=list)
     cancel_observed_revocation: bool = False
     cancel_forces: list[bool] = field(default_factory=list)
     cancel_handles: list[str] = field(default_factory=list)
@@ -236,9 +238,11 @@ class _WorkerClient:
         run_id: str,
         source_digest: str,
         gateway_url: str,
+        state_scope_worker_key: str | None = None,
         private_agent_names: tuple[str, ...] | None = None,
     ) -> None:
         del source_digest, gateway_url, private_agent_names
+        self.launch_state_scope_worker_keys.append(state_scope_worker_key)
         starting = self.store.get_run(run_id)
         assert starting.state is ScriptRunState.STARTING
         assert starting.worker_id == worker.worker_id
@@ -778,7 +782,7 @@ async def test_script_process_scope_is_user_agent_independent_of_tool_scope(
 @pytest.mark.asyncio
 async def test_script_process_target_preserves_private_agent_visibility(tmp_path: Path) -> None:
     """A private script keeps a run-specific worker but mounts its owning private state scope."""
-    manager, backend, _client = _manager(tmp_path)
+    manager, backend, client = _manager(tmp_path)
 
     run = await manager.run(_context(tmp_path, private=True), source="print('ok')\n")
 
@@ -791,6 +795,23 @@ async def test_script_process_target_preserves_private_agent_visibility(tmp_path
             state_scope_worker_key="v1:default:user_agent:@alice:example.test:watcher",
         ),
     ]
+    assert client.launch_state_scope_worker_keys == ["v1:default:user_agent:@alice:example.test:watcher"]
+
+
+@pytest.mark.asyncio
+async def test_private_user_scope_rejects_background_worker_before_persisting_run(tmp_path: Path) -> None:
+    """A script worker must not project the broader requester scope as an agent-specific workspace."""
+    manager, backend, client = _manager(tmp_path)
+
+    with pytest.raises(ScriptRunManagerError, match=r"private\.per=user_agent"):
+        await manager.run(
+            _context(tmp_path, private=True, private_scope="user"),
+            source="print('ok')\n",
+        )
+
+    assert manager.store.list_runs() == []
+    assert backend.specs == []
+    assert client.requested_handles == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_script_run_manager.py
+++ b/tests/test_script_run_manager.py
@@ -611,6 +611,7 @@ async def test_launch_grants_are_restricted_by_configured_allowed_tools(tmp_path
         ScriptToolGrant("calculator", "add"),
         ScriptToolGrant("website", "read_url"),
     )
+    manager.toolkit_name_resolver = lambda _context: frozenset({"calculator", "website"})
 
     run = await manager.run(
         _context(tmp_path),
@@ -623,11 +624,28 @@ async def test_launch_grants_are_restricted_by_configured_allowed_tools(tmp_path
 
 
 @pytest.mark.asyncio
+async def test_launch_allows_an_eligible_toolkit_with_no_current_functions(tmp_path: Path) -> None:
+    """A degraded optional integration must not make the entire allowlist invalid."""
+    manager, _backend, _client = _manager(tmp_path)
+    manager.grant_resolver = lambda _context: (ScriptToolGrant("calculator", "add"),)
+    manager.toolkit_name_resolver = lambda _context: frozenset({"calculator", "temporarily-empty"})
+
+    run = await manager.run(
+        _context(tmp_path),
+        source="print('ok')\n",
+        limits=ScriptRunLimits(allowed_tools=("calculator", "temporarily-empty")),
+    )
+
+    assert run.grants == (ScriptToolGrant("calculator", "add"),)
+    assert run.preapprove_launch_grants is True
+
+
+@pytest.mark.asyncio
 async def test_launch_rejects_unknown_allowed_toolkit_before_durable_work(tmp_path: Path) -> None:
     """A typo in the authored SDK allowlist must fail clearly instead of granting an empty surface."""
     manager, backend, _client = _manager(tmp_path)
 
-    with pytest.raises(ScriptRunManagerError, match=r"unknown toolkit.*typo-tool"):
+    with pytest.raises(ScriptRunManagerError, match=r"unknown or ineligible toolkit.*typo-tool"):
         await manager.run(
             _context(tmp_path),
             source="print('ok')\n",
@@ -675,6 +693,7 @@ async def test_concurrent_scripts_use_run_pinned_worker_roots_and_routes(tmp_pat
         ScriptToolGrant("calculator", "add"),
         ScriptToolGrant("website", "read_url"),
     )
+    manager.toolkit_name_resolver = lambda _context: frozenset({"calculator", "website"})
     context = _context(tmp_path)
 
     broad = await manager.run(

--- a/tests/test_script_run_manager.py
+++ b/tests/test_script_run_manager.py
@@ -36,7 +36,7 @@ from mindroom.script_runs.worker_client import (
 )
 from mindroom.tool_system.worker_routing import agent_workspace_root_path, worker_root_path
 from mindroom.workers.backends.static_runner import StaticSandboxRunnerBackend
-from mindroom.workers.models import WorkerHandle, WorkerSpec
+from mindroom.workers.models import ScriptResourceProfileName, WorkerHandle, WorkerSpec
 from tests.authorization_helpers import make_test_tool_runtime_context
 from tests.conftest import make_conversation_reader_mock, make_relation_lookup
 
@@ -159,6 +159,10 @@ class _WorkerBackend:
     saw_starting: bool = False
     list_worker_thread_ids: list[int] = field(default_factory=list)
     retired_worker_keys: list[str] = field(default_factory=list)
+    resource_profiles_payload: dict[str, object] | None = None
+
+    def script_resource_profiles(self) -> dict[str, object] | None:
+        return self.resource_profiles_payload
 
     def ensure_worker(
         self,
@@ -362,6 +366,122 @@ async def test_launch_uses_derived_supervisor_handle_from_the_run_id(tmp_path: P
     assert run.snapshot_locator is not None
     assert (context.runtime_paths.storage_root / run.snapshot_locator / "source.py").is_file()
     assert client.launch_paths[run.run_id][0].is_file()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requested_profile", "selected_profile", "expected_requests", "expected_limits"),
+    [
+        (None, "small", {"cpu": "100m", "memory": "256Mi"}, {"cpu": "500m", "memory": "1Gi"}),
+        ("standard", "standard", {"cpu": "250m", "memory": "512Mi"}, {"cpu": "1", "memory": "2Gi"}),
+    ],
+)
+async def test_launch_snapshots_selected_resource_profile_before_worker_creation(
+    tmp_path: Path,
+    requested_profile: ScriptResourceProfileName | None,
+    selected_profile: ScriptResourceProfileName,
+    expected_requests: dict[str, str],
+    expected_limits: dict[str, str],
+) -> None:
+    """An explicit or default profile resolves to administrator-owned quantities before durable launch."""
+    manager, backend, _client = _manager(tmp_path)
+    backend.resource_profiles_payload = {
+        "default_profile": "small",
+        "profiles": {
+            "small": {
+                "requests": {"cpu": "100m", "memory": "256Mi"},
+                "limits": {"cpu": "500m", "memory": "1Gi"},
+            },
+            "standard": {
+                "requests": {"cpu": "250m", "memory": "512Mi"},
+                "limits": {"cpu": "1", "memory": "2Gi"},
+            },
+            "large": {
+                "requests": {"cpu": "500m", "memory": "2Gi"},
+                "limits": {"cpu": "2", "memory": "8Gi"},
+            },
+        },
+    }
+
+    run = await manager.run(
+        _context(tmp_path),
+        source="print('ok')\n",
+        resource_profile=requested_profile,
+    )
+
+    assert backend.specs[-1].resource_profile == selected_profile
+    assert run.resource_profile == selected_profile
+    assert run.resource_requests == expected_requests
+    assert run.resource_limits == expected_limits
+    assert manager.store.get_run(run.run_id) == run
+
+
+@pytest.mark.asyncio
+async def test_launch_rejects_explicit_profile_without_backend_support(tmp_path: Path) -> None:
+    """An agent cannot turn a profile name into unenforced local or backend-specific resources."""
+    manager, backend, _client = _manager(tmp_path)
+
+    with pytest.raises(
+        ScriptRunManagerError,
+        match="Resource profiles require a worker backend that advertises enforceable profiles",
+    ):
+        await manager.run(
+            _context(tmp_path),
+            source="print('ok')\n",
+            resource_profile="large",
+        )
+
+    assert backend.specs == []
+    assert manager.store.list_runs() == []
+
+
+@pytest.mark.asyncio
+async def test_launch_snapshots_profile_from_the_backend_admitted_after_launch_gate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A config refresh during admission cannot make persisted quantities differ from the worker backend."""
+    manager, first_backend, client = _manager(tmp_path)
+    first_backend.resource_profiles_payload = {
+        "default_profile": "small",
+        "profiles": {
+            "small": {"requests": {"cpu": "100m", "memory": "256Mi"}, "limits": {"cpu": "500m", "memory": "1Gi"}},
+            "standard": {"requests": {"cpu": "250m", "memory": "512Mi"}, "limits": {"cpu": "1", "memory": "2Gi"}},
+            "large": {"requests": {"cpu": "500m", "memory": "2Gi"}, "limits": {"cpu": "2", "memory": "8Gi"}},
+        },
+    }
+    admitted_backend = _WorkerBackend(
+        store=manager.store,
+        runtime_paths=first_backend.runtime_paths,
+        cleanup_locator="locator-b",
+        resource_profiles_payload={
+            "default_profile": "small",
+            "profiles": {
+                "small": {"requests": {"cpu": "100m", "memory": "256Mi"}, "limits": {"cpu": "500m", "memory": "1Gi"}},
+                "standard": {"requests": {"cpu": "400m", "memory": "1Gi"}, "limits": {"cpu": "1", "memory": "3Gi"}},
+                "large": {"requests": {"cpu": "800m", "memory": "3Gi"}, "limits": {"cpu": "2", "memory": "8Gi"}},
+            },
+        },
+    )
+    original_admit = ScriptRunManager._admit_launch
+
+    async def admit_and_refresh(self: ScriptRunManager) -> None:
+        await original_admit(self)
+        self.worker_backend = admitted_backend
+
+    monkeypatch.setattr(ScriptRunManager, "_admit_launch", admit_and_refresh)
+
+    run = await manager.run(
+        _context(tmp_path),
+        source="print('ok')\n",
+        resource_profile="standard",
+    )
+
+    assert run.worker_backend_locator == "locator-b"
+    assert run.resource_requests == {"cpu": "400m", "memory": "1Gi"}
+    assert run.resource_limits == {"cpu": "1", "memory": "3Gi"}
+    assert admitted_backend.specs[-1].resource_profile == "standard"
+    assert client.requested_handles
 
 
 @pytest.mark.asyncio

--- a/tests/test_script_run_manager.py
+++ b/tests/test_script_run_manager.py
@@ -6,7 +6,7 @@ import asyncio
 import stat
 import sys
 import threading
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
@@ -51,10 +51,18 @@ def _runtime_paths(
     *,
     mode: str | None = "all",
     backend: str | None = None,
+    isolated_script_gateway: bool = False,
 ) -> RuntimePaths:
     process_env = {"MINDROOM_SANDBOX_EXECUTION_MODE": mode} if mode is not None else {}
     if backend is not None:
         process_env["MINDROOM_WORKER_BACKEND"] = backend
+    if isolated_script_gateway:
+        process_env.update(
+            {
+                "MINDROOM_SCRIPT_GATEWAY_ISOLATED": "true",
+                "MINDROOM_SCRIPT_GATEWAY_URL": "http://script-gateway.test/api/script-gateway",
+            },
+        )
     return RuntimePaths(
         config_path=tmp_path / "config.yaml",
         config_dir=tmp_path,
@@ -74,8 +82,14 @@ def _context(
     private: bool = False,
     worker_scope: str = "user_agent",
     backend: str | None = None,
+    isolated_script_gateway: bool = False,
 ) -> ToolRuntimeContext:
-    runtime_paths = _runtime_paths(tmp_path, mode=mode, backend=backend)
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        mode=mode,
+        backend=backend,
+        isolated_script_gateway=isolated_script_gateway,
+    )
     watcher: dict[str, object] = {
         "display_name": "Watcher",
         "worker_scope": worker_scope,
@@ -280,8 +294,14 @@ def _manager(
     *,
     mode: str | None = "all",
     backend: str | None = None,
+    isolated_script_gateway: bool = False,
 ) -> tuple[ScriptRunManager, _WorkerBackend, _WorkerClient]:
-    context = _context(tmp_path, mode=mode, backend=backend)
+    context = _context(
+        tmp_path,
+        mode=mode,
+        backend=backend,
+        isolated_script_gateway=isolated_script_gateway,
+    )
     store = ScriptRunStore(context.runtime_paths)
     backend = _WorkerBackend(store=store, runtime_paths=context.runtime_paths)
     client = _WorkerClient(store=store)
@@ -290,7 +310,11 @@ def _manager(
         broker=_Broker(store),
         worker_client=client,
         worker_backend=backend,
-        gateway_url="http://primary.test/api/script-gateway",
+        gateway_url=(
+            "http://script-gateway.test/api/script-gateway"
+            if isolated_script_gateway
+            else "http://primary.test/api/script-gateway"
+        ),
         grant_resolver=lambda _context: (ScriptToolGrant("calculator", "add"),),
         cancellation_grace_seconds=0,
         cancellation_poll_interval_seconds=0,
@@ -325,6 +349,7 @@ async def test_launch_uses_derived_supervisor_handle_from_the_run_id(tmp_path: P
             run.worker_key,
             private_agent_names=frozenset(),
             mirrored_credential_services=frozenset(),
+            state_scope_worker_key="v1:default:user_agent:@alice:example.test:watcher",
         ),
     ]
     assert client.requested_handles == [f"shell:{run.run_id.removeprefix('script-')}"]
@@ -451,6 +476,71 @@ async def test_kubernetes_worker_rejects_scripts_without_a_gateway_only_listener
 
     with pytest.raises(ScriptRunManagerError, match="gateway-only listener"):
         await manager.run(_context(tmp_path, backend="kubernetes"), source="print('unavailable')\n")
+
+    assert manager.store.list_runs() == []
+    assert backend.specs == []
+    assert client.requested_handles == []
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_worker_accepts_scripts_with_an_explicit_isolated_gateway(tmp_path: Path) -> None:
+    """An operator-attested path-only listener admits a run without weakening the default."""
+    manager, backend, client = _manager(
+        tmp_path,
+        backend="kubernetes",
+        isolated_script_gateway=True,
+    )
+    backend.backend_name = "kubernetes"
+
+    run = await manager.run(
+        _context(
+            tmp_path,
+            backend="kubernetes",
+            isolated_script_gateway=True,
+        ),
+        source="print('ok')\n",
+    )
+
+    assert run.state is ScriptRunState.RUNNING
+    assert backend.specs == [
+        WorkerSpec(
+            run.worker_key or "",
+            private_agent_names=frozenset(),
+            mirrored_credential_services=frozenset(),
+            state_scope_worker_key="v1:default:user_agent:@alice:example.test:watcher",
+        ),
+    ]
+    assert len(client.requested_handles) == 1
+
+
+@pytest.mark.asyncio
+async def test_kubernetes_worker_requires_an_explicit_gateway_with_isolation_attestation(tmp_path: Path) -> None:
+    """The isolation flag alone must not reinterpret a general API URL as a gateway-only listener."""
+    manager, backend, client = _manager(
+        tmp_path,
+        backend="kubernetes",
+        isolated_script_gateway=True,
+    )
+    backend.backend_name = "kubernetes"
+    context = _context(
+        tmp_path,
+        backend="kubernetes",
+        isolated_script_gateway=True,
+    )
+    context = replace(
+        context,
+        runtime_paths=replace(
+            context.runtime_paths,
+            process_env={
+                "MINDROOM_SANDBOX_EXECUTION_MODE": "all",
+                "MINDROOM_WORKER_BACKEND": "kubernetes",
+                "MINDROOM_SCRIPT_GATEWAY_ISOLATED": "true",
+            },
+        ),
+    )
+
+    with pytest.raises(ScriptRunManagerError, match="gateway-only listener"):
+        await manager.run(context, source="print('ok')\n")
 
     assert manager.store.list_runs() == []
     assert backend.specs == []
@@ -687,14 +777,20 @@ async def test_script_process_scope_is_user_agent_independent_of_tool_scope(
 
 @pytest.mark.asyncio
 async def test_script_process_target_preserves_private_agent_visibility(tmp_path: Path) -> None:
-    """Private-agent scripts fail closed rather than mounting a fresh empty state projection."""
+    """A private script keeps a run-specific worker but mounts its owning private state scope."""
     manager, backend, _client = _manager(tmp_path)
 
-    with pytest.raises(ScriptRunManagerError, match="private agents"):
-        await manager.run(_context(tmp_path, private=True), source="print('ok')\n")
+    run = await manager.run(_context(tmp_path, private=True), source="print('ok')\n")
 
-    assert backend.specs == []
-    assert manager.store.list_runs() == []
+    assert run.worker_key is not None
+    assert backend.specs == [
+        WorkerSpec(
+            run.worker_key,
+            private_agent_names=frozenset({"watcher"}),
+            mirrored_credential_services=frozenset(),
+            state_scope_worker_key="v1:default:user_agent:@alice:example.test:watcher",
+        ),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_script_run_store.py
+++ b/tests/test_script_run_store.py
@@ -82,6 +82,94 @@ def test_run_store_claims_one_logical_call_once(runtime_paths: RuntimePaths) -> 
     assert len(store.pending_calls(run.run_id)) == 1
 
 
+def test_run_store_migrates_existing_table_for_resource_snapshots(runtime_paths: RuntimePaths) -> None:
+    """An existing script database gains profile columns before the first profiled launch."""
+    database_path = runtime_paths.control_state_root / "script_runs" / "script_runs.sqlite3"
+    database_path.parent.mkdir(parents=True)
+    connection = sqlite3.connect(database_path)
+    try:
+        connection.execute(
+            """
+            CREATE TABLE script_runs (
+                run_id TEXT PRIMARY KEY,
+                agent_name TEXT NOT NULL,
+                owner_user_id TEXT NOT NULL,
+                room_id TEXT NOT NULL,
+                thread_root_event_id TEXT,
+                execution_identity_json TEXT NOT NULL,
+                source_digest TEXT NOT NULL,
+                grants_json TEXT NOT NULL,
+                token_hash TEXT NOT NULL,
+                preapprove_launch_grants INTEGER NOT NULL,
+                worker_key TEXT,
+                worker_id TEXT,
+                worker_backend_locator TEXT,
+                snapshot_locator TEXT,
+                name TEXT,
+                local_unsafe INTEGER NOT NULL,
+                max_tool_calls_per_minute INTEGER NOT NULL,
+                max_runtime_seconds INTEGER NOT NULL,
+                state TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                started_at TEXT,
+                finished_at TEXT,
+                exit_code INTEGER,
+                error TEXT,
+                output TEXT NOT NULL,
+                cancel_requested_at TEXT,
+                cancellation_reason TEXT
+            )
+            """,
+        )
+        connection.execute(
+            """
+            INSERT INTO script_runs (
+                run_id, agent_name, owner_user_id, room_id,
+                execution_identity_json, source_digest, grants_json, token_hash,
+                preapprove_launch_grants, local_unsafe,
+                max_tool_calls_per_minute, max_runtime_seconds,
+                state, created_at, output
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-run",
+                "watcher",
+                "@alice:example.test",
+                "!room:example.test",
+                "{}",
+                "source-digest",
+                "[]",
+                "capability-digest",
+                0,
+                0,
+                30,
+                3600,
+                "starting",
+                "2026-08-20T00:00:00Z",
+                "",
+            ),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    store = ScriptRunStore(runtime_paths)
+    legacy = store.get_run("legacy-run")
+    profiled = replace(
+        _new_run(),
+        resource_profile="standard",
+        resource_requests={"cpu": "250m", "memory": "512Mi"},
+        resource_limits={"cpu": "1", "memory": "2Gi"},
+    )
+
+    store.create_run(profiled)
+
+    assert legacy.resource_profile is None
+    assert legacy.resource_requests == {}
+    assert legacy.resource_limits == {}
+    assert store.get_run(profiled.run_id) == profiled
+
+
 def test_write_transaction_closes_connection_when_begin_fails(
     runtime_paths: RuntimePaths,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_script_runtime_lifecycle.py
+++ b/tests/test_script_runtime_lifecycle.py
@@ -289,9 +289,10 @@ class _BlockingLaunchWorkerClient(_TerminatingWorkerClient):
         run_id: str,
         source_digest: str,
         gateway_url: str,
+        state_scope_worker_key: str | None = None,
         private_agent_names: tuple[str, ...] | None = None,
     ) -> None:
-        del run_id, source_digest, gateway_url, private_agent_names
+        del run_id, source_digest, gateway_url, state_scope_worker_key, private_agent_names
         self.launch_entered.set()
         await self.release_launch.wait()
 

--- a/tests/test_script_tool.py
+++ b/tests/test_script_tool.py
@@ -73,8 +73,29 @@ def _run(*, state: ScriptRunState = ScriptRunState.RUNNING) -> ScriptRunRecord:
 @dataclass
 class _Manager:
     limits: ScriptRunLimits | None = None
+    requested_resource_profile: str | None = None
     calls: builtins.list[str] = field(default_factory=list)
     run_record: ScriptRunRecord = field(default_factory=_run)
+
+    def resource_profiles(self, context: ToolRuntimeContext) -> dict[str, object]:
+        del context
+        return {
+            "default_profile": "small",
+            "profiles": {
+                "small": {
+                    "requests": {"cpu": "100m", "memory": "256Mi"},
+                    "limits": {"cpu": "500m", "memory": "1Gi"},
+                },
+                "standard": {
+                    "requests": {"cpu": "250m", "memory": "512Mi"},
+                    "limits": {"cpu": "1", "memory": "2Gi"},
+                },
+                "large": {
+                    "requests": {"cpu": "500m", "memory": "2Gi"},
+                    "limits": {"cpu": "2", "memory": "8Gi"},
+                },
+            },
+        }
 
     async def run(
         self,
@@ -83,10 +104,12 @@ class _Manager:
         source: str | None = None,
         path: str | None = None,
         name: str | None = None,
+        resource_profile: str | None = None,
         limits: ScriptRunLimits | None = None,
     ) -> ScriptRunRecord:
         del context, source, path, name
         self.limits = limits
+        self.requested_resource_profile = resource_profile
         self.calls.append("run")
         return self.run_record
 
@@ -119,11 +142,12 @@ class _Manager:
 
 
 def test_script_tool_interface_exists() -> None:
-    """The registered toolkit exposes exactly the four script controls."""
+    """The registered toolkit exposes exactly the five script controls."""
     toolkit = ScriptTools()
 
     assert set(toolkit.async_functions) == {
         "cancel_script",
+        "get_script_resource_profiles",
         "get_script",
         "list_scripts",
         "start_script",
@@ -149,6 +173,40 @@ async def test_script_tool_requires_live_room_context() -> None:
     assert payload == {
         "message": "Background script controls require an active room context.",
         "status": "error",
+        "tool": "script",
+    }
+
+
+@pytest.mark.asyncio
+async def test_script_tool_shows_exact_resources_before_launch(
+    script_context: ToolRuntimeContext,
+) -> None:
+    """The model can compare every bounded profile before reserving a worker."""
+    bind_script_run_manager(_Manager())
+    try:
+        with tool_runtime_context(script_context):
+            payload = json.loads(await ScriptTools().get_script_resource_profiles())
+    finally:
+        bind_script_run_manager(None)
+
+    assert payload == {
+        "action": "resource_profiles",
+        "default_profile": "small",
+        "profiles": {
+            "small": {
+                "limits": {"cpu": "500m", "memory": "1Gi"},
+                "requests": {"cpu": "100m", "memory": "256Mi"},
+            },
+            "standard": {
+                "limits": {"cpu": "1", "memory": "2Gi"},
+                "requests": {"cpu": "250m", "memory": "512Mi"},
+            },
+            "large": {
+                "limits": {"cpu": "2", "memory": "8Gi"},
+                "requests": {"cpu": "500m", "memory": "2Gi"},
+            },
+        },
+        "status": "ok",
         "tool": "script",
     }
 
@@ -189,6 +247,36 @@ async def test_script_tool_public_run_uses_derived_execution_mode_without_redund
         max_tool_calls_per_minute=7,
         max_runtime_hours=3,
     )
+
+
+@pytest.mark.asyncio
+async def test_script_tool_selects_and_reports_exact_resource_profile(
+    script_context: ToolRuntimeContext,
+) -> None:
+    """The selected bounded profile and its exact reservation remain visible after launch."""
+    run = replace(
+        _run(),
+        resource_profile="large",
+        resource_requests={"cpu": "500m", "memory": "2Gi"},
+        resource_limits={"cpu": "2", "memory": "8Gi"},
+    )
+    manager = _Manager(run_record=run)
+    bind_script_run_manager(manager)
+    try:
+        with tool_runtime_context(script_context):
+            payload = json.loads(
+                await ScriptTools().start_script(
+                    source="print('ok')",
+                    resource_profile="large",
+                ),
+            )
+    finally:
+        bind_script_run_manager(None)
+
+    assert manager.requested_resource_profile == "large"
+    assert payload["run"]["resource_profile"] == "large"
+    assert payload["run"]["resource_requests"] == {"cpu": "500m", "memory": "2Gi"}
+    assert payload["run"]["resource_limits"] == {"cpu": "2", "memory": "8Gi"}
 
 
 @pytest.mark.asyncio

--- a/tests/test_script_tool_broker.py
+++ b/tests/test_script_tool_broker.py
@@ -136,6 +136,7 @@ def _context(
     preapprove_script_tool: bool = False,
     tool_function_filter: Callable[[Function], bool] | None = None,
     worker_scope: WorkerScope | None = None,
+    private: bool = False,
 ) -> ToolRuntimeContext:
     runtime_paths = _runtime_paths(tmp_path)
     config = bind_runtime_paths(
@@ -145,6 +146,7 @@ def _context(
                     display_name="Watcher",
                     tools=["calculator"],
                     worker_scope=worker_scope,
+                    private=({"per": "user_agent", "root": "private/watcher"} if private else None),
                 ),
             },
             defaults=DefaultsConfig(tools=[]),
@@ -283,6 +285,7 @@ def _broker(
     durable_local_unsafe: bool | None = None,
     live_local_unsafe: bool | None = None,
     worker_scope: WorkerScope | None = None,
+    private: bool = False,
     resolved_worker_targets: list[ResolvedWorkerTarget] | None = None,
     run_id: str = "run-1",
     authorized: bool = True,
@@ -296,6 +299,7 @@ def _broker(
         preapprove_script_tool=preapprove_script_tool,
         tool_function_filter=tool_function_filter,
         worker_scope=worker_scope,
+        private=private,
     )
     store = ScriptRunStore(context.runtime_paths)
     token, token_hash = mint_script_capability()
@@ -489,6 +493,33 @@ async def test_script_broker_separates_process_scope_from_tool_routing(
     assert resolved_worker_key is not None
     assert resolved_worker_key_scope(resolved_worker_key) == tool_worker_scope
     assert resolved_worker_key != f"v1:default:user_agent:@alice:example.test:{_WORKER_RUN_ID}:watcher"
+
+
+@pytest.mark.asyncio
+async def test_private_script_tool_call_uses_canonical_private_worker_target(tmp_path: Path) -> None:
+    """A private script process key must not replace the called tool's canonical state scope."""
+    events: list[str] = []
+    resolved_worker_targets: list[ResolvedWorkerTarget] = []
+    process_worker_key = f"v1:default:user_agent:@alice:example.test:{_WORKER_RUN_ID}:watcher"
+    broker, token = _broker(
+        tmp_path,
+        events=events,
+        private=True,
+        durable_worker_key=process_worker_key,
+        durable_worker_id="script-process-worker",
+        live_worker_id="script-process-worker",
+        resolved_worker_targets=resolved_worker_targets,
+        run_id=_WORKER_RUN_ID,
+    )
+
+    receipt = await _call_through_gateway(broker, _request(run_id=_WORKER_RUN_ID), token)
+
+    assert receipt.state is ScriptCallState.COMPLETED
+    assert len(resolved_worker_targets) == 2
+    assert resolved_worker_targets[0] == resolved_worker_targets[1]
+    assert resolved_worker_targets[0].worker_key == "v1:default:user_agent:@alice:example.test:watcher"
+    assert resolved_worker_targets[0].private_agent_names == frozenset({"watcher"})
+    assert resolved_worker_targets[0].worker_key != process_worker_key
 
 
 @pytest.mark.asyncio

--- a/tests/test_script_tool_registration.py
+++ b/tests/test_script_tool_registration.py
@@ -14,6 +14,7 @@ def test_script_tool_metadata_declares_primary_room_controls_and_limits() -> Non
     assert metadata.requires_room_context is True
     assert metadata.function_names == (
         "start_script",
+        "get_script_resource_profiles",
         "get_script",
         "cancel_script",
         "list_scripts",

--- a/tests/test_script_worker_client.py
+++ b/tests/test_script_worker_client.py
@@ -58,6 +58,7 @@ async def test_script_worker_client_sends_a_narrow_derived_launch_request() -> N
         run_id=f"script-{'a' * 32}",
         source_digest="a" * 64,
         gateway_url="http://primary.test/api/script-gateway",
+        state_scope_worker_key="v1:test:user_agent:alice:private-agent",
         private_agent_names=("private-agent",),
     )
 
@@ -67,6 +68,7 @@ async def test_script_worker_client_sends_a_narrow_derived_launch_request() -> N
     assert httpx.Response(200, content=str(observed["payload"])).json() == {
         "run_id": f"script-{'a' * 32}",
         "worker_key": "v1:test:shared:scripts",
+        "state_scope_worker_key": "v1:test:user_agent:alice:private-agent",
         "source_digest": "a" * 64,
         "gateway_url": "http://primary.test/api/script-gateway",
         "private_agent_names": ["private-agent"],

--- a/tests/test_worker_backend_config_signatures.py
+++ b/tests/test_worker_backend_config_signatures.py
@@ -342,7 +342,7 @@ def test_kubernetes_cleanup_signature_falls_back_to_stable_selected_cluster(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Service variables outside process env use kubeconfig without tracking user credentials."""
+    """Kubeconfig fallback tracks the API server, not rotating credentials or CA data."""
     kubeconfig = tmp_path / "kubeconfig.yaml"
     env = {
         **_MINIMAL_KUBERNETES_ENV,
@@ -358,7 +358,7 @@ def test_kubernetes_cleanup_signature_falls_back_to_stable_selected_cluster(
     monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
     monkeypatch.delenv("KUBERNETES_SERVICE_PORT", raising=False)
 
-    def write_kubeconfig(server: str, token: str) -> None:
+    def write_kubeconfig(server: str, token: str, certificate_authority_data: str) -> None:
         kubeconfig.write_text(
             (
                 "apiVersion: v1\n"
@@ -366,7 +366,7 @@ def test_kubernetes_cleanup_signature_falls_back_to_stable_selected_cluster(
                 "current-context: active\n"
                 "clusters:\n"
                 "  - name: selected\n"
-                f"    cluster:\n      server: {server}\n"
+                f"    cluster:\n      server: {server}\n      certificate-authority-data: {certificate_authority_data}\n"
                 "contexts:\n"
                 "  - name: active\n"
                 "    context:\n"
@@ -379,16 +379,16 @@ def test_kubernetes_cleanup_signature_falls_back_to_stable_selected_cluster(
             encoding="utf-8",
         )
 
-    write_kubeconfig("https://cluster-a.example.test", "token-a")
+    write_kubeconfig("https://cluster-a.example.test", "token-a", "ca-a")
     runtime_paths = _runtime_paths(tmp_path, env)
     base = kubernetes_backend_cleanup_signature(runtime_paths, storage_root=runtime_paths.storage_root)
 
-    write_kubeconfig("https://cluster-a.example.test", "token-b")
+    write_kubeconfig("https://cluster-a.example.test", "token-b", "ca-b")
     rotated_credentials = kubernetes_backend_cleanup_signature(
         runtime_paths,
         storage_root=runtime_paths.storage_root,
     )
-    write_kubeconfig("https://cluster-b.example.test", "token-b")
+    write_kubeconfig("https://cluster-b.example.test", "token-b", "ca-b")
     changed_cluster = kubernetes_backend_cleanup_signature(runtime_paths, storage_root=runtime_paths.storage_root)
 
     assert rotated_credentials == base

--- a/tests/test_worker_backend_config_signatures.py
+++ b/tests/test_worker_backend_config_signatures.py
@@ -342,7 +342,7 @@ def test_kubernetes_cleanup_signature_falls_back_to_stable_selected_cluster(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Missing in-cluster credentials use kubeconfig without tracking user credentials."""
+    """Service variables outside process env use kubeconfig without tracking user credentials."""
     kubeconfig = tmp_path / "kubeconfig.yaml"
     env = {
         **_MINIMAL_KUBERNETES_ENV,
@@ -353,9 +353,10 @@ def test_kubernetes_cleanup_signature_falls_back_to_stable_selected_cluster(
     monkeypatch.setattr(
         kubernetes_config_module,
         "_in_cluster_credentials_available",
-        lambda: False,
-        raising=False,
+        lambda: True,
     )
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    monkeypatch.delenv("KUBERNETES_SERVICE_PORT", raising=False)
 
     def write_kubeconfig(server: str, token: str) -> None:
         kubeconfig.write_text(

--- a/tests/test_worker_backend_config_signatures.py
+++ b/tests/test_worker_backend_config_signatures.py
@@ -109,6 +109,11 @@ def _legacy_kubernetes_backend_config_signature(
     extra_volumes_json = stable_signature_json(config.extra_volumes)
     resource_requests_json = json.dumps(config.resource_requests, sort_keys=True, separators=(",", ":"))
     resource_limits_json = json.dumps(config.resource_limits, sort_keys=True, separators=(",", ":"))
+    script_resource_profiles_json = json.dumps(
+        config.script_resource_profiles,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
     return (
         "kubernetes",
         config.namespace,
@@ -135,6 +140,8 @@ def _legacy_kubernetes_backend_config_signature(
         config.owner_deployment_name or "",
         resource_requests_json,
         resource_limits_json,
+        script_resource_profiles_json,
+        config.default_script_resource_profile,
         str(config.enable_service_links),
         config.auth_secret_name or "",
         str(config.reconcile_pod_templates),

--- a/tests/test_worker_backend_config_signatures.py
+++ b/tests/test_worker_backend_config_signatures.py
@@ -12,6 +12,7 @@ import pytest
 from mindroom.constants import resolve_primary_runtime_paths
 from mindroom.runtime_env_policy import CREDENTIALS_ENCRYPTION_KEY_ENV
 from mindroom.workers.backend import WorkerBackendError
+from mindroom.workers.backends import kubernetes_config as kubernetes_config_module
 from mindroom.workers.backends._dedicated_worker_common import stable_signature_json
 from mindroom.workers.backends.docker_config import (
     docker_backend_cleanup_signature,
@@ -337,10 +338,24 @@ def test_kubernetes_signature_changes_with_cluster_context(tmp_path: Path) -> No
     )
 
 
-def test_kubernetes_cleanup_signature_ignores_credentials_but_tracks_selected_cluster(tmp_path: Path) -> None:
-    """Credential rotation retains cleanup access while a cluster endpoint change does not."""
+def test_kubernetes_cleanup_signature_falls_back_to_stable_selected_cluster(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing in-cluster credentials use kubeconfig without tracking user credentials."""
     kubeconfig = tmp_path / "kubeconfig.yaml"
-    env = {**_MINIMAL_KUBERNETES_ENV, "KUBECONFIG": str(kubeconfig)}
+    env = {
+        **_MINIMAL_KUBERNETES_ENV,
+        "KUBECONFIG": str(kubeconfig),
+        "KUBERNETES_SERVICE_HOST": "kubernetes.default.svc",
+        "KUBERNETES_SERVICE_PORT": "443",
+    }
+    monkeypatch.setattr(
+        kubernetes_config_module,
+        "_in_cluster_credentials_available",
+        lambda: False,
+        raising=False,
+    )
 
     def write_kubeconfig(server: str, token: str) -> None:
         kubeconfig.write_text(

--- a/tests/test_worker_backend_config_signatures.py
+++ b/tests/test_worker_backend_config_signatures.py
@@ -20,6 +20,7 @@ from mindroom.workers.backends.docker_config import (
 from mindroom.workers.backends.kubernetes_config import (
     KubernetesWorkerBackendConfig,
     credentials_encryption_key_hash,
+    kubernetes_backend_cleanup_signature,
     kubernetes_backend_config_signature,
 )
 
@@ -327,6 +328,48 @@ def test_kubernetes_signature_changes_with_cluster_context(tmp_path: Path) -> No
         auth_token=_TEST_AUTH_TOKEN,
         storage_root=second.storage_root,
     )
+
+
+def test_kubernetes_cleanup_signature_ignores_credentials_but_tracks_selected_cluster(tmp_path: Path) -> None:
+    """Credential rotation retains cleanup access while a cluster endpoint change does not."""
+    kubeconfig = tmp_path / "kubeconfig.yaml"
+    env = {**_MINIMAL_KUBERNETES_ENV, "KUBECONFIG": str(kubeconfig)}
+
+    def write_kubeconfig(server: str, token: str) -> None:
+        kubeconfig.write_text(
+            (
+                "apiVersion: v1\n"
+                "kind: Config\n"
+                "current-context: active\n"
+                "clusters:\n"
+                "  - name: selected\n"
+                f"    cluster:\n      server: {server}\n"
+                "contexts:\n"
+                "  - name: active\n"
+                "    context:\n"
+                "      cluster: selected\n"
+                "      user: operator\n"
+                "users:\n"
+                "  - name: operator\n"
+                f"    user:\n      token: {token}\n"
+            ),
+            encoding="utf-8",
+        )
+
+    write_kubeconfig("https://cluster-a.example.test", "token-a")
+    runtime_paths = _runtime_paths(tmp_path, env)
+    base = kubernetes_backend_cleanup_signature(runtime_paths, storage_root=runtime_paths.storage_root)
+
+    write_kubeconfig("https://cluster-a.example.test", "token-b")
+    rotated_credentials = kubernetes_backend_cleanup_signature(
+        runtime_paths,
+        storage_root=runtime_paths.storage_root,
+    )
+    write_kubeconfig("https://cluster-b.example.test", "token-b")
+    changed_cluster = kubernetes_backend_cleanup_signature(runtime_paths, storage_root=runtime_paths.storage_root)
+
+    assert rotated_credentials == base
+    assert changed_cluster != base
 
 
 def test_docker_signature_is_stable_for_identical_config(tmp_path: Path) -> None:

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
@@ -392,6 +393,49 @@ def test_configured_worker_lease_requires_the_current_durable_backend_identity(
     assert matched is lease
     assert mismatched is None
     lease.release.assert_called_once_with()
+
+
+def test_kubernetes_cleanup_identity_ignores_launch_config_but_tracks_resource_owner(tmp_path: Path) -> None:
+    """Routine config changes retain cleanup access without crossing resource owners."""
+    storage_root = tmp_path / "shared-storage"
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=storage_root,
+        process_env={
+            "MINDROOM_WORKER_BACKEND": "kubernetes",
+            "MINDROOM_KUBERNETES_WORKER_IMAGE": "test-image",
+            "MINDROOM_KUBERNETES_WORKER_STORAGE_PVC_NAME": "test-pvc",
+        },
+    )
+    other_namespace_paths = replace(
+        runtime_paths,
+        process_env={
+            **runtime_paths.process_env,
+            "MINDROOM_KUBERNETES_WORKER_NAMESPACE": "other-namespace",
+        },
+    )
+
+    base = workers_runtime_module._primary_worker_backend_cleanup_signature(
+        runtime_paths,
+        storage_root=storage_root,
+        config_signature=("launch-config-a",),
+    )
+
+    assert base == workers_runtime_module._primary_worker_backend_cleanup_signature(
+        runtime_paths,
+        storage_root=storage_root,
+        config_signature=("launch-config-b",),
+    )
+    assert base != workers_runtime_module._primary_worker_backend_cleanup_signature(
+        other_namespace_paths,
+        storage_root=storage_root,
+        config_signature=("launch-config-a",),
+    )
+    assert base != workers_runtime_module._primary_worker_backend_cleanup_signature(
+        runtime_paths,
+        storage_root=tmp_path / "other-storage",
+        config_signature=("launch-config-a",),
+    )
 
 
 def test_configured_primary_worker_manager_lease_skips_kubernetes_without_runtime_config(


### PR DESCRIPTION
## Summary

- admit Kubernetes script workers only when an explicit gateway-only URL and operator isolation attestation are configured
- preserve canonical requester-agent state for isolated script workers, including private agents
- add fixed `small`, `standard`, and `large` resource profiles whose exact CPU and memory requests and limits remain operator-controlled
- let agents inspect the live profile values before launch, then persist and report the selected profile and exact resource snapshot
- keep run-specific lifecycle storage and cleanup bound to the exact dedicated worker

## Testing

- `uv run pre-commit run --all-files`
- `uv run pytest -q`

## Summary by Sourcery

Enable isolated Kubernetes background-script workers with bounded resources, canonical private-agent state, and exact per-run lifecycle ownership.

New Features:
- Enable isolated Kubernetes workers for background scripts when an explicit gateway-only URL and operator isolation attestation are configured.
- Add administrator-defined small, standard, and large Kubernetes script resource profiles that agents can inspect and select.
- Support private user-agent script workers while preserving canonical requester-agent workspace and lifecycle state.

Bug Fixes:
- Prevent script workers from mounting run-specific copies of canonical private state and ensure exact Kubernetes worker cleanup cannot affect unrelated workers.
- Validate allowed toolkits against eligible toolkit names, including toolkits with temporarily unavailable functions.

Enhancements:
- Persist and report each run's selected resource profile and exact CPU and memory requests and limits.
- Bind run-specific worker lifecycle storage, state scopes, and cleanup to the exact dedicated worker identity.

Deployment:
- Expose Kubernetes script resource profiles through the runtime Helm chart and environment configuration.
- Require Kubernetes background scripts to use an explicitly isolated gateway and disable them when Agent Vault identities cannot be retired exactly.

Documentation:
- Document Kubernetes gateway isolation requirements, resource profile controls, profile inspection, and private-agent worker support.

Tests:
- Add coverage for Kubernetes admission, resource profiles, private workspace projection, exact worker retirement, persistence migration, and gateway/tool behavior.