### PR TITLE
Offload LLM request log serialization

### DIFF
--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -321,7 +321,7 @@ class _RequestLogRef:
     log_path: Path
 
 
-async def _write_llm_request_log(
+def _write_llm_request_log_line(
     *,
     model: Model,
     agent_name: str,
@@ -331,12 +331,11 @@ async def _write_llm_request_log(
     request_context: dict[str, _JSONValue] | None = None,
     request_log_id: str,
 ) -> None:
-    """Persist one request record for an LLM invocation."""
+    """Build and persist one request record on the writer thread."""
     now = datetime.now().astimezone()
     resolved_request_context = request_context if request_context is not None else _snapshot_request_log_context()
-    await asyncio.to_thread(
-        _write_jsonl_line,
-        log_path,
+    payload = cast(
+        "dict[str, _JSONValue]",
         {
             "timestamp": now.isoformat(),
             "request_log_id": request_log_id,
@@ -350,6 +349,30 @@ async def _write_llm_request_log(
             "tool_count": len(tools or []),
             "model_params": model_params_payload(model),
         },
+    )
+    _write_jsonl_line(log_path, payload)
+
+
+async def _write_llm_request_log(
+    *,
+    model: Model,
+    agent_name: str,
+    messages: Sequence[Message],
+    tools: list[dict[str, _JSONValue]] | None,
+    log_path: Path,
+    request_context: dict[str, _JSONValue] | None = None,
+    request_log_id: str,
+) -> None:
+    """Persist one request record for an LLM invocation."""
+    await asyncio.to_thread(
+        _write_llm_request_log_line,
+        model=model,
+        agent_name=agent_name,
+        messages=messages,
+        tools=tools,
+        log_path=log_path,
+        request_context=request_context,
+        request_log_id=request_log_id,
     )
 
 

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import datetime
@@ -134,7 +134,7 @@ async def _checkpoint_for_cancellation() -> asyncio.CancelledError | None:
     return None
 
 
-async def _await_before_cancelling(task: asyncio.Task[None]) -> None:
+async def _await_before_cancelling[Result](task: asyncio.Task[Result]) -> Result:
     """Finish one accepted task before propagating caller cancellation once."""
     current_task = asyncio.current_task()
     assert current_task is not None
@@ -158,15 +158,15 @@ async def _await_before_cancelling(task: asyncio.Task[None]) -> None:
             raise
 
     try:
-        task.result()
+        result = task.result()
     except BaseException as task_error:
         if deferred_cancel is None:
             raise
         raise deferred_cancel from task_error
 
-    if deferred_cancel is None:
-        return
-    raise deferred_cancel
+    if deferred_cancel is not None:
+        raise deferred_cancel
+    return result
 
 
 def _json_safe(value: object) -> _JSONValue:
@@ -667,8 +667,8 @@ async def _invoke_with_llm_request_logging(
     try:
         with _model_request_scope(model, wire_tools_capture):
             response = await original_ainvoke(*args, **kwargs)
-    finally:
-        request_log_ref = await _write_llm_request_log_best_effort(
+    except BaseException:
+        await _write_llm_request_log_best_effort(
             model=model,
             agent_name=agent_name,
             kwargs=kwargs,
@@ -677,14 +677,42 @@ async def _invoke_with_llm_request_logging(
             request_context=request_context,
             wire_tools_capture=wire_tools_capture,
         )
-    await _write_llm_response_log_best_effort(
-        model=model,
-        agent_name=agent_name,
-        configured_provider=configured_provider,
-        request_log_ref=request_log_ref,
-        usage=response.response_usage,
-        request_context=request_context,
-    )
+        raise
+
+    async def _write_success_logs() -> None:
+        request_error: Exception | None = None
+        try:
+            request_log_ref = await _write_llm_request_log_if_enabled(
+                model=model,
+                agent_name=agent_name,
+                kwargs=kwargs,
+                debug_config=debug_config,
+                default_log_dir=default_log_dir,
+                request_context=request_context,
+                wire_tools_capture=wire_tools_capture,
+            )
+        except Exception as exc:
+            logger.exception(
+                "Failed to persist LLM request log",
+                agent_name=agent_name,
+                model_id=model.id,
+            )
+            request_log_ref = None
+            request_error = exc
+        await _write_llm_response_log_best_effort(
+            model=model,
+            agent_name=agent_name,
+            configured_provider=configured_provider,
+            request_log_ref=request_log_ref,
+            usage=response.response_usage,
+            request_context=request_context,
+        )
+        if request_error is not None:
+            raise request_error
+
+    finalizer = asyncio.create_task(_write_success_logs())
+    with suppress(Exception):
+        await _await_before_cancelling(finalizer)
     return response
 
 
@@ -705,38 +733,26 @@ def _stream_with_llm_request_logging(
     async def _stream() -> AsyncIterator[ModelResponse]:
         wire_tools_capture = _WireToolsCapture(enabled=debug_config.log_llm_requests)
         request_log_ref: _RequestLogRef | None = None
-        request_logged = False
+        request_log_task: asyncio.Task[_RequestLogRef | None] | None = None
         last_usage: MessageMetrics | None = None
 
         async def _write_request_once() -> None:
-            nonlocal request_log_ref, request_logged
-            if request_logged:
-                return
-            request_logged = True
-            request_log_ref = await _write_llm_request_log_best_effort(
-                model=model,
-                agent_name=agent_name,
-                kwargs=kwargs,
-                debug_config=debug_config,
-                default_log_dir=default_log_dir,
-                request_context=request_context,
-                wire_tools_capture=wire_tools_capture,
-            )
+            nonlocal request_log_ref, request_log_task
+            if request_log_task is None:
+                request_log_task = asyncio.create_task(
+                    _write_llm_request_log_best_effort(
+                        model=model,
+                        agent_name=agent_name,
+                        kwargs=kwargs,
+                        debug_config=debug_config,
+                        default_log_dir=default_log_dir,
+                        request_context=request_context,
+                        wire_tools_capture=wire_tools_capture,
+                    ),
+                )
+            request_log_ref = await _await_before_cancelling(request_log_task)
 
-        # finally: an abandoned stream (consumer break -> aclose()) must
-        # still record any usage already reported; awaiting during aclose()
-        # is allowed for async generators as long as nothing is yielded.
-        try:
-            scoped_stream = context_bound_async_stream(
-                context_factory=lambda: _model_request_scope(model, wire_tools_capture),
-                stream_factory=lambda: original_ainvoke_stream(*args, **kwargs),
-            )
-            async for chunk in scoped_stream:
-                await _write_request_once()
-                if chunk.response_usage is not None:
-                    last_usage = chunk.response_usage
-                yield chunk
-        finally:
+        async def _finalize_stream_logs() -> None:
             await _write_request_once()
             await _write_llm_response_log_best_effort(
                 model=model,
@@ -746,6 +762,31 @@ def _stream_with_llm_request_logging(
                 usage=last_usage,
                 request_context=request_context,
             )
+
+        # finally: an abandoned stream (consumer break -> aclose()) must
+        # still record any usage already reported; awaiting during aclose()
+        # is allowed for async generators as long as nothing is yielded.
+        deferred_cancel: asyncio.CancelledError | None = None
+        try:
+            scoped_stream = context_bound_async_stream(
+                context_factory=lambda: _model_request_scope(model, wire_tools_capture),
+                stream_factory=lambda: original_ainvoke_stream(*args, **kwargs),
+            )
+            async for chunk in scoped_stream:
+                if chunk.response_usage is not None:
+                    last_usage = chunk.response_usage
+                await _write_request_once()
+                yield chunk
+        except asyncio.CancelledError as exc:
+            deferred_cancel = exc
+        finally:
+            finalizer = asyncio.create_task(_finalize_stream_logs())
+            try:
+                await _await_before_cancelling(finalizer)
+            except asyncio.CancelledError as exc:
+                deferred_cancel = deferred_cancel or exc
+            if deferred_cancel is not None:
+                raise deferred_cancel
 
     return _stream()
 

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -593,7 +593,7 @@ async def _write_llm_request_log_if_enabled(
     )
 
 
-async def _write_llm_request_log_best_effort(
+async def _write_llm_request_log_reporting_errors(
     *,
     model: Model,
     agent_name: str,
@@ -603,7 +603,7 @@ async def _write_llm_request_log_best_effort(
     request_context: dict[str, _JSONValue],
     wire_tools_capture: _WireToolsCapture,
 ) -> _RequestLogRef | None:
-    """Persist an optional request record without changing model-call behavior."""
+    """Persist an optional request record and report any ordinary failure."""
     try:
         return await _write_llm_request_log_if_enabled(
             model=model,
@@ -620,6 +620,41 @@ async def _write_llm_request_log_best_effort(
             agent_name=agent_name,
             model_id=model.id,
         )
+        raise
+
+
+async def _write_llm_request_log_best_effort(
+    *,
+    model: Model,
+    agent_name: str,
+    kwargs: dict[str, object],
+    debug_config: DebugConfig,
+    default_log_dir: Path,
+    request_context: dict[str, _JSONValue],
+    wire_tools_capture: _WireToolsCapture,
+) -> _RequestLogRef | None:
+    """Persist an optional request record without changing model-call behavior."""
+    try:
+        return await _write_llm_request_log_reporting_errors(
+            model=model,
+            agent_name=agent_name,
+            kwargs=kwargs,
+            debug_config=debug_config,
+            default_log_dir=default_log_dir,
+            request_context=request_context,
+            wire_tools_capture=wire_tools_capture,
+        )
+    except Exception:
+        return None
+
+
+async def _await_request_log_task_best_effort(
+    task: asyncio.Task[_RequestLogRef | None],
+) -> _RequestLogRef | None:
+    """Return a reported request result without changing normal stream behavior."""
+    try:
+        return await _await_before_cancelling(task)
+    except Exception:
         return None
 
 
@@ -667,6 +702,25 @@ async def _invoke_with_llm_request_logging(
     try:
         with _model_request_scope(model, wire_tools_capture):
             response = await original_ainvoke(*args, **kwargs)
+    except asyncio.CancelledError as provider_cancel:
+        request_task = asyncio.create_task(
+            _write_llm_request_log_reporting_errors(
+                model=model,
+                agent_name=agent_name,
+                kwargs=kwargs,
+                debug_config=debug_config,
+                default_log_dir=default_log_dir,
+                request_context=request_context,
+                wire_tools_capture=wire_tools_capture,
+            ),
+        )
+        with suppress(BaseException):
+            await _await_before_cancelling(request_task)
+        try:
+            request_task.result()
+        except BaseException as request_error:
+            raise provider_cancel from request_error
+        raise
     except BaseException:
         await _write_llm_request_log_best_effort(
             model=model,
@@ -682,7 +736,7 @@ async def _invoke_with_llm_request_logging(
     async def _write_success_logs() -> None:
         request_error: Exception | None = None
         try:
-            request_log_ref = await _write_llm_request_log_if_enabled(
+            request_log_ref = await _write_llm_request_log_reporting_errors(
                 model=model,
                 agent_name=agent_name,
                 kwargs=kwargs,
@@ -692,11 +746,6 @@ async def _invoke_with_llm_request_logging(
                 wire_tools_capture=wire_tools_capture,
             )
         except Exception as exc:
-            logger.exception(
-                "Failed to persist LLM request log",
-                agent_name=agent_name,
-                model_id=model.id,
-            )
             request_log_ref = None
             request_error = exc
         await _write_llm_response_log_best_effort(
@@ -740,7 +789,7 @@ def _stream_with_llm_request_logging(
             nonlocal request_log_ref, request_log_task
             if request_log_task is None:
                 request_log_task = asyncio.create_task(
-                    _write_llm_request_log_best_effort(
+                    _write_llm_request_log_reporting_errors(
                         model=model,
                         agent_name=agent_name,
                         kwargs=kwargs,
@@ -750,7 +799,7 @@ def _stream_with_llm_request_logging(
                         wire_tools_capture=wire_tools_capture,
                     ),
                 )
-            request_log_ref = await _await_before_cancelling(request_log_task)
+            request_log_ref = await _await_request_log_task_best_effort(request_log_task)
 
         async def _finalize_stream_logs() -> None:
             await _write_request_once()

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -7,6 +7,7 @@ import base64
 import json
 from contextlib import contextmanager
 from contextvars import ContextVar
+from copy import deepcopy
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import datetime
 from pathlib import Path
@@ -68,6 +69,7 @@ type _JSONScalar = str | int | float | bool | None
 type _JSONValue = _JSONScalar | list["_JSONValue"] | dict[str, "_JSONValue"]
 _REQUEST_CONTEXT = ContextVar[dict[str, _JSONValue] | None]("mindroom_llm_request_log_context", default=None)
 _ACTIVE_MODEL_CALLS = ContextVar[frozenset[int]]("mindroom_llm_observability_active_models", default=frozenset())
+_UNSNAPSHOTTABLE = object()
 
 
 @dataclass
@@ -82,34 +84,74 @@ class _WireToolsCapture:
 _WIRE_TOOLS_CAPTURE = ContextVar[_WireToolsCapture | None]("mindroom_llm_wire_tools_capture", default=None)
 
 
+@dataclass(frozen=True)
+class _RequestModelSnapshot:
+    """Detached model values needed to build one durable request record."""
+
+    id: str
+    system_prompt: str
+    params: dict[str, object]
+
+
 def _daily_log_path(log_dir: str | None, default_log_dir: Path, now: datetime) -> Path:
     base_dir = Path(log_dir) if log_dir else default_log_dir
     return base_dir / f"llm-requests-{now.date().isoformat()}.jsonl"
 
 
-def _system_prompt(messages: Sequence[Message], model: Model) -> str:
+def _system_prompt(messages: Sequence[Message], model: Model | _RequestModelSnapshot) -> str:
     for message in messages:
         if message.role == "system":
             return message.get_content_string()
     return model.system_prompt or ""
 
 
-def _model_params(model: Model) -> dict[str, _JSONValue]:
+def _model_param_values(model: Model) -> dict[str, object]:
     if not is_dataclass(model):
         return {}
-    payload: dict[str, _JSONValue] = {}
+    payload: dict[str, object] = {}
     for field in fields(model):
         if field.name in _SKIP_MODEL_PARAM_NAMES:
             continue
         value = vars(model).get(field.name)
         if value is None:
             continue
+        payload[field.name] = value
+    return payload
+
+
+def _serializable_model_params(values: dict[str, object]) -> dict[str, _JSONValue]:
+    payload: dict[str, _JSONValue] = {}
+    for name, value in values.items():
         try:
             json.dumps(value)
         except TypeError:
             continue
-        payload[field.name] = value
+        payload[name] = cast("_JSONValue", value)
     return payload
+
+
+def _model_params(model: Model) -> dict[str, _JSONValue]:
+    return _serializable_model_params(_model_param_values(model))
+
+
+def _snapshot_model_param(value: object) -> object:
+    try:
+        return deepcopy(value)
+    except Exception:
+        return _UNSNAPSHOTTABLE
+
+
+def _snapshot_request_model(model: Model) -> _RequestModelSnapshot:
+    params: dict[str, object] = {}
+    for name, value in _model_param_values(model).items():
+        snapshot = _snapshot_model_param(value)
+        if snapshot is not _UNSNAPSHOTTABLE:
+            params[name] = snapshot
+    return _RequestModelSnapshot(
+        id=model.id,
+        system_prompt=cast("str", deepcopy(model.system_prompt) or ""),
+        params=params,
+    )
 
 
 def _write_jsonl_line(path: Path, payload: dict[str, _JSONValue]) -> None:
@@ -196,8 +238,10 @@ def current_llm_request_log_context() -> dict[str, _JSONValue]:
     return _snapshot_request_log_context()
 
 
-def model_params_payload(model: Model) -> dict[str, _JSONValue]:
+def model_params_payload(model: Model | _RequestModelSnapshot) -> dict[str, _JSONValue]:
     """Return JSON-safe model parameters suitable for durable request metadata."""
+    if isinstance(model, _RequestModelSnapshot):
+        return _serializable_model_params(model.params)
     return _model_params(model)
 
 
@@ -321,33 +365,42 @@ class _RequestLogRef:
     log_path: Path
 
 
+@dataclass(frozen=True)
+class _RequestLogSnapshot:
+    """Invocation-time values consumed later by the request writer thread."""
+
+    model: _RequestModelSnapshot
+    messages: tuple[Message, ...]
+    tools: list[dict[str, _JSONValue]] | None
+    request_context: dict[str, _JSONValue] | None
+    timestamp: datetime
+
+
 def _write_llm_request_log_line(
     *,
-    model: Model,
+    snapshot: _RequestLogSnapshot,
     agent_name: str,
-    messages: Sequence[Message],
-    tools: list[dict[str, _JSONValue]] | None,
     log_path: Path,
-    request_context: dict[str, _JSONValue] | None = None,
     request_log_id: str,
 ) -> None:
     """Build and persist one request record on the writer thread."""
-    now = datetime.now().astimezone()
-    resolved_request_context = request_context if request_context is not None else _snapshot_request_log_context()
+    resolved_request_context = (
+        snapshot.request_context if snapshot.request_context is not None else _snapshot_request_log_context()
+    )
     payload = cast(
         "dict[str, _JSONValue]",
         {
-            "timestamp": now.isoformat(),
+            "timestamp": snapshot.timestamp.isoformat(),
             "request_log_id": request_log_id,
             "agent_id": agent_name,
             **resolved_request_context,
-            "model_id": model.id,
-            "system_prompt": _system_prompt(messages, model),
-            "messages": _request_message_payloads(messages),
-            "message_count": len(messages),
-            "tools": _json_safe(tools),
-            "tool_count": len(tools or []),
-            "model_params": model_params_payload(model),
+            "model_id": snapshot.model.id,
+            "system_prompt": _system_prompt(snapshot.messages, snapshot.model),
+            "messages": _request_message_payloads(snapshot.messages),
+            "message_count": len(snapshot.messages),
+            "tools": _json_safe(snapshot.tools),
+            "tool_count": len(snapshot.tools or []),
+            "model_params": model_params_payload(snapshot.model),
         },
     )
     _write_jsonl_line(log_path, payload)
@@ -362,16 +415,21 @@ async def _write_llm_request_log(
     log_path: Path,
     request_context: dict[str, _JSONValue] | None = None,
     request_log_id: str,
+    timestamp: datetime | None = None,
 ) -> None:
     """Persist one request record for an LLM invocation."""
+    snapshot = _RequestLogSnapshot(
+        model=_snapshot_request_model(model),
+        messages=tuple(deepcopy(messages)),
+        tools=deepcopy(tools),
+        request_context=deepcopy(request_context),
+        timestamp=timestamp or datetime.now().astimezone(),
+    )
     await asyncio.to_thread(
         _write_llm_request_log_line,
-        model=model,
+        snapshot=snapshot,
         agent_name=agent_name,
-        messages=messages,
-        tools=tools,
         log_path=log_path,
-        request_context=request_context,
         request_log_id=request_log_id,
     )
 
@@ -491,9 +549,10 @@ async def _write_llm_request_log_if_present(
     messages = _request_messages(kwargs.get("messages"))
     if messages is None:
         return None
+    request_timestamp = datetime.now().astimezone()
     request_log_ref = _RequestLogRef(
         request_log_id=uuid4().hex,
-        log_path=_daily_log_path(log_dir, default_log_dir, datetime.now().astimezone()),
+        log_path=_daily_log_path(log_dir, default_log_dir, request_timestamp),
     )
     await _write_llm_request_log(
         model=model,
@@ -503,6 +562,7 @@ async def _write_llm_request_log_if_present(
         log_path=request_log_ref.log_path,
         request_context=request_context,
         request_log_id=request_log_ref.request_log_id,
+        timestamp=request_timestamp,
     )
     return request_log_ref
 

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -10,6 +10,7 @@ from contextvars import ContextVar
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import datetime
 from pathlib import Path
+from threading import Lock
 from typing import TYPE_CHECKING, cast
 from uuid import uuid4
 
@@ -33,6 +34,7 @@ if TYPE_CHECKING:
 
 _INSTALLED_ATTR = "_mindroom_llm_request_logging_installed"
 logger = get_logger(__name__)
+_JSONL_APPEND_LOCK = Lock()
 
 
 _SKIP_MODEL_PARAM_NAMES = {
@@ -72,7 +74,7 @@ _ACTIVE_MODEL_CALLS = ContextVar[frozenset[int]]("mindroom_llm_observability_act
 
 @dataclass
 class _WireToolsCapture:
-    """Request-local borrowed tools observed after provider wire transformations."""
+    """Request-local tool membership whose elements stay borrowed through logging."""
 
     enabled: bool
     observed: bool = False
@@ -113,14 +115,27 @@ def _model_params(model: Model) -> dict[str, _JSONValue]:
 
 
 def _write_serialized_jsonl_line(path: Path, line: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(line)
-        handle.write("\n")
+    record = f"{line}\n"
+    with _JSONL_APPEND_LOCK:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(record)
 
 
 def _write_jsonl_line(path: Path, payload: dict[str, _JSONValue]) -> None:
     _write_serialized_jsonl_line(path, json.dumps(redact_sensitive_data(payload)))
+
+
+def _consume_task_cancellations(task: asyncio.Task[object]) -> int:
+    cancel_count = task.cancelling()
+    for _ in range(cancel_count):
+        task.uncancel()
+    return cancel_count
+
+
+def _restore_task_cancellations(task: asyncio.Task[object], cancel_count: int) -> None:
+    for _ in range(cancel_count):
+        task.cancel()
 
 
 async def _await_before_cancelling(task: asyncio.Task[None]) -> None:
@@ -134,27 +149,27 @@ async def _await_before_cancelling(task: asyncio.Task[None]) -> None:
         try:
             await asyncio.shield(task)
         except asyncio.CancelledError as exc:
-            caller_cancel_count = current_task.cancelling()
+            caller_cancel_count = _consume_task_cancellations(current_task)
             if caller_cancel_count <= 0:
                 raise
-            for _ in range(caller_cancel_count):
-                current_task.uncancel()
             deferred_cancel_count += caller_cancel_count
             deferred_cancel = deferred_cancel or exc
+        except BaseException:
+            if task.done():
+                break
+            raise
 
     try:
         task.result()
     except BaseException as task_error:
         if deferred_cancel is None:
             raise
-        for _ in range(deferred_cancel_count):
-            current_task.cancel()
+        _restore_task_cancellations(current_task, deferred_cancel_count)
         raise deferred_cancel from task_error
 
     if deferred_cancel is None:
         return
-    for _ in range(deferred_cancel_count):
-        current_task.cancel()
+    _restore_task_cancellations(current_task, deferred_cancel_count)
     raise deferred_cancel
 
 
@@ -206,12 +221,12 @@ def _request_tools(value: object) -> list[dict[str, _JSONValue]] | None:
 
 
 def record_llm_request_tools(tools: object) -> None:
-    """Borrow final provider tools until the active model invocation is logged."""
+    """Capture final tool membership while borrowing elements until logging."""
     capture = _WIRE_TOOLS_CAPTURE.get()
     if capture is None or not capture.enabled:
         return
     capture.observed = True
-    capture.tools = tools
+    capture.tools = list(tools) if isinstance(tools, list) else tools
 
 
 def _normalized_string_list(values: object) -> list[str]:
@@ -402,15 +417,17 @@ async def _write_llm_request_log(
     request_log_id: str,
     timestamp: datetime | None = None,
 ) -> None:
-    """Serialize and append off-loop before exposing caller cancellation."""
+    """Pin container membership, then borrow elements through the awaited write."""
     request_timestamp = timestamp or datetime.now().astimezone()
+    captured_messages = tuple(messages)
+    captured_tools = list(tools) if isinstance(tools, list) else tools
 
     def serialize_and_write() -> None:
         serialized_line = _serialize_llm_request_log_line(
             model=model,
             agent_name=agent_name,
-            messages=messages,
-            tools=tools,
+            messages=captured_messages,
+            tools=captured_tools,
             request_context=request_context,
             request_log_id=request_log_id,
             timestamp=request_timestamp,
@@ -530,6 +547,8 @@ async def _write_llm_request_log_if_present(
 ) -> _RequestLogRef | None:
     """Write one request log entry when provider kwargs include API request messages.
 
+    Model configuration plus message and tool elements remain borrowed until
+    this awaited call returns or raises; their top-level containers are pinned.
     Returns the written record's join key and file so the matching response
     record can be joined to it later, in the same daily file.
     """
@@ -697,6 +716,7 @@ def _stream_with_llm_request_logging(
             nonlocal request_log_ref, request_logged
             if request_logged:
                 return
+            request_logged = True
             request_log_ref = await _write_llm_request_log_best_effort(
                 model=model,
                 agent_name=agent_name,
@@ -706,7 +726,6 @@ def _stream_with_llm_request_logging(
                 request_context=request_context,
                 wire_tools_capture=wire_tools_capture,
             )
-            request_logged = True
 
         # finally: an abandoned stream (consumer break -> aclose()) must
         # still record any usage already reported; awaiting during aclose()

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -123,6 +123,41 @@ def _write_jsonl_line(path: Path, payload: dict[str, _JSONValue]) -> None:
     _write_serialized_jsonl_line(path, json.dumps(redact_sensitive_data(payload)))
 
 
+async def _await_before_cancelling(task: asyncio.Task[None]) -> None:
+    """Finish one accepted task before restoring caller cancellation."""
+    current_task = asyncio.current_task()
+    assert current_task is not None
+    deferred_cancel_count = 0
+    deferred_cancel: asyncio.CancelledError | None = None
+
+    while not task.done():
+        try:
+            await asyncio.shield(task)
+        except asyncio.CancelledError as exc:
+            caller_cancel_count = current_task.cancelling()
+            if caller_cancel_count <= 0:
+                raise
+            for _ in range(caller_cancel_count):
+                current_task.uncancel()
+            deferred_cancel_count += caller_cancel_count
+            deferred_cancel = deferred_cancel or exc
+
+    try:
+        task.result()
+    except BaseException as task_error:
+        if deferred_cancel is None:
+            raise
+        for _ in range(deferred_cancel_count):
+            current_task.cancel()
+        raise deferred_cancel from task_error
+
+    if deferred_cancel is None:
+        return
+    for _ in range(deferred_cancel_count):
+        current_task.cancel()
+    raise deferred_cancel
+
+
 def _json_safe(value: object) -> _JSONValue:
     normalized: object = value
     if isinstance(normalized, BaseModel):
@@ -367,18 +402,23 @@ async def _write_llm_request_log(
     request_log_id: str,
     timestamp: datetime | None = None,
 ) -> None:
-    """Serialize borrowed request values off-loop, then append the immutable line."""
-    serialized_line = await asyncio.to_thread(
-        _serialize_llm_request_log_line,
-        model=model,
-        agent_name=agent_name,
-        messages=messages,
-        tools=tools,
-        request_context=request_context,
-        request_log_id=request_log_id,
-        timestamp=timestamp or datetime.now().astimezone(),
-    )
-    await asyncio.to_thread(_write_serialized_jsonl_line, log_path, serialized_line)
+    """Serialize and append off-loop before exposing caller cancellation."""
+    request_timestamp = timestamp or datetime.now().astimezone()
+
+    def serialize_and_write() -> None:
+        serialized_line = _serialize_llm_request_log_line(
+            model=model,
+            agent_name=agent_name,
+            messages=messages,
+            tools=tools,
+            request_context=request_context,
+            request_log_id=request_log_id,
+            timestamp=request_timestamp,
+        )
+        _write_serialized_jsonl_line(log_path, serialized_line)
+
+    write_task = asyncio.create_task(asyncio.to_thread(serialize_and_write))
+    await _await_before_cancelling(write_task)
 
 
 def _usage_payload(usage: MessageMetrics) -> dict[str, _JSONValue]:

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -653,12 +653,49 @@ async def _await_request_log_task_best_effort(
 ) -> _RequestLogRef | None:
     """Return a reported request result without changing normal stream behavior."""
     try:
+        if task.done():
+            return task.result()
         return await _await_before_cancelling(task)
     except Exception:
         return None
 
 
-async def _write_llm_response_log_best_effort(
+async def _await_log_finalizer(
+    task: asyncio.Task[None],
+    *,
+    deferred_cancel: asyncio.CancelledError | None = None,
+) -> None:
+    """Settle accepted logging, preserving cancellation and one worker error."""
+    finalizer_error: Exception | None = None
+    try:
+        await _await_before_cancelling(task)
+    except asyncio.CancelledError as exc:
+        deferred_cancel = deferred_cancel or exc
+    except Exception as exc:
+        finalizer_error = exc
+    try:
+        task.result()
+    except asyncio.CancelledError as exc:
+        deferred_cancel = deferred_cancel or exc
+    except Exception as exc:
+        finalizer_error = exc
+    if deferred_cancel is None:
+        return
+    if deferred_cancel.__cause__ is None and finalizer_error is not None:
+        raise deferred_cancel from finalizer_error
+    raise deferred_cancel
+
+
+def _settled_task_error[Result](task: asyncio.Task[Result]) -> Exception | None:
+    """Return one ordinary error from an already-settled task."""
+    try:
+        task.result()
+    except Exception as exc:
+        return exc
+    return None
+
+
+async def _write_llm_response_log_reporting_errors(
     *,
     model: Model,
     agent_name: str,
@@ -667,7 +704,7 @@ async def _write_llm_response_log_best_effort(
     usage: MessageMetrics | None,
     request_context: dict[str, _JSONValue],
 ) -> None:
-    """Emit usage and optional response records without affecting the model call."""
+    """Emit usage and an optional response record, reporting ordinary failure."""
     try:
         await _write_llm_response_log(
             model=model,
@@ -683,6 +720,31 @@ async def _write_llm_response_log_best_effort(
             agent_name=agent_name,
             model_id=model.id,
         )
+        raise
+
+
+async def _capture_llm_response_log_error(
+    *,
+    model: Model,
+    agent_name: str,
+    configured_provider: str | None,
+    request_log_ref: _RequestLogRef | None,
+    usage: MessageMetrics | None,
+    request_context: dict[str, _JSONValue],
+) -> Exception | None:
+    """Complete response logging and return an already-reported failure."""
+    try:
+        await _write_llm_response_log_reporting_errors(
+            model=model,
+            agent_name=agent_name,
+            configured_provider=configured_provider,
+            request_log_ref=request_log_ref,
+            usage=usage,
+            request_context=request_context,
+        )
+    except Exception as exc:
+        return exc
+    return None
 
 
 async def _invoke_with_llm_request_logging(
@@ -748,7 +810,7 @@ async def _invoke_with_llm_request_logging(
         except Exception as exc:
             request_log_ref = None
             request_error = exc
-        await _write_llm_response_log_best_effort(
+        response_error = await _capture_llm_response_log_error(
             model=model,
             agent_name=agent_name,
             configured_provider=configured_provider,
@@ -758,10 +820,11 @@ async def _invoke_with_llm_request_logging(
         )
         if request_error is not None:
             raise request_error
+        if response_error is not None:
+            raise response_error
 
     finalizer = asyncio.create_task(_write_success_logs())
-    with suppress(Exception):
-        await _await_before_cancelling(finalizer)
+    await _await_log_finalizer(finalizer)
     return response
 
 
@@ -803,7 +866,9 @@ def _stream_with_llm_request_logging(
 
         async def _finalize_stream_logs() -> None:
             await _write_request_once()
-            await _write_llm_response_log_best_effort(
+            assert request_log_task is not None
+            request_error = _settled_task_error(request_log_task)
+            response_error = await _capture_llm_response_log_error(
                 model=model,
                 agent_name=agent_name,
                 configured_provider=configured_provider,
@@ -811,6 +876,10 @@ def _stream_with_llm_request_logging(
                 usage=last_usage,
                 request_context=request_context,
             )
+            if request_error is not None:
+                raise request_error
+            if response_error is not None:
+                raise response_error
 
         # finally: an abandoned stream (consumer break -> aclose()) must
         # still record any usage already reported; awaiting during aclose()
@@ -830,12 +899,7 @@ def _stream_with_llm_request_logging(
             deferred_cancel = exc
         finally:
             finalizer = asyncio.create_task(_finalize_stream_logs())
-            try:
-                await _await_before_cancelling(finalizer)
-            except asyncio.CancelledError as exc:
-                deferred_cancel = deferred_cancel or exc
-            if deferred_cancel is not None:
-                raise deferred_cancel
+            await _await_log_finalizer(finalizer, deferred_cancel=deferred_cancel)
 
     return _stream()
 

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -151,7 +151,7 @@ async def _await_before_cancelling[Result](task: asyncio.Task[Result]) -> Result
                     break
                 raise
             observed_cancel_count = caller_cancel_count
-            deferred_cancel = deferred_cancel or exc
+            deferred_cancel = exc if deferred_cancel is None else deferred_cancel
         except BaseException:
             if task.done():
                 break
@@ -698,7 +698,7 @@ async def _await_log_finalizer(
     try:
         await _await_before_cancelling(task)
     except asyncio.CancelledError as exc:
-        deferred_cancel = deferred_cancel or exc
+        deferred_cancel = exc if deferred_cancel is None else deferred_cancel
         if isinstance(exc.__cause__, Exception):
             finalizer_error = exc.__cause__
     except Exception as exc:
@@ -717,14 +717,16 @@ async def _await_request_log_after_provider_cancellation(state: _RequestLogState
     try:
         await _await_before_cancelling(state.task)
     except asyncio.CancelledError as exc:
-        request_error = state.error or exc.__cause__
+        request_error = state.error
+        if request_error is None:
+            request_error = exc.__cause__
         if request_error is None and state.task.cancelled():
             request_error = exc
     except BaseException as exc:
-        request_error = state.error or exc
+        request_error = state.error if state.error is not None else exc
     finally:
         state.consumed = True
-    return state.error or request_error
+    return state.error if state.error is not None else request_error
 
 
 async def _write_llm_response_log_reporting_errors(

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -126,12 +126,20 @@ def _write_jsonl_line(path: Path, payload: dict[str, _JSONValue]) -> None:
     _write_serialized_jsonl_line(path, json.dumps(redact_sensitive_data(payload)))
 
 
+async def _checkpoint_for_cancellation() -> asyncio.CancelledError | None:
+    try:
+        await asyncio.sleep(0)
+    except asyncio.CancelledError as exc:
+        return exc
+    return None
+
+
 async def _await_before_cancelling(task: asyncio.Task[None]) -> None:
     """Finish one accepted task before propagating caller cancellation once."""
     current_task = asyncio.current_task()
     assert current_task is not None
+    deferred_cancel = await _checkpoint_for_cancellation()
     observed_cancel_count = current_task.cancelling()
-    deferred_cancel: asyncio.CancelledError | None = None
 
     while not task.done():
         try:

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -126,33 +126,23 @@ def _write_jsonl_line(path: Path, payload: dict[str, _JSONValue]) -> None:
     _write_serialized_jsonl_line(path, json.dumps(redact_sensitive_data(payload)))
 
 
-def _consume_task_cancellations(task: asyncio.Task[object]) -> int:
-    cancel_count = task.cancelling()
-    for _ in range(cancel_count):
-        task.uncancel()
-    return cancel_count
-
-
-def _restore_task_cancellations(task: asyncio.Task[object], cancel_count: int) -> None:
-    for _ in range(cancel_count):
-        task.cancel()
-
-
 async def _await_before_cancelling(task: asyncio.Task[None]) -> None:
-    """Finish one accepted task before restoring caller cancellation."""
+    """Finish one accepted task before propagating caller cancellation once."""
     current_task = asyncio.current_task()
     assert current_task is not None
-    deferred_cancel_count = 0
+    observed_cancel_count = current_task.cancelling()
     deferred_cancel: asyncio.CancelledError | None = None
 
     while not task.done():
         try:
             await asyncio.shield(task)
         except asyncio.CancelledError as exc:
-            caller_cancel_count = _consume_task_cancellations(current_task)
-            if caller_cancel_count <= 0:
+            caller_cancel_count = current_task.cancelling()
+            if caller_cancel_count <= observed_cancel_count:
+                if task.done():
+                    break
                 raise
-            deferred_cancel_count += caller_cancel_count
+            observed_cancel_count = caller_cancel_count
             deferred_cancel = deferred_cancel or exc
         except BaseException:
             if task.done():
@@ -164,12 +154,10 @@ async def _await_before_cancelling(task: asyncio.Task[None]) -> None:
     except BaseException as task_error:
         if deferred_cancel is None:
             raise
-        _restore_task_cancellations(current_task, deferred_cancel_count)
         raise deferred_cancel from task_error
 
     if deferred_cancel is None:
         return
-    _restore_task_cancellations(current_task, deferred_cancel_count)
     raise deferred_cancel
 
 

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -7,7 +7,6 @@ import base64
 import json
 from contextlib import contextmanager
 from contextvars import ContextVar
-from copy import deepcopy
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import datetime
 from pathlib import Path
@@ -69,28 +68,18 @@ type _JSONScalar = str | int | float | bool | None
 type _JSONValue = _JSONScalar | list["_JSONValue"] | dict[str, "_JSONValue"]
 _REQUEST_CONTEXT = ContextVar[dict[str, _JSONValue] | None]("mindroom_llm_request_log_context", default=None)
 _ACTIVE_MODEL_CALLS = ContextVar[frozenset[int]]("mindroom_llm_observability_active_models", default=frozenset())
-_UNSNAPSHOTTABLE = object()
 
 
 @dataclass
 class _WireToolsCapture:
-    """Request-local tools observed after provider wire transformations."""
+    """Request-local borrowed tools observed after provider wire transformations."""
 
     enabled: bool
     observed: bool = False
-    tools: list[dict[str, _JSONValue]] | None = None
+    tools: object = None
 
 
 _WIRE_TOOLS_CAPTURE = ContextVar[_WireToolsCapture | None]("mindroom_llm_wire_tools_capture", default=None)
-
-
-@dataclass(frozen=True)
-class _RequestModelSnapshot:
-    """Detached model values needed to build one durable request record."""
-
-    id: str
-    system_prompt: str
-    params: dict[str, object]
 
 
 def _daily_log_path(log_dir: str | None, default_log_dir: Path, now: datetime) -> Path:
@@ -98,67 +87,40 @@ def _daily_log_path(log_dir: str | None, default_log_dir: Path, now: datetime) -
     return base_dir / f"llm-requests-{now.date().isoformat()}.jsonl"
 
 
-def _system_prompt(messages: Sequence[Message], model: Model | _RequestModelSnapshot) -> str:
+def _system_prompt(messages: Sequence[Message], model: Model) -> str:
     for message in messages:
         if message.role == "system":
             return message.get_content_string()
     return model.system_prompt or ""
 
 
-def _model_param_values(model: Model) -> dict[str, object]:
+def _model_params(model: Model) -> dict[str, _JSONValue]:
     if not is_dataclass(model):
         return {}
-    payload: dict[str, object] = {}
+    payload: dict[str, _JSONValue] = {}
     for field in fields(model):
         if field.name in _SKIP_MODEL_PARAM_NAMES:
             continue
         value = vars(model).get(field.name)
         if value is None:
             continue
-        payload[field.name] = value
-    return payload
-
-
-def _serializable_model_params(values: dict[str, object]) -> dict[str, _JSONValue]:
-    payload: dict[str, _JSONValue] = {}
-    for name, value in values.items():
         try:
             json.dumps(value)
         except TypeError:
             continue
-        payload[name] = cast("_JSONValue", value)
+        payload[field.name] = value
     return payload
 
 
-def _model_params(model: Model) -> dict[str, _JSONValue]:
-    return _serializable_model_params(_model_param_values(model))
-
-
-def _snapshot_model_param(value: object) -> object:
-    try:
-        return deepcopy(value)
-    except Exception:
-        return _UNSNAPSHOTTABLE
-
-
-def _snapshot_request_model(model: Model) -> _RequestModelSnapshot:
-    params: dict[str, object] = {}
-    for name, value in _model_param_values(model).items():
-        snapshot = _snapshot_model_param(value)
-        if snapshot is not _UNSNAPSHOTTABLE:
-            params[name] = snapshot
-    return _RequestModelSnapshot(
-        id=model.id,
-        system_prompt=cast("str", deepcopy(model.system_prompt) or ""),
-        params=params,
-    )
+def _write_serialized_jsonl_line(path: Path, line: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(line)
+        handle.write("\n")
 
 
 def _write_jsonl_line(path: Path, payload: dict[str, _JSONValue]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(json.dumps(redact_sensitive_data(payload)))
-        handle.write("\n")
+    _write_serialized_jsonl_line(path, json.dumps(redact_sensitive_data(payload)))
 
 
 def _json_safe(value: object) -> _JSONValue:
@@ -209,13 +171,12 @@ def _request_tools(value: object) -> list[dict[str, _JSONValue]] | None:
 
 
 def record_llm_request_tools(tools: object) -> None:
-    """Record the final provider tools for the active request-log scope."""
+    """Borrow final provider tools until the active model invocation is logged."""
     capture = _WIRE_TOOLS_CAPTURE.get()
     if capture is None or not capture.enabled:
         return
     capture.observed = True
-    normalized_tools = _json_safe(tools)
-    capture.tools = _request_tools(normalized_tools)
+    capture.tools = tools
 
 
 def _normalized_string_list(values: object) -> list[str]:
@@ -238,10 +199,8 @@ def current_llm_request_log_context() -> dict[str, _JSONValue]:
     return _snapshot_request_log_context()
 
 
-def model_params_payload(model: Model | _RequestModelSnapshot) -> dict[str, _JSONValue]:
+def model_params_payload(model: Model) -> dict[str, _JSONValue]:
     """Return JSON-safe model parameters suitable for durable request metadata."""
-    if isinstance(model, _RequestModelSnapshot):
-        return _serializable_model_params(model.params)
     return _model_params(model)
 
 
@@ -365,45 +324,36 @@ class _RequestLogRef:
     log_path: Path
 
 
-@dataclass(frozen=True)
-class _RequestLogSnapshot:
-    """Invocation-time values consumed later by the request writer thread."""
-
-    model: _RequestModelSnapshot
-    messages: tuple[Message, ...]
-    tools: list[dict[str, _JSONValue]] | None
-    request_context: dict[str, _JSONValue] | None
-    timestamp: datetime
-
-
-def _write_llm_request_log_line(
+def _serialize_llm_request_log_line(
     *,
-    snapshot: _RequestLogSnapshot,
+    model: Model,
     agent_name: str,
-    log_path: Path,
+    messages: Sequence[Message],
+    tools: object,
+    request_context: dict[str, _JSONValue] | None,
     request_log_id: str,
-) -> None:
-    """Build and persist one request record on the writer thread."""
-    resolved_request_context = (
-        snapshot.request_context if snapshot.request_context is not None else _snapshot_request_log_context()
-    )
+    timestamp: datetime,
+) -> str:
+    """Serialize one immutable request-log line on a worker thread."""
+    resolved_request_context = request_context if request_context is not None else _snapshot_request_log_context()
+    normalized_tools = _request_tools(_json_safe(tools))
     payload = cast(
         "dict[str, _JSONValue]",
         {
-            "timestamp": snapshot.timestamp.isoformat(),
+            "timestamp": timestamp.isoformat(),
             "request_log_id": request_log_id,
             "agent_id": agent_name,
             **resolved_request_context,
-            "model_id": snapshot.model.id,
-            "system_prompt": _system_prompt(snapshot.messages, snapshot.model),
-            "messages": _request_message_payloads(snapshot.messages),
-            "message_count": len(snapshot.messages),
-            "tools": _json_safe(snapshot.tools),
-            "tool_count": len(snapshot.tools or []),
-            "model_params": model_params_payload(snapshot.model),
+            "model_id": model.id,
+            "system_prompt": _system_prompt(messages, model),
+            "messages": _request_message_payloads(messages),
+            "message_count": len(messages),
+            "tools": normalized_tools,
+            "tool_count": len(normalized_tools or []),
+            "model_params": model_params_payload(model),
         },
     )
-    _write_jsonl_line(log_path, payload)
+    return json.dumps(redact_sensitive_data(payload))
 
 
 async def _write_llm_request_log(
@@ -411,27 +361,24 @@ async def _write_llm_request_log(
     model: Model,
     agent_name: str,
     messages: Sequence[Message],
-    tools: list[dict[str, _JSONValue]] | None,
+    tools: object,
     log_path: Path,
     request_context: dict[str, _JSONValue] | None = None,
     request_log_id: str,
     timestamp: datetime | None = None,
 ) -> None:
-    """Persist one request record for an LLM invocation."""
-    snapshot = _RequestLogSnapshot(
-        model=_snapshot_request_model(model),
-        messages=tuple(deepcopy(messages)),
-        tools=deepcopy(tools),
-        request_context=deepcopy(request_context),
+    """Serialize borrowed request values off-loop, then append the immutable line."""
+    serialized_line = await asyncio.to_thread(
+        _serialize_llm_request_log_line,
+        model=model,
+        agent_name=agent_name,
+        messages=messages,
+        tools=tools,
+        request_context=request_context,
+        request_log_id=request_log_id,
         timestamp=timestamp or datetime.now().astimezone(),
     )
-    await asyncio.to_thread(
-        _write_llm_request_log_line,
-        snapshot=snapshot,
-        agent_name=agent_name,
-        log_path=log_path,
-        request_log_id=request_log_id,
-    )
+    await asyncio.to_thread(_write_serialized_jsonl_line, log_path, serialized_line)
 
 
 def _usage_payload(usage: MessageMetrics) -> dict[str, _JSONValue]:
@@ -558,7 +505,7 @@ async def _write_llm_request_log_if_present(
         model=model,
         agent_name=agent_name,
         messages=messages,
-        tools=(wire_tools_capture.tools if wire_tools_capture.observed else _request_tools(kwargs.get("tools"))),
+        tools=(wire_tools_capture.tools if wire_tools_capture.observed else kwargs.get("tools")),
         log_path=request_log_ref.log_path,
         request_context=request_context,
         request_log_id=request_log_ref.request_log_id,

--- a/src/mindroom/llm_request_logging.py
+++ b/src/mindroom/llm_request_logging.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import base64
 import json
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import asdict, dataclass, fields, is_dataclass
 from datetime import datetime
@@ -370,6 +370,16 @@ class _RequestLogRef:
     log_path: Path
 
 
+@dataclass
+class _RequestLogState:
+    """One accepted request write and its explicitly retained outcome."""
+
+    request_log_ref: _RequestLogRef | None = None
+    error: Exception | None = None
+    task: asyncio.Task[None] | None = None
+    consumed: bool = False
+
+
 def _serialize_llm_request_log_line(
     *,
     model: Model,
@@ -623,6 +633,17 @@ async def _write_llm_request_log_reporting_errors(
         raise
 
 
+async def _capture_request_log_outcome(
+    state: _RequestLogState,
+    write_request: Callable[[], Coroutine[object, object, _RequestLogRef | None]],
+) -> None:
+    """Retain a request result or already-reported ordinary error."""
+    try:
+        state.request_log_ref = await write_request()
+    except Exception as exc:
+        state.error = exc
+
+
 async def _write_llm_request_log_best_effort(
     *,
     model: Model,
@@ -648,16 +669,23 @@ async def _write_llm_request_log_best_effort(
         return None
 
 
-async def _await_request_log_task_best_effort(
-    task: asyncio.Task[_RequestLogRef | None],
-) -> _RequestLogRef | None:
-    """Return a reported request result without changing normal stream behavior."""
+async def _await_request_log_once(
+    state: _RequestLogState,
+    write_request: Callable[[], Coroutine[object, object, _RequestLogRef | None]],
+) -> None:
+    """Consume one accepted stream request task and retain its outcome."""
+    if state.consumed:
+        return
+    if state.task is None:
+        state.task = asyncio.create_task(_capture_request_log_outcome(state, write_request))
     try:
-        if task.done():
-            return task.result()
-        return await _await_before_cancelling(task)
-    except Exception:
-        return None
+        await _await_before_cancelling(state.task)
+    except asyncio.CancelledError as exc:
+        if exc.__cause__ is None and state.error is not None:
+            raise exc from state.error
+        raise
+    finally:
+        state.consumed = True
 
 
 async def _await_log_finalizer(
@@ -671,12 +699,8 @@ async def _await_log_finalizer(
         await _await_before_cancelling(task)
     except asyncio.CancelledError as exc:
         deferred_cancel = deferred_cancel or exc
-    except Exception as exc:
-        finalizer_error = exc
-    try:
-        task.result()
-    except asyncio.CancelledError as exc:
-        deferred_cancel = deferred_cancel or exc
+        if isinstance(exc.__cause__, Exception):
+            finalizer_error = exc.__cause__
     except Exception as exc:
         finalizer_error = exc
     if deferred_cancel is None:
@@ -686,13 +710,21 @@ async def _await_log_finalizer(
     raise deferred_cancel
 
 
-def _settled_task_error[Result](task: asyncio.Task[Result]) -> Exception | None:
-    """Return one ordinary error from an already-settled task."""
+async def _await_request_log_after_provider_cancellation(state: _RequestLogState) -> BaseException | None:
+    """Settle one provider-cancellation request write without replacing it."""
+    assert state.task is not None
+    request_error: BaseException | None = None
     try:
-        task.result()
-    except Exception as exc:
-        return exc
-    return None
+        await _await_before_cancelling(state.task)
+    except asyncio.CancelledError as exc:
+        request_error = state.error or exc.__cause__
+        if request_error is None and state.task.cancelled():
+            request_error = exc
+    except BaseException as exc:
+        request_error = state.error or exc
+    finally:
+        state.consumed = True
+    return state.error or request_error
 
 
 async def _write_llm_response_log_reporting_errors(
@@ -765,8 +797,10 @@ async def _invoke_with_llm_request_logging(
         with _model_request_scope(model, wire_tools_capture):
             response = await original_ainvoke(*args, **kwargs)
     except asyncio.CancelledError as provider_cancel:
-        request_task = asyncio.create_task(
-            _write_llm_request_log_reporting_errors(
+        request_state = _RequestLogState()
+
+        def _write_cancelled_request() -> Coroutine[object, object, _RequestLogRef | None]:
+            return _write_llm_request_log_reporting_errors(
                 model=model,
                 agent_name=agent_name,
                 kwargs=kwargs,
@@ -774,13 +808,13 @@ async def _invoke_with_llm_request_logging(
                 default_log_dir=default_log_dir,
                 request_context=request_context,
                 wire_tools_capture=wire_tools_capture,
-            ),
+            )
+
+        request_state.task = asyncio.create_task(
+            _capture_request_log_outcome(request_state, _write_cancelled_request),
         )
-        with suppress(BaseException):
-            await _await_before_cancelling(request_task)
-        try:
-            request_task.result()
-        except BaseException as request_error:
+        request_error = await _await_request_log_after_provider_cancellation(request_state)
+        if request_error is not None:
             raise provider_cancel from request_error
         raise
     except BaseException:
@@ -844,40 +878,32 @@ def _stream_with_llm_request_logging(
 
     async def _stream() -> AsyncIterator[ModelResponse]:
         wire_tools_capture = _WireToolsCapture(enabled=debug_config.log_llm_requests)
-        request_log_ref: _RequestLogRef | None = None
-        request_log_task: asyncio.Task[_RequestLogRef | None] | None = None
+        request_state = _RequestLogState()
         last_usage: MessageMetrics | None = None
 
-        async def _write_request_once() -> None:
-            nonlocal request_log_ref, request_log_task
-            if request_log_task is None:
-                request_log_task = asyncio.create_task(
-                    _write_llm_request_log_reporting_errors(
-                        model=model,
-                        agent_name=agent_name,
-                        kwargs=kwargs,
-                        debug_config=debug_config,
-                        default_log_dir=default_log_dir,
-                        request_context=request_context,
-                        wire_tools_capture=wire_tools_capture,
-                    ),
-                )
-            request_log_ref = await _await_request_log_task_best_effort(request_log_task)
+        def _write_request() -> Coroutine[object, object, _RequestLogRef | None]:
+            return _write_llm_request_log_reporting_errors(
+                model=model,
+                agent_name=agent_name,
+                kwargs=kwargs,
+                debug_config=debug_config,
+                default_log_dir=default_log_dir,
+                request_context=request_context,
+                wire_tools_capture=wire_tools_capture,
+            )
 
         async def _finalize_stream_logs() -> None:
-            await _write_request_once()
-            assert request_log_task is not None
-            request_error = _settled_task_error(request_log_task)
+            await _await_request_log_once(request_state, _write_request)
             response_error = await _capture_llm_response_log_error(
                 model=model,
                 agent_name=agent_name,
                 configured_provider=configured_provider,
-                request_log_ref=request_log_ref,
+                request_log_ref=request_state.request_log_ref,
                 usage=last_usage,
                 request_context=request_context,
             )
-            if request_error is not None:
-                raise request_error
+            if request_state.error is not None:
+                raise request_state.error
             if response_error is not None:
                 raise response_error
 
@@ -893,7 +919,7 @@ def _stream_with_llm_request_logging(
             async for chunk in scoped_stream:
                 if chunk.response_usage is not None:
                     last_usage = chunk.response_usage
-                await _write_request_once()
+                await _await_request_log_once(request_state, _write_request)
                 yield chunk
         except asyncio.CancelledError as exc:
             deferred_cancel = exc

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+import traceback
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -93,6 +94,10 @@ async def _assert_cancellation_is_deferred(task: asyncio.Task[Any]) -> None:
     asyncio.get_running_loop().call_soon(ready_callbacks_processed.set)
     await ready_callbacks_processed.wait()
     assert not task.done()
+
+
+def _traceback_frame_names(error: BaseException) -> list[str]:
+    return [frame.name for frame in traceback.extract_tb(error.__traceback__)]
 
 
 @dataclass
@@ -641,6 +646,7 @@ async def test_provider_cancellation_chains_request_worker_failure(
     assert cancelled.value is model.provider_cancellation
     assert cancelled.value.args == ("provider cancellation",)
     assert cancelled.value.__cause__ is worker_error
+    assert "failing_serialization" in _traceback_frame_names(worker_error)
     assert invoke_task.cancelling() == 1
 
 
@@ -952,6 +958,7 @@ async def test_stream_provider_cancellation_chains_final_request_worker_failure(
     assert cancelled.value is model.provider_cancellation
     assert cancelled.value.args == ("provider stream cancellation",)
     assert cancelled.value.__cause__ is worker_error
+    assert "failing_serialization" in _traceback_frame_names(worker_error)
     assert next_chunk.cancelling() == 2
 
 
@@ -1066,6 +1073,7 @@ async def test_response_worker_failure_is_chained_to_deferred_cancellation(
 
     assert cancelled.args == ("first cancellation",)
     assert cancelled.__cause__ is worker_error
+    assert "failing_response_write" in _traceback_frame_names(worker_error)
     assert cancel_count == 2
     assert call_task.cancelling() == 2
     entries = _read_log_entries(tmp_path)
@@ -1080,18 +1088,22 @@ async def test_settled_stream_request_task_does_not_reenter_cancellation_boundar
 ) -> None:
     """Later chunks and cleanup must use the settled request result directly."""
     original_await = llm_request_logging._await_before_cancelling
-    settled_request_task: asyncio.Task[_RequestLogRef | None] | None = None
+    original_request_write = llm_request_logging._write_llm_request_log_reporting_errors
+    settled_request_task: asyncio.Task[Any] | None = None
     settled_request_reentered_boundary = False
 
-    async def observe_boundary[Result](task: asyncio.Task[Result]) -> Result:
-        nonlocal settled_request_reentered_boundary, settled_request_task
-        if task is settled_request_task:
-            settled_request_reentered_boundary = True
-        result = await original_await(task)
-        if isinstance(result, _RequestLogRef):
-            settled_request_task = task
-        return result
+    async def observe_request_write(*args: object, **kwargs: object) -> _RequestLogRef | None:
+        nonlocal settled_request_task
+        settled_request_task = asyncio.current_task()
+        return await original_request_write(*args, **kwargs)  # type: ignore[arg-type]
 
+    async def observe_boundary[Result](task: asyncio.Task[Result]) -> Result:
+        nonlocal settled_request_reentered_boundary
+        if task is settled_request_task and task.done():
+            settled_request_reentered_boundary = True
+        return await original_await(task)
+
+    monkeypatch.setattr(llm_request_logging, "_write_llm_request_log_reporting_errors", observe_request_write)
     monkeypatch.setattr(llm_request_logging, "_await_before_cancelling", observe_boundary)
     model = _FakeModel(response_usage=MessageMetrics(input_tokens=3, output_tokens=2))
     install_llm_request_logging(
@@ -1114,6 +1126,58 @@ async def test_settled_stream_request_task_does_not_reenter_cancellation_boundar
     assert settled_request_task is not None
     assert not settled_request_reentered_boundary
     assert [entry.get("record") for entry in _read_log_entries(tmp_path)] == [None, "response"]
+
+
+@pytest.mark.asyncio
+async def test_failed_stream_request_task_is_consumed_once(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Later chunks and cleanup must retain one failed request-task outcome."""
+    worker_error = OSError("serialization failed")
+    original_await = llm_request_logging._await_before_cancelling
+    original_request_write = llm_request_logging._write_llm_request_log_reporting_errors
+    failed_request_task: asyncio.Task[Any] | None = None
+    failed_request_reentered_boundary = False
+
+    def failing_serialization(*_args: object, **_kwargs: object) -> str:
+        raise worker_error
+
+    async def observe_request_write(*args: object, **kwargs: object) -> _RequestLogRef | None:
+        nonlocal failed_request_task
+        failed_request_task = asyncio.current_task()
+        return await original_request_write(*args, **kwargs)  # type: ignore[arg-type]
+
+    async def observe_boundary[Result](task: asyncio.Task[Result]) -> Result:
+        nonlocal failed_request_reentered_boundary
+        if task is failed_request_task and task.done():
+            failed_request_reentered_boundary = True
+        return await original_await(task)
+
+    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", failing_serialization)
+    monkeypatch.setattr(llm_request_logging, "_write_llm_request_log_reporting_errors", observe_request_write)
+    monkeypatch.setattr(llm_request_logging, "_await_before_cancelling", observe_boundary)
+    model = _FakeModel(response_usage=MessageMetrics(input_tokens=3, output_tokens=2))
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    contents = [
+        chunk.content
+        async for chunk in model.ainvoke_stream(
+            messages=[Message(role="user", content="hello")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        )
+    ]
+
+    assert contents == ["ok", "!"]
+    assert failed_request_task is not None
+    assert not failed_request_reentered_boundary
+    assert "failing_serialization" in _traceback_frame_names(worker_error)
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -76,11 +76,9 @@ class _CoordinatedAppendHandle:
         self,
         handle: TextIO,
         first_writes: threading.Barrier,
-        lock_observations: list[bool],
     ) -> None:
         self._handle = handle
         self._first_writes = first_writes
-        self._lock_observations = lock_observations
 
     def __enter__(self) -> _CoordinatedAppendHandle:
         self._handle.__enter__()
@@ -90,12 +88,10 @@ class _CoordinatedAppendHandle:
         self._handle.__exit__(*args)  # type: ignore[arg-type]
 
     def write(self, value: str) -> int:
-        append_lock = getattr(llm_request_logging, "_JSONL_APPEND_LOCK", None)
-        lock_held = append_lock is not None and append_lock.locked()
-        self._lock_observations.append(lock_held)
-        if not lock_held and value != "\n":
+        if not value.endswith("\n"):
             self._first_writes.wait(timeout=5)
             written = self._handle.write(value)
+            self._handle.flush()
             self._first_writes.wait(timeout=5)
             return written
         return self._handle.write(value)
@@ -170,7 +166,7 @@ async def test_llm_request_payload_is_built_on_writer_thread(
     assert payload["tools"] == [{"name": "search"}]
 
 
-def test_concurrent_large_jsonl_appends_remain_parseable(
+def test_concurrent_jsonl_appends_remain_parseable(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
@@ -178,17 +174,16 @@ def test_concurrent_large_jsonl_appends_remain_parseable(
     first_writes = threading.Barrier(2)
     path_type = type(tmp_path)
     real_open = path_type.open
-    lock_observations: list[bool] = []
 
     def coordinated_open(path: Path, *args: object, **kwargs: object) -> _CoordinatedAppendHandle:
         handle = real_open(path, *args, **kwargs)  # type: ignore[arg-type]
-        return _CoordinatedAppendHandle(handle, first_writes, lock_observations)
+        return _CoordinatedAppendHandle(handle, first_writes)
 
     monkeypatch.setattr(path_type, "open", coordinated_open)
     log_path = tmp_path / "requests.jsonl"
     lines = [
-        json.dumps({"record": "first", "payload": "a" * 1_000_000}),
-        json.dumps({"record": "second", "payload": "b" * 1_000_000}),
+        json.dumps({"record": "first"}),
+        json.dumps({"record": "second"}),
     ]
     with ThreadPoolExecutor(max_workers=2) as executor:
         appends = [executor.submit(llm_request_logging._write_serialized_jsonl_line, log_path, line) for line in lines]
@@ -197,7 +192,6 @@ def test_concurrent_large_jsonl_appends_remain_parseable(
     with real_open(log_path, encoding="utf-8") as handle:
         records = [json.loads(line) for line in handle]
     assert {record["record"] for record in records} == {"first", "second"}
-    assert lock_observations == [True, True]
 
 
 @pytest.mark.asyncio
@@ -369,24 +363,31 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
     assert payload["model_params"] == {"temperature": 0.7}
 
 
+@pytest.mark.parametrize("worker_fails", [False, True])
 @pytest.mark.asyncio
-async def test_invoke_cancellation_wins_when_request_log_worker_fails(
+async def test_invoke_cancellation_is_delivered_once_before_caller_continues(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    *,
+    worker_fails: bool,
 ) -> None:
-    """A failed accepted write must not turn caller cancellation into success."""
-    serializer_started = threading.Event()
-    release_serializer = threading.Event()
-    cancellation_deferred = asyncio.Event()
+    """Deferred cancellation must not fire again after the caller catches it."""
+    serializer_started, release_serializer = (threading.Event() for _ in range(2))
+    cancellation_deferred, continuation_started, release_continuation = (asyncio.Event() for _ in range(3))
     serialization_error = OSError("serialization failed")
+    original_serialize = llm_request_logging._serialize_llm_request_log_line
+    caught_cancellations: list[asyncio.CancelledError] = []
+    cancellation_counts: list[int] = []
 
-    def fail_serialization(**_kwargs: object) -> str:
+    def controlled_serialization(*args: object, **kwargs: object) -> str:
         serializer_started.set()
         assert release_serializer.wait(timeout=5)
-        raise serialization_error
+        if worker_fails:
+            raise serialization_error
+        return original_serialize(*args, **kwargs)  # type: ignore[arg-type]
 
     monkeypatch.setattr(llm_request_logging.asyncio, "shield", _ShieldRetryObserver({2: cancellation_deferred}))
-    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", fail_serialization)
+    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", controlled_serialization)
     model = _FakeModel()
     install_llm_request_logging(
         model,
@@ -394,26 +395,72 @@ async def test_invoke_cancellation_wins_when_request_log_worker_fails(
         debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
         default_log_dir=tmp_path / "unused",
     )
-    invoke_task = asyncio.create_task(
-        model.ainvoke(
-            messages=[Message(role="user", content="hello")],
-            assistant_message=Message(role="assistant"),
-            tools=[],
-        ),
-    )
+
+    async def invoke_and_continue() -> str:
+        try:
+            await model.ainvoke(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+                tools=[],
+            )
+        except asyncio.CancelledError as exc:
+            caught_cancellations.append(exc)
+            current_task = asyncio.current_task()
+            assert current_task is not None
+            cancellation_counts.append(current_task.cancelling())
+        continuation_started.set()
+        await release_continuation.wait()
+        return "continued"
+
+    invoke_task = asyncio.create_task(invoke_and_continue())
     try:
         assert await asyncio.to_thread(serializer_started.wait, 5)
         invoke_task.cancel("cancel request")
         await cancellation_deferred.wait()
         release_serializer.set()
-        with pytest.raises(asyncio.CancelledError) as cancelled:
-            await invoke_task
+        await continuation_started.wait()
+        assert not invoke_task.done()
+        release_continuation.set()
+        result = await invoke_task
     finally:
         release_serializer.set()
+        release_continuation.set()
         await asyncio.gather(invoke_task, return_exceptions=True)
 
-    assert cancelled.value.args == ("cancel request",)
+    assert result == "continued"
+    assert len(caught_cancellations) == 1
+    assert caught_cancellations[0].args == ("cancel request",)
+    assert cancellation_counts == [1]
     assert invoke_task.cancelling() == 1
+    if worker_fails:
+        assert caught_cancellations[0].__cause__ is serialization_error
+    else:
+        assert caught_cancellations[0].__cause__ is None
+
+
+@pytest.mark.asyncio
+async def test_inner_worker_cancellation_is_not_counted_as_caller_cancellation() -> None:
+    """A cancelled worker must not masquerade as a new outer request."""
+
+    async def run_after_prior_cancellation() -> None:
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        current_task.cancel("prior cancellation")
+        with pytest.raises(asyncio.CancelledError, match="prior cancellation"):
+            await asyncio.Event().wait()
+
+        worker = asyncio.create_task(asyncio.Event().wait())
+        worker.cancel("worker cancelled")
+        with pytest.raises(asyncio.CancelledError) as cancelled:
+            await llm_request_logging._await_before_cancelling(worker)
+
+        assert current_task.cancelling() == 1
+        assert cancelled.value.args == ("worker cancelled",)
+        assert cancelled.value.__cause__ is None
+
+    completed = asyncio.create_task(run_after_prior_cancellation())
+    await completed
+    assert completed.cancelling() == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -7,7 +7,7 @@ import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -33,7 +33,7 @@ from mindroom.llm_request_logging import (
 from mindroom.openai_tool_search import request_params_with_deferred_tool_search
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable
+    from collections.abc import AsyncIterator
     from pathlib import Path
     from typing import TextIO
 
@@ -57,30 +57,25 @@ class _FakeModel:
         yield ModelResponse(content="!", response_usage=self.response_usage)
 
 
-class _ShieldRetryObserver:
-    def __init__(self, retry_events: dict[int, asyncio.Event]) -> None:
-        self._retry_events = retry_events
-        self._original_shield = asyncio.shield
-        self._calls = 0
-
-    async def __call__(self, awaitable: Awaitable[object]) -> object:
-        self._calls += 1
-        retry_event = self._retry_events.get(self._calls)
-        if retry_event is not None:
-            retry_event.set()
-        return await self._original_shield(awaitable)
+async def _assert_cancellation_is_deferred(task: asyncio.Task[Any]) -> None:
+    """Observe one requested cancellation without releasing blocked work."""
+    assert task.cancelling() > 0
+    ready_callbacks_processed = asyncio.Event()
+    asyncio.get_running_loop().call_soon(ready_callbacks_processed.set)
+    await ready_callbacks_processed.wait()
+    assert not task.done()
 
 
-class _CoordinatedAppendHandle:
+class _InterleavingAppendHandle:
     def __init__(
         self,
         handle: TextIO,
-        first_writes: threading.Barrier,
+        split_body_writes: threading.Barrier,
     ) -> None:
         self._handle = handle
-        self._first_writes = first_writes
+        self._split_body_writes = split_body_writes
 
-    def __enter__(self) -> _CoordinatedAppendHandle:
+    def __enter__(self) -> _InterleavingAppendHandle:
         self._handle.__enter__()
         return self
 
@@ -89,10 +84,10 @@ class _CoordinatedAppendHandle:
 
     def write(self, value: str) -> int:
         if not value.endswith("\n"):
-            self._first_writes.wait(timeout=5)
+            self._split_body_writes.wait(timeout=5)
             written = self._handle.write(value)
             self._handle.flush()
-            self._first_writes.wait(timeout=5)
+            self._split_body_writes.wait(timeout=5)
             return written
         return self._handle.write(value)
 
@@ -171,13 +166,18 @@ def test_concurrent_jsonl_appends_remain_parseable(
     tmp_path: Path,
 ) -> None:
     """Concurrent worker appends must each remain one complete JSONL record."""
-    first_writes = threading.Barrier(2)
+    append_attempts = threading.Barrier(2)
+    split_body_writes = threading.Barrier(2)
     path_type = type(tmp_path)
     real_open = path_type.open
 
-    def coordinated_open(path: Path, *args: object, **kwargs: object) -> _CoordinatedAppendHandle:
+    def coordinated_open(path: Path, *args: object, **kwargs: object) -> _InterleavingAppendHandle:
         handle = real_open(path, *args, **kwargs)  # type: ignore[arg-type]
-        return _CoordinatedAppendHandle(handle, first_writes)
+        return _InterleavingAppendHandle(handle, split_body_writes)
+
+    def append_after_rendezvous(log_path: Path, line: str) -> None:
+        append_attempts.wait(timeout=5)
+        llm_request_logging._write_serialized_jsonl_line(log_path, line)
 
     monkeypatch.setattr(path_type, "open", coordinated_open)
     log_path = tmp_path / "requests.jsonl"
@@ -186,11 +186,12 @@ def test_concurrent_jsonl_appends_remain_parseable(
         json.dumps({"record": "second"}),
     ]
     with ThreadPoolExecutor(max_workers=2) as executor:
-        appends = [executor.submit(llm_request_logging._write_serialized_jsonl_line, log_path, line) for line in lines]
+        appends = [executor.submit(append_after_rendezvous, log_path, line) for line in lines]
         for append in appends:
             append.result(timeout=5)
     with real_open(log_path, encoding="utf-8") as handle:
         records = [json.loads(line) for line in handle]
+    assert len(records) == 2
     assert {record["record"] for record in records} == {"first", "second"}
 
 
@@ -291,13 +292,52 @@ async def test_request_log_pins_container_membership_before_worker_dispatch(
 
 
 @pytest.mark.asyncio
+async def test_pending_cancellation_waits_for_accepted_worker() -> None:
+    """Cancellation requested before helper entry must wait for accepted work."""
+    worker_started = asyncio.Event()
+    release_worker = asyncio.Event()
+    cancellation_requested = asyncio.Event()
+
+    async def accepted_worker() -> None:
+        worker_started.set()
+        await release_worker.wait()
+
+    worker = asyncio.create_task(accepted_worker())
+    await worker_started.wait()
+
+    async def cancel_before_helper_entry() -> tuple[bool, tuple[object, ...], int]:
+        current_task = asyncio.current_task()
+        assert current_task is not None
+        current_task.cancel("pending cancellation")
+        cancellation_requested.set()
+        try:
+            await llm_request_logging._await_before_cancelling(worker)
+        except asyncio.CancelledError as exc:
+            return worker.done(), exc.args, current_task.cancelling()
+        pytest.fail("pending cancellation was not delivered")
+
+    caller = asyncio.create_task(cancel_before_helper_entry())
+    try:
+        await cancellation_requested.wait()
+        await _assert_cancellation_is_deferred(caller)
+        release_worker.set()
+        worker_done, cancel_args, cancel_count = await caller
+    finally:
+        release_worker.set()
+        await asyncio.gather(caller, worker, return_exceptions=True)
+
+    assert worker_done
+    assert cancel_args == ("pending cancellation",)
+    assert cancel_count == 1
+
+
+@pytest.mark.asyncio
 async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_persisted(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Cancellation must not release borrowed values before their record is durable."""
     serialization_started, release_serialization, serialization_finished = (threading.Event() for _ in range(3))
-    first_cancellation_deferred, second_cancellation_deferred = (asyncio.Event() for _ in range(2))
     original_serialize = llm_request_logging._serialize_llm_request_log_line
 
     def blocked_serialize(*args: object, **kwargs: object) -> str:
@@ -309,11 +349,6 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
             serialization_finished.set()
 
     monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", blocked_serialize)
-    monkeypatch.setattr(
-        llm_request_logging.asyncio,
-        "shield",
-        _ShieldRetryObserver({2: first_cancellation_deferred, 3: second_cancellation_deferred}),
-    )
     model = _FakeModel(id="submitted-model", temperature=0.7)
     messages = [Message(role="user", content="submitted message")]
     tools = [{"name": "submitted_tool"}]
@@ -329,11 +364,13 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
         ),
     )
     cancellation_observed = asyncio.Event()
+    caught_cancellations: list[asyncio.CancelledError] = []
 
     async def observe_cancellation() -> None:
         try:
             await write_task
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as exc:
+            caught_cancellations.append(exc)
             _mutate_borrowed_request_values(model, messages, tools)
             cancellation_observed.set()
             raise
@@ -341,11 +378,11 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
     observer = asyncio.create_task(observe_cancellation())
     try:
         assert await asyncio.to_thread(serialization_started.wait, 5)
-        write_task.cancel()
-        await first_cancellation_deferred.wait()
-        write_task.cancel()
-        await second_cancellation_deferred.wait()
-        cancellation_was_deferred = not cancellation_observed.is_set()
+        write_task.cancel("first cancellation")
+        await _assert_cancellation_is_deferred(write_task)
+        write_task.cancel("second cancellation")
+        await _assert_cancellation_is_deferred(write_task)
+        assert not cancellation_observed.is_set()
         release_serialization.set()
         with pytest.raises(asyncio.CancelledError):
             await observer
@@ -354,7 +391,8 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
         release_serialization.set()
         await asyncio.gather(write_task, observer, return_exceptions=True)
 
-    assert cancellation_was_deferred
+    assert len(caught_cancellations) == 1
+    assert caught_cancellations[0].args == ("first cancellation",)
     assert write_task.cancelling() == 2
     payload = json.loads(log_path.read_text(encoding="utf-8"))
     assert payload["model_id"] == "submitted-model"
@@ -373,7 +411,7 @@ async def test_invoke_cancellation_is_delivered_once_before_caller_continues(
 ) -> None:
     """Deferred cancellation must not fire again after the caller catches it."""
     serializer_started, release_serializer = (threading.Event() for _ in range(2))
-    cancellation_deferred, continuation_started, release_continuation = (asyncio.Event() for _ in range(3))
+    continuation_started, release_continuation = (asyncio.Event() for _ in range(2))
     serialization_error = OSError("serialization failed")
     original_serialize = llm_request_logging._serialize_llm_request_log_line
     caught_cancellations: list[asyncio.CancelledError] = []
@@ -386,7 +424,6 @@ async def test_invoke_cancellation_is_delivered_once_before_caller_continues(
             raise serialization_error
         return original_serialize(*args, **kwargs)  # type: ignore[arg-type]
 
-    monkeypatch.setattr(llm_request_logging.asyncio, "shield", _ShieldRetryObserver({2: cancellation_deferred}))
     monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", controlled_serialization)
     model = _FakeModel()
     install_llm_request_logging(
@@ -416,7 +453,7 @@ async def test_invoke_cancellation_is_delivered_once_before_caller_continues(
     try:
         assert await asyncio.to_thread(serializer_started.wait, 5)
         invoke_task.cancel("cancel request")
-        await cancellation_deferred.wait()
+        await _assert_cancellation_is_deferred(invoke_task)
         release_serializer.set()
         await continuation_started.wait()
         assert not invoke_task.done()
@@ -471,7 +508,6 @@ async def test_stream_cancellation_persists_one_request_record(
     """Generator cleanup must not retry an accepted request append."""
     writer_started = threading.Event()
     release_writer = threading.Event()
-    cancellation_deferred = asyncio.Event()
     original_write = llm_request_logging._write_serialized_jsonl_line
 
     def blocked_write(path: Path, line: str) -> None:
@@ -480,7 +516,6 @@ async def test_stream_cancellation_persists_one_request_record(
         original_write(path, line)
 
     monkeypatch.setattr(llm_request_logging, "_write_serialized_jsonl_line", blocked_write)
-    monkeypatch.setattr(llm_request_logging.asyncio, "shield", _ShieldRetryObserver({2: cancellation_deferred}))
     model = _FakeModel()
     install_llm_request_logging(
         model,
@@ -497,7 +532,7 @@ async def test_stream_cancellation_persists_one_request_record(
     try:
         assert await asyncio.to_thread(writer_started.wait, 5)
         next_chunk.cancel("cancel stream")
-        await cancellation_deferred.wait()
+        await _assert_cancellation_is_deferred(next_chunk)
         release_writer.set()
         with pytest.raises(asyncio.CancelledError):
             await next_chunk
@@ -584,8 +619,8 @@ async def test_llm_request_timestamp_and_daily_file_share_submission_time(
     tmp_path: Path,
 ) -> None:
     """A writer delayed past midnight must stay in its submission day's file."""
-    submission_time = datetime(2026, 8, 25, 12, tzinfo=UTC)
-    worker_time = datetime(2026, 8, 26, 12, tzinfo=UTC)
+    submission_time = datetime(2026, 8, 25, 12).astimezone()
+    worker_time = datetime(2026, 8, 26, 12).astimezone()
     observed_times = iter((submission_time, worker_time))
 
     class _Clock:

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -58,6 +58,16 @@ class _FakeModel:
         yield ModelResponse(content="!", response_usage=self.response_usage)
 
 
+class _FalseyWorkerError(OSError):
+    def __bool__(self) -> bool:
+        return False
+
+
+class _FalseyCancelledError(asyncio.CancelledError):
+    def __bool__(self) -> bool:
+        return False
+
+
 @dataclass
 class _CancellableInvokeModel(_FakeModel):
     invocation_started: asyncio.Event = field(default_factory=asyncio.Event)
@@ -76,14 +86,17 @@ class _CancellableInvokeModel(_FakeModel):
 class _CancellableStreamModel(_FakeModel):
     invocation_started: asyncio.Event = field(default_factory=asyncio.Event)
     provider_cancellation: asyncio.CancelledError | None = None
+    falsey_cancellation: bool = False
 
     async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
         self.invocation_started.set()
         try:
             await asyncio.Event().wait()
         except asyncio.CancelledError as exc:
+            if self.falsey_cancellation:
+                exc = _FalseyCancelledError(*exc.args)
             self.provider_cancellation = exc
-            raise
+            raise exc  # noqa: TRY201 - the falsey replacement is the behavior under test
         yield ModelResponse(content="unreachable")
 
 
@@ -602,14 +615,18 @@ async def test_provider_cancellation_remains_primary_during_request_write(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("falsey_worker_error", [False, True])
 async def test_provider_cancellation_chains_request_worker_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    *,
+    falsey_worker_error: bool,
 ) -> None:
     """Provider cancellation stays primary when accepted request persistence fails."""
     serializer_started = threading.Event()
     release_serializer = threading.Event()
-    worker_error = OSError("serialization failed")
+    error_type = _FalseyWorkerError if falsey_worker_error else OSError
+    worker_error = error_type("serialization failed")
 
     def failing_serialization(*_args: object, **_kwargs: object) -> str:
         serializer_started.set()
@@ -911,9 +928,12 @@ async def test_stream_cancellation_chains_request_worker_failure(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("falsey_provider_cancel", [False, True])
 async def test_stream_provider_cancellation_chains_final_request_worker_failure(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
+    *,
+    falsey_provider_cancel: bool,
 ) -> None:
     """Cleanup must retain a failed request task when no chunk was received."""
     serializer_started = threading.Event()
@@ -926,7 +946,7 @@ async def test_stream_provider_cancellation_chains_final_request_worker_failure(
         raise worker_error
 
     monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", failing_serialization)
-    model = _CancellableStreamModel()
+    model = _CancellableStreamModel(falsey_cancellation=falsey_provider_cancel)
     install_llm_request_logging(
         model,
         agent_name="default",

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -57,6 +57,20 @@ class _FakeModel:
         yield ModelResponse(content="!", response_usage=self.response_usage)
 
 
+@dataclass
+class _CancellableInvokeModel(_FakeModel):
+    invocation_started: asyncio.Event = field(default_factory=asyncio.Event)
+    provider_cancellation: asyncio.CancelledError | None = None
+
+    async def ainvoke(self, *_args: object, **_kwargs: object) -> ModelResponse:
+        self.invocation_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError as exc:
+            self.provider_cancellation = exc
+            raise
+
+
 async def _assert_cancellation_is_deferred(task: asyncio.Task[Any]) -> None:
     """Observe one requested cancellation without releasing blocked work."""
     assert task.cancelling() > 0
@@ -510,6 +524,112 @@ async def test_invoke_cancellation_is_delivered_once_before_caller_continues(
 
 
 @pytest.mark.asyncio
+async def test_provider_cancellation_remains_primary_during_request_write(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A later cancellation during request persistence must not replace the provider one."""
+    writer_started = threading.Event()
+    release_writer = threading.Event()
+    original_write = llm_request_logging._write_serialized_jsonl_line
+
+    def blocked_write(path: Path, line: str) -> None:
+        writer_started.set()
+        assert release_writer.wait(timeout=5)
+        original_write(path, line)
+
+    monkeypatch.setattr(llm_request_logging, "_write_serialized_jsonl_line", blocked_write)
+    model = _CancellableInvokeModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    async def invoke_and_capture() -> tuple[asyncio.CancelledError, int]:
+        try:
+            await model.ainvoke(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+                tools=[],
+            )
+        except asyncio.CancelledError as exc:
+            current_task = asyncio.current_task()
+            assert current_task is not None
+            return exc, current_task.cancelling()
+        pytest.fail("cancellation was not delivered")
+
+    invoke_task = asyncio.create_task(invoke_and_capture())
+    try:
+        await model.invocation_started.wait()
+        invoke_task.cancel("provider cancellation")
+        assert await asyncio.to_thread(writer_started.wait, 5)
+        invoke_task.cancel("later cancellation")
+        await _assert_cancellation_is_deferred(invoke_task)
+        release_writer.set()
+        cancelled, cancel_count = await invoke_task
+    finally:
+        release_writer.set()
+        await asyncio.gather(invoke_task, return_exceptions=True)
+
+    assert model.provider_cancellation is not None
+    assert cancelled is model.provider_cancellation
+    assert cancelled.args == ("provider cancellation",)
+    assert cancel_count == 2
+    assert invoke_task.cancelling() == 2
+    assert len(_read_log_entries(tmp_path)) == 1
+
+
+@pytest.mark.asyncio
+async def test_provider_cancellation_chains_request_worker_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Provider cancellation stays primary when accepted request persistence fails."""
+    serializer_started = threading.Event()
+    release_serializer = threading.Event()
+    worker_error = OSError("serialization failed")
+
+    def failing_serialization(*_args: object, **_kwargs: object) -> str:
+        serializer_started.set()
+        assert release_serializer.wait(timeout=5)
+        raise worker_error
+
+    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", failing_serialization)
+    model = _CancellableInvokeModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+    invoke_task = asyncio.create_task(
+        model.ainvoke(
+            messages=[Message(role="user", content="hello")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        ),
+    )
+    try:
+        await model.invocation_started.wait()
+        invoke_task.cancel("provider cancellation")
+        assert await asyncio.to_thread(serializer_started.wait, 5)
+        release_serializer.set()
+        with pytest.raises(asyncio.CancelledError) as cancelled:
+            await invoke_task
+    finally:
+        release_serializer.set()
+        await asyncio.gather(invoke_task, return_exceptions=True)
+
+    assert model.provider_cancellation is not None
+    assert cancelled.value is model.provider_cancellation
+    assert cancelled.value.args == ("provider cancellation",)
+    assert cancelled.value.__cause__ is worker_error
+    assert invoke_task.cancelling() == 1
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("blocked_record", ["request", "response"])
 async def test_invoke_cancellation_waits_for_linked_success_logs(
     monkeypatch: pytest.MonkeyPatch,
@@ -721,6 +841,100 @@ async def test_stream_cancellation_finalizes_received_chunk_usage(
     assert cancelled.value.args == ("first cancellation",)
     assert next_chunk.cancelling() == 2
     assert [entry["usage_available"] for entry in logs] == [True]
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation_chains_request_worker_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Stream cancellation must retain the accepted request worker's error."""
+    serializer_started = threading.Event()
+    release_serializer = threading.Event()
+    worker_error = OSError("serialization failed")
+
+    def failing_serialization(*_args: object, **_kwargs: object) -> str:
+        serializer_started.set()
+        assert release_serializer.wait(timeout=5)
+        raise worker_error
+
+    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", failing_serialization)
+    model = _FakeModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+    stream = model.ainvoke_stream(
+        messages=[Message(role="user", content="hello")],
+        assistant_message=Message(role="assistant"),
+        tools=[],
+    )
+    next_chunk = asyncio.create_task(anext(stream))
+    try:
+        assert await asyncio.to_thread(serializer_started.wait, 5)
+        next_chunk.cancel("stream cancellation")
+        await _assert_cancellation_is_deferred(next_chunk)
+        release_serializer.set()
+        with pytest.raises(asyncio.CancelledError) as cancelled:
+            await next_chunk
+    finally:
+        release_serializer.set()
+        await asyncio.gather(next_chunk, return_exceptions=True)
+        await stream.aclose()
+
+    assert cancelled.value.args == ("stream cancellation",)
+    assert cancelled.value.__cause__ is worker_error
+    assert next_chunk.cancelling() == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_uncancelled_request_worker_failure_remains_best_effort(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    streaming: bool,
+) -> None:
+    """An ordinary request worker failure must not change uncancelled provider behavior."""
+    worker_error = OSError("serialization failed")
+
+    def failing_serialization(*_args: object, **_kwargs: object) -> str:
+        raise worker_error
+
+    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", failing_serialization)
+    model = _FakeModel(response_usage=MessageMetrics(input_tokens=3, output_tokens=2))
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    with capture_logs() as logs:
+        if streaming:
+            contents = [
+                chunk.content
+                async for chunk in model.ainvoke_stream(
+                    messages=[Message(role="user", content="hello")],
+                    assistant_message=Message(role="assistant"),
+                    tools=[],
+                )
+            ]
+        else:
+            response = await model.ainvoke(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+                tools=[],
+            )
+            contents = [response.content]
+
+    assert contents == (["ok", "!"] if streaming else ["ok"])
+    assert [entry["event"] for entry in logs] == [
+        "Failed to persist LLM request log",
+        "LLM usage",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -12,11 +13,13 @@ from agno.models.message import Message, MessageMetrics
 from agno.models.response import ModelResponse
 from structlog.testing import capture_logs
 
+from mindroom import llm_request_logging
 from mindroom.claude_prompt_cache import install_claude_deferred_tool_search
 from mindroom.config.main import Config
 from mindroom.config.models import DebugConfig
 from mindroom.llm_request_logging import (
     _RequestLogRef,
+    _write_llm_request_log,
     _write_llm_response_log,
     bind_llm_request_log_context,
     current_llm_request_log_context,
@@ -48,6 +51,64 @@ class _FakeModel:
     async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
         yield ModelResponse(content="ok")
         yield ModelResponse(content="!", response_usage=self.response_usage)
+
+
+@pytest.mark.asyncio
+async def test_llm_request_payload_is_built_on_writer_thread(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Message, tool, and model serialization should stay off the event loop."""
+    event_loop_thread = threading.get_ident()
+    observed_threads: dict[str, int] = {}
+    written_payloads: list[dict[str, object]] = []
+
+    def _record(name: str, value: object) -> object:
+        observed_threads[name] = threading.get_ident()
+        return value
+
+    monkeypatch.setattr(
+        llm_request_logging,
+        "_system_prompt",
+        lambda *_args: _record("system_prompt", "system"),
+    )
+    monkeypatch.setattr(
+        llm_request_logging,
+        "_request_message_payloads",
+        lambda *_args: _record("messages", [{"role": "user", "content": "hello"}]),
+    )
+    monkeypatch.setattr(
+        llm_request_logging,
+        "_json_safe",
+        lambda value: _record("tools", value),
+    )
+    monkeypatch.setattr(
+        llm_request_logging,
+        "model_params_payload",
+        lambda *_args: _record("model_params", {"temperature": 0.7}),
+    )
+
+    def _write(_path: Path, payload: dict[str, object]) -> None:
+        observed_threads["write"] = threading.get_ident()
+        written_payloads.append(payload)
+
+    monkeypatch.setattr(llm_request_logging, "_write_jsonl_line", _write)
+
+    await _write_llm_request_log(
+        model=_FakeModel(),  # type: ignore[arg-type]
+        agent_name="assistant",
+        messages=[Message(role="user", content="hello")],
+        tools=[{"name": "search"}],
+        log_path=tmp_path / "requests.jsonl",
+        request_context={"correlation_id": "request-1"},
+        request_log_id="log-1",
+    )
+
+    assert set(observed_threads) == {"system_prompt", "messages", "tools", "model_params", "write"}
+    assert len(set(observed_threads.values())) == 1
+    assert event_loop_thread not in observed_threads.values()
+    assert written_payloads[0]["messages"] == [{"role": "user", "content": "hello"}]
+    assert written_payloads[0]["tools"] == [{"name": "search"}]
 
 
 class _PlainAsyncIterator:

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -510,6 +510,78 @@ async def test_invoke_cancellation_is_delivered_once_before_caller_continues(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("blocked_record", ["request", "response"])
+async def test_invoke_cancellation_waits_for_linked_success_logs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    blocked_record: str,
+) -> None:
+    """Successful-call cancellation must wait for its linked request and response."""
+    writer_started = threading.Event()
+    release_writer = threading.Event()
+    continuation_started = asyncio.Event()
+    release_continuation = asyncio.Event()
+    original_write = llm_request_logging._write_serialized_jsonl_line
+
+    def blocked_write(path: Path, line: str) -> None:
+        record_type = json.loads(line).get("record", "request")
+        if record_type == blocked_record:
+            writer_started.set()
+            assert release_writer.wait(timeout=5)
+        original_write(path, line)
+
+    monkeypatch.setattr(llm_request_logging, "_write_serialized_jsonl_line", blocked_write)
+    model = _FakeModel(response_usage=MessageMetrics(input_tokens=5, output_tokens=7))
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    async def invoke_and_continue() -> tuple[tuple[object, ...], int]:
+        try:
+            await model.ainvoke(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+                tools=[],
+            )
+        except asyncio.CancelledError as exc:
+            current_task = asyncio.current_task()
+            assert current_task is not None
+            continuation_started.set()
+            await release_continuation.wait()
+            return exc.args, current_task.cancelling()
+        pytest.fail("cancellation was not delivered")
+
+    with capture_logs() as logs:
+        invoke_task = asyncio.create_task(invoke_and_continue())
+        try:
+            assert await asyncio.to_thread(writer_started.wait, 5)
+            invoke_task.cancel("first cancellation")
+            await _assert_cancellation_is_deferred(invoke_task)
+            invoke_task.cancel("second cancellation")
+            await _assert_cancellation_is_deferred(invoke_task)
+            release_writer.set()
+            await continuation_started.wait()
+            release_continuation.set()
+            cancel_args, cancel_count = await invoke_task
+        finally:
+            release_writer.set()
+            release_continuation.set()
+            await asyncio.gather(invoke_task, return_exceptions=True)
+
+    request_entry, response_entry = _read_log_entries(tmp_path)
+    assert response_entry["record"] == "response"
+    assert response_entry["request_log_id"] == request_entry["request_log_id"]
+    assert response_entry["usage"]["input_tokens"] == 5
+    assert cancel_args == ("first cancellation",)
+    assert cancel_count == 2
+    assert invoke_task.cancelling() == 2
+    assert [entry["usage_available"] for entry in logs] == [True]
+
+
+@pytest.mark.asyncio
 async def test_inner_worker_cancellation_is_not_counted_as_caller_cancellation() -> None:
     """A cancelled worker must not masquerade as a new outer request."""
 
@@ -579,6 +651,76 @@ async def test_stream_cancellation_persists_one_request_record(
     assert len(entries) == 1
     assert entries[0]["messages"][0]["role"] == "user"
     assert entries[0]["messages"][0]["content"] == "hello"
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation_finalizes_received_chunk_usage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cancellation after a usage chunk must persist one linked response first."""
+
+    @dataclass
+    class _UsageOnFirstChunkModel(_FakeModel):
+        async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
+            yield ModelResponse(content="ok", response_usage=MessageMetrics(input_tokens=3, output_tokens=2))
+
+    request_writer_started = threading.Event()
+    release_request_writer = threading.Event()
+    response_writer_started = threading.Event()
+    release_response_writer = threading.Event()
+    original_write = llm_request_logging._write_serialized_jsonl_line
+
+    def blocked_write(path: Path, line: str) -> None:
+        if json.loads(line).get("record") == "response":
+            response_writer_started.set()
+            assert release_response_writer.wait(timeout=5)
+        else:
+            request_writer_started.set()
+            assert release_request_writer.wait(timeout=5)
+        original_write(path, line)
+
+    monkeypatch.setattr(llm_request_logging, "_write_serialized_jsonl_line", blocked_write)
+    model = _UsageOnFirstChunkModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+    stream = model.ainvoke_stream(
+        messages=[Message(role="user", content="hello")],
+        assistant_message=Message(role="assistant"),
+        tools=[],
+    )
+
+    with capture_logs() as logs:
+        next_chunk = asyncio.create_task(anext(stream))
+        try:
+            assert await asyncio.to_thread(request_writer_started.wait, 5)
+            next_chunk.cancel("first cancellation")
+            await _assert_cancellation_is_deferred(next_chunk)
+            release_request_writer.set()
+            assert await asyncio.to_thread(response_writer_started.wait, 5)
+            next_chunk.cancel("second cancellation")
+            await _assert_cancellation_is_deferred(next_chunk)
+            release_response_writer.set()
+            with pytest.raises(asyncio.CancelledError) as cancelled:
+                await next_chunk
+        finally:
+            release_request_writer.set()
+            release_response_writer.set()
+            await asyncio.gather(next_chunk, return_exceptions=True)
+            await stream.aclose()
+
+    request_entry, response_entry = _read_log_entries(tmp_path)
+    assert response_entry["record"] == "response"
+    assert response_entry["request_log_id"] == request_entry["request_log_id"]
+    assert response_entry["usage"]["input_tokens"] == 3
+    assert response_entry["usage"]["output_tokens"] == 2
+    assert cancelled.value.args == ("first cancellation",)
+    assert next_chunk.cancelling() == 2
+    assert [entry["usage_available"] for entry in logs] == [True]
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -63,7 +63,7 @@ async def test_llm_request_payload_is_built_on_writer_thread(
     """Message, tool, and model serialization should stay off the event loop."""
     event_loop_thread = threading.get_ident()
     observed_threads: dict[str, int] = {}
-    written_payloads: list[dict[str, object]] = []
+    written_lines: list[str] = []
 
     def _record(name: str, value: object) -> object:
         observed_threads[name] = threading.get_ident()
@@ -90,11 +90,11 @@ async def test_llm_request_payload_is_built_on_writer_thread(
         lambda *_args: _record("model_params", {"temperature": 0.7}),
     )
 
-    def _write(_path: Path, payload: dict[str, object]) -> None:
+    def _write(_path: Path, line: str) -> None:
         observed_threads["write"] = threading.get_ident()
-        written_payloads.append(payload)
+        written_lines.append(line)
 
-    monkeypatch.setattr(llm_request_logging, "_write_jsonl_line", _write)
+    monkeypatch.setattr(llm_request_logging, "_write_serialized_jsonl_line", _write)
 
     await _write_llm_request_log(
         model=_FakeModel(),  # type: ignore[arg-type]
@@ -107,34 +107,28 @@ async def test_llm_request_payload_is_built_on_writer_thread(
     )
 
     assert set(observed_threads) == {"system_prompt", "messages", "tools", "model_params", "write"}
-    assert len(set(observed_threads.values())) == 1
     assert event_loop_thread not in observed_threads.values()
-    assert written_payloads[0]["messages"] == [{"role": "user", "content": "hello"}]
-    assert written_payloads[0]["tools"] == [{"name": "search"}]
+    payload = json.loads(written_lines[0])
+    assert payload["messages"] == [{"role": "user", "content": "hello"}]
+    assert payload["tools"] == [{"name": "search"}]
 
 
 @pytest.mark.asyncio
-async def test_llm_request_payload_uses_submission_snapshot_when_writer_is_delayed(
+async def test_llm_request_log_uses_serialized_snapshot_when_file_write_is_delayed(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Executor delay must not let later mutation rewrite an accepted log entry."""
-    writer_queued = asyncio.Event()
-    release_writer = asyncio.Event()
-    written_payloads: list[dict[str, object]] = []
-    original_to_thread = asyncio.to_thread
+    """Mutation after serialization must not rewrite a queued immutable line."""
+    writer_started = threading.Event()
+    release_writer = threading.Event()
+    written_lines: list[str] = []
 
-    async def delayed_to_thread(function: object, /, *args: object, **kwargs: object) -> object:
-        writer_queued.set()
-        await release_writer.wait()
-        return await original_to_thread(function, *args, **kwargs)  # type: ignore[arg-type]
+    def delayed_write(_path: Path, line: str) -> None:
+        writer_started.set()
+        assert release_writer.wait(timeout=5)
+        written_lines.append(line)
 
-    monkeypatch.setattr(llm_request_logging.asyncio, "to_thread", delayed_to_thread)
-    monkeypatch.setattr(
-        llm_request_logging,
-        "_write_jsonl_line",
-        lambda _path, payload: written_payloads.append(payload),
-    )
+    monkeypatch.setattr(llm_request_logging, "_write_serialized_jsonl_line", delayed_write)
     model = _FakeModel(id="submitted-model", temperature=0.7)
     messages = [Message(role="user", content="submitted message")]
     tools = [{"name": "submitted_tool"}]
@@ -150,7 +144,7 @@ async def test_llm_request_payload_uses_submission_snapshot_when_writer_is_delay
         ),
     )
     try:
-        await writer_queued.wait()
+        assert await asyncio.to_thread(writer_started.wait, 5)
         model.id = "mutated-model"
         model.temperature = 1.0
         messages[0].content = "mutated message"
@@ -161,12 +155,76 @@ async def test_llm_request_payload_uses_submission_snapshot_when_writer_is_delay
         release_writer.set()
         await asyncio.gather(write_task, return_exceptions=True)
 
-    assert len(written_payloads) == 1
-    payload = written_payloads[0]
+    assert len(written_lines) == 1
+    payload = json.loads(written_lines[0])
     assert payload["model_id"] == "submitted-model"
     assert payload["messages"][0]["content"] == "submitted message"  # type: ignore[index]
     assert payload["tools"] == [{"name": "submitted_tool"}]
     assert payload["model_params"] == {"temperature": 0.7}
+
+
+@pytest.mark.asyncio
+async def test_wire_tool_normalization_runs_on_request_serializer_thread(tmp_path: Path) -> None:
+    """Provider wire-tool capture should borrow values until off-loop serialization."""
+    event_loop_thread = threading.get_ident()
+    traversal_threads: list[int] = []
+
+    class TraversalProbe(dict[str, object]):
+        def items(self):  # noqa: ANN202
+            traversal_threads.append(threading.get_ident())
+            return super().items()
+
+    capture = llm_request_logging._WireToolsCapture(enabled=True)
+    token = llm_request_logging._WIRE_TOOLS_CAPTURE.set(capture)
+    try:
+        record_llm_request_tools([TraversalProbe({"name": "search"})])
+    finally:
+        llm_request_logging._WIRE_TOOLS_CAPTURE.reset(token)
+
+    assert traversal_threads == []
+    await _write_llm_request_log(
+        model=_FakeModel(),  # type: ignore[arg-type]
+        agent_name="assistant",
+        messages=[Message(role="user", content="hello")],
+        tools=capture.tools,
+        log_path=tmp_path / "requests.jsonl",
+        request_log_id="log-1",
+    )
+
+    assert traversal_threads
+    assert event_loop_thread not in traversal_threads
+    payload = json.loads((tmp_path / "requests.jsonl").read_text(encoding="utf-8"))
+    assert payload["tools"] == [{"name": "search"}]
+
+
+@pytest.mark.asyncio
+async def test_llm_request_logging_preserves_serializable_values_that_reject_deepcopy(tmp_path: Path) -> None:
+    """Offloading must not narrow the logger's accepted JSON-compatible values."""
+
+    class CopyDisabledError(RuntimeError):
+        pass
+
+    class SerializableButNotCopyable(dict[str, object]):
+        def __deepcopy__(self, _memo: dict[int, object]) -> object:
+            raise CopyDisabledError
+
+    content = SerializableButNotCopyable({"nested": ["kept"]})
+    model = _FakeModel()
+    model.temperature = content  # type: ignore[assignment]
+
+    await _write_llm_request_log(
+        model=model,  # type: ignore[arg-type]
+        agent_name="assistant",
+        messages=[Message.model_construct(role="user", content=[content])],
+        tools=[{"payload": content}],
+        log_path=tmp_path / "requests.jsonl",
+        request_log_id="log-1",
+    )
+
+    payload = json.loads((tmp_path / "requests.jsonl").read_text(encoding="utf-8"))
+    assert payload["messages"][0]["content"] == [{"nested": ["kept"]}]
+    assert payload["tools"] == [{"payload": {"nested": ["kept"]}}]
+    assert payload["model_params"] == {"temperature": {"nested": ["kept"]}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -109,6 +111,95 @@ async def test_llm_request_payload_is_built_on_writer_thread(
     assert event_loop_thread not in observed_threads.values()
     assert written_payloads[0]["messages"] == [{"role": "user", "content": "hello"}]
     assert written_payloads[0]["tools"] == [{"name": "search"}]
+
+
+@pytest.mark.asyncio
+async def test_llm_request_payload_uses_submission_snapshot_when_writer_is_delayed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Executor delay must not let later mutation rewrite an accepted log entry."""
+    writer_queued = asyncio.Event()
+    release_writer = asyncio.Event()
+    written_payloads: list[dict[str, object]] = []
+    original_to_thread = asyncio.to_thread
+
+    async def delayed_to_thread(function: object, /, *args: object, **kwargs: object) -> object:
+        writer_queued.set()
+        await release_writer.wait()
+        return await original_to_thread(function, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(llm_request_logging.asyncio, "to_thread", delayed_to_thread)
+    monkeypatch.setattr(
+        llm_request_logging,
+        "_write_jsonl_line",
+        lambda _path, payload: written_payloads.append(payload),
+    )
+    model = _FakeModel(id="submitted-model", temperature=0.7)
+    messages = [Message(role="user", content="submitted message")]
+    tools = [{"name": "submitted_tool"}]
+
+    write_task = asyncio.create_task(
+        _write_llm_request_log(
+            model=model,  # type: ignore[arg-type]
+            agent_name="assistant",
+            messages=messages,
+            tools=tools,
+            log_path=tmp_path / "requests.jsonl",
+            request_log_id="log-1",
+        ),
+    )
+    try:
+        await writer_queued.wait()
+        model.id = "mutated-model"
+        model.temperature = 1.0
+        messages[0].content = "mutated message"
+        tools[0]["name"] = "mutated_tool"
+        release_writer.set()
+        await write_task
+    finally:
+        release_writer.set()
+        await asyncio.gather(write_task, return_exceptions=True)
+
+    assert len(written_payloads) == 1
+    payload = written_payloads[0]
+    assert payload["model_id"] == "submitted-model"
+    assert payload["messages"][0]["content"] == "submitted message"  # type: ignore[index]
+    assert payload["tools"] == [{"name": "submitted_tool"}]
+    assert payload["model_params"] == {"temperature": 0.7}
+
+
+@pytest.mark.asyncio
+async def test_llm_request_timestamp_and_daily_file_share_submission_time(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A writer delayed past midnight must stay in its submission day's file."""
+    submission_time = datetime(2026, 8, 25, 12, tzinfo=UTC)
+    worker_time = datetime(2026, 8, 26, 12, tzinfo=UTC)
+    observed_times = iter((submission_time, worker_time))
+
+    class _Clock:
+        @classmethod
+        def now(cls) -> datetime:
+            return next(observed_times)
+
+    monkeypatch.setattr(llm_request_logging, "datetime", _Clock)
+
+    request_log_ref = await llm_request_logging._write_llm_request_log_if_present(
+        model=_FakeModel(),  # type: ignore[arg-type]
+        agent_name="assistant",
+        kwargs={"messages": [Message(role="user", content="hello")], "tools": []},
+        log_dir=str(tmp_path),
+        default_log_dir=tmp_path / "unused",
+        request_context={},
+        wire_tools_capture=llm_request_logging._WireToolsCapture(enabled=True),
+    )
+
+    assert request_log_ref is not None
+    assert request_log_ref.log_path.name == "llm-requests-2026-08-25.jsonl"
+    entry = json.loads(request_log_ref.log_path.read_text(encoding="utf-8"))
+    assert entry["timestamp"] == submission_time.astimezone().isoformat()
 
 
 class _PlainAsyncIterator:

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -71,6 +71,21 @@ class _CancellableInvokeModel(_FakeModel):
             raise
 
 
+@dataclass
+class _CancellableStreamModel(_FakeModel):
+    invocation_started: asyncio.Event = field(default_factory=asyncio.Event)
+    provider_cancellation: asyncio.CancelledError | None = None
+
+    async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
+        self.invocation_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError as exc:
+            self.provider_cancellation = exc
+            raise
+        yield ModelResponse(content="unreachable")
+
+
 async def _assert_cancellation_is_deferred(task: asyncio.Task[Any]) -> None:
     """Observe one requested cancellation without releasing blocked work."""
     assert task.cancelling() > 0
@@ -890,6 +905,218 @@ async def test_stream_cancellation_chains_request_worker_failure(
 
 
 @pytest.mark.asyncio
+async def test_stream_provider_cancellation_chains_final_request_worker_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cleanup must retain a failed request task when no chunk was received."""
+    serializer_started = threading.Event()
+    release_serializer = threading.Event()
+    worker_error = OSError("serialization failed")
+
+    def failing_serialization(*_args: object, **_kwargs: object) -> str:
+        serializer_started.set()
+        assert release_serializer.wait(timeout=5)
+        raise worker_error
+
+    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", failing_serialization)
+    model = _CancellableStreamModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+    stream = model.ainvoke_stream(
+        messages=[Message(role="user", content="hello")],
+        assistant_message=Message(role="assistant"),
+        tools=[],
+    )
+    next_chunk = asyncio.create_task(anext(stream))
+    try:
+        await model.invocation_started.wait()
+        next_chunk.cancel("provider stream cancellation")
+        assert await asyncio.to_thread(serializer_started.wait, 5)
+        await _assert_cancellation_is_deferred(next_chunk)
+        next_chunk.cancel("later cancellation")
+        await _assert_cancellation_is_deferred(next_chunk)
+        release_serializer.set()
+        with pytest.raises(asyncio.CancelledError) as cancelled:
+            await next_chunk
+    finally:
+        release_serializer.set()
+        await asyncio.gather(next_chunk, return_exceptions=True)
+        await stream.aclose()
+
+    assert model.provider_cancellation is not None
+    assert cancelled.value is model.provider_cancellation
+    assert cancelled.value.args == ("provider stream cancellation",)
+    assert cancelled.value.__cause__ is worker_error
+    assert next_chunk.cancelling() == 2
+
+
+@pytest.mark.asyncio
+async def test_stream_request_worker_failure_does_not_mask_provider_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Ordinary provider failure remains primary over cleanup logging failure."""
+    provider_error = RuntimeError("provider failed")
+    worker_error = OSError("serialization failed")
+
+    @dataclass
+    class _FailingStreamModel(_FakeModel):
+        async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
+            raise provider_error
+            yield ModelResponse(content="unreachable")
+
+    def failing_serialization(*_args: object, **_kwargs: object) -> str:
+        raise worker_error
+
+    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", failing_serialization)
+    model = _FailingStreamModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+    stream = model.ainvoke_stream(
+        messages=[Message(role="user", content="hello")],
+        assistant_message=Message(role="assistant"),
+        tools=[],
+    )
+
+    with capture_logs() as logs, pytest.raises(RuntimeError) as raised:
+        await anext(stream)
+
+    assert raised.value is provider_error
+    assert [entry["event"] for entry in logs] == [
+        "Failed to persist LLM request log",
+        "LLM usage",
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_response_worker_failure_is_chained_to_deferred_cancellation(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    streaming: bool,
+) -> None:
+    """An accepted response append must report failure to its cancellation owner."""
+    response_writer_started = threading.Event()
+    release_response_writer = threading.Event()
+    worker_error = OSError("response append failed")
+    original_write = llm_request_logging._write_serialized_jsonl_line
+
+    def failing_response_write(path: Path, line: str) -> None:
+        if json.loads(line).get("record") == "response":
+            response_writer_started.set()
+            assert release_response_writer.wait(timeout=5)
+            raise worker_error
+        original_write(path, line)
+
+    monkeypatch.setattr(llm_request_logging, "_write_serialized_jsonl_line", failing_response_write)
+    model = _FakeModel(response_usage=MessageMetrics(input_tokens=3, output_tokens=2))
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    async def call_model() -> None:
+        if streaming:
+            async for _chunk in model.ainvoke_stream(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+                tools=[],
+            ):
+                pass
+        else:
+            await model.ainvoke(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+                tools=[],
+            )
+
+    async def call_and_capture() -> tuple[asyncio.CancelledError, int]:
+        try:
+            await call_model()
+        except asyncio.CancelledError as exc:
+            current_task = asyncio.current_task()
+            assert current_task is not None
+            return exc, current_task.cancelling()
+        pytest.fail("cancellation was not delivered")
+
+    call_task = asyncio.create_task(call_and_capture())
+    try:
+        assert await asyncio.to_thread(response_writer_started.wait, 5)
+        call_task.cancel("first cancellation")
+        await _assert_cancellation_is_deferred(call_task)
+        call_task.cancel("second cancellation")
+        await _assert_cancellation_is_deferred(call_task)
+        release_response_writer.set()
+        cancelled, cancel_count = await call_task
+    finally:
+        release_response_writer.set()
+        await asyncio.gather(call_task, return_exceptions=True)
+
+    assert cancelled.args == ("first cancellation",)
+    assert cancelled.__cause__ is worker_error
+    assert cancel_count == 2
+    assert call_task.cancelling() == 2
+    entries = _read_log_entries(tmp_path)
+    assert len(entries) == 1
+    assert entries[0].get("record") is None
+
+
+@pytest.mark.asyncio
+async def test_settled_stream_request_task_does_not_reenter_cancellation_boundary(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Later chunks and cleanup must use the settled request result directly."""
+    original_await = llm_request_logging._await_before_cancelling
+    settled_request_task: asyncio.Task[_RequestLogRef | None] | None = None
+    settled_request_reentered_boundary = False
+
+    async def observe_boundary[Result](task: asyncio.Task[Result]) -> Result:
+        nonlocal settled_request_reentered_boundary, settled_request_task
+        if task is settled_request_task:
+            settled_request_reentered_boundary = True
+        result = await original_await(task)
+        if isinstance(result, _RequestLogRef):
+            settled_request_task = task
+        return result
+
+    monkeypatch.setattr(llm_request_logging, "_await_before_cancelling", observe_boundary)
+    model = _FakeModel(response_usage=MessageMetrics(input_tokens=3, output_tokens=2))
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    contents = [
+        chunk.content
+        async for chunk in model.ainvoke_stream(
+            messages=[Message(role="user", content="hello")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        )
+    ]
+
+    assert contents == ["ok", "!"]
+    assert settled_request_task is not None
+    assert not settled_request_reentered_boundary
+    assert [entry.get("record") for entry in _read_log_entries(tmp_path)] == [None, "response"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("streaming", [False, True])
 async def test_uncancelled_request_worker_failure_remains_best_effort(
     monkeypatch: pytest.MonkeyPatch,
@@ -1625,6 +1852,57 @@ async def test_llm_response_log_failure_does_not_fail_invoke(
 
     assert response.content == "ok"
     assert [entry["event"] for entry in logs] == ["Failed to emit LLM response telemetry"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_uncancelled_response_worker_failure_remains_best_effort(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    streaming: bool,
+) -> None:
+    """A response append failure must not replace normal provider behavior."""
+    worker_error = OSError("response append failed")
+    original_write = llm_request_logging._write_serialized_jsonl_line
+
+    def failing_response_write(path: Path, line: str) -> None:
+        if json.loads(line).get("record") == "response":
+            raise worker_error
+        original_write(path, line)
+
+    monkeypatch.setattr(llm_request_logging, "_write_serialized_jsonl_line", failing_response_write)
+    model = _FakeModel(response_usage=MessageMetrics(input_tokens=3, output_tokens=2))
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+
+    with capture_logs() as logs:
+        if streaming:
+            contents = [
+                chunk.content
+                async for chunk in model.ainvoke_stream(
+                    messages=[Message(role="user", content="hello")],
+                    assistant_message=Message(role="assistant"),
+                    tools=[],
+                )
+            ]
+        else:
+            response = await model.ainvoke(
+                messages=[Message(role="user", content="hello")],
+                assistant_message=Message(role="assistant"),
+                tools=[],
+            )
+            contents = [response.content]
+
+    assert contents == (["ok", "!"] if streaming else ["ok"])
+    assert [entry["event"] for entry in logs] == [
+        "LLM usage",
+        "Failed to emit LLM response telemetry",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -164,6 +164,75 @@ async def test_llm_request_log_uses_serialized_snapshot_when_file_write_is_delay
 
 
 @pytest.mark.asyncio
+async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_persisted(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cancellation must not release borrowed values before their record is durable."""
+    serialization_started, release_serialization, serialization_finished = (threading.Event() for _ in range(3))
+    original_serialize = llm_request_logging._serialize_llm_request_log_line
+
+    def blocked_serialize(*args: object, **kwargs: object) -> str:
+        serialization_started.set()
+        assert release_serialization.wait(timeout=5)
+        try:
+            return original_serialize(*args, **kwargs)  # type: ignore[arg-type]
+        finally:
+            serialization_finished.set()
+
+    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", blocked_serialize)
+    model = _FakeModel(id="submitted-model", temperature=0.7)
+    messages = [Message(role="user", content="submitted message")]
+    tools = [{"name": "submitted_tool"}]
+    log_path = tmp_path / "requests.jsonl"
+    write_task = asyncio.create_task(
+        _write_llm_request_log(
+            model=model,  # type: ignore[arg-type]
+            agent_name="assistant",
+            messages=messages,
+            tools=tools,
+            log_path=log_path,
+            request_log_id="log-1",
+        ),
+    )
+    cancellation_observed = asyncio.Event()
+
+    async def observe_cancellation() -> None:
+        try:
+            await write_task
+        except asyncio.CancelledError:
+            model.id = "mutated-model"
+            model.temperature = 1.0
+            messages[0].content = "mutated message"
+            tools[0]["name"] = "mutated_tool"
+            cancellation_observed.set()
+            raise
+
+    observer = asyncio.create_task(observe_cancellation())
+    try:
+        assert await asyncio.to_thread(serialization_started.wait, 5)
+        write_task.cancel()
+        await asyncio.sleep(0)
+        write_task.cancel()
+        await asyncio.sleep(0)
+        cancellation_was_deferred = not cancellation_observed.is_set()
+        release_serialization.set()
+        with pytest.raises(asyncio.CancelledError):
+            await observer
+        assert await asyncio.to_thread(serialization_finished.wait, 5)
+    finally:
+        release_serialization.set()
+        await asyncio.gather(write_task, observer, return_exceptions=True)
+
+    assert cancellation_was_deferred
+    payload = json.loads(log_path.read_text(encoding="utf-8"))
+    assert payload["model_id"] == "submitted-model"
+    assert payload["messages"][0]["content"] == "submitted message"
+    assert payload["tools"] == [{"name": "submitted_tool"}]
+    assert payload["model_params"] == {"temperature": 0.7}
+
+
+@pytest.mark.asyncio
 async def test_wire_tool_normalization_runs_on_request_serializer_thread(tmp_path: Path) -> None:
     """Provider wire-tool capture should borrow values until off-loop serialization."""
     event_loop_thread = threading.get_ident()

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -6,7 +6,7 @@ import asyncio
 import json
 import threading
 from concurrent.futures import ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
@@ -66,16 +66,41 @@ async def _assert_cancellation_is_deferred(task: asyncio.Task[Any]) -> None:
     assert not task.done()
 
 
-class _InterleavingAppendHandle:
+@dataclass
+class _AppendBoundaryProbe:
+    first_writer_started: threading.Event = field(default_factory=threading.Event)
+    release_first_writer: threading.Event = field(default_factory=threading.Event)
+    guard: threading.Lock = field(default_factory=threading.Lock)
+    write_calls: int = 0
+    active_writers: int = 0
+    overlap_detected: bool = False
+
+
+class _ReleaseFirstWriterOnContention:
+    def __init__(self, probe: _AppendBoundaryProbe) -> None:
+        self._probe = probe
+        self._lock = threading.Lock()
+
+    def __enter__(self) -> _ReleaseFirstWriterOnContention:
+        if not self._lock.acquire(blocking=False):
+            self._probe.release_first_writer.set()
+            assert self._lock.acquire(timeout=5)
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self._lock.release()
+
+
+class _ObservedAppendHandle:
     def __init__(
         self,
         handle: TextIO,
-        split_body_writes: threading.Barrier,
+        probe: _AppendBoundaryProbe,
     ) -> None:
         self._handle = handle
-        self._split_body_writes = split_body_writes
+        self._probe = probe
 
-    def __enter__(self) -> _InterleavingAppendHandle:
+    def __enter__(self) -> _ObservedAppendHandle:
         self._handle.__enter__()
         return self
 
@@ -83,13 +108,23 @@ class _InterleavingAppendHandle:
         self._handle.__exit__(*args)  # type: ignore[arg-type]
 
     def write(self, value: str) -> int:
-        if not value.endswith("\n"):
-            self._split_body_writes.wait(timeout=5)
+        with self._probe.guard:
+            is_first_writer = self._probe.write_calls == 0
+            self._probe.write_calls += 1
+            self._probe.active_writers += 1
+            if self._probe.active_writers > 1:
+                self._probe.overlap_detected = True
+                self._probe.release_first_writer.set()
+        if is_first_writer:
+            self._probe.first_writer_started.set()
+            assert self._probe.release_first_writer.wait(timeout=5)
+        try:
             written = self._handle.write(value)
             self._handle.flush()
-            self._split_body_writes.wait(timeout=5)
             return written
-        return self._handle.write(value)
+        finally:
+            with self._probe.guard:
+                self._probe.active_writers -= 1
 
 
 def _mutate_borrowed_request_values(
@@ -161,36 +196,35 @@ async def test_llm_request_payload_is_built_on_writer_thread(
     assert payload["tools"] == [{"name": "search"}]
 
 
-def test_concurrent_jsonl_appends_remain_parseable(
+def test_concurrent_jsonl_appends_serialize_writer_boundary(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Concurrent worker appends must each remain one complete JSONL record."""
-    append_attempts = threading.Barrier(2)
-    split_body_writes = threading.Barrier(2)
+    """Concurrent appends must not overlap at the real-file writer boundary."""
+    probe = _AppendBoundaryProbe()
     path_type = type(tmp_path)
     real_open = path_type.open
 
-    def coordinated_open(path: Path, *args: object, **kwargs: object) -> _InterleavingAppendHandle:
+    def observed_open(path: Path, *args: object, **kwargs: object) -> _ObservedAppendHandle:
         handle = real_open(path, *args, **kwargs)  # type: ignore[arg-type]
-        return _InterleavingAppendHandle(handle, split_body_writes)
+        return _ObservedAppendHandle(handle, probe)
 
-    def append_after_rendezvous(log_path: Path, line: str) -> None:
-        append_attempts.wait(timeout=5)
-        llm_request_logging._write_serialized_jsonl_line(log_path, line)
-
-    monkeypatch.setattr(path_type, "open", coordinated_open)
+    monkeypatch.setattr(llm_request_logging, "_JSONL_APPEND_LOCK", _ReleaseFirstWriterOnContention(probe))
+    monkeypatch.setattr(path_type, "open", observed_open)
     log_path = tmp_path / "requests.jsonl"
     lines = [
         json.dumps({"record": "first"}),
         json.dumps({"record": "second"}),
     ]
     with ThreadPoolExecutor(max_workers=2) as executor:
-        appends = [executor.submit(append_after_rendezvous, log_path, line) for line in lines]
-        for append in appends:
-            append.result(timeout=5)
+        first_append = executor.submit(llm_request_logging._write_serialized_jsonl_line, log_path, lines[0])
+        assert probe.first_writer_started.wait(timeout=5)
+        second_append = executor.submit(llm_request_logging._write_serialized_jsonl_line, log_path, lines[1])
+        first_append.result(timeout=5)
+        second_append.result(timeout=5)
     with real_open(log_path, encoding="utf-8") as handle:
         records = [json.loads(line) for line in handle]
+    assert not probe.overlap_detected
     assert len(records) == 2
     assert {record["record"] for record in records} == {"first", "second"}
 

--- a/tests/test_llm_request_logging.py
+++ b/tests/test_llm_request_logging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
@@ -32,8 +33,9 @@ from mindroom.llm_request_logging import (
 from mindroom.openai_tool_search import request_params_with_deferred_tool_search
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Awaitable
     from pathlib import Path
+    from typing import TextIO
 
 
 @dataclass
@@ -53,6 +55,61 @@ class _FakeModel:
     async def ainvoke_stream(self, *_args: object, **_kwargs: object) -> AsyncIterator[ModelResponse]:
         yield ModelResponse(content="ok")
         yield ModelResponse(content="!", response_usage=self.response_usage)
+
+
+class _ShieldRetryObserver:
+    def __init__(self, retry_events: dict[int, asyncio.Event]) -> None:
+        self._retry_events = retry_events
+        self._original_shield = asyncio.shield
+        self._calls = 0
+
+    async def __call__(self, awaitable: Awaitable[object]) -> object:
+        self._calls += 1
+        retry_event = self._retry_events.get(self._calls)
+        if retry_event is not None:
+            retry_event.set()
+        return await self._original_shield(awaitable)
+
+
+class _CoordinatedAppendHandle:
+    def __init__(
+        self,
+        handle: TextIO,
+        first_writes: threading.Barrier,
+        lock_observations: list[bool],
+    ) -> None:
+        self._handle = handle
+        self._first_writes = first_writes
+        self._lock_observations = lock_observations
+
+    def __enter__(self) -> _CoordinatedAppendHandle:
+        self._handle.__enter__()
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        self._handle.__exit__(*args)  # type: ignore[arg-type]
+
+    def write(self, value: str) -> int:
+        append_lock = getattr(llm_request_logging, "_JSONL_APPEND_LOCK", None)
+        lock_held = append_lock is not None and append_lock.locked()
+        self._lock_observations.append(lock_held)
+        if not lock_held and value != "\n":
+            self._first_writes.wait(timeout=5)
+            written = self._handle.write(value)
+            self._first_writes.wait(timeout=5)
+            return written
+        return self._handle.write(value)
+
+
+def _mutate_borrowed_request_values(
+    model: _FakeModel,
+    messages: list[Message],
+    tools: list[dict[str, str]],
+) -> None:
+    model.id = "mutated-model"
+    model.temperature = 1.0
+    messages[0].content = "mutated message"
+    tools[0]["name"] = "mutated_tool"
 
 
 @pytest.mark.asyncio
@@ -113,6 +170,36 @@ async def test_llm_request_payload_is_built_on_writer_thread(
     assert payload["tools"] == [{"name": "search"}]
 
 
+def test_concurrent_large_jsonl_appends_remain_parseable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Concurrent worker appends must each remain one complete JSONL record."""
+    first_writes = threading.Barrier(2)
+    path_type = type(tmp_path)
+    real_open = path_type.open
+    lock_observations: list[bool] = []
+
+    def coordinated_open(path: Path, *args: object, **kwargs: object) -> _CoordinatedAppendHandle:
+        handle = real_open(path, *args, **kwargs)  # type: ignore[arg-type]
+        return _CoordinatedAppendHandle(handle, first_writes, lock_observations)
+
+    monkeypatch.setattr(path_type, "open", coordinated_open)
+    log_path = tmp_path / "requests.jsonl"
+    lines = [
+        json.dumps({"record": "first", "payload": "a" * 1_000_000}),
+        json.dumps({"record": "second", "payload": "b" * 1_000_000}),
+    ]
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        appends = [executor.submit(llm_request_logging._write_serialized_jsonl_line, log_path, line) for line in lines]
+        for append in appends:
+            append.result(timeout=5)
+    with real_open(log_path, encoding="utf-8") as handle:
+        records = [json.loads(line) for line in handle]
+    assert {record["record"] for record in records} == {"first", "second"}
+    assert lock_observations == [True, True]
+
+
 @pytest.mark.asyncio
 async def test_llm_request_log_uses_serialized_snapshot_when_file_write_is_delayed(
     monkeypatch: pytest.MonkeyPatch,
@@ -164,12 +251,59 @@ async def test_llm_request_log_uses_serialized_snapshot_when_file_write_is_delay
 
 
 @pytest.mark.asyncio
+async def test_request_log_pins_container_membership_before_worker_dispatch(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Queued serialization borrows elements from shallow-copied containers."""
+    worker_queued = asyncio.Event()
+    release_worker = asyncio.Event()
+    original_to_thread = asyncio.to_thread
+
+    async def delayed_to_thread(function: object, /, *args: object, **kwargs: object) -> object:
+        worker_queued.set()
+        await release_worker.wait()
+        return await original_to_thread(function, *args, **kwargs)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(llm_request_logging.asyncio, "to_thread", delayed_to_thread)
+    submitted_message = Message(role="user", content="submitted message")
+    submitted_tool = {"name": "submitted_tool"}
+    messages = [submitted_message]
+    tools = [submitted_tool]
+    log_path = tmp_path / "requests.jsonl"
+    write_task = asyncio.create_task(
+        _write_llm_request_log(
+            model=_FakeModel(),  # type: ignore[arg-type]
+            agent_name="assistant",
+            messages=messages,
+            tools=tools,
+            log_path=log_path,
+            request_log_id="log-1",
+        ),
+    )
+    try:
+        await worker_queued.wait()
+        messages[:] = [Message(role="user", content="replacement message")]
+        tools[:] = [{"name": "replacement_tool"}]
+        release_worker.set()
+        await write_task
+    finally:
+        release_worker.set()
+        await asyncio.gather(write_task, return_exceptions=True)
+
+    payload = json.loads(log_path.read_text(encoding="utf-8"))
+    assert payload["messages"][0]["content"] == "submitted message"
+    assert payload["tools"] == [{"name": "submitted_tool"}]
+
+
+@pytest.mark.asyncio
 async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_persisted(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
     """Cancellation must not release borrowed values before their record is durable."""
     serialization_started, release_serialization, serialization_finished = (threading.Event() for _ in range(3))
+    first_cancellation_deferred, second_cancellation_deferred = (asyncio.Event() for _ in range(2))
     original_serialize = llm_request_logging._serialize_llm_request_log_line
 
     def blocked_serialize(*args: object, **kwargs: object) -> str:
@@ -181,6 +315,11 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
             serialization_finished.set()
 
     monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", blocked_serialize)
+    monkeypatch.setattr(
+        llm_request_logging.asyncio,
+        "shield",
+        _ShieldRetryObserver({2: first_cancellation_deferred, 3: second_cancellation_deferred}),
+    )
     model = _FakeModel(id="submitted-model", temperature=0.7)
     messages = [Message(role="user", content="submitted message")]
     tools = [{"name": "submitted_tool"}]
@@ -201,10 +340,7 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
         try:
             await write_task
         except asyncio.CancelledError:
-            model.id = "mutated-model"
-            model.temperature = 1.0
-            messages[0].content = "mutated message"
-            tools[0]["name"] = "mutated_tool"
+            _mutate_borrowed_request_values(model, messages, tools)
             cancellation_observed.set()
             raise
 
@@ -212,9 +348,9 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
     try:
         assert await asyncio.to_thread(serialization_started.wait, 5)
         write_task.cancel()
-        await asyncio.sleep(0)
+        await first_cancellation_deferred.wait()
         write_task.cancel()
-        await asyncio.sleep(0)
+        await second_cancellation_deferred.wait()
         cancellation_was_deferred = not cancellation_observed.is_set()
         release_serialization.set()
         with pytest.raises(asyncio.CancelledError):
@@ -225,6 +361,7 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
         await asyncio.gather(write_task, observer, return_exceptions=True)
 
     assert cancellation_was_deferred
+    assert write_task.cancelling() == 2
     payload = json.loads(log_path.read_text(encoding="utf-8"))
     assert payload["model_id"] == "submitted-model"
     assert payload["messages"][0]["content"] == "submitted message"
@@ -233,8 +370,104 @@ async def test_llm_request_log_defers_cancellation_until_borrowed_values_are_per
 
 
 @pytest.mark.asyncio
+async def test_invoke_cancellation_wins_when_request_log_worker_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A failed accepted write must not turn caller cancellation into success."""
+    serializer_started = threading.Event()
+    release_serializer = threading.Event()
+    cancellation_deferred = asyncio.Event()
+    serialization_error = OSError("serialization failed")
+
+    def fail_serialization(**_kwargs: object) -> str:
+        serializer_started.set()
+        assert release_serializer.wait(timeout=5)
+        raise serialization_error
+
+    monkeypatch.setattr(llm_request_logging.asyncio, "shield", _ShieldRetryObserver({2: cancellation_deferred}))
+    monkeypatch.setattr(llm_request_logging, "_serialize_llm_request_log_line", fail_serialization)
+    model = _FakeModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+    invoke_task = asyncio.create_task(
+        model.ainvoke(
+            messages=[Message(role="user", content="hello")],
+            assistant_message=Message(role="assistant"),
+            tools=[],
+        ),
+    )
+    try:
+        assert await asyncio.to_thread(serializer_started.wait, 5)
+        invoke_task.cancel("cancel request")
+        await cancellation_deferred.wait()
+        release_serializer.set()
+        with pytest.raises(asyncio.CancelledError) as cancelled:
+            await invoke_task
+    finally:
+        release_serializer.set()
+        await asyncio.gather(invoke_task, return_exceptions=True)
+
+    assert cancelled.value.args == ("cancel request",)
+    assert invoke_task.cancelling() == 1
+
+
+@pytest.mark.asyncio
+async def test_stream_cancellation_persists_one_request_record(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Generator cleanup must not retry an accepted request append."""
+    writer_started = threading.Event()
+    release_writer = threading.Event()
+    cancellation_deferred = asyncio.Event()
+    original_write = llm_request_logging._write_serialized_jsonl_line
+
+    def blocked_write(path: Path, line: str) -> None:
+        writer_started.set()
+        assert release_writer.wait(timeout=5)
+        original_write(path, line)
+
+    monkeypatch.setattr(llm_request_logging, "_write_serialized_jsonl_line", blocked_write)
+    monkeypatch.setattr(llm_request_logging.asyncio, "shield", _ShieldRetryObserver({2: cancellation_deferred}))
+    model = _FakeModel()
+    install_llm_request_logging(
+        model,
+        agent_name="default",
+        debug_config=DebugConfig(log_llm_requests=True, llm_request_log_dir=str(tmp_path)),
+        default_log_dir=tmp_path / "unused",
+    )
+    stream = model.ainvoke_stream(
+        messages=[Message(role="user", content="hello")],
+        assistant_message=Message(role="assistant"),
+        tools=[],
+    )
+    next_chunk = asyncio.create_task(anext(stream))
+    try:
+        assert await asyncio.to_thread(writer_started.wait, 5)
+        next_chunk.cancel("cancel stream")
+        await cancellation_deferred.wait()
+        release_writer.set()
+        with pytest.raises(asyncio.CancelledError):
+            await next_chunk
+    finally:
+        release_writer.set()
+        await asyncio.gather(next_chunk, return_exceptions=True)
+        await stream.aclose()
+
+    entries = _read_log_entries(tmp_path)
+    assert len(entries) == 1
+    assert entries[0]["messages"][0]["role"] == "user"
+    assert entries[0]["messages"][0]["content"] == "hello"
+
+
+@pytest.mark.asyncio
 async def test_wire_tool_normalization_runs_on_request_serializer_thread(tmp_path: Path) -> None:
-    """Provider wire-tool capture should borrow values until off-loop serialization."""
+    """Capture pins membership while element traversal stays off-loop."""
     event_loop_thread = threading.get_ident()
     traversal_threads: list[int] = []
 
@@ -245,12 +478,14 @@ async def test_wire_tool_normalization_runs_on_request_serializer_thread(tmp_pat
 
     capture = llm_request_logging._WireToolsCapture(enabled=True)
     token = llm_request_logging._WIRE_TOOLS_CAPTURE.set(capture)
+    wire_tools = [TraversalProbe({"name": "search"})]
     try:
-        record_llm_request_tools([TraversalProbe({"name": "search"})])
+        record_llm_request_tools(wire_tools)
     finally:
         llm_request_logging._WIRE_TOOLS_CAPTURE.reset(token)
 
     assert traversal_threads == []
+    wire_tools.clear()
     await _write_llm_request_log(
         model=_FakeModel(),  # type: ignore[arg-type]
         agent_name="assistant",


### PR DESCRIPTION
## Summary

- build request log payloads and write them in one worker-thread operation
- preserve existing request context, redaction, and JSONL formats
- cover thread placement for system, message, tool, model, and write work

## Testing

- `uv run pytest -q -n 0 tests/test_llm_request_logging.py`
- `uv run pre-commit run --files src/mindroom/llm_request_logging.py tests/test_llm_request_logging.py`
- `uv run pytest -q -n 4`

## Summary by Sourcery

Offload LLM request-log serialization and persistence to worker threads while preserving logging behavior and robustly handling cancellation and failures.

Bug Fixes:
- Ensure LLM request and response logging remains reliable under concurrent writes, cancellation, stream cleanup, and logging-worker failures without masking provider outcomes.

Enhancements:
- Move request-log serialization and JSONL persistence off the event-loop thread while preserving request snapshots, context, redaction, timestamps, and existing formats.
- Strengthen asynchronous logging lifecycle handling so accepted request and response writes are completed, consumed once, and correctly chained with cancellation or provider errors.

Tests:
- Expand logging coverage for worker-thread placement, immutable request snapshots, serialized concurrent appends, cancellation semantics, stream finalization, error chaining, timestamp consistency, and best-effort behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of LLM request and response logging during concurrent activity.
  - Ensured logs are saved before cancellations are reported.
  - Preserved the original cancellation or model error while retaining related logging details.
  - Improved handling of interrupted streaming requests and cleanup.
  - Prevented incomplete or duplicate log entries.
  - Preserved request details, usage telemetry, response links, timestamps, and daily log placement.
  - Ensured failed calls retain available request logs without masking the original error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->