### PR TITLE
Use GitHub App credentials for Git knowledge sources

### DIFF
--- a/docs/dev/github-app-git-credentials-design.md
+++ b/docs/dev/github-app-git-credentials-design.md
@@ -34,6 +34,8 @@ The clean remote URL remains the only persisted URL.
 The control-plane runtime caches each repository-scoped token until five minutes before GitHub's reported expiry.
 Before starting a scheduled refresh child, the control plane resolves that cached token and sends the token plus its expiry only through the existing stdin request pipe.
 The child primes its process-local provider before Git synchronization, so refresh subprocess isolation does not cause another token mint.
+The handoff also identifies the App, installation, repository, and key path that authorized the token, and the child primes its provider only while its current credentials still match that identity.
+If credentials rotate between the parent mint and child startup, the child ignores the handed-off token and mints one for the current credentials.
 The parent-child handoff remains only in process memory and never uses a credential file, Git configuration, checkout metadata, refresh-child launch environment variable, or log.
 When token refresh is required, MindRoom reads the private-key file again, so key rotation takes effect without rewriting runtime credential metadata.
 Concurrent resolutions for one repository share one refresh operation.

--- a/docs/dev/github-app-git-credentials-design.md
+++ b/docs/dev/github-app-git-credentials-design.md
@@ -17,21 +17,33 @@ A named shared credential service may select GitHub App authentication with thes
 }
 ```
 
-`app_id` and `installation_id` are non-secret deployment metadata. `private_key_file` points to a read-only secret mount. MindRoom never copies the private key or an installation access token into a credential file, Git configuration, checkout metadata, or logs. Existing username/password/token credential services keep their current behavior.
+`app_id` and `installation_id` are non-secret deployment metadata.
+`private_key_file` points to a read-only secret mount.
+MindRoom never copies the private key or an installation access token into a credential file, Git configuration, checkout metadata, or logs.
+Existing username/password/token credential services keep their current behavior.
 
 ## Token flow
 
-Before an HTTPS clone, fetch, or Git LFS pull, MindRoom resolves the configured credential service. For `auth_type: github_app`, it validates that the remote is an ordinary `https://github.com/<owner>/<repository>` URL, reads the private key, creates a short-lived app JWT, and requests an installation access token from GitHub.
+Before an HTTPS clone, fetch, or Git LFS pull, MindRoom resolves the configured credential service.
+For `auth_type: github_app`, it validates that the remote is an ordinary `https://github.com/<owner>/<repository>` URL, reads the private key, creates a short-lived app JWT, and requests an installation access token from GitHub.
 
-The token request names exactly the repository from the remote and requests only `contents: read`. The returned token is supplied to Git as process-local HTTP Basic authentication with username `x-access-token`. The clean remote URL remains the only persisted URL.
+The token request names exactly the repository from the remote and requests only `contents: read`.
+The returned token is supplied to Git as process-local HTTP Basic authentication with username `x-access-token`.
+The clean remote URL remains the only persisted URL.
 
-Each knowledge source caches its repository-scoped token until five minutes before GitHub's reported expiry. A refresh reads the private-key file again, so key rotation takes effect without rewriting runtime credential metadata. Concurrent resolutions for one source share one refresh operation.
+Each knowledge source caches its repository-scoped token until five minutes before GitHub's reported expiry.
+A refresh reads the private-key file again, so key rotation takes effect without rewriting runtime credential metadata.
+Concurrent resolutions for one source share one refresh operation.
 
 ## Failure behavior
 
-Malformed GitHub App credentials fail closed with a field-specific configuration error. GitHub App credentials reject non-GitHub hosts and remotes that do not identify exactly one owner and repository. Missing or unreadable key files fail without including key contents. GitHub token endpoint failures report HTTP status and installation ID, never response bodies or tokens.
+Malformed GitHub App credentials fail closed with a field-specific configuration error.
+GitHub App credentials reject non-GitHub hosts and remotes that do not identify exactly one owner and repository.
+Missing or unreadable key files fail without including key contents.
+GitHub token endpoint failures report HTTP status and installation ID, never response bodies or tokens.
 
-If a cached token is still valid, a transient GitHub API failure does not occur because no refresh is attempted. Once refresh is required, authentication fails rather than falling back to anonymous Git or stale static credentials.
+If a cached token is still valid, a transient GitHub API failure does not occur because no refresh is attempted.
+Once refresh is required, authentication fails rather than falling back to anonymous Git or stale static credentials.
 
 ## Structure
 
@@ -41,6 +53,7 @@ If a cached token is still valid, a transient GitHub API failure does not occur 
 
 ## Tests
 
-Unit tests cover credential validation, GitHub URL validation, JWT/token request shape, least-privilege repository and permission scoping, cache reuse, expiry refresh, key rereading, concurrency, and redacted errors. Git source tests prove clone/fetch/LFS request fresh credentials through the resolver while static credentials and secret non-persistence remain unchanged.
+Unit tests cover credential validation, GitHub URL validation, JWT/token request shape, least-privilege repository and permission scoping, cache reuse, expiry refresh, key rereading, concurrency, and redacted errors.
+Git source tests prove clone/fetch/LFS request fresh credentials through the resolver while static credentials and secret non-persistence remain unchanged.
 
 Deployment tests must prove credential seeds contain metadata only, the private key is mounted read-only only in the control plane, and rendered resources never place private-key material in environment variables or ConfigMaps.

--- a/docs/dev/github-app-git-credentials-design.md
+++ b/docs/dev/github-app-git-credentials-design.md
@@ -31,9 +31,12 @@ The token request names exactly the repository from the remote and requests only
 The returned token is supplied to Git as process-local HTTP Basic authentication with username `x-access-token`.
 The clean remote URL remains the only persisted URL.
 
-Each knowledge source caches its repository-scoped token until five minutes before GitHub's reported expiry.
-A refresh reads the private-key file again, so key rotation takes effect without rewriting runtime credential metadata.
-Concurrent resolutions for one source share one refresh operation.
+The control-plane runtime caches each repository-scoped token until five minutes before GitHub's reported expiry.
+Before starting a scheduled refresh child, the control plane resolves that cached token and sends the token plus its expiry only through the existing stdin request pipe.
+The child primes its process-local provider before Git synchronization, so refresh subprocess isolation does not cause another token mint.
+The parent-child handoff remains only in process memory and never uses a credential file, Git configuration, checkout metadata, refresh-child launch environment variable, or log.
+When token refresh is required, MindRoom reads the private-key file again, so key rotation takes effect without rewriting runtime credential metadata.
+Concurrent resolutions for one repository share one refresh operation.
 
 ## Failure behavior
 
@@ -47,13 +50,14 @@ Once refresh is required, authentication fails rather than falling back to anony
 
 ## Structure
 
-- `mindroom.knowledge.github_app_auth` owns credential parsing, repository extraction, JWT creation, token minting, expiry handling, and caching.
+- `mindroom.knowledge.github_app_auth` owns credential parsing, repository extraction, JWT creation, token minting, expiry handling, process-lifetime caching, and child-cache priming.
 - `mindroom.knowledge.git_source` selects static credentials or the GitHub App provider and injects the resulting secret into each Git subprocess.
+- `mindroom.knowledge.refresh_runner` resolves cached tokens in the control plane and hands them to scheduled refresh children through the existing stdin request pipe.
 - `KnowledgeGitConfig.credentials_service` remains the public configuration surface; no repository configuration schema change is required.
 
 ## Tests
 
-Unit tests cover credential validation, GitHub URL validation, JWT/token request shape, least-privilege repository and permission scoping, cache reuse, expiry refresh, key rereading, concurrency, and redacted errors.
+Unit tests cover credential validation, GitHub URL validation, JWT/token request shape, least-privilege repository and permission scoping, cache reuse, expiry refresh, key rereading, concurrency, subprocess handoff, and redacted errors.
 Git source tests prove clone/fetch/LFS request fresh credentials through the resolver while static credentials and secret non-persistence remain unchanged.
 
 Deployment tests must prove credential seeds contain metadata only, the private key is mounted read-only only in the control plane, and rendered resources never place private-key material in environment variables or ConfigMaps.

--- a/docs/dev/github-app-git-credentials-design.md
+++ b/docs/dev/github-app-git-credentials-design.md
@@ -1,0 +1,46 @@
+# GitHub App Credentials for Git Knowledge Sources
+
+## Goal
+
+Allow a Git-backed knowledge source to authenticate as a GitHub App installation without storing a personal access token or a short-lived installation token in MindRoom's credential store.
+
+## Credential contract
+
+A named shared credential service may select GitHub App authentication with these fields:
+
+```json
+{
+  "auth_type": "github_app",
+  "app_id": 12345,
+  "installation_id": 67890,
+  "private_key_file": "/var/run/secrets/github-app/private-key.pem"
+}
+```
+
+`app_id` and `installation_id` are non-secret deployment metadata. `private_key_file` points to a read-only secret mount. MindRoom never copies the private key or an installation access token into a credential file, Git configuration, checkout metadata, or logs. Existing username/password/token credential services keep their current behavior.
+
+## Token flow
+
+Before an HTTPS clone, fetch, or Git LFS pull, MindRoom resolves the configured credential service. For `auth_type: github_app`, it validates that the remote is an ordinary `https://github.com/<owner>/<repository>` URL, reads the private key, creates a short-lived app JWT, and requests an installation access token from GitHub.
+
+The token request names exactly the repository from the remote and requests only `contents: read`. The returned token is supplied to Git as process-local HTTP Basic authentication with username `x-access-token`. The clean remote URL remains the only persisted URL.
+
+Each knowledge source caches its repository-scoped token until five minutes before GitHub's reported expiry. A refresh reads the private-key file again, so key rotation takes effect without rewriting runtime credential metadata. Concurrent resolutions for one source share one refresh operation.
+
+## Failure behavior
+
+Malformed GitHub App credentials fail closed with a field-specific configuration error. GitHub App credentials reject non-GitHub hosts and remotes that do not identify exactly one owner and repository. Missing or unreadable key files fail without including key contents. GitHub token endpoint failures report HTTP status and installation ID, never response bodies or tokens.
+
+If a cached token is still valid, a transient GitHub API failure does not occur because no refresh is attempted. Once refresh is required, authentication fails rather than falling back to anonymous Git or stale static credentials.
+
+## Structure
+
+- `mindroom.knowledge.github_app_auth` owns credential parsing, repository extraction, JWT creation, token minting, expiry handling, and caching.
+- `mindroom.knowledge.git_source` selects static credentials or the GitHub App provider and injects the resulting secret into each Git subprocess.
+- `KnowledgeGitConfig.credentials_service` remains the public configuration surface; no repository configuration schema change is required.
+
+## Tests
+
+Unit tests cover credential validation, GitHub URL validation, JWT/token request shape, least-privilege repository and permission scoping, cache reuse, expiry refresh, key rereading, concurrency, and redacted errors. Git source tests prove clone/fetch/LFS request fresh credentials through the resolver while static credentials and secret non-persistence remain unchanged.
+
+Deployment tests must prove credential seeds contain metadata only, the private key is mounted read-only only in the control plane, and rendered resources never place private-key material in environment variables or ConfigMaps.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -422,7 +422,9 @@ Store this object under the service named by `credentials_service`.
 `private_key_file` must be an absolute path to a read-only secret mount; do not put the PEM contents in the credential object.
 The remote must use the canonical `https://github.com/<owner>/<repository>` form.
 MindRoom reads the key when needed and mints a repository-scoped installation token with read-only Contents permission.
-It caches that token until shortly before GitHub's reported expiry and passes it only to the Git subprocess, never to the checkout config or credential store.
+The control-plane runtime caches that token until shortly before GitHub's reported expiry.
+Scheduled refresh children receive the cached token and expiry only through their stdin request pipe, then pass the token only to Git.
+MindRoom never copies the token into the checkout config, credential store, refresh-child launch environment, metadata, or logs.
 
 ## Embedder Configuration
 

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -424,6 +424,7 @@ The remote must use the canonical `https://github.com/<owner>/<repository>` form
 MindRoom reads the key when needed and mints a repository-scoped installation token with read-only Contents permission.
 The control-plane runtime caches that token until shortly before GitHub's reported expiry.
 Scheduled refresh children receive the cached token and expiry only through their stdin request pipe, then pass the token only to Git.
+The handoff includes the non-secret App, installation, repository, and key-path identity, and a child ignores the token if its current credentials no longer match.
 MindRoom never copies the token into the checkout config, credential store, refresh-child launch environment, metadata, or logs.
 
 ## Embedder Configuration

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -406,6 +406,23 @@ Accepted credential fields:
 | `username` + `password` | Basic HTTP auth |
 | `api_key` | Uses `x-access-token` as username automatically |
 
+For unattended GitHub repositories, a GitHub App installation can replace a personal access token:
+
+```json
+{
+  "auth_type": "github_app",
+  "app_id": 12345,
+  "installation_id": 67890,
+  "private_key_file": "/var/run/secrets/github-app/private-key.pem"
+}
+```
+
+Store this object under the service named by `credentials_service`.
+`private_key_file` must be an absolute path to a read-only secret mount; do not put the PEM contents in the credential object.
+The remote must use the canonical `https://github.com/<owner>/<repository>` form.
+MindRoom reads the key when needed and mints a repository-scoped installation token with read-only Contents permission.
+It caches that token until shortly before GitHub's reported expiry and passes it only to the Git subprocess, never to the checkout config or credential store.
+
 ## Embedder Configuration
 
 Semantic knowledge bases use the same embedder configured in the `memory` section.

--- a/docs/knowledge.md
+++ b/docs/knowledge.md
@@ -322,7 +322,8 @@ If a checkout already holds a credential-bearing remote from before this check e
 - Missing, stale, or failed knowledge schedules a per-binding refresh and the current request continues with availability metadata.
 - Explicit dashboard/API reindex or sync runs Git sync first for Git-backed bases.
 - Semantic Git refresh then advances a candidate index, while files-only Git refresh publishes source metadata.
-- When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
+- MindRoom disables implicit LFS smudge during clone, checkout, and reset for every Git-backed knowledge base.
+- When `lfs: true`, MindRoom explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
 - Change detection for Git-backed bases is the tracked revision, not file contents: while the checkout stays on the revision the index was published from, MindRoom republishes the existing index without reading the corpus.
 - Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14033,6 +14033,7 @@ The remote must use the canonical `https://github.com/<owner>/<repository>` form
 MindRoom reads the key when needed and mints a repository-scoped installation token with read-only Contents permission.
 The control-plane runtime caches that token until shortly before GitHub's reported expiry.
 Scheduled refresh children receive the cached token and expiry only through their stdin request pipe, then pass the token only to Git.
+The handoff includes the non-secret App, installation, repository, and key-path identity, and a child ignores the token if its current credentials no longer match.
 MindRoom never copies the token into the checkout config, credential store, refresh-child launch environment, metadata, or logs.
 
 ## Embedder Configuration

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13931,7 +13931,8 @@ If a checkout already holds a credential-bearing remote from before this check e
 - Missing, stale, or failed knowledge schedules a per-binding refresh and the current request continues with availability metadata.
 - Explicit dashboard/API reindex or sync runs Git sync first for Git-backed bases.
 - Semantic Git refresh then advances a candidate index, while files-only Git refresh publishes source metadata.
-- When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
+- MindRoom disables implicit LFS smudge during clone, checkout, and reset for every Git-backed knowledge base.
+- When `lfs: true`, MindRoom explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
 - Change detection for Git-backed bases is the tracked revision, not file contents: while the checkout stays on the revision the index was published from, MindRoom republishes the existing index without reading the corpus.
 - Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14015,6 +14015,23 @@ Accepted credential fields:
 | `username` + `password` | Basic HTTP auth |
 | `api_key` | Uses `x-access-token` as username automatically |
 
+For unattended GitHub repositories, a GitHub App installation can replace a personal access token:
+
+```json
+{
+  "auth_type": "github_app",
+  "app_id": 12345,
+  "installation_id": 67890,
+  "private_key_file": "/var/run/secrets/github-app/private-key.pem"
+}
+```
+
+Store this object under the service named by `credentials_service`.
+`private_key_file` must be an absolute path to a read-only secret mount; do not put the PEM contents in the credential object.
+The remote must use the canonical `https://github.com/<owner>/<repository>` form.
+MindRoom reads the key when needed and mints a repository-scoped installation token with read-only Contents permission.
+It caches that token until shortly before GitHub's reported expiry and passes it only to the Git subprocess, never to the checkout config or credential store.
+
 ## Embedder Configuration
 
 Semantic knowledge bases use the same embedder configured in the `memory` section.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -14031,7 +14031,9 @@ Store this object under the service named by `credentials_service`.
 `private_key_file` must be an absolute path to a read-only secret mount; do not put the PEM contents in the credential object.
 The remote must use the canonical `https://github.com/<owner>/<repository>` form.
 MindRoom reads the key when needed and mints a repository-scoped installation token with read-only Contents permission.
-It caches that token until shortly before GitHub's reported expiry and passes it only to the Git subprocess, never to the checkout config or credential store.
+The control-plane runtime caches that token until shortly before GitHub's reported expiry.
+Scheduled refresh children receive the cached token and expiry only through their stdin request pipe, then pass the token only to Git.
+MindRoom never copies the token into the checkout config, credential store, refresh-child launch environment, metadata, or logs.
 
 ## Embedder Configuration
 

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -420,6 +420,7 @@ The remote must use the canonical `https://github.com/<owner>/<repository>` form
 MindRoom reads the key when needed and mints a repository-scoped installation token with read-only Contents permission.
 The control-plane runtime caches that token until shortly before GitHub's reported expiry.
 Scheduled refresh children receive the cached token and expiry only through their stdin request pipe, then pass the token only to Git.
+The handoff includes the non-secret App, installation, repository, and key-path identity, and a child ignores the token if its current credentials no longer match.
 MindRoom never copies the token into the checkout config, credential store, refresh-child launch environment, metadata, or logs.
 
 ## Embedder Configuration

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -418,7 +418,9 @@ Store this object under the service named by `credentials_service`.
 `private_key_file` must be an absolute path to a read-only secret mount; do not put the PEM contents in the credential object.
 The remote must use the canonical `https://github.com/<owner>/<repository>` form.
 MindRoom reads the key when needed and mints a repository-scoped installation token with read-only Contents permission.
-It caches that token until shortly before GitHub's reported expiry and passes it only to the Git subprocess, never to the checkout config or credential store.
+The control-plane runtime caches that token until shortly before GitHub's reported expiry.
+Scheduled refresh children receive the cached token and expiry only through their stdin request pipe, then pass the token only to Git.
+MindRoom never copies the token into the checkout config, credential store, refresh-child launch environment, metadata, or logs.
 
 ## Embedder Configuration
 

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -318,7 +318,8 @@ If a checkout already holds a credential-bearing remote from before this check e
 - Missing, stale, or failed knowledge schedules a per-binding refresh and the current request continues with availability metadata.
 - Explicit dashboard/API reindex or sync runs Git sync first for Git-backed bases.
 - Semantic Git refresh then advances a candidate index, while files-only Git refresh publishes source metadata.
-- When `lfs: true`, MindRoom disables implicit LFS smudge during clone/checkout/reset and explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
+- MindRoom disables implicit LFS smudge during clone, checkout, and reset for every Git-backed knowledge base.
+- When `lfs: true`, MindRoom explicitly hydrates the checkout after sync, keeping the working tree complete even when indexing filters only include some file types.
 - Local edits to Git-tracked files are discarded during refresh sync, and tracked deletions are restored from the remote checkout.
 - Change detection for Git-backed bases is the tracked revision, not file contents: while the checkout stays on the revision the index was published from, MindRoom republishes the existing index without reading the corpus.
 - Consequently an out-of-band edit to a Git-backed checkout is not indexed while the revision is unchanged.

--- a/skills/mindroom-docs/references/page__knowledge__index.md
+++ b/skills/mindroom-docs/references/page__knowledge__index.md
@@ -402,6 +402,23 @@ Accepted credential fields:
 | `username` + `password` | Basic HTTP auth |
 | `api_key` | Uses `x-access-token` as username automatically |
 
+For unattended GitHub repositories, a GitHub App installation can replace a personal access token:
+
+```json
+{
+  "auth_type": "github_app",
+  "app_id": 12345,
+  "installation_id": 67890,
+  "private_key_file": "/var/run/secrets/github-app/private-key.pem"
+}
+```
+
+Store this object under the service named by `credentials_service`.
+`private_key_file` must be an absolute path to a read-only secret mount; do not put the PEM contents in the credential object.
+The remote must use the canonical `https://github.com/<owner>/<repository>` form.
+MindRoom reads the key when needed and mints a repository-scoped installation token with read-only Contents permission.
+It caches that token until shortly before GitHub's reported expiry and passes it only to the Git subprocess, never to the checkout config or credential store.
+
 ## Embedder Configuration
 
 Semantic knowledge bases use the same embedder configured in the `memory` section.

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -31,7 +31,10 @@ from mindroom.knowledge.file_listing import (
     git_tracked_relative_paths_from_checkout,
     include_knowledge_relative_path,
 )
-from mindroom.knowledge.github_app_auth import GitHubAppTokenProvider
+from mindroom.knowledge.github_app_auth import (
+    GitHubAppTokenProvider,
+    get_runtime_github_app_token_provider,
+)
 from mindroom.knowledge.redaction import (
     MAX_REDACTABLE_TOKEN_LENGTH,
     credential_free_repo_url,
@@ -410,7 +413,7 @@ class GitKnowledgeSource:
     lfs_hydrated_head_path: Path
     _sync_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
     _github_app_token_provider: GitHubAppTokenProvider = field(
-        default_factory=GitHubAppTokenProvider,
+        default_factory=get_runtime_github_app_token_provider,
         init=False,
         repr=False,
     )

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -219,21 +219,14 @@ async def _resolved_git_auth_env(
     github_app_token_provider: GitHubAppTokenProvider,
 ) -> dict[str, str] | None:
     """Resolve refreshable App credentials or retain existing static Git auth."""
-    clean_url = credential_free_repo_url(repo_url)
-    try:
-        parsed_clean_url = urlparse(clean_url)
-    except ValueError:
-        return _git_auth_env(repo_url, credentials_service, runtime_paths)
-
-    if (
-        embedded_http_userinfo(repo_url) is None
-        and credentials_service
-        and parsed_clean_url.scheme in {"http", "https"}
-    ):
-        credentials = get_runtime_shared_credentials_manager(runtime_paths).load_credentials(credentials_service) or {}
-        if credentials.get("auth_type") == "github_app":
-            username, token = await github_app_token_provider.resolve(repo_url, credentials)
-            return _git_http_basic_auth_env(clean_url, username, token)
+    credentials = (
+        get_runtime_shared_credentials_manager(runtime_paths).load_credentials(credentials_service) or {}
+        if credentials_service
+        else {}
+    )
+    if credentials.get("auth_type") == "github_app":
+        username, token = await github_app_token_provider.resolve(repo_url, credentials)
+        return _git_http_basic_auth_env(credential_free_repo_url(repo_url), username, token)
 
     return _git_auth_env(repo_url, credentials_service, runtime_paths)
 

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -31,6 +31,7 @@ from mindroom.knowledge.file_listing import (
     git_tracked_relative_paths_from_checkout,
     include_knowledge_relative_path,
 )
+from mindroom.knowledge.github_app_auth import GitHubAppTokenProvider
 from mindroom.knowledge.redaction import (
     MAX_REDACTABLE_TOKEN_LENGTH,
     credential_free_repo_url,
@@ -211,6 +212,32 @@ def _git_auth_env(
     }
 
 
+async def _resolved_git_auth_env(
+    repo_url: str,
+    credentials_service: str | None,
+    runtime_paths: RuntimePaths,
+    github_app_token_provider: GitHubAppTokenProvider,
+) -> dict[str, str] | None:
+    """Resolve refreshable App credentials or retain existing static Git auth."""
+    clean_url = credential_free_repo_url(repo_url)
+    try:
+        parsed_clean_url = urlparse(clean_url)
+    except ValueError:
+        return _git_auth_env(repo_url, credentials_service, runtime_paths)
+
+    if (
+        embedded_http_userinfo(repo_url) is None
+        and credentials_service
+        and parsed_clean_url.scheme in {"http", "https"}
+    ):
+        credentials = get_runtime_shared_credentials_manager(runtime_paths).load_credentials(credentials_service) or {}
+        if credentials.get("auth_type") == "github_app":
+            username, token = await github_app_token_provider.resolve(repo_url, credentials)
+            return _git_http_basic_auth_env(clean_url, username, token)
+
+    return _git_auth_env(repo_url, credentials_service, runtime_paths)
+
+
 #: scp-style SSH syntax (``git@github.com:org/repo.git``), which ``urlparse``
 #: reports as a bare path rather than a URL, plus the same form with the
 #: username left off (``github.com:org/repo.git``), which Git clones as the
@@ -377,6 +404,11 @@ class GitKnowledgeSource:
     #: restart does not re-pull every object for an unchanged checkout.
     lfs_hydrated_head_path: Path
     _sync_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False, repr=False)
+    _github_app_token_provider: GitHubAppTokenProvider = field(
+        default_factory=GitHubAppTokenProvider,
+        init=False,
+        repr=False,
+    )
     _last_synced_head: str | None = field(default=None, init=False)
     _lfs_checked: bool = field(default=False, init=False)
     _lfs_repository_ready: bool = field(default=False, init=False)
@@ -652,7 +684,12 @@ class GitKnowledgeSource:
         await self._run_git(
             self._lfs_pull_args(git_config),
             cwd=repo_root or self.source_path,
-            env=_git_auth_env(git_config.repo_url, git_config.credentials_service, self.runtime_paths),
+            env=await _resolved_git_auth_env(
+                git_config.repo_url,
+                git_config.credentials_service,
+                self.runtime_paths,
+                self._github_app_token_provider,
+            ),
         )
         if resolved_head is None:
             resolved_head = await self._rev_parse("HEAD")
@@ -706,7 +743,12 @@ class GitKnowledgeSource:
             ],
             cwd=knowledge_root.parent,
             env=_merge_git_env(
-                _git_auth_env(git_config.repo_url, git_config.credentials_service, runtime_paths),
+                await _resolved_git_auth_env(
+                    git_config.repo_url,
+                    git_config.credentials_service,
+                    runtime_paths,
+                    self._github_app_token_provider,
+                ),
                 self._lfs_skip_smudge_env(git_config),
             ),
         )
@@ -726,7 +768,12 @@ class GitKnowledgeSource:
         remote_ref = f"origin/{git_config.branch}"
         await self._run_git(
             ["fetch", "origin", f"+refs/heads/{git_config.branch}:refs/remotes/{remote_ref}"],
-            env=_git_auth_env(git_config.repo_url, git_config.credentials_service, self.runtime_paths),
+            env=await _resolved_git_auth_env(
+                git_config.repo_url,
+                git_config.credentials_service,
+                self.runtime_paths,
+                self._github_app_token_provider,
+            ),
         )
         remote_head = await self._rev_parse(remote_ref)
         if remote_head is None:

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -43,6 +43,8 @@ from mindroom.knowledge.redaction import (
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     from mindroom.config.knowledge import KnowledgeGitConfig
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -121,6 +123,8 @@ async def _terminate_git_process(
 def _http_credentials(
     credentials_service: str | None,
     runtime_paths: RuntimePaths,
+    *,
+    credentials: Mapping[str, object] | None = None,
 ) -> tuple[str, str] | None:
     """Return HTTP basic-auth userinfo for one credentials service, if any.
 
@@ -132,7 +136,8 @@ def _http_credentials(
     if not credentials_service:
         return None
 
-    credentials = get_runtime_shared_credentials_manager(runtime_paths).load_credentials(credentials_service) or {}
+    if credentials is None:
+        credentials = get_runtime_shared_credentials_manager(runtime_paths).load_credentials(credentials_service) or {}
     username = credentials.get("username")
     token = credentials.get("token") or credentials.get("api_key")
     password = credentials.get("password")
@@ -163,6 +168,8 @@ def _git_auth_env(
     repo_url: str,
     credentials_service: str | None,
     runtime_paths: RuntimePaths,
+    *,
+    credentials: Mapping[str, object] | None = None,
 ) -> dict[str, str] | None:
     """Return process-local Git config that injects credentials without persisting them.
 
@@ -191,7 +198,9 @@ def _git_auth_env(
         return _git_http_basic_auth_env(clean_url, *embedded_userinfo)
 
     credentials_userinfo = (
-        _http_credentials(credentials_service, runtime_paths) if parsed_clean_url.scheme in {"http", "https"} else None
+        _http_credentials(credentials_service, runtime_paths, credentials=credentials)
+        if parsed_clean_url.scheme in {"http", "https"}
+        else None
     )
     if credentials_userinfo is not None:
         return _git_http_basic_auth_env(clean_url, *credentials_userinfo)
@@ -219,16 +228,19 @@ async def _resolved_git_auth_env(
     github_app_token_provider: GitHubAppTokenProvider,
 ) -> dict[str, str] | None:
     """Resolve refreshable App credentials or retain existing static Git auth."""
-    credentials = (
-        get_runtime_shared_credentials_manager(runtime_paths).load_credentials(credentials_service) or {}
-        if credentials_service
-        else {}
-    )
+    credentials: Mapping[str, object] = {}
+    if credentials_service:
+        credentials = get_runtime_shared_credentials_manager(runtime_paths).load_credentials(credentials_service) or {}
     if credentials.get("auth_type") == "github_app":
         username, token = await github_app_token_provider.resolve(repo_url, credentials)
         return _git_http_basic_auth_env(credential_free_repo_url(repo_url), username, token)
 
-    return _git_auth_env(repo_url, credentials_service, runtime_paths)
+    return _git_auth_env(
+        repo_url,
+        credentials_service,
+        runtime_paths,
+        credentials=credentials if credentials_service else None,
+    )
 
 
 #: scp-style SSH syntax (``git@github.com:org/repo.git``), which ``urlparse``

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -664,9 +664,8 @@ class GitKnowledgeSource:
         await self._run_git(["lfs", "install", "--local"], cwd=repo_root)
         self._lfs_repository_ready = True
 
-    def _lfs_skip_smudge_env(self, git_config: KnowledgeGitConfig) -> dict[str, str] | None:
-        if not git_config.lfs:
-            return None
+    def _lfs_skip_smudge_env(self) -> dict[str, str]:
+        """Prevent implicit LFS downloads; enabled repositories hydrate explicitly."""
         return {"GIT_LFS_SKIP_SMUDGE": "1"}
 
     def _lfs_pull_args(self, git_config: KnowledgeGitConfig) -> list[str]:
@@ -754,7 +753,7 @@ class GitKnowledgeSource:
                     runtime_paths,
                     self._github_app_token_provider,
                 ),
-                self._lfs_skip_smudge_env(git_config),
+                self._lfs_skip_smudge_env(),
             ),
         )
         await self._run_git(["remote", "set-url", "origin", clone_url], cwd=knowledge_root)
@@ -793,11 +792,11 @@ class GitKnowledgeSource:
 
         await self._run_git(
             ["checkout", "--force", "-B", git_config.branch, remote_ref],
-            env=self._lfs_skip_smudge_env(git_config),
+            env=self._lfs_skip_smudge_env(),
         )
         # Reviewed with Bas (2026-04-17): program-owned checkout, hard reset is the
         # intentional way to realign it with the configured remote state.
-        await self._run_git(["reset", "--hard", remote_ref], env=self._lfs_skip_smudge_env(git_config))
+        await self._run_git(["reset", "--hard", remote_ref], env=self._lfs_skip_smudge_env())
         await self._hydrate_lfs_worktree(git_config, current_head=remote_head)
 
         after_files = await self._list_tracked_files()

--- a/src/mindroom/knowledge/github_app_auth.py
+++ b/src/mindroom/knowledge/github_app_auth.py
@@ -169,12 +169,13 @@ class GitHubAppTokenProvider:
         now: datetime,
     ) -> _CachedToken:
         try:
-            private_key = credentials.private_key_file.read_text(encoding="utf-8")
-        except OSError as exc:
+            private_key = await asyncio.to_thread(credentials.private_key_file.read_text, encoding="utf-8")
+        except (OSError, UnicodeError) as exc:
             msg = "GitHub App private_key_file could not be read"
             raise ValueError(msg) from exc
         try:
-            app_jwt = jwt.encode(
+            app_jwt = await asyncio.to_thread(
+                jwt.encode,
                 {
                     "iat": int(now.timestamp()) - 60,
                     "exp": int(now.timestamp()) + 540,

--- a/src/mindroom/knowledge/github_app_auth.py
+++ b/src/mindroom/knowledge/github_app_auth.py
@@ -1,0 +1,226 @@
+"""Short-lived GitHub App credentials for Git knowledge sources."""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+import httpx
+import jwt
+
+_GITHUB_API_ROOT = "https://api.github.com"
+_GITHUB_API_VERSION = "2022-11-28"
+_TOKEN_REFRESH_MARGIN = timedelta(minutes=5)
+_REPOSITORY_COMPONENT = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+@dataclass(frozen=True)
+class _GitHubAppCredentials:
+    app_id: int
+    installation_id: int
+    private_key_file: Path
+
+
+@dataclass(frozen=True)
+class _CachedToken:
+    token: str
+    expires_at: datetime
+
+
+def _positive_int(value: object, *, field_name: str) -> int:
+    if isinstance(value, int) and not isinstance(value, bool):
+        parsed = value
+    elif isinstance(value, str) and value.isdigit():
+        parsed = int(value)
+    else:
+        parsed = 0
+    if parsed <= 0:
+        msg = f"GitHub App credential field '{field_name}' must be a positive integer"
+        raise ValueError(msg)
+    return parsed
+
+
+def _parse_credentials(credentials: Mapping[str, Any]) -> _GitHubAppCredentials:
+    if credentials.get("auth_type") != "github_app":
+        msg = "GitHub App credentials require auth_type 'github_app'"
+        raise ValueError(msg)
+
+    app_id = _positive_int(credentials.get("app_id"), field_name="app_id")
+    installation_id = _positive_int(credentials.get("installation_id"), field_name="installation_id")
+    raw_private_key_file = credentials.get("private_key_file")
+    if not isinstance(raw_private_key_file, str) or not raw_private_key_file.strip():
+        msg = "GitHub App credential field 'private_key_file' must be a non-empty absolute path"
+        raise ValueError(msg)
+    private_key_file = Path(raw_private_key_file)
+    if not private_key_file.is_absolute():
+        msg = "GitHub App credential field 'private_key_file' must be an absolute path"
+        raise ValueError(msg)
+    return _GitHubAppCredentials(
+        app_id=app_id,
+        installation_id=installation_id,
+        private_key_file=private_key_file,
+    )
+
+
+def _github_repository(repo_url: str) -> tuple[str, str]:
+    try:
+        parsed = urlsplit(repo_url)
+        port = parsed.port
+    except ValueError as exc:
+        msg = "GitHub App credentials require a canonical https://github.com/<owner>/<repository> remote"
+        raise ValueError(msg) from exc
+
+    parts = [part for part in parsed.path.split("/") if part]
+    if (
+        parsed.scheme != "https"
+        or parsed.hostname != "github.com"
+        or port is not None
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+        or len(parts) != 2
+    ):
+        msg = "GitHub App credentials require a canonical https://github.com/<owner>/<repository> remote"
+        raise ValueError(msg)
+
+    owner, repository = parts
+    repository = repository.removesuffix(".git")
+    if (
+        not owner
+        or not repository
+        or not _REPOSITORY_COMPONENT.fullmatch(owner)
+        or not _REPOSITORY_COMPONENT.fullmatch(repository)
+    ):
+        msg = "GitHub App credentials require a canonical https://github.com/<owner>/<repository> remote"
+        raise ValueError(msg)
+    return owner, repository
+
+
+def _parse_expiry(value: object) -> datetime:
+    if not isinstance(value, str):
+        msg = "expires_at must be a string"
+        raise TypeError(msg)
+    try:
+        expires_at = datetime.fromisoformat(value)
+    except ValueError as exc:
+        msg = "expires_at must be an RFC3339 timestamp"
+        raise ValueError(msg) from exc
+    if expires_at.tzinfo is None:
+        msg = "expires_at must include a timezone"
+        raise ValueError(msg)
+    return expires_at.astimezone(UTC)
+
+
+class GitHubAppTokenProvider:
+    """Mint and cache repository-scoped GitHub App installation tokens."""
+
+    def __init__(
+        self,
+        *,
+        client: httpx.AsyncClient | None = None,
+        now: Callable[[], datetime] | None = None,
+    ) -> None:
+        self._client = client
+        self._now = now or (lambda: datetime.now(tz=UTC))
+        self._cache: dict[tuple[int, int, str, str, Path], _CachedToken] = {}
+        self._refresh_lock = asyncio.Lock()
+
+    async def resolve(self, repo_url: str, credentials: Mapping[str, Any]) -> tuple[str, str]:
+        """Return HTTP Basic userinfo for one GitHub repository."""
+        parsed_credentials = _parse_credentials(credentials)
+        owner, repository = _github_repository(repo_url)
+        cache_key = (
+            parsed_credentials.app_id,
+            parsed_credentials.installation_id,
+            owner.casefold(),
+            repository.casefold(),
+            parsed_credentials.private_key_file,
+        )
+        cached = self._cache.get(cache_key)
+        now = self._now().astimezone(UTC)
+        if cached is not None and now < cached.expires_at - _TOKEN_REFRESH_MARGIN:
+            return "x-access-token", cached.token
+
+        async with self._refresh_lock:
+            cached = self._cache.get(cache_key)
+            now = self._now().astimezone(UTC)
+            if cached is not None and now < cached.expires_at - _TOKEN_REFRESH_MARGIN:
+                return "x-access-token", cached.token
+            minted = await self._mint_token(
+                parsed_credentials,
+                repository=repository,
+                now=now,
+            )
+            self._cache[cache_key] = minted
+            return "x-access-token", minted.token
+
+    async def _mint_token(
+        self,
+        credentials: _GitHubAppCredentials,
+        *,
+        repository: str,
+        now: datetime,
+    ) -> _CachedToken:
+        try:
+            private_key = credentials.private_key_file.read_text(encoding="utf-8")
+        except OSError as exc:
+            msg = "GitHub App private_key_file could not be read"
+            raise ValueError(msg) from exc
+        try:
+            app_jwt = jwt.encode(
+                {
+                    "iat": int(now.timestamp()) - 60,
+                    "exp": int(now.timestamp()) + 540,
+                    "iss": str(credentials.app_id),
+                },
+                private_key,
+                algorithm="RS256",
+            )
+        except (TypeError, ValueError) as exc:
+            msg = "GitHub App private_key_file does not contain a usable RSA private key"
+            raise ValueError(msg) from exc
+
+        url = f"{_GITHUB_API_ROOT}/app/installations/{credentials.installation_id}/access_tokens"
+        headers = {
+            "Authorization": f"Bearer {app_jwt}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": _GITHUB_API_VERSION,
+        }
+        payload = {
+            "repositories": [repository],
+            "permissions": {"contents": "read"},
+        }
+        if self._client is not None:
+            response = await self._client.post(url, headers=headers, json=payload)
+        else:
+            async with httpx.AsyncClient(timeout=20) as client:
+                response = await client.post(url, headers=headers, json=payload)
+        if response.status_code != httpx.codes.CREATED:
+            msg = (
+                f"GitHub App token request for installation {credentials.installation_id} "
+                f"failed with HTTP {response.status_code}"
+            )
+            raise RuntimeError(msg)
+        try:
+            response_payload = response.json()
+        except ValueError as exc:
+            msg = "GitHub returned an invalid token response for the App installation"
+            raise RuntimeError(msg) from exc
+        token = response_payload.get("token") if isinstance(response_payload, Mapping) else None
+        expires_at_value = response_payload.get("expires_at") if isinstance(response_payload, Mapping) else None
+        if not isinstance(token, str) or not token:
+            msg = "GitHub returned an invalid token response for the App installation"
+            raise RuntimeError(msg)
+        try:
+            expires_at = _parse_expiry(expires_at_value)
+        except (TypeError, ValueError) as exc:
+            msg = "GitHub returned an invalid token response for the App installation"
+            raise RuntimeError(msg) from exc
+        return _CachedToken(token=token, expires_at=expires_at)

--- a/src/mindroom/knowledge/github_app_auth.py
+++ b/src/mindroom/knowledge/github_app_auth.py
@@ -76,7 +76,7 @@ def _github_repository(repo_url: str) -> tuple[str, str]:
         msg = "GitHub App credentials require a canonical https://github.com/<owner>/<repository> remote"
         raise ValueError(msg) from exc
 
-    parts = [part for part in parsed.path.split("/") if part]
+    parts = parsed.path.split("/")
     if (
         parsed.scheme != "https"
         or parsed.hostname != "github.com"
@@ -85,12 +85,13 @@ def _github_repository(repo_url: str) -> tuple[str, str]:
         or parsed.password is not None
         or parsed.query
         or parsed.fragment
-        or len(parts) != 2
+        or len(parts) != 3
+        or parts[0]
     ):
         msg = "GitHub App credentials require a canonical https://github.com/<owner>/<repository> remote"
         raise ValueError(msg)
 
-    owner, repository = parts
+    _, owner, repository = parts
     repository = repository.removesuffix(".git")
     if (
         not owner

--- a/src/mindroom/knowledge/github_app_auth.py
+++ b/src/mindroom/knowledge/github_app_auth.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import re
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -28,9 +28,29 @@ class _GitHubAppCredentials:
 
 
 @dataclass(frozen=True)
-class _CachedToken:
-    token: str
+class _GitHubAppToken:
+    """One repository-scoped installation token and its GitHub expiry."""
+
+    token: str = field(repr=False)
     expires_at: datetime
+
+
+_TokenCacheKey = tuple[int, int, str, str, Path]
+
+
+def _token_cache_key(
+    credentials: _GitHubAppCredentials,
+    *,
+    owner: str,
+    repository: str,
+) -> _TokenCacheKey:
+    return (
+        credentials.app_id,
+        credentials.installation_id,
+        owner.casefold(),
+        repository.casefold(),
+        credentials.private_key_file,
+    )
 
 
 def _positive_int(value: object, *, field_name: str) -> int:
@@ -130,37 +150,67 @@ class GitHubAppTokenProvider:
     ) -> None:
         self._client = client
         self._now = now or (lambda: datetime.now(tz=UTC))
-        self._cache: dict[tuple[int, int, str, str, Path], _CachedToken] = {}
+        self._cache: dict[_TokenCacheKey, _GitHubAppToken] = {}
         self._refresh_lock = asyncio.Lock()
 
     async def resolve(self, repo_url: str, credentials: Mapping[str, Any]) -> tuple[str, str]:
         """Return HTTP Basic userinfo for one GitHub repository."""
+        resolved = await self.resolve_token(repo_url, credentials)
+        return "x-access-token", resolved.token
+
+    async def resolve_token(self, repo_url: str, credentials: Mapping[str, Any]) -> _GitHubAppToken:
+        """Return one cached or newly minted installation token."""
         parsed_credentials = _parse_credentials(credentials)
         owner, repository = _github_repository(repo_url)
-        cache_key = (
-            parsed_credentials.app_id,
-            parsed_credentials.installation_id,
-            owner.casefold(),
-            repository.casefold(),
-            parsed_credentials.private_key_file,
+        cache_key = _token_cache_key(
+            parsed_credentials,
+            owner=owner,
+            repository=repository,
         )
         cached = self._cache.get(cache_key)
         now = self._now().astimezone(UTC)
         if cached is not None and now < cached.expires_at - _TOKEN_REFRESH_MARGIN:
-            return "x-access-token", cached.token
+            return cached
 
         async with self._refresh_lock:
             cached = self._cache.get(cache_key)
             now = self._now().astimezone(UTC)
             if cached is not None and now < cached.expires_at - _TOKEN_REFRESH_MARGIN:
-                return "x-access-token", cached.token
+                return cached
             minted = await self._mint_token(
                 parsed_credentials,
                 repository=repository,
                 now=now,
             )
             self._cache[cache_key] = minted
-            return "x-access-token", minted.token
+            return minted
+
+    def prime(
+        self,
+        repo_url: str,
+        credentials: Mapping[str, Any],
+        *,
+        token: str,
+        expires_at: datetime,
+    ) -> None:
+        """Seed a child runtime with a parent-resolved installation token."""
+        if not token:
+            msg = "GitHub App installation token must be non-empty"
+            raise ValueError(msg)
+        if expires_at.tzinfo is None:
+            msg = "GitHub App installation token expiry must include a timezone"
+            raise ValueError(msg)
+        parsed_credentials = _parse_credentials(credentials)
+        owner, repository = _github_repository(repo_url)
+        cache_key = _token_cache_key(
+            parsed_credentials,
+            owner=owner,
+            repository=repository,
+        )
+        self._cache[cache_key] = _GitHubAppToken(
+            token=token,
+            expires_at=expires_at.astimezone(UTC),
+        )
 
     async def _mint_token(
         self,
@@ -168,7 +218,7 @@ class GitHubAppTokenProvider:
         *,
         repository: str,
         now: datetime,
-    ) -> _CachedToken:
+    ) -> _GitHubAppToken:
         try:
             private_key = await asyncio.to_thread(credentials.private_key_file.read_text, encoding="utf-8")
         except (OSError, UnicodeError) as exc:
@@ -225,4 +275,12 @@ class GitHubAppTokenProvider:
         except (TypeError, ValueError) as exc:
             msg = "GitHub returned an invalid token response for the App installation"
             raise RuntimeError(msg) from exc
-        return _CachedToken(token=token, expires_at=expires_at)
+        return _GitHubAppToken(token=token, expires_at=expires_at)
+
+
+_RUNTIME_GITHUB_APP_TOKEN_PROVIDER = GitHubAppTokenProvider()
+
+
+def get_runtime_github_app_token_provider() -> GitHubAppTokenProvider:
+    """Return the process-lifetime provider shared by Git knowledge sources."""
+    return _RUNTIME_GITHUB_APP_TOKEN_PROVIDER

--- a/src/mindroom/knowledge/github_app_auth.py
+++ b/src/mindroom/knowledge/github_app_auth.py
@@ -183,7 +183,7 @@ class GitHubAppTokenProvider:
                 private_key,
                 algorithm="RS256",
             )
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError, jwt.exceptions.PyJWTError) as exc:
             msg = "GitHub App private_key_file does not contain a usable RSA private key"
             raise ValueError(msg) from exc
 

--- a/src/mindroom/knowledge/github_app_auth.py
+++ b/src/mindroom/knowledge/github_app_auth.py
@@ -35,21 +35,27 @@ class _GitHubAppToken:
     expires_at: datetime
 
 
+@dataclass(frozen=True)
+class GitHubAppTokenBinding:
+    """Non-secret identity that binds a token to one App repository scope."""
+
+    app_id: int
+    installation_id: int
+    owner: str
+    repository: str
+    private_key_file: str
+
+
 _TokenCacheKey = tuple[int, int, str, str, Path]
 
 
-def _token_cache_key(
-    credentials: _GitHubAppCredentials,
-    *,
-    owner: str,
-    repository: str,
-) -> _TokenCacheKey:
+def _token_cache_key(binding: GitHubAppTokenBinding) -> _TokenCacheKey:
     return (
-        credentials.app_id,
-        credentials.installation_id,
-        owner.casefold(),
-        repository.casefold(),
-        credentials.private_key_file,
+        binding.app_id,
+        binding.installation_id,
+        binding.owner.casefold(),
+        binding.repository.casefold(),
+        Path(binding.private_key_file),
     )
 
 
@@ -92,9 +98,9 @@ def _github_repository(repo_url: str) -> tuple[str, str]:
     try:
         parsed = urlsplit(repo_url)
         port = parsed.port
-    except ValueError as exc:
+    except ValueError:
         msg = "GitHub App credentials require a canonical https://github.com/<owner>/<repository> remote"
-        raise ValueError(msg) from exc
+        raise ValueError(msg) from None
 
     parts = parsed.path.split("/")
     if (
@@ -130,9 +136,9 @@ def _parse_expiry(value: object) -> datetime:
         raise TypeError(msg)
     try:
         expires_at = datetime.fromisoformat(value)
-    except ValueError as exc:
+    except ValueError:
         msg = "expires_at must be an RFC3339 timestamp"
-        raise ValueError(msg) from exc
+        raise ValueError(msg) from None
     if expires_at.tzinfo is None:
         msg = "expires_at must include a timezone"
         raise ValueError(msg)
@@ -158,15 +164,23 @@ class GitHubAppTokenProvider:
         resolved = await self.resolve_token(repo_url, credentials)
         return "x-access-token", resolved.token
 
+    def binding_for(self, repo_url: str, credentials: Mapping[str, Any]) -> GitHubAppTokenBinding:
+        """Return the non-secret identity a minted token is authorized for."""
+        parsed_credentials = _parse_credentials(credentials)
+        owner, repository = _github_repository(repo_url)
+        return GitHubAppTokenBinding(
+            app_id=parsed_credentials.app_id,
+            installation_id=parsed_credentials.installation_id,
+            owner=owner,
+            repository=repository,
+            private_key_file=str(parsed_credentials.private_key_file),
+        )
+
     async def resolve_token(self, repo_url: str, credentials: Mapping[str, Any]) -> _GitHubAppToken:
         """Return one cached or newly minted installation token."""
         parsed_credentials = _parse_credentials(credentials)
-        owner, repository = _github_repository(repo_url)
-        cache_key = _token_cache_key(
-            parsed_credentials,
-            owner=owner,
-            repository=repository,
-        )
+        binding = self.binding_for(repo_url, credentials)
+        cache_key = _token_cache_key(binding)
         cached = self._cache.get(cache_key)
         now = self._now().astimezone(UTC)
         if cached is not None and now < cached.expires_at - _TOKEN_REFRESH_MARGIN:
@@ -179,7 +193,7 @@ class GitHubAppTokenProvider:
                 return cached
             minted = await self._mint_token(
                 parsed_credentials,
-                repository=repository,
+                repository=binding.repository,
                 now=now,
             )
             self._cache[cache_key] = minted
@@ -200,13 +214,8 @@ class GitHubAppTokenProvider:
         if expires_at.tzinfo is None:
             msg = "GitHub App installation token expiry must include a timezone"
             raise ValueError(msg)
-        parsed_credentials = _parse_credentials(credentials)
-        owner, repository = _github_repository(repo_url)
-        cache_key = _token_cache_key(
-            parsed_credentials,
-            owner=owner,
-            repository=repository,
-        )
+        binding = self.binding_for(repo_url, credentials)
+        cache_key = _token_cache_key(binding)
         self._cache[cache_key] = _GitHubAppToken(
             token=token,
             expires_at=expires_at.astimezone(UTC),
@@ -262,9 +271,9 @@ class GitHubAppTokenProvider:
             raise RuntimeError(msg)
         try:
             response_payload = response.json()
-        except ValueError as exc:
+        except ValueError:
             msg = "GitHub returned an invalid token response for the App installation"
-            raise RuntimeError(msg) from exc
+            raise RuntimeError(msg) from None
         token = response_payload.get("token") if isinstance(response_payload, Mapping) else None
         expires_at_value = response_payload.get("expires_at") if isinstance(response_payload, Mapping) else None
         if not isinstance(token, str) or not token:
@@ -272,9 +281,9 @@ class GitHubAppTokenProvider:
             raise RuntimeError(msg)
         try:
             expires_at = _parse_expiry(expires_at_value)
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError):
             msg = "GitHub returned an invalid token response for the App installation"
-            raise RuntimeError(msg) from exc
+            raise RuntimeError(msg) from None
         return _GitHubAppToken(token=token, expires_at=expires_at)
 
 

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -26,7 +26,10 @@ from mindroom.constants import (
 )
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.knowledge.availability import KnowledgeAvailability
-from mindroom.knowledge.github_app_auth import get_runtime_github_app_token_provider
+from mindroom.knowledge.github_app_auth import (
+    GitHubAppTokenBinding,
+    get_runtime_github_app_token_provider,
+)
 from mindroom.knowledge.index_metadata import state_for_publication
 from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.redaction import redact_credentials_in_text
@@ -88,6 +91,7 @@ class KnowledgeRefreshResult:
 class _SubprocessGitHubAppToken:
     token: str = field(repr=False)
     expires_at_epoch: int
+    binding: GitHubAppTokenBinding
 
 
 @dataclass(frozen=True)
@@ -175,10 +179,12 @@ async def _resolve_subprocess_github_app_token(
     if binding is None:
         return None
     repo_url, credentials = binding
-    resolved = await get_runtime_github_app_token_provider().resolve_token(repo_url, credentials)
+    provider = get_runtime_github_app_token_provider()
+    resolved = await provider.resolve_token(repo_url, credentials)
     return _SubprocessGitHubAppToken(
         token=resolved.token,
         expires_at_epoch=int(resolved.expires_at.timestamp()),
+        binding=provider.binding_for(repo_url, credentials),
     )
 
 
@@ -1105,6 +1111,40 @@ async def _reconcile_cancelled_refresh(
     await asyncio.to_thread(mark_published_index_stale, key, reason="refresh_cancelled", refresh_job="idle")
 
 
+def _load_subprocess_github_app_binding(raw_binding_payload: object) -> GitHubAppTokenBinding:
+    if not isinstance(raw_binding_payload, dict):
+        msg = "Knowledge refresh subprocess request github_app_token.binding must be an object"
+        raise TypeError(msg)
+    binding_payload = cast("dict[str, object]", raw_binding_payload)
+    raw_app_id = binding_payload.get("app_id")
+    raw_installation_id = binding_payload.get("installation_id")
+    raw_owner = binding_payload.get("owner")
+    raw_repository = binding_payload.get("repository")
+    raw_private_key_file = binding_payload.get("private_key_file")
+    if not isinstance(raw_app_id, int) or isinstance(raw_app_id, bool) or raw_app_id <= 0:
+        msg = "Knowledge refresh subprocess request github_app_token.binding.app_id must be positive"
+        raise TypeError(msg)
+    if not isinstance(raw_installation_id, int) or isinstance(raw_installation_id, bool) or raw_installation_id <= 0:
+        msg = "Knowledge refresh subprocess request github_app_token.binding.installation_id must be positive"
+        raise TypeError(msg)
+    if not isinstance(raw_owner, str) or not raw_owner:
+        msg = "Knowledge refresh subprocess request github_app_token.binding.owner must be non-empty"
+        raise TypeError(msg)
+    if not isinstance(raw_repository, str) or not raw_repository:
+        msg = "Knowledge refresh subprocess request github_app_token.binding.repository must be non-empty"
+        raise TypeError(msg)
+    if not isinstance(raw_private_key_file, str) or not raw_private_key_file:
+        msg = "Knowledge refresh subprocess request github_app_token.binding.private_key_file must be non-empty"
+        raise TypeError(msg)
+    return GitHubAppTokenBinding(
+        app_id=raw_app_id,
+        installation_id=raw_installation_id,
+        owner=raw_owner,
+        repository=raw_repository,
+        private_key_file=raw_private_key_file,
+    )
+
+
 def _load_subprocess_github_app_token(raw_token_payload: object) -> _SubprocessGitHubAppToken | None:
     if raw_token_payload is None:
         return None
@@ -1123,6 +1163,7 @@ def _load_subprocess_github_app_token(raw_token_payload: object) -> _SubprocessG
     return _SubprocessGitHubAppToken(
         token=raw_token,
         expires_at_epoch=raw_expires_at_epoch,
+        binding=_load_subprocess_github_app_binding(token_payload.get("binding")),
     )
 
 
@@ -1182,15 +1223,17 @@ async def _prime_subprocess_github_app_token(
         runtime_paths=runtime_paths,
     )
     if binding is None:
-        msg = "Knowledge refresh subprocess GitHub App token does not match the configured credential service"
-        raise TypeError(msg)
+        return
     try:
         expires_at = datetime.fromtimestamp(request.github_app_token.expires_at_epoch, tz=UTC)
     except (OSError, OverflowError, ValueError) as exc:
         msg = "Knowledge refresh subprocess GitHub App token expiry is invalid"
         raise TypeError(msg) from exc
     repo_url, credentials = binding
-    get_runtime_github_app_token_provider().prime(
+    provider = get_runtime_github_app_token_provider()
+    if provider.binding_for(repo_url, credentials) != request.github_app_token.binding:
+        return
+    provider.prime(
         repo_url,
         credentials,
         token=request.github_app_token.token,

--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -10,10 +10,10 @@ import os
 import signal
 import sys
 from contextlib import asynccontextmanager, suppress
-from dataclasses import asdict, dataclass, replace
+from dataclasses import asdict, dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from mindroom.config.knowledge import KnowledgeBaseConfig
 from mindroom.config.main import Config
@@ -24,7 +24,9 @@ from mindroom.constants import (
     resolve_runtime_paths,
     runtime_env_values,
 )
+from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.knowledge.availability import KnowledgeAvailability
+from mindroom.knowledge.github_app_auth import get_runtime_github_app_token_provider
 from mindroom.knowledge.index_metadata import state_for_publication
 from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.redaction import redact_credentials_in_text
@@ -83,6 +85,12 @@ class KnowledgeRefreshResult:
 
 
 @dataclass(frozen=True)
+class _SubprocessGitHubAppToken:
+    token: str = field(repr=False)
+    expires_at_epoch: int
+
+
+@dataclass(frozen=True)
 class _SubprocessRefreshRequest:
     base_id: str
     config_data: dict[str, object]
@@ -90,6 +98,7 @@ class _SubprocessRefreshRequest:
     storage_root: str
     runtime_knowledge_base: dict[str, object] | None = None
     execution_identity: SerializedToolExecutionIdentity | None = None
+    github_app_token: _SubprocessGitHubAppToken | None = None
     force_reindex: bool = False
 
 
@@ -130,6 +139,49 @@ _REFRESH_SUBPROCESS_INTERMEDIATE_PENDING_REASONS = frozenset(
 )
 
 
+async def _github_app_refresh_binding(
+    base_id: str,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> tuple[str, dict[str, Any]] | None:
+    git_config = config.get_knowledge_base_config(base_id).git
+    if git_config is None or git_config.credentials_service is None:
+        return None
+    credentials_manager = get_runtime_shared_credentials_manager(runtime_paths)
+    credentials = (
+        await asyncio.to_thread(
+            credentials_manager.load_credentials,
+            git_config.credentials_service,
+        )
+        or {}
+    )
+    if credentials.get("auth_type") != "github_app":
+        return None
+    return git_config.repo_url, credentials
+
+
+async def _resolve_subprocess_github_app_token(
+    base_id: str,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> _SubprocessGitHubAppToken | None:
+    binding = await _github_app_refresh_binding(
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    if binding is None:
+        return None
+    repo_url, credentials = binding
+    resolved = await get_runtime_github_app_token_provider().resolve_token(repo_url, credentials)
+    return _SubprocessGitHubAppToken(
+        token=resolved.token,
+        expires_at_epoch=int(resolved.expires_at.timestamp()),
+    )
+
+
 async def refresh_knowledge_binding_in_subprocess(
     base_id: str,
     *,
@@ -153,24 +205,34 @@ async def refresh_knowledge_binding_in_subprocess(
         create=True,
     )
     initial_state = await asyncio.to_thread(load_published_index_state, published_index_metadata_path(key))
-    request_payload = _serialize_subprocess_refresh_request(
-        base_id,
-        config=config,
-        runtime_paths=runtime_paths,
-        execution_identity=execution_identity,
-        force_reindex=force_reindex,
-    )
+    try:
+        github_app_token = await _resolve_subprocess_github_app_token(
+            base_id,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+        request_payload = _serialize_subprocess_refresh_request(
+            base_id,
+            config=config,
+            runtime_paths=runtime_paths,
+            execution_identity=execution_identity,
+            github_app_token=github_app_token,
+            force_reindex=force_reindex,
+        )
+        # Resolved before the spawn so a malformed window rejects the refresh
+        # instead of leaving a child nobody is waiting on.
+        timeout = _refresh_subprocess_timeout_seconds(runtime_paths)
+    except Exception as exc:
+        await _reconcile_failed_refresh_subprocess(
+            key,
+            initial_state=initial_state,
+            error=redact_credentials_in_text(str(exc)),
+        )
+        raise
     env = dict(runtime_env_values(runtime_paths))
     env.setdefault("PATH", os.environ.get("PATH") or os.defpath)
     env.update(_REFRESH_SUBPROCESS_THREAD_ENV)
     env["MINDROOM_KNOWLEDGE_REFRESH_SUBPROCESS"] = "1"
-    # Resolved before the spawn so a malformed window rejects the refresh
-    # instead of leaving a child nobody is waiting on.
-    try:
-        timeout = _refresh_subprocess_timeout_seconds(runtime_paths)
-    except ValueError as exc:
-        await _reconcile_failed_refresh_subprocess(key, initial_state=initial_state, error=str(exc))
-        raise
     process = await asyncio.create_subprocess_exec(
         sys.executable,
         "-m",
@@ -236,6 +298,7 @@ def _serialize_subprocess_refresh_request(
     config: Config,
     runtime_paths: RuntimePaths,
     execution_identity: ToolExecutionIdentity | None,
+    github_app_token: _SubprocessGitHubAppToken | None = None,
     force_reindex: bool,
 ) -> bytes:
     runtime_knowledge_base = config.runtime_knowledge_base_overlay(base_id)
@@ -252,9 +315,13 @@ def _serialize_subprocess_refresh_request(
         execution_identity=None
         if execution_identity is None
         else serialize_tool_execution_identity(execution_identity),
+        github_app_token=github_app_token,
         force_reindex=force_reindex,
     )
-    return json.dumps(asdict(payload), sort_keys=True).encode()
+    serialized_payload = asdict(payload)
+    if github_app_token is None:
+        del serialized_payload["github_app_token"]
+    return json.dumps(serialized_payload, sort_keys=True).encode()
 
 
 async def _send_subprocess_refresh_request(
@@ -1038,6 +1105,27 @@ async def _reconcile_cancelled_refresh(
     await asyncio.to_thread(mark_published_index_stale, key, reason="refresh_cancelled", refresh_job="idle")
 
 
+def _load_subprocess_github_app_token(raw_token_payload: object) -> _SubprocessGitHubAppToken | None:
+    if raw_token_payload is None:
+        return None
+    if not isinstance(raw_token_payload, dict):
+        msg = "Knowledge refresh subprocess request github_app_token must be an object when present"
+        raise TypeError(msg)
+    token_payload = cast("dict[str, object]", raw_token_payload)
+    raw_token = token_payload.get("token")
+    raw_expires_at_epoch = token_payload.get("expires_at_epoch")
+    if not isinstance(raw_token, str) or not raw_token:
+        msg = "Knowledge refresh subprocess request github_app_token.token must be non-empty"
+        raise TypeError(msg)
+    if not isinstance(raw_expires_at_epoch, int) or isinstance(raw_expires_at_epoch, bool) or raw_expires_at_epoch <= 0:
+        msg = "Knowledge refresh subprocess request github_app_token.expires_at_epoch must be positive"
+        raise TypeError(msg)
+    return _SubprocessGitHubAppToken(
+        token=raw_token,
+        expires_at_epoch=raw_expires_at_epoch,
+    )
+
+
 def _load_subprocess_refresh_request(payload: bytes) -> _SubprocessRefreshRequest:
     raw_payload = json.loads(payload.decode())
     if not isinstance(raw_payload, dict):
@@ -1075,7 +1163,38 @@ def _load_subprocess_refresh_request(payload: bytes) -> _SubprocessRefreshReques
         storage_root=raw_storage_root,
         runtime_knowledge_base=cast("dict[str, object] | None", raw_runtime_knowledge_base),
         execution_identity=raw_execution_identity,
+        github_app_token=_load_subprocess_github_app_token(raw_payload.get("github_app_token")),
         force_reindex=bool(raw_force_reindex),
+    )
+
+
+async def _prime_subprocess_github_app_token(
+    request: _SubprocessRefreshRequest,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> None:
+    if request.github_app_token is None:
+        return
+    binding = await _github_app_refresh_binding(
+        request.base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    if binding is None:
+        msg = "Knowledge refresh subprocess GitHub App token does not match the configured credential service"
+        raise TypeError(msg)
+    try:
+        expires_at = datetime.fromtimestamp(request.github_app_token.expires_at_epoch, tz=UTC)
+    except (OSError, OverflowError, ValueError) as exc:
+        msg = "Knowledge refresh subprocess GitHub App token expiry is invalid"
+        raise TypeError(msg) from exc
+    repo_url, credentials = binding
+    get_runtime_github_app_token_provider().prime(
+        repo_url,
+        credentials,
+        token=request.github_app_token.token,
+        expires_at=expires_at,
     )
 
 
@@ -1090,6 +1209,11 @@ async def _run_subprocess_refresh_request(payload: bytes) -> KnowledgeRefreshRes
     if request.runtime_knowledge_base is not None:
         base_config = KnowledgeBaseConfig.model_validate(request.runtime_knowledge_base)
         config = config.with_runtime_knowledge_base_overlay(request.base_id, base_config)
+    await _prime_subprocess_github_app_token(
+        request,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
     execution_identity = (
         None
         if request.execution_identity is None

--- a/tach.toml
+++ b/tach.toml
@@ -3899,9 +3899,15 @@ visibility = ["mindroom.knowledge.manager"]
 path = "mindroom.knowledge.git_source"
 depends_on = [
     "mindroom.knowledge.file_listing",
+    "mindroom.knowledge.github_app_auth",
     "mindroom.knowledge.redaction",
 ]
 visibility = ["mindroom.knowledge.manager"]
+
+[[modules]]
+path = "mindroom.knowledge.github_app_auth"
+depends_on = []
+visibility = ["mindroom.knowledge.git_source"]
 
 [[modules]]
 path = "mindroom.knowledge.registry"

--- a/tach.toml
+++ b/tach.toml
@@ -3907,7 +3907,10 @@ visibility = ["mindroom.knowledge.manager"]
 [[modules]]
 path = "mindroom.knowledge.github_app_auth"
 depends_on = []
-visibility = ["mindroom.knowledge.git_source"]
+visibility = [
+    "mindroom.knowledge.git_source",
+    "mindroom.knowledge.refresh_runner",
+]
 
 [[modules]]
 path = "mindroom.knowledge.registry"
@@ -3993,7 +3996,9 @@ path = "mindroom.knowledge.refresh_runner"
 depends_on = [
     "mindroom.config.main",
     "mindroom.constants",
+    "mindroom.credentials",
     "mindroom.knowledge.availability",
+    "mindroom.knowledge.github_app_auth",
     "mindroom.knowledge.index_metadata",
     "mindroom.knowledge.manager",
     "mindroom.knowledge.redaction",

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from threading import get_ident
+from typing import Any
 
 import httpx
 import jwt
@@ -13,10 +15,6 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from mindroom.knowledge.github_app_auth import GitHubAppTokenProvider
-
-if TYPE_CHECKING:
-    from collections.abc import Callable
-    from pathlib import Path
 
 
 def _private_key(path: Path) -> rsa.RSAPrivateKey:
@@ -176,17 +174,27 @@ async def test_github_app_key_read_and_signing_run_off_event_loop(
     """Secret-file I/O and RSA signing must not block unrelated async work."""
     key_path = tmp_path / "private-key.pem"
     _private_key(key_path)
-    offloaded: list[str] = []
-    real_to_thread = asyncio.to_thread
+    loop_thread_id = get_ident()
+    offloaded: list[tuple[str, int]] = []
+    real_read_text = Path.read_text
+    real_encode = jwt.encode
 
-    async def _tracked_to_thread(
-        function: Callable[..., object],
-        /,
-        *args: object,
-        **kwargs: object,
-    ) -> object:
-        offloaded.append(getattr(function, "__name__", type(function).__name__))
-        return await real_to_thread(function, *args, **kwargs)
+    def _tracked_read_text(
+        path: Path,
+        encoding: str | None = None,
+        errors: str | None = None,
+        newline: str | None = None,
+    ) -> str:
+        offloaded.append(("read_text", get_ident()))
+        return real_read_text(path, encoding=encoding, errors=errors, newline=newline)
+
+    def _tracked_encode(
+        payload: dict[str, Any],
+        key: str | bytes,
+        algorithm: str | None = None,
+    ) -> str:
+        offloaded.append(("encode", get_ident()))
+        return real_encode(payload, key, algorithm=algorithm)
 
     async def _handler(_request: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -197,7 +205,8 @@ async def test_github_app_key_read_and_signing_run_off_event_loop(
             },
         )
 
-    monkeypatch.setattr(asyncio, "to_thread", _tracked_to_thread)
+    monkeypatch.setattr(Path, "read_text", _tracked_read_text)
+    monkeypatch.setattr(jwt, "encode", _tracked_encode)
     async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
         provider = GitHubAppTokenProvider(
             client=client,
@@ -208,7 +217,8 @@ async def test_github_app_key_read_and_signing_run_off_event_loop(
             _credentials(key_path),
         )
 
-    assert offloaded == ["read_text", "encode"]
+    assert [operation for operation, _thread_id in offloaded] == ["read_text", "encode"]
+    assert all(thread_id != loop_thread_id for _operation, thread_id in offloaded)
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -218,6 +218,27 @@ async def test_github_app_token_endpoint_error_does_not_include_response_body(tm
     assert "secret response detail" not in str(exc_info.value)
 
 
+@pytest.mark.parametrize("key_contents", [None, "secret invalid private key contents"])
+@pytest.mark.asyncio
+async def test_github_app_private_key_errors_are_redacted(
+    tmp_path: Path,
+    key_contents: str | None,
+) -> None:
+    """Unreadable and invalid private keys must fail without key or library detail."""
+    key_path = tmp_path / "private-key.pem"
+    if key_contents is not None:
+        key_path.write_text(key_contents, encoding="utf-8")
+
+    expected = "could not be read" if key_contents is None else "does not contain a usable RSA private key"
+    with pytest.raises(ValueError, match=expected) as exc_info:
+        await GitHubAppTokenProvider().resolve(
+            "https://github.com/example/private.git",
+            _credentials(key_path),
+        )
+
+    assert "secret invalid" not in str(exc_info.value)
+
+
 @pytest.mark.parametrize(
     "response_json",
     [

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -15,6 +15,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from mindroom.knowledge.github_app_auth import GitHubAppTokenProvider
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 
@@ -163,6 +164,49 @@ async def test_github_app_token_is_repository_scoped_read_only_cached_and_rotate
         options={"verify_exp": False, "verify_iat": False},
     )
     assert refreshed_claims["iat"] == int(current_time.timestamp()) - 60
+
+
+@pytest.mark.asyncio
+async def test_github_app_key_read_and_signing_run_off_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Secret-file I/O and RSA signing must not block unrelated async work."""
+    key_path = tmp_path / "private-key.pem"
+    _private_key(key_path)
+    offloaded: list[str] = []
+    real_to_thread = asyncio.to_thread
+
+    async def _tracked_to_thread(
+        function: Callable[..., object],
+        /,
+        *args: object,
+        **kwargs: object,
+    ) -> object:
+        offloaded.append(getattr(function, "__name__", type(function).__name__))
+        return await real_to_thread(function, *args, **kwargs)
+
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json={
+                "token": "installation-token",
+                "expires_at": "2026-08-21T13:00:00Z",
+            },
+        )
+
+    monkeypatch.setattr(asyncio, "to_thread", _tracked_to_thread)
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        provider = GitHubAppTokenProvider(
+            client=client,
+            now=lambda: datetime(2026, 8, 21, 12, 0, tzinfo=UTC),
+        )
+        await provider.resolve(
+            "https://github.com/example/private.git",
+            _credentials(key_path),
+        )
+
+    assert offloaded == ["read_text", "encode"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import traceback
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from threading import get_ident
@@ -94,6 +95,20 @@ async def test_github_app_credentials_reject_noncanonical_github_remotes(
         await GitHubAppTokenProvider().resolve(repo_url, _credentials(key_path))
 
     assert "secret" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_github_app_url_parse_traceback_does_not_include_credentials(tmp_path: Path) -> None:
+    """Parser causes must not leak embedded credentials through exception logs."""
+    key_path = tmp_path / "private-key.pem"
+    canary = "url" + "-credential-canary"
+    repo_url = f"https://user:{canary}@github.com{chr(0xFF0F)}example/private.git"
+
+    with pytest.raises(ValueError, match="canonical") as exc_info:
+        await GitHubAppTokenProvider().resolve(repo_url, _credentials(key_path))
+
+    rendered = "".join(traceback.format_exception(exc_info.value))
+    assert canary not in rendered
 
 
 @pytest.mark.asyncio
@@ -324,3 +339,32 @@ async def test_github_app_token_endpoint_rejects_invalid_success_payload_without
             await provider.resolve("https://github.com/example/private.git", _credentials(key_path))
 
     assert "secret-token" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_github_app_invalid_expiry_traceback_does_not_include_response_value(tmp_path: Path) -> None:
+    """Malformed expiry causes must not leak response data through exception logs."""
+    key_path = tmp_path / "private-key.pem"
+    _private_key(key_path)
+    canary = "expiry" + "-response-canary"
+
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json={
+                "token": "secret-token",
+                "expires_at": canary,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        provider = GitHubAppTokenProvider(
+            client=client,
+            now=lambda: datetime(2026, 8, 21, 12, 0, tzinfo=UTC),
+        )
+        with pytest.raises(RuntimeError, match="invalid token response") as exc_info:
+            await provider.resolve("https://github.com/example/private.git", _credentials(key_path))
+
+    rendered = "".join(traceback.format_exception(exc_info.value))
+    assert canary not in rendered
+    assert "secret-token" not in rendered

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -79,6 +79,8 @@ async def test_github_app_credentials_fail_closed_for_invalid_fields(
         "https://github.com/example/private.git#secret",
         "https://github.com/example",
         "https://github.com/example/private/extra",
+        "https://github.com/example//private.git",
+        "https://github.com/example/private.git/",
     ],
 )
 @pytest.mark.asyncio

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -1,0 +1,249 @@
+"""GitHub App installation authentication for Git knowledge sources."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from mindroom.knowledge.github_app_auth import GitHubAppTokenProvider
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _private_key(path: Path) -> rsa.RSAPrivateKey:
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    path.write_bytes(
+        key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+    )
+    return key
+
+
+def _credentials(default_private_key_file: Path, **overrides: object) -> dict[str, object]:
+    credentials: dict[str, object] = {
+        "auth_type": "github_app",
+        "app_id": 12345,
+        "installation_id": 67890,
+        "private_key_file": str(default_private_key_file),
+    }
+    credentials.update(overrides)
+    return credentials
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"app_id": 0}, "app_id"),
+        ({"app_id": "not-an-id"}, "app_id"),
+        ({"installation_id": -1}, "installation_id"),
+        ({"private_key_file": "relative.pem"}, "private_key_file"),
+        ({"private_key_file": ""}, "private_key_file"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_github_app_credentials_fail_closed_for_invalid_fields(
+    tmp_path: Path,
+    overrides: dict[str, object],
+    match: str,
+) -> None:
+    """Invalid App credential fields must fail before any network request."""
+    key_path = tmp_path / "private-key.pem"
+    _private_key(key_path)
+
+    with pytest.raises(ValueError, match=match):
+        await GitHubAppTokenProvider().resolve(
+            "https://github.com/example/private.git",
+            _credentials(key_path, **overrides),
+        )
+
+
+@pytest.mark.parametrize(
+    "repo_url",
+    [
+        "http://github.com/example/private.git",
+        "https://gitlab.com/example/private.git",
+        "https://user@github.com/example/private.git",
+        "https://github.com/example/private.git?token=secret",
+        "https://github.com/example/private.git#secret",
+        "https://github.com/example",
+        "https://github.com/example/private/extra",
+    ],
+)
+@pytest.mark.asyncio
+async def test_github_app_credentials_reject_noncanonical_github_remotes(
+    tmp_path: Path,
+    repo_url: str,
+) -> None:
+    """App auth must reject remotes whose repository identity is ambiguous."""
+    key_path = tmp_path / "private-key.pem"
+    _private_key(key_path)
+
+    with pytest.raises(ValueError, match="GitHub App credentials require") as exc_info:
+        await GitHubAppTokenProvider().resolve(repo_url, _credentials(key_path))
+
+    assert "secret" not in str(exc_info.value)
+
+
+@pytest.mark.asyncio
+async def test_github_app_token_is_repository_scoped_read_only_cached_and_rotates_key(tmp_path: Path) -> None:
+    """Mint least-privilege tokens, cache safely, and reread rotated keys."""
+    key_path = tmp_path / "private-key.pem"
+    first_key = _private_key(key_path)
+    current_time = datetime(2026, 8, 21, 12, 0, tzinfo=UTC)
+    requests: list[httpx.Request] = []
+
+    def _now() -> datetime:
+        return current_time
+
+    async def _handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            201,
+            json={
+                "token": f"installation-token-{len(requests)}",
+                "expires_at": (current_time + timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+                "permissions": {"contents": "read"},
+                "repository_selection": "selected",
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        provider = GitHubAppTokenProvider(client=client, now=_now)
+        first = await provider.resolve("https://github.com/Example/Private.git", _credentials(key_path))
+        cached = await provider.resolve("https://github.com/Example/Private.git", _credentials(key_path))
+
+        assert first == ("x-access-token", "installation-token-1")
+        assert cached == first
+        assert len(requests) == 1
+
+        request = requests[0]
+        assert request.url == "https://api.github.com/app/installations/67890/access_tokens"
+        assert request.headers["accept"] == "application/vnd.github+json"
+        assert request.headers["x-github-api-version"] == "2022-11-28"
+        assert request.headers["authorization"].startswith("Bearer ")
+        assert request.read() == b'{"repositories":["Private"],"permissions":{"contents":"read"}}'
+
+        encoded_jwt = request.headers["authorization"].removeprefix("Bearer ")
+        claims = jwt.decode(
+            encoded_jwt,
+            first_key.public_key(),
+            algorithms=["RS256"],
+            audience=None,
+            options={"verify_exp": False, "verify_iat": False},
+        )
+        assert claims == {
+            "iat": int(current_time.timestamp()) - 60,
+            "exp": int(current_time.timestamp()) + 540,
+            "iss": "12345",
+        }
+
+        current_time += timedelta(minutes=56)
+        second_key = _private_key(key_path)
+        refreshed = await provider.resolve("https://github.com/Example/Private.git", _credentials(key_path))
+
+    assert refreshed == ("x-access-token", "installation-token-2")
+    assert len(requests) == 2
+    refreshed_jwt = requests[1].headers["authorization"].removeprefix("Bearer ")
+    refreshed_claims = jwt.decode(
+        refreshed_jwt,
+        second_key.public_key(),
+        algorithms=["RS256"],
+        audience=None,
+        options={"verify_exp": False, "verify_iat": False},
+    )
+    assert refreshed_claims["iat"] == int(current_time.timestamp()) - 60
+
+
+@pytest.mark.asyncio
+async def test_concurrent_github_app_token_requests_share_one_refresh(tmp_path: Path) -> None:
+    """Concurrent Git operations must coalesce one installation-token refresh."""
+    key_path = tmp_path / "private-key.pem"
+    _private_key(key_path)
+    current_time = datetime(2026, 8, 21, 12, 0, tzinfo=UTC)
+    request_count = 0
+
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        nonlocal request_count
+        request_count += 1
+        await asyncio.sleep(0.01)
+        return httpx.Response(
+            201,
+            json={
+                "token": "shared-token",
+                "expires_at": (current_time + timedelta(hours=1)).isoformat().replace("+00:00", "Z"),
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        provider = GitHubAppTokenProvider(client=client, now=lambda: current_time)
+        results = await asyncio.gather(
+            *(
+                provider.resolve("https://github.com/example/private.git", _credentials(key_path))
+                for _index in range(10)
+            ),
+        )
+
+    assert results == [("x-access-token", "shared-token")] * 10
+    assert request_count == 1
+
+
+@pytest.mark.asyncio
+async def test_github_app_token_endpoint_error_does_not_include_response_body(tmp_path: Path) -> None:
+    """GitHub error bodies must not be copied into operator-facing errors."""
+    key_path = tmp_path / "private-key.pem"
+    _private_key(key_path)
+
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"message": "secret response detail"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        provider = GitHubAppTokenProvider(
+            client=client,
+            now=lambda: datetime(2026, 8, 21, 12, 0, tzinfo=UTC),
+        )
+        with pytest.raises(RuntimeError, match=r"installation 67890.*HTTP 403") as exc_info:
+            await provider.resolve("https://github.com/example/private.git", _credentials(key_path))
+
+    assert "secret response detail" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "response_json",
+    [
+        {"expires_at": "2026-08-21T13:00:00Z"},
+        {"token": "secret-token"},
+        {"token": "secret-token", "expires_at": "not-a-date"},
+    ],
+)
+@pytest.mark.asyncio
+async def test_github_app_token_endpoint_rejects_invalid_success_payload_without_leaking_token(
+    tmp_path: Path,
+    response_json: dict[str, Any],
+) -> None:
+    """Malformed success payloads must fail without exposing returned tokens."""
+    key_path = tmp_path / "private-key.pem"
+    _private_key(key_path)
+
+    async def _handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json=response_json)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(_handler)) as client:
+        provider = GitHubAppTokenProvider(
+            client=client,
+            now=lambda: datetime(2026, 8, 21, 12, 0, tzinfo=UTC),
+        )
+        with pytest.raises(RuntimeError, match="invalid token response") as exc_info:
+            await provider.resolve("https://github.com/example/private.git", _credentials(key_path))
+
+    assert "secret-token" not in str(exc_info.value)

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -9,6 +9,7 @@ index metadata.
 from __future__ import annotations
 
 import asyncio
+import base64
 import json
 import os
 import shlex
@@ -27,6 +28,7 @@ from mindroom import file_locks
 from mindroom.config.knowledge import KnowledgeGitConfig
 from mindroom.credentials import get_runtime_shared_credentials_manager
 from mindroom.knowledge.git_source import GitKnowledgeSource, GitSyncResult
+from mindroom.knowledge.github_app_auth import GitHubAppTokenProvider
 from mindroom.knowledge.manager import KnowledgeManager
 from mindroom.knowledge.redaction import redact_url_credentials
 from mindroom.knowledge.refresh_locks import refresh_source_root_lock
@@ -47,6 +49,39 @@ from tests.knowledge_test_support import (
 )
 
 pytestmark = pytest.mark.usefixtures("patch_vector_store")
+
+
+def _github_app_manager(tmp_path: Path, *, lfs: bool = False) -> tuple[KnowledgeManager, KnowledgeGitConfig]:
+    knowledge_path = tmp_path / "knowledge"
+    git_config = KnowledgeGitConfig(
+        repo_url="https://github.com/example/private.git",
+        branch="main",
+        credentials_service="github_app",
+        lfs=lfs,
+    )
+    config = _config(
+        tmp_path,
+        bases={"docs": knowledge_path},
+        agent_bases=["docs"],
+        git_configs={"docs": git_config},
+    )
+    runtime_paths = runtime_paths_for(config)
+    get_runtime_shared_credentials_manager(runtime_paths).save_credentials(
+        "github_app",
+        {
+            "auth_type": "github_app",
+            "app_id": 12345,
+            "installation_id": 67890,
+            "private_key_file": "/run/secrets/github-app/private-key.pem",
+        },
+    )
+    return KnowledgeManager("docs", config=config, runtime_paths=runtime_paths), git_config
+
+
+def _assert_github_app_auth_env(env: dict[str, str] | None) -> None:
+    assert env is not None
+    encoded = env["GIT_CONFIG_VALUE_0"].removeprefix("Authorization: Basic ")
+    assert base64.b64decode(encoded).decode() == "x-access-token:installation-token"
 
 
 def _git_manager(
@@ -480,6 +515,138 @@ async def test_git_credentials_service_token_stays_out_of_git_config_and_metadat
     assert clean_url in git_config_text
     assert "secret-token" not in metadata_text
     assert "x-access-token" not in metadata_text
+
+
+@pytest.mark.asyncio
+async def test_git_clone_resolves_github_app_credentials_for_each_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Initial clone must mint App credentials immediately before Git runs."""
+    manager, git_config = _github_app_manager(tmp_path)
+    clone_envs: list[dict[str, str] | None] = []
+    resolved: list[tuple[str, dict[str, object]]] = []
+
+    async def _resolve(
+        _self: GitHubAppTokenProvider,
+        repo_url: str,
+        credentials: dict[str, object],
+    ) -> tuple[str, str]:
+        resolved.append((repo_url, credentials))
+        return "x-access-token", "installation-token"
+
+    async def _run_git(
+        _self: GitKnowledgeSource,
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        _ = cwd
+        if args[0] == "clone":
+            clone_envs.append(env)
+        return ""
+
+    monkeypatch.setattr(GitHubAppTokenProvider, "resolve", _resolve)
+    monkeypatch.setattr(GitKnowledgeSource, "_run_git", _run_git)
+
+    assert await manager.git_source._ensure_repository(git_config) is True
+
+    assert len(resolved) == 1
+    assert resolved[0][0] == git_config.repo_url
+    assert resolved[0][1]["installation_id"] == 67890
+    _assert_github_app_auth_env(clone_envs[0])
+
+
+@pytest.mark.asyncio
+async def test_git_fetch_resolves_github_app_credentials_for_each_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every fetch must resolve App credentials so expired tokens can refresh."""
+    manager, git_config = _github_app_manager(tmp_path)
+    fetch_envs: list[dict[str, str] | None] = []
+    resolve_count = 0
+
+    async def _resolve(
+        _self: GitHubAppTokenProvider,
+        _repo_url: str,
+        _credentials: dict[str, object],
+    ) -> tuple[str, str]:
+        nonlocal resolve_count
+        resolve_count += 1
+        return "x-access-token", "installation-token"
+
+    async def _ensure_repository(_git_config: KnowledgeGitConfig) -> bool:
+        return False
+
+    async def _rev_parse(ref: str) -> str | None:
+        return "same-head" if ref in {"HEAD", "origin/main"} else None
+
+    async def _run_git(
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        _ = cwd
+        if args[0] == "fetch":
+            fetch_envs.append(env)
+        return ""
+
+    monkeypatch.setattr(GitHubAppTokenProvider, "resolve", _resolve)
+    monkeypatch.setattr(manager.git_source, "_ensure_repository", _ensure_repository)
+    monkeypatch.setattr(manager.git_source, "_rev_parse", _rev_parse)
+    monkeypatch.setattr(manager.git_source, "_run_git", _run_git)
+
+    changed, removed, updated = await manager.git_source._sync_once(git_config)
+
+    assert (changed, removed, updated) == (set(), set(), False)
+    assert resolve_count == 1
+    _assert_github_app_auth_env(fetch_envs[0])
+
+
+@pytest.mark.asyncio
+async def test_git_lfs_pull_resolves_github_app_credentials_for_each_operation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Git LFS pulls must use the same refreshable App credential path."""
+    manager, git_config = _github_app_manager(tmp_path, lfs=True)
+    lfs_envs: list[dict[str, str] | None] = []
+    resolve_count = 0
+
+    async def _resolve(
+        _self: GitHubAppTokenProvider,
+        _repo_url: str,
+        _credentials: dict[str, object],
+    ) -> tuple[str, str]:
+        nonlocal resolve_count
+        resolve_count += 1
+        return "x-access-token", "installation-token"
+
+    async def _rev_parse(_ref: str) -> str | None:
+        return "head"
+
+    async def _run_git(
+        args: list[str],
+        *,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        _ = cwd
+        if args[:2] == ["lfs", "pull"]:
+            lfs_envs.append(env)
+        return ""
+
+    monkeypatch.setattr(GitHubAppTokenProvider, "resolve", _resolve)
+    monkeypatch.setattr(manager.git_source, "_rev_parse", _rev_parse)
+    monkeypatch.setattr(manager.git_source, "_run_git", _run_git)
+
+    await manager.git_source._hydrate_lfs_worktree(git_config)
+
+    assert resolve_count == 1
+    _assert_github_app_auth_env(lfs_envs[0])
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -676,6 +676,38 @@ async def test_github_app_credentials_fail_closed_for_noncanonical_remotes(
 
 
 @pytest.mark.asyncio
+async def test_resolved_git_auth_loads_static_credentials_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inspecting auth type must reuse the same static credential snapshot."""
+    manager, _git_config = _github_app_manager(tmp_path)
+    credentials_manager = get_runtime_shared_credentials_manager(manager.runtime_paths)
+    credentials_manager.save_credentials("github_app", {"token": "static-token"})
+    real_load_credentials = credentials_manager.load_credentials
+    load_count = 0
+
+    def _load_credentials(service: str) -> dict[str, object] | None:
+        nonlocal load_count
+        load_count += 1
+        return real_load_credentials(service)
+
+    monkeypatch.setattr(credentials_manager, "load_credentials", _load_credentials)
+
+    env = await knowledge_git_source_module._resolved_git_auth_env(
+        "https://github.com/example/private.git",
+        "github_app",
+        manager.runtime_paths,
+        manager.git_source._github_app_token_provider,
+    )
+
+    assert load_count == 1
+    assert env is not None
+    encoded = env["GIT_CONFIG_VALUE_0"].removeprefix("Authorization: Basic ")
+    assert base64.b64decode(encoded).decode() == "x-access-token:static-token"
+
+
+@pytest.mark.asyncio
 async def test_git_embedded_userinfo_url_is_not_reused_in_git_auth_env(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -820,7 +820,7 @@ async def test_git_unsupported_scheme_userinfo_is_not_copied_to_git_config_env(
     serialized_clone_call = json.dumps({"args": clone_args, "env": clone_env}, sort_keys=True)
 
     assert result.index_published is True
-    assert clone_env is None
+    assert clone_env == {"GIT_LFS_SKIP_SMUDGE": "1"}
     assert clean_url in clone_args
     assert raw_url not in serialized_clone_call
     assert "secret-token" not in serialized_clone_call
@@ -1550,12 +1550,21 @@ async def test_sync_git_source_once_skips_repeated_lfs_pull_for_already_hydrated
 
 
 @pytest.mark.asyncio
-async def test_sync_git_source_once_pulls_lfs_after_reset(
+@pytest.mark.parametrize(
+    ("lfs", "expects_lfs_pull"),
+    [
+        pytest.param(True, True, id="lfs-enabled"),
+        pytest.param(False, False, id="lfs-disabled"),
+    ],
+)
+async def test_sync_git_source_once_controls_lfs_hydration_after_reset(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    lfs: bool,
+    expects_lfs_pull: bool,
 ) -> None:
-    """LFS-enabled repos should explicitly pull LFS objects after resetting to the remote branch."""
-    manager = _git_manager(tmp_path, lfs=True)
+    """Updates should suppress implicit smudging and hydrate only when LFS is enabled."""
+    manager = _git_manager(tmp_path, lfs=lfs)
     git_calls: list[list[str]] = []
     git_envs: list[tuple[list[str], dict[str, str] | None]] = []
 
@@ -1596,7 +1605,7 @@ async def test_sync_git_source_once_pulls_lfs_after_reset(
     assert updated is True
     assert changed_files == {"doc.md"}
     assert removed_files == set()
-    assert ["lfs", "pull", "origin", "main"] in git_calls
+    assert (["lfs", "pull", "origin", "main"] in git_calls) is expects_lfs_pull
     assert (
         ["checkout", "--force", "-B", "main", "origin/main"],
         {"GIT_LFS_SKIP_SMUDGE": "1"},
@@ -1649,12 +1658,21 @@ async def test_ensure_git_lfs_available_raises_clear_runtime_error(
 
 
 @pytest.mark.asyncio
-async def test_ensure_git_repository_clones_lfs_repo_with_skip_smudge_env(
+@pytest.mark.parametrize(
+    ("lfs", "expects_lfs_pull"),
+    [
+        pytest.param(True, True, id="lfs-enabled"),
+        pytest.param(False, False, id="lfs-disabled"),
+    ],
+)
+async def test_ensure_git_repository_clones_with_explicit_lfs_hydration_policy(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    lfs: bool,
+    expects_lfs_pull: bool,
 ) -> None:
-    """Initial LFS clones should hydrate even if an old hydrated-head marker matches the cloned commit."""
-    manager = _git_manager(tmp_path, lfs=True)
+    """Clones should suppress implicit smudging and hydrate only when LFS is enabled."""
+    manager = _git_manager(tmp_path, lfs=lfs)
     clone_envs: list[dict[str, str] | None] = []
     git_calls: list[list[str]] = []
     manager.git_source.lfs_hydrated_head_path.write_text("same", encoding="utf-8")
@@ -1681,7 +1699,7 @@ async def test_ensure_git_repository_clones_lfs_repo_with_skip_smudge_env(
 
     assert cloned is True
     assert clone_envs == [{"GIT_LFS_SKIP_SMUDGE": "1"}]
-    assert ["lfs", "pull", "origin", "main"] in git_calls
+    assert (["lfs", "pull", "origin", "main"] in git_calls) is expects_lfs_pull
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -649,6 +649,32 @@ async def test_git_lfs_pull_resolves_github_app_credentials_for_each_operation(
     _assert_github_app_auth_env(lfs_envs[0])
 
 
+@pytest.mark.parametrize(
+    "repo_url",
+    [
+        "git@github.com:example/private.git",
+        "https://embedded-token@github.com/example/private.git",
+        "https://example.com/example/private.git",
+        "not-a-remote",
+    ],
+)
+@pytest.mark.asyncio
+async def test_github_app_credentials_fail_closed_for_noncanonical_remotes(
+    tmp_path: Path,
+    repo_url: str,
+) -> None:
+    """Selecting App auth must never fall back to ambient or embedded credentials."""
+    manager, _git_config = _github_app_manager(tmp_path)
+
+    with pytest.raises(ValueError, match=r"canonical https://github.com"):
+        await knowledge_git_source_module._resolved_git_auth_env(
+            repo_url,
+            "github_app",
+            manager.runtime_paths,
+            manager.git_source._github_app_token_provider,
+        )
+
+
 @pytest.mark.asyncio
 async def test_git_embedded_userinfo_url_is_not_reused_in_git_auth_env(
     tmp_path: Path,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -5895,6 +5895,13 @@ async def test_subprocess_refresh_primes_parent_github_app_token(
     raw_payload["github_app_token"] = {
         "token": "parent-cached-token",
         "expires_at_epoch": 4_070_908_800,
+        "binding": {
+            "app_id": 12345,
+            "installation_id": 67890,
+            "owner": "example",
+            "repository": "private",
+            "private_key_file": str(tmp_path / "github-app.pem"),
+        },
     }
     mint_count = 0
 
@@ -5941,6 +5948,106 @@ async def test_subprocess_refresh_primes_parent_github_app_token(
 
     assert result.availability is KnowledgeAvailability.READY
     assert mint_count == 0
+
+
+@pytest.mark.asyncio
+async def test_subprocess_refresh_rejects_parent_token_after_credentials_rotate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A child must not bind an App token to credentials changed after minting."""
+    docs_path = tmp_path / "docs"
+    git_config = KnowledgeGitConfig(
+        repo_url="https://github.com/example/private.git",
+        credentials_service="github_app",
+    )
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={"docs": git_config},
+    )
+    runtime_paths = runtime_paths_for(config)
+    parent_credentials = {
+        "auth_type": "github_app",
+        "app_id": 12345,
+        "installation_id": 67890,
+        "private_key_file": str(tmp_path / "parent.pem"),
+    }
+    current_credentials = {
+        "auth_type": "github_app",
+        "app_id": 54321,
+        "installation_id": 9876,
+        "private_key_file": str(tmp_path / "current.pem"),
+    }
+    credentials_manager = get_runtime_shared_credentials_manager(runtime_paths)
+    credentials_manager.save_credentials("github_app", parent_credentials)
+    raw_payload = json.loads(
+        knowledge_refresh_runner._serialize_subprocess_refresh_request(
+            "docs",
+            config=config,
+            runtime_paths=runtime_paths,
+            execution_identity=None,
+            force_reindex=False,
+        ),
+    )
+    raw_payload["github_app_token"] = {
+        "token": "parent-cached-token",
+        "expires_at_epoch": 4_070_908_800,
+        "binding": {
+            "app_id": 12345,
+            "installation_id": 67890,
+            "owner": "example",
+            "repository": "private",
+            "private_key_file": str(tmp_path / "parent.pem"),
+        },
+    }
+    credentials_manager.save_credentials("github_app", current_credentials)
+    mint_count = 0
+
+    async def _fake_mint(
+        _self: GitHubAppTokenProvider,
+        _credentials: object,
+        *,
+        repository: str,
+        now: datetime,
+    ) -> object:
+        nonlocal mint_count
+        assert repository == "private"
+        assert now.tzinfo is not None
+        mint_count += 1
+        return SimpleNamespace(
+            token="current-token",  # noqa: S106
+            expires_at=datetime(2099, 1, 1, tzinfo=UTC),
+        )
+
+    async def _fake_refresh(
+        base_id: str,
+        *,
+        config: Config,
+        runtime_paths: RuntimePaths,
+        **_kwargs: object,
+    ) -> knowledge_refresh_runner.KnowledgeRefreshResult:
+        manager = KnowledgeManager(base_id, config=config, runtime_paths=runtime_paths)
+        resolved = await manager.git_source._github_app_token_provider.resolve(
+            git_config.repo_url,
+            current_credentials,
+        )
+        assert resolved == ("x-access-token", "current-token")
+        return knowledge_refresh_runner.KnowledgeRefreshResult(
+            key=resolve_published_index_key(base_id, config=config, runtime_paths=runtime_paths),
+            indexed_count=0,
+            index_published=False,
+            availability=KnowledgeAvailability.READY,
+        )
+
+    monkeypatch.setattr(GitHubAppTokenProvider, "_mint_token", _fake_mint)
+    monkeypatch.setattr(knowledge_refresh_runner, "refresh_knowledge_binding", _fake_refresh)
+
+    result = await knowledge_refresh_runner._run_subprocess_refresh_request(json.dumps(raw_payload).encode())
+
+    assert result.availability is KnowledgeAvailability.READY
+    assert mint_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from threading import Event, get_ident
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, cast
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import httpx
 import pytest
@@ -60,6 +60,7 @@ from mindroom.knowledge.file_listing import (
     list_knowledge_files,
 )
 from mindroom.knowledge.git_source import GitKnowledgeSource, GitSyncResult
+from mindroom.knowledge.github_app_auth import GitHubAppTokenProvider
 from mindroom.knowledge.indexing_config import IndexingSettings
 from mindroom.knowledge.manager import KnowledgeManager, _knowledge_source_signature
 from mindroom.knowledge.redaction import (
@@ -5772,6 +5773,174 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     assert captured_request["config_data"]["knowledge_bases"]["docs"]["chunk_size"] == 1234
     assert captured_request["runtime_knowledge_base"] is None
     assert captured_request["execution_identity"]["requester_id"] == "@alice:localhost"
+
+
+@pytest.mark.asyncio
+async def test_scheduled_refreshes_reuse_parent_github_app_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Consecutive refresh workers must receive one runtime-cached App token."""
+    docs_path = tmp_path / "docs"
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={
+            "docs": KnowledgeGitConfig(
+                repo_url="https://github.com/example/private.git",
+                credentials_service="github_app",
+            ),
+        },
+    )
+    runtime_paths = runtime_paths_for(config)
+    get_runtime_shared_credentials_manager(runtime_paths).save_credentials(
+        "github_app",
+        {
+            "auth_type": "github_app",
+            "app_id": 12345,
+            "installation_id": 67890,
+            "private_key_file": str(tmp_path / "github-app.pem"),
+        },
+    )
+    mint_count = 0
+    payloads: list[dict[str, object]] = []
+
+    async def _fake_mint(
+        _self: GitHubAppTokenProvider,
+        _credentials: object,
+        *,
+        repository: str,
+        now: datetime,
+    ) -> object:
+        nonlocal mint_count
+        assert repository == "private"
+        assert now.tzinfo is not None
+        mint_count += 1
+        return SimpleNamespace(
+            token="parent-cached-token",  # noqa: S106
+            expires_at=datetime(2099, 1, 1, tzinfo=UTC),
+        )
+
+    process = MagicMock(returncode=0)
+    process.wait = AsyncMock(return_value=0)
+
+    async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> MagicMock:
+        return process
+
+    async def _fake_send(_process: object, payload: bytes) -> None:
+        payloads.append(json.loads(payload))
+
+    async def _fake_terminate(_process: object) -> None:
+        pass
+
+    monkeypatch.setattr(GitHubAppTokenProvider, "_mint_token", _fake_mint)
+    monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_refresh_runner, "_subprocess_session_kwargs", dict)
+    monkeypatch.setattr(knowledge_refresh_runner, "_send_subprocess_refresh_request", _fake_send)
+    monkeypatch.setattr(knowledge_refresh_runner, "_terminate_refresh_subprocess", _fake_terminate)
+
+    await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
+        "docs",
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
+        "docs",
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+
+    assert mint_count == 1
+    assert [payload["github_app_token"]["token"] for payload in payloads] == [
+        "parent-cached-token",
+        "parent-cached-token",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_subprocess_refresh_primes_parent_github_app_token(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A refresh child must use its parent-provided token without reminting."""
+    docs_path = tmp_path / "docs"
+    git_config = KnowledgeGitConfig(
+        repo_url="https://github.com/example/private.git",
+        credentials_service="github_app",
+    )
+    config = _config(
+        tmp_path,
+        bases={"docs": docs_path},
+        agent_bases=["docs"],
+        git_configs={"docs": git_config},
+    )
+    runtime_paths = runtime_paths_for(config)
+    credentials = {
+        "auth_type": "github_app",
+        "app_id": 12345,
+        "installation_id": 67890,
+        "private_key_file": str(tmp_path / "github-app.pem"),
+    }
+    get_runtime_shared_credentials_manager(runtime_paths).save_credentials("github_app", credentials)
+    raw_payload = json.loads(
+        knowledge_refresh_runner._serialize_subprocess_refresh_request(
+            "docs",
+            config=config,
+            runtime_paths=runtime_paths,
+            execution_identity=None,
+            force_reindex=False,
+        ),
+    )
+    raw_payload["github_app_token"] = {
+        "token": "parent-cached-token",
+        "expires_at_epoch": 4_070_908_800,
+    }
+    mint_count = 0
+
+    async def _fake_mint(
+        _self: GitHubAppTokenProvider,
+        _credentials: object,
+        *,
+        repository: str,
+        now: datetime,
+    ) -> object:
+        nonlocal mint_count
+        assert repository == "private"
+        assert now.tzinfo is not None
+        mint_count += 1
+        return SimpleNamespace(
+            token="unexpected-remint",  # noqa: S106
+            expires_at=datetime(2099, 1, 1, tzinfo=UTC),
+        )
+
+    async def _fake_refresh(
+        base_id: str,
+        *,
+        config: Config,
+        runtime_paths: RuntimePaths,
+        **_kwargs: object,
+    ) -> knowledge_refresh_runner.KnowledgeRefreshResult:
+        manager = KnowledgeManager(base_id, config=config, runtime_paths=runtime_paths)
+        resolved = await manager.git_source._github_app_token_provider.resolve(
+            git_config.repo_url,
+            credentials,
+        )
+        assert resolved == ("x-access-token", "parent-cached-token")
+        return knowledge_refresh_runner.KnowledgeRefreshResult(
+            key=resolve_published_index_key(base_id, config=config, runtime_paths=runtime_paths),
+            indexed_count=0,
+            index_published=False,
+            availability=KnowledgeAvailability.READY,
+        )
+
+    monkeypatch.setattr(GitHubAppTokenProvider, "_mint_token", _fake_mint)
+    monkeypatch.setattr(knowledge_refresh_runner, "refresh_knowledge_binding", _fake_refresh)
+
+    result = await knowledge_refresh_runner._run_subprocess_refresh_request(json.dumps(raw_payload).encode())
+
+    assert result.availability is KnowledgeAvailability.READY
+    assert mint_count == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add refreshable GitHub App installation-token credentials for Git-backed knowledge sources
- scope tokens to one repository with read-only contents permission and cache them until near expiry
- use the same auth path for clone, fetch, and Git LFS while preserving static token credentials
- fail closed for noncanonical GitHub remotes and redact credential/API failures
- document deployment and credential configuration

## Verification
- `uv run pytest -n 0 tests/test_github_app_auth.py tests/test_knowledge_git_source.py -k "not direct_refresh_timeout_drains_git_descendants_before_releasing_source_lock"` (64 passed, 1 pre-existing timing test deselected)
- `uv run pre-commit run --files ...` on changed files

## Deployment sequencing
Merge and release this before switching runtime knowledge-base credential mappings to the new App-backed services.

## Summary by Sourcery

Enable secure GitHub App authentication for Git-backed knowledge sources and scheduled refreshes.

New Features:
- Add GitHub App installation-token authentication for Git-backed knowledge sources with repository-scoped read-only access and runtime caching.
- Pass cached App credentials safely to scheduled refresh subprocesses while supporting credential rotation.

Bug Fixes:
- Ensure GitHub App authentication fails closed for invalid or noncanonical remotes and redacts secret material from errors and persisted Git metadata.
- Apply consistent explicit Git LFS hydration behavior across Git-backed knowledge sources.

Enhancements:
- Use one refreshable authentication path for Git clone, fetch, and LFS operations while preserving existing static credentials.

Documentation:
- Document GitHub App credential configuration, token behavior, security constraints, and deployment requirements.

Tests:
- Add coverage for GitHub App credential validation, token scoping and caching, key rotation, concurrency, subprocess handoff, redaction, and Git/LFS integration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GitHub App authentication for private Git repositories.
  * Supports repository-scoped, read-only tokens for cloning, fetching, and Git LFS operations.
  * Tokens are securely cached and refreshed automatically.

* **Documentation**
  * Added configuration, repository URL, credential, and security guidance.
  * Clarified that Git LFS hydration occurs only when explicitly enabled.

* **Bug Fixes**
  * Improved Git LFS environment handling during checkout and reset.

* **Tests**
  * Added comprehensive authentication, security, caching, concurrency, and Git operation coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->