### PR TITLE
Expose profile avatar and room state reads to hooks

### DIFF
--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -573,9 +573,11 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Provides a narrow Matrix admin facade when MindRoom has a router-backed admin client available for the current hook context.
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
-The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
+`get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or the profile read fails.
+`get_room_state_event` returns `(True, content)` for a successful read, `(True, None)` when the homeserver confirms the event is missing, and `(False, None)` when the read fails.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 
 ### Transport objects

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -576,8 +576,9 @@ It is `None` when no admin-capable client is bound.
 The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
-`get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or the profile read fails.
-`get_room_state_event` returns `(True, content)` for a successful read, `(True, None)` when the homeserver confirms the event is missing, and `(False, None)` when the read fails.
+`get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or Matrix returns an error response.
+`get_room_state_event` returns `(True, content)` for a successful response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix error responses.
+Transport exceptions from both read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 
 ### Transport objects

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -577,7 +577,7 @@ The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_l
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
 `get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or Matrix returns an error response.
-`get_room_state_event` returns `(True, content)` for a successful response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix error responses.
+`get_room_state_event` returns `(True, content)` for a successful object response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix errors or malformed non-object content.
 Transport exceptions from both read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13268,7 +13268,7 @@ The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_l
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
 `get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or Matrix returns an error response.
-`get_room_state_event` returns `(True, content)` for a successful response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix error responses.
+`get_room_state_event` returns `(True, content)` for a successful object response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix errors or malformed non-object content.
 Transport exceptions from both read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13267,8 +13267,9 @@ It is `None` when no admin-capable client is bound.
 The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
-`get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or the profile read fails.
-`get_room_state_event` returns `(True, content)` for a successful read, `(True, None)` when the homeserver confirms the event is missing, and `(False, None)` when the read fails.
+`get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or Matrix returns an error response.
+`get_room_state_event` returns `(True, content)` for a successful response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix error responses.
+Transport exceptions from both read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 
 ### Transport objects

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13264,9 +13264,11 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Provides a narrow Matrix admin facade when MindRoom has a router-backed admin client available for the current hook context.
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
-The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
+`get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or the profile read fails.
+`get_room_state_event` returns `(True, content)` for a successful read, `(True, None)` when the homeserver confirms the event is missing, and `(False, None)` when the read fails.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 
 ### Transport objects

--- a/skills/mindroom-docs/references/page__hooks__index.md
+++ b/skills/mindroom-docs/references/page__hooks__index.md
@@ -573,7 +573,7 @@ The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_l
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
 `get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or Matrix returns an error response.
-`get_room_state_event` returns `(True, content)` for a successful response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix error responses.
+`get_room_state_event` returns `(True, content)` for a successful object response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix errors or malformed non-object content.
 Transport exceptions from both read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 

--- a/skills/mindroom-docs/references/page__hooks__index.md
+++ b/skills/mindroom-docs/references/page__hooks__index.md
@@ -572,8 +572,9 @@ It is `None` when no admin-capable client is bound.
 The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
-`get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or the profile read fails.
-`get_room_state_event` returns `(True, content)` for a successful read, `(True, None)` when the homeserver confirms the event is missing, and `(False, None)` when the read fails.
+`get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or Matrix returns an error response.
+`get_room_state_event` returns `(True, content)` for a successful response, `(True, None)` when Matrix confirms the event is missing, and `(False, None)` for other Matrix error responses.
+Transport exceptions from both read methods propagate to the caller.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 
 ### Transport objects

--- a/skills/mindroom-docs/references/page__hooks__index.md
+++ b/skills/mindroom-docs/references/page__hooks__index.md
@@ -569,9 +569,11 @@ Transport exceptions from the underlying Matrix client propagate to the hook.
 Provides a narrow Matrix admin facade when MindRoom has a router-backed admin client available for the current hook context.
 This facade is part of the supported hook contract and is intentionally not the raw Matrix client.
 It is `None` when no admin-capable client is bound.
-The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
+The available methods are `resolve_alias(alias)`, `create_room(name=..., alias_localpart=..., topic=..., power_user_ids=...)`, `invite_user(room_id, user_id)`, `force_join_user(room_id, user_id)`, `kick_user(room_id, user_id, reason=None)`, `get_room_members(room_id)`, `get_profile_avatar(user_id)`, `get_room_state_event(room_id, event_type, state_key)`, `add_room_to_space(space_room_id, room_id)`, and `put_room_state(room_id, event_type, state_key, content)`.
 Membership mutation methods return a boolean success result and surface transport exceptions consistently with the other admin operations.
 `get_room_members` returns `None` when the membership fetch fails, so callers can distinguish an unreadable room from a genuinely empty one.
+`get_profile_avatar` returns the user's Matrix avatar content URI, or `None` when no avatar is available or the profile read fails.
+`get_room_state_event` returns `(True, content)` for a successful read, `(True, None)` when the homeserver confirms the event is missing, and `(False, None)` when the read fails.
 Rooms created via `create_room` are retained for the creating bot across room cleanup and restarts, the same way rooms it is invited to are kept.
 
 ### Transport objects

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -96,6 +96,13 @@ class _BoundHookMatrixAdmin:
         """Return the current joined members for one room, or ``None`` when the fetch fails."""
         return await get_room_members(self.client, room_id)
 
+    async def get_profile_avatar(self, user_id: str) -> str | None:
+        """Return one user's Matrix avatar content URI, or ``None`` when unavailable."""
+        response = await self.client.get_profile(user_id)
+        if isinstance(response, nio.ProfileGetResponse):
+            return response.avatar_url
+        return None
+
     async def add_room_to_space(self, space_room_id: str, room_id: str) -> bool:
         """Link one room under an existing Matrix Space."""
         server_name = extract_server_name_from_homeserver(

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -103,6 +103,20 @@ class _BoundHookMatrixAdmin:
             return response.avatar_url
         return None
 
+    async def get_room_state_event(
+        self,
+        room_id: str,
+        event_type: str,
+        state_key: str,
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Return one state event while distinguishing missing from unreadable."""
+        response = await self.client.room_get_state_event(room_id, event_type, state_key)
+        if isinstance(response, nio.RoomGetStateEventResponse):
+            return True, response.content
+        if isinstance(response, nio.RoomGetStateEventError) and response.status_code == "M_NOT_FOUND":
+            return True, None
+        return False, None
+
     async def add_room_to_space(self, space_room_id: str, room_id: str) -> bool:
         """Link one room under an existing Matrix Space."""
         server_name = extract_server_name_from_homeserver(

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -100,7 +100,7 @@ class _BoundHookMatrixAdmin:
         """Return one user's Matrix avatar content URI, or ``None`` when unavailable."""
         response = await self.client.get_profile(user_id)
         if isinstance(response, nio.ProfileGetResponse):
-            return response.avatar_url
+            return response.avatar_url or None
         return None
 
     async def get_room_state_event(

--- a/src/mindroom/hooks/matrix_admin.py
+++ b/src/mindroom/hooks/matrix_admin.py
@@ -111,7 +111,7 @@ class _BoundHookMatrixAdmin:
     ) -> tuple[bool, dict[str, Any] | None]:
         """Return one state event while distinguishing missing from unreadable."""
         response = await self.client.room_get_state_event(room_id, event_type, state_key)
-        if isinstance(response, nio.RoomGetStateEventResponse):
+        if isinstance(response, nio.RoomGetStateEventResponse) and isinstance(response.content, dict):
             return True, response.content
         if isinstance(response, nio.RoomGetStateEventError) and response.status_code == "M_NOT_FOUND":
             return True, None

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -142,6 +142,9 @@ class HookMatrixAdmin(Protocol):
     async def get_room_members(self, room_id: str) -> set[str] | None:
         """Return joined members for one room, or ``None`` when the fetch fails."""
 
+    async def get_profile_avatar(self, user_id: str) -> str | None:
+        """Return one user's Matrix avatar content URI, or ``None`` when unavailable."""
+
     async def add_room_to_space(self, space_room_id: str, room_id: str) -> bool:
         """Link one room into one Space."""
 

--- a/src/mindroom/hooks/types.py
+++ b/src/mindroom/hooks/types.py
@@ -145,6 +145,19 @@ class HookMatrixAdmin(Protocol):
     async def get_profile_avatar(self, user_id: str) -> str | None:
         """Return one user's Matrix avatar content URI, or ``None`` when unavailable."""
 
+    async def get_room_state_event(
+        self,
+        room_id: str,
+        event_type: str,
+        state_key: str,
+    ) -> tuple[bool, dict[str, Any] | None]:
+        """Return ``(readable, content)`` for one state event.
+
+        ``(True, None)`` means the homeserver confirmed that the event is
+        missing. ``(False, None)`` means the read failed and callers must not
+        infer that the event is absent.
+        """
+
     async def add_room_to_space(self, space_room_id: str, room_id: str) -> bool:
         """Link one room into one Space."""
 

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -272,6 +272,24 @@ async def test_hook_matrix_admin_get_room_state_event_fails_closed(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_hook_matrix_admin_get_room_state_event_rejects_malformed_content(tmp_path: Path) -> None:
+    """Successful responses with non-object content should fail closed."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.homeserver = "http://localhost:8008"
+    client.room_get_state_event.return_value = nio.RoomGetStateEventResponse(
+        content=["not", "an", "object"],
+        event_type="m.room.avatar",
+        state_key="",
+        room_id="!personal:localhost",
+    )
+
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.get_room_state_event("!personal:localhost", "m.room.avatar", "") == (False, None)
+
+
+@pytest.mark.asyncio
 async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path: Path) -> None:
     """The hook builder should reuse the existing Matrix helper functions."""
     module = _matrix_admin_module()

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -160,6 +160,49 @@ async def test_build_hook_matrix_admin_resolve_alias_returns_none_on_error(tmp_p
 
 
 @pytest.mark.asyncio
+async def test_hook_matrix_admin_get_profile_avatar_returns_content_uri(tmp_path: Path) -> None:
+    """Profile avatar reads should expose the Matrix content URI."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.homeserver = "http://localhost:8008"
+    client.get_profile.return_value = nio.ProfileGetResponse(
+        displayname="Ada",
+        avatar_url="mxc://localhost/ada",
+    )
+
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.get_profile_avatar("@ada:localhost") == "mxc://localhost/ada"
+    client.get_profile.assert_awaited_once_with("@ada:localhost")
+
+
+@pytest.mark.asyncio
+async def test_hook_matrix_admin_get_profile_avatar_returns_none_without_avatar(tmp_path: Path) -> None:
+    """Profiles without avatars should remain unset."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.homeserver = "http://localhost:8008"
+    client.get_profile.return_value = nio.ProfileGetResponse(displayname="Ada")
+
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.get_profile_avatar("@ada:localhost") is None
+
+
+@pytest.mark.asyncio
+async def test_hook_matrix_admin_get_profile_avatar_returns_none_on_error(tmp_path: Path) -> None:
+    """Profile lookup errors should fail closed."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.homeserver = "http://localhost:8008"
+    client.get_profile.return_value = nio.ProfileGetError("not found", status_code="M_NOT_FOUND")
+
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.get_profile_avatar("@missing:localhost") is None
+
+
+@pytest.mark.asyncio
 async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path: Path) -> None:
     """The hook builder should reuse the existing Matrix helper functions."""
     module = _matrix_admin_module()

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -203,6 +203,62 @@ async def test_hook_matrix_admin_get_profile_avatar_returns_none_on_error(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_hook_matrix_admin_get_room_state_event_returns_content(tmp_path: Path) -> None:
+    """Single-event reads should expose successful content."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.homeserver = "http://localhost:8008"
+    client.room_get_state_event.return_value = nio.RoomGetStateEventResponse(
+        content={"url": "mxc://localhost/ada"},
+        event_type="m.room.avatar",
+        state_key="",
+        room_id="!personal:localhost",
+    )
+
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.get_room_state_event("!personal:localhost", "m.room.avatar", "") == (
+        True,
+        {"url": "mxc://localhost/ada"},
+    )
+    client.room_get_state_event.assert_awaited_once_with("!personal:localhost", "m.room.avatar", "")
+
+
+@pytest.mark.asyncio
+async def test_hook_matrix_admin_get_room_state_event_distinguishes_missing(tmp_path: Path) -> None:
+    """A missing state event should be distinguishable from a failed read."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.homeserver = "http://localhost:8008"
+    client.room_get_state_event.return_value = nio.RoomGetStateEventError(
+        "missing",
+        status_code="M_NOT_FOUND",
+        room_id="!personal:localhost",
+    )
+
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.get_room_state_event("!personal:localhost", "m.room.avatar", "") == (True, None)
+
+
+@pytest.mark.asyncio
+async def test_hook_matrix_admin_get_room_state_event_fails_closed(tmp_path: Path) -> None:
+    """A failed state read should not look like a confirmed missing event."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.homeserver = "http://localhost:8008"
+    client.room_get_state_event.return_value = nio.RoomGetStateEventError(
+        "forbidden",
+        status_code="M_FORBIDDEN",
+        room_id="!personal:localhost",
+    )
+
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.get_room_state_event("!personal:localhost", "m.room.avatar", "") == (False, None)
+
+
+@pytest.mark.asyncio
 async def test_build_hook_matrix_admin_delegates_existing_room_helpers(tmp_path: Path) -> None:
     """The hook builder should reuse the existing Matrix helper functions."""
     module = _matrix_admin_module()

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -190,6 +190,19 @@ async def test_hook_matrix_admin_get_profile_avatar_returns_none_without_avatar(
 
 
 @pytest.mark.asyncio
+async def test_hook_matrix_admin_get_profile_avatar_normalizes_empty_avatar(tmp_path: Path) -> None:
+    """An empty avatar URL should remain unavailable to hook callers."""
+    module = _matrix_admin_module()
+    client = AsyncMock(spec=nio.AsyncClient)
+    client.homeserver = "http://localhost:8008"
+    client.get_profile.return_value = nio.ProfileGetResponse(displayname="Ada", avatar_url="")
+
+    admin = module.build_hook_matrix_admin(client, runtime_paths=test_runtime_paths(tmp_path))
+
+    assert await admin.get_profile_avatar("@ada:localhost") is None
+
+
+@pytest.mark.asyncio
 async def test_hook_matrix_admin_get_profile_avatar_returns_none_on_error(tmp_path: Path) -> None:
     """Profile lookup errors should fail closed."""
     module = _matrix_admin_module()

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -80,6 +80,8 @@ collection_formats  # unused variable (src/mindroom/workers/backends/kubernetes_
 _.invite_user  # unused method (src/mindroom/hooks/types.py)
 _.force_join_user  # hook plugins call this public Matrix admin method (src/mindroom/hooks/types.py)
 _.kick_user  # hook plugins call this public Matrix admin method (src/mindroom/hooks/types.py)
+_.get_profile_avatar  # hook plugins call this public Matrix admin method (src/mindroom/hooks/types.py)
+_.get_room_state_event  # hook plugins call this public Matrix admin method (src/mindroom/hooks/types.py)
 _.make_request  # unused method (src/mindroom/tools/custom_api.py)
 _._async_crawl  # unused method (src/mindroom/tools/crawl4ai.py)
 _.redirect_request  # unused method (src/mindroom/tools/approved_egress.py)


### PR DESCRIPTION
## Summary

- expose Matrix profile avatar reads through the hook admin API
- expose single state-event reads while distinguishing missing events from failed reads
- add focused coverage and whitelist the plugin-facing dynamic API methods

## Test plan

- `uv run pytest -q tests/test_hook_matrix_admin.py tests/test_hook_room_state.py -n 0 --no-cov`
- `uv run pre-commit run --files src/mindroom/hooks/types.py src/mindroom/hooks/matrix_admin.py tests/test_hook_matrix_admin.py vulture_whitelist.py`

## Summary by Sourcery

Expose profile avatar and room state-event reads through the hook Matrix admin API.

New Features:
- Expose profile avatar lookups through the hook Matrix admin API.
- Expose single room state-event reads with distinct results for successful reads, confirmed missing events, and failed reads.

Enhancements:
- Whitelist the new plugin-facing Matrix admin methods for API usage detection.

Documentation:
- Document the new Matrix admin read methods and their result semantics in hook documentation.

Tests:
- Add focused coverage for avatar lookups and room state-event read outcomes, including missing, failed, and malformed responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Matrix administration capabilities to retrieve a user’s avatar.
  - Added support for reading room state events.
  - Clearly distinguishes successfully finding an event, an event not existing, and read failures.

- **Tests**
  - Added coverage for successful retrievals, missing avatars, Matrix errors, absent state events, and failed reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->