### PR TITLE
Add Google Drive file content replacement

### DIFF
--- a/src/mindroom/custom_tools/google_drive.py
+++ b/src/mindroom/custom_tools/google_drive.py
@@ -51,13 +51,15 @@ _MODEL_FUNCTION_NAME_ALIASES = {
     "read_file": "google_drive_read_file",
     "download_file": "google_drive_download_file",
     "upload_file": "google_drive_upload_file",
+    "update_file": "google_drive_update_file",
     "create_folder": "google_drive_create_folder",
     "move_file": "google_drive_move_file",
     "trash_file": "google_drive_trash_file",
 }
-_WRITE_FUNCTION_NAMES = ("upload_file", "create_folder", "move_file", "trash_file")
+_WRITE_FUNCTION_NAMES = ("upload_file", "update_file", "create_folder", "move_file", "trash_file")
 _WRITE_RESULT_FIELDS = "id,name,mimeType,modifiedTime,size,parents,trashed,webViewLink"
 _FOLDER_MIME_TYPE = "application/vnd.google-apps.folder"
+_GOOGLE_WORKSPACE_MIME_PREFIX = "application/vnd.google-apps."
 
 
 def _max_read_size_finite_error(value: object) -> TypeError | ValueError:
@@ -180,12 +182,14 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
     def _register_write_tools(self) -> None:
         sync_tools = (
             (self._upload_file, "upload_file"),
+            (self.update_file, "update_file"),
             (self.create_folder, "create_folder"),
             (self.move_file, "move_file"),
             (self.trash_file, "trash_file"),
         )
         async_tools = (
             (self._aupload_file, "upload_file"),
+            (self.aupdate_file, "update_file"),
             (self.acreate_folder, "create_folder"),
             (self.amove_file, "move_file"),
             (self.atrash_file, "trash_file"),
@@ -332,6 +336,51 @@ class GoogleDriveTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, Ag
             name=name,
             mime_type=mime_type,
         )
+
+    @authenticate
+    def update_file(self, file_id: str, local_path: str, mime_type: str | None = None) -> str:
+        """Replace the contents of one binary Drive file from the agent workspace."""
+        try:
+            path = self._resolve_upload_path(local_path)
+        except ValueError as exc:
+            return json.dumps({"error": str(exc)})
+        if not path.is_file():
+            return json.dumps({"error": f"The file '{path}' does not exist or is not a file."})
+
+        try:
+            metadata = self._get_file_metadata(file_id, "id,name,mimeType")
+            existing_mime_type = metadata.get("mimeType")
+            if isinstance(existing_mime_type, str) and existing_mime_type.startswith(_GOOGLE_WORKSPACE_MIME_PREFIX):
+                return json.dumps(
+                    {
+                        "error": (
+                            "Google Drive content replacement only supports binary files; "
+                            f"{existing_mime_type} requires its Google Workspace API"
+                        ),
+                    },
+                )
+            resolved_mime_type = mime_type or mimetypes.guess_type(path.name)[0] or "application/octet-stream"
+            service = cast("Any", self.service)
+            updated_file = (
+                service.files()
+                .update(
+                    fileId=file_id,
+                    media_body=MediaFileUpload(str(path), mimetype=resolved_mime_type),
+                    fields=_WRITE_RESULT_FIELDS,
+                    supportsAllDrives=True,
+                )
+                .execute()
+            )
+            return json.dumps(updated_file)
+        except HttpError as exc:
+            return json.dumps({"error": f"Google Drive API error: {exc}"})
+        except Exception as exc:
+            log_error(f"Could not update Google Drive file '{file_id}': {exc}")
+            return json.dumps({"error": f"Unexpected error: {type(exc).__name__}: {exc}"})
+
+    async def aupdate_file(self, file_id: str, local_path: str, mime_type: str | None = None) -> str:
+        """Replace one binary Drive file without blocking the async agent loop."""
+        return await asyncio.to_thread(self.update_file, file_id, local_path, mime_type=mime_type)
 
     @authenticate
     def create_folder(self, name: str, parent_id: str | None = None) -> str:

--- a/src/mindroom/tools/google_drive.py
+++ b/src/mindroom/tools/google_drive.py
@@ -67,7 +67,7 @@ if TYPE_CHECKING:
             type="boolean",
             required=False,
             default=True,
-            description="Allow uploading, creating folders, moving or renaming files, and trashing files.",
+            description="Allow uploading, replacing file contents, creating folders, moving or renaming, and trashing.",
         ),
         ConfigField(
             name="max_read_size",
@@ -98,6 +98,7 @@ if TYPE_CHECKING:
         "google_drive_read_file",
         "google_drive_download_file",
         "google_drive_upload_file",
+        "google_drive_update_file",
         "google_drive_create_folder",
         "google_drive_move_file",
         "google_drive_trash_file",

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -8198,7 +8198,7 @@
         {
           "authored_override": true,
           "default": true,
-          "description": "Allow uploading, creating folders, moving or renaming files, and trashing files.",
+          "description": "Allow uploading, replacing file contents, creating folders, moving or renaming, and trashing.",
           "label": "Allow Write Operations",
           "name": "write",
           "options": null,
@@ -8237,6 +8237,7 @@
         "google_drive_read_file",
         "google_drive_download_file",
         "google_drive_upload_file",
+        "google_drive_update_file",
         "google_drive_create_folder",
         "google_drive_move_file",
         "google_drive_trash_file"

--- a/tests/test_google_drive_oauth_tool.py
+++ b/tests/test_google_drive_oauth_tool.py
@@ -279,6 +279,7 @@ def test_google_drive_model_functions_do_not_collide_with_local_file_tools(tmp_p
         "google_drive_search_files",
         "google_drive_read_file",
         "google_drive_upload_file",
+        "google_drive_update_file",
         "google_drive_create_folder",
         "google_drive_move_file",
         "google_drive_trash_file",
@@ -307,6 +308,7 @@ def test_google_drive_write_config_defaults_enabled_and_can_disable(tmp_path: Pa
     )
     write_functions = {
         "google_drive_upload_file",
+        "google_drive_update_file",
         "google_drive_create_folder",
         "google_drive_move_file",
         "google_drive_trash_file",
@@ -322,6 +324,7 @@ def test_google_drive_write_config_defaults_enabled_and_can_disable(tmp_path: Pa
 def test_google_drive_write_functions_can_require_approval() -> None:
     write_functions = (
         "google_drive_upload_file",
+        "google_drive_update_file",
         "google_drive_create_folder",
         "google_drive_move_file",
         "google_drive_trash_file",
@@ -577,6 +580,7 @@ def test_google_drive_readonly_grant_blocks_direct_async_write_methods(tmp_path:
 
     results = (
         asyncio.run(tool._aupload_file("plan.txt")),
+        asyncio.run(tool.aupdate_file("file-id", "plan.txt")),
         asyncio.run(tool.acreate_folder("Plans")),
         asyncio.run(tool.amove_file("file-id", "parent-id")),
         asyncio.run(tool.atrash_file("file-id")),
@@ -867,6 +871,63 @@ def test_google_drive_upload_rejects_workspace_escape(
 
     assert "must stay within the workspace root" in result["error"]
     assert service.files_resource.create_kwargs is None
+
+
+def test_google_drive_update_replaces_binary_file_content(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service, workspace_root = _google_drive_write_tool(tmp_path, monkeypatch)
+    replacement = workspace_root / "reports" / "plan.md"
+    replacement.parent.mkdir()
+    replacement.write_text("revised plan")
+    service.files_resource.file_metadata = {
+        "id": "file-id",
+        "name": "plan.md",
+        "mimeType": "text/markdown",
+    }
+
+    result = json.loads(tool.update_file("file-id", "reports/plan.md"))
+
+    assert result == {"id": "file-id"}
+    assert service.files_resource.get_kwargs == {
+        "fileId": "file-id",
+        "fields": "id,name,mimeType",
+        "supportsAllDrives": True,
+    }
+    assert service.files_resource.update_kwargs is not None
+    media = service.files_resource.update_kwargs["media_body"]
+    assert isinstance(media, _FakeMediaFileUpload)
+    assert Path(media.filename) == replacement
+    assert media.mimetype == "text/markdown"
+    assert service.files_resource.update_kwargs == {
+        "fileId": "file-id",
+        "media_body": media,
+        "fields": "id,name,mimeType,modifiedTime,size,parents,trashed,webViewLink",
+        "supportsAllDrives": True,
+    }
+
+
+def test_google_drive_update_rejects_google_workspace_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    tool, service, workspace_root = _google_drive_write_tool(tmp_path, monkeypatch)
+    replacement = workspace_root / "plan.txt"
+    replacement.write_text("revised plan")
+    service.files_resource.file_metadata = {
+        "id": "file-id",
+        "name": "Plan",
+        "mimeType": "application/vnd.google-apps.document",
+    }
+
+    result = json.loads(tool.update_file("file-id", "plan.txt"))
+
+    assert result["error"] == (
+        "Google Drive content replacement only supports binary files; "
+        "application/vnd.google-apps.document requires its Google Workspace API"
+    )
+    assert service.files_resource.update_kwargs is None
 
 
 def test_google_drive_upload_rejects_absolute_workspace_escape(


### PR DESCRIPTION
## Summary

- add an explicit Drive tool for replacing the contents of an existing binary file
- preserve workspace path confinement, scoped OAuth, write approvals, and shared-drive support
- reject Google Workspace-native files with guidance to use their native APIs

## Tests

- `uv run pytest tests/test_google_drive_oauth_tool.py tests/test_tools_metadata.py::test_export_tools_metadata_json -q`
- changed-file pre-commit hooks

## Summary by Sourcery

Add approved Google Drive binary file content replacement while preserving existing safety and access controls.

New Features:
- Add a Google Drive tool for replacing the contents of existing binary files from the agent workspace.

Enhancements:
- Apply existing write authorization, workspace confinement, OAuth scoping, and shared-drive handling to file content replacement.
- Reject Google Workspace-native files with guidance to use their native APIs.

Tests:
- Add coverage for binary content replacement, Workspace-native file rejection, tool registration, and write-access controls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to replace the contents of existing binary files in Google Drive.
  * Supports optional MIME type specification and clear errors for missing files or unsupported Google Workspace documents.
  * Available through both synchronous and asynchronous tool operations.

* **Tests**
  * Added coverage for successful updates, read-only access restrictions, and unsupported file types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->