### PR TITLE
Retry truncated room recovery for stricter callers

### DIFF
--- a/src/mindroom/event_journal/journal.py
+++ b/src/mindroom/event_journal/journal.py
@@ -109,6 +109,7 @@ def _room_history_recovery_from_row(room_id: str, row: Row) -> RoomHistoryRecove
         room_id=room_id,
         state=HistoryRecoveryState(str(row["state"])),
         revision=int(row["revision"]),
+        attempted_policy_rank=int(row["attempted_policy_rank"]),
     )
 
 
@@ -120,7 +121,7 @@ def room_history_recovery(
     """Return one room's current history-recovery obligation, if any."""
     row = transaction.fetchone(
         """
-        SELECT state, revision FROM room_history_recovery
+        SELECT state, revision, attempted_policy_rank FROM room_history_recovery
         WHERE principal_id = ? AND room_id = ? AND state <> ?
         """,
         (principal_id, room_id, _REPAIRED_RECOVERY_STATE),
@@ -138,12 +139,15 @@ def record_room_history_recovery(
         return None
     row = transaction.fetchone(
         """
-        INSERT INTO room_history_recovery (principal_id, room_id, state, revision)
-        VALUES (?, ?, ?, 0)
+        INSERT INTO room_history_recovery (
+            principal_id, room_id, state, revision, attempted_policy_rank
+        )
+        VALUES (?, ?, ?, 0, 0)
         ON CONFLICT (principal_id, room_id) DO UPDATE SET
             state = excluded.state,
-            revision = room_history_recovery.revision + 1
-        RETURNING state, revision
+            revision = room_history_recovery.revision + 1,
+            attempted_policy_rank = 0
+        RETURNING state, revision, attempted_policy_rank
         """,
         (principal_id, room_id, HistoryRecoveryState.REPAIRABLE.value),
     )
@@ -163,6 +167,7 @@ def claim_room_history_recovery(
         """
         UPDATE room_history_recovery SET state = state
         WHERE principal_id = ? AND room_id = ? AND state = ? AND revision = ?
+          AND attempted_policy_rank = ?
         RETURNING room_id
         """,
         (
@@ -170,6 +175,7 @@ def claim_room_history_recovery(
             recovery.room_id,
             recovery.state.value,
             recovery.revision,
+            recovery.attempted_policy_rank,
         ),
     )
     return row is not None
@@ -181,6 +187,7 @@ def settle_room_history_recovery(
     recovery: RoomHistoryRecovery,
     *,
     exhausted_server: bool,
+    attempted_policy_rank: int,
 ) -> HistoryRecoveryOutcome:
     """Commit the terminal state of a previously claimed recovery obligation."""
     if exhausted_server:
@@ -194,10 +201,15 @@ def settle_room_history_recovery(
         return HistoryRecoveryOutcome.REPAIRED
     transaction.execute(
         """
-        UPDATE room_history_recovery SET state = ?
+        UPDATE room_history_recovery SET state = ?, attempted_policy_rank = ?
         WHERE principal_id = ? AND room_id = ?
         """,
-        (HistoryRecoveryState.TRUNCATED.value, principal_id, recovery.room_id),
+        (
+            HistoryRecoveryState.TRUNCATED.value,
+            attempted_policy_rank,
+            principal_id,
+            recovery.room_id,
+        ),
     )
     return HistoryRecoveryOutcome.TRUNCATED
 

--- a/src/mindroom/event_journal/postgres_backend.py
+++ b/src/mindroom/event_journal/postgres_backend.py
@@ -126,7 +126,8 @@ class PostgresBackend:
                   AND table_name IN (
                       'approval_continuation_calls',
                       'interactive_questions',
-                      'matrix_delivery_outbox'
+                      'matrix_delivery_outbox',
+                      'room_history_recovery'
                   )
                 """,
             )
@@ -142,10 +143,14 @@ class PostgresBackend:
             matrix_delivery_outbox_columns = frozenset(
                 str(row["column_name"]) for row in existing_columns if row["table_name"] == "matrix_delivery_outbox"
             )
+            room_history_recovery_columns = frozenset(
+                str(row["column_name"]) for row in existing_columns if row["table_name"] == "room_history_recovery"
+            )
             for statement in pre_schema_migration_statements(
                 approval_continuation_call_columns=approval_continuation_call_columns,
                 interactive_question_columns=interactive_question_columns,
                 matrix_delivery_outbox_columns=matrix_delivery_outbox_columns,
+                room_history_recovery_columns=room_history_recovery_columns,
             ):
                 cursor.execute(cast("LiteralString", statement))
             transaction = _PostgresTransaction(cursor)

--- a/src/mindroom/event_journal/schema.py
+++ b/src/mindroom/event_journal/schema.py
@@ -219,6 +219,10 @@ _TABLES = (
         room_id TEXT NOT NULL,
         state TEXT NOT NULL CHECK (state IN ('repairable', 'truncated', 'repaired')),
         revision BIGINT NOT NULL DEFAULT 0,
+        -- The widest bounded walk spent on this exact missing interval. A new
+        -- revision resets it because an older gap says nothing about the new
+        -- one; a wider caller may then make exactly one sequential attempt.
+        attempted_policy_rank BIGINT NOT NULL DEFAULT 0,
         PRIMARY KEY (principal_id, room_id)
     )
     """,

--- a/src/mindroom/event_journal/schema_migrations.py
+++ b/src/mindroom/event_journal/schema_migrations.py
@@ -8,6 +8,7 @@ def pre_schema_migration_statements(
     approval_continuation_call_columns: frozenset[str] = frozenset(),
     interactive_question_columns: frozenset[str] = frozenset(),
     matrix_delivery_outbox_columns: frozenset[str] = frozenset(),
+    room_history_recovery_columns: frozenset[str] = frozenset(),
 ) -> tuple[str, ...]:
     """Return upgrades that must run before installing the current schema."""
     statements: list[str] = []
@@ -19,6 +20,10 @@ def pre_schema_migration_statements(
         statements.append("ALTER TABLE matrix_delivery_outbox ADD COLUMN result_json TEXT")
     if matrix_delivery_outbox_columns and "permanent_failure_reason" not in matrix_delivery_outbox_columns:
         statements.append("ALTER TABLE matrix_delivery_outbox ADD COLUMN permanent_failure_reason TEXT")
+    if room_history_recovery_columns and "attempted_policy_rank" not in room_history_recovery_columns:
+        statements.append(
+            "ALTER TABLE room_history_recovery ADD COLUMN attempted_policy_rank BIGINT NOT NULL DEFAULT 0",
+        )
     if "claimed_source_event_id" in interactive_question_columns:
         statements.extend(
             (

--- a/src/mindroom/event_journal/sqlite_backend.py
+++ b/src/mindroom/event_journal/sqlite_backend.py
@@ -214,10 +214,14 @@ class SqliteBackend:
             matrix_delivery_outbox_columns = frozenset(
                 str(row[1]) for row in connection.execute("PRAGMA table_info(matrix_delivery_outbox)")
             )
+            room_history_recovery_columns = frozenset(
+                str(row[1]) for row in connection.execute("PRAGMA table_info(room_history_recovery)")
+            )
             for statement in pre_schema_migration_statements(
                 approval_continuation_call_columns=approval_continuation_call_columns,
                 interactive_question_columns=interactive_question_columns,
                 matrix_delivery_outbox_columns=matrix_delivery_outbox_columns,
+                room_history_recovery_columns=room_history_recovery_columns,
             ):
                 connection.execute(statement)
             transaction = _SqliteTransaction(connection)

--- a/src/mindroom/event_journal/store.py
+++ b/src/mindroom/event_journal/store.py
@@ -1419,6 +1419,7 @@ def _settle_history_recovery(
         principal_id,
         recovery,
         exhausted_server=exhausted_server,
+        attempted_policy_rank=attempted_policy_rank,
     )
 
 

--- a/src/mindroom/history_recovery.py
+++ b/src/mindroom/history_recovery.py
@@ -15,11 +15,12 @@ class HistoryRecoveryState(StrEnum):
 
 @dataclass(frozen=True, slots=True)
 class RoomHistoryRecovery:
-    """One room's durable obligation to account for unknown missing history."""
+    """One room's durable obligation and the widest policy spent on it."""
 
     room_id: str
     state: HistoryRecoveryState
     revision: int = 0
+    attempted_policy_rank: int = 0
 
 
 class HistoryRecoveryOutcome(StrEnum):

--- a/src/mindroom/matrix/conversation_hydration.py
+++ b/src/mindroom/matrix/conversation_hydration.py
@@ -502,8 +502,7 @@ class ConversationHydrator:
             recovery = await self.store.room_history_recovery(room_id)
             recovery_needs_walk = recovery is not None and recovery.state is HistoryRecoveryState.REPAIRABLE
             if recovery is not None and recovery.state is HistoryRecoveryState.TRUNCATED and self.require_complete:
-                room_coverage = await self.store.conversation_hydration_coverage(room_id=room_id, thread_id=None)
-                recovery_needs_walk = room_coverage is None or room_coverage.attempted_policy_rank < self.policy
+                recovery_needs_walk = recovery.attempted_policy_rank < self.policy
             if recovery is not None and recovery_needs_walk:
                 # Shared per room, so two readers in two threads walk one
                 # repairable gap -- or one truncated gap under a wider policy --

--- a/src/mindroom/matrix/conversation_hydration.py
+++ b/src/mindroom/matrix/conversation_hydration.py
@@ -500,9 +500,14 @@ class ConversationHydrator:
         """
         for _ in range(_HYDRATION_EPOCH_ATTEMPTS):
             recovery = await self.store.room_history_recovery(room_id)
-            if recovery is not None and recovery.state is HistoryRecoveryState.REPAIRABLE:
-                # Shared per room, so two readers in two threads of a repairable
-                # room walk it once between them rather than once each.
+            recovery_needs_walk = recovery is not None and recovery.state is HistoryRecoveryState.REPAIRABLE
+            if recovery is not None and recovery.state is HistoryRecoveryState.TRUNCATED and self.require_complete:
+                room_coverage = await self.store.conversation_hydration_coverage(room_id=room_id, thread_id=None)
+                recovery_needs_walk = room_coverage is None or room_coverage.attempted_policy_rank < self.policy
+            if recovery is not None and recovery_needs_walk:
+                # Shared per room, so two readers in two threads walk one
+                # repairable gap -- or one truncated gap under a wider policy --
+                # between them rather than once each.
                 await self._shared(
                     self._recoveries,
                     room_id,

--- a/tests/test_conversation_hydration.py
+++ b/tests/test_conversation_hydration.py
@@ -21,7 +21,7 @@ from mindroom.constants import (
     STREAM_STATUS_PENDING,
     STREAM_STATUS_STREAMING,
 )
-from mindroom.event_journal import EventClass, EventKind, HydrationPolicy, ProjectedEvent
+from mindroom.event_journal import EventClass, EventKind, HistoryRecoveryState, HydrationPolicy, ProjectedEvent
 from mindroom.matrix.agent_message_snapshot import AgentMessageSnapshot
 from mindroom.matrix.client_delivery import build_edit_event_content
 from mindroom.matrix.conversation_hydration import (
@@ -978,6 +978,44 @@ class TestCompletenessRequirement:
             "answer 2 v0",
             "answer 3 v0",
         ]
+
+    async def test_a_strict_caller_retries_room_recovery_past_a_prompt_ceiling(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """A wider caller must spend its room budget before refusing a thread.
+
+        A skipped sync interval is room-wide, so a complete relation walk cannot
+        make one thread trustworthy while that interval remains truncated. The
+        prompt caller may legitimately stop its repair at a small bound, but an
+        exporter has a larger bound precisely so it can finish that same walk.
+        """
+        client = FakeClient(
+            events={"$root": raw("$root", "root", ts=1_000)},
+            relations={"$root": [raw("$reply", "reply", ts=2_000, thread_id="$root")]},
+            pages=[
+                ([raw("$reply", "reply", ts=2_000, thread_id="$root")], "older"),
+                ([raw("$root", "root", ts=1_000)], None),
+            ],
+        )
+        await alice.record_room_history_recovery(ROOM)
+        await hydrator(alice, client, max_requests=1).ensure_hydrated(room_id=ROOM, thread_id="$root")
+        recovery = await alice.room_history_recovery(ROOM)
+        assert recovery is not None
+        assert recovery.state is HistoryRecoveryState.TRUNCATED
+        assert not await alice.conversation_is_complete(room_id=ROOM, thread_id="$root")
+        relation_calls = client.relation_calls
+        client.history_pages = 0
+
+        await hydrator(alice, client, max_requests=3, **EXPORT_CALLER).ensure_hydrated(
+            room_id=ROOM,
+            thread_id="$root",
+        )
+
+        assert await alice.room_history_recovery(ROOM) is None
+        assert await alice.conversation_is_complete(room_id=ROOM, thread_id="$root")
+        assert client.history_pages == 2
+        assert client.relation_calls == relation_calls
 
     async def test_a_strict_caller_accepts_a_walk_that_already_reached_the_end(
         self,

--- a/tests/test_conversation_hydration.py
+++ b/tests/test_conversation_hydration.py
@@ -1017,6 +1017,54 @@ class TestCompletenessRequirement:
         assert client.history_pages == 2
         assert client.relation_calls == relation_calls
 
+    async def test_a_new_gap_does_not_inherit_an_older_recovery_policy(
+        self,
+        alice: PrincipalStore,
+    ) -> None:
+        """A new recovery revision owes its own wider attempt.
+
+        Conversation coverage retains the widest walk for a membership, but a
+        later skipped interval is a new obligation. An export attempt against
+        the older gap must not make the new gap look as if export already spent
+        its allowance.
+        """
+        client = FakeClient(
+            events={"$root": raw("$root", "root", ts=1_000)},
+            relations={"$root": [raw("$reply", "reply", ts=2_000, thread_id="$root")]},
+            pages=[
+                ([raw("$reply", "reply", ts=2_000, thread_id="$root")], "older"),
+                ([raw("$root", "root", ts=1_000)], None),
+            ],
+        )
+        await alice.record_room_history_recovery(ROOM)
+        await hydrator(alice, client, max_requests=1, **EXPORT_CALLER).ensure_hydrated(
+            room_id=ROOM,
+            thread_id="$root",
+        )
+        client.history_pages = 0
+
+        await hydrator(alice, client, max_requests=1, **EXPORT_CALLER).ensure_hydrated(
+            room_id=ROOM,
+            thread_id="$root",
+        )
+        assert client.history_pages == 0
+
+        await alice.record_room_history_recovery(ROOM)
+        await hydrator(alice, client, max_requests=1).ensure_hydrated(room_id=ROOM, thread_id="$root")
+        recovery = await alice.room_history_recovery(ROOM)
+        assert recovery is not None
+        assert recovery.state is HistoryRecoveryState.TRUNCATED
+        client.history_pages = 0
+
+        await hydrator(alice, client, max_requests=3, **EXPORT_CALLER).ensure_hydrated(
+            room_id=ROOM,
+            thread_id="$root",
+        )
+
+        assert await alice.room_history_recovery(ROOM) is None
+        assert await alice.conversation_is_complete(room_id=ROOM, thread_id="$root")
+        assert client.history_pages == 2
+
     async def test_a_strict_caller_accepts_a_walk_that_already_reached_the_end(
         self,
         alice: PrincipalStore,

--- a/tests/test_event_journal_schema_migrations.py
+++ b/tests/test_event_journal_schema_migrations.py
@@ -20,6 +20,13 @@ def test_pre_schema_migrations_add_missing_delivery_result_column() -> None:
     )
 
 
+def test_pre_schema_migrations_add_missing_recovery_policy_column() -> None:
+    """An existing recovery table gains per-obligation policy coverage."""
+    assert pre_schema_migration_statements(
+        room_history_recovery_columns=frozenset({"state", "revision"}),
+    ) == ("ALTER TABLE room_history_recovery ADD COLUMN attempted_policy_rank BIGINT NOT NULL DEFAULT 0",)
+
+
 def test_pre_schema_migrations_skip_absent_or_current_approval_table() -> None:
     """The approval upgrade is a no-op without a legacy table needing it."""
     assert pre_schema_migration_statements() == ()
@@ -29,6 +36,7 @@ def test_pre_schema_migrations_skip_absent_or_current_approval_table() -> None:
             matrix_delivery_outbox_columns=frozenset(
                 {"payload_json", "result_json", "permanent_failure_reason"},
             ),
+            room_history_recovery_columns=frozenset({"state", "revision", "attempted_policy_rank"}),
         )
         == ()
     )
@@ -40,10 +48,12 @@ def test_pre_schema_migrations_compose_independent_upgrades() -> None:
         approval_continuation_call_columns=frozenset({"tool_call_id"}),
         interactive_question_columns=frozenset({"claimed_source_event_id"}),
         matrix_delivery_outbox_columns=frozenset({"payload_json"}),
+        room_history_recovery_columns=frozenset({"state", "revision"}),
     ) == (
         "ALTER TABLE approval_continuation_calls ADD COLUMN human_approval_required BOOLEAN",
         "ALTER TABLE matrix_delivery_outbox ADD COLUMN result_json TEXT",
         "ALTER TABLE matrix_delivery_outbox ADD COLUMN permanent_failure_reason TEXT",
+        "ALTER TABLE room_history_recovery ADD COLUMN attempted_policy_rank BIGINT NOT NULL DEFAULT 0",
         "CREATE TABLE interactive_questions_pre_selection AS SELECT * FROM interactive_questions",
         "DROP TABLE interactive_questions",
     )

--- a/tests/test_room_history_recovery.py
+++ b/tests/test_room_history_recovery.py
@@ -268,7 +268,7 @@ async def stored_recovery_row(principal: PrincipalStore) -> dict[str, Any] | Non
     row = await principal._backend.read(
         lambda transaction: transaction.fetchone(
             """
-            SELECT state, revision FROM room_history_recovery
+            SELECT state, revision, attempted_policy_rank FROM room_history_recovery
             WHERE principal_id = ? AND room_id = ?
             """,
             (principal._principal_id, ROOM),
@@ -747,6 +747,7 @@ async def test_recording_creates_a_repairable_unknown_obligation(principal: Prin
     assert await stored_recovery_row(principal) == {
         "state": "repairable",
         "revision": 0,
+        "attempted_policy_rank": 0,
     }
 
 
@@ -808,7 +809,12 @@ async def test_truncated_obligation_leaves_bounded_context_readable_but_incomple
     )
 
     assert outcome is HistoryRecoveryOutcome.TRUNCATED
-    assert (await principal.room_history_recovery(ROOM)).state is HistoryRecoveryState.TRUNCATED  # type: ignore[union-attr]
+    assert await principal.room_history_recovery(ROOM) == RoomHistoryRecovery(
+        room_id=ROOM,
+        state=HistoryRecoveryState.TRUNCATED,
+        revision=0,
+        attempted_policy_rank=3,
+    )
     assert await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
     assert not await principal.conversation_is_complete(room_id=ROOM, thread_id=None)
     coverage = await principal.conversation_hydration_coverage(room_id=ROOM, thread_id=None)
@@ -836,6 +842,7 @@ async def test_a_new_abandonment_resets_truncated_to_repairable(principal: Princ
         room_id=ROOM,
         state=HistoryRecoveryState.REPAIRABLE,
         revision=1,
+        attempted_policy_rank=0,
     )
     assert not await principal.conversation_is_hydrated(room_id=ROOM, thread_id=None)
 


### PR DESCRIPTION
## Summary
- retry truncated room-history recovery when a completeness-required caller has a wider hydration policy
- scope attempted policy coverage to each recovery revision so older gaps cannot suppress newer recovery
- add additive journal migrations for both supported backends
- cover prompt-to-export escalation, same-policy suppression, and successive recovery gaps

## Testing
- `uv run pytest -n auto --no-cov -q`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Retry truncated room-history recovery under progressively wider completeness policies while preventing duplicate attempts at the same policy.

New Features:
- Retry truncated room-history recovery when a completeness-required caller has a wider hydration policy.
- Track the widest recovery policy attempted for each durable room-history obligation.

Bug Fixes:
- Allow wider-budget callers to complete recovery after an earlier bounded attempt was truncated.

Enhancements:
- Preserve one-attempt-per-policy behavior and reset policy tracking for new recovery revisions.

Tests:
- Add coverage for prompt-budget truncation followed by export-budget completion and for policy tracking across new recovery gaps on both journal backends.

Chores:
- Add schema migration support for the recovery policy-tracking column in SQLite and PostgreSQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved conversation history recovery when earlier retrieval was incomplete or limited by a narrower request policy.
  * New recovery gaps are evaluated independently, preventing older recovery attempts from incorrectly satisfying current requests.
  * Strict completeness checks can retry recovery and correctly recognize fully restored conversation history.
  * Reduced unnecessary lookups during recovery decisions while preserving accurate restoration results.
* **Maintenance**
  * Existing installations automatically receive the required recovery-tracking database update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->