### PR TITLE
Reclaim orphaned Chroma segment directories

### DIFF
--- a/src/mindroom/knowledge/collections.py
+++ b/src/mindroom/knowledge/collections.py
@@ -10,6 +10,8 @@ needs as arguments.
 from __future__ import annotations
 
 import asyncio
+import shutil
+import sqlite3
 import uuid
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
@@ -279,13 +281,60 @@ async def delete_collection(space: CollectionSpace, collection_name: str) -> boo
 def _delete_collection_sync(space: CollectionSpace, collection_name: str) -> bool:
     """Delete one collection, treating an already-absent one as success."""
     vector_db = build_vector_db(space, collection_name)
-    if vector_db.delete():
-        return True
+    deleted = vector_db.delete()
+    if not deleted:
+        try:
+            vector_db.client.get_collection(name=vector_db.collection_name)
+        except NotFoundError:
+            deleted = True
+    if deleted:
+        _reclaim_orphaned_segment_directories(space)
+    return deleted
+
+
+def _reclaim_orphaned_segment_directories(space: CollectionSpace) -> None:
+    """Remove UUID-named Chroma directories that no live segment references."""
+    database_path = space.storage_path / "chroma.sqlite3"
+    if not database_path.is_file():
+        return
     try:
-        vector_db.client.get_collection(name=vector_db.collection_name)
-    except NotFoundError:
-        return True
-    return False
+        database_uri = f"{database_path.resolve().as_uri()}?mode=ro"
+        with sqlite3.connect(database_uri, uri=True) as connection:
+            live_segment_ids = {row[0] for row in connection.execute("SELECT id FROM segments")}
+        entries = tuple(space.storage_path.iterdir())
+    except (OSError, sqlite3.Error):
+        logger.warning(
+            "Failed to inspect knowledge segment storage for cleanup",
+            base_id=space.base_id,
+            exc_info=True,
+        )
+        return
+
+    reclaimed = 0
+    for path in entries:
+        try:
+            is_segment_directory = not path.is_symlink() and path.is_dir() and str(uuid.UUID(path.name)) == path.name
+        except (OSError, ValueError):
+            continue
+        if not is_segment_directory or path.name in live_segment_ids:
+            continue
+        try:
+            shutil.rmtree(path)
+        except OSError:
+            logger.warning(
+                "Failed to reclaim orphaned knowledge segment directory",
+                base_id=space.base_id,
+                segment_id=path.name,
+                exc_info=True,
+            )
+        else:
+            reclaimed += 1
+    if reclaimed:
+        logger.info(
+            "Reclaimed orphaned knowledge segment directories",
+            base_id=space.base_id,
+            segments=reclaimed,
+        )
 
 
 def cleanup_superseded_collections(
@@ -342,6 +391,7 @@ def cleanup_superseded_collections(
                 collection=collection_name,
                 exc_info=True,
             )
+    _reclaim_orphaned_segment_directories(space)
     if unowned:
         logger.info(
             "Preserved knowledge collections with unprovable ownership",

--- a/tests/test_knowledge_collection_cleanup.py
+++ b/tests/test_knowledge_collection_cleanup.py
@@ -1,0 +1,74 @@
+"""Integration tests for physical Chroma collection cleanup."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from mindroom.knowledge.collections import (
+    CollectionSpace,
+    build_vector_db,
+    cleanup_superseded_collections,
+    delete_collection,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from chromadb.api import ClientAPI
+
+
+def _create_collection_segment(storage_path: Path, client: ClientAPI, collection_name: str) -> Path:
+    """Create one populated collection and return its new physical segment directory."""
+    before = {path for path in storage_path.iterdir() if path.is_dir()}
+    collection = client.create_collection(collection_name, embedding_function=None)
+    collection.add(ids=["one"], embeddings=[[0.1, 0.2, 0.3]])
+    created = {path for path in storage_path.iterdir() if path.is_dir()} - before
+    assert len(created) == 1
+    return created.pop()
+
+
+@pytest.mark.asyncio
+async def test_delete_collection_reclaims_only_unreferenced_segment_directories(tmp_path: Path) -> None:
+    """Deleting a collection removes old orphans while preserving every live segment."""
+    storage_path = tmp_path / "chroma"
+    space = CollectionSpace(
+        base_id="docs",
+        knowledge_path=tmp_path / "docs",
+        storage_path=storage_path,
+        embedder_factory=MagicMock,
+    )
+    live_vector_db = build_vector_db(space, space.default_collection)
+    client = live_vector_db.client
+    live_segment = _create_collection_segment(storage_path, client, space.default_collection)
+    unrelated_directory = storage_path / "not-a-segment"
+    unrelated_directory.mkdir()
+
+    stale_name = f"{space.default_collection}_candidate_stale"
+    stale_segment = _create_collection_segment(storage_path, client, stale_name)
+    client.delete_collection(stale_name)
+    assert stale_segment.is_dir()
+
+    deleted_name = f"{space.default_collection}_candidate_deleted"
+    deleted_segment = _create_collection_segment(storage_path, client, deleted_name)
+
+    assert await delete_collection(space, deleted_name)
+    assert live_segment.is_dir()
+    assert client.get_collection(space.default_collection, embedding_function=None).count() == 1
+    assert unrelated_directory.is_dir()
+    assert not stale_segment.exists()
+    assert not deleted_segment.exists()
+
+    later_stale_name = f"{space.default_collection}_candidate_later_stale"
+    later_stale_segment = _create_collection_segment(storage_path, client, later_stale_name)
+    client.delete_collection(later_stale_name)
+    cleanup_superseded_collections(
+        space,
+        vector_db=live_vector_db,
+        preserved=frozenset({space.default_collection}),
+        candidates_only=True,
+    )
+    assert not later_stale_segment.exists()
+    assert live_segment.is_dir()


### PR DESCRIPTION
## Summary

- reclaim UUID-named Chroma segment directories that are no longer referenced
- run reclamation after successful collection deletion and normal superseded-collection cleanup
- query live segment IDs through a read-only SQLite connection and fail closed on inspection errors
- verify with a real Chroma store that live and non-segment directories remain untouched

## Testing

- uv run pytest -q tests/test_knowledge_collection_cleanup.py tests/test_knowledge_manager.py tests/test_knowledge_resumable_refresh.py
- uv run pre-commit run --files src/mindroom/knowledge/collections.py tests/test_knowledge_collection_cleanup.py

## Summary by Sourcery

Reclaim unreferenced Chroma segment directories during collection cleanup without disturbing active or unrelated storage.

Bug Fixes:
- Reclaim orphaned UUID-named Chroma segment directories after collection deletion and superseded-collection cleanup while preserving live and unrelated directories.

Enhancements:
- Inspect live segment references through a read-only SQLite connection and fail closed when storage inspection fails.

Tests:
- Add integration coverage using a real Chroma store to verify cleanup of stale segments and preservation of live and non-segment directories.