### PR TITLE
Deliver oversized Matrix responses as lossless Markdown segments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -287,6 +287,7 @@ defaults:
   tools: [scheduler]
   markdown: true
   enable_streaming: true
+  large_message_strategy: sidecar
 
 memory:
   backend: mem0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,6 +157,7 @@ Matrix sync callback
 | `credentials.py` | Unified credential management (CredentialsManager) |
 | `matrix/` | Matrix protocol integration (client, users, rooms, presence, provisioning, message formatting) |
 | `matrix/large_messages.py` | Large-message sidecar storage and retrieval for oversized Matrix payloads |
+| `matrix/segmented_messages.py` | Lossless splitting of oversized text responses into ordered rich-text events (`defaults.large_message_strategy: split`) |
 | `matrix/sync_checkpoint_trust.py` | Sync-checkpoint persistence and the journal generation a checkpoint is certified against |
 | `matrix/sync_continuity.py` | Crash-atomic checkpoint and pending join-fence persistence |
 | `matrix/journal_ingress.py` | The boundary where Matrix events become durable facts; nio provenance decides actionable vs context-only |

--- a/docs/architecture/matrix.md
+++ b/docs/architecture/matrix.md
@@ -169,6 +169,13 @@ Messages exceeding the 64KB Matrix event limit are automatically handled by `pre
 - Preview event is compact (for example no inline `io.mindroom.tool_trace`), while the sidecar preserves full content fidelity
 - Encrypted rooms: sidecar JSON is encrypted before upload (`message-content.json.enc`)
 
+With `defaults.large_message_strategy: split`, an oversized final text response is instead delivered as several complete rich-text events by `segment_matrix_content()` in `matrix/segmented_messages.py`.
+The body is cut at paragraph or line boundaries, never inside a fenced code block, and concatenating the segment bodies reproduces the original exactly.
+The first segment stays a final `m.replace` of the streaming placeholder when there is one; continuations are plain messages that stay in the thread when there is one.
+Every segment is rendered as standalone Markdown with `m.mentions` attached to the segment whose body carries the mention.
+Continuation payloads are frozen in the local outbox row and sent under deterministic transaction IDs, so a retry or restart resends only the segments the room does not already hold.
+Non-text payloads, metadata that alone exceeds the budget, and a single code fence larger than one event still use the sidecar path.
+
 ## Response Tracking
 
 Duplicate responses are prevented at two durable layers, both in `tracking/event_journal.db` under `mindroom_data/`.

--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -390,6 +390,7 @@ defaults:
     - scheduler                    # Plain string or single-key dict with inline config overrides
   markdown: true                   # Default: true
   enable_streaming: true           # Default: true (stream responses via message edits)
+  large_message_strategy: sidecar  # Default: sidecar (or split: deliver oversized responses as lossless segmented messages)
   streaming:
     update_interval: 5.0           # Default: 5.0 (steady-state seconds between streamed edits)
     min_update_interval: 0.5       # Default: 0.5 (fast-start seconds between early edits)

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -156,6 +156,7 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
+With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
 See [Matrix Integration — Large Messages](architecture/matrix.md#large-messages) for details.
 
 ## Visibility Toggles

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -1,18 +1,15 @@
-import type { PROVIDERS } from '@/lib/providers';
+import type { PROVIDERS } from "@/lib/providers";
 
 export type ProviderType = keyof typeof PROVIDERS;
-export type MemoryBackend = 'mem0' | 'file' | 'none';
-export type MemorySearchMode = 'keyword' | 'semantic';
-export type WorkerScope = 'shared' | 'user' | 'user_agent';
-export type PrivateWorkerScope = Exclude<WorkerScope, 'shared'>;
+export type MemoryBackend = "mem0" | "file" | "none";
+export type MemorySearchMode = "keyword" | "semantic";
+export type WorkerScope = "shared" | "user" | "user_agent";
+export type PrivateWorkerScope = Exclude<WorkerScope, "shared">;
 export type AgentPolicySource =
-  | 'private.per'
-  | 'agent.worker_scope'
-  | 'defaults.worker_scope'
-  | 'unscoped';
+  "private.per" | "agent.worker_scope" | "defaults.worker_scope" | "unscoped";
 export type AgentPoliciesByAgent = Record<string, AgentPolicy>;
-export const DEFAULT_PRIVATE_KNOWLEDGE_PATH = 'memory';
-export const SHARED_CONTEXT_FILE_PLACEHOLDER = 'SOUL.md';
+export const DEFAULT_PRIVATE_KNOWLEDGE_PATH = "memory";
+export const SHARED_CONTEXT_FILE_PLACEHOLDER = "SOUL.md";
 
 export interface ModelConfig {
   provider: ProviderType;
@@ -82,7 +79,7 @@ export interface KnowledgeGitConfig {
 }
 
 export interface KnowledgeBaseConfig {
-  mode?: 'semantic' | 'files';
+  mode?: "semantic" | "files";
   description?: string;
   path: string;
   watch: boolean;
@@ -109,10 +106,10 @@ export interface AgentPrivateConfig {
   knowledge?: AgentPrivateKnowledgeConfig | null;
 }
 
-export type LearningMode = 'always' | 'agentic';
-export type CultureMode = 'automatic' | 'agentic' | 'manual';
+export type LearningMode = "always" | "agentic";
+export type CultureMode = "automatic" | "agentic" | "manual";
 
-export type ThreadMode = 'thread' | 'room';
+export type ThreadMode = "thread" | "room";
 
 export interface ResponderAccessConfig {
   current_room_members?: boolean;
@@ -131,30 +128,34 @@ export interface CompactionConfig {
   fallback_model?: string | null;
 }
 
-const DEFAULT_INHERITED_TOOLS = ['scheduler'] as const;
+const DEFAULT_INHERITED_TOOLS = ["scheduler"] as const;
 
 // Every authored compaction field except the model names, which carry their own
 // clear semantics. Keep in sync with CompactionOverrideConfig in the backend:
 // authoring any of these marks the override as authored, which the backend
 // resolves to enabled compaction.
 const COMPACTION_NON_MODEL_FIELDS: readonly (keyof CompactionConfig)[] = [
-  'enabled',
-  'threshold_tokens',
-  'threshold_percent',
-  'replay_window_tokens',
-  'reserve_tokens',
-  'timeout_seconds',
+  "enabled",
+  "threshold_tokens",
+  "threshold_percent",
+  "replay_window_tokens",
+  "reserve_tokens",
+  "timeout_seconds",
 ];
 
-function hasAuthoredNonModelCompactionField(compaction: CompactionConfig): boolean {
-  return COMPACTION_NON_MODEL_FIELDS.some(field => compaction[field] !== undefined);
+function hasAuthoredNonModelCompactionField(
+  compaction: CompactionConfig,
+): boolean {
+  return COMPACTION_NON_MODEL_FIELDS.some(
+    (field) => compaction[field] !== undefined,
+  );
 }
 
 function isPureCompactionModelClear(compaction: CompactionConfig): boolean {
   const modelFields = [compaction.model, compaction.fallback_model];
   return (
-    modelFields.some(value => value === null) &&
-    modelFields.every(value => value === null || value === undefined) &&
+    modelFields.some((value) => value === null) &&
+    modelFields.every((value) => value === null || value === undefined) &&
     !hasAuthoredNonModelCompactionField(compaction)
   );
 }
@@ -168,7 +169,7 @@ function isEmptyCompactionOverride(compaction: CompactionConfig): boolean {
 }
 
 function resolveAuthoredCompactionEnabled(
-  compaction: CompactionConfig | null | undefined
+  compaction: CompactionConfig | null | undefined,
 ): boolean {
   if (compaction === null) {
     return false;
@@ -184,7 +185,7 @@ function resolveAuthoredCompactionEnabled(
 
 export function resolveEffectiveCompactionEnabled(
   compaction: CompactionConfig | null | undefined,
-  defaultCompaction: CompactionConfig | null | undefined
+  defaultCompaction: CompactionConfig | null | undefined,
 ): boolean {
   const defaultEnabled = resolveAuthoredCompactionEnabled(defaultCompaction);
   if (compaction == null) {
@@ -193,14 +194,17 @@ export function resolveEffectiveCompactionEnabled(
   if (compaction.enabled !== undefined) {
     return compaction.enabled;
   }
-  if (isEmptyCompactionOverride(compaction) || isPureCompactionModelClear(compaction)) {
+  if (
+    isEmptyCompactionOverride(compaction) ||
+    isPureCompactionModelClear(compaction)
+  ) {
     return defaultEnabled;
   }
   return true;
 }
 
 export function resolveEffectiveDefaultTools(
-  defaults: Config['defaults'] | null | undefined
+  defaults: Config["defaults"] | null | undefined,
 ): string[] {
   const defaultTools = defaults?.tools;
   if (defaultTools !== undefined) {
@@ -249,7 +253,7 @@ export interface Team {
   agents: string[]; // List of agent IDs
   rooms: string[];
   access?: ResponderAccessConfig;
-  mode: 'coordinate' | 'collaborate';
+  mode: "coordinate" | "collaborate";
   model?: string; // Optional team-specific model
   compaction?: CompactionConfig | null; // Per-team required-compaction overrides
   num_history_runs?: number | null; // Number of prior scoped runs to include as team history
@@ -257,7 +261,7 @@ export interface Team {
   max_tool_calls_from_history?: number | null; // Max tool call messages replayed from team history
 }
 
-export type TeamConfig = Omit<Team, 'id' | 'rooms'> & {
+export type TeamConfig = Omit<Team, "id" | "rooms"> & {
   rooms?: string[];
 };
 
@@ -279,7 +283,7 @@ export interface Room {
 export interface RoomConfig {
   display_name?: string;
   description?: string;
-  join_policy?: 'invite' | 'knock' | 'public';
+  join_policy?: "invite" | "knock" | "public";
   listed?: boolean;
   encrypted?: boolean;
   invite_users?: string[];
@@ -287,7 +291,7 @@ export interface RoomConfig {
 }
 
 export interface RoomDefaultsConfig {
-  join_policy?: 'invite' | 'knock' | 'public';
+  join_policy?: "invite" | "knock" | "public";
   listed?: boolean;
   encrypted?: boolean;
   invite_users?: string[];
@@ -295,7 +299,7 @@ export interface RoomDefaultsConfig {
 }
 
 export interface VoiceSTTConfig {
-  provider: 'openai' | 'openai_compatible';
+  provider: "openai" | "openai_compatible";
   model: string;
   api_key?: string;
   host?: string;
@@ -317,9 +321,9 @@ export interface Config {
   administrators?: string[];
   memory: MemoryConfig;
   knowledge_bases?: Record<string, KnowledgeBaseConfig>;
-  cultures?: Record<string, Omit<Culture, 'id'>>; // Culture configurations
+  cultures?: Record<string, Omit<Culture, "id">>; // Culture configurations
   models: Record<string, ModelConfig>;
-  agents: Record<string, Omit<Agent, 'id'>>;
+  agents: Record<string, Omit<Agent, "id">>;
   defaults: {
     markdown: boolean;
     learning?: boolean;
@@ -330,7 +334,7 @@ export interface Config {
     worker_tools?: string[]; // Tool names to route through scoped workers by default for all agents
     tools?: string[];
     enable_streaming?: boolean;
-    large_message_strategy?: 'sidecar' | 'split'; // Oversized message delivery strategy (defaults to sidecar)
+    large_message_strategy?: "sidecar" | "split"; // Oversized message delivery strategy (defaults to sidecar)
     show_stop_button?: boolean;
     num_history_runs?: number | null;
     num_history_messages?: number | null;
@@ -364,7 +368,7 @@ export interface AgentPolicy {
 }
 
 function normalizePrivateKnowledgeConfig(
-  knowledge: AgentPrivateKnowledgeConfig | null | undefined
+  knowledge: AgentPrivateKnowledgeConfig | null | undefined,
 ): AgentPrivateKnowledgeConfig | null | undefined {
   if (knowledge == null) {
     return knowledge;
@@ -374,7 +378,10 @@ function normalizePrivateKnowledgeConfig(
   if (knowledge.enabled === true) {
     return {
       ...knowledge,
-      path: trimmedPath && trimmedPath.length > 0 ? trimmedPath : DEFAULT_PRIVATE_KNOWLEDGE_PATH,
+      path:
+        trimmedPath && trimmedPath.length > 0
+          ? trimmedPath
+          : DEFAULT_PRIVATE_KNOWLEDGE_PATH,
     };
   }
 
@@ -385,7 +392,7 @@ function normalizePrivateKnowledgeConfig(
 }
 
 function normalizePrivateConfig(
-  privateConfig: AgentPrivateConfig | null | undefined
+  privateConfig: AgentPrivateConfig | null | undefined,
 ): AgentPrivateConfig | null | undefined {
   if (privateConfig == null) {
     return privateConfig;
@@ -393,28 +400,39 @@ function normalizePrivateConfig(
 
   return {
     ...privateConfig,
-    per: privateConfig.per ?? 'user',
+    per: privateConfig.per ?? "user",
     knowledge: normalizePrivateKnowledgeConfig(privateConfig.knowledge),
   };
 }
 
 function normalizeCompactionConfig(
-  compaction: CompactionConfig | null | undefined
+  compaction: CompactionConfig | null | undefined,
 ): CompactionConfig | null | undefined {
   if (compaction == null) {
     return compaction;
   }
 
-  const normalizeModelName = (modelName: string | null | undefined): string | null | undefined =>
-    modelName === null ? null : modelName?.trim() ? modelName.trim() : undefined;
-  const hasExplicitNullClear = Object.values(compaction).some(value => value === null);
+  const normalizeModelName = (
+    modelName: string | null | undefined,
+  ): string | null | undefined =>
+    modelName === null
+      ? null
+      : modelName?.trim()
+        ? modelName.trim()
+        : undefined;
+  const hasExplicitNullClear = Object.values(compaction).some(
+    (value) => value === null,
+  );
   const normalizedCompaction: CompactionConfig = {
     ...compaction,
     model: normalizeModelName(compaction.model),
     fallback_model: normalizeModelName(compaction.fallback_model),
   };
 
-  if (Object.values(normalizedCompaction).every(value => value == null) && !hasExplicitNullClear) {
+  if (
+    Object.values(normalizedCompaction).every((value) => value == null) &&
+    !hasExplicitNullClear
+  ) {
     return undefined;
   }
 
@@ -428,34 +446,39 @@ function normalizeCompactionConfig(
   return normalizedCompaction;
 }
 
-function normalizeCompactionUpdates<T extends { compaction?: CompactionConfig | null }>(
-  entity: T,
-  updates: Partial<T>
-): Partial<T> {
+function normalizeCompactionUpdates<
+  T extends { compaction?: CompactionConfig | null },
+>(entity: T, updates: Partial<T>): Partial<T> {
   const normalizedUpdates: Partial<T> = { ...updates };
-  const nextCompaction = 'compaction' in updates ? updates.compaction : entity.compaction;
+  const nextCompaction =
+    "compaction" in updates ? updates.compaction : entity.compaction;
 
-  if ('compaction' in updates || nextCompaction != null) {
+  if ("compaction" in updates || nextCompaction != null) {
     normalizedUpdates.compaction = normalizeCompactionConfig(
-      nextCompaction
-    ) as Partial<T>['compaction'];
+      nextCompaction,
+    ) as Partial<T>["compaction"];
   }
 
   return normalizedUpdates;
 }
 
-export function getDefaultPrivateConfig(agent: Pick<Agent, 'private'>): AgentPrivateConfig {
+export function getDefaultPrivateConfig(
+  agent: Pick<Agent, "private">,
+): AgentPrivateConfig {
   if (agent.private != null) {
     return agent.private;
   }
   return {
-    per: 'user',
+    per: "user",
   };
 }
 
-export function normalizeAgentUpdates(agent: Agent, updates: Partial<Agent>): Partial<Agent> {
+export function normalizeAgentUpdates(
+  agent: Agent,
+  updates: Partial<Agent>,
+): Partial<Agent> {
   const normalizedUpdates = normalizeCompactionUpdates(agent, updates);
-  const nextPrivate = 'private' in updates ? updates.private : agent.private;
+  const nextPrivate = "private" in updates ? updates.private : agent.private;
 
   if (nextPrivate != null) {
     normalizedUpdates.private = normalizePrivateConfig(nextPrivate);
@@ -465,6 +488,9 @@ export function normalizeAgentUpdates(agent: Agent, updates: Partial<Agent>): Pa
   return normalizedUpdates;
 }
 
-export function normalizeTeamUpdates(team: Team, updates: Partial<Team>): Partial<Team> {
+export function normalizeTeamUpdates(
+  team: Team,
+  updates: Partial<Team>,
+): Partial<Team> {
   return normalizeCompactionUpdates(team, updates);
 }

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -1,15 +1,18 @@
-import type { PROVIDERS } from "@/lib/providers";
+import type { PROVIDERS } from '@/lib/providers';
 
 export type ProviderType = keyof typeof PROVIDERS;
-export type MemoryBackend = "mem0" | "file" | "none";
-export type MemorySearchMode = "keyword" | "semantic";
-export type WorkerScope = "shared" | "user" | "user_agent";
-export type PrivateWorkerScope = Exclude<WorkerScope, "shared">;
+export type MemoryBackend = 'mem0' | 'file' | 'none';
+export type MemorySearchMode = 'keyword' | 'semantic';
+export type WorkerScope = 'shared' | 'user' | 'user_agent';
+export type PrivateWorkerScope = Exclude<WorkerScope, 'shared'>;
 export type AgentPolicySource =
-  "private.per" | "agent.worker_scope" | "defaults.worker_scope" | "unscoped";
+  | 'private.per'
+  | 'agent.worker_scope'
+  | 'defaults.worker_scope'
+  | 'unscoped';
 export type AgentPoliciesByAgent = Record<string, AgentPolicy>;
-export const DEFAULT_PRIVATE_KNOWLEDGE_PATH = "memory";
-export const SHARED_CONTEXT_FILE_PLACEHOLDER = "SOUL.md";
+export const DEFAULT_PRIVATE_KNOWLEDGE_PATH = 'memory';
+export const SHARED_CONTEXT_FILE_PLACEHOLDER = 'SOUL.md';
 
 export interface ModelConfig {
   provider: ProviderType;
@@ -79,7 +82,7 @@ export interface KnowledgeGitConfig {
 }
 
 export interface KnowledgeBaseConfig {
-  mode?: "semantic" | "files";
+  mode?: 'semantic' | 'files';
   description?: string;
   path: string;
   watch: boolean;
@@ -106,10 +109,10 @@ export interface AgentPrivateConfig {
   knowledge?: AgentPrivateKnowledgeConfig | null;
 }
 
-export type LearningMode = "always" | "agentic";
-export type CultureMode = "automatic" | "agentic" | "manual";
+export type LearningMode = 'always' | 'agentic';
+export type CultureMode = 'automatic' | 'agentic' | 'manual';
 
-export type ThreadMode = "thread" | "room";
+export type ThreadMode = 'thread' | 'room';
 
 export interface ResponderAccessConfig {
   current_room_members?: boolean;
@@ -128,34 +131,30 @@ export interface CompactionConfig {
   fallback_model?: string | null;
 }
 
-const DEFAULT_INHERITED_TOOLS = ["scheduler"] as const;
+const DEFAULT_INHERITED_TOOLS = ['scheduler'] as const;
 
 // Every authored compaction field except the model names, which carry their own
 // clear semantics. Keep in sync with CompactionOverrideConfig in the backend:
 // authoring any of these marks the override as authored, which the backend
 // resolves to enabled compaction.
 const COMPACTION_NON_MODEL_FIELDS: readonly (keyof CompactionConfig)[] = [
-  "enabled",
-  "threshold_tokens",
-  "threshold_percent",
-  "replay_window_tokens",
-  "reserve_tokens",
-  "timeout_seconds",
+  'enabled',
+  'threshold_tokens',
+  'threshold_percent',
+  'replay_window_tokens',
+  'reserve_tokens',
+  'timeout_seconds',
 ];
 
-function hasAuthoredNonModelCompactionField(
-  compaction: CompactionConfig,
-): boolean {
-  return COMPACTION_NON_MODEL_FIELDS.some(
-    (field) => compaction[field] !== undefined,
-  );
+function hasAuthoredNonModelCompactionField(compaction: CompactionConfig): boolean {
+  return COMPACTION_NON_MODEL_FIELDS.some(field => compaction[field] !== undefined);
 }
 
 function isPureCompactionModelClear(compaction: CompactionConfig): boolean {
   const modelFields = [compaction.model, compaction.fallback_model];
   return (
-    modelFields.some((value) => value === null) &&
-    modelFields.every((value) => value === null || value === undefined) &&
+    modelFields.some(value => value === null) &&
+    modelFields.every(value => value === null || value === undefined) &&
     !hasAuthoredNonModelCompactionField(compaction)
   );
 }
@@ -169,7 +168,7 @@ function isEmptyCompactionOverride(compaction: CompactionConfig): boolean {
 }
 
 function resolveAuthoredCompactionEnabled(
-  compaction: CompactionConfig | null | undefined,
+  compaction: CompactionConfig | null | undefined
 ): boolean {
   if (compaction === null) {
     return false;
@@ -185,7 +184,7 @@ function resolveAuthoredCompactionEnabled(
 
 export function resolveEffectiveCompactionEnabled(
   compaction: CompactionConfig | null | undefined,
-  defaultCompaction: CompactionConfig | null | undefined,
+  defaultCompaction: CompactionConfig | null | undefined
 ): boolean {
   const defaultEnabled = resolveAuthoredCompactionEnabled(defaultCompaction);
   if (compaction == null) {
@@ -194,17 +193,14 @@ export function resolveEffectiveCompactionEnabled(
   if (compaction.enabled !== undefined) {
     return compaction.enabled;
   }
-  if (
-    isEmptyCompactionOverride(compaction) ||
-    isPureCompactionModelClear(compaction)
-  ) {
+  if (isEmptyCompactionOverride(compaction) || isPureCompactionModelClear(compaction)) {
     return defaultEnabled;
   }
   return true;
 }
 
 export function resolveEffectiveDefaultTools(
-  defaults: Config["defaults"] | null | undefined,
+  defaults: Config['defaults'] | null | undefined
 ): string[] {
   const defaultTools = defaults?.tools;
   if (defaultTools !== undefined) {
@@ -253,7 +249,7 @@ export interface Team {
   agents: string[]; // List of agent IDs
   rooms: string[];
   access?: ResponderAccessConfig;
-  mode: "coordinate" | "collaborate";
+  mode: 'coordinate' | 'collaborate';
   model?: string; // Optional team-specific model
   compaction?: CompactionConfig | null; // Per-team required-compaction overrides
   num_history_runs?: number | null; // Number of prior scoped runs to include as team history
@@ -261,7 +257,7 @@ export interface Team {
   max_tool_calls_from_history?: number | null; // Max tool call messages replayed from team history
 }
 
-export type TeamConfig = Omit<Team, "id" | "rooms"> & {
+export type TeamConfig = Omit<Team, 'id' | 'rooms'> & {
   rooms?: string[];
 };
 
@@ -283,7 +279,7 @@ export interface Room {
 export interface RoomConfig {
   display_name?: string;
   description?: string;
-  join_policy?: "invite" | "knock" | "public";
+  join_policy?: 'invite' | 'knock' | 'public';
   listed?: boolean;
   encrypted?: boolean;
   invite_users?: string[];
@@ -291,7 +287,7 @@ export interface RoomConfig {
 }
 
 export interface RoomDefaultsConfig {
-  join_policy?: "invite" | "knock" | "public";
+  join_policy?: 'invite' | 'knock' | 'public';
   listed?: boolean;
   encrypted?: boolean;
   invite_users?: string[];
@@ -299,7 +295,7 @@ export interface RoomDefaultsConfig {
 }
 
 export interface VoiceSTTConfig {
-  provider: "openai" | "openai_compatible";
+  provider: 'openai' | 'openai_compatible';
   model: string;
   api_key?: string;
   host?: string;
@@ -321,9 +317,9 @@ export interface Config {
   administrators?: string[];
   memory: MemoryConfig;
   knowledge_bases?: Record<string, KnowledgeBaseConfig>;
-  cultures?: Record<string, Omit<Culture, "id">>; // Culture configurations
+  cultures?: Record<string, Omit<Culture, 'id'>>; // Culture configurations
   models: Record<string, ModelConfig>;
-  agents: Record<string, Omit<Agent, "id">>;
+  agents: Record<string, Omit<Agent, 'id'>>;
   defaults: {
     markdown: boolean;
     learning?: boolean;
@@ -334,6 +330,7 @@ export interface Config {
     worker_tools?: string[]; // Tool names to route through scoped workers by default for all agents
     tools?: string[];
     enable_streaming?: boolean;
+    large_message_strategy?: 'sidecar' | 'split'; // Oversized message delivery strategy (defaults to sidecar)
     show_stop_button?: boolean;
     num_history_runs?: number | null;
     num_history_messages?: number | null;
@@ -367,7 +364,7 @@ export interface AgentPolicy {
 }
 
 function normalizePrivateKnowledgeConfig(
-  knowledge: AgentPrivateKnowledgeConfig | null | undefined,
+  knowledge: AgentPrivateKnowledgeConfig | null | undefined
 ): AgentPrivateKnowledgeConfig | null | undefined {
   if (knowledge == null) {
     return knowledge;
@@ -377,10 +374,7 @@ function normalizePrivateKnowledgeConfig(
   if (knowledge.enabled === true) {
     return {
       ...knowledge,
-      path:
-        trimmedPath && trimmedPath.length > 0
-          ? trimmedPath
-          : DEFAULT_PRIVATE_KNOWLEDGE_PATH,
+      path: trimmedPath && trimmedPath.length > 0 ? trimmedPath : DEFAULT_PRIVATE_KNOWLEDGE_PATH,
     };
   }
 
@@ -391,7 +385,7 @@ function normalizePrivateKnowledgeConfig(
 }
 
 function normalizePrivateConfig(
-  privateConfig: AgentPrivateConfig | null | undefined,
+  privateConfig: AgentPrivateConfig | null | undefined
 ): AgentPrivateConfig | null | undefined {
   if (privateConfig == null) {
     return privateConfig;
@@ -399,39 +393,28 @@ function normalizePrivateConfig(
 
   return {
     ...privateConfig,
-    per: privateConfig.per ?? "user",
+    per: privateConfig.per ?? 'user',
     knowledge: normalizePrivateKnowledgeConfig(privateConfig.knowledge),
   };
 }
 
 function normalizeCompactionConfig(
-  compaction: CompactionConfig | null | undefined,
+  compaction: CompactionConfig | null | undefined
 ): CompactionConfig | null | undefined {
   if (compaction == null) {
     return compaction;
   }
 
-  const normalizeModelName = (
-    modelName: string | null | undefined,
-  ): string | null | undefined =>
-    modelName === null
-      ? null
-      : modelName?.trim()
-        ? modelName.trim()
-        : undefined;
-  const hasExplicitNullClear = Object.values(compaction).some(
-    (value) => value === null,
-  );
+  const normalizeModelName = (modelName: string | null | undefined): string | null | undefined =>
+    modelName === null ? null : modelName?.trim() ? modelName.trim() : undefined;
+  const hasExplicitNullClear = Object.values(compaction).some(value => value === null);
   const normalizedCompaction: CompactionConfig = {
     ...compaction,
     model: normalizeModelName(compaction.model),
     fallback_model: normalizeModelName(compaction.fallback_model),
   };
 
-  if (
-    Object.values(normalizedCompaction).every((value) => value == null) &&
-    !hasExplicitNullClear
-  ) {
+  if (Object.values(normalizedCompaction).every(value => value == null) && !hasExplicitNullClear) {
     return undefined;
   }
 
@@ -445,39 +428,34 @@ function normalizeCompactionConfig(
   return normalizedCompaction;
 }
 
-function normalizeCompactionUpdates<
-  T extends { compaction?: CompactionConfig | null },
->(entity: T, updates: Partial<T>): Partial<T> {
+function normalizeCompactionUpdates<T extends { compaction?: CompactionConfig | null }>(
+  entity: T,
+  updates: Partial<T>
+): Partial<T> {
   const normalizedUpdates: Partial<T> = { ...updates };
-  const nextCompaction =
-    "compaction" in updates ? updates.compaction : entity.compaction;
+  const nextCompaction = 'compaction' in updates ? updates.compaction : entity.compaction;
 
-  if ("compaction" in updates || nextCompaction != null) {
+  if ('compaction' in updates || nextCompaction != null) {
     normalizedUpdates.compaction = normalizeCompactionConfig(
-      nextCompaction,
-    ) as Partial<T>["compaction"];
+      nextCompaction
+    ) as Partial<T>['compaction'];
   }
 
   return normalizedUpdates;
 }
 
-export function getDefaultPrivateConfig(
-  agent: Pick<Agent, "private">,
-): AgentPrivateConfig {
+export function getDefaultPrivateConfig(agent: Pick<Agent, 'private'>): AgentPrivateConfig {
   if (agent.private != null) {
     return agent.private;
   }
   return {
-    per: "user",
+    per: 'user',
   };
 }
 
-export function normalizeAgentUpdates(
-  agent: Agent,
-  updates: Partial<Agent>,
-): Partial<Agent> {
+export function normalizeAgentUpdates(agent: Agent, updates: Partial<Agent>): Partial<Agent> {
   const normalizedUpdates = normalizeCompactionUpdates(agent, updates);
-  const nextPrivate = "private" in updates ? updates.private : agent.private;
+  const nextPrivate = 'private' in updates ? updates.private : agent.private;
 
   if (nextPrivate != null) {
     normalizedUpdates.private = normalizePrivateConfig(nextPrivate);
@@ -487,9 +465,6 @@ export function normalizeAgentUpdates(
   return normalizedUpdates;
 }
 
-export function normalizeTeamUpdates(
-  team: Team,
-  updates: Partial<Team>,
-): Partial<Team> {
+export function normalizeTeamUpdates(team: Team, updates: Partial<Team>): Partial<Team> {
   return normalizeCompactionUpdates(team, updates);
 }

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1272,6 +1272,7 @@ defaults:
     - scheduler                    # Plain string or single-key dict with inline config overrides
   markdown: true                   # Default: true
   enable_streaming: true           # Default: true (stream responses via message edits)
+  large_message_strategy: sidecar  # Default: sidecar (or split: deliver oversized responses as lossless segmented messages)
   streaming:
     update_interval: 5.0           # Default: 5.0 (steady-state seconds between streamed edits)
     min_update_interval: 0.5       # Default: 0.5 (fast-start seconds between early edits)

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -386,6 +386,7 @@ defaults:
     - scheduler                    # Plain string or single-key dict with inline config overrides
   markdown: true                   # Default: true
   enable_streaming: true           # Default: true (stream responses via message edits)
+  large_message_strategy: sidecar  # Default: sidecar (or split: deliver oversized responses as lossless segmented messages)
   streaming:
     update_interval: 5.0           # Default: 5.0 (steady-state seconds between streamed edits)
     min_update_interval: 0.5       # Default: 0.5 (fast-start seconds between early edits)

--- a/src/mindroom/config/models.py
+++ b/src/mindroom/config/models.py
@@ -32,6 +32,7 @@ class EffectiveToolConfig:
 
 
 AgentLearningMode = Literal["always", "agentic"]
+LargeMessageStrategy = Literal["sidecar", "split"]
 _DEFAULT_DEFAULT_TOOLS = ("scheduler",)
 _TOOL_CONFIG_CONTROL_KEYS = frozenset({"defer", "initial"})
 
@@ -359,6 +360,13 @@ class DefaultsConfig(BaseModel):
     enable_streaming: bool = Field(
         default=True,
         description="Enable streaming responses via progressive message edits",
+    )
+    large_message_strategy: LargeMessageStrategy = Field(
+        default="sidecar",
+        description=(
+            "How to deliver oversized text responses: 'sidecar' uploads the full content as an "
+            "attachment behind a preview event; 'split' sends the full text as lossless segmented messages"
+        ),
     )
     coalescing: CoalescingConfig = Field(
         default_factory=CoalescingConfig,

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -132,14 +132,12 @@ class _PreparedWirePayload:
 
 def _result_with_segment_payloads(
     result: dict[str, object] | None,
-    continuation_payloads: tuple[dict[str, Any], ...],
+    prepared: _PreparedWirePayload | MatrixDeliveryFailure,
 ) -> dict[str, object] | None:
     """Store continuation payloads in local outbox state, never on Matrix."""
-    if not continuation_payloads:
+    if isinstance(prepared, MatrixDeliveryFailure) or not prepared.continuation_payloads:
         return result
-    merged = dict(result or {})
-    merged[_SEGMENT_PAYLOADS_RESULT_KEY] = [dict(payload) for payload in continuation_payloads]
-    return merged
+    return {**(result or {}), _SEGMENT_PAYLOADS_RESULT_KEY: list(prepared.continuation_payloads)}
 
 
 def _continuation_payloads(result: Mapping[str, object] | None) -> tuple[dict[str, Any], ...]:
@@ -782,75 +780,61 @@ class DeliveryGateway:
         retry_sync_recovery: bool,
         operation: str = "send_message",
     ) -> DeliveredMatrixEvent:
-        """Send one claimed delivery exactly as it was frozen.
+        """Send one claimed delivery exactly as it was frozen, continuations included.
 
-        The payload comes from the row, never from whatever the caller happens
-        to be holding. A turn that ran twice sends what its first attempt
-        froze: content regenerated after a claim would go out under a
-        transaction ID the homeserver has already seen, be dropped as a
+        The payload is the stored envelope, not something rebuilt from the
+        request, and the transaction ID is the one the row already holds. A
+        retry that rebuilt either would let the homeserver accept the resend
+        as a new event instead of collapsing it onto the earlier one, mint a
         duplicate, and leave the durable result and the room disagreeing
-        forever.
+        forever. Continuations get deterministic transaction IDs derived from
+        the row's, so their retries collapse the same way.
         """
-        client = self._client()
-        outcome = await send_message_outcome(
-            client,
-            claimed.room_id,
+        outcome = await self._send_frozen(
+            claimed,
             dict(claimed.payload),
+            transaction_id=claimed.transaction_id,
+            what="delivery",
             operation=operation,
             retry_sync_recovery=retry_sync_recovery,
-            transaction_id=claimed.transaction_id,
-            content_is_prepared=True,
         )
-        if isinstance(outcome, MatrixDeliveryFailure):
-            detail = _matrix_delivery_failure_reason(outcome)
-            if outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
-                raise PermanentDeliveryError(detail)
-            msg = f"Matrix refused delivery for turn {claimed.delivery_id!r} stage {claimed.stage.value!r}: {detail}"
-            raise _DeliveryRefusedError(msg)
-
-        continuations = _continuation_payloads(claimed.result)
-        for index, continuation in enumerate(continuations, start=1):
-            await self._send_continuation(
+        for index, continuation in enumerate(_continuation_payloads(claimed.result), start=1):
+            await self._send_frozen(
                 claimed,
                 continuation,
-                index=index,
+                transaction_id=_segment_transaction_id(claimed.transaction_id, index),
+                what=f"continuation {index}",
                 retry_sync_recovery=retry_sync_recovery,
-            )
-        if continuations:
-            self.deps.logger.info(
-                "Sent segmented Matrix response",
-                delivery_id=claimed.delivery_id,
-                stage=claimed.stage.value,
-                continuation_count=len(continuations),
             )
         return outcome
 
-    async def _send_continuation(
+    async def _send_frozen(
         self,
         claimed: MatrixDelivery,
-        continuation: dict[str, Any],
+        content: dict[str, Any],
         *,
-        index: int,
+        transaction_id: str,
+        what: str,
+        operation: str = "send_message",
         retry_sync_recovery: bool,
-    ) -> None:
-        """Send one frozen continuation event under its stable transaction ID."""
+    ) -> DeliveredMatrixEvent:
+        """Send one frozen event of a claimed delivery, mapping refusals to exceptions."""
         outcome = await send_message_outcome(
             self._client(),
             claimed.room_id,
-            continuation,
+            content,
+            operation=operation,
             retry_sync_recovery=retry_sync_recovery,
-            transaction_id=_segment_transaction_id(claimed.transaction_id, index),
+            transaction_id=transaction_id,
             content_is_prepared=True,
         )
         if isinstance(outcome, MatrixDeliveryFailure):
             detail = _matrix_delivery_failure_reason(outcome)
             if outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
                 raise PermanentDeliveryError(detail)
-            msg = (
-                f"Matrix refused continuation {index} for turn {claimed.delivery_id!r} "
-                f"stage {claimed.stage.value!r}: {detail}"
-            )
+            msg = f"Matrix refused {what} for turn {claimed.delivery_id!r} stage {claimed.stage.value!r}: {detail}"
             raise _DeliveryRefusedError(msg)
+        return outcome
 
     async def _observe_matrix_event(
         self,
@@ -1012,10 +996,11 @@ class DeliveryGateway:
             delivery_event_type=claimed.event_type,
         )
         for index in missing_indices:
-            await self._send_continuation(
+            await self._send_frozen(
                 claimed,
                 continuations[index],
-                index=index + 1,
+                transaction_id=_segment_transaction_id(claimed.transaction_id, index + 1),
+                what=f"continuation {index + 1}",
                 retry_sync_recovery=True,
             )
         if missing_indices:
@@ -1101,10 +1086,7 @@ class DeliveryGateway:
         else:
             preparation_failure = None
             content = prepared.content
-        delivery_result = _result_with_segment_payloads(
-            request.delivery_result,
-            () if isinstance(prepared, MatrixDeliveryFailure) else prepared.continuation_payloads,
-        )
+        delivery_result = _result_with_segment_payloads(request.delivery_result, prepared)
 
         try:
             handoff = None if request.defer_source_handoff else self.deps.turn_handoff
@@ -1267,10 +1249,7 @@ class DeliveryGateway:
         else:
             preparation_failure = None
             envelope = prepared.content
-        delivery_result = _result_with_segment_payloads(
-            request.delivery_result,
-            () if isinstance(prepared, MatrixDeliveryFailure) else prepared.continuation_payloads,
-        )
+        delivery_result = _result_with_segment_payloads(request.delivery_result, prepared)
 
         try:
             handoff = None if request.defer_source_handoff else self.deps.turn_handoff

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -816,23 +816,12 @@ class DeliveryGateway:
 
         continuations = _continuation_payloads(claimed.result)
         for index, continuation in enumerate(continuations, start=1):
-            continuation_outcome = await send_message_outcome(
-                client,
-                claimed.room_id,
+            await self._send_continuation(
+                claimed,
                 continuation,
+                index=index,
                 retry_sync_recovery=retry_sync_recovery,
-                transaction_id=_segment_transaction_id(claimed.transaction_id, index),
-                content_is_prepared=True,
             )
-            if isinstance(continuation_outcome, MatrixDeliveryFailure):
-                detail = _matrix_delivery_failure_reason(continuation_outcome)
-                if continuation_outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
-                    raise PermanentDeliveryError(detail)
-                msg = (
-                    f"Matrix refused continuation {index} for turn {claimed.delivery_id!r} "
-                    f"stage {claimed.stage.value!r}: {detail}"
-                )
-                raise _DeliveryRefusedError(msg)
         if continuations:
             self.deps.logger.info(
                 "Sent segmented Matrix response",
@@ -841,6 +830,33 @@ class DeliveryGateway:
                 continuation_count=len(continuations),
             )
         return outcome
+
+    async def _send_continuation(
+        self,
+        claimed: MatrixDelivery,
+        continuation: dict[str, Any],
+        *,
+        index: int,
+        retry_sync_recovery: bool,
+    ) -> None:
+        """Send one frozen continuation event under its stable transaction ID."""
+        outcome = await send_message_outcome(
+            self._client(),
+            claimed.room_id,
+            continuation,
+            retry_sync_recovery=retry_sync_recovery,
+            transaction_id=_segment_transaction_id(claimed.transaction_id, index),
+            content_is_prepared=True,
+        )
+        if isinstance(outcome, MatrixDeliveryFailure):
+            detail = _matrix_delivery_failure_reason(outcome)
+            if outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
+                raise PermanentDeliveryError(detail)
+            msg = (
+                f"Matrix refused continuation {index} for turn {claimed.delivery_id!r} "
+                f"stage {claimed.stage.value!r}: {detail}"
+            )
+            raise _DeliveryRefusedError(msg)
 
     async def _observe_matrix_event(
         self,
@@ -961,7 +977,7 @@ class DeliveryGateway:
         response_sender = client.user_id
         if not response_sender:
             return None
-        return await find_outbox_delivery_event_id_via_room_messages(
+        event_id = await find_outbox_delivery_event_id_via_room_messages(
             client,
             claimed.room_id,
             delivery_sender=response_sender,
@@ -969,6 +985,49 @@ class DeliveryGateway:
             delivery_content=claimed.payload,
             delivery_event_type=claimed.event_type,
         )
+        if event_id is not None:
+            await self._deliver_missing_continuations(claimed)
+        return event_id
+
+    async def _deliver_missing_continuations(self, claimed: MatrixDelivery) -> None:
+        """Send the continuation events an earlier device never got into the room.
+
+        Adopting a segmented delivery keys on the primary event alone, so a
+        crash between the primary and its continuations would acknowledge the
+        row with most of the answer never sent. Each continuation is matched
+        by its exact frozen content first -- transaction IDs are scoped to the
+        device that used them, so a blind resend from this device would
+        duplicate every segment the earlier device did deliver. A failed
+        lookup or send raises, leaving the row unacknowledged so the next
+        recovery pass resumes exactly here.
+        """
+        continuations = _continuation_payloads(claimed.result)
+        if not continuations:
+            return
+        client = self._client()
+        response_sender = client.user_id
+        assert response_sender, "continuation reconciliation requires a logged-in client"
+        missing: list[tuple[int, dict[str, Any]]] = []
+        for index, continuation in enumerate(continuations, start=1):
+            delivered = await find_outbox_delivery_event_id_via_room_messages(
+                client,
+                claimed.room_id,
+                delivery_sender=response_sender,
+                source_event_ids=(),
+                delivery_content=continuation,
+                delivery_event_type=claimed.event_type,
+            )
+            if delivered is None:
+                missing.append((index, continuation))
+        for index, continuation in missing:
+            await self._send_continuation(claimed, continuation, index=index, retry_sync_recovery=True)
+        if missing:
+            self.deps.logger.info(
+                "Recovered segmented Matrix response continuations",
+                delivery_id=claimed.delivery_id,
+                stage=claimed.stage.value,
+                continuation_count=len(missing),
+            )
 
     async def recover_deliveries(self) -> RecoveryOutcome:
         """Resend every delivery whose Matrix outcome this process cannot know.

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -64,6 +64,7 @@ from mindroom.matrix.mentions import format_message_with_mentions
 from mindroom.matrix.message_builder import build_message_content
 from mindroom.matrix.room_history_reads import (
     find_outbox_delivery_event_id_via_room_messages,
+    missing_outbox_delivery_copy_indices_via_room_messages,
 )
 from mindroom.matrix.segmented_messages import segment_matrix_content
 from mindroom.matrix_delivery import (
@@ -994,10 +995,13 @@ class DeliveryGateway:
 
         Adopting a segmented delivery keys on the primary event alone, so a
         crash between the primary and its continuations would acknowledge the
-        row with most of the answer never sent. Each continuation is matched
-        by its exact frozen content first -- transaction IDs are scoped to the
-        device that used them, so a blind resend from this device would
-        duplicate every segment the earlier device did deliver. A failed
+        row with most of the answer never sent. Reconciliation counts copies
+        rather than checking existence: long homogeneous responses can repeat
+        a byte-identical continuation payload, and one observed event must not
+        satisfy several positions. Found copies are consumed as credits across
+        the expected positions, so exactly the missing ones are sent -- a
+        blind resend from this device would duplicate them, because
+        transaction IDs are scoped to the device that used them. A failed
         lookup or send raises, leaving the row unacknowledged so the next
         recovery pass resumes exactly here.
         """
@@ -1007,26 +1011,26 @@ class DeliveryGateway:
         client = self._client()
         response_sender = client.user_id
         assert response_sender, "continuation reconciliation requires a logged-in client"
-        missing: list[tuple[int, dict[str, Any]]] = []
-        for index, continuation in enumerate(continuations, start=1):
-            delivered = await find_outbox_delivery_event_id_via_room_messages(
-                client,
-                claimed.room_id,
-                delivery_sender=response_sender,
-                source_event_ids=(),
-                delivery_content=continuation,
-                delivery_event_type=claimed.event_type,
+        missing_indices = await missing_outbox_delivery_copy_indices_via_room_messages(
+            client,
+            claimed.room_id,
+            delivery_sender=response_sender,
+            delivery_contents=continuations,
+            delivery_event_type=claimed.event_type,
+        )
+        for index in missing_indices:
+            await self._send_continuation(
+                claimed,
+                continuations[index],
+                index=index + 1,
+                retry_sync_recovery=True,
             )
-            if delivered is None:
-                missing.append((index, continuation))
-        for index, continuation in missing:
-            await self._send_continuation(claimed, continuation, index=index, retry_sync_recovery=True)
-        if missing:
+        if missing_indices:
             self.deps.logger.info(
                 "Recovered segmented Matrix response continuations",
                 delivery_id=claimed.delivery_id,
                 stage=claimed.stage.value,
-                continuation_count=len(missing),
+                continuation_count=len(missing_indices),
             )
 
     async def recover_deliveries(self) -> RecoveryOutcome:

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -15,7 +15,6 @@ import nio
 from nio.exceptions import SendRetryError
 
 from mindroom import constants, interactive
-from mindroom.config.models import LargeMessageStrategy  # noqa: TC001
 from mindroom.constants import DURABLE_FINAL_OUTCOME_KEY, DURABLE_FINAL_OUTCOME_VERSION, SKIP_MENTIONS_KEY
 from mindroom.dispatch_source import SILENT_SCHEDULE_SOURCE_KIND
 from mindroom.event_journal import (
@@ -144,18 +143,12 @@ def _result_with_segment_payloads(
 
 
 def _continuation_payloads(result: Mapping[str, object] | None) -> tuple[dict[str, Any], ...]:
-    """Read a frozen continuation list from an outbox result, if present."""
+    """Read the frozen continuation list from an outbox result, if present."""
     if result is None:
         return ()
-    raw_payloads = result.get(_SEGMENT_PAYLOADS_RESULT_KEY)
-    if not isinstance(raw_payloads, list):
-        return ()
-    payloads: list[dict[str, Any]] = []
-    for payload in raw_payloads:
-        if not isinstance(payload, dict):
-            return ()
-        payloads.append(dict(cast("dict[str, Any]", payload)))
-    return tuple(payloads)
+    raw_payloads = result.get(_SEGMENT_PAYLOADS_RESULT_KEY, [])
+    assert isinstance(raw_payloads, list), f"corrupt outbox result: {_SEGMENT_PAYLOADS_RESULT_KEY} is not a list"
+    return tuple(dict(cast("dict[str, Any]", payload)) for payload in raw_payloads)
 
 
 def _segment_transaction_id(base_transaction_id: str, index: int) -> str:
@@ -1957,7 +1950,6 @@ class DeliveryGateway:
             stage,
             content,
         )
-        strategy: LargeMessageStrategy = self.deps.runtime.config.defaults.large_message_strategy
         segmented = (
             segment_matrix_content(
                 wire_content,
@@ -1965,29 +1957,18 @@ class DeliveryGateway:
                 continuation_thread_id=continuation_thread_id,
                 continuation_reply_to_event_id=continuation_reply_to_event_id,
             )
-            if strategy == "split"
+            if self.deps.runtime.config.defaults.large_message_strategy == "split"
             else None
         )
         if segmented is not None:
-            continuation_payloads = tuple(
-                matrix_delivery_payload(
-                    self.deps.outbox.principal_id,
-                    turn_id,
-                    stage,
-                    continuation,
-                )
-                for continuation in segmented.continuations
-            )
+            # Segments already carry the durable identity copied from wire_content.
             self.deps.logger.info(
                 "Prepared lossless Matrix response segmentation",
                 delivery_id=turn_id,
                 stage=stage.value,
-                continuation_count=len(continuation_payloads),
+                continuation_count=len(segmented.continuations),
             )
-            return _PreparedWirePayload(
-                content=segmented.first,
-                continuation_payloads=continuation_payloads,
-            )
+            return _PreparedWirePayload(content=segmented.first, continuation_payloads=segmented.continuations)
         try:
             prepared = await prepare_large_message(
                 client,

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -7,7 +7,8 @@ import json
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from html import escape as html_escape
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, cast
+from uuid import NAMESPACE_URL, uuid5
 from weakref import WeakValueDictionary
 
 import nio
@@ -63,6 +64,7 @@ from mindroom.matrix.message_builder import build_message_content
 from mindroom.matrix.room_history_reads import (
     find_outbox_delivery_event_id_via_room_messages,
 )
+from mindroom.matrix.segmented_messages import segment_matrix_content
 from mindroom.matrix_delivery import (
     DeliveryStage,
     MatrixDeliveryWorker,
@@ -89,7 +91,7 @@ from mindroom.streaming import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Awaitable, Callable
+    from collections.abc import AsyncIterator, Awaitable, Callable, Mapping
 
     import structlog
 
@@ -116,6 +118,47 @@ _PLACEHOLDER_DELIVERY_FAILURE_REASONS = frozenset(
         "terminal_update_failed",
     },
 )
+_SEGMENT_PAYLOADS_RESULT_KEY = "io.mindroom.matrix_segment_payloads"
+
+
+@dataclass(frozen=True, slots=True)
+class _PreparedWirePayload:
+    """One frozen primary event plus any lossless continuation events."""
+
+    content: dict[str, Any]
+    continuation_payloads: tuple[dict[str, Any], ...] = ()
+
+
+def _result_with_segment_payloads(
+    result: dict[str, object] | None,
+    continuation_payloads: tuple[dict[str, Any], ...],
+) -> dict[str, object] | None:
+    """Store continuation payloads in local outbox state, never on Matrix."""
+    if not continuation_payloads:
+        return result
+    merged = dict(result or {})
+    merged[_SEGMENT_PAYLOADS_RESULT_KEY] = [dict(payload) for payload in continuation_payloads]
+    return merged
+
+
+def _continuation_payloads(result: Mapping[str, object] | None) -> tuple[dict[str, Any], ...]:
+    """Read a frozen continuation list from an outbox result, if present."""
+    if result is None:
+        return ()
+    raw_payloads = result.get(_SEGMENT_PAYLOADS_RESULT_KEY)
+    if not isinstance(raw_payloads, list):
+        return ()
+    payloads: list[dict[str, Any]] = []
+    for payload in raw_payloads:
+        if not isinstance(payload, dict):
+            return ()
+        payloads.append(dict(cast("dict[str, Any]", payload)))
+    return tuple(payloads)
+
+
+def _segment_transaction_id(base_transaction_id: str, index: int) -> str:
+    """Derive a stable Matrix transaction ID for one continuation event."""
+    return str(uuid5(NAMESPACE_URL, f"mindroom-matrix-segment:{base_transaction_id}:{index}"))
 
 
 def _is_placeholder_delivery_failure(failure_reason: str) -> bool:
@@ -742,6 +785,7 @@ class DeliveryGateway:
         claimed: MatrixDelivery,
         *,
         retry_sync_recovery: bool,
+        operation: str = "send_message",
     ) -> DeliveredMatrixEvent:
         """Send one claimed delivery exactly as it was frozen.
 
@@ -752,10 +796,12 @@ class DeliveryGateway:
         duplicate, and leave the durable result and the room disagreeing
         forever.
         """
+        client = self._client()
         outcome = await send_message_outcome(
-            self._client(),
+            client,
             claimed.room_id,
             dict(claimed.payload),
+            operation=operation,
             retry_sync_recovery=retry_sync_recovery,
             transaction_id=claimed.transaction_id,
             content_is_prepared=True,
@@ -766,6 +812,33 @@ class DeliveryGateway:
                 raise PermanentDeliveryError(detail)
             msg = f"Matrix refused delivery for turn {claimed.delivery_id!r} stage {claimed.stage.value!r}: {detail}"
             raise _DeliveryRefusedError(msg)
+
+        continuations = _continuation_payloads(claimed.result)
+        for index, continuation in enumerate(continuations, start=1):
+            continuation_outcome = await send_message_outcome(
+                client,
+                claimed.room_id,
+                continuation,
+                retry_sync_recovery=retry_sync_recovery,
+                transaction_id=_segment_transaction_id(claimed.transaction_id, index),
+                content_is_prepared=True,
+            )
+            if isinstance(continuation_outcome, MatrixDeliveryFailure):
+                detail = _matrix_delivery_failure_reason(continuation_outcome)
+                if continuation_outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
+                    raise PermanentDeliveryError(detail)
+                msg = (
+                    f"Matrix refused continuation {index} for turn {claimed.delivery_id!r} "
+                    f"stage {claimed.stage.value!r}: {detail}"
+                )
+                raise _DeliveryRefusedError(msg)
+        if continuations:
+            self.deps.logger.info(
+                "Sent segmented Matrix response",
+                delivery_id=claimed.delivery_id,
+                stage=claimed.stage.value,
+                continuation_count=len(continuations),
+            )
         return outcome
 
     async def _observe_matrix_event(
@@ -961,6 +1034,8 @@ class DeliveryGateway:
             content,
             turn_id=request.delivery_turn_id,
             stage=request.delivery_stage,
+            continuation_thread_id=request.target.resolved_thread_id,
+            continuation_reply_to_event_id=request.target.reply_to_event_id,
         )
         if isinstance(prepared, MatrixDeliveryFailure):
             if prepared.kind is not MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
@@ -968,7 +1043,11 @@ class DeliveryGateway:
             preparation_failure: MatrixDeliveryFailure | None = prepared
         else:
             preparation_failure = None
-            content = prepared
+            content = prepared.content
+        delivery_result = _result_with_segment_payloads(
+            request.delivery_result,
+            () if isinstance(prepared, MatrixDeliveryFailure) else prepared.continuation_payloads,
+        )
 
         try:
             handoff = None if request.defer_source_handoff else self.deps.turn_handoff
@@ -978,7 +1057,7 @@ class DeliveryGateway:
                 room_id=room_id,
                 thread_id=request.target.resolved_thread_id,
                 payload=content,
-                result=request.delivery_result,
+                result=delivery_result,
                 permanent_failure_reason=(
                     _matrix_delivery_failure_reason(preparation_failure) if preparation_failure is not None else None
                 ),
@@ -1091,23 +1170,12 @@ class DeliveryGateway:
             # attempt landed, visible while the durable row says otherwise if it did
             # not. The stored envelope already is what that helper would build.
             nonlocal delivered
-            outcome = await send_message_outcome(
-                client,
-                claimed.room_id,
-                dict(claimed.payload),
-                operation="edit_message",
+            delivered = await self._send_claimed(
+                claimed,
                 retry_sync_recovery=request.retry_sync_recovery,
-                transaction_id=claimed.transaction_id,
-                content_is_prepared=True,
+                operation="edit_message",
             )
-            if isinstance(outcome, MatrixDeliveryFailure):
-                detail = _matrix_delivery_failure_reason(outcome)
-                if outcome.kind is MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
-                    raise PermanentDeliveryError(detail)
-                msg = f"Matrix refused the final edit for turn {claimed.delivery_id!r}: {detail}"
-                raise _DeliveryRefusedError(msg)
-            delivered = outcome
-            return outcome.event_id
+            return delivered.event_id
 
         # What is stored is the finished wire event, not the text it was built
         # from. Recovery sends the row exactly as frozen and has no request to
@@ -1132,6 +1200,8 @@ class DeliveryGateway:
             envelope,
             turn_id=request.delivery_turn_id,
             stage=DeliveryStage.FINAL,
+            continuation_thread_id=request.target.resolved_thread_id,
+            continuation_reply_to_event_id=request.event_id,
         )
         if isinstance(prepared, MatrixDeliveryFailure):
             if prepared.kind is not MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE:
@@ -1139,7 +1209,11 @@ class DeliveryGateway:
             preparation_failure = prepared
         else:
             preparation_failure = None
-            envelope = prepared
+            envelope = prepared.content
+        delivery_result = _result_with_segment_payloads(
+            request.delivery_result,
+            () if isinstance(prepared, MatrixDeliveryFailure) else prepared.continuation_payloads,
+        )
 
         try:
             handoff = None if request.defer_source_handoff else self.deps.turn_handoff
@@ -1149,7 +1223,7 @@ class DeliveryGateway:
                 room_id=room_id,
                 thread_id=request.target.resolved_thread_id,
                 payload=envelope,
-                result=request.delivery_result,
+                result=delivery_result,
                 edits_event_id=request.event_id,
                 permanent_failure_reason=(
                     _matrix_delivery_failure_reason(preparation_failure) if preparation_failure is not None else None
@@ -1785,7 +1859,9 @@ class DeliveryGateway:
         *,
         turn_id: str,
         stage: DeliveryStage,
-    ) -> dict[str, Any] | MatrixDeliveryFailure:
+        continuation_thread_id: str | None = None,
+        continuation_reply_to_event_id: str | None = None,
+    ) -> _PreparedWirePayload | MatrixDeliveryFailure:
         """Prepare a payload for the wire, unless a frozen one already exists.
 
         Preparation can upload a sidecar, so it must not run for a turn whose
@@ -1802,7 +1878,7 @@ class DeliveryGateway:
         """
         existing = await self.deps.outbox.load_matrix_delivery(delivery_id=turn_id, stage=stage)
         if existing is not None and existing.attempted:
-            return content
+            return _PreparedWirePayload(content=content)
         client = self._client()
         encryption_outcome = await resolve_room_encryption_outcome(
             client,
@@ -1817,14 +1893,41 @@ class DeliveryGateway:
             stage,
             content,
         )
+        segmented = segment_matrix_content(
+            wire_content,
+            room_encrypted=encryption_outcome,
+            continuation_thread_id=continuation_thread_id,
+            continuation_reply_to_event_id=continuation_reply_to_event_id,
+        )
+        if segmented is not None:
+            continuation_payloads = tuple(
+                matrix_delivery_payload(
+                    self.deps.outbox.principal_id,
+                    turn_id,
+                    stage,
+                    continuation,
+                )
+                for continuation in segmented.continuations
+            )
+            self.deps.logger.info(
+                "Prepared lossless Matrix response segmentation",
+                delivery_id=turn_id,
+                stage=stage.value,
+                continuation_count=len(continuation_payloads),
+            )
+            return _PreparedWirePayload(
+                content=segmented.first,
+                continuation_payloads=continuation_payloads,
+            )
         try:
-            return await prepare_large_message(
+            prepared = await prepare_large_message(
                 client,
                 room_id,
                 wire_content,
                 room_encrypted=encryption_outcome,
                 prepare_for_encrypted_delivery=True,
             )
+            return _PreparedWirePayload(content=prepared)
         except MatrixEventTooLargeError as error:
             return MatrixDeliveryFailure(MatrixDeliveryFailureKind.PAYLOAD_TOO_LARGE, str(error))
 

--- a/src/mindroom/delivery_gateway.py
+++ b/src/mindroom/delivery_gateway.py
@@ -15,6 +15,7 @@ import nio
 from nio.exceptions import SendRetryError
 
 from mindroom import constants, interactive
+from mindroom.config.models import LargeMessageStrategy  # noqa: TC001
 from mindroom.constants import DURABLE_FINAL_OUTCOME_KEY, DURABLE_FINAL_OUTCOME_VERSION, SKIP_MENTIONS_KEY
 from mindroom.dispatch_source import SILENT_SCHEDULE_SOURCE_KIND
 from mindroom.event_journal import (
@@ -1893,11 +1894,16 @@ class DeliveryGateway:
             stage,
             content,
         )
-        segmented = segment_matrix_content(
-            wire_content,
-            room_encrypted=encryption_outcome,
-            continuation_thread_id=continuation_thread_id,
-            continuation_reply_to_event_id=continuation_reply_to_event_id,
+        strategy: LargeMessageStrategy = self.deps.runtime.config.defaults.large_message_strategy
+        segmented = (
+            segment_matrix_content(
+                wire_content,
+                room_encrypted=encryption_outcome,
+                continuation_thread_id=continuation_thread_id,
+                continuation_reply_to_event_id=continuation_reply_to_event_id,
+            )
+            if strategy == "split"
+            else None
         )
         if segmented is not None:
             continuation_payloads = tuple(

--- a/src/mindroom/matrix/large_messages.py
+++ b/src/mindroom/matrix/large_messages.py
@@ -208,7 +208,7 @@ def _add_sidecar_metadata(
     }
 
 
-def _calculate_event_size(content: dict[str, Any]) -> int:
+def calculate_event_size(content: dict[str, Any]) -> int:
     """Calculate the approximate size of a Matrix event.
 
     Args:
@@ -240,7 +240,7 @@ def _calculate_delivery_event_size(
     boundary payload fail identically on every replay.
     """
     if not room_encrypted:
-        return _calculate_event_size(content)
+        return calculate_event_size(content)
 
     plaintext = nio.Api.to_json(
         {
@@ -274,7 +274,7 @@ def _calculate_delivery_event_size(
     if isinstance(relation, dict):
         estimated_content["m.relates_to"] = relation
     estimated_content.update(encryption_visible_metadata(content))
-    return _calculate_event_size(estimated_content)
+    return calculate_event_size(estimated_content)
 
 
 def _delivery_event_size_calculator(
@@ -301,7 +301,7 @@ def _delivery_event_size_calculator(
     return calculate
 
 
-def _is_edit_message(content: dict[str, Any]) -> bool:
+def is_edit_message(content: dict[str, Any]) -> bool:
     """Check if this is an edit message."""
     return "m.new_content" in content or (
         "m.relates_to" in content and content.get("m.relates_to", {}).get("rel_type") == "m.replace"
@@ -330,13 +330,13 @@ def should_send_oversized_nonterminal_streaming_edit(
     edit_content: dict[str, Any],
 ) -> bool:
     """Return whether one oversized non-terminal streaming edit may be sent now."""
-    if not original_event_id or not _is_edit_message(edit_content):
+    if not original_event_id or not is_edit_message(edit_content):
         return True
 
     source_content = edit_content.get("m.new_content")
     if not isinstance(source_content, dict) or not _is_nonterminal_stream_content(source_content):
         return True
-    if _calculate_event_size(edit_content) <= _EDIT_MESSAGE_LIMIT:
+    if calculate_event_size(edit_content) <= _EDIT_MESSAGE_LIMIT:
         return True
 
     key = (room_id, original_event_id)
@@ -766,7 +766,7 @@ def sidecar_upload_is_usable(
 
 def content_fits_normal_event(content: dict[str, Any]) -> bool:
     """Return whether one content payload fits a normal Matrix event send."""
-    return _calculate_event_size(content) <= _NORMAL_MESSAGE_LIMIT
+    return calculate_event_size(content) <= _NORMAL_MESSAGE_LIMIT
 
 
 async def upload_json_sidecar(
@@ -805,7 +805,7 @@ def _build_text_fallback_content(
             ),
         }
         _copy_preview_metadata(source_content, preview_content)
-        if _calculate_event_size(preview_content) <= size_limit or preview_limit == 0:
+        if calculate_event_size(preview_content) <= size_limit or preview_limit == 0:
             return preview_content
         preview_limit = max(0, preview_limit // 2)
 
@@ -905,7 +905,7 @@ async def prepare_large_message(
 
     """
     content = _without_local_recovery_data(content)
-    is_edit = _is_edit_message(content)
+    is_edit = is_edit_message(content)
     size_limit = _EDIT_MESSAGE_LIMIT if is_edit else _NORMAL_MESSAGE_LIMIT
     if room_encrypted is None:
         room_encrypted = _room_is_encrypted(client, room_id)
@@ -915,7 +915,7 @@ async def prepare_large_message(
         room_id=room_id,
         room_encrypted=encrypted_delivery_safe,
     )
-    current_size = _calculate_event_size(content)
+    current_size = calculate_event_size(content)
     if current_size <= size_limit and calculate_delivery_event_size(content) <= _MATRIX_EVENT_HARD_LIMIT:
         return content
 

--- a/src/mindroom/matrix/room_history_reads.py
+++ b/src/mindroom/matrix/room_history_reads.py
@@ -10,6 +10,7 @@ here.
 
 from __future__ import annotations
 
+import json
 import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
@@ -57,7 +58,7 @@ from mindroom.matrix.visible_body import visible_body_from_event_source
 from mindroom.timing import elapsed_ms_since
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, Collection, Iterable, Mapping
+    from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
 
 logger = get_logger(__name__)
 
@@ -335,6 +336,129 @@ async def find_outbox_delivery_event_id_via_room_messages(
         msg = f"Matrix delivery has {len(delivered)} exact copies in {room_id}"
         raise RuntimeError(msg)
     return next(iter(delivered), None)
+
+
+def _canonical_content_key(content: Mapping[str, Any]) -> str:
+    """Return the canonical form exact-content matching groups payloads by."""
+    return json.dumps(dict(content), sort_keys=True, separators=(",", ":"))
+
+
+def _matched_delivery_copy_key(
+    event: object,
+    *,
+    room_id: str,
+    delivery_sender: str,
+    delivery_event_type: str,
+    expected: Mapping[str, int],
+) -> str | None:
+    """Return the expected key one scanned event is an exact copy of, if any."""
+    if not isinstance(event, nio.Event):
+        return None
+    event_source = event.source if isinstance(event.source, dict) else {}
+    _refuse_opaque_exact_delivery_candidate(
+        room_id=room_id,
+        event_source=event_source,
+        response_sender=delivery_sender,
+        exact_content_required=True,
+    )
+    if event_source.get("sender") != delivery_sender or event_source.get("type") != delivery_event_type:
+        return None
+    content = event_source.get("content")
+    if not isinstance(content, dict):
+        return None
+    key = _canonical_content_key(content)
+    return key if key in expected else None
+
+
+async def _count_delivery_copies_via_room_messages(
+    client: nio.AsyncClient,
+    room_id: str,
+    *,
+    delivery_sender: str,
+    expected: Mapping[str, int],
+    delivery_event_type: str,
+) -> dict[str, int]:
+    """Count exact-content copies per canonical key, stopping when all are found."""
+    found: dict[str, int] = {}
+    from_token: str | None = None
+    seen_pagination_tokens: set[str] = set()
+    pages_fetched = 0
+
+    while any(found.get(key, 0) < count for key, count in expected.items()):
+        response = await client.room_messages(
+            room_id,
+            start=from_token,
+            limit=100,
+            message_filter={"types": [delivery_event_type, "m.room.encrypted"]},
+            direction=nio.MessageDirection.back,
+        )
+        if not isinstance(response, nio.RoomMessagesResponse):
+            msg = f"delivery copy count room scan failed for {room_id}: {response}"
+            raise RuntimeError(msg)  # noqa: TRY004
+        pages_fetched += 1
+        for event in response.chunk:
+            key = _matched_delivery_copy_key(
+                event,
+                room_id=room_id,
+                delivery_sender=delivery_sender,
+                delivery_event_type=delivery_event_type,
+                expected=expected,
+            )
+            if key is not None:
+                found[key] = found.get(key, 0) + 1
+        if not response.end:
+            break
+        if response.end in seen_pagination_tokens:
+            msg = f"delivery copy count room scan repeated pagination token for {room_id}"
+            raise RuntimeError(msg)
+        if _finish_exact_delivery_scan_at_bound(
+            room_id=room_id,
+            pages_fetched=pages_fetched,
+            delivery_found=all(found.get(key, 0) >= count for key, count in expected.items()),
+        ):
+            break
+        seen_pagination_tokens.add(response.end)
+        from_token = response.end
+
+    return found
+
+
+async def missing_outbox_delivery_copy_indices_via_room_messages(
+    client: nio.AsyncClient,
+    room_id: str,
+    *,
+    delivery_sender: str,
+    delivery_contents: Sequence[Mapping[str, Any]],
+    delivery_event_type: str,
+) -> list[int]:
+    """Return which expected payloads the room does not hold enough copies of.
+
+    One frozen payload can legitimately appear several times -- segmented
+    responses repeat byte-identical continuation events -- so reconciliation
+    needs multiplicities, not existence. Each room copy satisfies exactly one
+    expected position, consumed in order; the result lists the indices left
+    unsatisfied. The scan stops as soon as every position is accounted for,
+    and fails closed at the page bound while an absence stays unproven.
+    """
+    expected: dict[str, int] = {}
+    for content in delivery_contents:
+        key = _canonical_content_key(content)
+        expected[key] = expected.get(key, 0) + 1
+    found = await _count_delivery_copies_via_room_messages(
+        client,
+        room_id,
+        delivery_sender=delivery_sender,
+        expected=expected,
+        delivery_event_type=delivery_event_type,
+    )
+    missing: list[int] = []
+    for index, content in enumerate(delivery_contents):
+        key = _canonical_content_key(content)
+        if found.get(key, 0) > 0:
+            found[key] -= 1
+        else:
+            missing.append(index)
+    return missing
 
 
 @dataclass(frozen=True)

--- a/src/mindroom/matrix/room_history_reads.py
+++ b/src/mindroom/matrix/room_history_reads.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import time
+from collections import Counter
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
@@ -377,14 +378,14 @@ async def _count_delivery_copies_via_room_messages(
     delivery_sender: str,
     expected: Mapping[str, int],
     delivery_event_type: str,
-) -> dict[str, int]:
+) -> Counter[str]:
     """Count exact-content copies per canonical key, stopping when all are found."""
-    found: dict[str, int] = {}
+    found: Counter[str] = Counter()
     from_token: str | None = None
     seen_pagination_tokens: set[str] = set()
     pages_fetched = 0
 
-    while any(found.get(key, 0) < count for key, count in expected.items()):
+    while any(found[key] < count for key, count in expected.items()):
         response = await client.room_messages(
             room_id,
             start=from_token,
@@ -405,18 +406,14 @@ async def _count_delivery_copies_via_room_messages(
                 expected=expected,
             )
             if key is not None:
-                found[key] = found.get(key, 0) + 1
+                found[key] += 1
         if not response.end:
             break
         if response.end in seen_pagination_tokens:
             msg = f"delivery copy count room scan repeated pagination token for {room_id}"
             raise RuntimeError(msg)
-        if _finish_exact_delivery_scan_at_bound(
-            room_id=room_id,
-            pages_fetched=pages_fetched,
-            delivery_found=all(found.get(key, 0) >= count for key, count in expected.items()),
-        ):
-            break
+        # Still inside the loop, so something is missing: the bound can only raise.
+        _finish_exact_delivery_scan_at_bound(room_id=room_id, pages_fetched=pages_fetched, delivery_found=False)
         seen_pagination_tokens.add(response.end)
         from_token = response.end
 
@@ -440,21 +437,17 @@ async def missing_outbox_delivery_copy_indices_via_room_messages(
     unsatisfied. The scan stops as soon as every position is accounted for,
     and fails closed at the page bound while an absence stays unproven.
     """
-    expected: dict[str, int] = {}
-    for content in delivery_contents:
-        key = _canonical_content_key(content)
-        expected[key] = expected.get(key, 0) + 1
+    keys = [_canonical_content_key(content) for content in delivery_contents]
     found = await _count_delivery_copies_via_room_messages(
         client,
         room_id,
         delivery_sender=delivery_sender,
-        expected=expected,
+        expected=Counter(keys),
         delivery_event_type=delivery_event_type,
     )
     missing: list[int] = []
-    for index, content in enumerate(delivery_contents):
-        key = _canonical_content_key(content)
-        if found.get(key, 0) > 0:
+    for index, key in enumerate(keys):
+        if found[key] > 0:
             found[key] -= 1
         else:
             missing.append(index)

--- a/src/mindroom/matrix/segmented_messages.py
+++ b/src/mindroom/matrix/segmented_messages.py
@@ -37,6 +37,18 @@ _SEGMENT_METADATA_KEYS = frozenset(
     },
 )
 _MENTION_PILL_PATTERN = re.compile(r'<a href="(?P<href>https://matrix\.to/#/[^"]+)">[^<]+</a>')
+_CODE_REGION_PATTERN = re.compile(r"(<code\b[^>]*>.*?</code>)", re.DOTALL)
+
+
+def _user_id_boundary_pattern(user_ids: list[str]) -> re.Pattern[str]:
+    """Match whole user IDs only, longest first, never inside a longer token.
+
+    A bare substring test both attributes a prefix-overlapping ID (``@a:s`` inside
+    ``@a:s2``) and matches inside URLs; the lookarounds restrict matches to
+    positions the mention pipeline could have produced.
+    """
+    alternation = "|".join(re.escape(user_id) for user_id in sorted(user_ids, key=lambda uid: -len(uid)))
+    return re.compile(r"(?<![\w@.:/=-])(?:" + alternation + r")(?![\w:/=-])")
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,32 +116,44 @@ def _mention_pills(source: Mapping[str, Any]) -> dict[str, str]:
 
 
 def _chunk_mentions(source: Mapping[str, Any], body: str) -> dict[str, Any] | None:
-    """Return the mention metadata for just the users one chunk names.
+    """Return the mention metadata for just the mentions one chunk carries.
 
     ``m.mentions`` must travel with the event whose body carries the mention;
     leaving every mentioned user on the first segment both misattributes the
-    mention and can notify a user whose name never visibly arrived.
+    mention and can notify a user whose name never visibly arrived. A room
+    mention follows the same rule for the ``@room`` text.
     """
     mentions = source.get("m.mentions")
     if not isinstance(mentions, Mapping):
         return None
+    chunk_mentions: dict[str, Any] = {}
     user_ids = mentions.get("user_ids")
-    if not isinstance(user_ids, list):
-        return None
-    present = [user_id for user_id in user_ids if isinstance(user_id, str) and user_id in body]
-    return {"user_ids": present} if present else None
+    if isinstance(user_ids, list):
+        candidates = [user_id for user_id in user_ids if isinstance(user_id, str)]
+        if candidates:
+            present = set(_user_id_boundary_pattern(candidates).findall(body))
+            if present:
+                chunk_mentions["user_ids"] = [user_id for user_id in candidates if user_id in present]
+    if mentions.get("room") is True and "@room" in body:
+        chunk_mentions["room"] = True
+    return chunk_mentions or None
 
 
 def _render_segment_html(source: Mapping[str, Any], body: str) -> str:
-    """Render one chunk, restoring mention pills its plain body cannot carry."""
+    """Render one chunk, restoring mention pills its plain body cannot carry.
+
+    Substitution is boundary-aware and skips code regions: a user ID appearing
+    as literal text (code span, URL path) is content, not a mention.
+    """
     formatted = markdown_to_html(body)
     pills = _mention_pills(source)
     if not pills:
         return formatted
-    # One pass, longest ID first: a user ID can prefix another, and a second
-    # pass would match inside the anchor an earlier replacement inserted.
-    pattern = re.compile("|".join(re.escape(user_id) for user_id in sorted(pills, key=lambda uid: -len(uid))))
-    return pattern.sub(lambda match: pills[match.group(0)], formatted)
+    pattern = _user_id_boundary_pattern(list(pills))
+    parts = _CODE_REGION_PATTERN.split(formatted)
+    return "".join(
+        part if part.startswith("<code") else pattern.sub(lambda match: pills[match.group(0)], part) for part in parts
+    )
 
 
 def _rich_text_content(
@@ -168,18 +192,19 @@ def _edit_content_chunk(
     source: Mapping[str, Any],
     body: str,
 ) -> dict[str, Any]:
-    """Build the first edit event with one complete rich-text chunk."""
+    """Build the first edit event with one complete rich-text chunk.
+
+    The outer envelope keeps the source edit's own ``m.mentions`` -- for an
+    edit that is the revision delta, and re-deriving it from one chunk could
+    re-notify recipients an earlier revision already mentioned. The resolved
+    per-chunk set lives under ``m.new_content``.
+    """
     replacement = _rich_text_content(source, body, include_mentions=True)
     candidate = {key: value for key, value in content.items() if key not in _SEGMENT_FIRST_DROPPED_KEYS}
     candidate["body"] = f"* {body}"
     candidate["format"] = "org.matrix.custom.html"
     candidate["formatted_body"] = _render_segment_html(source, candidate["body"])
     candidate["m.new_content"] = replacement
-    chunk_mentions = _chunk_mentions(source, body)
-    if chunk_mentions is None:
-        candidate.pop("m.mentions", None)
-    else:
-        candidate["m.mentions"] = chunk_mentions
     return candidate
 
 
@@ -300,7 +325,7 @@ def _unclosed_fence_start(text: str, start: int, end: int) -> int | None:
     while pos < end:
         line_end = text.find("\n", pos, end)
         line_end = end if line_end == -1 else line_end
-        match = re.match(r"[ \t]*((?:>[ \t]?)*)(`{3,}|~{3,})(.*)", text[pos:line_end])
+        match = re.match(r"[ \t]*((?:>[ \t]{0,3})*)(`{3,}|~{3,})(.*)", text[pos:line_end])
         if match:
             quote_depth = match.group(1).count(">")
             marker = match.group(2)

--- a/src/mindroom/matrix/segmented_messages.py
+++ b/src/mindroom/matrix/segmented_messages.py
@@ -9,6 +9,7 @@ streaming placeholder; subsequent events are thread replies.
 from __future__ import annotations
 
 import json
+import re
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -35,6 +36,8 @@ _SEGMENT_METADATA_KEYS = frozenset(
         "m.mentions",
     },
 )
+_MENTION_PILL_PATTERN = re.compile(r'<a href="(?P<href>https://matrix\.to/#/[^"]+)">[^<]+</a>')
+_FENCE_MARKER_PATTERN = re.compile(r"^[ \t]*(`{3,}|~{3,})", re.MULTILINE)
 
 
 @dataclass(frozen=True, slots=True)
@@ -83,6 +86,32 @@ def _first_segment_metadata(source: Mapping[str, Any]) -> dict[str, Any]:
     }
 
 
+def _mention_pills(source: Mapping[str, Any]) -> dict[str, str]:
+    """Map each mentioned user ID to its pill anchor from the rendered source.
+
+    The plain ``body`` carries only the bare user ID where a mention goes; the
+    pill link exists solely in ``formatted_body``. Re-rendering one chunk from
+    its body would silently drop the link, so the anchor is copied across.
+    """
+    formatted = source.get("formatted_body")
+    if not isinstance(formatted, str):
+        return {}
+    pills: dict[str, str] = {}
+    for match in _MENTION_PILL_PATTERN.finditer(formatted):
+        target = match.group("href").removeprefix("https://matrix.to/#/")
+        if target.startswith("@"):
+            pills[target] = match.group(0)
+    return pills
+
+
+def _render_segment_html(source: Mapping[str, Any], body: str) -> str:
+    """Render one chunk, restoring mention pills its plain body cannot carry."""
+    formatted = markdown_to_html(body)
+    for user_id, pill in sorted(_mention_pills(source).items(), key=lambda item: -len(item[0])):
+        formatted = formatted.replace(user_id, pill)
+    return formatted
+
+
 def _rich_text_content(
     source: Mapping[str, Any],
     body: str,
@@ -101,7 +130,7 @@ def _rich_text_content(
         candidate["msgtype"] = source.get("msgtype", "m.text")
     candidate["body"] = body
     candidate["format"] = "org.matrix.custom.html"
-    candidate["formatted_body"] = markdown_to_html(body)
+    candidate["formatted_body"] = _render_segment_html(source, body)
     if include_relation:
         relation = source.get("m.relates_to")
         if isinstance(relation, Mapping):
@@ -119,7 +148,7 @@ def _edit_content_chunk(
     candidate = {key: value for key, value in content.items() if key not in _SEGMENT_FIRST_DROPPED_KEYS}
     candidate["body"] = f"* {body}"
     candidate["format"] = "org.matrix.custom.html"
-    candidate["formatted_body"] = markdown_to_html(candidate["body"])
+    candidate["formatted_body"] = _render_segment_html(source, candidate["body"])
     candidate["m.new_content"] = replacement
     return candidate
 
@@ -135,27 +164,25 @@ def _thread_relation(thread_id: str | None, reply_to_event_id: str | None) -> di
     }
 
 
-def _edit_continuation_content(
+def _continuation_content(
     source: Mapping[str, Any],
     body: str,
     *,
     thread_id: str | None,
     reply_to_event_id: str | None,
 ) -> dict[str, Any]:
-    """Build a normal rich-text thread reply for a continuation of an edit."""
+    """Build a continuation that recovery cannot mistake for a fresh answer.
+
+    Copying the source relation verbatim would repeat a genuine reply to the
+    turn's source event, and replay recovery counts every such event as a
+    visible response of the turn -- several for one segmented answer, which it
+    refuses. Continuations therefore always take the thread-fallback form (or
+    no relation outside threads), which recovery explicitly excludes.
+    """
     candidate = _rich_text_content(source, body, include_mentions=False)
     relation = _thread_relation(thread_id, reply_to_event_id)
     if relation is not None:
         candidate["m.relates_to"] = relation
-    return candidate
-
-
-def _normal_continuation_content(source: Mapping[str, Any], body: str) -> dict[str, Any]:
-    """Build a continuation preserving the original message's thread relation."""
-    candidate = _rich_text_content(source, body, include_mentions=False)
-    relation = source.get("m.relates_to")
-    if isinstance(relation, Mapping):
-        candidate["m.relates_to"] = dict(relation)
     return candidate
 
 
@@ -188,14 +215,6 @@ def _segment_builders(
         def first_builder(chunk: str) -> dict[str, Any]:
             return _edit_content_chunk(content, source, chunk)
 
-        def continuation_builder(chunk: str) -> dict[str, Any]:
-            return _edit_continuation_content(
-                source,
-                chunk,
-                thread_id=continuation_thread_id,
-                reply_to_event_id=continuation_reply_to_event_id,
-            )
-
     else:
 
         def first_builder(chunk: str) -> dict[str, Any]:
@@ -206,8 +225,13 @@ def _segment_builders(
                 include_relation=True,
             )
 
-        def continuation_builder(chunk: str) -> dict[str, Any]:
-            return _normal_continuation_content(source, chunk)
+    def continuation_builder(chunk: str) -> dict[str, Any]:
+        return _continuation_content(
+            source,
+            chunk,
+            thread_id=continuation_thread_id,
+            reply_to_event_id=continuation_reply_to_event_id,
+        )
 
     def size_builder(chunk: str) -> int:
         return max(
@@ -228,6 +252,20 @@ def _preferred_boundary(text: str, start: int, end: int) -> int:
     if line >= minimum and line + 1 <= end:
         return line + 1
     return end
+
+
+def _unclosed_fence_start(text: str, start: int, end: int) -> int | None:
+    """Return where an unclosed fenced code block opens inside text[start:end].
+
+    Segments are rendered as standalone Markdown, so a cut inside a fence
+    renders the remainder as plain text in one segment and a dangling opener
+    in the other. Chunks always begin fence-balanced, so a single toggle scan
+    finds the offending opener.
+    """
+    opener_start: int | None = None
+    for match in _FENCE_MARKER_PATTERN.finditer(text, start, end):
+        opener_start = None if opener_start is not None else match.start()
+    return opener_start
 
 
 def _split_body(
@@ -260,6 +298,13 @@ def _split_body(
         if best == offset:
             return None
         end = _preferred_boundary(text, offset, best)
+        fence_start = _unclosed_fence_start(text, offset, end)
+        if fence_start is not None:
+            if fence_start == offset:
+                # One fence spans the whole remaining budget; no cut can keep
+                # every segment self-contained, so the sidecar keeps it intact.
+                return None
+            end = fence_start
         chunks.append(text[offset:end])
         offset = end
     return chunks

--- a/src/mindroom/matrix/segmented_messages.py
+++ b/src/mindroom/matrix/segmented_messages.py
@@ -265,22 +265,29 @@ def _unclosed_fence_start(text: str, start: int, end: int) -> int | None:
     in the other. Chunks always begin fence-balanced, so a single scan finds
     the offending opener. Per CommonMark a fence closes only on the same
     marker character, at least the opening length, and nothing but trailing
-    whitespace.
+    whitespace, and a fence opened inside a block quote closes only at the
+    same quote depth.
     """
-    opener: tuple[str, int, int] | None = None
+    opener: tuple[int, str, int, int] | None = None
     pos = start
     while pos < end:
         line_end = text.find("\n", pos, end)
         line_end = end if line_end == -1 else line_end
-        match = re.match(r"[ \t]*(`{3,}|~{3,})(.*)", text[pos:line_end])
+        match = re.match(r"[ \t]*((?:>[ \t]?)*)(`{3,}|~{3,})(.*)", text[pos:line_end])
         if match:
-            marker = match.group(1)
+            quote_depth = match.group(1).count(">")
+            marker = match.group(2)
             if opener is None:
-                opener = (marker[0], len(marker), pos)
-            elif marker[0] == opener[0] and len(marker) >= opener[1] and not match.group(2).strip():
+                opener = (quote_depth, marker[0], len(marker), pos)
+            elif (
+                quote_depth == opener[0]
+                and marker[0] == opener[1]
+                and len(marker) >= opener[2]
+                and not match.group(3).strip()
+            ):
                 opener = None
         pos = line_end + 1
-    return opener[2] if opener is not None else None
+    return opener[3] if opener is not None else None
 
 
 def _split_body(

--- a/src/mindroom/matrix/segmented_messages.py
+++ b/src/mindroom/matrix/segmented_messages.py
@@ -1,0 +1,314 @@
+"""Split oversized text responses into complete Matrix message events.
+
+Matrix has a hard per-event size limit.  A long response should therefore be
+represented by several ordinary rich-text events instead of one truncated
+preview plus a private sidecar.  The first event can still be an edit of the
+streaming placeholder; subsequent events are thread replies.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from mindroom.matrix.message_builder import markdown_to_html
+
+_SEGMENT_TARGET_PLAINTEXT_BYTES = 46_000
+_SEGMENT_TARGET_EDIT_BYTES = 22_000
+_SEGMENT_TARGET_ENCRYPTED_PLAINTEXT_BYTES = 30_000
+_SEGMENT_TARGET_ENCRYPTED_EDIT_BYTES = 16_000
+_SEGMENT_FIRST_DROPPED_KEYS = frozenset(
+    {
+        # These fields are useful for rebuilding model context, but are not
+        # part of the visible answer. A long tool trace can otherwise make an
+        # otherwise segmentable response fall back to large_messages.py.
+        "io.mindroom.tool_trace",
+        "io.mindroom.visible_body",
+    },
+)
+_SEGMENT_METADATA_KEYS = frozenset(
+    {
+        "io.mindroom.tool_trace",
+        "io.mindroom.visible_body",
+        "m.mentions",
+    },
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentedMatrixContent:
+    """The first event payload and the continuation event payloads."""
+
+    first: dict[str, Any]
+    continuations: tuple[dict[str, Any], ...]
+
+
+def _estimated_event_size(content: Mapping[str, Any]) -> int:
+    """Estimate Matrix event bytes with the same conservative overhead as MindRoom."""
+    canonical = json.dumps(dict(content), sort_keys=True, separators=(",", ":"))
+    return len(canonical.encode("utf-8")) + 2000
+
+
+def _is_edit(content: Mapping[str, Any]) -> bool:
+    relation = content.get("m.relates_to")
+    return "m.new_content" in content or (isinstance(relation, Mapping) and relation.get("rel_type") == "m.replace")
+
+
+def _source_content(content: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    if _is_edit(content):
+        replacement = content.get("m.new_content")
+        return replacement if isinstance(replacement, Mapping) else None
+    return content
+
+
+def _continuation_metadata(source: Mapping[str, Any]) -> dict[str, Any]:
+    """Copy small semantic metadata without repeating bulky stream payloads."""
+    return {
+        key: value
+        for key, value in source.items()
+        if key not in {"body", "format", "formatted_body", "m.new_content", "m.relates_to"}
+        and key not in _SEGMENT_METADATA_KEYS
+    }
+
+
+def _first_segment_metadata(source: Mapping[str, Any]) -> dict[str, Any]:
+    """Copy visible-event metadata without internal streaming baggage."""
+    return {
+        key: value
+        for key, value in source.items()
+        if key not in {"body", "format", "formatted_body", "m.new_content", "m.relates_to"}
+        and key not in _SEGMENT_FIRST_DROPPED_KEYS
+    }
+
+
+def _rich_text_content(
+    source: Mapping[str, Any],
+    body: str,
+    *,
+    include_mentions: bool,
+    include_relation: bool = False,
+) -> dict[str, Any]:
+    """Build one normal rich-text content payload from one body chunk."""
+    if include_mentions:
+        # Keep mentions and other user-visible delivery metadata, but do not
+        # let internal tool-trace data consume the event budget needed for
+        # Markdown rendering.
+        candidate = _first_segment_metadata(source)
+    else:
+        candidate = _continuation_metadata(source)
+        candidate["msgtype"] = source.get("msgtype", "m.text")
+    candidate["body"] = body
+    candidate["format"] = "org.matrix.custom.html"
+    candidate["formatted_body"] = markdown_to_html(body)
+    if include_relation:
+        relation = source.get("m.relates_to")
+        if isinstance(relation, Mapping):
+            candidate["m.relates_to"] = dict(relation)
+    return candidate
+
+
+def _edit_content_chunk(
+    content: Mapping[str, Any],
+    source: Mapping[str, Any],
+    body: str,
+) -> dict[str, Any]:
+    """Build the first edit event with one complete rich-text chunk."""
+    replacement = _rich_text_content(source, body, include_mentions=True)
+    candidate = {key: value for key, value in content.items() if key not in _SEGMENT_FIRST_DROPPED_KEYS}
+    candidate["body"] = f"* {body}"
+    candidate["format"] = "org.matrix.custom.html"
+    candidate["formatted_body"] = markdown_to_html(candidate["body"])
+    candidate["m.new_content"] = replacement
+    return candidate
+
+
+def _thread_relation(thread_id: str | None, reply_to_event_id: str | None) -> dict[str, Any] | None:
+    if not thread_id:
+        return None
+    return {
+        "rel_type": "m.thread",
+        "event_id": thread_id,
+        "is_falling_back": True,
+        "m.in_reply_to": {"event_id": reply_to_event_id or thread_id},
+    }
+
+
+def _edit_continuation_content(
+    source: Mapping[str, Any],
+    body: str,
+    *,
+    thread_id: str | None,
+    reply_to_event_id: str | None,
+) -> dict[str, Any]:
+    """Build a normal rich-text thread reply for a continuation of an edit."""
+    candidate = _rich_text_content(source, body, include_mentions=False)
+    relation = _thread_relation(thread_id, reply_to_event_id)
+    if relation is not None:
+        candidate["m.relates_to"] = relation
+    return candidate
+
+
+def _normal_continuation_content(source: Mapping[str, Any], body: str) -> dict[str, Any]:
+    """Build a continuation preserving the original message's thread relation."""
+    candidate = _rich_text_content(source, body, include_mentions=False)
+    relation = source.get("m.relates_to")
+    if isinstance(relation, Mapping):
+        candidate["m.relates_to"] = dict(relation)
+    return candidate
+
+
+def _segment_target_bytes(*, room_encrypted: bool, is_edit: bool) -> int:
+    """Return a conservative per-event budget for one response segment."""
+    budgets = {
+        (False, False): _SEGMENT_TARGET_PLAINTEXT_BYTES,
+        (False, True): _SEGMENT_TARGET_EDIT_BYTES,
+        (True, False): _SEGMENT_TARGET_ENCRYPTED_PLAINTEXT_BYTES,
+        (True, True): _SEGMENT_TARGET_ENCRYPTED_EDIT_BYTES,
+    }
+    return budgets[room_encrypted, is_edit]
+
+
+def _segment_builders(
+    content: Mapping[str, Any],
+    source: Mapping[str, Any],
+    *,
+    is_edit: bool,
+    continuation_thread_id: str | None,
+    continuation_reply_to_event_id: str | None,
+) -> tuple[
+    Callable[[str], dict[str, Any]],
+    Callable[[str], dict[str, Any]],
+    Callable[[str], int],
+]:
+    """Build first, continuation, and worst-case sizing functions."""
+    if is_edit:
+
+        def first_builder(chunk: str) -> dict[str, Any]:
+            return _edit_content_chunk(content, source, chunk)
+
+        def continuation_builder(chunk: str) -> dict[str, Any]:
+            return _edit_continuation_content(
+                source,
+                chunk,
+                thread_id=continuation_thread_id,
+                reply_to_event_id=continuation_reply_to_event_id,
+            )
+
+    else:
+
+        def first_builder(chunk: str) -> dict[str, Any]:
+            return _rich_text_content(
+                source,
+                chunk,
+                include_mentions=True,
+                include_relation=True,
+            )
+
+        def continuation_builder(chunk: str) -> dict[str, Any]:
+            return _normal_continuation_content(source, chunk)
+
+    def size_builder(chunk: str) -> int:
+        return max(
+            _estimated_event_size(first_builder(chunk)),
+            _estimated_event_size(continuation_builder(chunk)),
+        )
+
+    return first_builder, continuation_builder, size_builder
+
+
+def _preferred_boundary(text: str, start: int, end: int) -> int:
+    """Prefer a paragraph or line boundary without making chunks too small."""
+    minimum = start + max(1, (end - start) // 3)
+    paragraph = text.rfind("\n\n", start + 1, end)
+    if paragraph >= minimum and paragraph + 2 <= end:
+        return paragraph + 2
+    line = text.rfind("\n", start + 1, end)
+    if line >= minimum and line + 1 <= end:
+        return line + 1
+    return end
+
+
+def _split_body(
+    text: str,
+    builder: Callable[[str], dict[str, Any]],
+    *,
+    target_bytes: int,
+    size_builder: Callable[[str], int] | None = None,
+) -> list[str] | None:
+    """Split text at fitting Unicode boundaries while retaining every character."""
+    fits = size_builder or (lambda chunk: _estimated_event_size(builder(chunk)))
+    if not text:
+        return [text]
+    if fits(text) <= target_bytes:
+        return [text]
+
+    chunks: list[str] = []
+    offset = 0
+    while offset < len(text):
+        lower = offset + 1
+        upper = len(text)
+        best = offset
+        while lower <= upper:
+            candidate_end = (lower + upper) // 2
+            if fits(text[offset:candidate_end]) <= target_bytes:
+                best = candidate_end
+                lower = candidate_end + 1
+            else:
+                upper = candidate_end - 1
+        if best == offset:
+            return None
+        end = _preferred_boundary(text, offset, best)
+        chunks.append(text[offset:end])
+        offset = end
+    return chunks
+
+
+def segment_matrix_content(
+    content: Mapping[str, Any],
+    *,
+    room_encrypted: bool,
+    continuation_thread_id: str | None = None,
+    continuation_reply_to_event_id: str | None = None,
+) -> SegmentedMatrixContent | None:
+    """Return lossless rich-text payloads when one event is too large.
+
+    The thresholds intentionally stay below MindRoom's sidecar thresholds so
+    every returned event passes through ``large_messages`` unchanged. Internal
+    streaming metadata that is not needed by the visible answer is omitted
+    from the first event before sizing, so metadata alone cannot force a
+    Markdown response into a sidecar. A ``None`` result means the payload is
+    not a plain text response or its remaining fixed metadata alone is too
+    large; the caller can use the normal sidecar fallback in those cases.
+    """
+    source = _source_content(content)
+    if source is None or not isinstance(source.get("body"), str):
+        return None
+
+    is_edit = _is_edit(content)
+    target_bytes = _segment_target_bytes(room_encrypted=room_encrypted, is_edit=is_edit)
+    if _estimated_event_size(content) <= target_bytes:
+        return None
+
+    body = source["body"]
+    first_builder, continuation_builder, size_builder = _segment_builders(
+        content,
+        source,
+        is_edit=is_edit,
+        continuation_thread_id=continuation_thread_id,
+        continuation_reply_to_event_id=continuation_reply_to_event_id,
+    )
+
+    chunks = _split_body(body, first_builder, target_bytes=target_bytes, size_builder=size_builder)
+    if chunks is None:
+        return None
+
+    first = first_builder(chunks[0])
+    continuations = tuple(continuation_builder(chunk) for chunk in chunks[1:])
+    if any(_estimated_event_size(candidate) > target_bytes for candidate in (first, *continuations)):
+        return None
+    return SegmentedMatrixContent(first=first, continuations=continuations)
+
+
+__all__ = ["SegmentedMatrixContent", "segment_matrix_content"]

--- a/src/mindroom/matrix/segmented_messages.py
+++ b/src/mindroom/matrix/segmented_messages.py
@@ -103,6 +103,23 @@ def _mention_pills(source: Mapping[str, Any]) -> dict[str, str]:
     return pills
 
 
+def _chunk_mentions(source: Mapping[str, Any], body: str) -> dict[str, Any] | None:
+    """Return the mention metadata for just the users one chunk names.
+
+    ``m.mentions`` must travel with the event whose body carries the mention;
+    leaving every mentioned user on the first segment both misattributes the
+    mention and can notify a user whose name never visibly arrived.
+    """
+    mentions = source.get("m.mentions")
+    if not isinstance(mentions, Mapping):
+        return None
+    user_ids = mentions.get("user_ids")
+    if not isinstance(user_ids, list):
+        return None
+    present = [user_id for user_id in user_ids if isinstance(user_id, str) and user_id in body]
+    return {"user_ids": present} if present else None
+
+
 def _render_segment_html(source: Mapping[str, Any], body: str) -> str:
     """Render one chunk, restoring mention pills its plain body cannot carry."""
     formatted = markdown_to_html(body)
@@ -134,6 +151,11 @@ def _rich_text_content(
     candidate["body"] = body
     candidate["format"] = "org.matrix.custom.html"
     candidate["formatted_body"] = _render_segment_html(source, body)
+    chunk_mentions = _chunk_mentions(source, body)
+    if chunk_mentions is None:
+        candidate.pop("m.mentions", None)
+    else:
+        candidate["m.mentions"] = chunk_mentions
     if include_relation:
         relation = source.get("m.relates_to")
         if isinstance(relation, Mapping):
@@ -153,6 +175,11 @@ def _edit_content_chunk(
     candidate["format"] = "org.matrix.custom.html"
     candidate["formatted_body"] = _render_segment_html(source, candidate["body"])
     candidate["m.new_content"] = replacement
+    chunk_mentions = _chunk_mentions(source, body)
+    if chunk_mentions is None:
+        candidate.pop("m.mentions", None)
+    else:
+        candidate["m.mentions"] = chunk_mentions
     return candidate
 
 

--- a/src/mindroom/matrix/segmented_messages.py
+++ b/src/mindroom/matrix/segmented_messages.py
@@ -37,7 +37,6 @@ _SEGMENT_METADATA_KEYS = frozenset(
     },
 )
 _MENTION_PILL_PATTERN = re.compile(r'<a href="(?P<href>https://matrix\.to/#/[^"]+)">[^<]+</a>')
-_FENCE_MARKER_PATTERN = re.compile(r"^[ \t]*(`{3,}|~{3,})", re.MULTILINE)
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,9 +106,13 @@ def _mention_pills(source: Mapping[str, Any]) -> dict[str, str]:
 def _render_segment_html(source: Mapping[str, Any], body: str) -> str:
     """Render one chunk, restoring mention pills its plain body cannot carry."""
     formatted = markdown_to_html(body)
-    for user_id, pill in sorted(_mention_pills(source).items(), key=lambda item: -len(item[0])):
-        formatted = formatted.replace(user_id, pill)
-    return formatted
+    pills = _mention_pills(source)
+    if not pills:
+        return formatted
+    # One pass, longest ID first: a user ID can prefix another, and a second
+    # pass would match inside the anchor an earlier replacement inserted.
+    pattern = re.compile("|".join(re.escape(user_id) for user_id in sorted(pills, key=lambda uid: -len(uid))))
+    return pattern.sub(lambda match: pills[match.group(0)], formatted)
 
 
 def _rich_text_content(
@@ -259,13 +262,25 @@ def _unclosed_fence_start(text: str, start: int, end: int) -> int | None:
 
     Segments are rendered as standalone Markdown, so a cut inside a fence
     renders the remainder as plain text in one segment and a dangling opener
-    in the other. Chunks always begin fence-balanced, so a single toggle scan
-    finds the offending opener.
+    in the other. Chunks always begin fence-balanced, so a single scan finds
+    the offending opener. Per CommonMark a fence closes only on the same
+    marker character, at least the opening length, and nothing but trailing
+    whitespace.
     """
-    opener_start: int | None = None
-    for match in _FENCE_MARKER_PATTERN.finditer(text, start, end):
-        opener_start = None if opener_start is not None else match.start()
-    return opener_start
+    opener: tuple[str, int, int] | None = None
+    pos = start
+    while pos < end:
+        line_end = text.find("\n", pos, end)
+        line_end = end if line_end == -1 else line_end
+        match = re.match(r"[ \t]*(`{3,}|~{3,})(.*)", text[pos:line_end])
+        if match:
+            marker = match.group(1)
+            if opener is None:
+                opener = (marker[0], len(marker), pos)
+            elif marker[0] == opener[0] and len(marker) >= opener[1] and not match.group(2).strip():
+                opener = None
+        pos = line_end + 1
+    return opener[2] if opener is not None else None
 
 
 def _split_body(

--- a/src/mindroom/matrix/segmented_messages.py
+++ b/src/mindroom/matrix/segmented_messages.py
@@ -8,36 +8,39 @@ streaming placeholder; subsequent events are thread replies.
 
 from __future__ import annotations
 
-import json
 import re
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from mindroom.matrix.large_messages import calculate_event_size, is_edit_message
 from mindroom.matrix.message_builder import markdown_to_html
 
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+# Budgets stay below the ``large_messages`` sidecar thresholds so every segment
+# is sent as built. Encrypted budgets leave room for Megolm base64 expansion.
 _SEGMENT_TARGET_PLAINTEXT_BYTES = 46_000
 _SEGMENT_TARGET_EDIT_BYTES = 22_000
 _SEGMENT_TARGET_ENCRYPTED_PLAINTEXT_BYTES = 30_000
 _SEGMENT_TARGET_ENCRYPTED_EDIT_BYTES = 16_000
-_SEGMENT_FIRST_DROPPED_KEYS = frozenset(
-    {
-        # These fields are useful for rebuilding model context, but are not
-        # part of the visible answer. A long tool trace can otherwise make an
-        # otherwise segmentable response fall back to large_messages.py.
-        "io.mindroom.tool_trace",
-        "io.mindroom.visible_body",
-    },
-)
-_SEGMENT_METADATA_KEYS = frozenset(
-    {
-        "io.mindroom.tool_trace",
-        "io.mindroom.visible_body",
-        "m.mentions",
-    },
-)
+_SEGMENT_SHRINK_MARGIN = 0.9
+# Useful for rebuilding model context, but not part of the visible answer. A
+# long tool trace would otherwise push a segmentable response into a sidecar.
+_INTERNAL_STREAM_KEYS = frozenset({"io.mindroom.tool_trace", "io.mindroom.visible_body"})
+# Rebuilt per segment from the chunk it carries, or dropped as internal.
+_SEGMENT_DROPPED_KEYS = _INTERNAL_STREAM_KEYS | {
+    "body",
+    "format",
+    "formatted_body",
+    "m.new_content",
+    "m.relates_to",
+    "m.mentions",
+}
 _MENTION_PILL_PATTERN = re.compile(r'<a href="(?P<href>https://matrix\.to/#/[^"]+)">[^<]+</a>')
 _CODE_REGION_PATTERN = re.compile(r"(<code\b[^>]*>.*?</code>)", re.DOTALL)
+_FENCE_LINE_PATTERN = re.compile(r"[ \t]*((?:>[ \t]{0,3})*)(`{3,}|~{3,})(.*)")
 
 
 def _user_id_boundary_pattern(user_ids: list[str]) -> re.Pattern[str]:
@@ -59,42 +62,11 @@ class SegmentedMatrixContent:
     continuations: tuple[dict[str, Any], ...]
 
 
-def _estimated_event_size(content: Mapping[str, Any]) -> int:
-    """Estimate Matrix event bytes with the same conservative overhead as MindRoom."""
-    canonical = json.dumps(dict(content), sort_keys=True, separators=(",", ":"))
-    return len(canonical.encode("utf-8")) + 2000
-
-
-def _is_edit(content: Mapping[str, Any]) -> bool:
-    relation = content.get("m.relates_to")
-    return "m.new_content" in content or (isinstance(relation, Mapping) and relation.get("rel_type") == "m.replace")
-
-
-def _source_content(content: Mapping[str, Any]) -> Mapping[str, Any] | None:
-    if _is_edit(content):
+def _source_content(content: dict[str, Any]) -> dict[str, Any] | None:
+    if is_edit_message(content):
         replacement = content.get("m.new_content")
-        return replacement if isinstance(replacement, Mapping) else None
+        return replacement if isinstance(replacement, dict) else None
     return content
-
-
-def _continuation_metadata(source: Mapping[str, Any]) -> dict[str, Any]:
-    """Copy small semantic metadata without repeating bulky stream payloads."""
-    return {
-        key: value
-        for key, value in source.items()
-        if key not in {"body", "format", "formatted_body", "m.new_content", "m.relates_to"}
-        and key not in _SEGMENT_METADATA_KEYS
-    }
-
-
-def _first_segment_metadata(source: Mapping[str, Any]) -> dict[str, Any]:
-    """Copy visible-event metadata without internal streaming baggage."""
-    return {
-        key: value
-        for key, value in source.items()
-        if key not in {"body", "format", "formatted_body", "m.new_content", "m.relates_to"}
-        and key not in _SEGMENT_FIRST_DROPPED_KEYS
-    }
 
 
 def _mention_pills(source: Mapping[str, Any]) -> dict[str, str]:
@@ -160,38 +132,23 @@ def _rich_text_content(
     source: Mapping[str, Any],
     body: str,
     *,
-    include_mentions: bool,
-    include_relation: bool = False,
+    relation: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build one normal rich-text content payload from one body chunk."""
-    if include_mentions:
-        # Keep mentions and other user-visible delivery metadata, but do not
-        # let internal tool-trace data consume the event budget needed for
-        # Markdown rendering.
-        candidate = _first_segment_metadata(source)
-    else:
-        candidate = _continuation_metadata(source)
-        candidate["msgtype"] = source.get("msgtype", "m.text")
-    candidate["body"] = body
-    candidate["format"] = "org.matrix.custom.html"
-    candidate["formatted_body"] = _render_segment_html(source, body)
-    chunk_mentions = _chunk_mentions(source, body)
-    if chunk_mentions is None:
-        candidate.pop("m.mentions", None)
-    else:
-        candidate["m.mentions"] = chunk_mentions
-    if include_relation:
-        relation = source.get("m.relates_to")
-        if isinstance(relation, Mapping):
-            candidate["m.relates_to"] = dict(relation)
-    return candidate
+    content = {key: value for key, value in source.items() if key not in _SEGMENT_DROPPED_KEYS}
+    content.setdefault("msgtype", "m.text")
+    content["body"] = body
+    content["format"] = "org.matrix.custom.html"
+    content["formatted_body"] = _render_segment_html(source, body)
+    mentions = _chunk_mentions(source, body)
+    if mentions is not None:
+        content["m.mentions"] = mentions
+    if relation is not None:
+        content["m.relates_to"] = dict(relation)
+    return content
 
 
-def _edit_content_chunk(
-    content: Mapping[str, Any],
-    source: Mapping[str, Any],
-    body: str,
-) -> dict[str, Any]:
+def _edit_content_chunk(content: dict[str, Any], source: dict[str, Any], body: str) -> dict[str, Any]:
     """Build the first edit event with one complete rich-text chunk.
 
     The outer envelope keeps the source edit's own ``m.mentions`` -- for an
@@ -199,28 +156,17 @@ def _edit_content_chunk(
     re-notify recipients an earlier revision already mentioned. The resolved
     per-chunk set lives under ``m.new_content``.
     """
-    replacement = _rich_text_content(source, body, include_mentions=True)
-    candidate = {key: value for key, value in content.items() if key not in _SEGMENT_FIRST_DROPPED_KEYS}
-    candidate["body"] = f"* {body}"
-    candidate["format"] = "org.matrix.custom.html"
-    candidate["formatted_body"] = _render_segment_html(source, candidate["body"])
-    candidate["m.new_content"] = replacement
-    return candidate
-
-
-def _thread_relation(thread_id: str | None, reply_to_event_id: str | None) -> dict[str, Any] | None:
-    if not thread_id:
-        return None
-    return {
-        "rel_type": "m.thread",
-        "event_id": thread_id,
-        "is_falling_back": True,
-        "m.in_reply_to": {"event_id": reply_to_event_id or thread_id},
-    }
+    replacement = _rich_text_content(source, body)
+    edit = {key: value for key, value in content.items() if key not in _INTERNAL_STREAM_KEYS}
+    edit["body"] = f"* {body}"
+    edit["format"] = "org.matrix.custom.html"
+    edit["formatted_body"] = replacement["formatted_body"]
+    edit["m.new_content"] = replacement
+    return edit
 
 
 def _continuation_content(
-    source: Mapping[str, Any],
+    source: dict[str, Any],
     body: str,
     *,
     thread_id: str | None,
@@ -234,11 +180,17 @@ def _continuation_content(
     refuses. Continuations therefore always take the thread-fallback form (or
     no relation outside threads), which recovery explicitly excludes.
     """
-    candidate = _rich_text_content(source, body, include_mentions=False)
-    relation = _thread_relation(thread_id, reply_to_event_id)
-    if relation is not None:
-        candidate["m.relates_to"] = relation
-    return candidate
+    relation = (
+        {
+            "rel_type": "m.thread",
+            "event_id": thread_id,
+            "is_falling_back": True,
+            "m.in_reply_to": {"event_id": reply_to_event_id or thread_id},
+        }
+        if thread_id
+        else None
+    )
+    return _rich_text_content(source, body, relation=relation)
 
 
 def _segment_target_bytes(*, room_encrypted: bool, is_edit: bool) -> int:
@@ -250,51 +202,6 @@ def _segment_target_bytes(*, room_encrypted: bool, is_edit: bool) -> int:
         (True, True): _SEGMENT_TARGET_ENCRYPTED_EDIT_BYTES,
     }
     return budgets[room_encrypted, is_edit]
-
-
-def _segment_builders(
-    content: Mapping[str, Any],
-    source: Mapping[str, Any],
-    *,
-    is_edit: bool,
-    continuation_thread_id: str | None,
-    continuation_reply_to_event_id: str | None,
-) -> tuple[
-    Callable[[str], dict[str, Any]],
-    Callable[[str], dict[str, Any]],
-    Callable[[str], int],
-]:
-    """Build first, continuation, and worst-case sizing functions."""
-    if is_edit:
-
-        def first_builder(chunk: str) -> dict[str, Any]:
-            return _edit_content_chunk(content, source, chunk)
-
-    else:
-
-        def first_builder(chunk: str) -> dict[str, Any]:
-            return _rich_text_content(
-                source,
-                chunk,
-                include_mentions=True,
-                include_relation=True,
-            )
-
-    def continuation_builder(chunk: str) -> dict[str, Any]:
-        return _continuation_content(
-            source,
-            chunk,
-            thread_id=continuation_thread_id,
-            reply_to_event_id=continuation_reply_to_event_id,
-        )
-
-    def size_builder(chunk: str) -> int:
-        return max(
-            _estimated_event_size(first_builder(chunk)),
-            _estimated_event_size(continuation_builder(chunk)),
-        )
-
-    return first_builder, continuation_builder, size_builder
 
 
 def _preferred_boundary(text: str, start: int, end: int) -> int:
@@ -325,7 +232,7 @@ def _unclosed_fence_start(text: str, start: int, end: int) -> int | None:
     while pos < end:
         line_end = text.find("\n", pos, end)
         line_end = end if line_end == -1 else line_end
-        match = re.match(r"[ \t]*((?:>[ \t]{0,3})*)(`{3,}|~{3,})(.*)", text[pos:line_end])
+        match = _FENCE_LINE_PATTERN.match(text[pos:line_end])
         if match:
             quote_depth = match.group(1).count(">")
             marker = match.group(2)
@@ -342,36 +249,45 @@ def _unclosed_fence_start(text: str, start: int, end: int) -> int | None:
     return opener[3] if opener is not None else None
 
 
+def _fitting_end(text: str, start: int, build: Callable[[str], dict[str, Any]], target_bytes: int) -> int | None:
+    """Return the largest end whose built event fits, or None when one character does not.
+
+    Rendering Markdown is the expensive step, so instead of bisecting the
+    search shrinks the chunk in proportion to the measured overshoot; a chunk
+    normally converges in one to three renders.
+    """
+    overhead = calculate_event_size(build(""))
+    budget = target_bytes - overhead
+    if budget <= 0:
+        return None
+    end = min(len(text), start + budget)
+    while True:
+        used = calculate_event_size(build(text[start:end])) - overhead
+        if used <= budget:
+            return end
+        if end == start + 1:
+            return None
+        end = start + max(1, int((end - start) * budget / used * _SEGMENT_SHRINK_MARGIN))
+
+
 def _split_body(
     text: str,
-    builder: Callable[[str], dict[str, Any]],
+    first_build: Callable[[str], dict[str, Any]],
+    continuation_build: Callable[[str], dict[str, Any]],
     *,
-    target_bytes: int,
-    size_builder: Callable[[str], int] | None = None,
+    first_target: int,
+    continuation_target: int,
 ) -> list[str] | None:
-    """Split text at fitting Unicode boundaries while retaining every character."""
-    fits = size_builder or (lambda chunk: _estimated_event_size(builder(chunk)))
-    if not text:
-        return [text]
-    if fits(text) <= target_bytes:
-        return [text]
-
+    """Split text at fitting Markdown boundaries while retaining every character."""
     chunks: list[str] = []
     offset = 0
     while offset < len(text):
-        lower = offset + 1
-        upper = len(text)
-        best = offset
-        while lower <= upper:
-            candidate_end = (lower + upper) // 2
-            if fits(text[offset:candidate_end]) <= target_bytes:
-                best = candidate_end
-                lower = candidate_end + 1
-            else:
-                upper = candidate_end - 1
-        if best == offset:
+        build, target = (first_build, first_target) if offset == 0 else (continuation_build, continuation_target)
+        end = _fitting_end(text, offset, build, target)
+        if end is None:
             return None
-        end = _preferred_boundary(text, offset, best)
+        if end < len(text):
+            end = _preferred_boundary(text, offset, end)
         fence_start = _unclosed_fence_start(text, offset, end)
         if fence_start is not None:
             if fence_start == offset:
@@ -381,11 +297,11 @@ def _split_body(
             end = fence_start
         chunks.append(text[offset:end])
         offset = end
-    return chunks
+    return chunks or None
 
 
 def segment_matrix_content(
-    content: Mapping[str, Any],
+    content: dict[str, Any],
     *,
     room_encrypted: bool,
     continuation_thread_id: str | None = None,
@@ -393,39 +309,51 @@ def segment_matrix_content(
 ) -> SegmentedMatrixContent | None:
     """Return lossless rich-text payloads when one event is too large.
 
-    The thresholds intentionally stay below MindRoom's sidecar thresholds so
-    every returned event passes through ``large_messages`` unchanged. Internal
-    streaming metadata that is not needed by the visible answer is omitted
-    from the first event before sizing, so metadata alone cannot force a
-    Markdown response into a sidecar. A ``None`` result means the payload is
-    not a plain text response or its remaining fixed metadata alone is too
-    large; the caller can use the normal sidecar fallback in those cases.
+    The first segment is sized against the edit budget when the source is an
+    edit; continuations are plain messages and use the larger plain budget.
+    Internal streaming metadata that is not needed by the visible answer is
+    omitted before sizing, so metadata alone cannot force a Markdown response
+    into a sidecar. A ``None`` result means the payload is not a plain text
+    response, its fixed metadata alone is too large, or a code fence cannot be
+    kept whole; the caller uses the sidecar fallback in those cases.
     """
     source = _source_content(content)
     if source is None or not isinstance(source.get("body"), str):
         return None
 
-    is_edit = _is_edit(content)
-    target_bytes = _segment_target_bytes(room_encrypted=room_encrypted, is_edit=is_edit)
-    if _estimated_event_size(content) <= target_bytes:
+    is_edit = is_edit_message(content)
+    first_target = _segment_target_bytes(room_encrypted=room_encrypted, is_edit=is_edit)
+    if calculate_event_size(content) <= first_target:
         return None
+    continuation_target = _segment_target_bytes(room_encrypted=room_encrypted, is_edit=False)
 
-    body = source["body"]
-    first_builder, continuation_builder, size_builder = _segment_builders(
-        content,
-        source,
-        is_edit=is_edit,
-        continuation_thread_id=continuation_thread_id,
-        continuation_reply_to_event_id=continuation_reply_to_event_id,
+    def first_build(chunk: str) -> dict[str, Any]:
+        if is_edit:
+            return _edit_content_chunk(content, source, chunk)
+        return _rich_text_content(source, chunk, relation=source.get("m.relates_to"))
+
+    def continuation_build(chunk: str) -> dict[str, Any]:
+        return _continuation_content(
+            source,
+            chunk,
+            thread_id=continuation_thread_id,
+            reply_to_event_id=continuation_reply_to_event_id,
+        )
+
+    chunks = _split_body(
+        source["body"],
+        first_build,
+        continuation_build,
+        first_target=first_target,
+        continuation_target=continuation_target,
     )
-
-    chunks = _split_body(body, first_builder, target_bytes=target_bytes, size_builder=size_builder)
     if chunks is None:
         return None
-
-    first = first_builder(chunks[0])
-    continuations = tuple(continuation_builder(chunk) for chunk in chunks[1:])
-    if any(_estimated_event_size(candidate) > target_bytes for candidate in (first, *continuations)):
+    first = first_build(chunks[0])
+    continuations = tuple(continuation_build(chunk) for chunk in chunks[1:])
+    if calculate_event_size(first) > first_target or any(
+        calculate_event_size(candidate) > continuation_target for candidate in continuations
+    ):
         return None
     return SegmentedMatrixContent(first=first, continuations=continuations)
 

--- a/tach.toml
+++ b/tach.toml
@@ -4480,6 +4480,7 @@ expose = [
     "find_response_event_ids_via_room_messages",
     "get_room_threads_page",
     "is_room_message_event",
+    "missing_outbox_delivery_copy_indices_via_room_messages",
 ]
 from = ["mindroom.matrix.room_history_reads"]
 

--- a/tests/test_config_manager_consolidated.py
+++ b/tests/test_config_manager_consolidated.py
@@ -1515,6 +1515,16 @@ class TestConsolidatedConfigManager:
         with pytest.raises(ValidationError, match="tool_output_auto_save_threshold_bytes"):
             DefaultsConfig(tool_output_auto_save_threshold_bytes=0)
 
+    def test_large_message_strategy_defaults_to_sidecar(self) -> None:
+        """Oversized responses keep the sidecar behavior unless split is configured."""
+        assert Config.model_validate({}).defaults.large_message_strategy == "sidecar"
+
+        config = Config.model_validate({"defaults": {"large_message_strategy": "split"}})
+        assert config.defaults.large_message_strategy == "split"
+
+        with pytest.raises(ValidationError, match="large_message_strategy"):
+            DefaultsConfig(large_message_strategy="chunks")
+
     def test_matrix_sync_null_section_uses_default_config(self) -> None:
         """An uncommented blank matrix_sync section should behave like an empty mapping."""
         config = Config.model_validate({"matrix_sync": None})

--- a/tests/test_large_messages.py
+++ b/tests/test_large_messages.py
@@ -30,10 +30,10 @@ from mindroom.matrix.large_messages import (
     _NORMAL_MESSAGE_LIMIT,
     _SIDECAR_UPLOAD_FALLBACK_INDICATOR,
     _calculate_delivery_event_size,
-    _calculate_event_size,
     _create_preview,
-    _is_edit_message,
     _oversized_nonterminal_streaming_edit_sent_at,
+    calculate_event_size,
+    is_edit_message,
     prepare_large_message,
     should_send_oversized_nonterminal_streaming_edit,
 )
@@ -101,7 +101,7 @@ def _actual_encrypted_event_size(
     config_reaction_id = content.get(CONFIG_CONFIRMATION_REACTION_KEY)
     if isinstance(config_reaction_id, str):
         encrypted_content[CONFIG_CONFIRMATION_REACTION_KEY] = config_reaction_id
-    return _calculate_event_size(encrypted_content)
+    return calculate_event_size(encrypted_content)
 
 
 def test_encrypted_event_size_estimate_bounds_real_megolm_output() -> None:
@@ -173,7 +173,7 @@ async def test_oversized_interactive_values_do_not_escape_the_matrix_event_limit
     )
 
     assert "io.mindroom.interactive" not in prepared
-    assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 def _assert_text_sidecar_fallback(result: dict[str, object], expected_prefix: str) -> None:
@@ -187,29 +187,29 @@ def _assert_text_sidecar_fallback(result: dict[str, object], expected_prefix: st
     assert "url" not in result
     assert "file" not in result
     assert "io.mindroom.long_text" not in result
-    assert _calculate_event_size(result) <= _NORMAL_MESSAGE_LIMIT
+    assert calculate_event_size(result) <= _NORMAL_MESSAGE_LIMIT
 
 
 def test_calculate_event_size() -> None:
     """Test event size calculation."""
     # Small message
     content = {"body": "Hello", "msgtype": "m.text"}
-    size = _calculate_event_size(content)
+    size = calculate_event_size(content)
     assert size < 3000  # Small message + overhead
 
     # Large message
     large_text = "x" * 50000
     content = {"body": large_text, "msgtype": "m.text"}
-    size = _calculate_event_size(content)
+    size = calculate_event_size(content)
     assert size > 50000
     assert size < 55000  # Text + overhead
 
 
-def test__is_edit_message() -> None:
+def test_is_edit_message() -> None:
     """Test edit message detection."""
     # Regular message
     regular = {"body": "Hello", "msgtype": "m.text"}
-    assert not _is_edit_message(regular)
+    assert not is_edit_message(regular)
 
     # Edit with m.new_content
     edit1 = {
@@ -217,7 +217,7 @@ def test__is_edit_message() -> None:
         "m.new_content": {"body": "Hello", "msgtype": "m.text"},
         "msgtype": "m.text",
     }
-    assert _is_edit_message(edit1)
+    assert is_edit_message(edit1)
 
     # Edit with m.relates_to replace
     edit2 = {
@@ -225,7 +225,7 @@ def test__is_edit_message() -> None:
         "m.relates_to": {"rel_type": "m.replace", "event_id": "$123"},
         "msgtype": "m.text",
     }
-    assert _is_edit_message(edit2)
+    assert is_edit_message(edit2)
 
 
 def test_oversized_nonterminal_streaming_edit_rate_limit_prunes_expired_entries(
@@ -370,7 +370,7 @@ async def test_prepare_large_message_truncation() -> None:
     assert json.loads(client.uploaded_data.decode("utf-8")) == content
 
     # Preview should fit in limit
-    assert _calculate_event_size(result) <= _NORMAL_MESSAGE_LIMIT
+    assert calculate_event_size(result) <= _NORMAL_MESSAGE_LIMIT
 
 
 @pytest.mark.asyncio
@@ -400,7 +400,7 @@ async def test_prepare_large_message_missing_content_uri_falls_back_to_text(
     mock_logger.warning.assert_any_call(
         "large_message_sidecar_unavailable_using_text_fallback",
         room_id="!room:server",
-        original_size_bytes=_calculate_event_size(content),
+        original_size_bytes=calculate_event_size(content),
         is_edit=False,
         has_mxc_uri=False,
         has_file_info=False,
@@ -566,7 +566,7 @@ async def test_prepare_streaming_edit_encrypted_incomplete_file_metadata_omits_s
     assert "url" not in inner
     assert "io.mindroom.long_text" not in inner
     assert "[Streaming preview truncated]" in inner["body"]
-    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -599,7 +599,7 @@ async def test_prepare_edit_message_upload_failure_falls_back_to_text() -> None:
     assert "url" not in inner
     assert "file" not in inner
     assert "io.mindroom.long_text" not in inner
-    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -639,7 +639,7 @@ async def test_prepare_nonterminal_streaming_edit_double_fallback_preserves_noti
     assert inner["msgtype"] == "m.notice"
     assert inner[STREAM_STATUS_KEY] == STREAM_STATUS_STREAMING
     assert _SIDECAR_UPLOAD_FALLBACK_TEXT in inner["body"]
-    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -756,7 +756,7 @@ async def test_prepare_terminal_edit_keeps_local_recovery_data_off_the_wire() ->
 
     result = await prepare_large_message(client, "!room:server", edit_content)
 
-    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
     assert DURABLE_FINAL_OUTCOME_KEY not in result
     assert DURABLE_FINAL_OUTCOME_KEY not in result["m.new_content"]
     assert client.uploaded_data is not None
@@ -786,7 +786,7 @@ async def test_prepare_terminal_edit_preserves_bounded_result_compatibility_mark
     result = await prepare_large_message(client, "!room:server", edit_content)
 
     assert result["m.new_content"][DURABLE_FINAL_OUTCOME_KEY] == {"version": 2}
-    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -813,7 +813,7 @@ async def test_prepare_terminal_edit_updates_sidecar_size_after_inner_preview_sh
     assert len(inner["body"]) < 22_000
     assert inner["io.mindroom.long_text"]["preview_size"] == len(inner["body"])
     assert inner["io.mindroom.required_metadata"] == metadata
-    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -839,7 +839,7 @@ async def test_prepare_terminal_edit_uses_empty_previews_at_the_metadata_boundar
     assert result["body"] == ""
     assert result["m.new_content"]["body"] == ""
     assert result["m.new_content"]["io.mindroom.required_metadata"] == metadata
-    assert _calculate_event_size(result) == _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(result) == _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -891,13 +891,13 @@ async def test_prepare_terminal_edit_keeps_the_largest_outer_preview_that_fits()
     result = await prepare_large_message(client, "!room:server", edit_content)
 
     assert result["m.new_content"]["body"] == text
-    assert _calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(result) <= _MATRIX_EVENT_HARD_LIMIT
     outer_preview = result["body"][2:]
     assert outer_preview.endswith("[Message continues in attached file]")
     visible_prefix_length = len(outer_preview) - len("\n\n[Message continues in attached file]")
     one_more_byte = dict(result)
     one_more_byte["body"] = f"* {text[: visible_prefix_length + 1]}\n\n[Message continues in attached file]"
-    assert _calculate_event_size(one_more_byte) > _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(one_more_byte) > _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -918,8 +918,8 @@ async def test_prepare_terminal_edit_rejects_irreducible_metadata_before_repeate
 
     with (
         patch(
-            "mindroom.matrix.large_messages._calculate_event_size",
-            wraps=_calculate_event_size,
+            "mindroom.matrix.large_messages.calculate_event_size",
+            wraps=calculate_event_size,
         ) as calculate_size,
         pytest.raises(ValueError, match="cannot fit within the Matrix event limit"),
     ):
@@ -1009,7 +1009,7 @@ async def test_prepare_oversized_file_edit_remains_parseable() -> None:
     assert prepared["url"] == prepared["m.new_content"]["url"]
     assert prepared["filename"] == prepared["m.new_content"]["filename"]
     assert prepared["info"] == prepared["m.new_content"]["info"]
-    assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -1074,7 +1074,7 @@ async def test_prepare_oversized_encrypted_file_edit_remains_parseable(
     assert prepared["file"] == prepared["m.new_content"]["file"]
     assert prepared["filename"] == prepared["m.new_content"]["filename"]
     assert prepared["info"] == prepared["m.new_content"]["info"]
-    assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.parametrize("room_encrypted", [False, True])
@@ -1123,7 +1123,7 @@ async def test_prepare_oversized_file_edit_upload_failure_uses_parseable_text_fa
         for media_key in ("url", "file", "filename", "info"):
             assert media_key not in fallback
 
-    assert _calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
+    assert calculate_event_size(prepared) <= _MATRIX_EVENT_HARD_LIMIT
 
 
 @pytest.mark.asyncio
@@ -1188,7 +1188,7 @@ async def test_prepare_nonterminal_streaming_edit_uses_rich_inline_preview() -> 
     uploaded_payload = json.loads(client.uploaded_data.decode("utf-8"))
     assert uploaded_payload == edit_content
     assert uploaded_payload["m.new_content"][_TOOL_TRACE_KEY] == tool_trace
-    assert _calculate_event_size(result) <= 64000
+    assert calculate_event_size(result) <= 64000
 
 
 @pytest.mark.asyncio
@@ -1248,7 +1248,7 @@ async def test_prepare_nonterminal_streaming_edit_keeps_preview_large_with_huge_
     assert client.uploaded_data is not None
     uploaded_payload = json.loads(client.uploaded_data.decode("utf-8"))
     assert uploaded_payload["m.new_content"][_TOOL_TRACE_KEY] == huge_tool_trace
-    assert _calculate_event_size(result) <= 64000
+    assert calculate_event_size(result) <= 64000
 
 
 @pytest.mark.asyncio

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -45,7 +45,7 @@ from mindroom.matrix.client_delivery import DeliveredMatrixEvent, MatrixDelivery
 from mindroom.matrix.large_messages import (
     _MATRIX_EVENT_HARD_LIMIT,
     _calculate_delivery_event_size,
-    _calculate_event_size,
+    calculate_event_size,
 )
 from mindroom.matrix_delivery import MatrixDeliveryWorker, PermanentDeliveryError, RecoveryOutcome
 from mindroom.message_target import MessageTarget
@@ -152,7 +152,7 @@ def _gateway(
     sending_device_id: str | None = "CURRENT-DEVICE",
     terminal_turn_for: Callable[[str, str], TurnRecord | None] | None = None,
     terminal_turn_committed: Callable[[str, str], Awaitable[None]] | None = None,
-    large_message_strategy: LargeMessageStrategy = "split",
+    large_message_strategy: LargeMessageStrategy = "sidecar",
 ) -> DeliveryGateway:
     """Return a delivery gateway whose only real collaborator is the outbox."""
     config = bind_runtime_paths(
@@ -1125,7 +1125,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
     ) -> None:
         """A recoverable final edit must not leave an impossible outbox retry."""
         outbox = FakeOutbox()
-        gateway = _gateway(tmp_path, outbox)
+        gateway = _gateway(tmp_path, outbox, large_message_strategy="split")
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID
@@ -1154,7 +1154,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert outcome.terminal_status == "completed"
         delivery = outbox.rows["$cause", "final"]
         frozen = delivery.payload
-        assert _calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
+        assert calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
         assert frozen["m.new_content"][DURABLE_FINAL_OUTCOME_KEY] == {"version": 2}
         assert delivery.result is not None
         assert delivery.result["body"] == answer
@@ -1176,7 +1176,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
     ) -> None:
         """The default strategy uploads one sidecar instead of segmenting the answer."""
         outbox = FakeOutbox()
-        gateway = _gateway(tmp_path, outbox, large_message_strategy="sidecar")
+        gateway = _gateway(tmp_path, outbox)
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID
@@ -1201,7 +1201,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         delivery = outbox.rows["$cause", "final"]
         frozen = delivery.payload
         assert frozen["msgtype"] == "m.file"
-        assert _calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
+        assert calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
         assert client.upload.await_count == 1
         assert client.room_send.await_count == 1
         assert delivery.result is not None
@@ -1220,7 +1220,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         the missing one goes out, under its stable derived transaction ID.
         """
         outbox = FakeOutbox()
-        gateway = _gateway(tmp_path, outbox)
+        gateway = _gateway(tmp_path, outbox, large_message_strategy="split")
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         answer = "\n\n".join(f"## Part {index}\n\n" + "x" * 500 for index in range(200))
 
@@ -1245,7 +1245,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
             return None
 
         missing_indices = [index for index in range(len(continuations)) if index != 1]
-        recovered_gateway = _gateway(tmp_path, outbox, sending_device_id="NEW-DEVICE")
+        recovered_gateway = _gateway(tmp_path, outbox, sending_device_id="NEW-DEVICE", large_message_strategy="split")
         delivered = DeliveredMatrixEvent("$continuation", {})
         with (
             patch(
@@ -1276,7 +1276,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
     ) -> None:
         """The exact persisted and sent event must fit after identity is attached."""
         outbox = FakeOutbox()
-        gateway = _gateway(tmp_path, outbox)
+        gateway = _gateway(tmp_path, outbox, large_message_strategy="split")
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID
@@ -1303,7 +1303,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
 
         assert outcome.terminal_status == "completed"
         frozen = outbox.rows["$cause", "final"].payload
-        assert _calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
+        assert calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
         assert client.room_send.await_args.kwargs["content"] == frozen
 
     async def test_uncached_encrypted_room_is_fitted_before_durable_enqueue(
@@ -1312,7 +1312,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
     ) -> None:
         """Remote encryption state must shape the payload before the outbox freezes it."""
         outbox = FakeOutbox()
-        gateway = _gateway(tmp_path, outbox)
+        gateway = _gateway(tmp_path, outbox, large_message_strategy="split")
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         client = AsyncMock(spec=nio.AsyncClient)
         client.rooms = {}
@@ -1356,7 +1356,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
     ) -> None:
         """Persistence must freeze bytes that remain valid if encryption is enabled."""
         outbox = FakeOutbox()
-        gateway = _gateway(tmp_path, outbox)
+        gateway = _gateway(tmp_path, outbox, large_message_strategy="split")
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID
@@ -1618,7 +1618,13 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         self,
         tmp_path: Path,
     ) -> None:
-        """Wire delivery must not prepare an already-frozen outbox payload again."""
+        """Wire delivery must not prepare an already-frozen outbox payload again.
+
+        A large edit becomes a sidecar-backed ``m.file`` replacement before
+        the outbox freezes it. Preparing that envelope a second time promotes
+        the inner ``m.file`` type to the outer edit without its required URL,
+        so nio rejects the event and later history reads cannot hydrate it.
+        """
         outbox = FakeOutbox()
         gateway = _gateway(tmp_path, outbox)
         client = AsyncMock(spec=nio.AsyncClient)
@@ -1655,19 +1661,10 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         )
 
         assert delivered is not None
+        assert client.upload.await_count == 1, "wire delivery uploaded a second sidecar"
         frozen = outbox.rows["$cause", "final"].payload
-        result = outbox.rows["$cause", "final"].result
-        assert result is not None
-        continuations = result[_SEGMENT_PAYLOADS_RESULT_KEY]
-        assert isinstance(continuations, list)
-        assert continuations
-        assert client.upload.await_count == 0
-        sent_contents = [call.kwargs["content"] for call in client.room_send.await_args_list]
-        assert sent_contents == [frozen, *continuations]
-        wire_content = sent_contents[0]
-        assert wire_content["msgtype"] == "m.text"
-        assert wire_content["m.new_content"]["format"] == "org.matrix.custom.html"
-        assert "".join([wire_content["m.new_content"]["body"], *(item["body"] for item in continuations)]) == answer
+        wire_content = client.room_send.await_args.kwargs["content"]
+        assert wire_content == frozen
         parsed = nio.Event.parse_event(
             {
                 "event_id": "$edit",
@@ -1729,15 +1726,8 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         delivered = await terminal(client, _ROOM_ID, "$streamed", content, answer)
 
         assert delivered is not None
-        result = outbox.rows["$cause", "final"].result
-        assert result is not None
-        continuations = result[_SEGMENT_PAYLOADS_RESULT_KEY]
-        assert isinstance(continuations, list)
-        assert continuations
-        assert client.upload.await_count == 0
-        sent_contents = [call.kwargs["content"] for call in client.room_send.await_args_list]
-        assert sent_contents[:2] == [frozen, frozen]
-        assert sent_contents[2:] == continuations
+        assert client.upload.await_count == 1
+        assert client.room_send.await_args.kwargs["content"] == frozen
 
     async def test_a_definitive_oversized_refusal_stops_recovery(
         self,
@@ -1784,7 +1774,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert second is None
         assert stored.permanent_failure_reason is not None
         assert client.room_send.await_count == 1
-        assert client.upload.await_count == 0
+        assert client.upload.await_count == 1
 
     async def test_a_streamed_terminal_edit_freezes_its_fallback_body_too(
         self,

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -1276,7 +1276,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
     ) -> None:
         """The exact persisted and sent event must fit after identity is attached."""
         outbox = FakeOutbox()
-        gateway = _gateway(tmp_path, outbox, large_message_strategy="split")
+        gateway = _gateway(tmp_path, outbox)
         gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
         client = AsyncMock(spec=nio.AsyncClient)
         client.user_id = _AGENT_USER_ID

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -86,6 +86,7 @@ pytestmark = pytest.mark.asyncio
 
 _ROOM_ID = "!room:localhost"
 _AGENT_USER_ID = "@agent:localhost"
+_SEGMENT_PAYLOADS_RESULT_KEY = "io.mindroom.matrix_segment_payloads"
 
 
 def _failed_delivery() -> MatrixDeliveryFailure:
@@ -1149,8 +1150,19 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         frozen = delivery.payload
         assert _calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
         assert frozen["m.new_content"][DURABLE_FINAL_OUTCOME_KEY] == {"version": 2}
-        assert delivery.result == {"body": answer, "interactive": None}
-        assert client.room_send.await_args.kwargs["content"] == frozen
+        assert delivery.result is not None
+        assert delivery.result["body"] == answer
+        assert delivery.result["interactive"] is None
+        continuations = delivery.result[_SEGMENT_PAYLOADS_RESULT_KEY]
+        assert isinstance(continuations, list)
+        assert continuations
+        parts = [frozen["m.new_content"], *continuations]
+        assert "".join(part["body"] for part in parts) == answer
+        assert all(part["format"] == "org.matrix.custom.html" for part in parts)
+        assert all("formatted_body" in part for part in parts)
+        assert all("file" not in part and "url" not in part for part in parts)
+        sent_contents = [call.kwargs["content"] for call in client.room_send.await_args_list]
+        assert sent_contents == [frozen, *continuations]
 
     async def test_delivery_identity_is_included_in_the_validated_event_size(
         self,
@@ -1212,17 +1224,24 @@ class TestTurnDeliveryGoesThroughTheOutbox:
             outcome = await gateway.deliver_final(self._final_request("x" * 50_000))
 
         assert outcome.event_id == "$sent"
-        frozen = outbox.rows["$cause", "final"].payload
-        assert frozen["msgtype"] == "m.file"
-        assert (
+        delivery = outbox.rows["$cause", "final"]
+        frozen = delivery.payload
+        assert frozen["msgtype"] == "m.text"
+        assert delivery.result is not None
+        continuations = delivery.result[_SEGMENT_PAYLOADS_RESULT_KEY]
+        assert isinstance(continuations, list)
+        assert continuations
+        assert all(
             _calculate_delivery_event_size(
-                frozen,
+                candidate,
                 room_id=_ROOM_ID,
                 room_encrypted=True,
                 device_id="DEVICE",
             )
             <= _MATRIX_EVENT_HARD_LIMIT
+            for candidate in [frozen, *continuations]
         )
+        client.upload.assert_not_awaited()
         client.room_get_state_event.assert_awaited_once_with(_ROOM_ID, "m.room.encryption")
 
     async def test_plaintext_durable_payload_is_fitted_for_a_later_encrypted_send(
@@ -1256,18 +1275,26 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         )
 
         assert outcome.terminal_status == "completed"
-        frozen = outbox.rows["$cause", "final"].payload
-        assert frozen["file"]["url"] == "mxc://localhost/transition-sidecar"
+        delivery = outbox.rows["$cause", "final"]
+        frozen = delivery.payload
+        assert frozen["msgtype"] == "m.text"
+        assert "file" not in frozen
         assert "url" not in frozen
-        assert (
+        assert delivery.result is not None
+        continuations = delivery.result[_SEGMENT_PAYLOADS_RESULT_KEY]
+        assert isinstance(continuations, list)
+        assert continuations
+        assert all(
             _calculate_delivery_event_size(
-                frozen,
+                candidate,
                 room_id=_ROOM_ID,
                 room_encrypted=True,
                 device_id="DEVICE",
             )
             <= _MATRIX_EVENT_HARD_LIMIT
+            for candidate in [frozen, *continuations]
         )
+        client.upload.assert_not_awaited()
 
     async def test_unknown_uncached_room_encryption_fails_before_durable_enqueue(
         self,
@@ -1485,13 +1512,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         self,
         tmp_path: Path,
     ) -> None:
-        """Wire delivery must not prepare an already-frozen outbox payload again.
-
-        A large edit becomes a sidecar-backed ``m.file`` replacement before
-        the outbox freezes it. Preparing that envelope a second time promotes
-        the inner ``m.file`` type to the outer edit without its required URL,
-        so nio rejects the event and later history reads cannot hydrate it.
-        """
+        """Wire delivery must not prepare an already-frozen outbox payload again."""
         outbox = FakeOutbox()
         gateway = _gateway(tmp_path, outbox)
         client = AsyncMock(spec=nio.AsyncClient)
@@ -1528,10 +1549,19 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         )
 
         assert delivered is not None
-        assert client.upload.await_count == 1, "wire delivery uploaded a second sidecar"
         frozen = outbox.rows["$cause", "final"].payload
-        wire_content = client.room_send.await_args.kwargs["content"]
-        assert wire_content == frozen
+        result = outbox.rows["$cause", "final"].result
+        assert result is not None
+        continuations = result[_SEGMENT_PAYLOADS_RESULT_KEY]
+        assert isinstance(continuations, list)
+        assert continuations
+        assert client.upload.await_count == 0
+        sent_contents = [call.kwargs["content"] for call in client.room_send.await_args_list]
+        assert sent_contents == [frozen, *continuations]
+        wire_content = sent_contents[0]
+        assert wire_content["msgtype"] == "m.text"
+        assert wire_content["m.new_content"]["format"] == "org.matrix.custom.html"
+        assert "".join([wire_content["m.new_content"]["body"], *(item["body"] for item in continuations)]) == answer
         parsed = nio.Event.parse_event(
             {
                 "event_id": "$edit",
@@ -1593,8 +1623,15 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         delivered = await terminal(client, _ROOM_ID, "$streamed", content, answer)
 
         assert delivered is not None
-        assert client.upload.await_count == 1
-        assert client.room_send.await_args.kwargs["content"] == frozen
+        result = outbox.rows["$cause", "final"].result
+        assert result is not None
+        continuations = result[_SEGMENT_PAYLOADS_RESULT_KEY]
+        assert isinstance(continuations, list)
+        assert continuations
+        assert client.upload.await_count == 0
+        sent_contents = [call.kwargs["content"] for call in client.room_send.await_args_list]
+        assert sent_contents[:2] == [frozen, frozen]
+        assert sent_contents[2:] == continuations
 
     async def test_a_definitive_oversized_refusal_stops_recovery(
         self,
@@ -1641,7 +1678,7 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert second is None
         assert stored.permanent_failure_reason is not None
         assert client.room_send.await_count == 1
-        assert client.upload.await_count == 1
+        assert client.upload.await_count == 0
 
     async def test_a_streamed_terminal_edit_freezes_its_fallback_body_too(
         self,

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -1242,16 +1242,19 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         ) -> str | None:
             if delivery_content == row.payload:
                 return "$primary"
-            if delivery_content == continuations[1]:
-                return "$continuation-2"
             return None
 
+        missing_indices = [index for index in range(len(continuations)) if index != 1]
         recovered_gateway = _gateway(tmp_path, outbox, sending_device_id="NEW-DEVICE")
-        delivered = DeliveredMatrixEvent("$continuation-1", continuations[0])
+        delivered = DeliveredMatrixEvent("$continuation", {})
         with (
             patch(
                 "mindroom.delivery_gateway.find_outbox_delivery_event_id_via_room_messages",
                 AsyncMock(side_effect=found_events),
+            ),
+            patch(
+                "mindroom.delivery_gateway.missing_outbox_delivery_copy_indices_via_room_messages",
+                AsyncMock(return_value=missing_indices),
             ),
             patch(
                 "mindroom.delivery_gateway.send_message_outcome",
@@ -1261,10 +1264,9 @@ class TestTurnDeliveryGoesThroughTheOutbox:
             recovered = await recovered_gateway.recover_deliveries()
 
         assert recovered.recovered == 1
-        expected_missing = [(index, c) for index, c in enumerate(continuations, start=1) if index != 2]
-        assert [call.args[2] for call in send.await_args_list] == [c for _, c in expected_missing]
+        assert [call.args[2] for call in send.await_args_list] == [continuations[i] for i in missing_indices]
         assert [call.kwargs["transaction_id"] for call in send.await_args_list] == [
-            _segment_transaction_id(row.transaction_id, index) for index, _ in expected_missing
+            _segment_transaction_id(row.transaction_id, index + 1) for index in missing_indices
         ]
         assert outbox.rows["$cause", "final"].acknowledged_event_id == "$primary"
 
@@ -3167,6 +3169,89 @@ class TestGenericDeliveryDeviceChangePolicy:
         assert stored is not None
         assert stored.acknowledged_event_id == "$prior"
         gateway.deps.runtime.client.room_messages.assert_awaited_once()
+
+    async def test_identical_continuations_reconcile_by_copy_count(
+        self,
+        tmp_path: Path,
+        alice: PrincipalStore,
+    ) -> None:
+        """One delivered copy must not satisfy two byte-identical continuations.
+
+        Long homogeneous responses can repeat a continuation payload exactly.
+        Existence-based reconciliation would see the first copy in the room and
+        acknowledge the row with the second copy never sent; counting copies
+        leaves exactly the missing positions to resend.
+        """
+        duplicate = {
+            "msgtype": "m.text",
+            "body": "z" * 1_000,
+            "format": "org.matrix.custom.html",
+            "formatted_body": "<p>zzz</p>\n",
+        }
+        tail = {**duplicate, "body": "the end", "formatted_body": "<p>the end</p>\n"}
+        await alice.enqueue_matrix_delivery(
+            delivery_id="segmented-turn",
+            stage=DeliveryStage.FINAL,
+            room_id=_ROOM_ID,
+            thread_id=None,
+            payload={"msgtype": "m.text", "body": "the start"},
+            result={_SEGMENT_PAYLOADS_RESULT_KEY: [duplicate, duplicate, tail]},
+        )
+        claimed = await alice.claim_matrix_delivery(
+            delivery_id="segmented-turn",
+            stage=DeliveryStage.FINAL,
+            sending_device_id="OLD-DEVICE",
+        )
+        assert claimed is not None
+        assert claimed.result is not None
+        continuations = claimed.result[_SEGMENT_PAYLOADS_RESULT_KEY]
+
+        def room_event(event_id: str, content: Mapping[str, object]) -> nio.Event:
+            event = nio.Event.parse_event(
+                {
+                    "event_id": event_id,
+                    "room_id": _ROOM_ID,
+                    "sender": _AGENT_USER_ID,
+                    "origin_server_ts": 1_000,
+                    "type": "m.room.message",
+                    "content": dict(content),
+                },
+            )
+            assert isinstance(event, nio.Event)
+            return event
+
+        # The earlier device delivered the primary and one copy of the
+        # duplicated continuation before crashing.
+        prior_primary = room_event("$prior-primary", dict(claimed.payload))
+        prior_continuation = room_event("$prior-continuation", dict(continuations[0]))
+        gateway = _gateway(tmp_path, alice, sending_device_id="NEW-DEVICE")
+        gateway.deps.runtime.client.room_messages = AsyncMock(
+            return_value=nio.RoomMessagesResponse(
+                room_id=_ROOM_ID,
+                chunk=[prior_continuation, prior_primary],
+                start="start",
+                end=None,
+            ),
+        )
+        sent = AsyncMock(return_value=DeliveredMatrixEvent("$resent", {}))
+
+        async def never_sends(_claimed: MatrixDelivery) -> str:
+            msg = "an adopted primary is never resent"
+            raise AssertionError(msg)
+
+        with patch("mindroom.delivery_gateway.send_message_outcome", sent):
+            outcome = await gateway._response_delivery(never_sends, handoff=None).recover()
+
+        stored = await alice.load_matrix_delivery(delivery_id="segmented-turn", stage=DeliveryStage.FINAL)
+        assert outcome == RecoveryOutcome(recovered=1, failed=0)
+        assert stored is not None
+        assert stored.acknowledged_event_id == "$prior-primary"
+        # The second duplicate and the tail were missing: exactly those go out.
+        assert [call.args[2] for call in sent.await_args_list] == [continuations[1], continuations[2]]
+        assert [call.kwargs["transaction_id"] for call in sent.await_args_list] == [
+            _segment_transaction_id(claimed.transaction_id, 2),
+            _segment_transaction_id(claimed.transaction_id, 3),
+        ]
 
     async def test_final_marker_does_not_adopt_the_initial_placeholder(
         self,

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -35,6 +35,7 @@ from mindroom.delivery_gateway import (
     ResponseIdentity,
     SendTextRequest,
     StreamingDeliveryRequest,
+    _segment_transaction_id,
 )
 from mindroom.dispatch_source import MESSAGE_SOURCE_KIND, SILENT_SCHEDULE_SOURCE_KIND
 from mindroom.event_journal import DepartureSource
@@ -1205,6 +1206,67 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert client.room_send.await_count == 1
         assert delivery.result is not None
         assert _SEGMENT_PAYLOADS_RESULT_KEY not in delivery.result
+
+    async def test_recovery_from_a_new_device_sends_only_the_missing_continuations(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Adopting the primary event must not strand or duplicate continuations.
+
+        The earlier device crashed between the primary send and the
+        continuations, and one continuation did land. Transaction IDs are
+        scoped to the dead device, so the replacement device cannot resend
+        blindly: each segment is matched by its exact frozen content and only
+        the missing one goes out, under its stable derived transaction ID.
+        """
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox)
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        answer = "\n\n".join(f"## Part {index}\n\n" + "x" * 500 for index in range(200))
+
+        with patch("mindroom.delivery_gateway.send_message_outcome", AsyncMock(return_value=_failed_delivery())):
+            await gateway.deliver_final(replace(self._final_request(answer), defer_source_handoff=True))
+        row = outbox.rows["$cause", "final"]
+        assert row.acknowledged_event_id is None
+        assert row.result is not None
+        continuations = row.result[_SEGMENT_PAYLOADS_RESULT_KEY]
+        assert isinstance(continuations, list)
+        assert len(continuations) >= 2
+
+        async def found_events(
+            _client: object,
+            _room_id: str,
+            *,
+            delivery_content: Mapping[str, object],
+            **_kwargs: object,
+        ) -> str | None:
+            if delivery_content == row.payload:
+                return "$primary"
+            if delivery_content == continuations[1]:
+                return "$continuation-2"
+            return None
+
+        recovered_gateway = _gateway(tmp_path, outbox, sending_device_id="NEW-DEVICE")
+        delivered = DeliveredMatrixEvent("$continuation-1", continuations[0])
+        with (
+            patch(
+                "mindroom.delivery_gateway.find_outbox_delivery_event_id_via_room_messages",
+                AsyncMock(side_effect=found_events),
+            ),
+            patch(
+                "mindroom.delivery_gateway.send_message_outcome",
+                AsyncMock(return_value=delivered),
+            ) as send,
+        ):
+            recovered = await recovered_gateway.recover_deliveries()
+
+        assert recovered.recovered == 1
+        expected_missing = [(index, c) for index, c in enumerate(continuations, start=1) if index != 2]
+        assert [call.args[2] for call in send.await_args_list] == [c for _, c in expected_missing]
+        assert [call.kwargs["transaction_id"] for call in send.await_args_list] == [
+            _segment_transaction_id(row.transaction_id, index) for index, _ in expected_missing
+        ]
+        assert outbox.rows["$cause", "final"].acknowledged_event_id == "$primary"
 
     async def test_delivery_identity_is_included_in_the_validated_event_size(
         self,

--- a/tests/test_response_delivery_gateway.py
+++ b/tests/test_response_delivery_gateway.py
@@ -19,6 +19,7 @@ import pytest
 
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
+from mindroom.config.models import DefaultsConfig, LargeMessageStrategy
 from mindroom.constants import (
     DURABLE_FINAL_OUTCOME_KEY,
     SILENT_SCHEDULE_NO_REPLY_TOKEN,
@@ -150,10 +151,14 @@ def _gateway(
     sending_device_id: str | None = "CURRENT-DEVICE",
     terminal_turn_for: Callable[[str, str], TurnRecord | None] | None = None,
     terminal_turn_committed: Callable[[str, str], Awaitable[None]] | None = None,
+    large_message_strategy: LargeMessageStrategy = "split",
 ) -> DeliveryGateway:
     """Return a delivery gateway whose only real collaborator is the outbox."""
     config = bind_runtime_paths(
-        Config(agents={"agent": AgentConfig(display_name="Agent")}),
+        Config(
+            agents={"agent": AgentConfig(display_name="Agent")},
+            defaults=DefaultsConfig(large_message_strategy=large_message_strategy),
+        ),
         test_runtime_paths(tmp_path),
     )
     client = AsyncMock()
@@ -1163,6 +1168,43 @@ class TestTurnDeliveryGoesThroughTheOutbox:
         assert all("file" not in part and "url" not in part for part in parts)
         sent_contents = [call.kwargs["content"] for call in client.room_send.await_args_list]
         assert sent_contents == [frozen, *continuations]
+
+    async def test_sidecar_strategy_keeps_oversized_final_on_the_attachment_path(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """The default strategy uploads one sidecar instead of segmenting the answer."""
+        outbox = FakeOutbox()
+        gateway = _gateway(tmp_path, outbox, large_message_strategy="sidecar")
+        gateway.deps.response_hooks._apply_before_response = self._hooks()._apply_before_response
+        client = AsyncMock(spec=nio.AsyncClient)
+        client.user_id = _AGENT_USER_ID
+        client.device_id = "DEVICE"
+        client.room_get_event = AsyncMock(side_effect=_delivered_event_response)
+        room = MagicMock()
+        room.encrypted = False
+        client.rooms = {_ROOM_ID: room}
+        client.olm = None
+        client.upload.return_value = (
+            nio.UploadResponse.from_dict({"content_uri": "mxc://localhost/sidecar-strategy"}),
+            None,
+        )
+        client.room_send.return_value = nio.RoomSendResponse(event_id="$sent", room_id=_ROOM_ID)
+        gateway.deps.runtime.client = client
+
+        outcome = await gateway.deliver_final(
+            replace(self._final_request("x" * 100_000), defer_source_handoff=True),
+        )
+
+        assert outcome.terminal_status == "completed"
+        delivery = outbox.rows["$cause", "final"]
+        frozen = delivery.payload
+        assert frozen["msgtype"] == "m.file"
+        assert _calculate_event_size(frozen) <= _MATRIX_EVENT_HARD_LIMIT
+        assert client.upload.await_count == 1
+        assert client.room_send.await_count == 1
+        assert delivery.result is not None
+        assert _SEGMENT_PAYLOADS_RESULT_KEY not in delivery.result
 
     async def test_delivery_identity_is_included_in_the_validated_event_size(
         self,

--- a/tests/test_segmented_messages.py
+++ b/tests/test_segmented_messages.py
@@ -5,6 +5,8 @@ from mindroom.matrix.segmented_messages import (
     _SEGMENT_TARGET_EDIT_BYTES,
     _SEGMENT_TARGET_PLAINTEXT_BYTES,
     _estimated_event_size,
+    _render_segment_html,
+    _unclosed_fence_start,
     segment_matrix_content,
 )
 
@@ -235,3 +237,35 @@ def test_mention_pills_survive_segmentation() -> None:
     assert '<a href="https://matrix.to/#/@alice:localhost">@Alice</a>' in mentioned[0]["formatted_body"]
     assert segmented.first["m.mentions"] == {"user_ids": ["@alice:localhost"]}
     assert all("m.mentions" not in part for part in segmented.continuations)
+
+
+def test_prefix_overlapping_mentions_do_not_nest_pills() -> None:
+    """A user ID that prefixes another must not match inside an inserted pill."""
+    body = "Thanks @alice:localhost and @alice:localhost2."
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": (
+            '<p>Thanks <a href="https://matrix.to/#/@alice:localhost">@Alice</a> and '
+            '<a href="https://matrix.to/#/@alice:localhost2">@Alice Two</a>.</p>'
+        ),
+        "m.mentions": {"user_ids": ["@alice:localhost", "@alice:localhost2"]},
+    }
+
+    rendered = _render_segment_html(content, body)
+
+    assert '<a href="https://matrix.to/#/@alice:localhost">@Alice</a>' in rendered
+    assert '<a href="https://matrix.to/#/@alice:localhost2">@Alice Two</a>' in rendered
+    assert rendered.count("<a ") == 2
+
+
+def test_unclosed_fence_requires_same_marker_and_length() -> None:
+    """Only a same-character fence of at least the opening length closes."""
+    opened = "```python\ncode\n"
+    assert _unclosed_fence_start(opened + "~~~\nmore\n", 0, len(opened) + 8) == 0
+    assert _unclosed_fence_start("````\ncode\n```\nstill open\n", 0, 24) == 0
+    closed = opened + "```   \n"
+    assert _unclosed_fence_start(closed, 0, len(closed)) is None
+    longer_closes = opened + "````\n"
+    assert _unclosed_fence_start(longer_closes, 0, len(longer_closes)) is None

--- a/tests/test_segmented_messages.py
+++ b/tests/test_segmented_messages.py
@@ -1,0 +1,105 @@
+"""Tests for lossless Matrix Markdown segmentation."""
+
+from mindroom.matrix.message_builder import build_matrix_edit_content, markdown_to_html
+from mindroom.matrix.segmented_messages import (
+    _SEGMENT_TARGET_EDIT_BYTES,
+    _SEGMENT_TARGET_PLAINTEXT_BYTES,
+    _estimated_event_size,
+    segment_matrix_content,
+)
+
+
+def _body() -> str:
+    """Return a body large enough to exercise paragraph segmentation."""
+    return "\n\n".join(
+        f"## Section {index}\n\n**value {index}** with [source](https://example.com)." for index in range(900)
+    )
+
+
+def test_plaintext_segments_preserve_markdown_body() -> None:
+    """A regular oversized response is split into rich-text events losslessly."""
+    body = _body()
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": markdown_to_html(body),
+        "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread"},
+    }
+
+    segmented = segment_matrix_content(content, room_encrypted=False)
+
+    assert segmented is not None
+    parts = [segmented.first, *segmented.continuations]
+    assert len(parts) >= 2
+    assert "".join(part["body"] for part in parts) == body
+    assert segmented.first["m.relates_to"] == content["m.relates_to"]
+    assert all(part["format"] == "org.matrix.custom.html" for part in parts)
+    assert all(part["formatted_body"] for part in parts)
+    assert all(_estimated_event_size(part) <= _SEGMENT_TARGET_PLAINTEXT_BYTES for part in parts)
+
+
+def test_edit_segments_use_replace_then_thread_replies() -> None:
+    """An oversized edit keeps the first replacement and threads continuations."""
+    body = _body()
+    content = build_matrix_edit_content(
+        event_id="$placeholder",
+        new_content={
+            "msgtype": "m.text",
+            "body": body,
+            "format": "org.matrix.custom.html",
+            "formatted_body": markdown_to_html(body),
+        },
+    )
+
+    segmented = segment_matrix_content(
+        content,
+        room_encrypted=False,
+        continuation_thread_id="$thread",
+        continuation_reply_to_event_id="$placeholder",
+    )
+
+    assert segmented is not None
+    parts = [segmented.first["m.new_content"], *segmented.continuations]
+    assert "".join(part["body"] for part in parts) == body
+    assert segmented.first["m.relates_to"]["rel_type"] == "m.replace"
+    assert all(part["m.relates_to"]["rel_type"] == "m.thread" for part in segmented.continuations)
+    assert all(
+        _estimated_event_size(part) <= _SEGMENT_TARGET_EDIT_BYTES
+        for part in [segmented.first, *segmented.continuations]
+    )
+
+
+def test_large_tool_trace_does_not_disable_visible_markdown() -> None:
+    """Internal tool metadata must not force a small completed answer into a sidecar."""
+    body = "\n\n".join(f"### Finding {index}\n\n**value**" for index in range(90))
+    content = build_matrix_edit_content(
+        event_id="$placeholder",
+        new_content={
+            "msgtype": "m.text",
+            "body": body,
+            "format": "org.matrix.custom.html",
+            "formatted_body": markdown_to_html(body),
+            "io.mindroom.tool_trace": {
+                "version": 2,
+                "events": [
+                    {
+                        "type": "tool_call_completed",
+                        "tool_name": "synthetic_tool",
+                        "result_preview": "x" * 500,
+                    }
+                    for _ in range(100)
+                ],
+            },
+        },
+    )
+
+    segmented = segment_matrix_content(content, room_encrypted=False)
+
+    assert segmented is not None
+    first = segmented.first["m.new_content"]
+    parts = [first, *segmented.continuations]
+    assert "".join(part["body"] for part in parts) == body
+    assert "io.mindroom.tool_trace" not in first
+    assert first["format"] == "org.matrix.custom.html"
+    assert first["formatted_body"]

--- a/tests/test_segmented_messages.py
+++ b/tests/test_segmented_messages.py
@@ -4,6 +4,7 @@ from mindroom.matrix.message_builder import build_matrix_edit_content, markdown_
 from mindroom.matrix.segmented_messages import (
     _SEGMENT_TARGET_EDIT_BYTES,
     _SEGMENT_TARGET_PLAINTEXT_BYTES,
+    _chunk_mentions,
     _estimated_event_size,
     _render_segment_html,
     _unclosed_fence_start,
@@ -281,6 +282,75 @@ def test_prefix_overlapping_mentions_do_not_nest_pills() -> None:
     assert '<a href="https://matrix.to/#/@alice:localhost">@Alice</a>' in rendered
     assert '<a href="https://matrix.to/#/@alice:localhost2">@Alice Two</a>' in rendered
     assert rendered.count("<a ") == 2
+    # The shorter ID must not be attributed to a chunk that names only the longer one.
+    assert _chunk_mentions(content, "ping @alice:localhost2 again") == {"user_ids": ["@alice:localhost2"]}
+    assert _chunk_mentions(content, body) == {"user_ids": ["@alice:localhost", "@alice:localhost2"]}
+
+
+def test_pill_restoration_leaves_literal_code_text_alone() -> None:
+    """A user ID inside a code span is content, not a mention."""
+    body = "Thanks @alice:localhost; the literal `@alice:localhost` stays code."
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": '<p>Thanks <a href="https://matrix.to/#/@alice:localhost">@Alice</a>.</p>',
+        "m.mentions": {"user_ids": ["@alice:localhost"]},
+    }
+
+    rendered = _render_segment_html(content, body)
+
+    assert '<a href="https://matrix.to/#/@alice:localhost">@Alice</a>' in rendered
+    assert "<code>@alice:localhost</code>" in rendered
+    assert rendered.count("<a ") == 1
+
+
+def test_room_mention_travels_with_its_segment() -> None:
+    """The room flag follows the chunk whose body carries ``@room``."""
+    lead = "\n\n".join(f"## Section {index}\n\n**value {index}**" for index in range(600))
+    body = f"{lead}\n\n@room please review."
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": markdown_to_html(body),
+        "m.mentions": {"room": True},
+    }
+
+    segmented = segment_matrix_content(content, room_encrypted=False)
+
+    assert segmented is not None
+    parts = [segmented.first, *segmented.continuations]
+    mentioned = [part for part in parts if "@room" in part["body"]]
+    assert len(mentioned) == 1
+    assert mentioned[0]["m.mentions"] == {"room": True}
+    assert all("m.mentions" not in part for part in parts if part is not mentioned[0])
+
+
+def test_edit_keeps_the_outer_mention_delta() -> None:
+    """An edit's outer m.mentions is the revision delta and stays verbatim."""
+    body = _body() + "\n\nThanks @alice:localhost."
+    mentions = {"user_ids": ["@alice:localhost"]}
+    content = build_matrix_edit_content(
+        event_id="$placeholder",
+        new_content={
+            "msgtype": "m.text",
+            "body": body,
+            "format": "org.matrix.custom.html",
+            "formatted_body": markdown_to_html(body),
+            "m.mentions": mentions,
+        },
+    )
+
+    segmented = segment_matrix_content(content, room_encrypted=False, continuation_thread_id="$thread")
+
+    assert segmented is not None
+    assert segmented.first["m.mentions"] == mentions
+    # The mention landed in a continuation, so the first chunk's resolved set is empty...
+    assert "m.mentions" not in segmented.first["m.new_content"]
+    mentioned = [part for part in segmented.continuations if "@alice:localhost" in part["body"]]
+    assert len(mentioned) == 1
+    assert mentioned[0]["m.mentions"] == mentions
 
 
 def test_unclosed_fence_requires_same_marker_and_length() -> None:
@@ -302,3 +372,8 @@ def test_unclosed_fence_inside_a_block_quote() -> None:
     assert _unclosed_fence_start(wrong_depth_closes, 0, len(wrong_depth_closes)) == 0
     quoted_closes = quoted_open + "> ```\n"
     assert _unclosed_fence_start(quoted_closes, 0, len(quoted_closes)) is None
+    # CommonMark allows up to three spaces of indentation after the quote marker.
+    indented_open = ">   ```python\n>   code\n"
+    assert _unclosed_fence_start(indented_open, 0, len(indented_open)) == 0
+    indented_closes = indented_open + ">   ```\n"
+    assert _unclosed_fence_start(indented_closes, 0, len(indented_closes)) is None

--- a/tests/test_segmented_messages.py
+++ b/tests/test_segmented_messages.py
@@ -212,6 +212,28 @@ def test_fence_spanning_the_whole_budget_falls_back_to_sidecar() -> None:
     assert segment_matrix_content(content, room_encrypted=False) is None
 
 
+def test_block_quoted_fence_is_not_split_mid_block() -> None:
+    """A fence inside a block quote is still a fence the splitter respects."""
+    prefix = "\n\n".join(f"## Lead {index}\n\nword " * 40 for index in range(30))
+    fence = "> ```python\n" + "".join(f"> value_{index} = {index}\n" for index in range(150)) + "> ```"
+    suffix = "\n\n".join(f"## Tail {index}\n\nword " * 40 for index in range(30))
+    body = f"{prefix}\n\n{fence}\n\n{suffix}"
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": markdown_to_html(body),
+    }
+
+    segmented = segment_matrix_content(content, room_encrypted=True)
+
+    assert segmented is not None
+    parts = [segmented.first, *segmented.continuations]
+    assert len(parts) >= 2
+    assert "".join(part["body"] for part in parts) == body
+    assert sum(fence in part["body"] for part in parts) == 1
+
+
 def test_mention_pills_survive_segmentation() -> None:
     """Re-rendering a chunk must not drop the link its plain body cannot carry."""
     lead = "\n\n".join(f"## Section {index}\n\n**value {index}**" for index in range(600))
@@ -269,3 +291,13 @@ def test_unclosed_fence_requires_same_marker_and_length() -> None:
     assert _unclosed_fence_start(closed, 0, len(closed)) is None
     longer_closes = opened + "````\n"
     assert _unclosed_fence_start(longer_closes, 0, len(longer_closes)) is None
+
+
+def test_unclosed_fence_inside_a_block_quote() -> None:
+    """A fence quoted with `>` opens and closes only at the same quote depth."""
+    quoted_open = "> ```python\n> code\n"
+    assert _unclosed_fence_start(quoted_open, 0, len(quoted_open)) == 0
+    wrong_depth_closes = quoted_open + "```\n"
+    assert _unclosed_fence_start(wrong_depth_closes, 0, len(wrong_depth_closes)) == 0
+    quoted_closes = quoted_open + "> ```\n"
+    assert _unclosed_fence_start(quoted_closes, 0, len(quoted_closes)) is None

--- a/tests/test_segmented_messages.py
+++ b/tests/test_segmented_messages.py
@@ -1,11 +1,11 @@
 """Tests for lossless Matrix Markdown segmentation."""
 
+from mindroom.matrix.large_messages import calculate_event_size
 from mindroom.matrix.message_builder import build_matrix_edit_content, markdown_to_html
 from mindroom.matrix.segmented_messages import (
     _SEGMENT_TARGET_EDIT_BYTES,
     _SEGMENT_TARGET_PLAINTEXT_BYTES,
     _chunk_mentions,
-    _estimated_event_size,
     _render_segment_html,
     _unclosed_fence_start,
     segment_matrix_content,
@@ -44,7 +44,7 @@ def test_plaintext_segments_preserve_markdown_body() -> None:
     assert segmented.first["m.relates_to"] == content["m.relates_to"]
     assert all(part["format"] == "org.matrix.custom.html" for part in parts)
     assert all(part["formatted_body"] for part in parts)
-    assert all(_estimated_event_size(part) <= _SEGMENT_TARGET_PLAINTEXT_BYTES for part in parts)
+    assert all(calculate_event_size(part) <= _SEGMENT_TARGET_PLAINTEXT_BYTES for part in parts)
 
 
 def test_continuations_use_thread_fallback_relation() -> None:
@@ -131,10 +131,8 @@ def test_edit_segments_use_replace_then_thread_replies() -> None:
     assert "".join(part["body"] for part in parts) == body
     assert segmented.first["m.relates_to"]["rel_type"] == "m.replace"
     assert all(part["m.relates_to"]["rel_type"] == "m.thread" for part in segmented.continuations)
-    assert all(
-        _estimated_event_size(part) <= _SEGMENT_TARGET_EDIT_BYTES
-        for part in [segmented.first, *segmented.continuations]
-    )
+    assert calculate_event_size(segmented.first) <= _SEGMENT_TARGET_EDIT_BYTES
+    assert all(calculate_event_size(part) <= _SEGMENT_TARGET_PLAINTEXT_BYTES for part in segmented.continuations)
 
 
 def test_large_tool_trace_does_not_disable_visible_markdown() -> None:

--- a/tests/test_segmented_messages.py
+++ b/tests/test_segmented_messages.py
@@ -257,8 +257,9 @@ def test_mention_pills_survive_segmentation() -> None:
     mentioned = [part for part in parts if "@alice:localhost" in part["body"]]
     assert len(mentioned) == 1
     assert '<a href="https://matrix.to/#/@alice:localhost">@Alice</a>' in mentioned[0]["formatted_body"]
-    assert segmented.first["m.mentions"] == {"user_ids": ["@alice:localhost"]}
-    assert all("m.mentions" not in part for part in segmented.continuations)
+    # m.mentions belongs to the event whose body carries the mention.
+    assert mentioned[0]["m.mentions"] == {"user_ids": ["@alice:localhost"]}
+    assert all("m.mentions" not in part for part in parts if part is not mentioned[0])
 
 
 def test_prefix_overlapping_mentions_do_not_nest_pills() -> None:

--- a/tests/test_segmented_messages.py
+++ b/tests/test_segmented_messages.py
@@ -27,7 +27,12 @@ def test_plaintext_segments_preserve_markdown_body() -> None:
         "m.relates_to": {"rel_type": "m.thread", "event_id": "$thread"},
     }
 
-    segmented = segment_matrix_content(content, room_encrypted=False)
+    segmented = segment_matrix_content(
+        content,
+        room_encrypted=False,
+        continuation_thread_id="$thread",
+        continuation_reply_to_event_id="$cause",
+    )
 
     assert segmented is not None
     parts = [segmented.first, *segmented.continuations]
@@ -37,6 +42,65 @@ def test_plaintext_segments_preserve_markdown_body() -> None:
     assert all(part["format"] == "org.matrix.custom.html" for part in parts)
     assert all(part["formatted_body"] for part in parts)
     assert all(_estimated_event_size(part) <= _SEGMENT_TARGET_PLAINTEXT_BYTES for part in parts)
+
+
+def test_continuations_use_thread_fallback_relation() -> None:
+    """Continuations never repeat a genuine reply to the turn's source event.
+
+    Replay recovery counts every non-fallback reply to a source as a visible
+    response of the turn; one segmented answer must produce exactly one.
+    """
+    body = _body()
+    genuine_reply = {
+        "rel_type": "m.thread",
+        "event_id": "$thread",
+        "is_falling_back": False,
+        "m.in_reply_to": {"event_id": "$cause"},
+    }
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": markdown_to_html(body),
+        "m.relates_to": genuine_reply,
+    }
+
+    segmented = segment_matrix_content(
+        content,
+        room_encrypted=False,
+        continuation_thread_id="$thread",
+        continuation_reply_to_event_id="$cause",
+    )
+
+    assert segmented is not None
+    assert segmented.first["m.relates_to"] == genuine_reply
+    assert segmented.continuations
+    for continuation in segmented.continuations:
+        assert continuation["m.relates_to"] == {
+            "rel_type": "m.thread",
+            "event_id": "$thread",
+            "is_falling_back": True,
+            "m.in_reply_to": {"event_id": "$cause"},
+        }
+
+
+def test_room_mode_continuations_carry_no_reply_relation() -> None:
+    """Outside threads a continuation is a bare message, not a second reply."""
+    body = _body()
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": markdown_to_html(body),
+        "m.relates_to": {"m.in_reply_to": {"event_id": "$cause"}},
+    }
+
+    segmented = segment_matrix_content(content, room_encrypted=False)
+
+    assert segmented is not None
+    assert segmented.continuations
+    assert all("m.relates_to" not in part for part in segmented.continuations)
+    assert "".join(part["body"] for part in [segmented.first, *segmented.continuations]) == body
 
 
 def test_edit_segments_use_replace_then_thread_replies() -> None:
@@ -103,3 +167,71 @@ def test_large_tool_trace_does_not_disable_visible_markdown() -> None:
     assert "io.mindroom.tool_trace" not in first
     assert first["format"] == "org.matrix.custom.html"
     assert first["formatted_body"]
+
+
+def _fence_balance(text: str) -> int:
+    """Return the net number of unclosed fence openers in one chunk."""
+    return sum(1 for line in text.splitlines() if line.lstrip().startswith(("```", "~~~"))) % 2
+
+
+def test_fenced_code_block_is_not_split_mid_block() -> None:
+    """Every segment must be self-contained Markdown, fences included."""
+    prefix = "\n\n".join(f"## Lead {index}\n\nword " * 40 for index in range(30))
+    fence = "```python\n" + "".join(f"value_{index} = {index}\n" for index in range(150)) + "```"
+    suffix = "\n\n".join(f"## Tail {index}\n\nword " * 40 for index in range(30))
+    body = f"{prefix}\n\n{fence}\n\n{suffix}"
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": markdown_to_html(body),
+    }
+
+    segmented = segment_matrix_content(content, room_encrypted=True)
+
+    assert segmented is not None
+    parts = [segmented.first, *segmented.continuations]
+    assert len(parts) >= 2
+    assert "".join(part["body"] for part in parts) == body
+    assert all(_fence_balance(part["body"]) == 0 for part in parts)
+    assert sum(fence in part["body"] for part in parts) == 1
+
+
+def test_fence_spanning_the_whole_budget_falls_back_to_sidecar() -> None:
+    """A code block no cut can keep whole stays on the sidecar path."""
+    body = "```\n" + "x" * (_SEGMENT_TARGET_PLAINTEXT_BYTES * 2) + "\n```"
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": markdown_to_html(body),
+    }
+
+    assert segment_matrix_content(content, room_encrypted=False) is None
+
+
+def test_mention_pills_survive_segmentation() -> None:
+    """Re-rendering a chunk must not drop the link its plain body cannot carry."""
+    lead = "\n\n".join(f"## Section {index}\n\n**value {index}**" for index in range(600))
+    body = f"{lead}\n\nThanks @alice:localhost for the review."
+    content = {
+        "msgtype": "m.text",
+        "body": body,
+        "format": "org.matrix.custom.html",
+        "formatted_body": (
+            markdown_to_html(lead)
+            + '<p>Thanks <a href="https://matrix.to/#/@alice:localhost">@Alice</a> for the review.</p>'
+        ),
+        "m.mentions": {"user_ids": ["@alice:localhost"]},
+    }
+
+    segmented = segment_matrix_content(content, room_encrypted=False)
+
+    assert segmented is not None
+    parts = [segmented.first, *segmented.continuations]
+    assert "".join(part["body"] for part in parts) == body
+    mentioned = [part for part in parts if "@alice:localhost" in part["body"]]
+    assert len(mentioned) == 1
+    assert '<a href="https://matrix.to/#/@alice:localhost">@Alice</a>' in mentioned[0]["formatted_body"]
+    assert segmented.first["m.mentions"] == {"user_ids": ["@alice:localhost"]}
+    assert all("m.mentions" not in part for part in segmented.continuations)


### PR DESCRIPTION
## Summary

Addresses #1924.

Oversized Matrix text responses are no longer forced onto the truncated-preview + JSON sidecar path. When enabled, the delivery gateway splits an oversized response into multiple complete, ordered, rich-text `m.room.message` events so the full Markdown answer stays visible and rendered in any Matrix client — no sidecar hydration required.

The behavior is gated behind a new opt-in config switch and defaults to the existing sidecar behavior:

```yaml
defaults:
  large_message_strategy: split   # default: sidecar
```

## How it works

- **`matrix/segmented_messages.py`** — splits the response body at paragraph/line boundaries (falling back to Unicode boundaries), preserving every character; concatenating segment bodies reproduces the original response exactly. Every segment keeps `format: org.matrix.custom.html` with a freshly rendered `formatted_body`. Internal streaming baggage (`io.mindroom.tool_trace`, `io.mindroom.visible_body`) is stripped from the visible first event so a long tool trace alone cannot force the answer into a sidecar.
- **First segment vs continuations** — the first segment stays a final `m.replace` of the streaming placeholder; continuations are normal rich-text messages that remain in the same thread when one exists.
- **Conservative per-event budgets** — 46 KB plaintext / 22 KB edit / 30 KB encrypted / 16 KB encrypted edit (estimated event size including a 2 KB margin), deliberately below the sidecar thresholds so every segment passes through `large_messages` unchanged.
- **Durable recovery** — continuation payloads are frozen into the local outbox record (`io.mindroom.matrix_segment_payloads`, never sent to Matrix), and each continuation gets a deterministic `uuid5` transaction ID derived from the turn, so retries after a crash/restart are idempotent and cannot post duplicates.
- **Sidecar remains the fallback** — non-text payloads, or metadata that alone exceeds the budget, still use the existing `large_messages` sidecar path; streaming in-progress edits are untouched.

## Commits

1. `Split oversized Matrix text responses into lossless segmented messages` — segmentation module, delivery-gateway integration, regression tests.
2. `Add opt-in large_message_strategy config for segmented Matrix responses` — the `defaults.large_message_strategy` switch (`sidecar` default, hot-reload aware), frontend type preservation, sidecar-mode regression test.

## Testing

- `tests/test_segmented_messages.py` — exact body preservation, rich-text fields, per-segment size budgets, thread relations, tool-trace stripping.
- `tests/test_response_delivery_gateway.py` — end-to-end outbox flow: frozen primary + continuations fit the hard limit, `room_send` receives `[primary, *continuations]`, no `m.file`/upload in split mode; sidecar mode asserts the legacy `m.file` + single upload behavior.
- `tests/test_config_manager_consolidated.py` — config parsing: `sidecar` default, `split` accepted, invalid values rejected.
- Full `pre-commit run --all-files` passes (ruff, ty, tach, privata, TypeScript check).

## Notes for reviewers

- With the default `sidecar`, observable behavior is unchanged from `main`; the issue's acceptance criteria are met with `large_message_strategy: split`. Happy to flip the default if preferred.
- `frontend/src/types/config.ts` includes a prettier reformat (double→single quotes) enforced by the repo's own hook on any touch of that file; the only semantic change is the added optional `large_message_strategy` field.

## Summary by Sourcery

Enable opt-in lossless segmentation of oversized Matrix Markdown responses while preserving the existing sidecar behavior by default.

New Features:
- Add an opt-in Matrix delivery strategy that splits oversized Markdown responses into ordered, lossless rich-text message segments.
- Preserve threading, mentions, formatting, and complete fenced code blocks across segmented Matrix responses.

Bug Fixes:
- Make segmented response delivery durable and crash-safe by persisting continuation payloads locally and recovering only missing events without duplicating identical segments.

Enhancements:
- Retain the existing sidecar upload behavior as the default fallback for unsupported or unsplittable oversized payloads.

Documentation:
- Document the new large_message_strategy configuration option and its sidecar default.

Tests:
- Add coverage for lossless segmentation, formatting, threading, mentions, code fences, size budgets, configuration validation, sidecar fallback, and recovery behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable handling for oversized responses.
  * Responses can be delivered as an attachment preview or split into lossless continuation messages.
  * Split messages preserve Markdown formatting, edits, threading, mentions, and safe Unicode boundaries.
  * Added configuration support for selecting the delivery strategy.

* **Bug Fixes**
  * Improved recovery to resend only missing continuation messages.
  * Prevented unsafe splitting of fenced code blocks and misidentified mentions.

* **Documentation**
  * Updated the example configuration with the new oversized-message setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->