### PR TITLE
Reconcile pending room invites after access grants

### DIFF
--- a/src/mindroom/agent_reply_membership_sync.py
+++ b/src/mindroom/agent_reply_membership_sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -42,6 +43,8 @@ class AgentReplyMembershipSync:
         self._refresh_attempt = 0
         self._refresh_retry_at = 0.0
         self._preserve_on_next_sync_start = False
+        self._live_transition_lock = asyncio.Lock()
+        self._live_effects_pending = False
 
     @property
     def memberships(self) -> AgentReplyMembershipIndex:
@@ -140,7 +143,7 @@ class AgentReplyMembershipSync:
             self._request_refresh()
         return authorization_changed
 
-    def apply_live_transition(
+    async def apply_live_transition(
         self,
         config: Config,
         runtime_paths: RuntimePaths,
@@ -148,15 +151,23 @@ class AgentReplyMembershipSync:
         event: nio.RoomMemberEvent,
         *,
         control_user_id: str,
-    ) -> bool:
-        """Apply one accepted durable LIVE membership transition."""
-        return self._memberships.apply_member_event(
-            config,
-            runtime_paths,
-            room_id,
-            event,
-            control_user_id=control_user_id,
-        )
+        reconcile_effects: Callable[[], Awaitable[None]],
+    ) -> None:
+        """Apply one durable LIVE transition and finish its dependent effects."""
+        async with self._live_transition_lock:
+            changed = self._memberships.apply_member_event(
+                config,
+                runtime_paths,
+                room_id,
+                event,
+                control_user_id=control_user_id,
+            )
+            if changed:
+                self._live_effects_pending = True
+            if not self._live_effects_pending:
+                return
+            await reconcile_effects()
+            self._live_effects_pending = False
 
 
 def _sync_response_has_uncertain_membership(

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1332,6 +1332,11 @@ class AgentBot:
         if call_manager is not None:
             await call_manager.reconcile_reply_authorization()
 
+    async def reconcile_pending_invites(self) -> None:
+        """Recheck cached room invites against the shared responder policy."""
+        if self.client is not None:
+            await self._room_lifecycle.reconcile_pending_invites()
+
     async def revoke_reply_authorized_calls(self) -> None:
         """End active calls that no longer pass current reply access."""
         call_manager = self._call_manager
@@ -2466,10 +2471,10 @@ class AgentBot:
     ) -> None:
         """Act on one invite without journalling it.
 
-        An invite has no Matrix event ID to key durable work on, and it does
-        not need one: an invite the bot has not acted on reappears in every
-        sync response until it does, so the homeserver already provides the
-        redelivery a journal row would have.
+        An invite has no Matrix event ID to key durable work on.
+        Matrix-nio retains outstanding invites in its client cache, and an
+        initial sync reconstructs that cache after a process restart.
+        Responder-access changes explicitly reconcile the live cache.
         """
         create_background_task(self._on_invite(room, event), owner=self._runtime_view)
 
@@ -2642,8 +2647,10 @@ class AgentBot:
             return
         orchestrator = self.orchestrator
         if orchestrator is None:
+            await self.reconcile_pending_invites()
             await self.reconcile_reply_authorized_calls()
         else:
+            await orchestrator.reconcile_pending_invites()
             await orchestrator.reconcile_reply_authorized_calls()
 
     async def _emit_room_member_joined_sync_state_hooks(

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -394,8 +394,6 @@ class AgentBot:
     _room_member_join_hooks_armed: bool
     _sliding_sync_startup_warning_emitted: bool
     _reply_membership_sync: AgentReplyMembershipSync | None
-    _reply_membership_transition_lock: asyncio.Lock
-    _reply_membership_effects_pending: bool
     _turn_controller: TurnController
     _room_lifecycle: BotRoomLifecycle
     _local_departures_awaiting_sync: set[str]
@@ -458,8 +456,6 @@ class AgentBot:
         self._room_member_join_hooks_armed = False
         self._room_member_join_lock = asyncio.Lock()
         self._sliding_sync_startup_warning_emitted = False
-        self._reply_membership_transition_lock = asyncio.Lock()
-        self._reply_membership_effects_pending = False
         if (
             agent_reply_membership_sync is not None
             and agent_reply_membership_sync.memberships is not agent_reply_memberships
@@ -2633,6 +2629,16 @@ class AgentBot:
             emit=self._emit_room_member_joined_hooks,
         )
 
+    async def _reconcile_reply_membership_effects(self) -> None:
+        """Run effects that depend on one committed reply-membership change."""
+        orchestrator = self.orchestrator
+        if orchestrator is None:
+            await self.reconcile_pending_invites()
+            await self.reconcile_reply_authorized_calls()
+            return
+        await orchestrator.reconcile_pending_invites()
+        await orchestrator.reconcile_reply_authorized_calls()
+
     async def _apply_live_reply_membership_transition(
         self,
         room_id: str,
@@ -2641,28 +2647,14 @@ class AgentBot:
         """Update reply grants from one durably admitted live Matrix transition."""
         if self.agent_name != ROUTER_AGENT_NAME:
             return
-        async with self._reply_membership_transition_lock:
-            changed = self._router_reply_membership_sync.apply_live_transition(
-                self.config,
-                self.runtime_paths,
-                room_id,
-                event,
-                control_user_id=self.matrix_id.full_id,
-            )
-            if changed:
-                # Keep the post-change effects armed until they all finish so
-                # durable event replay retries them after a partial failure.
-                self._reply_membership_effects_pending = True
-            if not self._reply_membership_effects_pending:
-                return
-            orchestrator = self.orchestrator
-            if orchestrator is None:
-                await self.reconcile_pending_invites()
-                await self.reconcile_reply_authorized_calls()
-            else:
-                await orchestrator.reconcile_pending_invites()
-                await orchestrator.reconcile_reply_authorized_calls()
-            self._reply_membership_effects_pending = False
+        await self._router_reply_membership_sync.apply_live_transition(
+            self.config,
+            self.runtime_paths,
+            room_id,
+            event,
+            control_user_id=self.matrix_id.full_id,
+            reconcile_effects=self._reconcile_reply_membership_effects,
+        )
 
     async def _emit_room_member_joined_sync_state_hooks(
         self,

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1391,6 +1391,7 @@ class AgentBot:
             if client is None:
                 return
             await self._runtime_view.agent_reply_memberships.refresh(self.config, self.runtime_paths, client)
+            await self.reconcile_pending_invites()
             await self.revoke_reply_authorized_calls()
             self.schedule_reply_authorized_call_reconciliation()
 
@@ -2465,9 +2466,6 @@ class AgentBot:
                 )
                 await asyncio.sleep(retry_delay)
 
-    async def _on_invite(self, room: nio.MatrixRoom, event: nio.InviteEvent) -> None:
-        await self._room_lifecycle.on_invite(room, event)
-
     async def _on_invite_before_sync_certification(
         self,
         room: nio.MatrixRoom,
@@ -2476,11 +2474,14 @@ class AgentBot:
         """Act on one invite without journalling it.
 
         An invite has no Matrix event ID to key durable work on.
-        Matrix-nio retains outstanding invites in its client cache, and an
-        initial sync reconstructs that cache after a process restart.
-        Responder-access changes explicitly reconcile the live cache.
+        Persist its room and inviter before network work moves to the
+        background so access changes and process restarts can reconcile it.
         """
-        create_background_task(self._on_invite(room, event), owner=self._runtime_view)
+        self._room_lifecycle.record_pending_room_invite(room.room_id, event.sender)
+        create_background_task(
+            self._room_lifecycle.handle_recorded_invite(room, event.sender),
+            owner=self._runtime_view,
+        )
 
     def _room_for_journal_event(self, room_id: str) -> nio.MatrixRoom:
         """Resolve one recovery room without depending on a new sync response."""

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -394,6 +394,8 @@ class AgentBot:
     _room_member_join_hooks_armed: bool
     _sliding_sync_startup_warning_emitted: bool
     _reply_membership_sync: AgentReplyMembershipSync | None
+    _reply_membership_transition_lock: asyncio.Lock
+    _reply_membership_effects_pending: bool
     _turn_controller: TurnController
     _room_lifecycle: BotRoomLifecycle
     _local_departures_awaiting_sync: set[str]
@@ -456,6 +458,8 @@ class AgentBot:
         self._room_member_join_hooks_armed = False
         self._room_member_join_lock = asyncio.Lock()
         self._sliding_sync_startup_warning_emitted = False
+        self._reply_membership_transition_lock = asyncio.Lock()
+        self._reply_membership_effects_pending = False
         if (
             agent_reply_membership_sync is not None
             and agent_reply_membership_sync.memberships is not agent_reply_memberships
@@ -2636,22 +2640,28 @@ class AgentBot:
         """Update reply grants from one durably admitted live Matrix transition."""
         if self.agent_name != ROUTER_AGENT_NAME:
             return
-        changed = self._router_reply_membership_sync.apply_live_transition(
-            self.config,
-            self.runtime_paths,
-            room_id,
-            event,
-            control_user_id=self.matrix_id.full_id,
-        )
-        if not changed:
-            return
-        orchestrator = self.orchestrator
-        if orchestrator is None:
-            await self.reconcile_pending_invites()
-            await self.reconcile_reply_authorized_calls()
-        else:
-            await orchestrator.reconcile_pending_invites()
-            await orchestrator.reconcile_reply_authorized_calls()
+        async with self._reply_membership_transition_lock:
+            changed = self._router_reply_membership_sync.apply_live_transition(
+                self.config,
+                self.runtime_paths,
+                room_id,
+                event,
+                control_user_id=self.matrix_id.full_id,
+            )
+            if changed:
+                # Keep the post-change effects armed until they all finish so
+                # durable event replay retries them after a partial failure.
+                self._reply_membership_effects_pending = True
+            if not self._reply_membership_effects_pending:
+                return
+            orchestrator = self.orchestrator
+            if orchestrator is None:
+                await self.reconcile_pending_invites()
+                await self.reconcile_reply_authorized_calls()
+            else:
+                await orchestrator.reconcile_pending_invites()
+                await orchestrator.reconcile_reply_authorized_calls()
+            self._reply_membership_effects_pending = False
 
     async def _emit_room_member_joined_sync_state_hooks(
         self,

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -16,7 +16,10 @@ from mindroom.matrix.client_room_admin import RoomJoinOutcome, get_joined_rooms,
 from mindroom.matrix.invited_rooms_store import (
     invited_rooms_path,
     load_invited_rooms,
+    load_pending_room_invites,
+    pending_room_invites_path,
     save_invited_rooms,
+    save_pending_room_invites,
     should_accept_invites,
     should_persist_invited_rooms,
 )
@@ -74,10 +77,12 @@ class BotRoomLifecycle:
 
     deps: BotRoomLifecycleDeps
     invited_rooms: set[str]
+    _pending_room_invites: dict[str, str]
 
     def __init__(self, deps: BotRoomLifecycleDeps) -> None:
         self.deps = deps
         self.invited_rooms = self._load_invited_rooms()
+        self._pending_room_invites = load_pending_room_invites(self._pending_room_invites_file_path())
         self._pending_forgotten_invited_rooms: set[str] = set()
         self._invite_join_locks: dict[str, asyncio.Lock] = {}
         self._welcome_locks: dict[str, asyncio.Lock] = {}
@@ -195,6 +200,10 @@ class BotRoomLifecycle:
         """Return the durable path for invited room IDs for this entity."""
         return invited_rooms_path(self.deps.runtime_paths.storage_root, self.deps.agent_name)
 
+    def _pending_room_invites_file_path(self) -> Path:
+        """Return the durable path for outstanding invites for this entity."""
+        return pending_room_invites_path(self.deps.runtime_paths.storage_root, self.deps.agent_name)
+
     def _load_invited_rooms(self) -> set[str]:
         """Load invited rooms persisted for one eligible entity."""
         if not self._should_persist_invited_rooms():
@@ -212,6 +221,7 @@ class BotRoomLifecycle:
 
     def forget_invited_room(self, room_id: str) -> None:
         """Stop preserving an ad-hoc room after this bot leaves it."""
+        self._forget_pending_room_invite(room_id)
         if not self._should_persist_invited_rooms():
             self.invited_rooms.discard(room_id)
         elif not self._update_invited_room(room_id, remember=False):
@@ -219,6 +229,32 @@ class BotRoomLifecycle:
             raise OSError(msg)
         self._handled_invite_room_ids.discard(room_id)
         self._welcomed_room_ids.discard(room_id)
+
+    def record_pending_room_invite(self, room_id: str, sender_id: str) -> None:
+        """Persist an outstanding invite before its network work runs."""
+        if not self._should_persist_invited_rooms():
+            return
+        pending_invites = load_pending_room_invites(self._pending_room_invites_file_path())
+        if pending_invites.get(room_id) == sender_id:
+            self._pending_room_invites = pending_invites
+            return
+        pending_invites[room_id] = sender_id
+        if not save_pending_room_invites(self._pending_room_invites_file_path(), pending_invites):
+            msg = f"Failed to persist pending room invite {room_id}"
+            raise OSError(msg)
+        self._pending_room_invites = pending_invites
+
+    def _forget_pending_room_invite(self, room_id: str) -> None:
+        """Forget a resolved outstanding invite without losing concurrent state."""
+        pending_invites = load_pending_room_invites(self._pending_room_invites_file_path())
+        if room_id not in pending_invites:
+            self._pending_room_invites = pending_invites
+            return
+        pending_invites.pop(room_id)
+        if not save_pending_room_invites(self._pending_room_invites_file_path(), pending_invites):
+            msg = f"Failed to forget pending room invite {room_id}"
+            raise OSError(msg)
+        self._pending_room_invites = pending_invites
 
     def _update_invited_room(self, room_id: str, *, remember: bool) -> bool:
         """Merge one update with durable and in-memory state before saving."""
@@ -395,16 +431,23 @@ class BotRoomLifecycle:
         self._logger().info("Welcome message sent", room_id=room_id)
         return True
 
-    async def on_invite(self, room: nio.MatrixRoom, event: nio.InviteEvent) -> None:
-        """Handle one inbound invite using the configured room membership policy."""
-        await self._handle_invite(room, event.sender)
+    async def handle_recorded_invite(self, room: nio.MatrixRoom, sender: str) -> None:
+        """Handle one invite whose identity is already durable."""
+        await self._handle_invite(room, sender)
 
     async def reconcile_pending_invites(self) -> None:
-        """Re-evaluate cached Matrix invites after responder access changes."""
+        """Re-evaluate durable and cached invites after responder access changes."""
         client = self._client()
+        self._pending_room_invites = load_pending_room_invites(self._pending_room_invites_file_path())
         for room in tuple(client.invited_rooms.values()):
             if room.inviter is not None:
-                await self._handle_invite(room, room.inviter)
+                self.record_pending_room_invite(room.room_id, room.inviter)
+        for room_id, sender in tuple(self._pending_room_invites.items()):
+            room = client.invited_rooms.get(room_id)
+            if room is None:
+                room = nio.MatrixInvitedRoom(room_id, self.deps.agent_user.user_id)
+                room.inviter = sender
+            await self._handle_invite(room, sender)
 
     async def _handle_invite(self, room: nio.MatrixRoom, sender: str) -> None:
         """Accept one invite when its inviter currently passes responder access."""
@@ -436,6 +479,7 @@ class BotRoomLifecycle:
                 await self.deps.on_room_joined(room.room_id)
                 self._remember_invited_room(room.room_id)
                 await self._send_invite_welcome(room.room_id, sender)
+                self._forget_pending_room_invite(room.room_id)
                 return
 
             self._logger().info("Received invite", room_id=room.room_id, sender=sender)
@@ -443,6 +487,7 @@ class BotRoomLifecycle:
             if join_outcome is not RoomJoinOutcome.JOINED:
                 self._logger().error("Failed to join room", room_id=room.room_id)
                 if join_outcome is RoomJoinOutcome.TERMINAL_FAILURE:
+                    self._forget_pending_room_invite(room.room_id)
                     return
                 msg = f"Failed to join invited room {room.room_id}"
                 raise RuntimeError(msg)
@@ -452,3 +497,4 @@ class BotRoomLifecycle:
             self._remember_invited_room(room.room_id)
             self._handled_invite_room_ids.add(room.room_id)
             await self._send_invite_welcome(room.room_id, sender)
+            self._forget_pending_room_invite(room.room_id)

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -183,13 +183,17 @@ class BotRoomLifecycle:
         )
         join_outcome = await join_room(client, room_id)
         if join_outcome is RoomJoinOutcome.TERMINAL_FAILURE:
-            self.apply_continuity_record(
-                await asyncio.to_thread(
-                    self.deps.continuity_store.update_join_fences,
-                    remove=(room_id,),
-                ),
-            )
+            await self._clear_join_decrypt_notice_fence(room_id)
         return join_outcome
+
+    async def _clear_join_decrypt_notice_fence(self, room_id: str) -> None:
+        """Clear a join fence after the current join work becomes terminal."""
+        self.apply_continuity_record(
+            await asyncio.to_thread(
+                self.deps.continuity_store.update_join_fences,
+                remove=(room_id,),
+            ),
+        )
 
     async def _on_configured_room_joined(self, room_id: str) -> None:
         """Apply common join state before configured-room setup."""
@@ -433,7 +437,7 @@ class BotRoomLifecycle:
 
     async def handle_recorded_invite(self, room: nio.MatrixRoom, sender: str) -> None:
         """Handle one invite whose identity is already durable."""
-        await self._handle_invite(room, sender)
+        await self._handle_invite(room, sender, invite_is_current=True)
 
     async def reconcile_pending_invites(self) -> None:
         """Re-evaluate durable and cached invites after responder access changes."""
@@ -444,12 +448,19 @@ class BotRoomLifecycle:
                 self.record_pending_room_invite(room.room_id, room.inviter)
         for room_id, sender in tuple(self._pending_room_invites.items()):
             room = client.invited_rooms.get(room_id)
+            invite_is_current = room is not None
             if room is None:
                 room = nio.MatrixInvitedRoom(room_id, self.deps.agent_user.user_id)
                 room.inviter = sender
-            await self._handle_invite(room, sender)
+            await self._handle_invite(room, sender, invite_is_current=invite_is_current)
 
-    async def _handle_invite(self, room: nio.MatrixRoom, sender: str) -> None:
+    async def _handle_invite(
+        self,
+        room: nio.MatrixRoom,
+        sender: str,
+        *,
+        invite_is_current: bool,
+    ) -> None:
         """Accept one invite when its inviter currently passes responder access."""
         client = self._client()
         if not self._should_accept_invite():
@@ -486,6 +497,10 @@ class BotRoomLifecycle:
             join_outcome = await self._join_room_with_decrypt_notice_fence(client, room.room_id)
             if join_outcome is not RoomJoinOutcome.JOINED:
                 self._logger().error("Failed to join room", room_id=room.room_id)
+                if join_outcome is RoomJoinOutcome.ACCESS_DENIED and not invite_is_current:
+                    await self._clear_join_decrypt_notice_fence(room.room_id)
+                    self._forget_pending_room_invite(room.room_id)
+                    return
                 if join_outcome is RoomJoinOutcome.TERMINAL_FAILURE:
                     self._forget_pending_room_invite(room.room_id)
                     return

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -397,14 +397,25 @@ class BotRoomLifecycle:
 
     async def on_invite(self, room: nio.MatrixRoom, event: nio.InviteEvent) -> None:
         """Handle one inbound invite using the configured room membership policy."""
+        await self._handle_invite(room, event.sender)
+
+    async def reconcile_pending_invites(self) -> None:
+        """Re-evaluate cached Matrix invites after responder access changes."""
+        client = self._client()
+        for room in tuple(client.invited_rooms.values()):
+            if room.inviter is not None:
+                await self._handle_invite(room, room.inviter)
+
+    async def _handle_invite(self, room: nio.MatrixRoom, sender: str) -> None:
+        """Accept one invite when its inviter currently passes responder access."""
         client = self._client()
         if not self._should_accept_invite():
-            self._logger().info("Ignored invite", room_id=room.room_id, sender=event.sender)
+            self._logger().info("Ignored invite", room_id=room.room_id, sender=sender)
             return
 
         config = self._config()
         invite_allowed = is_sender_allowed_for_agent_reply_in_room(
-            event.sender,
+            sender,
             self.deps.agent_name,
             config,
             room.room_id,
@@ -414,20 +425,20 @@ class BotRoomLifecycle:
         if not invite_allowed:
             self._logger().debug(
                 "ignoring_invite_from_unauthorized_sender",
-                user_id=event.sender,
+                user_id=sender,
                 room_id=room.room_id,
             )
             return
 
         async with self._lock_for_room(self._invite_join_locks, room.room_id):
             if room.room_id in self._handled_invite_room_ids:
-                self._logger().debug("Invite already handled", room_id=room.room_id, sender=event.sender)
+                self._logger().debug("Invite already handled", room_id=room.room_id, sender=sender)
                 await self.deps.on_room_joined(room.room_id)
                 self._remember_invited_room(room.room_id)
-                await self._send_invite_welcome(room.room_id, event.sender)
+                await self._send_invite_welcome(room.room_id, sender)
                 return
 
-            self._logger().info("Received invite", room_id=room.room_id, sender=event.sender)
+            self._logger().info("Received invite", room_id=room.room_id, sender=sender)
             join_outcome = await self._join_room_with_decrypt_notice_fence(client, room.room_id)
             if join_outcome is not RoomJoinOutcome.JOINED:
                 self._logger().error("Failed to join room", room_id=room.room_id)
@@ -440,4 +451,4 @@ class BotRoomLifecycle:
             await self.deps.on_room_joined(room.room_id)
             self._remember_invited_room(room.room_id)
             self._handled_invite_room_ids.add(room.room_id)
-            await self._send_invite_welcome(room.room_id, event.sender)
+            await self._send_invite_welcome(room.room_id, sender)

--- a/src/mindroom/matrix/client_room_admin.py
+++ b/src/mindroom/matrix/client_room_admin.py
@@ -48,6 +48,7 @@ class RoomJoinOutcome(StrEnum):
     """Typed outcome for one Matrix room join attempt."""
 
     JOINED = "joined"
+    ACCESS_DENIED = "access_denied"
     RETRYABLE_FAILURE = "retryable_failure"
     TERMINAL_FAILURE = "terminal_failure"
 
@@ -625,11 +626,12 @@ async def join_room(client: nio.AsyncClient, room_id: str) -> RoomJoinOutcome:
             )
         logger.info("matrix_room_joined", room_id=room_id)
         return RoomJoinOutcome.JOINED
-    outcome = (
-        RoomJoinOutcome.TERMINAL_FAILURE
-        if isinstance(response, nio.JoinError) and response.status_code in _TERMINAL_ROOM_JOIN_ERROR_CODES
-        else RoomJoinOutcome.RETRYABLE_FAILURE
-    )
+    if isinstance(response, nio.JoinError) and response.status_code in _TERMINAL_ROOM_JOIN_ERROR_CODES:
+        outcome = RoomJoinOutcome.TERMINAL_FAILURE
+    elif isinstance(response, nio.JoinError) and response.status_code == "M_FORBIDDEN":
+        outcome = RoomJoinOutcome.ACCESS_DENIED
+    else:
+        outcome = RoomJoinOutcome.RETRYABLE_FAILURE
     logger.warning(
         "matrix_room_join_failed",
         room_id=room_id,

--- a/src/mindroom/matrix/invited_rooms_store.py
+++ b/src/mindroom/matrix/invited_rooms_store.py
@@ -23,6 +23,11 @@ def invited_rooms_path(storage_root: Path, agent_name: str) -> Path:
     return agent_state_root_path(storage_root, agent_name) / "invited_rooms.json"
 
 
+def pending_room_invites_path(storage_root: Path, agent_name: str) -> Path:
+    """Return the storage path for one agent's outstanding room invites."""
+    return agent_state_root_path(storage_root, agent_name) / "pending_room_invites.json"
+
+
 def load_invited_rooms(path: Path) -> set[str]:
     """Load persisted invited rooms, failing open on missing or invalid files."""
     if not path.exists():
@@ -52,11 +57,41 @@ def save_invited_rooms(path: Path, room_ids: set[str]) -> bool:
     Callers replacing a cached set must first merge fresh durable state so a
     stale in-memory snapshot cannot discard another runtime component's write.
     """
+    return _save_json(path, sorted(room_ids))
+
+
+def load_pending_room_invites(path: Path) -> dict[str, str]:
+    """Load outstanding room IDs and their inviters from durable state."""
+    if not path.exists():
+        return {}
+
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        logger.warning("failed_to_load_pending_room_invites", path=str(path), exc_info=True)
+        return {}
+
+    if not isinstance(raw, dict) or any(
+        not isinstance(room_id, str) or not isinstance(sender_id, str) for room_id, sender_id in raw.items()
+    ):
+        logger.warning("invalid_pending_room_invites_file", path=str(path))
+        return {}
+
+    return raw
+
+
+def save_pending_room_invites(path: Path, pending_invites: dict[str, str]) -> bool:
+    """Atomically replace one agent's outstanding room invites."""
+    return _save_json(path, dict(sorted(pending_invites.items())))
+
+
+def _save_json(path: Path, value: object) -> bool:
+    """Atomically replace one JSON state file."""
     temp_path = path.with_name(f"{path.name}.{uuid4().hex}.tmp")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
         temp_path.write_text(
-            f"{json.dumps(sorted(room_ids), ensure_ascii=True, indent=2)}\n",
+            f"{json.dumps(value, ensure_ascii=True, indent=2)}\n",
             encoding="utf-8",
         )
         safe_replace(temp_path, path)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1352,6 +1352,10 @@ class _MultiAgentOrchestrator:
         """Recheck every active MatrixRTC call against current reply access."""
         await asyncio.gather(*(bot.reconcile_reply_authorized_calls() for bot in self.agent_bots.values()))
 
+    async def reconcile_pending_invites(self) -> None:
+        """Recheck every cached room invite against current responder access."""
+        await asyncio.gather(*(bot.reconcile_pending_invites() for bot in self.agent_bots.values()))
+
     async def revoke_reply_authorized_calls(self) -> None:
         """End active MatrixRTC calls that no longer pass current reply access."""
         await asyncio.gather(*(bot.revoke_reply_authorized_calls() for bot in self.agent_bots.values()))

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1368,6 +1368,7 @@ class _MultiAgentOrchestrator:
             self.invalidate_agent_reply_memberships(reason="router_unavailable")
             return
         await self.agent_reply_memberships.refresh(config, self.runtime_paths, router_bot.client)
+        await self.reconcile_pending_invites()
         await self.revoke_reply_authorized_calls()
         for bot in self.agent_bots.values():
             bot.schedule_reply_authorized_call_reconciliation()

--- a/src/mindroom/runtime_protocols.py
+++ b/src/mindroom/runtime_protocols.py
@@ -88,6 +88,10 @@ class OrchestratorRuntime(SupportsRunningState, Protocol):
         """End active calls whose requester no longer has reply access."""
         ...
 
+    def reconcile_pending_invites(self) -> Awaitable[None]:
+        """Recheck cached room invites against current responder access."""
+        ...
+
     def revoke_reply_authorized_calls(self) -> Awaitable[None]:
         """End active calls without running positive room reconciliation."""
         ...

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1148,6 +1148,7 @@ def make_matrix_client_mock(*, user_id: str = "@mindroom_test:example.com") -> A
     client.device_id = "TESTDEVICE"
     client.olm = None
     client.rooms = _AutoRoomCache(user_id)
+    client.invited_rooms = {}
     client.next_batch = "s_test_token"
     client.loaded_sync_token = ""
     client.has_uncommitted_classic_sync_state = False

--- a/tests/test_agent_reply_membership_sync.py
+++ b/tests/test_agent_reply_membership_sync.py
@@ -1,0 +1,61 @@
+"""Tests for router reply-membership sync coordination."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import nio
+import pytest
+
+from mindroom.agent_reply_membership import AgentReplyMembershipIndex
+from mindroom.agent_reply_membership_sync import AgentReplyMembershipSync
+from mindroom.config.main import Config
+from tests.conftest import test_runtime_paths
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.mark.asyncio
+async def test_live_transition_retries_unfinished_effects_after_event_replay(tmp_path: Path) -> None:
+    """A no-op replay must retry effects left pending by an earlier failure."""
+    memberships = MagicMock(spec=AgentReplyMembershipIndex)
+    memberships.apply_member_event.side_effect = [True, False, False]
+    membership_sync = AgentReplyMembershipSync(memberships)
+    event = nio.RoomMemberEvent.from_dict(
+        {
+            "type": "m.room.member",
+            "event_id": "$grant",
+            "sender": "@alice:localhost",
+            "state_key": "@alice:localhost",
+            "origin_server_ts": 1,
+            "content": {"membership": "join"},
+        },
+    )
+    assert isinstance(event, nio.RoomMemberEvent)
+    effect_attempts = 0
+
+    async def reconcile_effects() -> None:
+        nonlocal effect_attempts
+        effect_attempts += 1
+        if effect_attempts == 1:
+            msg = "effect failed"
+            raise RuntimeError(msg)
+
+    async def apply_transition() -> None:
+        await membership_sync.apply_live_transition(
+            Config(),
+            test_runtime_paths(tmp_path),
+            "!grant:localhost",
+            event,
+            control_user_id="@router:localhost",
+            reconcile_effects=reconcile_effects,
+        )
+
+    with pytest.raises(RuntimeError, match="effect failed"):
+        await apply_transition()
+    await apply_transition()
+    await apply_transition()
+
+    assert effect_attempts == 2

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -95,6 +95,7 @@ def _router_bot_with_orchestrator(tmp_path: Path) -> tuple[AgentBot, MagicMock]:
     )
     orchestrator.refresh_agent_reply_memberships = AsyncMock()
     orchestrator.revoke_reply_authorized_calls = AsyncMock()
+    orchestrator.reconcile_pending_invites = AsyncMock()
     orchestrator.handle_bot_ready = AsyncMock()
     bot.orchestrator = orchestrator
     return bot, orchestrator

--- a/tests/test_dm_functionality.py
+++ b/tests/test_dm_functionality.py
@@ -303,7 +303,8 @@ class TestDMIntegration:
             event = MagicMock()
             event.sender = "@user:localhost"
 
-            await bot._on_invite(room, event)
+            bot._room_lifecycle.record_pending_room_invite(room.room_id, event.sender)
+            await bot._room_lifecycle.handle_recorded_invite(room, event.sender)
 
             mock_join.assert_called_once()
             bot.logger.info.assert_any_call("Joined room", room_id="!dm:localhost")

--- a/tests/test_matrix_sync_continuity.py
+++ b/tests/test_matrix_sync_continuity.py
@@ -2208,16 +2208,16 @@ async def test_callback_failure_preserves_saved_checkpoint_immediately(tmp_path:
 
 
 @pytest.mark.asyncio
-async def test_durably_accepted_invite_failure_does_not_rewind_classic_cursor(
+async def test_durable_invite_failure_does_not_rewind_classic_cursor(
     tmp_path: Path,
 ) -> None:
-    """Accepted invite work must retry independently of raw sync continuity."""
+    """Durably recorded invite work must not rewind raw sync continuity."""
     bot = _agent_bot(tmp_path)
     bot.client = make_matrix_client_mock(user_id=bot.matrix_id.full_id)
     bot.client.next_batch = "s_after_invite"
     bot._sync_checkpoint_trust.state = SyncTrustState.CERTIFIED
     bot._sync_checkpoint_trust.checkpoint = SyncCheckpoint("s_before_invite")
-    bot._room_lifecycle.on_invite = AsyncMock(side_effect=RuntimeError("join failed"))
+    bot._room_lifecycle.handle_recorded_invite = AsyncMock(side_effect=RuntimeError("join failed"))
     room = nio.MatrixRoom("!invited:localhost", bot.matrix_id.full_id)
     event = nio.InviteEvent.parse_event(
         {
@@ -2228,20 +2228,14 @@ async def test_durably_accepted_invite_failure_does_not_rewind_classic_cursor(
         },
     )
     assert isinstance(event, nio.InviteEvent)
-    recovered_invite = AsyncMock()
-    bot._room_lifecycle.on_invite = recovered_invite
-
     await bot._on_invite_before_sync_certification(room, event)
     assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
 
     assert bot.client.next_batch == "s_after_invite"
-    # Invites are not journalled: the homeserver keeps offering an invite the
-    # bot has not acted on, so it needs no durable row of its own.
+    assert bot._room_lifecycle._pending_room_invites == {room.room_id: event.sender}
+    # The dedicated pending-invite store owns recovery, so no journal row is needed.
     assert await bot._journal_dispatcher.store.pending() == ()
-    recovered_invite.assert_awaited_once()
-    recovered_event = recovered_invite.await_args.args[1]
-    assert isinstance(recovered_event, nio.InviteMemberEvent)
-    assert recovered_event.content == {"membership": "invite"}
+    bot._room_lifecycle.handle_recorded_invite.assert_awaited_once_with(room, event.sender)
 
 
 @pytest.mark.asyncio

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -556,7 +556,8 @@ class TestAgentBot(AgentBotTestBase):
             patch("mindroom.bot_room_lifecycle.is_sender_allowed_for_agent_reply_in_room", return_value=True),
             patch("mindroom.bot_room_lifecycle.join_room", join_room),
         ):
-            await bot._on_invite(mock_room, mock_event)
+            bot._room_lifecycle.record_pending_room_invite(mock_room.room_id, mock_event.sender)
+            await bot._room_lifecycle.handle_recorded_invite(mock_room, mock_event.sender)
 
         assert join_room.await_count == expected_join_calls
 

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -658,7 +658,8 @@ async def test_agent_handles_room_invite(mock_calculator_agent: AgentMatrixUser,
         mock_event = MagicMock(spec=nio.InviteEvent)
         mock_event.sender = "@inviter:localhost"
 
-        await bot._on_invite(mock_room, mock_event)
+        bot._room_lifecycle.record_pending_room_invite(mock_room.room_id, mock_event.sender)
+        await bot._room_lifecycle.handle_recorded_invite(mock_room, mock_event.sender)
 
         # Verify new room was joined (not the initial room)
         bot.client.join.assert_called_with(invite_room)

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -101,10 +101,12 @@ async def test_reply_membership_refresh_revokes_before_scheduling_positive_call_
     orchestrator.config = config
     router_bot = MagicMock()
     router_bot.client = AsyncMock(spec=nio.AsyncClient)
+    router_bot.reconcile_pending_invites = AsyncMock()
     router_bot.revoke_reply_authorized_calls = AsyncMock()
     router_bot.reconcile_reply_authorized_calls = AsyncMock(side_effect=AssertionError("must be scheduled"))
     worker_bot = MagicMock()
     worker_bot.client = AsyncMock(spec=nio.AsyncClient)
+    worker_bot.reconcile_pending_invites = AsyncMock()
     worker_bot.revoke_reply_authorized_calls = AsyncMock()
     worker_bot.reconcile_reply_authorized_calls = AsyncMock(side_effect=AssertionError("must be scheduled"))
     orchestrator.agent_bots = {

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -1961,7 +1961,7 @@ async def test_grant_room_join_reconciles_previously_denied_invite(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Grant-room membership should recover an invite denied before the grant."""
+    """Grant-room membership should recover a denied invite after a transient failure."""
     sender_id = "@alice:localhost"
     grant_room_id = "!canonical:localhost"
     invited_room_id = "!invited-room:localhost"
@@ -2020,6 +2020,7 @@ async def test_grant_room_join_reconciles_previously_denied_invite(
     bot.orchestrator = orchestrator
     router_bot.orchestrator = orchestrator
     orchestrator.agent_bots = {"agent1": bot, ROUTER_AGENT_NAME: router_bot}
+    orchestrator.reconcile_reply_authorized_calls = AsyncMock()
 
     bot.client = make_matrix_client_mock(user_id=agent_user.user_id)
     invited_room = nio.MatrixInvitedRoom(invited_room_id, agent_user.user_id)
@@ -2033,7 +2034,9 @@ async def test_grant_room_join_reconciles_previously_denied_invite(
     router_bot.client.joined_members = AsyncMock(
         return_value=nio.JoinedMembersResponse(members=[], room_id=grant_room_id),
     )
-    join_room = AsyncMock(return_value=RoomJoinOutcome.JOINED)
+    join_room = AsyncMock(
+        side_effect=[RoomJoinOutcome.RETRYABLE_FAILURE, RoomJoinOutcome.JOINED],
+    )
     monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", join_room)
     event = nio.InviteEvent.parse_event(
         {
@@ -2061,7 +2064,8 @@ async def test_grant_room_join_reconciles_previously_denied_invite(
         },
     )
     assert isinstance(join_event, nio.RoomMemberEvent)
-    await router_bot._apply_live_reply_membership_transition(grant_room_id, join_event)
+    with pytest.raises(RuntimeError, match="Failed to join invited room"):
+        await router_bot._apply_live_reply_membership_transition(grant_room_id, join_event)
 
     assert is_sender_allowed_for_responder(
         sender_id,
@@ -2071,8 +2075,17 @@ async def test_grant_room_join_reconciles_previously_denied_invite(
         runtime_paths,
         orchestrator.agent_reply_memberships,
     )
+    assert bot._room_lifecycle.invited_rooms == set()
+    orchestrator.reconcile_reply_authorized_calls.assert_not_awaited()
+
+    await router_bot._apply_live_reply_membership_transition(grant_room_id, join_event)
+
     assert bot._room_lifecycle.invited_rooms == {invited_room_id}
-    join_room.assert_awaited_once_with(bot.client, invited_room_id)
+    orchestrator.reconcile_reply_authorized_calls.assert_awaited_once_with()
+    assert join_room.await_args_list == [
+        ((bot.client, invited_room_id),),
+        ((bot.client, invited_room_id),),
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from dataclasses import dataclass
 from pathlib import Path  # noqa: TC003
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
@@ -24,7 +25,13 @@ from mindroom.config.models import RouterConfig
 from mindroom.constants import ROUTER_AGENT_NAME
 from mindroom.hooks.matrix_admin import build_hook_matrix_admin
 from mindroom.matrix.client_room_admin import RoomJoinOutcome
-from mindroom.matrix.invited_rooms_store import invited_rooms_path, load_invited_rooms, save_invited_rooms
+from mindroom.matrix.invited_rooms_store import (
+    invited_rooms_path,
+    load_invited_rooms,
+    load_pending_room_invites,
+    pending_room_invites_path,
+    save_invited_rooms,
+)
 from mindroom.matrix.room_cleanup import cleanup_all_orphaned_bots
 from mindroom.matrix.state import MatrixState
 from mindroom.matrix.users import AgentMatrixUser
@@ -46,9 +53,22 @@ if TYPE_CHECKING:
 
     from nio.responses import Response
 
+    from mindroom.bot import AgentBot
+    from mindroom.constants import RuntimePaths
+
 
 def _invited_rooms_path(config: Config, agent_name: str) -> Path:
     return invited_rooms_path(runtime_paths_for(config).storage_root, agent_name)
+
+
+def _pending_room_invites(config: Config, agent_name: str) -> dict[str, str]:
+    path = pending_room_invites_path(runtime_paths_for(config).storage_root, agent_name)
+    return load_pending_room_invites(path)
+
+
+async def _handle_invite(bot: AgentBot, room: nio.MatrixRoom, event: nio.InviteEvent) -> None:
+    bot._room_lifecycle.record_pending_room_invite(room.room_id, event.sender)
+    await bot._room_lifecycle.handle_recorded_invite(room, event.sender)
 
 
 def _router_user() -> AgentMatrixUser:
@@ -341,7 +361,7 @@ async def test_router_accepts_agent_invite_persists_and_rejoins_on_startup(
     room.canonical_alias = None
     event = MagicMock(sender="@mindroom_agent1:localhost")
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     join_room.assert_awaited_once_with(bot.client, "!router-invited:localhost")
     assert fenced_during_join == [True]
@@ -399,7 +419,8 @@ async def test_invite_join_failure_propagates_to_sync_boundary(
     )
 
     with pytest.raises(RuntimeError, match="Failed to join invited room"):
-        await bot._on_invite(
+        await _handle_invite(
+            bot,
             MagicMock(room_id="!failed:localhost", canonical_alias=None),
             MagicMock(sender="@owner:localhost"),
         )
@@ -516,11 +537,11 @@ async def test_invite_sync_callback_runs_durable_join_in_background(tmp_path: Pa
     join_started = asyncio.Event()
     release_join = asyncio.Event()
 
-    async def delayed_invite(_room: nio.MatrixRoom, _event: nio.InviteEvent) -> None:
+    async def delayed_invite(_room: nio.MatrixRoom, _sender: str) -> None:
         join_started.set()
         await release_join.wait()
 
-    bot._room_lifecycle.on_invite = delayed_invite
+    bot._room_lifecycle.handle_recorded_invite = delayed_invite
     room = nio.MatrixRoom("!background-invite:localhost", bot.matrix_id.full_id)
     event = nio.InviteEvent.parse_event(
         {
@@ -539,9 +560,8 @@ async def test_invite_sync_callback_runs_durable_join_in_background(tmp_path: Pa
         await asyncio.wait_for(join_started.wait(), timeout=1)
         await asyncio.sleep(0)
         assert callback_task.done()
-        # Invites are not journalled: an invite the bot has not acted on
-        # reappears in every sync response, so the homeserver already provides
-        # the redelivery a journal row would have.
+        assert bot._room_lifecycle._pending_room_invites == {room.room_id: event.sender}
+        # The dedicated pending-invite store owns recovery, so no journal row is needed.
         assert await bot._journal_dispatcher.store.pending() == ()
     finally:
         release_join.set()
@@ -549,6 +569,41 @@ async def test_invite_sync_callback_runs_durable_join_in_background(tmp_path: Pa
 
     assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
     assert await bot._journal_dispatcher.store.pending() == ()
+
+
+@pytest.mark.asyncio
+async def test_invite_sync_callback_does_not_start_work_when_identity_save_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Invite work must not outlive a failed durable identity write."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = make_test_agent_bot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot._room_lifecycle.handle_recorded_invite = AsyncMock()
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.save_pending_room_invites", lambda *_args: False)
+    room = nio.MatrixRoom("!failed-pending-save:localhost", bot.matrix_id.full_id)
+    event = nio.InviteEvent.parse_event(
+        {
+            "type": "m.room.member",
+            "sender": "@owner:localhost",
+            "state_key": bot.matrix_id.full_id,
+            "content": {"membership": "invite"},
+        },
+    )
+    assert isinstance(event, nio.InviteEvent)
+
+    with pytest.raises(OSError, match="Failed to persist pending room invite"):
+        await bot._on_invite_before_sync_certification(room, event)
+
+    bot._room_lifecycle.handle_recorded_invite.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -582,7 +637,8 @@ async def test_invite_persistence_failure_propagates_to_sync_boundary(
     monkeypatch.setattr(bot._room_lifecycle, "send_welcome_message_if_empty", AsyncMock())
 
     with pytest.raises(OSError, match="Failed to persist invited room"):
-        await bot._on_invite(
+        await _handle_invite(
+            bot,
             MagicMock(room_id="!failed-save:localhost", canonical_alias=None),
             MagicMock(sender="@owner:localhost"),
         )
@@ -633,7 +689,7 @@ async def test_router_invite_preserves_room_created_after_lifecycle_loaded(
     room = MagicMock(room_id="!later-invite:localhost", canonical_alias=None)
     event = MagicMock(sender="@owner:localhost")
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     expected_rooms = {"!hook-created:localhost", "!later-invite:localhost"}
     assert bot._room_lifecycle.invited_rooms == expected_rooms
@@ -785,10 +841,11 @@ async def test_router_invite_keeps_memory_after_transient_persistence_failure(
     first_room = MagicMock(room_id="!first:localhost", canonical_alias=None)
     event = MagicMock(sender="@owner:localhost")
     with pytest.raises(OSError, match="Failed to persist invited room"):
-        await bot._on_invite(first_room, event)
+        await _handle_invite(bot, first_room, event)
 
-    await bot._on_invite(first_room, event)
-    await bot._on_invite(
+    await _handle_invite(bot, first_room, event)
+    await _handle_invite(
+        bot,
         MagicMock(room_id="!second:localhost", canonical_alias=None),
         event,
     )
@@ -851,9 +908,9 @@ async def test_router_deduplicates_concurrent_invite_callbacks(
     room.canonical_alias = None
     event = MagicMock(sender="@owner:localhost")
 
-    first_invite = asyncio.create_task(bot._on_invite(room, event))
+    first_invite = asyncio.create_task(_handle_invite(bot, room, event))
     await join_started.wait()
-    second_invite = asyncio.create_task(bot._on_invite(room, event))
+    second_invite = asyncio.create_task(_handle_invite(bot, room, event))
     release_join.set()
 
     await asyncio.gather(first_invite, second_invite)
@@ -905,10 +962,10 @@ async def test_router_departure_allows_fresh_reinvite(
     send_response = AsyncMock(return_value="$welcome")
     install_send_response_mock(bot, send_response)
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
     bot.client.rooms[room_id] = MagicMock()
     bot._room_lifecycle.forget_invited_room(room_id)
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     assert join_room.await_count == 2
     assert bot.client.room_messages.await_count == 2
@@ -1120,8 +1177,8 @@ async def test_router_duplicate_invite_retries_failed_welcome_delivery(
     event = MagicMock(sender="@owner:localhost")
 
     with pytest.raises(RuntimeError, match="Failed to complete welcome message"):
-        await bot._on_invite(room, event)
-    await bot._on_invite(room, event)
+        await _handle_invite(bot, room, event)
+    await _handle_invite(bot, room, event)
 
     join_room.assert_awaited_once_with(bot.client, "!router-invited:localhost")
     assert bot.client.room_messages.await_count == 2
@@ -1443,7 +1500,7 @@ async def test_router_invite_welcome_filters_ad_hoc_responders_for_inviter(
     room.canonical_alias = None
     event = MagicMock(sender="@alice:localhost")
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     response_text = send_response.await_args.kwargs["response_text"]
     assert "\u2022 **@code**: Writes code" in response_text
@@ -1570,7 +1627,7 @@ async def test_router_ignores_invite_when_accept_invites_disabled(
     room.canonical_alias = None
     event = MagicMock(sender="@owner:localhost")
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     join_room.assert_not_awaited()
     assert bot._room_lifecycle.invited_rooms == set()
@@ -1898,7 +1955,7 @@ async def test_agent_refuses_invite_when_accept_invites_disabled(
     room = MagicMock(room_id="!invited-room:localhost")
     event = MagicMock(sender="@user:localhost")
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     join_room.assert_not_awaited()
     assert not _invited_rooms_path(config, "agent1").exists()
@@ -1948,20 +2005,32 @@ async def test_agent_refuses_invite_from_unauthorized_sender(
     room.canonical_alias = None
     event = MagicMock(sender="@intruder:localhost")
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     join_room.assert_not_awaited()
     assert bot._room_lifecycle.invited_rooms == set()
     assert not _invited_rooms_path(config, "agent1").exists()
 
 
-@pytest.mark.asyncio
-@pytest.mark.usefixtures("enforce_turn_authorization")
-async def test_grant_room_join_reconciles_previously_denied_invite(
+@dataclass(frozen=True)
+class _GrantInviteScenario:
+    config: Config
+    runtime_paths: RuntimePaths
+    orchestrator: _MultiAgentOrchestrator
+    agent_user: AgentMatrixUser
+    bot: AgentBot
+    router_bot: AgentBot
+    join_room: AsyncMock
+    sender_id: str
+    grant_room_id: str
+    invited_room_id: str
+
+
+async def _grant_invite_scenario(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-) -> None:
-    """Grant-room membership should recover a denied invite after a transient failure."""
+) -> _GrantInviteScenario:
+    """Build a denied invite whose first authorized join will fail."""
     sender_id = "@alice:localhost"
     grant_room_id = "!canonical:localhost"
     invited_room_id = "!invited-room:localhost"
@@ -2049,15 +2118,84 @@ async def test_grant_room_join_reconciles_previously_denied_invite(
     assert isinstance(event, nio.InviteMemberEvent)
 
     await orchestrator.agent_reply_memberships.refresh(config, runtime_paths, router_bot.client)
-    await bot._on_invite(invited_room, event)
+    await _handle_invite(bot, invited_room, event)
     assert bot._room_lifecycle.invited_rooms == set()
+    assert _pending_room_invites(config, "agent1") == {invited_room_id: sender_id}
+    return _GrantInviteScenario(
+        config=config,
+        runtime_paths=runtime_paths,
+        orchestrator=orchestrator,
+        agent_user=agent_user,
+        bot=bot,
+        router_bot=router_bot,
+        join_room=join_room,
+        sender_id=sender_id,
+        grant_room_id=grant_room_id,
+        invited_room_id=invited_room_id,
+    )
+
+
+async def _restart_grant_invite_scenario(
+    scenario: _GrantInviteScenario,
+    tmp_path: Path,
+) -> AgentBot:
+    """Rebuild the bot fleet and recover its durable pending invite."""
+    restarted_orchestrator = _MultiAgentOrchestrator(runtime_paths=scenario.runtime_paths)
+    restarted_orchestrator.config = scenario.config
+    recovered_bot = make_test_agent_bot(
+        agent_user=scenario.agent_user,
+        storage_path=tmp_path,
+        config=scenario.config,
+        runtime_paths=scenario.runtime_paths,
+        agent_reply_memberships=restarted_orchestrator.agent_reply_memberships,
+    )
+    install_runtime_journal_support(recovered_bot)
+    restarted_router = make_test_agent_bot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=scenario.config,
+        runtime_paths=scenario.runtime_paths,
+        agent_reply_memberships=restarted_orchestrator.agent_reply_memberships,
+        agent_reply_membership_sync=restarted_orchestrator.agent_reply_membership_sync,
+    )
+    recovered_bot.orchestrator = restarted_orchestrator
+    restarted_router.orchestrator = restarted_orchestrator
+    restarted_orchestrator.agent_bots = {
+        "agent1": recovered_bot,
+        ROUTER_AGENT_NAME: restarted_router,
+    }
+    recovered_bot.client = make_matrix_client_mock(user_id=scenario.agent_user.user_id)
+    restarted_router.client = make_matrix_client_mock(user_id=restarted_router.agent_user.user_id)
+    restarted_router.client.joined_rooms = AsyncMock(
+        return_value=nio.JoinedRoomsResponse(rooms=[scenario.grant_room_id]),
+    )
+    restarted_router.client.joined_members = AsyncMock(
+        return_value=nio.JoinedMembersResponse(
+            members=[nio.RoomMember(scenario.sender_id, None, None)],
+            room_id=scenario.grant_room_id,
+        ),
+    )
+    await restarted_orchestrator.refresh_agent_reply_memberships()
+    return recovered_bot
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enforce_turn_authorization")
+@pytest.mark.parametrize("restart", [False, True], ids=["event-replay", "process-restart"])
+async def test_grant_room_join_reconciles_previously_denied_invite(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    restart: bool,
+) -> None:
+    """Grant-room membership should recover a denied invite after a transient failure."""
+    scenario = await _grant_invite_scenario(monkeypatch, tmp_path)
 
     join_event = nio.RoomMemberEvent.from_dict(
         {
             "type": "m.room.member",
             "event_id": "$alice-joined-canonical",
-            "sender": sender_id,
-            "state_key": sender_id,
+            "sender": scenario.sender_id,
+            "state_key": scenario.sender_id,
             "origin_server_ts": 1,
             "content": {"membership": "join"},
             "unsigned": {"prev_content": {"membership": "invite"}},
@@ -2065,26 +2203,31 @@ async def test_grant_room_join_reconciles_previously_denied_invite(
     )
     assert isinstance(join_event, nio.RoomMemberEvent)
     with pytest.raises(RuntimeError, match="Failed to join invited room"):
-        await router_bot._apply_live_reply_membership_transition(grant_room_id, join_event)
+        await scenario.router_bot._apply_live_reply_membership_transition(scenario.grant_room_id, join_event)
 
     assert is_sender_allowed_for_responder(
-        sender_id,
+        scenario.sender_id,
         "agent1",
-        invited_room_id,
-        config,
-        runtime_paths,
-        orchestrator.agent_reply_memberships,
+        scenario.invited_room_id,
+        scenario.config,
+        scenario.runtime_paths,
+        scenario.orchestrator.agent_reply_memberships,
     )
-    assert bot._room_lifecycle.invited_rooms == set()
-    orchestrator.reconcile_reply_authorized_calls.assert_not_awaited()
+    assert scenario.bot._room_lifecycle.invited_rooms == set()
+    scenario.orchestrator.reconcile_reply_authorized_calls.assert_not_awaited()
 
-    await router_bot._apply_live_reply_membership_transition(grant_room_id, join_event)
+    if restart:
+        recovered_bot = await _restart_grant_invite_scenario(scenario, tmp_path)
+    else:
+        recovered_bot = scenario.bot
+        await scenario.router_bot._apply_live_reply_membership_transition(scenario.grant_room_id, join_event)
+        scenario.orchestrator.reconcile_reply_authorized_calls.assert_awaited_once_with()
 
-    assert bot._room_lifecycle.invited_rooms == {invited_room_id}
-    orchestrator.reconcile_reply_authorized_calls.assert_awaited_once_with()
-    assert join_room.await_args_list == [
-        ((bot.client, invited_room_id),),
-        ((bot.client, invited_room_id),),
+    assert recovered_bot._room_lifecycle.invited_rooms == {scenario.invited_room_id}
+    assert _pending_room_invites(scenario.config, "agent1") == {}
+    assert scenario.join_room.await_args_list == [
+        ((scenario.bot.client, scenario.invited_room_id),),
+        ((recovered_bot.client, scenario.invited_room_id),),
     ]
 
 
@@ -2119,7 +2262,7 @@ async def test_unknown_entity_refuses_invite(
     room.canonical_alias = None
     event = MagicMock(sender="@user:localhost")
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     join_room.assert_not_awaited()
     assert not _invited_rooms_path(config, "agent1").exists()
@@ -2166,7 +2309,7 @@ async def test_agent_persists_non_dm_invited_room(monkeypatch: pytest.MonkeyPatc
     room.canonical_alias = None
     event = MagicMock(sender="@user:localhost")
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     join_room.assert_awaited_once_with(bot.client, "!project-room:localhost")
     assert bot._room_lifecycle.invited_rooms == {"!project-room:localhost"}
@@ -2239,7 +2382,7 @@ async def test_agent_invite_does_not_auto_add_router_to_ad_hoc_room(
     room.canonical_alias = None
     event = MagicMock(sender="@user:localhost")
 
-    await bot._on_invite(room, event)
+    await _handle_invite(bot, room, event)
 
     join_room.assert_awaited_once_with(bot.client, "!project-room:localhost")
     invite_router.assert_not_awaited()

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -15,6 +15,7 @@ from unittest.mock import AsyncMock, MagicMock
 import nio
 import pytest
 
+from mindroom.authorization import is_sender_allowed_for_responder
 from mindroom.background_tasks import wait_for_background_tasks
 from mindroom.config.access import ResponderAccessConfig
 from mindroom.config.agent import AgentConfig, TeamConfig
@@ -1952,6 +1953,126 @@ async def test_agent_refuses_invite_from_unauthorized_sender(
     join_room.assert_not_awaited()
     assert bot._room_lifecycle.invited_rooms == set()
     assert not _invited_rooms_path(config, "agent1").exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enforce_turn_authorization")
+async def test_grant_room_join_reconciles_previously_denied_invite(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Grant-room membership should recover an invite denied before the grant."""
+    sender_id = "@alice:localhost"
+    grant_room_id = "!canonical:localhost"
+    invited_room_id = "!invited-room:localhost"
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "agent1": AgentConfig(
+                    display_name="Agent 1",
+                    role="Test agent",
+                    rooms=["canonical"],
+                    access=ResponderAccessConfig(
+                        current_room_members=False,
+                        members_of_rooms=["canonical"],
+                    ),
+                ),
+            },
+            router=RouterConfig(
+                model="default",
+                access=ResponderAccessConfig(
+                    current_room_members=False,
+                    members_of_rooms=[],
+                ),
+            ),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    runtime_paths = runtime_paths_for(config)
+    state = MatrixState.load(runtime_paths=runtime_paths)
+    state.add_room("canonical", grant_room_id, "#canonical:localhost", "Canonical")
+    state.save(runtime_paths=runtime_paths)
+
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    orchestrator.config = config
+    agent_user = AgentMatrixUser(
+        agent_name="agent1",
+        user_id="@mindroom_agent1:localhost",
+        display_name="Agent 1",
+        password=TEST_PASSWORD,
+    )
+    bot = make_test_agent_bot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths,
+        agent_reply_memberships=orchestrator.agent_reply_memberships,
+    )
+    install_runtime_journal_support(bot)
+    router_bot = make_test_agent_bot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths,
+        agent_reply_memberships=orchestrator.agent_reply_memberships,
+        agent_reply_membership_sync=orchestrator.agent_reply_membership_sync,
+    )
+    bot.orchestrator = orchestrator
+    router_bot.orchestrator = orchestrator
+    orchestrator.agent_bots = {"agent1": bot, ROUTER_AGENT_NAME: router_bot}
+
+    bot.client = make_matrix_client_mock(user_id=agent_user.user_id)
+    invited_room = nio.MatrixInvitedRoom(invited_room_id, agent_user.user_id)
+    invited_room.inviter = sender_id
+    bot.client.invited_rooms = {invited_room_id: invited_room}
+    router_bot.client = make_matrix_client_mock(user_id=router_bot.agent_user.user_id)
+    router_bot.client.invited_rooms = {}
+    router_bot.client.joined_rooms = AsyncMock(
+        return_value=nio.JoinedRoomsResponse(rooms=[grant_room_id]),
+    )
+    router_bot.client.joined_members = AsyncMock(
+        return_value=nio.JoinedMembersResponse(members=[], room_id=grant_room_id),
+    )
+    join_room = AsyncMock(return_value=RoomJoinOutcome.JOINED)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", join_room)
+    event = nio.InviteEvent.parse_event(
+        {
+            "type": "m.room.member",
+            "sender": sender_id,
+            "state_key": agent_user.user_id,
+            "content": {"membership": "invite"},
+        },
+    )
+    assert isinstance(event, nio.InviteMemberEvent)
+
+    await orchestrator.agent_reply_memberships.refresh(config, runtime_paths, router_bot.client)
+    await bot._on_invite(invited_room, event)
+    assert bot._room_lifecycle.invited_rooms == set()
+
+    join_event = nio.RoomMemberEvent.from_dict(
+        {
+            "type": "m.room.member",
+            "event_id": "$alice-joined-canonical",
+            "sender": sender_id,
+            "state_key": sender_id,
+            "origin_server_ts": 1,
+            "content": {"membership": "join"},
+            "unsigned": {"prev_content": {"membership": "invite"}},
+        },
+    )
+    assert isinstance(join_event, nio.RoomMemberEvent)
+    await router_bot._apply_live_reply_membership_transition(grant_room_id, join_event)
+
+    assert is_sender_allowed_for_responder(
+        sender_id,
+        "agent1",
+        invited_room_id,
+        config,
+        runtime_paths,
+        orchestrator.agent_reply_memberships,
+    )
+    assert bot._room_lifecycle.invited_rooms == {invited_room_id}
+    join_room.assert_awaited_once_with(bot.client, invited_room_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -391,11 +391,11 @@ async def test_router_accepts_agent_invite_persists_and_rejoins_on_startup(
 
 
 @pytest.mark.asyncio
-async def test_invite_join_failure_propagates_to_sync_boundary(
+async def test_live_invite_forbidden_join_remains_retryable(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """Failed invite joins must remain retryable instead of returning success."""
+    """A live invite's ambiguous forbidden join must remain retryable."""
     config = bind_runtime_paths(
         Config(router=RouterConfig(model="default", accept_invites=True)),
         test_runtime_paths(tmp_path),
@@ -407,15 +407,12 @@ async def test_invite_join_failure_propagates_to_sync_boundary(
         runtime_paths=runtime_paths_for(config),
     )
     install_runtime_journal_support(bot)
-    bot.client = AsyncMock()
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
     bot.client.rooms = {}
+    bot.client.join = AsyncMock(return_value=nio.JoinError("forbidden", "M_FORBIDDEN"))
     monkeypatch.setattr(
         "mindroom.bot_room_lifecycle.is_sender_allowed_for_agent_reply_in_room",
         lambda *_args, **_kwargs: True,
-    )
-    monkeypatch.setattr(
-        "mindroom.bot_room_lifecycle.join_room",
-        AsyncMock(return_value=RoomJoinOutcome.RETRYABLE_FAILURE),
     )
 
     with pytest.raises(RuntimeError, match="Failed to join invited room"):
@@ -424,6 +421,9 @@ async def test_invite_join_failure_propagates_to_sync_boundary(
             MagicMock(room_id="!failed:localhost", canonical_alias=None),
             MagicMock(sender="@owner:localhost"),
         )
+    assert _pending_room_invites(config, ROUTER_AGENT_NAME) == {
+        "!failed:localhost": "@owner:localhost",
+    }
     assert bot._room_lifecycle.decrypt_notice_is_fenced("!failed:localhost")
 
 
@@ -470,6 +470,41 @@ async def test_terminal_invite_join_failure_does_not_abort_sync(
     bot.client.join.assert_awaited_once_with("!invalid-state:localhost")
     assert await bot._journal_dispatcher.store.pending() == ()
     assert not bot._room_lifecycle.decrypt_notice_is_fenced("!invalid-state:localhost")
+
+
+@pytest.mark.asyncio
+async def test_recovered_revoked_invite_is_forgotten_after_forbidden_join(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A durable invite revoked while offline must not retry forever."""
+    config = bind_runtime_paths(
+        Config(router=RouterConfig(model="default", accept_invites=True)),
+        test_runtime_paths(tmp_path),
+    )
+    bot = make_test_agent_bot(
+        agent_user=_router_user(),
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    install_runtime_journal_support(bot)
+    bot.client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    bot.client.invited_rooms = {}
+    bot.client.join = AsyncMock(return_value=nio.JoinError("not invited", "M_FORBIDDEN"))
+    monkeypatch.setattr(
+        "mindroom.bot_room_lifecycle.is_sender_allowed_for_agent_reply_in_room",
+        lambda *_args, **_kwargs: True,
+    )
+    room_id = "!revoked-invite:localhost"
+    bot._room_lifecycle.record_pending_room_invite(room_id, "@owner:localhost")
+
+    await bot._room_lifecycle.reconcile_pending_invites()
+    await bot._room_lifecycle.reconcile_pending_invites()
+
+    bot.client.join.assert_awaited_once_with(room_id)
+    assert _pending_room_invites(config, ROUTER_AGENT_NAME) == {}
+    assert not bot._room_lifecycle.decrypt_notice_is_fenced(room_id)
 
 
 @pytest.mark.asyncio

--- a/tests/test_send_file_message.py
+++ b/tests/test_send_file_message.py
@@ -1274,7 +1274,7 @@ class TestJoinRoom:
         [
             (
                 nio.JoinError("forbidden", "M_FORBIDDEN"),
-                RoomJoinOutcome.RETRYABLE_FAILURE,
+                RoomJoinOutcome.ACCESS_DENIED,
             ),
             (
                 nio.JoinError("not found", "M_NOT_FOUND"),
@@ -1294,7 +1294,7 @@ class TestJoinRoom:
             ),
         ],
         ids=[
-            "ambiguous-forbidden-join-error",
+            "access-denied-join-error",
             "ambiguous-not-found-join-error",
             "terminal-join-error",
             "retryable-join-error",

--- a/tests/test_team_invitations.py
+++ b/tests/test_team_invitations.py
@@ -222,6 +222,7 @@ class TestTeamRoomMembership:
         room.canonical_alias = None
         event = MagicMock(sender="@user:localhost")
 
-        await bot._on_invite(room, event)
+        bot._room_lifecycle.record_pending_room_invite(room.room_id, event.sender)
+        await bot._room_lifecycle.handle_recorded_invite(room, event.sender)
 
         join_room.assert_awaited_once_with(bot.client, "!team-room:localhost")


### PR DESCRIPTION
## Summary

- Re-evaluate outstanding matrix-nio invites whenever a live grant-room membership change updates responder access.
- Reuse the existing idempotent invite handler, preserving its join locks, persistence, and welcome behavior.
- Correct the stale incremental-sync redelivery comment and add regression coverage for the denied-then-granted flow.

## Testing

- uv run pytest -q
- uv run pre-commit run --all-files

## Summary by Sourcery

Reconcile pending room invites whenever responder access changes so previously denied invitations can be accepted reliably after access is granted.

New Features:
- Reconcile persisted pending room invites when responder access changes, allowing previously denied invites to be retried after access is granted.
- Persist outstanding invite identities across sync processing and process restarts.

Bug Fixes:
- Prevent pending invites from being retried indefinitely after a revoked or terminally inaccessible invitation.
- Ensure failed invite identity persistence prevents background invite work from starting.

Enhancements:
- Coordinate live membership transitions with dependent invite and call authorization effects, including retrying unfinished effects after event replay.
- Classify forbidden room joins separately from other retryable and terminal join failures while preserving existing invite locking and welcome behavior.

Tests:
- Add regression coverage for denied-then-granted invites across event replay and process restart scenarios.
- Expand invite lifecycle tests for durable recovery, revoked invites, persistence failures, and membership-effect retries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Pending room invitations are now stored and automatically rechecked when responder access changes.
  - Previously denied invitations can be accepted after authorization is granted.
  - Invitation handling remains consistent across single-agent and multi-agent setups.

- **Bug Fixes**
  - Improved recovery when invitation processing is interrupted or temporarily fails.
  - Forbidden room joins are now handled as definitive access denials instead of retryable failures.

- **Tests**
  - Added coverage for persistence, authorization changes, retries, and successful subsequent joining.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->