### PR TITLE
Fix private worker identity mounts

### DIFF
--- a/src/mindroom/workers/backends/_dedicated_worker_common.py
+++ b/src/mindroom/workers/backends/_dedicated_worker_common.py
@@ -11,6 +11,7 @@ from mindroom.agent_policy import build_agent_policy_seeds, resolve_agent_policy
 from mindroom.constants import RuntimePaths, deserialize_runtime_paths, serialize_public_runtime_paths
 from mindroom.runtime_env_policy import CONTROL_STATE_PATH_ENV, SANDBOX_RUNTIME_ENV_BY_KEY, SHARED_CREDENTIALS_PATH_ENV
 from mindroom.tool_system.worker_routing import (
+    private_instance_scope_root_path,
     resolved_worker_key_scope,
     visible_state_roots_for_worker_key,
     worker_key_agent_name,
@@ -260,16 +261,21 @@ def plan_scoped_visible_state_roots(
         )
 
     effective_private_agent_names = private_agent_names or frozenset()
-    worker_visible_roots = visible_state_roots_for_worker_key(
-        worker_visible_shared_storage_root,
-        worker_key,
-        private_agent_names=effective_private_agent_names,
-    )
-    local_roots = visible_state_roots_for_worker_key(
-        local_shared_storage_root,
-        worker_key,
-        private_agent_names=effective_private_agent_names,
-    )
+    agent_name = worker_key_agent_name(worker_key)
+    if scope == "user_agent" and agent_name is not None and agent_name in effective_private_agent_names:
+        worker_visible_roots = (private_instance_scope_root_path(worker_visible_shared_storage_root, worker_key),)
+        local_roots = (private_instance_scope_root_path(local_shared_storage_root, worker_key),)
+    else:
+        worker_visible_roots = visible_state_roots_for_worker_key(
+            worker_visible_shared_storage_root,
+            worker_key,
+            private_agent_names=effective_private_agent_names,
+        )
+        local_roots = visible_state_roots_for_worker_key(
+            local_shared_storage_root,
+            worker_key,
+            private_agent_names=effective_private_agent_names,
+        )
     if not worker_visible_roots or len(worker_visible_roots) != len(local_roots):
         msg = f"Unsupported worker key for scoped storage mounts: {worker_key}"
         raise WorkerBackendError(msg)

--- a/tests/test_docker_worker_backend.py
+++ b/tests/test_docker_worker_backend.py
@@ -3927,7 +3927,7 @@ def test_docker_backend_user_agent_mounts_private_root_from_worker_spec(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """User-agent workers should mount their private instance root when explicitly visible."""
+    """User-agent workers should mount their scope root so identity metadata remains accessible."""
     config_text, _projected_paths = _private_user_agent_projected_config_fixture(tmp_path)
     backend, fake_client, _sync_calls = _backend(monkeypatch, tmp_path, config_text=config_text)
     worker_key = resolve_worker_key(
@@ -3949,9 +3949,9 @@ def test_docker_backend_user_agent_mounts_private_root_from_worker_spec(
 
     volumes = fake_client.containers.run_calls[0]["volumes"]
     assert isinstance(volumes, dict)
-    expected_private_root = (tmp_path / "private_instances" / worker_dir_name(worker_key) / "alpha").resolve()
+    expected_private_root = (tmp_path / "private_instances" / worker_dir_name(worker_key)).resolve()
     assert volumes[str(expected_private_root)] == {
-        "bind": f"/app/worker/private_instances/{worker_dir_name(worker_key)}/alpha",
+        "bind": f"/app/worker/private_instances/{worker_dir_name(worker_key)}",
         "mode": "rw",
     }
     assert all(spec["bind"] != "/app/worker/agents/alpha" for spec in volumes.values())
@@ -3964,7 +3964,7 @@ def test_docker_script_worker_mounts_the_owning_private_state_scope(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    """A unique script worker must not derive a fresh private root from its run ID."""
+    """A script worker should mount its owning scope root, including identity metadata."""
     config_text, _projected_paths = _private_user_agent_projected_config_fixture(tmp_path)
     backend, fake_client, _sync_calls = _backend(monkeypatch, tmp_path, config_text=config_text)
     state_scope_worker_key = "v1:tenant-123:user_agent:@alice:example.org:alpha"
@@ -3981,12 +3981,10 @@ def test_docker_script_worker_mounts_the_owning_private_state_scope(
 
     volumes = fake_client.containers.run_calls[0]["volumes"]
     assert isinstance(volumes, dict)
-    expected_private_root = (
-        tmp_path / "private_instances" / worker_dir_name(state_scope_worker_key) / "alpha"
-    ).resolve()
+    expected_private_root = (tmp_path / "private_instances" / worker_dir_name(state_scope_worker_key)).resolve()
     expected_run_root = worker_root_path(tmp_path, worker_key)
     assert volumes[str(expected_private_root)] == {
-        "bind": f"/app/worker/private_instances/{worker_dir_name(state_scope_worker_key)}/alpha",
+        "bind": f"/app/worker/private_instances/{worker_dir_name(state_scope_worker_key)}",
         "mode": "rw",
     }
     assert str(expected_run_root) in volumes
@@ -4023,9 +4021,9 @@ def test_docker_backend_rejects_private_user_agent_container_without_target_visi
     assert len(fake_client.containers.run_calls) == 1
     second_volumes = fake_client.containers.run_calls[0]["volumes"]
     assert isinstance(second_volumes, dict)
-    expected_private_root = (tmp_path / "private_instances" / worker_dir_name(worker_key) / "alpha").resolve()
+    expected_private_root = (tmp_path / "private_instances" / worker_dir_name(worker_key)).resolve()
     assert second_volumes[str(expected_private_root)] == {
-        "bind": f"/app/worker/private_instances/{worker_dir_name(worker_key)}/alpha",
+        "bind": f"/app/worker/private_instances/{worker_dir_name(worker_key)}",
         "mode": "rw",
     }
     assert handle.status == "ready"

--- a/tests/test_kubernetes_worker_backend.py
+++ b/tests/test_kubernetes_worker_backend.py
@@ -30,7 +30,6 @@ from mindroom.runtime_env_policy import CREDENTIALS_ENCRYPTION_KEY_ENV
 from mindroom.script_runs.models import script_worker_key_for_run
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
-    _private_instance_state_root_path,
     descriptive_worker_id_for_key,
     resolve_unscoped_worker_key,
     resolve_worker_key,
@@ -2656,7 +2655,7 @@ router:
 
 
 def test_kubernetes_backend_user_agent_mounts_private_root_from_worker_spec() -> None:
-    """User-agent workers should mount their private root from the explicit worker spec visibility."""
+    """User-agent workers should mount their scope root so identity metadata remains accessible."""
     backend, apps_api, _core_api = _backend()
     worker_key = resolve_worker_key(
         "user_agent",
@@ -2678,22 +2677,16 @@ def test_kubernetes_backend_user_agent_mounts_private_root_from_worker_spec() ->
     deployment = apps_api.created_bodies[0]
     volume_mounts = deployment["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
     mount_paths = {mount["mountPath"]: mount.get("subPath") for mount in volume_mounts}
-    expected_private_root = str(
-        _private_instance_state_root_path(
-            Path("/app/worker"),
-            worker_key=worker_key,
-            agent_name="mind",
-        ),
-    )
-    expected_private_subpath = f"private_instances/{worker_dir_name(worker_key)}/mind"
+    expected_private_root = f"/app/worker/private_instances/{worker_dir_name(worker_key)}"
+    expected_private_subpath = f"private_instances/{worker_dir_name(worker_key)}"
 
     assert mount_paths[expected_private_root] == expected_private_subpath
     assert "/app/worker/agents/mind" not in mount_paths
-    assert f"/app/worker/private_instances/{worker_dir_name(worker_key)}" not in mount_paths
+    assert f"{expected_private_root}/mind" not in mount_paths
 
 
 def test_kubernetes_script_worker_mounts_the_owning_private_state_scope() -> None:
-    """A unique script worker must not derive a fresh private root from its run ID."""
+    """A script worker should mount its owning scope root, including identity metadata."""
     backend, apps_api, _core_api = _backend()
     state_scope_worker_key = "v1:tenant-123:user_agent:@alice:example.org:mind"
     run_id = f"script-{'a' * 32}"
@@ -2711,14 +2704,8 @@ def test_kubernetes_script_worker_mounts_the_owning_private_state_scope() -> Non
     deployment = apps_api.created_bodies[0]
     volume_mounts = deployment["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
     mount_paths = {mount["mountPath"]: mount.get("subPath") for mount in volume_mounts}
-    expected_private_root = str(
-        _private_instance_state_root_path(
-            Path("/app/worker"),
-            worker_key=state_scope_worker_key,
-            agent_name="mind",
-        ),
-    )
-    expected_private_subpath = f"private_instances/{worker_dir_name(state_scope_worker_key)}/mind"
+    expected_private_root = f"/app/worker/private_instances/{worker_dir_name(state_scope_worker_key)}"
+    expected_private_subpath = f"private_instances/{worker_dir_name(state_scope_worker_key)}"
     expected_run_root = f"/app/worker/workers/{worker_dir_name(worker_key)}"
 
     assert deployment["metadata"]["annotations"][_ANNOTATION_STATE_SCOPE_WORKER_KEY] == state_scope_worker_key
@@ -2773,14 +2760,8 @@ def test_kubernetes_backend_recreates_user_agent_deployment_when_private_visibil
     recreated = apps_api.created_bodies[-1]
     volume_mounts = recreated["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
     mount_paths = {mount["mountPath"]: mount.get("subPath") for mount in volume_mounts}
-    expected_private_root = str(
-        _private_instance_state_root_path(
-            Path("/app/worker"),
-            worker_key=worker_key,
-            agent_name="mind",
-        ),
-    )
-    expected_private_subpath = f"private_instances/{worker_dir_name(worker_key)}/mind"
+    expected_private_root = f"/app/worker/private_instances/{worker_dir_name(worker_key)}"
+    expected_private_subpath = f"private_instances/{worker_dir_name(worker_key)}"
 
     assert mount_paths[expected_private_root] == expected_private_subpath
     assert "/app/worker/agents/mind" not in mount_paths
@@ -2815,15 +2796,9 @@ def test_kubernetes_backend_waits_for_deployment_deletion_before_recreate() -> N
     recreated = apps_api.created_bodies[-1]
     volume_mounts = recreated["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
     mount_paths = {mount["mountPath"]: mount.get("subPath") for mount in volume_mounts}
-    expected_private_root = str(
-        _private_instance_state_root_path(
-            Path("/app/worker"),
-            worker_key=worker_key,
-            agent_name="mind",
-        ),
-    )
+    expected_private_root = f"/app/worker/private_instances/{worker_dir_name(worker_key)}"
 
-    assert mount_paths[expected_private_root] == f"private_instances/{worker_dir_name(worker_key)}/mind"
+    assert mount_paths[expected_private_root] == f"private_instances/{worker_dir_name(worker_key)}"
 
 
 def test_kubernetes_backend_mounts_only_scoped_agent_root_for_unscoped_workers() -> None:
@@ -3261,7 +3236,7 @@ def test_kubernetes_backend_reconcile_disabled_by_config(tmp_path: Path) -> None
 
 
 def test_kubernetes_backend_reconcile_uses_persisted_private_visibility(tmp_path: Path) -> None:
-    """Reconciliation should rebuild user-agent worker templates from persisted private visibility."""
+    """Reconciliation should rebuild the private scope-root mount from persisted visibility."""
     runtime_paths = resolve_primary_runtime_paths(
         config_path=Path("config.yaml"),
         storage_path=tmp_path / "mindroom-test-storage",
@@ -3299,18 +3274,12 @@ def test_kubernetes_backend_reconcile_uses_persisted_private_visibility(tmp_path
     mount_paths = {
         mount["mountPath"] for mount in recreated["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
     }
-    expected_private_root = str(
-        _private_instance_state_root_path(
-            Path("/app/worker"),
-            worker_key=worker_key,
-            agent_name="mind",
-        ),
-    )
+    expected_private_root = f"/app/worker/private_instances/{worker_dir_name(worker_key)}"
     assert expected_private_root in mount_paths
 
 
 def test_kubernetes_backend_reconcile_uses_persisted_script_state_scope(tmp_path: Path) -> None:
-    """Template reconciliation must preserve a script worker's canonical private workspace mount."""
+    """Template reconciliation must preserve a script worker's private scope-root mount."""
     runtime_paths = resolve_primary_runtime_paths(
         config_path=Path("config.yaml"),
         storage_path=tmp_path / "mindroom-test-storage",
@@ -3339,13 +3308,7 @@ def test_kubernetes_backend_reconcile_uses_persisted_script_state_scope(tmp_path
     mount_paths = {
         mount["mountPath"] for mount in recreated["spec"]["template"]["spec"]["containers"][0]["volumeMounts"]
     }
-    expected_private_root = str(
-        _private_instance_state_root_path(
-            Path("/app/worker"),
-            worker_key=state_scope_worker_key,
-            agent_name="mind",
-        ),
-    )
+    expected_private_root = f"/app/worker/private_instances/{worker_dir_name(state_scope_worker_key)}"
     assert expected_private_root in mount_paths
 
 


### PR DESCRIPTION
## Summary

- mount private requester-agent scope roots in dedicated worker backends so scope-level identity bookkeeping remains accessible
- preserve the owning scope for script workers and existing behavior for non-private scopes
- update Kubernetes and Docker regression coverage

## Testing

- `uv run pytest -q -n 8 --no-cov`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Mount private workers against their owning scope roots to preserve access to identity metadata.

Bug Fixes:
- Mount private user-agent scope roots in dedicated worker backends so identity metadata and scope-level bookkeeping remain accessible.

Enhancements:
- Preserve the owning private scope for script workers while retaining existing behavior for non-private scopes.

Tests:
- Update Docker and Kubernetes regression coverage for private scope-root mounts and worker reconciliation.