### PR TITLE
Keep blocking setup off the event loop

### DIFF
--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from collections.abc import Mapping
-from contextlib import aclosing
+from contextlib import aclosing, asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, cast
@@ -33,7 +33,8 @@ from mindroom.ai_run_metadata import (
     build_prepared_history_metadata_content,
     empty_request_metric_totals,
 )
-from mindroom.claude_prompt_cache import prewarm_anthropic_async_client
+from mindroom.background_tasks import run_coroutine_until_complete
+from mindroom.claude_prompt_cache import aclose_anthropic_async_client, prewarm_anthropic_async_client
 from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.execution_preparation import prepare_agent_execution_context, render_prepared_messages_text
 from mindroom.history.interrupted_replay import (
@@ -66,7 +67,7 @@ from mindroom.logging_config import get_logger
 from mindroom.media_inputs import MediaInputs
 from mindroom.memory import build_memory_prompt_parts, strip_user_turn_time_prefix
 from mindroom.metadata_merge import deep_merge_metadata
-from mindroom.pre_model_preparation import prepare_prompt_branches
+from mindroom.pre_model_preparation import build_agent_off_loop, close_unreturned_agent, prepare_prompt_branches
 from mindroom.response_turn import (
     AttemptResolved,
     BlockingAttemptResolution,
@@ -95,10 +96,11 @@ from mindroom.tool_system.events import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator, Callable, Sequence
+    from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Sequence
     from contextlib import AbstractContextManager
 
     from agno.agent import Agent
+    from agno.db.base import BaseDb
     from agno.knowledge.knowledge import Knowledge
     from agno.models.response import ToolExecution
     from agno.tools.function import Function
@@ -305,6 +307,7 @@ class _AgentTurnHolder:
     attempt: _AgentAttempt | None = None
     state: _StreamingAttemptState | None = None  # streaming turns only
     attempt_started: bool = False  # streaming turns only
+    retired_model: object | None = None
 
 
 @dataclass(frozen=True)
@@ -315,8 +318,31 @@ class _AgentTurnCallbacks:
     on_scope_opened: Callable[[ScopeSessionContext | None], None]
     release_attempt_entity: Callable[[ScopeSessionContext | None], None]
     close_runtime_dbs: Callable[[ScopeSessionContext | None], None]
+    finalize_attempt: Callable[[ScopeSessionContext | None], Awaitable[None]]
     discard_empty_run: Callable[[ScopeSessionContext | None, EmptyRunDiscard], None]
     persist_standalone_replay: Callable[[ScopeSessionContext | None, StandaloneReplaySnapshot], None]
+
+
+def _retire_agent_turn_model(holder: _AgentTurnHolder, *, retain_agent_runtime_state: bool) -> None:
+    """Keep one released attempt's model alive until async finalization."""
+    if not retain_agent_runtime_state and holder.agent is not None:
+        holder.retired_model = holder.agent.model
+
+
+async def _finalize_agent_turn_model(
+    holder: _AgentTurnHolder,
+    *,
+    retain_agent_runtime_state: bool,
+) -> None:
+    """Close one per-turn model client without taking ownership of reusable agents."""
+    if retain_agent_runtime_state:
+        return
+    model = holder.retired_model
+    holder.retired_model = None
+    if model is None and holder.agent is not None:
+        model = holder.agent.model
+    if model is not None:
+        await run_coroutine_until_complete(aclose_anthropic_async_client(model))
 
 
 def _build_agent_turn_callbacks(
@@ -358,6 +384,7 @@ def _build_agent_turn_callbacks(
         )
 
     def _release_attempt_entity(scope_context: ScopeSessionContext | None) -> None:
+        _retire_agent_turn_model(holder, retain_agent_runtime_state=retain_agent_runtime_state)
         _close_runtime_dbs(scope_context)
         holder.agent = None
         # Cancel snapshots taken between this release and the next attempt must
@@ -365,6 +392,12 @@ def _build_agent_turn_callbacks(
         # carried over via the turn state.
         holder.attempt = None
         holder.state = None
+
+    async def _finalize_attempt(_scope_context: ScopeSessionContext | None) -> None:
+        await _finalize_agent_turn_model(
+            holder,
+            retain_agent_runtime_state=retain_agent_runtime_state,
+        )
 
     def _discard_empty_run(scope_context: ScopeSessionContext | None, discard: EmptyRunDiscard) -> None:
         ai_runtime.discard_empty_completed_run(
@@ -399,6 +432,7 @@ def _build_agent_turn_callbacks(
         on_scope_opened=_on_scope_opened,
         release_attempt_entity=_release_attempt_entity,
         close_runtime_dbs=_close_runtime_dbs,
+        finalize_attempt=_finalize_attempt,
         discard_empty_run=_discard_empty_run,
         persist_standalone_replay=_persist_standalone_replay,
     )
@@ -934,6 +968,21 @@ def _mark_pipeline_timing(pipeline_timing: DispatchPipelineTiming | None, label:
         pipeline_timing.mark(label)
 
 
+@asynccontextmanager
+async def _close_agent_on_preparation_failure(
+    agent: Agent,
+    *,
+    shared_scope_storage: BaseDb | None,
+    caller_owned_agent: Agent | None,
+) -> AsyncIterator[None]:
+    """Reclaim a per-turn agent unless prompt preparation returns it."""
+    try:
+        yield
+    except BaseException:
+        await close_unreturned_agent(agent, shared_scope_storage, caller_owned_agent)
+        raise
+
+
 @timed("system_prompt_assembly")
 async def _prepare_agent_and_prompt(
     ctx: ResponseTurnContext,
@@ -1067,75 +1116,85 @@ async def _prepare_agent_and_prompt(
         )
         _mark_pipeline_timing(pipeline_timing, "memory_prepare_ready")
         _mark_pipeline_timing(pipeline_timing, "agent_build_start")
-        runtime_model, agent = await asyncio.to_thread(_resolve_model_and_build_agent)
+        runtime_model, agent = await build_agent_off_loop(
+            _resolve_model_and_build_agent,
+            agent_name=agent_name,
+            shared_scope_storage=scope_context.storage if scope_context is not None else None,
+            caller_owned_agent=reusable_agent,
+        )
         _mark_pipeline_timing(pipeline_timing, "agent_build_ready")
 
-    _append_additional_context(agent, prompt_parts.session_preamble)
-    if ctx.system_enrichment_items:
-        _append_additional_context(
-            agent,
-            _render_system_enrichment_context(ctx.system_enrichment_items),
-        )
-    transient_turn_context = render_transient_context(
-        (
-            prompt_parts.transient_turn_context,
-            render_enrichment_block(list(ctx.transient_enrichment_items)),
-        ),
-    )
-
-    prepared_execution = await prepare_agent_execution_context(
-        ctx,
-        scope_context=scope_context,
-        agent=agent,
-        prompt=current_turn_prompt,
-        transient_context_messages=(
-            (
-                Message(
-                    role="user",
-                    content=transient_turn_context,
-                    add_to_agent_memory=False,
-                ),
+    async with _close_agent_on_preparation_failure(
+        agent,
+        shared_scope_storage=scope_context.storage if scope_context is not None else None,
+        caller_owned_agent=reusable_agent,
+    ):
+        _append_additional_context(agent, prompt_parts.session_preamble)
+        if ctx.system_enrichment_items:
+            _append_additional_context(
+                agent,
+                _render_system_enrichment_context(ctx.system_enrichment_items),
             )
-            if transient_turn_context
-            else ()
-        ),
-        thread_history=thread_history,
-        runtime_paths=runtime_paths,
-        config=config,
-        resolved_runtime_model=runtime_model,
-        compaction_lifecycle=compaction_lifecycle,
-        current_sender_id=None if include_openai_compat_guidance else ctx.requester_id,
-        current_timestamp_ms=current_timestamp_ms,
-        current_event_id=current_event_id,
-        current_prompt_is_structured=current_prompt_is_structured,
-        include_openai_compat_guidance=include_openai_compat_guidance,
-        pipeline_timing=pipeline_timing,
-    )
-    prepared_history = prepared_execution.prepared_history
-    if prepared_execution.replay_plan is not None:
-        apply_replay_plan(target=agent, replay_plan=prepared_execution.replay_plan)
-    unseen_event_ids = prepared_execution.unseen_event_ids
-    run_messages = prepared_execution.messages
+        transient_turn_context = render_transient_context(
+            (
+                prompt_parts.transient_turn_context,
+                render_enrichment_block(list(ctx.transient_enrichment_items)),
+            ),
+        )
 
-    # Routine logs stay content-safe; detailed prompt text is emitted separately only at DEBUG.
-    logger.info(
-        "Preparing agent and prompt",
-        agent=agent_name,
-        message_count=len(run_messages),
-        unseen_event_count=len(unseen_event_ids),
-    )
-    logger.debug(
-        "Prepared agent full prompt",
-        agent=agent_name,
-        full_prompt=render_prepared_messages_text(run_messages),
-    )
-    return _PreparedAgentRun(
-        agent=agent,
-        messages=run_messages,
-        unseen_event_ids=unseen_event_ids,
-        prepared_history=prepared_history,
-        runtime_model_name=runtime_model.model_name,
-    )
+        prepared_execution = await prepare_agent_execution_context(
+            ctx,
+            scope_context=scope_context,
+            agent=agent,
+            prompt=current_turn_prompt,
+            transient_context_messages=(
+                (
+                    Message(
+                        role="user",
+                        content=transient_turn_context,
+                        add_to_agent_memory=False,
+                    ),
+                )
+                if transient_turn_context
+                else ()
+            ),
+            thread_history=thread_history,
+            runtime_paths=runtime_paths,
+            config=config,
+            resolved_runtime_model=runtime_model,
+            compaction_lifecycle=compaction_lifecycle,
+            current_sender_id=None if include_openai_compat_guidance else ctx.requester_id,
+            current_timestamp_ms=current_timestamp_ms,
+            current_event_id=current_event_id,
+            current_prompt_is_structured=current_prompt_is_structured,
+            include_openai_compat_guidance=include_openai_compat_guidance,
+            pipeline_timing=pipeline_timing,
+        )
+        prepared_history = prepared_execution.prepared_history
+        if prepared_execution.replay_plan is not None:
+            apply_replay_plan(target=agent, replay_plan=prepared_execution.replay_plan)
+        unseen_event_ids = prepared_execution.unseen_event_ids
+        run_messages = prepared_execution.messages
+
+        # Routine logs stay content-safe; detailed prompt text is emitted separately only at DEBUG.
+        logger.info(
+            "Preparing agent and prompt",
+            agent=agent_name,
+            message_count=len(run_messages),
+            unseen_event_count=len(unseen_event_ids),
+        )
+        logger.debug(
+            "Prepared agent full prompt",
+            agent=agent_name,
+            full_prompt=render_prepared_messages_text(run_messages),
+        )
+        return _PreparedAgentRun(
+            agent=agent,
+            messages=run_messages,
+            unseen_event_ids=unseen_event_ids,
+            prepared_history=prepared_history,
+            runtime_model_name=runtime_model.model_name,
+        )
 
 
 async def _prepare_agent_run_context(
@@ -1511,6 +1570,7 @@ async def ai_response(  # noqa: C901
         release_attempt_entity=callbacks.release_attempt_entity,
         close_runtime_dbs=callbacks.close_runtime_dbs,
         discard_empty_run=callbacks.discard_empty_run,
+        finalize_attempt=callbacks.finalize_attempt,
         on_scope_opened=callbacks.on_scope_opened,
         persist_standalone_replay=callbacks.persist_standalone_replay,
     )
@@ -1803,6 +1863,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
     )
 
     async def _finalize_streaming_attempt(scope_context: ScopeSessionContext | None) -> None:
+        await callbacks.finalize_attempt(scope_context)
         if not holder.attempt_started:
             return
         holder.attempt_started = False

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -33,6 +33,7 @@ from mindroom.ai_run_metadata import (
     build_prepared_history_metadata_content,
     empty_request_metric_totals,
 )
+from mindroom.claude_prompt_cache import prewarm_anthropic_async_client
 from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.execution_preparation import prepare_agent_execution_context, render_prepared_messages_text
 from mindroom.history.interrupted_replay import (
@@ -1000,6 +1001,7 @@ async def _prepare_agent_and_prompt(
                 supports_native_tool_approval=supports_native_tool_approval,
                 eager_deferred_tools=eager_deferred_tools,
             )
+            prewarm_anthropic_async_client(agent.model)
         return runtime_model, agent
 
     memory_backend = config.resolve_entity(agent_name).memory_backend

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -34,7 +34,7 @@ from mindroom.ai_run_metadata import (
     empty_request_metric_totals,
 )
 from mindroom.background_tasks import run_coroutine_until_complete
-from mindroom.claude_prompt_cache import aclose_anthropic_async_client, prewarm_anthropic_async_client
+from mindroom.claude_prompt_cache import aclose_anthropic_async_client
 from mindroom.error_handling import get_user_friendly_error_message
 from mindroom.execution_preparation import prepare_agent_execution_context, render_prepared_messages_text
 from mindroom.history.interrupted_replay import (
@@ -67,7 +67,12 @@ from mindroom.logging_config import get_logger
 from mindroom.media_inputs import MediaInputs
 from mindroom.memory import build_memory_prompt_parts, strip_user_turn_time_prefix
 from mindroom.metadata_merge import deep_merge_metadata
-from mindroom.pre_model_preparation import build_agent_off_loop, close_unreturned_agent, prepare_prompt_branches
+from mindroom.pre_model_preparation import (
+    build_agent_off_loop,
+    close_unreturned_agent,
+    prepare_prompt_branches,
+    prewarm_agent_model_client,
+)
 from mindroom.response_turn import (
     AttemptResolved,
     BlockingAttemptResolution,
@@ -1050,7 +1055,10 @@ async def _prepare_agent_and_prompt(
                 supports_native_tool_approval=supports_native_tool_approval,
                 eager_deferred_tools=eager_deferred_tools,
             )
-            prewarm_anthropic_async_client(agent.model)
+            prewarm_agent_model_client(
+                agent,
+                scope_context.storage if scope_context is not None else None,
+            )
         return runtime_model, agent
 
     memory_backend = config.resolve_entity(agent_name).memory_backend
@@ -1251,41 +1259,46 @@ async def _prepare_agent_run_context(
         supports_native_tool_approval=supports_native_tool_approval,
         reusable_agent=reusable_agent,
     )
-    if pipeline_timing is not None:
-        pipeline_timing.mark("history_ready", overwrite=True)
-        note_prepared_history_timing(pipeline_timing, prepared_run.prepared_history)
+    async with _close_agent_on_preparation_failure(
+        prepared_run.agent,
+        shared_scope_storage=scope_context.storage if scope_context is not None else None,
+        caller_owned_agent=reusable_agent,
+    ):
+        if pipeline_timing is not None:
+            pipeline_timing.mark("history_ready", overwrite=True)
+            note_prepared_history_timing(pipeline_timing, prepared_run.prepared_history)
 
-    agent = prepared_run.agent
-    if agent.model is not None:
-        ai_runtime.install_queued_message_notice_hook(
-            agent.model,
-            notice_text=config.get_prompt("QUEUED_MESSAGE_NOTICE_TEXT"),
+        agent = prepared_run.agent
+        if agent.model is not None:
+            ai_runtime.install_queued_message_notice_hook(
+                agent.model,
+                notice_text=config.get_prompt("QUEUED_MESSAGE_NOTICE_TEXT"),
+            )
+
+        run_extra_content = build_prepared_history_metadata_content(prepared_run.prepared_history)
+        metadata = build_matrix_run_metadata(
+            ctx.reply_to_event_id,
+            prepared_run.unseen_event_ids,
+            room_id=ctx.room_id,
+            thread_id=ctx.thread_id,
+            requester_id=ctx.requester_id,
+            correlation_id=ctx.correlation_id,
+            tools_schema=agent_tool_definition_payloads_for_logging(agent) if agent.model is not None else [],
+            model_params=model_params_payload(agent.model) if agent.model is not None else {},
+            extra_metadata=deep_merge_metadata(ctx.matrix_run_metadata, run_extra_content),
         )
+        if turn_recorder is not None:
+            turn_recorder.set_run_metadata(metadata)
 
-    run_extra_content = build_prepared_history_metadata_content(prepared_run.prepared_history)
-    metadata = build_matrix_run_metadata(
-        ctx.reply_to_event_id,
-        prepared_run.unseen_event_ids,
-        room_id=ctx.room_id,
-        thread_id=ctx.thread_id,
-        requester_id=ctx.requester_id,
-        correlation_id=ctx.correlation_id,
-        tools_schema=agent_tool_definition_payloads_for_logging(agent) if agent.model is not None else [],
-        model_params=model_params_payload(agent.model) if agent.model is not None else {},
-        extra_metadata=deep_merge_metadata(ctx.matrix_run_metadata, run_extra_content),
-    )
-    if turn_recorder is not None:
-        turn_recorder.set_run_metadata(metadata)
-
-    return _AgentRunContext(
-        turn=ctx,
-        session_id=session_id,
-        prompt=prompt,
-        model_prompt=model_prompt,
-        prepared_run=prepared_run,
-        run_input=prepared_run.run_input,
-        metadata=metadata,
-    )
+        return _AgentRunContext(
+            turn=ctx,
+            session_id=session_id,
+            prompt=prompt,
+            model_prompt=model_prompt,
+            prepared_run=prepared_run,
+            run_input=prepared_run.run_input,
+            metadata=metadata,
+        )
 
 
 async def ai_response(  # noqa: C901

--- a/src/mindroom/api/main.py
+++ b/src/mindroom/api/main.py
@@ -38,6 +38,7 @@ from mindroom.api.script_gateway import router as script_gateway_router
 from mindroom.api.skills import router as skills_router
 from mindroom.api.tools import router as tools_router
 from mindroom.api.workers import router as workers_router
+from mindroom.background_tasks import run_blocking_until_complete
 from mindroom.credentials_sync import sync_env_to_credentials
 from mindroom.embedder_health import get_embedder_failure
 from mindroom.knowledge import KnowledgeRefreshScheduler, reconcile_knowledge_mode_transition_states
@@ -487,7 +488,7 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     # Sync API keys from environment to CredentialsManager
     logger.info("Syncing API credentials from runtime env")
-    sync_env_to_credentials(runtime_paths=runtime_paths)
+    await run_blocking_until_complete(sync_env_to_credentials, runtime_paths)
 
     api_owned_knowledge_refresh_scheduler: KnowledgeRefreshScheduler | None = None
     standalone_knowledge_source_watcher: KnowledgeSourceWatcher | None = None

--- a/src/mindroom/bedrock_claude.py
+++ b/src/mindroom/bedrock_claude.py
@@ -42,8 +42,8 @@ class MindRoomBedrockClaude(ClaudeProviderCompat, AwsBedrockClaude):
         return client
 
     def get_async_client(self) -> AsyncAnthropicBedrockMantle:  # ty: ignore[invalid-method-override]  # Agno types only legacy clients
-        """Return an asynchronous Mantle client with current AWS credentials."""
-        if not self.session and self.async_client is not None and not self.async_client.is_closed():
+        """Return this model lifetime's asynchronous Mantle client."""
+        if self.async_client is not None and not self.async_client.is_closed():
             return self.async_client
 
         client_params = self._get_client_params()
@@ -54,6 +54,5 @@ class MindRoomBedrockClaude(ClaudeProviderCompat, AwsBedrockClaude):
                 logger.warning("bedrock_claude_async_http_client_ignored")
 
         client = AsyncAnthropicBedrockMantle(**client_params)
-        if not self.session:
-            self.async_client = client
+        self.async_client = client
         return client

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -63,6 +63,8 @@ if TYPE_CHECKING:
 
     from agno.models.anthropic import Claude as AnthropicClaude
 
+    from mindroom.bedrock_claude import MindRoomBedrockClaude
+
 _PROMPT_CACHE_HOOK_ATTR = "_mindroom_claude_prompt_cache_hook_installed"
 _DEFERRED_TOOL_NAMES_ATTR = "_mindroom_claude_deferred_tool_names"
 # The Anthropic API allows at most four cache_control markers per request.
@@ -97,6 +99,7 @@ def native_tool_search_supported(provider: str, model_id: str) -> bool:
 
 
 _ANTHROPIC_CLAUDE_CLASS = ("agno.models.anthropic.claude", "Claude")
+_BEDROCK_CLAUDE_CLASS = ("mindroom.bedrock_claude", "MindRoomBedrockClaude")
 
 
 def as_anthropic_claude(model: object) -> AnthropicClaude | None:
@@ -111,10 +114,17 @@ def as_anthropic_claude(model: object) -> AnthropicClaude | None:
     return cast("AnthropicClaude", model)
 
 
+def _is_session_backed_bedrock_claude(model: object) -> bool:
+    """Return whether a Bedrock model will not retain a prewarmed client."""
+    if not isinstance_of_loaded(model, _BEDROCK_CLAUDE_CLASS):
+        return False
+    return cast("MindRoomBedrockClaude", model).session is not None
+
+
 def prewarm_anthropic_async_client(model: object) -> None:
     """Build and cache a Claude async SDK client without making a request."""
     claude_model = as_anthropic_claude(model)
-    if claude_model is None or getattr(claude_model, "session", None) is not None:
+    if claude_model is None or _is_session_backed_bedrock_claude(claude_model):
         return
     claude_model.get_async_client()
 

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -114,8 +114,9 @@ def as_anthropic_claude(model: object) -> AnthropicClaude | None:
 def prewarm_anthropic_async_client(model: object) -> None:
     """Build and cache a Claude async SDK client without making a request."""
     claude_model = as_anthropic_claude(model)
-    if claude_model is not None:
-        claude_model.get_async_client()
+    if claude_model is None or getattr(claude_model, "session", None) is not None:
+        return
+    claude_model.get_async_client()
 
 
 def _prompt_cache_control(*, extended_cache_time: bool = False) -> dict[str, str]:

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -111,6 +111,13 @@ def as_anthropic_claude(model: object) -> AnthropicClaude | None:
     return cast("AnthropicClaude", model)
 
 
+def prewarm_anthropic_async_client(model: object) -> None:
+    """Build and cache a Claude async SDK client without making a request."""
+    claude_model = as_anthropic_claude(model)
+    if claude_model is not None:
+        claude_model.get_async_client()
+
+
 def _prompt_cache_control(*, extended_cache_time: bool = False) -> dict[str, str]:
     """Return the cache_control payload for one breakpoint marker."""
     cache_control: dict[str, str] = {"type": "ephemeral"}

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -53,8 +53,10 @@ from __future__ import annotations
 import asyncio
 from typing import TYPE_CHECKING, Any, cast
 
+from mindroom.background_tasks import run_blocking_until_complete, run_coroutine_until_complete
 from mindroom.hooks.enrichment import is_transient_context
 from mindroom.llm_request_logging import record_llm_request_tools
+from mindroom.logging_config import get_logger
 from mindroom.model_defaults import TOOL_SEARCH_UNSUPPORTED_MODEL_ID_PREFIXES
 from mindroom.model_instance_checks import isinstance_of_loaded
 
@@ -100,6 +102,7 @@ def native_tool_search_supported(provider: str, model_id: str) -> bool:
 
 _ANTHROPIC_CLAUDE_CLASS = ("agno.models.anthropic.claude", "Claude")
 _BEDROCK_CLAUDE_CLASS = ("mindroom.bedrock_claude", "MindRoomBedrockClaude")
+logger = get_logger(__name__)
 
 
 def as_anthropic_claude(model: object) -> AnthropicClaude | None:
@@ -115,7 +118,7 @@ def as_anthropic_claude(model: object) -> AnthropicClaude | None:
 
 
 def _is_session_backed_bedrock_claude(model: object) -> bool:
-    """Return whether a Bedrock model will not retain a prewarmed client."""
+    """Return whether a Bedrock model refreshes credentials from a session."""
     if not isinstance_of_loaded(model, _BEDROCK_CLAUDE_CLASS):
         return False
     return cast("MindRoomBedrockClaude", model).session is not None
@@ -124,19 +127,50 @@ def _is_session_backed_bedrock_claude(model: object) -> bool:
 def prewarm_anthropic_async_client(model: object) -> None:
     """Build and cache a Claude async SDK client without making a request."""
     claude_model = as_anthropic_claude(model)
-    if claude_model is None or _is_session_backed_bedrock_claude(claude_model):
+    if claude_model is None:
         return
-    claude_model.get_async_client()
+    try:
+        claude_model.get_async_client()
+    except Exception:
+        async_client, claude_model.async_client = claude_model.async_client, None
+        if async_client is not None:
+            try:
+                asyncio.run(async_client.close())
+            except Exception:
+                logger.exception("Failed to close partially initialized Claude async client")
+        raise
 
 
 async def aclose_anthropic_async_client(model: object) -> None:
     """Close and clear a retained Claude async SDK client, if present."""
     claude_model = as_anthropic_claude(model)
-    if claude_model is None or _is_session_backed_bedrock_claude(claude_model):
+    if claude_model is None:
         return
     async_client, claude_model.async_client = claude_model.async_client, None
     if async_client is not None:
         await async_client.close()
+
+
+async def arefresh_session_backed_bedrock_async_client(model: object) -> None:
+    """Refresh one retained session-backed client between serialized turns."""
+    if not _is_session_backed_bedrock_claude(model):
+        return
+    claude_model = cast("MindRoomBedrockClaude", model)
+    previous_client = claude_model.async_client
+
+    def replace_client() -> None:
+        claude_model.async_client = None
+        try:
+            prewarm_anthropic_async_client(claude_model)
+        except BaseException:
+            claude_model.async_client = previous_client
+            raise
+
+    try:
+        await run_blocking_until_complete(replace_client)
+    finally:
+        if previous_client is not None and claude_model.async_client is not previous_client:
+            await run_coroutine_until_complete(previous_client.close())
 
 
 def _prompt_cache_control(*, extended_cache_time: bool = False) -> dict[str, str]:

--- a/src/mindroom/claude_prompt_cache.py
+++ b/src/mindroom/claude_prompt_cache.py
@@ -129,6 +129,16 @@ def prewarm_anthropic_async_client(model: object) -> None:
     claude_model.get_async_client()
 
 
+async def aclose_anthropic_async_client(model: object) -> None:
+    """Close and clear a retained Claude async SDK client, if present."""
+    claude_model = as_anthropic_claude(model)
+    if claude_model is None or _is_session_backed_bedrock_claude(claude_model):
+        return
+    async_client, claude_model.async_client = claude_model.async_client, None
+    if async_client is not None:
+        await async_client.close()
+
+
 def _prompt_cache_control(*, extended_cache_time: bool = False) -> dict[str, str]:
     """Return the cache_control payload for one breakpoint marker."""
     cache_control: dict[str, str] = {"type": "ephemeral"}

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -34,6 +34,7 @@ from agno.tools.function import Function, FunctionCall
 
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agents import create_agent
+from mindroom.claude_prompt_cache import prewarm_anthropic_async_client
 from mindroom.history.interrupted_replay import persist_interrupted_replay
 from mindroom.history.runtime import (
     close_agent_runtime_state_dbs,
@@ -292,7 +293,7 @@ class _CallAgentCache:
             execution_identity=self.execution_identity,
         )
         try:
-            return create_agent(
+            agent = create_agent(
                 self.agent_name,
                 self.config,
                 self.runtime_paths,
@@ -308,9 +309,12 @@ class _CallAgentCache:
                 dynamic_tool_continuation=True,
                 eager_deferred_tools=True,
             )
+            prewarm_anthropic_async_client(getattr(agent, "model", None))
         except Exception:
             history_storage.close()
             raise
+        else:
+            return agent
 
 
 async def build_call_tools(

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -34,6 +34,7 @@ from agno.tools.function import Function, FunctionCall
 
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agents import create_agent
+from mindroom.background_tasks import run_blocking_until_complete, run_coroutine_until_complete
 from mindroom.claude_prompt_cache import aclose_anthropic_async_client, prewarm_anthropic_async_client
 from mindroom.history.interrupted_replay import persist_interrupted_replay
 from mindroom.history.runtime import (
@@ -255,10 +256,14 @@ class _CallAgentCache:
     @staticmethod
     async def _close_agent(agent: AgnoAgent) -> None:
         """Release one cached agent's async client and runtime databases."""
-        try:
-            await aclose_anthropic_async_client(agent.model)
-        finally:
-            await asyncio.to_thread(close_agent_runtime_state_dbs, agent)
+
+        async def release() -> None:
+            try:
+                await aclose_anthropic_async_client(agent.model)
+            finally:
+                await run_blocking_until_complete(close_agent_runtime_state_dbs, agent)
+
+        await run_coroutine_until_complete(release())
 
     async def _get_agent(
         self,

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -309,7 +309,7 @@ class _CallAgentCache:
                 dynamic_tool_continuation=True,
                 eager_deferred_tools=True,
             )
-            prewarm_anthropic_async_client(getattr(agent, "model", None))
+            prewarm_anthropic_async_client(agent.model)
         except Exception:
             history_storage.close()
             raise

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -34,8 +34,15 @@ from agno.tools.function import Function, FunctionCall
 
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agents import create_agent
-from mindroom.background_tasks import run_blocking_until_complete, run_coroutine_until_complete
-from mindroom.claude_prompt_cache import aclose_anthropic_async_client, prewarm_anthropic_async_client
+from mindroom.background_tasks import (
+    run_blocking_until_complete,
+    run_coroutine_until_complete,
+    wait_for_future_until_complete,
+)
+from mindroom.claude_prompt_cache import (
+    aclose_anthropic_async_client,
+    arefresh_session_backed_bedrock_async_client,
+)
 from mindroom.history.interrupted_replay import persist_interrupted_replay
 from mindroom.history.runtime import (
     close_agent_runtime_state_dbs,
@@ -48,6 +55,7 @@ from mindroom.hooks import EnrichmentItem
 from mindroom.knowledge.utils import knowledge_runtime_identity, resolve_agent_knowledge_access
 from mindroom.logging_config import get_logger
 from mindroom.message_target import MessageTarget
+from mindroom.pre_model_preparation import prewarm_agent_model_client
 from mindroom.session_ids import create_session_id
 from mindroom.tool_approval import tool_may_require_approval
 from mindroom.tool_system.declarations import (
@@ -237,12 +245,31 @@ class _CallAgentCache:
     ) -> str:
         """Run one turn, rebuilding only when call dependencies change identity."""
         async with self.lock:
+            reusing_agent = self._can_reuse_agent(
+                knowledge_identity=knowledge_identity,
+                refresh_scheduler=refresh_scheduler,
+            )
             agent = await self._get_agent(
                 knowledge=knowledge,
                 knowledge_identity=knowledge_identity,
                 refresh_scheduler=refresh_scheduler,
             )
+            if reusing_agent:
+                await arefresh_session_backed_bedrock_async_client(agent.model)
             return await operation(agent)
+
+    def _can_reuse_agent(
+        self,
+        *,
+        knowledge_identity: tuple[int, ...],
+        refresh_scheduler: KnowledgeRefreshScheduler | None,
+    ) -> bool:
+        """Return whether the cached agent matches this turn's dependencies."""
+        return (
+            self.agent is not None
+            and self.knowledge_identity == knowledge_identity
+            and self.refresh_scheduler is refresh_scheduler
+        )
 
     async def aclose(self) -> None:
         """Close the cached agent's caller-owned runtime state."""
@@ -272,22 +299,30 @@ class _CallAgentCache:
         knowledge_identity: tuple[int, ...],
         refresh_scheduler: KnowledgeRefreshScheduler | None,
     ) -> AgnoAgent:
-        if (
-            self.agent is not None
-            and self.knowledge_identity == knowledge_identity
-            and self.refresh_scheduler is refresh_scheduler
+        if self._can_reuse_agent(
+            knowledge_identity=knowledge_identity,
+            refresh_scheduler=refresh_scheduler,
         ):
+            assert self.agent is not None
             return self.agent
         if self.agent is not None:
             agent, self.agent = self.agent, None
             self.knowledge_identity = ()
             self.refresh_scheduler = None
             await self._close_agent(agent)
-        agent = await asyncio.to_thread(
-            self._build_agent,
-            knowledge=knowledge,
-            refresh_scheduler=refresh_scheduler,
+        build_task = asyncio.create_task(
+            asyncio.to_thread(
+                self._build_agent,
+                knowledge=knowledge,
+                refresh_scheduler=refresh_scheduler,
+            ),
         )
+        try:
+            agent = await wait_for_future_until_complete(build_task)
+        except asyncio.CancelledError:
+            if not build_task.cancelled() and build_task.exception() is None:
+                await self._close_agent(build_task.result())
+            raise
         self.agent = agent
         self.knowledge_identity = knowledge_identity
         self.refresh_scheduler = refresh_scheduler
@@ -307,6 +342,7 @@ class _CallAgentCache:
             runtime_paths=self.runtime_paths,
             execution_identity=self.execution_identity,
         )
+        agent: AgnoAgent | None = None
         try:
             agent = create_agent(
                 self.agent_name,
@@ -324,7 +360,7 @@ class _CallAgentCache:
                 dynamic_tool_continuation=True,
                 eager_deferred_tools=True,
             )
-            prewarm_anthropic_async_client(agent.model)
+            prewarm_agent_model_client(agent, history_storage)
         except Exception:
             history_storage.close()
             raise

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -34,7 +34,7 @@ from agno.tools.function import Function, FunctionCall
 
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.agents import create_agent
-from mindroom.claude_prompt_cache import prewarm_anthropic_async_client
+from mindroom.claude_prompt_cache import aclose_anthropic_async_client, prewarm_anthropic_async_client
 from mindroom.history.interrupted_replay import persist_interrupted_replay
 from mindroom.history.runtime import (
     close_agent_runtime_state_dbs,
@@ -250,7 +250,15 @@ class _CallAgentCache:
             self.knowledge_identity = ()
             self.refresh_scheduler = None
             if agent is not None:
-                await asyncio.to_thread(close_agent_runtime_state_dbs, agent)
+                await self._close_agent(agent)
+
+    @staticmethod
+    async def _close_agent(agent: AgnoAgent) -> None:
+        """Release one cached agent's async client and runtime databases."""
+        try:
+            await aclose_anthropic_async_client(agent.model)
+        finally:
+            await asyncio.to_thread(close_agent_runtime_state_dbs, agent)
 
     async def _get_agent(
         self,
@@ -266,8 +274,10 @@ class _CallAgentCache:
         ):
             return self.agent
         if self.agent is not None:
-            await asyncio.to_thread(close_agent_runtime_state_dbs, self.agent)
-            self.agent = None
+            agent, self.agent = self.agent, None
+            self.knowledge_identity = ()
+            self.refresh_scheduler = None
+            await self._close_agent(agent)
         agent = await asyncio.to_thread(
             self._build_agent,
             knowledge=knowledge,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -21,7 +21,7 @@ from mindroom.agents import ensure_default_agent_workspaces
 from mindroom.approval_transport import ApprovalMatrixTransport
 from mindroom.attachments import wait_for_attachment_cleanup_tasks
 from mindroom.authorization import is_authorized_sender
-from mindroom.background_tasks import create_background_task, wait_for_background_tasks
+from mindroom.background_tasks import create_background_task, run_blocking_until_complete, wait_for_background_tasks
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.embedder_health import check_embedder_health, handle_embedder_config_reload
 from mindroom.entity_resolution import (
@@ -2663,7 +2663,7 @@ async def main(
 
         # Credential synchronization and storage setup are synchronous. Keep the
         # ordered unit off-loop while retaining exception propagation to startup.
-        await asyncio.to_thread(_sync_credentials_and_prepare_storage, runtime_paths, storage_path)
+        await run_blocking_until_complete(_sync_credentials_and_prepare_storage, runtime_paths, storage_path)
 
         logger.info("Starting orchestrator...")
         orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths, api_enabled=api)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2626,6 +2626,13 @@ async def _wait_for_runtime_shutdown_cleanup(
             return
 
 
+def _sync_credentials_and_prepare_storage(runtime_paths: RuntimePaths, storage_path: Path) -> None:
+    """Complete the synchronous startup setup that must precede runtime construction."""
+    logger.info("Syncing API keys from environment to CredentialsManager...")
+    sync_env_to_credentials(runtime_paths=runtime_paths)
+    storage_path.mkdir(parents=True, exist_ok=True)
+
+
 async def main(
     log_level: str,
     runtime_paths: RuntimePaths,
@@ -2654,11 +2661,9 @@ async def main(
 
         stall_detector = start_event_loop_stall_detector(runtime_paths)
 
-        logger.info("Syncing API keys from environment to CredentialsManager...")
-        sync_env_to_credentials(runtime_paths=runtime_paths)
-
-        # Ensure storage exists before any runtime components try to write into it.
-        storage_path.mkdir(parents=True, exist_ok=True)
+        # Credential synchronization and storage setup are synchronous. Keep the
+        # ordered unit off-loop while retaining exception propagation to startup.
+        await asyncio.to_thread(_sync_credentials_and_prepare_storage, runtime_paths, storage_path)
 
         logger.info("Starting orchestrator...")
         orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths, api_enabled=api)

--- a/src/mindroom/pre_model_preparation.py
+++ b/src/mindroom/pre_model_preparation.py
@@ -7,7 +7,7 @@ import contextvars
 from typing import TYPE_CHECKING
 
 from mindroom.background_tasks import run_coroutine_until_complete
-from mindroom.claude_prompt_cache import aclose_anthropic_async_client
+from mindroom.claude_prompt_cache import aclose_anthropic_async_client, prewarm_anthropic_async_client
 from mindroom.history.runtime import close_agent_runtime_state_dbs
 from mindroom.logging_config import get_logger
 
@@ -36,6 +36,15 @@ def _log_secondary_agent_error(agent_name: str, error: Exception) -> None:
         agent=agent_name,
         error=repr(error),
     )
+
+
+def prewarm_agent_model_client(agent: Agent, shared_scope_storage: BaseDb | None) -> None:
+    """Prewarm one built agent or reclaim its runtime state on failure."""
+    try:
+        prewarm_anthropic_async_client(agent.model)
+    except Exception:
+        close_agent_runtime_state_dbs(agent, shared_scope_storage=shared_scope_storage)
+        raise
 
 
 async def close_unreturned_agent(

--- a/src/mindroom/pre_model_preparation.py
+++ b/src/mindroom/pre_model_preparation.py
@@ -6,6 +6,8 @@ import asyncio
 import contextvars
 from typing import TYPE_CHECKING
 
+from mindroom.background_tasks import run_coroutine_until_complete
+from mindroom.claude_prompt_cache import aclose_anthropic_async_client
 from mindroom.history.runtime import close_agent_runtime_state_dbs
 from mindroom.logging_config import get_logger
 
@@ -36,17 +38,30 @@ def _log_secondary_agent_error(agent_name: str, error: Exception) -> None:
     )
 
 
-def _close_unreturned_agent(
+async def close_unreturned_agent(
     agent: Agent,
     shared_scope_storage: BaseDb | None,
     caller_owned_agent: Agent | None,
 ) -> None:
+    """Close every resource owned by an agent that preparation cannot return."""
     if agent is caller_owned_agent:
         return
-    try:
-        close_agent_runtime_state_dbs(agent, shared_scope_storage=shared_scope_storage)
-    except Exception:
-        logger.exception("Failed to close unreturned agent runtime state", agent=agent.id)
+
+    async def close_resources() -> None:
+        try:
+            await asyncio.to_thread(
+                close_agent_runtime_state_dbs,
+                agent,
+                shared_scope_storage=shared_scope_storage,
+            )
+        except Exception:
+            logger.exception("Failed to close unreturned agent runtime state", agent=agent.id)
+        try:
+            await aclose_anthropic_async_client(agent.model)
+        except Exception:
+            logger.exception("Failed to close unreturned agent model client", agent=agent.id)
+
+    await run_coroutine_until_complete(close_resources())
 
 
 async def _drain_unreturned_agent_build(
@@ -71,10 +86,10 @@ async def _drain_unreturned_agent_build(
     except Exception as error:
         _log_secondary_agent_error(agent_name, error)
     else:
-        _close_unreturned_agent(unreturned_agent, shared_scope_storage, caller_owned_agent)
+        await close_unreturned_agent(unreturned_agent, shared_scope_storage, caller_owned_agent)
 
 
-def _discard_unreturned_agent_result(
+async def _discard_unreturned_agent_result(
     result: tuple[ResolvedRuntimeModel, Agent] | Exception,
     *,
     agent_name: str,
@@ -85,7 +100,29 @@ def _discard_unreturned_agent_result(
     if isinstance(result, Exception):
         _log_secondary_agent_error(agent_name, result)
     else:
-        _close_unreturned_agent(result[1], shared_scope_storage, caller_owned_agent)
+        await close_unreturned_agent(result[1], shared_scope_storage, caller_owned_agent)
+
+
+async def build_agent_off_loop(
+    build_agent: Callable[[], tuple[ResolvedRuntimeModel, Agent]],
+    *,
+    agent_name: str,
+    shared_scope_storage: BaseDb | None,
+    caller_owned_agent: Agent | None = None,
+) -> tuple[ResolvedRuntimeModel, Agent]:
+    """Build one agent off-loop and reclaim a completed result after cancellation."""
+    context = contextvars.copy_context()
+    build_future = asyncio.get_running_loop().run_in_executor(None, context.run, build_agent)
+    try:
+        return await asyncio.shield(build_future)
+    except asyncio.CancelledError:
+        await _drain_unreturned_agent_build(
+            build_future,
+            agent_name=agent_name,
+            shared_scope_storage=shared_scope_storage,
+            caller_owned_agent=caller_owned_agent,
+        )
+        raise
 
 
 async def prepare_prompt_branches(
@@ -144,7 +181,7 @@ async def prepare_prompt_branches(
     try:
         memory_result = memory_task.result()
     except BaseException:
-        _discard_unreturned_agent_result(
+        await _discard_unreturned_agent_result(
             agent_result,
             agent_name=agent_name,
             shared_scope_storage=shared_scope_storage,
@@ -152,7 +189,7 @@ async def prepare_prompt_branches(
         )
         raise
     if isinstance(memory_result, Exception):
-        _discard_unreturned_agent_result(
+        await _discard_unreturned_agent_result(
             agent_result,
             agent_name=agent_name,
             shared_scope_storage=shared_scope_storage,

--- a/tach.toml
+++ b/tach.toml
@@ -354,7 +354,10 @@ depends_on = [
     "mindroom.history.runtime",
     "mindroom.logging_config",
 ]
-visibility = ["mindroom.ai"]
+visibility = [
+    "mindroom.ai",
+    "mindroom.matrix_rtc.call_tools",
+]
 
 # The shared response-turn drivers own the turn lifecycle for both the agent
 # and (after adoption) team envelopes; entity modules inject adapters.
@@ -2876,6 +2879,7 @@ depends_on = [
     "mindroom.knowledge.utils",
     "mindroom.logging_config",
     "mindroom.message_target",
+    "mindroom.pre_model_preparation",
     "mindroom.session_ids",
     "mindroom.tool_approval",
     "mindroom.tool_system.declarations",

--- a/tests/api/test_lifespan.py
+++ b/tests/api/test_lifespan.py
@@ -1,0 +1,54 @@
+"""Tests for API process lifecycle work."""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi import FastAPI
+
+from mindroom import constants
+from mindroom.api import config_lifecycle, main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_api_lifespan_syncs_credentials_off_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Credential filesystem work should run outside the API event loop."""
+    runtime_paths = constants.resolve_primary_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "data",
+        process_env={},
+    )
+    api_app = FastAPI()
+    main.initialize_api_app(api_app, runtime_paths)
+    config_lifecycle.app_state(api_app).orchestrator_knowledge_refresh_scheduler = object()  # type: ignore[assignment]
+    event_loop_thread = threading.get_ident()
+    credential_sync_thread: int | None = None
+
+    def _sync_credentials(runtime_paths: constants.RuntimePaths) -> None:
+        nonlocal credential_sync_thread
+        assert runtime_paths is main._app_runtime_paths(api_app)
+        credential_sync_thread = threading.get_ident()
+
+    async def _no_op_async(*_args: object, **_kwargs: object) -> None:
+        return None
+
+    monkeypatch.setattr(constants, "ensure_writable_config_path", lambda **_kwargs: None)
+    monkeypatch.setattr(config_lifecycle, "load_config_into_app", lambda *_args: True)
+    monkeypatch.setattr(main, "sync_env_to_credentials", _sync_credentials)
+    monkeypatch.setattr(main, "_sync_standalone_knowledge_watchers", _no_op_async)
+    monkeypatch.setattr(main, "_watch_config", _no_op_async)
+    monkeypatch.setattr(main, "_worker_cleanup_loop", _no_op_async)
+
+    async with main._lifespan(api_app):
+        pass
+
+    assert credential_sync_thread is not None
+    assert credential_sync_thread != event_loop_thread

--- a/tests/test_ai_client_lifecycle.py
+++ b/tests/test_ai_client_lifecycle.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from agno.models.message import Message
 
 from mindroom import ai
+from mindroom.history.types import PreparedHistoryState
+from tests.conftest import make_turn_context, test_runtime_paths
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from mindroom.constants import RuntimePaths
 
 
@@ -110,3 +115,53 @@ async def test_reusable_agent_turn_does_not_close_shared_client(
     await _callbacks(holder, retain_agent_runtime_state=True).finalize_attempt(None)
 
     close_client.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prepare_agent_run_context_closes_agent_when_metadata_assembly_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preparation owns the built agent until the full run context is returned."""
+    agent = cast("Any", SimpleNamespace(model=object()))
+    prepared_run = ai._PreparedAgentRun(
+        agent=agent,
+        messages=(Message(role="user", content="hello"),),
+        unseen_event_ids=[],
+        prepared_history=PreparedHistoryState(),
+        runtime_model_name="default",
+    )
+    preparation_error = RuntimeError("metadata assembly failed")
+    config = MagicMock()
+    config.get_prompt.side_effect = preparation_error
+    close_unreturned_agent = AsyncMock()
+    monkeypatch.setattr(ai, "_prepare_agent_and_prompt", AsyncMock(return_value=prepared_run))
+    monkeypatch.setattr(ai, "close_unreturned_agent", close_unreturned_agent)
+
+    with pytest.raises(RuntimeError) as raised:
+        await ai._prepare_agent_run_context(
+            make_turn_context("assistant"),
+            prompt="hello",
+            session_id="session-1",
+            runtime_paths=test_runtime_paths(tmp_path),
+            config=config,
+            scope_context=None,
+            thread_history=None,
+            knowledge=None,
+            include_interactive_questions=True,
+            tool_function_filter=None,
+            include_openai_compat_guidance=False,
+            execution_identity=None,
+            compaction_lifecycle=None,
+            delegation_depth=0,
+            refresh_scheduler=None,
+            model_prompt=None,
+            current_timestamp_ms=None,
+            current_event_id=None,
+            current_prompt_is_structured=False,
+            turn_recorder=None,
+            pipeline_timing=None,
+        )
+
+    assert raised.value is preparation_error
+    close_unreturned_agent.assert_awaited_once_with(agent, None, None)

--- a/tests/test_ai_client_lifecycle.py
+++ b/tests/test_ai_client_lifecycle.py
@@ -1,0 +1,112 @@
+"""Tests for per-turn async model-client ownership."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import TYPE_CHECKING, Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from mindroom import ai
+
+if TYPE_CHECKING:
+    from mindroom.constants import RuntimePaths
+
+
+def _callbacks(
+    holder: ai._AgentTurnHolder,
+    *,
+    retain_agent_runtime_state: bool = False,
+) -> ai._AgentTurnCallbacks:
+    return ai._build_agent_turn_callbacks(
+        holder,
+        agent_name="assistant",
+        prompt="hello",
+        current_prompt_is_structured=False,
+        session_id="session-1",
+        runtime_paths=cast("RuntimePaths", object()),
+        config=cast("Any", object()),
+        execution_identity=None,
+        retain_agent_runtime_state=retain_agent_runtime_state,
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_turn_finalizer_closes_live_final_attempt_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A final attempt should close its prewarmed client before returning."""
+    model = object()
+    holder = ai._AgentTurnHolder(agent=cast("Any", SimpleNamespace(model=model)))
+    close_client = AsyncMock()
+    monkeypatch.setattr(ai, "aclose_anthropic_async_client", close_client)
+
+    await _callbacks(holder).finalize_attempt(None)
+
+    close_client.assert_awaited_once_with(model)
+
+
+@pytest.mark.asyncio
+async def test_agent_turn_finalizer_closes_released_continuation_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Releasing an attempt should retain its model until async finalization."""
+    model = object()
+    holder = ai._AgentTurnHolder(agent=cast("Any", SimpleNamespace(model=model)))
+    close_client = AsyncMock()
+    monkeypatch.setattr(ai, "aclose_anthropic_async_client", close_client)
+    monkeypatch.setattr(ai, "close_agent_runtime_state_dbs", lambda *_args, **_kwargs: None)
+    callbacks = _callbacks(holder)
+
+    callbacks.release_attempt_entity(None)
+    assert holder.agent is None
+    await callbacks.finalize_attempt(None)
+
+    close_client.assert_awaited_once_with(model)
+
+
+@pytest.mark.asyncio
+async def test_agent_turn_client_close_drains_before_cancellation_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation should wait for an accepted client close to finish."""
+    model = object()
+    holder = ai._AgentTurnHolder(agent=cast("Any", SimpleNamespace(model=model)))
+    close_started = asyncio.Event()
+    allow_close = asyncio.Event()
+    close_finished = asyncio.Event()
+
+    async def _close_client(_model: object) -> None:
+        close_started.set()
+        await allow_close.wait()
+        close_finished.set()
+
+    monkeypatch.setattr(ai, "aclose_anthropic_async_client", _close_client)
+    task = asyncio.create_task(_callbacks(holder).finalize_attempt(None))
+    await close_started.wait()
+
+    task.cancel()
+    await asyncio.sleep(0)
+    assert not task.done()
+
+    allow_close.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert close_finished.is_set()
+
+
+@pytest.mark.asyncio
+async def test_reusable_agent_turn_does_not_close_shared_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A caller-owned reusable agent should retain its async client."""
+    model = object()
+    holder = ai._AgentTurnHolder(agent=cast("Any", SimpleNamespace(model=model)))
+    close_client = AsyncMock()
+    monkeypatch.setattr(ai, "aclose_anthropic_async_client", close_client)
+
+    await _callbacks(holder, retain_agent_runtime_state=True).finalize_attempt(None)
+
+    close_client.assert_not_awaited()

--- a/tests/test_event_loop_offloading.py
+++ b/tests/test_event_loop_offloading.py
@@ -14,6 +14,7 @@ from agno.models.message import Message
 
 import mindroom.ai as ai_module
 import mindroom.memory._file_backend as file_backend_module
+import mindroom.pre_model_preparation as pre_model_preparation_module
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.constants import resolve_runtime_paths
@@ -279,6 +280,99 @@ async def test_prepare_agent_and_prompt_keeps_cold_default_workspace_serial(
     assert prepare_history.await_args.kwargs["resolved_runtime_model"].model_name == "default"
     assert pipeline_timing.metadata["prompt_branches_parallel"] is False
     assert pipeline_timing.metadata["prompt_branches_serial_reason"] == "default_workspace_scaffold_pending"
+
+
+@pytest.mark.asyncio
+async def test_prepare_agent_and_prompt_closes_built_agent_when_history_preparation_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A built per-turn agent must be closed when later preparation fails."""
+    built_agent = MagicMock()
+    built_agent.additional_context = ""
+    close_runtime = MagicMock()
+    close_client = AsyncMock()
+    preparation_error = RuntimeError("history preparation failed")
+
+    monkeypatch.setattr(ai_module, "build_memory_prompt_parts", AsyncMock(return_value=MemoryPromptParts()))
+    monkeypatch.setattr(ai_module, "create_agent", MagicMock(return_value=built_agent))
+    monkeypatch.setattr(
+        ai_module,
+        "prepare_agent_execution_context",
+        AsyncMock(side_effect=preparation_error),
+    )
+    monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_runtime)
+    monkeypatch.setattr(
+        pre_model_preparation_module,
+        "aclose_anthropic_async_client",
+        close_client,
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError) as raised:
+        await ai_module._prepare_agent_and_prompt(
+            make_turn_context("general"),
+            prompt="hello",
+            runtime_paths=test_runtime_paths(tmp_path),
+            config=_prompt_preparation_config(),
+        )
+
+    assert raised.value is preparation_error
+    close_runtime.assert_called_once_with(built_agent, shared_scope_storage=None)
+    close_client.assert_awaited_once_with(built_agent.model)
+
+
+@pytest.mark.asyncio
+async def test_serial_agent_build_cancellation_drains_and_closes_result(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation must wait for a serial build and close its unreturned agent."""
+    build_started = threading.Event()
+    release_build = threading.Event()
+    built_agent = MagicMock()
+    built_agent.additional_context = ""
+    close_runtime = MagicMock()
+    close_client = AsyncMock()
+
+    def blocked_create_agent(*_args: object, **_kwargs: object) -> MagicMock:
+        build_started.set()
+        assert release_build.wait(timeout=5)
+        return built_agent
+
+    monkeypatch.setattr(ai_module, "build_memory_prompt_parts", AsyncMock(return_value=MemoryPromptParts()))
+    monkeypatch.setattr(ai_module, "create_agent", blocked_create_agent)
+    monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_runtime)
+    monkeypatch.setattr(
+        pre_model_preparation_module,
+        "aclose_anthropic_async_client",
+        close_client,
+        raising=False,
+    )
+
+    task = asyncio.create_task(
+        ai_module._prepare_agent_and_prompt(
+            make_turn_context("general"),
+            prompt="hello",
+            runtime_paths=test_runtime_paths(tmp_path),
+            config=_prompt_preparation_config("file"),
+        ),
+    )
+    try:
+        assert await asyncio.to_thread(build_started.wait, 5)
+        task.cancel()
+        await asyncio.sleep(0)
+        assert not task.done()
+
+        release_build.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    finally:
+        release_build.set()
+        await asyncio.gather(task, return_exceptions=True)
+
+    close_runtime.assert_called_once_with(built_agent, shared_scope_storage=None)
+    close_client.assert_awaited_once_with(built_agent.model)
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_loop_offloading.py
+++ b/tests/test_event_loop_offloading.py
@@ -323,6 +323,35 @@ async def test_prepare_agent_and_prompt_closes_built_agent_when_history_preparat
 
 
 @pytest.mark.asyncio
+async def test_prepare_agent_and_prompt_closes_built_agent_when_prewarm_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed client prewarm must reclaim the agent built in the worker."""
+    built_agent = MagicMock()
+    close_runtime = MagicMock()
+
+    monkeypatch.setattr(ai_module, "build_memory_prompt_parts", AsyncMock(return_value=MemoryPromptParts()))
+    monkeypatch.setattr(ai_module, "create_agent", MagicMock(return_value=built_agent))
+    monkeypatch.setattr(
+        pre_model_preparation_module,
+        "prewarm_anthropic_async_client",
+        MagicMock(side_effect=RuntimeError("prewarm failed")),
+    )
+    monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_runtime)
+
+    with pytest.raises(RuntimeError, match="prewarm failed"):
+        await ai_module._prepare_agent_and_prompt(
+            make_turn_context("general"),
+            prompt="hello",
+            runtime_paths=test_runtime_paths(tmp_path),
+            config=_prompt_preparation_config(),
+        )
+
+    close_runtime.assert_called_once_with(built_agent, shared_scope_storage=None)
+
+
+@pytest.mark.asyncio
 async def test_serial_agent_build_cancellation_drains_and_closes_result(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_event_loop_offloading.py
+++ b/tests/test_event_loop_offloading.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from agno.models.anthropic import Claude
 from agno.models.message import Message
 
 import mindroom.ai as ai_module
@@ -94,6 +95,55 @@ async def test_prepare_agent_and_prompt_builds_agent_off_event_loop(
     gate.set()
     prepared_run = await prepare_task
     assert prepared_run.agent is built_agent
+
+
+@pytest.mark.asyncio
+async def test_prepare_agent_and_prompt_prewarms_anthropic_async_client_off_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first Anthropic async request must reuse a client built during agent construction."""
+    model = Claude(id="claude-sonnet-4-6", api_key="test-key")
+    client_build_thread_ids: list[int] = []
+    event_loop_thread_id = threading.get_ident()
+    built_agent = MagicMock()
+    built_agent.model = model
+    built_agent.additional_context = ""
+
+    def _build_async_client() -> object:
+        client_build_thread_ids.append(threading.get_ident())
+        return object()
+
+    vars(model)["get_async_client"] = _build_async_client
+    monkeypatch.setattr(ai_module, "create_agent", lambda *_args, **_kwargs: built_agent)
+    monkeypatch.setattr(
+        ai_module,
+        "build_memory_prompt_parts",
+        AsyncMock(return_value=MemoryPromptParts()),
+    )
+    monkeypatch.setattr(
+        ai_module,
+        "prepare_agent_execution_context",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                prepared_history=PreparedHistoryState(),
+                replay_plan=None,
+                unseen_event_ids=(),
+                messages=[],
+            ),
+        ),
+    )
+
+    prepared_run = await ai_module._prepare_agent_and_prompt(
+        make_turn_context("general"),
+        prompt="hello",
+        runtime_paths=test_runtime_paths(tmp_path),
+        config=Config.model_validate({"agents": {"general": {"display_name": "General", "role": "test"}}}),
+    )
+
+    assert prepared_run.agent is built_agent
+    assert len(client_build_thread_ids) == 1
+    assert client_build_thread_ids[0] != event_loop_thread_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_loop_offloading.py
+++ b/tests/test_event_loop_offloading.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from agno.models.anthropic import Claude
 from agno.models.message import Message
 
 import mindroom.ai as ai_module
@@ -95,55 +94,6 @@ async def test_prepare_agent_and_prompt_builds_agent_off_event_loop(
     gate.set()
     prepared_run = await prepare_task
     assert prepared_run.agent is built_agent
-
-
-@pytest.mark.asyncio
-async def test_prepare_agent_and_prompt_prewarms_anthropic_async_client_off_event_loop(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """The first Anthropic async request must reuse a client built during agent construction."""
-    model = Claude(id="claude-sonnet-4-6", api_key="test-key")
-    client_build_thread_ids: list[int] = []
-    event_loop_thread_id = threading.get_ident()
-    built_agent = MagicMock()
-    built_agent.model = model
-    built_agent.additional_context = ""
-
-    def _build_async_client() -> object:
-        client_build_thread_ids.append(threading.get_ident())
-        return object()
-
-    vars(model)["get_async_client"] = _build_async_client
-    monkeypatch.setattr(ai_module, "create_agent", lambda *_args, **_kwargs: built_agent)
-    monkeypatch.setattr(
-        ai_module,
-        "build_memory_prompt_parts",
-        AsyncMock(return_value=MemoryPromptParts()),
-    )
-    monkeypatch.setattr(
-        ai_module,
-        "prepare_agent_execution_context",
-        AsyncMock(
-            return_value=SimpleNamespace(
-                prepared_history=PreparedHistoryState(),
-                replay_plan=None,
-                unseen_event_ids=(),
-                messages=[],
-            ),
-        ),
-    )
-
-    prepared_run = await ai_module._prepare_agent_and_prompt(
-        make_turn_context("general"),
-        prompt="hello",
-        runtime_paths=test_runtime_paths(tmp_path),
-        config=Config.model_validate({"agents": {"general": {"display_name": "General", "role": "test"}}}),
-    )
-
-    assert prepared_run.agent is built_agent
-    assert len(client_build_thread_ids) == 1
-    assert client_build_thread_ids[0] != event_loop_thread_id
 
 
 @pytest.mark.asyncio

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -25,6 +25,7 @@ from agno.utils.models.claude import format_messages
 from anthropic import AsyncAnthropic
 from anthropic.types import Message as AnthropicMessage
 
+import mindroom.bedrock_claude as bedrock_claude_module
 from mindroom.bedrock_claude import MindRoomBedrockClaude
 from mindroom.claude_prompt_cache import (
     _DEFERRED_TOOL_NAMES_ATTR,
@@ -472,25 +473,37 @@ def test_bedrock_claude_provider_uses_runtime_env() -> None:
     assert model.extended_cache_time is True
 
 
-def test_prewarm_anthropic_async_client_skips_session_backed_client() -> None:
-    """Session-backed clients cannot retain an SDK client for a later async request."""
+def test_session_backed_bedrock_async_client_is_retained(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A session-backed model must reuse the client built before its request."""
     model = MindRoomBedrockClaude(
         id="anthropic.claude-opus-5",
         aws_region="us-east-1",
         session=object(),
     )
-    calls: list[None] = []
+    factory_calls: list[dict[str, object]] = []
 
-    def _unexpected_client_build() -> object:
-        calls.append(None)
-        msg = "session-backed clients must not be prewarmed"
-        raise AssertionError(msg)
+    class _FakeAsyncClient:
+        def is_closed(self) -> bool:
+            return False
 
-    vars(model)["get_async_client"] = _unexpected_client_build
+    built_client = _FakeAsyncClient()
 
-    prewarm_anthropic_async_client(model)
+    def _build_client(**kwargs: object) -> _FakeAsyncClient:
+        factory_calls.append(kwargs)
+        return built_client
 
-    assert calls == []
+    monkeypatch.setattr(bedrock_claude_module, "AsyncAnthropicBedrockMantle", _build_client)
+    vars(model)["_get_client_params"] = dict
+
+    first_client = model.get_async_client()
+    second_client = model.get_async_client()
+
+    assert first_client is built_client
+    assert second_client is built_client
+    assert model.async_client is built_client
+    assert factory_calls == [{}]
 
 
 def test_prewarm_anthropic_async_client_builds_cacheable_bedrock_client() -> None:
@@ -530,6 +543,58 @@ async def test_aclose_anthropic_async_client_closes_cacheable_bedrock_client() -
     model.async_client = _FakeAsyncClient()  # type: ignore[assignment]
 
     await aclose_anthropic_async_client(model)
+
+    assert closed is True
+    assert model.async_client is None
+
+
+@pytest.mark.asyncio
+async def test_aclose_anthropic_async_client_closes_session_backed_bedrock_client() -> None:
+    """A retained session-backed client must have the same deterministic owner."""
+    model = MindRoomBedrockClaude(
+        id="anthropic.claude-opus-5",
+        aws_region="us-east-1",
+        session=object(),
+    )
+    closed = False
+
+    class _FakeAsyncClient:
+        async def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    model.async_client = _FakeAsyncClient()  # type: ignore[assignment]
+
+    await aclose_anthropic_async_client(model)
+
+    assert closed is True
+    assert model.async_client is None
+
+
+def test_prewarm_anthropic_async_client_closes_partial_client_on_failure() -> None:
+    """A client retained before a failed prewarm must not lose its owner."""
+    model = MindRoomBedrockClaude(
+        id="anthropic.claude-opus-5",
+        aws_region="us-east-1",
+    )
+    closed = False
+
+    class _FakeAsyncClient:
+        async def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    partial_client = _FakeAsyncClient()
+
+    def _fail_after_retaining_client() -> object:
+        model.async_client = partial_client  # type: ignore[assignment]
+        msg = "client initialization failed"
+        raise RuntimeError(msg)
+
+    vars(model)["get_async_client"] = _fail_after_retaining_client
+
+    with pytest.raises(RuntimeError, match="client initialization failed"):
+        prewarm_anthropic_async_client(model)
 
     assert closed is True
     assert model.async_client is None

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -34,6 +34,7 @@ from mindroom.claude_prompt_cache import (
     _PromptCacheClientProxy,
     _request_kwargs_with_prompt_cache_ladder,
     _request_kwargs_with_replay_safe_tool_search_results,
+    aclose_anthropic_async_client,
     install_claude_deferred_tool_search,
     install_claude_prompt_cache_hook,
     native_tool_search_supported,
@@ -490,6 +491,48 @@ def test_prewarm_anthropic_async_client_skips_session_backed_client() -> None:
     prewarm_anthropic_async_client(model)
 
     assert calls == []
+
+
+def test_prewarm_anthropic_async_client_builds_cacheable_bedrock_client() -> None:
+    """A non-session Bedrock model should build its retained client off-loop."""
+    model = MindRoomBedrockClaude(
+        id="anthropic.claude-opus-5",
+        aws_region="us-east-1",
+    )
+    built_client = object()
+    calls: list[None] = []
+
+    def _build_client() -> object:
+        calls.append(None)
+        return built_client
+
+    vars(model)["get_async_client"] = _build_client
+
+    prewarm_anthropic_async_client(model)
+
+    assert calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_aclose_anthropic_async_client_closes_cacheable_bedrock_client() -> None:
+    """A retained non-session Bedrock client should be closed and detached."""
+    model = MindRoomBedrockClaude(
+        id="anthropic.claude-opus-5",
+        aws_region="us-east-1",
+    )
+    closed = False
+
+    class _FakeAsyncClient:
+        async def close(self) -> None:
+            nonlocal closed
+            closed = True
+
+    model.async_client = _FakeAsyncClient()  # type: ignore[assignment]
+
+    await aclose_anthropic_async_client(model)
+
+    assert closed is True
+    assert model.async_client is None
 
 
 def test_bedrock_claude_provider_respects_explicit_profile_over_env_static_keys(

--- a/tests/test_extra_kwargs.py
+++ b/tests/test_extra_kwargs.py
@@ -25,6 +25,7 @@ from agno.utils.models.claude import format_messages
 from anthropic import AsyncAnthropic
 from anthropic.types import Message as AnthropicMessage
 
+from mindroom.bedrock_claude import MindRoomBedrockClaude
 from mindroom.claude_prompt_cache import (
     _DEFERRED_TOOL_NAMES_ATTR,
     _MAX_CACHE_MARKERS,
@@ -36,6 +37,7 @@ from mindroom.claude_prompt_cache import (
     install_claude_deferred_tool_search,
     install_claude_prompt_cache_hook,
     native_tool_search_supported,
+    prewarm_anthropic_async_client,
 )
 from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
@@ -467,6 +469,27 @@ def test_bedrock_claude_provider_uses_runtime_env() -> None:
     assert model.aws_region == "us-east-1"
     assert model.cache_system_prompt is True
     assert model.extended_cache_time is True
+
+
+def test_prewarm_anthropic_async_client_skips_session_backed_client() -> None:
+    """Session-backed clients cannot retain an SDK client for a later async request."""
+    model = MindRoomBedrockClaude(
+        id="anthropic.claude-opus-5",
+        aws_region="us-east-1",
+        session=object(),
+    )
+    calls: list[None] = []
+
+    def _unexpected_client_build() -> object:
+        calls.append(None)
+        msg = "session-backed clients must not be prewarmed"
+        raise AssertionError(msg)
+
+    vars(model)["get_async_client"] = _unexpected_client_build
+
+    prewarm_anthropic_async_client(model)
+
+    assert calls == []
 
 
 def test_bedrock_claude_provider_respects_explicit_profile_over_env_static_keys(

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -201,7 +201,7 @@ async def test_call_agent_cache_prewarms_and_reuses_anthropic_async_client(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A cached call agent must initialize one reusable async client off the event loop."""
-    model = Claude(id="claude-sonnet-4-6", api_key="test-key")
+    model = Claude(id="claude-sonnet-5", api_key="test-key")
     install_claude_prompt_cache_hook(model)
     client_parameter_thread_ids: list[int] = []
     event_loop_thread_id = threading.get_ident()
@@ -242,6 +242,130 @@ async def test_call_agent_cache_prewarms_and_reuses_anthropic_async_client(
         async_client = vars(model).get("async_client")
         if async_client is not None:
             await async_client.close()
+
+
+@pytest.mark.asyncio
+async def test_call_agent_cache_closes_prewarmed_async_client_on_aclose(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closing a call cache must release the retained model connection pool."""
+    model = Claude(id="claude-sonnet-5", api_key="test-key")
+    agent = MagicMock(model=model)
+    close_agent_mock = MagicMock()
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_scope_session_storage", MagicMock())
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", MagicMock(return_value=agent))
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_agent_mock)
+    cache = _CallAgentCache(
+        agent_name=AGENT,
+        config=_config(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        context=SimpleNamespace(hook_registry=None, tool_function_filter=None),  # type: ignore[arg-type]
+        execution_identity=SimpleNamespace(),  # type: ignore[arg-type]
+        session_id="call-session",
+        active_model_name="default",
+    )
+
+    cached_agent = await cache._get_agent(
+        knowledge=None,
+        knowledge_identity=(),
+        refresh_scheduler=None,
+    )
+    async_client = vars(model)["async_client"]
+    try:
+        await cache.aclose()
+
+        assert async_client.is_closed()
+        assert model.async_client is None
+        close_agent_mock.assert_called_once_with(cached_agent)
+    finally:
+        if not async_client.is_closed():
+            await async_client.close()
+
+
+@pytest.mark.asyncio
+async def test_call_agent_cache_closes_prewarmed_async_client_on_replacement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Replacing a call agent must release the previous model connection pool."""
+    first_model = Claude(id="claude-sonnet-5", api_key="test-key")
+    second_model = Claude(id="claude-sonnet-5", api_key="test-key")
+    first_agent = MagicMock(model=first_model)
+    second_agent = MagicMock(model=second_model)
+    close_agent_mock = MagicMock()
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_scope_session_storage", MagicMock())
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.create_agent",
+        MagicMock(side_effect=(first_agent, second_agent)),
+    )
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_agent_mock)
+    cache = _CallAgentCache(
+        agent_name=AGENT,
+        config=_config(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        context=SimpleNamespace(hook_registry=None, tool_function_filter=None),  # type: ignore[arg-type]
+        execution_identity=SimpleNamespace(),  # type: ignore[arg-type]
+        session_id="call-session",
+        active_model_name="default",
+    )
+
+    await cache._get_agent(
+        knowledge=None,
+        knowledge_identity=(1,),
+        refresh_scheduler=None,
+    )
+    first_async_client = vars(first_model)["async_client"]
+    second_async_client = None
+    try:
+        await cache._get_agent(
+            knowledge=None,
+            knowledge_identity=(2,),
+            refresh_scheduler=None,
+        )
+        second_async_client = vars(second_model)["async_client"]
+
+        assert first_async_client.is_closed()
+        assert first_model.async_client is None
+        assert not second_async_client.is_closed()
+        close_agent_mock.assert_called_once_with(first_agent)
+    finally:
+        await cache.aclose()
+        for async_client in (first_async_client, second_async_client):
+            if async_client is not None and not async_client.is_closed():
+                await async_client.close()
+
+
+@pytest.mark.asyncio
+async def test_call_agent_cache_closes_runtime_dbs_when_async_client_close_is_cancelled(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Client-close cancellation must not skip the existing runtime DB cleanup."""
+    async_client = MagicMock()
+    async_client.is_closed.return_value = False
+    async_client.close = AsyncMock(side_effect=asyncio.CancelledError)
+    model = Claude(id="claude-sonnet-5", api_key="test-key", async_client=async_client)
+    agent = MagicMock(model=model)
+    close_agent_mock = MagicMock()
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_agent_mock)
+    cache = _CallAgentCache(
+        agent_name=AGENT,
+        config=_config(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        context=SimpleNamespace(hook_registry=None, tool_function_filter=None),  # type: ignore[arg-type]
+        execution_identity=SimpleNamespace(),  # type: ignore[arg-type]
+        session_id="call-session",
+        active_model_name="default",
+        agent=agent,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await cache.aclose()
+
+    async_client.close.assert_awaited_once_with()
+    close_agent_mock.assert_called_once_with(agent)
+    assert cache.agent is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -18,6 +18,7 @@ from agno.run.base import RunStatus
 from agno.tools.function import Function
 
 from mindroom.agent_knowledge_descriptions import KnowledgeToolDescribingAgent
+from mindroom.bedrock_claude import MindRoomBedrockClaude
 from mindroom.claude_prompt_cache import install_claude_prompt_cache_hook
 from mindroom.config.agent import AgentConfig
 from mindroom.config.approval import ApprovalRuleConfig, ToolApprovalConfig
@@ -193,6 +194,193 @@ def test_call_agent_cache_closes_history_storage_when_agent_build_fails(
         cache._build_agent(knowledge=None, refresh_scheduler=None)
 
     history_storage.close.assert_called_once_with()
+
+
+def test_call_agent_cache_closes_agent_runtime_when_prewarm_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A prewarm failure must reclaim the already-created cached agent."""
+    history_storage = MagicMock()
+    agent = MagicMock()
+    close_runtime = MagicMock()
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.create_scope_session_storage",
+        MagicMock(return_value=history_storage),
+    )
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.create_agent",
+        MagicMock(return_value=agent),
+    )
+    monkeypatch.setattr(
+        "mindroom.pre_model_preparation.prewarm_anthropic_async_client",
+        MagicMock(side_effect=RuntimeError("prewarm failed")),
+    )
+    monkeypatch.setattr(
+        "mindroom.pre_model_preparation.close_agent_runtime_state_dbs",
+        close_runtime,
+    )
+    cache = _CallAgentCache(
+        agent_name=AGENT,
+        config=_config(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        context=SimpleNamespace(hook_registry=None, tool_function_filter=None),  # type: ignore[arg-type]
+        execution_identity=SimpleNamespace(),  # type: ignore[arg-type]
+        session_id="call-session",
+        active_model_name="default",
+    )
+
+    with pytest.raises(RuntimeError, match="prewarm failed"):
+        cache._build_agent(knowledge=None, refresh_scheduler=None)
+
+    close_runtime.assert_called_once_with(agent, shared_scope_storage=history_storage)
+    history_storage.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_call_agent_cache_build_cancellation_reclaims_completed_agent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation must drain an accepted build and close its unreturned result."""
+    build_started = Event()
+    release_build = Event()
+    build_finished = Event()
+    history_storage = MagicMock()
+    agent = MagicMock(model=None)
+    close_client = AsyncMock()
+    close_runtime = MagicMock()
+
+    def _build_agent(*_args: object, **_kwargs: object) -> MagicMock:
+        build_started.set()
+        if not release_build.wait(timeout=5):
+            msg = "test did not release cached agent construction"
+            raise TimeoutError(msg)
+        build_finished.set()
+        return agent
+
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.create_scope_session_storage",
+        MagicMock(return_value=history_storage),
+    )
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", _build_agent)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.aclose_anthropic_async_client", close_client)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_runtime)
+    cache = _CallAgentCache(
+        agent_name=AGENT,
+        config=_config(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        context=SimpleNamespace(hook_registry=None, tool_function_filter=None),  # type: ignore[arg-type]
+        execution_identity=SimpleNamespace(),  # type: ignore[arg-type]
+        session_id="call-session",
+        active_model_name="default",
+    )
+
+    build_task = asyncio.create_task(
+        cache._get_agent(
+            knowledge=None,
+            knowledge_identity=(),
+            refresh_scheduler=None,
+        ),
+    )
+    try:
+        assert await asyncio.to_thread(build_started.wait, 5)
+        build_task.cancel()
+        await asyncio.sleep(0)
+        assert not build_task.done()
+
+        release_build.set()
+        with pytest.raises(asyncio.CancelledError):
+            await build_task
+    finally:
+        release_build.set()
+        assert await asyncio.to_thread(build_finished.wait, 5)
+        await asyncio.gather(build_task, return_exceptions=True)
+
+    assert cache.agent is None
+    close_client.assert_awaited_once_with(agent.model)
+    close_runtime.assert_called_once_with(agent)
+
+
+@pytest.mark.asyncio
+async def test_call_agent_cache_refreshes_session_client_before_reused_turn(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A long-lived call agent must refresh session credentials between turns."""
+    model = MindRoomBedrockClaude(
+        id="anthropic.claude-opus-5",
+        aws_region="us-east-1",
+        session=object(),
+    )
+    built_clients: list[_FakeSessionClient] = []
+
+    class _FakeSessionClient:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def is_closed(self) -> bool:
+            return self.closed
+
+        async def close(self) -> None:
+            self.closed = True
+
+    def _build_client(**_kwargs: object) -> _FakeSessionClient:
+        client = _FakeSessionClient()
+        built_clients.append(client)
+        return client
+
+    vars(model)["_get_client_params"] = dict
+    monkeypatch.setattr("mindroom.bedrock_claude.AsyncAnthropicBedrockMantle", _build_client)
+    agent = MagicMock(model=model)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_scope_session_storage", MagicMock())
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", MagicMock(return_value=agent))
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", MagicMock())
+    cache = _CallAgentCache(
+        agent_name=AGENT,
+        config=_config(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        context=SimpleNamespace(hook_registry=None, tool_function_filter=None),  # type: ignore[arg-type]
+        execution_identity=SimpleNamespace(),  # type: ignore[arg-type]
+        session_id="call-session",
+        active_model_name="default",
+    )
+    used_clients: list[_FakeSessionClient] = []
+
+    async def _use_client(cached_agent: object) -> str:
+        used_clients.append(cached_agent.model.get_async_client())  # type: ignore[attr-defined]
+        return "ok"
+
+    try:
+        assert (
+            await cache.run(
+                knowledge=None,
+                knowledge_identity=(),
+                refresh_scheduler=None,
+                operation=_use_client,
+            )
+            == "ok"
+        )
+        assert (
+            await cache.run(
+                knowledge=None,
+                knowledge_identity=(),
+                refresh_scheduler=None,
+                operation=_use_client,
+            )
+            == "ok"
+        )
+
+        assert used_clients == built_clients
+        assert len(built_clients) == 2
+        assert built_clients[0].closed is True
+        assert built_clients[1].closed is False
+        assert model.async_client is built_clients[1]
+    finally:
+        await cache.aclose()
+        for client in built_clients:
+            if not client.closed:
+                await client.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -369,6 +369,73 @@ async def test_call_agent_cache_closes_runtime_dbs_when_async_client_close_is_ca
 
 
 @pytest.mark.asyncio
+async def test_call_agent_cache_drains_cleanup_before_propagating_outer_cancellation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Accepted client and DB cleanup must finish before caller cancellation escapes."""
+    client_close_started = asyncio.Event()
+    allow_client_close = asyncio.Event()
+    client_close_finished = asyncio.Event()
+    db_close_started = Event()
+    allow_db_close = Event()
+    db_close_finished = Event()
+
+    async def close_client() -> None:
+        client_close_started.set()
+        await allow_client_close.wait()
+        client_close_finished.set()
+
+    def close_runtime_dbs(_agent: object) -> None:
+        db_close_started.set()
+        if not allow_db_close.wait(timeout=1):
+            msg = "test did not release runtime DB cleanup"
+            raise TimeoutError(msg)
+        db_close_finished.set()
+
+    async_client = MagicMock()
+    async_client.close = AsyncMock(side_effect=close_client)
+    model = Claude(id="claude-sonnet-5", api_key="test-key", async_client=async_client)
+    agent = MagicMock(model=model)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_runtime_dbs)
+    cache = _CallAgentCache(
+        agent_name=AGENT,
+        config=_config(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        context=SimpleNamespace(hook_registry=None, tool_function_filter=None),  # type: ignore[arg-type]
+        execution_identity=SimpleNamespace(),  # type: ignore[arg-type]
+        session_id="call-session",
+        active_model_name="default",
+        agent=agent,
+    )
+
+    close_task = asyncio.create_task(cache.aclose())
+    try:
+        await asyncio.wait_for(client_close_started.wait(), timeout=1)
+        close_task.cancel()
+        await asyncio.sleep(0)
+        assert not close_task.done()
+
+        allow_client_close.set()
+        assert await asyncio.to_thread(db_close_started.wait, 1)
+        assert not close_task.done()
+
+        allow_db_close.set()
+        with pytest.raises(asyncio.CancelledError):
+            await close_task
+
+        assert client_close_finished.is_set()
+        assert db_close_finished.is_set()
+    finally:
+        allow_client_close.set()
+        allow_db_close.set()
+        if not close_task.done():
+            close_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await close_task
+
+
+@pytest.mark.asyncio
 async def test_wrapped_tool_executes_sync_entrypoint_in_context() -> None:
     """Sync entrypoints run in a worker thread with the runtime context bound."""
     seen_context: list[object] = []

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 from contextlib import asynccontextmanager, nullcontext
 from threading import Event
 from types import SimpleNamespace
@@ -11,11 +12,13 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from agno.knowledge.knowledge import Knowledge
+from agno.models.anthropic import Claude
 from agno.models.metrics import Metrics
 from agno.run.base import RunStatus
 from agno.tools.function import Function
 
 from mindroom.agent_knowledge_descriptions import KnowledgeToolDescribingAgent
+from mindroom.claude_prompt_cache import install_claude_prompt_cache_hook
 from mindroom.config.agent import AgentConfig
 from mindroom.config.approval import ApprovalRuleConfig, ToolApprovalConfig
 from mindroom.config.main import Config
@@ -190,6 +193,55 @@ def test_call_agent_cache_closes_history_storage_when_agent_build_fails(
         cache._build_agent(knowledge=None, refresh_scheduler=None)
 
     history_storage.close.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_call_agent_cache_prewarms_and_reuses_anthropic_async_client(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cached call agent must initialize one reusable async client off the event loop."""
+    model = Claude(id="claude-sonnet-4-6", api_key="test-key")
+    install_claude_prompt_cache_hook(model)
+    client_parameter_thread_ids: list[int] = []
+    event_loop_thread_id = threading.get_ident()
+    original_client_parameters = model._get_client_params
+
+    def _record_client_parameters() -> dict[str, object]:
+        client_parameter_thread_ids.append(threading.get_ident())
+        return original_client_parameters()
+
+    vars(model)["_get_client_params"] = _record_client_parameters
+    agent = MagicMock(model=model)
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_scope_session_storage", MagicMock())
+    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", MagicMock(return_value=agent))
+    cache = _CallAgentCache(
+        agent_name=AGENT,
+        config=_config(),
+        runtime_paths=test_runtime_paths(tmp_path),
+        context=SimpleNamespace(hook_registry=None, tool_function_filter=None),  # type: ignore[arg-type]
+        execution_identity=SimpleNamespace(),  # type: ignore[arg-type]
+        session_id="call-session",
+        active_model_name="default",
+    )
+
+    try:
+        cached_agent = await cache._get_agent(
+            knowledge=None,
+            knowledge_identity=(),
+            refresh_scheduler=None,
+        )
+        first_client = cached_agent.model.get_async_client()
+        second_client = cached_agent.model.get_async_client()
+
+        assert first_client._client is second_client._client
+        assert vars(model)["async_client"] is first_client._client
+        assert client_parameter_thread_ids == [client_parameter_thread_ids[0]]
+        assert client_parameter_thread_ids[0] != event_loop_thread_id
+    finally:
+        async_client = vars(model).get("async_client")
+        if async_client is not None:
+            await async_client.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -570,7 +570,7 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
         )
         return "It is sunny."
 
-    cached_agent = SimpleNamespace(additional_context="base context")
+    cached_agent = SimpleNamespace(additional_context="base context", model=None)
     create_agent_mock = MagicMock(return_value=cached_agent)
     history_storage = MagicMock()
     create_scope_session_storage_mock = MagicMock(return_value=history_storage)
@@ -1034,8 +1034,8 @@ async def test_cascaded_responder_refreshes_knowledge_and_availability_each_turn
         ai_calls.append((turn, kwargs))
         return f"answer-{len(ai_calls)}"
 
-    first_agent = SimpleNamespace(additional_context="first base")
-    second_agent = SimpleNamespace(additional_context="second base")
+    first_agent = SimpleNamespace(additional_context="first base", model=None)
+    second_agent = SimpleNamespace(additional_context="second base", model=None)
     create_agent_mock = MagicMock(side_effect=(first_agent, second_agent))
     close_agent_mock = MagicMock()
     monkeypatch.setattr("mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access", resolve_knowledge)
@@ -1131,7 +1131,7 @@ async def test_cascaded_responder_waits_for_interrupted_playout_settlement(
     )
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools.create_agent",
-        MagicMock(return_value=SimpleNamespace(additional_context="base context")),
+        MagicMock(return_value=SimpleNamespace(additional_context="base context", model=None)),
     )
     monkeypatch.setattr("mindroom.ai.ai_response", fake_ai_response)
     monkeypatch.setattr(

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -6,8 +6,10 @@ import asyncio
 import os
 import signal
 import sys
+import threading
 from collections.abc import Awaitable, Callable
 from contextlib import contextmanager
+from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Self, cast
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
@@ -125,7 +127,6 @@ async def test_reply_membership_refresh_revokes_before_scheduling_positive_call_
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterator
-    from pathlib import Path
 
 
 @pytest.fixture(autouse=True)
@@ -1167,6 +1168,61 @@ class TestAgentBot(AgentBotTestBase):
 
         assert observed_logging_root == runtime_storage.resolve()
         assert observed_credentials_root == runtime_storage.resolve()
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_main_offloads_initial_credential_and_storage_setup(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Credential sync and initial storage creation must not block the event loop."""
+        runtime_paths = self._runtime_paths(tmp_path)
+        storage_path = runtime_paths.storage_root
+        event_loop_thread_id = threading.get_ident()
+        setup_thread_ids: list[int] = []
+        events: list[str] = []
+        mock_orchestrator = MagicMock()
+        mock_orchestrator.start = AsyncMock(side_effect=RuntimeError("stop after setup"))
+        mock_orchestrator.stop = AsyncMock()
+        stall_detector = MagicMock()
+        original_mkdir = Path.mkdir
+
+        def _record_storage_mkdir(path: Path, *args: object, **kwargs: object) -> None:
+            if path == storage_path:
+                setup_thread_ids.append(threading.get_ident())
+                events.append("storage")
+            original_mkdir(path, *args, **kwargs)
+
+        def _sync_credentials(*, runtime_paths: RuntimePaths) -> None:
+            assert runtime_paths is not None
+            setup_thread_ids.append(threading.get_ident())
+            events.append("credentials")
+
+        def _construct_orchestrator(*_args: object, **_kwargs: object) -> MagicMock:
+            assert storage_path.is_dir()
+            events.append("orchestrator")
+            return mock_orchestrator
+
+        monkeypatch.setattr(Path, "mkdir", _record_storage_mkdir)
+        with (
+            patch("mindroom.orchestrator.setup_logging"),
+            patch("mindroom.orchestrator.reset_primary_worker_manager"),
+            patch(
+                "mindroom.orchestrator.start_event_loop_stall_detector",
+                return_value=stall_detector,
+            ) as start_detector,
+            patch("mindroom.orchestrator.sync_env_to_credentials", side_effect=_sync_credentials),
+            patch("mindroom.orchestrator._MultiAgentOrchestrator", side_effect=_construct_orchestrator),
+            pytest.raises(RuntimeError, match="stop after setup"),
+        ):
+            await main(log_level="INFO", runtime_paths=runtime_paths, api=False)
+
+        start_detector.assert_called_once_with(runtime_paths)
+        assert events == ["credentials", "storage", "orchestrator"]
+        assert len(setup_thread_ids) == 2
+        assert setup_thread_ids[0] == setup_thread_ids[1]
+        assert setup_thread_ids[0] != event_loop_thread_id
+        stall_detector.stop.assert_called_once_with()
 
     @pytest.mark.asyncio
     async def test_orchestrator_main_shuts_down_primary_worker_manager(self, tmp_path: Path) -> None:

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -1225,6 +1225,47 @@ class TestAgentBot(AgentBotTestBase):
         stall_detector.stop.assert_called_once_with()
 
     @pytest.mark.asyncio
+    async def test_orchestrator_main_drains_cancelled_initial_setup_before_cleanup(self, tmp_path: Path) -> None:
+        """Cancellation must not let teardown overtake the active setup worker."""
+        reset_runtime_state()
+        setup_started = threading.Event()
+        release_setup = threading.Event()
+        events: list[str] = []
+        runtime_paths = self._runtime_paths(tmp_path)
+
+        def _blocked_credential_sync(*, runtime_paths: RuntimePaths) -> None:
+            assert runtime_paths is not None
+            events.append("setup_started")
+            setup_started.set()
+            assert release_setup.wait(2.0)
+            events.append("setup_finished")
+
+        with (
+            patch("mindroom.orchestrator.setup_logging"),
+            patch("mindroom.orchestrator.reset_primary_worker_manager"),
+            patch("mindroom.orchestrator.start_event_loop_stall_detector", return_value=MagicMock()),
+            patch("mindroom.orchestrator.sync_env_to_credentials", side_effect=_blocked_credential_sync),
+            patch(
+                "mindroom.orchestrator.shutdown_primary_worker_manager",
+                side_effect=lambda: events.append("cleanup"),
+            ),
+        ):
+            main_task = asyncio.create_task(main(log_level="INFO", runtime_paths=runtime_paths, api=False))
+            try:
+                assert await asyncio.to_thread(setup_started.wait, 2.0)
+                main_task.cancel()
+                await asyncio.sleep(0)
+                assert not main_task.done()
+                assert events == ["setup_started"]
+            finally:
+                release_setup.set()
+
+            with pytest.raises(asyncio.CancelledError):
+                await main_task
+
+        assert events == ["setup_started", "setup_finished", "cleanup"]
+
+    @pytest.mark.asyncio
     async def test_orchestrator_main_shuts_down_primary_worker_manager(self, tmp_path: Path) -> None:
         """The orchestrator should clear stale workers before startup and shut them down on exit."""
         reset_runtime_state()

--- a/tests/test_pre_model_preparation.py
+++ b/tests/test_pre_model_preparation.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -31,6 +31,7 @@ async def test_prepare_prompt_branches_propagates_failure_directly(
     built_agent = MagicMock()
     runtime_model = ResolvedRuntimeModel(model_name="default", context_window=None)
     close_unreturned = MagicMock()
+    close_client = AsyncMock()
     test_logger = MagicMock()
 
     async def memory_branch() -> MemoryPromptParts:
@@ -46,6 +47,12 @@ async def test_prepare_prompt_branches_propagates_failure_directly(
         return runtime_model, built_agent
 
     monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_unreturned)
+    monkeypatch.setattr(
+        pre_model_preparation_module,
+        "aclose_anthropic_async_client",
+        close_client,
+        raising=False,
+    )
     monkeypatch.setattr(pre_model_preparation_module, "logger", test_logger)
 
     expected_error_type = asyncio.CancelledError if failing_branch == "memory_cancelled" else RuntimeError
@@ -62,8 +69,10 @@ async def test_prepare_prompt_branches_propagates_failure_directly(
     assert raised.value is expected_error
     if failing_branch in {"memory", "memory_cancelled"}:
         close_unreturned.assert_called_once_with(built_agent, shared_scope_storage=None)
+        close_client.assert_awaited_once_with(built_agent.model)
     else:
         close_unreturned.assert_not_called()
+        close_client.assert_not_awaited()
     if failing_branch == "both":
         test_logger.error.assert_called_once()
     else:
@@ -83,6 +92,7 @@ async def test_prepare_prompt_branches_memory_failure_joins_agent_sibling(
     runtime_model = ResolvedRuntimeModel(model_name="default", context_window=None)
     built_agent = MagicMock()
     close_unreturned = MagicMock()
+    close_client = AsyncMock()
 
     async def failed_memory() -> MemoryPromptParts:
         assert await asyncio.to_thread(agent_started.wait, 5.0)
@@ -98,6 +108,12 @@ async def test_prepare_prompt_branches_memory_failure_joins_agent_sibling(
         return runtime_model, built_agent
 
     monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_unreturned)
+    monkeypatch.setattr(
+        pre_model_preparation_module,
+        "aclose_anthropic_async_client",
+        close_client,
+        raising=False,
+    )
 
     prepare_task = asyncio.create_task(
         prepare_prompt_branches(
@@ -121,6 +137,7 @@ async def test_prepare_prompt_branches_memory_failure_joins_agent_sibling(
     assert raised.value is memory_error
     assert agent_finished.is_set()
     close_unreturned.assert_called_once_with(built_agent, shared_scope_storage=None)
+    close_client.assert_awaited_once_with(built_agent.model)
 
 
 @pytest.mark.asyncio
@@ -131,6 +148,7 @@ async def test_prepare_prompt_branches_preserves_caller_owned_agent_on_memory_fa
     built_agent = MagicMock()
     runtime_model = ResolvedRuntimeModel(model_name="default", context_window=None)
     close_unreturned = MagicMock()
+    close_client = AsyncMock()
 
     async def memory_branch() -> MemoryPromptParts:
         await asyncio.sleep(0)
@@ -138,6 +156,12 @@ async def test_prepare_prompt_branches_preserves_caller_owned_agent_on_memory_fa
         raise RuntimeError(msg)
 
     monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_unreturned)
+    monkeypatch.setattr(
+        pre_model_preparation_module,
+        "aclose_anthropic_async_client",
+        close_client,
+        raising=False,
+    )
 
     with pytest.raises(RuntimeError, match="memory failed"):
         await prepare_prompt_branches(
@@ -150,6 +174,7 @@ async def test_prepare_prompt_branches_preserves_caller_owned_agent_on_memory_fa
         )
 
     close_unreturned.assert_not_called()
+    close_client.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -177,6 +202,7 @@ async def test_prepare_prompt_branches_cancellation_settles_agent_build(  # noqa
     built_agent = MagicMock()
     runtime_model = ResolvedRuntimeModel(model_name="default", context_window=None)
     close_unreturned = MagicMock()
+    close_client = AsyncMock()
     test_logger = MagicMock()
 
     async def blocked_memory() -> MemoryPromptParts:
@@ -203,6 +229,12 @@ async def test_prepare_prompt_branches_cancellation_settles_agent_build(  # noqa
         return runtime_model, built_agent
 
     monkeypatch.setattr(pre_model_preparation_module, "close_agent_runtime_state_dbs", close_unreturned)
+    monkeypatch.setattr(
+        pre_model_preparation_module,
+        "aclose_anthropic_async_client",
+        close_client,
+        raising=False,
+    )
     monkeypatch.setattr(pre_model_preparation_module, "logger", test_logger)
 
     baseline_tasks = set(asyncio.all_tasks())
@@ -240,8 +272,10 @@ async def test_prepare_prompt_branches_cancellation_settles_agent_build(  # noqa
     assert agent_finished.is_set()
     if agent_outcome in {"fails", "cancelled"} or caller_owned:
         close_unreturned.assert_not_called()
+        close_client.assert_not_awaited()
     else:
         close_unreturned.assert_called_once_with(built_agent, shared_scope_storage=None)
+        close_client.assert_awaited_once_with(built_agent.model)
     if agent_outcome == "fails":
         test_logger.error.assert_called_once()
     else:


### PR DESCRIPTION
## Summary

- move ordered credential and storage initialization through the existing blocking-work helper
- warm reusable async model clients inside existing worker-thread construction paths
- preserve cancellation cleanup and skip session-backed clients that do not need caching

## Testing

- full pytest suite
- all pre-commit hooks

## Summary by Sourcery

Move synchronous startup and agent setup work off the event loop while making model-client ownership and cancellation cleanup explicit.

Bug Fixes:
- Prevent blocking credential, storage, agent construction, and model-client initialization work from running on the event loop.
- Ensure cancelled or failed agent preparation and cache construction reclaim runtime databases and async model clients.
- Preserve reusable clients while refreshing session-backed Bedrock clients between serialized turns.

Enhancements:
- Add deterministic lifecycle management for prewarmed Anthropic and Bedrock async clients, including cancellation-safe cleanup and client replacement.
- Extend call-agent caching to prewarm, reuse, refresh, and close model clients across agent lifecycles.

Tests:
- Add coverage for event-loop offloading, cancellation draining, model-client prewarming and cleanup, Bedrock session refresh, and agent preparation failure handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved startup responsiveness by moving credential synchronization, storage preparation, and agent construction off the event loop.
  * Reuses initialized AI clients for cached call agents, reducing repeated setup work.
  * Prepares supported AI clients before use.

* **Reliability**
  * Ensures startup and shutdown operations complete safely, including during cancellation.
  * Closes temporary clients and runtime resources while preserving caller-owned reusable clients.
  * Handles Bedrock-backed sessions without unnecessary client initialization.
  * Added regression coverage for lifecycle cleanup, reuse, startup ordering, and cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->