### PR TITLE
Fix deterministic knowledge source signatures

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -419,7 +419,7 @@ def _knowledge_source_signature(
             else git_tracked_relative_paths_from_checkout(config, base_id, root)
         )
         files = knowledge_files_from_relative_paths(config, base_id, root, tracked_paths)
-    for path in files:
+    for path in sorted(files, key=lambda candidate: candidate.relative_to(root).as_posix()):
         try:
             stat = path.stat()
             relative_path = path.relative_to(root).as_posix()

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -419,10 +419,10 @@ def _knowledge_source_signature(
             else git_tracked_relative_paths_from_checkout(config, base_id, root)
         )
         files = knowledge_files_from_relative_paths(config, base_id, root, tracked_paths)
-    for path in sorted(files, key=lambda candidate: candidate.relative_to(root).as_posix()):
+    files_with_relative_paths = ((path.relative_to(root).as_posix(), path) for path in files)
+    for relative_path, path in sorted(files_with_relative_paths):
         try:
             stat = path.stat()
-            relative_path = path.relative_to(root).as_posix()
             source_digest = _file_content_digest(path)
         except OSError:
             continue

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -8194,6 +8194,24 @@ async def test_reindex_hashes_live_corpus_for_non_git_bases(
 
 
 @pytest.mark.asyncio
+async def test_non_git_refresh_publishes_when_file_and_directory_share_a_stem(tmp_path: Path) -> None:
+    """Stable corpora publish when a file and directory share a stem."""
+    docs_path = tmp_path / "docs"
+    nested_path = docs_path / "topic"
+    nested_path.mkdir(parents=True)
+    (docs_path / "topic.md").write_text("top-level topic", encoding="utf-8")
+    (nested_path / "details.md").write_text("nested topic details", encoding="utf-8")
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert result.index_published is True
+    assert result.availability is KnowledgeAvailability.READY
+    assert result.indexed_count == 2
+
+
+@pytest.mark.asyncio
 async def test_git_noop_refresh_ignores_untracked_indexable_file_changes(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Hash live knowledge files in canonical relative POSIX-path order.
- Keep live and candidate corpus signatures consistent when a file and directory share a stem.
- Add regression coverage through the real refresh and publish path.

## Testing
- `uv run pytest tests/test_knowledge_manager.py::test_non_git_refresh_publishes_when_file_and_directory_share_a_stem -n 0 --no-cov -q`
- `uv run pytest tests/test_knowledge_manager.py -n 0 --no-cov -q`
- `uv run pre-commit run --all-files`
- `uv run pytest` (15,153 passed, 23 skipped)

## Summary by Sourcery

Make knowledge source signatures deterministic and reliably publish stable non-Git corpora.

Bug Fixes:
- Ensure knowledge source signatures are deterministic by hashing files in canonical relative POSIX-path order.
- Keep live and candidate corpus signatures consistent when files and directories share a stem, allowing non-Git refreshes to publish correctly.

Tests:
- Add regression coverage through the real refresh and publish path for file and directory stem collisions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Knowledge refreshes now produce consistent results regardless of file discovery order.
  * Fixed refresh handling when a file and directory share the same name stem, ensuring both are indexed successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->