### PR TITLE
Restore requester-private OAuth connection management

### DIFF
--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -121,7 +121,8 @@ Platform administrators may use administrative commands when their independent f
 
 `agents.<name>.credential_managers` also contains concrete Matrix user IDs and does not accept wildcards.
 A credential manager may manage only the named shared agent's credentials and OAuth connections.
-Authenticated requesters may manage credentials and OAuth connections for their own requester-private agent scope without a static credential-manager entry.
+Authenticated requesters may manage OAuth connections for their own requester-private agent scope without a static credential-manager entry.
+Deployment-global OAuth client configuration remains restricted to platform administrators.
 
 Shared-agent dashboard and OAuth requests return HTTP 403 before credentials are exposed or changed when the requester is neither an administrator nor a configured credential manager.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard requests resolve to the owner Matrix identity.

--- a/docs/authorization.md
+++ b/docs/authorization.md
@@ -120,9 +120,10 @@ The same responder gate covers text, media, calls, reactions, approval actors, e
 Platform administrators may use administrative commands when their independent feature flag is enabled, manage any agent's credentials, and bypass responder policies.
 
 `agents.<name>.credential_managers` also contains concrete Matrix user IDs and does not accept wildcards.
-A credential manager may manage only the named agent's credentials and OAuth connections.
+A credential manager may manage only the named shared agent's credentials and OAuth connections.
+Authenticated requesters may manage credentials and OAuth connections for their own requester-private agent scope without a static credential-manager entry.
 
-Agent-scoped dashboard and OAuth requests return HTTP 403 before credentials are exposed or changed when the requester is neither an administrator nor a configured credential manager.
+Shared-agent dashboard and OAuth requests return HTTP 403 before credentials are exposed or changed when the requester is neither an administrator nor a configured credential manager.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard requests resolve to the owner Matrix identity.
 
 `!config` remains disabled by default through `authorization.config_command_enabled`.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -235,7 +235,8 @@ Credentials support scoping via query parameters:
 - `execution_scope` — scope credentials to a specific worker scope (e.g., `shared`, `unscoped`)
 
 Agent-scoped credential routes for shared agents require the authenticated dashboard requester to be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
-Requester-private agents allow authenticated requesters to manage credentials in their own isolated scope.
+Requester-private agents allow authenticated requesters to manage OAuth connections in their own isolated scope.
+Deployment-global OAuth client configuration requires platform-administrator authority, with or without `agent_name`.
 Responder access and room membership never grant credential-management access.
 Unauthorized agent-scoped requests return HTTP 403.
 Trusted upstream deployments should provide a Matrix requester identity through the configured Matrix user ID header or email-to-Matrix template.

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -234,7 +234,8 @@ Credentials support scoping via query parameters:
 - `agent_name` — scope credentials to a specific agent
 - `execution_scope` — scope credentials to a specific worker scope (e.g., `shared`, `unscoped`)
 
-Agent-scoped credential routes require the authenticated dashboard requester to be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
+Agent-scoped credential routes for shared agents require the authenticated dashboard requester to be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
+Requester-private agents allow authenticated requesters to manage credentials in their own isolated scope.
 Responder access and room membership never grant credential-management access.
 Unauthorized agent-scoped requests return HTTP 403.
 Trusted upstream deployments should provide a Matrix requester identity through the configured Matrix user ID header or email-to-Matrix template.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -807,7 +807,8 @@ Credentials support scoping via query parameters:
 - `agent_name` — scope credentials to a specific agent
 - `execution_scope` — scope credentials to a specific worker scope (e.g., `shared`, `unscoped`)
 
-Agent-scoped credential routes require the authenticated dashboard requester to be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
+Agent-scoped credential routes for shared agents require the authenticated dashboard requester to be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
+Requester-private agents allow authenticated requesters to manage credentials in their own isolated scope.
 Responder access and room membership never grant credential-management access.
 Unauthorized agent-scoped requests return HTTP 403.
 Trusted upstream deployments should provide a Matrix requester identity through the configured Matrix user ID header or email-to-Matrix template.
@@ -16494,9 +16495,10 @@ The same responder gate covers text, media, calls, reactions, approval actors, e
 Platform administrators may use administrative commands when their independent feature flag is enabled, manage any agent's credentials, and bypass responder policies.
 
 `agents.<name>.credential_managers` also contains concrete Matrix user IDs and does not accept wildcards.
-A credential manager may manage only the named agent's credentials and OAuth connections.
+A credential manager may manage only the named shared agent's credentials and OAuth connections.
+Authenticated requesters may manage credentials and OAuth connections for their own requester-private agent scope without a static credential-manager entry.
 
-Agent-scoped dashboard and OAuth requests return HTTP 403 before credentials are exposed or changed when the requester is neither an administrator nor a configured credential manager.
+Shared-agent dashboard and OAuth requests return HTTP 403 before credentials are exposed or changed when the requester is neither an administrator nor a configured credential manager.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard requests resolve to the owner Matrix identity.
 
 `!config` remains disabled by default through `authorization.config_command_enabled`.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -808,7 +808,8 @@ Credentials support scoping via query parameters:
 - `execution_scope` — scope credentials to a specific worker scope (e.g., `shared`, `unscoped`)
 
 Agent-scoped credential routes for shared agents require the authenticated dashboard requester to be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
-Requester-private agents allow authenticated requesters to manage credentials in their own isolated scope.
+Requester-private agents allow authenticated requesters to manage OAuth connections in their own isolated scope.
+Deployment-global OAuth client configuration requires platform-administrator authority, with or without `agent_name`.
 Responder access and room membership never grant credential-management access.
 Unauthorized agent-scoped requests return HTTP 403.
 Trusted upstream deployments should provide a Matrix requester identity through the configured Matrix user ID header or email-to-Matrix template.
@@ -16496,7 +16497,8 @@ Platform administrators may use administrative commands when their independent f
 
 `agents.<name>.credential_managers` also contains concrete Matrix user IDs and does not accept wildcards.
 A credential manager may manage only the named shared agent's credentials and OAuth connections.
-Authenticated requesters may manage credentials and OAuth connections for their own requester-private agent scope without a static credential-manager entry.
+Authenticated requesters may manage OAuth connections for their own requester-private agent scope without a static credential-manager entry.
+Deployment-global OAuth client configuration remains restricted to platform administrators.
 
 Shared-agent dashboard and OAuth requests return HTTP 403 before credentials are exposed or changed when the requester is neither an administrator nor a configured credential manager.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard requests resolve to the owner Matrix identity.

--- a/skills/mindroom-docs/references/page__authorization__index.md
+++ b/skills/mindroom-docs/references/page__authorization__index.md
@@ -116,9 +116,10 @@ The same responder gate covers text, media, calls, reactions, approval actors, e
 Platform administrators may use administrative commands when their independent feature flag is enabled, manage any agent's credentials, and bypass responder policies.
 
 `agents.<name>.credential_managers` also contains concrete Matrix user IDs and does not accept wildcards.
-A credential manager may manage only the named agent's credentials and OAuth connections.
+A credential manager may manage only the named shared agent's credentials and OAuth connections.
+Authenticated requesters may manage credentials and OAuth connections for their own requester-private agent scope without a static credential-manager entry.
 
-Agent-scoped dashboard and OAuth requests return HTTP 403 before credentials are exposed or changed when the requester is neither an administrator nor a configured credential manager.
+Shared-agent dashboard and OAuth requests return HTTP 403 before credentials are exposed or changed when the requester is neither an administrator nor a configured credential manager.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard requests resolve to the owner Matrix identity.
 
 `!config` remains disabled by default through `authorization.config_command_enabled`.

--- a/skills/mindroom-docs/references/page__authorization__index.md
+++ b/skills/mindroom-docs/references/page__authorization__index.md
@@ -117,7 +117,8 @@ Platform administrators may use administrative commands when their independent f
 
 `agents.<name>.credential_managers` also contains concrete Matrix user IDs and does not accept wildcards.
 A credential manager may manage only the named shared agent's credentials and OAuth connections.
-Authenticated requesters may manage credentials and OAuth connections for their own requester-private agent scope without a static credential-manager entry.
+Authenticated requesters may manage OAuth connections for their own requester-private agent scope without a static credential-manager entry.
+Deployment-global OAuth client configuration remains restricted to platform administrators.
 
 Shared-agent dashboard and OAuth requests return HTTP 403 before credentials are exposed or changed when the requester is neither an administrator nor a configured credential manager.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` so API-key dashboard requests resolve to the owner Matrix identity.

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -231,7 +231,8 @@ Credentials support scoping via query parameters:
 - `execution_scope` — scope credentials to a specific worker scope (e.g., `shared`, `unscoped`)
 
 Agent-scoped credential routes for shared agents require the authenticated dashboard requester to be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
-Requester-private agents allow authenticated requesters to manage credentials in their own isolated scope.
+Requester-private agents allow authenticated requesters to manage OAuth connections in their own isolated scope.
+Deployment-global OAuth client configuration requires platform-administrator authority, with or without `agent_name`.
 Responder access and room membership never grant credential-management access.
 Unauthorized agent-scoped requests return HTTP 403.
 Trusted upstream deployments should provide a Matrix requester identity through the configured Matrix user ID header or email-to-Matrix template.

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -230,7 +230,8 @@ Credentials support scoping via query parameters:
 - `agent_name` — scope credentials to a specific agent
 - `execution_scope` — scope credentials to a specific worker scope (e.g., `shared`, `unscoped`)
 
-Agent-scoped credential routes require the authenticated dashboard requester to be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
+Agent-scoped credential routes for shared agents require the authenticated dashboard requester to be a platform `administrator` or a concrete user in `agents.<name>.credential_managers`.
+Requester-private agents allow authenticated requesters to manage credentials in their own isolated scope.
 Responder access and room membership never grant credential-management access.
 Unauthorized agent-scoped requests return HTTP 403.
 Trusted upstream deployments should provide a Matrix requester identity through the configured Matrix user ID header or email-to-Matrix template.

--- a/src/mindroom/api/credentials_target.py
+++ b/src/mindroom/api/credentials_target.py
@@ -14,6 +14,7 @@ from mindroom.api.dashboard_credential_scope import (
     dashboard_scope_label,
     reject_unbound_private_dashboard_requester,
     require_agent_credential_management_authorized,
+    require_platform_administrator_authorized,
     resolve_dashboard_agent_execution_scope_request,
     resolve_dashboard_execution_scope_override,
 )
@@ -101,8 +102,19 @@ def resolve_request_credentials_target(
             request,
         )
 
-    # Plain dashboard credential reads/writes with no agent selection remain global and
-    # must not start depending on a persisted config file.
+    global_config_requested = any(
+        credential_service_policy(service, None).uses_primary_runtime_global_credentials for service in service_names
+    )
+    if global_config_requested:
+        config, runtime_paths = config_lifecycle.read_committed_runtime_config(request)
+        require_platform_administrator_authorized(
+            request,
+            config=config,
+            runtime_paths=runtime_paths,
+        )
+
+    # Non-global dashboard credential reads/writes with no agent selection retain the
+    # legacy primary-runtime target without requiring a persisted config file.
     if agent_name is None and not execution_scope_override_provided:
         return RequestCredentialsTarget(
             runtime_paths=runtime_paths,
@@ -134,7 +146,8 @@ def resolve_request_credentials_target(
         )
     execution_scope = scope_request.requested_execution_scope
     allow_private_agent_requester = (
-        scope_request.persisted_policy is not None
+        allow_private_scopes
+        and scope_request.persisted_policy is not None
         and scope_request.persisted_policy.is_private
         and execution_scope in {"user", "user_agent"}
         and not any(
@@ -167,11 +180,7 @@ def resolve_request_credentials_target(
         execution_scope=execution_scope,
         execution_scope_override_provided=execution_scope_override_provided,
     )
-    if (
-        not allow_private_scopes
-        and not allow_private_agent_requester
-        and not dashboard_credentials_supported_for_scope(execution_scope)
-    ):
+    if not allow_private_scopes and not dashboard_credentials_supported_for_scope(execution_scope):
         raise HTTPException(
             status_code=400,
             detail=(

--- a/src/mindroom/api/credentials_target.py
+++ b/src/mindroom/api/credentials_target.py
@@ -14,6 +14,7 @@ from mindroom.api.dashboard_credential_scope import (
     dashboard_scope_label,
     reject_unbound_private_dashboard_requester,
     require_agent_credential_management_authorized,
+    require_agent_oauth_connection_authorized,
     require_platform_administrator_authorized,
     resolve_dashboard_agent_execution_scope_request,
     resolve_dashboard_execution_scope_override,
@@ -155,12 +156,16 @@ def resolve_request_credentials_target(
             for service in service_names
         )
     )
-    execution_identity = require_agent_credential_management_authorized(
+    authorize = (
+        require_agent_oauth_connection_authorized
+        if allow_private_agent_requester
+        else require_agent_credential_management_authorized
+    )
+    execution_identity = authorize(
         request,
         config=config,
         runtime_paths=runtime_paths,
         agent_name=scope_request.agent_name,
-        allow_private_agent_requester=allow_private_agent_requester,
     )
     if execution_scope is None:
         return RequestCredentialsTarget(

--- a/src/mindroom/api/credentials_target.py
+++ b/src/mindroom/api/credentials_target.py
@@ -132,13 +132,23 @@ def resolve_request_credentials_target(
             execution_identity=None,
             allowed_shared_services=None,
         )
+    execution_scope = scope_request.requested_execution_scope
+    allow_private_agent_requester = (
+        scope_request.persisted_policy is not None
+        and scope_request.persisted_policy.is_private
+        and execution_scope in {"user", "user_agent"}
+        and not any(
+            credential_service_policy(service, execution_scope).uses_primary_runtime_global_credentials
+            for service in service_names
+        )
+    )
     execution_identity = require_agent_credential_management_authorized(
         request,
         config=config,
         runtime_paths=runtime_paths,
         agent_name=scope_request.agent_name,
+        allow_private_agent_requester=allow_private_agent_requester,
     )
-    execution_scope = scope_request.requested_execution_scope
     if execution_scope is None:
         return RequestCredentialsTarget(
             runtime_paths=runtime_paths,
@@ -157,7 +167,11 @@ def resolve_request_credentials_target(
         execution_scope=execution_scope,
         execution_scope_override_provided=execution_scope_override_provided,
     )
-    if not allow_private_scopes and not dashboard_credentials_supported_for_scope(execution_scope):
+    if (
+        not allow_private_scopes
+        and not allow_private_agent_requester
+        and not dashboard_credentials_supported_for_scope(execution_scope)
+    ):
         raise HTTPException(
             status_code=400,
             detail=(

--- a/src/mindroom/api/dashboard_credential_scope.py
+++ b/src/mindroom/api/dashboard_credential_scope.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, cast
 from fastapi import HTTPException, Request
 
 from mindroom.agent_policy import ResolvedAgentPolicy, resolve_agent_policy_from_data
-from mindroom.authorization import is_sender_allowed_for_agent_credential_management
+from mindroom.authorization import is_platform_administrator, is_sender_allowed_for_agent_credential_management
 from mindroom.matrix.identity import try_parse_historical_matrix_user_id
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, WorkerScope
 
@@ -237,4 +237,22 @@ def require_agent_credential_management_authorized(
         allow_private_agent_requester=allow_private_agent_requester,
     ):
         raise HTTPException(status_code=403, detail=f"Not authorized to manage credentials for agent '{agent_name}'")
+    return execution_identity
+
+
+def require_platform_administrator_authorized(
+    request: Request,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> ToolExecutionIdentity:
+    """Require platform-administrator authority for a global credential target."""
+    execution_identity = build_dashboard_execution_identity(
+        request,
+        "global_credentials",
+        runtime_paths=runtime_paths,
+    )
+    requester_id = execution_identity.requester_id
+    if requester_id is None or not is_platform_administrator(requester_id, config):
+        raise HTTPException(status_code=403, detail="Not authorized to manage global credential configuration")
     return execution_identity

--- a/src/mindroom/api/dashboard_credential_scope.py
+++ b/src/mindroom/api/dashboard_credential_scope.py
@@ -221,6 +221,7 @@ def require_agent_credential_management_authorized(
     config: Config,
     runtime_paths: RuntimePaths,
     agent_name: str,
+    allow_private_agent_requester: bool = False,
 ) -> ToolExecutionIdentity:
     """Require the dashboard requester to be allowed to manage one agent's credentials."""
     execution_identity = build_dashboard_execution_identity(
@@ -233,6 +234,7 @@ def require_agent_credential_management_authorized(
         requester_id,
         agent_name=agent_name,
         config=config,
+        allow_private_agent_requester=allow_private_agent_requester,
     ):
         raise HTTPException(status_code=403, detail=f"Not authorized to manage credentials for agent '{agent_name}'")
     return execution_identity

--- a/src/mindroom/api/dashboard_credential_scope.py
+++ b/src/mindroom/api/dashboard_credential_scope.py
@@ -221,7 +221,6 @@ def require_agent_credential_management_authorized(
     config: Config,
     runtime_paths: RuntimePaths,
     agent_name: str,
-    allow_private_agent_requester: bool = False,
 ) -> ToolExecutionIdentity:
     """Require the dashboard requester to be allowed to manage one agent's credentials."""
     execution_identity = build_dashboard_execution_identity(
@@ -234,10 +233,54 @@ def require_agent_credential_management_authorized(
         requester_id,
         agent_name=agent_name,
         config=config,
-        allow_private_agent_requester=allow_private_agent_requester,
     ):
         raise HTTPException(status_code=403, detail=f"Not authorized to manage credentials for agent '{agent_name}'")
     return execution_identity
+
+
+def _require_private_agent_requester_authorized(
+    request: Request,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    agent_name: str,
+) -> ToolExecutionIdentity:
+    """Require a bound requester identity for one requester-private agent."""
+    agent = config.agents.get(agent_name)
+    if agent is None or agent.private is None:
+        raise HTTPException(status_code=403, detail=f"Agent '{agent_name}' is not requester-private")
+    execution_identity = build_dashboard_execution_identity(
+        request,
+        agent_name,
+        runtime_paths=runtime_paths,
+    )
+    if execution_identity.requester_id is None:
+        raise HTTPException(status_code=403, detail=f"Could not resolve requester identity for agent '{agent_name}'")
+    return execution_identity
+
+
+def require_agent_oauth_connection_authorized(
+    request: Request,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    agent_name: str,
+) -> ToolExecutionIdentity:
+    """Require requester-private or managed-agent authority for OAuth connections."""
+    agent = config.agents.get(agent_name)
+    if agent is not None and agent.private is not None:
+        return _require_private_agent_requester_authorized(
+            request,
+            config=config,
+            runtime_paths=runtime_paths,
+            agent_name=agent_name,
+        )
+    return require_agent_credential_management_authorized(
+        request,
+        config=config,
+        runtime_paths=runtime_paths,
+        agent_name=agent_name,
+    )
 
 
 def require_platform_administrator_authorized(

--- a/src/mindroom/api/dashboard_credential_scope.py
+++ b/src/mindroom/api/dashboard_credential_scope.py
@@ -8,7 +8,11 @@ from typing import TYPE_CHECKING, Any, cast
 from fastapi import HTTPException, Request
 
 from mindroom.agent_policy import ResolvedAgentPolicy, resolve_agent_policy_from_data
-from mindroom.authorization import is_platform_administrator, is_sender_allowed_for_agent_credential_management
+from mindroom.authorization import (
+    is_platform_administrator,
+    is_sender_allowed_for_agent_credential_management,
+    is_sender_allowed_for_agent_oauth_connection_management,
+)
 from mindroom.matrix.identity import try_parse_historical_matrix_user_id
 from mindroom.tool_system.worker_routing import ToolExecutionIdentity, WorkerScope
 
@@ -238,27 +242,6 @@ def require_agent_credential_management_authorized(
     return execution_identity
 
 
-def _require_private_agent_requester_authorized(
-    request: Request,
-    *,
-    config: Config,
-    runtime_paths: RuntimePaths,
-    agent_name: str,
-) -> ToolExecutionIdentity:
-    """Require a bound requester identity for one requester-private agent."""
-    agent = config.agents.get(agent_name)
-    if agent is None or agent.private is None:
-        raise HTTPException(status_code=403, detail=f"Agent '{agent_name}' is not requester-private")
-    execution_identity = build_dashboard_execution_identity(
-        request,
-        agent_name,
-        runtime_paths=runtime_paths,
-    )
-    if execution_identity.requester_id is None:
-        raise HTTPException(status_code=403, detail=f"Could not resolve requester identity for agent '{agent_name}'")
-    return execution_identity
-
-
 def require_agent_oauth_connection_authorized(
     request: Request,
     *,
@@ -267,20 +250,22 @@ def require_agent_oauth_connection_authorized(
     agent_name: str,
 ) -> ToolExecutionIdentity:
     """Require requester-private or managed-agent authority for OAuth connections."""
-    agent = config.agents.get(agent_name)
-    if agent is not None and agent.private is not None:
-        return _require_private_agent_requester_authorized(
-            request,
-            config=config,
-            runtime_paths=runtime_paths,
-            agent_name=agent_name,
-        )
-    return require_agent_credential_management_authorized(
+    execution_identity = build_dashboard_execution_identity(
         request,
-        config=config,
+        agent_name,
         runtime_paths=runtime_paths,
-        agent_name=agent_name,
     )
+    requester_id = execution_identity.requester_id
+    if requester_id is None or not is_sender_allowed_for_agent_oauth_connection_management(
+        requester_id,
+        agent_name=agent_name,
+        config=config,
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Not authorized to manage OAuth connections for agent '{agent_name}'",
+        )
+    return execution_identity
 
 
 def require_platform_administrator_authorized(

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -26,7 +26,7 @@ from mindroom.api.credentials_target import (
 )
 from mindroom.api.dashboard_credential_scope import (
     build_dashboard_execution_identity,
-    require_agent_credential_management_authorized,
+    require_agent_oauth_connection_authorized,
 )
 from mindroom.authorization import is_sender_allowed_for_agent_credential_management
 from mindroom.background_tasks import run_coroutine_until_complete
@@ -465,12 +465,11 @@ def _verify_browser_reset_intent(
         raise HTTPException(status_code=503, detail="OAuth reset requires an active configuration")
     if not agent_name:
         raise HTTPException(status_code=403, detail="The current requester cannot manage this agent's credentials")
-    identity = require_agent_credential_management_authorized(
+    identity = require_agent_oauth_connection_authorized(
         request,
         config=config,
         runtime_paths=runtime_paths,
         agent_name=agent_name,
-        allow_private_agent_requester=True,
     )
     try:
         target = resolve_oauth_reset_target(

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -470,6 +470,7 @@ def _verify_browser_reset_intent(
         config=config,
         runtime_paths=runtime_paths,
         agent_name=agent_name,
+        allow_private_agent_requester=True,
     )
     try:
         target = resolve_oauth_reset_target(

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -28,7 +28,7 @@ from mindroom.api.dashboard_credential_scope import (
     build_dashboard_execution_identity,
     require_agent_oauth_connection_authorized,
 )
-from mindroom.authorization import is_sender_allowed_for_agent_credential_management
+from mindroom.authorization import is_sender_allowed_for_agent_oauth_connection_management
 from mindroom.background_tasks import run_coroutine_until_complete
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.logging_config import get_logger
@@ -339,7 +339,7 @@ def _verify_conversation_connect_target_authorized(request: Request, target: OAu
         config is None
         or not agent_name
         or not requester_id
-        or not is_sender_allowed_for_agent_credential_management(requester_id, agent_name, config)
+        or not is_sender_allowed_for_agent_oauth_connection_management(requester_id, agent_name, config)
     ):
         raise HTTPException(status_code=403, detail="The link requester cannot manage this agent's credentials")
     return config

--- a/src/mindroom/api/tools.py
+++ b/src/mindroom/api/tools.py
@@ -260,6 +260,7 @@ def _resolve_tool_availability_context(
             config=config,
             runtime_paths=runtime_paths,
             agent_name=scope_request.agent_name,
+            allow_private_agent_requester=execution_scope in {"user", "user_agent"},
         )
         if scope_request.agent_name is not None
         else None

--- a/src/mindroom/api/tools.py
+++ b/src/mindroom/api/tools.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from mindroom.agent_policy import dashboard_credentials_supported_for_scope
 from mindroom.api import config_lifecycle
 from mindroom.api.dashboard_credential_scope import (
-    require_agent_credential_management_authorized,
+    require_agent_oauth_connection_authorized,
     resolve_dashboard_agent_execution_scope_request,
     resolve_dashboard_execution_scope_override,
 )
@@ -255,12 +255,11 @@ def _resolve_tool_availability_context(
         execution_scope,
     )
     authorized_identity = (
-        require_agent_credential_management_authorized(
+        require_agent_oauth_connection_authorized(
             request,
             config=config,
             runtime_paths=runtime_paths,
             agent_name=scope_request.agent_name,
-            allow_private_agent_requester=execution_scope in {"user", "user_agent"},
         )
         if scope_request.agent_name is not None
         else None

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -120,7 +120,11 @@ def is_sender_allowed_for_agent_credential_management(
     if agent is None:
         return False
     resolved_sender = config.authorization.resolve_alias(sender_id)
-    return resolved_sender in config.administrators or resolved_sender in agent.credential_managers
+    return (
+        agent.private is not None
+        or resolved_sender in config.administrators
+        or resolved_sender in agent.credential_managers
+    )
 
 
 def is_platform_administrator(sender_id: str, config: Config) -> bool:

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -114,19 +114,13 @@ def is_sender_allowed_for_agent_credential_management(
     sender_id: str,
     agent_name: str,
     config: Config,
-    *,
-    allow_private_agent_requester: bool = False,
 ) -> bool:
     """Check whether a dashboard requester may manage credentials for one agent."""
     agent = config.agents.get(agent_name)
     if agent is None:
         return False
     resolved_sender = config.authorization.resolve_alias(sender_id)
-    return (
-        (allow_private_agent_requester and agent.private is not None)
-        or resolved_sender in config.administrators
-        or resolved_sender in agent.credential_managers
-    )
+    return resolved_sender in config.administrators or resolved_sender in agent.credential_managers
 
 
 def is_platform_administrator(sender_id: str, config: Config) -> bool:

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -114,6 +114,8 @@ def is_sender_allowed_for_agent_credential_management(
     sender_id: str,
     agent_name: str,
     config: Config,
+    *,
+    allow_private_agent_requester: bool = False,
 ) -> bool:
     """Check whether a dashboard requester may manage credentials for one agent."""
     agent = config.agents.get(agent_name)
@@ -121,7 +123,7 @@ def is_sender_allowed_for_agent_credential_management(
         return False
     resolved_sender = config.authorization.resolve_alias(sender_id)
     return (
-        agent.private is not None
+        (allow_private_agent_requester and agent.private is not None)
         or resolved_sender in config.administrators
         or resolved_sender in agent.credential_managers
     )

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -123,6 +123,26 @@ def is_sender_allowed_for_agent_credential_management(
     return resolved_sender in config.administrators or resolved_sender in agent.credential_managers
 
 
+def is_sender_allowed_for_agent_oauth_connection_management(
+    sender_id: str,
+    agent_name: str,
+    config: Config,
+) -> bool:
+    """Check whether a requester may manage their OAuth connection for one agent.
+
+    Callers granting the private-agent exception must resolve credentials to the
+    authenticated requester's isolated user or user-agent target.
+    """
+    if not sender_id:
+        return False
+    agent = config.agents.get(agent_name)
+    if agent is None:
+        return False
+    if agent.private is not None:
+        return True
+    return is_sender_allowed_for_agent_credential_management(sender_id, agent_name, config)
+
+
 def is_platform_administrator(sender_id: str, config: Config) -> bool:
     """Return whether a requester has platform-wide administrative authority."""
     resolved_sender = config.authorization.resolve_alias(sender_id)

--- a/src/mindroom/oauth/reset.py
+++ b/src/mindroom/oauth/reset.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 from urllib.parse import urlencode
 
-from mindroom.authorization import is_sender_allowed_for_agent_credential_management
+from mindroom.authorization import is_sender_allowed_for_agent_oauth_connection_management
 from mindroom.credentials import get_runtime_credentials_manager
 from mindroom.oauth.credential_binding import (
     OAuthCredentialBinding,
@@ -87,7 +87,7 @@ def resolve_oauth_reset_target(
         msg = "OAuth reset is available only during an agent request."
         raise OAuthResetTargetError(msg)
     requester_id = execution_identity.requester_id
-    if requester_id is None or not is_sender_allowed_for_agent_credential_management(
+    if requester_id is None or not is_sender_allowed_for_agent_oauth_connection_management(
         requester_id,
         agent_name=agent_name,
         config=config,

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -25,12 +25,14 @@ from tests.api.conftest import trusted_upstream_headers, use_trusted_upstream_ru
 def _config_with_worker_scope(
     worker_scope: str | None,
     *,
+    administrators: list[str] | None = None,
     credential_managers: list[str] | None = None,
+    private_per: str | None = None,
     worker_grantable_credentials: list[str] | None = None,
 ) -> Config:
     payload: dict[str, object] = {
         "models": {"default": {"provider": "openai", "id": "gpt-4o-mini"}},
-        "administrators": ["@alice:example.org"],
+        "administrators": administrators if administrators is not None else ["@alice:example.org"],
         "agents": {
             "general": {
                 "display_name": "General",
@@ -38,7 +40,10 @@ def _config_with_worker_scope(
                 "tools": ["calculator"],
                 "instructions": ["hi"],
                 "rooms": ["lobby"],
-                "credential_managers": credential_managers or ["@alice:example.org"],
+                "credential_managers": (
+                    credential_managers if credential_managers is not None else ["@alice:example.org"]
+                ),
+                **({"private": {"per": private_per}} if private_per is not None else {}),
             },
         },
         "defaults": {
@@ -47,7 +52,8 @@ def _config_with_worker_scope(
         },
     }
     config = Config.model_validate(payload)
-    config.agents["general"].worker_scope = worker_scope
+    if private_per is None:
+        config.agents["general"].worker_scope = worker_scope
     return config
 
 
@@ -1497,21 +1503,64 @@ class TestCredentialsAPI:
         assert credentials_target.primary_runtime_scoped_services_for_target(target) == {"acme_oauth"}
         assert credentials_target.primary_runtime_scoped_services_for_target(replace(target, agent_name=None)) == set()
 
-    def test_non_oauth_tool_settings_still_reject_private_scopes(
+    def test_private_agent_requester_can_save_own_credentials(
         self,
         client: TestClient,
     ) -> None:
-        """Private-scope writes stay limited to registered OAuth credential services."""
-        config = _config_with_worker_scope("user_agent")
+        """Private-agent writes must use the authenticated requester's isolated store."""
+        runtime_paths = _use_owner_runtime(client.app)
+        config = _config_with_worker_scope(
+            None,
+            administrators=[],
+            credential_managers=[],
+            private_per="user_agent",
+        )
         _publish_committed_runtime_config(client.app, config)
+        manager = get_runtime_credentials_manager(runtime_paths)
 
         response = client.post(
             "/api/credentials/weather?agent_name=general",
             json={"credentials": {"api_key": "weather-key"}},
         )
 
-        assert response.status_code == 400
-        assert "worker_scope=user_agent" in response.json()["detail"]
+        assert response.status_code == 200
+        worker_key = resolve_worker_key(
+            "user_agent",
+            ToolExecutionIdentity(
+                channel="matrix",
+                agent_name="general",
+                requester_id="@alice:example.org",
+                room_id=None,
+                thread_id=None,
+                resolved_thread_id=None,
+                session_id=None,
+            ),
+            agent_name="general",
+        )
+        assert worker_key is not None
+        assert manager.for_worker(worker_key).load_credentials("weather") == {
+            "api_key": "weather-key",
+            "_source": "ui",
+        }
+
+    def test_private_agent_requester_cannot_edit_global_oauth_client_config(self, client: TestClient) -> None:
+        """Private-agent ownership must not grant deployment-global OAuth client authority."""
+        runtime_paths = _use_owner_runtime(client.app)
+        config = _config_with_worker_scope(
+            None,
+            administrators=["@admin:example.org"],
+            credential_managers=[],
+            private_per="user_agent",
+        )
+        _publish_committed_runtime_config(client.app, config)
+
+        response = client.post(
+            "/api/credentials/google_drive_oauth_client?agent_name=general",
+            json={"credentials": {"client_id": "attacker", "client_secret": "secret"}},
+        )
+
+        assert response.status_code == 403
+        assert get_runtime_credentials_manager(runtime_paths).load_credentials("google_drive_oauth_client") is None
 
     def test_resolve_request_credentials_target_keeps_one_runtime_for_identity(
         self,

--- a/tests/api/test_credentials_api.py
+++ b/tests/api/test_credentials_api.py
@@ -87,6 +87,7 @@ def client(tmp_path: Path) -> TestClient:
             process_env={constants.OWNER_MATRIX_USER_ID_ENV: "@alice:example.org"},
         ),
     )
+    _publish_committed_runtime_config(app, _config_with_worker_scope(None))
     return TestClient(app)
 
 
@@ -1503,12 +1504,12 @@ class TestCredentialsAPI:
         assert credentials_target.primary_runtime_scoped_services_for_target(target) == {"acme_oauth"}
         assert credentials_target.primary_runtime_scoped_services_for_target(replace(target, agent_name=None)) == set()
 
-    def test_private_agent_requester_can_save_own_credentials(
+    def test_non_oauth_tool_settings_still_reject_private_scopes(
         self,
         client: TestClient,
     ) -> None:
-        """Private-agent writes must use the authenticated requester's isolated store."""
-        runtime_paths = _use_owner_runtime(client.app)
+        """Private-agent self-service stays limited to registered connection credentials."""
+        _use_owner_runtime(client.app)
         config = _config_with_worker_scope(
             None,
             administrators=[],
@@ -1516,32 +1517,12 @@ class TestCredentialsAPI:
             private_per="user_agent",
         )
         _publish_committed_runtime_config(client.app, config)
-        manager = get_runtime_credentials_manager(runtime_paths)
-
         response = client.post(
             "/api/credentials/weather?agent_name=general",
             json={"credentials": {"api_key": "weather-key"}},
         )
 
-        assert response.status_code == 200
-        worker_key = resolve_worker_key(
-            "user_agent",
-            ToolExecutionIdentity(
-                channel="matrix",
-                agent_name="general",
-                requester_id="@alice:example.org",
-                room_id=None,
-                thread_id=None,
-                resolved_thread_id=None,
-                session_id=None,
-            ),
-            agent_name="general",
-        )
-        assert worker_key is not None
-        assert manager.for_worker(worker_key).load_credentials("weather") == {
-            "api_key": "weather-key",
-            "_source": "ui",
-        }
+        assert response.status_code == 403
 
     def test_private_agent_requester_cannot_edit_global_oauth_client_config(self, client: TestClient) -> None:
         """Private-agent ownership must not grant deployment-global OAuth client authority."""
@@ -1561,6 +1542,62 @@ class TestCredentialsAPI:
 
         assert response.status_code == 403
         assert get_runtime_credentials_manager(runtime_paths).load_credentials("google_drive_oauth_client") is None
+
+    @pytest.mark.parametrize("agent_name", [None, "general"])
+    @pytest.mark.parametrize("method", ["GET", "POST", "DELETE"])
+    def test_non_admin_cannot_manage_global_oauth_client_config(
+        self,
+        client: TestClient,
+        agent_name: str | None,
+        method: str,
+    ) -> None:
+        """Neither global access nor agent-manager authority may edit deployment-global OAuth clients."""
+        runtime_paths = _use_owner_runtime(client.app)
+        config = _config_with_worker_scope(
+            "shared",
+            administrators=["@admin:example.org"],
+            credential_managers=["@alice:example.org"],
+        )
+        _publish_committed_runtime_config(client.app, config)
+        manager = get_runtime_credentials_manager(runtime_paths)
+        manager.save_credentials(
+            "google_drive_oauth_client",
+            {"client_id": "original", "client_secret": "original-secret", "_source": "ui"},
+        )
+        query = f"?agent_name={agent_name}" if agent_name is not None else ""
+
+        response = client.request(
+            method,
+            f"/api/credentials/google_drive_oauth_client{query}",
+            json={"credentials": {"client_id": "attacker", "client_secret": "secret"}},
+        )
+
+        assert response.status_code == 403
+        assert manager.load_credentials("google_drive_oauth_client") == {
+            "client_id": "original",
+            "client_secret": "original-secret",
+            "_source": "ui",
+        }
+
+    @pytest.mark.parametrize("agent_name", [None, "general"])
+    def test_admin_can_manage_global_oauth_client_config(self, client: TestClient, agent_name: str | None) -> None:
+        """Platform administrators retain global OAuth client configuration authority."""
+        runtime_paths = _use_owner_runtime(client.app)
+        config = _config_with_worker_scope("shared")
+        _publish_committed_runtime_config(client.app, config)
+        query = f"?agent_name={agent_name}" if agent_name is not None else ""
+
+        response = client.post(
+            f"/api/credentials/google_drive_oauth_client{query}",
+            json={"credentials": {"client_id": "admin-client", "client_secret": "admin-secret"}},
+        )
+
+        assert response.status_code == 200
+        assert get_runtime_credentials_manager(runtime_paths).load_credentials("google_drive_oauth_client") == {
+            "client_id": "admin-client",
+            "client_secret": "admin-secret",
+            "_source": "ui",
+        }
 
     def test_resolve_request_credentials_target_keeps_one_runtime_for_identity(
         self,

--- a/tests/api/test_dashboard_credential_scope.py
+++ b/tests/api/test_dashboard_credential_scope.py
@@ -31,6 +31,7 @@ def _config(
     worker_scope: str | None = None,
     *,
     credential_managers: list[str] | None = None,
+    private_per: str | None = None,
 ) -> Config:
     payload: dict[str, object] = {
         "models": {"default": {"provider": "openai", "id": "gpt-4o-mini"}},
@@ -42,6 +43,7 @@ def _config(
                 "instructions": ["hi"],
                 "rooms": ["lobby"],
                 "credential_managers": credential_managers or [],
+                **({"private": {"per": private_per}} if private_per is not None else {}),
             },
         },
     }
@@ -260,6 +262,25 @@ class TestRequireAgentCredentialManagementAuthorized:
                 agent_name="general",
             )
         assert exc_info.value.status_code == 403
+
+    @pytest.mark.parametrize("private_per", ["user", "user_agent"])
+    def test_requester_can_manage_own_private_agent_credentials_without_allowlist(self, private_per: str) -> None:
+        """A private agent requester must not need a static credential-manager entry."""
+        identity = require_agent_credential_management_authorized(
+            _request(
+                {
+                    "user_id": "alice",
+                    "auth_source": "trusted_upstream",
+                    "matrix_user_id": "@alice:example.org",
+                },
+            ),
+            config=_config(private_per=private_per),
+            runtime_paths=self._runtime_paths(),
+            agent_name="general",
+        )
+
+        assert identity.requester_id == "@alice:example.org"
+        assert identity.agent_name == "general"
 
     def test_unresolvable_requester_is_rejected(self) -> None:
         """Requests without a resolvable requester identity are rejected with 403."""

--- a/tests/api/test_dashboard_credential_scope.py
+++ b/tests/api/test_dashboard_credential_scope.py
@@ -7,6 +7,7 @@ from fastapi import HTTPException, Request
 
 from mindroom.api.dashboard_credential_scope import (
     require_agent_credential_management_authorized,
+    require_agent_oauth_connection_authorized,
     resolve_dashboard_agent_execution_scope_request,
     resolve_dashboard_execution_scope_override,
 )
@@ -220,7 +221,6 @@ class TestRequireAgentCredentialManagementAuthorized:
             config=_config(credential_managers=self._credential_managers),
             runtime_paths=self._runtime_paths(),
             agent_name="general",
-            allow_private_agent_requester=True,
         )
         assert identity.requester_id == "@alice:example.org"
         assert identity.agent_name == "general"
@@ -265,20 +265,32 @@ class TestRequireAgentCredentialManagementAuthorized:
         assert exc_info.value.status_code == 403
 
     @pytest.mark.parametrize("private_per", ["user", "user_agent"])
-    def test_requester_can_manage_own_private_agent_credentials_without_allowlist(self, private_per: str) -> None:
-        """A private agent requester must not need a static credential-manager entry."""
-        identity = require_agent_credential_management_authorized(
-            _request(
-                {
-                    "user_id": "alice",
-                    "auth_source": "trusted_upstream",
-                    "matrix_user_id": "@alice:example.org",
-                },
-            ),
-            config=_config(private_per=private_per),
-            runtime_paths=self._runtime_paths(),
+    def test_requester_can_manage_own_private_agent_oauth_without_allowlist(self, private_per: str) -> None:
+        """Private-agent OAuth authority is separate from generic credential management."""
+        request = _request(
+            {
+                "user_id": "alice",
+                "auth_source": "trusted_upstream",
+                "matrix_user_id": "@alice:example.org",
+            },
+        )
+        config = _config(private_per=private_per)
+        runtime_paths = self._runtime_paths()
+
+        with pytest.raises(HTTPException) as exc_info:
+            require_agent_credential_management_authorized(
+                request,
+                config=config,
+                runtime_paths=runtime_paths,
+                agent_name="general",
+            )
+        assert exc_info.value.status_code == 403
+
+        identity = require_agent_oauth_connection_authorized(
+            request,
+            config=config,
+            runtime_paths=runtime_paths,
             agent_name="general",
-            allow_private_agent_requester=True,
         )
 
         assert identity.requester_id == "@alice:example.org"

--- a/tests/api/test_dashboard_credential_scope.py
+++ b/tests/api/test_dashboard_credential_scope.py
@@ -220,6 +220,7 @@ class TestRequireAgentCredentialManagementAuthorized:
             config=_config(credential_managers=self._credential_managers),
             runtime_paths=self._runtime_paths(),
             agent_name="general",
+            allow_private_agent_requester=True,
         )
         assert identity.requester_id == "@alice:example.org"
         assert identity.agent_name == "general"
@@ -277,6 +278,7 @@ class TestRequireAgentCredentialManagementAuthorized:
             config=_config(private_per=private_per),
             runtime_paths=self._runtime_paths(),
             agent_name="general",
+            allow_private_agent_requester=True,
         )
 
         assert identity.requester_id == "@alice:example.org"

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -2795,6 +2795,7 @@ def test_generated_mcp_oauth_routes_follow_agent_scope_for_connect_status_and_di
     )
     config_payload = _mcp_oauth_config_payload(worker_scope=authored_worker_scope)
     if private_scope is not None:
+        config_payload["administrators"] = ["@admin:example.org"]
         agent_payload = config_payload["agents"]["general"]
         agent_payload.pop("worker_scope")
         agent_payload["private"] = {"per": private_scope}

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -2324,6 +2324,38 @@ def test_browser_reset_get_is_non_mutating_and_post_resets_then_authorizes(tmp_p
     assert _stored_oauth_credentials(provider, runtime_paths) is None
 
 
+def test_private_agent_requester_can_resolve_own_oauth_reset_target(tmp_path: Path) -> None:
+    """Private-agent requesters need no administrator or credential-manager grant to reset their own OAuth."""
+    runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
+    config_payload = _config_payload(worker_scope=None, allowed_users=[])
+    agent_payload = config_payload["agents"]["general"]
+    agent_payload.pop("worker_scope")
+    agent_payload["private"] = {"per": "user_agent"}
+    api_app = _make_test_app(runtime_paths, config_payload)
+    config = main._app_context(api_app).runtime_config
+    assert config is not None
+
+    target = oauth_reset.resolve_oauth_reset_target(
+        "google_drive",
+        agent_name="general",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="general",
+            requester_id="@alice:example.org",
+            room_id="!room:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+        ),
+    )
+
+    assert target.worker_target.worker_scope == "user_agent"
+    assert target.worker_target.execution_identity is not None
+    assert target.worker_target.execution_identity.requester_id == "@alice:example.org"
+
+
 def test_browser_reset_rejects_stale_connection_generation(tmp_path: Path) -> None:
     """A reset link cannot delete credentials replaced after the link was issued."""
     runtime_paths = _runtime_paths(
@@ -3758,6 +3790,48 @@ def test_agent_connect_token_stores_credentials_in_matrix_requester_scope(tmp_pa
     assert matrix_credentials["token"] == "google_drive-access-token"
     assert worker_credentials is None
     assert standalone_credentials is None
+
+
+def test_private_agent_requester_can_redeem_own_connect_token(tmp_path: Path) -> None:
+    """Private-agent requesters need no administrator or credential-manager grant to connect their own OAuth."""
+    runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())
+    config_payload = _config_payload(worker_scope=None, allowed_users=[])
+    agent_payload = config_payload["agents"]["general"]
+    agent_payload.pop("worker_scope")
+    agent_payload["private"] = {"per": "user_agent"}
+    api_app = _make_test_app(runtime_paths, config_payload)
+    provider = _fake_provider(provider_id="google_drive", credential_service="google_drive_oauth")
+    identity = ToolExecutionIdentity(
+        channel="matrix",
+        agent_name="general",
+        requester_id="@alice:example.org",
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+    worker_target = resolve_worker_target("user_agent", "general", execution_identity=identity)
+    connect_token = oauth_service._issue_oauth_connect_token(provider, runtime_paths, worker_target)
+    assert connect_token is not None
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app) as client:
+            authorize_response = client.get(
+                f"/api/oauth/{provider.id}/authorize?agent_name=general&execution_scope=user_agent"
+                f"&connect_token={connect_token}",
+                follow_redirects=False,
+            )
+            state = _state_from_auth_url(authorize_response.headers["location"])
+            callback_response = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                follow_redirects=False,
+            )
+
+    assert authorize_response.status_code == 307
+    assert callback_response.status_code == 200
+    credentials = _stored_oauth_credentials(provider, runtime_paths)
+    assert credentials is not None
+    assert credentials["token"] == "google_drive-access-token"
 
 
 def test_agent_connect_token_starts_without_dashboard_login(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- allow authenticated requesters to manage only their own requester-scoped OAuth connections for private agents
- keep arbitrary agent credentials restricted to platform administrators and explicit agent credential managers
- require platform-administrator authority for deployment-global OAuth client configuration, including `_oauth_client`, with or without `agent_name`
- document the capability boundaries and regenerate bundled documentation references

## Root cause

The membership-based access migration made `credential_managers` default to an empty list and required agent-scoped OAuth connection requests to match that list. Production Mind uses `private.per: user_agent` and has no static credential managers, so rightful private-agent requesters received HTTP 403 when reconnecting their own isolated accounts.

The dashboard credential API also had a pre-existing authorization gap: global OAuth client configuration could resolve without an administrator check. The fix separates requester-scoped connection authorization, agent-scoped credential authorization, and global OAuth client administration.

## Authorization model

- Private-agent requester: connect, reconnect, reset, inspect status, and disconnect only their own requester-bound OAuth connection.
- Explicit credential manager: manage credentials for the named agent only.
- Platform administrator: manage deployment-global OAuth client configuration.
- Non-admin requesters and credential managers cannot read, write, or delete global `_oauth_client` configuration, even when supplying a private `agent_name`.
- Public-agent behavior remains unchanged.

## Validation

- focused authorization, credential, and OAuth test matrix passed
- coverage includes rightful private reconnect, cross-requester rejection, global client GET/POST/DELETE denial with and without `agent_name`, administrator access, explicit-manager limits, and public-agent behavior
- relevant pre-commit hooks passed, including ruff, ty, vulture, docs reference generation, Tach, and module privacy
- independent review findings were validated and addressed with follow-up commits

## Summary by Sourcery

Restore requester-private OAuth self-service while enforcing administrator-only control of deployment-global OAuth client configuration.

New Features:
- Restore self-service OAuth connection management for authenticated requesters within their own private-agent scopes.
- Allow platform administrators to manage deployment-global OAuth client configuration. 

Bug Fixes:
- Prevent non-administrators and agent credential managers from accessing global OAuth client configuration, including when an agent name is supplied.
- Restore private-agent OAuth connect, reconnect, reset, status, and disconnect authorization without requiring static credential-manager entries.

Enhancements:
- Separate requester-private OAuth connection authorization from shared-agent credential management and platform-wide credential administration.

Documentation:
- Update authorization and dashboard documentation, including bundled generated references, to describe the separate private-agent, shared-agent, and global OAuth capability boundaries.

Tests:
- Expand authorization and OAuth coverage for private-agent self-service, cross-scope restrictions, global OAuth client access, administrator access, and unchanged public-agent behavior.