### PR TITLE
Remove unused OAuth pending state fields

### DIFF
--- a/src/mindroom/api/credentials_oauth_flows.py
+++ b/src/mindroom/api/credentials_oauth_flows.py
@@ -27,15 +27,12 @@ _PENDING_OAUTH_STATE_KIND = "dashboard_oauth_state"
 class _PendingOAuthState:
     """Pending OAuth connect request bound to its initiating authorization mode."""
 
-    service: str
-    user_id: str
     browser_user_required: bool
     agent_name: str | None
     execution_scope_override_provided: bool
     execution_scope_override: WorkerScope | None
     payload: dict[str, str] | None
     code_verifier: str | None
-    created_at: float
 
 
 def issue_pending_oauth_state(
@@ -115,13 +112,10 @@ def consume_pending_oauth_request(request: Request, service: str, state: str) ->
     )
     code_verifier = data.get("code_verifier")
     return _PendingOAuthState(
-        service=service,
-        user_id=user_id,
         browser_user_required=browser_user_required,
         agent_name=agent_name if isinstance(agent_name, str) and agent_name else None,
         execution_scope_override_provided=data.get("execution_scope_override_provided") is True,
         execution_scope_override=cast("WorkerScope | None", execution_scope_override),
         payload=payload,
         code_verifier=code_verifier if isinstance(code_verifier, str) and code_verifier else None,
-        created_at=0,
     )


### PR DESCRIPTION
## Summary

- remove the unused `service`, `user_id`, and `created_at` fields from the consumed OAuth state result
- retain provider/user validation before constructing the result
- leave serialized OAuth state and runtime behavior unchanged

## Verification

- `PYTEST_XDIST_AUTO_NUM_WORKERS=6 uv run pytest -n auto --no-cov -q tests/api/test_credentials_oauth_flows.py tests/api/test_oauth_api.py tests/test_credentials_api.py`
- `PYTEST_XDIST_AUTO_NUM_WORKERS=6 uv run pytest -n auto --no-cov -q`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Enhancements:
- Remove unused service, user ID, and creation timestamp fields from the consumed OAuth state representation while preserving validation and runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal OAuth request state handling by removing unused metadata.
  * OAuth flows continue to retain the information required for browser authentication, agent execution, payloads, and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->