### PR TITLE
Preserve paused team runs across approval handoff

### DIFF
--- a/src/mindroom/teams.py
+++ b/src/mindroom/teams.py
@@ -3382,6 +3382,7 @@ async def team_response_stream(  # noqa: C901, PLR0915
         completed_tool_executions: list[ToolExecution] = []
         emitted_output = False
         completed_run_event: TeamRunCompletedEvent | None = None
+        paused_resolution: PausedAttempt | None = None
         usage = _TeamStreamUsage()
 
         ai_runtime.note_attempt_run_id(run_id_callback, attempt_run_id)
@@ -3418,6 +3419,10 @@ async def team_response_stream(  # noqa: C901, PLR0915
         )
         bound_team_id = run.scope_context.scope.scope_id if run.scope_context is not None else team.id or ""
         async for event in raw_stream:
+            # Agno treats a stream closed at its pause event as cancellation and
+            # can overwrite the paused run. Drain its short post-pause tail first.
+            if paused_resolution is not None:
+                continue
             if isinstance(event, (TeamRunOutput, RunOutput)):
                 if isinstance(event, TeamRunOutput) and not _is_bound_team_output(event, team_id=bound_team_id):
                     logger.debug("Ignoring non-bound team run output", run_id=event.run_id)
@@ -3589,14 +3594,12 @@ async def team_response_stream(  # noqa: C901, PLR0915
                             tool_trace=list(paused_attempt.tool_trace),
                             presentation_state=paused_attempt.response_presentation_state,
                         )
-                    yield AttemptResolved(
-                        replace(
-                            paused_attempt,
-                            runtime_model_name=prepared_execution.runtime_model_name,
-                            team_member_model_names=tuple(sorted(holder.member_model_names.items())),
-                        ),
+                    paused_resolution = replace(
+                        paused_attempt,
+                        runtime_model_name=prepared_execution.runtime_model_name,
+                        team_member_model_names=tuple(sorted(holder.member_model_names.items())),
                     )
-                    return
+                    continue
                 yield AttemptResolved(
                     ExcludedAttempt(
                         original_status=RunStatus.paused,
@@ -3686,6 +3689,9 @@ async def team_response_stream(  # noqa: C901, PLR0915
                     presentation_state=presentation.to_state(),
                 )
 
+        if paused_resolution is not None:
+            yield AttemptResolved(paused_resolution)
+            return
         if emitted_output and ctx.reply_to_event_id:
             _persist_bound_seen_event_ids(
                 scope_context=run.scope_context,

--- a/tests/test_team_response.py
+++ b/tests/test_team_response.py
@@ -2764,8 +2764,13 @@ async def test_team_response_stream_raises_cancelled_error_for_team_run_cancelle
 
 
 @pytest.mark.asyncio
-async def test_team_response_stream_suspends_for_confirmation_pause_event() -> None:
-    """A streamed team confirmation pause must escape to the lifecycle suspension handler."""
+async def test_team_response_stream_drains_confirmation_pause_before_handoff() -> None:
+    """The provider must finish its persisted pause before control leaves the stream.
+
+    Agno persists the paused run before yielding ``TeamRunPausedEvent``. Closing
+    its stream at that yield is nevertheless treated as cancellation, which can
+    overwrite the paused run before a later approval resumes it.
+    """
     config = _build_test_config()
     runtime_paths = runtime_paths_for(config)
     orchestrator = MagicMock()
@@ -2787,8 +2792,10 @@ async def test_team_response_stream_suspends_for_confirmation_pause_event() -> N
         tool_args={"value": 1},
         requires_confirmation=True,
     )
+    provider_pause_finished = False
 
     async def fake_stream_raw(*_args: object, **_kwargs: object) -> AsyncIterator[object]:
+        nonlocal provider_pause_finished
         yield TeamRunContentEvent(content="Before approval.")
         yield TeamRunPausedEvent(
             run_id="run-paused",
@@ -2797,6 +2804,7 @@ async def test_team_response_stream_suspends_for_confirmation_pause_event() -> N
             tools=[tool],
             requirements=[RunRequirement(tool)],
         )
+        provider_pause_finished = True
 
     team_agent_ids = [
         fixture_entity_matrix_id(
@@ -2833,6 +2841,7 @@ async def test_team_response_stream_suspends_for_confirmation_pause_event() -> N
     assert "🔧 `dangerous` [1] ⏳" in raised.value.paused.response_text
     assert raised.value.paused.tool_trace[0].tool_call_id == "call-team-stream-approval"
     assert raised.value.paused.response_presentation_state["kind"] == "team_stream"
+    assert provider_pause_finished
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Summary:
- finish consuming a team provider's pause stream before transferring ownership to approval continuation
- preserve the paused run instead of letting premature stream closure convert it to cancellation
- extend the regression test to prove the provider pause lifecycle completes before handoff

Tests:
- uv run pre-commit run --all-files
- uv run pytest

## Summary by Sourcery

Preserve paused team runs across approval handoff instead of allowing premature stream closure to cancel them.

Bug Fixes:
- Preserve paused team runs during approval handoff by draining the provider stream before transferring control.

Tests:
- Extend the team response regression test to verify the provider completes its pause lifecycle before handoff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of paused team responses so streams finish cleanly before control is handed off.
  * Prevented paused runs from being incorrectly treated as cancelled.

* **Tests**
  * Added coverage confirming that streaming responses fully drain after a confirmation pause.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->