### PR TITLE
Fix reply membership reconciliation storms

### DIFF
--- a/src/mindroom/agent_reply_membership_sync.py
+++ b/src/mindroom/agent_reply_membership_sync.py
@@ -68,14 +68,13 @@ class AgentReplyMembershipSync:
         """Forget one stopped receive generation's preservation state."""
         self._preserve_on_next_sync_start = False
 
-    def _request_refresh(self) -> bool:
-        """Request an authoritative rebuild and report a new refresh gap."""
+    def _request_refresh(self) -> None:
+        """Request an authoritative rebuild."""
         if self._refresh_pending:
-            return False
+            return
         self._refresh_pending = True
         self._refresh_attempt = 0
         self._refresh_retry_at = 0.0
-        return True
 
     def invalidate(self, config: Config, *, reason: str) -> bool:
         """Fail every room grant closed and request one revocation wave per gap."""

--- a/src/mindroom/agent_reply_membership_sync.py
+++ b/src/mindroom/agent_reply_membership_sync.py
@@ -67,18 +67,19 @@ class AgentReplyMembershipSync:
         """Forget one stopped receive generation's preservation state."""
         self._preserve_on_next_sync_start = False
 
-    def _request_refresh(self) -> None:
-        """Request an authoritative rebuild without resetting active backoff."""
+    def _request_refresh(self) -> bool:
+        """Request an authoritative rebuild and report a new refresh gap."""
         if self._refresh_pending:
-            return
+            return False
         self._refresh_pending = True
         self._refresh_attempt = 0
         self._refresh_retry_at = 0.0
+        return True
 
-    def invalidate(self, config: Config, *, reason: str) -> None:
-        """Fail every room grant closed and request an authoritative rebuild."""
+    def invalidate(self, config: Config, *, reason: str) -> bool:
+        """Fail every room grant closed and report a newly requested rebuild."""
         self._memberships.invalidate(config, reason=reason)
-        self._request_refresh()
+        return self._request_refresh()
 
     async def refresh_if_needed(
         self,

--- a/src/mindroom/agent_reply_membership_sync.py
+++ b/src/mindroom/agent_reply_membership_sync.py
@@ -45,6 +45,7 @@ class AgentReplyMembershipSync:
         self._preserve_on_next_sync_start = False
         self._live_transition_lock = asyncio.Lock()
         self._live_effects_pending = False
+        self._revocation_wave_issued = False
 
     @property
     def memberships(self) -> AgentReplyMembershipIndex:
@@ -77,9 +78,18 @@ class AgentReplyMembershipSync:
         return True
 
     def invalidate(self, config: Config, *, reason: str) -> bool:
-        """Fail every room grant closed and report a newly requested rebuild."""
+        """Fail every room grant closed and request one revocation wave per gap."""
         self._memberships.invalidate(config, reason=reason)
-        return self._request_refresh()
+        self._request_refresh()
+        if self._revocation_wave_issued:
+            return False
+        self._revocation_wave_issued = True
+        return True
+
+    def record_authoritative_refresh(self, config: Config) -> None:
+        """Allow a future invalidation to issue a new revocation wave."""
+        if not self._memberships.needs_refresh(config):
+            self._revocation_wave_issued = False
 
     async def refresh_if_needed(
         self,
@@ -94,6 +104,7 @@ class AgentReplyMembershipSync:
         await refresh()
         self._refresh_pending = self._memberships.needs_refresh(config)
         if not self._refresh_pending:
+            self.record_authoritative_refresh(config)
             self._refresh_attempt = 0
             self._refresh_retry_at = 0.0
             return

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1353,6 +1353,16 @@ class AgentBot:
             owner=self._runtime_view,
         )
 
+    def schedule_reply_authorized_call_revocation(self) -> None:
+        """Schedule this bot's fail-closed active-call revocation."""
+        if self._call_manager is None:
+            return
+        create_background_task(
+            self.revoke_reply_authorized_calls(),
+            name=f"matrix_rtc_reply_authorization_revoke_{self.agent_name}",
+            owner=self._runtime_view,
+        )
+
     def _schedule_reply_authorized_call_revocation(self) -> None:
         """Revoke calls after a synchronous pre-admission policy change."""
         create_background_task(

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -1318,7 +1318,8 @@ class AgentBot:
             return
         orchestrator = self.orchestrator
         if orchestrator is None:
-            self._router_reply_membership_sync.invalidate(self.config, reason=reason)
+            if self._router_reply_membership_sync.invalidate(self.config, reason=reason):
+                self.schedule_reply_authorized_call_revocation()
         else:
             orchestrator.invalidate_agent_reply_memberships(reason=reason)
 
@@ -1397,8 +1398,11 @@ class AgentBot:
             if client is None:
                 return
             await self._runtime_view.agent_reply_memberships.refresh(self.config, self.runtime_paths, client)
+            self._router_reply_membership_sync.record_authoritative_refresh(self.config)
             await self.reconcile_pending_invites()
             await self.revoke_reply_authorized_calls()
+            if self._runtime_view.agent_reply_memberships.needs_refresh(self.config):
+                return
             self.schedule_reply_authorized_call_reconciliation()
 
         await self._router_reply_membership_sync.refresh_if_needed(self.config, refresh)

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1324,9 +1324,11 @@ class _MultiAgentOrchestrator:
     def invalidate_agent_reply_memberships(self, *, reason: str) -> None:
         """Synchronously revoke every room-backed reply grant."""
         if self.config is not None:
-            self.agent_reply_membership_sync.invalidate(self.config, reason=reason)
+            refresh_requested = self.agent_reply_membership_sync.invalidate(self.config, reason=reason)
+            if not refresh_requested:
+                return
             for bot in self.agent_bots.values():
-                bot.schedule_reply_authorized_call_reconciliation()
+                bot.schedule_reply_authorized_call_revocation()
 
     def _invalidate_reply_memberships_before_control_stop(self, entity_names: set[str]) -> None:
         """Fence room-backed grants before stopping their sole control client."""

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1324,8 +1324,8 @@ class _MultiAgentOrchestrator:
     def invalidate_agent_reply_memberships(self, *, reason: str) -> None:
         """Synchronously revoke every room-backed reply grant."""
         if self.config is not None:
-            refresh_requested = self.agent_reply_membership_sync.invalidate(self.config, reason=reason)
-            if not refresh_requested:
+            revocation_wave_requested = self.agent_reply_membership_sync.invalidate(self.config, reason=reason)
+            if not revocation_wave_requested:
                 return
             for bot in self.agent_bots.values():
                 bot.schedule_reply_authorized_call_revocation()
@@ -1370,9 +1370,11 @@ class _MultiAgentOrchestrator:
             self.invalidate_agent_reply_memberships(reason="router_unavailable")
             return
         await self.agent_reply_memberships.refresh(config, self.runtime_paths, router_bot.client)
-        await self.reconcile_pending_invites()
         self.agent_reply_membership_sync.record_authoritative_refresh(config)
+        await self.reconcile_pending_invites()
         await self.revoke_reply_authorized_calls()
+        if self.agent_reply_memberships.needs_refresh(config):
+            return
         for bot in self.agent_bots.values():
             bot.schedule_reply_authorized_call_reconciliation()
 

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -1371,6 +1371,7 @@ class _MultiAgentOrchestrator:
             return
         await self.agent_reply_memberships.refresh(config, self.runtime_paths, router_bot.client)
         await self.reconcile_pending_invites()
+        self.agent_reply_membership_sync.record_authoritative_refresh(config)
         await self.revoke_reply_authorized_calls()
         for bot in self.agent_bots.values():
             bot.schedule_reply_authorized_call_reconciliation()

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -476,6 +476,50 @@ async def test_repeated_membership_invalidation_preserves_refresh_backoff(tmp_pa
 
 
 @pytest.mark.asyncio
+async def test_detached_router_invalidation_during_post_refresh_effects_revokes_and_skips_positive(
+    tmp_path: Path,
+) -> None:
+    """A detached router must reopen revocation before awaiting refresh effects."""
+    room_id = "!grant:localhost"
+    bot = _agent_bot(tmp_path, agent_name=ROUTER_AGENT_NAME)
+    bot.config.router.access = ResponderAccessConfig(members_of_rooms=["grant"])
+    state = MatrixState.load(runtime_paths=bot.runtime_paths)
+    state.add_room("grant", room_id, "#grant:localhost", "Grant")
+    state.save(runtime_paths=bot.runtime_paths)
+    client = make_matrix_client_mock(user_id=bot.agent_user.user_id)
+    client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=[room_id])
+    client.joined_members.return_value = nio.JoinedMembersResponse(
+        members=[nio.RoomMember(bot.agent_user.user_id, None, None)],
+        room_id=room_id,
+    )
+    bot.client = client
+    effects_started = asyncio.Event()
+    release_effects = asyncio.Event()
+
+    async def block_post_refresh_effects() -> None:
+        effects_started.set()
+        await release_effects.wait()
+
+    bot.reconcile_pending_invites = AsyncMock(side_effect=block_post_refresh_effects)  # type: ignore[method-assign]
+    bot.revoke_reply_authorized_calls = AsyncMock()  # type: ignore[method-assign]
+    bot.schedule_reply_authorized_call_revocation = MagicMock()  # type: ignore[method-assign]
+    bot.schedule_reply_authorized_call_reconciliation = MagicMock()  # type: ignore[method-assign]
+    bot._invalidate_agent_reply_memberships(reason="initial_gap")
+    bot.schedule_reply_authorized_call_revocation.reset_mock()
+
+    refresh_task = asyncio.create_task(bot._refresh_agent_reply_memberships_if_needed())
+    await asyncio.wait_for(effects_started.wait(), timeout=1.0)
+    try:
+        bot._invalidate_agent_reply_memberships(reason="uncertain_sync_response")
+    finally:
+        release_effects.set()
+        await refresh_task
+
+    bot.schedule_reply_authorized_call_revocation.assert_called_once_with()
+    bot.schedule_reply_authorized_call_reconciliation.assert_not_called()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("transport", ["classic", "sliding"])
 async def test_router_authoritative_departure_revokes_grant_before_membership_fence(
     tmp_path: Path,

--- a/tests/test_bot_ready_hook.py
+++ b/tests/test_bot_ready_hook.py
@@ -508,8 +508,8 @@ async def test_detached_router_invalidation_during_post_refresh_effects_revokes_
     bot.schedule_reply_authorized_call_revocation.reset_mock()
 
     refresh_task = asyncio.create_task(bot._refresh_agent_reply_memberships_if_needed())
-    await asyncio.wait_for(effects_started.wait(), timeout=1.0)
     try:
+        await asyncio.wait_for(effects_started.wait(), timeout=1.0)
         bot._invalidate_agent_reply_memberships(reason="uncertain_sync_response")
     finally:
         release_effects.set()

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -126,6 +126,29 @@ async def test_reply_membership_refresh_revokes_before_scheduling_positive_call_
     worker_bot.reconcile_reply_authorized_calls.assert_not_awaited()
 
 
+def test_repeated_reply_membership_invalidation_schedules_one_revocation_wave(
+    tmp_path: Path,
+) -> None:
+    """Uncertain sync batches must not start overlapping positive call reconciliation."""
+    config = _runtime_bound_config(Config(), tmp_path)
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
+    orchestrator.config = config
+    router_bot = MagicMock()
+    worker_bot = MagicMock()
+    orchestrator.agent_bots = {
+        ROUTER_AGENT_NAME: router_bot,
+        "worker": worker_bot,
+    }
+
+    orchestrator.invalidate_agent_reply_memberships(reason="uncertain_sync_response")
+    orchestrator.invalidate_agent_reply_memberships(reason="uncertain_sync_response")
+
+    router_bot.schedule_reply_authorized_call_revocation.assert_called_once_with()
+    worker_bot.schedule_reply_authorized_call_revocation.assert_called_once_with()
+    router_bot.schedule_reply_authorized_call_reconciliation.assert_not_called()
+    worker_bot.schedule_reply_authorized_call_reconciliation.assert_not_called()
+
+
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable, Iterator
 

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -138,6 +138,7 @@ async def test_successful_reply_membership_refresh_opens_new_revocation_gap(
     orchestrator.config = config
     router_bot = MagicMock()
     router_bot.client = AsyncMock(spec=nio.AsyncClient)
+    router_bot.reconcile_pending_invites = AsyncMock()
     router_bot.revoke_reply_authorized_calls = AsyncMock()
     orchestrator.agent_bots = {ROUTER_AGENT_NAME: router_bot}
 

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -28,6 +28,7 @@ from mindroom.approval_manager import (
     initialize_approval_store,
 )
 from mindroom.background_tasks import wait_for_background_tasks
+from mindroom.config.access import ResponderAccessConfig
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.matrix import EventJournalConfig
@@ -126,8 +127,33 @@ async def test_reply_membership_refresh_revokes_before_scheduling_positive_call_
     worker_bot.reconcile_reply_authorized_calls.assert_not_awaited()
 
 
+@pytest.mark.asyncio
+async def test_successful_reply_membership_refresh_opens_new_revocation_gap(
+    tmp_path: Path,
+) -> None:
+    """A later invalidation must revoke calls again after an authoritative refresh."""
+    config = _runtime_bound_config(Config(), tmp_path)
+    config.router.access = ResponderAccessConfig(current_room_members=False, members_of_rooms=[])
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
+    orchestrator.config = config
+    router_bot = MagicMock()
+    router_bot.client = AsyncMock(spec=nio.AsyncClient)
+    router_bot.revoke_reply_authorized_calls = AsyncMock()
+    orchestrator.agent_bots = {ROUTER_AGENT_NAME: router_bot}
+
+    orchestrator.invalidate_agent_reply_memberships(reason="uncertain_sync_response")
+    await orchestrator.refresh_agent_reply_memberships()
+    router_bot.schedule_reply_authorized_call_revocation.reset_mock()
+
+    orchestrator.invalidate_agent_reply_memberships(reason="uncertain_sync_response")
+
+    router_bot.schedule_reply_authorized_call_revocation.assert_called_once_with()
+
+
+@pytest.mark.parametrize("preserve_startup_snapshot", [False, True])
 def test_repeated_reply_membership_invalidation_schedules_one_revocation_wave(
     tmp_path: Path,
+    preserve_startup_snapshot: bool,
 ) -> None:
     """Uncertain sync batches must not start overlapping positive call reconciliation."""
     config = _runtime_bound_config(Config(), tmp_path)
@@ -139,6 +165,9 @@ def test_repeated_reply_membership_invalidation_schedules_one_revocation_wave(
         ROUTER_AGENT_NAME: router_bot,
         "worker": worker_bot,
     }
+    if preserve_startup_snapshot:
+        orchestrator.agent_reply_membership_sync.preserve_on_next_sync_start()
+        assert not orchestrator.agent_reply_membership_sync.sync_loop_started()
 
     orchestrator.invalidate_agent_reply_memberships(reason="uncertain_sync_response")
     orchestrator.invalidate_agent_reply_memberships(reason="uncertain_sync_response")

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -115,7 +115,10 @@ async def test_reply_membership_refresh_revokes_before_scheduling_positive_call_
         "worker": worker_bot,
     }
 
-    with patch.object(orchestrator.agent_reply_memberships, "refresh", new=AsyncMock()) as refresh:
+    with (
+        patch.object(orchestrator.agent_reply_memberships, "refresh", new=AsyncMock()) as refresh,
+        patch.object(orchestrator.agent_reply_memberships, "needs_refresh", return_value=False),
+    ):
         await orchestrator.refresh_agent_reply_memberships()
 
     refresh.assert_awaited_once_with(config, orchestrator.runtime_paths, router_bot.client)
@@ -149,6 +152,52 @@ async def test_successful_reply_membership_refresh_opens_new_revocation_gap(
     orchestrator.invalidate_agent_reply_memberships(reason="uncertain_sync_response")
 
     router_bot.schedule_reply_authorized_call_revocation.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_invalidation_during_post_refresh_effects_skips_positive_reconciliation(
+    tmp_path: Path,
+) -> None:
+    """A new gap after refresh publication must revoke again and suppress positive starts."""
+    room_id = "!grant:localhost"
+    config = _runtime_bound_config(Config(), tmp_path)
+    config.router.access = ResponderAccessConfig(current_room_members=False, members_of_rooms=["grant"])
+    orchestrator = _MultiAgentOrchestrator(runtime_paths=runtime_paths_for(config))
+    orchestrator.config = config
+    state = MatrixState.load(runtime_paths=orchestrator.runtime_paths)
+    state.add_room("grant", room_id, "#grant:localhost", "Grant")
+    state.save(runtime_paths=orchestrator.runtime_paths)
+    client = make_matrix_client_mock(user_id="@mindroom_router:localhost")
+    client.joined_rooms.return_value = nio.JoinedRoomsResponse(rooms=[room_id])
+    client.joined_members.return_value = nio.JoinedMembersResponse(
+        members=[nio.RoomMember("@mindroom_router:localhost", None, None)],
+        room_id=room_id,
+    )
+    effects_started = asyncio.Event()
+    release_effects = asyncio.Event()
+
+    async def block_post_refresh_effects() -> None:
+        effects_started.set()
+        await release_effects.wait()
+
+    router_bot = MagicMock()
+    router_bot.client = client
+    router_bot.reconcile_pending_invites = AsyncMock(side_effect=block_post_refresh_effects)
+    router_bot.revoke_reply_authorized_calls = AsyncMock()
+    orchestrator.agent_bots = {ROUTER_AGENT_NAME: router_bot}
+    orchestrator.invalidate_agent_reply_memberships(reason="initial_gap")
+    router_bot.schedule_reply_authorized_call_revocation.reset_mock()
+
+    refresh_task = asyncio.create_task(orchestrator.refresh_agent_reply_memberships())
+    await asyncio.wait_for(effects_started.wait(), timeout=1.0)
+    try:
+        orchestrator.invalidate_agent_reply_memberships(reason="uncertain_sync_response")
+    finally:
+        release_effects.set()
+        await refresh_task
+
+    router_bot.schedule_reply_authorized_call_revocation.assert_called_once_with()
+    router_bot.schedule_reply_authorized_call_reconciliation.assert_not_called()
 
 
 @pytest.mark.parametrize("preserve_startup_snapshot", [False, True])

--- a/tests/test_sync_task_cancellation.py
+++ b/tests/test_sync_task_cancellation.py
@@ -2531,6 +2531,7 @@ async def test_start_runtime_waits_for_shutdown_after_initial_sync_generation_ex
     router_bot.running = True
     router_bot.stop = AsyncMock()
     router_bot.schedule_reply_authorized_call_reconciliation = MagicMock()
+    router_bot.schedule_reply_authorized_call_revocation = MagicMock()
 
     general_bot = AsyncMock()
     general_bot.agent_name = "general"
@@ -2538,6 +2539,7 @@ async def test_start_runtime_waits_for_shutdown_after_initial_sync_generation_ex
     general_bot.running = True
     general_bot.stop = AsyncMock()
     general_bot.schedule_reply_authorized_call_reconciliation = MagicMock()
+    general_bot.schedule_reply_authorized_call_revocation = MagicMock()
 
     orchestrator.agent_bots = {"router": router_bot, "general": general_bot}
 
@@ -2601,6 +2603,7 @@ async def test_start_runtime_waits_for_authoritative_memberships_before_sync_and
     router_bot.running = True
     router_bot.stop = AsyncMock()
     router_bot.schedule_reply_authorized_call_reconciliation = MagicMock()
+    router_bot.schedule_reply_authorized_call_revocation = MagicMock()
     router_bot.preserve_reply_memberships_on_next_sync_start = MagicMock()
 
     general_bot = AsyncMock()
@@ -2609,6 +2612,7 @@ async def test_start_runtime_waits_for_authoritative_memberships_before_sync_and
     general_bot.running = True
     general_bot.stop = AsyncMock()
     general_bot.schedule_reply_authorized_call_reconciliation = MagicMock()
+    general_bot.schedule_reply_authorized_call_revocation = MagicMock()
 
     orchestrator.agent_bots = {"router": router_bot, "general": general_bot}
 
@@ -2698,6 +2702,7 @@ def _orchestrator_with_membership_startup_bots(
     router_bot.running = True
     router_bot.stop = AsyncMock()
     router_bot.schedule_reply_authorized_call_reconciliation = MagicMock()
+    router_bot.schedule_reply_authorized_call_revocation = MagicMock()
     router_bot.preserve_reply_memberships_on_next_sync_start = MagicMock()
     general_bot = AsyncMock()
     general_bot.agent_name = "general"
@@ -2705,6 +2710,7 @@ def _orchestrator_with_membership_startup_bots(
     general_bot.running = True
     general_bot.stop = AsyncMock()
     general_bot.schedule_reply_authorized_call_reconciliation = MagicMock()
+    general_bot.schedule_reply_authorized_call_revocation = MagicMock()
     orchestrator.agent_bots = {"router": router_bot, "general": general_bot}
     return orchestrator, router_bot, general_bot
 
@@ -3020,9 +3026,11 @@ async def test_new_agent_not_started_twice(tmp_path: Path) -> None:
         mock_existing_bot.config = old_config
         mock_existing_bot.matrix_id = MatrixID.parse("@mindroom_general:localhost")
         mock_existing_bot.schedule_reply_authorized_call_reconciliation = MagicMock()
+        mock_existing_bot.schedule_reply_authorized_call_revocation = MagicMock()
         mock_router_bot = AsyncMock()
         mock_router_bot.matrix_id = MatrixID.parse("@mindroom_router:localhost")
         mock_router_bot.schedule_reply_authorized_call_reconciliation = MagicMock()
+        mock_router_bot.schedule_reply_authorized_call_revocation = MagicMock()
         orchestrator.agent_bots = {"general": mock_existing_bot, "router": mock_router_bot}
 
         async def existing_sync_loop() -> None:


### PR DESCRIPTION
## Summary

- fail room-backed reply grants closed on every uncertain sync while coalescing call revocation to one wave per unresolved refresh gap
- keep positive MatrixRTC reconciliation behind a still-current authoritative membership refresh
- preserve startup snapshots and pending-invite reconciliation behavior with regression coverage

## Why

Repeated limited or unrecovered sync responses scheduled full positive call reconciliation for every bot. Those remote membership scans overlapped, inflated active response counts, delayed hot reloads, and could starve ordinary replies.

## Tests

- `uv run pre-commit run --all-files`
- `uv run pytest -x -n auto --no-cov -q`

## Summary by Sourcery

Coalesce fail-closed call revocation across uncertain membership refresh gaps and gate positive reconciliation on authoritative membership state.

Bug Fixes:
- Prevent repeated uncertain membership syncs from triggering overlapping MatrixRTC call reconciliation waves.
- Ensure active reply-authorized calls are revoked once per unresolved membership gap and re-revoked after a later authoritative refresh.
- Suppress positive call reconciliation when membership freshness is still uncertain after refresh effects complete.

Enhancements:
- Preserve startup snapshots and pending-invite reconciliation while coordinating fail-closed membership and call authorization behavior.

Tests:
- Add regression coverage for coalesced revocation, authoritative refresh reopening, invalidation during post-refresh effects, and startup snapshot preservation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved membership refresh and invalidation handling to prevent redundant revocation operations.
  * Revokes reply-authorized calls promptly when membership changes require it.
  * Prevents positive reconciliation while membership data still requires refresh.
  * Ensures completed refreshes correctly reset invalidation state and restore reconciliation behavior.
  * Improved runtime reliability during startup, shutdown, and repeated membership changes.

* **Tests**
  * Added coverage for refresh, invalidation, revocation, reconciliation, and repeated-change scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->