### PR TITLE
Restore Agent Vault support for Kubernetes scripts

### DIFF
--- a/docs/tools/background-scripts.md
+++ b/docs/tools/background-scripts.md
@@ -195,7 +195,6 @@ The worker must also reach the primary script gateway over an authenticated netw
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
-Kubernetes background scripts are not supported while `MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED=true` because run-specific external vault identities cannot yet be retired exactly.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -10520,7 +10520,6 @@ The worker must also reach the primary script gateway over an authenticated netw
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
-Kubernetes background scripts are not supported while `MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED=true` because run-specific external vault identities cannot yet be retired exactly.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.

--- a/skills/mindroom-docs/references/page__tools__background-scripts__index.md
+++ b/skills/mindroom-docs/references/page__tools__background-scripts__index.md
@@ -191,7 +191,6 @@ The worker must also reach the primary script gateway over an authenticated netw
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
-Kubernetes background scripts are not supported while `MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED=true` because run-specific external vault identities cannot yet be retired exactly.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.

--- a/src/mindroom/script_runs/manager.py
+++ b/src/mindroom/script_runs/manager.py
@@ -20,7 +20,6 @@ from weakref import WeakValueDictionary
 from mindroom.background_tasks import run_blocking_until_complete, run_coroutine_until_complete
 from mindroom.constants import CONTROL_STATE_PATH_ENV
 from mindroom.logging_config import get_logger
-from mindroom.runtime_env_policy import KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY
 from mindroom.runtime_resolution import resolve_agent_runtime
 from mindroom.script_runs.models import (
     ScriptRunRecord,
@@ -1489,11 +1488,6 @@ def _require_script_launch_backend(
             "Kubernetes background scripts require a gateway-only listener; "
             "use Docker or explicit unsafe-local mode until that boundary is configured."
         )
-        raise ScriptRunManagerError(msg)
-    if admitted_backend.backend_name == "kubernetes" and runtime_paths.env_flag(
-        KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["agent_vault_enabled"],
-    ):
-        msg = "Kubernetes background scripts are not supported while Agent Vault is enabled."
         raise ScriptRunManagerError(msg)
     return admitted_backend
 

--- a/tests/test_script_run_manager.py
+++ b/tests/test_script_run_manager.py
@@ -638,8 +638,8 @@ async def test_kubernetes_worker_accepts_scripts_with_an_explicit_isolated_gatew
 
 
 @pytest.mark.asyncio
-async def test_kubernetes_worker_rejects_scripts_when_agent_vault_is_enabled(tmp_path: Path) -> None:
-    """Run-specific workers must not create external identities that exact retirement cannot delete."""
+async def test_kubernetes_worker_accepts_scripts_when_agent_vault_is_enabled(tmp_path: Path) -> None:
+    """Agent Vault egress must remain available to isolated Kubernetes script workers."""
     manager, backend, client = _manager(
         tmp_path,
         backend="kubernetes",
@@ -662,12 +662,18 @@ async def test_kubernetes_worker_rejects_scripts_when_agent_vault_is_enabled(tmp
         ),
     )
 
-    with pytest.raises(ScriptRunManagerError, match="Agent Vault"):
-        await manager.run(context, source="print('ok')\n")
+    run = await manager.run(context, source="print('ok')\n")
 
-    assert manager.store.list_runs() == []
-    assert backend.specs == []
-    assert client.requested_handles == []
+    assert run.state is ScriptRunState.RUNNING
+    assert backend.specs == [
+        WorkerSpec(
+            run.worker_key or "",
+            private_agent_names=frozenset(),
+            mirrored_credential_services=frozenset(),
+            state_scope_worker_key="v1:default:user_agent:@alice:example.test:watcher",
+        ),
+    ]
+    assert len(client.requested_handles) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- allow isolated Kubernetes background scripts when Agent Vault is enabled
- replace the rejection test with launch coverage
- remove the obsolete documentation prohibition

This is a focused correction for the restriction introduced during review of #1877. Exact external identity cleanup remains separate from launch support.

## Verification

- `uv run pytest tests/test_script_run_manager.py -x -n 0 --no-cov -q`
- `uv run pytest -n auto --no-cov -q`
- `uv run pre-commit run --files src/mindroom/script_runs/manager.py tests/test_script_run_manager.py docs/tools/background-scripts.md skills/mindroom-docs/references/llms-full.txt skills/mindroom-docs/references/page__tools__background-scripts__index.md`

## Summary by Sourcery

Restore isolated Kubernetes background script launches with Agent Vault enabled.

New Features:
- Restore support for launching isolated Kubernetes background scripts when Agent Vault is enabled.

Enhancements:
- Replace the Agent Vault rejection coverage with successful launch coverage for Kubernetes script workers.

Documentation:
- Remove the obsolete documentation prohibition on using Agent Vault with Kubernetes background scripts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Kubernetes background scripts can now run when Agent Vault is enabled.
  - Script workers launch successfully and report their running state in this configuration.

- **Documentation**
  - Updated background script guidance to reflect the expanded Kubernetes support.
  - Existing Kubernetes gateway isolation requirements remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->