### PR TITLE
Allow live inviters under current-room access

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -109,6 +109,8 @@ MindRoom resolves aliases before administrator and static-user matching.
 Internal MindRoom identities bypass responder restrictions because they are system participants.
 The authoritative membership index fails closed while a referenced room is missing, stale, unresolved, or unavailable.
 Invitations do not count as joined membership, and leave, kick, or ban events revoke membership grants.
+Before a responder joins, the authenticated sender of its current invite may satisfy `current_room_members` only for deciding whether to accept that invite.
+Recovered invite records without current Matrix invite state do not receive this exception, and normal post-join authorization remains unchanged.
 The router owns this authoritative index, so it must be joined to a room before `current_room_members` can authorize activity there.
 For an ad-hoc room where an agent arrived first, use the agent's `invite_router` recovery tool and retry after the router joins.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16483,6 +16483,8 @@ MindRoom resolves aliases before administrator and static-user matching.
 Internal MindRoom identities bypass responder restrictions because they are system participants.
 The authoritative membership index fails closed while a referenced room is missing, stale, unresolved, or unavailable.
 Invitations do not count as joined membership, and leave, kick, or ban events revoke membership grants.
+Before a responder joins, the authenticated sender of its current invite may satisfy `current_room_members` only for deciding whether to accept that invite.
+Recovered invite records without current Matrix invite state do not receive this exception, and normal post-join authorization remains unchanged.
 The router owns this authoritative index, so it must be joined to a room before `current_room_members` can authorize activity there.
 For an ad-hoc room where an agent arrived first, use the agent's `invite_router` recovery tool and retry after the router joins.
 

--- a/skills/mindroom-docs/references/page__authorization__index.md
+++ b/skills/mindroom-docs/references/page__authorization__index.md
@@ -105,6 +105,8 @@ MindRoom resolves aliases before administrator and static-user matching.
 Internal MindRoom identities bypass responder restrictions because they are system participants.
 The authoritative membership index fails closed while a referenced room is missing, stale, unresolved, or unavailable.
 Invitations do not count as joined membership, and leave, kick, or ban events revoke membership grants.
+Before a responder joins, the authenticated sender of its current invite may satisfy `current_room_members` only for deciding whether to accept that invite.
+Recovered invite records without current Matrix invite state do not receive this exception, and normal post-join authorization remains unchanged.
 The router owns this authoritative index, so it must be joined to a room before `current_room_members` can authorize activity there.
 For an ad-hoc room where an agent arrived first, use the agent's `invite_router` recovery tool and retry after the router joins.
 

--- a/src/mindroom/bot.py
+++ b/src/mindroom/bot.py
@@ -2474,6 +2474,12 @@ class AgentBot:
         Persist its room and inviter before network work moves to the
         background so access changes and process restarts can reconcile it.
         """
+        if (
+            not isinstance(event, nio.InviteMemberEvent)
+            or event.state_key != self.agent_user.user_id
+            or event.membership != "invite"
+        ):
+            return
         self._room_lifecycle.record_pending_room_invite(room.room_id, event.sender)
         create_background_task(
             self._room_lifecycle.handle_recorded_invite(room, event.sender),

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -249,10 +249,13 @@ class BotRoomLifecycle:
             raise OSError(msg)
         self._pending_room_invites = pending_invites
 
-    def _forget_pending_room_invite(self, room_id: str) -> None:
+    def _forget_pending_room_invite(self, room_id: str, sender_id: str | None = None) -> None:
         """Forget a resolved outstanding invite without losing concurrent state."""
         pending_invites = load_pending_room_invites(self._pending_room_invites_file_path())
         if room_id not in pending_invites:
+            self._pending_room_invites = pending_invites
+            return
+        if sender_id is not None and pending_invites[room_id] != sender_id:
             self._pending_room_invites = pending_invites
             return
         pending_invites.pop(room_id)
@@ -438,12 +441,7 @@ class BotRoomLifecycle:
 
     async def handle_recorded_invite(self, room: nio.MatrixRoom, sender: str) -> None:
         """Handle one invite whose identity is already durable."""
-        await self._handle_invite(
-            room,
-            sender,
-            invite_is_current=True,
-            sender_is_current_inviter=True,
-        )
+        await self._handle_invite(room, sender, require_current_inviter=True)
 
     async def reconcile_pending_invites(self) -> None:
         """Re-evaluate durable and cached invites after responder access changes."""
@@ -454,25 +452,17 @@ class BotRoomLifecycle:
                 self.record_pending_room_invite(room.room_id, room.inviter)
         for room_id, sender in tuple(self._pending_room_invites.items()):
             room = client.invited_rooms.get(room_id)
-            invite_is_current = room is not None
-            sender_is_current_inviter = room is not None and room.inviter == sender
             if room is None:
                 room = nio.MatrixInvitedRoom(room_id, self.deps.agent_user.user_id)
                 room.inviter = sender
-            await self._handle_invite(
-                room,
-                sender,
-                invite_is_current=invite_is_current,
-                sender_is_current_inviter=sender_is_current_inviter,
-            )
+            await self._handle_invite(room, sender, require_current_inviter=False)
 
     async def _handle_invite(
         self,
         room: nio.MatrixRoom,
         sender: str,
         *,
-        invite_is_current: bool,
-        sender_is_current_inviter: bool,
+        require_current_inviter: bool,
     ) -> None:
         """Accept one invite when its inviter currently passes responder access."""
         client = self._client()
@@ -480,32 +470,43 @@ class BotRoomLifecycle:
             self._logger().info("Ignored invite", room_id=room.room_id, sender=sender)
             return
 
-        config = self._config()
-        invite_allowed = is_sender_allowed_for_agent_reply_in_room(
-            sender,
-            self.deps.agent_name,
-            config,
-            room.room_id,
-            self.deps.runtime_paths,
-            self.deps.runtime.agent_reply_memberships,
-        )
-        if not invite_allowed and sender_is_current_inviter:
-            invite_allowed = resolve_responder_access(config, self.deps.agent_name).current_room_members
-        if not invite_allowed:
-            self._logger().debug(
-                "ignoring_invite_from_unauthorized_sender",
-                user_id=sender,
-                room_id=room.room_id,
-            )
-            return
-
         async with self._lock_for_room(self._invite_join_locks, room.room_id):
+            current_room = client.invited_rooms.get(room.room_id)
+            invite_is_current = current_room is not None
+            sender_is_current_inviter = current_room is not None and current_room.inviter == sender
+            if require_current_inviter and not sender_is_current_inviter:
+                self._logger().debug(
+                    "ignoring_stale_invite_sender",
+                    user_id=sender,
+                    room_id=room.room_id,
+                )
+                return
+
+            config = self._config()
+            invite_allowed = is_sender_allowed_for_agent_reply_in_room(
+                sender,
+                self.deps.agent_name,
+                config,
+                room.room_id,
+                self.deps.runtime_paths,
+                self.deps.runtime.agent_reply_memberships,
+            )
+            if not invite_allowed and sender_is_current_inviter:
+                invite_allowed = resolve_responder_access(config, self.deps.agent_name).current_room_members
+            if not invite_allowed:
+                self._logger().debug(
+                    "ignoring_invite_from_unauthorized_sender",
+                    user_id=sender,
+                    room_id=room.room_id,
+                )
+                return
+
             if room.room_id in self._handled_invite_room_ids:
                 self._logger().debug("Invite already handled", room_id=room.room_id, sender=sender)
                 await self.deps.on_room_joined(room.room_id)
                 self._remember_invited_room(room.room_id)
                 await self._send_invite_welcome(room.room_id, sender)
-                self._forget_pending_room_invite(room.room_id)
+                self._forget_pending_room_invite(room.room_id, sender)
                 return
 
             self._logger().info("Received invite", room_id=room.room_id, sender=sender)
@@ -514,10 +515,10 @@ class BotRoomLifecycle:
                 self._logger().error("Failed to join room", room_id=room.room_id)
                 if join_outcome is RoomJoinOutcome.ACCESS_DENIED and not invite_is_current:
                     await self._clear_join_decrypt_notice_fence(room.room_id)
-                    self._forget_pending_room_invite(room.room_id)
+                    self._forget_pending_room_invite(room.room_id, sender)
                     return
                 if join_outcome is RoomJoinOutcome.TERMINAL_FAILURE:
-                    self._forget_pending_room_invite(room.room_id)
+                    self._forget_pending_room_invite(room.room_id, sender)
                     return
                 msg = f"Failed to join invited room {room.room_id}"
                 raise RuntimeError(msg)
@@ -527,4 +528,4 @@ class BotRoomLifecycle:
             self._remember_invited_room(room.room_id)
             self._handled_invite_room_ids.add(room.room_id)
             await self._send_invite_welcome(room.room_id, sender)
-            self._forget_pending_room_invite(room.room_id)
+            self._forget_pending_room_invite(room.room_id, sender)

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Protocol
 
 import nio
 
+from mindroom.access_policy import resolve_responder_access
 from mindroom.authorization import is_sender_allowed_for_agent_reply_in_room
 from mindroom.commands.handler import generate_welcome_message_for_room
 from mindroom.constants import ROUTER_AGENT_NAME
@@ -476,6 +477,8 @@ class BotRoomLifecycle:
             self.deps.runtime_paths,
             self.deps.runtime.agent_reply_memberships,
         )
+        if not invite_allowed and invite_is_current:
+            invite_allowed = resolve_responder_access(config, self.deps.agent_name).current_room_members
         if not invite_allowed:
             self._logger().debug(
                 "ignoring_invite_from_unauthorized_sender",

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -449,7 +449,7 @@ class BotRoomLifecycle:
                 self.record_pending_room_invite(room.room_id, room.inviter)
         for room_id, sender in tuple(self._pending_room_invites.items()):
             room = client.invited_rooms.get(room_id)
-            invite_is_current = room is not None
+            invite_is_current = room is not None and room.inviter == sender
             if room is None:
                 room = nio.MatrixInvitedRoom(room_id, self.deps.agent_user.user_id)
                 room.inviter = sender

--- a/src/mindroom/bot_room_lifecycle.py
+++ b/src/mindroom/bot_room_lifecycle.py
@@ -438,7 +438,12 @@ class BotRoomLifecycle:
 
     async def handle_recorded_invite(self, room: nio.MatrixRoom, sender: str) -> None:
         """Handle one invite whose identity is already durable."""
-        await self._handle_invite(room, sender, invite_is_current=True)
+        await self._handle_invite(
+            room,
+            sender,
+            invite_is_current=True,
+            sender_is_current_inviter=True,
+        )
 
     async def reconcile_pending_invites(self) -> None:
         """Re-evaluate durable and cached invites after responder access changes."""
@@ -449,11 +454,17 @@ class BotRoomLifecycle:
                 self.record_pending_room_invite(room.room_id, room.inviter)
         for room_id, sender in tuple(self._pending_room_invites.items()):
             room = client.invited_rooms.get(room_id)
-            invite_is_current = room is not None and room.inviter == sender
+            invite_is_current = room is not None
+            sender_is_current_inviter = room is not None and room.inviter == sender
             if room is None:
                 room = nio.MatrixInvitedRoom(room_id, self.deps.agent_user.user_id)
                 room.inviter = sender
-            await self._handle_invite(room, sender, invite_is_current=invite_is_current)
+            await self._handle_invite(
+                room,
+                sender,
+                invite_is_current=invite_is_current,
+                sender_is_current_inviter=sender_is_current_inviter,
+            )
 
     async def _handle_invite(
         self,
@@ -461,6 +472,7 @@ class BotRoomLifecycle:
         sender: str,
         *,
         invite_is_current: bool,
+        sender_is_current_inviter: bool,
     ) -> None:
         """Accept one invite when its inviter currently passes responder access."""
         client = self._client()
@@ -477,7 +489,7 @@ class BotRoomLifecycle:
             self.deps.runtime_paths,
             self.deps.runtime.agent_reply_memberships,
         )
-        if not invite_allowed and invite_is_current:
+        if not invite_allowed and sender_is_current_inviter:
             invite_allowed = resolve_responder_access(config, self.deps.agent_name).current_room_members
         if not invite_allowed:
             self._logger().debug(

--- a/tests/test_dm_functionality.py
+++ b/tests/test_dm_functionality.py
@@ -302,6 +302,8 @@ class TestDMIntegration:
             room.canonical_alias = None
             event = MagicMock()
             event.sender = "@user:localhost"
+            room.inviter = event.sender
+            bot.client.invited_rooms = {room.room_id: room}
 
             bot._room_lifecycle.record_pending_room_invite(room.room_id, event.sender)
             await bot._room_lifecycle.handle_recorded_invite(room, event.sender)

--- a/tests/test_multi_agent_bot.py
+++ b/tests/test_multi_agent_bot.py
@@ -550,6 +550,8 @@ class TestAgentBot(AgentBotTestBase):
 
         mock_event = MagicMock()
         mock_event.sender = "@user:localhost"
+        mock_room.inviter = mock_event.sender
+        bot.client.invited_rooms = {mock_room.room_id: mock_room}
 
         join_room = AsyncMock(return_value=RoomJoinOutcome.JOINED)
         with (

--- a/tests/test_multi_agent_e2e.py
+++ b/tests/test_multi_agent_e2e.py
@@ -657,6 +657,8 @@ async def test_agent_handles_room_invite(mock_calculator_agent: AgentMatrixUser,
         mock_room.display_name = "Invite Room"
         mock_event = MagicMock(spec=nio.InviteEvent)
         mock_event.sender = "@inviter:localhost"
+        mock_room.inviter = mock_event.sender
+        bot.client.invited_rooms = {mock_room.room_id: mock_room}
 
         bot._room_lifecycle.record_pending_room_invite(mock_room.room_id, mock_event.sender)
         await bot._room_lifecycle.handle_recorded_invite(mock_room, mock_event.sender)

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -508,6 +508,54 @@ async def test_recovered_revoked_invite_is_forgotten_after_forbidden_join(
 
 
 @pytest.mark.asyncio
+async def test_cached_invite_without_inviter_keeps_authorized_join_retryable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Missing inviter metadata must not make cached membership work look revoked."""
+    sender_id = "@owner:localhost"
+    room_id = "!cached-invite:localhost"
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "agent1": AgentConfig(
+                    display_name="Agent 1",
+                    role="Test agent",
+                    access=ResponderAccessConfig(users=[sender_id]),
+                ),
+            },
+            router=RouterConfig(model="default"),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    agent_user = AgentMatrixUser(
+        agent_name="agent1",
+        user_id="@mindroom_agent1:localhost",
+        display_name="Agent 1",
+        password=TEST_PASSWORD,
+    )
+    bot = make_test_agent_bot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    install_runtime_journal_support(bot)
+    bot.client = make_matrix_client_mock(user_id=agent_user.user_id)
+    bot.client.invited_rooms = {room_id: nio.MatrixInvitedRoom(room_id, agent_user.user_id)}
+    monkeypatch.setattr(
+        "mindroom.bot_room_lifecycle.join_room",
+        AsyncMock(return_value=RoomJoinOutcome.ACCESS_DENIED),
+    )
+    bot._room_lifecycle.record_pending_room_invite(room_id, sender_id)
+
+    with pytest.raises(RuntimeError, match="Failed to join invited room"):
+        await bot._room_lifecycle.reconcile_pending_invites()
+
+    assert _pending_room_invites(config, "agent1") == {room_id: sender_id}
+
+
+@pytest.mark.asyncio
 async def test_initial_sync_invite_is_current_membership_work(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -552,6 +600,54 @@ async def test_initial_sync_invite_is_current_membership_work(
     welcome_message.assert_awaited_once_with(room.room_id, event.sender)
     assert bot._room_lifecycle.invited_rooms == {room.room_id}
     assert await bot._journal_dispatcher.store.pending() == ()
+
+
+@pytest.mark.asyncio
+async def test_invite_metadata_event_does_not_start_invite_work(tmp_path: Path) -> None:
+    """Stripped room metadata must not impersonate the self-membership inviter."""
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "agent1": AgentConfig(
+                    display_name="Agent 1",
+                    role="Test agent",
+                    access=ResponderAccessConfig(current_room_members=True),
+                ),
+            },
+            router=RouterConfig(model="default"),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    agent_user = AgentMatrixUser(
+        agent_name="agent1",
+        user_id="@mindroom_agent1:localhost",
+        display_name="Agent 1",
+        password=TEST_PASSWORD,
+    )
+    bot = make_test_agent_bot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    bot._room_lifecycle.handle_recorded_invite = AsyncMock()
+    room = nio.MatrixInvitedRoom("!metadata:localhost", agent_user.user_id)
+    room.inviter = "@owner:localhost"
+    event = nio.InviteEvent.parse_event(
+        {
+            "type": "m.room.name",
+            "sender": "@metadata-author:localhost",
+            "state_key": "",
+            "content": {"name": "Project"},
+        },
+    )
+    assert isinstance(event, nio.InviteNameEvent)
+
+    await bot._on_invite_before_sync_certification(room, event)
+    assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+
+    assert _pending_room_invites(config, "agent1") == {}
+    bot._room_lifecycle.handle_recorded_invite.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -2050,18 +2050,19 @@ async def test_agent_refuses_invite_from_unauthorized_sender(
 @pytest.mark.asyncio
 @pytest.mark.usefixtures("enforce_turn_authorization")
 @pytest.mark.parametrize(
-    ("invite_is_current", "expected_invited_rooms"),
+    ("invite_source", "expected_invited_rooms"),
     [
-        (True, {"!invited-room:localhost"}),
-        (False, set()),
+        ("current", {"!invited-room:localhost"}),
+        ("recovered", set()),
+        ("cached_without_inviter", set()),
     ],
-    ids=["current", "recovered"],
+    ids=["current", "recovered", "cached-without-inviter"],
 )
 async def test_current_room_members_only_authorize_a_current_invite(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     *,
-    invite_is_current: bool,
+    invite_source: str,
     expected_invited_rooms: set[str],
 ) -> None:
     """Only the authenticated sender of a live invite gets the pre-join exception."""
@@ -2095,13 +2096,13 @@ async def test_current_room_members_only_authorize_a_current_invite(
     install_runtime_journal_support(bot)
     bot.client = make_matrix_client_mock(user_id=agent_user.user_id)
     invited_room = nio.MatrixInvitedRoom(room_id, agent_user.user_id)
-    invited_room.inviter = sender_id
     monkeypatch.setattr(
         "mindroom.bot_room_lifecycle.join_room",
         AsyncMock(return_value=RoomJoinOutcome.JOINED),
     )
 
-    if invite_is_current:
+    if invite_source == "current":
+        invited_room.inviter = sender_id
         bot.client.invited_rooms = {room_id: invited_room}
         event = nio.InviteEvent.parse_event(
             {
@@ -2114,6 +2115,8 @@ async def test_current_room_members_only_authorize_a_current_invite(
         assert isinstance(event, nio.InviteMemberEvent)
         await _handle_invite(bot, invited_room, event)
     else:
+        if invite_source == "cached_without_inviter":
+            bot.client.invited_rooms = {room_id: invited_room}
         bot._room_lifecycle.record_pending_room_invite(room_id, sender_id)
         await bot._room_lifecycle.reconcile_pending_invites()
 

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -2047,6 +2047,80 @@ async def test_agent_refuses_invite_from_unauthorized_sender(
     assert not _invited_rooms_path(config, "agent1").exists()
 
 
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enforce_turn_authorization")
+@pytest.mark.parametrize(
+    ("invite_is_current", "expected_invited_rooms"),
+    [
+        (True, {"!invited-room:localhost"}),
+        (False, set()),
+    ],
+    ids=["current", "recovered"],
+)
+async def test_current_room_members_only_authorize_a_current_invite(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    *,
+    invite_is_current: bool,
+    expected_invited_rooms: set[str],
+) -> None:
+    """Only the authenticated sender of a live invite gets the pre-join exception."""
+    sender_id = "@member:localhost"
+    room_id = "!invited-room:localhost"
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "agent1": AgentConfig(
+                    display_name="Agent 1",
+                    role="Test agent",
+                    access=ResponderAccessConfig(current_room_members=True),
+                ),
+            },
+            router=RouterConfig(model="default"),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    agent_user = AgentMatrixUser(
+        agent_name="agent1",
+        user_id="@mindroom_agent1:localhost",
+        display_name="Agent 1",
+        password=TEST_PASSWORD,
+    )
+    bot = make_test_agent_bot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    install_runtime_journal_support(bot)
+    bot.client = make_matrix_client_mock(user_id=agent_user.user_id)
+    invited_room = nio.MatrixInvitedRoom(room_id, agent_user.user_id)
+    invited_room.inviter = sender_id
+    monkeypatch.setattr(
+        "mindroom.bot_room_lifecycle.join_room",
+        AsyncMock(return_value=RoomJoinOutcome.JOINED),
+    )
+
+    if invite_is_current:
+        bot.client.invited_rooms = {room_id: invited_room}
+        event = nio.InviteEvent.parse_event(
+            {
+                "type": "m.room.member",
+                "sender": sender_id,
+                "state_key": agent_user.user_id,
+                "content": {"membership": "invite"},
+            },
+        )
+        assert isinstance(event, nio.InviteMemberEvent)
+        await _handle_invite(bot, invited_room, event)
+    else:
+        bot._room_lifecycle.record_pending_room_invite(room_id, sender_id)
+        await bot._room_lifecycle.reconcile_pending_invites()
+
+    assert bot._room_lifecycle.invited_rooms == expected_invited_rooms
+    assert load_invited_rooms(_invited_rooms_path(config, "agent1")) == expected_invited_rooms
+
+
 @dataclass(frozen=True)
 class _GrantInviteScenario:
     config: Config

--- a/tests/test_room_invites.py
+++ b/tests/test_room_invites.py
@@ -67,8 +67,52 @@ def _pending_room_invites(config: Config, agent_name: str) -> dict[str, str]:
 
 
 async def _handle_invite(bot: AgentBot, room: nio.MatrixRoom, event: nio.InviteEvent) -> None:
+    if not isinstance(bot.client.invited_rooms, dict):
+        bot.client.invited_rooms = {}
+    room.inviter = event.sender
+    bot.client.invited_rooms[room.room_id] = room
     bot._room_lifecycle.record_pending_room_invite(room.room_id, event.sender)
     await bot._room_lifecycle.handle_recorded_invite(room, event.sender)
+
+
+def _live_current_room_member_invite(
+    tmp_path: Path,
+    *,
+    room_id: str,
+    sender_id: str,
+) -> tuple[Config, AgentBot, nio.MatrixInvitedRoom]:
+    """Build an agent with one live invite allowed only by current-room access."""
+    config = bind_runtime_paths(
+        Config(
+            agents={
+                "agent1": AgentConfig(
+                    display_name="Agent 1",
+                    role="Test agent",
+                    access=ResponderAccessConfig(current_room_members=True),
+                ),
+            },
+            router=RouterConfig(model="default"),
+        ),
+        test_runtime_paths(tmp_path),
+    )
+    agent_user = AgentMatrixUser(
+        agent_name="agent1",
+        user_id="@mindroom_agent1:localhost",
+        display_name="Agent 1",
+        password=TEST_PASSWORD,
+    )
+    bot = make_test_agent_bot(
+        agent_user=agent_user,
+        storage_path=tmp_path,
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+    )
+    install_runtime_journal_support(bot)
+    bot.client = make_matrix_client_mock(user_id=agent_user.user_id)
+    invited_room = nio.MatrixInvitedRoom(room_id, agent_user.user_id)
+    invited_room.inviter = sender_id
+    bot.client.invited_rooms = {room_id: invited_room}
+    return config, bot, invited_room
 
 
 def _router_user() -> AgentMatrixUser:
@@ -460,14 +504,14 @@ async def test_terminal_invite_join_failure_does_not_abort_sync(
         },
     )
     assert isinstance(event, nio.InviteMemberEvent)
+    room = nio.MatrixInvitedRoom("!invalid-state:localhost", bot.agent_user.user_id)
+    room.inviter = event.sender
+    bot.client.invited_rooms = {room.room_id: room}
 
-    await bot._on_invite_before_sync_certification(
-        nio.MatrixRoom("!invalid-state:localhost", bot.agent_user.user_id),
-        event,
-    )
+    await bot._on_invite_before_sync_certification(room, event)
     assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
 
-    bot.client.join.assert_awaited_once_with("!invalid-state:localhost")
+    bot.client.join.assert_awaited_once_with(room.room_id)
     assert await bot._journal_dispatcher.store.pending() == ()
     assert not bot._room_lifecycle.decrypt_notice_is_fenced("!invalid-state:localhost")
 
@@ -591,7 +635,9 @@ async def test_initial_sync_invite_is_current_membership_work(
         },
     )
     assert isinstance(event, nio.InviteMemberEvent)
-    room = nio.MatrixRoom("!invited:localhost", bot.agent_user.user_id)
+    room = nio.MatrixInvitedRoom("!invited:localhost", bot.agent_user.user_id)
+    room.inviter = event.sender
+    bot.client.invited_rooms = {room.room_id: room}
 
     await bot._on_invite_before_sync_certification(room, event)
     assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
@@ -1363,7 +1409,9 @@ async def test_redelivered_invite_retries_a_failed_welcome(
         },
     )
     assert isinstance(event, nio.InviteEvent)
-    room = nio.MatrixRoom("!router-invited:localhost", bot.matrix_id.full_id)
+    room = nio.MatrixInvitedRoom("!router-invited:localhost", bot.matrix_id.full_id)
+    room.inviter = event.sender
+    bot.client.invited_rooms = {room.room_id: room}
     await bot._on_invite_before_sync_certification(room, event)
     await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
 
@@ -2218,6 +2266,90 @@ async def test_current_room_members_only_authorize_a_current_invite(
 
     assert bot._room_lifecycle.invited_rooms == expected_invited_rooms
     assert load_invited_rooms(_invited_rooms_path(config, "agent1")) == expected_invited_rooms
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enforce_turn_authorization")
+async def test_deferred_live_invite_does_not_use_stale_inviter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Older background work must not authorize or erase a replacement invite."""
+    old_sender_id = "@old-member:localhost"
+    new_sender_id = "@new-member:localhost"
+    room_id = "!replaced-invite:localhost"
+    config, bot, invited_room = _live_current_room_member_invite(
+        tmp_path,
+        room_id=room_id,
+        sender_id=old_sender_id,
+    )
+    join_room = AsyncMock(return_value=RoomJoinOutcome.JOINED)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", join_room)
+    old_event = nio.InviteEvent.parse_event(
+        {
+            "type": "m.room.member",
+            "sender": old_sender_id,
+            "state_key": bot.agent_user.user_id,
+            "content": {"membership": "invite"},
+        },
+    )
+    assert isinstance(old_event, nio.InviteMemberEvent)
+
+    await bot._on_invite_before_sync_certification(invited_room, old_event)
+    invited_room.inviter = new_sender_id
+    bot._room_lifecycle.record_pending_room_invite(room_id, new_sender_id)
+    assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+
+    join_room.assert_not_awaited()
+    assert _pending_room_invites(config, "agent1") == {room_id: new_sender_id}
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("enforce_turn_authorization")
+async def test_completed_invite_work_does_not_erase_newer_inviter(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Completing an older join must preserve a replacement invite's identity."""
+    old_sender_id = "@old-member:localhost"
+    new_sender_id = "@new-member:localhost"
+    room_id = "!replaced-during-join:localhost"
+    config, bot, invited_room = _live_current_room_member_invite(
+        tmp_path,
+        room_id=room_id,
+        sender_id=old_sender_id,
+    )
+    join_started = asyncio.Event()
+    release_join = asyncio.Event()
+
+    async def delayed_join(_client: object, _room_id: str) -> RoomJoinOutcome:
+        join_started.set()
+        await release_join.wait()
+        return RoomJoinOutcome.JOINED
+
+    join_room = AsyncMock(side_effect=delayed_join)
+    monkeypatch.setattr("mindroom.bot_room_lifecycle.join_room", join_room)
+    old_event = nio.InviteEvent.parse_event(
+        {
+            "type": "m.room.member",
+            "sender": old_sender_id,
+            "state_key": bot.agent_user.user_id,
+            "content": {"membership": "invite"},
+        },
+    )
+    assert isinstance(old_event, nio.InviteMemberEvent)
+
+    await bot._on_invite_before_sync_certification(invited_room, old_event)
+    try:
+        await asyncio.wait_for(join_started.wait(), timeout=1)
+        invited_room.inviter = new_sender_id
+        bot._room_lifecycle.record_pending_room_invite(room_id, new_sender_id)
+    finally:
+        release_join.set()
+    assert await wait_for_background_tasks(timeout=1, owner=bot._runtime_view)
+
+    join_room.assert_awaited_once_with(bot.client, room_id)
+    assert _pending_room_invites(config, "agent1") == {room_id: new_sender_id}
 
 
 @dataclass(frozen=True)

--- a/tests/test_team_invitations.py
+++ b/tests/test_team_invitations.py
@@ -221,6 +221,8 @@ class TestTeamRoomMembership:
         room = MagicMock(room_id="!team-room:localhost")
         room.canonical_alias = None
         event = MagicMock(sender="@user:localhost")
+        room.inviter = event.sender
+        bot.client.invited_rooms = {room.room_id: room}
 
         bot._room_lifecycle.record_pending_room_invite(room.room_id, event.sender)
         await bot._room_lifecycle.handle_recorded_invite(room, event.sender)


### PR DESCRIPTION
## Summary
- allow the exact sender of a current self-membership invite when `current_room_members` is enabled
- ignore invite-room metadata events and require matching inviter evidence during reconciliation
- keep the existing persistence and retry lifecycle without adding new states or recovery machinery

## Behavior
- live membership inviters may authorize only that invitation
- recovered records without current inviter evidence still require ordinary access policy
- normal post-join authorization is unchanged

## Verification
- `uv run pytest` — 15,427 passed, 23 skipped
- `uv run pre-commit run --all-files` — passed

## Summary by Sourcery

Authorize eligible live inviters under current-room access while keeping recovered invites subject to normal policy and preserving existing invite lifecycle behavior.

Bug Fixes:
- Allow the authenticated sender of a live self-membership invite to satisfy current-room access when deciding whether to accept the invitation.
- Prevent stale, recovered, or metadata-only invite records from bypassing normal authorization or disrupting newer invite records.

Enhancements:
- Restrict invite processing to valid self-membership invite events and preserve pending-invite state across concurrent or replaced invitations.

Documentation:
- Document the limited pre-join authorization exception for live invite senders and clarify that recovered invites require ordinary access policy.

Tests:
- Add coverage for live versus recovered invites, invalid metadata events, missing inviter evidence, and concurrent invite replacement handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Current invite senders may satisfy room-member authorization when accepting an invite.
  * Recovered or incomplete invite records do not receive this exception.
* **Bug Fixes**
  * Ignore unrelated membership events during invite processing.
  * Prevent stale invite handling from affecting newer invitations.
  * Preserve retry behavior for cached invites when authorization permits.
* **Documentation**
  * Clarified invite authorization rules and post-join access behavior.
* **Tests**
  * Added coverage for live, cached, metadata-only, and replaced-invite scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->