### PR TITLE
Let agents switch models during a turn

### DIFF
--- a/docs/chat-commands.md
+++ b/docs/chat-commands.md
@@ -220,7 +220,7 @@ Model names come from the `models:` section of `config.yaml`.
 The override applies from the next message in the thread and survives restarts.
 Other threads keep their own thread override when present and otherwise use their room's effective default; other rooms remain independent.
 Use `!room_model` for a durable runtime room default or `room_models` in `config.yaml` for an authored room default.
-Agents can also switch the thread model themselves when they have the `thread_model` tool.
+Agents with the `thread_model` tool can list configured models and switch either after the tool call in the current response or from the next turn.
 
 ### `!room_model`
 

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -19,7 +19,7 @@ Use these tools when you need to send or inspect Matrix messages, manage thread 
 - [`thread_tags`] - Add, remove, and inspect shared tags on a Matrix thread.
 - [`thread_resolution`] - Explicitly resolve or reopen the active Matrix thread.
 - [`thread_summary`] - Set or update a Matrix thread summary from the current room and thread context.
-- [`thread_model`] - Show, switch, or reset the model override for the current Matrix thread.
+- [`thread_model`] - List models or show, switch, and reset the model override for the current Matrix thread.
 - [`matrix_api`] - Use a low-level Matrix event and state API with explicit room and event IDs.
 - [`attachments`] - List, inspect, and register context-scoped attachment IDs for later tool calls.
 
@@ -315,14 +315,18 @@ set_thread_summary(
 
 ## [`thread_model`]
 
-`thread_model` lets agents show, switch, or reset the model override for the current Matrix thread, mirroring the `!model` chat command.
+`thread_model` lets agents list configured models or show, switch, and reset the model override for the current Matrix thread, mirroring the `!model` chat command.
 
 ### What It Does
 
-`thread_model` exposes `get_thread_model()`, `switch_thread_model(model_name)`, and `reset_thread_model()`.
-All three functions require an active thread context and return an error outside a thread.
+`thread_model` exposes `list_models()`, `get_thread_model()`, `switch_thread_model(model_name, when)`, and `reset_thread_model()`.
+`list_models` returns every configured model alias with its provider and provider model ID and does not require an active thread.
+The other three functions require an active thread context and return an error outside a thread.
 `switch_thread_model` accepts a configured model name from the `models:` section of `config.yaml` and rejects unknown names with the available model list.
-The override applies to all agents and teams in the thread, persists across restarts, and takes effect from the next message; the current response keeps the model it started with.
+Its optional `when` argument accepts `after-toolcall` or `next-turn` and defaults to `next-turn`.
+With `after-toolcall`, MindRoom rebuilds the current agent or team with the selected model and continues the same response after the tool call.
+With `next-turn`, the current response continues with the model it started with and the selected model begins on the next user turn.
+The override applies to all agents and teams in the thread and persists across restarts.
 `get_thread_model` returns the active override and the available model names.
 When a stored override names a model that has been removed from `config.models`, runtime resolution ignores it, and `get_thread_model` reports `override: null` plus a `stale_override` field instead of an active override.
 `reset_thread_model` removes the thread override so room-level model selection applies: an active runtime `!room_model` override, then configured `room_models`, then each entity's configured model.
@@ -341,8 +345,9 @@ agents:
 ```
 
 ```python
+list_models()
 get_thread_model()
-switch_thread_model("opus")
+switch_thread_model("opus", when="after-toolcall")
 reset_thread_model()
 ```
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7135,7 +7135,7 @@ Use these tools when you need to send or inspect Matrix messages, manage thread 
 - [`thread_tags`] - Add, remove, and inspect shared tags on a Matrix thread.
 - [`thread_resolution`] - Explicitly resolve or reopen the active Matrix thread.
 - [`thread_summary`] - Set or update a Matrix thread summary from the current room and thread context.
-- [`thread_model`] - Show, switch, or reset the model override for the current Matrix thread.
+- [`thread_model`] - List models or show, switch, and reset the model override for the current Matrix thread.
 - [`matrix_api`] - Use a low-level Matrix event and state API with explicit room and event IDs.
 - [`attachments`] - List, inspect, and register context-scoped attachment IDs for later tool calls.
 
@@ -7431,14 +7431,18 @@ set_thread_summary(
 
 ## [`thread_model`]
 
-`thread_model` lets agents show, switch, or reset the model override for the current Matrix thread, mirroring the `!model` chat command.
+`thread_model` lets agents list configured models or show, switch, and reset the model override for the current Matrix thread, mirroring the `!model` chat command.
 
 ### What It Does
 
-`thread_model` exposes `get_thread_model()`, `switch_thread_model(model_name)`, and `reset_thread_model()`.
-All three functions require an active thread context and return an error outside a thread.
+`thread_model` exposes `list_models()`, `get_thread_model()`, `switch_thread_model(model_name, when)`, and `reset_thread_model()`.
+`list_models` returns every configured model alias with its provider and provider model ID and does not require an active thread.
+The other three functions require an active thread context and return an error outside a thread.
 `switch_thread_model` accepts a configured model name from the `models:` section of `config.yaml` and rejects unknown names with the available model list.
-The override applies to all agents and teams in the thread, persists across restarts, and takes effect from the next message; the current response keeps the model it started with.
+Its optional `when` argument accepts `after-toolcall` or `next-turn` and defaults to `next-turn`.
+With `after-toolcall`, MindRoom rebuilds the current agent or team with the selected model and continues the same response after the tool call.
+With `next-turn`, the current response continues with the model it started with and the selected model begins on the next user turn.
+The override applies to all agents and teams in the thread and persists across restarts.
 `get_thread_model` returns the active override and the available model names.
 When a stored override names a model that has been removed from `config.models`, runtime resolution ignores it, and `get_thread_model` reports `override: null` plus a `stale_override` field instead of an active override.
 `reset_thread_model` removes the thread override so room-level model selection applies: an active runtime `!room_model` override, then configured `room_models`, then each entity's configured model.
@@ -7457,8 +7461,9 @@ agents:
 ```
 
 ```python
+list_models()
 get_thread_model()
-switch_thread_model("opus")
+switch_thread_model("opus", when="after-toolcall")
 reset_thread_model()
 ```
 
@@ -15446,7 +15451,7 @@ Model names come from the `models:` section of `config.yaml`.
 The override applies from the next message in the thread and survives restarts.
 Other threads keep their own thread override when present and otherwise use their room's effective default; other rooms remain independent.
 Use `!room_model` for a durable runtime room default or `room_models` in `config.yaml` for an authored room default.
-Agents can also switch the thread model themselves when they have the `thread_model` tool.
+Agents with the `thread_model` tool can list configured models and switch either after the tool call in the current response or from the next turn.
 
 ### `!room_model`
 

--- a/skills/mindroom-docs/references/page__chat-commands__index.md
+++ b/skills/mindroom-docs/references/page__chat-commands__index.md
@@ -216,7 +216,7 @@ Model names come from the `models:` section of `config.yaml`.
 The override applies from the next message in the thread and survives restarts.
 Other threads keep their own thread override when present and otherwise use their room's effective default; other rooms remain independent.
 Use `!room_model` for a durable runtime room default or `room_models` in `config.yaml` for an authored room default.
-Agents can also switch the thread model themselves when they have the `thread_model` tool.
+Agents with the `thread_model` tool can list configured models and switch either after the tool call in the current response or from the next turn.
 
 ### `!room_model`
 

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -15,7 +15,7 @@ Use these tools when you need to send or inspect Matrix messages, manage thread 
 - [`thread_tags`] - Add, remove, and inspect shared tags on a Matrix thread.
 - [`thread_resolution`] - Explicitly resolve or reopen the active Matrix thread.
 - [`thread_summary`] - Set or update a Matrix thread summary from the current room and thread context.
-- [`thread_model`] - Show, switch, or reset the model override for the current Matrix thread.
+- [`thread_model`] - List models or show, switch, and reset the model override for the current Matrix thread.
 - [`matrix_api`] - Use a low-level Matrix event and state API with explicit room and event IDs.
 - [`attachments`] - List, inspect, and register context-scoped attachment IDs for later tool calls.
 
@@ -311,14 +311,18 @@ set_thread_summary(
 
 ## [`thread_model`]
 
-`thread_model` lets agents show, switch, or reset the model override for the current Matrix thread, mirroring the `!model` chat command.
+`thread_model` lets agents list configured models or show, switch, and reset the model override for the current Matrix thread, mirroring the `!model` chat command.
 
 ### What It Does
 
-`thread_model` exposes `get_thread_model()`, `switch_thread_model(model_name)`, and `reset_thread_model()`.
-All three functions require an active thread context and return an error outside a thread.
+`thread_model` exposes `list_models()`, `get_thread_model()`, `switch_thread_model(model_name, when)`, and `reset_thread_model()`.
+`list_models` returns every configured model alias with its provider and provider model ID and does not require an active thread.
+The other three functions require an active thread context and return an error outside a thread.
 `switch_thread_model` accepts a configured model name from the `models:` section of `config.yaml` and rejects unknown names with the available model list.
-The override applies to all agents and teams in the thread, persists across restarts, and takes effect from the next message; the current response keeps the model it started with.
+Its optional `when` argument accepts `after-toolcall` or `next-turn` and defaults to `next-turn`.
+With `after-toolcall`, MindRoom rebuilds the current agent or team with the selected model and continues the same response after the tool call.
+With `next-turn`, the current response continues with the model it started with and the selected model begins on the next user turn.
+The override applies to all agents and teams in the thread and persists across restarts.
 `get_thread_model` returns the active override and the available model names.
 When a stored override names a model that has been removed from `config.models`, runtime resolution ignores it, and `get_thread_model` reports `override: null` plus a `stale_override` field instead of an active override.
 `reset_thread_model` removes the thread override so room-level model selection applies: an active runtime `!room_model` override, then configured `room_models`, then each entity's configured model.
@@ -337,8 +341,9 @@ agents:
 ```
 
 ```python
+list_models()
 get_thread_model()
-switch_thread_model("opus")
+switch_thread_model("opus", when="after-toolcall")
 reset_thread_model()
 ```
 

--- a/src/mindroom/ai.py
+++ b/src/mindroom/ai.py
@@ -1328,6 +1328,7 @@ async def ai_response(  # noqa: C901
     pipeline_timing: DispatchPipelineTiming | None = None,
     eager_deferred_tools: bool = False,
     supports_native_tool_approval: bool = False,
+    attempt_model_runtime: ai_runtime.AttemptModelRuntime | None = None,
     reusable_agent: Agent | None = None,
 ) -> str:
     """Generates a response using the specified agno Agent with memory integration.
@@ -1371,6 +1372,7 @@ async def ai_response(  # noqa: C901
         pipeline_timing: Optional dispatch timing collector updated with AI-stage milestones.
         eager_deferred_tools: Whether to materialize every deferred toolkit without the dynamic loader.
         supports_native_tool_approval: Whether this caller can resume Agno confirmation pauses.
+        attempt_model_runtime: Optional composition-root boundary that exposes each attempt's model to tools.
         reusable_agent: Optional caller-owned agent materialized for repeated sequential turns.
             The caller must serialize uses and close its runtime database handles.
 
@@ -1407,6 +1409,7 @@ async def ai_response(  # noqa: C901
                 pipeline_timing=pipeline_timing,
                 eager_deferred_tools=eager_deferred_tools,
                 supports_native_tool_approval=supports_native_tool_approval,
+                attempt_model_runtime=attempt_model_runtime,
                 reusable_agent=reusable_agent,
             ),
             show_tool_calls=show_tool_calls,
@@ -1451,7 +1454,11 @@ async def ai_response(  # noqa: C901
         """Run one prepared agent attempt."""
         try:
             run_context = await _prepare_agent_run_context(
-                ctx,
+                (
+                    replace(ctx, active_model_name=continuation_state.active_model_name)
+                    if continuation_state.active_model_name is not None
+                    else ctx
+                ),
                 prompt=continuation_state.active_prompt,
                 session_id=session_id,
                 runtime_paths=runtime_paths,
@@ -1490,12 +1497,16 @@ async def ai_response(  # noqa: C901
             run_id=continuation_state.active_run_id,
         )
         holder.attempt = attempt
-        attempt_result = await _run_non_streaming_agent_attempts(
-            run_context=run_context,
-            attempt=attempt,
-            run_id_callback=run_id_callback,
-            scope_context=run.scope_context,
-            pipeline_timing=pipeline_timing,
+        attempt_result = await ai_runtime.run_attempt_with_model(
+            attempt_model_runtime,
+            active_model_name=prepared_run.runtime_model_name,
+            operation=lambda: _run_non_streaming_agent_attempts(
+                run_context=run_context,
+                attempt=attempt,
+                run_id_callback=run_id_callback,
+                scope_context=run.scope_context,
+                pipeline_timing=pipeline_timing,
+            ),
         )
         if attempt_result.user_error is not None:
             error_text = get_user_friendly_error_message(attempt_result.user_error, agent_name)
@@ -1568,6 +1579,7 @@ async def ai_response(  # noqa: C901
             session_id=response.session_id,
             run_id=response.run_id,
             attempt_run_id=attempt.attempt_run_id,
+            runtime_model_name=prepared_run.runtime_model_name,
             output_tokens=_usage_metric_int(response.metrics, "output_tokens"),
             tool_executions=tuple(response.tools or ()),
             completed_tools=tuple(response_tool_trace),
@@ -1795,6 +1807,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
     pipeline_timing: DispatchPipelineTiming | None = None,
     eager_deferred_tools: bool = False,
     supports_native_tool_approval: bool = False,
+    attempt_model_runtime: ai_runtime.AttemptModelRuntime | None = None,
     reusable_agent: Agent | None = None,
 ) -> AsyncIterator[AIStreamChunk]:
     """Generate streaming AI response using Agno's streaming API.
@@ -1834,6 +1847,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         pipeline_timing: Optional dispatch timing collector updated with AI-stage milestones.
         eager_deferred_tools: Whether to materialize every deferred toolkit without the dynamic loader.
         supports_native_tool_approval: Whether this caller can resume Agno confirmation pauses.
+        attempt_model_runtime: Optional composition-root boundary that exposes each attempt's model to tools.
         reusable_agent: Optional caller-owned agent materialized for repeated sequential turns.
             The caller must serialize uses and close its runtime database handles.
 
@@ -1894,7 +1908,11 @@ async def stream_agent_response(  # noqa: C901, PLR0915
         """Stream one agent attempt, ending with its ``AttemptResolved`` sentinel."""
         try:
             run_context = await _prepare_agent_run_context(
-                ctx,
+                (
+                    replace(ctx, active_model_name=continuation_state.active_model_name)
+                    if continuation_state.active_model_name is not None
+                    else ctx
+                ),
                 prompt=continuation_state.active_prompt,
                 session_id=session_id,
                 runtime_paths=runtime_paths,
@@ -1986,15 +2004,20 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                 interrupted_tools=[pending.trace_entry for pending in state_ref.pending_tools],
             )
 
-        async for stream_chunk in _stream_agent_attempt_chunks(
-            run_context=run_context,
-            attempt=attempt,
-            state=state,
-            show_tool_calls=show_tool_calls,
-            run_id_callback=run_id_callback,
-            state_updated=_sync_live_turn_recorder,
-            pipeline_timing=pipeline_timing,
-        ):
+        attempt_stream = ai_runtime.stream_attempt_with_model(
+            attempt_model_runtime,
+            _stream_agent_attempt_chunks(
+                run_context=run_context,
+                attempt=attempt,
+                state=state,
+                show_tool_calls=show_tool_calls,
+                run_id_callback=run_id_callback,
+                state_updated=_sync_live_turn_recorder,
+                pipeline_timing=pipeline_timing,
+            ),
+            active_model_name=prepared_run.runtime_model_name,
+        )
+        async for stream_chunk in attempt_stream:
             yield stream_chunk
 
         run_error = state.user_error or state.stream_exception
@@ -2114,6 +2137,7 @@ async def stream_agent_response(  # noqa: C901, PLR0915
                 session_id=state.completed_run_event.session_id if state.completed_run_event is not None else None,
                 run_id=state.completed_run_event.run_id if state.completed_run_event is not None else None,
                 attempt_run_id=attempt.attempt_run_id,
+                runtime_model_name=prepared_run.runtime_model_name,
                 output_tokens=state.request_metric_totals.get("output_tokens"),
                 tool_executions=tuple(state.completed_tool_executions),
                 completed_tools=tuple(state.completed_tools),

--- a/src/mindroom/ai_runtime.py
+++ b/src/mindroom/ai_runtime.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Generator, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable, Generator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "EMPTY_RESPONSE_NOTICE",
+    "AttemptModelRuntime",
     "ModelRunInput",
     "attach_media_to_run_input",
     "cached_agent_run",
@@ -43,12 +44,65 @@ __all__ = [
     "note_attempt_run_id",
     "queued_message_signal_context",
     "register_queued_notice_storage",
+    "run_attempt_with_model",
     "scrub_queued_notice_session_context",
+    "stream_attempt_with_model",
 ]
 
 logger = get_logger(__name__)
 
 type ModelRunInput = str | Sequence[Message]
+
+
+class AttemptModelRuntime(Protocol):
+    """Bind attempt-local model identity around provider execution."""
+
+    async def run_with_model[ResultT](
+        self,
+        *,
+        active_model_name: str,
+        operation: Callable[[], Awaitable[ResultT]],
+    ) -> ResultT:
+        """Run one blocking attempt with its model bound to runtime state."""
+
+    def stream_with_model[ChunkT](
+        self,
+        stream: AsyncIterator[ChunkT],
+        *,
+        active_model_name: str,
+    ) -> AsyncIterator[ChunkT]:
+        """Bind one streaming attempt's model during stream pulls and close."""
+
+
+async def run_attempt_with_model[ResultT](
+    runtime: AttemptModelRuntime | None,
+    *,
+    active_model_name: str,
+    operation: Callable[[], Awaitable[ResultT]],
+) -> ResultT:
+    """Run an attempt through its optional model-aware runtime boundary."""
+    if runtime is None:
+        return await operation()
+    return await runtime.run_with_model(
+        active_model_name=active_model_name,
+        operation=operation,
+    )
+
+
+def stream_attempt_with_model[ChunkT](
+    runtime: AttemptModelRuntime | None,
+    stream: AsyncIterator[ChunkT],
+    *,
+    active_model_name: str,
+) -> AsyncIterator[ChunkT]:
+    """Wrap a stream in its optional model-aware runtime boundary."""
+    if runtime is None:
+        return stream
+    return runtime.stream_with_model(
+        stream,
+        active_model_name=active_model_name,
+    )
+
 
 _QUEUED_MESSAGE_NOTICE_MARKER_KEY = "mindroom_queued_message_notice"
 _QUEUED_MESSAGE_NOTICE_PERSISTED_MARKER = "persisted"

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -19,7 +19,12 @@ from mindroom.ai import ResponseTurnContext, ai_response
 from mindroom.authorization import is_sender_allowed_for_agent_reply
 from mindroom.knowledge import resolve_agent_knowledge_access
 from mindroom.logging_config import get_logger
-from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context, tool_runtime_context
+from mindroom.tool_system.runtime_context import (
+    ToolRuntimeContext,
+    ToolRuntimeModelBinding,
+    get_tool_runtime_context,
+    tool_runtime_context,
+)
 
 if TYPE_CHECKING:
     from mindroom.config.main import Config
@@ -196,6 +201,7 @@ class DelegateTools(Toolkit):
                     execution_identity=execution_identity,
                     delegation_depth=self._delegation_depth + 1,
                     refresh_scheduler=self._refresh_scheduler,
+                    attempt_model_runtime=ToolRuntimeModelBinding(),
                 )
         except Exception as e:
             logger.exception(

--- a/src/mindroom/custom_tools/thread_model.py
+++ b/src/mindroom/custom_tools/thread_model.py
@@ -25,6 +25,8 @@ class ThreadModelTools(Toolkit):
             name="thread_model",
             tools=[self.list_models, self.get_thread_model, self.switch_thread_model, self.reset_thread_model],
         )
+        # Toolkit's stop-after list also exposes the raw result as assistant text.
+        # The continuation owns final delivery, so only enable the control boundary.
         self.async_functions["switch_thread_model"].stop_after_tool_call = True
 
     @staticmethod

--- a/src/mindroom/custom_tools/thread_model.py
+++ b/src/mindroom/custom_tools/thread_model.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from agno.tools import Toolkit
 
 from mindroom.custom_tools.tool_payloads import custom_tool_payload
@@ -12,6 +14,8 @@ from mindroom.thread_models import (
 )
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
 
+_MODEL_SWITCH_WHENS = ("after-toolcall", "next-turn")
+
 
 class ThreadModelTools(Toolkit):
     """Tools for switching the model used by all agents in the current Matrix thread."""
@@ -19,8 +23,9 @@ class ThreadModelTools(Toolkit):
     def __init__(self) -> None:
         super().__init__(
             name="thread_model",
-            tools=[self.get_thread_model, self.switch_thread_model, self.reset_thread_model],
+            tools=[self.list_models, self.get_thread_model, self.switch_thread_model, self.reset_thread_model],
         )
+        self.async_functions["switch_thread_model"].stop_after_tool_call = True
 
     @staticmethod
     def _payload(status: str, **kwargs: object) -> str:
@@ -34,6 +39,24 @@ class ThreadModelTools(Toolkit):
         if context.resolved_thread_id is None:
             return cls._payload("error", message="Thread model switching requires an active thread context.")
         return context, context.resolved_thread_id
+
+    async def list_models(self) -> str:
+        """List the configured model aliases available for selection."""
+        context = get_tool_runtime_context()
+        if context is None:
+            return self._payload("error", message="Thread model tool context is unavailable in this runtime path.")
+        return self._payload(
+            "ok",
+            action="list",
+            models=[
+                {
+                    "name": name,
+                    "provider": model.provider,
+                    "model_id": model.id,
+                }
+                for name, model in sorted(context.config.models.items())
+            ],
+        )
 
     async def get_thread_model(self) -> str:
         """Return the current thread's model override and the available model names."""
@@ -61,22 +84,34 @@ class ThreadModelTools(Toolkit):
             **stale_fields,
         )
 
-    async def switch_thread_model(self, model_name: str) -> str:
+    async def switch_thread_model(
+        self,
+        model_name: str,
+        when: Literal["after-toolcall", "next-turn"] = "next-turn",
+    ) -> str:
         """Switch the model that all agents and teams use in the current thread.
 
-        The override persists for this thread until reset. It takes effect from
-        the next message in the thread; the current response keeps the model it
-        started with.
+        The override persists for this thread until reset. It can take effect
+        after this tool call or from the next message in the thread.
 
         Args:
             model_name: Configured model name from the `models:` section of
                 config.yaml (for example "default" or "opus").
+            when: Whether the current response continues with the new model or
+                the change starts on the next turn.
 
         """
         resolved = self._thread_context()
         if isinstance(resolved, str):
             return resolved
         context, thread_id = resolved
+        if when not in _MODEL_SWITCH_WHENS:
+            return self._payload(
+                "error",
+                action="switch",
+                message=f"Unknown switch timing '{when}'.",
+                available_when=list(_MODEL_SWITCH_WHENS),
+            )
         if model_name not in context.config.models:
             return self._payload(
                 "error",
@@ -99,7 +134,12 @@ class ThreadModelTools(Toolkit):
             model=model_name,
             provider=model.provider,
             model_id=model.id,
-            note="The new model applies from the next message in this thread.",
+            when=when,
+            note=(
+                "The current response will continue with the new model after this tool call."
+                if when == "after-toolcall"
+                else "The new model applies from the next message in this thread."
+            ),
         )
 
     async def reset_thread_model(self) -> str:

--- a/src/mindroom/dynamic_tool_continuation.py
+++ b/src/mindroom/dynamic_tool_continuation.py
@@ -15,6 +15,7 @@ __all__ = ["DYNAMIC_TOOL_CONTINUATION_LIMIT", "continuation_decision_from_tools"
 
 DYNAMIC_TOOL_CONTINUATION_LIMIT = 4
 _DYNAMIC_TOOL_FUNCTION_NAMES = frozenset({"load_tool", "unload_tool"})
+_MODEL_SWITCH_FUNCTION_NAME = "switch_thread_model"
 _LOADED_STATUSES = frozenset({"loaded", "already_loaded"})
 _UNLOADED_STATUS = "unloaded"
 
@@ -35,6 +36,8 @@ class _DynamicToolContinuationDecision:
     continuation: _DynamicToolContinuation | None = None
     next_prompt: str | None = None
     limit_message: str | None = None
+    model_switch_name: str | None = None
+    model_switch_when: str | None = None
 
     @property
     def should_continue(self) -> bool:
@@ -42,8 +45,8 @@ class _DynamicToolContinuationDecision:
         return self.next_prompt is not None
 
 
-def _dynamic_tool_payload(result: object) -> dict[str, object] | None:
-    """Return the structured dynamic-tools payload from one tool result."""
+def _json_object(result: object) -> dict[str, object] | None:
+    """Decode one tool result as a JSON object."""
     if not isinstance(result, str):
         return None
     try:
@@ -52,10 +55,113 @@ def _dynamic_tool_payload(result: object) -> dict[str, object] | None:
         return None
     if not isinstance(decoded, dict):
         return None
-    payload = cast("dict[str, object]", decoded)
+    return cast("dict[str, object]", decoded)
+
+
+def _dynamic_tool_payload(result: object) -> dict[str, object] | None:
+    """Return the structured dynamic-tools payload from one tool result."""
+    payload = _json_object(result)
+    if payload is None:
+        return None
     if payload.get("tool") != "dynamic_tools":
         return None
     return payload
+
+
+def _model_switch_from_tools(
+    tools: Sequence[ToolExecution] | None,
+) -> tuple[str | None, str | None] | None:
+    """Return the last successful thread-model switch in provider call order."""
+    switch_seen = False
+    for tool in reversed(tools or ()):
+        if tool.tool_name != _MODEL_SWITCH_FUNCTION_NAME:
+            continue
+        switch_seen = True
+        payload = _json_object(tool.result)
+        if payload is None:
+            continue
+        model_name = payload.get("model")
+        when = payload.get("when")
+        if (
+            payload.get("tool") == "thread_model"
+            and payload.get("action") == "switch"
+            and payload.get("status") == "ok"
+            and isinstance(model_name, str)
+            and when in {"after-toolcall", "next-turn"}
+        ):
+            return model_name, cast("str", when)
+    return (None, None) if switch_seen else None
+
+
+def _model_switch_continuation_prompt(original_prompt: str, *, model_name: str, when: str) -> str:
+    """Append the hidden instruction that resumes a stopped model-switch call."""
+    instruction = (
+        f"Continue the same task with `{model_name}` now. Do not repeat the model switch."
+        if when == "after-toolcall"
+        else (
+            "Continue the same task with the model that started this response. "
+            f"The persisted `{model_name}` selection begins on the next user turn. "
+            "Do not repeat the model switch."
+        )
+    )
+    return (
+        f"{original_prompt}\n\n"
+        "[SYSTEM NOTICE - MODEL SWITCH TOOL CALL COMPLETED]\n"
+        f"The previous model step switched this thread to `{model_name}` with timing `{when}`. "
+        f"{instruction}"
+    )
+
+
+def _model_switch_limit_message(*, model_name: str, when: str) -> str:
+    """Return visible fallback text when repeated model switches do not converge."""
+    return (
+        "Model switching did not produce a final answer after "
+        f"{DYNAMIC_TOOL_CONTINUATION_LIMIT} continuation attempts. "
+        f"The last request selected `{model_name}` with timing `{when}`."
+    )
+
+
+def _failed_model_switch_continuation_prompt(original_prompt: str) -> str:
+    """Resume after a rejected stop-after-tool model switch."""
+    return (
+        f"{original_prompt}\n\n"
+        "[SYSTEM NOTICE - MODEL SWITCH TOOL CALL FAILED]\n"
+        "The previous model-switch request was rejected. "
+        "Continue the same task with the current model and do not repeat the invalid switch."
+    )
+
+
+def _model_switch_decision(
+    model_switch: tuple[str | None, str | None],
+    *,
+    original_prompt: str,
+    continuation_count: int,
+) -> _DynamicToolContinuationDecision:
+    """Return how to continue after one thread-model switch result."""
+    model_name, when = model_switch
+    if model_name is None or when is None:
+        if continuation_count >= DYNAMIC_TOOL_CONTINUATION_LIMIT:
+            return _DynamicToolContinuationDecision(
+                limit_message="Model switching did not produce a final answer after repeated rejected requests.",
+            )
+        return _DynamicToolContinuationDecision(
+            next_prompt=_failed_model_switch_continuation_prompt(original_prompt),
+        )
+    if continuation_count >= DYNAMIC_TOOL_CONTINUATION_LIMIT:
+        return _DynamicToolContinuationDecision(
+            limit_message=_model_switch_limit_message(model_name=model_name, when=when),
+            model_switch_name=model_name,
+            model_switch_when=when,
+        )
+    return _DynamicToolContinuationDecision(
+        next_prompt=_model_switch_continuation_prompt(
+            original_prompt,
+            model_name=model_name,
+            when=when,
+        ),
+        model_switch_name=model_name,
+        model_switch_when=when,
+    )
 
 
 def _dynamic_tool_continuation_from_tools(
@@ -134,6 +240,14 @@ def continuation_decision_from_tools(
     continuation_count: int,
 ) -> _DynamicToolContinuationDecision:
     """Return the continuation decision for a completed model response."""
+    model_switch = _model_switch_from_tools(tools)
+    if model_switch is not None:
+        return _model_switch_decision(
+            model_switch,
+            original_prompt=original_prompt,
+            continuation_count=continuation_count,
+        )
+
     continuation = _dynamic_tool_continuation_from_tools(tools)
     if continuation is None:
         return _DynamicToolContinuationDecision()

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -665,6 +665,7 @@ async def _run_authorized_call_agent(
                 turn_recorder=recorder,
                 eager_deferred_tools=True,
                 reusable_agent=agent,
+                attempt_model_runtime=tool_support,
             )
         finally:
             recorder.set_run_metadata({**(recorder.run_metadata or {}), **run_metadata})

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -3528,6 +3528,7 @@ class ResponseRunner:
                             else None,
                             reason_prefix=team_request.reason_prefix,
                             pipeline_timing=request.pipeline_timing,
+                            attempt_model_runtime=self.deps.tool_runtime,
                             turn_recorder=team_turn_recorder,
                         )
 
@@ -3624,6 +3625,7 @@ class ResponseRunner:
                                     else None,
                                     reason_prefix=team_request.reason_prefix,
                                     pipeline_timing=request.pipeline_timing,
+                                    attempt_model_runtime=self.deps.tool_runtime,
                                     turn_recorder=team_turn_recorder,
                                 )
 
@@ -3926,6 +3928,7 @@ class ResponseRunner:
                 turn_recorder=turn_recorder,
                 pipeline_timing=pipeline_timing,
                 supports_native_tool_approval=True,
+                attempt_model_runtime=self.deps.tool_runtime,
             )
 
         try:
@@ -4018,6 +4021,7 @@ class ResponseRunner:
             turn_recorder=turn_recorder,
             pipeline_timing=pipeline_timing,
             supports_native_tool_approval=True,
+            attempt_model_runtime=self.deps.tool_runtime,
         )
 
         try:

--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -210,6 +210,8 @@ class DynamicContinuationRunState:
     active_current_event_id: str | None
     active_run_id: str | None
     continuation_model_prompt_tail: str
+    active_model_name: str | None
+    apply_model_to_team_members: bool
 
     @classmethod
     def initial(
@@ -222,6 +224,8 @@ class DynamicContinuationRunState:
         current_event_id: str | None,
         run_id: str | None,
         continuation_model_prompt_tail: str,
+        active_model_name: str | None = None,
+        apply_model_to_team_members: bool = False,
     ) -> DynamicContinuationRunState:
         """Build the continuation state for one turn's first attempt."""
         return cls(
@@ -233,6 +237,8 @@ class DynamicContinuationRunState:
             active_current_event_id=current_event_id,
             active_run_id=run_id,
             continuation_model_prompt_tail=continuation_model_prompt_tail,
+            active_model_name=active_model_name,
+            apply_model_to_team_members=apply_model_to_team_members,
         )
 
     def advance(
@@ -240,6 +246,8 @@ class DynamicContinuationRunState:
         *,
         continuation_prompt: str,
         previous_run_id: str | None,
+        active_model_name: str | None,
+        apply_model_to_team_members: bool,
     ) -> DynamicContinuationRunState:
         """Return the continuation state for one more same-turn attempt."""
         return replace(
@@ -250,6 +258,8 @@ class DynamicContinuationRunState:
             active_current_prompt_is_structured=False,
             active_current_event_id=None,
             active_run_id=ai_runtime.next_retry_run_id(previous_run_id),
+            active_model_name=active_model_name,
+            apply_model_to_team_members=apply_model_to_team_members,
         )
 
 
@@ -332,6 +342,7 @@ class CompletedAttempt:
     session_id: str | None = None
     run_id: str | None = None
     attempt_run_id: str | None = None
+    runtime_model_name: str | None = None
     output_tokens: int | None = None
     tool_executions: tuple[ToolExecution, ...] = ()
     completed_tools: tuple[ToolTraceEntry, ...] = ()
@@ -728,6 +739,8 @@ def _advance_turn_continuation(
     continuation: DynamicContinuationRunState,
     *,
     next_prompt: str | None,
+    active_model_name: str | None,
+    apply_model_to_team_members: bool,
 ) -> DynamicContinuationRunState:
     """Close the spent attempt entity and prepare run state for one more continuation."""
     completed_tools_for_turn = run.turn_state.completed_tools_for(resolution.completed_tools)
@@ -735,6 +748,8 @@ def _advance_turn_continuation(
     advanced = continuation.advance(
         continuation_prompt=next_prompt or continuation.original_prompt,
         previous_run_id=resolution.attempt_run_id,
+        active_model_name=active_model_name,
+        apply_model_to_team_members=apply_model_to_team_members,
     )
     run.turn_state = _reset_turn_state_for_dynamic_continuation(
         turn_recorder=sinks.turn_recorder,
@@ -957,6 +972,14 @@ def _settle_completed_attempt(
                 resolution,
                 continuation,
                 next_prompt=decision.next_prompt,
+                active_model_name=(
+                    decision.model_switch_name
+                    if decision.model_switch_when == "after-toolcall"
+                    else resolution.runtime_model_name
+                    if decision.model_switch_when == "next-turn"
+                    else continuation.active_model_name
+                ),
+                apply_model_to_team_members=decision.model_switch_when == "after-toolcall",
             ),
             recorded_text="",
             recorded_tools=(),

--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -2718,6 +2718,7 @@ async def team_response(  # noqa: C901, PLR0915
     run_metadata_collector: dict[str, Any] | None = None,
     configured_team_name: str | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
+    attempt_model_runtime: ai_runtime.AttemptModelRuntime | None = None,
     *,
     turn_recorder: TurnRecorder,
     reason_prefix: str = "Team request",
@@ -2791,6 +2792,11 @@ async def team_response(  # noqa: C901, PLR0915
         continuation_state: DynamicContinuationRunState,
     ) -> BlockingAttemptResolution:
         """Run one prepared team attempt."""
+        if continuation_state.apply_model_to_team_members and continuation_state.active_model_name is not None:
+            holder.member_model_names = dict.fromkeys(
+                requested_agent_names,
+                continuation_state.active_model_name,
+            )
         attempt_members = await _ensure_attempt_team_members(
             holder,
             agent_names,
@@ -2805,7 +2811,7 @@ async def team_response(  # noqa: C901, PLR0915
         # instance and the run metadata cannot disagree.
         attempt_runtime_model = config.resolve_runtime_model(
             entity_name=configured_team_name,
-            active_model_name=model_name,
+            active_model_name=continuation_state.active_model_name or model_name,
             room_id=ctx.room_id,
             thread_id=ctx.thread_id,
             runtime_paths=orchestrator.runtime_paths,
@@ -2882,7 +2888,11 @@ async def team_response(  # noqa: C901, PLR0915
         holder.attempt_run_id = attempt_run_id
         holder.attempt_started = True
         try:
-            response = await _run(ai_runtime.copy_run_input(run_input), attempt_run_id)
+            response = await ai_runtime.run_attempt_with_model(
+                attempt_model_runtime,
+                active_model_name=attempt_runtime_model.model_name,
+                operation=lambda: _run(ai_runtime.copy_run_input(run_input), attempt_run_id),
+            )
         except Exception as e:
             logger.exception("team_response_failed", agents=agent_list)
             error_text = get_user_friendly_error_message(e, team_name)
@@ -3021,6 +3031,7 @@ async def team_response(  # noqa: C901, PLR0915
             session_id=response_session_id,
             run_id=response_run_id,
             attempt_run_id=attempt_run_id,
+            runtime_model_name=attempt_runtime_model.model_name,
             output_tokens=response_output_tokens,
             tool_executions=tuple(run_tool_executions),
             completed_tools=tuple(
@@ -3148,6 +3159,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
     run_metadata_collector: dict[str, Any] | None = None,
     configured_team_name: str | None = None,
     pipeline_timing: DispatchPipelineTiming | None = None,
+    attempt_model_runtime: ai_runtime.AttemptModelRuntime | None = None,
     *,
     turn_recorder: TurnRecorder,
     reason_prefix: str = "Team request",
@@ -3226,6 +3238,11 @@ async def team_response_stream(  # noqa: C901, PLR0915
         continuation_state: DynamicContinuationRunState,
     ) -> AsyncGenerator[_TeamStreamChunk | AttemptResolved, None]:
         """Stream one team attempt, ending with its ``AttemptResolved`` sentinel."""
+        if continuation_state.apply_model_to_team_members and continuation_state.active_model_name is not None:
+            holder.member_model_names = dict.fromkeys(
+                requested_agent_names,
+                continuation_state.active_model_name,
+            )
         attempt_members = await _ensure_attempt_team_members(
             holder,
             requested_agent_names,
@@ -3240,7 +3257,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
         # instance and the run metadata cannot disagree.
         attempt_runtime_model = config.resolve_runtime_model(
             entity_name=configured_team_name,
-            active_model_name=model_name,
+            active_model_name=continuation_state.active_model_name or model_name,
             room_id=ctx.room_id,
             thread_id=ctx.thread_id,
             runtime_paths=orchestrator.runtime_paths,
@@ -3369,14 +3386,23 @@ async def team_response_stream(  # noqa: C901, PLR0915
 
         ai_runtime.note_attempt_run_id(run_id_callback, attempt_run_id)
 
-        raw_stream = await _team_response_stream_raw(
-            team=team,
-            team_members=attempt_members,
-            prompt=attempt_run_input,
-            metadata=run_metadata,
-            session_id=ctx.session_id,
-            run_id=attempt_run_id,
-            user_id=user_id,
+        raw_stream = await ai_runtime.run_attempt_with_model(
+            attempt_model_runtime,
+            active_model_name=attempt_runtime_model.model_name,
+            operation=lambda: _team_response_stream_raw(
+                team=team,
+                team_members=attempt_members,
+                prompt=attempt_run_input,
+                metadata=run_metadata,
+                session_id=ctx.session_id,
+                run_id=attempt_run_id,
+                user_id=user_id,
+            ),
+        )
+        raw_stream = ai_runtime.stream_attempt_with_model(
+            attempt_model_runtime,
+            raw_stream,
+            active_model_name=attempt_runtime_model.model_name,
         )
         raw_stream = _capture_stream_interrupt(
             stream_with_llm_request_log_context(
@@ -3490,6 +3516,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                         session_id=event.session_id,
                         run_id=event.run_id,
                         attempt_run_id=attempt_run_id,
+                        runtime_model_name=attempt_runtime_model.model_name,
                         output_tokens=event.metrics.output_tokens if event.metrics is not None else None,
                         tool_executions=tuple(event_tool_executions),
                         completed_tools=tuple(_extract_completed_team_tool_trace(event)),
@@ -3690,6 +3717,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
                 is_empty=not emitted_output and not completed_tool_executions,
                 run_id=attempt_run_id,
                 attempt_run_id=attempt_run_id,
+                runtime_model_name=attempt_runtime_model.model_name,
                 output_tokens=usage.request_metric_totals.get("output_tokens"),
                 tool_executions=tuple(completed_tool_executions),
                 completed_tools=tuple(completed_tools),

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import threading
 from contextlib import contextmanager
 from contextvars import ContextVar
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, TypeVar
 from uuid import uuid4
 
@@ -218,8 +218,34 @@ class WorkerProgressPump:
     shutdown: threading.Event
 
 
+class ToolRuntimeModelBinding:
+    """Bind attempt-local model identity into the ambient tool context."""
+
+    async def run_with_model(
+        self,
+        *,
+        active_model_name: str,
+        operation: Callable[[], Awaitable[_ToolContextReturn]],
+    ) -> _ToolContextReturn:
+        """Run one provider attempt with its model visible to tools."""
+        with _tool_runtime_model_context(active_model_name):
+            return await operation()
+
+    def stream_with_model[ChunkT](
+        self,
+        stream: AsyncIterator[ChunkT],
+        *,
+        active_model_name: str,
+    ) -> AsyncIterator[ChunkT]:
+        """Bind one attempt's model while its stream is created, pulled, or closed."""
+        return context_bound_async_stream(
+            context_factory=lambda: _tool_runtime_model_context(active_model_name),
+            stream_factory=lambda: stream,
+        )
+
+
 @dataclass
-class ToolRuntimeSupport:
+class ToolRuntimeSupport(ToolRuntimeModelBinding):
     """Own shared tool-runtime context building and scoped execution helpers."""
 
     runtime: BotRuntimeView
@@ -586,6 +612,15 @@ def tool_runtime_context(context: ToolRuntimeContext | None) -> Iterator[None]:
         yield
     finally:
         _TOOL_RUNTIME_CONTEXT.reset(token)
+
+
+@contextmanager
+def _tool_runtime_model_context(active_model_name: str) -> Iterator[None]:
+    """Bind the model used by one provider attempt into the ambient tool context."""
+    context = get_tool_runtime_context()
+    resolved_context = replace(context, active_model_name=active_model_name) if context is not None else None
+    with tool_runtime_context(resolved_context):
+        yield
 
 
 @contextmanager

--- a/src/mindroom/tools/thread_model.py
+++ b/src/mindroom/tools/thread_model.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="thread_model",
     display_name="Thread Model",
-    description="Switch which configured model the current Matrix thread uses",
+    description="List configured models or switch which model the current Matrix thread uses",
     category=ToolCategory.PRODUCTIVITY,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     icon_color="text-purple-500",
     dependencies=["agno"],
     docs_url="https://github.com/mindroom-ai/mindroom",
-    function_names=("get_thread_model", "switch_thread_model", "reset_thread_model"),
+    function_names=("list_models", "get_thread_model", "switch_thread_model", "reset_thread_model"),
 )
 def thread_model_tools() -> type[ThreadModelTools]:
     """Return per-thread model switching tools."""

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -8966,10 +8966,11 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Switch which configured model the current Matrix thread uses",
+      "description": "List configured models or switch which model the current Matrix thread uses",
       "display_name": "Thread Model",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [
+        "list_models",
         "get_thread_model",
         "switch_thread_model",
         "reset_thread_model"

--- a/tach.toml
+++ b/tach.toml
@@ -4649,6 +4649,7 @@ expose = [
     "WorkerProgressEvent",
     "WorkerProgressPump",
     "ToolRuntimeContext",
+    "ToolRuntimeModelBinding",
     "ToolRuntimeHookBindings",
     "ToolRuntimeSupport",
     "append_tool_runtime_attachment_id",

--- a/tests/test_ai_user_id.py
+++ b/tests/test_ai_user_id.py
@@ -56,6 +56,7 @@ from mindroom.constants import (
     MATRIX_SOURCE_EVENT_IDS_METADATA_KEY,
     MATRIX_SOURCE_EVENT_PROMPTS_METADATA_KEY,
     MATRIX_TURN_DISCOVERY_EVENT_IDS_METADATA_KEY,
+    RuntimePaths,
 )
 from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT
 from mindroom.error_handling import MODEL_SAFEGUARD_REFUSAL_MESSAGE
@@ -78,6 +79,8 @@ from mindroom.synthetic_model import SyntheticModel
 from mindroom.tool_system.events import CollectedStreamPresentation
 from mindroom.tool_system.runtime_context import (
     LiveToolDispatchContext,
+    ToolRuntimeContext,
+    ToolRuntimeModelBinding,
     get_tool_runtime_context,
     tool_runtime_context,
 )
@@ -116,6 +119,26 @@ if TYPE_CHECKING:
     from agno.session.agent import AgentSession
 
     from mindroom.final_delivery import StreamTransportOutcome
+
+
+def _model_runtime_context(
+    config: Config,
+    runtime_paths: RuntimePaths,
+    *,
+    active_model_name: str,
+) -> ToolRuntimeContext:
+    """Build an ambient tool context for model-transition integration tests."""
+    return ToolRuntimeContext(
+        agent_name="general",
+        target=MessageTarget.resolve("!test:localhost", None, "$user-message", room_mode=True),
+        requester_id="@user:localhost",
+        client=AsyncMock(),
+        config=config,
+        runtime_paths=runtime_paths,
+        conversation_reader=MagicMock(),
+        relations=MagicMock(),
+        active_model_name=active_model_name,
+    )
 
 
 def test_serialize_metrics_preserves_zero_usage_fields_from_metrics() -> None:
@@ -1997,6 +2020,156 @@ class TestUserIdPassthrough:
         assert first_agent.arun.await_args.kwargs["run_id"] == "run-1"
         assert second_agent.arun.await_args.kwargs["run_id"] == run_ids[1]
         assert len(tool_trace) == 1
+
+    @pytest.mark.asyncio
+    async def test_ai_response_rebuilds_with_after_toolcall_model(self, tmp_path: Path) -> None:
+        """Passing the original turn context into preparation would silently rebuild the old model."""
+        observed_tool_models: list[str | None] = []
+        first_agent = MagicMock()
+        first_agent.model = MagicMock()
+        first_agent.model.__class__.__name__ = "OpenAIChat"
+        first_agent.model.id = "default-model"
+        first_agent.name = "GeneralAgent"
+        first_agent.add_history_to_context = False
+
+        second_agent = MagicMock()
+        second_agent.model = MagicMock()
+        second_agent.model.__class__.__name__ = "OpenAIChat"
+        second_agent.model.id = "large-model"
+        second_agent.name = "GeneralAgent"
+        second_agent.add_history_to_context = False
+
+        switch_execution = ToolExecution(
+            tool_call_id="call-switch-model",
+            tool_name="switch_thread_model",
+            tool_args={"model_name": "large", "when": "after-toolcall"},
+            result=json.dumps(
+                {
+                    "action": "switch",
+                    "model": "large",
+                    "status": "ok",
+                    "tool": "thread_model",
+                    "when": "after-toolcall",
+                },
+            ),
+            stop_after_tool_call=True,
+        )
+        first_run_output = MagicMock(content="", status=RunStatus.completed, tools=[switch_execution])
+
+        async def first_arun(*_args: object, **_kwargs: object) -> object:
+            context = get_tool_runtime_context()
+            observed_tool_models.append(context.active_model_name if context is not None else None)
+            return first_run_output
+
+        first_agent.arun = AsyncMock(side_effect=first_arun)
+        second_run_output = MagicMock(content="Finished.", status=RunStatus.completed, tools=[])
+
+        async def second_arun(*_args: object, **_kwargs: object) -> object:
+            context = get_tool_runtime_context()
+            observed_tool_models.append(context.active_model_name if context is not None else None)
+            return second_run_output
+
+        second_agent.arun = AsyncMock(side_effect=second_arun)
+
+        config = _config()
+        runtime_paths = _runtime_paths(tmp_path)
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.side_effect = [
+                _prepared_prompt_result(first_agent, runtime_model_name="default"),
+                _prepared_prompt_result(second_agent, runtime_model_name="large"),
+            ]
+            with tool_runtime_context(
+                _model_runtime_context(config, runtime_paths, active_model_name="default"),
+            ):
+                response = await ai_response(
+                    make_turn_context("general", session_id="session1", run_id="run-1"),
+                    prompt="test",
+                    runtime_paths=runtime_paths,
+                    config=config,
+                    show_tool_calls=False,
+                    attempt_model_runtime=ToolRuntimeModelBinding(),
+                )
+
+        assert response == "Finished."
+        assert mock_prepare.await_count == 2
+        assert mock_prepare.await_args_list[1].args[0].active_model_name == "large"
+        assert observed_tool_models == ["default", "large"]
+
+    @pytest.mark.asyncio
+    async def test_stream_agent_response_rebuilds_with_after_toolcall_model(self, tmp_path: Path) -> None:
+        """Streaming continuation must pass the requested alias into the rebuilt agent context."""
+        observed_tool_models: list[str | None] = []
+        first_agent = MagicMock()
+        first_agent.model = MagicMock()
+        first_agent.model.__class__.__name__ = "OpenAIChat"
+        first_agent.model.id = "default-model"
+        first_agent.name = "GeneralAgent"
+        first_agent.add_history_to_context = False
+
+        second_agent = MagicMock()
+        second_agent.model = MagicMock()
+        second_agent.model.__class__.__name__ = "OpenAIChat"
+        second_agent.model.id = "large-model"
+        second_agent.name = "GeneralAgent"
+        second_agent.add_history_to_context = False
+
+        switch_execution = ToolExecution(
+            tool_call_id="call-switch-model",
+            tool_name="switch_thread_model",
+            tool_args={"model_name": "large", "when": "after-toolcall"},
+            result=json.dumps(
+                {
+                    "action": "switch",
+                    "model": "large",
+                    "status": "ok",
+                    "tool": "thread_model",
+                    "when": "after-toolcall",
+                },
+            ),
+            stop_after_tool_call=True,
+        )
+
+        async def first_stream() -> AsyncIterator[object]:
+            context = get_tool_runtime_context()
+            observed_tool_models.append(context.active_model_name if context is not None else None)
+            yield ToolCallCompletedEvent(tool=switch_execution)
+            yield RunCompletedEvent(content=None)
+
+        async def second_stream() -> AsyncIterator[object]:
+            context = get_tool_runtime_context()
+            observed_tool_models.append(context.active_model_name if context is not None else None)
+            yield RunContentEvent(content="Finished.")
+            yield RunCompletedEvent(content="Finished.")
+
+        first_agent.arun = MagicMock(return_value=first_stream())
+        second_agent.arun = MagicMock(return_value=second_stream())
+
+        config = _config()
+        runtime_paths = _runtime_paths(tmp_path)
+        with patch("mindroom.ai._prepare_agent_and_prompt", new_callable=AsyncMock) as mock_prepare:
+            mock_prepare.side_effect = [
+                _prepared_prompt_result(first_agent, runtime_model_name="default"),
+                _prepared_prompt_result(second_agent, runtime_model_name="large"),
+            ]
+            with tool_runtime_context(
+                _model_runtime_context(config, runtime_paths, active_model_name="default"),
+            ):
+                chunks = [
+                    chunk
+                    async for chunk in stream_agent_response(
+                        make_turn_context("general", session_id="session1", run_id="run-1"),
+                        prompt="test",
+                        runtime_paths=runtime_paths,
+                        config=config,
+                        show_tool_calls=False,
+                        attempt_model_runtime=ToolRuntimeModelBinding(),
+                    )
+                ]
+
+        assert [chunk.content for chunk in chunks if isinstance(chunk, RunContentEvent)] == ["Finished."]
+        assert mock_prepare.await_count == 2
+        assert mock_prepare.await_args_list[1].args[0].active_model_name == "large"
+        assert observed_tool_models == ["default", "large"]
 
     @pytest.mark.asyncio
     async def test_ai_response_continuation_cancelled_run_preserves_dynamic_tool_trace(self, tmp_path: Path) -> None:

--- a/tests/test_dynamic_tool_continuation.py
+++ b/tests/test_dynamic_tool_continuation.py
@@ -33,6 +33,148 @@ def _dynamic_tool_execution(
     )
 
 
+def _model_switch_execution(when: str, *, model_name: str = "large") -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="call-switch-model",
+        tool_name="switch_thread_model",
+        tool_args={"model_name": model_name, "when": when},
+        result=json.dumps(
+            {
+                "action": "switch",
+                "model": model_name,
+                "status": "ok",
+                "tool": "thread_model",
+                "when": when,
+            },
+        ),
+        stop_after_tool_call=True,
+    )
+
+
+def test_continuation_decision_switches_model_after_tool_call() -> None:
+    """Ignoring an immediate model-switch result would end the turn before the new model can continue."""
+    decision = continuation_decision_from_tools(
+        [_model_switch_execution("after-toolcall")],
+        original_prompt="Solve the problem",
+        continuation_count=0,
+    )
+
+    assert decision.should_continue is True
+    assert decision.model_switch_name == "large"
+    assert decision.model_switch_when == "after-toolcall"
+    assert decision.next_prompt is not None
+    assert "Solve the problem" in decision.next_prompt
+    assert "Continue the same task with `large`" in decision.next_prompt
+
+
+def test_continuation_decision_defers_model_switch_until_next_turn() -> None:
+    """A next-turn switch still needs the original model to finish the stopped provider run."""
+    decision = continuation_decision_from_tools(
+        [_model_switch_execution("next-turn")],
+        original_prompt="Solve the problem",
+        continuation_count=0,
+    )
+
+    assert decision.should_continue is True
+    assert decision.model_switch_name == "large"
+    assert decision.model_switch_when == "next-turn"
+    assert decision.next_prompt is not None
+    assert "Continue the same task with the model that started this response" in decision.next_prompt
+
+
+def test_failed_model_switch_resumes_with_current_model() -> None:
+    """A rejected switch must not strand the response at its stop-after-tool boundary."""
+    execution = ToolExecution(
+        tool_call_id="call-switch-model",
+        tool_name="switch_thread_model",
+        tool_args={"model_name": "missing", "when": "after-toolcall"},
+        result=json.dumps(
+            {
+                "action": "switch",
+                "message": "Unknown model 'missing'.",
+                "status": "error",
+                "tool": "thread_model",
+            },
+        ),
+        stop_after_tool_call=True,
+    )
+
+    decision = continuation_decision_from_tools(
+        [execution],
+        original_prompt="Solve the problem",
+        continuation_count=0,
+    )
+
+    assert decision.should_continue is True
+    assert decision.model_switch_name is None
+    assert decision.model_switch_when is None
+    assert decision.next_prompt is not None
+    assert "Continue the same task with the current model" in decision.next_prompt
+
+
+def test_malformed_model_switch_result_resumes_with_current_model() -> None:
+    """A malformed switch result must not strand the response at its stop-after-tool boundary."""
+    execution = ToolExecution(
+        tool_call_id="call-switch-model",
+        tool_name="switch_thread_model",
+        tool_args={"model_name": "large", "when": "after-toolcall"},
+        result="not-json",
+        stop_after_tool_call=True,
+    )
+
+    decision = continuation_decision_from_tools(
+        [execution],
+        original_prompt="Solve the problem",
+        continuation_count=0,
+    )
+
+    assert decision.should_continue is True
+    assert decision.model_switch_name is None
+    assert decision.model_switch_when is None
+
+
+def test_latest_successful_model_switch_wins_over_later_rejection() -> None:
+    """A rejected later call cannot undo an earlier switch that was already persisted."""
+    rejected = ToolExecution(
+        tool_call_id="call-rejected-switch",
+        tool_name="switch_thread_model",
+        tool_args={"model_name": "missing", "when": "after-toolcall"},
+        result=json.dumps(
+            {
+                "action": "switch",
+                "message": "Unknown model 'missing'.",
+                "status": "error",
+                "tool": "thread_model",
+            },
+        ),
+        stop_after_tool_call=True,
+    )
+
+    decision = continuation_decision_from_tools(
+        [_model_switch_execution("after-toolcall"), rejected],
+        original_prompt="Solve the problem",
+        continuation_count=0,
+    )
+
+    assert decision.model_switch_name == "large"
+    assert decision.model_switch_when == "after-toolcall"
+
+
+def test_latest_successful_model_switch_wins_among_multiple_valid_calls() -> None:
+    """Provider call order determines the active alias when several switches succeed."""
+    decision = continuation_decision_from_tools(
+        [
+            _model_switch_execution("after-toolcall"),
+            _model_switch_execution("after-toolcall", model_name="default"),
+        ],
+        original_prompt="Solve the problem",
+        continuation_count=0,
+    )
+
+    assert decision.model_switch_name == "default"
+    assert decision.model_switch_when == "after-toolcall"
+
+
 def test_continuation_decision_detects_dynamic_tool_call() -> None:
     """A dynamic manager call produces a continuation prompt."""
     decision = continuation_decision_from_tools(

--- a/tests/test_dynamic_tool_continuation.py
+++ b/tests/test_dynamic_tool_continuation.py
@@ -131,6 +131,8 @@ def test_malformed_model_switch_result_resumes_with_current_model() -> None:
     assert decision.should_continue is True
     assert decision.model_switch_name is None
     assert decision.model_switch_when is None
+    assert decision.next_prompt is not None
+    assert "Continue the same task with the current model" in decision.next_prompt
 
 
 def test_latest_successful_model_switch_wins_over_later_rejection() -> None:

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -39,7 +39,12 @@ from mindroom.matrix_rtc.call_tools import (
 )
 from mindroom.memory import MemoryPromptParts
 from mindroom.tool_system.events import ToolTraceEntry
-from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context, tool_runtime_context
+from mindroom.tool_system.runtime_context import (
+    ToolRuntimeContext,
+    ToolRuntimeModelBinding,
+    get_tool_runtime_context,
+    tool_runtime_context,
+)
 from mindroom.tool_system.worker_routing import build_tool_execution_identity
 from tests.authorization_helpers import (
     make_test_tool_runtime_context,
@@ -1149,7 +1154,7 @@ async def test_cascaded_responder_records_effective_selected_model_metadata(
     execution_identity = SimpleNamespace()
     persisted_interruptions: list[dict[str, object]] = []
 
-    class StrictToolSupport:
+    class StrictToolSupport(ToolRuntimeModelBinding):
         def build_context(
             self,
             target: MessageTarget,

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -130,6 +130,24 @@ def _dynamic_tool_execution(tool_name: str = "sleep") -> ToolExecution:
     )
 
 
+def _model_switch_execution(when: str) -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="call-switch-model",
+        tool_name="switch_thread_model",
+        tool_args={"model_name": "large", "when": when},
+        result=json.dumps(
+            {
+                "action": "switch",
+                "model": "large",
+                "status": "ok",
+                "tool": "thread_model",
+                "when": when,
+            },
+        ),
+        stop_after_tool_call=True,
+    )
+
+
 def _ctx(**overrides: object) -> ResponseTurnContext:
     values: dict[str, Any] = {
         "entity_label": "helper",
@@ -800,6 +818,67 @@ def test_blocking_continuation_advances_and_resets_turn_state() -> None:
     assert recorder.synced_calls[-1]["completed_tools"] == [first_trace]
     # The final recording carries the first attempt's tools plus the second's.
     assert recorder.completed_calls[-1]["completed_tools"] == [first_trace, _trace("sleep")]
+
+
+def test_blocking_after_toolcall_switch_selects_new_continuation_model() -> None:
+    """Dropping the requested alias during continuation would rebuild the old model."""
+    log = _AdapterLog()
+    active_models: list[str | None] = []
+
+    async def _attempt(
+        _run: TurnRunState,
+        continuation: DynamicContinuationRunState,
+    ) -> CompletedAttempt:
+        active_models.append(continuation.active_model_name)
+        if len(active_models) == 1:
+            return CompletedAttempt(
+                attempt_run_id="run-1",
+                tool_executions=(_model_switch_execution("after-toolcall"),),
+            )
+        return CompletedAttempt(response_text="final", replayable_text="final", has_visible_content=True)
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation("original ask"),
+        ),
+    )
+
+    assert result == "final"
+    assert active_models == [None, "large"]
+
+
+def test_blocking_next_turn_switch_keeps_current_model_for_continuation() -> None:
+    """Re-reading the persisted override would apply a next-turn switch too early."""
+    log = _AdapterLog()
+    active_models: list[str | None] = []
+
+    async def _attempt(
+        _run: TurnRunState,
+        continuation: DynamicContinuationRunState,
+    ) -> CompletedAttempt:
+        active_models.append(continuation.active_model_name)
+        if len(active_models) == 1:
+            return CompletedAttempt(
+                attempt_run_id="run-1",
+                runtime_model_name="default",
+                tool_executions=(_model_switch_execution("next-turn"),),
+            )
+        return CompletedAttempt(response_text="final", replayable_text="final", has_visible_content=True)
+
+    result = asyncio.run(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt),
+            TurnSinks(),
+            continuation=_continuation("original ask"),
+        ),
+    )
+
+    assert result == "final"
+    assert active_models == [None, "default"]
 
 
 def test_blocking_continuation_limit_returns_limit_message() -> None:

--- a/tests/test_team_dynamic_continuation.py
+++ b/tests/test_team_dynamic_continuation.py
@@ -18,6 +18,7 @@ from mindroom.config.models import ModelConfig
 from mindroom.dynamic_tool_continuation import DYNAMIC_TOOL_CONTINUATION_LIMIT
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.knowledge.utils import _KnowledgeResolution
+from mindroom.message_target import MessageTarget
 from mindroom.room_model_overrides import set_room_model_override
 from mindroom.team_exact_members import ResolvedExactTeamMembers
 from mindroom.teams import (
@@ -28,6 +29,12 @@ from mindroom.teams import (
     materialize_exact_team_members,
     team_response,
     team_response_stream,
+)
+from mindroom.tool_system.runtime_context import (
+    ToolRuntimeContext,
+    ToolRuntimeModelBinding,
+    get_tool_runtime_context,
+    tool_runtime_context,
 )
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity
 from tests.conftest import make_turn_context, runtime_paths_for
@@ -58,6 +65,31 @@ def _dynamic_tool_team_output() -> TeamRunOutput:
     )
 
 
+def _model_switch_execution(when: str, *, model_name: str = "large") -> ToolExecution:
+    return ToolExecution(
+        tool_call_id="call-switch-model",
+        tool_name="switch_thread_model",
+        tool_args={"model_name": model_name, "when": when},
+        result=json.dumps(
+            {
+                "action": "switch",
+                "model": model_name,
+                "status": "ok",
+                "tool": "thread_model",
+                "when": when,
+            },
+        ),
+        stop_after_tool_call=True,
+    )
+
+
+def _model_switch_team_output(when: str) -> TeamRunOutput:
+    return TeamRunOutput(
+        content="",
+        member_responses=[RunOutput(agent_name="GeneralAgent", content="", tools=[_model_switch_execution(when)])],
+    )
+
+
 def _make_orchestrator() -> tuple[MagicMock, object]:
     config = _build_test_config()
     orchestrator = MagicMock()
@@ -66,6 +98,21 @@ def _make_orchestrator() -> tuple[MagicMock, object]:
     orchestrator.knowledge_managers = {}
     orchestrator.agent_bots = {"general": MagicMock()}
     return orchestrator, config
+
+
+def _team_tool_context(orchestrator: MagicMock) -> ToolRuntimeContext:
+    """Build an ambient team tool context that starts on the default model."""
+    return ToolRuntimeContext(
+        agent_name="test-team",
+        target=MessageTarget.resolve("!test:localhost", None, "$user-message", room_mode=True),
+        requester_id="@user:localhost",
+        client=AsyncMock(),
+        config=orchestrator.config,
+        runtime_paths=orchestrator.runtime_paths,
+        conversation_reader=MagicMock(),
+        relations=MagicMock(),
+        active_model_name="default",
+    )
 
 
 def _team_patches(mock_team: AgnoTeam) -> list[AbstractContextManager[object]]:
@@ -177,6 +224,151 @@ async def test_team_dynamic_continuation_pins_member_model_for_whole_turn() -> N
 
     assert "Used the loaded tool." in response
     assert [call.kwargs["active_model_name"] for call in mock_create.call_args_list] == ["large", "large"]
+
+
+@pytest.mark.asyncio
+async def test_team_after_toolcall_switch_rebuilds_members_with_new_model() -> None:
+    """Keeping the initial member snapshot would make team model switching ineffective until the next turn."""
+    orchestrator, config = _make_orchestrator()
+    config.models["large"] = ModelConfig(provider="openai", id="large-model")
+    observed_tool_models: list[str | None] = []
+    responses = iter(
+        [
+            _model_switch_team_output("after-toolcall"),
+            TeamRunOutput(content="Finished with the new model."),
+        ],
+    )
+
+    async def run_team(*_args: object, **_kwargs: object) -> TeamRunOutput:
+        context = get_tool_runtime_context()
+        observed_tool_models.append(context.active_model_name if context is not None else None)
+        return next(responses)
+
+    mock_team = _make_test_team()
+    mock_team.arun = AsyncMock(side_effect=run_team)
+    fake_agent = _make_test_agent("GeneralAgent")
+
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent) as mock_create,
+        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+        patch("mindroom.teams._create_team_instance", return_value=mock_team),
+        tool_runtime_context(_team_tool_context(orchestrator)),
+    ):
+        response = await team_response(
+            agent_names=["general"],
+            mode=TeamMode.COORDINATE,
+            message="Switch and finish the task.",
+            turn_recorder=TurnRecorder(user_message="Switch and finish the task."),
+            orchestrator=orchestrator,
+            execution_identity=None,
+            ctx=make_turn_context(session_id=None),
+            attempt_model_runtime=ToolRuntimeModelBinding(),
+        )
+
+    assert "Finished with the new model." in response
+    assert [call.kwargs["active_model_name"] for call in mock_create.call_args_list] == ["default", "large"]
+    assert observed_tool_models == ["default", "large"]
+
+
+@pytest.mark.asyncio
+async def test_streaming_team_after_toolcall_switch_rebuilds_members_with_new_model() -> None:
+    """Streaming teams must apply the same immediate member-model transition as blocking teams."""
+    orchestrator, config = _make_orchestrator()
+    config.models["large"] = ModelConfig(provider="openai", id="large-model")
+    observed_tool_models: list[str | None] = []
+
+    async def first_stream() -> AsyncIterator[object]:
+        context = get_tool_runtime_context()
+        observed_tool_models.append(context.active_model_name if context is not None else None)
+        yield _model_switch_team_output("after-toolcall")
+
+    async def second_stream() -> AsyncIterator[object]:
+        context = get_tool_runtime_context()
+        observed_tool_models.append(context.active_model_name if context is not None else None)
+        yield TeamRunOutput(content="Finished with the new model.")
+
+    mock_team = _make_test_team()
+    mock_team.arun = MagicMock(side_effect=[first_stream(), second_stream()])
+    fake_agent = _make_test_agent("GeneralAgent")
+
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent) as mock_create,
+        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+        patch("mindroom.teams._create_team_instance", return_value=mock_team),
+        tool_runtime_context(_team_tool_context(orchestrator)),
+    ):
+        chunks = [
+            chunk
+            async for chunk in team_response_stream(
+                agent_ids=[entity_ids(config, runtime_paths_for(config))["general"]],
+                mode=TeamMode.COORDINATE,
+                message="Switch and finish the task.",
+                turn_recorder=TurnRecorder(user_message="Switch and finish the task."),
+                orchestrator=orchestrator,
+                execution_identity=None,
+                ctx=make_turn_context(session_id=None),
+                attempt_model_runtime=ToolRuntimeModelBinding(),
+            )
+        ]
+
+    assert chunks
+    assert [call.kwargs["active_model_name"] for call in mock_create.call_args_list] == ["default", "large"]
+    assert observed_tool_models == ["default", "large"]
+
+
+@pytest.mark.asyncio
+async def test_team_uses_latest_successful_nested_switch_when_later_call_is_rejected() -> None:
+    """A failed sibling call cannot hide a successful switch nested in one member response."""
+    orchestrator, config = _make_orchestrator()
+    config.models["large"] = ModelConfig(provider="openai", id="large-model")
+    rejected = ToolExecution(
+        tool_call_id="call-rejected-switch",
+        tool_name="switch_thread_model",
+        tool_args={"model_name": "missing", "when": "after-toolcall"},
+        result=json.dumps(
+            {
+                "action": "switch",
+                "message": "Unknown model 'missing'.",
+                "status": "error",
+                "tool": "thread_model",
+            },
+        ),
+        stop_after_tool_call=True,
+    )
+    first_response = TeamRunOutput(
+        content="",
+        member_responses=[
+            RunOutput(
+                agent_name="GeneralAgent",
+                content="",
+                tools=[_model_switch_execution("after-toolcall"), rejected],
+            ),
+        ],
+    )
+    mock_team = _make_test_team()
+    mock_team.arun = AsyncMock(
+        side_effect=[first_response, TeamRunOutput(content="Finished with the successful model.")],
+    )
+    fake_agent = _make_test_agent("GeneralAgent")
+
+    with (
+        patch("mindroom.teams.create_agent", return_value=fake_agent) as mock_create,
+        patch("mindroom.teams.resolve_agent_knowledge_access", return_value=_KnowledgeResolution(knowledge=None)),
+        patch("mindroom.teams._create_team_instance", return_value=mock_team),
+    ):
+        response = await team_response(
+            agent_names=["general"],
+            mode=TeamMode.COORDINATE,
+            message="Switch and finish the task.",
+            turn_recorder=TurnRecorder(user_message="Switch and finish the task."),
+            orchestrator=orchestrator,
+            execution_identity=None,
+            ctx=make_turn_context(session_id=None),
+            attempt_model_runtime=ToolRuntimeModelBinding(),
+        )
+
+    assert "Finished with the successful model." in response
+    assert [call.kwargs["active_model_name"] for call in mock_create.call_args_list] == ["default", "large"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_models.py
+++ b/tests/test_thread_models.py
@@ -528,13 +528,14 @@ def test_thread_model_tool_registered() -> None:
     assert "list_models" in TOOL_METADATA["thread_model"].function_names
 
 
-def test_thread_model_switch_stops_the_provider_before_it_can_answer_again() -> None:
-    """Without a control boundary, after-toolcall could let the old model continue generating."""
+def test_thread_model_switch_stops_provider_without_exposing_raw_result() -> None:
+    """The continuation, not Agno's raw tool result, should own the final response."""
     tool = ThreadModelTools()
     function = tool.async_functions["switch_thread_model"]
     function.process_entrypoint(strict=False)
 
     assert function.stop_after_tool_call is True
+    assert function.show_result is False
     assert function.parameters["properties"]["model_name"]["type"] == "string"
     assert function.parameters["properties"]["when"]["enum"] == ["after-toolcall", "next-turn"]
     assert function.parameters["required"] == ["model_name"]

--- a/tests/test_thread_models.py
+++ b/tests/test_thread_models.py
@@ -520,12 +520,24 @@ def _make_tool_context(*, thread_id: str | None = THREAD_ID) -> ToolRuntimeConte
 def test_thread_model_tool_registered() -> None:
     """The thread_model tool should be available from the metadata registry."""
     config = _config_with_models(Path(tempfile.mkdtemp()))
+    toolkit = get_tool_by_name("thread_model", runtime_paths_for(config), worker_target=None)
 
     assert "thread_model" in TOOL_METADATA
-    assert isinstance(
-        get_tool_by_name("thread_model", runtime_paths_for(config), worker_target=None),
-        ThreadModelTools,
-    )
+    assert isinstance(toolkit, ThreadModelTools)
+    assert "list_models" in toolkit.async_functions
+    assert "list_models" in TOOL_METADATA["thread_model"].function_names
+
+
+def test_thread_model_switch_stops_the_provider_before_it_can_answer_again() -> None:
+    """Without a control boundary, after-toolcall could let the old model continue generating."""
+    tool = ThreadModelTools()
+    function = tool.async_functions["switch_thread_model"]
+    function.process_entrypoint(strict=False)
+
+    assert function.stop_after_tool_call is True
+    assert function.parameters["properties"]["model_name"]["type"] == "string"
+    assert function.parameters["properties"]["when"]["enum"] == ["after-toolcall", "next-turn"]
+    assert function.parameters["required"] == ["model_name"]
 
 
 @pytest.mark.asyncio
@@ -536,6 +548,25 @@ async def test_thread_model_tool_requires_runtime_context() -> None:
     assert payload["status"] == "error"
     assert payload["tool"] == "thread_model"
     assert "context" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_thread_model_tool_lists_configured_models_without_thread() -> None:
+    """Removing explicit discovery would leave agents unable to choose a configured alias."""
+    context = _make_tool_context(thread_id=None)
+
+    with tool_runtime_context(context):
+        payload = json.loads(await ThreadModelTools().list_models())
+
+    assert payload == {
+        "action": "list",
+        "models": [
+            {"model_id": "default-model", "name": "default", "provider": "openai"},
+            {"model_id": "large-model", "name": "large", "provider": "openai"},
+        ],
+        "status": "ok",
+        "tool": "thread_model",
+    }
 
 
 @pytest.mark.asyncio
@@ -566,6 +597,38 @@ async def test_thread_model_tool_switch_get_and_reset() -> None:
     assert get_payload["override"] == "large"
     assert reset_payload["status"] == "ok"
     assert reset_payload["cleared"] is True
+    assert _get_thread_model_override(context.runtime_paths, THREAD_ID) is None
+
+
+@pytest.mark.asyncio
+async def test_thread_model_tool_can_switch_after_current_tool_call() -> None:
+    """Ignoring the timing argument would leave the current response on the old model."""
+    context = _make_tool_context()
+
+    with tool_runtime_context(context):
+        payload = json.loads(
+            await ThreadModelTools().switch_thread_model("large", when="after-toolcall"),
+        )
+
+    assert payload["status"] == "ok"
+    assert payload["model"] == "large"
+    assert payload["when"] == "after-toolcall"
+    assert payload["note"] == "The current response will continue with the new model after this tool call."
+    assert _get_thread_model_override(context.runtime_paths, THREAD_ID) == "large"
+
+
+@pytest.mark.asyncio
+async def test_thread_model_tool_rejects_unknown_switch_timing() -> None:
+    """Accepting an unknown timing value could persist a change with undefined execution semantics."""
+    context = _make_tool_context()
+
+    with tool_runtime_context(context):
+        payload = json.loads(
+            await ThreadModelTools().switch_thread_model("large", when="later"),  # type: ignore[arg-type]
+        )
+
+    assert payload["status"] == "error"
+    assert payload["available_when"] == ["after-toolcall", "next-turn"]
     assert _get_thread_model_override(context.runtime_paths, THREAD_ID) is None
 
 


### PR DESCRIPTION
Summary
- Let agents list configured model aliases and switch the current thread model.
- Support immediate continuation after the tool call or activation on the next turn.
- Keep agent, team, delegated, and realtime model context consistent.

Tests
- uv run pre-commit run --all-files
- uv run pytest -q

## Summary by Sourcery

Let agents discover configured models and change the thread model with controlled same-turn or next-turn continuation.

New Features:
- Enable agents to discover configured model aliases and switch the active thread model either immediately or on the next turn.

Bug Fixes:
- Keep model selection consistent across agent, team, delegated, and realtime execution paths during model-switch continuations.

Enhancements:
- Allow the current response to continue safely after successful, rejected, or malformed model-switch tool calls while preserving persisted thread overrides.

Documentation:
- Update chat-command and tool reference documentation for model discovery and switch timing.

Tests:
- Add coverage for model-switch continuations, streaming behavior, team members, runtime context propagation, and invalid switch requests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to list configured models, including provider details, without an active thread.
  * Added model switching options for applying changes immediately after a tool call or starting with the next turn.
  * Model changes now carry through continued responses and team interactions.

* **Documentation**
  * Updated chat command and tool guidance with model listing, switching timing, behavior, and examples.

* **Bug Fixes**
  * Improved model consistency across streaming, delegated, voice, and team responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->