### PR TITLE
Suppress tool-only silent schedule replies

### DIFF
--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -84,6 +84,7 @@ from mindroom.streaming import (
     classify_cancel_source,
     interactive_response_for_visible_body,
     send_streaming_response,
+    strip_visible_tool_markers,
 )
 
 if TYPE_CHECKING:
@@ -1282,11 +1283,12 @@ class DeliveryGateway:
                 extra_content=request.extra_content,
             )
         suppression_reason = "suppressed_by_hook" if draft.suppress else None
-        if suppression_reason is None and (
-            draft.envelope.source_kind == SILENT_SCHEDULE_SOURCE_KIND
-            and constants.is_silent_schedule_no_report_response(draft.response_text)
-        ):
-            suppression_reason = "silent_no_report"
+        if suppression_reason is None and draft.envelope.source_kind == SILENT_SCHEDULE_SOURCE_KIND:
+            no_report_text = draft.response_text
+            if draft.tool_trace:
+                no_report_text = strip_visible_tool_markers(no_report_text)
+            if constants.is_silent_schedule_no_report_response(no_report_text):
+                suppression_reason = "silent_no_report"
         if suppression_reason is not None:
             self.deps.logger.info(
                 "Response suppressed",

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -84,7 +84,7 @@ from mindroom.streaming import (
     classify_cancel_source,
     interactive_response_for_visible_body,
     send_streaming_response,
-    strip_visible_tool_markers,
+    strip_matching_visible_tool_markers,
 )
 
 if TYPE_CHECKING:
@@ -1286,7 +1286,7 @@ class DeliveryGateway:
         if suppression_reason is None and draft.envelope.source_kind == SILENT_SCHEDULE_SOURCE_KIND:
             no_report_text = draft.response_text
             if draft.tool_trace:
-                no_report_text = strip_visible_tool_markers(no_report_text)
+                no_report_text = strip_matching_visible_tool_markers(no_report_text, draft.tool_trace)
             if constants.is_silent_schedule_no_report_response(no_report_text):
                 suppression_reason = "silent_no_report"
         if suppression_reason is not None:

--- a/src/mindroom/streaming.py
+++ b/src/mindroom/streaming.py
@@ -45,11 +45,12 @@ from mindroom.tool_system.events import (
     StructuredStreamChunk,
     complete_pending_tool_block,
     is_visible_tool_marker_line,
+    tool_markers_match_trace,
 )
 from mindroom.tool_system.runtime_context import worker_progress_pump_scope
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable, Sequence
 
     import nio
 
@@ -87,6 +88,7 @@ __all__ = [
     "interactive_response_for_visible_body",
     "is_interrupted_partial_reply",
     "send_streaming_response",
+    "strip_matching_visible_tool_markers",
     "strip_visible_tool_markers",
 ]
 
@@ -176,6 +178,13 @@ def strip_visible_tool_markers(text: str) -> str:
 
         filtered_lines.extend(spacer_lines)
     return "\n".join(filtered_lines).rstrip()
+
+
+def strip_matching_visible_tool_markers(text: str, tool_trace: Sequence[ToolTraceEntry]) -> str:
+    """Strip display-only markers only when they exactly represent the structured trace."""
+    if not tool_markers_match_trace(text, tool_trace):
+        return text
+    return strip_visible_tool_markers(text)
 
 
 class StreamingDeliveryError(Exception):

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -48,6 +48,7 @@ from mindroom.matrix.large_messages import (
 from mindroom.matrix_delivery import MatrixDeliveryWorker, PermanentDeliveryError, RecoveryOutcome
 from mindroom.message_target import MessageTarget
 from mindroom.streaming import PROGRESS_PLACEHOLDER
+from mindroom.tool_system.events import ToolTraceEntry
 from tests.conftest import (
     FakeOutbox,
     bind_runtime_paths,
@@ -243,6 +244,37 @@ class TestTurnDeliveryGoesThroughTheOutbox:
             outcome = await gateway.deliver_final(
                 self._final_request(text, source_kind=SILENT_SCHEDULE_SOURCE_KIND),
             )
+
+        assert outcome.terminal_status == "cancelled"
+        assert outcome.suppressed is True
+        assert outcome.event_id is None
+        assert outcome.failure_reason == "silent_no_report"
+        assert outbox.rows == {}
+        send.assert_not_awaited()
+
+    async def test_silent_schedule_tool_trace_no_reply_is_suppressed(self, tmp_path: Path) -> None:
+        """Display-only tool markers must not turn a silent no-report result into a visible response."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        send = AsyncMock(return_value=DeliveredMatrixEvent("$sent", {"body": SILENT_SCHEDULE_NO_REPLY_TOKEN}))
+        request = replace(
+            self._final_request(
+                f"🔧 `run_shell_command` [1]\n\n{SILENT_SCHEDULE_NO_REPLY_TOKEN}",
+                source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+            ),
+            tool_trace=[
+                ToolTraceEntry(
+                    type="tool_call_completed",
+                    tool_name="run_shell_command",
+                    args_preview="cmd=true",
+                    result_preview="done",
+                ),
+            ],
+        )
+
+        with patch("mindroom.delivery_gateway.send_message_outcome", send):
+            outcome = await gateway.deliver_final(request)
 
         assert outcome.terminal_status == "cancelled"
         assert outcome.suppressed is True

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -283,6 +283,33 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert outbox.rows == {}
         send.assert_not_awaited()
 
+    async def test_silent_schedule_unmatched_tool_marker_no_reply_remains_visible(self, tmp_path: Path) -> None:
+        """Marker-shaped findings must not be stripped when they do not match the trace."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        text = f"🔧 `reported_finding` [1]\n\n{SILENT_SCHEDULE_NO_REPLY_TOKEN}"
+        send = AsyncMock(return_value=DeliveredMatrixEvent("$sent", {"body": text}))
+        request = replace(
+            self._final_request(text, source_kind=SILENT_SCHEDULE_SOURCE_KIND),
+            tool_trace=[
+                ToolTraceEntry(
+                    type="tool_call_completed",
+                    tool_name="run_shell_command",
+                    args_preview="cmd=true",
+                    result_preview="done",
+                ),
+            ],
+        )
+
+        with patch("mindroom.delivery_gateway.send_message_outcome", send):
+            outcome = await gateway.deliver_final(request)
+
+        assert outcome.terminal_status == "completed"
+        assert outcome.suppressed is False
+        assert outcome.event_id == "$sent"
+        send.assert_awaited_once()
+
     @pytest.mark.parametrize(
         ("text", "source_kind"),
         [


### PR DESCRIPTION
## Summary

- suppress the final Matrix envelope when a silent scheduled run ends with only validated tool markers and `NO_REPLY`
- match visible tool markers against the structured trace before ignoring them, preserving marker-shaped findings
- add delivery regressions for both matched and unmatched marker cases

## Testing

- `uv run pre-commit run --all-files`
- `uv run pytest` (15,140 passed, 122 skipped)

## Summary by Sourcery

Prevent silent scheduled runs from delivering tool-only `NO_REPLY` responses while preserving unmatched marker content.

Bug Fixes:
- Suppress silent scheduled-run replies when their visible tool markers correspond to the validated structured tool trace and the remaining content is `NO_REPLY`.
- Preserve marker-shaped findings when visible tool markers do not match the structured tool trace.

Tests:
- Add delivery regression coverage for matched tool markers being suppressed and unmatched markers remaining visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of silent scheduled responses containing visible tool markers.
  * Matching display-only tool markers are suppressed as intended.
  * Unmatched markers remain visible and are delivered normally.
  * Explicit suppression behavior remains unchanged.

* **Tests**
  * Added coverage for matching and unmatched tool-marker scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->