### PR TITLE
Prepare background script workers before readiness

### DIFF
--- a/src/mindroom/api/sandbox_runner_app.py
+++ b/src/mindroom/api/sandbox_runner_app.py
@@ -15,6 +15,9 @@ from mindroom.api.sandbox_runner import (
     startup_runner_token_from_env,
 )
 from mindroom.api.sandbox_runner import router as sandbox_runner_router
+from mindroom.api.sandbox_runner_scripts import (
+    prepare_script_worker_before_serving,
+)
 from mindroom.api.sandbox_runner_scripts import router as sandbox_runner_scripts_router
 from mindroom.workers.compatibility import worker_health_payload
 
@@ -35,6 +38,7 @@ async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
         config=config,
         runner_token=runner_token,
     )
+    await prepare_script_worker_before_serving(app)
     yield
 
 

--- a/src/mindroom/api/sandbox_runner_scripts.py
+++ b/src/mindroom/api/sandbox_runner_scripts.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Literal
 from urllib.parse import urlsplit
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Query, Request
 from fastapi.routing import APIRoute
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field
 
@@ -23,7 +23,11 @@ from mindroom.api.sandbox_runner import (
     validate_runner_token,
 )
 from mindroom.constants import CONTROL_STATE_PATH_ENV
-from mindroom.script_runs.models import script_worker_key_for_run, supervisor_handle_for_run
+from mindroom.script_runs.models import (
+    script_worker_key_belongs_to_run,
+    script_worker_key_for_run,
+    supervisor_handle_for_run,
+)
 from mindroom.shell_supervisor import (
     ShellSupervisorStartupError,
     background_script_supervision_supported,
@@ -54,10 +58,30 @@ __all__ = [
     "SandboxScriptRunResponse",
     "SandboxScriptStatusResponse",
     "cancel_script_in_worker",
+    "prepare_script_worker_before_serving",
     "router",
     "run_script_in_worker",
     "status_script_in_worker",
 ]
+
+
+async def prepare_script_worker_before_serving(app: FastAPI) -> None:
+    """Finish cold script-worker setup before the runner advertises readiness."""
+    runtime_paths = app_runtime_paths(app)
+    worker_key = sandbox_exec.runner_dedicated_worker_key(runtime_paths)
+    if worker_key is None:
+        return
+    parts = worker_key.split(":")
+    if len(parts) < 6 or not script_worker_key_belongs_to_run(worker_key, parts[-2]):
+        return
+
+    await asyncio.to_thread(
+        sandbox_worker_prep.prepare_worker,
+        worker_key,
+        runtime_paths,
+        runner_token=app_runner_token(app),
+    )
+    await asyncio.to_thread(ensure_shell_supervisor)
 
 
 async def _bounded_replay_request(request: Request) -> Request:

--- a/src/mindroom/api/sandbox_runner_scripts.py
+++ b/src/mindroom/api/sandbox_runner_scripts.py
@@ -24,7 +24,7 @@ from mindroom.api.sandbox_runner import (
 )
 from mindroom.constants import CONTROL_STATE_PATH_ENV
 from mindroom.script_runs.models import (
-    script_worker_key_belongs_to_run,
+    script_run_id_from_worker_key,
     script_worker_key_for_run,
     supervisor_handle_for_run,
 )
@@ -71,8 +71,7 @@ async def prepare_script_worker_before_serving(app: FastAPI) -> None:
     worker_key = sandbox_exec.runner_dedicated_worker_key(runtime_paths)
     if worker_key is None:
         return
-    parts = worker_key.split(":")
-    if len(parts) < 6 or not script_worker_key_belongs_to_run(worker_key, parts[-2]):
+    if script_run_id_from_worker_key(worker_key) is None:
         return
 
     await asyncio.to_thread(

--- a/src/mindroom/api/sandbox_worker_prep.py
+++ b/src/mindroom/api/sandbox_worker_prep.py
@@ -184,6 +184,16 @@ def _prepare_worker(
     return get_local_worker_manager(runtime_paths).ensure_worker(WorkerSpec(worker_key))
 
 
+def prepare_worker(
+    worker_key: str,
+    runtime_paths: RuntimePaths,
+    *,
+    runner_token: str | None = None,
+) -> WorkerHandle:
+    """Prepare worker state outside a request dispatch."""
+    return _prepare_worker(worker_key, runtime_paths, runner_token=runner_token)
+
+
 def normalize_request_worker_key(
     worker_key: str | None,
     runtime_paths: RuntimePaths,

--- a/src/mindroom/script_runs/models.py
+++ b/src/mindroom/script_runs/models.py
@@ -132,3 +132,12 @@ def script_worker_key_belongs_to_run(worker_key: str, run_id: str) -> bool:
         return script_worker_key_for_run(base_worker_key, run_id) == worker_key
     except ValueError:
         return False
+
+
+def script_run_id_from_worker_key(worker_key: str) -> str | None:
+    """Return the run ID encoded by a valid run-pinned script worker key."""
+    parts = worker_key.split(":")
+    if len(parts) < 6:
+        return None
+    run_id = parts[-2]
+    return run_id if script_worker_key_belongs_to_run(worker_key, run_id) else None

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -27,6 +27,7 @@ import mindroom.api.sandbox_exec as sandbox_exec_module
 import mindroom.api.sandbox_protocol as sandbox_protocol_module
 import mindroom.api.sandbox_runner as sandbox_runner_module
 import mindroom.api.sandbox_runner_app as sandbox_runner_app_module
+import mindroom.api.sandbox_runner_scripts as sandbox_runner_scripts_module
 import mindroom.api.sandbox_worker_prep as sandbox_worker_prep_module
 import mindroom.constants as constants_module
 import mindroom.tool_system.metadata as metadata_module
@@ -48,6 +49,7 @@ from mindroom.credentials import (
 )
 from mindroom.oauth.providers import OAuthConnectionRequired
 from mindroom.runtime_env_policy import SHARED_CREDENTIALS_PATH_ENV
+from mindroom.script_runs.models import script_worker_key_for_run
 from mindroom.tool_system.bootstrap import ensure_tool_registry_loaded
 from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolMetadata, ToolStatus
 from mindroom.tool_system.metadata import (
@@ -210,6 +212,31 @@ def _initialize_runner_app_from_env() -> RuntimePaths:
         config=sandbox_runner_module._runtime_config_or_empty(runtime_paths),
     )
     return runtime_paths
+
+
+def _lifespan_app_for_dedicated_worker(
+    tmp_path: Path,
+    *,
+    worker_key: str,
+) -> FastAPI:
+    worker_root = tmp_path / "dedicated-worker"
+    runtime_paths = resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=worker_root,
+        process_env={
+            "MINDROOM_NAMESPACE": "alpha1234",
+            "MINDROOM_SANDBOX_DEDICATED_WORKER_KEY": worker_key,
+            "MINDROOM_SANDBOX_DEDICATED_WORKER_ROOT": str(worker_root),
+        },
+    )
+    app = FastAPI(lifespan=sandbox_runner_app_module._lifespan)
+    sandbox_runner_module.initialize_sandbox_runner_app(
+        app,
+        runtime_paths,
+        config=sandbox_runner_module._runtime_config_or_empty(runtime_paths),
+        runner_token=SANDBOX_TOKEN,
+    )
+    return app
 
 
 def _invalid_plugin_config_path(tmp_path: Path) -> Path:
@@ -497,6 +524,70 @@ def test_lifespan_reuses_initialized_runner_context_without_reloading_disk_confi
     assert response.status_code == 200
     assert sandbox_runner_module.app_runner_token(sandbox_runner_app) == preserved_runner_token
     assert sandbox_runner_module.app_runtime_config(sandbox_runner_app) == config
+
+
+def test_lifespan_prepares_script_worker_before_serving(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A cold script worker must finish setup before its readiness endpoint is served."""
+    run_id = f"script-{'a' * 32}"
+    worker_key = script_worker_key_for_run(
+        "v1:tenant:user_agent:alice:assistant",
+        run_id,
+    )
+    app = _lifespan_app_for_dedicated_worker(tmp_path, worker_key=worker_key)
+    startup_steps: list[str] = []
+
+    def prepare_worker_state(_paths: object) -> None:
+        startup_steps.append("worker-state")
+
+    def prepare_shell_supervisor() -> str:
+        assert startup_steps == ["worker-state"]
+        startup_steps.append("shell-supervisor")
+        return "unused-test-socket"
+
+    monkeypatch.setattr(
+        sandbox_worker_prep_module,
+        "ensure_local_worker_state_locked",
+        prepare_worker_state,
+    )
+    monkeypatch.setattr(
+        sandbox_runner_scripts_module,
+        "ensure_shell_supervisor",
+        prepare_shell_supervisor,
+    )
+
+    with TestClient(app):
+        assert startup_steps == ["worker-state", "shell-supervisor"]
+
+
+def test_lifespan_does_not_eagerly_prepare_regular_dedicated_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Ordinary tool workers should retain lazy initialization."""
+    app = _lifespan_app_for_dedicated_worker(
+        tmp_path,
+        worker_key="v1:tenant:user_agent:alice:assistant",
+    )
+
+    def unexpected_startup(*_args: object, **_kwargs: object) -> None:
+        pytest.fail("regular dedicated workers must stay lazily initialized")
+
+    monkeypatch.setattr(
+        sandbox_worker_prep_module,
+        "ensure_local_worker_state_locked",
+        unexpected_startup,
+    )
+    monkeypatch.setattr(
+        sandbox_runner_scripts_module,
+        "ensure_shell_supervisor",
+        unexpected_startup,
+    )
+
+    with TestClient(app):
+        pass
 
 
 def test_startup_runtime_rehydrates_runtime_env_from_process_env_and_dotenv(


### PR DESCRIPTION
## Summary

- initialize run-pinned script worker state during application startup
- start the shell supervisor before worker readiness is exposed
- keep ordinary dedicated workers lazily initialized

## Why

The first launch on a cold script worker could spend the request timeout building its runtime even though the launched process might already exist. Readiness now covers that setup.

## Tests

- `uv run pytest`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Prepare run-pinned script workers before serving readiness while preserving lazy initialization for ordinary dedicated workers.

Bug Fixes:
- Prepare run-pinned script workers and their shell supervisor during application startup so readiness is not advertised before cold-worker setup completes.

Enhancements:
- Keep regular dedicated workers lazily initialized while adding validation for run-pinned worker keys.

Tests:
- Add startup-order coverage for script workers and regression coverage confirming ordinary dedicated workers remain lazy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Script workers are now fully prepared before the sandbox accepts requests.
  * Shell supervision starts during worker startup, improving readiness and reliability for script execution.
  * Invalid or missing run-scoped credentials are detected before readiness is advertised.
  * Regular dedicated workers retain lazy initialization behavior.

* **Tests**
  * Added coverage for startup preparation and credential validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->