### PR TITLE
Speed up run-scoped script worker startup

### DIFF
--- a/src/mindroom/api/sandbox_runner_scripts.py
+++ b/src/mindroom/api/sandbox_runner_scripts.py
@@ -75,7 +75,7 @@ async def prepare_script_worker_before_serving(app: FastAPI) -> None:
         return
 
     await asyncio.to_thread(
-        sandbox_worker_prep.prepare_worker,
+        sandbox_worker_prep.prepare_script_worker,
         worker_key,
         runtime_paths,
         runner_token=app_runner_token(app),

--- a/src/mindroom/api/sandbox_worker_prep.py
+++ b/src/mindroom/api/sandbox_worker_prep.py
@@ -22,6 +22,7 @@ from mindroom.tool_system.worker_routing import (
 from mindroom.workers.backend import WorkerBackendError
 from mindroom.workers.backends.local import (
     LocalWorkerStatePaths,
+    ensure_local_script_worker_state_locked,
     ensure_local_worker_state_locked,
     get_local_worker_manager,
     local_worker_state_paths_for_root,
@@ -147,6 +148,7 @@ def _prepare_worker(
     runtime_paths: RuntimePaths,
     *,
     runner_token: str | None = None,
+    run_scoped_script: bool = False,
 ) -> WorkerHandle:
     """Ensure a worker is ready and return its handle."""
     dedicated_worker_key = sandbox_exec.runner_dedicated_worker_key(runtime_paths)
@@ -160,7 +162,10 @@ def _prepare_worker(
             raise WorkerBackendError(msg)
         paths = local_worker_state_paths_for_root(dedicated_root)
         try:
-            ensure_local_worker_state_locked(paths)
+            if run_scoped_script:
+                ensure_local_script_worker_state_locked(paths)
+            else:
+                ensure_local_worker_state_locked(paths)
         except Exception as exc:
             failure_reason = f"Failed to initialize dedicated worker '{worker_key}': {exc}"
             raise WorkerBackendError(failure_reason) from exc
@@ -184,14 +189,19 @@ def _prepare_worker(
     return get_local_worker_manager(runtime_paths).ensure_worker(WorkerSpec(worker_key))
 
 
-def prepare_worker(
+def prepare_script_worker(
     worker_key: str,
     runtime_paths: RuntimePaths,
     *,
     runner_token: str | None = None,
 ) -> WorkerHandle:
-    """Prepare worker state outside a request dispatch."""
-    return _prepare_worker(worker_key, runtime_paths, runner_token=runner_token)
+    """Prepare one run-scoped script worker with its lightweight runtime."""
+    return _prepare_worker(
+        worker_key,
+        runtime_paths,
+        runner_token=runner_token,
+        run_scoped_script=True,
+    )
 
 
 def normalize_request_worker_key(

--- a/src/mindroom/workers/backends/local.py
+++ b/src/mindroom/workers/backends/local.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+import os
+import shutil
+import subprocess
+import sys
 import threading
 import time
 import venv
@@ -131,11 +135,15 @@ def local_worker_state_paths_from_handle(handle: WorkerHandle) -> LocalWorkerSta
     return local_worker_state_paths_for_root(Path(state_root))
 
 
-def _ensure_local_worker_state(paths: LocalWorkerStatePaths) -> None:
-    """Create the persistent directories and venv for one worker runtime root."""
+def _ensure_local_worker_directories(paths: LocalWorkerStatePaths) -> None:
     paths.workspace.mkdir(parents=True, exist_ok=True)
     paths.cache_dir.mkdir(parents=True, exist_ok=True)
     paths.metadata_dir.mkdir(parents=True, exist_ok=True)
+
+
+def _ensure_local_worker_state(paths: LocalWorkerStatePaths) -> None:
+    """Create the persistent directories and venv for one worker runtime root."""
+    _ensure_local_worker_directories(paths)
     if (paths.venv_dir / "bin" / "python").exists():
         return
 
@@ -143,10 +151,46 @@ def _ensure_local_worker_state(paths: LocalWorkerStatePaths) -> None:
     builder.create(paths.venv_dir)
 
 
+def _ensure_local_script_worker_state(paths: LocalWorkerStatePaths) -> None:
+    """Create run-scoped worker state with a fast unseeded uv virtualenv."""
+    _ensure_local_worker_directories(paths)
+    if (paths.venv_dir / "bin" / "python").exists():
+        return
+
+    uv_path = shutil.which("uv")
+    if uv_path is None:
+        msg = "uv is required to prepare run-scoped script workers."
+        raise WorkerBackendError(msg)
+    env = dict(os.environ)
+    env.pop("UV_VENV_SEED", None)
+    subprocess.run(
+        [
+            uv_path,
+            "venv",
+            "--no-project",
+            "--no-config",
+            "--offline",
+            "--no-python-downloads",
+            "--system-site-packages",
+            "--python",
+            sys.executable,
+            str(paths.venv_dir),
+        ],
+        check=True,
+        env=env,
+    )
+
+
 def ensure_local_worker_state_locked(paths: LocalWorkerStatePaths) -> None:
     """Create one worker runtime root under a shared per-worker initialization lock."""
     with _shared_worker_initialization_lock(paths):
         _ensure_local_worker_state(paths)
+
+
+def ensure_local_script_worker_state_locked(paths: LocalWorkerStatePaths) -> None:
+    """Create run-scoped worker state under the shared initialization lock."""
+    with _shared_worker_initialization_lock(paths):
+        _ensure_local_script_worker_state(paths)
 
 
 def _shared_worker_initialization_lock(paths: LocalWorkerStatePaths) -> threading.Lock:

--- a/tests/api/test_sandbox_runner_api.py
+++ b/tests/api/test_sandbox_runner_api.py
@@ -549,7 +549,7 @@ def test_lifespan_prepares_script_worker_before_serving(
 
     monkeypatch.setattr(
         sandbox_worker_prep_module,
-        "ensure_local_worker_state_locked",
+        "ensure_local_script_worker_state_locked",
         prepare_worker_state,
     )
     monkeypatch.setattr(
@@ -560,6 +560,55 @@ def test_lifespan_prepares_script_worker_before_serving(
 
     with TestClient(app):
         assert startup_steps == ["worker-state", "shell-supervisor"]
+
+
+@requires_linux(reason=LINUX_LOCAL_WORKER_REASON, timeout=LINUX_LOCAL_WORKER_TIMEOUT_SECONDS)
+def test_lifespan_prepares_script_worker_without_seeding_pip(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Run-scoped workers should avoid the expensive pip bootstrap before readiness."""
+    run_id = f"script-{'b' * 32}"
+    worker_key = script_worker_key_for_run(
+        "v1:tenant:user_agent:alice:assistant",
+        run_id,
+    )
+    app = _lifespan_app_for_dedicated_worker(tmp_path, worker_key=worker_key)
+    monkeypatch.setenv("UV_VENV_SEED", "1")
+    monkeypatch.setattr(
+        sandbox_runner_scripts_module,
+        "ensure_shell_supervisor",
+        lambda: "unused-test-socket",
+    )
+
+    with TestClient(app):
+        pass
+
+    venv_dir = tmp_path / "dedicated-worker" / "venv"
+    assert (venv_dir / "bin" / "python").exists()
+    assert not (venv_dir / "bin" / "pip").exists()
+    assert not (venv_dir / "bin" / "pip3").exists()
+    assert (
+        "include-system-site-packages = true"
+        in (venv_dir / "pyvenv.cfg")
+        .read_text(
+            encoding="utf-8",
+        )
+        .lower()
+    )
+    worker_paths = local_workers_module.local_worker_state_paths_for_root(tmp_path / "dedicated-worker")
+    python_executable, environment, cwd = sandbox_exec_module.resolve_subprocess_worker_context(worker_paths)
+    assert python_executable is not None
+    assert environment is not None
+    completed = subprocess.run(
+        [python_executable, "-c", "from mindroom.script_sdk import MindRoomTools; print(MindRoomTools.__name__)"],
+        check=True,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=environment,
+    )
+    assert completed.stdout.strip() == "MindRoomTools"
 
 
 def test_lifespan_does_not_eagerly_prepare_regular_dedicated_worker(


### PR DESCRIPTION
## Summary

- Create run-scoped script worker virtual environments with unseeded `uv venv`.
- Keep pip-seeded persistent environments for ordinary workers.
- Keep runtime preparation before readiness.

## Why

Each background script gets a fresh run-scoped worker, so bootstrapping pip on every start adds avoidable latency and filesystem writes. An unseeded environment preserves isolation and uses the packaged runtime through existing system-site and Python path wiring.

## Tests

- `uv run pytest`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Speed up run-scoped script worker startup by creating isolated unseeded environments while preserving runtime availability and persistent-worker behavior.

Enhancements:
- Use lightweight, unseeded virtual environments for run-scoped script workers while retaining pip-seeded environments for persistent workers.
- Prepare run-scoped script worker runtimes before readiness without bootstrapping pip.

Tests:
- Add coverage verifying run-scoped script workers omit pip while retaining access to the packaged MindRoom runtime.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for preparing run-scoped script workers.
  * Script workers now initialize in an offline virtual environment and can use installed system packages.
  * Added clear setup errors when the required environment tooling is unavailable.

* **Bug Fixes**
  * Improved script-worker initialization before services become ready.

* **Tests**
  * Added coverage verifying script workers can run tools successfully during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->