### PR TITLE
Recover from unreadable knowledge candidates

### DIFF
--- a/src/mindroom/knowledge/candidate_checkpoint.py
+++ b/src/mindroom/knowledge/candidate_checkpoint.py
@@ -344,5 +344,7 @@ def append_candidate_journal(
 
 def delete_candidate_checkpoint(base_storage_path: Path) -> None:
     """Remove candidate state once the candidate is published or discarded."""
-    _candidate_checkpoint_path(base_storage_path).unlink(missing_ok=True)
+    # Retire the journal first so a failure before the final unlink leaves the
+    # authoritative snapshot available for a safe retry.
     _candidate_journal_path(base_storage_path).unlink(missing_ok=True)
+    _candidate_checkpoint_path(base_storage_path).unlink(missing_ok=True)

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -21,6 +21,7 @@ from agno.knowledge.reader.json_reader import JSONReader
 from agno.knowledge.reader.markdown_reader import MarkdownReader
 from agno.knowledge.reader.text_reader import TextReader
 from agno.vectordb.chroma import ChromaDb
+from chromadb.errors import InternalError
 
 from mindroom.chunking import SafeFixedSizeChunking
 from mindroom.constants import (
@@ -1365,7 +1366,13 @@ class KnowledgeManager:
                 checkpoint,
                 embedder=embedder,
             )
-        except Exception:
+        except InternalError as inspection_error:
+            error_detail = str(inspection_error).lower()
+            if not any(
+                marker in error_detail
+                for marker in ("error constructing hnsw segment reader", "error deserializing pickle file")
+            ):
+                raise
             # A candidate is never live until publication, so an unreadable
             # one may be abandoned without risking the last-good index.
             # Retire its checkpoint even when provider cleanup fails; the

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1345,13 +1345,12 @@ class KnowledgeManager:
         immediately after its rows land, so its pre-existing unclaimed window is
         bounded by the in-flight file rather than the whole copied corpus.
         """
-        if checkpoint.completed:
-            return False
         vector_db = build_vector_db(self._collections, checkpoint.collection, embedder=embedder)
         if not vector_db.exists():
             return False
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
-        return bool(collection.get(limit=1, include=[])["ids"])
+        has_rows = bool(collection.get(limit=1, include=[])["ids"])
+        return not checkpoint.completed and has_rows
 
     async def _inspect_candidate_shape(
         self,
@@ -1377,8 +1376,15 @@ class KnowledgeManager:
                 collection=checkpoint.collection,
                 exc_info=True,
             )
+            try:
+                await asyncio.to_thread(delete_candidate_checkpoint, self._base_storage_path)
+            except OSError as cleanup_error:
+                # Do not delete the collection unless its durable resume pointer
+                # was retired first. A read-only storage failure cannot be
+                # recovered safely in process, but both indexes remain intact.
+                message = "Cannot retire unreadable knowledge candidate checkpoint"
+                raise RuntimeError(message) from cleanup_error
             await delete_collection(self._collections, checkpoint.collection)
-            await asyncio.to_thread(delete_candidate_checkpoint, self._base_storage_path)
             return None, False
         return checkpoint, holds_unclaimed_rows
 

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1353,6 +1353,35 @@ class KnowledgeManager:
         collection = vector_db.client.get_collection(name=vector_db.collection_name)
         return bool(collection.get(limit=1, include=[])["ids"])
 
+    async def _inspect_candidate_shape(
+        self,
+        checkpoint: CandidateCheckpoint,
+        *,
+        embedder: Embedder,
+    ) -> tuple[CandidateCheckpoint | None, bool]:
+        """Return candidate shape, retiring an unreadable unpublished index."""
+        try:
+            holds_unclaimed_rows = await asyncio.to_thread(
+                self._candidate_holds_unclaimed_rows,
+                checkpoint,
+                embedder=embedder,
+            )
+        except Exception:
+            # A candidate is never live until publication, so an unreadable
+            # one may be abandoned without risking the last-good index.
+            # Retire its checkpoint even when provider cleanup fails; the
+            # superseded-collection sweep can retry physical reclamation.
+            logger.warning(
+                "Discarding unreadable knowledge candidate",
+                base_id=self.base_id,
+                collection=checkpoint.collection,
+                exc_info=True,
+            )
+            await delete_collection(self._collections, checkpoint.collection)
+            await asyncio.to_thread(delete_candidate_checkpoint, self._base_storage_path)
+            return None, False
+        return checkpoint, holds_unclaimed_rows
+
     async def _rebuild_candidate_collection(
         self,
         checkpoint: CandidateCheckpoint,
@@ -1486,13 +1515,20 @@ class KnowledgeManager:
             checkpoint = None
 
         embedder = BatchPrefetchEmbedder(inner=create_configured_embedder(self.config, self.runtime_paths))
+        candidate_holds_unclaimed_rows = False
+        if checkpoint is not None:
+            checkpoint, candidate_holds_unclaimed_rows = await self._inspect_candidate_shape(
+                checkpoint,
+                embedder=embedder,
+            )
+
         rebuild = checkpoint is None
         if checkpoint is None:
             checkpoint = CandidateCheckpoint(
                 collection=candidate_collection_name(self._collections),
                 settings=self._indexing_settings,
             )
-        elif await asyncio.to_thread(self._candidate_holds_unclaimed_rows, checkpoint, embedder=embedder):
+        elif candidate_holds_unclaimed_rows:
             logger.warning(
                 "Rebuilding a knowledge candidate holding vectors it never claimed",
                 base_id=self.base_id,

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -3717,7 +3717,11 @@ async def test_an_unreadable_candidate_is_discarded_without_touching_the_publish
     _FakeVectorDb.store[unreadable_candidate] = list(published_records)
     save_candidate_checkpoint(
         _storage_path(config, runtime_paths),
-        CandidateCheckpoint(collection=unreadable_candidate, settings=manager._indexing_settings),
+        CandidateCheckpoint(
+            collection=unreadable_candidate,
+            settings=manager._indexing_settings,
+            completed={names[0]: (1, 1, "digest")},
+        ),
     )
     original_get = _FakeCollection.get
 
@@ -3735,6 +3739,52 @@ async def test_an_unreadable_candidate_is_discarded_without_touching_the_publish
     assert run.checkpoint.collection != unreadable_candidate
     assert sorted(run.completed) == names
     assert unreadable_candidate not in _FakeVectorDb.store
+    assert _FakeVectorDb.store[published_collection] == published_records
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_candidate_is_not_deleted_when_its_checkpoint_cannot_be_retired(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cleanup failure must leave the candidate and published index recoverable."""
+    docs_path = tmp_path / "docs"
+    _write_corpus(docs_path, 1)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    manager = _manager(config)
+    await manager.reindex_all()
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.collection is not None
+    published_collection = state.collection
+    published_records = list(_FakeVectorDb.store[published_collection])
+
+    unreadable_candidate = candidate_collection_name(manager._collections)
+    _FakeVectorDb.store[unreadable_candidate] = list(published_records)
+    save_candidate_checkpoint(
+        _storage_path(config, runtime_paths),
+        CandidateCheckpoint(collection=unreadable_candidate, settings=manager._indexing_settings),
+    )
+    original_get = _FakeCollection.get
+
+    def _fail_unreadable_candidate(self: _FakeCollection, **kwargs: object) -> dict[str, object]:
+        if self._name == unreadable_candidate:
+            message = "Error constructing hnsw segment reader: EOF while parsing"
+            raise InternalError(message)
+        return original_get(self, **kwargs)
+
+    def _fail_checkpoint_cleanup(_base_storage_path: Path) -> None:
+        message = "checkpoint directory is read-only"
+        raise PermissionError(message)
+
+    monkeypatch.setattr(_FakeCollection, "get", _fail_unreadable_candidate)
+    monkeypatch.setattr(knowledge_manager_module, "delete_candidate_checkpoint", _fail_checkpoint_cleanup)
+
+    with pytest.raises(RuntimeError, match="Cannot retire unreadable knowledge candidate checkpoint"):
+        await manager._open_candidate_run()
+
+    assert unreadable_candidate in _FakeVectorDb.store
     assert _FakeVectorDb.store[published_collection] == published_records
 
 

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -1626,6 +1626,42 @@ def test_candidate_checkpoint_replays_journal_and_tolerates_a_torn_tail(tmp_path
     assert reloaded.failed == checkpoint.failed
 
 
+def test_candidate_checkpoint_retirement_deletes_the_authoritative_snapshot_last(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failure on the second unlink must leave a resumable checkpoint."""
+    storage_path = tmp_path / "state"
+    settings = _manager(_config(tmp_path / "cfg", tmp_path / "cfg" / "docs"))._indexing_settings
+    save_candidate_checkpoint(
+        storage_path,
+        CandidateCheckpoint(collection="candidate", settings=settings, completed={"a.md": (1, 2, "digest")}),
+    )
+    append_candidate_journal(storage_path, completed=[("b.md", (3, 4, "journal-digest"))])
+    snapshot_path = _candidate_checkpoint_path(storage_path)
+    journal_path = _candidate_journal_path(storage_path)
+    original_unlink = Path.unlink
+    unlinked: list[Path] = []
+
+    def _fail_second_unlink(path: Path, *args: object, **kwargs: object) -> None:
+        unlinked.append(path)
+        if len(unlinked) == 2:
+            message = "checkpoint directory stopped accepting unlinks"
+            raise OSError(message)
+        original_unlink(path, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "unlink", _fail_second_unlink)
+
+    with pytest.raises(OSError, match="stopped accepting unlinks"):
+        delete_candidate_checkpoint(storage_path)
+
+    assert unlinked == [journal_path, snapshot_path]
+    checkpoint = load_candidate_checkpoint(storage_path)
+    assert checkpoint is not None
+    assert checkpoint.collection == "candidate"
+    assert checkpoint.completed == {"a.md": (1, 2, "digest")}
+
+
 def test_unknown_checkpoint_schema_version_is_ignored(tmp_path: Path) -> None:
     """Future or corrupt candidate state must never be resumed blindly."""
     storage_path = tmp_path / "state"

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -3789,6 +3789,51 @@ async def test_an_unreadable_candidate_is_not_deleted_when_its_checkpoint_cannot
 
 
 @pytest.mark.asyncio
+async def test_a_transient_candidate_probe_failure_preserves_resumable_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An unrelated vector-store failure is not evidence of index corruption."""
+    docs_path = tmp_path / "docs"
+    _write_corpus(docs_path, 1)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    manager = _manager(config)
+    await manager.reindex_all()
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.collection is not None
+    published_collection = state.collection
+    published_records = list(_FakeVectorDb.store[published_collection])
+
+    candidate = candidate_collection_name(manager._collections)
+    _FakeVectorDb.store[candidate] = list(published_records)
+    storage = _storage_path(config, runtime_paths)
+    save_candidate_checkpoint(
+        storage,
+        CandidateCheckpoint(collection=candidate, settings=manager._indexing_settings),
+    )
+    original_get = _FakeCollection.get
+
+    def _fail_transient_probe(self: _FakeCollection, **kwargs: object) -> dict[str, object]:
+        if self._name == candidate:
+            message = "database connection unexpectedly closed"
+            raise InternalError(message)
+        return original_get(self, **kwargs)
+
+    monkeypatch.setattr(_FakeCollection, "get", _fail_transient_probe)
+
+    with pytest.raises(InternalError, match="database connection unexpectedly closed"):
+        await manager._open_candidate_run()
+
+    checkpoint = load_candidate_checkpoint(storage)
+    assert checkpoint is not None
+    assert checkpoint.collection == candidate
+    assert candidate in _FakeVectorDb.store
+    assert _FakeVectorDb.store[published_collection] == published_records
+
+
+@pytest.mark.asyncio
 async def test_unclaimed_row_probe_reuses_the_refresh_embedder(
     tmp_path: Path,
     embedder: _RecordingEmbedder,

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -3696,6 +3696,49 @@ async def test_a_candidate_whose_collection_vanished_is_rebuilt_rather_than_resu
 
 
 @pytest.mark.asyncio
+async def test_an_unreadable_candidate_is_discarded_without_touching_the_published_index(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A corrupt unpublished vector segment must not permanently block refresh."""
+    docs_path = tmp_path / "docs"
+    names = _write_corpus(docs_path, 3)
+    config = _config(tmp_path, docs_path)
+    runtime_paths = runtime_paths_for(config)
+    manager = _manager(config)
+    await manager.reindex_all()
+    state = _published_state(config, runtime_paths)
+    assert state is not None
+    assert state.collection is not None
+    published_collection = state.collection
+    published_records = list(_FakeVectorDb.store[published_collection])
+
+    unreadable_candidate = candidate_collection_name(manager._collections)
+    _FakeVectorDb.store[unreadable_candidate] = list(published_records)
+    save_candidate_checkpoint(
+        _storage_path(config, runtime_paths),
+        CandidateCheckpoint(collection=unreadable_candidate, settings=manager._indexing_settings),
+    )
+    original_get = _FakeCollection.get
+
+    def _fail_unreadable_candidate(self: _FakeCollection, **kwargs: object) -> dict[str, object]:
+        if self._name == unreadable_candidate:
+            message = "Error constructing hnsw segment reader: EOF while parsing"
+            raise InternalError(message)
+        return original_get(self, **kwargs)
+
+    monkeypatch.setattr(_FakeCollection, "get", _fail_unreadable_candidate)
+
+    run = await manager._open_candidate_run()
+
+    assert run.resumed is False
+    assert run.checkpoint.collection != unreadable_candidate
+    assert sorted(run.completed) == names
+    assert unreadable_candidate not in _FakeVectorDb.store
+    assert _FakeVectorDb.store[published_collection] == published_records
+
+
+@pytest.mark.asyncio
 async def test_unclaimed_row_probe_reuses_the_refresh_embedder(
     tmp_path: Path,
     embedder: _RecordingEmbedder,


### PR DESCRIPTION
## Summary

- discard an unpublished candidate when Chroma cannot construct or deserialize its HNSW index
- preserve the last published collection and seed a replacement candidate from it
- preserve resumable candidates on unrelated read failures and make checkpoint retirement failure-safe
- cover corrupt, partially completed, transient-error, and partial-cleanup lifecycle paths

## Testing

- `uv run pytest -q`
- `uv run pytest -q tests/test_knowledge_resumable_refresh.py`
- `uv run pre-commit run --files src/mindroom/knowledge/candidate_checkpoint.py src/mindroom/knowledge/manager.py tests/test_knowledge_resumable_refresh.py`