### PR TITLE
Record silent schedule runs in agent workspaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,6 +145,7 @@ Matrix sync callback
 | `tool_system/plugins.py` | Plugin loading and tool/skill extension |
 | `scheduling.py` | Cron and natural-language task scheduling |
 | `scheduling_executor.py` | Fire one scheduled task: hook emission, visible or silent Matrix delivery, and failure notices |
+| `scheduled_run_records.py` | Agent-workspace JSON receipts for silent scheduled runs |
 | `tools/` | 100+ tool integrations |
 | `tool_system/dependencies.py` | Auto-install per-tool optional dependencies at runtime |
 | `ai.py` | AI response generation, streaming, and Matrix run metadata |

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -90,6 +90,14 @@ Say `make this schedule silent` or `make this schedule visible` to change the mo
 
 Silent delivery controls room presentation, not storage or transport.
 The task body still travels through Matrix as a custom timeline event and remains subject to homeserver retention, encrypted transport where enabled, and MindRoom's local durable recovery journal.
+Every admitted silent run also writes a versioned JSON receipt to `<agent-workspace>/.mindroom/scheduled_runs/<sha256(source-event-id)>.json`.
+The receipt starts with `status: "started"` before generation and is atomically replaced with `status: "completed"`, a `result` of `reported`, `no_report`, or `suppressed`, and the final response text after response hooks.
+A receipt left in `started` shows that the run began but did not reach a final response decision.
+Version 1 always includes `schema_version`, `source_event_id`, `entity_name`, `agent_name`, `room_id`, `thread_id`, `prompt`, `status`, `result`, `response_text`, `started_at`, and `completed_at`, with result, response, thread, and completion fields set to `null` until applicable.
+Timestamps use UTC RFC 3339 strings ending in `Z`.
+Replaying the same source event rewrites the same file and preserves a valid original `started_at` value.
+Team runs write one receipt to each member agent's workspace, and private agents write inside the matching requester-scoped workspace.
+The hidden `.mindroom` directory keeps receipts out of default workspace knowledge indexing.
 
 ## Agent and Team Mentions
 

--- a/docs/scheduling.md
+++ b/docs/scheduling.md
@@ -93,7 +93,7 @@ The task body still travels through Matrix as a custom timeline event and remain
 Every admitted silent run also writes a versioned JSON receipt to `<agent-workspace>/.mindroom/scheduled_runs/<sha256(source-event-id)>.json`.
 The receipt starts with `status: "started"` before generation and is atomically replaced with `status: "completed"`, a `result` of `reported`, `no_report`, or `suppressed`, and the final response text after response hooks.
 A receipt left in `started` shows that the run began but did not reach a final response decision.
-Version 1 always includes `schema_version`, `source_event_id`, `entity_name`, `agent_name`, `room_id`, `thread_id`, `prompt`, `status`, `result`, `response_text`, `started_at`, and `completed_at`, with result, response, thread, and completion fields set to `null` until applicable.
+Version 1 always includes `schema_version`, `source_event_id`, `entity_name`, `agent_name`, `room_id`, `thread_id`, `prompt`, `status`, `result`, `response_text`, `started_at`, and `completed_at`, with `result`, `response_text`, `thread_id`, and `completed_at` set to `null` until applicable.
 Timestamps use UTC RFC 3339 strings ending in `Z`.
 Replaying the same source event rewrites the same file and preserves a valid original `started_at` value.
 Team runs write one receipt to each member agent's workspace, and private agents write inside the matching requester-scoped workspace.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15902,6 +15902,14 @@ Say `make this schedule silent` or `make this schedule visible` to change the mo
 
 Silent delivery controls room presentation, not storage or transport.
 The task body still travels through Matrix as a custom timeline event and remains subject to homeserver retention, encrypted transport where enabled, and MindRoom's local durable recovery journal.
+Every admitted silent run also writes a versioned JSON receipt to `<agent-workspace>/.mindroom/scheduled_runs/<sha256(source-event-id)>.json`.
+The receipt starts with `status: "started"` before generation and is atomically replaced with `status: "completed"`, a `result` of `reported`, `no_report`, or `suppressed`, and the final response text after response hooks.
+A receipt left in `started` shows that the run began but did not reach a final response decision.
+Version 1 always includes `schema_version`, `source_event_id`, `entity_name`, `agent_name`, `room_id`, `thread_id`, `prompt`, `status`, `result`, `response_text`, `started_at`, and `completed_at`, with result, response, thread, and completion fields set to `null` until applicable.
+Timestamps use UTC RFC 3339 strings ending in `Z`.
+Replaying the same source event rewrites the same file and preserves a valid original `started_at` value.
+Team runs write one receipt to each member agent's workspace, and private agents write inside the matching requester-scoped workspace.
+The hidden `.mindroom` directory keeps receipts out of default workspace knowledge indexing.
 
 ## Agent and Team Mentions
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15905,7 +15905,7 @@ The task body still travels through Matrix as a custom timeline event and remain
 Every admitted silent run also writes a versioned JSON receipt to `<agent-workspace>/.mindroom/scheduled_runs/<sha256(source-event-id)>.json`.
 The receipt starts with `status: "started"` before generation and is atomically replaced with `status: "completed"`, a `result` of `reported`, `no_report`, or `suppressed`, and the final response text after response hooks.
 A receipt left in `started` shows that the run began but did not reach a final response decision.
-Version 1 always includes `schema_version`, `source_event_id`, `entity_name`, `agent_name`, `room_id`, `thread_id`, `prompt`, `status`, `result`, `response_text`, `started_at`, and `completed_at`, with result, response, thread, and completion fields set to `null` until applicable.
+Version 1 always includes `schema_version`, `source_event_id`, `entity_name`, `agent_name`, `room_id`, `thread_id`, `prompt`, `status`, `result`, `response_text`, `started_at`, and `completed_at`, with `result`, `response_text`, `thread_id`, and `completed_at` set to `null` until applicable.
 Timestamps use UTC RFC 3339 strings ending in `Z`.
 Replaying the same source event rewrites the same file and preserves a valid original `started_at` value.
 Team runs write one receipt to each member agent's workspace, and private agents write inside the matching requester-scoped workspace.

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -89,7 +89,7 @@ The task body still travels through Matrix as a custom timeline event and remain
 Every admitted silent run also writes a versioned JSON receipt to `<agent-workspace>/.mindroom/scheduled_runs/<sha256(source-event-id)>.json`.
 The receipt starts with `status: "started"` before generation and is atomically replaced with `status: "completed"`, a `result` of `reported`, `no_report`, or `suppressed`, and the final response text after response hooks.
 A receipt left in `started` shows that the run began but did not reach a final response decision.
-Version 1 always includes `schema_version`, `source_event_id`, `entity_name`, `agent_name`, `room_id`, `thread_id`, `prompt`, `status`, `result`, `response_text`, `started_at`, and `completed_at`, with result, response, thread, and completion fields set to `null` until applicable.
+Version 1 always includes `schema_version`, `source_event_id`, `entity_name`, `agent_name`, `room_id`, `thread_id`, `prompt`, `status`, `result`, `response_text`, `started_at`, and `completed_at`, with `result`, `response_text`, `thread_id`, and `completed_at` set to `null` until applicable.
 Timestamps use UTC RFC 3339 strings ending in `Z`.
 Replaying the same source event rewrites the same file and preserves a valid original `started_at` value.
 Team runs write one receipt to each member agent's workspace, and private agents write inside the matching requester-scoped workspace.

--- a/skills/mindroom-docs/references/page__scheduling__index.md
+++ b/skills/mindroom-docs/references/page__scheduling__index.md
@@ -86,6 +86,14 @@ Say `make this schedule silent` or `make this schedule visible` to change the mo
 
 Silent delivery controls room presentation, not storage or transport.
 The task body still travels through Matrix as a custom timeline event and remains subject to homeserver retention, encrypted transport where enabled, and MindRoom's local durable recovery journal.
+Every admitted silent run also writes a versioned JSON receipt to `<agent-workspace>/.mindroom/scheduled_runs/<sha256(source-event-id)>.json`.
+The receipt starts with `status: "started"` before generation and is atomically replaced with `status: "completed"`, a `result` of `reported`, `no_report`, or `suppressed`, and the final response text after response hooks.
+A receipt left in `started` shows that the run began but did not reach a final response decision.
+Version 1 always includes `schema_version`, `source_event_id`, `entity_name`, `agent_name`, `room_id`, `thread_id`, `prompt`, `status`, `result`, `response_text`, `started_at`, and `completed_at`, with result, response, thread, and completion fields set to `null` until applicable.
+Timestamps use UTC RFC 3339 strings ending in `Z`.
+Replaying the same source event rewrites the same file and preserves a valid original `started_at` value.
+Team runs write one receipt to each member agent's workspace, and private agents write inside the matching requester-scoped workspace.
+The hidden `.mindroom` directory keeps receipts out of default workspace knowledge indexing.
 
 ## Agent and Team Mentions
 

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -140,6 +140,7 @@ class ResponseIdentity:
     response_kind: str
     response_envelope: MessageEnvelope
     correlation_id: str
+    participating_agent_names: tuple[str, ...] = ()
 
 
 @dataclass
@@ -1292,6 +1293,7 @@ class DeliveryGateway:
                 suppression_reason = "silent_no_report"
         await record_silent_schedule_result_if_needed(
             entity_name=self.deps.agent_name,
+            agent_names=request.identity.participating_agent_names or (self.deps.agent_name,),
             envelope=request.identity.response_envelope,
             config=self.deps.runtime.config,
             runtime_paths=self.deps.runtime_paths,

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -72,6 +72,7 @@ from mindroom.matrix_delivery import (
     TurnHandoff,
 )
 from mindroom.runtime_protocols import SupportsClientConfig  # noqa: TC001
+from mindroom.scheduled_run_records import record_silent_schedule_result_if_needed
 from mindroom.streaming import (
     PROGRESS_PLACEHOLDER,
     FinalTextTransform,
@@ -1289,6 +1290,14 @@ class DeliveryGateway:
                 no_report_text = strip_matching_visible_tool_markers(no_report_text, draft.tool_trace)
             if constants.is_silent_schedule_no_report_response(no_report_text):
                 suppression_reason = "silent_no_report"
+        await record_silent_schedule_result_if_needed(
+            entity_name=self.deps.agent_name,
+            envelope=request.identity.response_envelope,
+            config=self.deps.runtime.config,
+            runtime_paths=self.deps.runtime_paths,
+            suppression_reason=suppression_reason,
+            response_text=draft.response_text,
+        )
         if suppression_reason is not None:
             self.deps.logger.info(
                 "Response suppressed",

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -432,6 +432,7 @@ class ResponseRequest:
     attachment_ids: tuple[str, ...] | None = None
     correlation_id: str | None = None
     matrix_run_metadata: Mapping[str, Any] | None = None
+    participating_agent_names: tuple[str, ...] = ()
     transient_enrichment_items: tuple[EnrichmentItem, ...] = ()
     system_enrichment_items: tuple[EnrichmentItem, ...] = ()
     requires_model_history_refresh: bool = False
@@ -1437,6 +1438,7 @@ class ResponseRunner:
             user_id=continuation.requester_id,
             attachment_ids=continuation.attachment_ids,
             correlation_id=continuation.correlation_id,
+            participating_agent_names=continuation.team_member_names or (continuation.entity_name,),
         )
 
     def _approval_post_response_outcome(
@@ -2579,6 +2581,7 @@ class ResponseRunner:
             response_kind=response_kind,
             response_envelope=request.response_envelope,
             correlation_id=self._correlation_id_for_request(request),
+            participating_agent_names=request.participating_agent_names or (self.deps.agent_name,),
         )
 
     def _agent_turn_context(
@@ -2773,6 +2776,7 @@ class ResponseRunner:
             return None
         await record_silent_schedule_started_if_needed(
             entity_name=self.deps.agent_name,
+            agent_names=request.participating_agent_names or (self.deps.agent_name,),
             envelope=request.response_envelope,
             config=self.deps.runtime.config,
             runtime_paths=self.deps.runtime_paths,
@@ -3269,6 +3273,7 @@ class ResponseRunner:
         agent_names = [
             registry.current_entity_name_for_user_id(mid.full_id) or mid.username for mid in team_request.team_agents
         ]
+        request = replace(request, participating_agent_names=tuple(agent_names))
         if not request.prompt.strip():
             return await self._finalize_empty_prompt_locked(
                 request,
@@ -4398,6 +4403,7 @@ class ResponseRunner:
     ) -> str | None:
         """Generate one agent response after acquiring the per-thread lock."""
         placeholder_state = early_placeholder_state or _EarlyPlaceholderState()
+        request = replace(request, participating_agent_names=(self.deps.agent_name,))
         history_scope = self.deps.state_writer.history_scope()
         execution_identity = self.deps.tool_runtime.build_execution_identity(
             target=resolved_target,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -86,6 +86,7 @@ from mindroom.response_terminal import (
 )
 from mindroom.response_turn import CompletedApprovalRun, PausedAttempt, ResponsePausedForApproval
 from mindroom.runtime_shutdown import GENERIC_SHUTDOWN, RuntimeShutdownIntent
+from mindroom.scheduled_run_records import record_silent_schedule_started_if_needed
 from mindroom.streaming import (
     INTERRUPTED_RESPONSE_NOTE,
     PROGRESS_PLACEHOLDER,
@@ -2727,19 +2728,16 @@ class ResponseRunner:
             reply_entity_names=reply_entity_names,
         )
 
-    async def _begin_locked_turn(
+    async def _admit_locked_turn(
         self,
         request: ResponseRequest,
         *,
         resolved_target: MessageTarget,
         history_scope: HistoryScope,
         execution_identity: ToolExecutionIdentity,
-        placeholder_message: str | None = None,
-        early_placeholder_state: _EarlyPlaceholderState | None = None,
         reply_entity_names: tuple[str, ...] = (),
     ) -> ResponseRequest | None:
-        """Expose a locked turn before running its potentially slow preparation."""
-        placeholder_state = early_placeholder_state or _EarlyPlaceholderState()
+        """Pass locked replay, authorization, and terminal-source gates before setup."""
         if not await self._locked_turn_can_begin(
             request,
             history_scope=history_scope,
@@ -2773,6 +2771,26 @@ class ResponseRunner:
             if request.on_source_turn_suppressed is not None:
                 await request.on_source_turn_suppressed()
             return None
+        await record_silent_schedule_started_if_needed(
+            entity_name=self.deps.agent_name,
+            envelope=request.response_envelope,
+            config=self.deps.runtime.config,
+            runtime_paths=self.deps.runtime_paths,
+        )
+        return request
+
+    async def _prepare_admitted_locked_turn(
+        self,
+        request: ResponseRequest,
+        *,
+        resolved_target: MessageTarget,
+        history_scope: HistoryScope,
+        execution_identity: ToolExecutionIdentity,
+        placeholder_message: str | None = None,
+        early_placeholder_state: _EarlyPlaceholderState | None = None,
+    ) -> ResponseRequest:
+        """Run placeholder and request preparation for an already-admitted locked turn."""
+        placeholder_state = early_placeholder_state or _EarlyPlaceholderState()
         placeholder_event_id = None
         if (
             placeholder_message is not None
@@ -2813,6 +2831,36 @@ class ResponseRunner:
             exclude_history_event_id=placeholder_event_id,
         )
         return self._request_with_locked_target(request, resolved_target)
+
+    async def _begin_locked_turn(
+        self,
+        request: ResponseRequest,
+        *,
+        resolved_target: MessageTarget,
+        history_scope: HistoryScope,
+        execution_identity: ToolExecutionIdentity,
+        placeholder_message: str | None = None,
+        early_placeholder_state: _EarlyPlaceholderState | None = None,
+        reply_entity_names: tuple[str, ...] = (),
+    ) -> ResponseRequest | None:
+        """Admit and prepare one turn after its lifecycle lock is acquired."""
+        admitted_request = await self._admit_locked_turn(
+            request,
+            resolved_target=resolved_target,
+            history_scope=history_scope,
+            execution_identity=execution_identity,
+            reply_entity_names=reply_entity_names,
+        )
+        if admitted_request is None:
+            return None
+        return await self._prepare_admitted_locked_turn(
+            admitted_request,
+            resolved_target=resolved_target,
+            history_scope=history_scope,
+            execution_identity=execution_identity,
+            placeholder_message=placeholder_message,
+            early_placeholder_state=early_placeholder_state,
+        )
 
     def _sync_restart_retry_is_current(
         self,
@@ -3230,6 +3278,16 @@ class ResponseRunner:
                 execution_identity=retry_execution_identity,
                 reply_entity_names=tuple(agent_names),
             )
+        admitted_request = await self._admit_locked_turn(
+            request,
+            resolved_target=resolved_target,
+            history_scope=session_scope,
+            execution_identity=retry_execution_identity,
+            reply_entity_names=tuple(agent_names),
+        )
+        if admitted_request is None:
+            return None
+        request = admitted_request
         turn_models = (
             None
             if team_request.resolution_reason is not None
@@ -3242,18 +3300,14 @@ class ResponseRunner:
                 thread_id=resolved_target.resolved_thread_id,
             )
         )
-        prepared_request = await self._begin_locked_turn(
+        request = await self._prepare_admitted_locked_turn(
             request,
             resolved_target=resolved_target,
             history_scope=session_scope,
             execution_identity=retry_execution_identity,
             placeholder_message=(None if _is_silent_schedule_response(request) else "🤝 Team Response: Thinking..."),
             early_placeholder_state=placeholder_state,
-            reply_entity_names=tuple(agent_names),
         )
-        if prepared_request is None:
-            return None
-        request = prepared_request
         team_request = replace(team_request, request=request)
         reason = team_request.resolution_reason
         if reason is not None:
@@ -4357,6 +4411,15 @@ class ResponseRunner:
                 history_scope=history_scope,
                 execution_identity=execution_identity,
             )
+        admitted_request = await self._admit_locked_turn(
+            request,
+            resolved_target=resolved_target,
+            history_scope=history_scope,
+            execution_identity=execution_identity,
+        )
+        if admitted_request is None:
+            return None
+        request = admitted_request
         response_thread_id = _response_thread_id(request, resolved_target)
         active_model_name = self.deps.runtime.config.resolve_runtime_model(
             entity_name=self.deps.agent_name,
@@ -4364,7 +4427,7 @@ class ResponseRunner:
             thread_id=response_thread_id,
             runtime_paths=self.deps.runtime_paths,
         ).model_name
-        prepared_request = await self._begin_locked_turn(
+        request = await self._prepare_admitted_locked_turn(
             request,
             resolved_target=resolved_target,
             history_scope=history_scope,
@@ -4372,9 +4435,6 @@ class ResponseRunner:
             placeholder_message=None if _is_silent_schedule_response(request) else "Thinking...",
             early_placeholder_state=placeholder_state,
         )
-        if prepared_request is None:
-            return None
-        request = prepared_request
         memory_prompt, memory_thread_history, model_prompt_text, model_thread_history = (
             prepare_memory_and_model_context(
                 request.prompt,

--- a/src/mindroom/scheduled_run_records.py
+++ b/src/mindroom/scheduled_run_records.py
@@ -46,6 +46,14 @@ class _ScheduledRunReceipt:
     completed_at: str | None
 
 
+@dataclass(frozen=True)
+class _ExistingReceiptState:
+    """Validated lifecycle state reused when rewriting one receipt."""
+
+    status: Literal["started", "completed"]
+    started_at: str
+
+
 _RECEIPT_FIELDS = frozenset(
     {
         "schema_version",
@@ -155,7 +163,7 @@ def _receipt_state_is_valid(payload: dict[object, object]) -> bool:
     )
 
 
-def _existing_started_at(path: Path, expected: _ScheduledRunReceipt) -> str | None:
+def _existing_receipt_state(path: Path, expected: _ScheduledRunReceipt) -> _ExistingReceiptState | None:
     try:
         payload = json.loads(path.read_text(encoding="utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError):
@@ -187,7 +195,7 @@ def _existing_started_at(path: Path, expected: _ScheduledRunReceipt) -> str | No
         or not _receipt_state_is_valid(payload)
     ):
         return None
-    return payload["started_at"]
+    return _ExistingReceiptState(status=payload["status"], started_at=payload["started_at"])
 
 
 def _write_started_receipts(
@@ -221,8 +229,10 @@ def _write_started_receipts(
             started_at=started_at,
             completed_at=None,
         )
-        if _existing_started_at(path, receipt) is not None:
-            continue
+        if existing := _existing_receipt_state(path, receipt):
+            receipt = replace(receipt, started_at=existing.started_at)
+            if existing.status == "started":
+                continue
         _atomic_write_receipt(path, receipt)
 
 
@@ -259,8 +269,8 @@ def _write_completed_receipts(
             started_at=completed_at,
             completed_at=completed_at,
         )
-        if started_at := _existing_started_at(path, receipt):
-            receipt = replace(receipt, started_at=started_at)
+        if existing := _existing_receipt_state(path, receipt):
+            receipt = replace(receipt, started_at=existing.started_at)
         _atomic_write_receipt(path, receipt)
 
 

--- a/src/mindroom/scheduled_run_records.py
+++ b/src/mindroom/scheduled_run_records.py
@@ -1,0 +1,311 @@
+"""Machine-readable evidence for silent scheduled runs in agent workspaces."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from dataclasses import asdict, dataclass, replace
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from mindroom.dispatch_source import SILENT_SCHEDULE_SOURCE_KIND
+from mindroom.durable_write import create_directory_durable, write_json_file_durable
+from mindroom.runtime_resolution import resolve_agent_runtime
+from mindroom.tool_system.worker_routing import (
+    agent_workspace_root_path,
+    build_tool_execution_identity,
+)
+from mindroom.workspaces import resolve_workspace_relative_path
+
+if TYPE_CHECKING:
+    from mindroom.config.main import Config
+    from mindroom.constants import RuntimePaths
+    from mindroom.hooks import MessageEnvelope
+
+_SCHEMA_VERSION = 1
+_RUN_DIRECTORY = ".mindroom/scheduled_runs"
+
+
+@dataclass(frozen=True)
+class _ScheduledRunReceipt:
+    """One agent-local view of a silent scheduled run."""
+
+    schema_version: int
+    source_event_id: str
+    entity_name: str
+    agent_name: str
+    room_id: str
+    thread_id: str | None
+    prompt: str
+    status: Literal["started", "completed"]
+    result: Literal["reported", "no_report", "suppressed"] | None
+    response_text: str | None
+    started_at: str
+    completed_at: str | None
+
+
+_RECEIPT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "source_event_id",
+        "entity_name",
+        "agent_name",
+        "room_id",
+        "thread_id",
+        "prompt",
+        "status",
+        "result",
+        "response_text",
+        "started_at",
+        "completed_at",
+    },
+)
+_COMPLETED_RESULTS = frozenset({"reported", "no_report", "suppressed"})
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _receipt_path(workspace: Path, source_event_id: str) -> Path:
+    source_digest = hashlib.sha256(source_event_id.encode("utf-8")).hexdigest()
+    return resolve_workspace_relative_path(
+        workspace,
+        Path(_RUN_DIRECTORY) / f"{source_digest}.json",
+        field_name="Silent schedule receipt",
+    )
+
+
+def _atomic_write_receipt(path: Path, receipt: _ScheduledRunReceipt) -> None:
+    create_directory_durable(path.parent.parent, mode=0o700)
+    create_directory_durable(path.parent, mode=0o700)
+    write_json_file_durable(
+        path,
+        asdict(receipt),
+        strict_atomic_replace=True,
+        indent=2,
+        sort_keys=True,
+        trailing_newline=True,
+    )
+
+
+def _agent_names(config: Config, entity_name: str) -> tuple[str, ...]:
+    team = config.teams.get(entity_name)
+    if team is not None:
+        return tuple(dict.fromkeys(team.agents))
+    return (entity_name,)
+
+
+def _workspace_for_agent(
+    agent_name: str,
+    *,
+    entity_name: str,
+    envelope: MessageEnvelope,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> Path:
+    if agent_name not in config.agents:
+        return agent_workspace_root_path(runtime_paths.storage_root, agent_name)
+    target = envelope.target
+    execution_identity = build_tool_execution_identity(
+        channel="matrix",
+        agent_name=agent_name,
+        transport_agent_name=entity_name,
+        runtime_paths=runtime_paths,
+        requester_id=envelope.requester_id,
+        room_id=target.room_id,
+        thread_id=target.resolved_thread_id,
+        resolved_thread_id=target.resolved_thread_id,
+        session_id=target.session_id,
+    )
+    resolved = resolve_agent_runtime(
+        agent_name,
+        config,
+        runtime_paths,
+        execution_identity=execution_identity,
+        create=True,
+    )
+    if resolved.workspace is not None:
+        return resolved.workspace.root
+    return agent_workspace_root_path(runtime_paths.storage_root, agent_name)
+
+
+def _is_utc_timestamp(value: object) -> bool:
+    if not isinstance(value, str) or not value.endswith("Z"):
+        return False
+    try:
+        parsed = datetime.fromisoformat(f"{value[:-1]}+00:00")
+    except ValueError:
+        return False
+    canonical = parsed.isoformat().replace("+00:00", "Z")
+    return parsed.tzinfo is not None and parsed.utcoffset() == UTC.utcoffset(parsed) and value == canonical
+
+
+def _receipt_state_is_valid(payload: dict[object, object]) -> bool:
+    if payload["status"] == "started":
+        return all(payload[field] is None for field in ("result", "response_text", "completed_at"))
+    return (
+        payload["status"] == "completed"
+        and isinstance(payload["result"], str)
+        and payload["result"] in _COMPLETED_RESULTS
+        and isinstance(payload["response_text"], str)
+        and _is_utc_timestamp(payload["completed_at"])
+    )
+
+
+def _existing_started_at(path: Path, expected: _ScheduledRunReceipt) -> str | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict) or payload.keys() != _RECEIPT_FIELDS:
+        return None
+    identity = (
+        payload["schema_version"],
+        payload["source_event_id"],
+        payload["entity_name"],
+        payload["agent_name"],
+        payload["room_id"],
+        payload["thread_id"],
+        payload["prompt"],
+    )
+    expected_identity = (
+        expected.schema_version,
+        expected.source_event_id,
+        expected.entity_name,
+        expected.agent_name,
+        expected.room_id,
+        expected.thread_id,
+        expected.prompt,
+    )
+    if (
+        type(payload["schema_version"]) is not int
+        or identity != expected_identity
+        or not _is_utc_timestamp(payload["started_at"])
+        or not _receipt_state_is_valid(payload)
+    ):
+        return None
+    return payload["started_at"]
+
+
+def _write_started_receipts(
+    *,
+    entity_name: str,
+    envelope: MessageEnvelope,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> None:
+    started_at = _utc_timestamp()
+    for agent_name in _agent_names(config, entity_name):
+        workspace = _workspace_for_agent(
+            agent_name,
+            entity_name=entity_name,
+            envelope=envelope,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+        path = _receipt_path(workspace, envelope.source_event_id)
+        receipt = _ScheduledRunReceipt(
+            schema_version=_SCHEMA_VERSION,
+            source_event_id=envelope.source_event_id,
+            entity_name=entity_name,
+            agent_name=agent_name,
+            room_id=envelope.room_id,
+            thread_id=envelope.target.resolved_thread_id,
+            prompt=envelope.body,
+            status="started",
+            result=None,
+            response_text=None,
+            started_at=started_at,
+            completed_at=None,
+        )
+        if _existing_started_at(path, receipt) is not None:
+            continue
+        _atomic_write_receipt(path, receipt)
+
+
+def _write_completed_receipts(
+    *,
+    entity_name: str,
+    envelope: MessageEnvelope,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    result: Literal["reported", "no_report", "suppressed"],
+    response_text: str,
+) -> None:
+    completed_at = _utc_timestamp()
+    for agent_name in _agent_names(config, entity_name):
+        workspace = _workspace_for_agent(
+            agent_name,
+            entity_name=entity_name,
+            envelope=envelope,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+        path = _receipt_path(workspace, envelope.source_event_id)
+        receipt = _ScheduledRunReceipt(
+            schema_version=_SCHEMA_VERSION,
+            source_event_id=envelope.source_event_id,
+            entity_name=entity_name,
+            agent_name=agent_name,
+            room_id=envelope.room_id,
+            thread_id=envelope.target.resolved_thread_id,
+            prompt=envelope.body,
+            status="completed",
+            result=result,
+            response_text=response_text,
+            started_at=completed_at,
+            completed_at=completed_at,
+        )
+        if started_at := _existing_started_at(path, receipt):
+            receipt = replace(receipt, started_at=started_at)
+        _atomic_write_receipt(path, receipt)
+
+
+async def record_silent_schedule_result_if_needed(
+    *,
+    entity_name: str,
+    envelope: MessageEnvelope,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    suppression_reason: str | None,
+    response_text: str,
+) -> None:
+    """Persist the final result only when the response is a silent schedule."""
+    if envelope.source_kind != SILENT_SCHEDULE_SOURCE_KIND:
+        return
+    result: Literal["reported", "no_report", "suppressed"] = "reported"
+    if suppression_reason == "silent_no_report":
+        result = "no_report"
+    elif suppression_reason is not None:
+        result = "suppressed"
+    await asyncio.to_thread(
+        _write_completed_receipts,
+        entity_name=entity_name,
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+        result=result,
+        response_text=response_text,
+    )
+
+
+async def record_silent_schedule_started_if_needed(
+    *,
+    entity_name: str,
+    envelope: MessageEnvelope,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> None:
+    """Create an idempotent start receipt only for a silent schedule."""
+    if envelope.source_kind != SILENT_SCHEDULE_SOURCE_KIND:
+        return
+    await asyncio.to_thread(
+        _write_started_receipts,
+        entity_name=entity_name,
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+    )

--- a/src/mindroom/scheduled_run_records.py
+++ b/src/mindroom/scheduled_run_records.py
@@ -2,14 +2,15 @@
 
 from __future__ import annotations
 
-import asyncio
 import hashlib
 import json
 from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from mindroom.background_tasks import run_blocking_until_complete
 from mindroom.dispatch_source import SILENT_SCHEDULE_SOURCE_KIND
 from mindroom.durable_write import create_directory_durable, write_json_file_durable
 from mindroom.runtime_resolution import resolve_agent_runtime
@@ -99,13 +100,6 @@ def _atomic_write_receipt(path: Path, receipt: _ScheduledRunReceipt) -> None:
     )
 
 
-def _agent_names(config: Config, entity_name: str) -> tuple[str, ...]:
-    team = config.teams.get(entity_name)
-    if team is not None:
-        return tuple(dict.fromkeys(team.agents))
-    return (entity_name,)
-
-
 def _workspace_for_agent(
     agent_name: str,
     *,
@@ -140,26 +134,30 @@ def _workspace_for_agent(
     return agent_workspace_root_path(runtime_paths.storage_root, agent_name)
 
 
-def _is_utc_timestamp(value: object) -> bool:
+def _parse_utc_timestamp(value: object) -> datetime | None:
     if not isinstance(value, str) or not value.endswith("Z"):
-        return False
+        return None
     try:
         parsed = datetime.fromisoformat(f"{value[:-1]}+00:00")
     except ValueError:
-        return False
+        return None
     canonical = parsed.isoformat().replace("+00:00", "Z")
-    return parsed.tzinfo is not None and parsed.utcoffset() == UTC.utcoffset(parsed) and value == canonical
+    if parsed.tzinfo is None or parsed.utcoffset() != UTC.utcoffset(parsed) or value != canonical:
+        return None
+    return parsed
 
 
-def _receipt_state_is_valid(payload: dict[object, object]) -> bool:
+def _receipt_state_is_valid(payload: dict[object, object], *, started_at: datetime) -> bool:
     if payload["status"] == "started":
         return all(payload[field] is None for field in ("result", "response_text", "completed_at"))
+    completed_at = _parse_utc_timestamp(payload["completed_at"])
     return (
         payload["status"] == "completed"
         and isinstance(payload["result"], str)
         and payload["result"] in _COMPLETED_RESULTS
         and isinstance(payload["response_text"], str)
-        and _is_utc_timestamp(payload["completed_at"])
+        and completed_at is not None
+        and completed_at >= started_at
     )
 
 
@@ -188,11 +186,17 @@ def _existing_receipt_state(path: Path, expected: _ScheduledRunReceipt) -> _Exis
         expected.thread_id,
         expected.prompt,
     )
+    started_at = _parse_utc_timestamp(payload["started_at"])
+    replacement_completed_at = _parse_utc_timestamp(expected.completed_at)
     if (
         type(payload["schema_version"]) is not int
         or identity != expected_identity
-        or not _is_utc_timestamp(payload["started_at"])
-        or not _receipt_state_is_valid(payload)
+        or started_at is None
+        or (
+            expected.status == "completed"
+            and (replacement_completed_at is None or started_at > replacement_completed_at)
+        )
+        or not _receipt_state_is_valid(payload, started_at=started_at)
     ):
         return None
     return _ExistingReceiptState(status=payload["status"], started_at=payload["started_at"])
@@ -201,12 +205,13 @@ def _existing_receipt_state(path: Path, expected: _ScheduledRunReceipt) -> _Exis
 def _write_started_receipts(
     *,
     entity_name: str,
+    agent_names: tuple[str, ...],
     envelope: MessageEnvelope,
     config: Config,
     runtime_paths: RuntimePaths,
 ) -> None:
     started_at = _utc_timestamp()
-    for agent_name in _agent_names(config, entity_name):
+    for agent_name in agent_names:
         workspace = _workspace_for_agent(
             agent_name,
             entity_name=entity_name,
@@ -239,6 +244,7 @@ def _write_started_receipts(
 def _write_completed_receipts(
     *,
     entity_name: str,
+    agent_names: tuple[str, ...],
     envelope: MessageEnvelope,
     config: Config,
     runtime_paths: RuntimePaths,
@@ -246,7 +252,7 @@ def _write_completed_receipts(
     response_text: str,
 ) -> None:
     completed_at = _utc_timestamp()
-    for agent_name in _agent_names(config, entity_name):
+    for agent_name in agent_names:
         workspace = _workspace_for_agent(
             agent_name,
             entity_name=entity_name,
@@ -277,6 +283,7 @@ def _write_completed_receipts(
 async def record_silent_schedule_result_if_needed(
     *,
     entity_name: str,
+    agent_names: tuple[str, ...],
     envelope: MessageEnvelope,
     config: Config,
     runtime_paths: RuntimePaths,
@@ -291,20 +298,24 @@ async def record_silent_schedule_result_if_needed(
         result = "no_report"
     elif suppression_reason is not None:
         result = "suppressed"
-    await asyncio.to_thread(
-        _write_completed_receipts,
-        entity_name=entity_name,
-        envelope=envelope,
-        config=config,
-        runtime_paths=runtime_paths,
-        result=result,
-        response_text=response_text,
+    await run_blocking_until_complete(
+        partial(
+            _write_completed_receipts,
+            entity_name=entity_name,
+            agent_names=agent_names,
+            envelope=envelope,
+            config=config,
+            runtime_paths=runtime_paths,
+            result=result,
+            response_text=response_text,
+        ),
     )
 
 
 async def record_silent_schedule_started_if_needed(
     *,
     entity_name: str,
+    agent_names: tuple[str, ...],
     envelope: MessageEnvelope,
     config: Config,
     runtime_paths: RuntimePaths,
@@ -312,10 +323,13 @@ async def record_silent_schedule_started_if_needed(
     """Create an idempotent start receipt only for a silent schedule."""
     if envelope.source_kind != SILENT_SCHEDULE_SOURCE_KIND:
         return
-    await asyncio.to_thread(
-        _write_started_receipts,
-        entity_name=entity_name,
-        envelope=envelope,
-        config=config,
-        runtime_paths=runtime_paths,
+    await run_blocking_until_complete(
+        partial(
+            _write_started_receipts,
+            entity_name=entity_name,
+            agent_names=agent_names,
+            envelope=envelope,
+            config=config,
+            runtime_paths=runtime_paths,
+        ),
     )

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -55,6 +55,7 @@ from tests.conftest import (
     ignore_delivered_projection,
     ignore_final_delivery_handoff,
     make_outbox_mock,
+    request_envelope,
     runtime_paths_for,
     test_runtime_paths,
 )
@@ -100,8 +101,11 @@ def _identity(
     """Return the identity of one visible response, caused by one event."""
     return ResponseIdentity(
         response_kind="agent",
-        response_envelope=SimpleNamespace(  # type: ignore[arg-type]
-            source_event_id=source_event_id,
+        response_envelope=request_envelope(
+            room_id=_ROOM_ID,
+            reply_to_event_id=source_event_id,
+            prompt="Test response request",
+            agent_name="agent",
             source_kind=source_kind,
         ),
         correlation_id="c1",
@@ -251,6 +255,149 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert outcome.failure_reason == "silent_no_report"
         assert outbox.rows == {}
         send.assert_not_awaited()
+
+    async def test_silent_schedule_writes_machine_readable_run_receipt(self, tmp_path: Path) -> None:
+        """Removing the workspace receipt must make an evidence-free silent completion fail this test."""
+        gateway = _gateway(tmp_path, FakeOutbox())
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        request = replace(
+            self._final_request(SILENT_SCHEDULE_NO_REPLY_TOKEN, source_kind=SILENT_SCHEDULE_SOURCE_KIND),
+            identity=ResponseIdentity(
+                response_kind="agent",
+                response_envelope=request_envelope(
+                    room_id=_ROOM_ID,
+                    reply_to_event_id="$cause",
+                    prompt="Check the inbox",
+                    agent_name="agent",
+                    source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+                ),
+                correlation_id="c1",
+            ),
+        )
+
+        outcome = await gateway.deliver_final(request)
+
+        assert outcome.failure_reason == "silent_no_report"
+        receipt_path = (
+            tmp_path
+            / "mindroom_data"
+            / "agents"
+            / "agent"
+            / "workspace"
+            / ".mindroom"
+            / "scheduled_runs"
+            / "d70fd85d0319a4c275c5df743feff6424bb8b85982e28a97e317285e7c441830.json"
+        )
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        assert receipt == {
+            "agent_name": "agent",
+            "completed_at": receipt["completed_at"],
+            "entity_name": "agent",
+            "prompt": "Check the inbox",
+            "result": "no_report",
+            "response_text": SILENT_SCHEDULE_NO_REPLY_TOKEN,
+            "room_id": _ROOM_ID,
+            "schema_version": 1,
+            "source_event_id": "$cause",
+            "started_at": receipt["started_at"],
+            "status": "completed",
+            "thread_id": None,
+        }
+        assert receipt["completed_at"].endswith("Z")
+        assert receipt["started_at"].endswith("Z")
+
+    async def test_silent_schedule_receipt_uses_original_envelope_after_hooks(self, tmp_path: Path) -> None:
+        """A hook may transform presentation fields but cannot redirect durable run identity."""
+        gateway = _gateway(tmp_path, FakeOutbox())
+        hook_service = self._hooks()
+
+        async def replace_envelope(**kwargs: object) -> object:
+            draft = await hook_service._apply_before_response(**kwargs)  # type: ignore[arg-type]
+            draft.envelope = replace(draft.envelope, source_event_id="$hook-replaced")
+            return draft
+
+        gateway.deps.response_hooks._apply_before_response = AsyncMock(side_effect=replace_envelope)
+
+        outcome = await gateway.deliver_final(
+            self._final_request(SILENT_SCHEDULE_NO_REPLY_TOKEN, source_kind=SILENT_SCHEDULE_SOURCE_KIND),
+        )
+
+        assert outcome.failure_reason == "silent_no_report"
+        receipt_directory = (
+            tmp_path / "mindroom_data" / "agents" / "agent" / "workspace" / ".mindroom" / "scheduled_runs"
+        )
+        receipts = list(receipt_directory.glob("*.json"))
+        assert len(receipts) == 1
+        assert json.loads(receipts[0].read_text(encoding="utf-8"))["source_event_id"] == "$cause"
+
+    @pytest.mark.parametrize(
+        "invalid_update",
+        [None, {"result": []}, {"schema_version": True}],
+    )
+    async def test_silent_schedule_completion_repairs_malformed_receipt(
+        self,
+        tmp_path: Path,
+        invalid_update: dict[str, object] | None,
+    ) -> None:
+        """A damaged start receipt cannot prevent the final machine-readable record."""
+        gateway = _gateway(tmp_path, FakeOutbox())
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        receipt_path = (
+            tmp_path
+            / "mindroom_data"
+            / "agents"
+            / "agent"
+            / "workspace"
+            / ".mindroom"
+            / "scheduled_runs"
+            / "d70fd85d0319a4c275c5df743feff6424bb8b85982e28a97e317285e7c441830.json"
+        )
+        receipt_path.parent.mkdir(parents=True)
+        invalid_receipt: dict[str, object] = {
+            "agent_name": "agent",
+            "completed_at": "2026-08-24T12:01:00Z",
+            "entity_name": "agent",
+            "prompt": "Test response request",
+            "result": "reported",
+            "response_text": "stale",
+            "room_id": _ROOM_ID,
+            "schema_version": 1,
+            "source_event_id": "$cause",
+            "started_at": "2026-08-24T12:00:00Z",
+            "status": "completed",
+            "thread_id": None,
+        }
+        if invalid_update is None:
+            receipt_path.write_text("not json", encoding="utf-8")
+        else:
+            invalid_receipt.update(invalid_update)
+            receipt_path.write_text(json.dumps(invalid_receipt), encoding="utf-8")
+
+        outcome = await gateway.deliver_final(
+            self._final_request(SILENT_SCHEDULE_NO_REPLY_TOKEN, source_kind=SILENT_SCHEDULE_SOURCE_KIND),
+        )
+
+        assert outcome.failure_reason == "silent_no_report"
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        assert receipt["source_event_id"] == "$cause"
+        assert receipt["status"] == "completed"
+
+    async def test_silent_schedule_receipt_rejects_symlinked_metadata_directory(self, tmp_path: Path) -> None:
+        """Agent-controlled workspace symlinks cannot redirect a host receipt write."""
+        gateway = _gateway(tmp_path, FakeOutbox())
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        workspace = tmp_path / "mindroom_data" / "agents" / "agent" / "workspace"
+        outside = tmp_path / "outside"
+        workspace.mkdir(parents=True)
+        outside.mkdir()
+        (workspace / ".mindroom").symlink_to(outside, target_is_directory=True)
+
+        with pytest.raises(ValueError, match="workspace root"):
+            await gateway.deliver_final(
+                self._final_request(SILENT_SCHEDULE_NO_REPLY_TOKEN, source_kind=SILENT_SCHEDULE_SOURCE_KIND),
+            )
+
+        assert list(outside.iterdir()) == []
 
     async def test_silent_schedule_tool_trace_no_reply_is_suppressed(self, tmp_path: Path) -> None:
         """Display-only tool markers must not turn a silent no-report result into a visible response."""

--- a/tests/test_response_runner_agent.py
+++ b/tests/test_response_runner_agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from contextlib import asynccontextmanager
 from dataclasses import replace
 from datetime import datetime
@@ -2325,6 +2326,131 @@ class TestAgentBot(AgentBotTestBase):
         redact_message_event.assert_not_awaited()
         add_stop_button.assert_not_awaited()
         bot.client.room_send.assert_not_awaited()
+        receipt_path = (
+            runtime_paths_for(config).storage_root
+            / "agents"
+            / "calculator"
+            / "workspace"
+            / ".mindroom"
+            / "scheduled_runs"
+            / "940ffb8fc9eedd9c606a71df9cf9f467e5d3c1e94d1874613e496ae5b6d8c752.json"
+        )
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        assert receipt["status"] == "completed"
+        assert receipt["result"] == ("reported" if expected_event_id is not None else "no_report")
+        assert receipt["response_text"] == response_text
+        assert receipt["started_at"] <= receipt["completed_at"]
+
+    @pytest.mark.asyncio
+    async def test_silent_schedule_writes_started_receipt_before_locked_preparation(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A locked-preparation failure must leave machine-readable evidence that the silent run started."""
+        config = self._config_for_storage(tmp_path)
+        bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = _make_matrix_client_mock()
+        receipt_path = (
+            runtime_paths_for(config).storage_root
+            / "agents"
+            / "calculator"
+            / "workspace"
+            / ".mindroom"
+            / "scheduled_runs"
+            / "940ffb8fc9eedd9c606a71df9cf9f467e5d3c1e94d1874613e496ae5b6d8c752.json"
+        )
+        receipt_path.parent.mkdir(parents=True)
+        receipt_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "source_event_id": "$event",
+                    "started_at": "2026-08-24T12:00:00Z",
+                },
+            ),
+            encoding="utf-8",
+        )
+
+        with (
+            patch.object(
+                bot._response_runner,
+                "_prepare_request_after_lock",
+                AsyncMock(side_effect=RuntimeError("preparation failed")),
+            ),
+            pytest.raises(RuntimeError, match="preparation failed"),
+        ):
+            await bot._response_runner.generate_response(
+                ResponseRequest(
+                    prompt="Check for updates",
+                    thread_history=[],
+                    user_id="@alice:localhost",
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event",
+                        prompt="Check for updates",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                        source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+                    ),
+                ),
+            )
+
+        receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+        assert receipt == {
+            "agent_name": "calculator",
+            "completed_at": None,
+            "entity_name": "calculator",
+            "prompt": "Check for updates",
+            "result": None,
+            "response_text": None,
+            "room_id": "!test:localhost",
+            "schema_version": 1,
+            "source_event_id": "$event",
+            "started_at": receipt["started_at"],
+            "status": "started",
+            "thread_id": None,
+        }
+        assert receipt["started_at"].endswith("Z")
+
+    @pytest.mark.asyncio
+    async def test_silent_schedule_terminal_source_does_not_write_started_receipt(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A source rejected by the locked terminal gate never claims that execution started."""
+        config = self._config_for_storage(tmp_path)
+        bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = _make_matrix_client_mock()
+
+        event_id = await bot._response_runner.generate_response(
+            ResponseRequest(
+                prompt="Check for updates",
+                thread_history=[],
+                user_id="@alice:localhost",
+                response_envelope=request_envelope(
+                    room_id="!test:localhost",
+                    reply_to_event_id="$terminal-event",
+                    prompt="Check for updates",
+                    user_id="@alice:localhost",
+                    agent_name=bot.agent_name,
+                    source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+                ),
+                prepare_source_turn=AsyncMock(return_value=True),
+            ),
+        )
+
+        assert event_id is None
+        receipt_directory = (
+            runtime_paths_for(config).storage_root
+            / "agents"
+            / "calculator"
+            / "workspace"
+            / ".mindroom"
+            / "scheduled_runs"
+        )
+        assert not receipt_directory.exists()
 
     @pytest.mark.asyncio
     async def test_generate_response_refreshes_thread_history_after_lock(

--- a/tests/test_response_runner_team.py
+++ b/tests/test_response_runner_team.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1213,6 +1214,69 @@ class TestAgentBot(AgentBotTestBase):
         bot._redact_message_event.assert_not_awaited()
         add_stop_button.assert_not_awaited()
         bot.client.room_send.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_silent_schedule_ad_hoc_team_writes_receipt_to_each_member(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A dynamic team's resolved participants must each receive the run receipt."""
+        config = self._config_for_storage(tmp_path)
+        runtime_paths = runtime_paths_for(config)
+        bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        bot.client = _make_matrix_client_mock()
+        bot.orchestrator = MagicMock()
+        matrix_ids = entity_ids(config, runtime_paths)
+
+        async def team_response_with_started_receipt_check(*_args: object, **_kwargs: object) -> str:
+            for agent_name in ("calculator", "general"):
+                receipt_directory = (
+                    runtime_paths.storage_root / "agents" / agent_name / "workspace" / ".mindroom" / "scheduled_runs"
+                )
+                [receipt_path] = list(receipt_directory.glob("*.json"))
+                receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+                assert receipt["status"] == "started"
+            return "Finding"
+
+        with (
+            patch_response_runner_module(
+                team_response=AsyncMock(side_effect=team_response_with_started_receipt_check),
+            ),
+            patch(
+                "mindroom.delivery_gateway.DeliveryGateway.send_text",
+                new=AsyncMock(return_value="$response"),
+            ),
+        ):
+            await bot._response_runner.generate_team_response_helper(
+                ResponseRequest(
+                    prompt="Check for updates",
+                    thread_history=[],
+                    user_id="@alice:localhost",
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$ad-hoc-silent-run",
+                        prompt="Check for updates",
+                        user_id="@alice:localhost",
+                        agent_name=bot.agent_name,
+                        source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+                    ),
+                    correlation_id="corr-ad-hoc-silent-team",
+                ),
+                team_agents=[matrix_ids["calculator"], matrix_ids["general"]],
+                team_mode="collaborate",
+            )
+
+        for agent_name in ("calculator", "general"):
+            receipt_directory = (
+                runtime_paths.storage_root / "agents" / agent_name / "workspace" / ".mindroom" / "scheduled_runs"
+            )
+            receipts = list(receipt_directory.glob("*.json"))
+            assert len(receipts) == 1
+            receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+            assert receipt["entity_name"] == bot.agent_name
+            assert receipt["agent_name"] == agent_name
+            assert receipt["status"] == "completed"
 
     @pytest.mark.asyncio
     async def test_generate_team_response_helper_keeps_streamed_visible_reply_when_before_response_suppresses(

--- a/tests/test_response_runner_team.py
+++ b/tests/test_response_runner_team.py
@@ -106,7 +106,7 @@ class TestAgentBot(AgentBotTestBase):
         bot.client = _make_matrix_client_mock()
         bot.orchestrator = MagicMock(current_config=config, config=config, runtime_paths=runtime_paths)
         coordinator = unwrap_extracted_collaborator(bot._response_runner)
-        original_begin_locked_turn = coordinator._begin_locked_turn
+        original_prepare_admitted_turn = coordinator._prepare_admitted_locked_turn
         matrix_ids = entity_ids(config, runtime_paths)
         mock_team_response = AsyncMock(return_value="Team reply")
 
@@ -117,10 +117,10 @@ class TestAgentBot(AgentBotTestBase):
                 model_name="default",
                 set_by="@admin:localhost",
             )
-            return await original_begin_locked_turn(*args, **kwargs)  # type: ignore[arg-type]
+            return await original_prepare_admitted_turn(*args, **kwargs)  # type: ignore[arg-type]
 
         with (
-            patch.object(coordinator, "_begin_locked_turn", new=change_room_default_during_preparation),
+            patch.object(coordinator, "_prepare_admitted_locked_turn", new=change_room_default_during_preparation),
             patch(
                 "mindroom.delivery_gateway.send_message_outcome",
                 new=AsyncMock(side_effect=delivered_matrix_side_effect("$team")),

--- a/tests/test_scheduled_run_records.py
+++ b/tests/test_scheduled_run_records.py
@@ -121,3 +121,52 @@ async def test_private_agent_silent_run_uses_requester_scoped_workspace(tmp_path
     assert receipt["result"] == "no_report"
     assert receipt["status"] == "completed"
     assert not (runtime_paths.storage_root / "agents" / "private" / "workspace" / ".mindroom").exists()
+
+
+async def test_replayed_completed_silent_run_reenters_started_state(tmp_path: Path) -> None:
+    """A replay must not leave the previous completion visible while its new attempt is running."""
+    config = _config(agents={"watcher": AgentConfig(display_name="Watcher")})
+    runtime_paths = test_runtime_paths(tmp_path)
+    envelope = request_envelope(
+        room_id="!room:localhost",
+        reply_to_event_id="$replayed-run",
+        prompt="Check for changes",
+        agent_name="watcher",
+        source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+    )
+
+    await record_silent_schedule_started_if_needed(
+        entity_name="watcher",
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    await record_silent_schedule_result_if_needed(
+        entity_name="watcher",
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+        suppression_reason=None,
+        response_text="A change was found",
+    )
+    [receipt_path] = list(
+        (runtime_paths.storage_root / "agents" / "watcher" / "workspace" / ".mindroom" / "scheduled_runs").glob(
+            "*.json",
+        ),
+    )
+    completed_receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert completed_receipt["status"] == "completed"
+
+    await record_silent_schedule_started_if_needed(
+        entity_name="watcher",
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+
+    replayed_receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert replayed_receipt["status"] == "started"
+    assert replayed_receipt["result"] is None
+    assert replayed_receipt["response_text"] is None
+    assert replayed_receipt["completed_at"] is None
+    assert replayed_receipt["started_at"] == completed_receipt["started_at"]

--- a/tests/test_scheduled_run_records.py
+++ b/tests/test_scheduled_run_records.py
@@ -1,0 +1,123 @@
+"""Silent scheduled-run receipt routing and schema tests."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.dispatch_source import SILENT_SCHEDULE_SOURCE_KIND
+from mindroom.scheduled_run_records import (
+    record_silent_schedule_result_if_needed,
+    record_silent_schedule_started_if_needed,
+)
+from tests.conftest import request_envelope, test_runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+pytestmark = pytest.mark.asyncio
+
+
+def _config(*, agents: dict[str, AgentConfig], teams: dict[str, TeamConfig] | None = None) -> Config:
+    return Config(
+        agents=agents,
+        teams=teams or {},
+        models={"default": ModelConfig(provider="test", id="test-model")},
+    )
+
+
+async def test_team_silent_run_writes_one_receipt_per_member_workspace(tmp_path: Path) -> None:
+    """A configured team leaves independently discoverable evidence for every member agent."""
+    config = _config(
+        agents={
+            "alpha": AgentConfig(display_name="Alpha"),
+            "beta": AgentConfig(display_name="Beta"),
+        },
+        teams={
+            "watchers": TeamConfig(
+                display_name="Watchers",
+                role="Check for changes",
+                agents=["alpha", "beta"],
+            ),
+        },
+    )
+    runtime_paths = test_runtime_paths(tmp_path)
+    envelope = request_envelope(
+        room_id="!room:localhost",
+        reply_to_event_id="$team-run",
+        prompt="Check both systems",
+        agent_name="watchers",
+        source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+    )
+
+    await record_silent_schedule_started_if_needed(
+        entity_name="watchers",
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+
+    for agent_name in ("alpha", "beta"):
+        receipts = list(
+            (runtime_paths.storage_root / "agents" / agent_name / "workspace" / ".mindroom" / "scheduled_runs").glob(
+                "*.json",
+            ),
+        )
+        assert len(receipts) == 1
+        receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+        assert receipt["entity_name"] == "watchers"
+        assert receipt["agent_name"] == agent_name
+        assert receipt["status"] == "started"
+
+
+async def test_private_agent_silent_run_uses_requester_scoped_workspace(tmp_path: Path) -> None:
+    """Private receipts stay with the requester materialization instead of shared agent state."""
+    config = _config(
+        agents={
+            "private": AgentConfig(
+                display_name="Private",
+                private=AgentPrivateConfig(per="user", root="private_data"),
+            ),
+        },
+    )
+    runtime_paths = test_runtime_paths(tmp_path)
+    envelope = request_envelope(
+        room_id="!room:localhost",
+        reply_to_event_id="$private-run",
+        prompt="Check my private inbox",
+        user_id="@alice:localhost",
+        agent_name="private",
+        source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+    )
+
+    await record_silent_schedule_started_if_needed(
+        entity_name="private",
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    await record_silent_schedule_result_if_needed(
+        entity_name="private",
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+        suppression_reason="silent_no_report",
+        response_text="NO_REPLY",
+    )
+
+    receipts = list(
+        runtime_paths.storage_root.glob(
+            "private_instances/*/private/private_data/.mindroom/scheduled_runs/*.json",
+        ),
+    )
+    assert len(receipts) == 1
+    receipt = json.loads(receipts[0].read_text(encoding="utf-8"))
+    assert receipt["agent_name"] == "private"
+    assert receipt["result"] == "no_report"
+    assert receipt["status"] == "completed"
+    assert not (runtime_paths.storage_root / "agents" / "private" / "workspace" / ".mindroom").exists()

--- a/tests/test_scheduled_run_records.py
+++ b/tests/test_scheduled_run_records.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+from threading import Event
 from typing import TYPE_CHECKING
+from unittest.mock import patch
 
 import pytest
 
+from mindroom import scheduled_run_records
 from mindroom.config.agent import AgentConfig, AgentPrivateConfig, TeamConfig
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
@@ -57,6 +61,7 @@ async def test_team_silent_run_writes_one_receipt_per_member_workspace(tmp_path:
 
     await record_silent_schedule_started_if_needed(
         entity_name="watchers",
+        agent_names=("alpha", "beta"),
         envelope=envelope,
         config=config,
         runtime_paths=runtime_paths,
@@ -97,12 +102,14 @@ async def test_private_agent_silent_run_uses_requester_scoped_workspace(tmp_path
 
     await record_silent_schedule_started_if_needed(
         entity_name="private",
+        agent_names=("private",),
         envelope=envelope,
         config=config,
         runtime_paths=runtime_paths,
     )
     await record_silent_schedule_result_if_needed(
         entity_name="private",
+        agent_names=("private",),
         envelope=envelope,
         config=config,
         runtime_paths=runtime_paths,
@@ -137,12 +144,14 @@ async def test_replayed_completed_silent_run_reenters_started_state(tmp_path: Pa
 
     await record_silent_schedule_started_if_needed(
         entity_name="watcher",
+        agent_names=("watcher",),
         envelope=envelope,
         config=config,
         runtime_paths=runtime_paths,
     )
     await record_silent_schedule_result_if_needed(
         entity_name="watcher",
+        agent_names=("watcher",),
         envelope=envelope,
         config=config,
         runtime_paths=runtime_paths,
@@ -159,6 +168,7 @@ async def test_replayed_completed_silent_run_reenters_started_state(tmp_path: Pa
 
     await record_silent_schedule_started_if_needed(
         entity_name="watcher",
+        agent_names=("watcher",),
         envelope=envelope,
         config=config,
         runtime_paths=runtime_paths,
@@ -170,3 +180,154 @@ async def test_replayed_completed_silent_run_reenters_started_state(tmp_path: Pa
     assert replayed_receipt["response_text"] is None
     assert replayed_receipt["completed_at"] is None
     assert replayed_receipt["started_at"] == completed_receipt["started_at"]
+
+
+async def test_replay_repairs_receipt_with_completion_before_start(tmp_path: Path) -> None:
+    """A semantically invalid lifecycle must not poison timestamps on replay."""
+    config = _config(agents={"watcher": AgentConfig(display_name="Watcher")})
+    runtime_paths = test_runtime_paths(tmp_path)
+    envelope = request_envelope(
+        room_id="!room:localhost",
+        reply_to_event_id="$invalid-lifecycle",
+        prompt="Check for changes",
+        agent_name="watcher",
+        source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+    )
+    await record_silent_schedule_started_if_needed(
+        entity_name="watcher",
+        agent_names=("watcher",),
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    await record_silent_schedule_result_if_needed(
+        entity_name="watcher",
+        agent_names=("watcher",),
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+        suppression_reason=None,
+        response_text="A change was found",
+    )
+    [receipt_path] = list(
+        (runtime_paths.storage_root / "agents" / "watcher" / "workspace" / ".mindroom" / "scheduled_runs").glob(
+            "*.json",
+        ),
+    )
+    malformed_receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    malformed_receipt["started_at"] = "9999-12-31T23:59:59Z"
+    malformed_receipt["completed_at"] = "2000-01-01T00:00:00Z"
+    receipt_path.write_text(json.dumps(malformed_receipt), encoding="utf-8")
+
+    await record_silent_schedule_started_if_needed(
+        entity_name="watcher",
+        agent_names=("watcher",),
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    await record_silent_schedule_result_if_needed(
+        entity_name="watcher",
+        agent_names=("watcher",),
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+        suppression_reason=None,
+        response_text="A newer change was found",
+    )
+
+    repaired_receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert repaired_receipt["started_at"] <= repaired_receipt["completed_at"]
+
+
+async def test_completion_repairs_started_receipt_from_future(tmp_path: Path) -> None:
+    """Completion must not preserve a start timestamp later than itself."""
+    config = _config(agents={"watcher": AgentConfig(display_name="Watcher")})
+    runtime_paths = test_runtime_paths(tmp_path)
+    envelope = request_envelope(
+        room_id="!room:localhost",
+        reply_to_event_id="$future-start",
+        prompt="Check for changes",
+        agent_name="watcher",
+        source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+    )
+    await record_silent_schedule_started_if_needed(
+        entity_name="watcher",
+        agent_names=("watcher",),
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+    [receipt_path] = list(
+        (runtime_paths.storage_root / "agents" / "watcher" / "workspace" / ".mindroom" / "scheduled_runs").glob(
+            "*.json",
+        ),
+    )
+    future_receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    future_receipt["started_at"] = "9999-12-31T23:59:59Z"
+    receipt_path.write_text(json.dumps(future_receipt), encoding="utf-8")
+
+    await record_silent_schedule_result_if_needed(
+        entity_name="watcher",
+        agent_names=("watcher",),
+        envelope=envelope,
+        config=config,
+        runtime_paths=runtime_paths,
+        suppression_reason=None,
+        response_text="A change was found",
+    )
+
+    repaired_receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+    assert repaired_receipt["started_at"] <= repaired_receipt["completed_at"]
+
+
+async def test_started_receipt_write_finishes_before_cancellation_propagates(tmp_path: Path) -> None:
+    """Cancellation cannot revoke a durable write after the run is admitted."""
+    config = _config(agents={"watcher": AgentConfig(display_name="Watcher")})
+    runtime_paths = test_runtime_paths(tmp_path)
+    envelope = request_envelope(
+        room_id="!room:localhost",
+        reply_to_event_id="$cancelled-start",
+        prompt="Check for changes",
+        agent_name="watcher",
+        source_kind=SILENT_SCHEDULE_SOURCE_KIND,
+    )
+    write_started = Event()
+    allow_write = Event()
+    write_finished = Event()
+    atomic_write = scheduled_run_records._atomic_write_receipt
+
+    def blocking_write(*args: object, **kwargs: object) -> None:
+        write_started.set()
+        allow_write.wait()
+        try:
+            atomic_write(*args, **kwargs)  # type: ignore[arg-type]
+        finally:
+            write_finished.set()
+
+    with patch.object(scheduled_run_records, "_atomic_write_receipt", side_effect=blocking_write):
+        task = asyncio.create_task(
+            record_silent_schedule_started_if_needed(
+                entity_name="watcher",
+                agent_names=("watcher",),
+                envelope=envelope,
+                config=config,
+                runtime_paths=runtime_paths,
+            ),
+        )
+        assert await asyncio.to_thread(write_started.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        cancellation_propagated_before_write = task.done()
+        allow_write.set()
+        assert await asyncio.to_thread(write_finished.wait, 5)
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    assert not cancellation_propagated_before_write
+    receipts = list(
+        (runtime_paths.storage_root / "agents" / "watcher" / "workspace" / ".mindroom" / "scheduled_runs").glob(
+            "*.json",
+        ),
+    )
+    assert len(receipts) == 1


### PR DESCRIPTION
## Summary
- write a versioned JSON receipt for every admitted silent scheduled run
- preserve started evidence across failures and atomically finalize completed outcomes
- route receipts to shared, requester-scoped, and team-member workspaces safely
- document the schema, path, timestamps, and replay behavior

## Testing
- `uv run pytest -q`
- `uv run pre-commit run --all-files`
- `uv run zensical build`

## Summary by Sourcery

Persist durable, machine-readable evidence for silent scheduled runs from admission through final response.

New Features:
- Record versioned JSON receipts for admitted silent scheduled runs in the relevant agent workspaces.
- Capture started and completed outcomes, including reported, no-report, and suppressed results.

Bug Fixes:
- Preserve valid start evidence across failures and replay while repairing malformed or inconsistent receipt state.

Enhancements:
- Route receipts safely across shared, requester-scoped, and team-member workspaces, with atomic writes and workspace indexing isolation.

Documentation:
- Document the receipt schema, storage path, lifecycle timestamps, replay behavior, and routing rules.

Tests:
- Add coverage for receipt lifecycle, team and private workspace routing, replay repair, cancellation durability, hook identity preservation, and symlink protection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Silent scheduled runs now create durable, machine-readable receipts.
  - Receipts track status, outcome, response text, timestamps, scheduling context, and participating agents.
  - Receipts distinguish reported, no-report, suppressed, and unfinished runs, with unavailable fields clearly marked.
  - Replayed runs update existing receipts while preserving the original start time.
  - Receipt files are excluded from default knowledge indexing.

- **Documentation**
  - Expanded guidance on receipt format, lifecycle, replay behavior, and workspace storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->