### PR TITLE
Skip restart auto-resume when its identity is absent

### DIFF
--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -156,6 +156,26 @@ def _cleanup_scan_policy(
     )
 
 
+def _auto_resume_threads_for_room(
+    room_id: str,
+    interrupted_threads: list[_InterruptedThread],
+    *,
+    resume_client: nio.AsyncClient | None,
+    resume_user_id: str | None,
+    joined_actors: dict[str, nio.AsyncClient],
+) -> list[_InterruptedThread]:
+    """Keep auto-resume work only where its Matrix identity is joined."""
+    if not interrupted_threads or resume_client is None or resume_user_id in joined_actors:
+        return interrupted_threads
+    logger.info(
+        "Skipping auto-resume because resume identity is not joined",
+        room_id=room_id,
+        resume_user_id=resume_user_id,
+        interrupted_count=len(interrupted_threads),
+    )
+    return []
+
+
 def _requester_resolution_message(
     *,
     event_id: str,
@@ -212,7 +232,7 @@ async def recover_stale_streaming_messages(
             scan_client = joined_actors[min(joined_actors)]
         async with semaphore:
             try:
-                return await _cleanup_stale_streaming_room(
+                cleaned_count, interrupted_threads = await _cleanup_stale_streaming_room(
                     scan_client,
                     room_id=room_id,
                     actors=joined_actors,
@@ -226,6 +246,15 @@ async def recover_stale_streaming_messages(
                 scanned_room_ids.discard(room_id)
                 logger.warning("Failed stale stream recovery for room", room_id=room_id, exc_info=True)
                 return 0, []
+            else:
+                interrupted_threads = _auto_resume_threads_for_room(
+                    room_id,
+                    interrupted_threads,
+                    resume_client=resume_client,
+                    resume_user_id=resume_user_id,
+                    joined_actors=joined_actors,
+                )
+                return cleaned_count, interrupted_threads
 
     tasks = [
         asyncio.create_task(recover_room(room_id, joined_actors), name=f"stale_stream_recovery:{room_id}")

--- a/src/mindroom/matrix/stale_stream_cleanup.py
+++ b/src/mindroom/matrix/stale_stream_cleanup.py
@@ -140,6 +140,14 @@ class _CleanupScanPolicy:
     max_extra_old_pages: int
 
 
+@dataclass(frozen=True)
+class _JoinedRoomState:
+    """Actor rooms to scan plus the independent resume identity membership."""
+
+    room_actors: dict[str, dict[str, nio.AsyncClient]]
+    resume_room_ids: frozenset[str] | None
+
+
 def _cleanup_scan_policy(
     config: Config,
     *,
@@ -160,17 +168,25 @@ def _auto_resume_threads_for_room(
     room_id: str,
     interrupted_threads: list[_InterruptedThread],
     *,
+    auto_resume_enabled: bool,
     resume_client: nio.AsyncClient | None,
-    resume_user_id: str | None,
-    joined_actors: dict[str, nio.AsyncClient],
+    resume_room_ids: frozenset[str] | None,
+    scanned_room_ids: set[str],
 ) -> list[_InterruptedThread]:
-    """Keep auto-resume work only where its Matrix identity is joined."""
-    if not interrupted_threads or resume_client is None or resume_user_id in joined_actors:
+    """Keep eligible work and leave membership-deferred rooms retryable."""
+    if (
+        not auto_resume_enabled
+        or not interrupted_threads
+        or resume_client is None
+        or (resume_room_ids is not None and room_id in resume_room_ids)
+    ):
         return interrupted_threads
+    scanned_room_ids.discard(room_id)
     logger.info(
-        "Skipping auto-resume because resume identity is not joined",
+        "Deferring auto-resume until resume identity membership is available",
         room_id=room_id,
-        resume_user_id=resume_user_id,
+        resume_user_id=resume_client.user_id,
+        membership_known=resume_room_ids is not None,
         interrupted_count=len(interrupted_threads),
     )
     return []
@@ -210,9 +226,10 @@ async def recover_stale_streaming_messages(
     room_concurrency: int = _RECOVERY_ROOM_CONCURRENCY,
 ) -> _StaleStreamRecoveryResult:
     """Recover stale streams through one concurrent Matrix-history path."""
+    joined_room_state = await _joined_room_actors(actors, resume_client=resume_client)
     room_actors = {
         room_id: joined_actors
-        for room_id, joined_actors in (await _joined_room_actors(actors)).items()
+        for room_id, joined_actors in joined_room_state.room_actors.items()
         if room_id not in scanned_room_ids and (target_room_ids is None or room_id in target_room_ids)
     }
     scanned_room_ids.update(room_actors)
@@ -250,9 +267,10 @@ async def recover_stale_streaming_messages(
                 interrupted_threads = _auto_resume_threads_for_room(
                     room_id,
                     interrupted_threads,
+                    auto_resume_enabled=config.defaults.auto_resume_after_restart,
                     resume_client=resume_client,
-                    resume_user_id=resume_user_id,
-                    joined_actors=joined_actors,
+                    resume_room_ids=joined_room_state.resume_room_ids,
+                    scanned_room_ids=scanned_room_ids,
                 )
                 return cleaned_count, interrupted_threads
 
@@ -290,13 +308,15 @@ async def recover_stale_streaming_messages(
 
 async def _joined_room_actors(
     actors: dict[str, nio.AsyncClient],
-) -> dict[str, dict[str, nio.AsyncClient]]:
-    """Return each joined room once with every available bot account in it."""
+    *,
+    resume_client: nio.AsyncClient | None,
+) -> _JoinedRoomState:
+    """Discover actor scan rooms and resume membership without widening scans."""
 
     async def joined_rooms_for_actor(
         bot_user_id: str,
         client: nio.AsyncClient,
-    ) -> tuple[str, nio.AsyncClient, list[str]]:
+    ) -> tuple[str, nio.AsyncClient, list[str] | None]:
         try:
             joined_rooms = await get_joined_rooms(client)
         except Exception:
@@ -306,16 +326,25 @@ async def _joined_room_actors(
                 exc_info=True,
             )
             joined_rooms = None
-        return bot_user_id, client, joined_rooms or []
+        return bot_user_id, client, joined_rooms
 
+    membership_clients = dict(actors)
+    resume_user_id = resume_client.user_id if resume_client is not None else None
+    if isinstance(resume_user_id, str) and resume_client is not None:
+        membership_clients[resume_user_id] = resume_client
     joined_room_results = await asyncio.gather(
-        *(joined_rooms_for_actor(bot_user_id, client) for bot_user_id, client in actors.items()),
+        *(joined_rooms_for_actor(bot_user_id, client) for bot_user_id, client in membership_clients.items()),
     )
     room_actors: dict[str, dict[str, nio.AsyncClient]] = {}
+    resume_room_ids: frozenset[str] | None = None
     for bot_user_id, client, joined_room_ids in joined_room_results:
-        for room_id in joined_room_ids:
+        if bot_user_id == resume_user_id and joined_room_ids is not None:
+            resume_room_ids = frozenset(joined_room_ids)
+        if bot_user_id not in actors:
+            continue
+        for room_id in joined_room_ids or []:
             room_actors.setdefault(room_id, {})[bot_user_id] = client
-    return room_actors
+    return _JoinedRoomState(room_actors=room_actors, resume_room_ids=resume_room_ids)
 
 
 async def _auto_resume_interrupted_threads(

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -3056,6 +3056,57 @@ async def test_recovery_scans_unique_rooms_and_resumes_before_slow_rooms_finish(
 
 
 @pytest.mark.asyncio
+async def test_recovery_skips_auto_resume_when_resume_identity_is_not_joined(tmp_path: Path) -> None:
+    """A resume identity must not read or write a room it is not joined to."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    agent_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    actors = {
+        "@actual_router:localhost": router_client,
+        BOT_USER_ID: agent_client,
+    }
+    interrupted = InterruptedThread(
+        room_id=ROOM_ID,
+        thread_id="$thread",
+        target_event_id="$target",
+        partial_text="Partial",
+        agent_name="test_agent",
+    )
+
+    async def joined_rooms(client: object) -> list[str]:
+        if client is router_client:
+            return []
+        assert client is agent_client
+        return [ROOM_ID]
+
+    with (
+        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
+            new=AsyncMock(return_value=(1, [interrupted])),
+        ),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
+            new=AsyncMock(return_value=1),
+        ) as auto_resume,
+    ):
+        scanned_room_ids: set[str] = set()
+        result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=scanned_room_ids,
+        )
+
+    assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)
+    assert scanned_room_ids == {ROOM_ID}
+    auto_resume.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_recovery_resumes_all_51_rooms_even_when_newest_room_finishes_last(tmp_path: Path) -> None:
     """Completion order must not impose a hidden total resume cap."""
     config = _make_config(tmp_path)

--- a/tests/test_stale_stream_cleanup.py
+++ b/tests/test_stale_stream_cleanup.py
@@ -3102,8 +3102,116 @@ async def test_recovery_skips_auto_resume_when_resume_identity_is_not_joined(tmp
         )
 
     assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)
-    assert scanned_room_ids == {ROOM_ID}
+    assert scanned_room_ids == set()
     auto_resume.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovery_retries_auto_resume_after_resume_identity_joins(tmp_path: Path) -> None:
+    """A pre-join cleanup scan must not hide the room from the post-setup delta."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_user_id = "@actual_router:localhost"
+    router_client = make_matrix_client_mock(user_id=router_user_id)
+    agent_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    actors = {
+        router_user_id: router_client,
+        BOT_USER_ID: agent_client,
+    }
+    interrupted = InterruptedThread(
+        room_id=ROOM_ID,
+        thread_id="$thread",
+        target_event_id="$target",
+        partial_text="Partial",
+        agent_name="test_agent",
+    )
+    router_is_joined = False
+
+    async def joined_rooms(client: object) -> list[str]:
+        if client is router_client:
+            return [ROOM_ID] if router_is_joined else []
+        assert client is agent_client
+        return [ROOM_ID]
+
+    with (
+        patch("mindroom.matrix.stale_stream_cleanup.get_joined_rooms", side_effect=joined_rooms),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
+            new=AsyncMock(return_value=(1, [interrupted])),
+        ) as cleanup_room,
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
+            new=AsyncMock(return_value=1),
+        ) as auto_resume,
+    ):
+        scanned_room_ids: set[str] = set()
+        initial_result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=scanned_room_ids,
+        )
+        router_is_joined = True
+        delta_result = await recover_stale_streaming_messages(
+            actors,
+            resume_client=router_client,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=NOW_MS,
+            scanned_room_ids=scanned_room_ids,
+        )
+
+    assert initial_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=0)
+    assert delta_result == StaleStreamRecoveryResult(room_count=1, cleaned_count=1, resumed_count=1)
+    assert cleanup_room.await_count == 2
+    auto_resume.assert_awaited_once()
+    assert scanned_room_ids == {ROOM_ID}
+
+
+@pytest.mark.asyncio
+async def test_targeted_recovery_tracks_resume_membership_outside_scan_actors(tmp_path: Path) -> None:
+    """Replacement recovery must check its separate resume client's membership."""
+    config = _make_config(tmp_path)
+    config.defaults.auto_resume_after_restart = True
+    router_client = make_matrix_client_mock(user_id="@actual_router:localhost")
+    agent_client = make_matrix_client_mock(user_id=BOT_USER_ID)
+    interrupted = InterruptedThread(
+        room_id=ROOM_ID,
+        thread_id="$thread",
+        target_event_id="$target",
+        partial_text="Partial",
+        agent_name="test_agent",
+    )
+
+    with (
+        patch(
+            "mindroom.matrix.stale_stream_cleanup.get_joined_rooms",
+            new=AsyncMock(return_value=[ROOM_ID]),
+        ) as joined_rooms,
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._cleanup_stale_streaming_room",
+            new=AsyncMock(return_value=(0, [interrupted])),
+        ),
+        patch(
+            "mindroom.matrix.stale_stream_cleanup._auto_resume_interrupted_threads",
+            new=AsyncMock(return_value=1),
+        ) as auto_resume,
+    ):
+        result = await recover_stale_streaming_messages(
+            {BOT_USER_ID: agent_client},
+            resume_client=router_client,
+            config=config,
+            runtime_paths=runtime_paths_for(config),
+            startup_cutoff_ms=None,
+            scanned_room_ids=set(),
+            target_room_ids={ROOM_ID},
+        )
+
+    assert result == StaleStreamRecoveryResult(room_count=1, cleaned_count=0, resumed_count=1)
+    assert {call.args[0] for call in joined_rooms.await_args_list} == {agent_client, router_client}
+    auto_resume.assert_awaited_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- Preserve stale-stream cleanup when any managed identity can scan the room.
- Schedule restart auto-resume only after confirming the resume identity is joined.
- Keep deferred rooms eligible for post-setup and targeted recovery retries.

## Why

Startup recovery can scan a room through one managed identity before the identity responsible for auto-resume has joined. Auto-resume must not read or write through an identity without room membership, and an early cleanup pass must not prevent a later post-join retry.

## Testing

- `uv run pytest -q`
- `uv run pre-commit run --files src/mindroom/matrix/stale_stream_cleanup.py tests/test_stale_stream_cleanup.py`
- Regression coverage for:
  - rooms where the resume identity is not joined
  - joining between the initial and delta recovery passes
  - targeted recovery with a separate resume client