### PR TITLE
Keep script workers outside Agent Vault identity lifecycle

### DIFF
--- a/docs/tools/background-scripts.md
+++ b/docs/tools/background-scripts.md
@@ -195,7 +195,9 @@ The worker must also reach the primary script gateway over an authenticated netw
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
-Kubernetes background scripts are not supported while `MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED=true` because run-specific external vault identities cannot yet be retired exactly.
+When Agent Vault is enabled, run-specific Kubernetes script process pods deliberately omit Agent Vault init, token, proxy, and CA material because their lifecycle is scoped to one run.
+Calls through `MindRoomTools` still use the authenticated script gateway and normal live tool-execution routing, so ordinary dedicated tool workers retain their configured Agent Vault boundary.
+Direct network clients started by the script process do not receive Agent Vault credential injection.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -10520,7 +10520,9 @@ The worker must also reach the primary script gateway over an authenticated netw
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
-Kubernetes background scripts are not supported while `MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED=true` because run-specific external vault identities cannot yet be retired exactly.
+When Agent Vault is enabled, run-specific Kubernetes script process pods deliberately omit Agent Vault init, token, proxy, and CA material because their lifecycle is scoped to one run.
+Calls through `MindRoomTools` still use the authenticated script gateway and normal live tool-execution routing, so ordinary dedicated tool workers retain their configured Agent Vault boundary.
+Direct network clients started by the script process do not receive Agent Vault credential injection.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.

--- a/skills/mindroom-docs/references/page__tools__background-scripts__index.md
+++ b/skills/mindroom-docs/references/page__tools__background-scripts__index.md
@@ -191,7 +191,9 @@ The worker must also reach the primary script gateway over an authenticated netw
 Kubernetes background scripts are disabled by default because a general primary API listener exposes more authority than the capability-gated script gateway.
 They are admitted only when `MINDROOM_SCRIPT_GATEWAY_URL` names a gateway-only listener and the operator sets `MINDROOM_SCRIPT_GATEWAY_ISOLATED=true` to attest that workers cannot reach other primary API routes through that listener.
 Enforce that boundary with a separate listener or path-filtering proxy and network policy; the environment flag does not create network isolation by itself.
-Kubernetes background scripts are not supported while `MINDROOM_KUBERNETES_AGENT_VAULT_ENABLED=true` because run-specific external vault identities cannot yet be retired exactly.
+When Agent Vault is enabled, run-specific Kubernetes script process pods deliberately omit Agent Vault init, token, proxy, and CA material because their lifecycle is scoped to one run.
+Calls through `MindRoomTools` still use the authenticated script gateway and normal live tool-execution routing, so ordinary dedicated tool workers retain their configured Agent Vault boundary.
+Direct network clients started by the script process do not receive Agent Vault credential injection.
 
 Set `MINDROOM_SCRIPT_GATEWAY_URL` to the complete worker-reachable gateway base, including `/api/script-gateway`.
 For Docker only, `MINDROOM_PUBLIC_URL` can instead name the reachable MindRoom origin and MindRoom appends `/api/script-gateway`.

--- a/src/mindroom/script_runs/manager.py
+++ b/src/mindroom/script_runs/manager.py
@@ -20,7 +20,6 @@ from weakref import WeakValueDictionary
 from mindroom.background_tasks import run_blocking_until_complete, run_coroutine_until_complete
 from mindroom.constants import CONTROL_STATE_PATH_ENV
 from mindroom.logging_config import get_logger
-from mindroom.runtime_env_policy import KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY
 from mindroom.runtime_resolution import resolve_agent_runtime
 from mindroom.script_runs.models import (
     ScriptRunRecord,
@@ -1489,11 +1488,6 @@ def _require_script_launch_backend(
             "Kubernetes background scripts require a gateway-only listener; "
             "use Docker or explicit unsafe-local mode until that boundary is configured."
         )
-        raise ScriptRunManagerError(msg)
-    if admitted_backend.backend_name == "kubernetes" and runtime_paths.env_flag(
-        KUBERNETES_WORKER_BACKEND_CONFIG_ENV_BY_KEY["agent_vault_enabled"],
-    ):
-        msg = "Kubernetes background scripts are not supported while Agent Vault is enabled."
         raise ScriptRunManagerError(msg)
     return admitted_backend
 

--- a/src/mindroom/workers/backends/kubernetes_resources.py
+++ b/src/mindroom/workers/backends/kubernetes_resources.py
@@ -1266,6 +1266,8 @@ class KubernetesResourceManager:
         resource_profile: str | None = None,
     ) -> dict[str, object]:
         resource_requests, resource_limits = self.config.resources_for_profile(resource_profile)
+        owns_state_scope = resolve_state_scope_worker_key(worker_key, state_scope_worker_key) == worker_key
+        include_agent_vault = self.config.agent_vault is not None and owns_state_scope
         worker_labels = _labels(extra_labels=self.config.extra_labels, worker_id=worker_id)
         template_annotations = dict(self.config.extra_annotations)
         template_annotations[ANNOTATION_WORKER_KEY] = worker_key
@@ -1302,12 +1304,14 @@ class KubernetesResourceManager:
                         worker_id=worker_id,
                         state_subpath=state_subpath,
                         startup_manifest_path=startup_manifest_path,
+                        include_agent_vault=include_agent_vault,
                     ),
                     "volumeMounts": self._volume_mounts(
                         worker_key,
                         state_subpath,
                         private_agent_names,
                         state_scope_worker_key=state_scope_worker_key,
+                        include_agent_vault=include_agent_vault,
                     ),
                     "readinessProbe": {
                         "httpGet": {"path": "/healthz", "port": "api"},
@@ -1334,7 +1338,7 @@ class KubernetesResourceManager:
                     },
                 },
             ],
-            "volumes": self._volumes(),
+            "volumes": self._volumes(include_agent_vault=include_agent_vault),
         }
         containers = cast("list[dict[str, object]]", template_spec["containers"])
         _extend_unique_named_pod_entries(
@@ -1342,7 +1346,7 @@ class KubernetesResourceManager:
             self.config.extra_containers,
             field_name="extra_containers",
         )
-        if self.config.agent_vault is not None:
+        if include_agent_vault:
             template_spec["initContainers"] = [self._agent_vault_init_container(worker_key=worker_key)]
         node_name = self._worker_node_name_or_none()
         if node_name is not None:
@@ -1426,6 +1430,7 @@ class KubernetesResourceManager:
         worker_id: str,
         state_subpath: str,
         startup_manifest_path: str,
+        include_agent_vault: bool,
     ) -> list[dict[str, object]]:
         dedicated_root = f"{self.config.storage_mount_path}/{state_subpath}".rstrip("/")
         venv_path = f"{dedicated_root}/venv"
@@ -1454,7 +1459,8 @@ class KubernetesResourceManager:
         if credentials_encryption_key_env is not None:
             env.append(credentials_encryption_key_env)
 
-        env.extend(self._agent_vault_main_env(worker_key=worker_key))
+        if include_agent_vault:
+            env.extend(self._agent_vault_main_env(worker_key=worker_key))
 
         for name, value in sorted(worker_extra_env(self.config.extra_env).items()):
             env.append({"name": name, "value": value})
@@ -1588,6 +1594,7 @@ class KubernetesResourceManager:
         private_agent_names: frozenset[str] | None,
         *,
         state_scope_worker_key: str | None = None,
+        include_agent_vault: bool,
     ) -> list[dict[str, object]]:
         mounts = self._scoped_storage_mounts(
             worker_key,
@@ -1606,7 +1613,7 @@ class KubernetesResourceManager:
                     "readOnly": True,
                 },
             )
-        if self.config.agent_vault is not None:
+        if include_agent_vault:
             mounts.append(
                 {
                     "name": AGENT_VAULT_TOKEN_VOLUME_NAME,
@@ -1614,7 +1621,7 @@ class KubernetesResourceManager:
                     "readOnly": True,
                 },
             )
-        if self._agent_vault_worker_ca_configmap_name() is not None:
+        if include_agent_vault and self._agent_vault_worker_ca_configmap_name() is not None:
             mounts.append(
                 {
                     "name": AGENT_VAULT_CA_VOLUME_NAME,
@@ -1662,7 +1669,7 @@ class KubernetesResourceManager:
             },
         ]
 
-    def _volumes(self) -> list[dict[str, object]]:
+    def _volumes(self, *, include_agent_vault: bool) -> list[dict[str, object]]:
         volumes: list[dict[str, object]] = [
             {
                 "name": WORKER_STORAGE_VOLUME_NAME,
@@ -1676,8 +1683,9 @@ class KubernetesResourceManager:
                     "configMap": {"name": self.config.config_map_name},
                 },
             )
-        volumes.extend(self._agent_vault_volumes())
-        ca_configmap_name = self._agent_vault_worker_ca_configmap_name()
+        if include_agent_vault:
+            volumes.extend(self._agent_vault_volumes())
+        ca_configmap_name = self._agent_vault_worker_ca_configmap_name() if include_agent_vault else None
         if ca_configmap_name is not None:
             volumes.append(
                 {

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -4303,6 +4303,41 @@ def test_kubernetes_backend_adds_agent_vault_mint_init_container(tmp_path: Path)
     assert backend._resources._agent_vault_vault_name(worker_key) == expected_vault
 
 
+def test_kubernetes_script_worker_omits_agent_vault_identity_material(tmp_path: Path) -> None:
+    """A run-scoped process pod must not mint an external identity that retirement cannot delete."""
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=Path("config.yaml"),
+        storage_path=tmp_path / "mindroom-test-storage",
+    )
+    backend, apps_api, _core_api = _backend(
+        runtime_paths=runtime_paths,
+        agent_vault=_test_agent_vault_config(worker_ca_configmap_name="agent-vault-ca"),
+    )
+    state_scope_worker_key = "v1:tenant-123:user_agent:@alice:example.org:mind"
+    worker_key = script_worker_key_for_run(state_scope_worker_key, f"script-{'a' * 32}")
+
+    handle = backend.ensure_worker(
+        WorkerSpec(
+            worker_key,
+            private_agent_names=frozenset({"mind"}),
+            state_scope_worker_key=state_scope_worker_key,
+        ),
+        now=10.0,
+    )
+
+    deployment = next(b for b in apps_api.created_bodies if b["metadata"]["name"] == handle.worker_id)
+    template_spec = deployment["spec"]["template"]["spec"]
+    main = template_spec["containers"][0]
+    main_env_names = {entry["name"] for entry in main["env"]}
+    main_mount_names = {mount["name"] for mount in main["volumeMounts"]}
+    volume_names = {volume["name"] for volume in template_spec["volumes"]}
+
+    assert "initContainers" not in template_spec
+    assert not any(name.startswith("MINDROOM_WORKER_EGRESS_PROXY_") for name in main_env_names)
+    assert not {"agent-vault-token", "agent-vault-bootstrap", "agent-vault-ca"} & main_mount_names
+    assert not {"agent-vault-token", "agent-vault-bootstrap", "agent-vault-ca"} & volume_names
+
+
 def test_agent_vault_main_env_error_names_worker_key_when_vault_name_missing(tmp_path: Path) -> None:
     """The defensive vault-name guard should include the worker key that failed."""
     runtime_paths = resolve_primary_runtime_paths(

--- a/tests/test_script_run_manager.py
+++ b/tests/test_script_run_manager.py
@@ -638,8 +638,8 @@ async def test_kubernetes_worker_accepts_scripts_with_an_explicit_isolated_gatew
 
 
 @pytest.mark.asyncio
-async def test_kubernetes_worker_rejects_scripts_when_agent_vault_is_enabled(tmp_path: Path) -> None:
-    """Run-specific workers must not create external identities that exact retirement cannot delete."""
+async def test_kubernetes_worker_accepts_scripts_when_agent_vault_is_enabled(tmp_path: Path) -> None:
+    """Run-specific workers may launch when their pod omits external vault identity material."""
     manager, backend, client = _manager(
         tmp_path,
         backend="kubernetes",
@@ -662,12 +662,18 @@ async def test_kubernetes_worker_rejects_scripts_when_agent_vault_is_enabled(tmp
         ),
     )
 
-    with pytest.raises(ScriptRunManagerError, match="Agent Vault"):
-        await manager.run(context, source="print('ok')\n")
+    run = await manager.run(context, source="print('ok')\n")
 
-    assert manager.store.list_runs() == []
-    assert backend.specs == []
-    assert client.requested_handles == []
+    assert run.state is ScriptRunState.RUNNING
+    assert backend.specs == [
+        WorkerSpec(
+            run.worker_key or "",
+            private_agent_names=frozenset(),
+            mirrored_credential_services=frozenset(),
+            state_scope_worker_key="v1:default:user_agent:@alice:example.test:watcher",
+        ),
+    ]
+    assert len(client.requested_handles) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow run-scoped Kubernetes script workers when Agent Vault is enabled
- omit vault init, token, proxy, and CA material from ephemeral script pods while preserving ordinary worker injection
- document the boundary and add regression coverage

## Testing
- uv run pytest -q
- uv run pre-commit run --all-files

## Summary by Sourcery

Allow run-scoped Kubernetes script workers to operate alongside Agent Vault without inheriting external vault identities.

New Features:
- Allow Kubernetes script-run workers to launch when Agent Vault is enabled without receiving run-scoped vault identity material.

Bug Fixes:
- Prevent ephemeral script pods from receiving Agent Vault initialization, credentials, proxy, and CA resources that cannot be retired with the run lifecycle.

Enhancements:
- Preserve Agent Vault injection for ordinary state-scoped worker pods while keeping script gateway tool calls authenticated.

Documentation:
- Document the Agent Vault boundary for Kubernetes script workers and direct network clients.

Tests:
- Add regression coverage for vault material omission from script worker pods and successful script launches with Agent Vault enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kubernetes background scripts are now supported when Agent Vault is enabled.
  * Brokered tool calls continue through the authenticated gateway and standard worker routing.

* **Bug Fixes**
  * Script workers no longer receive Agent Vault credentials or identity materials, improving isolation and security.
  * Direct network clients in background scripts cannot access Agent Vault credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->