### PR TITLE
Keep knowledge refresh setup off the event loop

### DIFF
--- a/src/mindroom/knowledge/refresh_runner.py
+++ b/src/mindroom/knowledge/refresh_runner.py
@@ -217,7 +217,8 @@ async def refresh_knowledge_binding_in_subprocess(
             config=config,
             runtime_paths=runtime_paths,
         )
-        request_payload = _serialize_subprocess_refresh_request(
+        request_payload = await asyncio.to_thread(
+            _serialize_subprocess_refresh_request,
             base_id,
             config=config,
             runtime_paths=runtime_paths,

--- a/src/mindroom/knowledge/refresh_scheduler.py
+++ b/src/mindroom/knowledge/refresh_scheduler.py
@@ -186,7 +186,9 @@ class KnowledgeRefreshScheduler:
 
         request = _ScheduledRefresh(
             base_id=base_id,
-            config=config.model_copy(deep=True),
+            # Config reloads replace the object, so retaining this generation
+            # avoids a CPU-heavy deep copy on the event loop.
+            config=config,
             runtime_paths=runtime_paths,
             execution_identity=execution_identity,
             health_recorder=capture_embedder_health_recorder(),

--- a/tests/test_knowledge_manager.py
+++ b/tests/test_knowledge_manager.py
@@ -5365,6 +5365,32 @@ async def test_refresh_scheduler_runs_independent_per_binding_tasks(
 
 
 @pytest.mark.asyncio
+async def test_refresh_scheduler_does_not_deep_copy_config_on_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scheduling a refresh must not deep-copy the full config on the event loop."""
+    docs_path = tmp_path / "docs"
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    scheduler = KnowledgeRefreshScheduler()
+    refreshed = asyncio.Event()
+
+    async def _fake_refresh(_base_id: str, **_kwargs: object) -> None:
+        refreshed.set()
+
+    def _unexpected_copy(_self: Config, **_kwargs: object) -> Config:
+        pytest.fail("schedule_refresh deep-copied the config")
+
+    monkeypatch.setattr("mindroom.knowledge.refresh_runner.refresh_knowledge_binding_in_subprocess", _fake_refresh)
+    monkeypatch.setattr(Config, "model_copy", _unexpected_copy)
+
+    scheduler.schedule_refresh("docs", config=config, runtime_paths=runtime_paths)
+    await asyncio.wait_for(refreshed.wait(), timeout=5)
+    await scheduler.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_refresh_scheduler_probes_embedder_after_persisted_refresh_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -5775,6 +5801,47 @@ async def test_scheduled_refresh_subprocess_receives_config_snapshot(
     assert captured_request["config_data"]["knowledge_bases"]["docs"]["chunk_size"] == 1234
     assert captured_request["runtime_knowledge_base"] is None
     assert captured_request["execution_identity"]["requester_id"] == "@alice:localhost"
+
+
+@pytest.mark.asyncio
+async def test_subprocess_refresh_serializes_request_off_event_loop(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Large config serialization must not block the control-plane event loop."""
+    docs_path = tmp_path / "docs"
+    config = _config(tmp_path, bases={"docs": docs_path}, agent_bases=["docs"])
+    runtime_paths = runtime_paths_for(config)
+    event_loop_thread = get_ident()
+    serialization_threads: list[int] = []
+    process = MagicMock(returncode=0)
+    process.wait = AsyncMock(return_value=0)
+    process.stdin.drain = AsyncMock()
+    process.stdin.wait_closed = AsyncMock()
+
+    def _fake_serialize(*_args: object, **_kwargs: object) -> bytes:
+        serialization_threads.append(get_ident())
+        return b"{}"
+
+    async def _fake_create_subprocess_exec(*_args: object, **_kwargs: object) -> MagicMock:
+        return process
+
+    async def _fake_terminate(_process: object) -> None:
+        pass
+
+    monkeypatch.setattr(knowledge_refresh_runner, "_serialize_subprocess_refresh_request", _fake_serialize)
+    monkeypatch.setattr(knowledge_refresh_runner.asyncio, "create_subprocess_exec", _fake_create_subprocess_exec)
+    monkeypatch.setattr(knowledge_refresh_runner, "_subprocess_session_kwargs", dict)
+    monkeypatch.setattr(knowledge_refresh_runner, "_terminate_refresh_subprocess", _fake_terminate)
+
+    await knowledge_refresh_runner.refresh_knowledge_binding_in_subprocess(
+        "docs",
+        config=config,
+        runtime_paths=runtime_paths,
+    )
+
+    assert serialization_threads
+    assert serialization_threads[0] != event_loop_thread
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- retain the resolved config generation when a background knowledge refresh is queued
- serialize subprocess refresh requests in a background thread
- cover both event-loop boundaries with focused regression tests

## Why

Large configurations made refresh scheduling perform a deep copy and a full Pydantic/JSON serialization synchronously. Both operations can delay unrelated async work before the isolated refresh subprocess starts.

Config reloads replace the resolved `Config` object, so a queued request can retain that generation without copying it. The serializer still materializes an independent payload before the child process receives it.

## Tests

- `uv run pytest tests/test_knowledge_manager.py -q -k 'refresh_scheduler or subprocess_refresh or scheduled_refresh_subprocess'`
- `uv run pre-commit run --files src/mindroom/knowledge/refresh_scheduler.py src/mindroom/knowledge/refresh_runner.py tests/test_knowledge_manager.py`

## Summary by Sourcery

Prevent knowledge refresh setup from blocking the event loop.

Enhancements:
- Keep scheduled knowledge refresh configuration handling non-blocking by retaining the resolved configuration generation and moving refresh request serialization off the event loop.

Tests:
- Add regression coverage confirming scheduling avoids synchronous configuration deep copies and subprocess refresh serialization runs in a background thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Improved knowledge refresh responsiveness by moving request preparation off the main event loop.
  - Reduced unnecessary configuration copying when scheduling refreshes, helping refresh operations run more efficiently.

- **Reliability**
  - Added coverage to verify that scheduled refreshes and subprocess refresh preparation do not block normal application activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->