### PR TITLE
fix: scope managed room invitation candidates

### DIFF
--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -60,6 +60,37 @@ def _lookup_managed_room_identifiers(
     return None, None
 
 
+def explicit_room_permission_user_ids(
+    config: Config,
+    room_id: str,
+    runtime_paths: RuntimePaths,
+) -> frozenset[str] | None:
+    """Return the explicit permission entry for a room, if one is configured."""
+    room_permissions = config.authorization.room_permissions
+
+    # Prefer direct room identifiers. A room ID is stable; a direct alias target
+    # is an explicit caller target rather than room state content.
+    for permission_key in _room_permission_lookup_keys(room_id, runtime_paths=runtime_paths):
+        if permission_key in room_permissions:
+            return frozenset(room_permissions[permission_key])
+
+    # Resolve persisted managed-room identifiers when only a room ID is
+    # available. Arbitrary canonical aliases from Matrix room events are not
+    # trusted for this mapping.
+    if room_id.startswith("!") and not all(key.startswith("!") for key in room_permissions):
+        room_key, persisted_alias = _lookup_managed_room_identifiers(room_id, runtime_paths)
+        for permission_key in _room_permission_lookup_keys(
+            room_id,
+            room_alias=persisted_alias,
+            room_key=room_key,
+            runtime_paths=runtime_paths,
+        ):
+            if permission_key in room_permissions:
+                return frozenset(room_permissions[permission_key])
+
+    return None
+
+
 def is_authorized_sender(
     sender_id: str,
     config: Config,
@@ -89,28 +120,9 @@ def is_authorized_sender(
     if resolved_id in config.authorization.global_users:
         return True
 
-    room_permissions = config.authorization.room_permissions
-    # Check room-specific permissions by direct room identifiers first. A room
-    # ID is stable; a direct alias target is an explicit caller target rather
-    # than room state content.
-    for permission_key in _room_permission_lookup_keys(room_id, runtime_paths=runtime_paths):
-        if permission_key in room_permissions:
-            return resolved_id in room_permissions[permission_key]
-
-    # Try persisted managed-room identifiers so room key/alias permissions still
-    # work when only room_id is available. This state is authored by MindRoom's
-    # room-management flow, unlike arbitrary canonical aliases from Matrix room
-    # events.
-    if room_id.startswith("!") and not all(key.startswith("!") for key in room_permissions):
-        room_key, persisted_alias = _lookup_managed_room_identifiers(room_id, runtime_paths)
-        for permission_key in _room_permission_lookup_keys(
-            room_id,
-            room_alias=persisted_alias,
-            room_key=room_key,
-            runtime_paths=runtime_paths,
-        ):
-            if permission_key in room_permissions:
-                return resolved_id in room_permissions[permission_key]
+    room_user_ids = explicit_room_permission_user_ids(config, room_id, runtime_paths)
+    if room_user_ids is not None:
+        return resolved_id in room_user_ids
 
     # Use default access for rooms not explicitly configured
     return config.authorization.default_room_access

--- a/src/mindroom/orchestration/rooms.py
+++ b/src/mindroom/orchestration/rooms.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from mindroom.authorization import explicit_room_permission_user_ids
 from mindroom.entity_resolution import mindroom_user_id
 from mindroom.logging_config import get_logger
 from mindroom.matrix_identifiers import split_concrete_matrix_user_ids
@@ -23,10 +24,15 @@ def _filter_concrete_matrix_user_ids(user_ids: set[str], *, warning_message: str
     return set(concrete_user_ids)
 
 
-def get_authorized_user_ids_to_invite(config: Config) -> set[str]:
-    """Collect Matrix users from authorization config that can be invited."""
+def get_authorized_user_ids_to_invite(
+    config: Config,
+    room_id: str,
+    runtime_paths: RuntimePaths,
+) -> set[str]:
+    """Collect Matrix users explicitly eligible for invitation to one room."""
     user_ids = set(config.authorization.global_users)
-    for room_users in config.authorization.room_permissions.values():
+    room_users = explicit_room_permission_user_ids(config, room_id, runtime_paths)
+    if room_users is not None:
         user_ids.update(room_users)
     return _filter_concrete_matrix_user_ids(
         user_ids,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2047,12 +2047,11 @@ class _MultiAgentOrchestrator:
         self,
         config: Config,
         joined_rooms: list[str],
-        authorized_user_ids: set[str],
-    ) -> set[str]:
+    ) -> str | None:
         """Invite the configured internal user to all joined rooms when needed."""
         router_bot = self._router_bot()
         if router_bot is None:
-            return authorized_user_ids
+            return None
         assert router_bot.client is not None
 
         server_name = extract_server_name_from_homeserver(
@@ -2061,9 +2060,8 @@ class _MultiAgentOrchestrator:
         )
         user_id = managed_account_user_id(INTERNAL_USER_ACCOUNT_KEY, server_name, self.runtime_paths)
         if config.mindroom_user is None or user_id is None:
-            return authorized_user_ids
+            return None
 
-        authorized_user_ids.discard(user_id)
         for room_id in joined_rooms:
             room_members = await get_room_members(router_bot.client, room_id)
             if room_members is None:
@@ -2076,7 +2074,7 @@ class _MultiAgentOrchestrator:
                 success_message=f"Invited user {user_id} to room {room_id}",
                 failure_message=f"Failed to invite user {user_id} to room {room_id}",
             )
-        return authorized_user_ids
+        return user_id
 
     async def _invite_authorized_users_to_room(
         self,
@@ -2133,12 +2131,7 @@ class _MultiAgentOrchestrator:
         if not joined_rooms:
             return
 
-        authorized_user_ids = get_authorized_user_ids_to_invite(config)
-        authorized_user_ids = await self._invite_internal_user_to_rooms(
-            config,
-            joined_rooms,
-            authorized_user_ids,
-        )
+        internal_user_id = await self._invite_internal_user_to_rooms(config, joined_rooms)
 
         for room_id in joined_rooms:
             configured_bots = configured_bot_user_ids_for_room(config, room_id, self.runtime_paths)
@@ -2149,6 +2142,9 @@ class _MultiAgentOrchestrator:
             if current_members is None:
                 logger.warning("room_invitations_skipped_members_unavailable", room_id=room_id)
                 continue
+            authorized_user_ids = get_authorized_user_ids_to_invite(config, room_id, self.runtime_paths)
+            if internal_user_id is not None:
+                authorized_user_ids.discard(internal_user_id)
             await self._invite_authorized_users_to_room(room_id, current_members, authorized_user_ids, config)
             if configured_bots:
                 await self._invite_configured_bots_to_room(room_id, current_members, configured_bots)

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -1423,6 +1423,65 @@ class TestMultiAgentOrchestrator:
         }
 
     @pytest.mark.asyncio
+    async def test_ensure_room_invitations_does_not_expand_room_grants_via_default_access(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A user explicitly granted one room must not become an invite candidate elsewhere."""
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "general": AgentConfig(
+                        display_name="GeneralAgent",
+                        rooms=["!room1:localhost", "!room2:localhost"],
+                    ),
+                },
+                authorization={
+                    "global_users": ["@alice:localhost"],
+                    "room_permissions": {"room1": ["@bob:localhost"]},
+                    "default_room_access": True,
+                },
+            ),
+            tmp_path,
+        )
+        state = MatrixState.load(runtime_paths=runtime_paths_for(config))
+        state.add_room("room1", "!room1:localhost", "#room1:localhost", "Room 1")
+        state.add_room("room2", "!room2:localhost", "#room2:localhost", "Room 2")
+        state.save(runtime_paths=runtime_paths_for(config))
+        orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
+        orchestrator.config = config
+
+        router_bot = MagicMock()
+        router_bot.client = AsyncMock()
+        orchestrator.agent_bots = {"router": router_bot}
+
+        room_members = {
+            "!room1:localhost": {"@mindroom_general:localhost", "@mindroom_router:localhost"},
+            "!room2:localhost": {"@mindroom_general:localhost", "@mindroom_router:localhost"},
+        }
+
+        async def mock_get_room_members(_client: AsyncMock, room_id: str) -> set[str]:
+            return room_members[room_id]
+
+        mock_invite = AsyncMock(return_value=True)
+
+        with (
+            patch("mindroom.constants.runtime_matrix_homeserver", return_value="http://localhost:8008"),
+            patch("mindroom.orchestrator.is_authorized_sender", side_effect=is_authorized_sender_for_test),
+            patch("mindroom.orchestrator.get_joined_rooms", new=AsyncMock(return_value=list(room_members))),
+            patch("mindroom.orchestrator.get_room_members", side_effect=mock_get_room_members),
+            patch("mindroom.orchestrator.invite_to_room", mock_invite),
+        ):
+            await orchestrator._ensure_room_invitations()
+
+        invited_users_by_room = {(call.args[1], call.args[2]) for call in mock_invite.await_args_list}
+        assert invited_users_by_room == {
+            ("!room1:localhost", "@alice:localhost"),
+            ("!room2:localhost", "@alice:localhost"),
+            ("!room1:localhost", "@bob:localhost"),
+        }
+
+    @pytest.mark.asyncio
     async def test_ensure_room_invitations_skips_room_when_members_fetch_fails(self, tmp_path: Path) -> None:
         """A failed membership fetch must skip that room instead of inviting everyone into it."""
         config = _runtime_bound_config(


### PR DESCRIPTION
## Problem

Room-specific authorization grants were being combined into one global invitation candidate set. With default room access enabled, a user granted access to one managed room could therefore be invited to unrelated managed rooms.

## Solution

- Centralize explicit room-permission resolution using the existing room ID, key, and alias rules.
- Derive invitation candidates independently for each managed room.
- Invite global users plus only the users explicitly granted access to that room.
- Preserve the existing sender-authorization behavior.

## Regression coverage

The regression test configures two managed rooms, one global user, and one user with an explicit grant for only the first room. Before this change, the room-specific user was also invited to the second room. The test now verifies that the user is invited only to the explicitly granted room while the global user remains eligible for both.

## Testing

- `uv run pytest -q tests/test_orchestrator_runtime.py tests/test_authorization.py`
- `uv run pre-commit run --files src/mindroom/authorization.py src/mindroom/orchestration/rooms.py src/mindroom/orchestrator.py tests/test_orchestrator_runtime.py`
- `uv run pytest -q`