### PR TITLE
Fix unsigned reasoning replay with Claude

### DIFF
--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -41,6 +41,22 @@ _VERTEX_TOOL_SEARCH_HISTORY_BLOCK_TYPES = frozenset(
 _VERTEX_TOOL_SEARCH_TOKEN_RESERVE = 256
 
 
+def _messages_with_replay_safe_reasoning(messages: list[Message]) -> list[Message]:
+    """Omit reasoning that cannot be replayed as an Anthropic thinking block."""
+    sanitized_messages: list[Message] | None = None
+    for index, message in enumerate(messages):
+        if message.reasoning_content is None or message.provider_data is None:
+            continue
+        if isinstance(message.provider_data.get("signature"), str):
+            continue
+        if sanitized_messages is None:
+            sanitized_messages = list(messages)
+        sanitized_message = message.model_copy(deep=True)
+        sanitized_message.reasoning_content = None
+        sanitized_messages[index] = sanitized_message
+    return sanitized_messages if sanitized_messages is not None else messages
+
+
 def _strip_vertex_claude_tool_strict(
     tools: list[dict[str, Any]] | None,
 ) -> list[dict[str, Any]] | None:
@@ -326,6 +342,7 @@ class MindroomVertexAIClaude(ClaudeProviderCompat, VertexAIClaude):
         compress_tool_results: bool,
     ) -> list[Message]:
         """Drop the oldest replay turns until the exact request fits."""
+        messages = _messages_with_replay_safe_reasoning(messages)
         if self.context_window is None:
             return messages
         output_reserve = self.max_tokens or 0

--- a/src/mindroom/vertex_claude_compat.py
+++ b/src/mindroom/vertex_claude_compat.py
@@ -47,7 +47,8 @@ def _messages_with_replay_safe_reasoning(messages: list[Message]) -> list[Messag
     for index, message in enumerate(messages):
         if message.reasoning_content is None or message.provider_data is None:
             continue
-        if isinstance(message.provider_data.get("signature"), str):
+        signature = message.provider_data.get("signature")
+        if isinstance(signature, str) and signature:
             continue
         if sanitized_messages is None:
             sanitized_messages = list(messages)

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -716,8 +716,15 @@ def test_mindroom_vertexai_claude_request_kwargs_strip_tool_strict() -> None:
     assert model._has_beta_features(tools=[_strict_tool_definition()]) is False
 
 
+@pytest.mark.parametrize(
+    "codex_provider_data",
+    [{"response_id": "response-1"}, {"signature": ""}],
+    ids=["missing-signature", "empty-signature"],
+)
 @pytest.mark.asyncio
-async def test_mindroom_vertexai_claude_omits_unsigned_reasoning_from_cross_provider_replay() -> None:
+async def test_mindroom_vertexai_claude_omits_unsigned_reasoning_from_cross_provider_replay(
+    codex_provider_data: dict[str, str],
+) -> None:
     """Codex reasoning without an Anthropic signature must not become a thinking block."""
     model = MindroomVertexAIClaude(
         id="claude-opus-5",
@@ -728,7 +735,7 @@ async def test_mindroom_vertexai_claude_omits_unsigned_reasoning_from_cross_prov
         role="assistant",
         content="Codex answer",
         reasoning_content="Unsigned Codex reasoning",
-        provider_data={"response_id": "response-1"},
+        provider_data=codex_provider_data,
         tool_calls=[
             {
                 "id": "call-1",
@@ -768,10 +775,10 @@ async def test_mindroom_vertexai_claude_omits_unsigned_reasoning_from_cross_prov
     assert fitted_codex_message.reasoning_content is None
     assert fitted_codex_message.content == "Codex answer"
     assert fitted_codex_message.tool_calls == codex_message.tool_calls
-    assert fitted_codex_message.provider_data == {"response_id": "response-1"}
+    assert fitted_codex_message.provider_data == codex_provider_data
     assert fitted_messages[3] is claude_message
     assert codex_message.reasoning_content == "Unsigned Codex reasoning"
-    assert codex_message.provider_data == {"response_id": "response-1"}
+    assert codex_message.provider_data == codex_provider_data
 
 
 def _vertex_claude_model(*, extended_cache_time: bool = True) -> VertexAIClaude:

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -716,6 +716,64 @@ def test_mindroom_vertexai_claude_request_kwargs_strip_tool_strict() -> None:
     assert model._has_beta_features(tools=[_strict_tool_definition()]) is False
 
 
+@pytest.mark.asyncio
+async def test_mindroom_vertexai_claude_omits_unsigned_reasoning_from_cross_provider_replay() -> None:
+    """Codex reasoning without an Anthropic signature must not become a thinking block."""
+    model = MindroomVertexAIClaude(
+        id="claude-opus-5",
+        project_id="demo-project",
+        region="global",
+    )
+    codex_message = Message(
+        role="assistant",
+        content="Codex answer",
+        reasoning_content="Unsigned Codex reasoning",
+        provider_data={"response_id": "response-1"},
+        tool_calls=[
+            {
+                "id": "call-1",
+                "type": "function",
+                "function": {"name": "demo_tool", "arguments": "{}"},
+            },
+        ],
+        from_history=True,
+    )
+    claude_message = Message(
+        role="assistant",
+        content="Claude answer",
+        reasoning_content="Signed Claude reasoning",
+        provider_data={"signature": "signature-1"},
+        from_history=True,
+    )
+    messages = [
+        Message(role="user", content="First question", from_history=True),
+        codex_message,
+        Message(role="user", content="Second question", from_history=True),
+        claude_message,
+        Message(role="user", content="Current question"),
+    ]
+
+    fitted_messages = await model._fit_request_messages(
+        messages,
+        tools=None,
+        response_format=None,
+        compress_tool_results=False,
+    )
+    chat_messages, _system_prompt = format_messages(fitted_messages)
+
+    assert [block.type for block in chat_messages[1]["content"]] == ["text", "tool_use"]
+    assert [block.type for block in chat_messages[3]["content"]] == ["thinking", "text"]
+    fitted_codex_message = fitted_messages[1]
+    assert fitted_codex_message is not codex_message
+    assert fitted_codex_message.reasoning_content is None
+    assert fitted_codex_message.content == "Codex answer"
+    assert fitted_codex_message.tool_calls == codex_message.tool_calls
+    assert fitted_codex_message.provider_data == {"response_id": "response-1"}
+    assert fitted_messages[3] is claude_message
+    assert codex_message.reasoning_content == "Unsigned Codex reasoning"
+    assert codex_message.provider_data == {"response_id": "response-1"}
+
+
 def _vertex_claude_model(*, extended_cache_time: bool = True) -> VertexAIClaude:
     return VertexAIClaude(
         id="claude-sonnet-4-6",


### PR DESCRIPTION
## Summary

- omit cross-provider reasoning that lacks an Anthropic thinking signature before Vertex Claude formatting
- preserve message content, tool calls, provider metadata, and signed Anthropic thinking through copy-on-write sanitization
- add a regression test for switching a thread from Codex/Luna to Claude/Opus

## Testing

- `uv run pytest -q`
- `uv run pre-commit run --files src/mindroom/vertex_claude_compat.py tests/test_extra_kwargs.py`

## Summary by Sourcery

Safely sanitize replayed reasoning before formatting Claude requests while retaining valid signed reasoning and the rest of each message.

Bug Fixes:
- Prevent unsigned cross-provider reasoning from being replayed as Anthropic thinking blocks when switching conversations to Claude.
- Preserve message content, tool calls, provider metadata, and signed reasoning while sanitizing incompatible replayed reasoning.

Tests:
- Add regression coverage for missing and empty Anthropic signatures during Codex-to-Claude conversation replay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cross-provider conversation replay by omitting historical reasoning content when its replay signature is missing or empty.
  - Preserved signed reasoning, message content, tool calls, and provider information during request processing.
  - Ensured original conversation data remains unchanged during replay preparation.

- **Tests**
  - Added regression coverage for missing and empty replay signatures, including verification of signed reasoning preservation and message integrity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->