### PR TITLE
feat: defer thread model tool in Mind template

### DIFF
--- a/src/mindroom/cli/config.py
+++ b/src/mindroom/cli/config.py
@@ -984,6 +984,8 @@ agents:
       - todo
       - subagents
       - matrix_message
+      - name: thread_model
+        defer: true
       - thread_tags
       - thread_summary
     skills:

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -332,6 +332,7 @@ class TestConfigInit:
             "todo",
             "subagents",
             "matrix_message",
+            {"name": "thread_model", "defer": True},
             "thread_tags",
             "thread_summary",
         ]
@@ -339,6 +340,10 @@ class TestConfigInit:
             entry for entry in load_config_yaml(target).agents["mind"].tools if entry.name == "config_manager"
         )
         assert config_manager_entry.defer is True
+        thread_model_entry = next(
+            entry for entry in load_config_yaml(target).agents["mind"].tools if entry.name == "thread_model"
+        )
+        assert thread_model_entry.defer is True
         assert "thread_resolution" not in mind["tools"]
         assert mind["skills"] == ["mindroom-docs"]
         assert (


### PR DESCRIPTION
## Summary

- add the existing thread_model toolkit to newly generated Mind agents
- keep it deferred so it does not expand the initial tool schema
- verify both generated YAML and parsed defer behavior

## Verification

- focused config-init regression test with -n auto
- full tests with -x -n auto --no-cov -q
- pre-commit run --all-files

## Summary by Sourcery

Add the thread model tool to generated Mind agents without expanding their initial tool schema.

New Features:
- Include the existing deferred thread model tool in newly generated Mind agent configurations.

Tests:
- Verify that generated Mind configuration includes the deferred thread model tool and preserves its parsed defer behavior.