### PR TITLE
Keep media-root captions in one routed turn

### DIFF
--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -331,15 +331,21 @@ class CoalescingGate:
         return gate
 
     @staticmethod
-    def _queued_event_is_thread_root_media(queued: _QueuedEvent, thread_id: str) -> bool:
-        if queued.source_event_id != thread_id or CoalescingGate._queued_kind(queued) is not QueueKind.NORMAL:
-            return False
+    def _queued_event_allows_room_scope_batching(queued: _QueuedEvent) -> bool:
         return source_or_event_allows_room_scope_batching(
             queued.source_kind,
             queued.pending_event.event,
         ) or source_or_event_allows_room_scope_batching(
             queued.pending_event.event.source_kind,
             queued.pending_event.event,
+        )
+
+    @staticmethod
+    def _queued_event_is_thread_root_media(queued: _QueuedEvent, thread_id: str) -> bool:
+        return (
+            queued.source_event_id == thread_id
+            and CoalescingGate._queued_kind(queued) is QueueKind.NORMAL
+            and CoalescingGate._queued_event_allows_room_scope_batching(queued)
         )
 
     def _promote_pending_room_media(self, key: CoalescingKey) -> _GateEntry | None:
@@ -352,7 +358,11 @@ class CoalescingGate:
             return None
         candidate_count = self._front_normal_run_length(room_gate, coalesce_normal_events=True)
         candidates = list(room_gate.queue)[:candidate_count]
-        if not any(self._queued_event_is_thread_root_media(queued, key.thread_id) for queued in candidates):
+        if (
+            not candidates
+            or not self._queued_event_allows_room_scope_batching(candidates[-1])
+            or not any(self._queued_event_is_thread_root_media(queued, key.thread_id) for queued in candidates)
+        ):
             return None
 
         thread_gate = self._get_or_create_gate(key)
@@ -802,7 +812,7 @@ class CoalescingGate:
             if not await self._wait_for_deadline(gate, deadline):
                 return _DebounceWaitResult(quiet_deadline=quiet_deadline)
             coalesce = coalesce_normal_events()
-            if self._front_normal_run_ends_with_text(gate, coalesce_normal_events=coalesce):
+            if not gate.queue or self._front_normal_run_ends_with_text(gate, coalesce_normal_events=coalesce):
                 gate.deadline = time.monotonic()
                 return _DebounceWaitResult(quiet_deadline=gate.deadline)
             if (

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -147,7 +147,6 @@ class _GateEntry:
     phase: _GatePhase = _GatePhase.DEBOUNCE
     queue: deque[_QueuedEvent] = field(default_factory=deque)
     claimed_admissions: list[_QueuedEvent] = field(default_factory=list)
-    dispatch_key: CoalescingKey | None = None
     drain_task: asyncio.Task[None] | None = None
     wake_event: asyncio.Event = field(default_factory=asyncio.Event)
     wake_generation: int = 0
@@ -326,7 +325,7 @@ class CoalescingGate:
     def _get_or_create_gate(self, key: CoalescingKey) -> _GateEntry:
         gate = self._gates.get(key)
         if gate is None:
-            gate = _GateEntry(dispatch_key=key)
+            gate = _GateEntry()
             gate.drain_context = self._active_drain_context
             self._gates[key] = gate
         return gate
@@ -343,27 +342,30 @@ class CoalescingGate:
             queued.pending_event.event,
         )
 
+    def _promote_pending_room_media(self, key: CoalescingKey) -> _GateEntry | None:
+        """Move one pending room media burst to the thread started on its upload."""
+        if key.thread_id is None:
+            return None
+        room_key = CoalescingKey(key.room_id, None, key.owner)
+        room_gate = self._gates.get(room_key)
+        if room_gate is None or room_gate.phase is not _GatePhase.DEBOUNCE or room_gate.claimed_admissions:
+            return None
+        candidate_count = self._front_normal_run_length(room_gate, coalesce_normal_events=True)
+        candidates = list(room_gate.queue)[:candidate_count]
+        if not any(self._queued_event_is_thread_root_media(queued, key.thread_id) for queued in candidates):
+            return None
+
+        thread_gate = self._get_or_create_gate(key)
+        for _ in range(candidate_count):
+            self._insert_queued_event(thread_gate, room_gate.queue.popleft())
+        self._schedule_drain(room_key, room_gate)
+        return thread_gate
+
     def _gate_for_admission(self, key: CoalescingKey) -> tuple[CoalescingKey, _GateEntry]:
         """Return the gate that owns an admission, promoting a pending media root when needed."""
         if (gate := self._gates.get(key)) is not None:
             return key, gate
-        if key.thread_id is not None:
-            room_key = CoalescingKey(key.room_id, None, key.owner)
-            room_gate = self._gates.get(room_key)
-            if (
-                room_gate is not None
-                and room_gate.phase is _GatePhase.DEBOUNCE
-                and not room_gate.claimed_admissions
-                and room_gate.dispatch_key in {room_key, key}
-                and any(self._queued_event_is_thread_root_media(queued, key.thread_id) for queued in room_gate.queue)
-            ):
-                room_gate.dispatch_key = key
-                return room_key, room_gate
-        return key, self._get_or_create_gate(key)
-
-    @staticmethod
-    def _dispatch_key(storage_key: CoalescingKey, gate: _GateEntry) -> CoalescingKey:
-        return gate.dispatch_key or storage_key
+        return key, self._promote_pending_room_media(key) or self._get_or_create_gate(key)
 
     def _current_drain_context(self, gate: _GateEntry | None = None) -> _DrainContext | None:
         if gate is not None and gate.drain_context is not None:
@@ -705,7 +707,6 @@ class CoalescingGate:
         enqueue_start = time.monotonic()
         key = self._busy_conversation_key(key, ready_result)
         storage_key, gate = self._gate_for_admission(key)
-        dispatch_key = self._dispatch_key(storage_key, gate)
         admission = _QueuedEvent(
             received_at=received_at if received_at is not None else time.time(),
             receipt_time=receipt_time if receipt_time is not None else time.monotonic(),
@@ -719,7 +720,7 @@ class CoalescingGate:
         kind = self._queued_kind(admission)
         path = self._enqueue_path(kind, ready_result.pending_event)
         self._record_enqueue(
-            dispatch_key,
+            storage_key,
             gate,
             ready_result.pending_event,
             enqueue_start,
@@ -868,16 +869,15 @@ class CoalescingGate:
         pending_events: list[PendingEvent],
     ) -> str:
         """Dispatch a claimed batch."""
-        dispatch_key = self._dispatch_key(key, gate)
         flush_start = time.monotonic()
         gate.phase = _GatePhase.IN_FLIGHT
         gate.deadline = None
         pending_count = len(pending_events)
         timing_scope = event_timing_scope(pending_events[-1].event.event_id)
         log_context: dict[str, object] = {
-            "room_id": dispatch_key.room_id,
-            "thread_id": dispatch_key.thread_id,
-            "requester_user_id": coalescing_owner_log_label(dispatch_key.owner),
+            "room_id": key.room_id,
+            "thread_id": key.thread_id,
+            "requester_user_id": coalescing_owner_log_label(key.owner),
             "pending_count": pending_count,
             "oldest_pending_age_ms": self._oldest_pending_events_age_ms(pending_events),
             "source_event_ids": self._source_event_ids(pending_events),
@@ -885,7 +885,7 @@ class CoalescingGate:
         }
         dispatched = False
         try:
-            diagnostics = self._flush_diagnostics(dispatch_key, pending_events)
+            diagnostics = self._flush_diagnostics(key, pending_events)
             pending_count = diagnostics.pending_count
             timing_scope = diagnostics.timing_scope
             log_context = diagnostics.log_context
@@ -1001,10 +1001,9 @@ class CoalescingGate:
                 await self._wait_for_lane_slots(gate, window_slots)
                 return
 
-        dispatch_key = self._dispatch_key(key, gate)
         candidate_count = self._front_normal_run_length(
             gate,
-            coalesce_normal_events=self._should_coalesce_normal_events(dispatch_key, gate),
+            coalesce_normal_events=self._should_coalesce_normal_events(key, gate),
             max_receipt_time=debounce_result.quiet_deadline,
         )
         if candidate_count == 0:
@@ -1037,7 +1036,7 @@ class CoalescingGate:
     async def _drain_gate_iteration(self, key: CoalescingKey, gate: _GateEntry) -> None:
         drain_context = self._current_drain_context(gate)
         if not (self._is_shutting_down() or self._is_bounded_drain(drain_context)):
-            await self._wait_until_dispatch_allowed(self._dispatch_key(key, gate))
+            await self._wait_until_dispatch_allowed(key)
         if not gate.queue:
             return
 
@@ -1050,10 +1049,7 @@ class CoalescingGate:
 
         debounce_result = await self._wait_for_debounce(
             gate,
-            coalesce_normal_events=lambda key=key, entry=gate: self._should_coalesce_normal_events(
-                self._dispatch_key(key, entry),
-                entry,
-            ),
+            coalesce_normal_events=lambda key=key, entry=gate: self._should_coalesce_normal_events(key, entry),
         )
         if not gate.queue:
             return

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -334,7 +334,6 @@ class CoalescingGate:
     def _queued_event_allows_room_scope_batching(queued: _QueuedEvent) -> bool:
         return source_or_event_allows_room_scope_batching(
             queued.source_kind,
-            queued.pending_event.event,
         ) or source_or_event_allows_room_scope_batching(
             queued.pending_event.event.source_kind,
             queued.pending_event.event,
@@ -372,11 +371,11 @@ class CoalescingGate:
         self._schedule_drain(room_key, room_gate)
         return thread_gate
 
-    def _gate_for_admission(self, key: CoalescingKey) -> tuple[CoalescingKey, _GateEntry]:
+    def _gate_for_admission(self, key: CoalescingKey) -> _GateEntry:
         """Return the gate that owns an admission, promoting a pending media root when needed."""
         if (gate := self._gates.get(key)) is not None:
-            return key, gate
-        return key, self._promote_pending_room_media(key) or self._get_or_create_gate(key)
+            return gate
+        return self._promote_pending_room_media(key) or self._get_or_create_gate(key)
 
     def _current_drain_context(self, gate: _GateEntry | None = None) -> _DrainContext | None:
         if gate is not None and gate.drain_context is not None:
@@ -717,7 +716,7 @@ class CoalescingGate:
         """
         enqueue_start = time.monotonic()
         key = self._busy_conversation_key(key, ready_result)
-        storage_key, gate = self._gate_for_admission(key)
+        gate = self._gate_for_admission(key)
         admission = _QueuedEvent(
             received_at=received_at if received_at is not None else time.time(),
             receipt_time=receipt_time if receipt_time is not None else time.monotonic(),
@@ -727,11 +726,11 @@ class CoalescingGate:
             lane_slot=lane_slot,
         )
         self._insert_queued_event(gate, admission)
-        self._schedule_drain(storage_key, gate)
+        self._schedule_drain(key, gate)
         kind = self._queued_kind(admission)
         path = self._enqueue_path(kind, ready_result.pending_event)
         self._record_enqueue(
-            storage_key,
+            key,
             gate,
             ready_result.pending_event,
             enqueue_start,
@@ -838,12 +837,7 @@ class CoalescingGate:
         for queued in gate.queue:
             if CoalescingGate._queued_kind(queued) is not QueueKind.NORMAL:
                 return False
-            if source_or_event_allows_room_scope_batching(queued.source_kind):
-                return True
-            if source_or_event_allows_room_scope_batching(
-                queued.pending_event.event.source_kind,
-                queued.pending_event.event,
-            ):
+            if CoalescingGate._queued_event_allows_room_scope_batching(queued):
                 return True
         return False
 

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -147,6 +147,7 @@ class _GateEntry:
     phase: _GatePhase = _GatePhase.DEBOUNCE
     queue: deque[_QueuedEvent] = field(default_factory=deque)
     claimed_admissions: list[_QueuedEvent] = field(default_factory=list)
+    dispatch_key: CoalescingKey | None = None
     drain_task: asyncio.Task[None] | None = None
     wake_event: asyncio.Event = field(default_factory=asyncio.Event)
     wake_generation: int = 0
@@ -325,10 +326,44 @@ class CoalescingGate:
     def _get_or_create_gate(self, key: CoalescingKey) -> _GateEntry:
         gate = self._gates.get(key)
         if gate is None:
-            gate = _GateEntry()
+            gate = _GateEntry(dispatch_key=key)
             gate.drain_context = self._active_drain_context
             self._gates[key] = gate
         return gate
+
+    @staticmethod
+    def _queued_event_is_thread_root_media(queued: _QueuedEvent, thread_id: str) -> bool:
+        if queued.source_event_id != thread_id or CoalescingGate._queued_kind(queued) is not QueueKind.NORMAL:
+            return False
+        return source_or_event_allows_room_scope_batching(
+            queued.source_kind,
+            queued.pending_event.event,
+        ) or source_or_event_allows_room_scope_batching(
+            queued.pending_event.event.source_kind,
+            queued.pending_event.event,
+        )
+
+    def _gate_for_admission(self, key: CoalescingKey) -> tuple[CoalescingKey, _GateEntry]:
+        """Return the gate that owns an admission, promoting a pending media root when needed."""
+        if (gate := self._gates.get(key)) is not None:
+            return key, gate
+        if key.thread_id is not None:
+            room_key = CoalescingKey(key.room_id, None, key.owner)
+            room_gate = self._gates.get(room_key)
+            if (
+                room_gate is not None
+                and room_gate.phase is _GatePhase.DEBOUNCE
+                and not room_gate.claimed_admissions
+                and room_gate.dispatch_key in {room_key, key}
+                and any(self._queued_event_is_thread_root_media(queued, key.thread_id) for queued in room_gate.queue)
+            ):
+                room_gate.dispatch_key = key
+                return room_key, room_gate
+        return key, self._get_or_create_gate(key)
+
+    @staticmethod
+    def _dispatch_key(storage_key: CoalescingKey, gate: _GateEntry) -> CoalescingKey:
+        return gate.dispatch_key or storage_key
 
     def _current_drain_context(self, gate: _GateEntry | None = None) -> _DrainContext | None:
         if gate is not None and gate.drain_context is not None:
@@ -669,7 +704,8 @@ class CoalescingGate:
         """
         enqueue_start = time.monotonic()
         key = self._busy_conversation_key(key, ready_result)
-        gate = self._get_or_create_gate(key)
+        storage_key, gate = self._gate_for_admission(key)
+        dispatch_key = self._dispatch_key(storage_key, gate)
         admission = _QueuedEvent(
             received_at=received_at if received_at is not None else time.time(),
             receipt_time=receipt_time if receipt_time is not None else time.monotonic(),
@@ -679,11 +715,11 @@ class CoalescingGate:
             lane_slot=lane_slot,
         )
         self._insert_queued_event(gate, admission)
-        self._schedule_drain(key, gate)
+        self._schedule_drain(storage_key, gate)
         kind = self._queued_kind(admission)
         path = self._enqueue_path(kind, ready_result.pending_event)
         self._record_enqueue(
-            key,
+            dispatch_key,
             gate,
             ready_result.pending_event,
             enqueue_start,
@@ -832,15 +868,16 @@ class CoalescingGate:
         pending_events: list[PendingEvent],
     ) -> str:
         """Dispatch a claimed batch."""
+        dispatch_key = self._dispatch_key(key, gate)
         flush_start = time.monotonic()
         gate.phase = _GatePhase.IN_FLIGHT
         gate.deadline = None
         pending_count = len(pending_events)
         timing_scope = event_timing_scope(pending_events[-1].event.event_id)
         log_context: dict[str, object] = {
-            "room_id": key.room_id,
-            "thread_id": key.thread_id,
-            "requester_user_id": coalescing_owner_log_label(key.owner),
+            "room_id": dispatch_key.room_id,
+            "thread_id": dispatch_key.thread_id,
+            "requester_user_id": coalescing_owner_log_label(dispatch_key.owner),
             "pending_count": pending_count,
             "oldest_pending_age_ms": self._oldest_pending_events_age_ms(pending_events),
             "source_event_ids": self._source_event_ids(pending_events),
@@ -848,7 +885,7 @@ class CoalescingGate:
         }
         dispatched = False
         try:
-            diagnostics = self._flush_diagnostics(key, pending_events)
+            diagnostics = self._flush_diagnostics(dispatch_key, pending_events)
             pending_count = diagnostics.pending_count
             timing_scope = diagnostics.timing_scope
             log_context = diagnostics.log_context
@@ -964,9 +1001,10 @@ class CoalescingGate:
                 await self._wait_for_lane_slots(gate, window_slots)
                 return
 
+        dispatch_key = self._dispatch_key(key, gate)
         candidate_count = self._front_normal_run_length(
             gate,
-            coalesce_normal_events=self._should_coalesce_normal_events(key, gate),
+            coalesce_normal_events=self._should_coalesce_normal_events(dispatch_key, gate),
             max_receipt_time=debounce_result.quiet_deadline,
         )
         if candidate_count == 0:
@@ -999,7 +1037,7 @@ class CoalescingGate:
     async def _drain_gate_iteration(self, key: CoalescingKey, gate: _GateEntry) -> None:
         drain_context = self._current_drain_context(gate)
         if not (self._is_shutting_down() or self._is_bounded_drain(drain_context)):
-            await self._wait_until_dispatch_allowed(key)
+            await self._wait_until_dispatch_allowed(self._dispatch_key(key, gate))
         if not gate.queue:
             return
 
@@ -1012,7 +1050,10 @@ class CoalescingGate:
 
         debounce_result = await self._wait_for_debounce(
             gate,
-            coalesce_normal_events=lambda key=key, entry=gate: self._should_coalesce_normal_events(key, entry),
+            coalesce_normal_events=lambda key=key, entry=gate: self._should_coalesce_normal_events(
+                self._dispatch_key(key, entry),
+                entry,
+            ),
         )
         if not gate.queue:
             return

--- a/src/mindroom/coalescing.py
+++ b/src/mindroom/coalescing.py
@@ -360,6 +360,7 @@ class CoalescingGate:
         candidates = list(room_gate.queue)[:candidate_count]
         if (
             not candidates
+            or pending_event_is_text(candidates[-1].pending_event)
             or not self._queued_event_allows_room_scope_batching(candidates[-1])
             or not any(self._queued_event_is_thread_root_media(queued, key.thread_id) for queued in candidates)
         ):

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -491,6 +491,22 @@ class TurnController:
             response_envelope=envelope,
         )
 
+    def _event_allows_queued_notice(
+        self,
+        event: PreparedIngress,
+        envelope: MessageEnvelope,
+    ) -> bool:
+        """Return whether this event may notify the conversation's active response."""
+        if envelope.origin.intent is not TurnIntent.ROUTER_HANDOFF:
+            return True
+        mentioned_agents, am_i_mentioned, has_non_agent_mentions = check_agent_mentioned(
+            event.source,
+            self.deps.matrix_id,
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
+        return am_i_mentioned or not (mentioned_agents or has_non_agent_mentions)
+
     def _voice_queued_notice_reservation(
         self,
         *,
@@ -538,11 +554,15 @@ class TurnController:
             reply_to_event_id=prepared_event.event_id,
             event_source=prepared_event.source,
         )
-        queued_notice_reservation = self._queued_notice_reservation_if_busy(
-            target=target,
-            envelope=envelope,
-            existing=queued_notice_reservation,
-        )
+        if self._event_allows_queued_notice(prepared_event, envelope):
+            queued_notice_reservation = self._queued_notice_reservation_if_busy(
+                target=target,
+                envelope=envelope,
+                existing=queued_notice_reservation,
+            )
+        elif queued_notice_reservation is not None:
+            queued_notice_reservation.cancel()
+            queued_notice_reservation = None
         try:
             await self._enqueue_for_dispatch(
                 prepared_event,

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -591,6 +591,43 @@ async def test_room_level_text_dispatches_before_late_media() -> None:
 
 
 @pytest.mark.asyncio
+async def test_thread_caption_promotes_only_the_pending_room_media_burst() -> None:
+    """Later room traffic must stay outside a media turn promoted into a thread."""
+    batches: list[PreparedTurn] = []
+
+    async def dispatch_batch(batch: PreparedTurn) -> None:
+        batches.append(batch)
+
+    gate = CoalescingGate(
+        dispatch_turn=dispatch_batch,
+        debounce_seconds=lambda: 60.0,
+        is_shutting_down=lambda: False,
+    )
+    owner = RequesterCoalescingOwner("@user:localhost")
+    room_key = CoalescingKey("!room:localhost", None, owner)
+    thread_key = CoalescingKey("!room:localhost", "$image:localhost", owner)
+
+    await _admit_ready(gate, room_key, _image_pending("$image:localhost", 1_000_000))
+    await _admit_ready(
+        gate,
+        thread_key,
+        _pending(_text_event("$caption:localhost", "describe this", 1_000_100)),
+    )
+    await _admit_ready(
+        gate,
+        room_key,
+        _pending(_text_event("$room:localhost", "unrelated room message", 1_000_200)),
+    )
+
+    await gate.drain_all()
+
+    assert {batch.ingress.coalescing_key.thread_id: list(batch.handled_turn.source_event_ids) for batch in batches} == {
+        "$image:localhost": ["$image:localhost", "$caption:localhost"],
+        None: ["$room:localhost"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_text_dispatch_waits_for_same_window_unready_media_lane_slot() -> None:
     """An immediate text flush must not run before an in-window unready media slot delivers."""
     batches: list[PreparedTurn] = []

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -621,10 +621,75 @@ async def test_thread_caption_promotes_only_the_pending_room_media_burst() -> No
 
     await gate.drain_all()
 
+    assert len(batches) == 2
     assert {batch.ingress.coalescing_key.thread_id: list(batch.handled_turn.source_event_ids) for batch in batches} == {
         "$image:localhost": ["$image:localhost", "$caption:localhost"],
         None: ["$room:localhost"],
     }
+
+
+@pytest.mark.asyncio
+async def test_thread_reply_does_not_promote_a_completed_room_media_turn() -> None:
+    """A room turn already closed by text must keep its original conversation scope."""
+    batches: list[PreparedTurn] = []
+
+    async def dispatch_batch(batch: PreparedTurn) -> None:
+        batches.append(batch)
+
+    gate = CoalescingGate(
+        dispatch_turn=dispatch_batch,
+        debounce_seconds=lambda: 60.0,
+        is_shutting_down=lambda: False,
+    )
+    owner = RequesterCoalescingOwner("@user:localhost")
+    room_key = CoalescingKey("!room:localhost", None, owner)
+    thread_key = CoalescingKey("!room:localhost", "$image:localhost", owner)
+
+    await _admit_ready(gate, room_key, _image_pending("$image:localhost", 1_000_000))
+    await _admit_ready(
+        gate,
+        room_key,
+        _pending(_text_event("$room-text:localhost", "room caption", 1_000_100)),
+    )
+    await _admit_ready(
+        gate,
+        thread_key,
+        _pending(_text_event("$thread-reply:localhost", "later reply", 1_000_200)),
+    )
+
+    await gate.drain_all()
+
+    assert len(batches) == 2
+    assert {batch.ingress.coalescing_key.thread_id: list(batch.handled_turn.source_event_ids) for batch in batches} == {
+        None: ["$image:localhost", "$room-text:localhost"],
+        "$image:localhost": ["$thread-reply:localhost"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_media_promotion_promptly_releases_the_empty_room_gate() -> None:
+    """Promotion must wake an already-waiting room drain so its empty gate exits."""
+    gate = CoalescingGate(
+        dispatch_turn=AsyncMock(),
+        debounce_seconds=lambda: 60.0,
+        is_shutting_down=lambda: False,
+    )
+    owner = RequesterCoalescingOwner("@user:localhost")
+    room_key = CoalescingKey("!room:localhost", None, owner)
+    thread_key = CoalescingKey("!room:localhost", "$image:localhost", owner)
+
+    await _admit_ready(gate, room_key, _image_pending("$image:localhost", 1_000_000))
+    await _wait_for(lambda: gate._gates[room_key].deadline is not None)
+    await _admit_ready(
+        gate,
+        thread_key,
+        _pending(_text_event("$caption:localhost", "describe this", 1_000_100)),
+    )
+
+    try:
+        await _wait_for(lambda: room_key not in gate._gates, deadline_seconds=0.1)
+    finally:
+        await gate.drain_all()
 
 
 @pytest.mark.asyncio

--- a/tests/test_coalescing.py
+++ b/tests/test_coalescing.py
@@ -629,8 +629,9 @@ async def test_thread_caption_promotes_only_the_pending_room_media_burst() -> No
 
 
 @pytest.mark.asyncio
-async def test_thread_reply_does_not_promote_a_completed_room_media_turn() -> None:
-    """A room turn already closed by text must keep its original conversation scope."""
+@pytest.mark.parametrize("completion_kind", ["text", "voice"])
+async def test_thread_reply_does_not_promote_a_completed_room_media_turn(completion_kind: str) -> None:
+    """A room turn closed by text-like content must keep its conversation scope."""
     batches: list[PreparedTurn] = []
 
     async def dispatch_batch(batch: PreparedTurn) -> None:
@@ -646,11 +647,12 @@ async def test_thread_reply_does_not_promote_a_completed_room_media_turn() -> No
     thread_key = CoalescingKey("!room:localhost", "$image:localhost", owner)
 
     await _admit_ready(gate, room_key, _image_pending("$image:localhost", 1_000_000))
-    await _admit_ready(
-        gate,
-        room_key,
-        _pending(_text_event("$room-text:localhost", "room caption", 1_000_100)),
+    completion_event = (
+        _pending(_text_event("$room-text:localhost", "room caption", 1_000_100))
+        if completion_kind == "text"
+        else _voice_pending("$voice:localhost", "voice caption", 1_000_100)
     )
+    await _admit_ready(gate, room_key, completion_event)
     await _admit_ready(
         gate,
         thread_key,
@@ -661,7 +663,7 @@ async def test_thread_reply_does_not_promote_a_completed_room_media_turn() -> No
 
     assert len(batches) == 2
     assert {batch.ingress.coalescing_key.thread_id: list(batch.handled_turn.source_event_ids) for batch in batches} == {
-        None: ["$image:localhost", "$room-text:localhost"],
+        None: ["$image:localhost", completion_event.event.event_id],
         "$image:localhost": ["$thread-reply:localhost"],
     }
 

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -841,6 +841,48 @@ async def test_room_root_image_and_caption_coalesce_into_single_dispatch(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_room_root_image_and_thread_caption_coalesce_into_single_thread_dispatch(tmp_path: Path) -> None:
+    """A caption that starts a thread on its upload must remain part of that upload turn."""
+    bot = _make_bot(tmp_path, debounce_ms=60_000)
+    room = _make_room()
+    image_event = _image_event(event_id="$img", server_timestamp=1000)
+    caption = _text_event(
+        event_id="$caption",
+        body="describe this",
+        server_timestamp=1001,
+        thread_id=image_event.event_id,
+    )
+    calls: list[tuple[list[str], str | None]] = []
+
+    async def record_dispatch(
+        _room: nio.MatrixRoom,
+        _dispatched_event: nio.RoomMessageText,
+        _requester_user_id: str,
+        *,
+        handled_turn: TurnRecord | None = None,
+        ingress_metadata: DispatchIngressMetadata | None = None,
+        **_metadata: object,
+    ) -> None:
+        coalescing_key = ingress_metadata.coalescing_key if ingress_metadata is not None else None
+        calls.append(
+            (
+                _handled_turn_source_event_ids(handled_turn),
+                coalescing_key.thread_id if coalescing_key is not None else None,
+            ),
+        )
+
+    with patch(
+        "mindroom.turn_controller.dispatch_text_message",
+        new=AsyncMock(side_effect=prepared_turn_recorder(record_dispatch)),
+    ):
+        await bot._turn_controller.handle_media_event(room, image_event)
+        await bot._turn_controller.handle_text_event(room, caption)
+        await bot._coalescing_gate.drain_all()
+
+    assert calls == [(["$img", "$caption"], "$img")]
+
+
+@pytest.mark.asyncio
 async def test_images_then_caption_coalesce_into_single_dispatch(tmp_path: Path) -> None:
     """Uploads arrive first and the trailing caption closes the batch into one dispatch."""
     bot = _make_bot(tmp_path, debounce_ms=60_000)

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -1679,7 +1679,7 @@ class TestAgentBot(AgentBotTestBase):
         runtime_paths = runtime_paths_for(config)
         ids = entity_ids(config, runtime_paths)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
-        bot.client = _make_matrix_client_mock()
+        replace_turn_controller_deps(bot, runtime=replace(bot._runtime_view, client=_make_matrix_client_mock()))
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
         event = self._router_relay_event(body="@general could you help with this?")
@@ -1732,7 +1732,7 @@ class TestAgentBot(AgentBotTestBase):
         runtime_paths = runtime_paths_for(config)
         ids = entity_ids(config, runtime_paths)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
-        bot.client = _make_matrix_client_mock()
+        replace_turn_controller_deps(bot, runtime=replace(bot._runtime_view, client=_make_matrix_client_mock()))
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
         body = "@calculator could you help with this?" if explicit_self_target else "could you help with this?"

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -1719,6 +1719,61 @@ class TestAgentBot(AgentBotTestBase):
         assert all(item.kind != "queued_notice_reservation" for item in ready_result.pending_event.dispatch_metadata)
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("explicit_self_target", [True, False])
+    async def test_router_handoff_for_this_agent_or_without_a_target_signals_active_response(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+        *,
+        explicit_self_target: bool,
+    ) -> None:
+        """Only a handoff explicitly addressed elsewhere suppresses the queued notice."""
+        config = self._config_for_storage(tmp_path)
+        runtime_paths = runtime_paths_for(config)
+        ids = entity_ids(config, runtime_paths)
+        bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        bot.client = _make_matrix_client_mock()
+        room = MagicMock(spec=nio.MatrixRoom)
+        room.room_id = "!room:localhost"
+        body = "@calculator could you help with this?" if explicit_self_target else "could you help with this?"
+        event = self._router_relay_event(body=body)
+        if explicit_self_target:
+            event.source["content"]["m.mentions"] = {"user_ids": [ids["calculator"].full_id]}
+        prepared_event = PreparedIngress(
+            sender=event.sender,
+            event_id=event.event_id,
+            body=event.body,
+            source=event.source,
+            server_timestamp=event.server_timestamp,
+        )
+
+        with (
+            patch.object(bot._response_runner, "has_active_response_for_target", return_value=True),
+            patch.object(
+                bot._response_runner,
+                "reserve_waiting_human_message",
+                return_value=MagicMock(),
+            ) as reserve_waiting_human_message,
+            patch.object(bot._coalescing_gate, "admit", new=AsyncMock()) as admit,
+        ):
+            reservation_owner = bot._turn_controller.reserve_prompt_ingress_order(room, "@user:localhost")
+            outcome = await bot._turn_controller._dispatch_prepared_text_like_ingress(
+                room=room,
+                prepared_event=prepared_event,
+                requester_user_id="@user:localhost",
+                reservation_owner=reservation_owner,
+                coalescing_thread_id="$thread_root:localhost",
+            )
+            await asyncio.wait_for(reservation_owner.slot.settled.wait(), timeout=1.0)
+
+        assert outcome is _IngressAdmissionOutcome.DEFERRED
+        reserve_waiting_human_message.assert_called_once()
+        admit.assert_awaited_once()
+        ready_result = admit.await_args.kwargs["ready_result"]
+        assert isinstance(ready_result, ReadyPendingEvent)
+        assert any(item.kind == "queued_notice_reservation" for item in ready_result.pending_event.dispatch_metadata)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("source_kind", ["hook", "hook_dispatch"])
     async def test_handle_message_inner_enqueues_trusted_hook_source_kind_as_gate_bypass(
         self,

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -1669,12 +1669,15 @@ class TestAgentBot(AgentBotTestBase):
         assert metadata.payload is mock_reserve_waiting_human_message.return_value
 
     @pytest.mark.asyncio
-    async def test_router_handoff_for_another_agent_does_not_signal_active_response(
+    @pytest.mark.parametrize("mention_kind", ["other_agent", "non_agent"])
+    async def test_router_handoff_for_another_target_does_not_signal_active_response(
         self,
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
+        *,
+        mention_kind: str,
     ) -> None:
-        """A router handoff for another agent must not interrupt this agent's active turn."""
+        """A router handoff addressed elsewhere must not interrupt this agent's active turn."""
         config = self._config_for_storage(tmp_path)
         runtime_paths = runtime_paths_for(config)
         ids = entity_ids(config, runtime_paths)
@@ -1682,8 +1685,14 @@ class TestAgentBot(AgentBotTestBase):
         replace_turn_controller_deps(bot, runtime=replace(bot._runtime_view, client=_make_matrix_client_mock()))
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
-        event = self._router_relay_event(body="@general could you help with this?")
-        event.source["content"]["m.mentions"] = {"user_ids": [ids["general"].full_id]}
+        if mention_kind == "other_agent":
+            body = "@general could you help with this?"
+            mentioned_user_id = ids["general"].full_id
+        else:
+            body = "@person:localhost could you help with this?"
+            mentioned_user_id = "@person:localhost"
+        event = self._router_relay_event(body=body)
+        event.source["content"]["m.mentions"] = {"user_ids": [mentioned_user_id]}
         prepared_event = PreparedIngress(
             sender=event.sender,
             event_id=event.event_id,

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -1669,6 +1669,56 @@ class TestAgentBot(AgentBotTestBase):
         assert metadata.payload is mock_reserve_waiting_human_message.return_value
 
     @pytest.mark.asyncio
+    async def test_router_handoff_for_another_agent_does_not_signal_active_response(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """A router handoff for another agent must not interrupt this agent's active turn."""
+        config = self._config_for_storage(tmp_path)
+        runtime_paths = runtime_paths_for(config)
+        ids = entity_ids(config, runtime_paths)
+        bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
+        bot.client = _make_matrix_client_mock()
+        room = MagicMock(spec=nio.MatrixRoom)
+        room.room_id = "!room:localhost"
+        event = self._router_relay_event(body="@general could you help with this?")
+        event.source["content"]["m.mentions"] = {"user_ids": [ids["general"].full_id]}
+        prepared_event = PreparedIngress(
+            sender=event.sender,
+            event_id=event.event_id,
+            body=event.body,
+            source=event.source,
+            server_timestamp=event.server_timestamp,
+        )
+
+        with (
+            patch.object(bot._response_runner, "has_active_response_for_target", return_value=True),
+            patch.object(
+                bot._response_runner,
+                "reserve_waiting_human_message",
+                return_value=MagicMock(),
+            ) as reserve_waiting_human_message,
+            patch.object(bot._coalescing_gate, "admit", new=AsyncMock()) as admit,
+        ):
+            reservation_owner = bot._turn_controller.reserve_prompt_ingress_order(room, "@user:localhost")
+            outcome = await bot._turn_controller._dispatch_prepared_text_like_ingress(
+                room=room,
+                prepared_event=prepared_event,
+                requester_user_id="@user:localhost",
+                reservation_owner=reservation_owner,
+                coalescing_thread_id="$thread_root:localhost",
+            )
+            await asyncio.wait_for(reservation_owner.slot.settled.wait(), timeout=1.0)
+
+        assert outcome is _IngressAdmissionOutcome.DEFERRED
+        reserve_waiting_human_message.assert_not_called()
+        admit.assert_awaited_once()
+        ready_result = admit.await_args.kwargs["ready_result"]
+        assert isinstance(ready_result, ReadyPendingEvent)
+        assert all(item.kind != "queued_notice_reservation" for item in ready_result.pending_event.dispatch_metadata)
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("source_kind", ["hook", "hook_dispatch"])
     async def test_handle_message_inner_enqueues_trusted_hook_source_kind_as_gate_bypass(
         self,


### PR DESCRIPTION
## Summary
- keep a room-level media upload and its first threaded caption in one routed turn
- preserve later or already-completed room turns as independent conversations
- prevent handoffs explicitly addressed to another agent from interrupting an unrelated active response

## Why
Some Matrix clients send an attachment as a room-level event and the accompanying caption as the first reply in a new thread. Treating those events as separate turns can produce multiple routing decisions and competing responses.

## Tests
- regression coverage for room-root media followed by a thread-starting caption
- isolation coverage for later room traffic and text-complete media turns
- queued-notice coverage for cross-target, self-targeted, and unaddressed handoffs
- full pytest suite
- all pre-commit hooks

## Summary by Sourcery

Keep media-root captions coalesced with their upload and make queued handoff notices respect the addressed target.

Bug Fixes:
- Keep a room-level media upload and its first threaded caption in a single routed turn while preserving later room traffic and completed media turns as separate conversations.
- Prevent router handoffs explicitly addressed to another agent or non-agent recipient from generating queued notices that interrupt an unrelated active response.

Enhancements:
- Improve coalescing gate promotion and lifecycle handling for media events that become thread roots.

Tests:
- Add regression coverage for room-root media and thread captions, turn isolation, gate cleanup, and targeted handoff notification behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media handling so room-level media followed by a matching thread caption is combined into one response.
  * Prevented unrelated messages or completed media exchanges from being incorrectly merged into a thread.
  * Improved response timing by promptly releasing media processing when no items remain.
  * Adjusted queued notices during agent handoffs so notices are not shown when the handoff targets another agent or includes unsupported mentions.
* **Tests**
  * Added coverage for media coalescing, thread behavior, and handoff notice handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->