### PR TITLE
Respect room membership for non-agent mentions

### DIFF
--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -152,7 +152,9 @@ The rules are:
 2. **Non-thread messages** — a single eligible agent or team can auto-respond, regardless of how many humans are present.
 3. **Threads with one human** — normal auto-response behavior applies, so the agent or team continues the conversation.
 4. **Threads with two or more humans** — agents and teams stay silent unless explicitly mentioned.
-5. **Mentioning a non-MindRoom user** — if a message tags only humans or unmanaged users, agents and teams stay silent.
+5. **Mentioning another joined room participant** — if a message tags only joined humans or unmanaged users, agents and teams stay silent.
+
+Mentions of absent or merely invited user IDs do not suppress normal routing or automatic responses.
 
 #### Bot accounts
 

--- a/docs/configuration/router.md
+++ b/docs/configuration/router.md
@@ -152,7 +152,7 @@ The rules are:
 2. **Non-thread messages** — a single eligible agent or team can auto-respond, regardless of how many humans are present.
 3. **Threads with one human** — normal auto-response behavior applies, so the agent or team continues the conversation.
 4. **Threads with two or more humans** — agents and teams stay silent unless explicitly mentioned.
-5. **Mentioning another joined room participant** — if a message tags only joined humans or unmanaged users, agents and teams stay silent.
+5. **Mentioning another joined room participant** — if a message tags only joined users who are neither managed entities nor configured bot accounts, agents and teams stay silent.
 
 Mentions of absent or merely invited user IDs do not suppress normal routing or automatic responses.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3225,7 +3225,7 @@ The rules are:
 2. **Non-thread messages** — a single eligible agent or team can auto-respond, regardless of how many humans are present.
 3. **Threads with one human** — normal auto-response behavior applies, so the agent or team continues the conversation.
 4. **Threads with two or more humans** — agents and teams stay silent unless explicitly mentioned.
-5. **Mentioning another joined room participant** — if a message tags only joined humans or unmanaged users, agents and teams stay silent.
+5. **Mentioning another joined room participant** — if a message tags only joined users who are neither managed entities nor configured bot accounts, agents and teams stay silent.
 
 Mentions of absent or merely invited user IDs do not suppress normal routing or automatic responses.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -3225,7 +3225,9 @@ The rules are:
 2. **Non-thread messages** — a single eligible agent or team can auto-respond, regardless of how many humans are present.
 3. **Threads with one human** — normal auto-response behavior applies, so the agent or team continues the conversation.
 4. **Threads with two or more humans** — agents and teams stay silent unless explicitly mentioned.
-5. **Mentioning a non-MindRoom user** — if a message tags only humans or unmanaged users, agents and teams stay silent.
+5. **Mentioning another joined room participant** — if a message tags only joined humans or unmanaged users, agents and teams stay silent.
+
+Mentions of absent or merely invited user IDs do not suppress normal routing or automatic responses.
 
 #### Bot accounts
 

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -148,7 +148,9 @@ The rules are:
 2. **Non-thread messages** — a single eligible agent or team can auto-respond, regardless of how many humans are present.
 3. **Threads with one human** — normal auto-response behavior applies, so the agent or team continues the conversation.
 4. **Threads with two or more humans** — agents and teams stay silent unless explicitly mentioned.
-5. **Mentioning a non-MindRoom user** — if a message tags only humans or unmanaged users, agents and teams stay silent.
+5. **Mentioning another joined room participant** — if a message tags only joined humans or unmanaged users, agents and teams stay silent.
+
+Mentions of absent or merely invited user IDs do not suppress normal routing or automatic responses.
 
 #### Bot accounts
 

--- a/skills/mindroom-docs/references/page__configuration__router__index.md
+++ b/skills/mindroom-docs/references/page__configuration__router__index.md
@@ -148,7 +148,7 @@ The rules are:
 2. **Non-thread messages** — a single eligible agent or team can auto-respond, regardless of how many humans are present.
 3. **Threads with one human** — normal auto-response behavior applies, so the agent or team continues the conversation.
 4. **Threads with two or more humans** — agents and teams stay silent unless explicitly mentioned.
-5. **Mentioning another joined room participant** — if a message tags only joined humans or unmanaged users, agents and teams stay silent.
+5. **Mentioning another joined room participant** — if a message tags only joined users who are neither managed entities nor configured bot accounts, agents and teams stay silent.
 
 Mentions of absent or merely invited user IDs do not suppress normal routing or automatic responses.
 

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -233,10 +233,10 @@ def get_available_responders_in_room(
 
     The router is excluded because it is not a regular conversation participant.
     """
-    return _available_responders_from_member_ids(joined_member_ids(room), config, runtime_paths)
+    return _available_responders_from_member_ids(cached_joined_member_ids(room), config, runtime_paths)
 
 
-def joined_member_ids(room: nio.MatrixRoom) -> frozenset[str]:
+def cached_joined_member_ids(room: nio.MatrixRoom) -> frozenset[str]:
     """Return cached room members that are joined rather than merely invited."""
     return frozenset(room.users).difference(room.invited_users)
 
@@ -287,6 +287,47 @@ def _apply_authoritative_joined_members(
     room.members_synced = True
 
 
+async def ensure_room_membership_synced(
+    client: nio.AsyncClient,
+    room: nio.MatrixRoom,
+    *,
+    sender_id: str,
+) -> bool:
+    """Refresh an incomplete room-member cache before membership-sensitive decisions."""
+    if room.members_synced:
+        return True
+
+    cached_member_count = len(cached_joined_member_ids(room))
+    try:
+        response = await client.joined_members(room.room_id)
+    except Exception as exc:
+        logger.warning(
+            "authoritative_room_membership_fetch_failed",
+            room_id=room.room_id,
+            sender_id=sender_id,
+            error=str(exc),
+        )
+        return False
+    if not isinstance(response, nio.JoinedMembersResponse):
+        logger.warning(
+            "authoritative_room_membership_fetch_failed",
+            room_id=room.room_id,
+            sender_id=sender_id,
+            error=str(response),
+        )
+        return False
+
+    _apply_authoritative_joined_members(room, response.members)
+    logger.info(
+        "authoritative_room_membership_refreshed",
+        room_id=room.room_id,
+        sender_id=sender_id,
+        cached_member_count=cached_member_count,
+        refreshed_member_count=len(response.members),
+    )
+    return True
+
+
 async def _get_available_responders_for_sender_authoritative(
     client: nio.AsyncClient,
     room: nio.MatrixRoom,
@@ -308,38 +349,17 @@ async def _get_available_responders_for_sender_authoritative(
     if room.members_synced:
         return cached_visible_responders
 
-    response = await client.joined_members(room.room_id)
-    if not isinstance(response, nio.JoinedMembersResponse):
-        logger.warning(
-            "authoritative_room_membership_fetch_failed",
-            room_id=room.room_id,
-            sender_id=sender_id,
-            error=str(response),
-        )
+    if not await ensure_room_membership_synced(client, room, sender_id=sender_id):
         return cached_visible_responders
 
-    _apply_authoritative_joined_members(room, response.members)
-    refreshed_room_responders = _available_responders_from_member_ids(
-        (member.user_id for member in response.members),
-        config,
-        runtime_paths,
-    )
-    refreshed_responders = filter_responders_by_sender_permissions(
-        refreshed_room_responders,
+    return filter_responders_by_sender_permissions(
+        get_available_responders_in_room(room, config, runtime_paths),
         sender_id,
         config,
         runtime_paths,
         membership_index,
         room.room_id,
     )
-    logger.info(
-        "authoritative_room_membership_refreshed",
-        room_id=room.room_id,
-        sender_id=sender_id,
-        cached_responder_count=len(cached_room_responders),
-        refreshed_responder_count=len(refreshed_responders),
-    )
-    return refreshed_responders
 
 
 def responder_candidate_entities_from_cached_room(

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -410,15 +410,15 @@ def _configured_responder_candidates_for_room(
     )
 
 
-async def responder_candidate_entities_for_room(
-    client: nio.AsyncClient | None,
+async def responder_candidate_entities_with_membership_refresh(
+    client: nio.AsyncClient,
     room: nio.MatrixRoom,
     sender_id: str,
     config: Config,
     runtime_paths: RuntimePaths,
     membership_index: AgentReplyMembershipIndex,
 ) -> list[MatrixID]:
-    """Return sender-visible responder candidates without widening configured rooms."""
+    """Return candidates, refreshing unsynced ad-hoc room membership when possible."""
     configured_entities = _configured_responder_candidates_for_room(
         room,
         sender_id,
@@ -428,8 +428,6 @@ async def responder_candidate_entities_for_room(
     )
     if configured_entities is not None:
         return configured_entities
-    if client is None:
-        return _get_available_responders_for_sender(room, sender_id, config, runtime_paths, membership_index)
     return await _get_available_responders_for_sender_authoritative(
         client,
         room,

--- a/src/mindroom/authorization.py
+++ b/src/mindroom/authorization.py
@@ -233,13 +233,12 @@ def get_available_responders_in_room(
 
     The router is excluded because it is not a regular conversation participant.
     """
-    return _available_responders_from_member_ids(_joined_member_ids(room), config, runtime_paths)
+    return _available_responders_from_member_ids(joined_member_ids(room), config, runtime_paths)
 
 
-def _joined_member_ids(room: nio.MatrixRoom) -> Iterable[str]:
+def joined_member_ids(room: nio.MatrixRoom) -> frozenset[str]:
     """Return cached room members that are joined rather than merely invited."""
-    invited_user_ids = set(room.invited_users)
-    return (user_id for user_id in room.users if user_id not in invited_user_ids)
+    return frozenset(room.users).difference(room.invited_users)
 
 
 def _get_available_responders_for_sender(

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -360,7 +360,13 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
     elif command.type == CommandType.SCHEDULE:
         full_text = command.args["full_text"]
 
-        mentioned_agents, _, _ = check_agent_mentioned(event.source, None, context.config, context.runtime_paths)
+        mentioned_agents, _, _ = check_agent_mentioned(
+            event.source,
+            None,
+            context.config,
+            context.runtime_paths,
+            room=room,
+        )
 
         _, response_text = await schedule_task(
             runtime=_scheduling_runtime(context, room),

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Protocol
 
-from mindroom.authorization import is_platform_administrator, responder_candidate_entities_for_room
+from mindroom.authorization import (
+    is_platform_administrator,
+    responder_candidate_entities_from_cached_room,
+    responder_candidate_entities_with_membership_refresh,
+)
 from mindroom.commands import config_confirmation
 from mindroom.commands.config_commands import handle_config_command
 from mindroom.commands.desktop_commands import (
@@ -117,9 +121,9 @@ class CommandHandlerContext:
     record_command_result: Callable[[str], Awaitable[None]]
     send_response: _CommandResponseSender
     agent_reply_memberships: AgentReplyMembershipIndex
+    responder_candidates_for_room: Callable[[nio.MatrixRoom, str], Awaitable[list[MatrixID]]]
     reload_plugins: Callable[[], Awaitable[PluginReloadResult]] | None = None
     matrix_admin: HookMatrixAdmin | None = None
-    responder_candidates_for_room: Callable[[nio.MatrixRoom, str], Awaitable[list[MatrixID]]] | None = None
 
 
 def _format_agent_description(agent_name: str, config: Config) -> str:
@@ -213,8 +217,16 @@ async def generate_welcome_message_for_room(
     """Generate a welcome message for callers without a live turn-policy candidate source."""
     if sender_id is None:
         candidate_entities = configured_routable_entity_ids_for_room(config, room.room_id, runtime_paths)
+    elif client is None:
+        candidate_entities = responder_candidate_entities_from_cached_room(
+            room,
+            sender_id,
+            config,
+            runtime_paths,
+            agent_reply_memberships,
+        )
     else:
-        candidate_entities = await responder_candidate_entities_for_room(
+        candidate_entities = await responder_candidate_entities_with_membership_refresh(
             client,
             room,
             sender_id,
@@ -267,17 +279,7 @@ async def _desktop_agent_for_room(
     requester_user_id: str,
 ) -> str | None:
     """Resolve one eligible agent from a room containing only the requester and serving bots."""
-    if context.responder_candidates_for_room is None:
-        candidates = await responder_candidate_entities_for_room(
-            context.client,
-            room,
-            requester_user_id,
-            context.config,
-            context.runtime_paths,
-            context.agent_reply_memberships,
-        )
-    else:
-        candidates = await context.responder_candidates_for_room(room, requester_user_id)
+    candidates = await context.responder_candidates_for_room(room, requester_user_id)
     registry = entity_identity_registry(context.config, context.runtime_paths)
     eligible: list[tuple[str, str]] = []
     for candidate in candidates:
@@ -327,18 +329,8 @@ async def handle_command(  # noqa: C901, PLR0912, PLR0915
                 response_text = f"❌ Plugin reload failed: {exc}"
 
     elif command.type == CommandType.HI:
-        if context.responder_candidates_for_room is None:
-            response_text = await generate_welcome_message_for_room(
-                context.client,
-                room,
-                requester_user_id,
-                context.config,
-                context.runtime_paths,
-                context.agent_reply_memberships,
-            )
-        else:
-            candidate_entities = await context.responder_candidates_for_room(room, requester_user_id)
-            response_text = _format_welcome_message(candidate_entities, context.config, context.runtime_paths)
+        candidate_entities = await context.responder_candidates_for_room(room, requester_user_id)
+        response_text = _format_welcome_message(candidate_entities, context.config, context.runtime_paths)
 
     elif command.type == CommandType.DESKTOP:
         desktop_agent_name = await _desktop_agent_for_room(context, room, requester_user_id)

--- a/src/mindroom/commands/handler.py
+++ b/src/mindroom/commands/handler.py
@@ -78,6 +78,7 @@ def _scheduling_runtime(context: CommandHandlerContext, room: nio.MatrixRoom) ->
         conversation_reader=context.conversation_reader,
         matrix_admin=context.matrix_admin,
         agent_reply_memberships=context.agent_reply_memberships,
+        responder_candidates_for_room=context.responder_candidates_for_room,
     )
 
 

--- a/src/mindroom/conversation_resolver.py
+++ b/src/mindroom/conversation_resolver.py
@@ -268,6 +268,8 @@ class ConversationResolver:
     def _mention_facts(
         self,
         event_source: dict[str, Any],
+        *,
+        room: nio.MatrixRoom,
     ) -> tuple[list[MatrixID], bool, bool]:
         """Return mention facts from one already-normalized event source."""
         if _should_skip_mentions(event_source):
@@ -277,6 +279,7 @@ class ConversationResolver:
             self._matrix_id(),
             self.deps.runtime.config,
             self.deps.runtime_paths,
+            room=room,
         )
 
     def _mentioned_agent_names(self, mentioned_agents: Sequence[MatrixID]) -> tuple[str, ...]:
@@ -360,6 +363,7 @@ class ConversationResolver:
     def pre_hydration_policy_facts(
         self,
         *,
+        room: nio.MatrixRoom,
         event: DispatchEvent,
         requester_user_id: str,
         payload_metadata: DispatchPayloadMetadata | None = None,
@@ -369,7 +373,10 @@ class ConversationResolver:
     ) -> _PreHydrationPolicyFacts:
         """Classify mention and origin policy without reading conversation history."""
         event_source = _source_with_payload_metadata(event.source, payload_metadata)
-        mentioned_agents, am_i_mentioned, _has_non_agent_mentions = self._mention_facts(event_source)
+        mentioned_agents, am_i_mentioned, _has_non_agent_mentions = self._mention_facts(
+            event_source,
+            room=room,
+        )
         resolved_source_kind, _hook_source, _message_received_depth = self._envelope_ingress_metadata(
             event=event,
             source_kind=source_kind,
@@ -890,7 +897,10 @@ class ConversationResolver:
         resolved_event_source = _source_with_payload_metadata(resolved_event_source, payload_metadata)
         config = self.deps.runtime.config
 
-        mentioned_agents, am_i_mentioned, has_non_agent_mentions = self._mention_facts(resolved_event_source)
+        mentioned_agents, am_i_mentioned, has_non_agent_mentions = self._mention_facts(
+            resolved_event_source,
+            room=room,
+        )
 
         if am_i_mentioned:
             self.deps.logger.info("Mentioned", event_id=event.event_id, room_id=room.room_id)
@@ -954,7 +964,10 @@ class ConversationResolver:
         resolved_event_source = _source_with_payload_metadata(resolved_event_source, payload_metadata)
         config = self.deps.runtime.config
 
-        mentioned_agents, am_i_mentioned, has_non_agent_mentions = self._mention_facts(resolved_event_source)
+        mentioned_agents, am_i_mentioned, has_non_agent_mentions = self._mention_facts(
+            resolved_event_source,
+            room=room,
+        )
 
         if am_i_mentioned:
             self.deps.logger.info("Mentioned", event_id=event.event_id, room_id=room.room_id)

--- a/src/mindroom/custom_tools/subagents.py
+++ b/src/mindroom/custom_tools/subagents.py
@@ -14,7 +14,10 @@ import nio
 from agno.tools import Toolkit
 
 from mindroom.agent_descriptions import describe_agent
-from mindroom.authorization import responder_candidate_entities_for_room, responder_candidate_entities_from_cached_room
+from mindroom.authorization import (
+    responder_candidate_entities_from_cached_room,
+    responder_candidate_entities_with_membership_refresh,
+)
 from mindroom.constants import ORIGINAL_SENDER_KEY, SOURCE_KIND_KEY
 from mindroom.dispatch_source import TRUSTED_INTERNAL_RELAY_SOURCE_KIND
 from mindroom.entity_resolution import entity_identity_registry
@@ -294,19 +297,15 @@ async def _available_subagent_names(context: ToolRuntimeContext, *, room_id: str
     context = replace(context, config=context.current_config, config_provider=None)
     target_room_id = room_id or context.room_id
     target_room = _cached_target_room(context, target_room_id)
-    if target_room is not None:
-        candidates = await responder_candidate_entities_for_room(
+    if target_room_id == context.room_id:
+        candidates = await context.responder_candidates_for_current_room(
+            target_room or _context_room(context),
+            context.requester_id,
+        )
+    elif target_room is not None:
+        candidates = await responder_candidate_entities_with_membership_refresh(
             context.client,
             target_room,
-            context.requester_id,
-            context.config,
-            context.runtime_paths,
-            context.require_agent_reply_memberships(),
-        )
-    elif target_room_id == context.room_id:
-        candidates = await responder_candidate_entities_for_room(
-            context.client,
-            _context_room(context),
             context.requester_id,
             context.config,
             context.runtime_paths,

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -20,7 +20,6 @@ from croniter import CroniterError, croniter
 from pydantic import BaseModel, Field, field_validator
 
 from mindroom import model_loading, scheduling_executor
-from mindroom.authorization import responder_candidate_entities_for_room
 from mindroom.entity_resolution import entity_identity_registry
 from mindroom.hooks import build_hook_matrix_admin
 from mindroom.logging_config import bound_log_context, get_logger
@@ -183,8 +182,8 @@ class SchedulingRuntime:
     room: nio.MatrixRoom
     conversation_reader: ConversationReader
     agent_reply_memberships: AgentReplyMembershipIndex
+    responder_candidates_for_room: Callable[[nio.MatrixRoom, str], Awaitable[list[MatrixID]]]
     matrix_admin: HookMatrixAdmin | None = None
-    responder_candidates_for_room: Callable[[nio.MatrixRoom, str], Awaitable[list[MatrixID]]] | None = None
 
 
 @dataclass
@@ -1383,17 +1382,7 @@ async def schedule_task(  # noqa: C901, PLR0912, PLR0915
     if mentioned_agents is None:
         mentioned_agents = _extract_mentioned_agents_from_text(full_text, config, runtime_paths)
 
-    if runtime.responder_candidates_for_room is None:
-        sender_visible_room_responders = await responder_candidate_entities_for_room(
-            client,
-            room,
-            scheduled_by,
-            config,
-            runtime_paths,
-            runtime.agent_reply_memberships,
-        )
-    else:
-        sender_visible_room_responders = await runtime.responder_candidates_for_room(room, scheduled_by)
+    sender_visible_room_responders = await runtime.responder_candidates_for_room(room, scheduled_by)
 
     available_responders: list[MatrixID] = []
     if new_thread:

--- a/src/mindroom/scheduling.py
+++ b/src/mindroom/scheduling.py
@@ -31,6 +31,8 @@ from mindroom.message_target import MessageTarget
 from mindroom.thread_utils import filter_thread_agents_for_sender, get_agents_in_thread
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from mindroom.agent_reply_membership import AgentReplyMembershipIndex
     from mindroom.config.main import Config
     from mindroom.constants import RuntimePaths
@@ -182,6 +184,7 @@ class SchedulingRuntime:
     conversation_reader: ConversationReader
     agent_reply_memberships: AgentReplyMembershipIndex
     matrix_admin: HookMatrixAdmin | None = None
+    responder_candidates_for_room: Callable[[nio.MatrixRoom, str], Awaitable[list[MatrixID]]] | None = None
 
 
 @dataclass
@@ -1380,14 +1383,17 @@ async def schedule_task(  # noqa: C901, PLR0912, PLR0915
     if mentioned_agents is None:
         mentioned_agents = _extract_mentioned_agents_from_text(full_text, config, runtime_paths)
 
-    sender_visible_room_responders = await responder_candidate_entities_for_room(
-        client,
-        room,
-        scheduled_by,
-        config,
-        runtime_paths,
-        runtime.agent_reply_memberships,
-    )
+    if runtime.responder_candidates_for_room is None:
+        sender_visible_room_responders = await responder_candidate_entities_for_room(
+            client,
+            room,
+            scheduled_by,
+            config,
+            runtime_paths,
+            runtime.agent_reply_memberships,
+        )
+    else:
+        sender_visible_room_responders = await runtime.responder_candidates_for_room(room, scheduled_by)
 
     available_responders: list[MatrixID] = []
     if new_thread:

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -110,8 +110,8 @@ def check_agent_mentioned(
 
     Returns (mentioned_agents, am_i_mentioned, has_non_agent_mentions).
     ``has_non_agent_mentions`` is True when the message explicitly tags a
-    joined user who is *not* a configured agent and not in
-    ``config.bot_accounts`` (i.e. a real human participant).
+    joined participant who is *not* a configured agent and not in
+    ``config.bot_accounts``.
     """
     raw_content = event_source.get("content", {})
     content = visible_content_from_content(raw_content) if isinstance(raw_content, dict) else {}
@@ -119,9 +119,9 @@ def check_agent_mentioned(
     mentioned_agents = _agents_from_user_ids(all_mentioned_ids, config, runtime_paths)
     am_i_mentioned = agent_id in mentioned_agents
     non_agent_mentions = [uid for uid in all_mentioned_ids if not _is_bot_or_agent(uid, config, runtime_paths)]
-    has_non_agent_mentions = bool(non_agent_mentions) and not authorization.joined_member_ids(room).isdisjoint(
-        non_agent_mentions,
-    )
+    has_non_agent_mentions = bool(non_agent_mentions) and not authorization.cached_joined_member_ids(
+        room,
+    ).isdisjoint(non_agent_mentions)
 
     return mentioned_agents, am_i_mentioned, has_non_agent_mentions
 
@@ -374,7 +374,7 @@ def decide_agent_response(
     if am_i_mentioned:
         return AgentResponseDecision(True)
 
-    # Never respond if another managed entity or joined human is explicitly mentioned.
+    # Never respond if another managed entity or joined unmanaged participant is explicitly mentioned.
     if mentioned_agents or has_non_agent_mentions:
         return AgentResponseDecision(False, "other_explicit_mention")
 

--- a/src/mindroom/thread_utils.py
+++ b/src/mindroom/thread_utils.py
@@ -103,20 +103,25 @@ def check_agent_mentioned(
     agent_id: MatrixID | None,
     config: Config,
     runtime_paths: RuntimePaths,
+    *,
+    room: nio.MatrixRoom,
 ) -> tuple[list[MatrixID], bool, bool]:
     """Check if an agent is mentioned in a message.
 
     Returns (mentioned_agents, am_i_mentioned, has_non_agent_mentions).
     ``has_non_agent_mentions`` is True when the message explicitly tags a
-    user who is *not* a configured agent and not in ``config.bot_accounts``
-    (i.e. a real human user).
+    joined user who is *not* a configured agent and not in
+    ``config.bot_accounts`` (i.e. a real human participant).
     """
     raw_content = event_source.get("content", {})
     content = visible_content_from_content(raw_content) if isinstance(raw_content, dict) else {}
     all_mentioned_ids = _extract_mentioned_user_ids(content, config, runtime_paths)
     mentioned_agents = _agents_from_user_ids(all_mentioned_ids, config, runtime_paths)
     am_i_mentioned = agent_id in mentioned_agents
-    has_non_agent_mentions = any(not _is_bot_or_agent(uid, config, runtime_paths) for uid in all_mentioned_ids)
+    non_agent_mentions = [uid for uid in all_mentioned_ids if not _is_bot_or_agent(uid, config, runtime_paths)]
+    has_non_agent_mentions = bool(non_agent_mentions) and not authorization.joined_member_ids(room).isdisjoint(
+        non_agent_mentions,
+    )
 
     return mentioned_agents, am_i_mentioned, has_non_agent_mentions
 
@@ -335,7 +340,7 @@ def decide_agent_response(
         runtime_paths: Explicit runtime context for permissions and mention resolution
         membership_index: Shared authoritative grant-room membership index
         mentioned_agents: List of all agent MatrixIDs mentioned in the message
-        has_non_agent_mentions: True when the message explicitly tags a non-agent user
+        has_non_agent_mentions: True when the message explicitly tags a joined non-agent user
         sender_id: Sender Matrix ID used for per-agent reply permissions
         available_responders_in_room: Optional precomputed sender-visible responders for the room
         agents_in_thread: Optional precomputed agents that have participated in the thread
@@ -369,7 +374,7 @@ def decide_agent_response(
     if am_i_mentioned:
         return AgentResponseDecision(True)
 
-    # Never respond if anyone else is explicitly mentioned (agent or not)
+    # Never respond if another managed entity or joined human is explicitly mentioned.
     if mentioned_agents or has_non_agent_mentions:
         return AgentResponseDecision(False, "other_explicit_mention")
 

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -114,6 +114,39 @@ class ToolRuntimeContext:
             raise RuntimeError(msg)
         return self.agent_reply_memberships
 
+    async def responder_candidates_for_current_room(
+        self,
+        room: nio.MatrixRoom,
+        requester_user_id: str,
+    ) -> list[MatrixID]:
+        """Resolve current-room candidates through this context's membership boundary."""
+        from mindroom.authorization import (  # noqa: PLC0415
+            responder_candidate_entities_from_cached_room,
+            responder_candidate_entities_with_membership_refresh,
+        )
+
+        if room.room_id != self.room_id:
+            msg = "Tool runtime current-room candidate resolution requires the context room"
+            raise ValueError(msg)
+        config = self.current_config
+        membership_index = self.require_agent_reply_memberships()
+        if self.membership_turn_id is not None:
+            return responder_candidate_entities_from_cached_room(
+                room,
+                requester_user_id,
+                config,
+                self.runtime_paths,
+                membership_index,
+            )
+        return await responder_candidate_entities_with_membership_refresh(
+            self.client,
+            room,
+            requester_user_id,
+            config,
+            self.runtime_paths,
+            membership_index,
+        )
+
     @property
     def room_id(self) -> str:
         """Return the canonical target room ID."""
@@ -490,6 +523,7 @@ def build_scheduling_runtime_from_tool_runtime_context(context: ToolRuntimeConte
         conversation_reader=context.conversation_reader,
         matrix_admin=context.matrix_admin,
         agent_reply_memberships=context.require_agent_reply_memberships(),
+        responder_candidates_for_room=context.responder_candidates_for_current_room,
     )
 
 

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -494,6 +494,7 @@ class TurnController:
 
     def _event_allows_queued_notice(
         self,
+        room: nio.MatrixRoom,
         event: PreparedIngress,
         envelope: MessageEnvelope,
     ) -> bool:
@@ -505,6 +506,7 @@ class TurnController:
             self.deps.matrix_id,
             self.deps.runtime.config,
             self.deps.runtime_paths,
+            room=room,
         )
         return am_i_mentioned or not (mentioned_agents or has_non_agent_mentions)
 
@@ -555,7 +557,7 @@ class TurnController:
             reply_to_event_id=prepared_event.event_id,
             event_source=prepared_event.source,
         )
-        if self._event_allows_queued_notice(prepared_event, envelope):
+        if self._event_allows_queued_notice(room, prepared_event, envelope):
             queued_notice_reservation = self._queued_notice_reservation_if_busy(
                 target=target,
                 envelope=envelope,
@@ -657,6 +659,7 @@ class TurnController:
             self.deps.matrix_id,
             self.deps.runtime.config,
             self.deps.runtime_paths,
+            room=room,
         )
         if mentioned_agents or has_non_agent_mentions:
             return not is_router_only_agent_mention(
@@ -1024,6 +1027,7 @@ class TurnController:
     ) -> bool:
         """Settle managed chatter before thread hydration can make it retryable."""
         policy = self.deps.resolver.pre_hydration_policy_facts(
+            room=room,
             event=event,
             requester_user_id=requester_user_id,
             payload_metadata=payload_metadata,

--- a/src/mindroom/turn_controller.py
+++ b/src/mindroom/turn_controller.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from mindroom import interactive
 from mindroom.attachments import parse_attachment_ids_from_event_source
+from mindroom.authorization import ensure_room_membership_synced
 from mindroom.background_tasks import run_coroutine_until_complete
 from mindroom.coalescing import CoalescingGate, ReadyPendingEvent
 from mindroom.coalescing_batch import (
@@ -2195,6 +2196,11 @@ class TurnController:
             return TurnDispatchOutcome.INTENTIONALLY_IGNORED
         if is_nonterminal_stream:
             return TurnDispatchOutcome.INTENTIONALLY_IGNORED
+        await ensure_room_membership_synced(
+            self._client(),
+            room,
+            sender_id=prechecked_event.requester_user_id,
+        )
 
         dispatch_timing = create_dispatch_pipeline_timing(
             event_id=event.event_id,
@@ -2335,6 +2341,11 @@ class TurnController:
                 sender=prechecked_event.event.sender,
             )
             return TurnDispatchOutcome.INTENTIONALLY_IGNORED
+        await ensure_room_membership_synced(
+            self._client(),
+            room,
+            sender_id=prechecked_event.requester_user_id,
+        )
         pending_turn = TurnRecord.create([prechecked_event.event.event_id], completed=False)
         turn_claim = await self._claim_live_turn(
             pending_turn,

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -351,11 +351,11 @@ class TurnPolicy:
         requester_user_id: str,
         availability: _ResponderAvailability | None = None,
     ) -> list[MatrixID]:
-        """Return sender-visible candidates filtered by live responder availability."""
+        """Return candidates from the boundary-prepared room membership snapshot."""
         if availability is None:
             availability = self.responder_availability()
         available_responders = await responder_candidate_entities_for_room(
-            self.deps.runtime.client,
+            None,
             room,
             requester_user_id,
             self.deps.runtime.config,
@@ -695,7 +695,7 @@ class TurnPolicy:
         planning_thread_history = context.planning_thread_history
         availability = self.responder_availability()
         sender_visible_responders_in_room = await responder_candidate_entities_for_room(
-            self.deps.runtime.client,
+            None,
             room,
             requester_user_id,
             self.deps.runtime.config,

--- a/src/mindroom/turn_policy.py
+++ b/src/mindroom/turn_policy.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Literal
 
 from mindroom.authorization import (
     is_sender_allowed_for_agent_reply_in_room,
-    responder_candidate_entities_for_room,
+    responder_candidate_entities_from_cached_room,
 )
 from mindroom.constants import MATRIX_MESSAGE_TARGET_ENRICHMENT_KEY, ROUTER_AGENT_NAME, RuntimePaths
 from mindroom.dispatch_source import ACTIVE_THREAD_FOLLOW_UP_SOURCE_KIND, ScheduledHistoryBudget
@@ -354,8 +354,7 @@ class TurnPolicy:
         """Return candidates from the boundary-prepared room membership snapshot."""
         if availability is None:
             availability = self.responder_availability()
-        available_responders = await responder_candidate_entities_for_room(
-            None,
+        available_responders = responder_candidate_entities_from_cached_room(
             room,
             requester_user_id,
             self.deps.runtime.config,
@@ -694,8 +693,7 @@ class TurnPolicy:
         requester_user_id = dispatch.requester_user_id
         planning_thread_history = context.planning_thread_history
         availability = self.responder_availability()
-        sender_visible_responders_in_room = await responder_candidate_entities_for_room(
-            None,
+        sender_visible_responders_in_room = responder_candidate_entities_from_cached_room(
             room,
             requester_user_id,
             self.deps.runtime.config,

--- a/src/mindroom/voice_handler.py
+++ b/src/mindroom/voice_handler.py
@@ -16,7 +16,7 @@ from agno.media import Audio
 
 from mindroom import model_loading
 from mindroom.attachments import register_audio_attachment
-from mindroom.authorization import responder_candidate_entities_for_room
+from mindroom.authorization import responder_candidate_entities_from_cached_room
 from mindroom.config.voice import normalize_speech_base_url
 from mindroom.constants import (
     ATTACHMENT_IDS_KEY,
@@ -417,8 +417,7 @@ async def _handle_voice_message(
 
         logger.info("voice_transcription_received", transcription=transcription)
 
-        available_agent_names, available_team_names = await _get_available_entities_for_sender(
-            client,
+        available_agent_names, available_team_names = _get_available_entities_for_sender(
             room,
             event.sender,
             config,
@@ -644,8 +643,7 @@ async def _process_transcription(
         return transcription
 
 
-async def _get_available_entities_for_sender(
-    client: nio.AsyncClient,
+def _get_available_entities_for_sender(
     room: nio.MatrixRoom,
     sender_id: str,
     config: Config,
@@ -657,8 +655,7 @@ async def _get_available_entities_for_sender(
     available_team_names: list[str] = []
     registry = entity_identity_registry(config, runtime_paths)
 
-    for matrix_id in await responder_candidate_entities_for_room(
-        client,
+    for matrix_id in responder_candidate_entities_from_cached_room(
         room,
         sender_id,
         config,

--- a/tests/authorization_helpers.py
+++ b/tests/authorization_helpers.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    import nio
+
     from mindroom.agent_reply_membership import AgentReplyMembershipIndex
     from mindroom.bot import AgentBot, TeamBot
     from mindroom.commands.handler import CommandHandlerContext
+    from mindroom.matrix.identity import MatrixID
     from mindroom.orchestration.external_trigger_runtime import ExternalTriggerRuntimeCoordinator
     from mindroom.scheduling import SchedulingRuntime
     from mindroom.tool_system.runtime_context import ToolRuntimeContext
@@ -19,6 +22,30 @@ def isolated_membership_index() -> AgentReplyMembershipIndex:
     from mindroom.agent_reply_membership import AgentReplyMembershipIndex  # noqa: PLC0415
 
     return AgentReplyMembershipIndex()
+
+
+def _add_default_responder_candidate_resolver(kwargs: dict[str, Any]) -> None:
+    """Give detached test runtimes the production authoritative fallback."""
+    from mindroom.authorization import responder_candidate_entities_with_membership_refresh  # noqa: PLC0415
+
+    membership_index = kwargs.setdefault("agent_reply_memberships", isolated_membership_index())
+    if "responder_candidates_for_room" in kwargs:
+        return
+    client = kwargs["client"]
+    config = kwargs["config"]
+    runtime_paths = kwargs["runtime_paths"]
+
+    async def resolve_responder_candidates(room: nio.MatrixRoom, sender_id: str) -> list[MatrixID]:
+        return await responder_candidate_entities_with_membership_refresh(
+            client,
+            room,
+            sender_id,
+            config,
+            runtime_paths,
+            membership_index,
+        )
+
+    kwargs["responder_candidates_for_room"] = resolve_responder_candidates
 
 
 def make_test_tool_runtime_context(*args: Any, **kwargs: Any) -> ToolRuntimeContext:  # noqa: ANN401
@@ -41,7 +68,7 @@ def make_test_command_handler_context(*args: Any, **kwargs: Any) -> CommandHandl
     """Build a detached command context with an explicit isolated index."""
     from mindroom.commands.handler import CommandHandlerContext  # noqa: PLC0415
 
-    kwargs.setdefault("agent_reply_memberships", isolated_membership_index())
+    _add_default_responder_candidate_resolver(kwargs)
     return CommandHandlerContext(*args, **kwargs)
 
 
@@ -49,7 +76,7 @@ def make_test_scheduling_runtime(*args: Any, **kwargs: Any) -> SchedulingRuntime
     """Build a detached scheduling runtime with an explicit isolated index."""
     from mindroom.scheduling import SchedulingRuntime  # noqa: PLC0415
 
-    kwargs.setdefault("agent_reply_memberships", isolated_membership_index())
+    _add_default_responder_candidate_resolver(kwargs)
     return SchedulingRuntime(*args, **kwargs)
 
 

--- a/tests/test_agent_order_preservation.py
+++ b/tests/test_agent_order_preservation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 
+import nio
 import pytest
 
 from mindroom.config.agent import AgentConfig
@@ -74,6 +75,11 @@ def _entity_user_ids(config: Config) -> dict[str, str]:
     return {name: matrix_id.full_id for name, matrix_id in entity_ids(config, runtime_paths).items() if matrix_id}
 
 
+def _room() -> nio.MatrixRoom:
+    """Return an empty room for managed-mention parsing tests."""
+    return nio.MatrixRoom("!test:localhost", "@mindroom_router:localhost")
+
+
 class TestAgentOrderPreservation:
     """Test that agent order is preserved in various functions."""
 
@@ -93,7 +99,13 @@ class TestAgentOrderPreservation:
             },
         }
 
-        agents, _, _ = check_agent_mentioned(event_source, None, mock_config, runtime_paths)
+        agents, _, _ = check_agent_mentioned(
+            event_source,
+            None,
+            mock_config,
+            runtime_paths,
+            room=_room(),
+        )
 
         # Order should be preserved as phone, email, research
         agent_names = [entity_name_for_id(mid, mock_config, runtime_paths) for mid in agents]
@@ -237,8 +249,20 @@ class TestAgentOrderPreservation:
             },
         }
 
-        agents1, _, _ = check_agent_mentioned(event_source1, None, mock_config, runtime_paths)
-        agents2, _, _ = check_agent_mentioned(event_source2, None, mock_config, runtime_paths)
+        agents1, _, _ = check_agent_mentioned(
+            event_source1,
+            None,
+            mock_config,
+            runtime_paths,
+            room=_room(),
+        )
+        agents2, _, _ = check_agent_mentioned(
+            event_source2,
+            None,
+            mock_config,
+            runtime_paths,
+            room=_room(),
+        )
 
         # Different orders should be preserved
         agent_names1 = [entity_name_for_id(mid, mock_config, runtime_paths) for mid in agents1]

--- a/tests/test_agent_response_logic.py
+++ b/tests/test_agent_response_logic.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import tempfile
 from pathlib import Path
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -362,8 +362,8 @@ class TestAgentResponseLogic:
 
         candidate_ids = entity_ids(self.config, self.runtime_paths)
         with patch(
-            "mindroom.turn_policy.responder_candidate_entities_for_room",
-            new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+            "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+            new=MagicMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
         ):
             multiple_visible_action = await policy._resolve_response_action(
                 dispatch,
@@ -375,8 +375,8 @@ class TestAgentResponseLogic:
         assert multiple_visible_action.kind == "skip"
 
         with patch(
-            "mindroom.turn_policy.responder_candidate_entities_for_room",
-            new=AsyncMock(return_value=[candidate_ids["calculator"]]),
+            "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+            new=MagicMock(return_value=[candidate_ids["calculator"]]),
         ):
             single_visible_action = await policy._resolve_response_action(
                 dispatch,
@@ -440,8 +440,8 @@ class TestAgentResponseLogic:
 
         with (
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
-                new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+                new=MagicMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
             ),
             patch(
                 "mindroom.turn_policy.decide_team_formation",
@@ -522,8 +522,8 @@ class TestAgentResponseLogic:
         candidate_ids = entity_ids(self.config, self.runtime_paths)
 
         with patch(
-            "mindroom.turn_policy.responder_candidate_entities_for_room",
-            new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+            "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+            new=MagicMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
         ):
             action = await policy._resolve_response_action(
                 dispatch,
@@ -601,8 +601,8 @@ class TestAgentResponseLogic:
 
         with (
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
-                new=AsyncMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+                new=MagicMock(return_value=[candidate_ids["calculator"], candidate_ids["general"]]),
             ),
             patch(
                 "mindroom.turn_policy.decide_team_formation",

--- a/tests/test_agent_response_logic.py
+++ b/tests/test_agent_response_logic.py
@@ -987,6 +987,7 @@ class TestAgentResponseLogic:
             router_id,
             self.config,
             self.runtime_paths,
+            room=create_mock_room(config=self.config),
         )
 
         assert mentioned_agents == [router_id]

--- a/tests/test_bot_media_dispatch.py
+++ b/tests/test_bot_media_dispatch.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
+import nio
 import pytest
 from agno.media import Image
 
@@ -69,8 +70,6 @@ from tests.conftest import (
 if TYPE_CHECKING:
     from pathlib import Path
 
-    import nio
-
     from mindroom.ingress_lanes import ReceiptLaneKey
     from mindroom.matrix.users import AgentMatrixUser
 
@@ -90,6 +89,12 @@ def _assert_ready_voice_claim_handoff(ready_event: ReadyPendingEvent | None) -> 
     )
     assert claim_metadata.payload == TurnRecord.create(["$voice_event"], completed=False)
     claim_metadata.close()
+
+
+def _synced_room(own_user_id: str) -> nio.MatrixRoom:
+    room = nio.MatrixRoom("!test:localhost", own_user_id)
+    room.members_synced = True
+    return room
 
 
 class TestAgentBot(AgentBotTestBase):
@@ -124,8 +129,7 @@ class TestAgentBot(AgentBotTestBase):
         generate_response = AsyncMock(return_value="$response")
         install_generate_response_mock(bot, generate_response)
 
-        room = MagicMock()
-        room.room_id = "!test:localhost"
+        room = _synced_room(bot.matrix_id.full_id)
 
         event = _room_image_event(sender="@user:localhost", event_id="$img_event", body="photo.jpg")
         event.source = {"content": {"body": "photo.jpg"}}  # no filename → body is filename
@@ -214,8 +218,7 @@ class TestAgentBot(AgentBotTestBase):
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
-        room = MagicMock()
-        room.room_id = "!test:localhost"
+        room = _synced_room(bot.matrix_id.full_id)
         event = self._make_handler_event("image", sender="@user:localhost", event_id="$img_event")
         prechecked_event = SimpleNamespace(event=event, requester_user_id="@user:localhost")
         bot._conversation_resolver.coalescing_thread_id = AsyncMock(return_value=None)
@@ -238,7 +241,7 @@ class TestAgentBot(AgentBotTestBase):
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
-        room = SimpleNamespace(room_id="!test:localhost")
+        room = _synced_room(bot.matrix_id.full_id)
         event = self._make_handler_event("voice", sender="@user:localhost", event_id="$voice_event")
         call_order: list[str] = []
         admitted_ready_task: asyncio.Task[ReadyPendingEvent | None] | None = None
@@ -319,7 +322,8 @@ class TestAgentBot(AgentBotTestBase):
         """A media replay cannot repeat thread resolution while the first delivery owns the turn."""
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        room = SimpleNamespace(room_id="!test:localhost")
+        bot.client = _make_matrix_client_mock()
+        room = _synced_room(bot.matrix_id.full_id)
         event = _room_image_event(sender="@user:localhost", event_id="$image_event", body="photo.jpg")
         resolution_started = asyncio.Event()
 
@@ -355,7 +359,8 @@ class TestAgentBot(AgentBotTestBase):
         """A durable competing owner settles redelivery without repeating media resolution."""
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        room = SimpleNamespace(room_id="!test:localhost")
+        bot.client = _make_matrix_client_mock()
+        room = _synced_room(bot.matrix_id.full_id)
         event = _room_image_event(sender="@user:localhost", event_id="$image_event", body="photo.jpg")
 
         ingress = MagicMock(spec=IngressValidator, wraps=bot._ingress_validator)
@@ -384,7 +389,8 @@ class TestAgentBot(AgentBotTestBase):
         """Claim-and-reserve must leave the source retryable when lane creation fails."""
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        room = SimpleNamespace(room_id="!test:localhost")
+        bot.client = _make_matrix_client_mock()
+        room = _synced_room(bot.matrix_id.full_id)
         event = _room_image_event(sender="@user:localhost", event_id="$image_event", body="photo.jpg")
         competing_claim = TurnRecord.create([event.event_id], completed=False)
 
@@ -417,8 +423,7 @@ class TestAgentBot(AgentBotTestBase):
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
-        room = MagicMock()
-        room.room_id = "!test:localhost"
+        room = _synced_room(bot.matrix_id.full_id)
         event = self._make_handler_event("voice", sender="@user:localhost", event_id="$voice_event")
         prechecked_event = SimpleNamespace(event=event, requester_user_id="@user:localhost")
 

--- a/tests/test_bot_scheduling.py
+++ b/tests/test_bot_scheduling.py
@@ -1804,8 +1804,8 @@ class TestRouterSkipsSingleAgent:
         with (
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
-                new_callable=AsyncMock,
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+                new_callable=MagicMock,
             ) as mock_get_available,
         ):
             # Return only one agent (general)
@@ -1891,8 +1891,8 @@ class TestRouterSkipsSingleAgent:
         with (
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
-                new_callable=AsyncMock,
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+                new_callable=MagicMock,
             ) as mock_get_available,
         ):
             # Return multiple agents
@@ -1995,8 +1995,8 @@ class TestRouterSkipsSingleAgent:
         with (
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
-                new_callable=AsyncMock,
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+                new_callable=MagicMock,
             ) as mock_get_available,
         ):
             mock_get_available.return_value = [
@@ -2077,8 +2077,8 @@ class TestRouterSkipsSingleAgent:
 
         with (
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
-                new_callable=AsyncMock,
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+                new_callable=MagicMock,
             ) as mock_get_available,
         ):
             mock_get_available.return_value = [entity_ids(config, runtime_paths_for(config))["general"]]
@@ -2145,8 +2145,8 @@ class TestRouterSkipsSingleAgent:
 
         with (
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
-                new_callable=AsyncMock,
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+                new_callable=MagicMock,
             ) as mock_get_available,
         ):
             mock_get_available.return_value = [entity_ids(config, runtime_paths_for(config))["general"]]
@@ -2229,8 +2229,8 @@ class TestRouterSkipsSingleAgent:
 
         with (
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
-                new_callable=AsyncMock,
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+                new_callable=MagicMock,
             ) as mock_get_available,
             patch("mindroom.turn_policy.get_agents_in_thread") as mock_agents_in_thread,
         ):
@@ -2305,8 +2305,8 @@ class TestRouterSkipsSingleAgent:
 
         with (
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
-                new_callable=AsyncMock,
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
+                new_callable=MagicMock,
             ) as mock_get_available,
         ):
             mock_get_available.return_value = [

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -9,6 +9,10 @@ from unittest.mock import AsyncMock, MagicMock
 import nio
 import pytest
 
+from mindroom.authorization import (
+    ensure_room_membership_synced,
+    responder_candidate_entities_from_cached_room,
+)
 from mindroom.commands.handler import generate_welcome_message_for_room, handle_command
 from mindroom.commands.parsing import (
     _COMMAND_DOCS,
@@ -551,6 +555,68 @@ async def test_hi_command_uses_live_responder_candidates_when_available(tmp_path
     response_text = send_response.await_args.args[0]
     assert "\u2022 **@code**: Writes code" in response_text
     assert "@research" not in response_text
+
+
+@pytest.mark.asyncio
+async def test_schedule_command_reuses_failed_boundary_membership_snapshot(tmp_path: Path) -> None:
+    """Live scheduling must not retry a failed membership refresh from the same turn."""
+    config = Config()
+    runtime_paths = _test_runtime_paths(tmp_path)
+    persist_entity_accounts(config, runtime_paths, usernames={"router": "mindroom_router"})
+    membership_index = isolated_membership_index()
+    room = nio.MatrixRoom(room_id="!adhoc:localhost", own_user_id="@mindroom_router:localhost")
+    room.add_member("@mindroom_router:localhost", "Router", None)
+    room.add_member("@alice:localhost", "Alice", None)
+    client = AsyncMock()
+    client.joined_members.side_effect = TimeoutError("membership lookup timed out")
+    send_response = AsyncMock(return_value="$schedule-response")
+    command = Command(
+        type=CommandType.SCHEDULE,
+        args={"full_text": "in 5 minutes check logs"},
+        raw_text="!schedule in 5 minutes check logs",
+    )
+    event = SimpleNamespace(
+        sender="@alice:localhost",
+        event_id="$schedule",
+        body=command.raw_text,
+        source={"content": {"body": command.raw_text}},
+    )
+
+    async def cached_responder_candidates(candidate_room: nio.MatrixRoom, sender_id: str) -> list[MatrixID]:
+        return responder_candidate_entities_from_cached_room(
+            candidate_room,
+            sender_id,
+            config,
+            runtime_paths,
+            membership_index,
+        )
+
+    context = make_test_command_handler_context(
+        client=client,
+        config=config,
+        runtime_paths=runtime_paths,
+        logger=MagicMock(),
+        conversation_reader=make_conversation_reader_mock(),
+        stable_target=MessageTarget.resolve(room.room_id, None, event.event_id),
+        record_handled_turn=AsyncMock(),
+        record_command_result=AsyncMock(),
+        send_response=send_response,
+        responder_candidates_for_room=cached_responder_candidates,
+        agent_reply_memberships=membership_index,
+    )
+
+    assert not await ensure_room_membership_synced(client, room, sender_id=event.sender)
+
+    await handle_command(
+        context=context,
+        room=room,
+        event=event,
+        command=command,
+        requester_user_id=event.sender,
+    )
+
+    assert client.joined_members.await_count == 1
+    assert "No agents or teams" in send_response.await_args.args[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_conversation_resolver.py
+++ b/tests/test_conversation_resolver.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 
 _ROOM_ID = "!test:localhost"
 _SENDER = "@user:localhost"
+_HUMAN_USER_ID = "@human:localhost"
 _BOT_USER_ID = "@mindroom_general:localhost"
 _EVENT_ID = "$event:localhost"
 _THREAD_ROOT = "$root:localhost"
@@ -435,7 +436,7 @@ async def test_dispatch_context_extracts_agent_mentions(config: Config) -> None:
     event = _event(
         {
             "body": "hello @general",
-            "m.mentions": {"user_ids": [general_id.full_id, "@human:localhost"]},
+            "m.mentions": {"user_ids": [general_id.full_id, _HUMAN_USER_ID]},
         },
     )
 
@@ -443,7 +444,43 @@ async def test_dispatch_context_extracts_agent_mentions(config: Config) -> None:
 
     assert result.context.am_i_mentioned is True
     assert [agent.full_id for agent in result.context.mentioned_agents] == [general_id.full_id]
-    assert result.context.has_non_agent_mentions is True
+    assert result.context.has_non_agent_mentions is False
+
+
+@pytest.mark.parametrize(
+    ("membership", "expected"),
+    [
+        ("absent", False),
+        ("invited", False),
+        ("joined", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_dispatch_context_only_counts_joined_non_agent_mentions(
+    config: Config,
+    membership: str,
+    expected: bool,
+) -> None:
+    """Only a human who is joined to the room should suppress automatic agent replies."""
+    resolver = _resolver(config)
+    room = _room()
+    if membership != "absent":
+        room.add_member(
+            _HUMAN_USER_ID,
+            "Human",
+            None,
+            invited=membership == "invited",
+        )
+    event = _event(
+        {
+            "body": f"hello {_HUMAN_USER_ID}",
+            "m.mentions": {"user_ids": [_HUMAN_USER_ID]},
+        },
+    )
+
+    result = await resolver.extract_dispatch_context(room, event)
+
+    assert result.context.has_non_agent_mentions is expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -31,6 +31,7 @@ from mindroom.constants import (
     ATTACHMENT_IDS_KEY,
     HOOK_MESSAGE_RECEIVED_DEPTH_KEY,
     ORIGINAL_SENDER_KEY,
+    ROUTER_AGENT_NAME,
     SKIP_MENTIONS_KEY,
     SOURCE_KIND_KEY,
     STREAM_STATUS_KEY,
@@ -315,6 +316,8 @@ def _make_room(room_id: str = "!room:localhost") -> MagicMock:
     room = MagicMock(spec=nio.MatrixRoom)
     room.room_id = room_id
     room.canonical_alias = None
+    room.users = {}
+    room.invited_users = {}
     return room
 
 
@@ -7503,6 +7506,48 @@ async def test_router_early_skip_keeps_sidecar_preview_for_hydration(tmp_path: P
     )
 
     assert should_skip is False
+
+
+@pytest.mark.parametrize(
+    ("membership", "expected"),
+    [
+        ("absent", False),
+        ("invited", False),
+        ("joined", True),
+    ],
+)
+@pytest.mark.asyncio
+async def test_router_early_skip_only_honors_joined_non_agent_mentions(
+    tmp_path: Path,
+    membership: str,
+    expected: bool,
+) -> None:
+    """An absent or merely invited human mention must not bypass normal router dispatch."""
+    bot = _make_bot(tmp_path, agent_name=ROUTER_AGENT_NAME)
+    room = nio.MatrixRoom("!room:localhost", bot.matrix_id.full_id)
+    room.add_member(bot.matrix_id.full_id, "Router", None)
+    room.add_member("@user:localhost", "User", None)
+    mentioned_user_id = "@human:localhost"
+    if membership != "absent":
+        room.add_member(
+            mentioned_user_id,
+            "Human",
+            None,
+            invited=membership == "invited",
+        )
+    event = _text_event(event_id="$human-mention", body=f"hello {mentioned_user_id}")
+    content = event.source["content"]
+    assert isinstance(content, dict)
+    content["m.mentions"] = {"user_ids": [mentioned_user_id]}
+
+    should_skip = await bot._turn_controller._should_skip_router_before_shared_ingress_work(
+        room,
+        event,
+        requester_user_id="@user:localhost",
+        thread_id=None,
+    )
+
+    assert should_skip is expected
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -316,6 +316,7 @@ def _make_room(room_id: str = "!room:localhost") -> MagicMock:
     room = MagicMock(spec=nio.MatrixRoom)
     room.room_id = room_id
     room.canonical_alias = None
+    room.members_synced = True
     room.users = {}
     room.invited_users = {}
     return room
@@ -7548,6 +7549,65 @@ async def test_router_early_skip_only_honors_joined_non_agent_mentions(
     )
 
     assert should_skip is expected
+
+
+@pytest.mark.asyncio
+async def test_first_router_turn_refreshes_lazy_members_before_mention_routing(tmp_path: Path) -> None:
+    """A partial lazy-member cache must not hide a joined mentioned participant."""
+    bot = _make_bot(tmp_path, agent_name=ROUTER_AGENT_NAME)
+    room = nio.MatrixRoom("!room:localhost", bot.matrix_id.full_id)
+    requester_user_id = "@user:localhost"
+    mentioned_user_id = "@human:localhost"
+    room.add_member(bot.matrix_id.full_id, "Router", None)
+    room.add_member(requester_user_id, "User", None)
+    bot.client.joined_members.return_value = nio.JoinedMembersResponse(
+        members=[
+            nio.RoomMember(bot.matrix_id.full_id, "Router", None),
+            nio.RoomMember(requester_user_id, "User", None),
+            nio.RoomMember(mentioned_user_id, "Human", None),
+        ],
+        room_id=room.room_id,
+    )
+    event = _text_event(event_id="$lazy-human-mention", body=f"hello {mentioned_user_id}")
+    content = event.source["content"]
+    assert isinstance(content, dict)
+    content["m.mentions"] = {"user_ids": [mentioned_user_id]}
+
+    with patch.object(
+        bot._turn_controller,
+        "_dispatch_prepared_text_like_ingress",
+        new=AsyncMock(return_value=_IngressAdmissionOutcome.DEFERRED),
+    ):
+        outcome = await bot._turn_controller.handle_text_event(room, event)
+
+    assert outcome is TurnDispatchOutcome.INTENTIONALLY_IGNORED
+    assert room.members_synced
+    assert mentioned_user_id in room.users
+
+
+@pytest.mark.asyncio
+async def test_first_turn_membership_refresh_failure_uses_cached_state(tmp_path: Path) -> None:
+    """A transport failure must not block routing from the best available cache."""
+    bot = _make_bot(tmp_path, agent_name=ROUTER_AGENT_NAME)
+    room = nio.MatrixRoom("!room:localhost", bot.matrix_id.full_id)
+    requester_user_id = "@user:localhost"
+    room.add_member(bot.matrix_id.full_id, "Router", None)
+    room.add_member(requester_user_id, "User", None)
+    bot.client.joined_members.side_effect = TimeoutError("membership lookup timed out")
+    event = _text_event(event_id="$membership-timeout", body="hello @absent:localhost")
+    content = event.source["content"]
+    assert isinstance(content, dict)
+    content["m.mentions"] = {"user_ids": ["@absent:localhost"]}
+
+    with patch.object(
+        bot._turn_controller,
+        "_dispatch_prepared_text_like_ingress",
+        new=AsyncMock(return_value=_IngressAdmissionOutcome.DEFERRED),
+    ):
+        outcome = await bot._turn_controller.handle_text_event(room, event)
+
+    assert outcome is TurnDispatchOutcome.DEFERRED
+    assert not room.members_synced
 
 
 @pytest.mark.asyncio

--- a/tests/test_live_message_coalescing.py
+++ b/tests/test_live_message_coalescing.py
@@ -7586,27 +7586,23 @@ async def test_first_router_turn_refreshes_lazy_members_before_mention_routing(t
 
 
 @pytest.mark.asyncio
-async def test_first_turn_membership_refresh_failure_uses_cached_state(tmp_path: Path) -> None:
-    """A transport failure must not block routing from the best available cache."""
-    bot = _make_bot(tmp_path, agent_name=ROUTER_AGENT_NAME)
-    room = nio.MatrixRoom("!room:localhost", bot.matrix_id.full_id)
+async def test_first_turn_membership_refresh_failure_reuses_cached_state_for_planning(tmp_path: Path) -> None:
+    """A failed boundary refresh must not be retried during the same turn's planning."""
+    bot = _make_bot(tmp_path, debounce_ms=0)
+    room = nio.MatrixRoom("!adhoc:localhost", bot.matrix_id.full_id)
     requester_user_id = "@user:localhost"
-    room.add_member(bot.matrix_id.full_id, "Router", None)
+    room.add_member(bot.matrix_id.full_id, "TestAgent", None)
     room.add_member(requester_user_id, "User", None)
     bot.client.joined_members.side_effect = TimeoutError("membership lookup timed out")
-    event = _text_event(event_id="$membership-timeout", body="hello @absent:localhost")
-    content = event.source["content"]
-    assert isinstance(content, dict)
-    content["m.mentions"] = {"user_ids": ["@absent:localhost"]}
+    event = _text_event(event_id="$membership-timeout", body="hello")
 
-    with patch.object(
-        bot._turn_controller,
-        "_dispatch_prepared_text_like_ingress",
-        new=AsyncMock(return_value=_IngressAdmissionOutcome.DEFERRED),
-    ):
+    with patch.object(bot._turn_controller, "_execute_response_action", new=AsyncMock()):
         outcome = await bot._turn_controller.handle_text_event(room, event)
+        drain_result = await bot._coalescing_gate.drain_all()
 
     assert outcome is TurnDispatchOutcome.DEFERRED
+    assert drain_result.dispatch_failure_count == 0
+    bot.client.joined_members.assert_awaited_once_with(room.room_id)
     assert not room.members_synced
 
 

--- a/tests/test_router_configured_agents.py
+++ b/tests/test_router_configured_agents.py
@@ -8,7 +8,10 @@ import nio
 import pytest
 
 from mindroom.agent_reply_membership import AgentReplyMembershipIndex
-from mindroom.authorization import get_available_responders_in_room, responder_candidate_entities_for_room
+from mindroom.authorization import (
+    get_available_responders_in_room,
+    responder_candidate_entities_with_membership_refresh,
+)
 from mindroom.config.access import ResponderAccessConfig
 from mindroom.config.agent import AgentConfig, TeamConfig
 from mindroom.config.main import Config
@@ -146,7 +149,7 @@ class TestResponderCandidateSelection:
         client = AsyncMock()
         client.joined_members = AsyncMock()
 
-        available = await responder_candidate_entities_for_room(
+        available = await responder_candidate_entities_with_membership_refresh(
             client,
             room,
             "@user:localhost",
@@ -174,7 +177,7 @@ class TestResponderCandidateSelection:
         client = AsyncMock()
         client.joined_members = AsyncMock()
 
-        available = await responder_candidate_entities_for_room(
+        available = await responder_candidate_entities_with_membership_refresh(
             client,
             room,
             "@user:localhost",
@@ -206,7 +209,7 @@ class TestResponderCandidateSelection:
         client = AsyncMock()
         client.joined_members = AsyncMock()
 
-        available = await responder_candidate_entities_for_room(
+        available = await responder_candidate_entities_with_membership_refresh(
             client,
             room,
             "@user:localhost",
@@ -236,7 +239,7 @@ class TestResponderCandidateSelection:
         client = AsyncMock()
         client.joined_members = AsyncMock()
 
-        available = await responder_candidate_entities_for_room(
+        available = await responder_candidate_entities_with_membership_refresh(
             client,
             room,
             "@user:localhost",
@@ -282,7 +285,7 @@ class TestResponderCandidateSelection:
         client = AsyncMock()
         client.joined_members = AsyncMock()
 
-        available = await responder_candidate_entities_for_room(
+        available = await responder_candidate_entities_with_membership_refresh(
             client,
             room,
             "@user:localhost",
@@ -312,7 +315,7 @@ class TestResponderCandidateSelection:
         client = AsyncMock()
         client.joined_members = AsyncMock()
 
-        available = await responder_candidate_entities_for_room(
+        available = await responder_candidate_entities_with_membership_refresh(
             client,
             room,
             "@user:localhost",
@@ -345,7 +348,7 @@ class TestResponderCandidateSelection:
         client = AsyncMock()
         client.joined_members = AsyncMock()
 
-        available = await responder_candidate_entities_for_room(
+        available = await responder_candidate_entities_with_membership_refresh(
             client,
             room,
             "@user:localhost",
@@ -376,7 +379,7 @@ class TestResponderCandidateSelection:
         client = AsyncMock()
         client.joined_members = AsyncMock()
 
-        available = await responder_candidate_entities_for_room(
+        available = await responder_candidate_entities_with_membership_refresh(
             client,
             room,
             "@user:localhost",
@@ -422,7 +425,7 @@ class TestResponderCandidateSelection:
         dm.add_member(assistant_id, "Assistant", None)
         dm.members_synced = True
 
-        available = await responder_candidate_entities_for_room(
+        available = await responder_candidate_entities_with_membership_refresh(
             client,
             dm,
             "@alice:localhost",

--- a/tests/test_router_dispatch.py
+++ b/tests/test_router_dispatch.py
@@ -120,7 +120,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
-            patch("mindroom.turn_policy.responder_candidate_entities_for_room") as mock_get_available,
+            patch("mindroom.turn_policy.responder_candidate_entities_from_cached_room") as mock_get_available,
             patch("mindroom.turn_policy.TurnPolicy.can_reply_to_sender_in_room", return_value=True),
             patch("mindroom.dispatch_handoff.extract_media_caption", return_value="[Attached image]"),
         ):
@@ -265,7 +265,7 @@ class TestAgentBot(AgentBotTestBase):
         with (
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
-            patch("mindroom.turn_policy.responder_candidate_entities_for_room") as mock_get_available,
+            patch("mindroom.turn_policy.responder_candidate_entities_from_cached_room") as mock_get_available,
             patch("mindroom.turn_policy.TurnPolicy.can_reply_to_sender_in_room", return_value=True),
             patch(
                 "mindroom.inbound_turn_normalizer.register_matrix_media_attachment",
@@ -659,7 +659,7 @@ class TestAgentBot(AgentBotTestBase):
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
                 return_value=[
                     entity_ids(config, runtime_paths_for(config))["calculator"],
                     entity_ids(config, runtime_paths_for(config))["general"],
@@ -750,7 +750,7 @@ class TestAgentBot(AgentBotTestBase):
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
                 return_value=[
                     entity_ids(config, runtime_paths_for(config))["calculator"],
                     entity_ids(config, runtime_paths_for(config))["general"],
@@ -925,7 +925,7 @@ class TestAgentBot(AgentBotTestBase):
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
             patch("mindroom.turn_policy.thread_requires_explicit_agent_targeting", return_value=False),
             patch(
-                "mindroom.turn_policy.responder_candidate_entities_for_room",
+                "mindroom.turn_policy.responder_candidate_entities_from_cached_room",
                 return_value=[entity_ids(config, runtime_paths_for(config))["calculator"]],
             ),
             patch("mindroom.turn_policy.TurnPolicy.can_reply_to_sender_in_room", return_value=True),
@@ -1045,7 +1045,7 @@ class TestAgentBot(AgentBotTestBase):
             patch("mindroom.turn_policy.TurnPolicy.can_reply_to_sender_in_room", return_value=True),
             patch("mindroom.text_ingress_dispatch.is_dm_room", new_callable=AsyncMock, return_value=False),
             patch("mindroom.turn_policy.get_agents_in_thread", return_value=[]),
-            patch("mindroom.turn_policy.responder_candidate_entities_for_room", return_value=[]),
+            patch("mindroom.turn_policy.responder_candidate_entities_from_cached_room", return_value=[]),
             patch(
                 "mindroom.inbound_turn_normalizer.resolve_thread_attachment_ids",
                 new_callable=AsyncMock,

--- a/tests/test_router_dispatch.py
+++ b/tests/test_router_dispatch.py
@@ -638,6 +638,7 @@ class TestAgentBot(AgentBotTestBase):
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
+        room.members_synced = True
         room.canonical_alias = None
         room.users = {
             "@mindroom_router:localhost": MagicMock(),
@@ -722,6 +723,7 @@ class TestAgentBot(AgentBotTestBase):
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
+        room.members_synced = True
         room.canonical_alias = None
         room.users = {
             "@mindroom_router:localhost": MagicMock(),
@@ -908,6 +910,7 @@ class TestAgentBot(AgentBotTestBase):
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
+        room.members_synced = True
         room.canonical_alias = None
         room.users = {
             "@mindroom_router:localhost": MagicMock(),
@@ -956,6 +959,7 @@ class TestAgentBot(AgentBotTestBase):
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
+        room.members_synced = True
         room.canonical_alias = None
         room.encrypted = False
         room.users = {

--- a/tests/test_routing.py
+++ b/tests/test_routing.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import nio
 import pytest
 
 import mindroom.routing
@@ -64,9 +65,20 @@ def check_agent_mentioned(
     event_source: dict,
     agent_id: MatrixID | None,
     config: Config,
+    *,
+    joined_user_ids: tuple[str, ...] = (),
 ) -> tuple[list[MatrixID], bool, bool]:
     """Check mentions with the test config's bound runtime context."""
-    return mindroom.thread_utils.check_agent_mentioned(event_source, agent_id, config, runtime_paths_for(config))
+    room = nio.MatrixRoom("!test:localhost", "@mindroom_router:localhost")
+    for user_id in joined_user_ids:
+        room.add_member(user_id, None, None)
+    return mindroom.thread_utils.check_agent_mentioned(
+        event_source,
+        agent_id,
+        config,
+        runtime_paths_for(config),
+        room=room,
+    )
 
 
 def _message(
@@ -513,14 +525,19 @@ class TestThreadUtils:
         assert has_multiple_non_agent_users_in_thread(history, self.config) is False
 
     def test_check_agent_mentioned_detects_non_agent_mentions(self) -> None:
-        """Tagging a non-agent user sets has_non_agent_mentions."""
+        """Tagging a joined non-agent user sets has_non_agent_mentions."""
         event_source = {
             "content": {
                 "m.mentions": {"user_ids": ["@bob:localhost"]},
             },
         }
         agent_id = MatrixID.from_username("mindroom_calculator", "localhost")
-        _, am_i_mentioned, has_non_agent = check_agent_mentioned(event_source, agent_id, self.config)
+        _, am_i_mentioned, has_non_agent = check_agent_mentioned(
+            event_source,
+            agent_id,
+            self.config,
+            joined_user_ids=("@bob:localhost",),
+        )
         assert am_i_mentioned is False
         assert has_non_agent is True
 
@@ -579,7 +596,12 @@ class TestThreadUtils:
             },
         }
         agent_id = MatrixID.from_username("mindroom_calculator", "localhost")
-        _, _, has_non_agent = check_agent_mentioned(event_source, agent_id, config)
+        _, _, has_non_agent = check_agent_mentioned(
+            event_source,
+            agent_id,
+            config,
+            joined_user_ids=("@telegram:localhost",),
+        )
         assert has_non_agent is False
 
     def test_check_agent_mentioned_mixed_bot_and_human_mentions(self) -> None:
@@ -599,7 +621,12 @@ class TestThreadUtils:
             },
         }
         agent_id = MatrixID.from_username("mindroom_calculator", "localhost")
-        _, _, has_non_agent = check_agent_mentioned(event_source, agent_id, config)
+        _, _, has_non_agent = check_agent_mentioned(
+            event_source,
+            agent_id,
+            config,
+            joined_user_ids=("@bob:localhost",),
+        )
         assert has_non_agent is True
 
 
@@ -675,7 +702,12 @@ class TestBridgeMentionFallback:
             },
         }
         agent_id = MatrixID.from_username("mindroom_calculator", "localhost")
-        _, am_i_mentioned, has_non_agent = check_agent_mentioned(event_source, agent_id, self.config)
+        _, am_i_mentioned, has_non_agent = check_agent_mentioned(
+            event_source,
+            agent_id,
+            self.config,
+            joined_user_ids=("@alice:localhost",),
+        )
         assert am_i_mentioned is False
         assert has_non_agent is True
 

--- a/tests/test_scheduler_tool.py
+++ b/tests/test_scheduler_tool.py
@@ -7,16 +7,22 @@ from dataclasses import replace
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import nio
 import pytest
 
 import mindroom.tools  # noqa: F401
+from mindroom.authorization import ensure_room_membership_synced
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.constants import SILENT_SCHEDULE_NO_REPLY_TOKEN
 from mindroom.custom_tools.scheduler import SchedulerTools
 from mindroom.message_target import MessageTarget
 from mindroom.scheduling import SchedulingRuntime, _extract_mentioned_agents_from_text
-from mindroom.tool_system.runtime_context import ToolRuntimeContext, tool_runtime_context
+from mindroom.tool_system.runtime_context import (
+    ToolRuntimeContext,
+    build_scheduling_runtime_from_tool_runtime_context,
+    tool_runtime_context,
+)
 from tests.authorization_helpers import (
     make_test_tool_runtime_context,
 )
@@ -136,6 +142,7 @@ async def test_scheduler_tool_uses_shared_backend() -> None:
         conversation_reader=context.conversation_reader,
         matrix_admin=matrix_admin,
         agent_reply_memberships=context.agent_reply_memberships,
+        responder_candidates_for_room=context.responder_candidates_for_current_room,
     )
     assert first_call == {
         "runtime": expected_runtime,
@@ -167,6 +174,39 @@ async def test_scheduler_tool_uses_shared_backend() -> None:
         "history_limit": 0,
         "silent": None,
     }
+
+
+@pytest.mark.asyncio
+async def test_scheduler_tool_reuses_failed_turn_membership_snapshot() -> None:
+    """A turn-bound scheduler runtime must not retry its failed membership refresh."""
+    requester_id = "@user:localhost"
+    config = _bind_runtime_paths(
+        Config(
+            agents={"general": AgentConfig(display_name="General Agent")},
+            administrators=[requester_id],
+        ),
+    )
+    general_id = entity_ids(config, runtime_paths_for(config))["general"]
+    room = nio.MatrixRoom(room_id="!room:localhost", own_user_id=general_id.full_id)
+    room.add_member(general_id.full_id, "General Agent", None)
+    room.add_member(requester_id, "User", None)
+    client = AsyncMock()
+    client.joined_members.side_effect = TimeoutError("membership lookup timed out")
+    context = replace(
+        _make_context(config),
+        client=client,
+        requester_id=requester_id,
+        room=room,
+        membership_turn_id="$turn",
+    )
+
+    assert not await ensure_room_membership_synced(client, room, sender_id=requester_id)
+
+    runtime = build_scheduling_runtime_from_tool_runtime_context(context)
+    candidates = await runtime.responder_candidates_for_room(room, requester_id)
+
+    assert candidates == [general_id]
+    assert client.joined_members.await_count == 1
 
 
 @pytest.mark.asyncio
@@ -252,6 +292,7 @@ async def test_edit_schedule_tool_calls_backend() -> None:
         room=context.room,
         conversation_reader=context.conversation_reader,
         agent_reply_memberships=context.agent_reply_memberships,
+        responder_candidates_for_room=context.responder_candidates_for_current_room,
     )
     assert mock_edit.await_count == 3
     assert mock_edit.await_args_list[0].kwargs == {

--- a/tests/test_scheduling.py
+++ b/tests/test_scheduling.py
@@ -1961,7 +1961,10 @@ async def test_edit_scheduled_task_persists_via_admin_and_preserves_omitted_sile
     )
 
     with (
-        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch(
+            "mindroom.authorization.responder_candidate_entities_with_membership_refresh",
+            return_value=[ids["assistant"]],
+        ),
         patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=updated_workflow)),
     ):
         result = await edit_scheduled_task(
@@ -2159,7 +2162,7 @@ async def test_schedule_task_returns_error_when_sender_blocked_from_all_agents()
 
     with (
         patch(
-            "mindroom.scheduling.responder_candidate_entities_for_room",
+            "mindroom.authorization.responder_candidate_entities_with_membership_refresh",
             return_value=[],
         ),
         patch(
@@ -2188,7 +2191,7 @@ async def test_schedule_task_blocked_sender_new_thread_returns_error() -> None:
 
     with (
         patch(
-            "mindroom.scheduling.responder_candidate_entities_for_room",
+            "mindroom.authorization.responder_candidate_entities_with_membership_refresh",
             return_value=[],
         ),
         patch(
@@ -2313,7 +2316,10 @@ async def test_schedule_task_persists_via_admin_when_active_agent_lacks_state_po
     )
 
     with (
-        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch(
+            "mindroom.authorization.responder_candidate_entities_with_membership_refresh",
+            return_value=[ids["assistant"]],
+        ),
         patch("mindroom.scheduling._extract_mentioned_agents_from_text", return_value=[]),
         patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=workflow)),
         patch("mindroom.scheduling._start_scheduled_task", return_value=True),
@@ -2374,7 +2380,10 @@ async def test_schedule_task_explicit_history_limit_overrides_parse_and_round_tr
     )
 
     with (
-        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch(
+            "mindroom.authorization.responder_candidate_entities_with_membership_refresh",
+            return_value=[ids["assistant"]],
+        ),
         patch("mindroom.scheduling._extract_mentioned_agents_from_text", return_value=[]),
         patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=workflow)),
         patch("mindroom.scheduling._start_scheduled_task", return_value=True),
@@ -2435,7 +2444,10 @@ async def test_schedule_task_keeps_parse_produced_history_limit(tmp_path: Path) 
     )
 
     with (
-        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch(
+            "mindroom.authorization.responder_candidate_entities_with_membership_refresh",
+            return_value=[ids["assistant"]],
+        ),
         patch("mindroom.scheduling._extract_mentioned_agents_from_text", return_value=[]),
         patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=workflow)),
         patch("mindroom.scheduling._start_scheduled_task", return_value=True),
@@ -2506,7 +2518,10 @@ async def test_schedule_task_returns_error_when_state_write_fails_without_admin_
     )
 
     with (
-        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch(
+            "mindroom.authorization.responder_candidate_entities_with_membership_refresh",
+            return_value=[ids["assistant"]],
+        ),
         patch("mindroom.scheduling._extract_mentioned_agents_from_text", return_value=[]),
         patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=workflow)),
         patch("mindroom.scheduling._start_scheduled_task", return_value=True) as start_task,
@@ -2577,7 +2592,10 @@ async def test_schedule_task_returns_error_when_active_write_returns_unexpected_
     )
 
     with (
-        patch("mindroom.scheduling.responder_candidate_entities_for_room", return_value=[ids["assistant"]]),
+        patch(
+            "mindroom.authorization.responder_candidate_entities_with_membership_refresh",
+            return_value=[ids["assistant"]],
+        ),
         patch("mindroom.scheduling._extract_mentioned_agents_from_text", return_value=[]),
         patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=workflow)),
         patch("mindroom.scheduling._start_scheduled_task", return_value=True) as start_task,
@@ -2696,13 +2714,6 @@ async def test_schedule_task_rejects_mentions_outside_existing_thread_scope(tmp_
     )
     conversation_reader = make_conversation_reader_mock()
     serve_conversation_reader(conversation_reader, [thread_message])
-    runtime = _scheduling_runtime(
-        client=client,
-        config=config,
-        runtime_paths=runtime_paths,
-        room=room,
-        conversation_reader=conversation_reader,
-    )
     parse_result = ScheduledWorkflow(
         schedule_type="once",
         execute_at=datetime.now(UTC) + timedelta(minutes=5),
@@ -2714,12 +2725,19 @@ async def test_schedule_task_rejects_mentions_outside_existing_thread_scope(tmp_
 
     with (
         patch(
-            "mindroom.scheduling.responder_candidate_entities_for_room",
+            "mindroom.authorization.responder_candidate_entities_with_membership_refresh",
             new=AsyncMock(return_value=[ids["assistant"], ids["writer"]]),
         ),
         patch("mindroom.scheduling._parse_workflow_schedule", new=AsyncMock(return_value=parse_result)),
         patch("mindroom.scheduling._save_pending_scheduled_task", new=AsyncMock()) as save_task,
     ):
+        runtime = _scheduling_runtime(
+            client=client,
+            config=config,
+            runtime_paths=runtime_paths,
+            room=room,
+            conversation_reader=conversation_reader,
+        )
         task_id, message = await schedule_task(
             runtime=runtime,
             room_id="!test:server",

--- a/tests/test_subagents.py
+++ b/tests/test_subagents.py
@@ -13,6 +13,7 @@ import pytest
 
 import mindroom.tools  # noqa: F401
 from mindroom.agent_descriptions import describe_agent
+from mindroom.authorization import ensure_room_membership_synced
 from mindroom.config.access import ResponderAccessConfig
 from mindroom.config.agent import AgentConfig
 from mindroom.config.auth import AuthorizationConfig
@@ -445,6 +446,28 @@ async def test_agents_list_can_delegate_aligns_with_delegate_tools(tmp_path: Pat
     result = await delegate_tools.delegate_task("C", "task")
     assert "Cannot delegate to 'C'" in result
     assert "Run agents_list to inspect can_delegate flags." in result
+
+
+@pytest.mark.asyncio
+async def test_agents_list_reuses_failed_turn_membership_snapshot(tmp_path: Path) -> None:
+    """Current-room discovery must not retry a failed turn membership refresh."""
+    base_context = _make_context(tmp_path)
+    assert base_context.room is not None
+    base_context.room.members_synced = False
+    base_context.client.joined_members.side_effect = TimeoutError("membership lookup timed out")
+    context = replace(base_context, membership_turn_id="$turn")
+
+    assert not await ensure_room_membership_synced(
+        context.client,
+        context.room,
+        sender_id=context.requester_id,
+    )
+
+    with tool_runtime_context(context):
+        payload = json.loads(await SubAgentsTools().agents_list())
+
+    assert [agent["name"] for agent in payload["agents"]] == ["code", "research"]
+    assert context.client.joined_members.await_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -1460,6 +1460,7 @@ class TestAgentBot(AgentBotTestBase):
         bot.client = _make_matrix_client_mock()
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
+        room.members_synced = True
         event = nio.RoomMessageText.from_dict(
             {
                 "event_id": "$source",
@@ -1507,6 +1508,7 @@ class TestAgentBot(AgentBotTestBase):
         bot.client = _make_matrix_client_mock()
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
+        room.members_synced = True
         event = self._router_relay_event()
         ingress_started = asyncio.Event()
         release_ingress = asyncio.Event()
@@ -1555,6 +1557,7 @@ class TestAgentBot(AgentBotTestBase):
         bot.client = _make_matrix_client_mock()
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
+        room.members_synced = True
         event = nio.RoomMessageText.from_dict(
             {
                 "event_id": "$followup",
@@ -1801,6 +1804,7 @@ class TestAgentBot(AgentBotTestBase):
         bot.client = _make_matrix_client_mock()
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!room:localhost"
+        room.members_synced = True
         event = nio.RoomMessageText.from_dict(
             {
                 "event_id": f"${source_kind}",
@@ -2518,6 +2522,7 @@ class TestAgentBot(AgentBotTestBase):
 
         room = MagicMock(spec=nio.MatrixRoom)
         room.room_id = "!test:localhost"
+        room.members_synced = True
         room.canonical_alias = None
         room.users = {"@mindroom_calculator:localhost": MagicMock(), "@user:localhost": MagicMock()}
         event = _room_image_event(sender="@user:localhost", event_id="$img_event_fail", body="photo.jpg")

--- a/tests/test_turn_dispatch_pipeline.py
+++ b/tests/test_turn_dispatch_pipeline.py
@@ -1663,7 +1663,7 @@ class TestAgentBot(AgentBotTestBase):
         assert metadata.payload is mock_reserve_waiting_human_message.return_value
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("mention_kind", ["other_agent", "non_agent"])
+    @pytest.mark.parametrize("mention_kind", ["other_agent", "joined_human"])
     async def test_router_handoff_for_another_target_does_not_signal_active_response(
         self,
         mock_agent_user: AgentMatrixUser,
@@ -1677,14 +1677,16 @@ class TestAgentBot(AgentBotTestBase):
         ids = entity_ids(config, runtime_paths)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
         replace_turn_controller_deps(bot, runtime=replace(bot._runtime_view, client=_make_matrix_client_mock()))
-        room = MagicMock(spec=nio.MatrixRoom)
-        room.room_id = "!room:localhost"
+        room = nio.MatrixRoom("!room:localhost", bot.matrix_id.full_id)
+        room.add_member(bot.matrix_id.full_id, "Calculator", None)
+        room.add_member("@user:localhost", "User", None)
         if mention_kind == "other_agent":
             body = "@general could you help with this?"
             mentioned_user_id = ids["general"].full_id
         else:
             body = "@person:localhost could you help with this?"
             mentioned_user_id = "@person:localhost"
+            room.add_member(mentioned_user_id, "Person", None)
         event = self._router_relay_event(body=body)
         event.source["content"]["m.mentions"] = {"user_ids": [mentioned_user_id]}
         prepared_event = PreparedIngress(
@@ -1722,26 +1724,35 @@ class TestAgentBot(AgentBotTestBase):
         assert all(item.kind != "queued_notice_reservation" for item in ready_result.pending_event.dispatch_metadata)
 
     @pytest.mark.asyncio
-    @pytest.mark.parametrize("explicit_self_target", [True, False])
-    async def test_router_handoff_for_this_agent_or_without_a_target_signals_active_response(
+    @pytest.mark.parametrize("target_kind", ["self", "none", "absent_human"])
+    async def test_router_handoff_without_another_room_participant_signals_active_response(
         self,
         mock_agent_user: AgentMatrixUser,
         tmp_path: Path,
         *,
-        explicit_self_target: bool,
+        target_kind: str,
     ) -> None:
-        """Only a handoff explicitly addressed elsewhere suppresses the queued notice."""
+        """Only a handoff addressed to another joined participant suppresses the queued notice."""
         config = self._config_for_storage(tmp_path)
         runtime_paths = runtime_paths_for(config)
         ids = entity_ids(config, runtime_paths)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths)
         replace_turn_controller_deps(bot, runtime=replace(bot._runtime_view, client=_make_matrix_client_mock()))
-        room = MagicMock(spec=nio.MatrixRoom)
-        room.room_id = "!room:localhost"
-        body = "@calculator could you help with this?" if explicit_self_target else "could you help with this?"
+        room = nio.MatrixRoom("!room:localhost", bot.matrix_id.full_id)
+        room.add_member(bot.matrix_id.full_id, "Calculator", None)
+        room.add_member("@user:localhost", "User", None)
+        if target_kind == "self":
+            body = "@calculator could you help with this?"
+            mentioned_user_ids = [ids["calculator"].full_id]
+        elif target_kind == "absent_human":
+            body = "@person:localhost could you help with this?"
+            mentioned_user_ids = ["@person:localhost"]
+        else:
+            body = "could you help with this?"
+            mentioned_user_ids = []
         event = self._router_relay_event(body=body)
-        if explicit_self_target:
-            event.source["content"]["m.mentions"] = {"user_ids": [ids["calculator"].full_id]}
+        if mentioned_user_ids:
+            event.source["content"]["m.mentions"] = {"user_ids": mentioned_user_ids}
         prepared_event = PreparedIngress(
             sender=event.sender,
             event_id=event.event_id,

--- a/tests/test_unknown_command_response.py
+++ b/tests/test_unknown_command_response.py
@@ -60,6 +60,7 @@ async def test_unknown_command_in_main_room(tmp_path: Path) -> None:
     # Create mock room and event
     room = MagicMock(spec=nio.MatrixRoom)
     room.room_id = "!test:localhost"
+    room.members_synced = True
     room.canonical_alias = None
     room.name = "Test Room"
     room.users = {
@@ -155,6 +156,7 @@ async def test_unknown_command_in_thread(tmp_path: Path) -> None:
     # Create mock room and event
     room = MagicMock(spec=nio.MatrixRoom)
     room.room_id = "!test:localhost"
+    room.members_synced = True
     room.canonical_alias = None
     room.name = "Test Room"
     room.users = {
@@ -267,6 +269,7 @@ async def test_unknown_command_with_reply_starts_prompt_thread(tmp_path: Path) -
     # Create mock room and event
     room = MagicMock(spec=nio.MatrixRoom)
     room.room_id = "!test:localhost"
+    room.members_synced = True
     room.canonical_alias = None
     room.name = "Test Room"
     room.users = {

--- a/tests/test_voice_handler.py
+++ b/tests/test_voice_handler.py
@@ -14,6 +14,7 @@ import pytest
 from agno.media import Audio
 
 from mindroom import voice_handler
+from mindroom.authorization import ensure_room_membership_synced
 from mindroom.config.agent import AgentConfig
 from mindroom.config.main import Config
 from mindroom.config.voice import VoiceConfig, VoiceSTTConfig, _VoiceLLMConfig
@@ -479,6 +480,40 @@ class TestVoiceHandler:
         assert mock_process.await_count == 1
         assert mock_process.await_args.kwargs["available_agent_names"] == ["openclaw"]
         assert mock_process.await_args.kwargs["available_team_names"] == []
+
+    @pytest.mark.asyncio
+    async def test_voice_handler_reuses_failed_boundary_membership_snapshot(self) -> None:
+        """Voice normalization must not retry a failed membership refresh from the same turn."""
+        config = _runtime_bound_config(Config(voice=VoiceConfig(enabled=True)))
+        client = AsyncMock()
+        client.joined_members.side_effect = TimeoutError("membership lookup timed out")
+        room = _matrix_room(
+            "!voice:localhost",
+            members=("@mindroom_router:localhost", "@alice:example.com"),
+            members_synced=False,
+        )
+        event = MagicMock(spec=nio.RoomMessageAudio)
+        event.event_id = "$voice"
+        event.sender = "@alice:example.com"
+        event.body = "voice.ogg"
+        event.source = {"content": {"body": "voice.ogg"}}
+
+        assert not await ensure_room_membership_synced(client, room, sender_id=event.sender)
+
+        with (
+            patch("mindroom.voice_handler._transcribe_audio", return_value="hello"),
+            patch("mindroom.voice_handler._process_transcription", return_value="hello"),
+        ):
+            result = await _handle_voice_message(
+                client,
+                room,
+                event,
+                config,
+                audio=Audio(content=b"audio", mime_type="audio/ogg"),
+            )
+
+        assert result == "🎤 hello"
+        assert client.joined_members.await_count == 1
 
     @pytest.mark.asyncio
     async def test_download_audio_unencrypted(self) -> None:


### PR DESCRIPTION
## Summary

- Count non-agent mentions only when the Matrix user is currently joined to the room.
- Let absent or invited-only user IDs pass through normal routing and automatic-response behavior.
- Apply the same cached membership rule to conversation resolution, router short-circuiting, and queued notices.
- Add regression coverage and update the router documentation.

## Testing

- `uv run pre-commit run --from-ref origin/main --to-ref HEAD`
- `uv run pytest -q`

## Summary by Sourcery

Respect current room membership when deciding whether non-agent mentions should suppress automated responses.

Bug Fixes:
- Restrict non-agent mention suppression to users who are currently joined to the room, allowing absent and invited-only mentions to follow normal routing and automatic-response behavior.

Enhancements:
- Centralize room membership snapshots and refresh handling across conversation resolution, router decisions, responder discovery, commands, scheduling, subagents, voice handling, and queued notices.
- Reuse membership refresh results or failures within a turn to avoid inconsistent decisions and redundant membership lookups.

Documentation:
- Update router documentation to describe joined-participant mention behavior and the treatment of absent or invited users.

Tests:
- Add regression coverage for joined, invited, and absent non-agent mentions, lazy membership refreshes, and reuse of failed membership lookups across routing and auxiliary workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic response routing so only mentions of joined, non-managed participants suppress agent and team responses.
  * Mentions of absent or invited participants no longer incorrectly prevent normal routing or automatic replies.
  * Improved room membership handling for scheduled, queued, voice, and media responses, including reliable fallback when membership updates are unavailable.

* **Documentation**
  * Clarified multi-human thread protection rules and routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->