### PR TITLE
Settle ignored managed events before thread hydration

### DIFF
--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -228,6 +228,14 @@ class DispatchContextResult:
 
 
 @dataclass(frozen=True)
+class _PreHydrationPolicyFacts:
+    """Policy facts available without resolving thread history."""
+
+    origin: TurnOrigin
+    am_i_mentioned: bool
+
+
+@dataclass(frozen=True)
 class ConversationResolverDeps:
     """Explicit collaborators for conversation resolution."""
 
@@ -255,6 +263,20 @@ class ConversationResolver:
 
     def _matrix_id(self) -> MatrixID:
         return self.deps.matrix_id
+
+    def _mention_facts(
+        self,
+        event_source: dict[str, Any],
+    ) -> tuple[list[MatrixID], bool, bool]:
+        """Return mention facts from one already-normalized event source."""
+        if _should_skip_mentions(event_source):
+            return [], False, False
+        return check_agent_mentioned(
+            event_source,
+            self._matrix_id(),
+            self.deps.runtime.config,
+            self.deps.runtime_paths,
+        )
 
     def _envelope_ingress_metadata(  # noqa: C901
         self,
@@ -324,6 +346,34 @@ class ConversationResolver:
             source_kind=source_kind,
             original_sender=original_sender,
             trusted_user_relay=trusted_human_relay,
+        )
+
+    def pre_hydration_policy_facts(
+        self,
+        *,
+        event: DispatchEvent,
+        requester_user_id: str,
+        payload_metadata: DispatchPayloadMetadata | None = None,
+        source_kind: str | None = None,
+        original_sender: str | None = None,
+        trusted_user_relay: bool = False,
+    ) -> _PreHydrationPolicyFacts:
+        """Classify mention and origin policy without reading conversation history."""
+        event_source = _source_with_payload_metadata(event.source, payload_metadata)
+        _mentioned_agents, am_i_mentioned, _has_non_agent_mentions = self._mention_facts(event_source)
+        resolved_source_kind, _hook_source, _message_received_depth = self._envelope_ingress_metadata(
+            event=event,
+            source_kind=source_kind,
+        )
+        return _PreHydrationPolicyFacts(
+            origin=self._turn_origin_for_event(
+                event=event,
+                requester_user_id=requester_user_id,
+                source_kind=resolved_source_kind,
+                original_sender=original_sender,
+                trusted_user_relay=trusted_user_relay,
+            ),
+            am_i_mentioned=am_i_mentioned,
         )
 
     def _sender_is_managed_entity(self, user_id: str) -> bool:
@@ -835,17 +885,7 @@ class ConversationResolver:
         resolved_event_source = _source_with_payload_metadata(resolved_event_source, payload_metadata)
         config = self.deps.runtime.config
 
-        if _should_skip_mentions(resolved_event_source):
-            mentioned_agents: list[MatrixID] = []
-            am_i_mentioned = False
-            has_non_agent_mentions = False
-        else:
-            mentioned_agents, am_i_mentioned, has_non_agent_mentions = check_agent_mentioned(
-                resolved_event_source,
-                self._matrix_id(),
-                config,
-                self.deps.runtime_paths,
-            )
+        mentioned_agents, am_i_mentioned, has_non_agent_mentions = self._mention_facts(resolved_event_source)
 
         if am_i_mentioned:
             self.deps.logger.info("Mentioned", event_id=event.event_id, room_id=room.room_id)
@@ -909,17 +949,7 @@ class ConversationResolver:
         resolved_event_source = _source_with_payload_metadata(resolved_event_source, payload_metadata)
         config = self.deps.runtime.config
 
-        if _should_skip_mentions(resolved_event_source):
-            mentioned_agents: list[MatrixID] = []
-            am_i_mentioned = False
-            has_non_agent_mentions = False
-        else:
-            mentioned_agents, am_i_mentioned, has_non_agent_mentions = check_agent_mentioned(
-                resolved_event_source,
-                self._matrix_id(),
-                config,
-                self.deps.runtime_paths,
-            )
+        mentioned_agents, am_i_mentioned, has_non_agent_mentions = self._mention_facts(resolved_event_source)
 
         if am_i_mentioned:
             self.deps.logger.info("Mentioned", event_id=event.event_id, room_id=room.room_id)

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -1006,6 +1006,38 @@ class TurnController:
         )
         return _IngressAdmissionOutcome.DEFERRED
 
+    async def _settle_unmentioned_managed_sender_before_hydration(
+        self,
+        *,
+        event: PreparedIngress,
+        requester_user_id: str,
+        event_label: str,
+        handled_turn: TurnRecord,
+        ingress_metadata: DispatchIngressMetadata | None,
+        payload_metadata: DispatchPayloadMetadata | None,
+        original_sender: str | None,
+        trusted_user_relay: bool,
+    ) -> bool:
+        """Settle managed chatter before thread hydration can make it retryable."""
+        policy = self.deps.resolver.pre_hydration_policy_facts(
+            event=event,
+            requester_user_id=requester_user_id,
+            payload_metadata=payload_metadata,
+            source_kind=ingress_metadata.source_kind if ingress_metadata is not None else None,
+            original_sender=original_sender,
+            trusted_user_relay=trusted_user_relay,
+        )
+        if not policy.origin.blocks_unmentioned_managed_sender or policy.am_i_mentioned:
+            return False
+        self.deps.logger.debug(
+            "ignore_unmentioned_agent_event",
+            agent=policy.origin.requester_entity_name,
+            event_label=event_label,
+            user_id=requester_user_id,
+        )
+        await self.deps.visible_responses.settle_source_events_ignored(handled_turn)
+        return True
+
     async def _prepare_dispatch(
         self,
         room: nio.MatrixRoom,
@@ -1021,13 +1053,37 @@ class TurnController:
     ) -> _DispatchPreparation | None:
         """Build the shared dispatch context for one prepared inbound turn."""
         extract_context_start = time.monotonic()
-        use_trusted_router_relay_context = False
         coalescing_key = ingress_metadata.coalescing_key if ingress_metadata is not None else None
         context_event = (
             _room_level_context_event(event)
             if coalescing_key is not None and coalescing_key.thread_id is None
             else event
         )
+        use_trusted_router_relay_context = (
+            not use_command_context
+            and self.deps.ingress.should_use_trusted_router_relay_context(
+                event,
+                ingress_metadata=ingress_metadata,
+                payload_metadata=payload_metadata,
+            )
+        )
+        original_sender = payload_metadata.original_sender if payload_metadata is not None else None
+        if original_sender is None and use_trusted_router_relay_context:
+            original_sender = payload_metadata_from_source(
+                event.source,
+                trust_internal_metadata=True,
+            ).original_sender
+        if await self._settle_unmentioned_managed_sender_before_hydration(
+            event=event,
+            requester_user_id=requester_user_id,
+            event_label=event_label,
+            handled_turn=handled_turn,
+            ingress_metadata=ingress_metadata,
+            payload_metadata=payload_metadata,
+            original_sender=original_sender,
+            trusted_user_relay=use_trusted_router_relay_context,
+        ):
+            return None
         if use_command_context:
             dispatch_context_result = await self.deps.resolver.extract_dispatch_context(
                 room,
@@ -1040,11 +1096,7 @@ class TurnController:
                 extract_context_start,
                 path="command",
             )
-        elif use_trusted_router_relay_context := self.deps.ingress.should_use_trusted_router_relay_context(
-            event,
-            ingress_metadata=ingress_metadata,
-            payload_metadata=payload_metadata,
-        ):
+        elif use_trusted_router_relay_context:
             dispatch_context_result = await self.deps.resolver.extract_trusted_router_relay_context(
                 room,
                 context_event,
@@ -1104,12 +1156,6 @@ class TurnController:
         )
         correlation_id = event.event_id
         envelope_start = time.monotonic()
-        original_sender = payload_metadata.original_sender if payload_metadata is not None else None
-        if original_sender is None and use_trusted_router_relay_context:
-            original_sender = payload_metadata_from_source(
-                event.source,
-                trust_internal_metadata=True,
-            ).original_sender
         envelope = self.deps.resolver.build_message_envelope(
             event=event,
             requester_user_id=requester_user_id,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -153,6 +153,18 @@ _PENDING_TURN_CLAIM_METADATA_KIND = "pending_turn_claim"
 _INTERACTIVE_SELECTION_METADATA_KIND = "interactive_selection"
 
 
+def _turn_sources_can_be_settled_for_requester(
+    handled_turn: TurnRecord,
+    requester_user_id: str,
+) -> bool:
+    """Return whether whole-turn settlement is safe for one requester-owned decision."""
+    replayable_sources = handled_turn.replay_source_event_ids
+    return len(replayable_sources) <= 1 or all(
+        handled_turn.requester_id_for_source(source_event_id) == requester_user_id
+        for source_event_id in replayable_sources
+    )
+
+
 @dataclass(frozen=True)
 class _InteractiveSelectionDispatch:
     """Deferred selection work carried through receipt-ordered coalescing."""
@@ -1027,7 +1039,11 @@ class TurnController:
             original_sender=original_sender,
             trusted_user_relay=trusted_user_relay,
         )
-        if not policy.origin.blocks_unmentioned_managed_sender or policy.am_i_mentioned:
+        if (
+            not policy.origin.blocks_unmentioned_managed_sender
+            or policy.am_i_mentioned
+            or not _turn_sources_can_be_settled_for_requester(handled_turn, requester_user_id)
+        ):
             return False
         self.deps.logger.debug(
             "ignore_unmentioned_agent_event",
@@ -1204,7 +1220,11 @@ class TurnController:
         origin = envelope.origin
         sender_agent_name = origin.requester_entity_name
         blocks_unmentioned_managed_sender = origin.blocks_unmentioned_managed_sender
-        if blocks_unmentioned_managed_sender and not context.am_i_mentioned:
+        if (
+            blocks_unmentioned_managed_sender
+            and not context.am_i_mentioned
+            and _turn_sources_can_be_settled_for_requester(handled_turn, requester_user_id)
+        ):
             self.deps.logger.debug(
                 "ignore_unmentioned_agent_event",
                 agent=sender_agent_name,

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -619,6 +619,7 @@ async def test_prepare_dispatch_skips_hook_reemission_but_keeps_hook_dispatch(tm
             "content": {
                 "msgtype": "m.text",
                 "body": "automation",
+                "m.mentions": {"user_ids": ["@mindroom_code:localhost"]},
                 SOURCE_KIND_KEY: "hook",
                 "com.mindroom.hook_source": "hook-plugin:message:received",
                 HOOK_MESSAGE_RECEIVED_DEPTH_KEY: 1,

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -1454,6 +1454,56 @@ async def test_router_silent_ignore_compacts_exact_callback(config: Config, tmp_
 
 
 @pytest.mark.asyncio
+async def test_unmentioned_managed_attachment_settles_before_unavailable_thread_history(
+    config: Config,
+    tmp_path: Path,
+) -> None:
+    """Non-actionable managed chatter must not become a poison retry during hydration."""
+    harness = _build_harness(config, tmp_path, agent_name=ROUTER_AGENT_NAME)
+    room = _room_with_members(config, ROUTER_AGENT_NAME, "general")
+    event = cast(
+        "nio.RoomMessageFile",
+        nio.RoomMessageFile.from_dict(
+            {
+                "event_id": "$managed-attachment:localhost",
+                "sender": _entity_user_id(config, "general"),
+                "origin_server_ts": 1_000,
+                "room_id": room.room_id,
+                "type": "m.room.message",
+                "content": {
+                    "msgtype": "m.file",
+                    "body": "response.md",
+                    "filename": "response.md",
+                    "url": "mxc://localhost/managed-attachment",
+                    "info": {"mimetype": "text/markdown"},
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": "$unavailable-root:localhost",
+                        "is_falling_back": True,
+                        "m.in_reply_to": {"event_id": "$unavailable-root:localhost"},
+                    },
+                },
+            },
+        ),
+    )
+    reader = harness.controller.deps.resolver.deps.conversation_reader
+    history_error = RuntimeError("RoomEventRelationsError: M_NOT_FOUND: Event not found in room")
+    reader.read.side_effect = history_error
+    reader.read_strict.side_effect = history_error
+
+    outcome = await harness.controller.handle_media_event(room, event)
+    await harness.gate.drain_all()
+
+    assert outcome is TurnDispatchOutcome.DEFERRED
+    assert harness.ignored_dispatch_sources == [(event.event_id,)]
+    assert harness.retried_dispatch_sources == []
+    reader.read.assert_not_awaited()
+    reader.read_strict.assert_not_awaited()
+    assert harness.policy.plan_turn_calls == 0
+    assert harness.runner.requests == []
+
+
+@pytest.mark.asyncio
 async def test_sender_outside_reply_allowlist_is_dropped_at_precheck(tmp_path: Path) -> None:
     """An unauthorized sender is filtered at precheck and the turn gets a terminal record."""
     config = bind_runtime_paths(

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -28,11 +28,13 @@ from mindroom import constants, interactive
 from mindroom.agent_reply_membership import AgentReplyMembershipIndex
 from mindroom.attachments import register_local_attachment
 from mindroom.bot_runtime_view import BotRuntimeState
-from mindroom.coalescing import CoalescingGate, IngressAdmissionClosedError
+from mindroom.coalescing import CoalescingGate, IngressAdmissionClosedError, ReadyPendingEvent
 from mindroom.coalescing_batch import (
     CoalescingKey,
+    PendingEvent,
     PreparedTurn,
     RequesterCoalescingOwner,
+    active_follow_up_coalescing_key,
     build_prepared_turn,
 )
 from mindroom.command_turn_executor import CommandTurnExecutor, CommandTurnExecutorDeps
@@ -46,7 +48,10 @@ from mindroom.conversation_state_writer import ConversationStateWriter, Conversa
 from mindroom.dispatch_callback_outcome import TurnDispatchOutcome
 from mindroom.dispatch_recovery_context import turn_dispatch_recovery_scope
 from mindroom.dispatch_source import (
+    ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
     EXTERNAL_TRIGGER_SOURCE_KIND,
+    MEDIA_SOURCE_KIND,
+    MESSAGE_SOURCE_KIND,
     SCHEDULED_SOURCE_KIND,
     SILENT_SCHEDULE_SOURCE_KIND,
     TRUSTED_INTERNAL_RELAY_SOURCE_KIND,
@@ -678,6 +683,40 @@ def _image_event(*, event_id: str) -> nio.RoomMessageImage:
                 "origin_server_ts": 1_000_000,
                 "room_id": _ROOM_ID,
                 "type": "m.room.message",
+            },
+        ),
+    )
+
+
+def _managed_file_event(
+    config: Config,
+    *,
+    event_id: str,
+    thread_id: str,
+) -> nio.RoomMessageFile:
+    """Return an unmentioned threaded file event authored by a managed agent."""
+    return cast(
+        "nio.RoomMessageFile",
+        nio.RoomMessageFile.from_dict(
+            {
+                "event_id": event_id,
+                "sender": _entity_user_id(config, "general"),
+                "origin_server_ts": 1_000,
+                "room_id": _ROOM_ID,
+                "type": "m.room.message",
+                "content": {
+                    "msgtype": "m.file",
+                    "body": "response.md",
+                    "filename": "response.md",
+                    "url": "mxc://localhost/managed-attachment",
+                    "info": {"mimetype": "text/markdown"},
+                    "m.relates_to": {
+                        "rel_type": "m.thread",
+                        "event_id": thread_id,
+                        "is_falling_back": True,
+                        "m.in_reply_to": {"event_id": thread_id},
+                    },
+                },
             },
         ),
     )
@@ -1461,30 +1500,10 @@ async def test_unmentioned_managed_attachment_settles_before_unavailable_thread_
     """Non-actionable managed chatter must not become a poison retry during hydration."""
     harness = _build_harness(config, tmp_path, agent_name=ROUTER_AGENT_NAME)
     room = _room_with_members(config, ROUTER_AGENT_NAME, "general")
-    event = cast(
-        "nio.RoomMessageFile",
-        nio.RoomMessageFile.from_dict(
-            {
-                "event_id": "$managed-attachment:localhost",
-                "sender": _entity_user_id(config, "general"),
-                "origin_server_ts": 1_000,
-                "room_id": room.room_id,
-                "type": "m.room.message",
-                "content": {
-                    "msgtype": "m.file",
-                    "body": "response.md",
-                    "filename": "response.md",
-                    "url": "mxc://localhost/managed-attachment",
-                    "info": {"mimetype": "text/markdown"},
-                    "m.relates_to": {
-                        "rel_type": "m.thread",
-                        "event_id": "$unavailable-root:localhost",
-                        "is_falling_back": True,
-                        "m.in_reply_to": {"event_id": "$unavailable-root:localhost"},
-                    },
-                },
-            },
-        ),
+    event = _managed_file_event(
+        config,
+        event_id="$managed-attachment:localhost",
+        thread_id="$unavailable-root:localhost",
     )
     reader = harness.controller.deps.resolver.deps.conversation_reader
     history_error = RuntimeError("RoomEventRelationsError: M_NOT_FOUND: Event not found in room")
@@ -1499,6 +1518,75 @@ async def test_unmentioned_managed_attachment_settles_before_unavailable_thread_
     assert harness.retried_dispatch_sources == []
     reader.read.assert_not_awaited()
     reader.read_strict.assert_not_awaited()
+    assert harness.policy.plan_turn_calls == 0
+    assert harness.runner.requests == []
+
+
+@pytest.mark.asyncio
+async def test_managed_primary_cannot_settle_human_source_in_mixed_follow_up_batch(
+    config: Config,
+    tmp_path: Path,
+) -> None:
+    """Whole-batch suppression requires every replayable source to share one requester."""
+    harness = _build_harness(config, tmp_path, agent_name=ROUTER_AGENT_NAME)
+    room = _room_with_members(config, ROUTER_AGENT_NAME, "general")
+    human_event = _text_event(
+        "please inspect the attachment",
+        event_id="$human-follow-up:localhost",
+        thread_id="$unavailable-root:localhost",
+        origin_server_ts=999,
+    )
+    managed_event = _managed_file_event(
+        config,
+        event_id="$managed-follow-up:localhost",
+        thread_id="$unavailable-root:localhost",
+    )
+    pending_events = (
+        make_pending_event(
+            human_event,
+            room,
+            source_kind=MESSAGE_SOURCE_KIND,
+            requester_user_id=_SENDER,
+            dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+        ),
+        make_pending_event(
+            managed_event,
+            room,
+            source_kind=MEDIA_SOURCE_KIND,
+            requester_user_id=_entity_user_id(config, "general"),
+            dispatch_policy_source_kind=ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND,
+        ),
+    )
+    reader = harness.controller.deps.resolver.deps.conversation_reader
+    history_error = RuntimeError("RoomEventRelationsError: M_NOT_FOUND: Event not found in room")
+    reader.read.side_effect = history_error
+    reader.read_strict.side_effect = history_error
+    key = active_follow_up_coalescing_key(room.room_id, "$unavailable-root:localhost")
+    retried_batches: list[tuple[str, ...]] = []
+
+    def record_failed_batch(failed_events: tuple[PendingEvent, ...]) -> None:
+        retried_batches.append(tuple(pending.event.event_id for pending in failed_events))
+
+    gate = CoalescingGate(
+        dispatch_turn=harness.controller.handle_prepared_turn,
+        debounce_seconds=lambda: 0.0,
+        is_shutting_down=lambda: False,
+        on_dispatch_failure=record_failed_batch,
+    )
+
+    for pending_event in pending_events:
+        await gate.admit(
+            key,
+            ready_result=ReadyPendingEvent(pending_event=pending_event),
+            source_event_id=pending_event.event.event_id,
+            source_kind=pending_event.event.source_kind or MESSAGE_SOURCE_KIND,
+        )
+    await gate.drain_all()
+
+    source_event_ids = tuple(event.event_id for event in (human_event, managed_event))
+    assert harness.ignored_dispatch_sources == []
+    assert retried_batches == [source_event_ids]
+    assert reader.read.await_count + reader.read_strict.await_count > 0
     assert harness.policy.plan_turn_calls == 0
     assert harness.runner.requests == []
 


### PR DESCRIPTION
## Summary

- Apply the existing managed-sender mention gate before conversation history hydration.
- Settle non-actionable managed events without scheduling a journal retry when related history is unavailable.
- Require every replayable source in a coalesced turn to belong to the classified requester before whole-turn settlement.
- Preserve dispatch for mentioned and explicitly exempt synthetic events, with the existing post-hydration guard retained as defense in depth.

## Regression coverage

One controller regression queues an unmentioned file event from a managed sender whose thread history returns M_NOT_FOUND. It verifies that the source is settled, never handed back for retry, and never reaches history reads, policy, or response execution.

A second regression builds an active-follow-up batch containing a human source followed by an unmentioned managed attachment. It verifies that unavailable history returns the entire mixed-requester batch for retry instead of settling the human source.

## Verification

- uv run pytest --no-cov (15,359 passed, 23 skipped)
- uv run pre-commit run --all-files
- uv run tach check --dependencies --interfaces

## Summary by Sourcery

Settle non-actionable managed events before thread hydration while preserving valid dispatch and safe batch handling.

Bug Fixes:
- Settle unmentioned events from managed senders before conversation history hydration, preventing unavailable history from turning non-actionable events into retries.

Enhancements:
- Preserve dispatch for mentioned and explicitly exempt synthetic events while retaining the post-hydration policy check as a safeguard.
- Prevent suppression of mixed follow-up batches when replayable sources belong to different requesters.

Tests:
- Add regression coverage for managed attachments with unavailable thread history and mixed human/managed follow-up batches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of messages from managed senders when no agent is explicitly mentioned.
  * Ignored, unmentioned attachments are now settled before conversation history loads, preventing unnecessary processing and retries.
  * Improved mixed-source message handling so unrelated events are not incorrectly suppressed.
  * Preserved correct behavior for trusted relay and hook-originated messages.

* **Tests**
  * Added regression coverage for ignored attachments, mixed-source batches, and explicit agent mentions in hook-generated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->