### PR TITLE
Preserve ingress hooks before managed event settlement

### DIFF
--- a/src/mindroom/coalescing_batch.py
+++ b/src/mindroom/coalescing_batch.py
@@ -415,15 +415,17 @@ def build_prepared_turn(
     source_event_prompts = _batch_source_event_prompts(ordered_pending_events)
     source_event_metadata = _batch_source_event_metadata(ordered_pending_events)
     routed_aliases = tuple(filter(None, (item.discovery_event_id for item in source_event_metadata.values())))
+    requester_user_id = _batch_requester_user_id(key, primary_pending_event)
     return PreparedTurn(
         room=primary_pending_event.room,
         event=replace(primary_pending_event.event, body=prompt_rendering.prompt),
-        requester_user_id=_batch_requester_user_id(key, primary_pending_event),
+        requester_user_id=requester_user_id,
         handled_turn=TurnRecord.create(
             source_event_ids,
             discovery_event_ids=routed_aliases,
             source_event_prompts=source_event_prompts,
             source_event_metadata=source_event_metadata if len(source_event_ids) > 1 or routed_aliases else None,
+            requester_id=requester_user_id,
         ),
         ingress=DispatchIngressMetadata(
             source_kind=_batch_source_kind(ordered_pending_events),

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -233,6 +233,7 @@ class _PreHydrationPolicyFacts:
 
     origin: TurnOrigin
     am_i_mentioned: bool
+    mentioned_agents: tuple[MatrixID, ...]
 
 
 @dataclass(frozen=True)
@@ -276,6 +277,14 @@ class ConversationResolver:
             self._matrix_id(),
             self.deps.runtime.config,
             self.deps.runtime_paths,
+        )
+
+    def _mentioned_agent_names(self, mentioned_agents: Sequence[MatrixID]) -> tuple[str, ...]:
+        """Return canonical entity names for mentioned managed users."""
+        registry = entity_identity_registry(self.deps.runtime.config, self.deps.runtime_paths)
+        return tuple(
+            registry.current_entity_name_for_user_id(agent_id.full_id) or agent_id.username
+            for agent_id in mentioned_agents
         )
 
     def _envelope_ingress_metadata(  # noqa: C901
@@ -360,7 +369,7 @@ class ConversationResolver:
     ) -> _PreHydrationPolicyFacts:
         """Classify mention and origin policy without reading conversation history."""
         event_source = _source_with_payload_metadata(event.source, payload_metadata)
-        _mentioned_agents, am_i_mentioned, _has_non_agent_mentions = self._mention_facts(event_source)
+        mentioned_agents, am_i_mentioned, _has_non_agent_mentions = self._mention_facts(event_source)
         resolved_source_kind, _hook_source, _message_received_depth = self._envelope_ingress_metadata(
             event=event,
             source_kind=source_kind,
@@ -374,6 +383,7 @@ class ConversationResolver:
                 trusted_user_relay=trusted_user_relay,
             ),
             am_i_mentioned=am_i_mentioned,
+            mentioned_agents=tuple(mentioned_agents),
         )
 
     def _sender_is_managed_entity(self, user_id: str) -> bool:
@@ -489,15 +499,12 @@ class ConversationResolver:
         """Build the normalized inbound envelope consumed by message hooks."""
         from mindroom.hooks import MessageEnvelope  # noqa: PLC0415
 
-        config = self.deps.runtime.config
         resolved_source_kind, hook_source, message_received_depth = self._envelope_ingress_metadata(
             event=event,
             source_kind=source_kind,
             hook_source=hook_source,
             message_received_depth=message_received_depth,
         )
-        registry = entity_identity_registry(config, self.deps.runtime_paths)
-
         return MessageEnvelope(
             source_event_id=event.event_id,
             target=target,
@@ -505,10 +512,7 @@ class ConversationResolver:
             attachment_ids=tuple(
                 attachment_ids if attachment_ids is not None else parse_attachment_ids_from_event_source(event.source),
             ),
-            mentioned_agents=tuple(
-                registry.current_entity_name_for_user_id(agent_id.full_id) or agent_id.username
-                for agent_id in context.mentioned_agents
-            ),
+            mentioned_agents=self._mentioned_agent_names(context.mentioned_agents),
             agent_name=agent_name or self.deps.agent_name,
             hook_source=hook_source,
             message_received_depth=message_received_depth,
@@ -535,6 +539,7 @@ class ConversationResolver:
         dispatch_policy_source_kind: str | None = None,
         hook_source: str | None = None,
         message_received_depth: int | None = None,
+        mentioned_agents: Sequence[MatrixID] = (),
         original_sender: str | None = None,
         trusted_user_relay: bool = False,
     ) -> MessageEnvelope:
@@ -554,7 +559,7 @@ class ConversationResolver:
             attachment_ids=tuple(
                 attachment_ids if attachment_ids is not None else parse_attachment_ids_from_event_source(event.source),
             ),
-            mentioned_agents=(),
+            mentioned_agents=self._mentioned_agent_names(mentioned_agents),
             agent_name=agent_name or self.deps.agent_name,
             hook_source=hook_source,
             message_received_depth=message_received_depth,

--- a/src/mindroom/text_ingress_dispatch.py
+++ b/src/mindroom/text_ingress_dispatch.py
@@ -240,19 +240,6 @@ def _parsed_command_for_event(
     return command_parser.parse(event.body)
 
 
-def _turn_sources_all_from_requester(handled_turn: TurnRecord, requester_user_id: str) -> bool:
-    """Return whether every replayable source in one turn was sent by ``requester_user_id``.
-
-    Whole-turn suppression settles every source in a coalesced batch, so it is only safe when the
-    turn provably belongs to that one requester, and a source the record cannot attribute fails
-    closed. Redacted sources are excluded because they own no reply.
-    """
-    return all(
-        handled_turn.requester_id_for_source(source_event_id) == requester_user_id
-        for source_event_id in handled_turn.replay_source_event_ids
-    )
-
-
 async def _blocked_before_plan(
     controller: TurnController,
     room: nio.MatrixRoom,
@@ -281,7 +268,7 @@ async def _blocked_before_plan(
 
     may_be_superseded = (
         prepared.dispatch.envelope.origin.may_be_superseded_by_newer_requester_turn
-        and _turn_sources_all_from_requester(prepared.handled_turn, requester_user_id)
+        and prepared.handled_turn.replay_sources_all_from_requester(requester_user_id)
     )
     if prepared.replay_guard.degraded:
         skips_turn = await controller._has_newer_unresponded_journal_thread_event(

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -153,18 +153,6 @@ _PENDING_TURN_CLAIM_METADATA_KIND = "pending_turn_claim"
 _INTERACTIVE_SELECTION_METADATA_KIND = "interactive_selection"
 
 
-def _turn_sources_can_be_settled_for_requester(
-    handled_turn: TurnRecord,
-    requester_user_id: str,
-) -> bool:
-    """Return whether whole-turn settlement is safe for one requester-owned decision."""
-    replayable_sources = handled_turn.replay_source_event_ids
-    return len(replayable_sources) <= 1 or all(
-        handled_turn.requester_id_for_source(source_event_id) == requester_user_id
-        for source_event_id in replayable_sources
-    )
-
-
 @dataclass(frozen=True)
 class _InteractiveSelectionDispatch:
     """Deferred selection work carried through receipt-ordered coalescing."""
@@ -1021,7 +1009,9 @@ class TurnController:
     async def _settle_unmentioned_managed_sender_before_hydration(
         self,
         *,
+        room: nio.MatrixRoom,
         event: PreparedIngress,
+        context_event: PreparedIngress,
         requester_user_id: str,
         event_label: str,
         handled_turn: TurnRecord,
@@ -1042,15 +1032,84 @@ class TurnController:
         if (
             not policy.origin.blocks_unmentioned_managed_sender
             or policy.am_i_mentioned
-            or not _turn_sources_can_be_settled_for_requester(handled_turn, requester_user_id)
+            or not handled_turn.replay_sources_all_from_requester(requester_user_id)
         ):
             return False
+        coalescing_key = ingress_metadata.coalescing_key if ingress_metadata is not None else None
+        target = self.deps.resolver.build_message_target(
+            room_id=room.room_id,
+            thread_id=(
+                coalescing_key.thread_id
+                if coalescing_key is not None
+                else EventInfo.from_event(context_event.source).thread_id
+            ),
+            reply_to_event_id=event.event_id,
+            event_source=context_event.source,
+        )
+        envelope = self.deps.resolver.build_ingress_envelope(
+            event=event,
+            requester_user_id=requester_user_id,
+            target=target,
+            attachment_ids=(
+                list(payload_metadata.attachment_ids)
+                if payload_metadata is not None and payload_metadata.attachment_ids is not None
+                else None
+            ),
+            source_kind=ingress_metadata.source_kind if ingress_metadata is not None else None,
+            dispatch_policy_source_kind=(
+                ingress_metadata.dispatch_policy_source_kind if ingress_metadata is not None else None
+            ),
+            hook_source=ingress_metadata.hook_source if ingress_metadata is not None else None,
+            message_received_depth=(ingress_metadata.message_received_depth if ingress_metadata is not None else None),
+            mentioned_agents=policy.mentioned_agents,
+            original_sender=original_sender,
+            trusted_user_relay=trusted_user_relay,
+        )
+        if await self._message_received_hook_settles_turn(
+            room=room,
+            envelope=envelope,
+            correlation_id=event.event_id,
+            handled_turn=handled_turn,
+        ):
+            return True
         self.deps.logger.debug(
             "ignore_unmentioned_agent_event",
             agent=policy.origin.requester_entity_name,
             event_label=event_label,
             user_id=requester_user_id,
         )
+        await self.deps.visible_responses.settle_source_events_ignored(handled_turn)
+        return True
+
+    async def _message_received_hook_settles_turn(
+        self,
+        *,
+        room: nio.MatrixRoom,
+        envelope: MessageEnvelope,
+        correlation_id: str,
+        handled_turn: TurnRecord,
+    ) -> bool:
+        """Run the authorized ingress hook and settle when it blocks dispatch."""
+        hooks_start = time.monotonic()
+        async with admitted_response_decision(
+            self.deps.runtime.response_admission_gate,
+            self.deps.response_runner.wait_for_admission_or_shutdown,
+        ):
+            if not self.deps.turn_policy.can_reply_to_sender_in_room(envelope.requester_id, room.room_id):
+                await self.deps.visible_responses.settle_source_events_ignored(handled_turn)
+                return True
+            suppressed = await self.deps.ingress_hook_runner.emit_message_received_hooks(
+                envelope=envelope,
+                correlation_id=correlation_id,
+                policy=hook_ingress_policy(envelope),
+            )
+        emit_elapsed_timing(
+            "dispatch_handoff.prepare_dispatch.emit_message_received_hooks",
+            hooks_start,
+            suppressed=suppressed,
+        )
+        if not suppressed:
+            return False
         await self.deps.visible_responses.settle_source_events_ignored(handled_turn)
         return True
 
@@ -1090,7 +1149,9 @@ class TurnController:
                 trust_internal_metadata=True,
             ).original_sender
         if await self._settle_unmentioned_managed_sender_before_hydration(
+            room=room,
             event=event,
+            context_event=context_event,
             requester_user_id=requester_user_id,
             event_label=event_label,
             handled_turn=handled_turn,
@@ -1194,27 +1255,12 @@ class TurnController:
             envelope_start,
             source_kind=envelope.source_kind,
         )
-        ingress_policy = hook_ingress_policy(envelope)
-        hooks_start = time.monotonic()
-        async with admitted_response_decision(
-            self.deps.runtime.response_admission_gate,
-            self.deps.response_runner.wait_for_admission_or_shutdown,
+        if await self._message_received_hook_settles_turn(
+            room=room,
+            envelope=envelope,
+            correlation_id=correlation_id,
+            handled_turn=handled_turn,
         ):
-            if not self.deps.turn_policy.can_reply_to_sender_in_room(requester_user_id, room.room_id):
-                await self.deps.visible_responses.settle_source_events_ignored(handled_turn)
-                return None
-            suppressed = await self.deps.ingress_hook_runner.emit_message_received_hooks(
-                envelope=envelope,
-                correlation_id=correlation_id,
-                policy=ingress_policy,
-            )
-        emit_elapsed_timing(
-            "dispatch_handoff.prepare_dispatch.emit_message_received_hooks",
-            hooks_start,
-            suppressed=suppressed,
-        )
-        if suppressed:
-            await self.deps.visible_responses.settle_source_events_ignored(handled_turn)
             return None
 
         origin = envelope.origin
@@ -1223,7 +1269,7 @@ class TurnController:
         if (
             blocks_unmentioned_managed_sender
             and not context.am_i_mentioned
-            and _turn_sources_can_be_settled_for_requester(handled_turn, requester_user_id)
+            and handled_turn.replay_sources_all_from_requester(requester_user_id)
         ):
             self.deps.logger.debug(
                 "ignore_unmentioned_agent_event",

--- a/src/mindroom/turn_record.py
+++ b/src/mindroom/turn_record.py
@@ -242,9 +242,10 @@ class TurnRecord:
 
     def replay_sources_all_from_requester(self, requester_user_id: str) -> bool:
         """Return whether every replayable source is proven to belong to one requester."""
-        return all(
+        replay_source_event_ids = self.replay_source_event_ids
+        return bool(replay_source_event_ids) and all(
             self.requester_id_for_source(source_event_id) == requester_user_id
-            for source_event_id in self.replay_source_event_ids
+            for source_event_id in replay_source_event_ids
         )
 
     @property

--- a/src/mindroom/turn_record.py
+++ b/src/mindroom/turn_record.py
@@ -240,6 +240,13 @@ class TurnRecord:
         metadata = self.source_event_metadata.get(self.prompt_source_event_id(event_id))
         return metadata.sender if metadata is not None else None
 
+    def replay_sources_all_from_requester(self, requester_user_id: str) -> bool:
+        """Return whether every replayable source is proven to belong to one requester."""
+        return all(
+            self.requester_id_for_source(source_event_id) == requester_user_id
+            for source_event_id in self.replay_source_event_ids
+        )
+
     @property
     def replay_source_event_ids(self) -> tuple[str, ...]:
         """Return source IDs whose content remains eligible for replay or regeneration."""

--- a/tests/test_handled_turns.py
+++ b/tests/test_handled_turns.py
@@ -596,6 +596,53 @@ def test_turn_record_cannot_mutate_after_ledger_publication() -> None:
         record.response_event_id = "$replacement"  # type: ignore[misc]
 
 
+@pytest.mark.parametrize(
+    ("record", "expected"),
+    [
+        (TurnRecord.create(["$single"], requester_id="@bob:localhost"), True),
+        (TurnRecord.create(["$single"]), False),
+        (
+            TurnRecord.create(
+                ["$first", "$second"],
+                source_event_metadata={
+                    "$first": SourceEventMetadata(sender="@bob:localhost"),
+                    "$second": SourceEventMetadata(sender="@bob:localhost"),
+                },
+            ),
+            True,
+        ),
+        (
+            TurnRecord.create(
+                ["$first", "$second"],
+                source_event_metadata={
+                    "$first": SourceEventMetadata(sender="@alice:localhost"),
+                    "$second": SourceEventMetadata(sender="@bob:localhost"),
+                },
+            ),
+            False,
+        ),
+        (
+            TurnRecord.create(
+                ["$first", "$second"],
+                redacted_source_event_ids=["$first"],
+                source_event_metadata={
+                    "$first": SourceEventMetadata(sender="@alice:localhost"),
+                    "$second": SourceEventMetadata(sender="@bob:localhost"),
+                },
+            ),
+            True,
+        ),
+    ],
+)
+def test_turn_record_proves_all_replay_sources_belong_to_requester(
+    record: TurnRecord,
+    *,
+    expected: bool,
+) -> None:
+    """Whole-turn decisions must fail closed unless every live source has the requester."""
+    assert record.replay_sources_all_from_requester("@bob:localhost") is expected
+
+
 @pytest.mark.asyncio
 async def test_command_execution_checkpoint_persists_across_restart(journal_store: EventJournalStore) -> None:
     """Command effect and result evidence must survive process replacement."""

--- a/tests/test_handled_turns.py
+++ b/tests/test_handled_turns.py
@@ -632,6 +632,14 @@ def test_turn_record_cannot_mutate_after_ledger_publication() -> None:
             ),
             True,
         ),
+        (
+            TurnRecord.create(
+                ["$first"],
+                redacted_source_event_ids=["$first"],
+                requester_id="@bob:localhost",
+            ),
+            False,
+        ),
     ],
 )
 def test_turn_record_proves_all_replay_sources_belong_to_requester(

--- a/tests/test_hook_sender.py
+++ b/tests/test_hook_sender.py
@@ -2107,7 +2107,10 @@ async def test_prepare_dispatch_still_filters_plain_hook_without_mention(tmp_pat
         event,
         "@mindroom_router:localhost",
         event_label="message",
-        handled_turn=TurnRecord.create([event.event_id]),
+        handled_turn=TurnRecord.create(
+            [event.event_id],
+            requester_id="@mindroom_router:localhost",
+        ),
     )
 
     # Plain hook messages without mention should still be filtered

--- a/tests/test_turn_controller_focused.py
+++ b/tests/test_turn_controller_focused.py
@@ -42,6 +42,7 @@ from mindroom.commands.parsing import CommandType, command_parser
 from mindroom.config.agent import AgentConfig
 from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
+from mindroom.config.plugin import PluginEntryConfig
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.conversation_resolver import ConversationResolver, ConversationResolverDeps, MessageContext
 from mindroom.conversation_state_writer import ConversationStateWriter, ConversationStateWriterDeps
@@ -69,7 +70,14 @@ from mindroom.event_journal import (
 from mindroom.event_journal.store import TurnRecordStore
 from mindroom.event_journal_open import open_event_journal
 from mindroom.handled_turns import TurnRecord
-from mindroom.hooks import HookContextSupport, HookRegistry, HookRegistryState
+from mindroom.hooks import (
+    EVENT_MESSAGE_RECEIVED,
+    HookContextSupport,
+    HookRegistry,
+    HookRegistryState,
+    MessageReceivedContext,
+    hook,
+)
 from mindroom.inbound_turn_normalizer import (
     InboundTurnNormalizer,
     InboundTurnNormalizerDeps,
@@ -1509,6 +1517,20 @@ async def test_unmentioned_managed_attachment_settles_before_unavailable_thread_
     history_error = RuntimeError("RoomEventRelationsError: M_NOT_FOUND: Event not found in room")
     reader.read.side_effect = history_error
     reader.read_strict.side_effect = history_error
+    received_event_ids: list[str] = []
+
+    @hook(EVENT_MESSAGE_RECEIVED)
+    async def received(context: MessageReceivedContext) -> None:
+        received_event_ids.append(context.envelope.source_event_id)
+
+    plugin = SimpleNamespace(
+        name="managed-ingress-observer",
+        discovered_hooks=(received,),
+        entry_config=PluginEntryConfig(path="./plugins/managed-ingress-observer"),
+        plugin_order=0,
+    )
+    hook_context = harness.controller.deps.ingress_hook_runner.hook_context
+    hook_context.hook_registry_state.registry = HookRegistry.from_plugins([cast("Any", plugin)])
 
     outcome = await harness.controller.handle_media_event(room, event)
     await harness.gate.drain_all()
@@ -1516,6 +1538,7 @@ async def test_unmentioned_managed_attachment_settles_before_unavailable_thread_
     assert outcome is TurnDispatchOutcome.DEFERRED
     assert harness.ignored_dispatch_sources == [(event.event_id,)]
     assert harness.retried_dispatch_sources == []
+    assert received_event_ids == [event.event_id]
     reader.read.assert_not_awaited()
     reader.read_strict.assert_not_awaited()
     assert harness.policy.plan_turn_calls == 0


### PR DESCRIPTION
## Summary

- Preserve `message:received` delivery for authorized unmentioned managed events before history-free settlement.
- Reuse the existing admission, authorization, hook-ingress policy, and lightweight envelope boundaries without reading thread history.
- Centralize whole-turn requester ownership proof on `TurnRecord` with fail-closed semantics.
- Record the canonical requester when constructing a prepared turn so single-source and coalesced consumers share one invariant.

## Regression coverage

- Verify an unmentioned managed attachment reaches `message:received` exactly once while unavailable thread history remains unread.
- Cover known, unknown, uniform, mixed, and redacted requester ownership shapes.
- Preserve the mixed-requester retry regression and the plain-hook managed-sender filter.

## Verification

- `nix-shell shell.nix --run 'uv run pytest -n 0 --no-cov -q'`\n- `nix-shell shell.nix --run 'uv run pytest tests/test_turn_controller_focused.py tests/test_handled_turns.py tests/test_hook_sender.py tests/test_live_message_coalescing.py -n 0 --no-cov -q'`\n- `nix-shell shell.nix --run 'uv run pre-commit run --all-files'`\n\nFollow-up to #1907.

## Summary by Sourcery

Preserve authorized ingress hook delivery while making managed-event settlement depend on proven whole-turn requester ownership.

New Features:
- Preserve authorized `message:received` hook delivery for unmentioned managed events before history-free settlement.

Bug Fixes:
- Ensure managed attachments can reach ingress hooks without reading unavailable thread history.
- Prevent whole-turn settlement when requester ownership cannot be proven for every replayable source.

Enhancements:
- Centralize fail-closed replay-source requester ownership checks on `TurnRecord`.
- Carry canonical requester identity and mentioned managed agents through prepared turns and ingress envelopes.

Tests:
- Add coverage for requester ownership shapes and hook delivery for unmentioned managed attachments while thread history is unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved mentioned-agent information when processing and forwarding messages.
  - Improved requester attribution for batched and replayed messages.
  - Prevented turns from being incorrectly superseded when source messages belong to different requesters or are redacted.
  - Ensured message-received hooks are triggered correctly during managed attachment handling.
  - Improved settlement and permission handling for pre-hydrated and managed messages.

- **Tests**
  - Added coverage for requester validation, redacted sources, mentions, and message-received hook behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->