### PR TITLE
Keep published knowledge lookup off the response event loop

### DIFF
--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -76,7 +76,7 @@ from mindroom.api.openai_streaming_protocol import (
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_env_flag
 from mindroom.execution_preparation import render_prepared_team_messages_text
 from mindroom.history.runtime import ScopeSessionContext, close_team_runtime_state_dbs, open_bound_scope_session_context
-from mindroom.knowledge import KnowledgeAvailabilityDetail, resolve_agent_knowledge_access
+from mindroom.knowledge import KnowledgeAvailabilityDetail, resolve_agent_knowledge_access_async
 from mindroom.llm_request_logging import (
     bind_llm_request_log_context,
     build_llm_request_log_context,
@@ -517,7 +517,7 @@ async def chat_completions(  # noqa: C901, PLR0912
         else:
             # Resolve knowledge base for this agent
             try:
-                knowledge_resolution = resolve_agent_knowledge_access(
+                knowledge_resolution = await resolve_agent_knowledge_access_async(
                     agent_name,
                     config,
                     runtime_paths,

--- a/src/mindroom/approval_execution.py
+++ b/src/mindroom/approval_execution.py
@@ -151,10 +151,12 @@ class AgentApprovalExecution:
         if continuation.entity_name not in config.agents:
             msg = f"Agent {continuation.entity_name!r} is no longer configured"
             raise RuntimeError(msg)
-        knowledge = self.knowledge_access.for_agent(
-            continuation.entity_name,
-            execution_identity=execution_identity,
-        )
+        knowledge = (
+            await self.knowledge_access.resolve_for_agent_async(
+                continuation.entity_name,
+                execution_identity=execution_identity,
+            )
+        ).knowledge
         history_storage = await asyncio.to_thread(
             create_session_storage,
             continuation.entity_name,

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -17,7 +17,7 @@ from mindroom.agent_descriptions import describe_agent
 from mindroom.agent_run_context import append_knowledge_availability_enrichment
 from mindroom.ai import ResponseTurnContext, ai_response
 from mindroom.authorization import is_sender_allowed_for_responder
-from mindroom.knowledge import resolve_agent_knowledge_access
+from mindroom.knowledge import resolve_agent_knowledge_access_async
 from mindroom.logging_config import get_logger
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeContext,
@@ -133,7 +133,7 @@ class DelegateTools(Toolkit):
                 else None
             )
 
-            knowledge_resolution = resolve_agent_knowledge_access(
+            knowledge_resolution = await resolve_agent_knowledge_access_async(
                 agent_name,
                 active_config,
                 self._runtime_paths,

--- a/src/mindroom/knowledge/__init__.py
+++ b/src/mindroom/knowledge/__init__.py
@@ -12,7 +12,9 @@ from mindroom.knowledge.utils import (
     KnowledgeBaseAccessResolution,
     format_knowledge_availability_notice,
     resolve_agent_knowledge_access,
+    resolve_agent_knowledge_access_async,
     resolve_knowledge_base_access,
+    resolve_knowledge_base_access_async,
 )
 
 __all__ = [
@@ -25,5 +27,7 @@ __all__ = [
     "list_knowledge_files",
     "reconcile_knowledge_mode_transition_states",
     "resolve_agent_knowledge_access",
+    "resolve_agent_knowledge_access_async",
     "resolve_knowledge_base_access",
+    "resolve_knowledge_base_access_async",
 ]

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -214,6 +214,52 @@ def _resolve_base_knowledge(
         runtime_paths=runtime_paths,
         execution_identity=execution_identity,
     )
+    return _finish_base_knowledge_resolution(
+        base_id,
+        lookup=lookup,
+        config=config,
+        runtime_paths=runtime_paths,
+        refresh_scheduler=refresh_scheduler,
+        execution_identity=execution_identity,
+    )
+
+
+async def _resolve_base_knowledge_async(
+    base_id: str,
+    *,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    refresh_scheduler: KnowledgeRefreshScheduler | None,
+    execution_identity: ToolExecutionIdentity | None,
+) -> tuple[Knowledge | None, KnowledgeAvailability, str | None]:
+    """Resolve one knowledge base without blocking the event loop on storage I/O."""
+    lookup = await asyncio.to_thread(
+        _lookup_knowledge_for_base,
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=execution_identity,
+    )
+    return _finish_base_knowledge_resolution(
+        base_id,
+        lookup=lookup,
+        config=config,
+        runtime_paths=runtime_paths,
+        refresh_scheduler=refresh_scheduler,
+        execution_identity=execution_identity,
+    )
+
+
+def _finish_base_knowledge_resolution(
+    base_id: str,
+    *,
+    lookup: PublishedIndexResolution | None,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    refresh_scheduler: KnowledgeRefreshScheduler | None,
+    execution_identity: ToolExecutionIdentity | None,
+) -> tuple[Knowledge | None, KnowledgeAvailability, str | None]:
+    """Finish one lookup on the caller's thread, including refresh scheduling."""
     # One instant per resolve: the poll-interval boundary must not be evaluated
     # against two different clock readings within a single turn.
     wall_now = datetime.now(tz=UTC)
@@ -256,20 +302,60 @@ def resolve_agent_knowledge_access(
     base_ids = _semantic_agent_knowledge_base_ids(agent_name, config)
     if file_memory is not None:
         base_ids = (*base_ids, file_memory.base_id)
-    if not base_ids:
-        return _KnowledgeResolution(knowledge=None)
-
-    missing_base_ids: list[str] = []
-    unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
-    knowledges: list[Knowledge] = []
-    for base_id in base_ids:
-        knowledge, availability, last_error = _resolve_base_knowledge(
+    resolved_bases = [
+        _resolve_base_knowledge(
             base_id,
             config=effective_config,
             runtime_paths=runtime_paths,
             refresh_scheduler=refresh_scheduler,
             execution_identity=execution_identity,
         )
+        for base_id in base_ids
+    ]
+    return _merge_agent_knowledge_resolutions(agent_name, base_ids, resolved_bases)
+
+
+async def _resolve_agent_knowledge_access_async(
+    agent_name: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    refresh_scheduler: KnowledgeRefreshScheduler | None = None,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> _KnowledgeResolution:
+    """Resolve agent knowledge without blocking the event loop on published-index I/O."""
+    file_memory = resolve_agent_file_memory_knowledge(
+        agent_name,
+        config,
+        runtime_paths,
+        execution_identity,
+    )
+    effective_config = file_memory.config if file_memory is not None else config
+    base_ids = _semantic_agent_knowledge_base_ids(agent_name, config)
+    if file_memory is not None:
+        base_ids = (*base_ids, file_memory.base_id)
+    resolved_bases = [
+        await _resolve_base_knowledge_async(
+            base_id,
+            config=effective_config,
+            runtime_paths=runtime_paths,
+            refresh_scheduler=refresh_scheduler,
+            execution_identity=execution_identity,
+        )
+        for base_id in base_ids
+    ]
+    return _merge_agent_knowledge_resolutions(agent_name, base_ids, resolved_bases)
+
+
+def _merge_agent_knowledge_resolutions(
+    agent_name: str,
+    base_ids: tuple[str, ...],
+    resolved_bases: list[tuple[Knowledge | None, KnowledgeAvailability, str | None]],
+) -> _KnowledgeResolution:
+    """Merge per-base resolution results into one agent knowledge handle."""
+    missing_base_ids: list[str] = []
+    unavailable_bases: dict[str, KnowledgeAvailabilityDetail] = {}
+    knowledges: list[Knowledge] = []
+    for base_id, (knowledge, availability, last_error) in zip(base_ids, resolved_bases, strict=True):
         if availability is not KnowledgeAvailability.READY:
             unavailable_bases[base_id] = KnowledgeAvailabilityDetail(
                 availability=availability,
@@ -404,6 +490,24 @@ class KnowledgeAccessSupport:
         refresh_scheduler = orchestrator.knowledge_refresh_scheduler if orchestrator is not None else None
 
         return resolve_agent_knowledge_access(
+            agent_name,
+            self.runtime.config,
+            self.runtime_paths,
+            refresh_scheduler=refresh_scheduler,
+            execution_identity=execution_identity,
+        )
+
+    async def resolve_for_agent_async(
+        self,
+        agent_name: str,
+        *,
+        execution_identity: ToolExecutionIdentity | None = None,
+    ) -> _KnowledgeResolution:
+        """Return current knowledge without blocking the event loop on index I/O."""
+        orchestrator = self.runtime.orchestrator
+        refresh_scheduler = orchestrator.knowledge_refresh_scheduler if orchestrator is not None else None
+
+        return await _resolve_agent_knowledge_access_async(
             agent_name,
             self.runtime.config,
             self.runtime_paths,

--- a/src/mindroom/knowledge/utils.py
+++ b/src/mindroom/knowledge/utils.py
@@ -315,7 +315,7 @@ def resolve_agent_knowledge_access(
     return _merge_agent_knowledge_resolutions(agent_name, base_ids, resolved_bases)
 
 
-async def _resolve_agent_knowledge_access_async(
+async def resolve_agent_knowledge_access_async(
     agent_name: str,
     config: Config,
     runtime_paths: RuntimePaths,
@@ -323,7 +323,8 @@ async def _resolve_agent_knowledge_access_async(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> _KnowledgeResolution:
     """Resolve agent knowledge without blocking the event loop on published-index I/O."""
-    file_memory = resolve_agent_file_memory_knowledge(
+    file_memory = await asyncio.to_thread(
+        resolve_agent_file_memory_knowledge,
         agent_name,
         config,
         runtime_paths,
@@ -387,19 +388,31 @@ def resolve_knowledge_base_access(
     execution_identity: ToolExecutionIdentity | None = None,
 ) -> KnowledgeBaseAccessResolution:
     """Resolve one knowledge base without going through an agent assignment."""
-    lookup = _lookup_knowledge_for_base(
+    knowledge, availability, last_error = _resolve_base_knowledge(
         base_id,
         config=config,
         runtime_paths=runtime_paths,
+        refresh_scheduler=None,
         execution_identity=execution_identity,
     )
-    availability = lookup.availability if lookup is not None else KnowledgeAvailability.INITIALIZING
-    if lookup is not None and availability is KnowledgeAvailability.READY:
-        availability = ready_index_effective_availability(lookup, config, wall_now=datetime.now(tz=UTC))
-    knowledge = lookup.index.knowledge if lookup is not None and lookup.index is not None else None
-    if knowledge is not None:
-        _apply_knowledge_metadata(base_id, knowledge, config)
-    last_error = lookup.state.last_error if lookup is not None and lookup.state is not None else None
+    return KnowledgeBaseAccessResolution(knowledge=knowledge, availability=availability, last_error=last_error)
+
+
+async def resolve_knowledge_base_access_async(
+    base_id: str,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    *,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> KnowledgeBaseAccessResolution:
+    """Resolve one knowledge base without blocking the event loop on index I/O."""
+    knowledge, availability, last_error = await _resolve_base_knowledge_async(
+        base_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        refresh_scheduler=None,
+        execution_identity=execution_identity,
+    )
     return KnowledgeBaseAccessResolution(knowledge=knowledge, availability=availability, last_error=last_error)
 
 
@@ -507,7 +520,7 @@ class KnowledgeAccessSupport:
         orchestrator = self.runtime.orchestrator
         refresh_scheduler = orchestrator.knowledge_refresh_scheduler if orchestrator is not None else None
 
-        return await _resolve_agent_knowledge_access_async(
+        return await resolve_agent_knowledge_access_async(
             agent_name,
             self.runtime.config,
             self.runtime_paths,

--- a/src/mindroom/matrix_rtc/call_tools.py
+++ b/src/mindroom/matrix_rtc/call_tools.py
@@ -52,7 +52,7 @@ from mindroom.history.runtime import (
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.history.types import HistoryScope
 from mindroom.hooks import EnrichmentItem
-from mindroom.knowledge.utils import knowledge_runtime_identity, resolve_agent_knowledge_access
+from mindroom.knowledge.utils import knowledge_runtime_identity, resolve_agent_knowledge_access_async
 from mindroom.logging_config import get_logger
 from mindroom.message_target import MessageTarget
 from mindroom.pre_model_preparation import prewarm_agent_model_client
@@ -471,7 +471,7 @@ async def build_call_tools(
         )
 
     refresh_scheduler = context.orchestrator.knowledge_refresh_scheduler if context.orchestrator is not None else None
-    knowledge_resolution = resolve_agent_knowledge_access(
+    knowledge_resolution = await resolve_agent_knowledge_access_async(
         agent_name,
         config,
         runtime_paths,
@@ -617,66 +617,68 @@ async def _run_authorized_call_agent(
     """Run one admitted call transcript through the normal MindRoom agent."""
     from mindroom.ai import ResponseTurnContext, ai_response  # noqa: PLC0415 - heavy optional call path
 
-    refresh_scheduler = context.orchestrator.knowledge_refresh_scheduler if context.orchestrator is not None else None
-    knowledge_resolution = resolve_agent_knowledge_access(
-        agent_name,
-        config,
-        runtime_paths,
-        refresh_scheduler=refresh_scheduler,
-        execution_identity=execution_identity,
-    )
-    transient_enrichment_items = append_knowledge_availability_enrichment(
-        (),
-        knowledge_resolution.unavailable,
-    )
     recorder = TurnRecorder(user_message=transcript)
     fallback_run_id = f"{session_id}:turn:{uuid4().hex}"
-    turn = ResponseTurnContext(
-        entity_label=agent_name,
-        session_id=session_id,
-        run_id=None,
-        correlation_id=uuid4().hex,
-        reply_to_event_id=None,
-        room_id=room_id,
-        thread_id=None,
-        requester_id=requester_id,
-        matrix_run_metadata=None,
-        active_model_name=active_model_name,
-        transient_enrichment_items=transient_enrichment_items,
-        system_enrichment_items=voice_enrichment_items,
-    )
-    run_metadata: dict[str, Any] = {}
-
-    async def _respond(agent: AgnoAgent) -> str:
-        try:
-            return await ai_response(
-                turn,
-                prompt=transcript,
-                runtime_paths=runtime_paths,
-                config=config,
-                knowledge=knowledge_resolution.knowledge,
-                run_id_callback=recorder.set_run_id,
-                include_interactive_questions=False,
-                tool_function_filter=context.tool_function_filter,
-                show_tool_calls=False,
-                run_metadata_collector=run_metadata,
-                execution_identity=execution_identity,
-                refresh_scheduler=refresh_scheduler,
-                turn_recorder=recorder,
-                eager_deferred_tools=True,
-                reusable_agent=agent,
-                attempt_model_runtime=tool_support,
-            )
-        finally:
-            recorder.set_run_metadata({**(recorder.run_metadata or {}), **run_metadata})
-
-    async def _run_with_agent(agent: AgnoAgent) -> str:
-        return await tool_support.run_in_context(
-            tool_context=context,
-            operation=functools.partial(_respond, agent),
-        )
-
     try:
+        refresh_scheduler = (
+            context.orchestrator.knowledge_refresh_scheduler if context.orchestrator is not None else None
+        )
+        knowledge_resolution = await resolve_agent_knowledge_access_async(
+            agent_name,
+            config,
+            runtime_paths,
+            refresh_scheduler=refresh_scheduler,
+            execution_identity=execution_identity,
+        )
+        transient_enrichment_items = append_knowledge_availability_enrichment(
+            (),
+            knowledge_resolution.unavailable,
+        )
+        turn = ResponseTurnContext(
+            entity_label=agent_name,
+            session_id=session_id,
+            run_id=None,
+            correlation_id=uuid4().hex,
+            reply_to_event_id=None,
+            room_id=room_id,
+            thread_id=None,
+            requester_id=requester_id,
+            matrix_run_metadata=None,
+            active_model_name=active_model_name,
+            transient_enrichment_items=transient_enrichment_items,
+            system_enrichment_items=voice_enrichment_items,
+        )
+        run_metadata: dict[str, Any] = {}
+
+        async def _respond(agent: AgnoAgent) -> str:
+            try:
+                return await ai_response(
+                    turn,
+                    prompt=transcript,
+                    runtime_paths=runtime_paths,
+                    config=config,
+                    knowledge=knowledge_resolution.knowledge,
+                    run_id_callback=recorder.set_run_id,
+                    include_interactive_questions=False,
+                    tool_function_filter=context.tool_function_filter,
+                    show_tool_calls=False,
+                    run_metadata_collector=run_metadata,
+                    execution_identity=execution_identity,
+                    refresh_scheduler=refresh_scheduler,
+                    turn_recorder=recorder,
+                    eager_deferred_tools=True,
+                    reusable_agent=agent,
+                    attempt_model_runtime=tool_support,
+                )
+            finally:
+                recorder.set_run_metadata({**(recorder.run_metadata or {}), **run_metadata})
+
+        async def _run_with_agent(agent: AgnoAgent) -> str:
+            return await tool_support.run_in_context(
+                tool_context=context,
+                operation=functools.partial(_respond, agent),
+            )
+
         response = await agent_cache.run(
             knowledge=knowledge_resolution.knowledge,
             knowledge_identity=knowledge_runtime_identity(knowledge_resolution.knowledge),

--- a/src/mindroom/memory/_semantic_file_search.py
+++ b/src/mindroom/memory/_semantic_file_search.py
@@ -12,7 +12,7 @@ from mindroom.knowledge import (
     KnowledgeAvailability,
     KnowledgeRefreshScheduler,
     list_knowledge_files,
-    resolve_knowledge_base_access,
+    resolve_knowledge_base_access_async,
 )
 from mindroom.logging_config import get_logger
 from mindroom.memory._shared import MemoryResult
@@ -157,7 +157,7 @@ async def search_semantic_file_memories(
 
     access_start = time.monotonic()
     resolve_start = time.monotonic()
-    resolution = resolve_knowledge_base_access(
+    resolution = await resolve_knowledge_base_access_async(
         file_memory.base_id,
         file_memory.config,
         runtime_paths,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -3986,45 +3986,45 @@ class ResponseRunner:
             if visible_event_id_callback is not None:
                 visible_event_id_callback(response_event_id)
 
-        knowledge_resolution = await self.deps.knowledge_access.resolve_for_agent_async(
-            self.deps.agent_name,
-            execution_identity=runtime.tool_dispatch.execution_identity,
-        )
-        transient_enrichment_items = append_knowledge_availability_enrichment(
-            request.transient_enrichment_items,
-            knowledge_resolution.unavailable,
-        )
-        response_stream = stream_agent_response(
-            self._agent_turn_context(
-                request,
-                runtime=runtime,
-                run_id=run_id,
-                active_event_ids=active_event_ids,
-                transient_enrichment_items=transient_enrichment_items,
-                system_enrichment_items=request.system_enrichment_items,
-            ),
-            prompt=request.prompt,
-            runtime_paths=self.deps.runtime_paths,
-            config=self.deps.runtime.config,
-            thread_history=request.thread_history,
-            model_prompt=runtime.model_prompt,
-            current_timestamp_ms=request.current_timestamp_ms,
-            current_prompt_is_structured=request.current_prompt_is_structured,
-            knowledge=knowledge_resolution.knowledge,
-            run_id_callback=note_attempt_run_id,
-            media=runtime.media_inputs,
-            show_tool_calls=runtime.show_tool_calls,
-            run_metadata_collector=run_metadata_content,
-            execution_identity=runtime.tool_dispatch.execution_identity,
-            compaction_lifecycle=compaction_lifecycle,
-            refresh_scheduler=self._knowledge_refresh_scheduler(),
-            turn_recorder=turn_recorder,
-            pipeline_timing=pipeline_timing,
-            supports_native_tool_approval=True,
-            attempt_model_runtime=self.deps.tool_runtime,
-        )
-
         try:
+            knowledge_resolution = await self.deps.knowledge_access.resolve_for_agent_async(
+                self.deps.agent_name,
+                execution_identity=runtime.tool_dispatch.execution_identity,
+            )
+            transient_enrichment_items = append_knowledge_availability_enrichment(
+                request.transient_enrichment_items,
+                knowledge_resolution.unavailable,
+            )
+            response_stream = stream_agent_response(
+                self._agent_turn_context(
+                    request,
+                    runtime=runtime,
+                    run_id=run_id,
+                    active_event_ids=active_event_ids,
+                    transient_enrichment_items=transient_enrichment_items,
+                    system_enrichment_items=request.system_enrichment_items,
+                ),
+                prompt=request.prompt,
+                runtime_paths=self.deps.runtime_paths,
+                config=self.deps.runtime.config,
+                thread_history=request.thread_history,
+                model_prompt=runtime.model_prompt,
+                current_timestamp_ms=request.current_timestamp_ms,
+                current_prompt_is_structured=request.current_prompt_is_structured,
+                knowledge=knowledge_resolution.knowledge,
+                run_id_callback=note_attempt_run_id,
+                media=runtime.media_inputs,
+                show_tool_calls=runtime.show_tool_calls,
+                run_metadata_collector=run_metadata_content,
+                execution_identity=runtime.tool_dispatch.execution_identity,
+                compaction_lifecycle=compaction_lifecycle,
+                refresh_scheduler=self._knowledge_refresh_scheduler(),
+                turn_recorder=turn_recorder,
+                pipeline_timing=pipeline_timing,
+                supports_native_tool_approval=True,
+                attempt_model_runtime=self.deps.tool_runtime,
+            )
+
             async with _response_typing_indicator(self._client(), request):
                 wrapped_response_stream = self._stream_in_tool_context(
                     tool_dispatch=runtime.tool_dispatch,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -3891,7 +3891,7 @@ class ResponseRunner:
         show_tool_calls = runtime.show_tool_calls
 
         async def build_response_text() -> str:
-            knowledge_resolution = self.deps.knowledge_access.resolve_for_agent(
+            knowledge_resolution = await self.deps.knowledge_access.resolve_for_agent_async(
                 self.deps.agent_name,
                 execution_identity=runtime.tool_dispatch.execution_identity,
             )
@@ -3986,7 +3986,7 @@ class ResponseRunner:
             if visible_event_id_callback is not None:
                 visible_event_id_callback(response_event_id)
 
-        knowledge_resolution = self.deps.knowledge_access.resolve_for_agent(
+        knowledge_resolution = await self.deps.knowledge_access.resolve_for_agent_async(
             self.deps.agent_name,
             execution_identity=runtime.tool_dispatch.execution_identity,
         )

--- a/tach.toml
+++ b/tach.toml
@@ -4224,7 +4224,9 @@ expose = [
     "PerBindingKnowledgeRefreshScheduler",
     "reconcile_knowledge_mode_transition_states",
     "resolve_agent_knowledge_access",
+    "resolve_agent_knowledge_access_async",
     "resolve_knowledge_base_access",
+    "resolve_knowledge_base_access_async",
     "StandaloneKnowledgeRefreshScheduler",
 ]
 from = ["mindroom.knowledge"]

--- a/tests/ai_user_id_helpers.py
+++ b/tests/ai_user_id_helpers.py
@@ -302,6 +302,12 @@ def _knowledge_access_support(
                 unavailable=unavailable or {},
             ),
         ),
+        resolve_for_agent_async=AsyncMock(
+            return_value=_KnowledgeResolution(
+                knowledge=cast("Knowledge | None", knowledge),
+                unavailable=unavailable or {},
+            ),
+        ),
     )
 
 

--- a/tests/bot_helpers.py
+++ b/tests/bot_helpers.py
@@ -313,10 +313,10 @@ def _set_turn_store_tracker(bot: AgentBot | TeamBot, tracker: MagicMock) -> Magi
 def _set_knowledge_for_agent(bot: AgentBot, knowledge_for_agent: MagicMock) -> MagicMock:
     """Replace the captured knowledge resolver on the real response coordinator."""
     bot._knowledge_access_support.for_agent = knowledge_for_agent
-    resolve_for_agent = MagicMock(
+    resolve_for_agent = AsyncMock(
         return_value=_KnowledgeResolution(knowledge=knowledge_for_agent.return_value),
     )
-    bot._knowledge_access_support.resolve_for_agent = resolve_for_agent
+    bot._knowledge_access_support.resolve_for_agent_async = resolve_for_agent
     return resolve_for_agent
 
 

--- a/tests/test_ai_error_message_display.py
+++ b/tests/test_ai_error_message_display.py
@@ -102,6 +102,7 @@ def _knowledge_access_support() -> SimpleNamespace:
     return SimpleNamespace(
         for_agent=MagicMock(return_value=None),
         resolve_for_agent=MagicMock(return_value=_KnowledgeResolution(knowledge=None)),
+        resolve_for_agent_async=AsyncMock(return_value=_KnowledgeResolution(knowledge=None)),
     )
 
 

--- a/tests/test_delegate_tools.py
+++ b/tests/test_delegate_tools.py
@@ -513,7 +513,8 @@ class TestDelegateKnowledge:
         with (
             tool_runtime_context(_delegate_runtime_context(config, runtime_paths)),
             patch(
-                "mindroom.custom_tools.delegate.resolve_agent_knowledge_access",
+                "mindroom.custom_tools.delegate.resolve_agent_knowledge_access_async",
+                new_callable=AsyncMock,
                 return_value=_KnowledgeResolution(knowledge=mock_knowledge),
             ) as mock_get,
             patch(
@@ -524,8 +525,8 @@ class TestDelegateKnowledge:
         ):
             result = await tools.delegate_task("researcher", "Find info about X")
 
-            mock_get.assert_called_once()
-            args, kwargs = mock_get.call_args
+            mock_get.assert_awaited_once()
+            args, kwargs = mock_get.await_args
             assert args == ("researcher", config, runtime_paths)
             assert kwargs["execution_identity"] is None
             ai_kwargs = mock_ai_response.await_args.kwargs

--- a/tests/test_event_loop_offloading.py
+++ b/tests/test_event_loop_offloading.py
@@ -13,6 +13,7 @@ import pytest
 from agno.models.message import Message
 
 import mindroom.ai as ai_module
+import mindroom.knowledge.utils as knowledge_utils
 import mindroom.memory._file_backend as file_backend_module
 import mindroom.pre_model_preparation as pre_model_preparation_module
 from mindroom.config.agent import AgentConfig
@@ -36,6 +37,67 @@ async def _assert_loop_heartbeats_while_pending(task: asyncio.Task) -> None:
         await asyncio.sleep(0)
         heartbeats += 1
     assert not task.done()
+
+
+@pytest.mark.asyncio
+async def test_agent_knowledge_lookup_runs_off_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow published-index lookup must not stall other event-loop work."""
+    gate = threading.Event()
+    lookup_started = threading.Event()
+    loop_thread_id = threading.get_ident()
+    schedule_thread_ids: list[int] = []
+
+    def gated_lookup(*_args: object, **_kwargs: object) -> None:
+        lookup_started.set()
+        assert threading.get_ident() != loop_thread_id
+        if not gate.wait(5.0):
+            msg = "timed out waiting to release published-index lookup"
+            raise TimeoutError(msg)
+
+    def record_refresh_schedule(
+        *_args: object,
+        availability: knowledge_utils.KnowledgeAvailability,
+        **_kwargs: object,
+    ) -> knowledge_utils.KnowledgeAvailability:
+        schedule_thread_ids.append(threading.get_ident())
+        return availability
+
+    monkeypatch.setattr(knowledge_utils, "_lookup_knowledge_for_base", gated_lookup)
+    monkeypatch.setattr(knowledge_utils, "_schedule_refresh_for_availability", record_refresh_schedule)
+    config = Config.model_validate(
+        {
+            "agents": {
+                "general": {
+                    "display_name": "General",
+                    "role": "test",
+                    "knowledge_bases": ["docs"],
+                },
+            },
+            "knowledge_bases": {"docs": {"path": str(tmp_path / "docs")}},
+        },
+    )
+    resolve_task = asyncio.create_task(
+        knowledge_utils._resolve_agent_knowledge_access_async(
+            "general",
+            config,
+            test_runtime_paths(tmp_path),
+            refresh_scheduler=MagicMock(),
+        ),
+    )
+    try:
+        assert await asyncio.to_thread(lookup_started.wait, 5.0)
+        await _assert_loop_heartbeats_while_pending(resolve_task)
+    finally:
+        gate.set()
+
+    resolution = await resolve_task
+    assert resolution.knowledge is None
+    assert resolution.unavailable["docs"].availability is knowledge_utils.KnowledgeAvailability.INITIALIZING
+    assert resolution.unavailable["docs"].search_available is False
+    assert schedule_thread_ids == [loop_thread_id]
 
 
 def _prompt_preparation_config(memory_backend: str = "mem0") -> Config:

--- a/tests/test_event_loop_offloading.py
+++ b/tests/test_event_loop_offloading.py
@@ -80,7 +80,7 @@ async def test_agent_knowledge_lookup_runs_off_event_loop(
         },
     )
     resolve_task = asyncio.create_task(
-        knowledge_utils._resolve_agent_knowledge_access_async(
+        knowledge_utils.resolve_agent_knowledge_access_async(
             "general",
             config,
             test_runtime_paths(tmp_path),
@@ -98,6 +98,93 @@ async def test_agent_knowledge_lookup_runs_off_event_loop(
     assert resolution.unavailable["docs"].availability is knowledge_utils.KnowledgeAvailability.INITIALIZING
     assert resolution.unavailable["docs"].search_available is False
     assert schedule_thread_ids == [loop_thread_id]
+
+
+@pytest.mark.asyncio
+async def test_agent_file_memory_resolution_runs_off_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """File-memory workspace resolution must not stall other event-loop work."""
+    gate = threading.Event()
+    resolution_started = threading.Event()
+    loop_thread_id = threading.get_ident()
+
+    def gated_file_memory_resolution(*_args: object, **_kwargs: object) -> None:
+        resolution_started.set()
+        assert threading.get_ident() != loop_thread_id
+        if not gate.wait(5.0):
+            msg = "timed out waiting to release file-memory resolution"
+            raise TimeoutError(msg)
+
+    monkeypatch.setattr(
+        knowledge_utils,
+        "resolve_agent_file_memory_knowledge",
+        gated_file_memory_resolution,
+    )
+    config = Config.model_validate(
+        {
+            "agents": {"general": {"display_name": "General", "role": "test", "memory_backend": "file"}},
+            "memory": {"search": {"mode": "semantic"}},
+        },
+    )
+    resolve_task = asyncio.create_task(
+        knowledge_utils.resolve_agent_knowledge_access_async(
+            "general",
+            config,
+            test_runtime_paths(tmp_path),
+        ),
+    )
+    try:
+        assert await asyncio.to_thread(resolution_started.wait, 5.0)
+        await _assert_loop_heartbeats_while_pending(resolve_task)
+    finally:
+        gate.set()
+
+    resolution = await resolve_task
+    assert resolution.knowledge is None
+    assert resolution.unavailable == {}
+
+
+@pytest.mark.asyncio
+async def test_knowledge_base_lookup_runs_off_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A direct published-index lookup must not stall other event-loop work."""
+    gate = threading.Event()
+    lookup_started = threading.Event()
+    loop_thread_id = threading.get_ident()
+
+    def gated_lookup(*_args: object, **_kwargs: object) -> None:
+        lookup_started.set()
+        assert threading.get_ident() != loop_thread_id
+        if not gate.wait(5.0):
+            msg = "timed out waiting to release direct published-index lookup"
+            raise TimeoutError(msg)
+
+    monkeypatch.setattr(knowledge_utils, "_lookup_knowledge_for_base", gated_lookup)
+    config = Config.model_validate(
+        {
+            "knowledge_bases": {"docs": {"path": str(tmp_path / "docs")}},
+        },
+    )
+    resolve_task = asyncio.create_task(
+        knowledge_utils.resolve_knowledge_base_access_async(
+            "docs",
+            config,
+            test_runtime_paths(tmp_path),
+        ),
+    )
+    try:
+        assert await asyncio.to_thread(lookup_started.wait, 5.0)
+        await _assert_loop_heartbeats_while_pending(resolve_task)
+    finally:
+        gate.set()
+
+    resolution = await resolve_task
+    assert resolution.knowledge is None
+    assert resolution.availability is knowledge_utils.KnowledgeAvailability.INITIALIZING
 
 
 def _prompt_preparation_config(memory_backend: str = "mem0") -> Config:

--- a/tests/test_matrix_rtc_call_tools.py
+++ b/tests/test_matrix_rtc_call_tools.py
@@ -809,11 +809,14 @@ async def test_build_call_tools_returns_same_agent_prompt_and_tools(
         fake_create_agent,
     )
 
-    def fake_resolve_knowledge(*_args: object, **kwargs: object) -> SimpleNamespace:
+    async def fake_resolve_knowledge(*_args: object, **kwargs: object) -> SimpleNamespace:
         knowledge_calls.append(kwargs)
         return SimpleNamespace(knowledge=knowledge)
 
-    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access", fake_resolve_knowledge)
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        fake_resolve_knowledge,
+    )
     seen_targets: list[MessageTarget] = []
 
     class StrictToolSupport:
@@ -966,8 +969,8 @@ async def test_cascaded_responder_uses_normal_agent_turn_and_filters_unsafe_func
     )
     monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_agent_mock)
     monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
-        lambda *_args, **_kwargs: SimpleNamespace(knowledge=knowledge, unavailable=()),
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        AsyncMock(return_value=SimpleNamespace(knowledge=knowledge, unavailable=())),
     )
     monkeypatch.setattr("mindroom.ai.ai_response", fake_ai_response)
     monkeypatch.setattr(
@@ -1224,8 +1227,8 @@ async def test_cascaded_responder_records_effective_selected_model_metadata(
         lambda **_kwargs: nullcontext(None),
     )
     monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
-        lambda *_args, **_kwargs: SimpleNamespace(knowledge=None, unavailable=()),
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        AsyncMock(return_value=SimpleNamespace(knowledge=None, unavailable=())),
     )
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools.open_resolved_scope_session_context",
@@ -1309,6 +1312,79 @@ async def test_cascaded_close_releases_agent_when_settlement_wait_is_cancelled()
         await _close_cascaded_call_resources(tracker, cache)  # type: ignore[arg-type]
 
     cache.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cascaded_cancellation_during_knowledge_resolution_persists_transcript(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation during knowledge lookup must persist the admitted transcript."""
+    config = _config()
+    runtime_paths = test_runtime_paths(tmp_path)
+    execution_identity = build_tool_execution_identity(
+        channel="matrix",
+        agent_name=AGENT,
+        runtime_paths=runtime_paths,
+        requester_id=REQUESTER,
+        room_id="!room:example.org",
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id="call-session",
+    )
+    resolution_started = asyncio.Event()
+
+    async def blocked_resolution(*_args: object, **_kwargs: object) -> SimpleNamespace:
+        resolution_started.set()
+        await asyncio.Event().wait()
+        msg = "blocked resolution unexpectedly resumed"
+        raise AssertionError(msg)
+
+    persisted_interruptions: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        blocked_resolution,
+    )
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.open_resolved_scope_session_context",
+        lambda **_kwargs: nullcontext(SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.persist_interrupted_replay",
+        lambda **kwargs: persisted_interruptions.append(kwargs),
+    )
+    tooling = await build_call_tools(
+        agent_name=AGENT,
+        config=config,
+        runtime_paths=runtime_paths,
+        tool_support=SimpleNamespace(
+            build_context=lambda target, **_kwargs: _runtime_context(
+                config=config,
+                runtime_paths=runtime_paths,
+                target=target,
+            ),
+            build_execution_identity=lambda **_kwargs: execution_identity,
+        ),  # type: ignore[arg-type]
+        room_id="!room:example.org",
+        requester_id=REQUESTER,
+        authorize_operation=_authorized_call_operation,
+        session_id="call-session",
+        enable_responder=True,
+    )
+    assert tooling.responder is not None
+
+    response_task = asyncio.create_task(tooling.responder("Never speak this", None))
+    await asyncio.wait_for(resolution_started.wait(), timeout=5)
+    response_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await response_task
+
+    assert len(persisted_interruptions) == 1
+    persisted = persisted_interruptions[0]
+    assert persisted["session_id"] == "call-session"
+    assert persisted["user_message"] == "Never speak this"
+    assert persisted["partial_text"] == ""
+    assert persisted["original_status"] is RunStatus.cancelled
 
 
 @pytest.mark.asyncio
@@ -1410,7 +1486,7 @@ async def test_cascaded_responder_refreshes_knowledge_and_availability_each_turn
             assert tool_context.tool_function_filter is not None
             return await operation()
 
-    def resolve_knowledge(*_args: object, **kwargs: object) -> SimpleNamespace:
+    async def resolve_knowledge(*_args: object, **kwargs: object) -> SimpleNamespace:
         resolver_calls.append(kwargs)
         return next(resolutions)
 
@@ -1422,7 +1498,10 @@ async def test_cascaded_responder_refreshes_knowledge_and_availability_each_turn
     second_agent = SimpleNamespace(additional_context="second base", model=None)
     create_agent_mock = MagicMock(side_effect=(first_agent, second_agent))
     close_agent_mock = MagicMock()
-    monkeypatch.setattr("mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access", resolve_knowledge)
+    monkeypatch.setattr(
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        resolve_knowledge,
+    )
     monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", create_agent_mock)
     monkeypatch.setattr("mindroom.matrix_rtc.call_tools.close_agent_runtime_state_dbs", close_agent_mock)
     monkeypatch.setattr("mindroom.ai.ai_response", fake_ai_response)
@@ -1510,8 +1589,8 @@ async def test_cascaded_responder_waits_for_interrupted_playout_settlement(
         persisted.append(cast("str", kwargs["run_id"]))
 
     monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
-        lambda *_args, **_kwargs: SimpleNamespace(knowledge=None, unavailable={}),
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        AsyncMock(return_value=SimpleNamespace(knowledge=None, unavailable={})),
     )
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools.create_agent",
@@ -1609,8 +1688,8 @@ async def test_build_call_tools_includes_agno_added_knowledge_and_skill_function
         lambda *_args, **_kwargs: FakeAgnoAgent(functions),
     )
     monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
-        lambda *_args, **_kwargs: SimpleNamespace(knowledge=None),
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        AsyncMock(return_value=SimpleNamespace(knowledge=None)),
     )
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools._wrap_agno_function",
@@ -1660,8 +1739,8 @@ async def test_build_call_tools_hides_agno_added_knowledge_function_needing_appr
 
     monkeypatch.setattr("mindroom.matrix_rtc.call_tools.create_agent", create_knowledge_agent)
     monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
-        lambda *_args, **_kwargs: SimpleNamespace(knowledge=knowledge),
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        AsyncMock(return_value=SimpleNamespace(knowledge=knowledge)),
     )
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools._wrap_agno_function",
@@ -1717,8 +1796,8 @@ async def test_build_call_tools_hides_functions_needing_text_chat(
         lambda *_a, **_k: FakeAgnoAgent(list(functions.values())),
     )
     monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
-        lambda *_a, **_k: SimpleNamespace(knowledge=None),
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        AsyncMock(return_value=SimpleNamespace(knowledge=None)),
     )
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools._wrap_agno_function",
@@ -1761,8 +1840,8 @@ async def test_build_call_tools_keeps_builtin_invite_router_under_approval_polic
         lambda *_a, **_k: FakeAgnoAgent([invite_router]),
     )
     monkeypatch.setattr(
-        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access",
-        lambda *_a, **_k: SimpleNamespace(knowledge=None),
+        "mindroom.matrix_rtc.call_tools.resolve_agent_knowledge_access_async",
+        AsyncMock(return_value=SimpleNamespace(knowledge=None)),
     )
     monkeypatch.setattr(
         "mindroom.matrix_rtc.call_tools._wrap_agno_function",

--- a/tests/test_memory_file_backend.py
+++ b/tests/test_memory_file_backend.py
@@ -325,7 +325,7 @@ async def test_semantic_memory_search_uses_ready_published_index_without_refresh
 
     access_base_ids: list[str] = []
 
-    def resolve_access(
+    async def resolve_access(
         base_id: str,
         access_config: Config,
         access_runtime_paths: object,
@@ -351,7 +351,7 @@ async def test_semantic_memory_search_uses_ready_published_index_without_refresh
         return [memory_file.resolve()]
 
     monkeypatch.setattr(semantic_file_search, "list_knowledge_files", list_files)
-    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access", resolve_access, raising=False)
+    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access_async", resolve_access)
     monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler(), raising=False)
 
     results = await semantic_file_search.search_semantic_file_memories(
@@ -395,7 +395,7 @@ async def test_semantic_memory_search_emits_nested_query_timings(
     runtime_paths = runtime_paths_for(config)
     fake_knowledge = _FakeSemanticTimingKnowledge()
 
-    def resolve_access(*_args: object, **_kwargs: object) -> object:
+    async def resolve_access(*_args: object, **_kwargs: object) -> object:
         return SimpleNamespace(knowledge=fake_knowledge, availability=KnowledgeAvailability.READY)
 
     emitted: list[tuple[str, str | None]] = []
@@ -404,7 +404,7 @@ async def test_semantic_memory_search_emits_nested_query_timings(
         emitted.append((label, timing_scope.get()))
 
     monkeypatch.setattr(semantic_file_search, "list_knowledge_files", lambda *_args, **_kwargs: [memory_file.resolve()])
-    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access", resolve_access)
+    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access_async", resolve_access)
     monkeypatch.setattr(semantic_file_search, "emit_elapsed_timing", emit_timing)
 
     token = timing_scope.set("scope-123")
@@ -449,11 +449,11 @@ async def test_semantic_memory_missing_knowledge_index_schedules_refresh_and_rai
     def list_files(*_args: object, **_kwargs: object) -> list[Path]:
         return [memory_file.resolve()]
 
-    def resolve_access(*_args: object, **_kwargs: object) -> KnowledgeBaseAccessResolution:
+    async def resolve_access(*_args: object, **_kwargs: object) -> KnowledgeBaseAccessResolution:
         return KnowledgeBaseAccessResolution(knowledge=None, availability=KnowledgeAvailability.INITIALIZING)
 
     monkeypatch.setattr(semantic_file_search, "list_knowledge_files", list_files)
-    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access", resolve_access)
+    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access_async", resolve_access)
     monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
 
     with pytest.raises(semantic_file_search.SemanticFileMemoryIndexUnavailableError) as excinfo:
@@ -491,7 +491,7 @@ async def test_semantic_memory_cold_failed_index_carries_classified_cause(
     def list_files(*_args: object, **_kwargs: object) -> list[Path]:
         return [memory_file.resolve()]
 
-    def resolve_access(*_args: object, **_kwargs: object) -> KnowledgeBaseAccessResolution:
+    async def resolve_access(*_args: object, **_kwargs: object) -> KnowledgeBaseAccessResolution:
         return KnowledgeBaseAccessResolution(
             knowledge=None,
             availability=KnowledgeAvailability.REFRESH_FAILED,
@@ -501,7 +501,7 @@ async def test_semantic_memory_cold_failed_index_carries_classified_cause(
         )
 
     monkeypatch.setattr(semantic_file_search, "list_knowledge_files", list_files)
-    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access", resolve_access)
+    monkeypatch.setattr(semantic_file_search, "resolve_knowledge_base_access_async", resolve_access)
     monkeypatch.setattr(semantic_file_search, "_memory_refresh_scheduler", FakeScheduler())
 
     with pytest.raises(semantic_file_search.SemanticFileMemoryIndexUnavailableError) as excinfo:

--- a/tests/test_openai_compat.py
+++ b/tests/test_openai_compat.py
@@ -5322,7 +5322,8 @@ class TestKnowledgeIntegration:
         with (
             patch("mindroom.api.openai_compat.ai_response", new_callable=AsyncMock) as mock_ai,
             patch(
-                "mindroom.api.openai_compat.resolve_agent_knowledge_access",
+                "mindroom.api.openai_compat.resolve_agent_knowledge_access_async",
+                new_callable=AsyncMock,
                 side_effect=RuntimeError("DB connection failed"),
             ),
         ):

--- a/tests/test_response_runner_agent.py
+++ b/tests/test_response_runner_agent.py
@@ -657,7 +657,7 @@ class TestAgentBot(AgentBotTestBase):
             tmp_path,
         )
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
-        bot.client = AsyncMock()
+        bot.client = _make_matrix_client_mock()
         bot._knowledge_access_support.resolve_for_agent_async = AsyncMock(
             side_effect=asyncio.CancelledError("cancelled"),
         )

--- a/tests/test_response_runner_agent.py
+++ b/tests/test_response_runner_agent.py
@@ -639,6 +639,57 @@ class TestAgentBot(AgentBotTestBase):
         assert kwargs["execution_identity"] is not None
 
     @pytest.mark.asyncio
+    async def test_streaming_cancellation_during_knowledge_resolution_persists_turn(
+        self,
+        mock_agent_user: AgentMatrixUser,
+        tmp_path: Path,
+    ) -> None:
+        """Cancellation during async knowledge lookup must preserve the interrupted turn."""
+        config = _runtime_bound_config(
+            Config(
+                agents={
+                    "calculator": AgentConfig(
+                        display_name="CalculatorAgent",
+                        rooms=["!test:localhost"],
+                    ),
+                },
+            ),
+            tmp_path,
+        )
+        bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
+        bot.client = AsyncMock()
+        bot._knowledge_access_support.resolve_for_agent_async = AsyncMock(
+            side_effect=asyncio.CancelledError("cancelled"),
+        )
+        persist_interrupted = AsyncMock()
+
+        with (
+            patch.object(
+                bot._response_runner,
+                "_persist_interrupted_recorder_off_loop",
+                new=persist_interrupted,
+            ),
+            pytest.raises(asyncio.CancelledError, match="cancelled"),
+        ):
+            await bot._response_runner._process_and_respond_streaming(
+                _response_request(
+                    room_id="!test:localhost",
+                    prompt="Hello",
+                    reply_to_event_id="$event456",
+                    thread_history=[],
+                    user_id="@user:localhost",
+                    response_envelope=request_envelope(
+                        room_id="!test:localhost",
+                        reply_to_event_id="$event456",
+                        prompt="Hello",
+                        user_id="@user:localhost",
+                    ),
+                ),
+            )
+
+        persist_interrupted.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_process_and_respond_includes_attachment_ids_in_response_metadata(
         self,
         mock_agent_user: AgentMatrixUser,

--- a/tests/test_response_runner_agent.py
+++ b/tests/test_response_runner_agent.py
@@ -633,8 +633,8 @@ class TestAgentBot(AgentBotTestBase):
                 )
 
         assert generation.delivery.event_id == "$response"
-        bot._knowledge_access_support.resolve_for_agent.assert_called_once()
-        args, kwargs = bot._knowledge_access_support.resolve_for_agent.call_args
+        bot._knowledge_access_support.resolve_for_agent_async.assert_awaited_once()
+        args, kwargs = bot._knowledge_access_support.resolve_for_agent_async.call_args
         assert args == ("calculator",)
         assert kwargs["execution_identity"] is not None
 
@@ -2696,7 +2696,9 @@ class TestAgentBot(AgentBotTestBase):
         config = self._config_for_storage(tmp_path)
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
-        bot._knowledge_access_support.resolve_for_agent = MagicMock(return_value=_KnowledgeResolution(knowledge=None))
+        bot._knowledge_access_support.resolve_for_agent_async = AsyncMock(
+            return_value=_KnowledgeResolution(knowledge=None),
+        )
         thread_history = [
             _visible_message(
                 sender=f"@user{i}:localhost",
@@ -2819,7 +2821,9 @@ class TestAgentBot(AgentBotTestBase):
         config.defaults.thread_summary_first_threshold = 1
         bot = make_test_agent_bot(mock_agent_user, tmp_path, config=config, runtime_paths=runtime_paths_for(config))
         bot.client = _make_matrix_client_mock()
-        bot._knowledge_access_support.resolve_for_agent = MagicMock(return_value=_KnowledgeResolution(knowledge=None))
+        bot._knowledge_access_support.resolve_for_agent_async = AsyncMock(
+            return_value=_KnowledgeResolution(knowledge=None),
+        )
         root_event_id = "$root_event"
         resolved_target = MessageTarget.resolve(
             room_id="!test:localhost",

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -2493,8 +2493,9 @@ async def test_agent_continuation_executes_real_agno_confirmation(
     with (
         patch.object(
             runner.deps.knowledge_access,
-            "for_agent",
-            return_value=knowledge,
+            "resolve_for_agent_async",
+            new_callable=AsyncMock,
+            return_value=SimpleNamespace(knowledge=knowledge),
         ) as resolve_knowledge,
         patch("mindroom.approval_execution.create_agent", return_value=agent) as create_agent,
         patch.object(agent, "acontinue_run", new=continue_run),
@@ -2518,7 +2519,7 @@ async def test_agent_continuation_executes_real_agno_confirmation(
     assert "io.mindroom.ai_run" in result.metadata_content
     assert bool(executed) is approved
     assert observed_metadata == ([original_metadata] if approved else [])
-    resolve_knowledge.assert_called_once_with("general", execution_identity=identity)
+    resolve_knowledge.assert_awaited_once_with("general", execution_identity=identity)
     assert create_agent.call_args.kwargs["knowledge"] is knowledge
     assert create_agent.call_args.kwargs["refresh_scheduler"] is refresh_scheduler
     continued_requirement = continue_run.call_args.kwargs["requirements"][0]
@@ -2614,7 +2615,12 @@ async def test_agent_continuation_rejects_non_exact_persisted_call_ids(
     denial_reasons = dict.fromkeys(decision_call_ids)
 
     with (
-        patch.object(runner.deps.knowledge_access, "for_agent", return_value=MagicMock()),
+        patch.object(
+            runner.deps.knowledge_access,
+            "resolve_for_agent_async",
+            new_callable=AsyncMock,
+            return_value=SimpleNamespace(knowledge=MagicMock()),
+        ),
         patch("mindroom.approval_execution.create_agent", return_value=agent),
         patch("mindroom.approval_execution.close_agent_runtime_state_dbs"),
         pytest.raises(RuntimeError, match="no longer match the approval continuation"),
@@ -2664,7 +2670,12 @@ async def test_agent_continuation_closes_runtime_when_notice_hook_setup_fails(tm
     )
 
     with (
-        patch.object(runner.deps.knowledge_access, "for_agent", return_value=MagicMock()),
+        patch.object(
+            runner.deps.knowledge_access,
+            "resolve_for_agent_async",
+            new_callable=AsyncMock,
+            return_value=SimpleNamespace(knowledge=MagicMock()),
+        ),
         patch("mindroom.approval_execution.create_session_storage", return_value=storage),
         patch("mindroom.approval_execution.create_agent", return_value=agent),
         patch(


### PR DESCRIPTION
## Summary

- move published-index lookup off the chat response event loop
- keep availability calculation and refresh scheduling on the loop
- cover a blocked lookup with a deterministic gate-based regression test

## Testing

- uv run pytest -q tests/test_event_loop_offloading.py tests/test_response_runner_agent.py tests/test_ai_error_message_display.py tests/test_knowledge_manager.py
- uv run pre-commit run --files src/mindroom/knowledge/utils.py src/mindroom/response_runner.py tests/ai_user_id_helpers.py tests/bot_helpers.py tests/test_ai_error_message_display.py tests/test_event_loop_offloading.py tests/test_response_runner_agent.py

## Summary by Sourcery

Move knowledge resolution to asynchronous APIs so published-index I/O stays off the response event loop while availability handling and interruption recovery remain reliable.

Bug Fixes:
- Prevent published knowledge and file-memory lookups from blocking the response event loop.
- Preserve interrupted chat and call transcripts when cancellation occurs during asynchronous knowledge resolution.

Enhancements:
- Add asynchronous knowledge-resolution APIs and use them across chat, delegation, approval continuation, semantic memory, OpenAI-compatible, and Matrix RTC response paths.
- Keep availability calculation, metadata updates, and refresh scheduling on the event loop after offloaded storage lookups.

Tests:
- Add deterministic event-loop regression tests covering blocked agent, direct knowledge-base, and file-memory lookups.
- Add cancellation regression tests verifying interrupted response and call turns are persisted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Knowledge-base lookups now run asynchronously, keeping streaming and non-streaming responses responsive while searches are being resolved.
  - Slow published-index lookups no longer block other application activity.

- **Bug Fixes**
  - Agents now correctly report knowledge bases as initializing when their search index is still unavailable, while refresh processing continues in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->