### PR TITLE
Fix conversation-issued OAuth handoff

### DIFF
--- a/docs/oauth-framework.md
+++ b/docs/oauth-framework.md
@@ -10,20 +10,21 @@ Providers supply only provider-specific metadata and parsing behavior, such as O
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/success`, `/api/oauth/{provider}/status`, `/api/oauth/{provider}/disconnect`, and the authenticated `GET`/`POST` `/api/oauth/{provider}/reset` confirmation flow.
 When a scoped token exists but cannot be decoded, status returns `reset_required: true`, and the dashboard offers the decode-free scoped disconnect path before reconnecting.
 Agent-facing OAuth tools return the same structured `reset_required` signal and direct the requester to the authenticated dashboard Integrations page, which supports every credential scope and avoids prescribing an unavailable agent tool or unusable connect link.
-Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
+Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the browser-openable `authorize` URL before MindRoom redirects to the external provider.
 Dashboard OAuth state is opaque, time-limited, single-use, and bound to the authenticated MindRoom user plus the persisted agent execution scope resolved by the existing credentials target machinery.
 When an OAuth request targets an agent with `agent_name`, the authenticated dashboard requester must be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
 Responder access and room membership never grant OAuth-management access.
 Unauthorized agent-scoped OAuth connect, authorize, status, disconnect, and callback requests return HTTP 403 before credentials are exposed or changed.
 Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result.
-That connect token also carries the requester identity from the tool runtime, and MindRoom rejects redemption unless the authenticated dashboard user resolves to the same requester for scoped credentials.
+That token is a bearer capability for the exact provider, Matrix requester, worker target, and credential connection generation, so its authorize and callback requests do not require a dashboard login.
+MindRoom rechecks the requester's current agent credential-management permission at authorization and callback, and rejects a link if its credential generation changed after issuance.
+Executions without a concrete requester cannot form a conversation capability; their links omit the connect token and use the existing dashboard-authenticated flow.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.
 `MINDROOM_OWNER_USER_ID` is a single-owner shortcut and is not suitable for a hosted multi-user private-agent deployment.
 Hosted deployments that put MindRoom behind an external access layer should enable trusted upstream auth and configure the exact headers MindRoom may trust.
 When trusted upstream auth is enabled, MindRoom reads the configured stable user ID and optional email headers into `request.scope["auth_user"]`.
 For Matrix-backed private agents, the trusted identity must resolve to a Matrix user ID either from a configured Matrix user ID header or from `MINDROOM_TRUSTED_UPSTREAM_EMAIL_TO_MATRIX_USER_ID_TEMPLATE`.
 The email-to-Matrix template must contain exactly one `{localpart}` placeholder and requires `MINDROOM_TRUSTED_UPSTREAM_EMAIL_HEADER`.
-If a browser request cannot map to the requester stored in the conversation connect token, the OAuth authorize or callback path fails closed and no credential is saved.
 The access layer must strip any client-supplied copies of the trusted headers before injecting verified values.
 
 Plugins may declare an `oauth_module` in `mindroom.plugin.json`.
@@ -41,7 +42,7 @@ Versions that predate the SQLite lifecycle ignore the new store, so downgrading 
 Providers can declare that credentials follow the requester independently of agent worker reuse.
 GitHub uses that policy, so its managed token always lands in the requester's `user` scope and can never fall back to a shared or global token store.
 For providers without that policy, private-agent tokens follow the authenticated requester and the agent's saved `worker_scope`, shared-scope agent tokens use a per-agent primary-runtime store, and unscoped agents use the global credential store.
-If MindRoom cannot resolve the authenticated dashboard user to the requester carried by a conversation-issued link, the link fails closed and no credential is saved.
+Conversation capabilities reconstruct the bound requester and worker target from server-side state; invalid, expired, reused, unauthorized, or stale links fail closed and save no credentials.
 Credential placement and visibility policy is centralized in `src/mindroom/credential_policy.py`.
 That module owns service classification, OAuth token field filtering, local-only credential service names, and worker-grantable rejections.
 Storage, API routing, OAuth provider loading, and worker identity derivation stay in their existing modules.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -13621,20 +13621,21 @@ Providers supply only provider-specific metadata and parsing behavior, such as O
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/success`, `/api/oauth/{provider}/status`, `/api/oauth/{provider}/disconnect`, and the authenticated `GET`/`POST` `/api/oauth/{provider}/reset` confirmation flow.
 When a scoped token exists but cannot be decoded, status returns `reset_required: true`, and the dashboard offers the decode-free scoped disconnect path before reconnecting.
 Agent-facing OAuth tools return the same structured `reset_required` signal and direct the requester to the authenticated dashboard Integrations page, which supports every credential scope and avoids prescribing an unavailable agent tool or unusable connect link.
-Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
+Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the browser-openable `authorize` URL before MindRoom redirects to the external provider.
 Dashboard OAuth state is opaque, time-limited, single-use, and bound to the authenticated MindRoom user plus the persisted agent execution scope resolved by the existing credentials target machinery.
 When an OAuth request targets an agent with `agent_name`, the authenticated dashboard requester must be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
 Responder access and room membership never grant OAuth-management access.
 Unauthorized agent-scoped OAuth connect, authorize, status, disconnect, and callback requests return HTTP 403 before credentials are exposed or changed.
 Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result.
-That connect token also carries the requester identity from the tool runtime, and MindRoom rejects redemption unless the authenticated dashboard user resolves to the same requester for scoped credentials.
+That token is a bearer capability for the exact provider, Matrix requester, worker target, and credential connection generation, so its authorize and callback requests do not require a dashboard login.
+MindRoom rechecks the requester's current agent credential-management permission at authorization and callback, and rejects a link if its credential generation changed after issuance.
+Executions without a concrete requester cannot form a conversation capability; their links omit the connect token and use the existing dashboard-authenticated flow.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.
 `MINDROOM_OWNER_USER_ID` is a single-owner shortcut and is not suitable for a hosted multi-user private-agent deployment.
 Hosted deployments that put MindRoom behind an external access layer should enable trusted upstream auth and configure the exact headers MindRoom may trust.
 When trusted upstream auth is enabled, MindRoom reads the configured stable user ID and optional email headers into `request.scope["auth_user"]`.
 For Matrix-backed private agents, the trusted identity must resolve to a Matrix user ID either from a configured Matrix user ID header or from `MINDROOM_TRUSTED_UPSTREAM_EMAIL_TO_MATRIX_USER_ID_TEMPLATE`.
 The email-to-Matrix template must contain exactly one `{localpart}` placeholder and requires `MINDROOM_TRUSTED_UPSTREAM_EMAIL_HEADER`.
-If a browser request cannot map to the requester stored in the conversation connect token, the OAuth authorize or callback path fails closed and no credential is saved.
 The access layer must strip any client-supplied copies of the trusted headers before injecting verified values.
 
 Plugins may declare an `oauth_module` in `mindroom.plugin.json`.
@@ -13652,7 +13653,7 @@ Versions that predate the SQLite lifecycle ignore the new store, so downgrading 
 Providers can declare that credentials follow the requester independently of agent worker reuse.
 GitHub uses that policy, so its managed token always lands in the requester's `user` scope and can never fall back to a shared or global token store.
 For providers without that policy, private-agent tokens follow the authenticated requester and the agent's saved `worker_scope`, shared-scope agent tokens use a per-agent primary-runtime store, and unscoped agents use the global credential store.
-If MindRoom cannot resolve the authenticated dashboard user to the requester carried by a conversation-issued link, the link fails closed and no credential is saved.
+Conversation capabilities reconstruct the bound requester and worker target from server-side state; invalid, expired, reused, unauthorized, or stale links fail closed and save no credentials.
 Credential placement and visibility policy is centralized in `src/mindroom/credential_policy.py`.
 That module owns service classification, OAuth token field filtering, local-only credential service names, and worker-grantable rejections.
 Storage, API routing, OAuth provider loading, and worker identity derivation stay in their existing modules.

--- a/skills/mindroom-docs/references/page__oauth-framework__index.md
+++ b/skills/mindroom-docs/references/page__oauth-framework__index.md
@@ -6,20 +6,21 @@ Providers supply only provider-specific metadata and parsing behavior, such as O
 The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/success`, `/api/oauth/{provider}/status`, `/api/oauth/{provider}/disconnect`, and the authenticated `GET`/`POST` `/api/oauth/{provider}/reset` confirmation flow.
 When a scoped token exists but cannot be decoded, status returns `reset_required: true`, and the dashboard offers the decode-free scoped disconnect path before reconnecting.
 Agent-facing OAuth tools return the same structured `reset_required` signal and direct the requester to the authenticated dashboard Integrations page, which supports every credential scope and avoids prescribing an unavailable agent tool or unusable connect link.
-Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the `authorize` URL so the user opens a normal authenticated MindRoom page before MindRoom redirects to the external provider.
+Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the browser-openable `authorize` URL before MindRoom redirects to the external provider.
 Dashboard OAuth state is opaque, time-limited, single-use, and bound to the authenticated MindRoom user plus the persisted agent execution scope resolved by the existing credentials target machinery.
 When an OAuth request targets an agent with `agent_name`, the authenticated dashboard requester must be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
 Responder access and room membership never grant OAuth-management access.
 Unauthorized agent-scoped OAuth connect, authorize, status, disconnect, and callback requests return HTTP 403 before credentials are exposed or changed.
 Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result.
-That connect token also carries the requester identity from the tool runtime, and MindRoom rejects redemption unless the authenticated dashboard user resolves to the same requester for scoped credentials.
+That token is a bearer capability for the exact provider, Matrix requester, worker target, and credential connection generation, so its authorize and callback requests do not require a dashboard login.
+MindRoom rechecks the requester's current agent credential-management permission at authorization and callback, and rejects a link if its credential generation changed after issuance.
+Executions without a concrete requester cannot form a conversation capability; their links omit the connect token and use the existing dashboard-authenticated flow.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.
 `MINDROOM_OWNER_USER_ID` is a single-owner shortcut and is not suitable for a hosted multi-user private-agent deployment.
 Hosted deployments that put MindRoom behind an external access layer should enable trusted upstream auth and configure the exact headers MindRoom may trust.
 When trusted upstream auth is enabled, MindRoom reads the configured stable user ID and optional email headers into `request.scope["auth_user"]`.
 For Matrix-backed private agents, the trusted identity must resolve to a Matrix user ID either from a configured Matrix user ID header or from `MINDROOM_TRUSTED_UPSTREAM_EMAIL_TO_MATRIX_USER_ID_TEMPLATE`.
 The email-to-Matrix template must contain exactly one `{localpart}` placeholder and requires `MINDROOM_TRUSTED_UPSTREAM_EMAIL_HEADER`.
-If a browser request cannot map to the requester stored in the conversation connect token, the OAuth authorize or callback path fails closed and no credential is saved.
 The access layer must strip any client-supplied copies of the trusted headers before injecting verified values.
 
 Plugins may declare an `oauth_module` in `mindroom.plugin.json`.
@@ -37,7 +38,7 @@ Versions that predate the SQLite lifecycle ignore the new store, so downgrading 
 Providers can declare that credentials follow the requester independently of agent worker reuse.
 GitHub uses that policy, so its managed token always lands in the requester's `user` scope and can never fall back to a shared or global token store.
 For providers without that policy, private-agent tokens follow the authenticated requester and the agent's saved `worker_scope`, shared-scope agent tokens use a per-agent primary-runtime store, and unscoped agents use the global credential store.
-If MindRoom cannot resolve the authenticated dashboard user to the requester carried by a conversation-issued link, the link fails closed and no credential is saved.
+Conversation capabilities reconstruct the bound requester and worker target from server-side state; invalid, expired, reused, unauthorized, or stale links fail closed and save no credentials.
 Credential placement and visibility policy is centralized in `src/mindroom/credential_policy.py`.
 That module owns service classification, OAuth token field filtering, local-only credential service names, and worker-grantable rejections.
 Storage, API routing, OAuth provider loading, and worker identity derivation stay in their existing modules.

--- a/src/mindroom/api/credentials_oauth_flows.py
+++ b/src/mindroom/api/credentials_oauth_flows.py
@@ -1,7 +1,7 @@
-"""Pending OAuth connect state for dashboard credential flows.
+"""Pending OAuth connect state for dashboard and conversation credential flows.
 
-Owns issue/consume of the opaque OAuth state that binds one dashboard OAuth
-connect request to one authenticated user and credential target.
+Owns issue/consume of the opaque OAuth state that binds one OAuth connect
+request to its authorization mode and credential target.
 """
 
 from __future__ import annotations
@@ -25,10 +25,11 @@ _PENDING_OAUTH_STATE_KIND = "dashboard_oauth_state"
 
 @dataclass(frozen=True)
 class _PendingOAuthState:
-    """Pending OAuth connect request bound to one authenticated dashboard user."""
+    """Pending OAuth connect request bound to its initiating authorization mode."""
 
     service: str
     user_id: str
+    browser_user_required: bool
     agent_name: str | None
     execution_scope_override_provided: bool
     execution_scope_override: WorkerScope | None
@@ -44,10 +45,16 @@ def issue_pending_oauth_state(
     *,
     payload: dict[str, str] | None = None,
     code_verifier: str | None = None,
+    browser_user_required: bool = True,
 ) -> str:
-    """Create an opaque OAuth state bound to the current user and target."""
-    user_id = require_auth_user_id(request)
-    execution_scope_override_provided, execution_scope_override = resolve_dashboard_execution_scope_override(request)
+    """Create opaque OAuth state bound to a browser user or conversation capability."""
+    user_id = require_auth_user_id(request) if browser_user_required else ""
+    if browser_user_required:
+        execution_scope_override_provided, execution_scope_override = resolve_dashboard_execution_scope_override(
+            request,
+        )
+    else:
+        execution_scope_override_provided, execution_scope_override = False, None
     runtime_paths = config_lifecycle.bind_current_request_snapshot(request).runtime_paths
     return issue_opaque_oauth_state(
         runtime_paths,
@@ -56,6 +63,7 @@ def issue_pending_oauth_state(
         data={
             "service": service,
             "user_id": user_id,
+            "browser_user_required": browser_user_required,
             "agent_name": agent_name or "",
             "execution_scope_override_provided": execution_scope_override_provided,
             "execution_scope_override": execution_scope_override or "",
@@ -65,9 +73,8 @@ def issue_pending_oauth_state(
     )
 
 
-def consume_pending_oauth_request(request: Request, service: str, state: str) -> _PendingOAuthState:
-    """Consume and validate a previously issued dashboard OAuth state token."""
-    user_id = require_auth_user_id(request)
+def _read_pending_oauth_request(request: Request, service: str, state: str) -> dict[str, object]:
+    """Read and validate pending OAuth state without consuming it."""
     runtime_paths = config_lifecycle.bind_current_request_snapshot(request).runtime_paths
     try:
         data = read_opaque_oauth_state(runtime_paths, kind=_PENDING_OAUTH_STATE_KIND, token=state)
@@ -75,7 +82,22 @@ def consume_pending_oauth_request(request: Request, service: str, state: str) ->
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     if data.get("service") != service:
         raise HTTPException(status_code=400, detail="OAuth state does not match this integration")
-    if data.get("user_id") != user_id:
+    return data
+
+
+def pending_oauth_state_requires_browser_user(request: Request, service: str, state: str) -> bool:
+    """Return whether pending OAuth state must match an authenticated browser user."""
+    data = _read_pending_oauth_request(request, service, state)
+    return data.get("browser_user_required") is not False
+
+
+def consume_pending_oauth_request(request: Request, service: str, state: str) -> _PendingOAuthState:
+    """Consume and validate a previously issued OAuth state token."""
+    runtime_paths = config_lifecycle.bind_current_request_snapshot(request).runtime_paths
+    data = _read_pending_oauth_request(request, service, state)
+    browser_user_required = data.get("browser_user_required") is not False
+    user_id = require_auth_user_id(request) if browser_user_required else ""
+    if browser_user_required and data.get("user_id") != user_id:
         raise HTTPException(status_code=403, detail="OAuth state does not belong to the current user")
     try:
         consume_opaque_oauth_state(runtime_paths, kind=_PENDING_OAUTH_STATE_KIND, token=state)
@@ -83,15 +105,23 @@ def consume_pending_oauth_request(request: Request, service: str, state: str) ->
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     execution_scope_raw = data.get("execution_scope_override")
     execution_scope_override = execution_scope_raw if execution_scope_raw in {"shared", "user", "user_agent"} else None
-    payload = data.get("payload")
+    agent_name = data.get("agent_name")
+    payload_raw = data.get("payload")
+    payload = (
+        cast("dict[str, str]", payload_raw)
+        if isinstance(payload_raw, dict)
+        and all(isinstance(key, str) and isinstance(value, str) for key, value in payload_raw.items())
+        else None
+    )
     code_verifier = data.get("code_verifier")
     return _PendingOAuthState(
         service=service,
         user_id=user_id,
-        agent_name=data.get("agent_name") or None,
+        browser_user_required=browser_user_required,
+        agent_name=agent_name if isinstance(agent_name, str) and agent_name else None,
         execution_scope_override_provided=data.get("execution_scope_override_provided") is True,
         execution_scope_override=cast("WorkerScope | None", execution_scope_override),
-        payload=payload if isinstance(payload, dict) else None,
+        payload=payload,
         code_verifier=code_verifier if isinstance(code_verifier, str) and code_verifier else None,
         created_at=0,
     )

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -74,10 +74,15 @@ from mindroom.oauth.service import (
     oauth_provider_service_account_configured,
     oauth_success_redirect_url,
 )
-from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, ToolExecutionIdentity
+from mindroom.tool_system.worker_routing import (
+    ResolvedWorkerTarget,
+    ToolExecutionIdentity,
+    build_agent_toolkit_worker_target,
+)
 
 if TYPE_CHECKING:
     from mindroom.api.credentials_target import RequestCredentialsTarget
+    from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
     from mindroom.tool_system.worker_routing import WorkerScope
 
@@ -250,16 +255,17 @@ async def _issue_authorization_url(
     connect_token: str | None = None,
 ) -> OAuthConnectResponse:
     connect_target = None
+    conversation_context = None
     if connect_token:
         try:
             connect_target = lookup_oauth_connect_token(provider, runtime_paths, connect_token)
         except OAuthProviderError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        _verify_conversation_connect_target_authorized(request, connect_target)
+        conversation_context = _conversation_connect_context(request, provider, runtime_paths, connect_target)
         _verify_connect_target_query(connect_target.binding, agent_name, request.query_params.get("execution_scope"))
     await _client_config_resolution_for_request(request, provider, runtime_paths, reject_remote_provisioned=True)
-    if connect_target is not None:
-        context = _conversation_connect_context(provider, runtime_paths, connect_target)
+    if conversation_context is not None:
+        context = conversation_context
     else:
         target = _resolve_oauth_credentials_target(request, provider, agent_name=agent_name)
         context = _credential_context(provider, target.runtime_paths, target)
@@ -324,7 +330,7 @@ async def _conversation_target_payload(
     return payload
 
 
-def _verify_conversation_connect_target_authorized(request: Request, target: OAuthConnectTarget) -> None:
+def _verify_conversation_connect_target_authorized(request: Request, target: OAuthConnectTarget) -> Config:
     snapshot = config_lifecycle.bind_current_request_snapshot(request)
     config = snapshot.runtime_config
     agent_name = target.binding.requested_agent_name
@@ -336,19 +342,21 @@ def _verify_conversation_connect_target_authorized(request: Request, target: OAu
         or not is_sender_allowed_for_agent_credential_management(requester_id, agent_name, config)
     ):
         raise HTTPException(status_code=403, detail="The link requester cannot manage this agent's credentials")
+    return config
 
 
 def _conversation_connect_context(
+    request: Request,
     provider: OAuthProvider,
     runtime_paths: RuntimePaths,
     target: OAuthConnectTarget,
 ) -> OAuthCredentialContext:
+    config = _verify_conversation_connect_target_authorized(request, target)
     binding = target.binding
     agent_name = binding.requested_agent_name
     requester_id = target.requester_id
     if not agent_name or not requester_id:
         raise HTTPException(status_code=400, detail="OAuth link target is invalid")
-    worker_scope = None if binding.worker_scope == "unscoped" else binding.worker_scope
     identity = ToolExecutionIdentity(
         channel="matrix",
         agent_name=agent_name,
@@ -358,20 +366,24 @@ def _conversation_connect_context(
         resolved_thread_id=None,
         session_id=None,
     )
-    worker_target = ResolvedWorkerTarget(
-        worker_scope=worker_scope,
-        routing_agent_name=agent_name,
+    worker_target = build_agent_toolkit_worker_target(
+        config.resolve_entity(agent_name).execution_scope,
+        agent_name,
+        is_private=config.get_agent(agent_name).private is not None,
         execution_identity=identity,
-        tenant_id=None,
-        account_id=None,
-        worker_key=binding.worker_key,
-    )
-    return OAuthCredentialContext(
-        provider=provider,
         runtime_paths=runtime_paths,
-        credentials_manager=get_runtime_credentials_manager(runtime_paths),
-        worker_target=worker_target,
     )
+    context = resolve_oauth_credential_context(
+        provider,
+        runtime_paths,
+        get_runtime_credentials_manager(runtime_paths),
+        worker_target,
+        execution_identity=identity,
+        authorization=config.authorization,
+    )
+    if target.binding != oauth_credential_binding(provider, context.worker_target):
+        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONVERSATION_MESSAGE)
+    return context
 
 
 def _conversation_context_from_pending_payload(
@@ -401,8 +413,7 @@ def _conversation_context_from_pending_payload(
         requester_id=requester_id,
         connection_generation=connection_generation,
     )
-    _verify_conversation_connect_target_authorized(request, target)
-    return _conversation_connect_context(provider, runtime_paths, target)
+    return _conversation_connect_context(request, provider, runtime_paths, target)
 
 
 def _verify_connect_target_authorized(request: Request, requester_id: str | None, runtime_paths: RuntimePaths) -> None:

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -14,7 +14,11 @@ from pydantic import BaseModel, Field
 
 from mindroom.api import config_lifecycle
 from mindroom.api.auth import login_redirect_for_request, verify_user
-from mindroom.api.credentials_oauth_flows import consume_pending_oauth_request, issue_pending_oauth_state
+from mindroom.api.credentials_oauth_flows import (
+    consume_pending_oauth_request,
+    issue_pending_oauth_state,
+    pending_oauth_state_requires_browser_user,
+)
 from mindroom.api.credentials_target import (
     resolve_request_credentials_target,
     resolve_requester_credentials_target,
@@ -24,7 +28,9 @@ from mindroom.api.dashboard_credential_scope import (
     build_dashboard_execution_identity,
     require_agent_credential_management_authorized,
 )
+from mindroom.authorization import is_sender_allowed_for_agent_credential_management
 from mindroom.background_tasks import run_coroutine_until_complete
+from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.logging_config import get_logger
 from mindroom.oauth import (
     OAuthClaimValidationError,
@@ -36,8 +42,10 @@ from mindroom.oauth import (
 )
 from mindroom.oauth.credential_binding import (
     OAuthCredentialBinding,
+    OAuthCredentialBindingParseError,
     oauth_credential_binding,
     oauth_credential_binding_payload,
+    parse_oauth_credential_binding_payload,
 )
 from mindroom.oauth.credential_lifecycle import (
     OAuthCredentialConflictError,
@@ -60,16 +68,18 @@ from mindroom.oauth.reset import (
 )
 from mindroom.oauth.reset_execution import OAuthResetPreparationError, retire_and_reset_oauth_credentials
 from mindroom.oauth.service import (
+    OAuthConnectTarget,
     consume_oauth_connect_token,
     lookup_oauth_connect_token,
     oauth_provider_service_account_configured,
     oauth_success_redirect_url,
 )
+from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, ToolExecutionIdentity
 
 if TYPE_CHECKING:
     from mindroom.api.credentials_target import RequestCredentialsTarget
     from mindroom.constants import RuntimePaths
-    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, WorkerScope
+    from mindroom.tool_system.worker_routing import WorkerScope
 
 router = APIRouter(prefix="/api/oauth", tags=["oauth"])
 logger = get_logger(__name__)
@@ -77,8 +87,8 @@ _OAUTH_COMPLETE_MESSAGE_TYPE = "mindroom:oauth-complete"
 _OAUTH_STALE_CONNECTION_MESSAGE = (
     "This OAuth connection changed before the request completed. Start the connection again from the dashboard."
 )
-# OAuth callbacks intentionally verify the browser user inline instead of relying on
-# standalone-public-path bypasses, because callbacks write scoped credentials.
+# Dashboard callbacks verify the browser user inline. Conversation-issued links
+# instead use their short-lived, single-use server-side capability state.
 
 
 class OAuthConnectResponse(BaseModel):
@@ -236,29 +246,37 @@ async def _issue_authorization_url(
     agent_name: str | None,
     connect_token: str | None = None,
 ) -> OAuthConnectResponse:
-    await _client_config_resolution_for_request(request, provider, runtime_paths, reject_remote_provisioned=True)
     connect_target = None
     if connect_token:
         try:
             connect_target = lookup_oauth_connect_token(provider, runtime_paths, connect_token)
         except OAuthProviderError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        _verify_connect_target_authorized(request, connect_target.requester_id, runtime_paths)
+        _verify_conversation_connect_target_authorized(request, connect_target)
         _verify_connect_target_query(connect_target.binding, agent_name, request.query_params.get("execution_scope"))
-    target = _resolve_oauth_credentials_target(request, provider, agent_name=agent_name)
+    await _client_config_resolution_for_request(request, provider, runtime_paths, reject_remote_provisioned=True)
     if connect_target is not None:
-        _verify_connect_target_binding(connect_target.binding, provider, worker_target_for_credentials_target(target))
+        context = _conversation_connect_context(provider, runtime_paths, connect_target)
+    else:
+        target = _resolve_oauth_credentials_target(request, provider, agent_name=agent_name)
+        context = _credential_context(provider, target.runtime_paths, target)
     try:
+        payload = (
+            await _conversation_target_payload(context, connect_target.requester_id)
+            if connect_target is not None
+            else await _credential_context_binding_payload(context)
+        )
         code_verifier = provider.issue_pkce_code_verifier()
         state = issue_pending_oauth_state(
             request,
             provider.id,
             agent_name,
-            payload=await _target_binding_payload(provider, target),
+            payload=payload,
             code_verifier=code_verifier,
+            browser_user_required=connect_target is None,
         )
         auth_url = await provider.authorization_uri_async(
-            target.runtime_paths,
+            runtime_paths,
             state=state,
             code_verifier=code_verifier,
         )
@@ -279,11 +297,100 @@ async def _issue_authorization_url(
 
 
 async def _target_binding_payload(provider: OAuthProvider, target: RequestCredentialsTarget) -> dict[str, str]:
-    snapshot = await load_oauth_credentials_snapshot(_credential_context(provider, target.runtime_paths, target))
-    binding = oauth_credential_binding(provider, worker_target_for_credentials_target(target))
+    return await _credential_context_binding_payload(_credential_context(provider, target.runtime_paths, target))
+
+
+async def _credential_context_binding_payload(context: OAuthCredentialContext) -> dict[str, str]:
+    snapshot = await load_oauth_credentials_snapshot(context)
+    binding = oauth_credential_binding(context.provider, context.worker_target)
     payload = oauth_credential_binding_payload(binding)
     payload["connection_generation"] = snapshot.connection_generation
     return payload
+
+
+async def _conversation_target_payload(
+    context: OAuthCredentialContext,
+    requester_id: str | None,
+) -> dict[str, str]:
+    payload = await _credential_context_binding_payload(context)
+    payload["conversation_requester_id"] = requester_id or ""
+    return payload
+
+
+def _verify_conversation_connect_target_authorized(request: Request, target: OAuthConnectTarget) -> None:
+    snapshot = config_lifecycle.bind_current_request_snapshot(request)
+    config = snapshot.runtime_config
+    agent_name = target.binding.requested_agent_name
+    requester_id = target.requester_id
+    if (
+        config is None
+        or not agent_name
+        or not requester_id
+        or not is_sender_allowed_for_agent_credential_management(requester_id, agent_name, config)
+    ):
+        raise HTTPException(status_code=403, detail="The link requester cannot manage this agent's credentials")
+
+
+def _conversation_connect_context(
+    provider: OAuthProvider,
+    runtime_paths: RuntimePaths,
+    target: OAuthConnectTarget,
+) -> OAuthCredentialContext:
+    binding = target.binding
+    agent_name = binding.requested_agent_name
+    requester_id = target.requester_id
+    if not agent_name or not requester_id:
+        raise HTTPException(status_code=400, detail="OAuth link target is invalid")
+    worker_scope = None if binding.worker_scope == "unscoped" else binding.worker_scope
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name=agent_name,
+        requester_id=requester_id,
+        room_id=None,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = ResolvedWorkerTarget(
+        worker_scope=worker_scope,
+        routing_agent_name=agent_name,
+        execution_identity=identity,
+        tenant_id=None,
+        account_id=None,
+        worker_key=binding.worker_key,
+    )
+    return OAuthCredentialContext(
+        provider=provider,
+        runtime_paths=runtime_paths,
+        credentials_manager=get_runtime_credentials_manager(runtime_paths),
+        worker_target=worker_target,
+    )
+
+
+def _conversation_context_from_pending_payload(
+    request: Request,
+    provider: OAuthProvider,
+    runtime_paths: RuntimePaths,
+    payload: dict[str, str] | None,
+) -> OAuthCredentialContext:
+    if payload is None:
+        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONNECTION_MESSAGE)
+    try:
+        binding = parse_oauth_credential_binding_payload(
+            provider,
+            payload,
+            allowed_worker_scopes=frozenset({"shared", "user", "user_agent"}),
+            require_agent_name=True,
+            require_worker_key=True,
+        )
+    except OAuthCredentialBindingParseError as exc:
+        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONNECTION_MESSAGE) from exc
+    requester_id = payload.get("conversation_requester_id")
+    if not requester_id:
+        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONNECTION_MESSAGE)
+    target = OAuthConnectTarget(binding=binding, requester_id=requester_id)
+    _verify_conversation_connect_target_authorized(request, target)
+    return _conversation_connect_context(provider, runtime_paths, target)
 
 
 def _verify_connect_target_authorized(request: Request, requester_id: str | None, runtime_paths: RuntimePaths) -> None:
@@ -427,9 +534,10 @@ async def authorize(
     connect_token: str | None = None,
 ) -> RedirectResponse:
     """Start a provider OAuth flow from a browser-openable MindRoom URL."""
-    login_redirect = await _require_oauth_browser_user(request)
-    if login_redirect is not None:
-        return login_redirect
+    if not connect_token:
+        login_redirect = await _require_oauth_browser_user(request)
+        if login_redirect is not None:
+            return login_redirect
     provider, runtime_paths = _load_provider(request, provider_id)
     response = await _issue_authorization_url(
         request,
@@ -560,6 +668,11 @@ async def success(provider_id: str, request: Request) -> HTMLResponse:
     """Signal OAuth completion to the dashboard popup opener."""
     await _require_oauth_api_user(request)
     provider, _runtime_paths = _load_provider(request, provider_id)
+    return _oauth_success_response(provider)
+
+
+def _oauth_success_response(provider: OAuthProvider) -> HTMLResponse:
+    """Render a browser-readable OAuth completion response."""
     message = {
         "type": _OAUTH_COMPLETE_MESSAGE_TYPE,
         "provider": provider.id,
@@ -593,48 +706,47 @@ async def _store_callback_credentials(
     *,
     code: str,
     state: str,
-) -> None:
+) -> bool:
     """Resolve and store one callback's exact credential target."""
     pending = consume_pending_oauth_request(request, provider.id, state)
-    target = _resolve_oauth_credentials_target(
-        request,
-        provider,
-        agent_name=pending.agent_name,
-        execution_scope_override_provided=pending.execution_scope_override_provided,
-        execution_scope_override=pending.execution_scope_override,
-    )
+    if pending.browser_user_required:
+        target = _resolve_oauth_credentials_target(
+            request,
+            provider,
+            agent_name=pending.agent_name,
+            execution_scope_override_provided=pending.execution_scope_override_provided,
+            execution_scope_override=pending.execution_scope_override,
+        )
+        context = _credential_context(provider, runtime_paths, target)
+    else:
+        target = None
+        context = _conversation_context_from_pending_payload(request, provider, runtime_paths, pending.payload)
 
     async def verify_and_store() -> None:
-        await _verify_pending_target_binding(provider, pending.payload, target)
+        if target is not None:
+            await _verify_pending_target_binding(provider, pending.payload, target)
         await exchange_and_store_oauth_credentials(
-            _credential_context(provider, runtime_paths, target),
+            context,
             code,
             pending.code_verifier,
             expected_connection_generation=_pending_connection_generation(pending.payload),
         )
 
     await run_coroutine_until_complete(verify_and_store())
+    return pending.browser_user_required
 
 
-@router.get("/{provider_id}/callback")
-async def callback(provider_id: str, request: Request) -> Response:
-    """Handle a provider OAuth callback and store scoped credentials."""
-    error = request.query_params.get("error")
-    if error:
-        raise HTTPException(status_code=400, detail=f"OAuth provider returned an error: {error}")
-
-    code = request.query_params.get("code")
-    if not code:
-        raise HTTPException(status_code=400, detail="No authorization code received")
-
-    state = request.query_params.get("state")
-    if not state:
-        raise HTTPException(status_code=400, detail="No OAuth state received")
-
-    await _require_oauth_api_user(request)
-    provider, runtime_paths = _load_provider(request, provider_id)
+async def _complete_oauth_callback(
+    request: Request,
+    provider: OAuthProvider,
+    runtime_paths: RuntimePaths,
+    *,
+    code: str,
+    state: str,
+) -> bool:
+    """Store callback credentials and map failures to the public OAuth boundary."""
     try:
-        await _store_callback_credentials(
+        return await _store_callback_credentials(
             request,
             provider,
             runtime_paths,
@@ -643,10 +755,10 @@ async def callback(provider_id: str, request: Request) -> Response:
         )
     except HTTPException as exc:
         if exc.status_code == 409:
-            return _oauth_browser_error_response(str(exc.detail), status_code=409)
+            raise OAuthCredentialConflictError(str(exc.detail)) from exc
         raise
     except OAuthCredentialConflictError:
-        return _oauth_browser_error_response(_OAUTH_STALE_CONNECTION_MESSAGE, status_code=409)
+        raise
     except OAuthClaimValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except OAuthProviderError as exc:
@@ -664,6 +776,39 @@ async def callback(provider_id: str, request: Request) -> Response:
         )
         raise HTTPException(status_code=500, detail="OAuth callback failed") from exc
 
+
+@router.get("/{provider_id}/callback")
+async def callback(provider_id: str, request: Request) -> Response:
+    """Handle a provider OAuth callback and store scoped credentials."""
+    error = request.query_params.get("error")
+    if error:
+        raise HTTPException(status_code=400, detail=f"OAuth provider returned an error: {error}")
+
+    code = request.query_params.get("code")
+    if not code:
+        raise HTTPException(status_code=400, detail="No authorization code received")
+
+    state = request.query_params.get("state")
+    if not state:
+        raise HTTPException(status_code=400, detail="No OAuth state received")
+
+    provider, runtime_paths = _load_provider(request, provider_id)
+    browser_user_required = pending_oauth_state_requires_browser_user(request, provider.id, state)
+    if browser_user_required:
+        await _require_oauth_api_user(request)
+    try:
+        browser_user_required = await _complete_oauth_callback(
+            request,
+            provider,
+            runtime_paths,
+            code=code,
+            state=state,
+        )
+    except OAuthCredentialConflictError:
+        return _oauth_browser_error_response(_OAUTH_STALE_CONNECTION_MESSAGE, status_code=409)
+
+    if not browser_user_required:
+        return _oauth_success_response(provider)
     return RedirectResponse(url=oauth_success_redirect_url(provider, runtime_paths))
 
 

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -87,6 +87,9 @@ _OAUTH_COMPLETE_MESSAGE_TYPE = "mindroom:oauth-complete"
 _OAUTH_STALE_CONNECTION_MESSAGE = (
     "This OAuth connection changed before the request completed. Start the connection again from the dashboard."
 )
+_OAUTH_STALE_CONVERSATION_MESSAGE = (
+    "This OAuth connection changed before the request completed. Request a fresh connection link from the conversation."
+)
 # Dashboard callbacks verify the browser user inline. Conversation-issued links
 # instead use their short-lived, single-use server-side capability state.
 
@@ -262,7 +265,7 @@ async def _issue_authorization_url(
         context = _credential_context(provider, target.runtime_paths, target)
     try:
         payload = (
-            await _conversation_target_payload(context, connect_target.requester_id)
+            await _conversation_target_payload(context, connect_target)
             if connect_target is not None
             else await _credential_context_binding_payload(context)
         )
@@ -310,10 +313,14 @@ async def _credential_context_binding_payload(context: OAuthCredentialContext) -
 
 async def _conversation_target_payload(
     context: OAuthCredentialContext,
-    requester_id: str | None,
+    target: OAuthConnectTarget,
 ) -> dict[str, str]:
-    payload = await _credential_context_binding_payload(context)
-    payload["conversation_requester_id"] = requester_id or ""
+    snapshot = await load_oauth_credentials_snapshot(context)
+    if snapshot.connection_generation != target.connection_generation:
+        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONVERSATION_MESSAGE)
+    payload = oauth_credential_binding_payload(target.binding)
+    payload["conversation_requester_id"] = target.requester_id or ""
+    payload["connection_generation"] = target.connection_generation
     return payload
 
 
@@ -374,7 +381,7 @@ def _conversation_context_from_pending_payload(
     payload: dict[str, str] | None,
 ) -> OAuthCredentialContext:
     if payload is None:
-        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONNECTION_MESSAGE)
+        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONVERSATION_MESSAGE)
     try:
         binding = parse_oauth_credential_binding_payload(
             provider,
@@ -384,11 +391,16 @@ def _conversation_context_from_pending_payload(
             require_worker_key=True,
         )
     except OAuthCredentialBindingParseError as exc:
-        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONNECTION_MESSAGE) from exc
+        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONVERSATION_MESSAGE) from exc
     requester_id = payload.get("conversation_requester_id")
-    if not requester_id:
-        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONNECTION_MESSAGE)
-    target = OAuthConnectTarget(binding=binding, requester_id=requester_id)
+    connection_generation = payload.get("connection_generation")
+    if not requester_id or not connection_generation:
+        raise HTTPException(status_code=409, detail=_OAUTH_STALE_CONVERSATION_MESSAGE)
+    target = OAuthConnectTarget(
+        binding=binding,
+        requester_id=requester_id,
+        connection_generation=connection_generation,
+    )
     _verify_conversation_connect_target_authorized(request, target)
     return _conversation_connect_context(provider, runtime_paths, target)
 
@@ -805,7 +817,8 @@ async def callback(provider_id: str, request: Request) -> Response:
             state=state,
         )
     except OAuthCredentialConflictError:
-        return _oauth_browser_error_response(_OAUTH_STALE_CONNECTION_MESSAGE, status_code=409)
+        message = _OAUTH_STALE_CONNECTION_MESSAGE if browser_user_required else _OAUTH_STALE_CONVERSATION_MESSAGE
+        return _oauth_browser_error_response(message, status_code=409)
 
     if not browser_user_required:
         return _oauth_success_response(provider)

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
-from urllib.parse import urlencode, urlparse
+from urllib.parse import parse_qs, urlencode, urlparse
 
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.oauth.credential_binding import (
@@ -267,20 +267,22 @@ def build_oauth_reconnect_instruction(
             "The original operation may have partially succeeded; do not automatically retry it after reconnecting."
         )
         expiry_guidance = "request a fresh reconnect link without repeating the original operation"
+    link_guidance = (
+        f"This link is valid for {OAUTH_CONNECT_TOKEN_TTL_MINUTES} minutes; if it expires, "
+        f"{expiry_guidance}: {connect_url}"
+        if "connect_token" in parse_qs(urlparse(connect_url).query)
+        else f"Reconnect here: {connect_url}"
+    )
     if oauth_connect_url_requires_host_browser(connect_url):
         return (
             f"{provider.display_name} session for this agent expired or is no longer valid. "
             "Open this MindRoom link in a browser on the computer where the MindRoom process is running, "
             "not on a phone or another computer. If needed, open this conversation there or copy the complete "
-            f"link into that browser. {retry_guidance} "
-            f"This link is valid for {OAUTH_CONNECT_TOKEN_TTL_MINUTES} minutes; if it expires, "
-            f"{expiry_guidance}: {connect_url}"
+            f"link into that browser. {retry_guidance} {link_guidance}"
         )
     return (
         f"{provider.display_name} session for this agent expired or is no longer valid. "
-        f"Reconnect it with this MindRoom link. {retry_guidance} "
-        f"This link is valid for {OAUTH_CONNECT_TOKEN_TTL_MINUTES} minutes; if it expires, "
-        f"{expiry_guidance}: {connect_url}"
+        f"Reconnect it with this MindRoom link. {retry_guidance} {link_guidance}"
     )
 
 

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -79,7 +79,12 @@ def _issue_oauth_connect_token(
     worker_target: ResolvedWorkerTarget | None,
 ) -> str | None:
     """Create an opaque token that binds an OAuth link to one requester and target."""
-    if worker_target is None or worker_target.execution_identity is None or not worker_target.worker_key:
+    if (
+        worker_target is None
+        or worker_target.execution_identity is None
+        or not worker_target.execution_identity.requester_id
+        or not worker_target.worker_key
+    ):
         return None
     requester_id = worker_target.execution_identity.requester_id
 

--- a/src/mindroom/oauth/service.py
+++ b/src/mindroom/oauth/service.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 from urllib.parse import urlencode, urlparse
 
+from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.oauth.credential_binding import (
     OAuthCredentialBinding,
     OAuthCredentialBindingParseError,
@@ -13,6 +14,7 @@ from mindroom.oauth.credential_binding import (
     oauth_credential_binding_payload,
     parse_oauth_credential_binding_payload,
 )
+from mindroom.oauth.credential_lifecycle import OAuthCredentialContext, load_oauth_credentials_snapshot_sync
 from mindroom.oauth.providers import (
     OAuthConnectionRequired,
     OAuthProviderError,
@@ -22,7 +24,6 @@ from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_
 
 if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
-    from mindroom.oauth.credential_lifecycle import OAuthCredentialContext
     from mindroom.oauth.providers import OAuthProvider
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
 
@@ -69,6 +70,7 @@ class OAuthConnectTarget:
 
     binding: OAuthCredentialBinding
     requester_id: str | None
+    connection_generation: str
 
 
 def _issue_oauth_connect_token(
@@ -82,8 +84,17 @@ def _issue_oauth_connect_token(
     requester_id = worker_target.execution_identity.requester_id
 
     binding = oauth_credential_binding(provider, worker_target)
+    snapshot = load_oauth_credentials_snapshot_sync(
+        OAuthCredentialContext(
+            provider=provider,
+            runtime_paths=runtime_paths,
+            credentials_manager=get_runtime_credentials_manager(runtime_paths),
+            worker_target=worker_target,
+        ),
+    )
     payload = oauth_credential_binding_payload(binding)
     payload["requester_id"] = requester_id or ""
+    payload["connection_generation"] = snapshot.connection_generation
     return issue_opaque_oauth_state(
         runtime_paths,
         kind=_OAUTH_CONNECT_TOKEN_KIND,
@@ -107,7 +118,16 @@ def _connect_target_from_payload(provider: OAuthProvider, payload: dict[str, obj
         else:
             msg = "OAuth connect link target is invalid"
         raise OAuthProviderError(msg) from exc
-    return OAuthConnectTarget(binding=binding, requester_id=str(payload.get("requester_id") or "") or None)
+    requester_id = payload.get("requester_id")
+    connection_generation = payload.get("connection_generation")
+    if not isinstance(requester_id, str) or not isinstance(connection_generation, str) or not connection_generation:
+        msg = "OAuth connect link target is invalid"
+        raise OAuthProviderError(msg)
+    return OAuthConnectTarget(
+        binding=binding,
+        requester_id=requester_id or None,
+        connection_generation=connection_generation,
+    )
 
 
 def lookup_oauth_connect_token(provider: OAuthProvider, runtime_paths: RuntimePaths, token: str) -> OAuthConnectTarget:

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -2689,6 +2689,7 @@ async def test_callback_maps_locked_connection_generation_race_to_conflict(
         execution_identity=None,
     )
     pending = SimpleNamespace(
+        browser_user_required=True,
         agent_name=None,
         execution_scope_override_provided=False,
         execution_scope_override=None,
@@ -2698,6 +2699,7 @@ async def test_callback_maps_locked_connection_generation_race_to_conflict(
     conflict = OAuthCredentialConflictError("OAuth connection state is stale because this credential changed")
     monkeypatch.setattr(oauth_api, "_require_oauth_api_user", AsyncMock())
     monkeypatch.setattr(oauth_api, "_load_provider", lambda *_args: (provider, runtime_paths))
+    monkeypatch.setattr(oauth_api, "pending_oauth_state_requires_browser_user", lambda *_args: True)
     monkeypatch.setattr(oauth_api, "consume_pending_oauth_request", lambda *_args: pending)
     monkeypatch.setattr(oauth_api, "_resolve_oauth_credentials_target", lambda *_args, **_kwargs: target)
     monkeypatch.setattr(oauth_api, "_verify_pending_target_binding", AsyncMock())
@@ -2737,6 +2739,7 @@ async def test_callback_hides_provider_controlled_exchange_error(
         execution_identity=None,
     )
     pending = SimpleNamespace(
+        browser_user_required=True,
         agent_name=None,
         execution_scope_override_provided=False,
         execution_scope_override=None,
@@ -2746,6 +2749,7 @@ async def test_callback_hides_provider_controlled_exchange_error(
     provider_error = OAuthProviderError("provider-controlled-callback-secret")
     monkeypatch.setattr(oauth_api, "_require_oauth_api_user", AsyncMock())
     monkeypatch.setattr(oauth_api, "_load_provider", lambda *_args: (provider, runtime_paths))
+    monkeypatch.setattr(oauth_api, "pending_oauth_state_requires_browser_user", lambda *_args: True)
     monkeypatch.setattr(oauth_api, "consume_pending_oauth_request", lambda *_args: pending)
     monkeypatch.setattr(oauth_api, "_resolve_oauth_credentials_target", lambda *_args, **_kwargs: target)
     monkeypatch.setattr(oauth_api, "_verify_pending_target_binding", AsyncMock())
@@ -3116,7 +3120,7 @@ def test_requester_scoped_conversation_link_for_user_agent_uses_user_store(tmp_p
             )
 
     assert authorize_response.status_code == 307
-    assert callback_response.status_code == 307
+    assert callback_response.status_code == 200
     manager = get_runtime_credentials_manager(runtime_paths)
     user_credentials = _stored_oauth_credentials(provider, runtime_paths, worker_scope="user")
     assert user_credentials is not None
@@ -3194,7 +3198,7 @@ def test_bridge_alias_reset_link_authorizes_and_callback_stores_canonical_scope(
             )
 
     assert authorize_response.status_code == 307
-    assert callback_response.status_code == 307
+    assert callback_response.status_code == 200
     canonical_credentials = _stored_oauth_credentials(
         provider,
         runtime_paths,
@@ -3432,6 +3436,7 @@ async def test_callback_saves_exchanged_credentials_before_propagating_cancellat
         execution_identity=None,
     )
     pending = SimpleNamespace(
+        browser_user_required=True,
         agent_name=None,
         execution_scope_override_provided=False,
         execution_scope_override=None,
@@ -3455,6 +3460,7 @@ async def test_callback_saves_exchanged_credentials_before_propagating_cancellat
 
     monkeypatch.setattr(oauth_api, "_require_oauth_api_user", allow_request)
     monkeypatch.setattr(oauth_api, "_load_provider", lambda *_args: (provider, runtime_paths))
+    monkeypatch.setattr(oauth_api, "pending_oauth_state_requires_browser_user", lambda *_args: True)
     monkeypatch.setattr(oauth_api, "consume_pending_oauth_request", lambda *_args: pending)
     monkeypatch.setattr(oauth_api, "_resolve_oauth_credentials_target", lambda *_args, **_kwargs: target)
     monkeypatch.setattr(oauth_api, "_verify_pending_target_binding", AsyncMock())
@@ -3509,6 +3515,7 @@ async def test_callback_finishes_target_verification_after_state_consumption_bef
         execution_identity=None,
     )
     pending = SimpleNamespace(
+        browser_user_required=True,
         agent_name=None,
         execution_scope_override_provided=False,
         execution_scope_override=None,
@@ -3525,6 +3532,7 @@ async def test_callback_finishes_target_verification_after_state_consumption_bef
 
     monkeypatch.setattr(oauth_api, "_require_oauth_api_user", AsyncMock())
     monkeypatch.setattr(oauth_api, "_load_provider", lambda *_args: (provider, runtime_paths))
+    monkeypatch.setattr(oauth_api, "pending_oauth_state_requires_browser_user", lambda *_args: True)
     monkeypatch.setattr(oauth_api, "consume_pending_oauth_request", lambda *_args: pending)
     monkeypatch.setattr(oauth_api, "_resolve_oauth_credentials_target", lambda *_args, **_kwargs: target)
     monkeypatch.setattr(oauth_api, "_verify_pending_target_binding", verify)
@@ -3728,6 +3736,7 @@ def test_agent_connect_token_stores_credentials_in_matrix_requester_scope(tmp_pa
                 f"&connect_token={connect_token}",
                 follow_redirects=False,
             )
+            assert urlparse(authorize_response.headers["location"]).netloc == "auth.example.test"
             state = _state_from_auth_url(authorize_response.headers["location"])
             callback_response = client.get(
                 f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
@@ -3735,7 +3744,7 @@ def test_agent_connect_token_stores_credentials_in_matrix_requester_scope(tmp_pa
             )
 
     assert authorize_response.status_code == 307
-    assert callback_response.status_code == 307
+    assert callback_response.status_code == 200
     manager = get_runtime_credentials_manager(runtime_paths)
     matrix_credentials = _stored_oauth_credentials(provider, runtime_paths)
     worker_credentials = manager.for_worker(_worker_key_for_matrix_user("@alice:example.org")).load_credentials(
@@ -3748,6 +3757,129 @@ def test_agent_connect_token_stores_credentials_in_matrix_requester_scope(tmp_pa
     assert matrix_credentials["token"] == "google_drive-access-token"
     assert worker_credentials is None
     assert standalone_credentials is None
+
+
+def test_agent_connect_token_starts_without_dashboard_login(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    connect_token = oauth_service._issue_oauth_connect_token(provider, runtime_paths, worker_target)
+    assert connect_token is not None
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
+                f"&connect_token={connect_token}",
+                follow_redirects=False,
+            )
+
+    assert response.status_code == 307
+    assert urlparse(response.headers["location"]).netloc == "auth.example.test"
+
+
+def test_agent_connect_token_callback_stores_bound_scope_without_dashboard_login(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    connect_token = oauth_service._issue_oauth_connect_token(provider, runtime_paths, worker_target)
+    assert connect_token is not None
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            authorize_response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
+                f"&connect_token={connect_token}",
+                follow_redirects=False,
+            )
+            state = _state_from_auth_url(authorize_response.headers["location"])
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                follow_redirects=False,
+            )
+
+    assert callback_response.status_code == 200
+    assert "Test Drive is connected" in callback_response.text
+    assert _stored_oauth_credentials(provider, runtime_paths) is not None
+    standalone_manager = get_runtime_credentials_manager(runtime_paths).for_worker(_worker_key_for_standalone_user())
+    assert standalone_manager.load_credentials(provider.credential_service) is None
+
+
+def test_agent_connect_token_callback_rechecks_link_requester_permission(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    connect_token = oauth_service._issue_oauth_connect_token(provider, runtime_paths, worker_target)
+    assert connect_token is not None
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            authorize_response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
+                f"&connect_token={connect_token}",
+                follow_redirects=False,
+            )
+            state = _state_from_auth_url(authorize_response.headers["location"])
+            _publish_config(
+                api_app,
+                runtime_paths,
+                _config_payload(worker_scope="user_agent", allowed_users=["@bob:example.org"]),
+            )
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                follow_redirects=False,
+            )
+
+    assert callback_response.status_code == 403
+    assert _stored_oauth_credentials(provider, runtime_paths) is None
 
 
 def _trusted_upstream_oauth_env() -> dict[str, str]:
@@ -4020,7 +4152,7 @@ def test_agent_connect_token_uses_trusted_upstream_matrix_requester(tmp_path: Pa
             )
 
     assert authorize_response.status_code == 307
-    assert callback_response.status_code == 307
+    assert callback_response.status_code == 200
     manager = get_runtime_credentials_manager(runtime_paths)
     matrix_credentials = _stored_oauth_credentials(provider, runtime_paths)
     standalone_credentials = manager.for_worker(_worker_key_for_standalone_user()).load_credentials(
@@ -4069,7 +4201,7 @@ def test_agent_connect_token_accepts_trusted_upstream_derived_matrix_requester(t
             )
 
     assert authorize_response.status_code == 307
-    assert callback_response.status_code == 307
+    assert callback_response.status_code == 200
     matrix_credentials = _stored_oauth_credentials(provider, runtime_paths)
     assert matrix_credentials is not None
     assert matrix_credentials["token"] == "google_drive-access-token"
@@ -4108,7 +4240,7 @@ def test_agent_connect_token_rejects_historical_requester_without_explicit_autho
     assert authorize_response.status_code == 403
 
 
-def test_agent_connect_token_rejects_trusted_upstream_requester_mismatch(tmp_path: Path) -> None:
+def test_agent_connect_token_uses_link_target_despite_trusted_upstream_requester_mismatch(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
     api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
     _use_runtime_auth_settings(api_app)
@@ -4139,11 +4271,11 @@ def test_agent_connect_token_rejects_trusted_upstream_requester_mismatch(tmp_pat
                 follow_redirects=False,
             )
 
-    assert authorize_response.status_code == 403
-    assert "current user" in authorize_response.json()["detail"]
+    assert authorize_response.status_code == 307
+    assert urlparse(authorize_response.headers["location"]).netloc == "auth.example.test"
 
 
-def test_agent_connect_token_rejects_missing_trusted_upstream_identity(tmp_path: Path) -> None:
+def test_agent_connect_token_starts_without_trusted_upstream_identity(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
     api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
     _use_runtime_auth_settings(api_app)
@@ -4169,11 +4301,11 @@ def test_agent_connect_token_rejects_missing_trusted_upstream_identity(tmp_path:
                 follow_redirects=False,
             )
 
-    assert authorize_response.status_code == 401
-    assert "trusted upstream identity header" in authorize_response.json()["detail"]
+    assert authorize_response.status_code == 307
+    assert urlparse(authorize_response.headers["location"]).netloc == "auth.example.test"
 
 
-def test_agent_connect_token_missing_trusted_identity_does_not_redirect_to_standalone_login(
+def test_agent_connect_token_missing_trusted_identity_bypasses_standalone_login(
     tmp_path: Path,
 ) -> None:
     runtime_paths = _runtime_paths(
@@ -4204,12 +4336,11 @@ def test_agent_connect_token_missing_trusted_identity_does_not_redirect_to_stand
                 follow_redirects=False,
             )
 
-    assert authorize_response.status_code == 401
-    assert "location" not in authorize_response.headers
-    assert "trusted upstream identity header" in authorize_response.json()["detail"]
+    assert authorize_response.status_code == 307
+    assert urlparse(authorize_response.headers["location"]).netloc == "auth.example.test"
 
 
-def test_agent_connect_token_rejects_trusted_upstream_identity_without_matrix_mapping(
+def test_agent_connect_token_uses_link_target_without_browser_matrix_mapping(
     tmp_path: Path,
 ) -> None:
     runtime_paths = _runtime_paths(
@@ -4241,11 +4372,11 @@ def test_agent_connect_token_rejects_trusted_upstream_identity_without_matrix_ma
                 follow_redirects=False,
             )
 
-    assert authorize_response.status_code == 403
-    assert "current user" in authorize_response.json()["detail"]
+    assert authorize_response.status_code == 307
+    assert urlparse(authorize_response.headers["location"]).netloc == "auth.example.test"
 
 
-def test_agent_connect_token_callback_rejects_missing_trusted_upstream_identity(tmp_path: Path) -> None:
+def test_agent_connect_token_callback_uses_state_without_trusted_upstream_identity(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
     api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
     _use_runtime_auth_settings(api_app)
@@ -4278,11 +4409,11 @@ def test_agent_connect_token_callback_rejects_missing_trusted_upstream_identity(
             )
 
     assert authorize_response.status_code == 307
-    assert callback_response.status_code == 401
-    assert "trusted upstream identity header" in callback_response.json()["detail"]
+    assert callback_response.status_code == 200
+    assert "Test Drive is connected" in callback_response.text
 
 
-def test_agent_connect_token_callback_rejects_changed_trusted_matrix_requester(tmp_path: Path) -> None:
+def test_agent_connect_token_callback_uses_state_despite_changed_trusted_matrix_requester(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
     api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
     _use_runtime_auth_settings(api_app)
@@ -4316,8 +4447,8 @@ def test_agent_connect_token_callback_rejects_changed_trusted_matrix_requester(t
             )
 
     assert authorize_response.status_code == 307
-    assert callback_response.status_code == 403
-    assert "Not authorized" in callback_response.json()["detail"]
+    assert callback_response.status_code == 200
+    assert "Test Drive is connected" in callback_response.text
 
 
 def _config_payload_with_extra_google_agents(worker_scope: str = "user_agent") -> dict[str, Any]:
@@ -4372,7 +4503,7 @@ def test_connect_token_binding_setup_error_returns_503(
     provider = _fake_provider()
     connect_token = _connect_token_for_devagent(provider, runtime_paths)
     setup_error = OAuthProviderError("provider-controlled-connect-secret")
-    monkeypatch.setattr(oauth_api, "_target_binding_payload", AsyncMock(side_effect=setup_error))
+    monkeypatch.setattr(oauth_api, "_conversation_target_payload", AsyncMock(side_effect=setup_error))
 
     with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
         with TestClient(api_app) as client:
@@ -4465,7 +4596,7 @@ def test_connect_token_rejects_omitted_target_params(tmp_path: Path) -> None:
     assert "target" in response.json()["detail"]
 
 
-def test_agent_connect_token_rejects_wrong_authenticated_requester(tmp_path: Path) -> None:
+def test_agent_connect_token_uses_link_target_despite_authenticated_requester(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(
         tmp_path / "wrong-user",
         {"TEST_OAUTH_CLIENT_ID": "client-id", "TEST_OAUTH_CLIENT_SECRET": "client-secret"},
@@ -4499,7 +4630,7 @@ def test_agent_connect_token_rejects_wrong_authenticated_requester(tmp_path: Pat
                 follow_redirects=False,
             )
 
-    assert authorize_response.status_code == 403
+    assert authorize_response.status_code == 307
     wrong_manager = get_runtime_credentials_manager(runtime_paths)
     wrong_matrix_credentials = wrong_manager.for_worker(
         _worker_key_for_matrix_user("@alice:example.org"),
@@ -4509,7 +4640,7 @@ def test_agent_connect_token_rejects_wrong_authenticated_requester(tmp_path: Pat
     assert wrong_matrix_credentials is None
 
 
-def test_shared_agent_connect_token_rejects_wrong_authenticated_requester(tmp_path: Path) -> None:
+def test_shared_agent_connect_token_uses_link_target_despite_authenticated_requester(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(
         tmp_path,
         {
@@ -4547,8 +4678,8 @@ def test_shared_agent_connect_token_rejects_wrong_authenticated_requester(tmp_pa
                 follow_redirects=False,
             )
 
-    assert authorize_response.status_code == 403
-    assert "current user" in authorize_response.json()["detail"]
+    assert authorize_response.status_code == 307
+    assert urlparse(authorize_response.headers["location"]).netloc == "auth.example.test"
 
 
 def test_callback_rejects_wrong_provider_state(tmp_path: Path) -> None:

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -3794,6 +3794,39 @@ def test_agent_connect_token_starts_without_dashboard_login(tmp_path: Path) -> N
     assert urlparse(response.headers["location"]).netloc == "auth.example.test"
 
 
+def test_requesterless_oauth_link_uses_dashboard_login(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="shared"))
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="openai_compat",
+        agent_name="general",
+        requester_id=None,
+        room_id=None,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id="session-id",
+    )
+    worker_target = resolve_worker_target("shared", "general", execution_identity=identity)
+    connect_url = oauth_service.oauth_connect_url(provider, runtime_paths, worker_target=worker_target)
+    parsed_connect_url = urlparse(connect_url)
+
+    assert "connect_token" not in parse_qs(parsed_connect_url.query)
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            response = client.get(connect_url, follow_redirects=False)
+
+    assert response.status_code == 307
+    assert response.headers["location"].startswith("/login?")
+
+
 def test_agent_connect_token_callback_stores_bound_scope_without_dashboard_login(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(
         tmp_path,

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -3915,6 +3915,67 @@ def test_agent_connect_token_callback_rechecks_link_requester_permission(tmp_pat
     assert _stored_oauth_credentials(provider, runtime_paths) is None
 
 
+@pytest.mark.parametrize("change_before_authorize", [True, False])
+@pytest.mark.parametrize("change_kind", ["scope", "alias"])
+def test_agent_connect_token_rejects_changed_canonical_target(
+    tmp_path: Path,
+    change_kind: str,
+    change_before_authorize: bool,
+) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    connect_token = oauth_service._issue_oauth_connect_token(provider, runtime_paths, worker_target)
+    assert connect_token is not None
+    changed_payload = (
+        _config_payload(worker_scope="shared")
+        if change_kind == "scope"
+        else _config_payload(
+            worker_scope="user_agent",
+            allowed_users=["@bob:example.org"],
+            aliases={"@bob:example.org": ["@alice:example.org"]},
+        )
+    )
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            if change_before_authorize:
+                _publish_config(api_app, runtime_paths, changed_payload)
+            authorize_response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
+                f"&connect_token={connect_token}",
+                follow_redirects=False,
+            )
+            if change_before_authorize:
+                stale_response = authorize_response
+            else:
+                state = _state_from_auth_url(authorize_response.headers["location"])
+                _publish_config(api_app, runtime_paths, changed_payload)
+                stale_response = client.get(
+                    f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                    follow_redirects=False,
+                )
+
+    assert stale_response.status_code == 409
+    assert _stored_oauth_credentials(provider, runtime_paths) is None
+
+
 def test_agent_connect_token_rejects_generation_changed_after_link_issuance(tmp_path: Path) -> None:
     runtime_paths = _runtime_paths(
         tmp_path,

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -3882,6 +3882,96 @@ def test_agent_connect_token_callback_rechecks_link_requester_permission(tmp_pat
     assert _stored_oauth_credentials(provider, runtime_paths) is None
 
 
+def test_agent_connect_token_rejects_generation_changed_after_link_issuance(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    connect_token = oauth_service._issue_oauth_connect_token(provider, runtime_paths, worker_target)
+    assert connect_token is not None
+    context = oauth_lifecycle.resolve_oauth_credential_context(
+        provider,
+        runtime_paths,
+        get_runtime_credentials_manager(runtime_paths),
+        worker_target,
+    )
+    asyncio.run(oauth_lifecycle.reset_oauth_credentials(context))
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
+                f"&connect_token={connect_token}",
+                follow_redirects=False,
+            )
+
+    assert response.status_code == 409
+    assert "fresh connection link from the conversation" in response.json()["detail"]
+
+
+def test_agent_connect_token_callback_rejects_generation_changed_after_authorize(tmp_path: Path) -> None:
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    connect_token = oauth_service._issue_oauth_connect_token(provider, runtime_paths, worker_target)
+    assert connect_token is not None
+    context = oauth_lifecycle.resolve_oauth_credential_context(
+        provider,
+        runtime_paths,
+        get_runtime_credentials_manager(runtime_paths),
+        worker_target,
+    )
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            authorize_response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
+                f"&connect_token={connect_token}",
+                follow_redirects=False,
+            )
+            state = _state_from_auth_url(authorize_response.headers["location"])
+            asyncio.run(oauth_lifecycle.reset_oauth_credentials(context))
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                follow_redirects=False,
+            )
+
+    assert callback_response.status_code == 409
+    assert "fresh connection link from the conversation" in callback_response.text
+    assert _stored_oauth_credentials(provider, runtime_paths) is None
+
+
 def _trusted_upstream_oauth_env() -> dict[str, str]:
     return {
         "TEST_OAUTH_CLIENT_ID": "client-id",

--- a/tests/test_google_oauth_providers.py
+++ b/tests/test_google_oauth_providers.py
@@ -625,3 +625,14 @@ def test_build_oauth_reconnect_instruction_explains_loopback_device_handoff() ->
         "This link is valid for 10 minutes; if it expires, rerun the original request for a fresh link: "
         f"{connect_url}"
     )
+
+
+def test_build_oauth_reconnect_instruction_omits_expiry_for_dashboard_link() -> None:
+    """Requester-less dashboard fallback links must not claim a capability TTL."""
+    connect_url = "https://mindroom.example/api/oauth/google_drive/authorize?agent_name=general&execution_scope=shared"
+
+    assert build_oauth_reconnect_instruction(google_drive_oauth_provider(), connect_url) == (
+        "Google Drive session for this agent expired or is no longer valid. "
+        "Reconnect it with this MindRoom link. After reconnecting, retry the request. "
+        f"Reconnect here: {connect_url}"
+    )


### PR DESCRIPTION
## Summary

- let short-lived, single-use conversation OAuth links complete without a dashboard login
- carry the exact provider, agent, Matrix requester, worker scope/key, and issued connection generation through callback
- recheck current credential-management permission at authorization and callback while leaving dashboard OAuth browser-bound
- reject links invalidated by disconnect/reset and return conversation-specific recovery guidance

## Security model

The opaque 10-minute conversation link is a bearer capability, analogous to an account-recovery link. It is server-side and single-use; target query fields are validated, current agent authorization is rechecked twice, and credential writes use the original connection-generation CAS.

## Verification

- full `pytest -n auto --no-cov -q` suite
- complete pre-commit hook set, including ruff, ty, vulture, Tach, and privata
- OAuth API/service/pending-state focused suites
- independent code review: approved with no remaining findings

## Summary by Sourcery

Enable secure, single-use conversation OAuth handoffs without dashboard login while preserving authenticated dashboard flows and rejecting stale or unauthorized links.

New Features:
- Allow conversation-issued OAuth links to complete authorization and callbacks without dashboard authentication.
- Bind conversation OAuth capabilities to the provider, requester, worker target, and credential connection generation.
- Provide conversation-specific recovery guidance for expired or invalidated OAuth links.

Bug Fixes:
- Prevent stale, reset, disconnected, reused, or unauthorized conversation links from changing credentials.
- Ensure credential-management authorization is revalidated when authorization starts and when the callback completes.

Enhancements:
- Keep requester-less and dashboard OAuth flows browser-authenticated while reconstructing conversation targets from server-side capability state.

Documentation:
- Update OAuth framework documentation to describe unauthenticated conversation capabilities, permission rechecks, stale-link handling, and dashboard fallback behavior.

Tests:
- Expand OAuth API coverage for login-free conversation flows, authorization changes, target changes, connection-generation invalidation, and requester identity handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth connect links for conversation-based credential setup without requiring dashboard login.
  * Added support for both dashboard and conversation-based OAuth flows.
  * Improved OAuth callback handling with flow-specific authentication and success responses.

* **Bug Fixes**
  * Prevented stale or changed connections from completing OAuth authorization.
  * Rechecked requester permissions before storing credentials.
  * Improved handling and messaging for expired or invalid connection flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->