### PR TITLE
Require all configured members for thread exports

### DIFF
--- a/src/mindroom/thread_export/execution.py
+++ b/src/mindroom/thread_export/execution.py
@@ -88,8 +88,8 @@ async def _authorized_room_accumulators(
         if not target_accepts_room(accumulator.target, room):
             retract_room_export(accumulator, room)
 
-    scoped = [accumulator for accumulator in eligible if accumulator.target.required_member_user_id is not None]
-    authorized = [accumulator for accumulator in eligible if accumulator.target.required_member_user_id is None]
+    scoped = [accumulator for accumulator in eligible if accumulator.target.required_member_user_ids]
+    authorized = [accumulator for accumulator in eligible if not accumulator.target.required_member_user_ids]
     if not scoped:
         return authorized
     try:
@@ -104,8 +104,8 @@ async def _authorized_room_accumulators(
         return authorized
 
     for accumulator in scoped:
-        member_user_id = accumulator.target.required_member_user_id
-        if member_user_id in member_ids:
+        required_member_user_ids = accumulator.target.required_member_user_ids
+        if member_ids.issuperset(required_member_user_ids):
             authorized.append(accumulator)
         else:
             retract_room_export(accumulator, room)

--- a/src/mindroom/thread_export/models.py
+++ b/src/mindroom/thread_export/models.py
@@ -75,39 +75,13 @@ class ThreadExportStats:
         return len(self.failed_items)
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True)
 class ThreadExportTarget:
     """One export destination and its optional room-membership scope."""
 
     output_dir: Path
     required_member_user_ids: tuple[str, ...] = ()
     include_invited_rooms: bool = True
-
-    def __init__(
-        self,
-        output_dir: Path,
-        required_member_user_id: str | None = None,
-        include_invited_rooms: bool = True,
-        *,
-        required_member_user_ids: tuple[str, ...] = (),
-    ) -> None:
-        """Normalize the transitional singular constructor input."""
-        if required_member_user_id is not None and required_member_user_ids:
-            msg = "Pass required_member_user_ids only, not both membership scope forms."
-            raise ValueError(msg)
-        normalized_member_ids = (
-            (required_member_user_id,) if required_member_user_id is not None else required_member_user_ids
-        )
-        object.__setattr__(self, "output_dir", output_dir)
-        object.__setattr__(self, "required_member_user_ids", normalized_member_ids)
-        object.__setattr__(self, "include_invited_rooms", include_invited_rooms)
-
-    @property
-    def required_member_user_id(self) -> str | None:
-        """Return the transitional singular view when exactly one member is required."""
-        if len(self.required_member_user_ids) == 1:
-            return self.required_member_user_ids[0]
-        return None
 
 
 @dataclass

--- a/src/mindroom/thread_export/models.py
+++ b/src/mindroom/thread_export/models.py
@@ -96,9 +96,7 @@ class ThreadExportTarget:
             msg = "Pass required_member_user_ids only, not both membership scope forms."
             raise ValueError(msg)
         normalized_member_ids = (
-            (required_member_user_id,)
-            if required_member_user_id is not None
-            else required_member_user_ids
+            (required_member_user_id,) if required_member_user_id is not None else required_member_user_ids
         )
         object.__setattr__(self, "output_dir", output_dir)
         object.__setattr__(self, "required_member_user_ids", normalized_member_ids)

--- a/src/mindroom/thread_export/models.py
+++ b/src/mindroom/thread_export/models.py
@@ -80,7 +80,7 @@ class ThreadExportTarget:
     """One export destination and its optional room-membership scope."""
 
     output_dir: Path
-    required_member_user_id: str | None = None
+    required_member_user_ids: tuple[str, ...] = ()
     include_invited_rooms: bool = True
 
 

--- a/src/mindroom/thread_export/models.py
+++ b/src/mindroom/thread_export/models.py
@@ -75,13 +75,41 @@ class ThreadExportStats:
         return len(self.failed_items)
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class ThreadExportTarget:
     """One export destination and its optional room-membership scope."""
 
     output_dir: Path
     required_member_user_ids: tuple[str, ...] = ()
     include_invited_rooms: bool = True
+
+    def __init__(
+        self,
+        output_dir: Path,
+        required_member_user_ids: tuple[str, ...] = (),
+        include_invited_rooms: bool = True,
+        *,
+        required_member_user_id: str | None = None,
+    ) -> None:
+        """Normalize the transitional singular constructor input."""
+        if required_member_user_id is not None and required_member_user_ids:
+            msg = "Pass required_member_user_ids only, not both membership scope forms."
+            raise ValueError(msg)
+        normalized_member_ids = (
+            (required_member_user_id,)
+            if required_member_user_id is not None
+            else required_member_user_ids
+        )
+        object.__setattr__(self, "output_dir", output_dir)
+        object.__setattr__(self, "required_member_user_ids", normalized_member_ids)
+        object.__setattr__(self, "include_invited_rooms", include_invited_rooms)
+
+    @property
+    def required_member_user_id(self) -> str | None:
+        """Return the transitional singular view when exactly one member is required."""
+        if len(self.required_member_user_ids) == 1:
+            return self.required_member_user_ids[0]
+        return None
 
 
 @dataclass

--- a/src/mindroom/thread_export/models.py
+++ b/src/mindroom/thread_export/models.py
@@ -86,10 +86,10 @@ class ThreadExportTarget:
     def __init__(
         self,
         output_dir: Path,
-        required_member_user_ids: tuple[str, ...] = (),
+        required_member_user_id: str | None = None,
         include_invited_rooms: bool = True,
         *,
-        required_member_user_id: str | None = None,
+        required_member_user_ids: tuple[str, ...] = (),
     ) -> None:
         """Normalize the transitional singular constructor input."""
         if required_member_user_id is not None and required_member_user_ids:

--- a/src/mindroom/thread_export/service.py
+++ b/src/mindroom/thread_export/service.py
@@ -256,9 +256,9 @@ async def export_threads_to_targets_once(
     after that the body costs no Matrix history call at all.
 
     Each source thread is fetched once per room and fanned out to every authorized target.
-    Scoped targets export only rooms where their required member is currently joined.
+    Scoped targets export only rooms where every required member is currently joined.
     A failed membership check leaves prior exports untouched, records a failure, and writes nothing new.
-    A successful check that proves the member absent removes the prior room export.
+    A successful check that proves any required member absent removes the prior room export.
     """
     if not targets:
         return ()

--- a/src/mindroom/thread_export/service.py
+++ b/src/mindroom/thread_export/service.py
@@ -337,7 +337,7 @@ async def export_threads_once(
     output_dir: Path | None = None,
     room_filter: str | None = None,
     max_thread_roots: int = 2000,
-    required_member_user_id: str | None = None,
+    required_member_user_ids: tuple[str, ...] = (),
     include_invited_rooms: bool = True,
 ) -> ThreadExportStats:
     """Run one thread export pass for a single destination."""
@@ -347,7 +347,7 @@ async def export_threads_once(
         targets=(
             ThreadExportTarget(
                 output_dir=output_dir or _default_thread_export_dir(runtime_paths),
-                required_member_user_id=required_member_user_id,
+                required_member_user_ids=required_member_user_ids,
                 include_invited_rooms=include_invited_rooms,
             ),
         ),

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -70,6 +70,27 @@ async def _export_threads_for_client(
     return accumulators[0].stats()
 
 
+def test_singular_member_scope_alias_normalizes_to_tuple(tmp_path: Path) -> None:
+    """The transitional singular constructor input should keep one stored source of truth."""
+    target = ThreadExportTarget(
+        output_dir=tmp_path,
+        required_member_user_id="@alice:localhost",
+    )
+
+    assert target.required_member_user_ids == ("@alice:localhost",)
+    assert target.required_member_user_id == "@alice:localhost"
+
+
+def test_singular_member_scope_alias_rejects_plural_input(tmp_path: Path) -> None:
+    """Callers must not supply both membership-scope constructor forms."""
+    with pytest.raises(ValueError, match="required_member_user_ids only"):
+        ThreadExportTarget(
+            output_dir=tmp_path,
+            required_member_user_id="@alice:localhost",
+            required_member_user_ids=("@bob:localhost",),
+        )
+
+
 @pytest.mark.asyncio
 async def test_export_threads_fetches_from_matrix_source_and_writes_yaml(tmp_path: Path) -> None:
     """Exporter should enumerate Matrix threads, fetch source history, and write grep-friendly YAML."""

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -81,6 +81,16 @@ def test_singular_member_scope_alias_normalizes_to_tuple(tmp_path: Path) -> None
     assert target.required_member_user_id == "@alice:localhost"
 
 
+def test_singular_member_scope_alias_preserves_positional_constructor(
+    tmp_path: Path,
+) -> None:
+    """The transitional alias should preserve the former positional API."""
+    target = ThreadExportTarget(tmp_path, "@alice:localhost", False)
+
+    assert target.required_member_user_ids == ("@alice:localhost",)
+    assert target.include_invited_rooms is False
+
+
 def test_singular_member_scope_alias_rejects_plural_input(tmp_path: Path) -> None:
     """Callers must not supply both membership-scope constructor forms."""
     with pytest.raises(ValueError, match="required_member_user_ids only"):

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -70,35 +70,14 @@ async def _export_threads_for_client(
     return accumulators[0].stats()
 
 
-def test_singular_member_scope_alias_normalizes_to_tuple(tmp_path: Path) -> None:
-    """The transitional singular constructor input should keep one stored source of truth."""
-    target = ThreadExportTarget(
-        output_dir=tmp_path,
-        required_member_user_id="@alice:localhost",
-    )
-
-    assert target.required_member_user_ids == ("@alice:localhost",)
-    assert target.required_member_user_id == "@alice:localhost"
-
-
-def test_singular_member_scope_alias_preserves_positional_constructor(
-    tmp_path: Path,
-) -> None:
-    """The transitional alias should preserve the former positional API."""
-    target = ThreadExportTarget(tmp_path, "@alice:localhost", False)
-
-    assert target.required_member_user_ids == ("@alice:localhost",)
-    assert target.include_invited_rooms is False
-
-
-def test_singular_member_scope_alias_rejects_plural_input(tmp_path: Path) -> None:
-    """Callers must not supply both membership-scope constructor forms."""
-    with pytest.raises(ValueError, match="required_member_user_ids only"):
-        ThreadExportTarget(
-            output_dir=tmp_path,
-            required_member_user_id="@alice:localhost",
-            required_member_user_ids=("@bob:localhost",),
-        )
+def test_thread_export_target_rejects_legacy_singular_scope(tmp_path: Path) -> None:
+    """Callers must use the plural membership-scope contract."""
+    legacy_kwargs: dict[str, object] = {
+        "output_dir": tmp_path,
+        "required_member_user_id": "@alice:localhost",
+    }
+    with pytest.raises(TypeError, match="required_member_user_id"):
+        ThreadExportTarget(**legacy_kwargs)
 
 
 @pytest.mark.asyncio

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -50,7 +50,7 @@ async def _export_threads_for_client(
     rooms: Sequence[_ThreadExportRoom],
     output_dir: Path,
     max_thread_roots: int = 2000,
-    required_member_user_id: str | None = None,
+    required_member_user_ids: tuple[str, ...] = (),
 ) -> ThreadExportStats:
     """Adapt the multi-target execution seam for single-target test cases."""
     accumulators = await _export_threads_for_targets_for_client(
@@ -62,7 +62,7 @@ async def _export_threads_for_client(
         targets=(
             ThreadExportTarget(
                 output_dir=output_dir,
-                required_member_user_id=required_member_user_id,
+                required_member_user_ids=required_member_user_ids,
             ),
         ),
         max_thread_roots=max_thread_roots,
@@ -840,7 +840,7 @@ async def test_definitive_non_member_on_non_aliased_target_removes_room_export(
             runtime_paths=runtime_paths,
             output_dir=tmp_path / "exports",
             rooms=_export_rooms(runtime_paths, None),
-            required_member_user_id="@alice:localhost",
+            required_member_user_ids=("@alice:localhost",),
         )
 
     assert stats.rooms_exported == 1
@@ -903,10 +903,10 @@ async def test_admitted_empty_root_handles_retraction_and_zero_thread_export_wit
 
 
 @pytest.mark.parametrize(
-    ("invited", "required_member_user_id"),
+    ("invited", "required_member_user_ids"),
     [
-        pytest.param(True, None, id="excluded-invited-room"),
-        pytest.param(False, "@alice:localhost", id="definitive-non-member"),
+        pytest.param(True, (), id="excluded-invited-room"),
+        pytest.param(False, ("@alice:localhost",), id="definitive-non-member"),
     ],
 )
 @pytest.mark.asyncio
@@ -914,7 +914,7 @@ async def test_room_removal_failure_is_scoped_to_the_rejected_target(
     tmp_path: Path,
     *,
     invited: bool,
-    required_member_user_id: str | None,
+    required_member_user_ids: tuple[str, ...],
 ) -> None:
     """A failed retraction should not prevent another target from exporting the room."""
     config = _config(tmp_path)
@@ -927,13 +927,13 @@ async def test_room_removal_failure_is_scoped_to_the_rejected_target(
         invited=invited,
     )
     client = Mock()
-    if required_member_user_id is not None:
+    if required_member_user_ids:
         client.joined_members = AsyncMock(
             return_value=nio.JoinedMembersResponse(members=[], room_id=room.room_id),
         )
     rejected_target = ThreadExportTarget(
         output_dir=tmp_path / "rejected",
-        required_member_user_id=required_member_user_id,
+        required_member_user_ids=required_member_user_ids,
         include_invited_rooms=not invited,
     )
     healthy_target = ThreadExportTarget(output_dir=tmp_path / "healthy")
@@ -1012,12 +1012,12 @@ async def test_target_membership_and_invited_room_setting_are_both_enforced(tmp_
     targets = (
         ThreadExportTarget(
             output_dir=tmp_path / "code",
-            required_member_user_id="@mindroom_code:localhost",
+            required_member_user_ids=("@mindroom_code:localhost",),
             include_invited_rooms=True,
         ),
         ThreadExportTarget(
             output_dir=tmp_path / "research",
-            required_member_user_id="@mindroom_research:localhost",
+            required_member_user_ids=("@mindroom_research:localhost",),
             include_invited_rooms=False,
         ),
     )
@@ -1040,6 +1040,62 @@ async def test_target_membership_and_invited_room_setting_are_both_enforced(tmp_
     assert accumulators[1].retained_room_keys == {"dev"}
     assert client.joined_members.await_count == 3
     assert enumerate_threads.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_target_requires_every_configured_room_member(tmp_path: Path) -> None:
+    """A target scoped to multiple members must reject rooms missing either member."""
+    config = _config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    rooms = (
+        _ThreadExportRoom("both", "!both:localhost", "#both:localhost", "Both"),
+        _ThreadExportRoom("owner", "!owner:localhost", "#owner:localhost", "Owner"),
+        _ThreadExportRoom("agent", "!agent:localhost", "#agent:localhost", "Agent"),
+    )
+    members_by_room = {
+        "!both:localhost": ["@owner:localhost", "@mindroom_assistant:localhost"],
+        "!owner:localhost": ["@owner:localhost"],
+        "!agent:localhost": ["@mindroom_assistant:localhost"],
+    }
+
+    async def joined_members(room_id: str) -> nio.JoinedMembersResponse:
+        return nio.JoinedMembersResponse(
+            members=[nio.RoomMember(user_id, "", "") for user_id in members_by_room[room_id]],
+            room_id=room_id,
+        )
+
+    client = Mock()
+    client.joined_members = AsyncMock(side_effect=joined_members)
+    enumerate_threads = AsyncMock(return_value=([], False))
+
+    with patch(
+        "mindroom.thread_export.execution.enumerate_room_thread_root_ids",
+        new=enumerate_threads,
+    ):
+        accumulators = await _export_threads_for_targets_for_client(
+            client=client,
+            reader=Mock(),
+            config=config,
+            runtime_paths=runtime_paths,
+            rooms=rooms,
+            targets=(
+                ThreadExportTarget(
+                    output_dir=tmp_path / "private-assistant",
+                    required_member_user_ids=(
+                        "@owner:localhost",
+                        "@mindroom_assistant:localhost",
+                    ),
+                ),
+            ),
+        )
+
+    assert accumulators[0].rooms_exported == 1
+    assert accumulators[0].retained_room_keys == {"both"}
+    enumerate_threads.assert_awaited_once_with(
+        client,
+        "!both:localhost",
+        max_thread_roots=2000,
+    )
 
 
 @pytest.mark.asyncio
@@ -1069,7 +1125,7 @@ async def test_member_filter_lookup_failure_keeps_exports_and_records_failure(tm
             targets=(
                 ThreadExportTarget(
                     output_dir=tmp_path / "exports",
-                    required_member_user_id="@alice:localhost",
+                    required_member_user_ids=("@alice:localhost",),
                 ),
             ),
         )

--- a/tests/test_thread_export_service.py
+++ b/tests/test_thread_export_service.py
@@ -351,7 +351,7 @@ async def test_full_pass_retains_scoped_exports_when_account_group_cannot_run(tm
             targets=(
                 ThreadExportTarget(
                     output_dir=output_dir,
-                    required_member_user_id="@alice:localhost",
+                    required_member_user_ids=("@alice:localhost",),
                 ),
             ),
         )


### PR DESCRIPTION
## Summary

- let one export target require multiple current room members
- export a room only when every required member is joined
- keep membership lookup failures non-destructive

## Testing

- `uv run pytest`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Require all configured members to be joined before exporting a room to a scoped target.

New Features:
- Allow thread export targets to require multiple joined room members.
- Export rooms for scoped targets only when all configured members are currently joined.

Bug Fixes:
- Preserve existing exports when membership lookups fail, while retracting exports when a successful check finds a required member absent.

Enhancements:
- Replace the singular membership-scope contract with a plural member list across the thread export API and tests.

Tests:
- Add coverage for multi-member authorization and rejection of the legacy singular scope argument.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread exports can now be scoped to rooms containing multiple required members.
  * A room is included only when all configured required members are present.

* **Bug Fixes**
  * Improved authorization checks to prevent exports from rooms missing any required member.

* **Tests**
  * Added coverage for multi-member room requirements and updated existing export scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->