### PR TITLE
Harden plugin-owned thread export lifecycle

### DIFF
--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -2262,6 +2262,7 @@ class AgentBot:
         self._room_member_callback_registered = False
         clear_matrix_sync_state(self.agent_name)
         await self._emit_agent_lifecycle_event(EVENT_AGENT_STOPPED, stop_reason=shutdown_intent.stop_reason)
+        self.hook_registry = HookRegistry.empty()
 
         call_manager = self._call_manager
         self._call_manager = None

--- a/src/mindroom/history/compaction.py
+++ b/src/mindroom/history/compaction.py
@@ -176,6 +176,7 @@ async def _emit_compaction_hook(
         token_count_before=token_count_before,
         token_count_after=token_count_after,
         compaction_summary=compaction_summary,
+        _hook_registry_state=runtime_context.hook_registry_state,
     )
     await emit(runtime_context.hook_registry, event_name, context)
 

--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -221,6 +221,7 @@ class HookContextSupport:
             "matrix_admin": self.matrix_admin(),
             "room_state_querier": self.room_state_querier(),
             "room_state_putter": self.room_state_putter(),
+            "_hook_registry_state": self.hook_registry_state,
         }
 
 
@@ -318,6 +319,26 @@ class HookContext:
     matrix_admin: HookMatrixAdmin | None = field(default=None, kw_only=True)
     room_state_querier: HookRoomStateQuerier | None = field(default=None, kw_only=True)
     room_state_putter: HookRoomStatePutter | None = field(default=None, kw_only=True)
+    _hook_registry_state: HookRegistryState | None = field(
+        default=None,
+        kw_only=True,
+        repr=False,
+        compare=False,
+    )
+    _hook_registry_snapshot: HookRegistry | None = field(
+        default=None,
+        kw_only=True,
+        repr=False,
+        compare=False,
+    )
+
+    def is_active(self) -> bool:
+        """Return whether this hook still belongs to the live registry snapshot."""
+        return (
+            self._hook_registry_state is None
+            or self._hook_registry_snapshot is None
+            or self._hook_registry_state.registry is self._hook_registry_snapshot
+        )
 
     @property
     def state_root(self) -> Path:

--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -317,9 +317,9 @@ class _HookLifecycleContext:
     def is_active(self) -> bool:
         """Return whether this hook still belongs to the live registry snapshot."""
         return (
-            self._hook_registry_state is None
-            or self._hook_registry_snapshot is None
-            or self._hook_registry_state.registry is self._hook_registry_snapshot
+            self._hook_registry_state is not None
+            and self._hook_registry_snapshot is not None
+            and self._hook_registry_state.registry is self._hook_registry_snapshot
         )
 
 

--- a/src/mindroom/hooks/context.py
+++ b/src/mindroom/hooks/context.py
@@ -299,8 +299,32 @@ class ResponseResult:
     envelope: MessageEnvelope
 
 
+@dataclass(slots=True, kw_only=True)
+class _HookLifecycleContext:
+    """Track whether a bound hook still belongs to the active registry."""
+
+    _hook_registry_state: HookRegistryState | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _hook_registry_snapshot: HookRegistry | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+
+    def is_active(self) -> bool:
+        """Return whether this hook still belongs to the live registry snapshot."""
+        return (
+            self._hook_registry_state is None
+            or self._hook_registry_snapshot is None
+            or self._hook_registry_state.registry is self._hook_registry_snapshot
+        )
+
+
 @dataclass(slots=True)
-class HookContext:
+class HookContext(_HookLifecycleContext):
     """Base fields available to every hook."""
 
     event_name: str
@@ -319,26 +343,6 @@ class HookContext:
     matrix_admin: HookMatrixAdmin | None = field(default=None, kw_only=True)
     room_state_querier: HookRoomStateQuerier | None = field(default=None, kw_only=True)
     room_state_putter: HookRoomStatePutter | None = field(default=None, kw_only=True)
-    _hook_registry_state: HookRegistryState | None = field(
-        default=None,
-        kw_only=True,
-        repr=False,
-        compare=False,
-    )
-    _hook_registry_snapshot: HookRegistry | None = field(
-        default=None,
-        kw_only=True,
-        repr=False,
-        compare=False,
-    )
-
-    def is_active(self) -> bool:
-        """Return whether this hook still belongs to the live registry snapshot."""
-        return (
-            self._hook_registry_state is None
-            or self._hook_registry_snapshot is None
-            or self._hook_registry_state.registry is self._hook_registry_snapshot
-        )
 
     @property
     def state_root(self) -> Path:
@@ -660,7 +664,7 @@ class CustomEventContext(HookContext):
 
 
 @dataclass(slots=True)
-class ToolBeforeCallContext:
+class ToolBeforeCallContext(_HookLifecycleContext):
     """Context passed to tool:before_call hook callbacks."""
 
     tool_name: str
@@ -753,7 +757,7 @@ class ToolBeforeCallContext:
 
 
 @dataclass(slots=True)
-class ToolAfterCallContext:
+class ToolAfterCallContext(_HookLifecycleContext):
     """Context passed to tool:after_call hook callbacks."""
 
     tool_name: str

--- a/src/mindroom/hooks/execution.py
+++ b/src/mindroom/hooks/execution.py
@@ -168,9 +168,8 @@ def _bind_hook_context(
         "plugin_name": hook.plugin_name,
         "settings": dict(hook.settings),
         "logger": _context_logger(hook),
+        "_hook_registry_snapshot": registry,
     }
-    if isinstance(context, HookContext):
-        replacement_kwargs["_hook_registry_snapshot"] = registry
     if isinstance(context, ToolBeforeCallContext | ToolAfterCallContext):
         replacement_kwargs["arguments"] = deepcopy(context.arguments)
     if isinstance(context, ToolAfterCallContext):

--- a/src/mindroom/hooks/execution.py
+++ b/src/mindroom/hooks/execution.py
@@ -159,12 +159,18 @@ def _snapshot_compaction_messages(messages: list[Message]) -> list[Message] | No
             return None
 
 
-def _bind_hook_context(hook: RegisteredHook, context: _HookExecutionContext) -> _HookExecutionContext | None:
+def _bind_hook_context(
+    registry: HookRegistry,
+    hook: RegisteredHook,
+    context: _HookExecutionContext,
+) -> _HookExecutionContext | None:
     replacement_kwargs: dict[str, object] = {
         "plugin_name": hook.plugin_name,
         "settings": dict(hook.settings),
         "logger": _context_logger(hook),
     }
+    if isinstance(context, HookContext):
+        replacement_kwargs["_hook_registry_snapshot"] = registry
     if isinstance(context, ToolBeforeCallContext | ToolAfterCallContext):
         replacement_kwargs["arguments"] = deepcopy(context.arguments)
     if isinstance(context, ToolAfterCallContext):
@@ -270,7 +276,7 @@ async def emit(
     token = _EMIT_DEPTH.set(depth + 1)
     try:
         for hook in _eligible_hooks(registry, event_name, context):
-            hook_context = _bind_hook_context(hook, context)
+            hook_context = _bind_hook_context(registry, hook, context)
             if hook_context is None:
                 return
             try:
@@ -307,7 +313,10 @@ async def emit_gate(
     token = _EMIT_DEPTH.set(depth + 1)
     try:
         for hook in _eligible_hooks(registry, event_name, context):
-            hook_context = cast("ToolBeforeCallContext", _bind_hook_context(hook, context))
+            hook_context = cast(
+                "ToolBeforeCallContext",
+                _bind_hook_context(registry, hook, context),
+            )
             if hook_context is None:
                 return
             invocation = await _invoke_hook(hook, hook_context)
@@ -348,7 +357,10 @@ async def emit_collect(
 
     async def run_hook(hook: RegisteredHook) -> list[EnrichmentItem]:
         async with semaphore:
-            hook_context = cast("MessageEnrichContext | SystemEnrichContext", _bind_hook_context(hook, context))
+            hook_context = cast(
+                "MessageEnrichContext | SystemEnrichContext",
+                _bind_hook_context(registry, hook, context),
+            )
             invocation = await _invoke_hook(hook, hook_context)
             return _normalize_collector_result(invocation.value, hook_context)
 
@@ -431,7 +443,11 @@ async def _emit_serial_transform(
     current_draft = context.draft
     for hook in _eligible_hooks(registry, event_name, context):
         hook_draft = _copy_transform_draft(current_draft) if copy_on_write else current_draft
-        bound_context = _bind_hook_context(hook, _transform_context_with_draft(context, hook_draft))
+        bound_context = _bind_hook_context(
+            registry,
+            hook,
+            _transform_context_with_draft(context, hook_draft),
+        )
         if bound_context is None:
             return current_draft
         hook_context = cast("_TransformContext", bound_context)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -36,6 +36,7 @@ from mindroom.hooks import (
     EVENT_CONFIG_RELOADED,
     ConfigReloadedContext,
     HookRegistry,
+    HookRegistryState,
     build_hook_matrix_admin,
     build_hook_room_state_putter,
     build_hook_room_state_querier,
@@ -274,7 +275,11 @@ class _MultiAgentOrchestrator:
     plugin_watch: PluginWatchState = field(init=False)
     _knowledge_refresh_scheduler: KnowledgeRefreshScheduler = field(init=False)
     _knowledge_source_watcher: KnowledgeSourceWatcher = field(init=False)
-    hook_registry: HookRegistry = field(default_factory=HookRegistry.empty, init=False)
+    _hook_registry_state: HookRegistryState = field(
+        default_factory=lambda: HookRegistryState(HookRegistry.empty()),
+        init=False,
+        repr=False,
+    )
     _runtime_shutdown_event: asyncio.Event | None = field(default=None, init=False, repr=False)
     _router_reply_memberships_live_sync_ready: asyncio.Event = field(
         default_factory=asyncio.Event,
@@ -355,6 +360,16 @@ class _MultiAgentOrchestrator:
             sync_runtime_support=lambda config: self._sync_runtime_support_services(config, start_watcher=True),
             mark_runtime_support_ready=lambda: self._approval_transport.mark_startup_runtime_support_ready(),
         )
+
+    @property
+    def hook_registry(self) -> HookRegistry:
+        """Return the currently active hook registry."""
+        return self._hook_registry_state.registry
+
+    @hook_registry.setter
+    def hook_registry(self, value: HookRegistry) -> None:
+        """Update the active hook registry snapshot."""
+        self._hook_registry_state.registry = value
 
     @property
     def script_runtime(self) -> ScriptRuntimeLifecycle:
@@ -1568,6 +1583,7 @@ class _MultiAgentOrchestrator:
             matrix_admin=self.hook_matrix_admin(),
             room_state_querier=self.hook_room_state_querier(),
             room_state_putter=self.hook_room_state_putter(),
+            _hook_registry_state=self._hook_registry_state,
             changed_entities=tuple(sorted(changed_entities)),
             added_entities=tuple(sorted(added_entities)),
             removed_entities=tuple(sorted(removed_entities)),
@@ -1593,9 +1609,10 @@ class _MultiAgentOrchestrator:
         await self._approval_transport.reconcile_unavailable_entities(removed_entities)
 
         for entity_name in removed_entities:
-            bot = self.agent_bots.pop(entity_name, None)
+            bot = self.agent_bots.get(entity_name)
             if bot is not None:
                 await bot.cleanup()
+                self.agent_bots.pop(entity_name, None)
 
     async def _stop_entities_before_mcp_sync(
         self,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2207,6 +2207,7 @@ class _MultiAgentOrchestrator:
     async def stop(self) -> None:
         """Stop all agent bots."""
         self.running = False
+        self.hook_registry = HookRegistry.empty()
         self.invalidate_agent_reply_memberships(reason="shutdown")
         if self._runtime_shutdown_event is not None:
             self._runtime_shutdown_event.set()

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2208,6 +2208,7 @@ class _MultiAgentOrchestrator:
         """Stop all agent bots."""
         self.running = False
         self.hook_registry = HookRegistry.empty()
+        set_scheduling_hook_registry(self.hook_registry)
         self.invalidate_agent_reply_memberships(reason="shutdown")
         if self._runtime_shutdown_event is not None:
             self._runtime_shutdown_event.set()

--- a/src/mindroom/response_lifecycle.py
+++ b/src/mindroom/response_lifecycle.py
@@ -697,6 +697,7 @@ class ResponseLifecycle:
             session_id=watch.session_id,
             room_id=watch.room_id,
             thread_id=watch.thread_id,
+            _hook_registry_state=watch.tool_context.hook_registry_state,
         )
         await emit(watch.tool_context.hook_registry, EVENT_SESSION_STARTED, context)
 

--- a/src/mindroom/scheduling_executor.py
+++ b/src/mindroom/scheduling_executor.py
@@ -17,6 +17,7 @@ from mindroom.dispatch_source import SCHEDULED_SOURCE_KIND, SILENT_SCHEDULE_SOUR
 from mindroom.hooks import (
     EVENT_SCHEDULE_FIRED,
     HookRegistry,
+    HookRegistryState,
     ScheduleFiredContext,
     build_hook_message_sender,
     build_hook_room_state_putter,
@@ -40,13 +41,12 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_ACTIVE_HOOK_REGISTRY: HookRegistry = HookRegistry.empty()
+_SCHEDULING_HOOK_REGISTRY_STATE = HookRegistryState(HookRegistry.empty())
 
 
 def set_scheduling_hook_registry(hook_registry: HookRegistry) -> None:
     """Update the immutable hook snapshot used by scheduled task runners."""
-    global _ACTIVE_HOOK_REGISTRY
-    _ACTIVE_HOOK_REGISTRY = hook_registry
+    _SCHEDULING_HOOK_REGISTRY_STATE.registry = hook_registry
 
 
 @dataclass(frozen=True)
@@ -188,7 +188,8 @@ async def execute_scheduled_workflow(
     with bound_log_context(**target.log_context):
         try:
             message_text = workflow.message
-            if _ACTIVE_HOOK_REGISTRY.has_hooks(EVENT_SCHEDULE_FIRED):
+            hook_registry = _SCHEDULING_HOOK_REGISTRY_STATE.registry
+            if hook_registry.has_hooks(EVENT_SCHEDULE_FIRED):
                 context = ScheduleFiredContext(
                     event_name=EVENT_SCHEDULE_FIRED,
                     plugin_name="",
@@ -212,8 +213,9 @@ async def execute_scheduled_workflow(
                     thread_id=target.resolved_thread_id,
                     created_by=workflow.created_by,
                     message_text=message_text,
+                    _hook_registry_state=_SCHEDULING_HOOK_REGISTRY_STATE,
                 )
-                await emit(_ACTIVE_HOOK_REGISTRY, EVENT_SCHEDULE_FIRED, context)
+                await emit(hook_registry, EVENT_SCHEDULE_FIRED, context)
                 if context.suppress:
                     logger.info("Scheduled workflow suppressed by hook", task_id=task_id, room_id=workflow.room_id)
                     return ScheduledWorkflowOutcome(delivered=False, failure_reason="suppressed by hook")

--- a/src/mindroom/thread_export/__init__.py
+++ b/src/mindroom/thread_export/__init__.py
@@ -2,10 +2,12 @@
 
 from mindroom.thread_export.models import ThreadExportStats, ThreadExportTarget
 from mindroom.thread_export.service import export_threads_once, export_threads_to_targets_once
+from mindroom.thread_export.storage import clear_thread_export_root
 
 __all__ = [
     "ThreadExportStats",
     "ThreadExportTarget",
+    "clear_thread_export_root",
     "export_threads_once",
     "export_threads_to_targets_once",
 ]

--- a/src/mindroom/thread_export/execution.py
+++ b/src/mindroom/thread_export/execution.py
@@ -41,7 +41,11 @@ logger = get_logger(__name__)
 def retract_room_export(accumulator: ThreadExportAccumulator, room: ThreadExportRoom) -> None:
     """Remove one target's room export or record a room-scoped storage failure."""
     try:
-        remove_room_export(accumulator.target.output_dir, room)
+        remove_room_export(
+            accumulator.target.output_dir,
+            room,
+            trusted_root=accumulator.target.trusted_root,
+        )
     except (OSError, RuntimeError) as exc:
         accumulator.failed_items.append(failure_for_room(room, f"Room removal failed: {exc}"))
 
@@ -141,6 +145,7 @@ async def _write_thread_to_targets(
                 room,
                 thread_id,
                 payload,
+                trusted_root=accumulator.target.trusted_root,
             )
         except Exception as exc:
             accumulator.failed_items.append(failure_for_room(room, str(exc), thread_id=thread_id))
@@ -164,7 +169,15 @@ def _finish_room_exports(
     for accumulator in accumulators:
         try:
             output_dir = accumulator.target.output_dir
-            skip_empty_reconciliation = not truncated and not thread_ids and room_has_thread_exports(output_dir, room)
+            skip_empty_reconciliation = (
+                not truncated
+                and not thread_ids
+                and room_has_thread_exports(
+                    output_dir,
+                    room,
+                    trusted_root=accumulator.target.trusted_root,
+                )
+            )
             if skip_empty_reconciliation:
                 logger.warning(
                     "Skipping stale thread reconciliation after empty enumeration",
@@ -177,6 +190,7 @@ def _finish_room_exports(
                     output_dir,
                     room,
                     thread_ids,
+                    trusted_root=accumulator.target.trusted_root,
                 )
                 if removed_stale_threads:
                     changed_accumulator_ids.add(id(accumulator))
@@ -184,6 +198,7 @@ def _finish_room_exports(
                 output_dir,
                 room,
                 thread_files_changed=id(accumulator) in changed_accumulator_ids,
+                trusted_root=accumulator.target.trusted_root,
             )
         except Exception as exc:
             accumulator.failed_items.append(failure_for_room(room, f"Room reconciliation failed: {exc}"))

--- a/src/mindroom/thread_export/models.py
+++ b/src/mindroom/thread_export/models.py
@@ -82,6 +82,7 @@ class ThreadExportTarget:
     output_dir: Path
     required_member_user_ids: tuple[str, ...] = ()
     include_invited_rooms: bool = True
+    trusted_root: Path | None = None
 
 
 @dataclass

--- a/src/mindroom/thread_export/service.py
+++ b/src/mindroom/thread_export/service.py
@@ -114,6 +114,7 @@ def _reconcile_full_pass(accumulators: Sequence[ThreadExportAccumulator]) -> Non
             reconcile_room_directories(
                 output_dir,
                 accumulator.retained_room_keys,
+                trusted_root=accumulator.target.trusted_root,
             )
         except (OSError, RuntimeError) as exc:
             accumulator.failed_items.append(
@@ -173,7 +174,10 @@ def _validated_targets(
             )
             continue
         try:
-            prepare_export_root(accumulator.target.output_dir)
+            prepare_export_root(
+                accumulator.target.output_dir,
+                trusted_root=accumulator.target.trusted_root,
+            )
         except (OSError, RuntimeError) as exc:
             accumulator.failed_items.append(failure_for_target(f"output directory preparation failed: {exc}"))
             logger.warning(

--- a/src/mindroom/thread_export/storage.py
+++ b/src/mindroom/thread_export/storage.py
@@ -6,10 +6,12 @@ import json
 import os
 import shutil
 import stat
+import threading
 from contextlib import suppress
 from datetime import UTC, datetime
+from functools import wraps
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
 from urllib.parse import quote, unquote
 from uuid import uuid4
 
@@ -19,7 +21,7 @@ from mindroom import yaml_io
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Sequence
+    from collections.abc import Callable, Collection, Sequence
 
     from mindroom.matrix.client_visible_messages import ResolvedVisibleMessage
     from mindroom.thread_export.models import ThreadExportRoom
@@ -33,6 +35,20 @@ _DIRECTORY_OPEN_FLAGS = os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW
 
 
 logger = get_logger(__name__)
+_P = ParamSpec("_P")
+_R = TypeVar("_R")
+_THREAD_EXPORT_MUTATION_LOCK = threading.RLock()
+
+
+def _serialized_export_mutation(function: Callable[_P, _R]) -> Callable[_P, _R]:
+    """Serialize target mutations so cleanup cannot race a replacement writer."""
+
+    @wraps(function)
+    def serialized(*args: _P.args, **kwargs: _P.kwargs) -> _R:
+        with _THREAD_EXPORT_MUTATION_LOCK:
+            return function(*args, **kwargs)
+
+    return serialized
 
 
 class _UnsafeThreadExportPathError(RuntimeError):
@@ -397,6 +413,7 @@ def _require_owned_export_root(root_fd: int, output_dir: Path) -> None:
     raise _unowned_export_root(output_dir)
 
 
+@_serialized_export_mutation
 def prepare_export_root(
     output_dir: Path,
     *,
@@ -684,6 +701,7 @@ def _room_index_filename_set_matches(room_fd: int) -> bool:
     return declared_filenames == disk_filenames
 
 
+@_serialized_export_mutation
 def write_room_index(
     output_dir: Path,
     room: ThreadExportRoom,
@@ -790,6 +808,7 @@ def _remove_room_export_entries(
         os.close(room_fd)
 
 
+@_serialized_export_mutation
 def remove_room_export(
     output_dir: Path,
     room: ThreadExportRoom,
@@ -832,6 +851,7 @@ def remove_room_export(
         os.close(root_fd)
 
 
+@_serialized_export_mutation
 def remove_stale_thread_exports(
     output_dir: Path,
     room: ThreadExportRoom,
@@ -892,6 +912,7 @@ def _remove_reconciliation_room(root_fd: int, output_dir: Path, room_name: str) 
     return False
 
 
+@_serialized_export_mutation
 def reconcile_room_directories(
     output_dir: Path,
     retained_room_keys: set[str],
@@ -919,12 +940,16 @@ def reconcile_room_directories(
         os.close(root_fd)
 
 
+@_serialized_export_mutation
 def clear_thread_export_root(
     output_dir: Path,
     *,
     trusted_root: Path | None = None,
+    should_clear: Callable[[], bool] | None = None,
 ) -> None:
     """Remove exporter-owned content from one target and preserve unrelated entries."""
+    if should_clear is not None and not should_clear():
+        return
     root_fd = _open_owned_export_root(
         output_dir,
         create=False,
@@ -965,6 +990,7 @@ def _existing_payload_matches(room_fd: int, filename: str, payload: dict[str, ob
     return _payload_without_exported_at(existing) == _payload_without_exported_at(payload)
 
 
+@_serialized_export_mutation
 def write_thread_payload(
     output_dir: Path,
     room: ThreadExportRoom,

--- a/src/mindroom/thread_export/storage.py
+++ b/src/mindroom/thread_export/storage.py
@@ -90,6 +90,24 @@ def canonicalize_output_dir(output_dir: Path) -> Path:
     return Path(os.path.abspath(output_dir))  # noqa: PTH100 - resolve() would hide a final symlink
 
 
+def _canonicalize_trusted_output_dir(
+    output_dir: Path,
+    trusted_root: Path | None,
+) -> tuple[Path, Path | None]:
+    """Return a lexical output path and its optional containing root."""
+    canonical_output_dir = canonicalize_output_dir(output_dir)
+    if trusted_root is None:
+        return canonical_output_dir, None
+    canonical_trusted_root = Path(os.path.abspath(trusted_root))  # noqa: PTH100
+    outside_trusted_root = not canonical_output_dir.is_relative_to(
+        canonical_trusted_root,
+    )
+    if canonical_output_dir == canonical_trusted_root or outside_trusted_root:
+        msg = f"Thread export output must be a descendant of its trusted root: {canonical_output_dir}"
+        raise _UnsafeThreadExportPathError(msg)
+    return canonical_output_dir, canonical_trusted_root
+
+
 def _open_directory_at(
     parent_fd: int,
     name: str,
@@ -116,9 +134,57 @@ def _open_directory_at(
         raise _unsafe_directory(path, label) from exc
 
 
-def _open_export_root(output_dir: Path, *, create: bool) -> int | None:
+def _open_anchored_directory(
+    trusted_root: Path,
+    relative_parts: tuple[str, ...],
+    *,
+    create: bool,
+    final_label: str,
+) -> int | None:
+    """Open one descendant by descriptor-relative traversal without symlinks."""
+    descriptors: list[int] = []
+    try:
+        descriptors.append(os.open(trusted_root, _DIRECTORY_OPEN_FLAGS))
+        for index, part in enumerate(relative_parts):
+            descriptor = _open_directory_at(
+                descriptors[-1],
+                part,
+                path=trusted_root.joinpath(*relative_parts[: index + 1]),
+                label=final_label if index == len(relative_parts) - 1 else "root parent",
+                create=create,
+            )
+            if descriptor is None:
+                return None
+            descriptors.append(descriptor)
+    except FileNotFoundError:
+        if not create:
+            return None
+        raise
+    else:
+        return descriptors.pop()
+    finally:
+        for descriptor in reversed(descriptors):
+            os.close(descriptor)
+
+
+def _open_export_root(
+    output_dir: Path,
+    *,
+    create: bool,
+    trusted_root: Path | None = None,
+) -> int | None:
     """Open the final export directory without following a symlink at that entry."""
-    canonical_output_dir = canonicalize_output_dir(output_dir)
+    canonical_output_dir, canonical_trusted_root = _canonicalize_trusted_output_dir(
+        output_dir,
+        trusted_root,
+    )
+    if canonical_trusted_root is not None:
+        return _open_anchored_directory(
+            canonical_trusted_root,
+            canonical_output_dir.relative_to(canonical_trusted_root).parts,
+            create=create,
+            final_label="root",
+        )
     if create:
         canonical_output_dir.parent.mkdir(parents=True, exist_ok=True)
     try:
@@ -331,10 +397,18 @@ def _require_owned_export_root(root_fd: int, output_dir: Path) -> None:
     raise _unowned_export_root(output_dir)
 
 
-def prepare_export_root(output_dir: Path) -> None:
+def prepare_export_root(
+    output_dir: Path,
+    *,
+    trusted_root: Path | None = None,
+) -> None:
     """Create an export root if needed and install its marker when recognizable."""
     canonical_output_dir = canonicalize_output_dir(output_dir)
-    root_fd = _open_export_root(canonical_output_dir, create=True)
+    root_fd = _open_export_root(
+        canonical_output_dir,
+        create=True,
+        trusted_root=trusted_root,
+    )
     assert root_fd is not None
     try:
         _claim_export_root(root_fd, canonical_output_dir)
@@ -342,10 +416,19 @@ def prepare_export_root(output_dir: Path) -> None:
         os.close(root_fd)
 
 
-def _open_owned_export_root(output_dir: Path, *, create: bool) -> int | None:
+def _open_owned_export_root(
+    output_dir: Path,
+    *,
+    create: bool,
+    trusted_root: Path | None = None,
+) -> int | None:
     """Open an owned root, claiming recognizable storage only for write creation."""
     canonical_output_dir = canonicalize_output_dir(output_dir)
-    root_fd = _open_export_root(canonical_output_dir, create=create)
+    root_fd = _open_export_root(
+        canonical_output_dir,
+        create=create,
+        trusted_root=trusted_root,
+    )
     if root_fd is None:
         return None
     try:
@@ -606,9 +689,14 @@ def write_room_index(
     room: ThreadExportRoom,
     *,
     thread_files_changed: bool = True,
+    trusted_root: Path | None = None,
 ) -> None:
     """Rebuild a room index after YAML changes or detected filename-set drift."""
-    root_fd = _open_owned_export_root(output_dir, create=False)
+    root_fd = _open_owned_export_root(
+        output_dir,
+        create=False,
+        trusted_root=trusted_root,
+    )
     if root_fd is None:
         return
     try:
@@ -628,9 +716,18 @@ def write_room_index(
         os.close(room_fd)
 
 
-def room_has_thread_exports(output_dir: Path, room: ThreadExportRoom) -> bool:
+def room_has_thread_exports(
+    output_dir: Path,
+    room: ThreadExportRoom,
+    *,
+    trusted_root: Path | None = None,
+) -> bool:
     """Return whether a safe room directory contains recognizable thread YAML."""
-    root_fd = _open_export_root(output_dir, create=False)
+    root_fd = _open_export_root(
+        output_dir,
+        create=False,
+        trusted_root=trusted_root,
+    )
     if root_fd is None:
         return False
     try:
@@ -693,13 +790,22 @@ def _remove_room_export_entries(
         os.close(room_fd)
 
 
-def remove_room_export(output_dir: Path, room: ThreadExportRoom) -> None:
+def remove_room_export(
+    output_dir: Path,
+    room: ThreadExportRoom,
+    *,
+    trusted_root: Path | None = None,
+) -> None:
     """Retract one room export, preserving and reporting entries the exporter does not own.
 
     Retraction is idempotent: once every exporter-owned entry is gone, later passes over the
     same room are quiet no-ops rather than a failure the operator can never clear.
     """
-    root_fd = _open_owned_export_root(output_dir, create=False)
+    root_fd = _open_owned_export_root(
+        output_dir,
+        create=False,
+        trusted_root=trusted_root,
+    )
     if root_fd is None:
         return
     room_name = _room_path_segment(room.key)
@@ -730,9 +836,15 @@ def remove_stale_thread_exports(
     output_dir: Path,
     room: ThreadExportRoom,
     thread_ids: Sequence[str],
+    *,
+    trusted_root: Path | None = None,
 ) -> bool:
     """Remove recognizable thread files absent from a complete enumeration."""
-    root_fd = _open_owned_export_root(output_dir, create=False)
+    root_fd = _open_owned_export_root(
+        output_dir,
+        create=False,
+        trusted_root=trusted_root,
+    )
     if root_fd is None:
         return False
     try:
@@ -780,9 +892,18 @@ def _remove_reconciliation_room(root_fd: int, output_dir: Path, room_name: str) 
     return False
 
 
-def reconcile_room_directories(output_dir: Path, retained_room_keys: set[str]) -> None:
+def reconcile_room_directories(
+    output_dir: Path,
+    retained_room_keys: set[str],
+    *,
+    trusted_root: Path | None = None,
+) -> None:
     """Remove recognizable room directories outside the retained authorization scope."""
-    root_fd = _open_owned_export_root(output_dir, create=False)
+    root_fd = _open_owned_export_root(
+        output_dir,
+        create=False,
+        trusted_root=trusted_root,
+    )
     if root_fd is None:
         return
     try:
@@ -794,6 +915,29 @@ def reconcile_room_directories(output_dir: Path, retained_room_keys: set[str]) -
             removed = _remove_reconciliation_room(root_fd, output_dir, name) or removed
         if removed:
             _fsync_directory_fd(root_fd)
+    finally:
+        os.close(root_fd)
+
+
+def clear_thread_export_root(
+    output_dir: Path,
+    *,
+    trusted_root: Path | None = None,
+) -> None:
+    """Remove exporter-owned content from one target and preserve unrelated entries."""
+    root_fd = _open_owned_export_root(
+        output_dir,
+        create=False,
+        trusted_root=trusted_root,
+    )
+    if root_fd is None:
+        return
+    try:
+        for name in os.listdir(root_fd):  # noqa: PTH208 - root_fd pins the directory
+            if name == _ROOT_MARKER_FILENAME:
+                continue
+            _remove_reconciliation_room(root_fd, output_dir, name)
+        _fsync_directory_fd(root_fd)
     finally:
         os.close(root_fd)
 
@@ -826,9 +970,15 @@ def write_thread_payload(
     room: ThreadExportRoom,
     thread_id: str,
     payload: dict[str, object],
+    *,
+    trusted_root: Path | None = None,
 ) -> bool:
     """Write one thread payload when changed and return whether bytes were replaced."""
-    root_fd = _open_owned_export_root(output_dir, create=True)
+    root_fd = _open_owned_export_root(
+        output_dir,
+        create=True,
+        trusted_root=trusted_root,
+    )
     if root_fd is None:
         msg = f"Failed to create thread export root: {output_dir}"
         raise RuntimeError(msg)

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -40,7 +40,13 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.conversation_resolver import ConversationResolver
     from mindroom.event_journal import PrincipalStore
-    from mindroom.hooks import HookMatrixAdmin, HookMessageSender, HookRoomStatePutter, HookRoomStateQuerier
+    from mindroom.hooks import (
+        HookMatrixAdmin,
+        HookMessageSender,
+        HookRegistryState,
+        HookRoomStatePutter,
+        HookRoomStateQuerier,
+    )
     from mindroom.matrix.conversation_reads import ConversationReader
     from mindroom.matrix.identity import MatrixID
     from mindroom.matrix.relation_lookup import RelationLookup
@@ -83,6 +89,7 @@ class ToolRuntimeContext:
     runtime_attachment_ids: list[str] = field(default_factory=list)
     runtime_media_attachments: dict[str, RuntimeEncryptedMediaAttachment] = field(default_factory=dict)
     hook_registry: HookRegistry = field(default_factory=HookRegistry.empty)
+    hook_registry_state: HookRegistryState | None = None
     correlation_id: str | None = None
     hook_message_sender: HookMessageSender | None = None
     matrix_admin: HookMatrixAdmin | None = None
@@ -288,6 +295,7 @@ class ToolRuntimeSupport(ToolRuntimeModelBinding):
             storage_path=self.storage_path,
             attachment_ids=tuple(attachment_ids or ()),
             hook_registry=self.hook_context.registry,
+            hook_registry_state=self.hook_context.hook_registry_state,
             correlation_id=correlation_id,
             hook_message_sender=self.hook_context.message_sender(),
             matrix_admin=self.hook_context.matrix_admin(),
@@ -600,6 +608,7 @@ async def emit_custom_event(
         thread_id=context.resolved_thread_id,
         sender_id=context.requester_id,
         message_received_depth=bindings.message_received_depth,
+        _hook_registry_state=context.hook_registry_state,
     )
     await emit(context.hook_registry, event_name, hook_context)
 

--- a/src/mindroom/tool_system/tool_hooks.py
+++ b/src/mindroom/tool_system/tool_hooks.py
@@ -51,6 +51,7 @@ if TYPE_CHECKING:
         HookMatrixAdmin,
         HookMessageSender,
         HookRegistry,
+        HookRegistryState,
         HookRoomStatePutter,
         HookRoomStateQuerier,
     )
@@ -174,6 +175,7 @@ class _ResolvedToolContext:
     room_state_querier: HookRoomStateQuerier | None
     room_state_putter: HookRoomStatePutter | None
     message_received_depth: int
+    hook_registry_state: HookRegistryState | None
     origin: BackgroundScriptToolOrigin | None
 
     def hook_context_kwargs(self, arguments: dict[str, Any]) -> dict[str, Any]:
@@ -192,6 +194,7 @@ class _ResolvedToolContext:
             "room_state_querier": self.room_state_querier,
             "room_state_putter": self.room_state_putter,
             "message_received_depth": self.message_received_depth,
+            "_hook_registry_state": self.hook_registry_state,
         }
 
 
@@ -273,6 +276,7 @@ def _resolve_tool_context(
             room_state_querier=bindings.room_state_querier,
             room_state_putter=bindings.room_state_putter,
             message_received_depth=bindings.message_received_depth,
+            hook_registry_state=runtime_context.hook_registry_state,
             origin=bridge_context.origin,
         )
 
@@ -297,6 +301,7 @@ def _resolve_tool_context(
             room_state_querier=None,
             room_state_putter=None,
             message_received_depth=0,
+            hook_registry_state=None,
             origin=bridge_context.origin,
         )
 
@@ -318,6 +323,7 @@ def _resolve_tool_context(
         room_state_querier=None,
         room_state_putter=None,
         message_received_depth=0,
+        hook_registry_state=None,
         origin=bridge_context.origin,
     )
 

--- a/src/mindroom/workspaces.py
+++ b/src/mindroom/workspaces.py
@@ -28,6 +28,7 @@ class ResolvedAgentWorkspace:
     """Resolved workspace paths for one agent in one execution scope."""
 
     root: Path
+    lexical_root: Path
     context_files: tuple[Path, ...]
     file_memory_path: Path | None
 
@@ -381,6 +382,7 @@ def _resolve_workspace(
     if agent_config.private is None:
         if config.resolve_entity(agent_name).memory_backend != "file":
             return None
+        lexical_root = state_storage_path.expanduser() / "workspace"
         root = resolve_workspace_relative_path(
             state_storage_path,
             "workspace",
@@ -390,6 +392,7 @@ def _resolve_workspace(
             root.mkdir(parents=True, exist_ok=True)
         return ResolvedAgentWorkspace(
             root=root,
+            lexical_root=lexical_root,
             context_files=(),
             file_memory_path=root,
         )
@@ -401,6 +404,7 @@ def _resolve_workspace(
         msg = f"Private agent '{agent_name}' requires an active execution identity to resolve requester-local state"
         raise ValueError(msg)
 
+    lexical_root = state_storage_path.expanduser() / workspace.root_path
     root = resolve_workspace_relative_path(
         state_storage_path,
         workspace.root_path,
@@ -436,6 +440,7 @@ def _resolve_workspace(
 
     return ResolvedAgentWorkspace(
         root=root,
+        lexical_root=lexical_root,
         context_files=context_files,
         file_memory_path=file_memory_path,
     )

--- a/tach.toml
+++ b/tach.toml
@@ -2700,6 +2700,7 @@ path = "mindroom.thread_export"
 depends_on = [
     "mindroom.thread_export.models",
     "mindroom.thread_export.service",
+    "mindroom.thread_export.storage",
 ]
 
 [[modules]]
@@ -2717,6 +2718,7 @@ visibility = [
 path = "mindroom.thread_export.storage"
 depends_on = []
 visibility = [
+    "mindroom.thread_export",
     "mindroom.thread_export.execution",
     "mindroom.thread_export.service",
 ]

--- a/tests/test_history_compaction_rewrite.py
+++ b/tests/test_history_compaction_rewrite.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -49,6 +50,7 @@ from mindroom.hooks import (
     EVENT_COMPACTION_BEFORE,
     CompactionHookContext,
     HookRegistry,
+    HookRegistryState,
     build_hook_matrix_admin,
     hook,
 )
@@ -627,9 +629,14 @@ async def test_prepare_history_for_run_emits_compaction_before_and_after_hooks(t
     storage.upsert_session(session)
 
     observed: list[tuple[str, list[str], int, int | None, str | None]] = []
+    active_states: list[bool] = []
 
     @hook(EVENT_COMPACTION_BEFORE, priority=10)
     async def before_first(ctx: CompactionHookContext) -> None:
+        active_states.append(ctx.is_active())
+        registry_state.registry = HookRegistry.empty()
+        active_states.append(ctx.is_active())
+        registry_state.registry = registry
         persisted = get_agent_session(storage, "session-1")
         assert persisted is not None
         assert [run.run_id for run in persisted.runs or []] == ["run-1", "run-2"]
@@ -662,12 +669,16 @@ async def test_prepare_history_for_run_emits_compaction_before_and_after_hooks(t
         )
 
     registry = HookRegistry.from_plugins([_plugin("compaction-hooks", [before_first, before_second, after])])
+    registry_state = HookRegistryState(registry)
     agent = _agent(db=storage)
-    runtime_context = _hook_runtime_context(
-        config=config,
-        runtime_paths=runtime_paths,
-        registry=registry,
-        session_id="session-1",
+    runtime_context = replace(
+        _hook_runtime_context(
+            config=config,
+            runtime_paths=runtime_paths,
+            registry=registry,
+            session_id="session-1",
+        ),
+        hook_registry_state=registry_state,
     )
 
     with (
@@ -713,6 +724,7 @@ async def test_prepare_history_for_run_emits_compaction_before_and_after_hooks(t
     )
     assert observed[0][3] == prepared.compaction_outcomes[0].before_tokens
     assert observed[2][3] == prepared.compaction_outcomes[0].before_tokens
+    assert active_states == [True, False]
 
 
 @pytest.mark.asyncio

--- a/tests/test_hook_execution.py
+++ b/tests/test_hook_execution.py
@@ -196,6 +196,11 @@ def _final_response_transform_context(
     )
 
 
+def test_unbound_hook_context_is_inactive(tmp_path: Path) -> None:
+    """A context without lifecycle bindings must fail closed."""
+    assert _message_received_context(tmp_path).is_active() is False
+
+
 def test_final_response_transform_builtin_event_can_register() -> None:
     """The final-response transform event should be accepted as a built-in hook."""
 

--- a/tests/test_hook_execution.py
+++ b/tests/test_hook_execution.py
@@ -25,6 +25,7 @@ from mindroom.hooks import (
     FinalResponseDraft,
     FinalResponseTransformContext,
     HookRegistry,
+    HookRegistryState,
     MessageEnrichContext,
     MessageEnvelope,
     MessageReceivedContext,
@@ -237,6 +238,32 @@ async def test_emit_observer_continues_after_failure_and_propagates_suppression(
 
     assert seen == ["failing", "suppressing"]
     assert context.suppress is True
+
+
+@pytest.mark.asyncio
+async def test_bound_hook_context_tracks_whether_its_registry_is_still_active(
+    tmp_path: Path,
+) -> None:
+    """Long-running hooks can stop work after their registry is replaced."""
+    observed: list[bool] = []
+
+    @hook(EVENT_MESSAGE_RECEIVED)
+    async def observer(ctx: MessageReceivedContext) -> None:
+        observed.append(ctx.is_active())
+        registry_state.registry = replacement_registry
+        observed.append(ctx.is_active())
+
+    active_registry = HookRegistry.from_plugins([_plugin("observer-plugin", [observer])])
+    replacement_registry = HookRegistry.empty()
+    registry_state = HookRegistryState(active_registry)
+    context = replace(
+        _message_received_context(tmp_path),
+        _hook_registry_state=registry_state,
+    )
+
+    await emit(active_registry, EVENT_MESSAGE_RECEIVED, context)
+
+    assert observed == [True, False]
 
 
 @pytest.mark.asyncio

--- a/tests/test_hook_matrix_admin.py
+++ b/tests/test_hook_matrix_admin.py
@@ -669,3 +669,4 @@ async def test_emit_config_reloaded_context_includes_matrix_admin(tmp_path: Path
 
     context = mock_emit.await_args.args[2]
     assert context.matrix_admin is not None
+    assert context._hook_registry_state is orchestrator._hook_registry_state

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -3516,7 +3516,7 @@ class TestMultiAgentOrchestrator:
         mock_shutdown_approvals.assert_awaited_once()
 
     @pytest.mark.asyncio
-    async def test_orchestrator_stop_invalidates_config_reload_hooks_first(
+    async def test_orchestrator_stop_invalidates_hook_registries_first(
         self,
         tmp_path: Path,
     ) -> None:
@@ -3542,6 +3542,7 @@ class TestMultiAgentOrchestrator:
             plugin_changes=(),
         )
         active_during_script_shutdown: list[bool] = []
+        scheduling_registries: list[HookRegistry] = []
 
         async def record_hook_state() -> None:
             active_during_script_shutdown.append(context.is_active())
@@ -3559,11 +3560,16 @@ class TestMultiAgentOrchestrator:
                 new=AsyncMock(side_effect=RuntimeError("stop boundary")),
                 create=True,
             ),
+            patch(
+                "mindroom.orchestrator.set_scheduling_hook_registry",
+                side_effect=scheduling_registries.append,
+            ),
             pytest.raises(RuntimeError, match="stop boundary"),
         ):
             await orchestrator.stop()
 
         assert active_during_script_shutdown == [False]
+        assert scheduling_registries == [HookRegistry.empty()]
 
     @pytest.mark.asyncio
     async def test_config_update_forwards_plan_to_stable_script_runtime_before_replacement(

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -39,6 +39,7 @@ from mindroom.constants import (
 )
 from mindroom.event_journal_open import record_opened_event_journal
 from mindroom.hooks import (
+    ConfigReloadedContext,
     HookRegistry,
 )
 from mindroom.matrix.client import PermanentMatrixStartupError
@@ -3513,6 +3514,56 @@ class TestMultiAgentOrchestrator:
 
         assert calls == ["scripts", "transport", "approvals", "mcp"]
         mock_shutdown_approvals.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_stop_invalidates_config_reload_hooks_first(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Shutdown must retire orchestrator hooks before stopping subsystems."""
+        orchestrator = _MultiAgentOrchestrator(
+            runtime_paths=TestAgentBot._runtime_paths(tmp_path),
+        )
+        active_registry = HookRegistry.empty()
+        orchestrator.hook_registry = active_registry
+        context = ConfigReloadedContext(
+            event_name="config:reloaded",
+            plugin_name="test",
+            settings={},
+            config=MagicMock(spec=Config),
+            runtime_paths=orchestrator.runtime_paths,
+            logger=MagicMock(),
+            correlation_id="reload",
+            _hook_registry_state=orchestrator._hook_registry_state,
+            _hook_registry_snapshot=active_registry,
+            changed_entities=(),
+            added_entities=(),
+            removed_entities=(),
+            plugin_changes=(),
+        )
+        active_during_script_shutdown: list[bool] = []
+
+        async def record_hook_state() -> None:
+            active_during_script_shutdown.append(context.is_active())
+
+        assert context.is_active()
+        with (
+            patch.object(
+                type(orchestrator._script_runtime),
+                "shutdown",
+                new=AsyncMock(side_effect=record_hook_state),
+            ),
+            patch.object(
+                orchestrator._approval_transport,
+                "close",
+                new=AsyncMock(side_effect=RuntimeError("stop boundary")),
+                create=True,
+            ),
+            pytest.raises(RuntimeError, match="stop boundary"),
+        ):
+            await orchestrator.stop()
+
+        assert active_during_script_shutdown == [False]
 
     @pytest.mark.asyncio
     async def test_config_update_forwards_plan_to_stable_script_runtime_before_replacement(

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -249,6 +249,31 @@ async def test_entity_removal_recovers_original_final_before_bot_cleanup(tmp_pat
     assert "removed" not in orchestrator.agent_bots
 
 
+@pytest.mark.asyncio
+async def test_entity_removal_keeps_bot_registered_until_cleanup_succeeds(
+    tmp_path: Path,
+) -> None:
+    """Failed cleanup cannot detach a bot whose hook contexts are still live."""
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("router:\n  model: default\n", encoding="utf-8")
+    runtime_paths = resolve_runtime_paths(
+        config_path=config_path,
+        storage_path=tmp_path / "data",
+        process_env={},
+    )
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths)
+    bot = MagicMock()
+    bot.prepare_for_sync_shutdown = AsyncMock()
+    bot.cleanup = AsyncMock(side_effect=RuntimeError("cleanup failed"))
+    orchestrator.agent_bots["removed"] = bot
+    orchestrator._approval_transport.reconcile_unavailable_entities = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="cleanup failed"):
+        await orchestrator._remove_deleted_entities({"removed"})
+
+    assert orchestrator.agent_bots["removed"] is bot
+
+
 class TestAgentBot(AgentBotTestBase):
     """Bot behavior tests moved verbatim from tests/test_multi_agent_bot.py."""
 

--- a/tests/test_response_runner_session_lifecycle.py
+++ b/tests/test_response_runner_session_lifecycle.py
@@ -359,9 +359,14 @@ async def test_process_and_respond_emits_session_started_after_first_persisted_t
     storage = _SessionStorage()
     sequence: list[tuple[str, str | None, str | None, str | None]] = []
     saw_matrix_admin: list[bool] = []
+    active_states: list[bool] = []
 
     @hook(EVENT_SESSION_STARTED, priority=10)
     async def first(ctx: SessionHookContext) -> None:
+        active_states.append(ctx.is_active())
+        registry_state.registry = HookRegistry.empty()
+        active_states.append(ctx.is_active())
+        registry_state.registry = registry
         saw_matrix_admin.append(ctx.matrix_admin is not None)
         sequence.append(("first", ctx.scope.key, ctx.session_id, ctx.thread_id))
 
@@ -392,6 +397,7 @@ async def test_process_and_respond_emits_session_started_after_first_persisted_t
             ),
             enable_streaming=False,
         )
+        registry_state = coordinator.deps.tool_runtime.hook_context.hook_registry_state
 
         async def fake_ai_response(*_args: object, **_kwargs: object) -> str:
             context = get_tool_runtime_context()
@@ -437,6 +443,7 @@ async def test_process_and_respond_emits_session_started_after_first_persisted_t
         ("deliver", None, None, None),
     ]
     assert saw_matrix_admin == [True]
+    assert active_states == [True, False]
 
 
 @pytest.mark.asyncio

--- a/tests/test_scheduling_executor.py
+++ b/tests/test_scheduling_executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
@@ -388,6 +389,45 @@ async def test_hook_emission_fires_with_task_context(tmp_path: Path) -> None:
     assert outcome.delivered is True
     assert seen == [("task-hooked", "$thread")]
     assert "Prepare the agenda (hooked)" in mock_send.await_args.args[2]["body"]
+
+
+@pytest.mark.asyncio
+async def test_running_schedule_hook_becomes_inactive_after_registry_replacement(tmp_path: Path) -> None:
+    """A registry replacement retires a schedule hook that is already running."""
+    hook_started = asyncio.Event()
+    resume_hook = asyncio.Event()
+    active_states: list[bool] = []
+
+    @hook(EVENT_SCHEDULE_FIRED)
+    async def observe_lifecycle(ctx: ScheduleFiredContext) -> None:
+        active_states.append(ctx.is_active())
+        hook_started.set()
+        await resume_hook.wait()
+        active_states.append(ctx.is_active())
+
+    config = _config(tmp_path)
+    set_scheduling_hook_registry(HookRegistry.from_plugins([_plugin("schedule-plugin", [observe_lifecycle])]))
+
+    with patch(
+        "mindroom.scheduling_executor.send_matrix_message",
+        new=AsyncMock(side_effect=delivered_matrix_side_effect("$delivered")),
+    ):
+        execution = asyncio.create_task(
+            execute_scheduled_workflow(
+                AsyncMock(),
+                _workflow("Prepare the agenda"),
+                config,
+                runtime_paths_for(config),
+                _conversation_reader(latest_thread_event_id="$latest"),
+            ),
+        )
+        await hook_started.wait()
+        set_scheduling_hook_registry(HookRegistry.empty())
+        resume_hook.set()
+        outcome = await execution
+
+    assert outcome.delivered is True
+    assert active_states == [True, False]
 
 
 @pytest.mark.asyncio

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -35,6 +35,7 @@ from mindroom.config.main import Config
 from mindroom.config.matrix import MatrixSyncConfig
 from mindroom.config.models import ModelConfig
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths
+from mindroom.hooks import HookRegistry, HookRegistryState
 from mindroom.matrix.health import (
     SyncCacheWriteProgress,
     get_matrix_sync_cache_write_progress,
@@ -2311,6 +2312,8 @@ async def test_stop_entities_uses_generic_shutdown_for_removed_entities() -> Non
 async def test_agent_bot_stop_preserves_restart_shutdown_intent() -> None:
     """AgentBot.stop() must keep restart provenance for final drains."""
     bot = object.__new__(AgentBot)
+    active_hook_registry = HookRegistry.empty()
+    bot._hook_registry_state = HookRegistryState(active_hook_registry)
     bot.agent_user = AgentMatrixUser(
         agent_name="test_agent",
         user_id="@mindroom_test_agent:localhost",
@@ -2345,6 +2348,7 @@ async def test_agent_bot_stop_preserves_restart_shutdown_intent() -> None:
     await AgentBot.stop(bot, shutdown_intent=SYNC_RESTART_SHUTDOWN)
 
     bot._emit_agent_lifecycle_event.assert_awaited_once_with("agent:stopped", stop_reason="restart")
+    assert bot.hook_registry is not active_hook_registry
     bot.prepare_for_sync_shutdown.assert_awaited_once_with(shutdown_intent=SYNC_RESTART_SHUTDOWN)
     bot._response_runner.wait_for_source_owned_inbox_responses.assert_awaited_once_with()
 

--- a/tests/test_thread_export_execution.py
+++ b/tests/test_thread_export_execution.py
@@ -967,7 +967,11 @@ async def test_room_removal_failure_is_scoped_to_the_rejected_target(
             targets=(rejected_target, healthy_target),
         )
 
-    remove_export.assert_called_once_with(rejected_target.output_dir, room)
+    remove_export.assert_called_once_with(
+        rejected_target.output_dir,
+        room,
+        trusted_root=None,
+    )
     enumerate_threads.assert_awaited_once_with(client, room.room_id, max_thread_roots=2000)
     assert accumulators[0].rooms_exported == 0
     assert accumulators[0].failed_items[0].error == "Room removal failed: storage unavailable"

--- a/tests/test_thread_export_service.py
+++ b/tests/test_thread_export_service.py
@@ -23,6 +23,7 @@ from mindroom.event_journal_open import (
 )
 from mindroom.matrix.users import INTERNAL_USER_ACCOUNT_KEY
 from mindroom.thread_export import ThreadExportTarget, export_threads_once, export_threads_to_targets_once
+from mindroom.thread_export import service as thread_export_service
 from mindroom.thread_export.models import ThreadExportAccumulator, ThreadExportGroupFailure, ThreadExportRoom
 from mindroom.thread_export.storage import _ROOT_MARKER_FILENAME
 from tests.conftest import runtime_paths_for
@@ -473,6 +474,52 @@ async def test_symlinked_final_target_is_skipped_without_touching_destination(tm
     assert "symlinked thread export root" in stats[0].failed_items[0].error
     assert victim.read_text(encoding="utf-8") == "secret"
     assert output_dir.is_symlink()
+
+
+@pytest.mark.asyncio
+async def test_trusted_root_target_rejects_parent_replaced_after_validation(
+    tmp_path: Path,
+) -> None:
+    """Replacing a validated parent cannot redirect an anchored export target."""
+    config = thread_export_config(tmp_path)
+    runtime_paths = runtime_paths_for(config)
+    instance_root = tmp_path / "private_instances" / "scope" / "agent"
+    output_dir = instance_root / "workspace" / "thread_exports"
+    instance_root.mkdir(parents=True)
+    saved_instance_root = instance_root.with_name("agent-saved")
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "keep.txt"
+    sentinel.write_text("keep", encoding="utf-8")
+    original_prepare = thread_export_service.prepare_export_root
+    swapped = False
+
+    def swap_before_prepare(path: Path, *, trusted_root: Path | None = None) -> None:
+        nonlocal swapped
+        instance_root.rename(saved_instance_root)
+        instance_root.symlink_to(outside, target_is_directory=True)
+        swapped = True
+        original_prepare(path, trusted_root=trusted_root)
+
+    with patch(
+        "mindroom.thread_export.service.prepare_export_root",
+        side_effect=swap_before_prepare,
+    ):
+        stats = await export_threads_to_targets_once(
+            config=config,
+            runtime_paths=runtime_paths,
+            targets=(
+                ThreadExportTarget(
+                    output_dir,
+                    trusted_root=runtime_paths.storage_root,
+                ),
+            ),
+        )
+
+    assert swapped is True
+    assert stats[0].failures == 1
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+    assert not (outside / "workspace" / "thread_exports").exists()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_thread_export_storage.py
+++ b/tests/test_thread_export_storage.py
@@ -119,6 +119,8 @@ def test_inactive_cleanup_cannot_race_a_replacement_writer(tmp_path: Path) -> No
     prepare_export_root(output_dir, trusted_root=tmp_path)
     write_started = threading.Event()
     release_write = threading.Event()
+    clear_started = threading.Event()
+    should_clear_called = threading.Event()
     active = True
 
     original_atomic_write = thread_export_storage._atomic_write_at
@@ -127,6 +129,18 @@ def test_inactive_cleanup_cannot_race_a_replacement_writer(tmp_path: Path) -> No
         write_started.set()
         assert release_write.wait(2)
         original_atomic_write(*args, **kwargs)
+
+    def should_clear() -> bool:
+        should_clear_called.set()
+        return active
+
+    def run_clear() -> None:
+        clear_started.set()
+        clear_thread_export_root(
+            output_dir,
+            trusted_root=tmp_path,
+            should_clear=should_clear,
+        )
 
     with (
         patch("mindroom.thread_export.storage._atomic_write_at", side_effect=pause_write),
@@ -142,15 +156,13 @@ def test_inactive_cleanup_cannot_race_a_replacement_writer(tmp_path: Path) -> No
         )
         assert write_started.wait(2)
         active = False
-        clear = pool.submit(
-            clear_thread_export_root,
-            output_dir,
-            trusted_root=tmp_path,
-            should_clear=lambda: active,
-        )
+        clear = pool.submit(run_clear)
+        assert clear_started.wait(2)
+        assert not should_clear_called.wait(0.1)
         release_write.set()
         assert write.result(timeout=2) is True
         clear.result(timeout=2)
+        assert should_clear_called.is_set()
 
     assert (output_dir / _room().key / _thread_filename("$thread:localhost")).exists()
 

--- a/tests/test_thread_export_storage.py
+++ b/tests/test_thread_export_storage.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -9,6 +11,7 @@ import pytest
 import yaml
 
 from mindroom.thread_export import clear_thread_export_root
+from mindroom.thread_export import storage as thread_export_storage
 from mindroom.thread_export.models import ThreadExportRoom
 from mindroom.thread_export.storage import (
     _ROOT_MARKER_FILENAME,
@@ -108,6 +111,48 @@ def test_clear_thread_export_root_never_drops_ownership_before_cleanup_finishes(
 
     unlink.assert_not_called()
     assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+
+
+def test_inactive_cleanup_cannot_race_a_replacement_writer(tmp_path: Path) -> None:
+    """A superseded cleanup must not delete payloads written by its replacement."""
+    output_dir = tmp_path / "agent" / "workspace" / "thread_exports"
+    prepare_export_root(output_dir, trusted_root=tmp_path)
+    write_started = threading.Event()
+    release_write = threading.Event()
+    active = True
+
+    original_atomic_write = thread_export_storage._atomic_write_at
+
+    def pause_write(*args: object, **kwargs: object) -> None:
+        write_started.set()
+        assert release_write.wait(2)
+        original_atomic_write(*args, **kwargs)
+
+    with (
+        patch("mindroom.thread_export.storage._atomic_write_at", side_effect=pause_write),
+        ThreadPoolExecutor(max_workers=2) as pool,
+    ):
+        write = pool.submit(
+            write_thread_payload,
+            output_dir,
+            _room(),
+            "$thread:localhost",
+            {"messages": ["replacement"]},
+            trusted_root=tmp_path,
+        )
+        assert write_started.wait(2)
+        active = False
+        clear = pool.submit(
+            clear_thread_export_root,
+            output_dir,
+            trusted_root=tmp_path,
+            should_clear=lambda: active,
+        )
+        release_write.set()
+        assert write.result(timeout=2) is True
+        clear.result(timeout=2)
+
+    assert (output_dir / _room().key / _thread_filename("$thread:localhost")).exists()
 
 
 def test_clear_thread_export_root_rejects_replaced_parent(tmp_path: Path) -> None:

--- a/tests/test_thread_export_storage.py
+++ b/tests/test_thread_export_storage.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 import pytest
 import yaml
 
+from mindroom.thread_export import clear_thread_export_root
 from mindroom.thread_export.models import ThreadExportRoom
 from mindroom.thread_export.storage import (
     _ROOT_MARKER_FILENAME,
@@ -61,6 +62,96 @@ def _write_thread_export(room_dir: Path, thread_id: str = "$thread:localhost") -
         encoding="utf-8",
     )
     return path
+
+
+def test_clear_thread_export_root_removes_only_owned_content(tmp_path: Path) -> None:
+    """Plugins can retract a target without owning path traversal or broad deletion."""
+    output_dir = tmp_path / "agent" / "workspace" / "thread_exports"
+    _mark_export_root(output_dir)
+    room_dir = output_dir / "lobby"
+    room_dir.mkdir()
+    _write_thread_export(room_dir)
+    (room_dir / "index.json").write_text("{}\n", encoding="utf-8")
+    note = output_dir / "operator-note.txt"
+    note.write_text("keep", encoding="utf-8")
+
+    clear_thread_export_root(output_dir, trusted_root=tmp_path)
+
+    assert not room_dir.exists()
+    assert (output_dir / _ROOT_MARKER_FILENAME).exists()
+    assert note.read_text(encoding="utf-8") == "keep"
+
+    prepare_export_root(output_dir, trusted_root=tmp_path)
+
+
+def test_clear_thread_export_root_retains_empty_owned_directory(
+    tmp_path: Path,
+) -> None:
+    """Cleanup retains the owned root so later exports can reuse it safely."""
+    output_dir = tmp_path / "agent" / "workspace" / "thread_exports"
+    _mark_export_root(output_dir)
+
+    clear_thread_export_root(output_dir, trusted_root=tmp_path)
+
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+
+
+def test_clear_thread_export_root_never_drops_ownership_before_cleanup_finishes(
+    tmp_path: Path,
+) -> None:
+    """Cleanup must not expose a markerless root to concurrent writers."""
+    output_dir = tmp_path / "agent" / "workspace" / "thread_exports"
+    _mark_export_root(output_dir)
+
+    with patch("mindroom.thread_export.storage.os.unlink") as unlink:
+        clear_thread_export_root(output_dir, trusted_root=tmp_path)
+
+    unlink.assert_not_called()
+    assert (output_dir / _ROOT_MARKER_FILENAME).read_text(encoding="utf-8") == _ROOT_MARKER_TEXT
+
+
+def test_clear_thread_export_root_rejects_replaced_parent(tmp_path: Path) -> None:
+    """Cleanup cannot follow an intermediate symlink installed after discovery."""
+    instance_root = tmp_path / "private_instances" / "scope" / "agent"
+    output_dir = instance_root / "workspace" / "thread_exports"
+    _mark_export_root(output_dir)
+    saved_instance_root = instance_root.with_name("agent-saved")
+    instance_root.rename(saved_instance_root)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    sentinel = outside / "keep.txt"
+    sentinel.write_text("keep", encoding="utf-8")
+    instance_root.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="thread export root parent"):
+        clear_thread_export_root(output_dir, trusted_root=tmp_path)
+
+    assert sentinel.read_text(encoding="utf-8") == "keep"
+    assert (saved_instance_root / "workspace" / "thread_exports" / _ROOT_MARKER_FILENAME).exists()
+
+
+def test_write_thread_payload_rejects_replaced_parent(tmp_path: Path) -> None:
+    """A prepared target cannot be redirected before a later write."""
+    instance_root = tmp_path / "private_instances" / "scope" / "agent"
+    output_dir = instance_root / "workspace" / "thread_exports"
+    prepare_export_root(output_dir, trusted_root=tmp_path)
+    saved_instance_root = instance_root.with_name("agent-saved")
+    instance_root.rename(saved_instance_root)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    instance_root.symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(RuntimeError, match="thread export root parent"):
+        write_thread_payload(
+            output_dir,
+            _room(),
+            "$thread:localhost",
+            {"messages": []},
+            trusted_root=tmp_path,
+        )
+
+    assert not (outside / "workspace" / "thread_exports").exists()
+    assert (saved_instance_root / "workspace" / "thread_exports" / _ROOT_MARKER_FILENAME).exists()
 
 
 def test_safe_path_segment_blocks_dot_directory_segments() -> None:

--- a/tests/test_tool_hooks.py
+++ b/tests/test_tool_hooks.py
@@ -30,6 +30,7 @@ from mindroom.hooks import (
     EVENT_TOOL_BEFORE_CALL,
     CustomEventContext,
     HookRegistry,
+    HookRegistryState,
     ToolAfterCallContext,
     ToolBeforeCallContext,
     emit_gate,
@@ -1868,6 +1869,7 @@ async def test_emit_custom_event_preserves_message_received_depth_and_bound_room
     custom_event_name = "demo:tool_custom_event"
     sent: list[dict[str, object] | None] = []
     seen: list[tuple[dict[str, object] | None, bool]] = []
+    active_states: list[bool] = []
     room_state_querier = AsyncMock(return_value={"name": "Lobby"})
     room_state_putter = AsyncMock(return_value=True)
 
@@ -1886,6 +1888,10 @@ async def test_emit_custom_event_preserves_message_received_depth_and_bound_room
 
     @hook(custom_event_name)
     async def on_custom_event(ctx: CustomEventContext) -> None:
+        active_states.append(ctx.is_active())
+        registry_state.registry = HookRegistry.empty()
+        active_states.append(ctx.is_active())
+        registry_state.registry = registry
         query_result = await ctx.query_room_state("!room:localhost", "m.room.name", "")
         put_result = await ctx.put_room_state(
             "!room:localhost",
@@ -1898,19 +1904,24 @@ async def test_emit_custom_event_preserves_message_received_depth_and_bound_room
         assert event_id == "$dispatch-event"
 
     registry = HookRegistry.from_plugins([_plugin("tool-policy", [on_custom_event])])
-    runtime_context = _tool_runtime_context(
-        tmp_path,
-        hook_message_sender=hook_message_sender,
-        room_state_querier=room_state_querier,
-        room_state_putter=room_state_putter,
-        message_received_depth=1,
-        hook_registry=registry,
+    registry_state = HookRegistryState(registry)
+    runtime_context = replace(
+        _tool_runtime_context(
+            tmp_path,
+            hook_message_sender=hook_message_sender,
+            room_state_querier=room_state_querier,
+            room_state_putter=room_state_putter,
+            message_received_depth=1,
+            hook_registry=registry,
+        ),
+        hook_registry_state=registry_state,
     )
 
     with tool_runtime_context(runtime_context):
         await emit_custom_event("tool-policy", custom_event_name, {"item_id": "123"})
 
     assert seen == [({"name": "Lobby"}, True)]
+    assert active_states == [True, False]
     room_state_querier.assert_awaited_once_with("!room:localhost", "m.room.name", "")
     room_state_putter.assert_awaited_once_with(
         "!room:localhost",
@@ -1978,6 +1989,45 @@ async def test_tool_hook_bridge_fails_open_when_before_hook_raises(tmp_path: Pat
 
     assert result == "ok"
     assert next_func.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_tool_hook_contexts_track_registry_lifecycle(tmp_path: Path) -> None:
+    """Before- and after-call hooks can detect registry replacement."""
+    active_states: list[tuple[str, bool]] = []
+
+    @hook(EVENT_TOOL_BEFORE_CALL)
+    async def before(ctx: ToolBeforeCallContext) -> None:
+        active_states.append(("before", ctx.is_active()))
+        registry_state.registry = HookRegistry.empty()
+        active_states.append(("before", ctx.is_active()))
+        registry_state.registry = registry
+
+    @hook(EVENT_TOOL_AFTER_CALL)
+    async def after(ctx: ToolAfterCallContext) -> None:
+        active_states.append(("after", ctx.is_active()))
+        registry_state.registry = HookRegistry.empty()
+        active_states.append(("after", ctx.is_active()))
+        registry_state.registry = registry
+
+    registry = HookRegistry.from_plugins([_plugin("tool-policy", [before, after])])
+    registry_state = HookRegistryState(registry)
+    runtime_context = replace(
+        _tool_runtime_context(tmp_path, hook_registry=registry),
+        hook_registry_state=registry_state,
+    )
+    bridge = build_tool_hook_bridge(registry, agent_name="code")
+
+    with tool_runtime_context(runtime_context):
+        result = await bridge("read_file", AsyncMock(return_value="ok"), {})
+
+    assert result == "ok"
+    assert active_states == [
+        ("before", True),
+        ("before", False),
+        ("after", True),
+        ("after", False),
+    ]
 
 
 @pytest.mark.asyncio

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -99,6 +99,7 @@ healthz  # unused function (src/mindroom/api/sandbox_runner_app.py)
 is_kubernetes_worker_backend_config_env_name  # unused function (src/mindroom/workers/backends/kubernetes_config.py)
 _.serialize  # unused method (src/mindroom/config/models.py)
 _.decline  # unused method (src/mindroom/hooks/context.py)
+_.is_active  # plugin hooks inspect whether their registry snapshot is still live
 _.get_embedding_and_usage  # unused method (src/mindroom/knowledge/manager.py)
 _.async_get_embedding  # unused method (src/mindroom/knowledge/manager.py)
 _.async_get_embedding_and_usage  # unused method (src/mindroom/knowledge/manager.py)


### PR DESCRIPTION
## In simple terms

This PR stops outdated plugin work after a reload or shutdown, and keeps thread-export file changes inside the intended folder.

## Summary

- Let hooks detect when their registry snapshot has been superseded.
- Anchor thread-export filesystem operations below an optional trusted root.
- Preserve lexical workspace roots for descriptor-anchored consumers.
- Remove export payloads while retaining the ownership marker for safe reuse.

## Why

Hot-reloaded plugins can retain queued work from an older registry, while path validation alone cannot prevent an ancestor from being replaced between resolution and a later write or cleanup. These guarantees belong in core so plugins do not duplicate lifecycle or filesystem-security logic.

## Validation

- Full test suite
- All pre-commit hooks
- Plugin compatibility suite

## Summary by Sourcery

Harden plugin lifecycle invalidation and thread-export filesystem operations against stale work, path replacement, and unsafe cleanup.

New Features:
- Add lifecycle state checks so hook contexts can detect when their registry snapshot is no longer active.
- Support optional trusted roots for thread-export targets and expose safe export-root cleanup.

Bug Fixes:
- Prevent stale plugin hooks and scheduled work from continuing to act as active after registry replacement or shutdown.
- Prevent thread-export writes and cleanup from following replaced ancestor paths or racing concurrent mutations.
- Preserve thread-export ownership markers and unrelated files while clearing exporter-owned payloads.
- Retain bot registration until cleanup succeeds so failed cleanup can be retried safely.

Enhancements:
- Preserve lexical workspace roots alongside resolved paths for consumers that require descriptor-anchored filesystem operations.

Build:
- Update module dependency and visibility declarations for thread-export storage.

Tests:
- Add coverage for hook registry invalidation across compaction, response, tool, scheduling, shutdown, and entity-cleanup lifecycles.
- Add coverage for trusted-root filesystem anchoring, concurrent export cleanup, ownership preservation, and protection against replaced parent directories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added safeguards to keep thread exports within approved storage locations.
  - Added an API for clearing owned thread-export data while preserving unrelated files.
  - Added status tracking for whether hook contexts remain active.

- **Bug Fixes**
  - Improved cleanup reliability and prevented concurrent export operations from interfering.
  - Prevented symlink-based redirects from writing or deleting data outside approved locations.
  - Ensured stopped bots no longer retain active hooks.

- **Tests**
  - Expanded coverage for hook lifecycles, cleanup failures, safe exports, concurrency, and symlink protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->