### PR TITLE
Cache schemas for customized tools

### DIFF
--- a/src/mindroom/tool_schema_cache.py
+++ b/src/mindroom/tool_schema_cache.py
@@ -49,12 +49,12 @@ class _HasSchemaCacheMetadata(Protocol):
 class _SchemaCacheEntrypoint:
     """Hashable schema inputs while retaining the live entrypoint out of the cache key."""
 
-    cache_source: Callable[..., object]
+    cache_source_ref: ReferenceType[Callable[..., object]]
     schema_fingerprint: tuple[str, str, str | None]
     entrypoint_ref: ReferenceType[Callable[..., object]] = field(compare=False, hash=False, repr=False)
 
     def __hash__(self) -> int:
-        return hash((self.cache_source, self.schema_fingerprint))
+        return hash((self.cache_source_ref, self.schema_fingerprint))
 
 
 def set_schema_cache_postprocessor(function: Function, postprocessor: _SchemaCachePostprocessor) -> None:
@@ -79,12 +79,16 @@ def set_schema_cache_postprocessor(function: Function, postprocessor: _SchemaCac
 
 
 def set_schema_cache_source(function: Function, source: Callable[..., object]) -> None:
-    """Set a private stable cache source without changing the live entrypoint."""
+    """Set a stable cache source, or leave unsupported callable forms uncached."""
+    metadata = _schema_cache_metadata(function) or _SchemaCacheMetadata()
     cache_source = source.__func__ if isinstance(source, MethodType) else source
     if not isinstance(cache_source, FunctionType):
-        msg = "Schema cache sources must be functions."
-        raise TypeError(msg)
-    metadata = _schema_cache_metadata(function) or _SchemaCacheMetadata()
+        object.__setattr__(
+            function,
+            _CACHE_METADATA_ATTR,
+            replace(metadata, cache_source=None),
+        )
+        return
     object.__setattr__(
         function,
         _CACHE_METADATA_ATTR,
@@ -136,7 +140,7 @@ def _schema_cache_entrypoint(function: Function) -> _SchemaCacheEntrypoint | Non
 
     try:
         return _SchemaCacheEntrypoint(
-            cache_source=source_callable,
+            cache_source_ref=ref(source_callable),
             schema_fingerprint=(
                 str(signature(entrypoint)),
                 repr(entrypoint.__annotations__),

--- a/src/mindroom/tool_schema_cache.py
+++ b/src/mindroom/tool_schema_cache.py
@@ -16,6 +16,10 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
+_CACHE_POSTPROCESSOR_ATTR = "_mindroom_schema_cache_postprocessor"
+type _SchemaCachePostprocessor = Callable[[Function, bool], None]
+
+
 @dataclass(frozen=True, slots=True)
 class _ProcessedFunctionSchema:
     """Processed prompt schema snapshot for one Function."""
@@ -23,6 +27,18 @@ class _ProcessedFunctionSchema:
     parameters: dict[str, Any]
     description: str | None
     user_input_schema: tuple[UserInputField, ...] | None
+
+
+def set_schema_cache_postprocessor(function: Function, postprocessor: _SchemaCachePostprocessor) -> None:
+    """Allow a custom entrypoint processor to reuse cached schema preparation.
+
+    ``postprocessor`` must be a module-level function that applies the custom
+    processor's complete behavior to a cache-owned ``Function``.
+    """
+    if not isfunction(postprocessor):
+        msg = "Schema cache postprocessors must be module-level functions."
+        raise TypeError(msg)
+    object.__setattr__(function, _CACHE_POSTPROCESSOR_ATTR, postprocessor)
 
 
 def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFunctionSchema | None:
@@ -35,8 +51,15 @@ def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFu
     if function.entrypoint is None:
         return None
 
+    cache_postprocessor = getattr(function, _CACHE_POSTPROCESSOR_ATTR, None)
     processor = function.process_entrypoint
-    if isinstance(processor, MethodType) and processor.__func__ is not Function.process_entrypoint:
+    if (
+        isinstance(processor, MethodType)
+        and processor.__func__ is not Function.process_entrypoint
+        and cache_postprocessor is None
+    ):
+        return None
+    if cache_postprocessor is not None and not isfunction(cache_postprocessor):
         return None
 
     source_callable = getattr(function.entrypoint, "__wrapped__", function.entrypoint)
@@ -60,6 +83,7 @@ def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFu
         tuple(function.user_input_fields) if function.user_input_fields is not None else None,
         function.strict,
         strict,
+        cache_postprocessor,
     )
     # Copy at the boundary so callers can never corrupt the shared LRU entry.
     return _ProcessedFunctionSchema(
@@ -85,6 +109,7 @@ def _cached_processed_function_schema(
     user_input_fields: tuple[str, ...] | None,
     function_strict: bool | None,
     strict: bool,
+    cache_postprocessor: _SchemaCachePostprocessor | None,
 ) -> _ProcessedFunctionSchema:
     function = Function(
         name=name,
@@ -96,7 +121,10 @@ def _cached_processed_function_schema(
         user_input_fields=list(user_input_fields) if user_input_fields is not None else None,
         strict=function_strict,
     )
-    function.process_entrypoint(strict=strict)
+    if cache_postprocessor is None:
+        function.process_entrypoint(strict=strict)
+    else:
+        cache_postprocessor(function, strict)
     return _ProcessedFunctionSchema(
         parameters=deepcopy(function.parameters),
         description=function.description,

--- a/src/mindroom/tool_schema_cache.py
+++ b/src/mindroom/tool_schema_cache.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import json
 from copy import deepcopy
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from functools import lru_cache
-from inspect import isfunction, ismethod, signature
-from types import MethodType
-from typing import TYPE_CHECKING, Any
+from inspect import signature
+from types import FunctionType, MethodType
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from weakref import ReferenceType, ref
 
 from agno.tools.function import Function, UserInputField
@@ -17,8 +17,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
 
-_CACHE_POSTPROCESSOR_ATTR = "_mindroom_schema_cache_postprocessor"
-_CACHE_SOURCE_ATTR = "_mindroom_schema_cache_source"
+_CACHE_METADATA_ATTR = "_mindroom_schema_cache_metadata"
 type _SchemaCachePostprocessor = Callable[[Function, bool], None]
 
 
@@ -29,6 +28,21 @@ class _ProcessedFunctionSchema:
     parameters: dict[str, Any]
     description: str | None
     user_input_schema: tuple[UserInputField, ...] | None
+
+
+@dataclass(frozen=True, slots=True)
+class _SchemaCacheMetadata:
+    """Typed cache customization attached to an Agno Function."""
+
+    postprocessor: _SchemaCachePostprocessor | None = None
+    cache_source: FunctionType | None = None
+
+
+@runtime_checkable
+class _HasSchemaCacheMetadata(Protocol):
+    """Agno Function extension carrying MindRoom schema-cache metadata."""
+
+    _mindroom_schema_cache_metadata: _SchemaCacheMetadata
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,33 +64,51 @@ def set_schema_cache_postprocessor(function: Function, postprocessor: _SchemaCac
     processor's complete behavior to a cache-owned ``Function``.
     """
     if (
-        not isfunction(postprocessor)
+        not isinstance(postprocessor, FunctionType)
         or "<locals>" in postprocessor.__qualname__
         or postprocessor.__closure__ is not None
     ):
         msg = "Schema cache postprocessors must be module-level functions."
         raise TypeError(msg)
-    object.__setattr__(function, _CACHE_POSTPROCESSOR_ATTR, postprocessor)
+    metadata = _schema_cache_metadata(function) or _SchemaCacheMetadata()
+    object.__setattr__(
+        function,
+        _CACHE_METADATA_ATTR,
+        replace(metadata, postprocessor=postprocessor),
+    )
 
 
 def set_schema_cache_source(function: Function, source: Callable[..., object]) -> None:
     """Set a private stable cache source without changing the live entrypoint."""
-    cache_source = source.__func__ if ismethod(source) else source
-    if not isfunction(cache_source):
+    cache_source = source.__func__ if isinstance(source, MethodType) else source
+    if not isinstance(cache_source, FunctionType):
         msg = "Schema cache sources must be functions."
         raise TypeError(msg)
-    object.__setattr__(function, _CACHE_SOURCE_ATTR, cache_source)
+    metadata = _schema_cache_metadata(function) or _SchemaCacheMetadata()
+    object.__setattr__(
+        function,
+        _CACHE_METADATA_ATTR,
+        replace(metadata, cache_source=cache_source),
+    )
 
 
-def get_schema_cache_source(function: Function) -> Callable[..., object] | None:
+def _schema_cache_metadata(function: Function) -> _SchemaCacheMetadata | None:
+    if isinstance(function, _HasSchemaCacheMetadata):
+        return function._mindroom_schema_cache_metadata
+    return None
+
+
+def get_schema_cache_source(function: Function) -> FunctionType | None:
     """Return the private stable cache source for a custom schema processor."""
-    source = getattr(function, _CACHE_SOURCE_ATTR, None)
-    return source if isfunction(source) else None
+    metadata = _schema_cache_metadata(function)
+    return metadata.cache_source if metadata is not None else None
 
 
 def _is_stable_cache_postprocessor(postprocessor: object) -> bool:
     return (
-        isfunction(postprocessor) and "<locals>" not in postprocessor.__qualname__ and postprocessor.__closure__ is None
+        isinstance(postprocessor, FunctionType)
+        and "<locals>" not in postprocessor.__qualname__
+        and postprocessor.__closure__ is None
     )
 
 
@@ -90,24 +122,27 @@ def _uses_default_entrypoint_processor(function: Function) -> bool:
 
 
 def _schema_cache_entrypoint(function: Function) -> _SchemaCacheEntrypoint | None:
-    if function.entrypoint is None or not callable(function.entrypoint):
+    entrypoint = function.entrypoint
+    if not isinstance(entrypoint, (FunctionType, MethodType)):
         return None
 
-    source_callable = get_schema_cache_source(function) or function.entrypoint
-    if isinstance(source_callable, MethodType) or ismethod(source_callable):
+    source_callable = get_schema_cache_source(function) or entrypoint
+    if isinstance(source_callable, MethodType):
         source_callable = source_callable.__func__
-    elif not isfunction(source_callable):
+    if not isinstance(source_callable, FunctionType):
+        return None
+    if source_callable.__closure__ is not None:
         return None
 
     try:
         return _SchemaCacheEntrypoint(
             cache_source=source_callable,
             schema_fingerprint=(
-                str(signature(function.entrypoint)),
-                repr(getattr(function.entrypoint, "__annotations__", {})),
-                getattr(function.entrypoint, "__doc__", None),
+                str(signature(entrypoint)),
+                repr(entrypoint.__annotations__),
+                entrypoint.__doc__,
             ),
-            entrypoint_ref=ref(function.entrypoint),
+            entrypoint_ref=ref(entrypoint),
         )
     except (TypeError, ValueError):
         return None
@@ -120,7 +155,8 @@ def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFu
     parameters cannot form a stable cache key, in which case callers must fall
     back to full entrypoint processing on a private copy.
     """
-    cache_postprocessor = getattr(function, _CACHE_POSTPROCESSOR_ATTR, None)
+    metadata = _schema_cache_metadata(function)
+    cache_postprocessor = metadata.postprocessor if metadata is not None else None
     if not _uses_default_entrypoint_processor(function) and cache_postprocessor is None:
         return None
     if cache_postprocessor is not None and not _is_stable_cache_postprocessor(cache_postprocessor):

--- a/src/mindroom/tool_schema_cache.py
+++ b/src/mindroom/tool_schema_cache.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import json
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import lru_cache
-from inspect import isfunction, ismethod
+from inspect import isfunction, ismethod, signature
 from types import MethodType
 from typing import TYPE_CHECKING, Any
 
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 
 
 _CACHE_POSTPROCESSOR_ATTR = "_mindroom_schema_cache_postprocessor"
+_CACHE_SOURCE_ATTR = "_mindroom_schema_cache_source"
 type _SchemaCachePostprocessor = Callable[[Function, bool], None]
 
 
@@ -29,16 +30,86 @@ class _ProcessedFunctionSchema:
     user_input_schema: tuple[UserInputField, ...] | None
 
 
+@dataclass(frozen=True, slots=True)
+class _SchemaCacheEntrypoint:
+    """Hashable schema inputs while retaining the live entrypoint out of the cache key."""
+
+    cache_source: Callable[..., object]
+    schema_fingerprint: tuple[str, str, str | None]
+    entrypoint: Callable[..., object] = field(compare=False, hash=False, repr=False)
+
+    def __hash__(self) -> int:
+        return hash((self.cache_source, self.schema_fingerprint))
+
+
 def set_schema_cache_postprocessor(function: Function, postprocessor: _SchemaCachePostprocessor) -> None:
     """Allow a custom entrypoint processor to reuse cached schema preparation.
 
     ``postprocessor`` must be a module-level function that applies the custom
     processor's complete behavior to a cache-owned ``Function``.
     """
-    if not isfunction(postprocessor):
+    if (
+        not isfunction(postprocessor)
+        or "<locals>" in postprocessor.__qualname__
+        or postprocessor.__closure__ is not None
+    ):
         msg = "Schema cache postprocessors must be module-level functions."
         raise TypeError(msg)
     object.__setattr__(function, _CACHE_POSTPROCESSOR_ATTR, postprocessor)
+
+
+def set_schema_cache_source(function: Function, source: Callable[..., object]) -> None:
+    """Set a private stable cache source without changing the live entrypoint."""
+    cache_source = source.__func__ if ismethod(source) else source
+    if not isfunction(cache_source):
+        msg = "Schema cache sources must be functions."
+        raise TypeError(msg)
+    object.__setattr__(function, _CACHE_SOURCE_ATTR, cache_source)
+
+
+def get_schema_cache_source(function: Function) -> Callable[..., object] | None:
+    """Return the private stable cache source for a custom schema processor."""
+    source = getattr(function, _CACHE_SOURCE_ATTR, None)
+    return source if isfunction(source) else None
+
+
+def _is_stable_cache_postprocessor(postprocessor: object) -> bool:
+    return (
+        isfunction(postprocessor) and "<locals>" not in postprocessor.__qualname__ and postprocessor.__closure__ is None
+    )
+
+
+def _uses_default_entrypoint_processor(function: Function) -> bool:
+    processor = function.process_entrypoint
+    return (
+        isinstance(processor, MethodType)
+        and processor.__self__ is function
+        and processor.__func__ is Function.process_entrypoint
+    )
+
+
+def _schema_cache_entrypoint(function: Function) -> _SchemaCacheEntrypoint | None:
+    if function.entrypoint is None or not callable(function.entrypoint):
+        return None
+
+    source_callable = get_schema_cache_source(function) or function.entrypoint
+    if isinstance(source_callable, MethodType) or ismethod(source_callable):
+        source_callable = source_callable.__func__
+    elif not isfunction(source_callable):
+        return None
+
+    try:
+        return _SchemaCacheEntrypoint(
+            cache_source=source_callable,
+            schema_fingerprint=(
+                str(signature(function.entrypoint)),
+                repr(getattr(function.entrypoint, "__annotations__", {})),
+                getattr(function.entrypoint, "__doc__", None),
+            ),
+            entrypoint=function.entrypoint,
+        )
+    except (TypeError, ValueError):
+        return None
 
 
 def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFunctionSchema | None:
@@ -52,20 +123,13 @@ def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFu
         return None
 
     cache_postprocessor = getattr(function, _CACHE_POSTPROCESSOR_ATTR, None)
-    processor = function.process_entrypoint
-    if (
-        isinstance(processor, MethodType)
-        and processor.__func__ is not Function.process_entrypoint
-        and cache_postprocessor is None
-    ):
+    if not _uses_default_entrypoint_processor(function) and cache_postprocessor is None:
         return None
-    if cache_postprocessor is not None and not isfunction(cache_postprocessor):
+    if cache_postprocessor is not None and not _is_stable_cache_postprocessor(cache_postprocessor):
         return None
 
-    source_callable = getattr(function.entrypoint, "__wrapped__", function.entrypoint)
-    if isinstance(source_callable, MethodType) or ismethod(source_callable):
-        source_callable = source_callable.__func__
-    elif not isfunction(source_callable):
+    entrypoint = _schema_cache_entrypoint(function)
+    if entrypoint is None:
         return None
 
     try:
@@ -74,7 +138,7 @@ def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFu
         return None
 
     snapshot = _cached_processed_function_schema(
-        source_callable,
+        entrypoint,
         function.name,
         function.description,
         parameters_json,
@@ -100,7 +164,7 @@ def clear_tool_schema_cache() -> None:
 
 @lru_cache(maxsize=4096)
 def _cached_processed_function_schema(
-    source_callable: Callable[..., object],
+    entrypoint: _SchemaCacheEntrypoint,
     name: str,
     description: str | None,
     parameters_json: str,
@@ -115,7 +179,7 @@ def _cached_processed_function_schema(
         name=name,
         description=description,
         parameters=json.loads(parameters_json),
-        entrypoint=source_callable,
+        entrypoint=entrypoint.entrypoint,
         skip_entrypoint_processing=skip_entrypoint_processing,
         requires_user_input=requires_user_input,
         user_input_fields=list(user_input_fields) if user_input_fields is not None else None,

--- a/src/mindroom/tool_schema_cache.py
+++ b/src/mindroom/tool_schema_cache.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from inspect import isfunction, ismethod, signature
 from types import MethodType
 from typing import TYPE_CHECKING, Any
+from weakref import ReferenceType, ref
 
 from agno.tools.function import Function, UserInputField
 
@@ -36,7 +37,7 @@ class _SchemaCacheEntrypoint:
 
     cache_source: Callable[..., object]
     schema_fingerprint: tuple[str, str, str | None]
-    entrypoint: Callable[..., object] = field(compare=False, hash=False, repr=False)
+    entrypoint_ref: ReferenceType[Callable[..., object]] = field(compare=False, hash=False, repr=False)
 
     def __hash__(self) -> int:
         return hash((self.cache_source, self.schema_fingerprint))
@@ -106,7 +107,7 @@ def _schema_cache_entrypoint(function: Function) -> _SchemaCacheEntrypoint | Non
                 repr(getattr(function.entrypoint, "__annotations__", {})),
                 getattr(function.entrypoint, "__doc__", None),
             ),
-            entrypoint=function.entrypoint,
+            entrypoint_ref=ref(function.entrypoint),
         )
     except (TypeError, ValueError):
         return None
@@ -119,9 +120,6 @@ def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFu
     parameters cannot form a stable cache key, in which case callers must fall
     back to full entrypoint processing on a private copy.
     """
-    if function.entrypoint is None:
-        return None
-
     cache_postprocessor = getattr(function, _CACHE_POSTPROCESSOR_ATTR, None)
     if not _uses_default_entrypoint_processor(function) and cache_postprocessor is None:
         return None
@@ -149,6 +147,8 @@ def cached_processed_schema(function: Function, *, strict: bool) -> _ProcessedFu
         strict,
         cache_postprocessor,
     )
+    if snapshot is None:
+        return None
     # Copy at the boundary so callers can never corrupt the shared LRU entry.
     return _ProcessedFunctionSchema(
         parameters=deepcopy(snapshot.parameters),
@@ -174,12 +174,15 @@ def _cached_processed_function_schema(
     function_strict: bool | None,
     strict: bool,
     cache_postprocessor: _SchemaCachePostprocessor | None,
-) -> _ProcessedFunctionSchema:
+) -> _ProcessedFunctionSchema | None:
+    schema_entrypoint = entrypoint.entrypoint_ref()
+    if schema_entrypoint is None:
+        return None
     function = Function(
         name=name,
         description=description,
         parameters=json.loads(parameters_json),
-        entrypoint=entrypoint.entrypoint,
+        entrypoint=schema_entrypoint,
         skip_entrypoint_processing=skip_entrypoint_processing,
         requires_user_input=requires_user_input,
         user_input_fields=list(user_input_fields) if user_input_fields is not None else None,

--- a/src/mindroom/tool_system/output_files.py
+++ b/src/mindroom/tool_system/output_files.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel
 from mindroom import agno_function_patch
 from mindroom.constants import DEFAULT_TOOL_OUTPUT_AUTO_SAVE_THRESHOLD_BYTES
 from mindroom.logging_config import get_logger
+from mindroom.tool_schema_cache import set_schema_cache_postprocessor
 from mindroom.workspaces import resolve_relative_path_within_root_preserving_leaf
 
 if TYPE_CHECKING:
@@ -248,6 +249,10 @@ def _process_entrypoint_with_output_path_schema(self: Function, strict: bool = F
     ensure_output_path_schema_optional(self)
 
 
+def _process_cached_entrypoint_with_output_path_schema(function: Function, strict: bool) -> None:
+    _process_entrypoint_with_output_path_schema(function, strict=strict)
+
+
 def _copy_function_model(self: Function, *, update: Mapping[str, object] | None, deep: bool) -> Function:
     model_copy_parameters = inspect.signature(Function.model_copy).parameters
     if "update" in model_copy_parameters:
@@ -278,6 +283,7 @@ def _install_output_path_schema_postprocessor(function: Function) -> None:
         "process_entrypoint",
         MethodType(_process_entrypoint_with_output_path_schema, function),
     )
+    set_schema_cache_postprocessor(function, _process_cached_entrypoint_with_output_path_schema)
     object.__setattr__(
         function,
         "model_copy",
@@ -733,6 +739,7 @@ def _wrap_entrypoint(
     wrapper.__doc__ = _docstring_with_output_path(getattr(entrypoint, "__doc__", None))
     wrapper.__module__ = getattr(entrypoint, "__module__", __name__)
     wrapper.__dict__["__signature__"] = _signature_with_output_path(entrypoint)
+    wrapper.__dict__["__wrapped__"] = entrypoint
     _copy_annotations_with_output_path(wrapper, entrypoint)
     setattr(wrapper, _WRAPPED_ATTR, True)
     return wrapper

--- a/src/mindroom/tool_system/output_files.py
+++ b/src/mindroom/tool_system/output_files.py
@@ -20,7 +20,11 @@ from pydantic import BaseModel
 from mindroom import agno_function_patch
 from mindroom.constants import DEFAULT_TOOL_OUTPUT_AUTO_SAVE_THRESHOLD_BYTES
 from mindroom.logging_config import get_logger
-from mindroom.tool_schema_cache import set_schema_cache_postprocessor
+from mindroom.tool_schema_cache import (
+    get_schema_cache_source,
+    set_schema_cache_postprocessor,
+    set_schema_cache_source,
+)
 from mindroom.workspaces import resolve_relative_path_within_root_preserving_leaf
 
 if TYPE_CHECKING:
@@ -272,11 +276,15 @@ def _model_copy_with_output_path_schema(
     deep: bool = False,
 ) -> Function:
     copied = _copy_function_model(self, update=update, deep=deep)
-    _install_output_path_schema_postprocessor(copied)
+    _install_output_path_schema_postprocessor(copied, cache_source=get_schema_cache_source(self))
     return copied
 
 
-def _install_output_path_schema_postprocessor(function: Function) -> None:
+def _install_output_path_schema_postprocessor(
+    function: Function,
+    *,
+    cache_source: Callable[..., object] | None = None,
+) -> None:
     """Install a per-function schema sanitizer that survives Agno's Function copies."""
     object.__setattr__(
         function,
@@ -284,6 +292,8 @@ def _install_output_path_schema_postprocessor(function: Function) -> None:
         MethodType(_process_entrypoint_with_output_path_schema, function),
     )
     set_schema_cache_postprocessor(function, _process_cached_entrypoint_with_output_path_schema)
+    if cache_source is not None:
+        set_schema_cache_source(function, cache_source)
     object.__setattr__(
         function,
         "model_copy",
@@ -739,7 +749,6 @@ def _wrap_entrypoint(
     wrapper.__doc__ = _docstring_with_output_path(getattr(entrypoint, "__doc__", None))
     wrapper.__module__ = getattr(entrypoint, "__module__", __name__)
     wrapper.__dict__["__signature__"] = _signature_with_output_path(entrypoint)
-    wrapper.__dict__["__wrapped__"] = entrypoint
     _copy_annotations_with_output_path(wrapper, entrypoint)
     setattr(wrapper, _WRAPPED_ATTR, True)
     return wrapper
@@ -758,9 +767,10 @@ def wrap_function_for_output_files(function: Function, policy: ToolOutputFilePol
         return function
 
     uses_custom_parameters = function.skip_entrypoint_processing or function.parameters != _DEFAULT_PARAMETERS
-    function.entrypoint = _wrap_entrypoint(function.entrypoint, policy, tool_name=function.name)
+    source_entrypoint = function.entrypoint
+    function.entrypoint = _wrap_entrypoint(source_entrypoint, policy, tool_name=function.name)
     function.strict = False
-    _install_output_path_schema_postprocessor(function)
+    _install_output_path_schema_postprocessor(function, cache_source=source_entrypoint)
     if uses_custom_parameters:
         ensure_output_path_schema_optional(function)
     return function

--- a/src/mindroom/tool_system/output_files.py
+++ b/src/mindroom/tool_system/output_files.py
@@ -253,10 +253,6 @@ def _process_entrypoint_with_output_path_schema(self: Function, strict: bool = F
     ensure_output_path_schema_optional(self)
 
 
-def _process_cached_entrypoint_with_output_path_schema(function: Function, strict: bool) -> None:
-    _process_entrypoint_with_output_path_schema(function, strict=strict)
-
-
 def _copy_function_model(self: Function, *, update: Mapping[str, object] | None, deep: bool) -> Function:
     model_copy_parameters = inspect.signature(Function.model_copy).parameters
     if "update" in model_copy_parameters:
@@ -291,7 +287,7 @@ def _install_output_path_schema_postprocessor(
         "process_entrypoint",
         MethodType(_process_entrypoint_with_output_path_schema, function),
     )
-    set_schema_cache_postprocessor(function, _process_cached_entrypoint_with_output_path_schema)
+    set_schema_cache_postprocessor(function, _process_entrypoint_with_output_path_schema)
     if cache_source is not None:
         set_schema_cache_source(function, cache_source)
     object.__setattr__(

--- a/tach.toml
+++ b/tach.toml
@@ -89,6 +89,7 @@ depends_on = []
 visibility = [
     "mindroom.history.prompt_tokens",
     "mindroom.tool_system.plugins",
+    "mindroom.tool_system.output_files",
 ]
 
 [[modules]]
@@ -3429,6 +3430,7 @@ path = "mindroom.tool_system.output_files"
 depends_on = [
     "mindroom.constants",
     "mindroom.logging_config",
+    "mindroom.tool_schema_cache",
     "mindroom.workspaces",
 ]
 

--- a/tests/test_history_prompt_tokens.py
+++ b/tests/test_history_prompt_tokens.py
@@ -37,11 +37,15 @@ from mindroom.history.types import (
     ResolvedHistorySettings,
 )
 from mindroom.token_budget import estimate_text_tokens, stable_serialize
+from mindroom.tool_schema_cache import clear_tool_schema_cache
+from mindroom.tool_system.output_files import ToolOutputFilePolicy, wrap_function_for_output_files
 from tests.conftest import (
     FakeModel,
 )
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pytest
 from tests.history_helpers import (  # noqa: F401
     _agent,
@@ -437,6 +441,48 @@ def test_tool_definition_payloads_cached_equal_ordered_and_isolated() -> None:
     cast("dict[str, object]", first[1]["parameters"])["injected"] = True
 
     assert agent_tool_definition_payloads_for_logging(warm_agent) == cached
+
+
+def test_output_wrapped_tool_schema_is_reused_across_agent_instances(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Static-token preparation should process one shared wrapped schema only once."""
+
+    def export_report(report_id: str) -> str:
+        """Export one report."""
+        return report_id
+
+    original_process_entrypoint = Function.process_entrypoint
+    process_calls = 0
+
+    def _counting_process_entrypoint(self: Function, strict: bool = False) -> None:
+        nonlocal process_calls
+        process_calls += 1
+        original_process_entrypoint(self, strict=strict)
+
+    monkeypatch.setattr(Function, "process_entrypoint", _counting_process_entrypoint)
+    clear_tool_schema_cache()
+
+    def make_agent() -> Agent:
+        function = Function(name="export_report", entrypoint=export_report)
+        wrap_function_for_output_files(function, ToolOutputFilePolicy(workspace_root=tmp_path))
+        agent = _agent()
+        agent.tools = [function]
+        return agent
+
+    first_agent = make_agent()
+    second_agent = make_agent()
+
+    first_estimate = estimate_agent_static_tokens(first_agent, "Current prompt")
+    second_estimate = estimate_agent_static_tokens(second_agent, "Current prompt")
+    first_payloads = agent_tool_definition_payloads_for_logging(first_agent)
+    second_payloads = agent_tool_definition_payloads_for_logging(second_agent)
+
+    assert first_estimate == second_estimate
+    assert first_payloads == second_payloads
+    assert process_calls == 1
+    clear_tool_schema_cache()
 
 
 def test_tool_surfaces_are_keyed_per_agent_instance() -> None:

--- a/tests/test_tool_schema_cache.py
+++ b/tests/test_tool_schema_cache.py
@@ -2,9 +2,19 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from agno.tools.function import Function
 
 from mindroom.tool_schema_cache import cached_processed_schema
+from mindroom.tool_system.output_files import (
+    OUTPUT_PATH_ARGUMENT,
+    ToolOutputFilePolicy,
+    wrap_function_for_output_files,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_cached_processed_schema_returns_private_copies() -> None:
@@ -26,3 +36,33 @@ def test_cached_processed_schema_returns_private_copies() -> None:
     assert "injected" not in second.parameters["properties"]
     assert second.parameters["required"] == ["title"]
     assert second.parameters is not first.parameters
+
+
+def test_cached_processed_schema_applies_output_path_postprocessor_without_sharing_results(tmp_path: Path) -> None:
+    """Output-wrapped functions should reuse schema work without changing the live function."""
+
+    def export_report(report_id: str) -> str:
+        """Export one report."""
+        return report_id
+
+    function = Function(name="export_report", entrypoint=export_report)
+    wrap_function_for_output_files(function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+    first = cached_processed_schema(function, strict=True)
+
+    assert first is not None
+    assert first.parameters["properties"][OUTPUT_PATH_ARGUMENT]["default"] is None
+    assert first.parameters["required"] == ["report_id"]
+    assert OUTPUT_PATH_ARGUMENT not in function.parameters["properties"]
+
+    live = function.model_copy(deep=True)
+    live.process_entrypoint(strict=True)
+    assert first.parameters == live.parameters
+    assert first.description == live.description
+
+    first.parameters["properties"][OUTPUT_PATH_ARGUMENT]["default"] = "changed"
+
+    second = cached_processed_schema(function, strict=True)
+
+    assert second is not None
+    assert second.parameters["properties"][OUTPUT_PATH_ARGUMENT]["default"] is None

--- a/tests/test_tool_schema_cache.py
+++ b/tests/test_tool_schema_cache.py
@@ -2,11 +2,18 @@
 
 from __future__ import annotations
 
+import inspect
+from functools import partial
 from typing import TYPE_CHECKING
 
+import pytest
 from agno.tools.function import Function
 
-from mindroom.tool_schema_cache import cached_processed_schema
+from mindroom.tool_schema_cache import (
+    cached_processed_schema,
+    clear_tool_schema_cache,
+    set_schema_cache_postprocessor,
+)
 from mindroom.tool_system.output_files import (
     OUTPUT_PATH_ARGUMENT,
     ToolOutputFilePolicy,
@@ -66,3 +73,136 @@ def test_cached_processed_schema_applies_output_path_postprocessor_without_shari
 
     assert second is not None
     assert second.parameters["properties"][OUTPUT_PATH_ARGUMENT]["default"] is None
+
+
+def test_cached_processed_schema_matches_output_wrapper_documentation_and_user_input(tmp_path: Path) -> None:
+    """Cached output-path schemas must retain every wrapper-provided prompt field."""
+
+    def export_report(report_id: str, include_notes: bool = False) -> str:
+        """Export one report.
+
+        Args:
+            report_id: Report to export.
+            include_notes: Whether to include notes.
+
+        """
+        return f"{report_id}:{include_notes}"
+
+    function = Function(name="export_report", entrypoint=export_report, requires_user_input=True)
+    wrap_function_for_output_files(function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+    cached = cached_processed_schema(function, strict=True)
+    live = function.model_copy(deep=True)
+    live.process_entrypoint(strict=True)
+
+    assert cached is not None
+    assert cached.parameters == live.parameters
+    assert cached.description == live.description
+    assert cached.user_input_schema == tuple(live.user_input_schema)
+    assert [field.name for field in cached.user_input_schema] == [
+        "report_id",
+        "include_notes",
+        OUTPUT_PATH_ARGUMENT,
+    ]
+
+    cached.user_input_schema[0].description = "changed"
+
+    second = cached_processed_schema(function, strict=True)
+
+    assert second is not None
+    assert second.user_input_schema[0].description is None
+    assert second.user_input_schema[0] is not cached.user_input_schema[0]
+
+
+def test_cached_processed_schema_reuses_independently_wrapped_functions_without_unwrapping(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Equivalent output wrappers must share cached work without changing inspect.unwrap."""
+
+    def export_report(report_id: str) -> str:
+        """Export one report."""
+        return report_id
+
+    clear_tool_schema_cache()
+    original_process_entrypoint = Function.process_entrypoint
+    process_entrypoint_calls = 0
+
+    def counting_process_entrypoint(self: Function, strict: bool = False) -> None:
+        nonlocal process_entrypoint_calls
+        process_entrypoint_calls += 1
+        original_process_entrypoint(self, strict=strict)
+
+    monkeypatch.setattr(Function, "process_entrypoint", counting_process_entrypoint)
+    first_function = Function(name="export_report", entrypoint=export_report)
+    second_function = Function(name="export_report", entrypoint=export_report)
+    wrap_function_for_output_files(first_function, ToolOutputFilePolicy(workspace_root=tmp_path))
+    wrap_function_for_output_files(second_function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+    first = cached_processed_schema(first_function, strict=False)
+    second = cached_processed_schema(second_function, strict=False)
+
+    assert first is not None
+    assert second is not None
+    assert process_entrypoint_calls == 1
+    assert inspect.unwrap(first_function.entrypoint) is first_function.entrypoint
+    clear_tool_schema_cache()
+
+
+def test_cached_processed_schema_rejects_plain_custom_processor_without_opt_in() -> None:
+    """An unregistered plain custom processor must fall back to live processing."""
+
+    def export_report(report_id: str) -> str:
+        return report_id
+
+    def custom_processor(strict: bool = False) -> None:
+        del strict
+
+    function = Function(name="export_report", entrypoint=export_report)
+    object.__setattr__(function, "process_entrypoint", custom_processor)
+
+    assert cached_processed_schema(function, strict=False) is None
+
+
+def test_cached_processed_schema_rejects_partial_custom_processor_without_opt_in() -> None:
+    """An unregistered partial custom processor must fall back to live processing."""
+
+    def export_report(report_id: str) -> str:
+        return report_id
+
+    function = Function(name="export_report", entrypoint=export_report)
+    object.__setattr__(function, "process_entrypoint", partial(Function.process_entrypoint, function))
+
+    assert cached_processed_schema(function, strict=False) is None
+
+
+def test_set_schema_cache_postprocessor_rejects_nested_functions() -> None:
+    """Cache processors must have stable module-level identity."""
+
+    def export_report(report_id: str) -> str:
+        return report_id
+
+    def nested_postprocessor(function: Function, strict: bool) -> None:
+        function.process_entrypoint(strict=strict)
+
+    function = Function(name="export_report", entrypoint=export_report)
+
+    with pytest.raises(TypeError, match="module-level"):
+        set_schema_cache_postprocessor(function, nested_postprocessor)
+
+
+def test_cached_processed_schema_uses_bound_method_cache_source(tmp_path: Path) -> None:
+    """Output-path wrapping must retain cache support for toolkit-bound methods."""
+
+    class ReportExporter:
+        def export_report(self, report_id: str) -> str:
+            return report_id
+
+    function = Function(name="export_report", entrypoint=ReportExporter().export_report)
+
+    wrap_function_for_output_files(function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+    snapshot = cached_processed_schema(function, strict=False)
+
+    assert snapshot is not None
+    assert snapshot.parameters["required"] == ["report_id"]

--- a/tests/test_tool_schema_cache.py
+++ b/tests/test_tool_schema_cache.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import gc
 import inspect
 from functools import partial
 from typing import TYPE_CHECKING
+from weakref import ref
 
 import pytest
 from agno.tools.function import Function
@@ -206,3 +208,36 @@ def test_cached_processed_schema_uses_bound_method_cache_source(tmp_path: Path) 
 
     assert snapshot is not None
     assert snapshot.parameters["required"] == ["report_id"]
+
+
+def test_cached_processed_schema_does_not_retain_wrapped_method_owner(tmp_path: Path) -> None:
+    """Cached snapshots must not keep a wrapper's bound-method owner alive."""
+
+    class ReportExporter:
+        def export_report(self, report_id: str) -> str:
+            return report_id
+
+    clear_tool_schema_cache()
+    owner = ReportExporter()
+    owner_ref = ref(owner)
+    function = Function(name="export_report", entrypoint=owner.export_report)
+    wrap_function_for_output_files(function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+    try:
+        first = cached_processed_schema(function, strict=False)
+        assert first is not None
+
+        del function
+        del owner
+        gc.collect()
+
+        assert owner_ref() is None
+
+        next_function = Function(name="export_report", entrypoint=ReportExporter().export_report)
+        wrap_function_for_output_files(next_function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+        second = cached_processed_schema(next_function, strict=False)
+
+        assert second == first
+    finally:
+        clear_tool_schema_cache()

--- a/tests/test_tool_schema_cache.py
+++ b/tests/test_tool_schema_cache.py
@@ -178,6 +178,33 @@ def test_cached_processed_schema_rejects_partial_custom_processor_without_opt_in
     assert cached_processed_schema(function, strict=False) is None
 
 
+@pytest.mark.parametrize("entrypoint_kind", ["partial", "builtin", "callable"])
+def test_output_wrapper_falls_back_for_unsupported_cache_sources(
+    entrypoint_kind: str,
+    tmp_path: Path,
+) -> None:
+    """Valid callables without stable function identity must remain usable uncached."""
+
+    def export_report(report_id: str) -> str:
+        return report_id
+
+    class ReportExporter:
+        def __call__(self, report_id: str) -> str:
+            return report_id
+
+    entrypoint = {
+        "partial": partial(export_report),
+        "builtin": len,
+        "callable": ReportExporter(),
+    }[entrypoint_kind]
+    function = Function(name="export_report", entrypoint=entrypoint)
+
+    wrapped = wrap_function_for_output_files(function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+    assert wrapped is function
+    assert cached_processed_schema(function, strict=False) is None
+
+
 def test_set_schema_cache_postprocessor_rejects_nested_functions() -> None:
     """Cache processors must have stable module-level identity."""
 
@@ -263,6 +290,66 @@ def test_cached_processed_schema_does_not_retain_wrapped_closure_owner(tmp_path:
 
     try:
         cached_processed_schema(function, strict=False)
+
+        del function
+        gc.collect()
+
+        assert owner_ref() is None
+    finally:
+        clear_tool_schema_cache()
+
+
+def test_cached_processed_schema_does_not_retain_default_bound_owner(tmp_path: Path) -> None:
+    """Cache keys must not retain owners captured by source-function defaults."""
+
+    class ReportExporter:
+        report_prefix = "report"
+
+    def build_function() -> tuple[Function, ref[ReportExporter]]:
+        owner = ReportExporter()
+
+        def export_report(report_id: str, retained_owner: ReportExporter = owner) -> str:
+            return f"{retained_owner.report_prefix}:{report_id}"
+
+        return Function(name="export_report", entrypoint=export_report), ref(owner)
+
+    clear_tool_schema_cache()
+    function, owner_ref = build_function()
+    wrap_function_for_output_files(function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+    try:
+        assert cached_processed_schema(function, strict=False) is not None
+
+        del function
+        gc.collect()
+
+        assert owner_ref() is None
+    finally:
+        clear_tool_schema_cache()
+
+
+def test_cached_processed_schema_does_not_retain_wrapped_attribute_owner(tmp_path: Path) -> None:
+    """Cache keys must not retain owners referenced by a source's wrapped attribute."""
+
+    class ReportExporter:
+        def export_report(self, report_id: str) -> str:
+            return report_id
+
+    def build_function() -> tuple[Function, ref[ReportExporter]]:
+        owner = ReportExporter()
+
+        def export_report(report_id: str) -> str:
+            return report_id
+
+        export_report.__wrapped__ = owner.export_report  # type: ignore[attr-defined]
+        return Function(name="export_report", entrypoint=export_report), ref(owner)
+
+    clear_tool_schema_cache()
+    function, owner_ref = build_function()
+    wrap_function_for_output_files(function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+    try:
+        assert cached_processed_schema(function, strict=False) is not None
 
         del function
         gc.collect()

--- a/tests/test_tool_schema_cache.py
+++ b/tests/test_tool_schema_cache.py
@@ -241,3 +241,32 @@ def test_cached_processed_schema_does_not_retain_wrapped_method_owner(tmp_path: 
         assert second == first
     finally:
         clear_tool_schema_cache()
+
+
+def test_cached_processed_schema_does_not_retain_wrapped_closure_owner(tmp_path: Path) -> None:
+    """Cached snapshots must not keep a closure's captured owner alive."""
+
+    class ReportExporter:
+        report_prefix = "report"
+
+    def build_function() -> tuple[Function, ref[ReportExporter]]:
+        owner = ReportExporter()
+
+        def export_report(report_id: str) -> str:
+            return f"{owner.report_prefix}:{report_id}"
+
+        return Function(name="export_report", entrypoint=export_report), ref(owner)
+
+    clear_tool_schema_cache()
+    function, owner_ref = build_function()
+    wrap_function_for_output_files(function, ToolOutputFilePolicy(workspace_root=tmp_path))
+
+    try:
+        cached_processed_schema(function, strict=False)
+
+        del function
+        gc.collect()
+
+        assert owner_ref() is None
+    finally:
+        clear_tool_schema_cache()


### PR DESCRIPTION
## Summary

- cache tool schema customization for opted-in postprocessors
- preserve wrapper signature, documentation, strictness, and user-input behavior
- avoid retaining bound wrapper owners in the cache

## Testing

- full pytest suite
- all pre-commit hooks

## Summary by Sourcery

Cache schemas for opted-in customized tools while preserving runtime behavior and avoiding unintended object retention.

New Features:
- Enable opted-in customized tool processors to reuse cached schema preparation.

Bug Fixes:
- Preserve customized tool schema behavior, including signatures, documentation, strictness, and user-input metadata, when served from cache.
- Prevent schema cache entries from retaining bound-method or closure owners.

Enhancements:
- Add stable cache metadata and safe fallback behavior for unsupported callable and processor forms.

Tests:
- Add coverage for customized output-file schemas, cache reuse, behavior preservation, unsupported callables, and object lifetime safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved schema caching for wrapped tools that redirect output to files.
  - Preserved tool documentation and user-input details when cached schemas are reused.
  - Prevented stale or unsafe cached processing when wrapped entrypoints are no longer available.
  - Ensured independently wrapped tools can safely reuse compatible cached schemas.

- **Reliability**
  - Added safeguards for custom schema processors, nested processing, and bound methods.
  - Prevented unnecessary retention of objects associated with bound methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->