### PR TITLE
Add bounded context to event loop stall reports

### DIFF
--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -19,12 +19,15 @@ import threading
 import time
 import traceback
 from collections import deque
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from mindroom.logging_config import get_logger
 from mindroom.timing import elapsed_ms_between
 
 if TYPE_CHECKING:
+    from types import FrameType
+
     from mindroom.constants import RuntimePaths
 
 logger = get_logger(__name__)
@@ -35,8 +38,11 @@ _HEARTBEAT_INTERVAL_SECONDS = 0.05
 _SCHEDULER_LAG_WINDOW_SECONDS = 60.0
 _REPEAT_LOG_INTERVAL_SECONDS = 30.0
 _THREAD_JOIN_TIMEOUT_SECONDS = 2.0
-_MAX_OTHER_THREAD_STACKS = 16
-_MAX_STACK_FRAMES = 64
+_MAX_OTHER_THREAD_STACKS = 8
+_MAX_STACK_FRAMES = 32
+_MAX_OTHER_THREAD_STACK_CHARACTERS = 2_000
+_MAX_OTHER_THREAD_STACK_TOTAL_CHARACTERS = 8_000
+_MAX_THREAD_NAME_CHARACTERS = 160
 
 
 def _event_loop_stall_threshold_seconds(runtime_paths: RuntimePaths) -> float:
@@ -45,6 +51,14 @@ def _event_loop_stall_threshold_seconds(runtime_paths: RuntimePaths) -> float:
     if not raw:
         return _DEFAULT_EVENT_LOOP_STALL_THRESHOLD_SECONDS
     return float(raw)
+
+
+@dataclass(frozen=True)
+class _Heartbeat:
+    """One atomically published heartbeat and its matching process CPU baseline."""
+
+    monotonic_seconds: float
+    process_cpu_seconds: float
 
 
 class EventLoopStallDetector:
@@ -69,8 +83,7 @@ class EventLoopStallDetector:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._loop_thread_ident: int | None = None
         self._heartbeat_handle: asyncio.TimerHandle | None = None
-        self._last_beat: float = 0.0
-        self._last_beat_process_cpu: float = 0.0
+        self._heartbeat = _Heartbeat(monotonic_seconds=0.0, process_cpu_seconds=0.0)
         self._stalled_beat: float | None = None
         self._next_repeat_log: float = 0.0
         self._scheduler_lag_samples: deque[float] = deque(
@@ -85,8 +98,10 @@ class EventLoopStallDetector:
         """Arm the heartbeat on the running loop and start the watcher thread."""
         self._loop = asyncio.get_running_loop()
         self._loop_thread_ident = threading.get_ident()
-        self._last_beat = time.monotonic()
-        self._last_beat_process_cpu = time.process_time()
+        self._heartbeat = _Heartbeat(
+            monotonic_seconds=time.monotonic(),
+            process_cpu_seconds=time.process_time(),
+        )
         self._scheduler_lag_window_started_at = time.monotonic()
         self._schedule_heartbeat(self._loop.time() + self.heartbeat_interval_seconds)
         self._thread = threading.Thread(
@@ -120,8 +135,10 @@ class EventLoopStallDetector:
         """Refresh heartbeat, sample callback lag, and re-arm from actual loop time."""
         assert self._loop is not None
         actual_loop_time = self._loop.time()
-        self._last_beat = time.monotonic()
-        self._last_beat_process_cpu = time.process_time()
+        self._heartbeat = _Heartbeat(
+            monotonic_seconds=time.monotonic(),
+            process_cpu_seconds=time.process_time(),
+        )
         with self._scheduler_lag_lock:
             self._scheduler_lag_samples.append(max(0.0, actual_loop_time - scheduled_loop_time))
         if not self._stop_event.is_set():
@@ -147,52 +164,86 @@ class EventLoopStallDetector:
             max_ms=milliseconds[-1],
         )
 
-    def _loop_thread_stack(self) -> str | None:
+    def _loop_thread_stack(self, frames: dict[int, FrameType] | None = None) -> str | None:
         """Return the loop thread's current stack, formatted for logging."""
         if self._loop_thread_ident is None:
             return None
-        frame = sys._current_frames().get(self._loop_thread_ident)
+        captured_frames = frames if frames is not None else sys._current_frames()
+        frame = captured_frames.get(self._loop_thread_ident)
         if frame is None:
             return None
         return "".join(traceback.format_stack(frame))
 
-    def _other_thread_stacks(self) -> tuple[list[dict[str, object]], int]:
-        """Return bounded stacks for Python threads other than the loop and watcher."""
+    def _other_thread_stacks(
+        self,
+        frames: dict[int, FrameType] | None = None,
+    ) -> tuple[list[dict[str, object]], int, int]:
+        """Return bounded stacks from a frame snapshot, excluding loop and watcher."""
         current_ident = threading.get_ident()
-        frames = sys._current_frames()
+        captured_frames = frames if frames is not None else sys._current_frames()
+        known_threads = {thread.ident: thread for thread in threading.enumerate() if thread.ident is not None}
         candidates = sorted(
             (
-                thread
-                for thread in threading.enumerate()
-                if thread.ident is not None
-                and thread.ident not in {self._loop_thread_ident, current_ident}
-                and thread.ident in frames
+                thread_ident
+                for thread_ident in captured_frames
+                if thread_ident not in {self._loop_thread_ident, current_ident}
             ),
-            key=lambda thread: (thread.daemon, thread.name, thread.ident or 0),
+            key=lambda thread_ident: (
+                known_threads[thread_ident].daemon if thread_ident in known_threads else True,
+                known_threads[thread_ident].name if thread_ident in known_threads else f"thread-{thread_ident}",
+                thread_ident,
+            ),
         )
-        reported = candidates[:_MAX_OTHER_THREAD_STACKS]
-        stacks = [
-            {
-                "thread_name": thread.name,
-                "thread_ident": thread.ident,
-                "daemon": thread.daemon,
-                "stack": "".join(traceback.format_stack(frames[thread.ident], limit=_MAX_STACK_FRAMES)),
-            }
-            for thread in reported
-            if thread.ident is not None
-        ]
-        return stacks, len(candidates) - len(reported)
+        stacks: list[dict[str, object]] = []
+        omitted = 0
+        truncated = 0
+        stack_characters = 0
+        for thread_ident in candidates:
+            if len(stacks) >= _MAX_OTHER_THREAD_STACKS:
+                omitted += 1
+                continue
+            remaining = _MAX_OTHER_THREAD_STACK_TOTAL_CHARACTERS - stack_characters
+            if remaining <= 0:
+                omitted += 1
+                continue
+            thread = known_threads.get(thread_ident)
+            thread_name = thread.name if thread is not None else f"thread-{thread_ident}"
+            full_stack = "".join(traceback.format_stack(captured_frames[thread_ident], limit=_MAX_STACK_FRAMES))
+            stack = full_stack[: min(_MAX_OTHER_THREAD_STACK_CHARACTERS, remaining)]
+            if len(stack) < len(full_stack):
+                truncated += 1
+            stack_characters += len(stack)
+            stacks.append(
+                {
+                    "thread_name": thread_name[:_MAX_THREAD_NAME_CHARACTERS],
+                    "thread_ident": thread_ident,
+                    "daemon": thread.daemon if thread is not None else None,
+                    "stack": stack,
+                },
+            )
+        return stacks, omitted, truncated
 
-    def _stall_diagnostics(self) -> dict[str, object]:
+    def _stall_diagnostics(
+        self,
+        heartbeat: _Heartbeat,
+        *,
+        frames: dict[int, FrameType] | None = None,
+        current_process_cpu: float | None = None,
+    ) -> dict[str, object]:
         """Capture process activity and competing Python work for one stall log."""
-        other_thread_stacks, omitted_thread_stack_count = self._other_thread_stacks()
+        current_process_cpu = time.process_time() if current_process_cpu is None else current_process_cpu
+        captured_frames = sys._current_frames() if frames is None else frames
+        other_thread_stacks, omitted_thread_stack_count, truncated_thread_stack_count = self._other_thread_stacks(
+            captured_frames,
+        )
         return {
             "process_cpu_seconds_since_heartbeat": round(
-                max(0.0, time.process_time() - self._last_beat_process_cpu),
+                max(0.0, current_process_cpu - heartbeat.process_cpu_seconds),
                 3,
             ),
             "other_thread_stacks": other_thread_stacks,
             "omitted_thread_stack_count": omitted_thread_stack_count,
+            "truncated_thread_stack_count": truncated_thread_stack_count,
         }
 
     def _note_stall_ended(self, fresh_beat: float) -> None:
@@ -204,27 +255,32 @@ class EventLoopStallDetector:
         )
         self._stalled_beat = None
 
-    def _note_stalled(self, now: float, last_beat: float) -> None:
+    def _note_stalled(self, now: float, heartbeat: _Heartbeat) -> None:
         """Log one stalled heartbeat, rate-limited to once per repeat interval."""
+        last_beat = heartbeat.monotonic_seconds
         stalled_for_seconds = round(now - last_beat, 3)
         if self._stalled_beat is None:
             self._stalled_beat = last_beat
             self._next_repeat_log = now + self.repeat_log_interval_seconds
+            current_process_cpu = time.process_time()
+            frames = sys._current_frames()
             logger.error(
                 "event_loop_stall_detected",
                 stalled_for_seconds=stalled_for_seconds,
                 threshold_seconds=self.threshold_seconds,
-                stack=self._loop_thread_stack(),
-                **self._stall_diagnostics(),
+                stack=self._loop_thread_stack(frames),
+                **self._stall_diagnostics(heartbeat, frames=frames, current_process_cpu=current_process_cpu),
             )
         elif now >= self._next_repeat_log:
             self._next_repeat_log = now + self.repeat_log_interval_seconds
+            current_process_cpu = time.process_time()
+            frames = sys._current_frames()
             logger.error(
                 "event_loop_stall_ongoing",
                 stalled_for_seconds=stalled_for_seconds,
                 threshold_seconds=self.threshold_seconds,
-                stack=self._loop_thread_stack(),
-                **self._stall_diagnostics(),
+                stack=self._loop_thread_stack(frames),
+                **self._stall_diagnostics(heartbeat, frames=frames, current_process_cpu=current_process_cpu),
             )
 
     def _watch(self) -> None:
@@ -232,11 +288,12 @@ class EventLoopStallDetector:
         while not self._stop_event.wait(self.poll_interval_seconds):
             now = time.monotonic()
             self._report_scheduler_lag(now)
-            last_beat = self._last_beat
+            heartbeat = self._heartbeat
+            last_beat = heartbeat.monotonic_seconds
             if self._stalled_beat is not None and last_beat != self._stalled_beat:
                 self._note_stall_ended(last_beat)
             if now - last_beat > self.threshold_seconds:
-                self._note_stalled(now, last_beat)
+                self._note_stalled(now, heartbeat)
 
 
 def _nearest_rank_percentile(samples: list[float], percentile: int) -> float:

--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -40,9 +40,8 @@ _REPEAT_LOG_INTERVAL_SECONDS = 30.0
 _THREAD_JOIN_TIMEOUT_SECONDS = 2.0
 _MAX_OTHER_THREAD_STACKS = 8
 _MAX_STACK_FRAMES = 32
-_MAX_OTHER_THREAD_STACK_CHARACTERS = 2_000
-_MAX_OTHER_THREAD_STACK_TOTAL_CHARACTERS = 8_000
-_MAX_THREAD_NAME_CHARACTERS = 160
+# Eight one-thousand-character stacks bound stack text to eight thousand characters.
+_MAX_OTHER_THREAD_STACK_CHARACTERS = 1_000
 _STACK_TRUNCATION_MARKER = "\n...\n"
 
 
@@ -54,13 +53,11 @@ def _event_loop_stall_threshold_seconds(runtime_paths: RuntimePaths) -> float:
     return float(raw)
 
 
-def _truncate_stack(stack: str, character_budget: int) -> str:
-    """Return an exact-budget stack suffix, marked when both can fit."""
-    if len(stack) <= character_budget:
+def _truncate_stack(stack: str) -> str:
+    """Return a bounded stack suffix while preserving its active tail."""
+    if len(stack) <= _MAX_OTHER_THREAD_STACK_CHARACTERS:
         return stack
-    if character_budget <= len(_STACK_TRUNCATION_MARKER):
-        return stack[-character_budget:] if character_budget > 0 else ""
-    tail_length = character_budget - len(_STACK_TRUNCATION_MARKER)
+    tail_length = _MAX_OTHER_THREAD_STACK_CHARACTERS - len(_STACK_TRUNCATION_MARKER)
     return f"{_STACK_TRUNCATION_MARKER}{stack[-tail_length:]}"
 
 
@@ -72,6 +69,14 @@ def _frame_chain_exceeds_limit(frame: FrameType, frame_limit: int) -> bool:
         if older_frame is None:
             return False
     return True
+
+
+def _format_bounded_stack(frame: FrameType) -> tuple[str, bool]:
+    """Format one stack and report whether its frame or character limit applied."""
+    frame_limit_truncated = _frame_chain_exceeds_limit(frame, _MAX_STACK_FRAMES)
+    full_stack = "".join(traceback.format_stack(frame, limit=_MAX_STACK_FRAMES))
+    stack = _truncate_stack(full_stack)
+    return stack, frame_limit_truncated or len(stack) < len(full_stack)
 
 
 @dataclass(frozen=True)
@@ -185,30 +190,24 @@ class EventLoopStallDetector:
             max_ms=milliseconds[-1],
         )
 
-    def _loop_thread_stack(self, frames: dict[int, FrameType] | None = None) -> str | None:
+    def _loop_thread_stack(self, frames: dict[int, FrameType]) -> str | None:
         """Return the loop thread's current stack, formatted for logging."""
         if self._loop_thread_ident is None:
             return None
-        captured_frames = frames if frames is not None else sys._current_frames()
-        frame = captured_frames.get(self._loop_thread_ident)
+        frame = frames.get(self._loop_thread_ident)
         if frame is None:
             return None
         return "".join(traceback.format_stack(frame))
 
     def _other_thread_stacks(
         self,
-        frames: dict[int, FrameType] | None = None,
-    ) -> tuple[list[dict[str, object]], int, int]:
+        frames: dict[int, FrameType],
+    ) -> tuple[list[dict[str, object]], int]:
         """Return bounded stacks from a frame snapshot, excluding loop and watcher."""
         current_ident = threading.get_ident()
-        captured_frames = frames if frames is not None else sys._current_frames()
         known_threads = {thread.ident: thread for thread in threading.enumerate() if thread.ident is not None}
         candidates = sorted(
-            (
-                thread_ident
-                for thread_ident in captured_frames
-                if thread_ident not in {self._loop_thread_ident, current_ident}
-            ),
+            (thread_ident for thread_ident in frames if thread_ident not in {self._loop_thread_ident, current_ident}),
             key=lambda thread_ident: (
                 known_threads[thread_ident].daemon if thread_ident in known_threads else True,
                 known_threads[thread_ident].name if thread_ident in known_threads else f"thread-{thread_ident}",
@@ -216,49 +215,30 @@ class EventLoopStallDetector:
             ),
         )
         stacks: list[dict[str, object]] = []
-        omitted = 0
-        truncated = 0
-        stack_characters = 0
-        for thread_ident in candidates:
-            if len(stacks) >= _MAX_OTHER_THREAD_STACKS:
-                omitted += 1
-                continue
-            remaining = _MAX_OTHER_THREAD_STACK_TOTAL_CHARACTERS - stack_characters
-            if remaining <= 0:
-                omitted += 1
-                continue
+        for thread_ident in candidates[:_MAX_OTHER_THREAD_STACKS]:
             thread = known_threads.get(thread_ident)
             thread_name = thread.name if thread is not None else f"thread-{thread_ident}"
-            frame = captured_frames[thread_ident]
-            frame_limit_truncated = _frame_chain_exceeds_limit(frame, _MAX_STACK_FRAMES)
-            full_stack = "".join(traceback.format_stack(frame, limit=_MAX_STACK_FRAMES))
-            stack = _truncate_stack(full_stack, min(_MAX_OTHER_THREAD_STACK_CHARACTERS, remaining))
-            if frame_limit_truncated or len(stack) < len(full_stack):
-                truncated += 1
-            stack_characters += len(stack)
+            stack, truncated = _format_bounded_stack(frames[thread_ident])
             stacks.append(
                 {
-                    "thread_name": thread_name[:_MAX_THREAD_NAME_CHARACTERS],
+                    "thread_name": thread_name,
                     "thread_ident": thread_ident,
                     "daemon": thread.daemon if thread is not None else None,
                     "stack": stack,
+                    "truncated": truncated,
                 },
             )
-        return stacks, omitted, truncated
+        return stacks, len(candidates) - len(stacks)
 
     def _stall_diagnostics(
         self,
         heartbeat: _Heartbeat,
         *,
-        frames: dict[int, FrameType] | None = None,
-        current_process_cpu: float | None = None,
+        frames: dict[int, FrameType],
+        current_process_cpu: float,
     ) -> dict[str, object]:
         """Capture process activity and competing Python work for one stall log."""
-        current_process_cpu = time.process_time() if current_process_cpu is None else current_process_cpu
-        captured_frames = sys._current_frames() if frames is None else frames
-        other_thread_stacks, omitted_thread_stack_count, truncated_thread_stack_count = self._other_thread_stacks(
-            captured_frames,
-        )
+        other_thread_stacks, omitted_thread_stack_count = self._other_thread_stacks(frames)
         return {
             "process_cpu_seconds_since_heartbeat": round(
                 max(0.0, current_process_cpu - heartbeat.process_cpu_seconds),
@@ -266,7 +246,6 @@ class EventLoopStallDetector:
             ),
             "other_thread_stacks": other_thread_stacks,
             "omitted_thread_stack_count": omitted_thread_stack_count,
-            "truncated_thread_stack_count": truncated_thread_stack_count,
         }
 
     def _note_stall_ended(self, fresh_beat: float) -> None:

--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -64,6 +64,16 @@ def _truncate_stack(stack: str, character_budget: int) -> str:
     return f"{_STACK_TRUNCATION_MARKER}{stack[-tail_length:]}"
 
 
+def _frame_chain_exceeds_limit(frame: FrameType, frame_limit: int) -> bool:
+    """Return whether walking at most ``frame_limit`` frames omits an ancestor."""
+    older_frame: FrameType | None = frame
+    for _ in range(frame_limit):
+        older_frame = older_frame.f_back
+        if older_frame is None:
+            return False
+    return True
+
+
 @dataclass(frozen=True)
 class _Heartbeat:
     """One atomically published heartbeat and its matching process CPU baseline."""
@@ -219,9 +229,11 @@ class EventLoopStallDetector:
                 continue
             thread = known_threads.get(thread_ident)
             thread_name = thread.name if thread is not None else f"thread-{thread_ident}"
-            full_stack = "".join(traceback.format_stack(captured_frames[thread_ident], limit=_MAX_STACK_FRAMES))
+            frame = captured_frames[thread_ident]
+            frame_limit_truncated = _frame_chain_exceeds_limit(frame, _MAX_STACK_FRAMES)
+            full_stack = "".join(traceback.format_stack(frame, limit=_MAX_STACK_FRAMES))
             stack = _truncate_stack(full_stack, min(_MAX_OTHER_THREAD_STACK_CHARACTERS, remaining))
-            if len(stack) < len(full_stack):
+            if frame_limit_truncated or len(stack) < len(full_stack):
                 truncated += 1
             stack_characters += len(stack)
             stacks.append(

--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -43,6 +43,7 @@ _MAX_STACK_FRAMES = 32
 _MAX_OTHER_THREAD_STACK_CHARACTERS = 2_000
 _MAX_OTHER_THREAD_STACK_TOTAL_CHARACTERS = 8_000
 _MAX_THREAD_NAME_CHARACTERS = 160
+_STACK_TRUNCATION_MARKER = "\n...\n"
 
 
 def _event_loop_stall_threshold_seconds(runtime_paths: RuntimePaths) -> float:
@@ -51,6 +52,16 @@ def _event_loop_stall_threshold_seconds(runtime_paths: RuntimePaths) -> float:
     if not raw:
         return _DEFAULT_EVENT_LOOP_STALL_THRESHOLD_SECONDS
     return float(raw)
+
+
+def _truncate_stack(stack: str, character_budget: int) -> str:
+    """Return an exact-budget stack suffix, marked when both can fit."""
+    if len(stack) <= character_budget:
+        return stack
+    if character_budget <= len(_STACK_TRUNCATION_MARKER):
+        return stack[-character_budget:] if character_budget > 0 else ""
+    tail_length = character_budget - len(_STACK_TRUNCATION_MARKER)
+    return f"{_STACK_TRUNCATION_MARKER}{stack[-tail_length:]}"
 
 
 @dataclass(frozen=True)
@@ -209,7 +220,7 @@ class EventLoopStallDetector:
             thread = known_threads.get(thread_ident)
             thread_name = thread.name if thread is not None else f"thread-{thread_ident}"
             full_stack = "".join(traceback.format_stack(captured_frames[thread_ident], limit=_MAX_STACK_FRAMES))
-            stack = full_stack[: min(_MAX_OTHER_THREAD_STACK_CHARACTERS, remaining)]
+            stack = _truncate_stack(full_stack, min(_MAX_OTHER_THREAD_STACK_CHARACTERS, remaining))
             if len(stack) < len(full_stack):
                 truncated += 1
             stack_characters += len(stack)

--- a/src/mindroom/event_loop_stall.py
+++ b/src/mindroom/event_loop_stall.py
@@ -35,6 +35,8 @@ _HEARTBEAT_INTERVAL_SECONDS = 0.05
 _SCHEDULER_LAG_WINDOW_SECONDS = 60.0
 _REPEAT_LOG_INTERVAL_SECONDS = 30.0
 _THREAD_JOIN_TIMEOUT_SECONDS = 2.0
+_MAX_OTHER_THREAD_STACKS = 16
+_MAX_STACK_FRAMES = 64
 
 
 def _event_loop_stall_threshold_seconds(runtime_paths: RuntimePaths) -> float:
@@ -68,6 +70,7 @@ class EventLoopStallDetector:
         self._loop_thread_ident: int | None = None
         self._heartbeat_handle: asyncio.TimerHandle | None = None
         self._last_beat: float = 0.0
+        self._last_beat_process_cpu: float = 0.0
         self._stalled_beat: float | None = None
         self._next_repeat_log: float = 0.0
         self._scheduler_lag_samples: deque[float] = deque(
@@ -83,6 +86,7 @@ class EventLoopStallDetector:
         self._loop = asyncio.get_running_loop()
         self._loop_thread_ident = threading.get_ident()
         self._last_beat = time.monotonic()
+        self._last_beat_process_cpu = time.process_time()
         self._scheduler_lag_window_started_at = time.monotonic()
         self._schedule_heartbeat(self._loop.time() + self.heartbeat_interval_seconds)
         self._thread = threading.Thread(
@@ -117,6 +121,7 @@ class EventLoopStallDetector:
         assert self._loop is not None
         actual_loop_time = self._loop.time()
         self._last_beat = time.monotonic()
+        self._last_beat_process_cpu = time.process_time()
         with self._scheduler_lag_lock:
             self._scheduler_lag_samples.append(max(0.0, actual_loop_time - scheduled_loop_time))
         if not self._stop_event.is_set():
@@ -151,6 +156,45 @@ class EventLoopStallDetector:
             return None
         return "".join(traceback.format_stack(frame))
 
+    def _other_thread_stacks(self) -> tuple[list[dict[str, object]], int]:
+        """Return bounded stacks for Python threads other than the loop and watcher."""
+        current_ident = threading.get_ident()
+        frames = sys._current_frames()
+        candidates = sorted(
+            (
+                thread
+                for thread in threading.enumerate()
+                if thread.ident is not None
+                and thread.ident not in {self._loop_thread_ident, current_ident}
+                and thread.ident in frames
+            ),
+            key=lambda thread: (thread.daemon, thread.name, thread.ident or 0),
+        )
+        reported = candidates[:_MAX_OTHER_THREAD_STACKS]
+        stacks = [
+            {
+                "thread_name": thread.name,
+                "thread_ident": thread.ident,
+                "daemon": thread.daemon,
+                "stack": "".join(traceback.format_stack(frames[thread.ident], limit=_MAX_STACK_FRAMES)),
+            }
+            for thread in reported
+            if thread.ident is not None
+        ]
+        return stacks, len(candidates) - len(reported)
+
+    def _stall_diagnostics(self) -> dict[str, object]:
+        """Capture process activity and competing Python work for one stall log."""
+        other_thread_stacks, omitted_thread_stack_count = self._other_thread_stacks()
+        return {
+            "process_cpu_seconds_since_heartbeat": round(
+                max(0.0, time.process_time() - self._last_beat_process_cpu),
+                3,
+            ),
+            "other_thread_stacks": other_thread_stacks,
+            "omitted_thread_stack_count": omitted_thread_stack_count,
+        }
+
     def _note_stall_ended(self, fresh_beat: float) -> None:
         """Log the end of one stall using the heartbeat gap as its duration."""
         assert self._stalled_beat is not None
@@ -171,6 +215,7 @@ class EventLoopStallDetector:
                 stalled_for_seconds=stalled_for_seconds,
                 threshold_seconds=self.threshold_seconds,
                 stack=self._loop_thread_stack(),
+                **self._stall_diagnostics(),
             )
         elif now >= self._next_repeat_log:
             self._next_repeat_log = now + self.repeat_log_interval_seconds
@@ -179,6 +224,7 @@ class EventLoopStallDetector:
                 stalled_for_seconds=stalled_for_seconds,
                 threshold_seconds=self.threshold_seconds,
                 stack=self._loop_thread_stack(),
+                **self._stall_diagnostics(),
             )
 
     def _watch(self) -> None:

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -51,6 +51,22 @@ class _LoopClock:
         callback(scheduled_loop_time)
 
 
+class _FakeFrame:
+    """Minimal frame chain for deterministic stack-depth tests."""
+
+    def __init__(self, f_back: _FakeFrame | None = None) -> None:
+        self.f_back = f_back
+
+
+def _fake_frame_chain(depth: int) -> _FakeFrame:
+    """Return an active fake frame with ``depth`` linked frames."""
+    frame: _FakeFrame | None = None
+    for _ in range(depth):
+        frame = _FakeFrame(frame)
+    assert frame is not None
+    return frame
+
+
 def _fake_runtime_paths(**env_overrides: str) -> RuntimePaths:
     fake = Path("/var/empty/mindroom-test")
     return RuntimePaths(
@@ -255,7 +271,7 @@ def test_other_thread_stacks_keeps_snapshot_frame_when_thread_metadata_has_gone_
     """A frame present in the snapshot remains reportable through metadata lookup races."""
     detector = _detector()
     frame_ident = 123
-    frame = object()
+    frame = _FakeFrame()
     monkeypatch.setattr(event_loop_stall.sys, "_current_frames", lambda: {frame_ident: frame})
     monkeypatch.setattr(event_loop_stall.threading, "enumerate", list)
     monkeypatch.setattr(event_loop_stall.traceback, "format_stack", lambda *_args, **_kwargs: ["snapshot-frame"])
@@ -282,7 +298,7 @@ def test_other_thread_stacks_excludes_loop_and_watcher_and_bounds_characters(mon
     first_ident = 20
     second_ident = 30
     third_ident = 40
-    frames = {ident: object() for ident in (loop_ident, watcher_ident, first_ident, second_ident, third_ident)}
+    frames = {ident: _FakeFrame() for ident in (loop_ident, watcher_ident, first_ident, second_ident, third_ident)}
     names = {
         first_ident: SimpleNamespace(ident=first_ident, name="first", daemon=False),
         second_ident: SimpleNamespace(ident=second_ident, name="second", daemon=True),
@@ -319,7 +335,7 @@ def test_other_thread_stack_truncation_keeps_the_active_frame_tail(monkeypatch: 
     """A bounded stack retains its active frame at the formatted-stack tail."""
     detector = _detector()
     frame_ident = 123
-    frame = object()
+    frame = _FakeFrame()
     monkeypatch.setattr(event_loop_stall.sys, "_current_frames", lambda: {frame_ident: frame})
     monkeypatch.setattr(event_loop_stall.threading, "enumerate", list)
     monkeypatch.setattr(
@@ -335,6 +351,28 @@ def test_other_thread_stack_truncation_keeps_the_active_frame_tail(monkeypatch: 
     assert stacks[0]["stack"] == "\n...\nt\nactive-frame\n"
     assert len(stacks[0]["stack"]) == 20
     assert stacks[0]["stack"].endswith("active-frame\n")
+    assert omitted == 0
+    assert truncated == 1
+
+
+def test_other_thread_stacks_counts_frame_limit_truncation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The truncation count includes stacks whose older frames exceed the frame cap."""
+    detector = _detector()
+    frame_ident = 123
+    frame = _fake_frame_chain(event_loop_stall._MAX_STACK_FRAMES + 1)
+    observed_limits: list[int | None] = []
+    monkeypatch.setattr(event_loop_stall.sys, "_current_frames", lambda: {frame_ident: frame})
+    monkeypatch.setattr(event_loop_stall.threading, "enumerate", list)
+    monkeypatch.setattr(
+        event_loop_stall.traceback,
+        "format_stack",
+        lambda *_args, limit=None: observed_limits.append(limit) or ["active-frame\n"],
+    )
+
+    stacks, omitted, truncated = detector._other_thread_stacks()
+
+    assert stacks[0]["stack"] == "active-frame\n"
+    assert observed_limits == [event_loop_stall._MAX_STACK_FRAMES]
     assert omitted == 0
     assert truncated == 1
 

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -8,7 +8,7 @@ import threading
 import time
 from pathlib import Path
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import pytest
 from structlog.testing import capture_logs
@@ -229,7 +229,9 @@ async def test_detector_logs_process_cpu_and_other_python_thread_stacks() -> Non
     worker_stacks = [entry for entry in other_thread_stacks if entry["thread_name"] == "stall-context-worker"]
     assert len(worker_stacks) == 1
     assert "parked_worker" in worker_stacks[0]["stack"]
+    assert worker_stacks[0]["truncated"] is False
     assert detected[0]["omitted_thread_stack_count"] >= 0
+    assert "truncated_thread_stack_count" not in detected[0]
 
 
 def test_other_thread_stacks_uses_frame_snapshot_for_low_level_thread() -> None:
@@ -251,14 +253,14 @@ def test_other_thread_stacks_uses_frame_snapshot_for_low_level_thread() -> None:
     try:
         assert worker_started.wait(timeout=1.0)
         detector = _detector()
-        stacks, omitted, truncated = detector._other_thread_stacks()
+        frames = event_loop_stall.sys._current_frames()
+        stacks, omitted = detector._other_thread_stacks(frames)
     finally:
         release_worker.set()
     assert worker_stopped.wait(timeout=1.0)
 
     assert worker_ident[0] not in {thread.ident for thread in threading.enumerate()}
     assert omitted == 0
-    assert truncated == 0
     stack = next(entry for entry in stacks if entry["thread_ident"] == worker_ident[0])
     assert stack["thread_name"] == f"thread-{worker_ident[0]}"
     assert stack["daemon"] is None
@@ -276,7 +278,8 @@ def test_other_thread_stacks_keeps_snapshot_frame_when_thread_metadata_has_gone_
     monkeypatch.setattr(event_loop_stall.threading, "enumerate", list)
     monkeypatch.setattr(event_loop_stall.traceback, "format_stack", lambda *_args, **_kwargs: ["snapshot-frame"])
 
-    stacks, omitted, truncated = detector._other_thread_stacks()
+    frames = event_loop_stall.sys._current_frames()
+    stacks, omitted = detector._other_thread_stacks(frames)
 
     assert stacks == [
         {
@@ -284,51 +287,64 @@ def test_other_thread_stacks_keeps_snapshot_frame_when_thread_metadata_has_gone_
             "thread_ident": 123,
             "daemon": None,
             "stack": "snapshot-frame",
+            "truncated": False,
         },
     ]
     assert omitted == 0
-    assert truncated == 0
 
 
-def test_other_thread_stacks_excludes_loop_and_watcher_and_bounds_characters(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Only eligible snapshot frames consume the exact per-stack and total budgets."""
+def test_other_thread_stacks_keeps_complete_thread_name(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Thread metadata names are retained even when they exceed old limits."""
+    detector = _detector()
+    frame_ident = 123
+    frame = _FakeFrame()
+    complete_name = "thread-name-" + "x" * 200
+    monkeypatch.setattr(event_loop_stall.traceback, "format_stack", lambda *_args, **_kwargs: ["snapshot-frame"])
+    monkeypatch.setattr(
+        event_loop_stall.threading,
+        "enumerate",
+        lambda: [SimpleNamespace(ident=frame_ident, name=complete_name, daemon=False)],
+    )
+
+    stacks, omitted = detector._other_thread_stacks({frame_ident: frame})
+
+    assert stacks == [
+        {
+            "thread_name": complete_name,
+            "thread_ident": frame_ident,
+            "daemon": False,
+            "stack": "snapshot-frame",
+            "truncated": False,
+        },
+    ]
+    assert omitted == 0
+
+
+def test_other_thread_stacks_excludes_loop_and_watcher_and_bounds_output(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only the first eight eligible frames are independently bounded."""
     detector = _detector()
     watcher_ident = threading.get_ident()
     loop_ident = 10
-    first_ident = 20
-    second_ident = 30
-    third_ident = 40
-    frames = {ident: _FakeFrame() for ident in (loop_ident, watcher_ident, first_ident, second_ident, third_ident)}
-    names = {
-        first_ident: SimpleNamespace(ident=first_ident, name="first", daemon=False),
-        second_ident: SimpleNamespace(ident=second_ident, name="second", daemon=True),
-        third_ident: SimpleNamespace(ident=third_ident, name="third", daemon=True),
-    }
+    candidate_idents = tuple(range(20, 120, 10))
+    candidate_count = len(candidate_idents)
+    frames = {ident: _FakeFrame() for ident in (loop_ident, watcher_ident, *candidate_idents)}
+    names = {ident: SimpleNamespace(ident=ident, name=f"thread-{ident}", daemon=False) for ident in candidate_idents}
     detector._loop_thread_ident = loop_ident
-    monkeypatch.setattr(event_loop_stall.sys, "_current_frames", lambda: frames)
     monkeypatch.setattr(event_loop_stall.threading, "enumerate", lambda: list(names.values()))
     monkeypatch.setattr(
         event_loop_stall.traceback,
         "format_stack",
-        lambda frame, **_kwargs: {  # type: ignore[call-arg]
-            frames[first_ident]: ["abcdefgh"],
-            frames[second_ident]: ["ijklmnop"],
-            frames[third_ident]: ["qrstuvwx"],
-        }[frame],
+        lambda *_args, **_kwargs: ["unimportant\n" + "x" * 2_000, "active-frame\n"],
     )
-    monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACKS", 3)
-    monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACK_CHARACTERS", 5)
-    monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACK_TOTAL_CHARACTERS", 7)
 
-    stacks, omitted, truncated = detector._other_thread_stacks()
+    stacks, omitted = detector._other_thread_stacks(frames)
 
-    assert [(entry["thread_name"], entry["stack"]) for entry in stacks] == [
-        ("first", "defgh"),
-        ("second", "op"),
-    ]
-    assert omitted == 1
-    assert truncated == 2
-    assert sum(len(entry["stack"]) for entry in stacks) == 7
+    assert len(stacks) == 8
+    assert omitted == candidate_count - len(stacks)
+    assert all(entry["truncated"] is True for entry in stacks)
+    assert all(len(cast("str", entry["stack"])) <= 1_000 for entry in stacks)
+    assert all(cast("str", entry["stack"]).startswith("\n...\n") for entry in stacks)
+    assert all(cast("str", entry["stack"]).endswith("active-frame\n") for entry in stacks)
 
 
 def test_other_thread_stack_truncation_keeps_the_active_frame_tail(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -344,24 +360,22 @@ def test_other_thread_stack_truncation_keeps_the_active_frame_tail(monkeypatch: 
         lambda *_args, **_kwargs: ["unimportant\n", "active-frame\n"],
     )
     monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACK_CHARACTERS", 20)
-    monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACK_TOTAL_CHARACTERS", 20)
 
-    stacks, omitted, truncated = detector._other_thread_stacks()
+    stacks, omitted = detector._other_thread_stacks({frame_ident: frame})
 
     assert stacks[0]["stack"] == "\n...\nt\nactive-frame\n"
     assert len(stacks[0]["stack"]) == 20
     assert stacks[0]["stack"].endswith("active-frame\n")
+    assert stacks[0]["truncated"] is True
     assert omitted == 0
-    assert truncated == 1
 
 
 def test_other_thread_stacks_counts_frame_limit_truncation(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The truncation count includes stacks whose older frames exceed the frame cap."""
+    """Each stack marks truncation when older frames exceed the frame cap."""
     detector = _detector()
     frame_ident = 123
     frame = _fake_frame_chain(event_loop_stall._MAX_STACK_FRAMES + 1)
     observed_limits: list[int | None] = []
-    monkeypatch.setattr(event_loop_stall.sys, "_current_frames", lambda: {frame_ident: frame})
     monkeypatch.setattr(event_loop_stall.threading, "enumerate", list)
     monkeypatch.setattr(
         event_loop_stall.traceback,
@@ -369,34 +383,33 @@ def test_other_thread_stacks_counts_frame_limit_truncation(monkeypatch: pytest.M
         lambda *_args, limit=None: observed_limits.append(limit) or ["active-frame\n"],
     )
 
-    stacks, omitted, truncated = detector._other_thread_stacks()
+    stacks, omitted = detector._other_thread_stacks({frame_ident: frame})
 
     assert stacks[0]["stack"] == "active-frame\n"
     assert observed_limits == [event_loop_stall._MAX_STACK_FRAMES]
     assert omitted == 0
-    assert truncated == 1
+    assert stacks[0]["truncated"] is True
 
 
-def test_stall_diagnostics_uses_one_heartbeat_snapshot_and_samples_cpu_before_formatting(
+def test_stall_diagnostics_uses_supplied_snapshot_and_cpu_sample(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """CPU work is measured from the observed heartbeat before stack formatting begins."""
+    """Diagnostics use the coherent frame and process-CPU samples supplied by the watcher."""
     detector = _detector()
     heartbeat = event_loop_stall._Heartbeat(monotonic_seconds=1.0, process_cpu_seconds=10.0)
     detector._heartbeat = event_loop_stall._Heartbeat(monotonic_seconds=2.0, process_cpu_seconds=20.0)
     events: list[str] = []
-    monkeypatch.setattr(event_loop_stall.time, "process_time", lambda: events.append("cpu") or 12.345)
-    monkeypatch.setattr(event_loop_stall.sys, "_current_frames", dict)
     monkeypatch.setattr(
         detector,
         "_other_thread_stacks",
-        lambda _frames: events.append("format") or ([], 0, 0),
+        lambda _frames: events.append("format") or ([], 0),
     )
 
-    diagnostics = detector._stall_diagnostics(heartbeat)
+    diagnostics = detector._stall_diagnostics(heartbeat, frames={}, current_process_cpu=12.345)
 
     assert diagnostics["process_cpu_seconds_since_heartbeat"] == 2.345
-    assert events == ["cpu", "format"]
+    assert events == ["format"]
+    assert "truncated_thread_stack_count" not in diagnostics
 
 
 def test_watch_passes_the_observed_heartbeat_snapshot_to_stall_reporting(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -306,10 +306,37 @@ def test_other_thread_stacks_excludes_loop_and_watcher_and_bounds_characters(mon
 
     stacks, omitted, truncated = detector._other_thread_stacks()
 
-    assert [(entry["thread_name"], entry["stack"]) for entry in stacks] == [("first", "abcde"), ("second", "ij")]
+    assert [(entry["thread_name"], entry["stack"]) for entry in stacks] == [
+        ("first", "defgh"),
+        ("second", "op"),
+    ]
     assert omitted == 1
     assert truncated == 2
     assert sum(len(entry["stack"]) for entry in stacks) == 7
+
+
+def test_other_thread_stack_truncation_keeps_the_active_frame_tail(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A bounded stack retains its active frame at the formatted-stack tail."""
+    detector = _detector()
+    frame_ident = 123
+    frame = object()
+    monkeypatch.setattr(event_loop_stall.sys, "_current_frames", lambda: {frame_ident: frame})
+    monkeypatch.setattr(event_loop_stall.threading, "enumerate", list)
+    monkeypatch.setattr(
+        event_loop_stall.traceback,
+        "format_stack",
+        lambda *_args, **_kwargs: ["unimportant\n", "active-frame\n"],
+    )
+    monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACK_CHARACTERS", 20)
+    monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACK_TOTAL_CHARACTERS", 20)
+
+    stacks, omitted, truncated = detector._other_thread_stacks()
+
+    assert stacks[0]["stack"] == "\n...\nt\nactive-frame\n"
+    assert len(stacks[0]["stack"]) == 20
+    assert stacks[0]["stack"].endswith("active-frame\n")
+    assert omitted == 0
+    assert truncated == 1
 
 
 def test_stall_diagnostics_uses_one_heartbeat_snapshot_and_samples_cpu_before_formatting(

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -172,6 +173,44 @@ async def test_detector_logs_blocking_stack_and_stall_duration() -> None:
     ended = [entry for entry in logs if entry["event"] == "event_loop_stall_ended"]
     assert len(ended) == 1
     assert ended[0]["stall_duration_seconds"] >= 0.5
+
+
+@pytest.mark.asyncio
+async def test_detector_logs_process_cpu_and_other_python_thread_stacks() -> None:
+    """A stall report must distinguish process activity and expose competing Python work."""
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+
+    def parked_worker() -> None:
+        worker_started.set()
+        release_worker.wait()
+
+    worker = threading.Thread(target=parked_worker, name="stall-context-worker")
+    worker.start()
+    assert worker_started.wait(timeout=1.0)
+
+    detector = _detector()
+    try:
+        with capture_logs() as logs:
+            detector.start()
+            await asyncio.sleep(0.1)
+            time.sleep(0.6)  # noqa: ASYNC251 - deliberately block the event loop.
+            await asyncio.sleep(0.2)
+            detector.stop()
+    finally:
+        release_worker.set()
+        worker.join(timeout=1.0)
+
+    detected = [entry for entry in logs if entry["event"] == "event_loop_stall_detected"]
+    assert len(detected) == 1
+    assert isinstance(detected[0]["process_cpu_seconds_since_heartbeat"], float)
+    assert detected[0]["process_cpu_seconds_since_heartbeat"] >= 0
+    other_thread_stacks = detected[0]["other_thread_stacks"]
+    assert isinstance(other_thread_stacks, list)
+    worker_stacks = [entry for entry in other_thread_stacks if entry["thread_name"] == "stall-context-worker"]
+    assert len(worker_stacks) == 1
+    assert "parked_worker" in worker_stacks[0]["stack"]
+    assert detected[0]["omitted_thread_stack_count"] >= 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_event_loop_stall.py
+++ b/tests/test_event_loop_stall.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+import _thread
 import asyncio
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
 import pytest
 from structlog.testing import capture_logs
 
+from mindroom import event_loop_stall
 from mindroom.constants import RuntimePaths
 from mindroom.event_loop_stall import (
     _DEFAULT_EVENT_LOOP_STALL_THRESHOLD_SECONDS,
@@ -180,26 +183,26 @@ async def test_detector_logs_process_cpu_and_other_python_thread_stacks() -> Non
     """A stall report must distinguish process activity and expose competing Python work."""
     worker_started = threading.Event()
     release_worker = threading.Event()
+    detector = _detector()
 
     def parked_worker() -> None:
         worker_started.set()
         release_worker.wait()
 
     worker = threading.Thread(target=parked_worker, name="stall-context-worker")
-    worker.start()
-    assert worker_started.wait(timeout=1.0)
-
-    detector = _detector()
     try:
+        worker.start()
+        assert worker_started.wait(timeout=1.0)
         with capture_logs() as logs:
             detector.start()
             await asyncio.sleep(0.1)
             time.sleep(0.6)  # noqa: ASYNC251 - deliberately block the event loop.
             await asyncio.sleep(0.2)
-            detector.stop()
     finally:
+        detector.stop()
         release_worker.set()
         worker.join(timeout=1.0)
+    assert not worker.is_alive()
 
     detected = [entry for entry in logs if entry["event"] == "event_loop_stall_detected"]
     assert len(detected) == 1
@@ -211,6 +214,149 @@ async def test_detector_logs_process_cpu_and_other_python_thread_stacks() -> Non
     assert len(worker_stacks) == 1
     assert "parked_worker" in worker_stacks[0]["stack"]
     assert detected[0]["omitted_thread_stack_count"] >= 0
+
+
+def test_other_thread_stacks_uses_frame_snapshot_for_low_level_thread() -> None:
+    """A live native thread is reported even when threading does not know about it."""
+    worker_started = threading.Event()
+    release_worker = threading.Event()
+    worker_stopped = threading.Event()
+    worker_ident: list[int] = []
+
+    def low_level_worker() -> None:
+        try:
+            worker_ident.append(threading.get_ident())
+            worker_started.set()
+            release_worker.wait()
+        finally:
+            worker_stopped.set()
+
+    _thread.start_new_thread(low_level_worker, ())
+    try:
+        assert worker_started.wait(timeout=1.0)
+        detector = _detector()
+        stacks, omitted, truncated = detector._other_thread_stacks()
+    finally:
+        release_worker.set()
+    assert worker_stopped.wait(timeout=1.0)
+
+    assert worker_ident[0] not in {thread.ident for thread in threading.enumerate()}
+    assert omitted == 0
+    assert truncated == 0
+    stack = next(entry for entry in stacks if entry["thread_ident"] == worker_ident[0])
+    assert stack["thread_name"] == f"thread-{worker_ident[0]}"
+    assert stack["daemon"] is None
+    assert "low_level_worker" in stack["stack"]
+
+
+def test_other_thread_stacks_keeps_snapshot_frame_when_thread_metadata_has_gone_away(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A frame present in the snapshot remains reportable through metadata lookup races."""
+    detector = _detector()
+    frame_ident = 123
+    frame = object()
+    monkeypatch.setattr(event_loop_stall.sys, "_current_frames", lambda: {frame_ident: frame})
+    monkeypatch.setattr(event_loop_stall.threading, "enumerate", list)
+    monkeypatch.setattr(event_loop_stall.traceback, "format_stack", lambda *_args, **_kwargs: ["snapshot-frame"])
+
+    stacks, omitted, truncated = detector._other_thread_stacks()
+
+    assert stacks == [
+        {
+            "thread_name": "thread-123",
+            "thread_ident": 123,
+            "daemon": None,
+            "stack": "snapshot-frame",
+        },
+    ]
+    assert omitted == 0
+    assert truncated == 0
+
+
+def test_other_thread_stacks_excludes_loop_and_watcher_and_bounds_characters(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Only eligible snapshot frames consume the exact per-stack and total budgets."""
+    detector = _detector()
+    watcher_ident = threading.get_ident()
+    loop_ident = 10
+    first_ident = 20
+    second_ident = 30
+    third_ident = 40
+    frames = {ident: object() for ident in (loop_ident, watcher_ident, first_ident, second_ident, third_ident)}
+    names = {
+        first_ident: SimpleNamespace(ident=first_ident, name="first", daemon=False),
+        second_ident: SimpleNamespace(ident=second_ident, name="second", daemon=True),
+        third_ident: SimpleNamespace(ident=third_ident, name="third", daemon=True),
+    }
+    detector._loop_thread_ident = loop_ident
+    monkeypatch.setattr(event_loop_stall.sys, "_current_frames", lambda: frames)
+    monkeypatch.setattr(event_loop_stall.threading, "enumerate", lambda: list(names.values()))
+    monkeypatch.setattr(
+        event_loop_stall.traceback,
+        "format_stack",
+        lambda frame, **_kwargs: {  # type: ignore[call-arg]
+            frames[first_ident]: ["abcdefgh"],
+            frames[second_ident]: ["ijklmnop"],
+            frames[third_ident]: ["qrstuvwx"],
+        }[frame],
+    )
+    monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACKS", 3)
+    monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACK_CHARACTERS", 5)
+    monkeypatch.setattr(event_loop_stall, "_MAX_OTHER_THREAD_STACK_TOTAL_CHARACTERS", 7)
+
+    stacks, omitted, truncated = detector._other_thread_stacks()
+
+    assert [(entry["thread_name"], entry["stack"]) for entry in stacks] == [("first", "abcde"), ("second", "ij")]
+    assert omitted == 1
+    assert truncated == 2
+    assert sum(len(entry["stack"]) for entry in stacks) == 7
+
+
+def test_stall_diagnostics_uses_one_heartbeat_snapshot_and_samples_cpu_before_formatting(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CPU work is measured from the observed heartbeat before stack formatting begins."""
+    detector = _detector()
+    heartbeat = event_loop_stall._Heartbeat(monotonic_seconds=1.0, process_cpu_seconds=10.0)
+    detector._heartbeat = event_loop_stall._Heartbeat(monotonic_seconds=2.0, process_cpu_seconds=20.0)
+    events: list[str] = []
+    monkeypatch.setattr(event_loop_stall.time, "process_time", lambda: events.append("cpu") or 12.345)
+    monkeypatch.setattr(event_loop_stall.sys, "_current_frames", dict)
+    monkeypatch.setattr(
+        detector,
+        "_other_thread_stacks",
+        lambda _frames: events.append("format") or ([], 0, 0),
+    )
+
+    diagnostics = detector._stall_diagnostics(heartbeat)
+
+    assert diagnostics["process_cpu_seconds_since_heartbeat"] == 2.345
+    assert events == ["cpu", "format"]
+
+
+def test_watch_passes_the_observed_heartbeat_snapshot_to_stall_reporting(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The watcher never pairs a stale monotonic time with a newer CPU baseline."""
+    detector = _detector(threshold_seconds=0.1)
+    heartbeat = event_loop_stall._Heartbeat(monotonic_seconds=1.0, process_cpu_seconds=10.0)
+    detector._heartbeat = heartbeat
+    observed: list[object] = []
+
+    class _OnePollStopEvent:
+        def __init__(self) -> None:
+            self.polls = 0
+
+        def wait(self, _timeout: float) -> bool:
+            self.polls += 1
+            return self.polls > 1
+
+    detector._stop_event = _OnePollStopEvent()  # type: ignore[assignment]
+    monkeypatch.setattr(detector, "_report_scheduler_lag", lambda _now: None)
+    monkeypatch.setattr(event_loop_stall.time, "monotonic", lambda: 2.0)
+    monkeypatch.setattr(detector, "_note_stalled", lambda _now, seen: observed.append(seen))
+
+    detector._watch()
+
+    assert observed == [heartbeat]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- sample process CPU together with each heartbeat
- capture bounded stacks for other Python threads from one frame snapshot
- preserve active frames and report truncation and omission metadata

## Testing

- full pytest suite
- all pre-commit hooks

## Summary by Sourcery

Enrich event-loop stall reports with bounded execution context and process activity diagnostics.

New Features:
- Add process CPU usage and bounded snapshots of other Python threads to event-loop stall reports.

Bug Fixes:
- Preserve coherent heartbeat timing and CPU baselines when collecting stall diagnostics.

Enhancements:
- Bound reported thread stacks and include metadata identifying truncation and omitted thread stacks while retaining active stack frames.

Tests:
- Add coverage for CPU diagnostics, thread snapshot handling, stack bounds, truncation metadata, and heartbeat consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced event-loop stall diagnostics with process CPU activity and heartbeat timing details.
  * Included bounded stack traces for other running threads, including thread names and omitted-thread counts.
  * Clearly indicated when diagnostic stacks are truncated.

* **Bug Fixes**
  * Improved diagnostic consistency during thread metadata changes and stall detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->