### PR TITLE
Speed up Docker worker tool calls

### DIFF
--- a/src/mindroom/tool_system/sandbox_proxy.py
+++ b/src/mindroom/tool_system/sandbox_proxy.py
@@ -422,11 +422,12 @@ def _primary_worker_manager_context(runtime_paths: RuntimePaths) -> _PrimaryWork
     )
     kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
     kubernetes_config_snapshot: dict[str, object] | None = None
-    if context is not None and primary_worker_backend_name(runtime_paths) == "kubernetes":
+    if context is not None and primary_worker_backend_name(runtime_paths) in {"docker", "kubernetes"}:
         kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
             runtime_paths,
             runtime_config=context.config,
         )
+    if context is not None and primary_worker_backend_name(runtime_paths) == "kubernetes":
         kubernetes_config_snapshot = serialized_kubernetes_worker_config_snapshot(context.config)
     return _PrimaryWorkerManagerContext(
         storage_root=storage_root,

--- a/src/mindroom/tool_system/sandbox_proxy.py
+++ b/src/mindroom/tool_system/sandbox_proxy.py
@@ -48,8 +48,8 @@ from mindroom.workers.runtime import (
     primary_worker_backend_available,
     primary_worker_backend_is_dedicated,
     primary_worker_backend_name,
+    serialized_dedicated_worker_validation_snapshot,
     serialized_kubernetes_worker_config_snapshot,
-    serialized_kubernetes_worker_validation_snapshot,
 )
 
 if TYPE_CHECKING:
@@ -164,7 +164,7 @@ class _PrimaryWorkerManagerContext:
     """Runtime-context-derived parameters for resolving the primary worker manager."""
 
     storage_root: Path
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None
     kubernetes_config_snapshot: dict[str, object] | None
     worker_grantable_credentials: frozenset[str] | None
 
@@ -420,10 +420,10 @@ def _primary_worker_manager_context(runtime_paths: RuntimePaths) -> _PrimaryWork
     storage_root = (
         context.storage_path if context is not None and context.storage_path is not None else runtime_paths.storage_root
     )
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None = None
     kubernetes_config_snapshot: dict[str, object] | None = None
     if context is not None and primary_worker_backend_name(runtime_paths) in {"docker", "kubernetes"}:
-        kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
+        dedicated_worker_validation_snapshot = serialized_dedicated_worker_validation_snapshot(
             runtime_paths,
             runtime_config=context.config,
         )
@@ -431,7 +431,7 @@ def _primary_worker_manager_context(runtime_paths: RuntimePaths) -> _PrimaryWork
         kubernetes_config_snapshot = serialized_kubernetes_worker_config_snapshot(context.config)
     return _PrimaryWorkerManagerContext(
         storage_root=storage_root,
-        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=kubernetes_config_snapshot,
         worker_grantable_credentials=(
             context.config.get_worker_grantable_credentials() if context is not None else None
@@ -449,7 +449,7 @@ def _get_worker_manager(
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=manager_context.storage_root,
-        kubernetes_tool_validation_snapshot=manager_context.kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=manager_context.dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=manager_context.kubernetes_config_snapshot,
         worker_grantable_credentials=manager_context.worker_grantable_credentials,
     )
@@ -564,7 +564,7 @@ def save_attachment_to_worker(
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=manager_context.storage_root,
-        kubernetes_tool_validation_snapshot=manager_context.kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=manager_context.dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=manager_context.kubernetes_config_snapshot,
         worker_grantable_credentials=manager_context.worker_grantable_credentials,
     ) as worker_manager:
@@ -799,7 +799,7 @@ def _call_proxy_sync(
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=manager_context.storage_root,
-        kubernetes_tool_validation_snapshot=manager_context.kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=manager_context.dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=manager_context.kubernetes_config_snapshot,
         worker_grantable_credentials=manager_context.worker_grantable_credentials,
     ) as worker_manager:

--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -23,6 +23,7 @@ from mindroom.constants import (
     runtime_env_values,
     runtime_paths_with_config_path,
     runtime_paths_with_storage_root,
+    sandbox_startup_manifest_path,
     serialize_runtime_paths,
     write_startup_manifest,
 )
@@ -1028,6 +1029,7 @@ class DockerWorkerBackend:
     def _write_startup_manifest(self, paths: LocalWorkerStatePaths, *, worker_key: str) -> None:
         """Persist primary validation state before starting one Docker worker."""
         if self._tool_validation_snapshot is None:
+            sandbox_startup_manifest_path(paths.root).unlink(missing_ok=True)
             return
         dedicated_root = Path(self.config.storage_mount_path)
         write_startup_manifest(

--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -1206,6 +1206,7 @@ class DockerWorkerBackend:
             "name_prefix": self.config.name_prefix,
             "publish_host": self.config.publish_host,
             "storage_mount_path": self.config.storage_mount_path,
+            "tool_validation_snapshot": self._tool_validation_snapshot,
             "workers_root": str(self._workers_root),
             "user": self.config.user or "",
             "worker_port": self.config.worker_port,

--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -24,10 +24,15 @@ from mindroom.constants import (
     runtime_paths_with_config_path,
     runtime_paths_with_storage_root,
     serialize_runtime_paths,
+    write_startup_manifest,
 )
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager, sync_shared_credentials_to_worker
 from mindroom.redaction import redact_sensitive_text
-from mindroom.runtime_env_policy import SANDBOX_RUNTIME_ENV_BY_KEY, SHARED_CREDENTIALS_PATH_ENV
+from mindroom.runtime_env_policy import (
+    SANDBOX_RUNTIME_ENV_BY_KEY,
+    SANDBOX_STARTUP_MANIFEST_PATH_ENV,
+    SHARED_CREDENTIALS_PATH_ENV,
+)
 from mindroom.tool_system.dependencies import ensure_optional_deps
 from mindroom.tool_system.worker_routing import resolved_worker_key_scope, worker_dir_name, worker_key_agent_name
 from mindroom.workers.backend import WorkerBackendError
@@ -324,6 +329,7 @@ class DockerWorkerBackend:
         auth_token: str | None,
         storage_path: Path | None = None,
         runtime_paths: RuntimePaths | None = None,
+        tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
         worker_grantable_credentials: frozenset[str] = DEFAULT_WORKER_GRANTABLE_CREDENTIALS,
     ) -> None:
         if auth_token is None:
@@ -352,6 +358,7 @@ class DockerWorkerBackend:
         if config.host_config_path is not None:
             base_runtime_paths = runtime_paths_with_config_path(base_runtime_paths, config.host_config_path)
         self._runtime_paths = runtime_paths_with_storage_root(base_runtime_paths, self._storage_path)
+        self._tool_validation_snapshot = tool_validation_snapshot
         self._client, self._docker_errors = _load_docker_client_and_errors(runtime_paths=self._runtime_paths)
         self._worker_locks: dict[str, threading.Lock] = {}
         self._worker_locks_lock = threading.Lock()
@@ -376,6 +383,7 @@ class DockerWorkerBackend:
         *,
         auth_token: str | None,
         storage_path: Path | None = None,
+        tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
         worker_grantable_credentials: frozenset[str] = DEFAULT_WORKER_GRANTABLE_CREDENTIALS,
     ) -> DockerWorkerBackend:
         """Construct a backend instance from one explicit runtime context."""
@@ -384,6 +392,7 @@ class DockerWorkerBackend:
             auth_token=auth_token,
             storage_path=storage_path,
             runtime_paths=runtime_paths,
+            tool_validation_snapshot=tool_validation_snapshot,
             worker_grantable_credentials=worker_grantable_credentials,
         )
 
@@ -836,6 +845,7 @@ class DockerWorkerBackend:
             container = None
 
         if container is None:
+            self._write_startup_manifest(paths, worker_key=metadata.worker_key)
             volumes = self._container_volumes(
                 paths,
                 worker_key=metadata.worker_key,
@@ -1008,8 +1018,24 @@ class DockerWorkerBackend:
         }
         if self.config.host_config_path is not None:
             env["MINDROOM_CONFIG_PATH"] = self.config.config_path
+        if self._tool_validation_snapshot is not None:
+            env[SANDBOX_STARTUP_MANIFEST_PATH_ENV] = str(
+                Path(self.config.storage_mount_path) / ".runtime" / "startup_manifest.json",
+            )
         env.update(self.config.extra_env)
         return env
+
+    def _write_startup_manifest(self, paths: LocalWorkerStatePaths, *, worker_key: str) -> None:
+        """Persist primary validation state before starting one Docker worker."""
+        if self._tool_validation_snapshot is None:
+            return
+        dedicated_root = Path(self.config.storage_mount_path)
+        write_startup_manifest(
+            paths.root,
+            self._worker_runtime_paths(worker_key=worker_key, dedicated_root=dedicated_root),
+            tool_validation_snapshot=self._tool_validation_snapshot,
+            public_runtime=True,
+        )
 
     def _container_env_matches(
         self,

--- a/src/mindroom/workers/backends/docker.py
+++ b/src/mindroom/workers/backends/docker.py
@@ -1018,11 +1018,11 @@ class DockerWorkerBackend:
         }
         if self.config.host_config_path is not None:
             env["MINDROOM_CONFIG_PATH"] = self.config.config_path
+        env.update(self.config.extra_env)
         if self._tool_validation_snapshot is not None:
             env[SANDBOX_STARTUP_MANIFEST_PATH_ENV] = str(
                 Path(self.config.storage_mount_path) / ".runtime" / "startup_manifest.json",
             )
-        env.update(self.config.extra_env)
         return env
 
     def _write_startup_manifest(self, paths: LocalWorkerStatePaths, *, worker_key: str) -> None:

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -331,11 +331,12 @@ def _configured_primary_worker_manager_inputs(
     worker_grantable_credentials: frozenset[str] | None = None
     if runtime_config is not None:
         worker_grantable_credentials = runtime_config.get_worker_grantable_credentials()
-        if backend_name == "kubernetes":
+        if backend_name in _DEDICATED_WORKER_BACKENDS:
             kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
                 runtime_paths,
                 runtime_config=runtime_config,
             )
+        if backend_name == "kubernetes":
             kubernetes_config_snapshot = serialized_kubernetes_worker_config_snapshot(runtime_config)
     return _ConfiguredPrimaryWorkerManagerInputs(
         proxy_url=proxy_config.proxy_url,
@@ -400,13 +401,20 @@ def _primary_worker_backend_config_signature(
     if backend_name == "static_runner":
         return _static_runner_backend_config_signature(proxy_url=proxy_url, proxy_token=proxy_token)
     if backend_name == "docker":
-        return docker_backend_config_signature(
+        backend_signature = docker_backend_config_signature(
             runtime_paths,
             auth_token=proxy_token,
             storage_path=resolved_storage_root,
             worker_grantable_credentials=_resolve_worker_grantable_credentials(
                 worker_grantable_credentials,
             ),
+        )
+        if kubernetes_tool_validation_snapshot is None:
+            return backend_signature
+        return (
+            *backend_signature,
+            "__tool_validation_snapshot__",
+            json.dumps(kubernetes_tool_validation_snapshot, separators=(",", ":"), sort_keys=True),
         )
     if backend_name == "kubernetes":
         backend_signature = kubernetes_backend_config_signature(
@@ -480,6 +488,7 @@ def _build_primary_worker_manager(
                 runtime_paths,
                 auth_token=proxy_token,
                 storage_path=resolved_storage_root,
+                tool_validation_snapshot=kubernetes_tool_validation_snapshot,
                 worker_grantable_credentials=_resolve_worker_grantable_credentials(
                     worker_grantable_credentials,
                 ),

--- a/src/mindroom/workers/runtime.py
+++ b/src/mindroom/workers/runtime.py
@@ -44,8 +44,8 @@ __all__ = [
     "primary_worker_backend_is_dedicated",
     "primary_worker_backend_name",
     "reset_primary_worker_manager",
+    "serialized_dedicated_worker_validation_snapshot",
     "serialized_kubernetes_worker_config_snapshot",
-    "serialized_kubernetes_worker_validation_snapshot",
     "shutdown_primary_worker_manager",
 ]
 
@@ -103,7 +103,7 @@ class _ConfiguredPrimaryWorkerManagerInputs:
     proxy_url: str | None
     proxy_token: str | None
     storage_root: Path
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None
     kubernetes_config_snapshot: dict[str, object] | None
     worker_grantable_credentials: frozenset[str] | None
 
@@ -149,7 +149,7 @@ def clear_worker_validation_snapshot_cache() -> None:
     clear_resolved_tool_state_cache()
 
 
-def serialized_kubernetes_worker_validation_snapshot(
+def serialized_dedicated_worker_validation_snapshot(
     runtime_paths: RuntimePaths,
     *,
     runtime_config: Config | None = None,
@@ -283,7 +283,7 @@ def _lease_configured_primary_worker_manager(
         proxy_url=inputs.proxy_url,
         proxy_token=inputs.proxy_token,
         storage_root=inputs.storage_root,
-        kubernetes_tool_validation_snapshot=inputs.kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=inputs.dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=inputs.kubernetes_config_snapshot,
         worker_grantable_credentials=inputs.worker_grantable_credentials,
     )
@@ -302,7 +302,7 @@ def configured_primary_worker_manager_identity(
         proxy_url=inputs.proxy_url,
         proxy_token=inputs.proxy_token,
         storage_root=inputs.storage_root,
-        kubernetes_tool_validation_snapshot=inputs.kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=inputs.dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=inputs.kubernetes_config_snapshot,
         worker_grantable_credentials=inputs.worker_grantable_credentials,
     )
@@ -326,13 +326,13 @@ def _configured_primary_worker_manager_inputs(
     backend_name = primary_worker_backend_name(runtime_paths)
     if runtime_config is None and backend_name == "kubernetes":
         return None
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None = None
     kubernetes_config_snapshot: dict[str, object] | None = None
     worker_grantable_credentials: frozenset[str] | None = None
     if runtime_config is not None:
         worker_grantable_credentials = runtime_config.get_worker_grantable_credentials()
         if backend_name in _DEDICATED_WORKER_BACKENDS:
-            kubernetes_tool_validation_snapshot = serialized_kubernetes_worker_validation_snapshot(
+            dedicated_worker_validation_snapshot = serialized_dedicated_worker_validation_snapshot(
                 runtime_paths,
                 runtime_config=runtime_config,
             )
@@ -342,19 +342,19 @@ def _configured_primary_worker_manager_inputs(
         proxy_url=proxy_config.proxy_url,
         proxy_token=proxy_config.proxy_token,
         storage_root=runtime_paths.storage_root,
-        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=kubernetes_config_snapshot,
         worker_grantable_credentials=worker_grantable_credentials,
     )
 
 
 def _require_kubernetes_tool_validation_snapshot(
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None,
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None,
 ) -> dict[str, dict[str, object]]:
-    if kubernetes_tool_validation_snapshot is None:
+    if dedicated_worker_validation_snapshot is None:
         msg = "Kubernetes worker backend requires an explicit tool validation snapshot."
         raise WorkerBackendError(msg)
-    return kubernetes_tool_validation_snapshot
+    return dedicated_worker_validation_snapshot
 
 
 def _require_kubernetes_config_snapshot(
@@ -392,7 +392,7 @@ def _primary_worker_backend_config_signature(
     proxy_url: str | None,
     proxy_token: str | None,
     storage_root: Path | None,
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None = None,
     kubernetes_config_snapshot: dict[str, object] | None = None,
     worker_grantable_credentials: frozenset[str] | None = None,
 ) -> tuple[str, ...]:
@@ -409,12 +409,12 @@ def _primary_worker_backend_config_signature(
                 worker_grantable_credentials,
             ),
         )
-        if kubernetes_tool_validation_snapshot is None:
+        if dedicated_worker_validation_snapshot is None:
             return backend_signature
         return (
             *backend_signature,
             "__tool_validation_snapshot__",
-            json.dumps(kubernetes_tool_validation_snapshot, separators=(",", ":"), sort_keys=True),
+            json.dumps(dedicated_worker_validation_snapshot, separators=(",", ":"), sort_keys=True),
         )
     if backend_name == "kubernetes":
         backend_signature = kubernetes_backend_config_signature(
@@ -428,7 +428,7 @@ def _primary_worker_backend_config_signature(
         return (
             *backend_signature,
             json.dumps(
-                _require_kubernetes_tool_validation_snapshot(kubernetes_tool_validation_snapshot),
+                _require_kubernetes_tool_validation_snapshot(dedicated_worker_validation_snapshot),
                 separators=(",", ":"),
                 sort_keys=True,
             ),
@@ -470,7 +470,7 @@ def _build_primary_worker_manager(
     proxy_url: str | None,
     proxy_token: str | None,
     storage_root: Path | None,
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None = None,
     kubernetes_config_snapshot: dict[str, object] | None = None,
     worker_grantable_credentials: frozenset[str] | None = None,
 ) -> WorkerBackend:
@@ -488,7 +488,7 @@ def _build_primary_worker_manager(
                 runtime_paths,
                 auth_token=proxy_token,
                 storage_path=resolved_storage_root,
-                tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+                tool_validation_snapshot=dedicated_worker_validation_snapshot,
                 worker_grantable_credentials=_resolve_worker_grantable_credentials(
                     worker_grantable_credentials,
                 ),
@@ -503,7 +503,7 @@ def _build_primary_worker_manager(
             auth_token=proxy_token,
             storage_root=resolved_storage_root,
             tool_validation_snapshot=_require_kubernetes_tool_validation_snapshot(
-                kubernetes_tool_validation_snapshot,
+                dedicated_worker_validation_snapshot,
             ),
             config_snapshot=_require_kubernetes_config_snapshot(kubernetes_config_snapshot),
             worker_grantable_credentials=_resolve_worker_grantable_credentials(
@@ -648,7 +648,7 @@ def _resolve_primary_worker_manager_entry(
     proxy_token: str | None,
     storage_root: Path | None,
     acquire_lease: bool,
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None = None,
     kubernetes_config_snapshot: dict[str, object] | None = None,
     worker_grantable_credentials: frozenset[str] | None = None,
 ) -> tuple[_WorkerManagerEntry, list[WorkerBackend]]:
@@ -658,7 +658,7 @@ def _resolve_primary_worker_manager_entry(
         proxy_url=proxy_url,
         proxy_token=proxy_token,
         storage_root=storage_root,
-        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=kubernetes_config_snapshot,
         worker_grantable_credentials=worker_grantable_credentials,
     )
@@ -681,7 +681,7 @@ def _resolve_primary_worker_manager_entry(
             proxy_url=proxy_url,
             proxy_token=proxy_token,
             storage_root=storage_root,
-            kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+            dedicated_worker_validation_snapshot=dedicated_worker_validation_snapshot,
             kubernetes_config_snapshot=kubernetes_config_snapshot,
             worker_grantable_credentials=worker_grantable_credentials,
         )
@@ -725,7 +725,7 @@ def get_primary_worker_manager(
     proxy_url: str | None,
     proxy_token: str | None,
     storage_root: Path | None = None,
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None = None,
     kubernetes_config_snapshot: dict[str, object] | None = None,
     worker_grantable_credentials: frozenset[str] | None = None,
 ) -> WorkerBackend:
@@ -736,7 +736,7 @@ def get_primary_worker_manager(
         proxy_token=proxy_token,
         storage_root=storage_root,
         acquire_lease=False,
-        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=kubernetes_config_snapshot,
         worker_grantable_credentials=worker_grantable_credentials,
     )
@@ -755,7 +755,7 @@ def lease_primary_worker_manager(
     proxy_url: str | None,
     proxy_token: str | None,
     storage_root: Path | None = None,
-    kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
+    dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None = None,
     kubernetes_config_snapshot: dict[str, object] | None = None,
     worker_grantable_credentials: frozenset[str] | None = None,
 ) -> PrimaryWorkerManagerLease:
@@ -766,7 +766,7 @@ def lease_primary_worker_manager(
         proxy_token=proxy_token,
         storage_root=storage_root,
         acquire_lease=True,
-        kubernetes_tool_validation_snapshot=kubernetes_tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=dedicated_worker_validation_snapshot,
         kubernetes_config_snapshot=kubernetes_config_snapshot,
         worker_grantable_credentials=worker_grantable_credentials,
     )

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -1354,6 +1354,43 @@ def test_docker_backend_writes_authoritative_worker_validation_snapshot(
     assert env["MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH"] == "/app/worker/.runtime/startup_manifest.json"
 
 
+def test_docker_backend_removes_stale_validation_manifest_for_snapshotless_worker(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A snapshotless worker must not reuse validation state persisted by an older worker."""
+    backend, fake_client, _sync_calls = _backend(
+        monkeypatch,
+        tmp_path,
+        tool_validation_snapshot={"shell": {"name": "shell", "config_fields": []}},
+    )
+    first_handle = backend.ensure_worker(WorkerSpec(_TEST_UNSCOPED_WORKER_KEY), now=10.0)
+    first_container = fake_client.containers.by_name[first_handle.worker_id]
+    manifest_path = worker_root_path(tmp_path, _TEST_UNSCOPED_WORKER_KEY) / ".runtime" / "startup_manifest.json"
+    assert manifest_path.exists()
+
+    snapshotless_backend = DockerWorkerBackend(
+        config=backend.config,
+        auth_token=_TEST_AUTH_TOKEN,
+        storage_path=tmp_path,
+    )
+    monkeypatch.setattr(
+        snapshotless_backend,
+        "_wait_for_ready",
+        lambda container: (
+            f"http://127.0.0.1:{snapshotless_backend._container_host_port(container)}/api/sandbox-runner/execute"
+        ),
+    )
+
+    snapshotless_backend.ensure_worker(WorkerSpec(_TEST_UNSCOPED_WORKER_KEY), now=20.0)
+
+    assert not manifest_path.exists()
+    assert first_container.removed == 1
+    env = fake_client.containers.run_calls[-1]["environment"]
+    assert isinstance(env, dict)
+    assert "MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH" not in env
+
+
 def test_docker_script_worker_profile_mirrors_no_global_credentials(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -2970,6 +2970,47 @@ def test_docker_backend_recreates_container_when_launch_config_changes(
     assert second_run_call["user"] == "2000:2000"
 
 
+def test_docker_backend_recreates_container_when_validation_snapshot_changes(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A surviving worker must restart when its authoritative validation state changes."""
+    first_snapshot = {"shell": {"name": "shell", "config_fields": []}}
+    backend, fake_client, _sync_calls = _backend(
+        monkeypatch,
+        tmp_path,
+        tool_validation_snapshot=first_snapshot,
+    )
+    first_handle = backend.ensure_worker(WorkerSpec(_TEST_UNSCOPED_WORKER_KEY), now=10.0)
+    first_container = fake_client.containers.by_name[first_handle.worker_id]
+
+    second_snapshot = {
+        **first_snapshot,
+        "file": {"name": "file", "config_fields": []},
+    }
+    updated_backend = DockerWorkerBackend(
+        config=backend.config,
+        auth_token=_TEST_AUTH_TOKEN,
+        storage_path=tmp_path,
+        tool_validation_snapshot=second_snapshot,
+    )
+    monkeypatch.setattr(
+        updated_backend,
+        "_wait_for_ready",
+        lambda container: (
+            f"http://127.0.0.1:{updated_backend._container_host_port(container)}/api/sandbox-runner/execute"
+        ),
+    )
+
+    updated_backend.ensure_worker(WorkerSpec(_TEST_UNSCOPED_WORKER_KEY), now=20.0)
+
+    second_container = fake_client.containers.by_name[first_handle.worker_id]
+    assert second_container is not first_container
+    assert first_container.removed == 1
+    manifest_path = worker_root_path(tmp_path, _TEST_UNSCOPED_WORKER_KEY) / ".runtime" / "startup_manifest.json"
+    assert json.loads(manifest_path.read_text(encoding="utf-8"))["tool_validation_snapshot"] == second_snapshot
+
+
 def test_docker_backend_recreates_container_when_name_prefix_changes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -626,6 +626,7 @@ def _backend(
     runtime_paths: RuntimePaths | None = None,
     storage_path: Path | None = None,
     host_config_path: Path | None = None,
+    tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
 ) -> tuple[DockerWorkerBackend, _FakeDockerClient, list[tuple[str, frozenset[str]]]]:
     config = _DockerWorkerBackendConfig(
         image="ghcr.io/mindroom-ai/mindroom:latest",
@@ -676,6 +677,7 @@ def _backend(
         auth_token=_TEST_AUTH_TOKEN,
         storage_path=tmp_path if storage_path is None else storage_path,
         runtime_paths=runtime_paths,
+        tool_validation_snapshot=tool_validation_snapshot,
     )
     monkeypatch.setattr(
         backend,
@@ -1323,6 +1325,29 @@ def test_docker_backend_ensures_worker_container_and_bind_mount(
     metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
     assert metadata["status"] == "ready"
     assert metadata["startup_count"] == 1
+
+
+def test_docker_backend_writes_authoritative_worker_validation_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Docker workers should inherit primary validation state instead of rebuilding it per call."""
+    validation_snapshot = {"shell": {"name": "shell", "config_fields": []}}
+    backend, fake_client, _sync_calls = _backend(
+        monkeypatch,
+        tmp_path,
+        tool_validation_snapshot=validation_snapshot,
+    )
+
+    backend.ensure_worker(WorkerSpec(_TEST_UNSCOPED_WORKER_KEY), now=10.0)
+
+    worker_root = worker_root_path(tmp_path, _TEST_UNSCOPED_WORKER_KEY)
+    manifest = json.loads((worker_root / ".runtime" / "startup_manifest.json").read_text(encoding="utf-8"))
+    assert manifest["tool_validation_snapshot"] == validation_snapshot
+    assert manifest["runtime_paths"]["storage_root"] == "/app/worker"
+    env = fake_client.containers.run_calls[0]["environment"]
+    assert isinstance(env, dict)
+    assert env["MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH"] == "/app/worker/.runtime/startup_manifest.json"
 
 
 def test_docker_script_worker_profile_mirrors_no_global_credentials(

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -1338,6 +1338,10 @@ def test_docker_backend_writes_authoritative_worker_validation_snapshot(
         tmp_path,
         tool_validation_snapshot=validation_snapshot,
     )
+    backend.config = replace(
+        backend.config,
+        extra_env={"MINDROOM_SANDBOX_STARTUP_MANIFEST_PATH": "/untrusted/manifest.json"},
+    )
 
     backend.ensure_worker(WorkerSpec(_TEST_UNSCOPED_WORKER_KEY), now=10.0)
 

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -4506,6 +4506,49 @@ def test_get_worker_manager_passes_committed_snapshot_from_tool_runtime_context(
     )
 
 
+def test_get_docker_worker_manager_passes_committed_snapshot_from_tool_runtime_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Docker worker routing should receive the committed tool-validation snapshot."""
+    monkeypatch.setenv("MINDROOM_WORKER_BACKEND", "docker")
+    monkeypatch.setenv("MINDROOM_DOCKER_WORKER_IMAGE", "ghcr.io/mindroom-ai/mindroom:latest")
+    runtime_paths = _configure_proxy_runtime(
+        monkeypatch,
+        proxy_url=None,
+        proxy_token=_TEST_AUTH_TOKEN,
+        execution_mode="off",
+    )
+    runtime_config = load_config(runtime_paths)
+    captured_kwargs: dict[str, object] = {}
+
+    def _fake_get_primary_worker_manager(*_args: object, **kwargs: object) -> object:
+        captured_kwargs.update(kwargs)
+        return object()
+
+    runtime_context = make_test_tool_runtime_context(
+        agent_name="code",
+        target=MessageTarget.resolve(
+            room_id="!room:example.org",
+            thread_id=None,
+            reply_to_event_id=None,
+        ),
+        requester_id="@user:example.org",
+        client=object(),
+        config=runtime_config,
+        runtime_paths=runtime_paths,
+        relations=make_relation_lookup(),
+        conversation_reader=make_conversation_reader_mock(),
+    )
+    proxy_config = sandbox_proxy_module.sandbox_proxy_config(runtime_paths)
+    monkeypatch.setattr(sandbox_proxy_module, "get_primary_worker_manager", _fake_get_primary_worker_manager)
+
+    with tool_runtime_context(runtime_context):
+        sandbox_proxy_module._get_worker_manager(runtime_paths, proxy_config)
+
+    assert captured_kwargs["kubernetes_tool_validation_snapshot"] is not None
+    assert captured_kwargs["kubernetes_config_snapshot"] is None
+
+
 def test_get_worker_manager_reuses_cached_kubernetes_validation_snapshot(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -3419,9 +3419,10 @@ def test_docker_worker_manager_rebuilds_when_runtime_storage_path_changes(
             *,
             auth_token: str | None,
             storage_path: Path | None = None,
+            tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
             worker_grantable_credentials: frozenset[str] = frozenset(),
         ) -> _FakeDockerBackend:
-            _ = worker_grantable_credentials
+            _ = tool_validation_snapshot, worker_grantable_credentials
             assert auth_token == _TEST_AUTH_TOKEN
             assert storage_path is not None
             built_storage_paths.append(storage_path)
@@ -3570,9 +3571,10 @@ def test_superseded_worker_manager_disposes_when_its_last_lease_releases(
             *,
             auth_token: str | None,
             storage_path: Path | None = None,
+            tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
             worker_grantable_credentials: frozenset[str] = frozenset(),
         ) -> _FakeDockerBackend:
-            _ = worker_grantable_credentials
+            _ = tool_validation_snapshot, worker_grantable_credentials
             assert auth_token == _TEST_AUTH_TOKEN
             assert storage_path is not None
             assert runtime_paths.storage_root == storage_path
@@ -3656,9 +3658,10 @@ def test_shutdown_primary_worker_manager_keeps_leased_retired_manager_tracked_un
             *,
             auth_token: str | None,
             storage_path: Path | None = None,
+            tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
             worker_grantable_credentials: frozenset[str] = frozenset(),
         ) -> _FakeDockerBackend:
-            _ = worker_grantable_credentials
+            _ = tool_validation_snapshot, worker_grantable_credentials
             assert auth_token == _TEST_AUTH_TOKEN
             assert storage_path is not None
             assert runtime_paths.storage_root == storage_path
@@ -3728,9 +3731,10 @@ def test_docker_worker_manager_preserves_cached_manager_when_new_build_fails(
             *,
             auth_token: str | None,
             storage_path: Path | None = None,
+            tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
             worker_grantable_credentials: frozenset[str] = frozenset(),
         ) -> _FakeDockerBackend:
-            _ = worker_grantable_credentials
+            _ = tool_validation_snapshot, worker_grantable_credentials
             assert auth_token == _TEST_AUTH_TOKEN
             assert storage_path is not None
             assert runtime_paths.storage_root == storage_path
@@ -3813,9 +3817,10 @@ def test_docker_worker_manager_replacement_disposes_previous_once_despite_shutdo
             *,
             auth_token: str | None,
             storage_path: Path | None = None,
+            tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
             worker_grantable_credentials: frozenset[str] = frozenset(),
         ) -> _FakeDockerBackend:
-            _ = worker_grantable_credentials
+            _ = tool_validation_snapshot, worker_grantable_credentials
             assert auth_token == _TEST_AUTH_TOKEN
             assert storage_path is not None
             assert runtime_paths.storage_root == storage_path
@@ -3916,9 +3921,10 @@ def test_docker_worker_manager_build_does_not_hold_cache_lock(
             *,
             auth_token: str | None,
             storage_path: Path | None = None,
+            tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
             worker_grantable_credentials: frozenset[str] = frozenset(),
         ) -> _FakeDockerBackend:
-            _ = runtime_paths, storage_path, worker_grantable_credentials
+            _ = runtime_paths, storage_path, tool_validation_snapshot, worker_grantable_credentials
             assert auth_token == _TEST_AUTH_TOKEN
             build_started.set()
             assert allow_build.wait(timeout=5.0)
@@ -3993,9 +3999,10 @@ def test_docker_worker_manager_replacement_disposes_unleased_generation_before_r
             *,
             auth_token: str | None,
             storage_path: Path | None = None,
+            tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
             worker_grantable_credentials: frozenset[str] = frozenset(),
         ) -> _FakeDockerBackend:
-            _ = worker_grantable_credentials
+            _ = tool_validation_snapshot, worker_grantable_credentials
             assert auth_token == _TEST_AUTH_TOKEN
             assert storage_path is not None
             assert runtime_paths.storage_root == storage_path
@@ -4089,9 +4096,10 @@ def test_docker_worker_manager_rebuilds_when_runtime_shared_credentials_path_cha
             *,
             auth_token: str | None,
             storage_path: Path | None = None,
+            tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
             worker_grantable_credentials: frozenset[str] = frozenset(),
         ) -> _FakeDockerBackend:
-            _ = worker_grantable_credentials
+            _ = tool_validation_snapshot, worker_grantable_credentials
             assert auth_token == _TEST_AUTH_TOKEN
             assert storage_path == tmp_path.resolve()
             built_shared_paths.append(runtime_paths.env_value("MINDROOM_SHARED_CREDENTIALS_PATH"))
@@ -4162,9 +4170,10 @@ def test_docker_worker_manager_rebuilds_when_committed_runtime_env_changes(
             *,
             auth_token: str | None,
             storage_path: Path | None = None,
+            tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
             worker_grantable_credentials: frozenset[str] = frozenset(),
         ) -> _FakeDockerBackend:
-            _ = worker_grantable_credentials
+            _ = tool_validation_snapshot, worker_grantable_credentials
             assert auth_token == _TEST_AUTH_TOKEN
             assert storage_path == tmp_path.resolve()
             built_browser_paths.append(runtime_paths.env_value("BROWSER_EXECUTABLE_PATH"))

--- a/tests/test_sandbox_proxy.py
+++ b/tests/test_sandbox_proxy.py
@@ -2517,7 +2517,7 @@ def test_get_worker_manager_falls_back_to_runtime_storage_root_without_tool_cont
         proxy_url: str | None,
         proxy_token: str | None,
         storage_root: Path | None = None,
-        kubernetes_tool_validation_snapshot: dict[str, dict[str, object]] | None = None,
+        dedicated_worker_validation_snapshot: dict[str, dict[str, object]] | None = None,
         kubernetes_config_snapshot: dict[str, object] | None = None,
         worker_grantable_credentials: frozenset[str] | None = None,
     ) -> str:
@@ -2525,7 +2525,7 @@ def test_get_worker_manager_falls_back_to_runtime_storage_root_without_tool_cont
         captured["proxy_url"] = proxy_url
         captured["proxy_token"] = proxy_token
         captured["storage_root"] = storage_root
-        captured["kubernetes_tool_validation_snapshot"] = kubernetes_tool_validation_snapshot
+        captured["dedicated_worker_validation_snapshot"] = dedicated_worker_validation_snapshot
         captured["kubernetes_config_snapshot"] = kubernetes_config_snapshot
         captured["worker_grantable_credentials"] = worker_grantable_credentials
         return "manager"
@@ -2550,7 +2550,7 @@ def test_get_worker_manager_falls_back_to_runtime_storage_root_without_tool_cont
     assert manager == "manager"
     assert captured["runtime_paths"] == runtime_paths
     assert captured["storage_root"] == (tmp_path / "storage").resolve()
-    assert captured["kubernetes_tool_validation_snapshot"] is None
+    assert captured["dedicated_worker_validation_snapshot"] is None
     assert captured["kubernetes_config_snapshot"] is None
     assert captured["worker_grantable_credentials"] is None
 
@@ -4300,7 +4300,7 @@ def test_get_worker_manager_rebuilds_kubernetes_backend_when_committed_snapshot_
         proxy_url=None,
         proxy_token=_TEST_AUTH_TOKEN,
         storage_root=tmp_path,
-        kubernetes_tool_validation_snapshot=first_snapshot,
+        dedicated_worker_validation_snapshot=first_snapshot,
         kubernetes_config_snapshot=_TEST_KUBERNETES_CONFIG_SNAPSHOT,
     )
     second_manager = workers_runtime_module.get_primary_worker_manager(
@@ -4308,7 +4308,7 @@ def test_get_worker_manager_rebuilds_kubernetes_backend_when_committed_snapshot_
         proxy_url=None,
         proxy_token=_TEST_AUTH_TOKEN,
         storage_root=tmp_path,
-        kubernetes_tool_validation_snapshot=second_snapshot,
+        dedicated_worker_validation_snapshot=second_snapshot,
         kubernetes_config_snapshot=_TEST_KUBERNETES_CONFIG_SNAPSHOT,
     )
     third_manager = workers_runtime_module.get_primary_worker_manager(
@@ -4316,7 +4316,7 @@ def test_get_worker_manager_rebuilds_kubernetes_backend_when_committed_snapshot_
         proxy_url=None,
         proxy_token=_TEST_AUTH_TOKEN,
         storage_root=tmp_path,
-        kubernetes_tool_validation_snapshot=second_snapshot,
+        dedicated_worker_validation_snapshot=second_snapshot,
         kubernetes_config_snapshot=second_config_snapshot,
     )
 
@@ -4365,7 +4365,7 @@ def test_get_primary_worker_manager_requires_explicit_snapshot_for_kubernetes(
             proxy_url=None,
             proxy_token=_TEST_AUTH_TOKEN,
             storage_root=tmp_path,
-            kubernetes_tool_validation_snapshot=_TEST_KUBERNETES_VALIDATION_SNAPSHOT,
+            dedicated_worker_validation_snapshot=_TEST_KUBERNETES_VALIDATION_SNAPSHOT,
         )
 
 
@@ -4444,7 +4444,7 @@ def test_get_primary_worker_manager_reuses_cached_manager_without_rereading_disk
         proxy_url=None,
         proxy_token=_TEST_AUTH_TOKEN,
         storage_root=tmp_path,
-        kubernetes_tool_validation_snapshot=tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=tool_validation_snapshot,
         kubernetes_config_snapshot=config_snapshot,
     )
     config_path.write_text("models: [\n", encoding="utf-8")
@@ -4453,7 +4453,7 @@ def test_get_primary_worker_manager_reuses_cached_manager_without_rereading_disk
         proxy_url=None,
         proxy_token=_TEST_AUTH_TOKEN,
         storage_root=tmp_path,
-        kubernetes_tool_validation_snapshot=tool_validation_snapshot,
+        dedicated_worker_validation_snapshot=tool_validation_snapshot,
         kubernetes_config_snapshot=config_snapshot,
     )
 
@@ -4500,7 +4500,7 @@ def test_get_worker_manager_passes_committed_snapshot_from_tool_runtime_context(
     with tool_runtime_context(runtime_context):
         sandbox_proxy_module._get_worker_manager(runtime_paths, proxy_config)
 
-    assert captured_kwargs["kubernetes_tool_validation_snapshot"] is not None
+    assert captured_kwargs["dedicated_worker_validation_snapshot"] is not None
     assert captured_kwargs["kubernetes_config_snapshot"] == (
         workers_runtime_module.serialized_kubernetes_worker_config_snapshot(runtime_config)
     )
@@ -4545,7 +4545,7 @@ def test_get_docker_worker_manager_passes_committed_snapshot_from_tool_runtime_c
     with tool_runtime_context(runtime_context):
         sandbox_proxy_module._get_worker_manager(runtime_paths, proxy_config)
 
-    assert captured_kwargs["kubernetes_tool_validation_snapshot"] is not None
+    assert captured_kwargs["dedicated_worker_validation_snapshot"] is not None
     assert captured_kwargs["kubernetes_config_snapshot"] is None
 
 
@@ -4573,7 +4573,7 @@ def test_get_worker_manager_reuses_cached_kubernetes_validation_snapshot(
         return {"fake": ToolValidationInfo(name="fake")}
 
     def fake_get_primary_worker_manager(*_args: object, **kwargs: object) -> object:
-        captured_snapshots.append(kwargs["kubernetes_tool_validation_snapshot"])
+        captured_snapshots.append(kwargs["dedicated_worker_validation_snapshot"])
         return object()
 
     runtime_context = make_test_tool_runtime_context(
@@ -4704,7 +4704,7 @@ def test_proxy_leases_worker_manager_with_committed_runtime_context(
 
     assert result == "proxied"
     assert captured_kwargs["storage_root"] == request_storage_path
-    assert captured_kwargs["kubernetes_tool_validation_snapshot"] is not None
+    assert captured_kwargs["dedicated_worker_validation_snapshot"] is not None
     assert captured_kwargs["worker_grantable_credentials"] == frozenset({"gmail"})
 
 

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -64,7 +64,7 @@ def test_duplicate_worker_manager_build_is_immediately_disposable() -> None:
         workers_runtime_module._PRIMARY_WORKER_MANAGER_BUILDING_SIGNATURES = previous_building
 
 
-def test_serialized_kubernetes_worker_validation_snapshot_reuses_cached_resolver_result(
+def test_serialized_dedicated_worker_validation_snapshot_reuses_cached_resolver_result(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -82,11 +82,11 @@ def test_serialized_kubernetes_worker_validation_snapshot_reuses_cached_resolver
         fake_resolver,
     )
 
-    first_snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    first_snapshot = workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=runtime_config,
     )
-    second_snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    second_snapshot = workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=runtime_config,
     )
@@ -95,7 +95,7 @@ def test_serialized_kubernetes_worker_validation_snapshot_reuses_cached_resolver
     assert first_snapshot == second_snapshot
 
 
-def test_serialized_kubernetes_worker_validation_snapshot_tolerates_plugin_load_errors(
+def test_serialized_dedicated_worker_validation_snapshot_tolerates_plugin_load_errors(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -113,7 +113,7 @@ def test_serialized_kubernetes_worker_validation_snapshot_tolerates_plugin_load_
         fake_resolver,
     )
 
-    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=runtime_config,
     )
@@ -121,7 +121,7 @@ def test_serialized_kubernetes_worker_validation_snapshot_tolerates_plugin_load_
     assert tolerate_values == [True]
 
 
-def test_serialized_kubernetes_worker_validation_snapshot_loads_config_tolerantly(
+def test_serialized_dedicated_worker_validation_snapshot_loads_config_tolerantly(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -153,12 +153,12 @@ def test_serialized_kubernetes_worker_validation_snapshot_loads_config_tolerantl
         fake_resolver,
     )
 
-    snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(runtime_paths)
+    snapshot = workers_runtime_module.serialized_dedicated_worker_validation_snapshot(runtime_paths)
 
     assert set(snapshot) == {"fake", "scheduler"}
 
 
-def test_serialized_kubernetes_worker_validation_snapshot_clear_recomputes(
+def test_serialized_dedicated_worker_validation_snapshot_clear_recomputes(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -177,12 +177,12 @@ def test_serialized_kubernetes_worker_validation_snapshot_clear_recomputes(
         fake_resolver,
     )
 
-    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=runtime_config,
     )
     workers_runtime_module.clear_worker_validation_snapshot_cache()
-    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=runtime_config,
     )
@@ -190,7 +190,7 @@ def test_serialized_kubernetes_worker_validation_snapshot_clear_recomputes(
     assert calls == 2
 
 
-def test_serialized_kubernetes_worker_validation_snapshot_returns_independent_copies(
+def test_serialized_dedicated_worker_validation_snapshot_returns_independent_copies(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -209,12 +209,12 @@ def test_serialized_kubernetes_worker_validation_snapshot_returns_independent_co
         fake_resolver,
     )
 
-    first_snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    first_snapshot = workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=runtime_config,
     )
     first_snapshot["fake"]["config_fields"].append({"name": "mutated"})
-    second_snapshot = workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    second_snapshot = workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=runtime_config,
     )
@@ -223,7 +223,7 @@ def test_serialized_kubernetes_worker_validation_snapshot_returns_independent_co
     assert second_snapshot["fake"]["config_fields"] == []
 
 
-def test_serialized_kubernetes_worker_validation_snapshot_cache_key_includes_mcp_config(
+def test_serialized_dedicated_worker_validation_snapshot_cache_key_includes_mcp_config(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -257,15 +257,15 @@ def test_serialized_kubernetes_worker_validation_snapshot_cache_key_includes_mcp
         fake_resolver,
     )
 
-    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=first_config,
     )
-    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=first_config,
     )
-    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=second_config,
     )
@@ -273,7 +273,7 @@ def test_serialized_kubernetes_worker_validation_snapshot_cache_key_includes_mcp
     assert calls == 2
 
 
-def test_serialized_kubernetes_worker_validation_snapshot_cache_key_includes_plugin_entries(
+def test_serialized_dedicated_worker_validation_snapshot_cache_key_includes_plugin_entries(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -293,15 +293,15 @@ def test_serialized_kubernetes_worker_validation_snapshot_cache_key_includes_plu
         fake_resolver,
     )
 
-    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=first_config,
     )
-    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=first_config,
     )
-    workers_runtime_module.serialized_kubernetes_worker_validation_snapshot(
+    workers_runtime_module.serialized_dedicated_worker_validation_snapshot(
         runtime_paths,
         runtime_config=second_config,
     )
@@ -354,7 +354,7 @@ def test_configured_docker_worker_manager_receives_validation_snapshot(
     monkeypatch.setattr(workers_runtime_module, "primary_worker_backend_name", lambda _paths: "docker")
     monkeypatch.setattr(
         workers_runtime_module,
-        "serialized_kubernetes_worker_validation_snapshot",
+        "serialized_dedicated_worker_validation_snapshot",
         MagicMock(return_value=validation_snapshot),
     )
     lease_manager = MagicMock(return_value=MagicMock())
@@ -365,7 +365,7 @@ def test_configured_docker_worker_manager_receives_validation_snapshot(
         runtime_config=runtime_config,
     )
 
-    assert lease_manager.call_args.kwargs["kubernetes_tool_validation_snapshot"] == validation_snapshot
+    assert lease_manager.call_args.kwargs["dedicated_worker_validation_snapshot"] == validation_snapshot
 
 
 def test_docker_worker_manager_build_passes_validation_snapshot(
@@ -385,7 +385,7 @@ def test_docker_worker_manager_build_passes_validation_snapshot(
         proxy_url=None,
         proxy_token="worker-token",  # noqa: S106
         storage_root=runtime_paths.storage_root,
-        kubernetes_tool_validation_snapshot=validation_snapshot,
+        dedicated_worker_validation_snapshot=validation_snapshot,
     )
 
     assert resolved is expected
@@ -417,7 +417,7 @@ def test_docker_worker_manager_identity_tracks_validation_snapshot(
         proxy_url=None,
         proxy_token="worker-token",  # noqa: S106
         storage_root=runtime_paths.storage_root,
-        kubernetes_tool_validation_snapshot=validation_snapshot,
+        dedicated_worker_validation_snapshot=validation_snapshot,
     )
 
     assert with_snapshot != without_snapshot

--- a/tests/test_worker_runtime.py
+++ b/tests/test_worker_runtime.py
@@ -338,6 +338,91 @@ def test_configured_primary_worker_manager_lease_uses_one_committed_config_snaps
     )
 
 
+def test_configured_docker_worker_manager_receives_validation_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The Docker manager should receive the committed primary tool-validation snapshot."""
+    runtime_paths = _runtime_paths(tmp_path)
+    runtime_config = Config()
+    validation_snapshot = {"shell": {"name": "shell", "config_fields": []}}
+    monkeypatch.setattr(
+        "mindroom.tool_system.sandbox_proxy.sandbox_proxy_config",
+        lambda _paths: MagicMock(proxy_url="http://worker.test", proxy_token="worker-token"),  # noqa: S106
+    )
+    monkeypatch.setattr(workers_runtime_module, "primary_worker_backend_available", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(workers_runtime_module, "primary_worker_backend_name", lambda _paths: "docker")
+    monkeypatch.setattr(
+        workers_runtime_module,
+        "serialized_kubernetes_worker_validation_snapshot",
+        MagicMock(return_value=validation_snapshot),
+    )
+    lease_manager = MagicMock(return_value=MagicMock())
+    monkeypatch.setattr(workers_runtime_module, "lease_primary_worker_manager", lease_manager)
+
+    workers_runtime_module.lease_configured_primary_worker_manager(
+        runtime_paths,
+        runtime_config=runtime_config,
+    )
+
+    assert lease_manager.call_args.kwargs["kubernetes_tool_validation_snapshot"] == validation_snapshot
+
+
+def test_docker_worker_manager_build_passes_validation_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Docker backend construction should retain the committed validation snapshot."""
+    runtime_paths = _runtime_paths(tmp_path)
+    validation_snapshot = {"shell": {"name": "shell", "config_fields": []}}
+    expected = MagicMock()
+    from_runtime = MagicMock(return_value=expected)
+    monkeypatch.setattr(workers_runtime_module, "primary_worker_backend_name", lambda _paths: "docker")
+    monkeypatch.setattr(workers_runtime_module.DockerWorkerBackend, "from_runtime", from_runtime)
+
+    resolved = workers_runtime_module._build_primary_worker_manager(
+        runtime_paths,
+        proxy_url=None,
+        proxy_token="worker-token",  # noqa: S106
+        storage_root=runtime_paths.storage_root,
+        kubernetes_tool_validation_snapshot=validation_snapshot,
+    )
+
+    assert resolved is expected
+    assert from_runtime.call_args.kwargs["tool_validation_snapshot"] == validation_snapshot
+
+
+def test_docker_worker_manager_identity_tracks_validation_snapshot(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Adding a committed snapshot should replace a snapshot-less Docker manager."""
+    runtime_paths = _runtime_paths(tmp_path)
+    validation_snapshot = {"shell": {"name": "shell", "config_fields": []}}
+    monkeypatch.setattr(workers_runtime_module, "primary_worker_backend_name", lambda _paths: "docker")
+    monkeypatch.setattr(
+        workers_runtime_module,
+        "docker_backend_config_signature",
+        lambda *_args, **_kwargs: ("docker", "base"),
+    )
+
+    without_snapshot = workers_runtime_module._primary_worker_backend_config_signature(
+        runtime_paths,
+        proxy_url=None,
+        proxy_token="worker-token",  # noqa: S106
+        storage_root=runtime_paths.storage_root,
+    )
+    with_snapshot = workers_runtime_module._primary_worker_backend_config_signature(
+        runtime_paths,
+        proxy_url=None,
+        proxy_token="worker-token",  # noqa: S106
+        storage_root=runtime_paths.storage_root,
+        kubernetes_tool_validation_snapshot=validation_snapshot,
+    )
+
+    assert with_snapshot != without_snapshot
+
+
 def test_configured_primary_worker_manager_identity_uses_the_lease_signature_without_constructing(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- propagate the primary tool-validation snapshot into Docker worker startup manifests
- include snapshot state in worker-manager and container identities so stale workers restart
- avoid full runtime/plugin validation in every forked Docker tool-call child

## Testing

- uv run pytest tests/test_docker_worker_backend.py tests/test_worker_runtime.py tests/test_sandbox_proxy.py tests/api/test_sandbox_runner_api.py -q -n 0 --no-cov
- uv run pre-commit run --all-files
- full parallel suite: all tests pass except the unrelated one-second test_background_script_approval_uses_exact_matrix_actor_and_first_decision[denied] timeout; it passes in isolation

## Summary by Sourcery

Propagate authoritative tool-validation state to dedicated workers so Docker tool calls avoid redundant validation and stale workers are restarted.

Bug Fixes:
- Ensure Docker workers do not reuse stale tool-validation state when the authoritative snapshot is absent or changes.

Enhancements:
- Propagate the committed tool-validation snapshot to Docker and Kubernetes worker managers and include it in worker identities so outdated workers are replaced.
- Allow Docker worker children to consume the committed startup validation manifest instead of repeating full runtime and plugin validation for every tool call.

Tests:
- Add coverage for Docker validation-manifest creation, cleanup, worker replacement, and propagation of validation snapshots through worker-manager construction and identity.

Chores:
- Generalize validation-snapshot handling from Kubernetes-specific workers to all dedicated worker backends.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Docker-based workers now receive the same tool-validation information as Kubernetes-based workers.
  - Worker startup manifests and environment settings reflect the active tool-validation configuration.

- **Bug Fixes**
  - Docker worker containers are automatically refreshed when tool-validation settings change, ensuring updated configurations take effect reliably.
  - Docker worker launches now consistently use the authoritative validation settings.

- **Tests**
  - Added coverage for validation-data propagation, startup behavior, configuration precedence, and container recreation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->