### PR TITLE
feat: add retained model usage breakdown

### DIFF
--- a/docs/tools/agent-orchestration.md
+++ b/docs/tools/agent-orchestration.md
@@ -145,7 +145,7 @@ A successful response also includes `scope`, token `totals`, `session_count`, an
 Token totals separately report input, output, cache-read, cache-write, reasoning, and audio dimensions.
 
 The admin response groups session aggregates by configured agent or team ID.
-The self response has no breakdown because its scope is already one agent and requester.
+The self-response omits only the entity breakdown because its scope is already one agent and requester; it still includes `model_breakdown` and `model_coverage`.
 Admin breakdown rows include every configured entity with retained usage and are sorted by total tokens.
 Both responses group retained top-level runs by provider and model in `model_breakdown`.
 Model rows include token totals and run counts and are sorted by total tokens.

--- a/docs/tools/agent-orchestration.md
+++ b/docs/tools/agent-orchestration.md
@@ -141,13 +141,17 @@ Both functions are intentionally parameter-free.
 ### Response And Coverage
 
 Both functions return a JSON custom-tool envelope with `status` and `tool` fields.
-A successful response also includes `scope`, token `totals`, `session_count`, a `breakdown`, and `coverage`.
+A successful response also includes `scope`, token `totals`, `session_count`, an entity `breakdown`, `coverage`, a `model_breakdown`, and `model_coverage`.
 Token totals separately report input, output, cache-read, cache-write, reasoning, and audio dimensions.
 
 The admin response groups session aggregates by configured agent or team ID.
 The self response has no breakdown because its scope is already one agent and requester.
 Admin breakdown rows include every configured entity with retained usage and are sorted by total tokens.
+Both responses group retained top-level runs by provider and model in `model_breakdown`.
+Model rows include token totals and run counts and are sorted by total tokens.
 Coverage reports scanned sources, unavailable or partially unreadable sources, and the retained-history limitation.
+Model coverage is reported separately because compacted history and nested team-member usage can contribute to report totals without model attribution.
+Consequently, model rows do not necessarily sum to the top-level totals.
 The tool does not change Agno persistence settings.
 Admin team totals use Agno's member-inclusive session aggregate without reading nested response content.
 Compacted shared-agent self-service runs and deleted sessions are unavailable to this read-only report.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9776,13 +9776,17 @@ Both functions are intentionally parameter-free.
 ### Response And Coverage
 
 Both functions return a JSON custom-tool envelope with `status` and `tool` fields.
-A successful response also includes `scope`, token `totals`, `session_count`, a `breakdown`, and `coverage`.
+A successful response also includes `scope`, token `totals`, `session_count`, an entity `breakdown`, `coverage`, a `model_breakdown`, and `model_coverage`.
 Token totals separately report input, output, cache-read, cache-write, reasoning, and audio dimensions.
 
 The admin response groups session aggregates by configured agent or team ID.
 The self response has no breakdown because its scope is already one agent and requester.
 Admin breakdown rows include every configured entity with retained usage and are sorted by total tokens.
+Both responses group retained top-level runs by provider and model in `model_breakdown`.
+Model rows include token totals and run counts and are sorted by total tokens.
 Coverage reports scanned sources, unavailable or partially unreadable sources, and the retained-history limitation.
+Model coverage is reported separately because compacted history and nested team-member usage can contribute to report totals without model attribution.
+Consequently, model rows do not necessarily sum to the top-level totals.
 The tool does not change Agno persistence settings.
 Admin team totals use Agno's member-inclusive session aggregate without reading nested response content.
 Compacted shared-agent self-service runs and deleted sessions are unavailable to this read-only report.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9780,7 +9780,7 @@ A successful response also includes `scope`, token `totals`, `session_count`, an
 Token totals separately report input, output, cache-read, cache-write, reasoning, and audio dimensions.
 
 The admin response groups session aggregates by configured agent or team ID.
-The self response has no breakdown because its scope is already one agent and requester.
+The self-response omits only the entity breakdown because its scope is already one agent and requester; it still includes `model_breakdown` and `model_coverage`.
 Admin breakdown rows include every configured entity with retained usage and are sorted by total tokens.
 Both responses group retained top-level runs by provider and model in `model_breakdown`.
 Model rows include token totals and run counts and are sorted by total tokens.

--- a/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
+++ b/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
@@ -137,13 +137,17 @@ Both functions are intentionally parameter-free.
 ### Response And Coverage
 
 Both functions return a JSON custom-tool envelope with `status` and `tool` fields.
-A successful response also includes `scope`, token `totals`, `session_count`, a `breakdown`, and `coverage`.
+A successful response also includes `scope`, token `totals`, `session_count`, an entity `breakdown`, `coverage`, a `model_breakdown`, and `model_coverage`.
 Token totals separately report input, output, cache-read, cache-write, reasoning, and audio dimensions.
 
 The admin response groups session aggregates by configured agent or team ID.
 The self response has no breakdown because its scope is already one agent and requester.
 Admin breakdown rows include every configured entity with retained usage and are sorted by total tokens.
+Both responses group retained top-level runs by provider and model in `model_breakdown`.
+Model rows include token totals and run counts and are sorted by total tokens.
 Coverage reports scanned sources, unavailable or partially unreadable sources, and the retained-history limitation.
+Model coverage is reported separately because compacted history and nested team-member usage can contribute to report totals without model attribution.
+Consequently, model rows do not necessarily sum to the top-level totals.
 The tool does not change Agno persistence settings.
 Admin team totals use Agno's member-inclusive session aggregate without reading nested response content.
 Compacted shared-agent self-service runs and deleted sessions are unavailable to this read-only report.

--- a/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
+++ b/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
@@ -141,7 +141,7 @@ A successful response also includes `scope`, token `totals`, `session_count`, an
 Token totals separately report input, output, cache-read, cache-write, reasoning, and audio dimensions.
 
 The admin response groups session aggregates by configured agent or team ID.
-The self response has no breakdown because its scope is already one agent and requester.
+The self-response omits only the entity breakdown because its scope is already one agent and requester; it still includes `model_breakdown` and `model_coverage`.
 Admin breakdown rows include every configured entity with retained usage and are sorted by total tokens.
 Both responses group retained top-level runs by provider and model in `model_breakdown`.
 Model rows include token totals and run counts and are sorted by total tokens.

--- a/src/mindroom/usage_stats.py
+++ b/src/mindroom/usage_stats.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from dataclasses import field as dataclass_field
 from typing import TYPE_CHECKING, Literal
 
 from mindroom.usage_stats_storage import (
@@ -207,6 +208,88 @@ class _ModelAggregate:
         self.run_count += 1
 
 
+@dataclass(slots=True)
+class _UsageAccumulator:
+    total: TokenTotals = TokenTotals()
+    sessions: set[tuple[str, str]] = dataclass_field(default_factory=set)
+    buckets: dict[str, _Aggregate] = dataclass_field(default_factory=dict)
+    seen_runs: set[tuple[str, str, str]] = dataclass_field(default_factory=set)
+    unavailable_sources: set[str] = dataclass_field(default_factory=set)
+
+    def add_row(
+        self,
+        row: UsageSessionRow,
+        *,
+        config: Config,
+        scope: _Scope,
+        expected_agent: str | None,
+        expected_requester: str | None,
+    ) -> None:
+        if not row.session_metrics_available:
+            self.unavailable_sources.add(row.source.path_label)
+            return
+        try:
+            if scope == "self":
+                row_totals = _self_row_totals(
+                    row,
+                    config=config,
+                    expected_agent=expected_agent,
+                    expected_requester=expected_requester,
+                    seen_runs=self.seen_runs,
+                )
+                entity_id = None
+            else:
+                entity_id = _admin_entity_id(row)
+                row_totals = _metrics_totals(row.session_metrics) if entity_id is not None else None
+        except ValueError:
+            self.unavailable_sources.add(row.source.path_label)
+            return
+        if row_totals is None:
+            return
+        self.total = self.total.plus(row_totals)
+        self.sessions.add((row.source.path_label, row.row_key))
+        if entity_id is not None:
+            self.buckets.setdefault(entity_id, _Aggregate()).add(row_totals)
+
+
+@dataclass(slots=True)
+class _ModelUsageAccumulator:
+    buckets: dict[tuple[str, str], _ModelAggregate] = dataclass_field(default_factory=dict)
+    seen_runs: set[tuple[str, str, str]] = dataclass_field(default_factory=set)
+    unavailable_sources: set[str] = dataclass_field(default_factory=set)
+
+    def add_row(
+        self,
+        row: UsageSessionRow,
+        *,
+        config: Config,
+        scope: _Scope,
+        expected_agent: str | None,
+        expected_requester: str | None,
+    ) -> None:
+        if not row.runs_available:
+            self.unavailable_sources.add(row.source.path_label)
+            return
+        try:
+            entries = _model_entries_for_row(
+                row,
+                config=config,
+                scope=scope,
+                expected_agent=expected_agent,
+                expected_requester=expected_requester,
+            )
+        except ValueError:
+            self.unavailable_sources.add(row.source.path_label)
+            return
+        _add_model_entries(
+            entries,
+            source_path=row.source.path_label,
+            row_key=row.row_key,
+            buckets=self.buckets,
+            seen_runs=self.seen_runs,
+        )
+
+
 def collect_self_usage(
     *,
     agent_name: str,
@@ -250,122 +333,67 @@ def _collect_usage(
     expected_requester: str | None,
 ) -> UsageReport:
     discovered_sources = tuple(sources)
-    total = TokenTotals()
-    sessions: set[tuple[str, str]] = set()
-    buckets: dict[str, _Aggregate] = {}
-    seen_runs: set[tuple[str, str, str]] = set()
+    usage = _UsageAccumulator()
+    model_usage = _ModelUsageAccumulator()
     scanned_sources: set[str] = set()
-    unavailable_sources: set[str] = set()
     for discovered in discovered_sources:
         if isinstance(discovered, UsageStorageDiagnostic):
-            unavailable_sources.add(discovered.path_label)
+            usage.unavailable_sources.add(discovered.path_label)
+            model_usage.unavailable_sources.add(discovered.path_label)
             continue
         source = discovered
         scanned_sources.add(source.path_label)
-        mode = "runs" if scope == "self" and not source.requester_isolated else "session_metrics"
+        mode = "runs" if scope == "self" and not source.requester_isolated else "both"
         for item in iter_usage_storage_rows(source, mode=mode):
             if isinstance(item, UsageStorageDiagnostic):
-                unavailable_sources.add(item.path_label)
+                usage.unavailable_sources.add(item.path_label)
+                model_usage.unavailable_sources.add(item.path_label)
                 continue
-            try:
-                if scope == "self":
-                    row_totals = _self_row_totals(
-                        item,
-                        config=config,
-                        expected_agent=expected_agent,
-                        expected_requester=expected_requester,
-                        seen_runs=seen_runs,
-                    )
-                    entity_id = None
-                else:
-                    entity_id = _admin_entity_id(item)
-                    row_totals = _metrics_totals(item.session_metrics) if entity_id is not None else None
-            except ValueError:
-                unavailable_sources.add(source.path_label)
-                continue
-            if row_totals is None:
-                continue
-            total = total.plus(row_totals)
-            sessions.add((source.path_label, item.row_key))
-            if entity_id is not None:
-                buckets.setdefault(entity_id, _Aggregate()).add(row_totals)
+            usage.add_row(
+                item,
+                config=config,
+                scope=scope,
+                expected_agent=expected_agent,
+                expected_requester=expected_requester,
+            )
+            model_usage.add_row(
+                item,
+                config=config,
+                scope=scope,
+                expected_agent=expected_agent,
+                expected_requester=expected_requester,
+            )
 
     breakdown = tuple(
         UsageBreakdownRow(key=entity_id, totals=aggregate.totals, session_count=aggregate.session_count)
         for entity_id, aggregate in sorted(
-            buckets.items(),
+            usage.buckets.items(),
             key=lambda item: (-item[1].totals.total_tokens, item[0]),
         )
     )
-    model_breakdown, model_coverage = _collect_model_usage(
-        sources=discovered_sources,
-        config=config,
-        scope=scope,
-        expected_agent=expected_agent,
-        expected_requester=expected_requester,
+    model_breakdown = _model_breakdown(model_usage.buckets)
+    model_coverage = UsageModelCoverage(
+        scanned_sources=len(scanned_sources),
+        unavailable_sources=len(model_usage.unavailable_sources),
     )
     return UsageReport(
         scope=scope,
-        totals=total,
-        session_count=len(sessions),
+        totals=usage.total,
+        session_count=len(usage.sessions),
         breakdown=breakdown,
         coverage=UsageCoverage(
             scanned_sources=len(scanned_sources),
-            unavailable_sources=len(unavailable_sources),
+            unavailable_sources=len(usage.unavailable_sources),
         ),
         model_breakdown=model_breakdown,
         model_coverage=model_coverage,
     )
 
 
-def _collect_model_usage(
-    *,
-    sources: Iterable[UsageStorageSource | UsageStorageDiagnostic],
-    config: Config,
-    scope: _Scope,
-    expected_agent: str | None,
-    expected_requester: str | None,
-) -> tuple[tuple[UsageModelBreakdownRow, ...], UsageModelCoverage]:
-    buckets: dict[tuple[str, str], _ModelAggregate] = {}
-    seen_runs: set[tuple[str, str, str]] = set()
-    scanned_sources: set[str] = set()
-    unavailable_sources: set[str] = set()
-    for discovered in sources:
-        if isinstance(discovered, UsageStorageDiagnostic):
-            unavailable_sources.add(discovered.path_label)
-            continue
-        source = discovered
-        scanned_sources.add(source.path_label)
-        for item in iter_usage_storage_rows(source, mode="runs"):
-            if isinstance(item, UsageStorageDiagnostic):
-                unavailable_sources.add(item.path_label)
-                continue
-            try:
-                entries = _model_entries_for_row(
-                    item,
-                    config=config,
-                    scope=scope,
-                    expected_agent=expected_agent,
-                    expected_requester=expected_requester,
-                )
-            except ValueError:
-                unavailable_sources.add(source.path_label)
-                continue
-            row_seen_runs: set[tuple[str, str, str]] = set()
-            accepted_entries: list[tuple[tuple[str, str], TokenTotals]] = []
-            for run, totals in entries:
-                if run.run_id is not None:
-                    identity = (source.path_label, item.row_key, run.run_id)
-                    if identity in seen_runs or identity in row_seen_runs:
-                        continue
-                    row_seen_runs.add(identity)
-                key = (run.model_provider or "unknown", run.model or "unknown")
-                accepted_entries.append((key, totals))
-            seen_runs.update(row_seen_runs)
-            for key, totals in accepted_entries:
-                buckets.setdefault(key, _ModelAggregate()).add(totals)
-
-    breakdown = tuple(
+def _model_breakdown(
+    buckets: Mapping[tuple[str, str], _ModelAggregate],
+) -> tuple[UsageModelBreakdownRow, ...]:
+    return tuple(
         UsageModelBreakdownRow(
             model_provider=key[0],
             model=key[1],
@@ -377,10 +405,29 @@ def _collect_model_usage(
             key=lambda item: (-item[1].totals.total_tokens, item[0]),
         )
     )
-    return breakdown, UsageModelCoverage(
-        scanned_sources=len(scanned_sources),
-        unavailable_sources=len(unavailable_sources),
-    )
+
+
+def _add_model_entries(
+    entries: Iterable[tuple[UsageRunNode, TokenTotals]],
+    *,
+    source_path: str,
+    row_key: str,
+    buckets: dict[tuple[str, str], _ModelAggregate],
+    seen_runs: set[tuple[str, str, str]],
+) -> None:
+    row_seen_runs: set[tuple[str, str, str]] = set()
+    accepted_entries: list[tuple[tuple[str, str], TokenTotals]] = []
+    for run, totals in entries:
+        if run.run_id is not None:
+            identity = (source_path, row_key, run.run_id)
+            if identity in seen_runs or identity in row_seen_runs:
+                continue
+            row_seen_runs.add(identity)
+        key = (run.model_provider or "unknown", run.model or "unknown")
+        accepted_entries.append((key, totals))
+    seen_runs.update(row_seen_runs)
+    for key, totals in accepted_entries:
+        buckets.setdefault(key, _ModelAggregate()).add(totals)
 
 
 def _model_entries_for_row(

--- a/src/mindroom/usage_stats.py
+++ b/src/mindroom/usage_stats.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Literal
 
 from mindroom.usage_stats_storage import (
     TOKEN_FIELDS,
+    UsageRunNode,
     UsageSessionRow,
     UsageStorageDiagnostic,
     UsageStorageSource,
@@ -26,6 +27,8 @@ __all__ = [
     "TokenTotals",
     "UsageBreakdownRow",
     "UsageCoverage",
+    "UsageModelBreakdownRow",
+    "UsageModelCoverage",
     "UsageReport",
     "collect_admin_usage",
     "collect_self_usage",
@@ -37,6 +40,11 @@ _COVERAGE_NOTE = (
     "Shared self totals use requester-attributed retained agent runs. "
     "Private self and admin totals use Agno session aggregates, including team members. "
     "Deleted sessions are unavailable."
+)
+_MODEL_COVERAGE_NOTE = (
+    "Model breakdown uses retained top-level runs with usable token metrics. "
+    "It does not necessarily sum to report totals, which may include compacted history "
+    "and nested team-member usage."
 )
 
 
@@ -119,6 +127,42 @@ class UsageCoverage:
 
 
 @dataclass(frozen=True, slots=True)
+class UsageModelBreakdownRow:
+    """Retained top-level usage for one provider and model."""
+
+    model_provider: str
+    model: str
+    totals: TokenTotals
+    run_count: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the public model breakdown row."""
+        return {
+            "provider": self.model_provider,
+            "model": self.model,
+            "totals": self.totals.to_dict(),
+            "run_count": self.run_count,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class UsageModelCoverage:
+    """Coverage of the separately retained model attribution."""
+
+    scanned_sources: int
+    unavailable_sources: int
+    note: str = _MODEL_COVERAGE_NOTE
+
+    def to_dict(self) -> dict[str, object]:
+        """Return model-attribution coverage without implying completeness."""
+        return {
+            "scanned_sources": self.scanned_sources,
+            "unavailable_sources": self.unavailable_sources,
+            "note": self.note,
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class UsageReport:
     """Aggregate-only retained token usage."""
 
@@ -127,6 +171,8 @@ class UsageReport:
     session_count: int
     breakdown: tuple[UsageBreakdownRow, ...]
     coverage: UsageCoverage
+    model_breakdown: tuple[UsageModelBreakdownRow, ...]
+    model_coverage: UsageModelCoverage
 
     def to_dict(self) -> dict[str, object]:
         """Return the stable custom-tool payload fields."""
@@ -136,6 +182,8 @@ class UsageReport:
             "session_count": self.session_count,
             "breakdown": [row.to_dict() for row in self.breakdown],
             "coverage": self.coverage.to_dict(),
+            "model_breakdown": [row.to_dict() for row in self.model_breakdown],
+            "model_coverage": self.model_coverage.to_dict(),
         }
 
 
@@ -147,6 +195,16 @@ class _Aggregate:
     def add(self, totals: TokenTotals) -> None:
         self.totals = self.totals.plus(totals)
         self.session_count += 1
+
+
+@dataclass(slots=True)
+class _ModelAggregate:
+    totals: TokenTotals = TokenTotals()
+    run_count: int = 0
+
+    def add(self, totals: TokenTotals) -> None:
+        self.totals = self.totals.plus(totals)
+        self.run_count += 1
 
 
 def collect_self_usage(
@@ -191,13 +249,14 @@ def _collect_usage(
     expected_agent: str | None,
     expected_requester: str | None,
 ) -> UsageReport:
+    discovered_sources = tuple(sources)
     total = TokenTotals()
     sessions: set[tuple[str, str]] = set()
     buckets: dict[str, _Aggregate] = {}
     seen_runs: set[tuple[str, str, str]] = set()
     scanned_sources: set[str] = set()
     unavailable_sources: set[str] = set()
-    for discovered in sources:
+    for discovered in discovered_sources:
         if isinstance(discovered, UsageStorageDiagnostic):
             unavailable_sources.add(discovered.path_label)
             continue
@@ -238,6 +297,13 @@ def _collect_usage(
             key=lambda item: (-item[1].totals.total_tokens, item[0]),
         )
     )
+    model_breakdown, model_coverage = _collect_model_usage(
+        sources=discovered_sources,
+        config=config,
+        scope=scope,
+        expected_agent=expected_agent,
+        expected_requester=expected_requester,
+    )
     return UsageReport(
         scope=scope,
         totals=total,
@@ -247,7 +313,102 @@ def _collect_usage(
             scanned_sources=len(scanned_sources),
             unavailable_sources=len(unavailable_sources),
         ),
+        model_breakdown=model_breakdown,
+        model_coverage=model_coverage,
     )
+
+
+def _collect_model_usage(
+    *,
+    sources: Iterable[UsageStorageSource | UsageStorageDiagnostic],
+    config: Config,
+    scope: _Scope,
+    expected_agent: str | None,
+    expected_requester: str | None,
+) -> tuple[tuple[UsageModelBreakdownRow, ...], UsageModelCoverage]:
+    buckets: dict[tuple[str, str], _ModelAggregate] = {}
+    seen_runs: set[tuple[str, str, str]] = set()
+    scanned_sources: set[str] = set()
+    unavailable_sources: set[str] = set()
+    for discovered in sources:
+        if isinstance(discovered, UsageStorageDiagnostic):
+            unavailable_sources.add(discovered.path_label)
+            continue
+        source = discovered
+        scanned_sources.add(source.path_label)
+        for item in iter_usage_storage_rows(source, mode="runs"):
+            if isinstance(item, UsageStorageDiagnostic):
+                unavailable_sources.add(item.path_label)
+                continue
+            try:
+                entries = _model_entries_for_row(
+                    item,
+                    config=config,
+                    scope=scope,
+                    expected_agent=expected_agent,
+                    expected_requester=expected_requester,
+                )
+            except ValueError:
+                unavailable_sources.add(source.path_label)
+                continue
+            row_seen_runs: set[tuple[str, str, str]] = set()
+            accepted_entries: list[tuple[tuple[str, str], TokenTotals]] = []
+            for run, totals in entries:
+                if run.run_id is not None:
+                    identity = (source.path_label, item.row_key, run.run_id)
+                    if identity in seen_runs or identity in row_seen_runs:
+                        continue
+                    row_seen_runs.add(identity)
+                key = (run.model_provider or "unknown", run.model or "unknown")
+                accepted_entries.append((key, totals))
+            seen_runs.update(row_seen_runs)
+            for key, totals in accepted_entries:
+                buckets.setdefault(key, _ModelAggregate()).add(totals)
+
+    breakdown = tuple(
+        UsageModelBreakdownRow(
+            model_provider=key[0],
+            model=key[1],
+            totals=aggregate.totals,
+            run_count=aggregate.run_count,
+        )
+        for key, aggregate in sorted(
+            buckets.items(),
+            key=lambda item: (-item[1].totals.total_tokens, item[0]),
+        )
+    )
+    return breakdown, UsageModelCoverage(
+        scanned_sources=len(scanned_sources),
+        unavailable_sources=len(unavailable_sources),
+    )
+
+
+def _model_entries_for_row(
+    row: UsageSessionRow,
+    *,
+    config: Config,
+    scope: _Scope,
+    expected_agent: str | None,
+    expected_requester: str | None,
+) -> list[tuple[UsageRunNode, TokenTotals]]:
+    if scope == "admin":
+        if _admin_entity_id(row) is None:
+            return []
+    elif row.source.source_agent_id != expected_agent or expected_agent not in row.source.allowed_agent_ids:
+        return []
+
+    entries: list[tuple[UsageRunNode, TokenTotals]] = []
+    for run in row.runs:
+        if scope == "self" and not row.source.requester_isolated:
+            requester_id = config.authorization.resolve_alias(run.requester_id) if run.requester_id else None
+            if requester_id is None:
+                raise ValueError
+            if requester_id != expected_requester:
+                continue
+        totals = _metrics_totals(run.metrics)
+        if totals is not None:
+            entries.append((run, totals))
+    return entries
 
 
 def _self_row_totals(

--- a/src/mindroom/usage_stats.py
+++ b/src/mindroom/usage_stats.py
@@ -197,7 +197,8 @@ class _UsageAccumulator:
         expected_agent: str | None,
         expected_requester: str | None,
     ) -> None:
-        if not row.session_metrics_available:
+        uses_runs = scope == "self" and not row.source.requester_isolated
+        if (uses_runs and not row.runs_available) or (not uses_runs and not row.session_metrics_available):
             self.unavailable_sources.add(row.source.path_label)
             return
         try:

--- a/src/mindroom/usage_stats.py
+++ b/src/mindroom/usage_stats.py
@@ -29,7 +29,6 @@ __all__ = [
     "UsageBreakdownRow",
     "UsageCoverage",
     "UsageModelBreakdownRow",
-    "UsageModelCoverage",
     "UsageReport",
     "collect_admin_usage",
     "collect_self_usage",
@@ -147,23 +146,6 @@ class UsageModelBreakdownRow:
 
 
 @dataclass(frozen=True, slots=True)
-class UsageModelCoverage:
-    """Coverage of the separately retained model attribution."""
-
-    scanned_sources: int
-    unavailable_sources: int
-    note: str = _MODEL_COVERAGE_NOTE
-
-    def to_dict(self) -> dict[str, object]:
-        """Return model-attribution coverage without implying completeness."""
-        return {
-            "scanned_sources": self.scanned_sources,
-            "unavailable_sources": self.unavailable_sources,
-            "note": self.note,
-        }
-
-
-@dataclass(frozen=True, slots=True)
 class UsageReport:
     """Aggregate-only retained token usage."""
 
@@ -173,7 +155,7 @@ class UsageReport:
     breakdown: tuple[UsageBreakdownRow, ...]
     coverage: UsageCoverage
     model_breakdown: tuple[UsageModelBreakdownRow, ...]
-    model_coverage: UsageModelCoverage
+    model_coverage: UsageCoverage
 
     def to_dict(self) -> dict[str, object]:
         """Return the stable custom-tool payload fields."""
@@ -191,21 +173,11 @@ class UsageReport:
 @dataclass(slots=True)
 class _Aggregate:
     totals: TokenTotals = TokenTotals()
-    session_count: int = 0
+    count: int = 0
 
     def add(self, totals: TokenTotals) -> None:
         self.totals = self.totals.plus(totals)
-        self.session_count += 1
-
-
-@dataclass(slots=True)
-class _ModelAggregate:
-    totals: TokenTotals = TokenTotals()
-    run_count: int = 0
-
-    def add(self, totals: TokenTotals) -> None:
-        self.totals = self.totals.plus(totals)
-        self.run_count += 1
+        self.count += 1
 
 
 @dataclass(slots=True)
@@ -254,7 +226,7 @@ class _UsageAccumulator:
 
 @dataclass(slots=True)
 class _ModelUsageAccumulator:
-    buckets: dict[tuple[str, str], _ModelAggregate] = dataclass_field(default_factory=dict)
+    buckets: dict[tuple[str, str], _Aggregate] = dataclass_field(default_factory=dict)
     seen_runs: set[tuple[str, str, str]] = dataclass_field(default_factory=set)
     unavailable_sources: set[str] = dataclass_field(default_factory=set)
 
@@ -332,11 +304,10 @@ def _collect_usage(
     expected_agent: str | None,
     expected_requester: str | None,
 ) -> UsageReport:
-    discovered_sources = tuple(sources)
     usage = _UsageAccumulator()
     model_usage = _ModelUsageAccumulator()
     scanned_sources: set[str] = set()
-    for discovered in discovered_sources:
+    for discovered in sources:
         if isinstance(discovered, UsageStorageDiagnostic):
             usage.unavailable_sources.add(discovered.path_label)
             model_usage.unavailable_sources.add(discovered.path_label)
@@ -365,16 +336,17 @@ def _collect_usage(
             )
 
     breakdown = tuple(
-        UsageBreakdownRow(key=entity_id, totals=aggregate.totals, session_count=aggregate.session_count)
+        UsageBreakdownRow(key=entity_id, totals=aggregate.totals, session_count=aggregate.count)
         for entity_id, aggregate in sorted(
             usage.buckets.items(),
             key=lambda item: (-item[1].totals.total_tokens, item[0]),
         )
     )
     model_breakdown = _model_breakdown(model_usage.buckets)
-    model_coverage = UsageModelCoverage(
+    model_coverage = UsageCoverage(
         scanned_sources=len(scanned_sources),
         unavailable_sources=len(model_usage.unavailable_sources),
+        note=_MODEL_COVERAGE_NOTE,
     )
     return UsageReport(
         scope=scope,
@@ -391,14 +363,14 @@ def _collect_usage(
 
 
 def _model_breakdown(
-    buckets: Mapping[tuple[str, str], _ModelAggregate],
+    buckets: Mapping[tuple[str, str], _Aggregate],
 ) -> tuple[UsageModelBreakdownRow, ...]:
     return tuple(
         UsageModelBreakdownRow(
             model_provider=key[0],
             model=key[1],
             totals=aggregate.totals,
-            run_count=aggregate.run_count,
+            run_count=aggregate.count,
         )
         for key, aggregate in sorted(
             buckets.items(),
@@ -412,7 +384,7 @@ def _add_model_entries(
     *,
     source_path: str,
     row_key: str,
-    buckets: dict[tuple[str, str], _ModelAggregate],
+    buckets: dict[tuple[str, str], _Aggregate],
     seen_runs: set[tuple[str, str, str]],
 ) -> None:
     row_seen_runs: set[tuple[str, str, str]] = set()
@@ -427,7 +399,7 @@ def _add_model_entries(
         accepted_entries.append((key, totals))
     seen_runs.update(row_seen_runs)
     for key, totals in accepted_entries:
-        buckets.setdefault(key, _ModelAggregate()).add(totals)
+        buckets.setdefault(key, _Aggregate()).add(totals)
 
 
 def _model_entries_for_row(

--- a/src/mindroom/usage_stats_storage.py
+++ b/src/mindroom/usage_stats_storage.py
@@ -76,6 +76,8 @@ class UsageRunNode:
     team_id: str | None
     requester_id: str | None
     run_id: str | None
+    model_provider: str | None
+    model: str | None
     metrics: Mapping[str, _MetricValue]
 
 
@@ -466,6 +468,8 @@ def _extract_run(raw_run: object, *, row_requester: str | None) -> UsageRunNode 
         team_id=_optional_string(run.get("team_id")),
         requester_id=metadata_requester or _optional_string(run.get("user_id")) or row_requester,
         run_id=_optional_string(run.get("run_id")),
+        model_provider=_optional_string(run.get("model_provider")),
+        model=_optional_string(run.get("model")),
         metrics=selected_metrics,
     )
 

--- a/src/mindroom/usage_stats_storage.py
+++ b/src/mindroom/usage_stats_storage.py
@@ -418,8 +418,8 @@ def _extract_row(
     row_requester = _optional_string(row["user_id"])
     if not isinstance(entity_id, str) or not entity_id or not isinstance(row_key, str) or not row_key:
         raise ValueError
-    runs_available = True
-    session_metrics_available = True
+    runs_available = mode != "session_metrics"
+    session_metrics_available = mode != "runs"
     if mode == "runs":
         runs = _extract_runs(row["payload"], row_requester=row_requester)
         session_metrics = MappingProxyType({})

--- a/src/mindroom/usage_stats_storage.py
+++ b/src/mindroom/usage_stats_storage.py
@@ -34,6 +34,7 @@ __all__ = [
 ]
 
 type _UsageStorageScope = Literal["shared_agent", "private_agent", "team"]
+type _UsageReadMode = Literal["runs", "session_metrics", "both"]
 type _MetricValue = int | float | str | None
 
 _MAX_STRING_LENGTH = 512
@@ -92,6 +93,8 @@ class UsageSessionRow:
     runs: tuple[UsageRunNode, ...]
     session_metrics: Mapping[str, _MetricValue] = field(default_factory=lambda: MappingProxyType({}))
     payload_bytes: int = 0
+    runs_available: bool = True
+    session_metrics_available: bool = True
 
 
 @dataclass(frozen=True, slots=True)
@@ -322,10 +325,10 @@ def _source(
 def iter_usage_storage_rows(
     source: UsageStorageSource,
     *,
-    mode: Literal["runs", "session_metrics"] = "runs",
+    mode: _UsageReadMode = "runs",
 ) -> Iterator[UsageSessionRow | UsageStorageDiagnostic]:
     """Yield the requested aggregate-only fields without writing or creating a database."""
-    if mode not in {"runs", "session_metrics"}:
+    if mode not in {"runs", "session_metrics", "both"}:
         raise ValueError(mode)
     if not source.path.is_file():
         yield _source_diagnostic(source, "absent", "database absent")
@@ -337,20 +340,42 @@ def iter_usage_storage_rows(
                 yield schema_error
                 return
             table = _quote_identifier(source.expected_session_table)
-            payload_column = "runs" if mode == "runs" else "session_data"
-            query = (
-                "SELECT session_id, session_type, agent_id, team_id, user_id, "  # noqa: S608
-                f"{payload_column} AS payload, "
-                f"length(CAST({payload_column} AS BLOB)) AS payload_bytes "
-                f"FROM {table}"
-            )
+            if mode == "both":
+                query = (
+                    "SELECT session_id, session_type, agent_id, team_id, user_id, "  # noqa: S608
+                    "runs AS runs_payload, "
+                    "length(CAST(runs AS BLOB)) AS runs_payload_bytes, "
+                    "session_data AS session_payload, "
+                    "length(CAST(session_data AS BLOB)) AS session_payload_bytes "
+                    f"FROM {table}"
+                )
+            else:
+                payload_column = "runs" if mode == "runs" else "session_data"
+                query = (
+                    "SELECT session_id, session_type, agent_id, team_id, user_id, "  # noqa: S608
+                    f"{payload_column} AS payload, "
+                    f"length(CAST({payload_column} AS BLOB)) AS payload_bytes "
+                    f"FROM {table}"
+                )
             for row in connection.execute(query):
-                payload_bytes = row["payload_bytes"] or 0
-                if isinstance(payload_bytes, bool) or not isinstance(payload_bytes, int) or payload_bytes < 0:
+                payload_sizes = (
+                    (row["runs_payload_bytes"], row["session_payload_bytes"])
+                    if mode == "both"
+                    else (row["payload_bytes"],)
+                )
+                if any(
+                    isinstance(size, bool) or (size is not None and (not isinstance(size, int) or size < 0))
+                    for size in payload_sizes
+                ):
                     yield _source_diagnostic(source, "partial", "malformed retained session")
                     continue
                 try:
-                    yield _extract_row(source, row, mode=mode)
+                    yield _extract_row(
+                        source,
+                        row,
+                        mode=mode,
+                        payload_bytes=sum(size or 0 for size in payload_sizes),
+                    )
                 except (RecursionError, TypeError, ValueError, json.JSONDecodeError):
                     yield _source_diagnostic(source, "partial", "malformed retained session")
     except sqlite3.Error as error:
@@ -382,7 +407,8 @@ def _extract_row(
     source: UsageStorageSource,
     row: sqlite3.Row,
     *,
-    mode: Literal["runs", "session_metrics"],
+    mode: _UsageReadMode,
+    payload_bytes: int,
 ) -> UsageSessionRow:
     entity_kind = row["session_type"]
     if entity_kind not in {"agent", "team"}:
@@ -392,25 +418,45 @@ def _extract_row(
     row_requester = _optional_string(row["user_id"])
     if not isinstance(entity_id, str) or not entity_id or not isinstance(row_key, str) or not row_key:
         raise ValueError
-    payload_bytes = row["payload_bytes"] or 0
-    if isinstance(payload_bytes, bool) or not isinstance(payload_bytes, int) or payload_bytes < 0:
-        raise TypeError
-    raw_runs = _decode_runs(row["payload"]) if mode == "runs" else []
-    session_metrics = _decode_session_metrics(row["payload"]) if mode == "session_metrics" else MappingProxyType({})
-    runs: list[UsageRunNode] = []
-    for raw_run in raw_runs:
-        extracted = _extract_run(raw_run, row_requester=row_requester)
-        if extracted is not None:
-            runs.append(extracted)
+    runs_available = True
+    session_metrics_available = True
+    if mode == "runs":
+        runs = _extract_runs(row["payload"], row_requester=row_requester)
+        session_metrics = MappingProxyType({})
+    elif mode == "session_metrics":
+        runs = ()
+        session_metrics = _decode_session_metrics(row["payload"])
+    else:
+        try:
+            runs = _extract_runs(row["runs_payload"], row_requester=row_requester)
+        except (RecursionError, TypeError, ValueError, json.JSONDecodeError):
+            runs = ()
+            runs_available = False
+        try:
+            session_metrics = _decode_session_metrics(row["session_payload"])
+        except (RecursionError, TypeError, ValueError, json.JSONDecodeError):
+            session_metrics = MappingProxyType({})
+            session_metrics_available = False
     return UsageSessionRow(
         source=source,
         entity_id=_bounded_string(entity_id),
         entity_kind=cast("Literal['agent', 'team']", entity_kind),
         row_key=_bounded_string(row_key),
-        runs=tuple(runs),
+        runs=runs,
         session_metrics=session_metrics,
         payload_bytes=payload_bytes,
+        runs_available=runs_available,
+        session_metrics_available=session_metrics_available,
     )
+
+
+def _extract_runs(raw_value: object, *, row_requester: str | None) -> tuple[UsageRunNode, ...]:
+    runs: list[UsageRunNode] = []
+    for raw_run in _decode_runs(raw_value):
+        extracted = _extract_run(raw_run, row_requester=row_requester)
+        if extracted is not None:
+            runs.append(extracted)
+    return tuple(runs)
 
 
 def _decode_runs(raw_value: object) -> list[object]:

--- a/tests/test_usage_stats.py
+++ b/tests/test_usage_stats.py
@@ -105,6 +105,8 @@ def _row(
     session_metrics: Mapping[str, object] | None = None,
     row_key: str = "session-1",
     payload_bytes: int = 0,
+    runs_available: bool = True,
+    session_metrics_available: bool = True,
 ) -> UsageSessionRow:
     is_team = source.scope == "team"
     return UsageSessionRow(
@@ -115,6 +117,8 @@ def _row(
         runs=tuple(runs),
         session_metrics=MappingProxyType(dict(session_metrics or {})),
         payload_bytes=payload_bytes,
+        runs_available=runs_available,
+        session_metrics_available=session_metrics_available,
     )
 
 
@@ -122,6 +126,7 @@ def _wire(
     monkeypatch: pytest.MonkeyPatch,
     sources: tuple[UsageStorageSource | UsageStorageDiagnostic, ...],
     rows: dict[str, tuple[UsageSessionRow | UsageStorageDiagnostic, ...]],
+    calls: list[tuple[str, str]] | None = None,
 ) -> None:
     monkeypatch.setattr("mindroom.usage_stats.discover_self_usage_sources", lambda **_: sources)
     monkeypatch.setattr("mindroom.usage_stats.discover_admin_usage_sources", lambda **_: sources)
@@ -131,7 +136,8 @@ def _wire(
         *,
         mode: str = "runs",
     ) -> Iterator[UsageSessionRow | UsageStorageDiagnostic]:
-        del mode
+        if calls is not None:
+            calls.append((source.path_label, mode))
         yield from rows.get(source.path_label, ())
 
     monkeypatch.setattr("mindroom.usage_stats.iter_usage_storage_rows", iter_rows)
@@ -193,6 +199,30 @@ def test_self_usage_is_requester_scoped_and_small(tmp_path: Path, monkeypatch: p
     assert "window" not in payload
     assert "run_count" not in payload
     assert "first_observed_at" not in payload
+
+
+def test_shared_self_reads_each_source_once_for_totals_and_models(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    calls: list[tuple[str, str]] = []
+    _wire(
+        monkeypatch,
+        (source,),
+        {source.path_label: (_row(source, _run()),)},
+        calls,
+    )
+
+    collect_self_usage(
+        agent_name="code",
+        requester_id="@alice:example.test",
+        config=_config(),
+        runtime_paths=_paths(tmp_path),
+        execution_identity=_identity(),
+    )
+
+    assert calls == [(source.path_label, "runs")]
 
 
 def test_self_usage_accepts_missing_requester_in_exact_private_store(
@@ -298,6 +328,24 @@ def test_admin_usage_uses_member_inclusive_session_metrics(
         ("openai", "gpt-5.6", 7, 1),
         ("vertexai", "claude-opus-5", 5, 1),
     ]
+
+
+def test_admin_reads_each_source_once_for_session_and_model_views(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    calls: list[tuple[str, str]] = []
+    _wire(
+        monkeypatch,
+        (source,),
+        {source.path_label: (_row(source, _run(), session_metrics=_metrics()),)},
+        calls,
+    )
+
+    collect_admin_usage(config=_config(), runtime_paths=_paths(tmp_path))
+
+    assert calls == [(source.path_label, "both")]
 
 
 def test_model_breakdown_groups_runs_and_uses_unknown_for_missing_identity(
@@ -440,6 +488,60 @@ def test_invalid_model_run_does_not_discard_authoritative_admin_totals(
     assert report.coverage.unavailable_sources == 0
     assert report.model_breakdown == ()
     assert report.model_coverage.unavailable_sources == 1
+
+
+def test_unavailable_model_payload_does_not_discard_authoritative_admin_totals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    _wire(
+        monkeypatch,
+        (source,),
+        {
+            source.path_label: (
+                _row(
+                    source,
+                    session_metrics=_metrics(20),
+                    runs_available=False,
+                ),
+            ),
+        },
+    )
+
+    report = collect_admin_usage(config=_config(), runtime_paths=_paths(tmp_path))
+
+    assert report.totals.total_tokens == 20
+    assert report.coverage.unavailable_sources == 0
+    assert report.model_breakdown == ()
+    assert report.model_coverage.unavailable_sources == 1
+
+
+def test_unavailable_session_payload_does_not_discard_model_attribution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    _wire(
+        monkeypatch,
+        (source,),
+        {
+            source.path_label: (
+                _row(
+                    source,
+                    _run(total_tokens=12),
+                    session_metrics_available=False,
+                ),
+            ),
+        },
+    )
+
+    report = collect_admin_usage(config=_config(), runtime_paths=_paths(tmp_path))
+
+    assert report.totals.total_tokens == 0
+    assert report.coverage.unavailable_sources == 1
+    assert report.model_breakdown[0].totals.total_tokens == 12
+    assert report.model_coverage.unavailable_sources == 0
 
 
 def test_admin_usage_reads_every_retained_session(

--- a/tests/test_usage_stats.py
+++ b/tests/test_usage_stats.py
@@ -210,11 +210,11 @@ def test_shared_self_reads_each_source_once_for_totals_and_models(
     _wire(
         monkeypatch,
         (source,),
-        {source.path_label: (_row(source, _run()),)},
+        {source.path_label: (_row(source, _run(), session_metrics_available=False),)},
         calls,
     )
 
-    collect_self_usage(
+    report = collect_self_usage(
         agent_name="code",
         requester_id="@alice:example.test",
         config=_config(),
@@ -223,6 +223,8 @@ def test_shared_self_reads_each_source_once_for_totals_and_models(
     )
 
     assert calls == [(source.path_label, "runs")]
+    assert report.totals.total_tokens == 10
+    assert report.model_breakdown[0].totals.total_tokens == 10
 
 
 def test_self_usage_accepts_missing_requester_in_exact_private_store(

--- a/tests/test_usage_stats.py
+++ b/tests/test_usage_stats.py
@@ -85,11 +85,15 @@ def _run(
     requester_id: str | None = "@alice:example.test",
     run_id: str | None = "run-1",
     total_tokens: int = 10,
+    model_provider: str | None = "openai",
+    model: str | None = "gpt-5.6",
 ) -> UsageRunNode:
     return UsageRunNode(
         team_id=None,
         requester_id=requester_id,
         run_id=run_id,
+        model_provider=model_provider,
+        model=model,
         metrics=_metrics(total_tokens),
     )
 
@@ -143,7 +147,12 @@ def test_self_usage_is_requester_scoped_and_small(tmp_path: Path, monkeypatch: p
                 _row(
                     source,
                     _run(requester_id="@telegram-alice:example.test", run_id="own"),
-                    _run(requester_id="@bob:example.test", run_id="other", total_tokens=50),
+                    _run(
+                        requester_id="@bob:example.test",
+                        run_id="other",
+                        total_tokens=50,
+                        model="other-model",
+                    ),
                 ),
             ),
         },
@@ -162,6 +171,25 @@ def test_self_usage_is_requester_scoped_and_small(tmp_path: Path, monkeypatch: p
     assert payload["totals"]["total_tokens"] == 10  # type: ignore[index]
     assert payload["session_count"] == 1
     assert payload["breakdown"] == []
+    assert payload["model_breakdown"] == [
+        {
+            "provider": "openai",
+            "model": "gpt-5.6",
+            "totals": {
+                **_metrics(),
+                "cache_read_tokens": 0,
+                "cache_write_tokens": 0,
+                "reasoning_tokens": 0,
+                "audio_input_tokens": 0,
+                "audio_output_tokens": 0,
+                "audio_total_tokens": 0,
+            },
+            "run_count": 1,
+        },
+    ]
+    assert payload["model_coverage"]["scanned_sources"] == 1  # type: ignore[index]
+    assert payload["model_coverage"]["unavailable_sources"] == 0  # type: ignore[index]
+    assert "retained top-level runs" in payload["model_coverage"]["note"]  # type: ignore[index]
     assert "window" not in payload
     assert "run_count" not in payload
     assert "first_observed_at" not in payload
@@ -193,7 +221,7 @@ def test_private_self_usage_uses_compaction_safe_session_metrics(
     _wire(
         monkeypatch,
         (source,),
-        {source.path_label: (_row(source, session_metrics=_metrics(25)),)},
+        {source.path_label: (_row(source, _run(total_tokens=10), session_metrics=_metrics(25)),)},
     )
 
     report = collect_self_usage(
@@ -206,6 +234,8 @@ def test_private_self_usage_uses_compaction_safe_session_metrics(
 
     assert report.totals.total_tokens == 25
     assert report.session_count == 1
+    assert report.model_breakdown[0].totals.total_tokens == 10
+    assert report.model_breakdown[0].run_count == 1
 
 
 def test_self_usage_marks_missing_shared_requester_incomplete(
@@ -237,8 +267,20 @@ def test_admin_usage_uses_member_inclusive_session_metrics(
         monkeypatch,
         (agent_source, team_source),
         {
-            agent_source.path_label: (_row(agent_source, _run(total_tokens=999), session_metrics=_metrics(10)),),
-            team_source.path_label: (_row(team_source, _run(total_tokens=999), session_metrics=_metrics(30)),),
+            agent_source.path_label: (
+                _row(
+                    agent_source,
+                    _run(total_tokens=7, model_provider="openai", model="gpt-5.6"),
+                    session_metrics=_metrics(10),
+                ),
+            ),
+            team_source.path_label: (
+                _row(
+                    team_source,
+                    _run(total_tokens=5, model_provider="vertexai", model="claude-opus-5"),
+                    session_metrics=_metrics(30),
+                ),
+            ),
         },
     )
 
@@ -250,6 +292,43 @@ def test_admin_usage_uses_member_inclusive_session_metrics(
         ("code", 10),
         ("engineering", 30),
     }
+    assert [
+        (row.model_provider, row.model, row.totals.total_tokens, row.run_count) for row in report.model_breakdown
+    ] == [
+        ("openai", "gpt-5.6", 7, 1),
+        ("vertexai", "claude-opus-5", 5, 1),
+    ]
+
+
+def test_model_breakdown_groups_runs_and_uses_unknown_for_missing_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    _wire(
+        monkeypatch,
+        (source,),
+        {
+            source.path_label: (
+                _row(
+                    source,
+                    _run(run_id="run-1", total_tokens=8),
+                    _run(run_id="run-2", total_tokens=12),
+                    _run(run_id="run-3", total_tokens=5, model_provider=None, model=None),
+                    session_metrics=_metrics(30),
+                ),
+            ),
+        },
+    )
+
+    report = collect_admin_usage(config=_config(), runtime_paths=_paths(tmp_path))
+
+    assert [
+        (row.model_provider, row.model, row.totals.total_tokens, row.run_count) for row in report.model_breakdown
+    ] == [
+        ("openai", "gpt-5.6", 20, 2),
+        ("unknown", "unknown", 5, 1),
+    ]
 
 
 def test_admin_usage_rejects_unconfigured_entity_attribution(
@@ -263,6 +342,7 @@ def test_admin_usage_rejects_unconfigured_entity_attribution(
 
     assert report.totals.total_tokens == 0
     assert report.session_count == 0
+    assert report.model_breakdown == ()
 
 
 def test_invalid_admin_session_metrics_mark_source_incomplete(
@@ -280,6 +360,33 @@ def test_invalid_admin_session_metrics_mark_source_incomplete(
 
     assert report.totals.total_tokens == 0
     assert report.coverage.unavailable_sources == 1
+
+
+def test_invalid_model_run_does_not_discard_authoritative_admin_totals(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    invalid_run = UsageRunNode(
+        team_id=None,
+        requester_id="@alice:example.test",
+        run_id="invalid",
+        model_provider="openai",
+        model="gpt-5.6",
+        metrics=MappingProxyType({"total_tokens": -1}),
+    )
+    _wire(
+        monkeypatch,
+        (source,),
+        {source.path_label: (_row(source, invalid_run, session_metrics=_metrics(20)),)},
+    )
+
+    report = collect_admin_usage(config=_config(), runtime_paths=_paths(tmp_path))
+
+    assert report.totals.total_tokens == 20
+    assert report.coverage.unavailable_sources == 0
+    assert report.model_breakdown == ()
+    assert report.model_coverage.unavailable_sources == 1
 
 
 def test_admin_usage_reads_every_retained_session(

--- a/tests/test_usage_stats.py
+++ b/tests/test_usage_stats.py
@@ -331,6 +331,59 @@ def test_model_breakdown_groups_runs_and_uses_unknown_for_missing_identity(
     ]
 
 
+def test_model_breakdown_deduplicates_repeated_retained_run_ids(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    _wire(
+        monkeypatch,
+        (source,),
+        {
+            source.path_label: (
+                _row(
+                    source,
+                    _run(run_id="duplicate", total_tokens=8),
+                    _run(run_id="duplicate", total_tokens=8),
+                    session_metrics=_metrics(8),
+                ),
+            ),
+        },
+    )
+
+    report = collect_admin_usage(config=_config(), runtime_paths=_paths(tmp_path))
+
+    assert [(row.totals.total_tokens, row.run_count) for row in report.model_breakdown] == [(8, 1)]
+
+
+def test_model_breakdown_uses_provider_and_model_as_equal_token_tiebreakers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _source()
+    _wire(
+        monkeypatch,
+        (source,),
+        {
+            source.path_label: (
+                _row(
+                    source,
+                    _run(run_id="z-model", model_provider="zeta", model="alpha"),
+                    _run(run_id="a-model", model_provider="alpha", model="zeta"),
+                    session_metrics=_metrics(20),
+                ),
+            ),
+        },
+    )
+
+    report = collect_admin_usage(config=_config(), runtime_paths=_paths(tmp_path))
+
+    assert [(row.model_provider, row.model) for row in report.model_breakdown] == [
+        ("alpha", "zeta"),
+        ("zeta", "alpha"),
+    ]
+
+
 def test_admin_usage_rejects_unconfigured_entity_attribution(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_usage_stats_storage.py
+++ b/tests/test_usage_stats_storage.py
@@ -205,6 +205,8 @@ def test_reader_extracts_only_top_level_usage_fields(tmp_path: Path) -> None:
     assert row.runs[0].requester_id == "@alice:example.test"
     assert row.runs[0].model_provider == "openai"
     assert row.runs[0].model == "gpt-5.6"
+    assert row.runs_available is True
+    assert row.session_metrics_available is False
     assert row.payload_bytes > 0
     assert not hasattr(row.runs[0], "member_responses")
     assert "secret" not in repr(row)
@@ -298,6 +300,8 @@ def test_reader_extracts_team_session_metrics_written_by_agno(tmp_path: Path) ->
     assert isinstance(row, UsageSessionRow)
     assert row.session_metrics == {"input_tokens": 21, "output_tokens": 9, "total_tokens": 30}
     assert row.runs == ()
+    assert row.runs_available is False
+    assert row.session_metrics_available is True
 
 
 def test_reader_both_mode_keeps_session_metrics_when_runs_are_malformed(tmp_path: Path) -> None:

--- a/tests/test_usage_stats_storage.py
+++ b/tests/test_usage_stats_storage.py
@@ -300,6 +300,53 @@ def test_reader_extracts_team_session_metrics_written_by_agno(tmp_path: Path) ->
     assert row.runs == ()
 
 
+def test_reader_both_mode_keeps_session_metrics_when_runs_are_malformed(tmp_path: Path) -> None:
+    """Run-attribution corruption cannot erase authoritative session metrics."""
+    database = tmp_path / "code.db"
+    _create_database(database)
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute(
+            'UPDATE "code_sessions" SET runs = ?, session_data = ?',
+            ("not-json", json.dumps({"session_metrics": {"total_tokens": 30}})),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = list(iter_usage_storage_rows(_source(database), mode="both"))
+
+    assert len(result) == 1
+    row = result[0]
+    assert isinstance(row, UsageSessionRow)
+    assert row.runs == ()
+    assert row.runs_available is False
+    assert row.session_metrics == {"total_tokens": 30}
+    assert row.session_metrics_available is True
+
+
+def test_reader_both_mode_keeps_runs_when_session_metrics_are_malformed(tmp_path: Path) -> None:
+    """Session-aggregate corruption cannot erase retained model attribution."""
+    database = tmp_path / "code.db"
+    _create_database(database)
+    connection = sqlite3.connect(database)
+    try:
+        connection.execute('UPDATE "code_sessions" SET session_data = ?', ("not-json",))
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = list(iter_usage_storage_rows(_source(database), mode="both"))
+
+    assert len(result) == 1
+    row = result[0]
+    assert isinstance(row, UsageSessionRow)
+    assert len(row.runs) == 1
+    assert row.runs_available is True
+    assert row.session_metrics == {}
+    assert row.session_metrics_available is False
+
+
 def test_reader_excludes_persisted_child_runs(tmp_path: Path) -> None:
     """Delegated sibling runs must not be counted as top-level usage."""
     database = tmp_path / "code.db"

--- a/tests/test_usage_stats_storage.py
+++ b/tests/test_usage_stats_storage.py
@@ -203,6 +203,8 @@ def test_reader_extracts_only_top_level_usage_fields(tmp_path: Path) -> None:
     assert len(row.runs) == 1
     assert row.runs[0].metrics == {"input_tokens": 12, "output_tokens": 8, "total_tokens": 20}
     assert row.runs[0].requester_id == "@alice:example.test"
+    assert row.runs[0].model_provider == "openai"
+    assert row.runs[0].model == "gpt-5.6"
     assert row.payload_bytes > 0
     assert not hasattr(row.runs[0], "member_responses")
     assert "secret" not in repr(row)
@@ -249,6 +251,8 @@ def test_reader_extracts_runs_written_by_mindroom_agno_storage(tmp_path: Path) -
     assert isinstance(row, UsageSessionRow)
     assert len(row.runs) == 1
     assert row.runs[0].metrics == {"input_tokens": 12, "output_tokens": 8, "total_tokens": 20}
+    assert row.runs[0].model_provider == "openai"
+    assert row.runs[0].model == "gpt-5.6"
 
 
 def test_reader_extracts_team_session_metrics_written_by_agno(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- preserve provider and model identifiers from retained top-level Agno runs
- add separate `model_breakdown` and `model_coverage` fields without changing authoritative totals or entity rows
- read each SQLite source once while decoding authoritative and model payloads independently
- document attribution limits and test requester scoping, compaction gaps, malformed runs, deduplication, and stable ordering

## Verification

- `uv run pre-commit run --all-files`
- `nix-shell shell.nix --run 'uv run pytest -x -n auto --no-cov -q'` — 15,231 passed, 122 skipped
- read-only production smoke test preserving the existing aggregate total

## Summary by Sourcery

Add retained model usage attribution to usage reports without changing authoritative totals or entity-level aggregates.

New Features:
- Add provider/model usage breakdowns with token totals and retained run counts to admin and self usage reports.

Bug Fixes:
- Preserve authoritative aggregate totals when model or session payloads are malformed or unavailable.

Enhancements:
- Read each SQLite source once for independent authoritative and model attribution views, with requester scoping, deduplication, stable ordering, and explicit model coverage limitations.

Documentation:
- Document model breakdown fields, ordering, and the limitations caused by compacted history and nested team-member usage.

Tests:
- Expand usage statistics coverage for model attribution, source-read behavior, scoping, malformed data, deduplication, unknown identities, and deterministic ordering.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage reports now include provider- and model-level token totals and run counts.
  * Model usage is sorted by total tokens and includes separate coverage information.
  * Self-reports retain model breakdowns and coverage details.

* **Bug Fixes**
  * Reports preserve available usage data when some underlying details are unavailable.
  * Model-attributed totals may differ from overall totals when attribution is unavailable.

* **Documentation**
  * Updated usage reporting documentation with model breakdowns, sorting, coverage, and attribution details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->