### PR TITLE
Add pre-seeded repository sandbox tool

### DIFF
--- a/src/mindroom/custom_tools/repo_sandbox.py
+++ b/src/mindroom/custom_tools/repo_sandbox.py
@@ -1,0 +1,421 @@
+"""Repository sandbox tools for safe pre-seeded local inspect/edit/test workflows."""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+import re
+import shlex
+import subprocess
+from pathlib import Path
+from urllib.parse import urlparse
+
+from agno.tools import Toolkit
+
+from mindroom.custom_tools.coding import CodingTools
+from mindroom.tools.path_safety import resolve_base_dir_path
+
+_DEFAULT_ALLOWED_REPOS = ("schmits/repo-sandbox-fixture",)
+_DEFAULT_DENIED_REPOS = (
+    "schmits/prod",
+    "schmits/production",
+    "schmits/secrets",
+    "schmits/security",
+)
+_DEFAULT_ALLOWED_TEST_COMMANDS = ("pytest -q", "python -m pytest -q", "npm test", "npm run test", "pnpm test")
+_GITHUB_REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_GITHUB_SSH_RE = re.compile(r"^(?:git@|ssh://git@)github\.com[:/](?P<path>[^?#]+)$", re.IGNORECASE)
+_MAX_COMMAND_OUTPUT_BYTES = 60_000
+_DEFAULT_TEST_TIMEOUT_SECONDS = 120
+
+
+class RepoSandboxTools(Toolkit):
+    """Safe repository sandbox wrapper for non-production coding fixtures.
+
+    The wrapper intentionally avoids generic shell access and authenticated
+    GitHub access: git operations are limited to local verification, status, and
+    diff commands. Repository names are allowlisted, filesystem access is
+    confined to one repository directory under ``sandbox_root``, and mutating
+    edit/test operations require ``confirm_write=True``.
+    """
+
+    def __init__(
+        self,
+        sandbox_root: str | None = None,
+        allowed_repos: list[str] | str | None = None,
+        denied_repos: list[str] | str | None = None,
+        allowed_test_commands: list[str] | str | None = None,
+        default_repo: str = "schmits/repo-sandbox-fixture",
+    ) -> None:
+        self.sandbox_root = Path(sandbox_root).resolve() if sandbox_root else (Path.cwd() / "repo_sandbox").resolve()
+        self.allowed_repos = _normalize_repo_patterns(allowed_repos, fallback=_DEFAULT_ALLOWED_REPOS, field_name="allowed_repos")
+        self.denied_repos = _normalize_repo_patterns(denied_repos, fallback=_DEFAULT_DENIED_REPOS, field_name="denied_repos")
+        self.allowed_test_commands = _normalize_string_list(allowed_test_commands) or list(_DEFAULT_ALLOWED_TEST_COMMANDS)
+        self.default_repo = default_repo
+        super().__init__(
+            name="repo_sandbox",
+            tools=[
+                self.clone_or_update,
+                self.status,
+                self.list_files,
+                self.read_file,
+                self.grep,
+                self.edit_file,
+                self.write_file,
+                self.run_tests,
+            ],
+        )
+
+    def clone_or_update(
+        self,
+        repo: str | None = None,
+        ref: str | None = None,
+        confirm_write: bool = False,
+    ) -> str:
+        """Verify an allowlisted, pre-seeded local repository checkout.
+
+        This compatibility-named function no longer clones, fetches, checks out,
+        or authenticates to GitHub. Repositories must already exist under
+        ``sandbox_root`` using the configured owner/name slug directory.
+
+        Args:
+            repo: GitHub repository in owner/name form. Defaults to the configured fixture repository.
+            ref: Optional branch, tag, or commit-like ref that must already resolve to the current HEAD.
+            confirm_write: Accepted for backward compatibility; no write is performed.
+
+        Returns:
+            A status message with the sandbox-relative repository path.
+
+        """
+        try:
+            repo_name = self._validate_repo(repo)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        repo_dir = self._repo_dir(repo_name)
+        if not repo_dir.exists():
+            return _preseeded_repo_missing_error()
+        if not (repo_dir / ".git").is_dir():
+            return f"Error: sandbox path exists but is not a git repository: {repo_dir}"
+
+        inside = self._run_git(["rev-parse", "--is-inside-work-tree"], cwd=repo_dir)
+        if inside.returncode != 0 or inside.stdout.strip() != "true":
+            return _format_completed_process("git repository verification failed", inside)
+
+        head = self._run_git(["rev-parse", "HEAD"], cwd=repo_dir)
+        if head.returncode != 0:
+            return _format_completed_process("git HEAD verification failed", head)
+        head_sha = head.stdout.strip()
+
+        if ref:
+            if not _valid_git_ref(ref):
+                return "Error: ref contains unsupported characters. Use a branch, tag, or commit-like ref."
+            ref_result = self._run_git(["rev-parse", "--verify", f"{ref}^{{commit}}"], cwd=repo_dir)
+            if ref_result.returncode != 0:
+                return _format_completed_process("git ref verification failed", ref_result)
+            ref_sha = ref_result.stdout.strip()
+            if ref_sha != head_sha:
+                short_head = head_sha[:7]
+                short_ref = ref_sha[:7]
+                return f"Error: pre-seeded checkout is at {short_head}, but ref '{ref}' resolves to {short_ref}. Seed the expected ref locally before using repo_sandbox."
+
+        suffix = f" at {head_sha[:7]}" if head_sha else ""
+        return f"Repository ready: {_repo_slug(repo_name)}/{suffix}"
+
+    def status(self, repo: str | None = None) -> str:
+        """Return git status and a compact diff summary for an allowlisted sandbox repository."""
+        repo_dir = self._existing_repo_dir(repo)
+        if isinstance(repo_dir, str):
+            return repo_dir
+        status_result = self._run_git(["status", "--short", "--branch"], cwd=repo_dir)
+        diff_result = self._run_git(["diff", "--stat", "--"], cwd=repo_dir)
+        parts = ["# git status", status_result.stdout or status_result.stderr]
+        if diff_result.stdout:
+            parts.extend(["\n# git diff --stat", diff_result.stdout])
+        return _truncate_output("\n".join(parts).strip())
+
+    def list_files(self, repo: str | None = None, pattern: str = "**/*", limit: int = 500) -> str:
+        """List repository files matching a glob pattern, excluding the .git directory."""
+        repo_dir = self._existing_repo_dir(repo)
+        if isinstance(repo_dir, str):
+            return repo_dir
+        if limit <= 0:
+            return "Error: limit must be positive."
+        matches: list[str] = []
+        for path in repo_dir.rglob("*"):
+            if ".git" in path.relative_to(repo_dir).parts:
+                continue
+            rel = path.relative_to(repo_dir).as_posix() + ("/" if path.is_dir() else "")
+            if fnmatch.fnmatch(rel, pattern):
+                matches.append(rel)
+            if len(matches) >= limit:
+                break
+        if not matches:
+            return "No files found."
+        suffix = f"\n[limited to {limit} entries]" if len(matches) >= limit else ""
+        return "\n".join(matches) + suffix
+
+    def read_file(self, path: str, repo: str | None = None, offset: int | None = None, limit: int | None = None) -> str:
+        """Read a file from an allowlisted sandbox repository with line numbers."""
+        coding = self._coding_tools(repo)
+        if isinstance(coding, str):
+            return coding
+        return coding.read_file(path, offset=offset, limit=limit)
+
+    def grep(
+        self,
+        pattern: str,
+        repo: str | None = None,
+        path: str | None = None,
+        glob: str | None = None,
+        ignore_case: bool = False,
+        literal: bool = False,
+        context: int = 0,
+        limit: int = 100,
+    ) -> str:
+        """Search file contents inside an allowlisted sandbox repository."""
+        coding = self._coding_tools(repo)
+        if isinstance(coding, str):
+            return coding
+        return coding.grep(pattern, path=path, glob=glob, ignore_case=ignore_case, literal=literal, context=context, limit=limit)
+
+    def edit_file(self, path: str, old_text: str, new_text: str, repo: str | None = None, confirm_write: bool = False) -> str:
+        """Replace a unique text occurrence in a sandbox repository file. Requires confirm_write=true."""
+        if not confirm_write:
+            return _write_confirmation_error("edit_file")
+        coding = self._coding_tools(repo)
+        if isinstance(coding, str):
+            return coding
+        return coding.edit_file(path, old_text, new_text)
+
+    def write_file(self, path: str, content: str, repo: str | None = None, confirm_write: bool = False) -> str:
+        """Write a file inside a sandbox repository. Requires confirm_write=true."""
+        if not confirm_write:
+            return _write_confirmation_error("write_file")
+        coding = self._coding_tools(repo)
+        if isinstance(coding, str):
+            return coding
+        return coding.write_file(path, content)
+
+    def run_tests(
+        self,
+        command: str = "pytest -q",
+        repo: str | None = None,
+        timeout_seconds: int = _DEFAULT_TEST_TIMEOUT_SECONDS,
+        confirm_write: bool = False,
+    ) -> str:
+        """Run an allowlisted test command inside a sandbox repository. Requires confirm_write=true.
+
+        Test commands are treated as mutating because they may create caches or
+        build artifacts. Commands are split with shlex and run without a shell.
+        """
+        if not confirm_write:
+            return _write_confirmation_error("run_tests")
+        if command not in self.allowed_test_commands:
+            allowed = ", ".join(repr(item) for item in self.allowed_test_commands)
+            return f"Error: test command is not allowlisted. Allowed commands: {allowed}."
+        if timeout_seconds <= 0 or timeout_seconds > 600:
+            return "Error: timeout_seconds must be between 1 and 600."
+        repo_dir = self._existing_repo_dir(repo)
+        if isinstance(repo_dir, str):
+            return repo_dir
+        try:
+            argv = shlex.split(command)
+        except ValueError as exc:
+            return f"Error parsing command: {exc}"
+        if not argv:
+            return "Error: command must be non-empty."
+        try:
+            result = subprocess.run(
+                argv,
+                cwd=repo_dir,
+                env=_safe_subprocess_env(),
+                text=True,
+                capture_output=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            return f"Error: executable not found: {exc.filename}"
+        except subprocess.TimeoutExpired as exc:
+            partial = "\n".join(part for part in (exc.stdout, exc.stderr) if isinstance(part, str))
+            return _truncate_output(f"Command timed out after {timeout_seconds}s.\n{partial}".strip())
+        return _format_completed_process(f"test command exited {result.returncode}", result)
+
+    def _validate_repo(self, repo: str | None) -> str:
+        repo_name = _canonical_github_repo(repo or self.default_repo)
+        if _matches_repo_patterns(repo_name, self.denied_repos):
+            denied = ", ".join(self.denied_repos)
+            raise ValueError(f"repository '{repo_name}' is explicitly denied. Denied repositories: {denied}.")
+        if not _matches_repo_patterns(repo_name, self.allowed_repos):
+            allowed = ", ".join(self.allowed_repos)
+            raise ValueError(f"repository '{repo_name}' is not allowlisted. Allowed repositories: {allowed}.")
+        return repo_name
+
+    def _repo_dir(self, repo: str) -> Path:
+        return resolve_base_dir_path(self.sandbox_root, _repo_slug(repo), restrict_to_base_dir=True)
+
+    def _existing_repo_dir(self, repo: str | None) -> Path | str:
+        try:
+            repo_name = self._validate_repo(repo)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        repo_dir = self._repo_dir(repo_name)
+        if not (repo_dir / ".git").is_dir():
+            return _preseeded_repo_missing_error()
+        return repo_dir
+
+    def _coding_tools(self, repo: str | None) -> CodingTools | str:
+        repo_dir = self._existing_repo_dir(repo)
+        if isinstance(repo_dir, str):
+            return repo_dir
+        return CodingTools(base_dir=str(repo_dir), restrict_to_base_dir=True)
+
+    @staticmethod
+    def _run_git(args: list[str], *, cwd: Path, extra_env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+        env = _safe_subprocess_env()
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=120,
+            check=False,
+        )
+
+
+def _normalize_string_list(value: list[str] | str | None) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [item.strip() for item in value.replace("\n", ",").split(",") if item.strip()]
+    return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _normalize_repo_patterns(value: list[str] | str | None, *, fallback: tuple[str, ...], field_name: str) -> list[str]:
+    raw_patterns = _normalize_string_list(value) or list(fallback)
+    normalized: list[str] = []
+    for raw in raw_patterns:
+        try:
+            if raw.endswith("*"):
+                if not raw.endswith("/*"):
+                    raise ValueError("wildcard patterns must end with '/*'.")
+                owner_repo = _canonical_github_repo(f"{raw.removesuffix('/*')}/placeholder")
+                canonical = f"{owner_repo.split('/', 1)[0]}/*"
+            else:
+                canonical = _canonical_github_repo(raw)
+        except ValueError as exc:
+            raise ValueError(f"{field_name}: invalid repository pattern '{raw}': {exc}") from exc
+        normalized.append(canonical)
+    return normalized
+
+
+def _canonical_github_repo(repo: str) -> str:
+    repo_name = repo.strip()
+    if not repo_name:
+        raise ValueError("repo must be non-empty.")
+
+    ssh_match = _GITHUB_SSH_RE.fullmatch(repo_name)
+    if ssh_match:
+        repo_name = ssh_match.group("path")
+    elif "://" in repo_name:
+        parsed = urlparse(repo_name)
+        if parsed.scheme not in {"https", "http"}:
+            raise ValueError("repo URL must use https://github.com/ or owner/name form.")
+        if parsed.hostname != "github.com":
+            raise ValueError("repo URL host must be github.com.")
+        repo_name = parsed.path
+    elif repo_name.lower().startswith("github.com/"):
+        repo_name = repo_name[len("github.com/") :]
+    elif ":" in repo_name or "@" in repo_name:
+        raise ValueError("repo must be a GitHub owner/name, https URL, or git@github.com SSH URL.")
+
+    repo_name = repo_name.strip("/")
+    if repo_name.endswith(".git"):
+        repo_name = repo_name[:-4]
+    parts = repo_name.split("/")
+    if len(parts) != 2 or any(not part for part in parts):
+        raise ValueError("repo must identify exactly one GitHub repository in owner/name form.")
+    if any(part in {".", ".."} for part in parts) or not _GITHUB_REPO_RE.fullmatch(repo_name):
+        raise ValueError("repo contains unsupported characters.")
+    return f"{parts[0].lower()}/{parts[1]}"
+
+
+def _matches_repo_patterns(repo: str, patterns: list[str]) -> bool:
+    for pattern in patterns:
+        if pattern.endswith("/*"):
+            owner = pattern.removesuffix("/*")
+            if repo.startswith(f"{owner}/"):
+                return True
+        elif repo == pattern:
+            return True
+    return False
+
+
+def _repo_slug(repo: str) -> str:
+    return repo.replace("/", "__")
+
+
+def _valid_git_ref(ref: str) -> bool:
+    return bool(ref) and all(ch.isalnum() or ch in "._/-" for ch in ref) and ".." not in ref and not ref.startswith("-")
+
+
+def _looks_like_commit(ref: str) -> bool:
+    return len(ref) >= 7 and all(ch in "0123456789abcdefABCDEF" for ch in ref)
+
+
+def _safe_subprocess_env() -> dict[str, str]:
+    keys = {
+        "HOME",
+        "LANG",
+        "LC_ALL",
+        "LC_CTYPE",
+        "PATH",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "REQUESTS_CA_BUNDLE",
+        "GIT_SSL_CAINFO",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+    }
+    return {key: value for key, value in os.environ.items() if key in keys}
+
+
+def _preseeded_repo_missing_error() -> str:
+    return "Error: repository is not available locally. Pre-seed the allowlisted checkout under sandbox_root before using repo_sandbox."
+
+
+def _write_confirmation_error(action: str) -> str:
+    return f"Error: {action} writes inside the repository sandbox. Re-run with confirm_write=true after confirming the target repo/path/command."
+
+
+def _truncate_output(text: str) -> str:
+    encoded = text.encode("utf-8", errors="replace")
+    if len(encoded) <= _MAX_COMMAND_OUTPUT_BYTES:
+        return text
+    return encoded[:_MAX_COMMAND_OUTPUT_BYTES].decode("utf-8", errors="ignore") + "\n[truncated]"
+
+
+def _redact_text(text: str, secrets: list[str] | None = None) -> str:
+    redacted = text
+    for secret in secrets or []:
+        if secret:
+            redacted = redacted.replace(secret, "[REDACTED]")
+    return redacted
+
+
+def _format_completed_process(label: str, result: subprocess.CompletedProcess[str], *, secrets: list[str] | None = None) -> str:
+    parts = [label]
+    if result.stdout:
+        parts.extend(["\nstdout:", result.stdout])
+    if result.stderr:
+        parts.extend(["\nstderr:", result.stderr])
+    if not result.stdout and not result.stderr:
+        parts.append("\n(no output)")
+    return _truncate_output(_redact_text("".join(parts).strip(), secrets))

--- a/src/mindroom/tools/__init__.py
+++ b/src/mindroom/tools/__init__.py
@@ -55,7 +55,6 @@ from mindroom.tools.custom_api import custom_api_tools
 from mindroom.tools.dalle import dalle_tools
 from mindroom.tools.daytona import daytona_tools
 from mindroom.tools.desi_vocal import desi_vocal_tools
-from mindroom.tools.desktop import desktop_tools
 from mindroom.tools.discord import discord_tools
 from mindroom.tools.docker import docker_tools
 from mindroom.tools.duckdb import duckdb_tools
@@ -111,6 +110,7 @@ from mindroom.tools.reasoning import reasoning_tools
 from mindroom.tools.reddit import reddit_tools
 from mindroom.tools.redshift import redshift_tools
 from mindroom.tools.replicate import replicate_tools
+from mindroom.tools.repo_sandbox import repo_sandbox_tools
 from mindroom.tools.resend import resend_tools
 from mindroom.tools.scheduler import scheduler_tools
 from mindroom.tools.scrapegraph import scrapegraph_tools
@@ -186,7 +186,6 @@ __all__ = [
     "dalle_tools",
     "daytona_tools",
     "desi_vocal_tools",
-    "desktop_tools",
     "discord_tools",
     "docker_tools",
     "duckdb_tools",
@@ -243,6 +242,7 @@ __all__ = [
     "redshift_tools",
     "register_thread_summary_tools",
     "replicate_tools",
+    "repo_sandbox_tools",
     "resend_tools",
     "scheduler_tools",
     "scrapegraph_tools",

--- a/src/mindroom/tools/repo_sandbox.py
+++ b/src/mindroom/tools/repo_sandbox.py
@@ -1,0 +1,119 @@
+"""Pre-seeded local repo sandbox tool configuration."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.tool_system.declarations import ConfigField, SetupType, ToolCategory, ToolExecutionTarget, ToolStatus
+from mindroom.tool_system.registration import register_tool_with_metadata
+
+if TYPE_CHECKING:
+    from mindroom.custom_tools.repo_sandbox import RepoSandboxTools
+
+
+@register_tool_with_metadata(
+    name="repo_sandbox",
+    display_name="Repository Sandbox",
+    description=(
+        "Allowlisted pre-seeded local repository inspect/edit/test workflow confined to a sandbox directory. "
+        "No GitHub clone, fetch, or authenticated network access is performed; edit, write, and test calls require explicit confirm_write=true."
+    ),
+    category=ToolCategory.DEVELOPMENT,
+    status=ToolStatus.AVAILABLE,
+    setup_type=SetupType.NONE,
+    default_execution_target=ToolExecutionTarget.WORKER,
+    consumes_workspace_paths=True,
+    icon="GitBranch",
+    icon_color="text-emerald-600",
+    config_fields=[
+        ConfigField(
+            name="sandbox_root",
+            label="Sandbox Root",
+            type="text",
+            required=False,
+            default=None,
+            description="Directory containing pre-seeded allowlisted repositories. Defaults to ./repo_sandbox in the worker workspace.",
+        ),
+        ConfigField(
+            name="allowed_repos",
+            label="Allowed GitHub Repositories",
+            type="string[]",
+            required=False,
+            default=["schmits/repo-sandbox-fixture"],
+            description="Owner/name repositories or owner/* repository patterns this tool may access when already pre-seeded locally.",
+        ),
+        ConfigField(
+            name="denied_repos",
+            label="Denied GitHub Repositories",
+            type="string[]",
+            required=False,
+            default=["schmits/prod", "schmits/production", "schmits/secrets", "schmits/security"],
+            description="Owner/name repositories or owner/* patterns that are denied before allow rules are evaluated.",
+        ),
+        ConfigField(
+            name="allowed_test_commands",
+            label="Allowed Test Commands",
+            type="string[]",
+            required=False,
+            default=["pytest -q", "python -m pytest -q", "npm test", "npm run test", "pnpm test"],
+            description="Exact test commands allowed by run_tests. Commands run without a shell.",
+        ),
+        ConfigField(
+            name="default_repo",
+            label="Default Repository",
+            type="text",
+            required=False,
+            default="schmits/repo-sandbox-fixture",
+            description="Default owner/name repository when a call omits repo.",
+        ),
+    ],
+    agent_override_fields=[
+        ConfigField(
+            name="sandbox_root",
+            label="Sandbox Root",
+            type="text",
+            required=False,
+            default=None,
+            description="Per-agent sandbox root. Defaults to ./repo_sandbox in the worker workspace.",
+        ),
+        ConfigField(
+            name="allowed_repos",
+            label="Allowed GitHub Repositories",
+            type="string[]",
+            required=False,
+            default=["schmits/repo-sandbox-fixture"],
+            description="Per-agent owner/name repositories or owner/* repository patterns this tool may access when already pre-seeded locally.",
+        ),
+        ConfigField(
+            name="denied_repos",
+            label="Denied GitHub Repositories",
+            type="string[]",
+            required=False,
+            default=["schmits/prod", "schmits/production", "schmits/secrets", "schmits/security"],
+            description="Per-agent owner/name repositories or owner/* patterns denied before allow rules are evaluated.",
+        ),
+        ConfigField(
+            name="allowed_test_commands",
+            label="Allowed Test Commands",
+            type="string[]",
+            required=False,
+            default=["pytest -q", "python -m pytest -q", "npm test", "npm run test", "pnpm test"],
+            description="Per-agent exact test commands allowed by run_tests.",
+        ),
+        ConfigField(
+            name="default_repo",
+            label="Default Repository",
+            type="text",
+            required=False,
+            default="schmits/repo-sandbox-fixture",
+            description="Per-agent default owner/name repository when a call omits repo.",
+        ),
+    ],
+    dependencies=[],
+    function_names=("clone_or_update", "edit_file", "grep", "list_files", "read_file", "run_tests", "status", "write_file"),
+)
+def repo_sandbox_tools() -> type[RepoSandboxTools]:
+    """Return safe repository sandbox tools."""
+    from mindroom.custom_tools.repo_sandbox import RepoSandboxTools
+
+    return RepoSandboxTools

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -2674,7 +2674,7 @@
         {
           "authored_override": true,
           "default": null,
-          "description": "Optional allowlist of Docker command functions to expose. Leave unset to expose all commands.",
+          "description": "Optional allowlist of Docker command functions to expose. Leave empty to expose all Docker commands.",
           "label": "Exposed Docker Commands",
           "name": "include_tools",
           "options": null,
@@ -4055,7 +4055,7 @@
         },
         {
           "authored_override": true,
-          "default": true,
+          "default": false,
           "description": "Allow creating new spreadsheets",
           "label": "Enable Create Operations",
           "name": "create",
@@ -4067,7 +4067,7 @@
         },
         {
           "authored_override": true,
-          "default": true,
+          "default": false,
           "description": "Allow updating existing spreadsheets",
           "label": "Enable Update Operations",
           "name": "update",
@@ -5772,6 +5772,183 @@
       "requires_room_context": false,
       "setup_type": "api_key",
       "status": "requires_config"
+    },
+    {
+      "agent_override_fields": [
+        {
+          "authored_override": true,
+          "default": null,
+          "description": "Per-agent sandbox root. Defaults to ./repo_sandbox in the worker workspace.",
+          "label": "Sandbox Root",
+          "name": "sandbox_root",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "text",
+          "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": [
+            "schmits/repo-sandbox-fixture"
+          ],
+          "description": "Per-agent owner/name repositories or owner/* repository patterns this tool may access when already pre-seeded locally.",
+          "label": "Allowed GitHub Repositories",
+          "name": "allowed_repos",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "string[]",
+          "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": [
+            "schmits/prod",
+            "schmits/production",
+            "schmits/secrets",
+            "schmits/security"
+          ],
+          "description": "Per-agent owner/name repositories or owner/* patterns denied before allow rules are evaluated.",
+          "label": "Denied GitHub Repositories",
+          "name": "denied_repos",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "string[]",
+          "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": [
+            "pytest -q",
+            "python -m pytest -q",
+            "npm test",
+            "npm run test",
+            "pnpm test"
+          ],
+          "description": "Per-agent exact test commands allowed by run_tests.",
+          "label": "Allowed Test Commands",
+          "name": "allowed_test_commands",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "string[]",
+          "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": "schmits/repo-sandbox-fixture",
+          "description": "Per-agent default owner/name repository when a call omits repo.",
+          "label": "Default Repository",
+          "name": "default_repo",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "text",
+          "validation": null
+        }
+      ],
+      "auth_provider": null,
+      "category": "development",
+      "config_fields": [
+        {
+          "authored_override": true,
+          "default": null,
+          "description": "Directory containing pre-seeded allowlisted repositories. Defaults to ./repo_sandbox in the worker workspace.",
+          "label": "Sandbox Root",
+          "name": "sandbox_root",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "text",
+          "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": [
+            "schmits/repo-sandbox-fixture"
+          ],
+          "description": "Owner/name repositories or owner/* repository patterns this tool may access when already pre-seeded locally.",
+          "label": "Allowed GitHub Repositories",
+          "name": "allowed_repos",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "string[]",
+          "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": [
+            "schmits/prod",
+            "schmits/production",
+            "schmits/secrets",
+            "schmits/security"
+          ],
+          "description": "Owner/name repositories or owner/* patterns that are denied before allow rules are evaluated.",
+          "label": "Denied GitHub Repositories",
+          "name": "denied_repos",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "string[]",
+          "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": [
+            "pytest -q",
+            "python -m pytest -q",
+            "npm test",
+            "npm run test",
+            "pnpm test"
+          ],
+          "description": "Exact test commands allowed by run_tests. Commands run without a shell.",
+          "label": "Allowed Test Commands",
+          "name": "allowed_test_commands",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "string[]",
+          "validation": null
+        },
+        {
+          "authored_override": true,
+          "default": "schmits/repo-sandbox-fixture",
+          "description": "Default owner/name repository when a call omits repo.",
+          "label": "Default Repository",
+          "name": "default_repo",
+          "options": null,
+          "placeholder": null,
+          "required": false,
+          "type": "text",
+          "validation": null
+        }
+      ],
+      "consumes_workspace_paths": true,
+      "default_execution_target": "worker",
+      "dependencies": [],
+      "description": "Allowlisted pre-seeded local repository inspect/edit/test workflow confined to a sandbox directory. No GitHub clone, fetch, or authenticated network access is performed; edit, write, and test calls require explicit confirm_write=true.",
+      "display_name": "Repository Sandbox",
+      "docs_url": null,
+      "function_names": [
+        "clone_or_update",
+        "edit_file",
+        "grep",
+        "list_files",
+        "read_file",
+        "run_tests",
+        "status",
+        "write_file"
+      ],
+      "helper_text": null,
+      "icon": "GitBranch",
+      "icon_color": "text-emerald-600",
+      "name": "repo_sandbox",
+      "requires_room_context": false,
+      "setup_type": "none",
+      "status": "available"
     },
     {
       "agent_override_fields": null,
@@ -7658,41 +7835,6 @@
       "config_fields": [
         {
           "authored_override": true,
-          "default": 30,
-          "description": "Short-lived command and response timeout, from 1 to 120 seconds.",
-          "label": "Command Timeout Seconds",
-          "name": "timeout_seconds",
-          "options": null,
-          "placeholder": null,
-          "required": false,
-          "type": "number",
-          "validation": null
-        }
-      ],
-      "consumes_workspace_paths": false,
-      "default_execution_target": "primary",
-      "dependencies": null,
-      "description": "Operate exact locally allowlisted applications through accessibility state over Matrix encryption",
-      "display_name": "Matrix Desktop",
-      "docs_url": "https://docs.mindroom.chat/tools/desktop/",
-      "function_names": [
-        "desktop"
-      ],
-      "helper_text": "Ask the requester to send `!desktop setup` in a private Matrix room containing only them and one Desktop-enabled agent, plus the router when it serves the command.",
-      "icon": "MonitorUp",
-      "icon_color": "text-cyan-500",
-      "name": "desktop",
-      "requires_room_context": true,
-      "setup_type": "special",
-      "status": "requires_config"
-    },
-    {
-      "agent_override_fields": null,
-      "auth_provider": null,
-      "category": "productivity",
-      "config_fields": [
-        {
-          "authored_override": true,
           "default": null,
           "description": null,
           "label": "Db Path",
@@ -7872,7 +8014,7 @@
         },
         {
           "authored_override": true,
-          "default": true,
+          "default": false,
           "description": "Allow the agent to create, update, and delete calendar events",
           "label": "Allow Updates",
           "name": "allow_update",
@@ -8040,18 +8182,6 @@
         },
         {
           "authored_override": true,
-          "default": true,
-          "description": "Allow uploading, creating folders, moving or renaming files, and trashing files.",
-          "label": "Allow Write Operations",
-          "name": "write",
-          "options": null,
-          "placeholder": null,
-          "required": false,
-          "type": "boolean",
-          "validation": null
-        },
-        {
-          "authored_override": true,
           "default": 10485760,
           "description": "Maximum non-Google-Workspace file size to read in bytes.",
           "label": "Max Read Size",
@@ -8063,7 +8193,7 @@
           "validation": null
         }
       ],
-      "consumes_workspace_paths": true,
+      "consumes_workspace_paths": false,
       "default_execution_target": "primary",
       "dependencies": [
         "google-api-python-client",
@@ -8071,18 +8201,14 @@
         "google-auth-httplib2",
         "google-auth-oauthlib"
       ],
-      "description": "Search, read, upload, and organize files in the connected user's Google Drive",
+      "description": "Search and read files from the connected user's Google Drive",
       "display_name": "Google Drive",
       "docs_url": "https://docs.agno.com/tools/toolkits/others/google_drive",
       "function_names": [
         "google_drive_list_files",
         "google_drive_search_files",
         "google_drive_read_file",
-        "google_drive_download_file",
-        "google_drive_upload_file",
-        "google_drive_create_folder",
-        "google_drive_move_file",
-        "google_drive_trash_file"
+        "google_drive_download_file"
       ],
       "helper_text": null,
       "icon": "SiGoogledrive",
@@ -9772,7 +9898,7 @@
         {
           "authored_override": true,
           "default": null,
-          "description": "Optional host target directory for browser screenshots, PDFs, and downloads. Defaults to the active storage path's browser/ directory. The desktop target instead uses its local storage path's desktop-browser/ directory.",
+          "description": "Optional directory for browser screenshots, PDFs, and downloads. Defaults to the active storage path's browser/ directory.",
           "label": "Output Directory",
           "name": "output_dir",
           "options": null,
@@ -9791,75 +9917,6 @@
           "placeholder": null,
           "required": false,
           "type": "boolean",
-          "validation": null
-        },
-        {
-          "authored_override": true,
-          "default": "host",
-          "description": "Use host for MindRoom's managed Playwright profile or desktop for the Playwright extension installed in the user's existing local browser profile.",
-          "label": "Default Browser Target",
-          "name": "default_target",
-          "options": [
-            {
-              "label": "MindRoom host profile",
-              "value": "host"
-            },
-            {
-              "label": "Matrix desktop profile",
-              "value": "desktop"
-            }
-          ],
-          "placeholder": null,
-          "required": false,
-          "type": "select",
-          "validation": null
-        },
-        {
-          "authored_override": true,
-          "default": null,
-          "description": "Required for target=desktop; dedicated Matrix account used by the local desktop bridge.",
-          "label": "Desktop Matrix User ID",
-          "name": "device_user_id",
-          "options": null,
-          "placeholder": null,
-          "required": false,
-          "type": "text",
-          "validation": null
-        },
-        {
-          "authored_override": true,
-          "default": null,
-          "description": "Required for target=desktop; exact device ID printed by 'mindroom desktop login'.",
-          "label": "Desktop Matrix Device ID",
-          "name": "device_id",
-          "options": null,
-          "placeholder": null,
-          "required": false,
-          "type": "text",
-          "validation": null
-        },
-        {
-          "authored_override": true,
-          "default": null,
-          "description": "Required for target=desktop; exact Ed25519 fingerprint of the local bridge device.",
-          "label": "Desktop Device Fingerprint",
-          "name": "device_ed25519",
-          "options": null,
-          "placeholder": null,
-          "required": false,
-          "type": "text",
-          "validation": null
-        },
-        {
-          "authored_override": true,
-          "default": 90,
-          "description": "Matrix and local Playwright MCP timeout from 1 to 120 seconds.",
-          "label": "Desktop Browser Timeout Seconds",
-          "name": "timeout_seconds",
-          "options": null,
-          "placeholder": null,
-          "required": false,
-          "type": "number",
           "validation": null
         }
       ],

--- a/tests/test_config_validation_helpers.py
+++ b/tests/test_config_validation_helpers.py
@@ -6,8 +6,10 @@ import pytest
 
 from mindroom.config.agent import AgentConfig, CultureConfig, TeamConfig
 from mindroom.config.auth import AuthorizationConfig
+from mindroom.config.main import Config
 from mindroom.config.models import DefaultsConfig, ToolConfigEntry
 from mindroom.config.validation import duplicate_items, validate_history_limit_choice
+from mindroom.constants import resolve_runtime_paths
 
 
 def test_duplicate_items_preserves_first_duplicate_encounter_order() -> None:
@@ -91,3 +93,89 @@ def test_history_limit_validators_preserve_error_message(factory: object, match:
     """Defaults, agents, and teams should reject ambiguous history limits consistently."""
     with pytest.raises(ValueError, match=match):
         factory()
+
+
+def _runtime_paths_for_validation() -> object:
+    """Return runtime paths for catalog-aware config validation."""
+    return resolve_runtime_paths(config_path="config.yaml", process_env={})
+
+
+def test_github_dev_coding_sandbox_fixture_includes_repo_sandbox_and_production_github_dev_does_not() -> None:
+    """The non-production GitHub Dev sandbox fixture should be the only GitHub Dev config with repo_sandbox."""
+    config = Config.validate_with_runtime(
+        {
+            "agents": {
+                "github_dev": {
+                    "display_name": "GitHub Dev",
+                    "role": "Production GitHub development agent",
+                    "tools": ["github"],
+                },
+                "github_dev_coding_sandbox": {
+                    "display_name": "GitHub Dev Coding Sandbox",
+                    "role": "Non-production GitHub Dev coding sandbox fixture",
+                    "tools": ["github", "repo_sandbox"],
+                },
+            },
+        },
+        _runtime_paths_for_validation(),
+    )
+
+    assert "repo_sandbox" in config.agents["github_dev_coding_sandbox"].tool_names
+    assert "repo_sandbox" not in config.agents["github_dev"].tool_names
+
+
+def test_github_dev_coding_sandbox_repo_sandbox_structured_fields_validate() -> None:
+    """Structured repo_sandbox entries should accept supported fields in the sandbox fixture."""
+    config = Config.validate_with_runtime(
+        {
+            "agents": {
+                "github_dev": {
+                    "display_name": "GitHub Dev",
+                    "role": "Production GitHub development agent",
+                    "tools": ["github"],
+                },
+                "github_dev_coding_sandbox": {
+                    "display_name": "GitHub Dev Coding Sandbox",
+                    "role": "Non-production GitHub Dev coding sandbox fixture",
+                    "tools": [
+                        "github",
+                        {
+                            "repo_sandbox": {
+                                "sandbox_root": "./repo_sandbox",
+                                "allowed_repos": ["schmits/repo-sandbox-fixture"],
+                                "denied_repos": ["schmits/prod"],
+                                "allowed_test_commands": ["pytest -q"],
+                                "default_repo": "schmits/repo-sandbox-fixture",
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+        _runtime_paths_for_validation(),
+    )
+
+    assert config.agents["github_dev_coding_sandbox"].get_tool_overrides("repo_sandbox") == {
+        "sandbox_root": "./repo_sandbox",
+        "allowed_repos": ["schmits/repo-sandbox-fixture"],
+        "denied_repos": ["schmits/prod"],
+        "allowed_test_commands": ["pytest -q"],
+        "default_repo": "schmits/repo-sandbox-fixture",
+    }
+    assert config.agents["github_dev"].get_tool_overrides("repo_sandbox") is None
+
+
+def test_github_dev_coding_sandbox_repo_sandbox_rejects_unknown_structured_field() -> None:
+    """Runtime validation should reject unsupported structured repo_sandbox fields."""
+    with pytest.raises(ValueError, match=r"repo_sandbox\.unknown_field: unknown authored override field"):
+        Config.validate_with_runtime(
+            {
+                "agents": {
+                    "github_dev_coding_sandbox": {
+                        "display_name": "GitHub Dev Coding Sandbox",
+                        "tools": [{"repo_sandbox": {"unknown_field": True}}],
+                    },
+                },
+            },
+            _runtime_paths_for_validation(),
+        )

--- a/tests/test_repo_sandbox_tools.py
+++ b/tests/test_repo_sandbox_tools.py
@@ -1,0 +1,200 @@
+"""Tests for repo_sandbox custom tools."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from mindroom.custom_tools.repo_sandbox import RepoSandboxTools
+from mindroom.tool_system.registry_state import BUILTIN_TOOL_METADATA
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir()
+    subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=path, check=True)
+    (path / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-m", "initial"], cwd=path, check=True, capture_output=True, text=True)
+
+
+def test_repo_sandbox_metadata_registered() -> None:
+    metadata = BUILTIN_TOOL_METADATA["repo_sandbox"]
+    assert metadata.default_execution_target.value == "worker"
+    assert metadata.consumes_workspace_paths is True
+    assert "clone_or_update" in metadata.function_names
+
+
+def test_write_operations_require_confirmation(tmp_path: Path) -> None:
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["schmits/repo-sandbox-fixture"])
+
+    assert "Pre-seed the allowlisted checkout" in tools.clone_or_update()
+    assert "confirm_write=true" in tools.edit_file("README.md", "a", "b")
+    assert "confirm_write=true" in tools.write_file("README.md", "content")
+    assert "confirm_write=true" in tools.run_tests()
+
+
+def test_rejects_unallowlisted_repo(tmp_path: Path) -> None:
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["schmits/repo-sandbox-fixture"])
+
+    assert "not allowlisted" in tools.status(repo="octocat/Hello-World")
+
+
+def test_scoped_repo_pattern_allows_canonical_github_inputs(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "schmits__example"
+    _init_repo(repo_dir)
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["github.com/schmits/*"])
+
+    assert tools.status(repo="github.com/schmits/example").startswith("# git status")
+    assert tools.status(repo="https://github.com/schmits/example.git").startswith("# git status")
+    assert tools.status(repo="git@github.com:schmits/example.git").startswith("# git status")
+
+
+def test_scoped_repo_pattern_denies_malformed_and_lookalike_inputs(tmp_path: Path) -> None:
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["github.com/schmits/*"])
+
+    denied_inputs = [
+        "octocat/example",
+        "github.com/schmitsfoo/example",
+        "https://evil.test/schmits/example",
+        "https://github.evil.test/schmits/example",
+        "https://gitlab.com/schmits/example",
+        "git@gitlab.com:schmits/example.git",
+        "schmits/../secrets",
+        "https://github.com/schmits/example/../../secrets",
+    ]
+
+    for repo in denied_inputs:
+        result = tools.status(repo=repo)
+        assert result.startswith("Error:"), repo
+        assert "not allowlisted" in result or "repo" in result, repo
+
+
+def test_repo_deny_rules_take_precedence_over_scoped_allow_patterns(tmp_path: Path) -> None:
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["github.com/schmits/*"])
+
+    for repo in ["schmits/prod", "schmits/production", "schmits/secrets", "schmits/security"]:
+        result = tools.status(repo=repo)
+        assert "explicitly denied" in result
+
+
+def test_file_access_confined_to_preseeded_repo(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "schmits__repo-sandbox-fixture"
+    _init_repo(repo_dir)
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["schmits/repo-sandbox-fixture"])
+
+    assert "hello" in tools.read_file("README.md")
+    assert "outside base_dir" in tools.read_file("../outside.txt")
+
+
+def test_edit_and_status_inside_existing_repo(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "schmits__repo-sandbox-fixture"
+    _init_repo(repo_dir)
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["schmits/repo-sandbox-fixture"])
+
+    result = tools.edit_file("README.md", "hello", "hi", confirm_write=True)
+
+    assert "Applied edit" in result
+    assert "README.md" in tools.status()
+
+
+def test_run_tests_uses_exact_allowlist(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "schmits__repo-sandbox-fixture"
+    _init_repo(repo_dir)
+    tools = RepoSandboxTools(
+        sandbox_root=str(tmp_path),
+        allowed_repos=["schmits/repo-sandbox-fixture"],
+        allowed_test_commands=["python -c 'print(123)'"],
+    )
+
+    assert "not allowlisted" in tools.run_tests("python -c 'print(456)'", confirm_write=True)
+    assert "123" in tools.run_tests("python -c 'print(123)'", confirm_write=True)
+
+
+def test_mode_separation_keeps_repo_and_test_allowlists_independent(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "schmits__example"
+    _init_repo(repo_dir)
+    tools = RepoSandboxTools(
+        sandbox_root=str(tmp_path),
+        allowed_repos=["github.com/schmits/*"],
+        allowed_test_commands=["python -c 'print(123)'"],
+    )
+
+    assert "# git status" in tools.status(repo="schmits/example")
+    assert "not allowlisted" in tools.run_tests("pytest -q", repo="schmits/example", confirm_write=True)
+    assert "123" in tools.run_tests("python -c 'print(123)'", repo="schmits/example", confirm_write=True)
+    assert "not allowlisted" in tools.run_tests("python -c 'print(123)'", repo="octocat/example", confirm_write=True)
+
+
+def test_clone_or_update_verifies_preseeded_repo_without_clone_fetch_or_auth(monkeypatch, tmp_path: Path) -> None:
+    repo_dir = tmp_path / "schmits__repo-sandbox-fixture"
+    _init_repo(repo_dir)
+    calls: list[list[str]] = []
+    real_run_git = RepoSandboxTools._run_git
+
+    def spy_run_git(args: list[str], **kwargs: object):
+        calls.append(args)
+        assert args[0] not in {"clone", "fetch", "checkout"}
+        extra_env = kwargs.get("extra_env")
+        assert not extra_env
+        return real_run_git(args, **kwargs)
+
+    monkeypatch.setenv("REPO_SANDBOX_GITHUB_TOKEN", "sandbox-token")
+    monkeypatch.setenv("REPO_SANDBOX_GITHUB_APP_TOKEN", "app-token")
+    monkeypatch.setattr(RepoSandboxTools, "_run_git", staticmethod(spy_run_git))
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["schmits/repo-sandbox-fixture"])
+
+    result = tools.clone_or_update(confirm_write=True)
+
+    assert result.startswith("Repository ready: schmits__repo-sandbox-fixture/ at ")
+    assert calls
+    assert [call[0] for call in calls] == ["rev-parse", "rev-parse"]
+
+
+def test_clone_or_update_does_not_require_confirmation_for_local_verification(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "schmits__repo-sandbox-fixture"
+    _init_repo(repo_dir)
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["schmits/repo-sandbox-fixture"])
+
+    assert tools.clone_or_update().startswith("Repository ready:")
+
+
+def test_clone_or_update_missing_repo_reports_preseed_requirement(tmp_path: Path) -> None:
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["schmits/repo-sandbox-fixture"])
+
+    result = tools.clone_or_update(confirm_write=True)
+
+    assert "Pre-seed the allowlisted checkout" in result
+
+
+def test_clone_or_update_ref_must_match_current_preseeded_head(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "schmits__repo-sandbox-fixture"
+    _init_repo(repo_dir)
+    subprocess.run(["git", "checkout", "-b", "other"], cwd=repo_dir, check=True, capture_output=True, text=True)
+    (repo_dir / "README.md").write_text("changed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=repo_dir, check=True)
+    subprocess.run(["git", "commit", "-m", "other"], cwd=repo_dir, check=True, capture_output=True, text=True)
+    subprocess.run(["git", "checkout", "master"], cwd=repo_dir, check=True, capture_output=True, text=True)
+    tools = RepoSandboxTools(sandbox_root=str(tmp_path), allowed_repos=["schmits/repo-sandbox-fixture"])
+
+    result = tools.clone_or_update(ref="other", confirm_write=True)
+
+    assert "pre-seeded checkout is at" in result
+    assert "Seed the expected ref locally" in result
+
+
+def test_safe_subprocess_env_filters_git_auth_and_tokens(monkeypatch) -> None:
+    monkeypatch.setenv("REPO_SANDBOX_GITHUB_TOKEN", "sandbox-token")
+    monkeypatch.setenv("REPO_SANDBOX_GITHUB_APP_TOKEN", "app-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "generic-token")
+    monkeypatch.setenv("GIT_ASKPASS", "/tmp/askpass")
+    monkeypatch.setenv("GIT_TERMINAL_PROMPT", "1")
+
+    env = RepoSandboxTools._run_git.__globals__["_safe_subprocess_env"]()
+
+    assert "REPO_SANDBOX_GITHUB_TOKEN" not in env
+    assert "REPO_SANDBOX_GITHUB_APP_TOKEN" not in env
+    assert "GITHUB_TOKEN" not in env
+    assert "GIT_ASKPASS" not in env
+    assert "GIT_TERMINAL_PROMPT" not in env


### PR DESCRIPTION
## Summary by Sourcery

Introduce a pre-seeded local repository sandbox for safe development workflows without cloning, fetching, or authenticating to GitHub.

New Features:
- Add a repository sandbox tool for inspecting, editing, and testing pre-seeded local GitHub repositories.

Enhancements:
- Restrict repository access through allowlists, deny rules, path confinement, safe subprocess environments, and explicit write confirmation.
- Support local repository verification, file browsing, content search, controlled edits, and exact allowlisted test commands without GitHub network access.
- Register the repository sandbox in the tool catalog with configurable global and per-agent settings.

Tests:
- Add coverage for repository validation, sandbox path safety, write confirmation, command allowlists, local Git verification, and configuration validation.

Chores:
- Remove the desktop tool from the built-in tool exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Repository Sandbox for inspecting, searching, editing, and testing approved local repositories.
  * Added repository allowlists, denylists, path confinement, approved test commands, and write confirmations.
  * Added support for pre-seeded checkouts without cloning, fetching, or authenticated network access.

* **Security & Configuration**
  * Made Google Drive read-only and disabled selected write operations for Google Sheets and Calendar.
  * Removed desktop-specific browser and Matrix configuration.

* **Tests**
  * Added coverage for repository permissions, safe file access, command restrictions, metadata, and credential filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->