### PR TITLE
Fix reserved browser tool namespace

### DIFF
--- a/src/mindroom/custom_tools/browser.py
+++ b/src/mindroom/custom_tools/browser.py
@@ -1,6 +1,6 @@
 """Browser tool for MindRoom.
 
-This exposes a single ``browser`` function with an ``action`` parameter.
+This exposes a single ``browser_control`` function with an ``action`` parameter.
 """
 # ruff: noqa: N803, A002
 
@@ -37,6 +37,7 @@ from mindroom.logging_config import get_logger
 from mindroom.matrix.olm_to_device import PinnedMatrixDevice
 from mindroom.server_fetch_url import validate_server_fetch_url
 from mindroom.tool_system.runtime_context import get_tool_runtime_context
+from mindroom.tool_system.toolkit_aliases import apply_toolkit_function_aliases
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
@@ -532,6 +533,7 @@ class BrowserTools(Toolkit):
         timeout_seconds: float = 90.0,
     ) -> None:
         super().__init__(name="browser", tools=[self.browser])
+        apply_toolkit_function_aliases(self, {"browser": "browser_control"})
         self._runtime_paths = runtime_paths
         self._allow_private_networks = allow_private_networks
         self._default_target = self._validated_default_target(default_target)
@@ -559,7 +561,7 @@ class BrowserTools(Toolkit):
 
     def _describe_browser_schema(self) -> None:
         """Attach explicit model-facing descriptions for browser action routing."""
-        function = self.async_functions.get("browser")
+        function = self.async_functions.get("browser_control")
         if function is None:
             raise _BrowserFunctionNotRegisteredError
         function.process_entrypoint(strict=False)

--- a/src/mindroom/tools/browser.py
+++ b/src/mindroom/tools/browser.py
@@ -100,7 +100,7 @@ if TYPE_CHECKING:
             description="Matrix and local Playwright MCP timeout from 1 to 120 seconds.",
         ),
     ],
-    function_names=("browser",),
+    function_names=("browser_control",),
 )
 def browser_tools() -> type[BrowserTools]:
     """Return Browser tools with OpenClaw-style action routing."""

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -9978,7 +9978,7 @@
       "display_name": "Browser",
       "docs_url": "https://github.com/openclaw/openclaw/blob/main/docs/tools/browser.md",
       "function_names": [
-        "browser"
+        "browser_control"
       ],
       "helper_text": null,
       "icon": "FaChrome",

--- a/tests/test_browser_tool.py
+++ b/tests/test_browser_tool.py
@@ -333,7 +333,7 @@ def test_browser_function_schema_documents_actions_and_act_request() -> None:
     """Tool schema should make browser actions and act request kinds discoverable."""
     tool = BrowserTools(TEST_RUNTIME_PATHS)
 
-    parameters = tool.async_functions["browser"].parameters
+    parameters = tool.async_functions["browser_control"].parameters
     properties = parameters["properties"]
 
     action_schema = properties["action"]
@@ -351,12 +351,12 @@ def test_browser_function_schema_documents_actions_and_act_request() -> None:
 def test_browser_schema_description_requires_registered_browser_function() -> None:
     """BrowserTools should fail fast if the browser entrypoint is missing."""
     tool = BrowserTools(TEST_RUNTIME_PATHS)
-    function = tool.async_functions.pop("browser")
+    function = tool.async_functions.pop("browser_control")
     try:
         with pytest.raises(RuntimeError, match="Browser function was not registered"):
             tool._describe_browser_schema()
     finally:
-        tool.async_functions["browser"] = function
+        tool.async_functions["browser_control"] = function
 
 
 def test_browser_docstring_lists_discovery_actions() -> None:

--- a/tests/test_dynamic_toolkits.py
+++ b/tests/test_dynamic_toolkits.py
@@ -1442,6 +1442,24 @@ def test_openai_native_tool_search_attaches_deferred_toolkits_and_skips_homegrow
     assert ("code", "thread-a") not in dynamic_toolkits_module._loaded_tools
 
 
+def test_codex_deferred_browser_uses_non_reserved_function_name(tmp_path: Path) -> None:
+    """The deferred browser function must not collide with Codex's reserved browser namespace."""
+    raw = _base_config_data()
+    raw["models"]["codex"] = {"provider": "codex", "id": "gpt-5.6"}  # type: ignore[index]
+    raw["agents"]["code"]["model"] = "codex"  # type: ignore[index]
+    raw["agents"]["code"]["tools"] = [{"browser": {"defer": True}}]  # type: ignore[index]
+    config = _validated_config(tmp_path, raw)
+
+    agent = create_agent("code", config, _runtime_paths(tmp_path), execution_identity=None, session_id="thread-a")
+
+    function_names = {
+        name for toolkit in agent.tools for name in (*toolkit.get_functions(), *toolkit.get_async_functions())
+    }
+    assert "browser_control" in function_names
+    assert "browser" not in function_names
+    assert vars(agent.model)[_OPENAI_DEFERRED_TOOL_NAMES_ATTR] == frozenset({"browser_control"})
+
+
 def test_immutable_tool_schema_eagerly_materializes_every_deferred_tool(tmp_path: Path) -> None:
     """Voice-style immutable schemas expose deferred tools without load_tool."""
     raw = _base_config_data()


### PR DESCRIPTION
## Summary

- rename the model-visible browser function to `browser_control`
- keep the configured toolkit and Python runtime entrypoint named `browser`
- add Codex deferred-tool regression coverage and refresh tool metadata

## Testing

- `uv run pytest`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Prevent browser tool namespace collisions by exposing the browser capability to models as `browser_control` while retaining the existing toolkit and runtime entrypoint name.

Bug Fixes:
- Rename the model-facing browser function to avoid collisions with Codex’s reserved browser namespace while preserving the configured toolkit and runtime entrypoint name.

Enhancements:
- Refresh browser tool metadata and schema handling to use the new model-visible function name.

Tests:
- Add regression coverage verifying deferred Codex browser tools expose only the non-reserved function name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the browser tool’s registered name to `browser_control`, avoiding conflicts with reserved tool names.
  * Browser tool metadata and documentation now consistently display the updated name.

* **Tests**
  * Added coverage confirming deferred browser tools use `browser_control` and not the reserved `browser` name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->