### PR TITLE
Use Git deltas to skip unchanged knowledge files

### DIFF
--- a/src/mindroom/knowledge/candidate_checkpoint.py
+++ b/src/mindroom/knowledge/candidate_checkpoint.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 
 #: Bumped whenever the persisted candidate layout changes incompatibly. An
 #: unknown version is treated as "no resumable candidate" rather than an error.
-_CANDIDATE_CHECKPOINT_SCHEMA_VERSION = 1
+_CANDIDATE_CHECKPOINT_SCHEMA_VERSION = 2
 
 _CANDIDATE_CHECKPOINT_FILENAME = "candidate_index.json"
 _CANDIDATE_JOURNAL_FILENAME = "candidate_index.jsonl"

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -474,7 +474,11 @@ class GitKnowledgeSource:
                 exc_info=True,
             )
             return None
-        return frozenset(path for path in output.split("\0") if path and self._include_relative_path(path))
+        changed_paths = frozenset(path for path in output.split("\0") if path)
+        # Attributes can alter checkout bytes without changing a managed blob.
+        if any(path.rsplit("/", 1)[-1] == ".gitattributes" for path in changed_paths):
+            return None
+        return frozenset(path for path in changed_paths if self._include_relative_path(path))
 
     async def sync(self) -> GitSyncResult:
         """Fetch and force-align one configured Git repository checkout.

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -417,7 +417,6 @@ class GitKnowledgeSource:
         init=False,
         repr=False,
     )
-    _last_synced_head: str | None = field(default=None, init=False)
     _lfs_checked: bool = field(default=False, init=False)
     _lfs_repository_ready: bool = field(default=False, init=False)
     _tracked_relative_paths: set[str] | None = field(default=None, init=False, repr=False)
@@ -425,11 +424,6 @@ class GitKnowledgeSource:
     def is_configured(self) -> bool:
         """Return whether this knowledge base is backed by a Git repository."""
         return self._git_config() is not None
-
-    @property
-    def last_synced_head(self) -> str | None:
-        """Return the revision this process last synchronized, or None."""
-        return self._last_synced_head
 
     def cached_tracked_relative_paths(self) -> set[str] | None:
         """Return tracked paths already listed in this process, without listing any.
@@ -498,7 +492,6 @@ class GitKnowledgeSource:
             self._clear_orphaned_index_lock()
             changed_files, removed_files, updated = await self._sync_once(git_config)
             current_head = await self._rev_parse("HEAD")
-            self._last_synced_head = current_head
 
         if updated:
             logger.info(

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -829,19 +829,9 @@ class GitKnowledgeSource:
         if before_head is None:
             changed_paths = after_files
         else:
-            try:
-                diff_output = await self._run_git(
-                    ["diff", "--name-only", "--no-renames", "-z", f"{before_head}..HEAD"],
-                )
-            except RuntimeError:
-                logger.warning(
-                    "Could not compute knowledge Git delta; falling back to a full scan",
-                    base_id=self.base_id,
-                    exc_info=True,
-                )
+            changed_paths = await self.changed_files_between(before_head, "HEAD")
+            if changed_paths is None:
                 changed_paths = after_files
-            else:
-                changed_paths = {path for path in diff_output.split("\0") if path and self._include_relative_path(path)}
 
         removed_files = before_files - after_files
         changed_files = {path for path in changed_paths if path in after_files} | (after_files - before_files)

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -470,7 +470,9 @@ class GitKnowledgeSource:
         if before_head == after_head:
             return frozenset()
         try:
-            output = await self._run_git(["diff", "--name-only", "--no-renames", f"{before_head}..{after_head}"])
+            output = await self._run_git(
+                ["diff", "--name-only", "--no-renames", "-z", f"{before_head}..{after_head}"],
+            )
         except RuntimeError:
             logger.warning(
                 "Could not compute knowledge Git delta; falling back to a full scan",
@@ -478,7 +480,7 @@ class GitKnowledgeSource:
                 exc_info=True,
             )
             return None
-        return frozenset(path for path in output.splitlines() if self._include_relative_path(path))
+        return frozenset(path for path in output.split("\0") if path and self._include_relative_path(path))
 
     async def sync(self) -> GitSyncResult:
         """Fetch and force-align one configured Git repository checkout.
@@ -828,7 +830,9 @@ class GitKnowledgeSource:
             changed_paths = after_files
         else:
             try:
-                diff_output = await self._run_git(["diff", "--name-only", "--no-renames", f"{before_head}..HEAD"])
+                diff_output = await self._run_git(
+                    ["diff", "--name-only", "--no-renames", "-z", f"{before_head}..HEAD"],
+                )
             except RuntimeError:
                 logger.warning(
                     "Could not compute knowledge Git delta; falling back to a full scan",
@@ -837,7 +841,7 @@ class GitKnowledgeSource:
                 )
                 changed_paths = after_files
             else:
-                changed_paths = {path for path in diff_output.splitlines() if self._include_relative_path(path)}
+                changed_paths = {path for path in diff_output.split("\0") if path and self._include_relative_path(path)}
 
         removed_files = before_files - after_files
         changed_files = {path for path in changed_paths if path in after_files} | (after_files - before_files)

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -459,6 +459,27 @@ class GitKnowledgeSource:
         """Return the checkout's current revision, or None when it cannot be read."""
         return await self._rev_parse("HEAD")
 
+    async def changed_files_between(
+        self,
+        before_head: str | None,
+        after_head: str | None,
+    ) -> frozenset[str] | None:
+        """Return a filtered Git delta, or None when callers must inspect everything."""
+        if before_head is None or after_head is None:
+            return None
+        if before_head == after_head:
+            return frozenset()
+        try:
+            output = await self._run_git(["diff", "--name-only", "--no-renames", f"{before_head}..{after_head}"])
+        except RuntimeError:
+            logger.warning(
+                "Could not compute knowledge Git delta; falling back to a full scan",
+                base_id=self.base_id,
+                exc_info=True,
+            )
+            return None
+        return frozenset(path for path in output.splitlines() if self._include_relative_path(path))
+
     async def sync(self) -> GitSyncResult:
         """Fetch and force-align one configured Git repository checkout.
 
@@ -806,8 +827,17 @@ class GitKnowledgeSource:
         if before_head is None:
             changed_paths = after_files
         else:
-            diff_output = await self._run_git(["diff", "--name-only", "--no-renames", f"{before_head}..HEAD"])
-            changed_paths = {path for path in diff_output.splitlines() if self._include_relative_path(path)}
+            try:
+                diff_output = await self._run_git(["diff", "--name-only", "--no-renames", f"{before_head}..HEAD"])
+            except RuntimeError:
+                logger.warning(
+                    "Could not compute knowledge Git delta; falling back to a full scan",
+                    base_id=self.base_id,
+                    exc_info=True,
+                )
+                changed_paths = after_files
+            else:
+                changed_paths = {path for path in diff_output.splitlines() if self._include_relative_path(path)}
 
         removed_files = before_files - after_files
         changed_files = {path for path in changed_paths if path in after_files} | (after_files - before_files)

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1824,9 +1824,9 @@ class KnowledgeManager:
                 status="failed" if run.failed else "building",
                 completed=dict(run.completed),
                 failed=dict(run.failed),
-                # The target revision advances only once the reconciled state
-                # it describes is about to be durable.
-                target_revision=self.git_source.last_synced_head,
+                # The baseline advances only after reconciliation returns, so
+                # this revision describes the durable candidate exactly.
+                target_revision=run.baseline_revision,
                 # The corpus this candidate targets, not a high-water mark of
                 # completed files: status subtracts completed from this to
                 # report how much work is still outstanding.
@@ -1945,18 +1945,19 @@ class KnowledgeManager:
 
     async def _advance_candidate(self, run: _CandidateRun, progress: _CandidateProgress) -> None:
         """Reconcile, index and publish until the candidate matches the live source."""
-        changed_files = (
-            await self.git_source.changed_files_between(
-                run.baseline_revision,
-                self.git_source.last_synced_head,
-            )
-            if self.git_source.is_configured()
-            else None
-        )
         for _round in range(_MAX_CANDIDATE_RECONCILE_ROUNDS):
             round_revision = await self._source_revision()
+            changed_files = (
+                await self.git_source.changed_files_between(
+                    run.baseline_revision,
+                    round_revision,
+                )
+                if _round == 0 and self.git_source.is_configured()
+                else None
+            )
             files = await asyncio.to_thread(self.list_files)
             plan = await self._reconcile_candidate(run, files, changed_files=changed_files)
+            run.baseline_revision = round_revision
             progress.total = len(plan.expected)
             progress.completed = len(run.completed)
             if run.checkpoint.total_files != run.total_files:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -747,13 +747,14 @@ class KnowledgeManager:
         candidate_vector_db: ChromaDb,
         indexed_count: int,
         source_signature: str,
+        published_revision: str | None,
     ) -> bool:
         state = state_for_publication(
             settings=self._indexing_settings,
             collection=candidate_vector_db.collection_name,
             indexed_count=indexed_count,
             source_signature=source_signature,
-            published_revision=self.git_source.last_synced_head,
+            published_revision=published_revision,
         )
         save_task = asyncio.create_task(
             asyncio.to_thread(save_published_index_state, self._indexing_settings_path, state),
@@ -774,12 +775,14 @@ class KnowledgeManager:
         candidate_vector_db: ChromaDb,
         indexed_count: int,
         source_signature: str,
+        published_revision: str | None,
         publish_state: _CandidatePublishState,
     ) -> None:
         publish_cancelled = await self._save_candidate_publish_metadata(
             candidate_vector_db=candidate_vector_db,
             indexed_count=indexed_count,
             source_signature=source_signature,
+            published_revision=published_revision,
         )
         publish_state.index_published = True
         # Adopt the candidate as this manager's live vector database:
@@ -2045,6 +2048,7 @@ class KnowledgeManager:
                 candidate_vector_db=run.vector_db,
                 indexed_count=len(run.completed),
                 source_signature=source_signature,
+                published_revision=run.baseline_revision,
                 publish_state=publish_state,
             )
         finally:

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -218,7 +218,7 @@ class _CandidateRun:
     knowledge: Knowledge
     vector_db: ChromaDb
     embedder: BatchPrefetchEmbedder | None
-    #: Revision whose file signatures seeded this candidate, when known.
+    #: Revision the candidate's file signatures describe, when known.
     baseline_revision: str | None = None
     completed: dict[str, FileSignature] = field(default_factory=dict)
     failed: dict[str, CandidateFailure] = field(default_factory=dict)
@@ -2028,7 +2028,6 @@ class KnowledgeManager:
                     base_id=self.base_id,
                     collection=run.checkpoint.collection,
                 )
-                changed_files = None
                 continue
 
             await self._publish_candidate(run, candidate_source_signature)

--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -218,6 +218,8 @@ class _CandidateRun:
     knowledge: Knowledge
     vector_db: ChromaDb
     embedder: BatchPrefetchEmbedder | None
+    #: Revision whose file signatures seeded this candidate, when known.
+    baseline_revision: str | None = None
     completed: dict[str, FileSignature] = field(default_factory=dict)
     failed: dict[str, CandidateFailure] = field(default_factory=dict)
     vanished: set[str] = field(default_factory=set)
@@ -1550,13 +1552,22 @@ class KnowledgeManager:
             rebuild = True
 
         if rebuild:
+            reusable_published_collection = (
+                None if force_reindex else self._reusable_published_collection(persisted_state)
+            )
             opened = await self._rebuild_candidate_collection(
                 checkpoint,
                 embedder=embedder,
-                published_collection=None if force_reindex else self._reusable_published_collection(persisted_state),
+                published_collection=reusable_published_collection,
+            )
+            baseline_revision = (
+                persisted_state.published_revision
+                if reusable_published_collection is not None and persisted_state is not None
+                else None
             )
         else:
             opened = await self._resume_candidate_collection(checkpoint, embedder=embedder)
+            baseline_revision = checkpoint.target_revision
         checkpoint = opened.checkpoint
 
         run = _CandidateRun(
@@ -1564,6 +1575,7 @@ class KnowledgeManager:
             knowledge=opened.knowledge,
             vector_db=opened.vector_db,
             embedder=embedder,
+            baseline_revision=baseline_revision,
             completed=dict(checkpoint.completed),
             failed=dict(checkpoint.failed),
             # Rows this process just copied need no vector-existence probe: the
@@ -1696,12 +1708,35 @@ class KnowledgeManager:
         self,
         run: _CandidateRun,
         files: Sequence[Path],
+        *,
+        changed_files: frozenset[str] | None = None,
     ) -> _CandidateReconciliation:
         """Align the durable candidate with the current source listing."""
         # ``vanished`` describes files lost during one indexing pass, so it must
         # not outlive the pass and permanently exclude a path that came back.
         run.vanished.clear()
-        signatures = await self._file_signatures_for(files)
+        if changed_files is None:
+            signatures = await self._file_signatures_for(files)
+        else:
+            files_by_relative_path = {self._relative_path(file_path): file_path for file_path in files}
+            files_to_scan = [
+                file_path
+                for relative_path, file_path in files_by_relative_path.items()
+                if relative_path in changed_files or relative_path not in run.completed
+            ]
+            signatures = {
+                relative_path: (run.completed[relative_path], file_path)
+                for relative_path, file_path in files_by_relative_path.items()
+                if relative_path not in changed_files and relative_path in run.completed
+            }
+            signatures.update(await self._file_signatures_for(files_to_scan))
+            logger.info(
+                "Used knowledge Git delta for candidate reconciliation",
+                base_id=self.base_id,
+                changed_count=len(changed_files),
+                scanned_count=len(files_to_scan),
+                managed_count=len(files),
+            )
         present = set(signatures)
 
         # Vectors are dropped for paths that left the corpus and for paths whose
@@ -1910,10 +1945,18 @@ class KnowledgeManager:
 
     async def _advance_candidate(self, run: _CandidateRun, progress: _CandidateProgress) -> None:
         """Reconcile, index and publish until the candidate matches the live source."""
+        changed_files = (
+            await self.git_source.changed_files_between(
+                run.baseline_revision,
+                self.git_source.last_synced_head,
+            )
+            if self.git_source.is_configured()
+            else None
+        )
         for _round in range(_MAX_CANDIDATE_RECONCILE_ROUNDS):
             round_revision = await self._source_revision()
             files = await asyncio.to_thread(self.list_files)
-            plan = await self._reconcile_candidate(run, files)
+            plan = await self._reconcile_candidate(run, files, changed_files=changed_files)
             progress.total = len(plan.expected)
             progress.completed = len(run.completed)
             if run.checkpoint.total_files != run.total_files:
@@ -1981,6 +2024,7 @@ class KnowledgeManager:
                     base_id=self.base_id,
                     collection=run.checkpoint.collection,
                 )
+                changed_files = None
                 continue
 
             await self._publish_candidate(run, candidate_source_signature)

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -1614,6 +1614,53 @@ async def test_sync_git_source_once_controls_lfs_hydration_after_reset(
 
 
 @pytest.mark.asyncio
+async def test_sync_git_source_once_falls_back_when_diff_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed best-effort delta must leave the successful checkout usable."""
+    manager = _git_manager(tmp_path)
+
+    async def _fake_ensure_git_repository(_git_config: object) -> bool:
+        return False
+
+    async def _fake_git_rev_parse(ref: str) -> str | None:
+        if ref == "HEAD":
+            return "before"
+        if ref == "origin/main":
+            return "after"
+        return None
+
+    list_tracked_files_results = iter(
+        [
+            {"keep.md", "removed.md"},
+            {"added.md", "keep.md"},
+        ],
+    )
+
+    async def _fake_git_list_tracked_files() -> set[str]:
+        return next(list_tracked_files_results)
+
+    async def _fake_run_git(args: list[str], **_: object) -> str:
+        if args[:3] == ["diff", "--name-only", "--no-renames"]:
+            msg = "diff unavailable"
+            raise RuntimeError(msg)
+        return ""
+
+    monkeypatch.setattr(manager.git_source, "_ensure_repository", _fake_ensure_git_repository)
+    monkeypatch.setattr(manager.git_source, "_rev_parse", _fake_git_rev_parse)
+    monkeypatch.setattr(manager.git_source, "_list_tracked_files", _fake_git_list_tracked_files)
+    monkeypatch.setattr(manager.git_source, "_run_git", _fake_run_git)
+
+    changed_files, removed_files, updated = await manager.git_source._sync_once(manager.git_source._git_config())
+
+    assert changed_files == {"added.md", "keep.md"}
+    assert removed_files == {"removed.md"}
+    assert updated is True
+    assert await manager.git_source.changed_files_between("before", "after") is None
+
+
+@pytest.mark.asyncio
 async def test_hydrate_git_lfs_worktree_ignores_index_extension_filters(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -1592,7 +1592,7 @@ async def test_sync_git_source_once_controls_lfs_hydration_after_reset(
         git_calls.append(args)
         git_envs.append((args, env))
         if args[:3] == ["diff", "--name-only", "--no-renames"]:
-            return "doc.md\n"
+            return "doc.md\0"
         return ""
 
     monkeypatch.setattr(manager.git_source, "_ensure_repository", _fake_ensure_git_repository)
@@ -1658,6 +1658,26 @@ async def test_sync_git_source_once_falls_back_when_diff_is_unavailable(
     assert removed_files == {"removed.md"}
     assert updated is True
     assert await manager.git_source.changed_files_between("before", "after") is None
+
+
+@pytest.mark.asyncio
+async def test_changed_files_between_preserves_special_character_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Git deltas must use an unambiguous delimiter for every valid pathname."""
+    manager = _git_manager(tmp_path)
+    newline_path = "line\nbreak.md"
+
+    async def _fake_run_git(args: list[str], **_: object) -> str:
+        assert "-z" in args
+        return f"{newline_path}\0unicodé.md\0"
+
+    monkeypatch.setattr(manager.git_source, "_run_git", _fake_run_git)
+
+    changed = await manager.git_source.changed_files_between("before", "after")
+
+    assert changed == frozenset({newline_path, "unicodé.md"})
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -174,7 +174,6 @@ async def test_git_source_sync_does_not_mutate_index_directly(
     assert not hasattr(manager, "remove_file")
     assert not hasattr(manager, "index_file")
     assert result == GitSyncResult(head="rev-source-only", updated=True)
-    assert manager.git_source.last_synced_head == "rev-source-only"
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -1680,6 +1680,22 @@ async def test_changed_files_between_preserves_special_character_paths(
 
 
 @pytest.mark.asyncio
+async def test_changed_files_between_falls_back_when_attributes_change(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Attributes can change checkout bytes without changing a managed blob."""
+    manager = _git_manager(tmp_path)
+
+    async def _fake_run_git(_args: list[str], **_: object) -> str:
+        return "nested/.gitattributes\0"
+
+    monkeypatch.setattr(manager.git_source, "_run_git", _fake_run_git)
+
+    assert await manager.git_source.changed_files_between("before", "after") is None
+
+
+@pytest.mark.asyncio
 async def test_hydrate_git_lfs_worktree_ignores_index_extension_filters(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -456,7 +456,6 @@ def _record_git_sync(
     *relative_paths: str,
 ) -> GitSyncResult:
     """Record a faked sync's outcome the way a real one would, then return it."""
-    source._last_synced_head = result.head
     source._tracked_relative_paths = set(relative_paths)
     return result
 
@@ -3430,6 +3429,7 @@ async def test_publish_metadata_save_finishes_before_repeated_cancellation_escap
             candidate_vector_db=candidate_vector_db,
             indexed_count=0,
             source_signature="source-signature",
+            published_revision=None,
         ),
     )
     await save_started.wait()
@@ -3473,6 +3473,7 @@ async def test_cancelled_publish_metadata_save_surfaces_a_failed_write(
             candidate_vector_db=candidate_vector_db,
             indexed_count=0,
             source_signature="source-signature",
+            published_revision=None,
         ),
     )
     await save_started.wait()
@@ -3527,6 +3528,7 @@ async def test_publishing_states_every_field_of_the_state_file(tmp_path: Path) -
             candidate_vector_db=candidate_vector_db,
             indexed_count=4,
             source_signature="new-signature",
+            published_revision=None,
         )
         is False
     )
@@ -7874,6 +7876,7 @@ async def test_git_refresh_syncs_before_reindex_and_publishes_revision_without_s
 
     monkeypatch.setattr(GitKnowledgeSource, "sync", _sync_success)
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
+    _install_git_revisions(monkeypatch, ["rev-git"])
 
     result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
@@ -7986,6 +7989,7 @@ async def test_git_noop_refresh_skips_full_reindex_when_index_is_complete(
         return await original_reindex(self, force_reindex=force_reindex)
 
     monkeypatch.setattr(KnowledgeManager, "reindex_all", _track_reindex)
+    _install_git_revisions(monkeypatch, ["rev-a"])
 
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
     key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
@@ -8020,6 +8024,7 @@ async def test_git_noop_refresh_skips_corpus_hash_when_revision_is_unchanged(
             GitSyncResult(head="rev-a", updated=False),
         ],
     )
+    _install_git_revisions(monkeypatch, ["rev-a"])
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
     def _unexpected_signature(*_args: object, **_kwargs: object) -> str:
@@ -8225,6 +8230,58 @@ async def test_git_delta_targets_the_revision_verified_by_the_refresh_round(
 
     assert result.index_published is True
     assert result.indexed_count == 2
+
+
+@pytest.mark.asyncio
+async def test_git_publish_records_verified_revision_before_later_rollback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Published metadata must identify the revision whose vectors were verified."""
+    config, runtime_paths = _git_noop_config(tmp_path)
+    _install_git_sync_results(
+        monkeypatch,
+        [
+            GitSyncResult(head="rev-a", updated=True),
+            GitSyncResult(head="rev-b", updated=True),
+            GitSyncResult(head="rev-b", updated=True),
+        ],
+    )
+    _install_git_revisions(monkeypatch, ["rev-a", "rev-a", "rev-c", "rev-c", "rev-b", "rev-b"])
+
+    async def _changed_files_between(
+        _self: GitKnowledgeSource,
+        before_head: str | None,
+        after_head: str | None,
+    ) -> frozenset[str] | None:
+        if before_head is None:
+            return None
+        return frozenset({"doc.md"}) if before_head != after_head else frozenset()
+
+    monkeypatch.setattr(GitKnowledgeSource, "changed_files_between", _changed_files_between)
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    docs_path = tmp_path / "docs"
+    (docs_path / "doc.md").write_text("content at rev-c", encoding="utf-8")
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    key = resolve_published_index_key("docs", config=config, runtime_paths=runtime_paths)
+    state_at_rev_c = load_published_index_state(published_index_metadata_path(key))
+
+    (docs_path / "doc.md").write_text("content at rev-b", encoding="utf-8")
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    state_at_rev_b = load_published_index_state(published_index_metadata_path(key))
+
+    assert state_at_rev_c is not None
+    assert state_at_rev_c.published_revision == "rev-c"
+    assert state_at_rev_b is not None
+    assert state_at_rev_b.published_revision == "rev-b"
+    assert state_at_rev_b.source_signature == _knowledge_source_signature(
+        config,
+        "docs",
+        docs_path,
+        tracked_relative_paths={"doc.md"},
+    )
+    assert result.index_published is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -8147,6 +8147,87 @@ async def test_git_update_uses_reliable_delta_for_file_signature_scan(
 
 
 @pytest.mark.asyncio
+async def test_git_candidate_cancelled_before_reconciliation_rescans_on_resume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A cancelled refresh must not checkpoint an unreconciled Git revision."""
+    config, runtime_paths = _git_noop_config(tmp_path)
+    _install_git_sync_results(
+        monkeypatch,
+        [
+            GitSyncResult(head="rev-a", updated=True),
+            GitSyncResult(head="rev-b", updated=True),
+            GitSyncResult(head="rev-b", updated=False),
+        ],
+    )
+    _install_git_revisions(monkeypatch, ["rev-a", "rev-a", "rev-b", "rev-b"])
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    (tmp_path / "docs" / "doc.md").write_text("changed", encoding="utf-8")
+
+    delta_calls = 0
+
+    async def _cancel_once(
+        _self: GitKnowledgeSource,
+        before_head: str | None,
+        after_head: str | None,
+    ) -> frozenset[str]:
+        nonlocal delta_calls
+        delta_calls += 1
+        if delta_calls == 1:
+            raise asyncio.CancelledError
+        return frozenset({"doc.md"}) if (before_head, after_head) == ("rev-a", "rev-b") else frozenset()
+
+    monkeypatch.setattr(GitKnowledgeSource, "changed_files_between", _cancel_once)
+
+    with pytest.raises(asyncio.CancelledError):
+        await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert result.index_published is True
+    assert result.indexed_count == 1
+
+
+@pytest.mark.asyncio
+async def test_git_delta_targets_the_revision_verified_by_the_refresh_round(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first reconciliation delta must cover the round's exact Git revision."""
+    names = ("first.md", "second.md")
+    config, runtime_paths = _git_noop_config(tmp_path, files=names)
+    _install_git_sync_results(
+        monkeypatch,
+        [
+            GitSyncResult(head="rev-a", updated=True),
+            GitSyncResult(head="rev-b", updated=True),
+        ],
+        tracked=names,
+    )
+    _install_git_revisions(monkeypatch, ["rev-a", "rev-a", "rev-c", "rev-c"])
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    (tmp_path / "docs" / "first.md").write_text("changed in rev-b", encoding="utf-8")
+
+    async def _changed_files_between(
+        _self: GitKnowledgeSource,
+        _before_head: str | None,
+        after_head: str | None,
+    ) -> frozenset[str]:
+        (tmp_path / "docs" / "second.md").write_text("changed in rev-c", encoding="utf-8")
+        if after_head == "rev-c":
+            return frozenset(names)
+        return frozenset({"first.md"})
+
+    monkeypatch.setattr(GitKnowledgeSource, "changed_files_between", _changed_files_between)
+
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert result.index_published is True
+    assert result.indexed_count == 2
+
+
+@pytest.mark.asyncio
 async def test_reindex_skips_live_corpus_hash_when_revision_is_stable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -99,7 +99,7 @@ from tests.knowledge_test_support import (
 pytestmark = pytest.mark.usefixtures("patch_vector_store")
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable, Coroutine, Iterable
+    from collections.abc import AsyncIterator, Callable, Coroutine, Iterable, Sequence
     from contextlib import AbstractAsyncContextManager
     from types import ModuleType
 
@@ -8085,6 +8085,65 @@ async def test_git_noop_refresh_hashes_corpus_when_index_predates_revision_track
     await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
 
     assert counter.calls == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("changed_files", "expected_scanned"),
+    [
+        pytest.param(frozenset({"second.md"}), [("second.md",)], id="reliable-delta"),
+        pytest.param(None, [("first.md", "second.md", "third.md")], id="full-scan-fallback"),
+    ],
+)
+async def test_git_update_uses_reliable_delta_for_file_signature_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    changed_files: frozenset[str] | None,
+    expected_scanned: list[tuple[str, ...]],
+) -> None:
+    """A revision-matched Git delta should avoid hashing every unchanged file."""
+    names = ("first.md", "second.md", "third.md")
+    config, runtime_paths = _git_noop_config(tmp_path, files=names)
+    _install_git_sync_results(
+        monkeypatch,
+        [
+            GitSyncResult(head="rev-a", updated=True),
+            GitSyncResult(head="rev-b", updated=True),
+        ],
+        tracked=names,
+    )
+    _install_git_revisions(monkeypatch, ["rev-a", "rev-a", "rev-b", "rev-b"])
+    await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+    (tmp_path / "docs" / "second.md").write_text("changed", encoding="utf-8")
+
+    async def _changed_files_between(
+        _self: GitKnowledgeSource,
+        before_head: str | None,
+        after_head: str | None,
+    ) -> frozenset[str] | None:
+        assert before_head == "rev-a"
+        assert after_head == "rev-b"
+        return changed_files
+
+    monkeypatch.setattr(GitKnowledgeSource, "changed_files_between", _changed_files_between)
+
+    scanned: list[tuple[str, ...]] = []
+    original_file_signatures_for = KnowledgeManager._file_signatures_for
+
+    async def _record_scanned_files(
+        self: KnowledgeManager,
+        files: Sequence[Path],
+    ) -> dict[str, tuple[tuple[int, int, str], Path]]:
+        scanned.append(tuple(sorted(path.name for path in files)))
+        return await original_file_signatures_for(self, files)
+
+    monkeypatch.setattr(KnowledgeManager, "_file_signatures_for", _record_scanned_files)
+
+    result = await refresh_knowledge_binding("docs", config=config, runtime_paths=runtime_paths)
+
+    assert result.index_published is True
+    assert result.indexed_count == 1
+    assert scanned == expected_scanned
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- derive a candidate-specific Git delta from the revision that seeded it
- hash only changed and new files during reconciliation
- fall back to the existing full scan when revisions or the delta are unavailable

## Testing

- `uv run pytest -q`
- `uv run pytest -q tests/test_knowledge_manager.py tests/test_knowledge_resumable_refresh.py tests/test_knowledge_git_source.py -x`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Optimize knowledge refreshes by using verified Git deltas to skip unchanged files while retaining safe full-scan fallbacks and accurate revision tracking.

New Features:
- Use Git revision deltas to identify changed knowledge files and avoid hashing unchanged files during candidate reconciliation.

Bug Fixes:
- Fall back to full scans when Git revisions or deltas are unavailable, invalidated by attribute changes, or cannot be computed.
- Preserve accurate candidate and published revision metadata across cancellation, concurrent revision changes, and rollbacks.

Enhancements:
- Version candidate checkpoints for the updated revision-tracking layout.

Tests:
- Add coverage for reliable Git delta scans, fallback behavior, special-character paths, attribute changes, cancellation and resume, revision targeting, and publication metadata.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Git-backed knowledge refreshes now scan only files changed since the previous revision when reliable change information is available.
  * Completed results for unchanged files are reused where possible.
  * Refreshes fall back to a full scan when repository attributes change or change information is unavailable.

* **Reliability**
  * File paths containing special characters are handled correctly during change detection.
  * Published knowledge now records the revision whose content was verified, improving consistency across refreshes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->