### PR TITLE
Keep response scope storage off the event loop

### DIFF
--- a/src/mindroom/response_turn.py
+++ b/src/mindroom/response_turn.py
@@ -19,6 +19,8 @@ out of it and crosses via ``TurnSinks`` or the adapters.
 from __future__ import annotations
 
 import asyncio
+import sys
+from contextlib import asynccontextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, NoReturn
@@ -28,6 +30,7 @@ from agno.run.base import RunStatus
 
 from mindroom import ai_runtime
 from mindroom.ai_turn_state import AITurnState
+from mindroom.background_tasks import run_blocking_until_complete, wait_for_future_until_complete
 from mindroom.cancellation import build_cancelled_error
 from mindroom.constants import (
     MATRIX_EVENT_ID_METADATA_KEY,
@@ -759,6 +762,49 @@ def _advance_turn_continuation(
     return advanced
 
 
+def _enter_scope_context(
+    open_scope: Callable[[], AbstractContextManager[ScopeSessionContext | None]],
+) -> tuple[AbstractContextManager[ScopeSessionContext | None], ScopeSessionContext | None]:
+    """Enter one synchronous scope context on a worker thread."""
+    manager = open_scope()
+    return manager, manager.__enter__()
+
+
+@asynccontextmanager
+async def _open_scope_off_event_loop(
+    open_scope: Callable[[], AbstractContextManager[ScopeSessionContext | None]],
+) -> AsyncIterator[ScopeSessionContext | None]:
+    """Keep synchronous session storage open and close work off the event loop."""
+    entry_task = asyncio.create_task(asyncio.to_thread(_enter_scope_context, open_scope))
+    try:
+        manager, scope_context = await wait_for_future_until_complete(entry_task)
+    except asyncio.CancelledError as cancellation:
+        # The guarded wait drains the entry task before propagating cancellation.
+        # If entry succeeded, close the newly opened storage before returning it.
+        try:
+            manager, _scope_context = entry_task.result()
+        except BaseException as entry_error:
+            raise cancellation from entry_error
+        try:
+            await run_blocking_until_complete(
+                manager.__exit__,
+                type(cancellation),
+                cancellation,
+                cancellation.__traceback__,
+            )
+        except BaseException as exit_error:
+            raise cancellation from exit_error
+        raise
+
+    try:
+        yield scope_context
+    except BaseException:
+        if not await run_blocking_until_complete(manager.__exit__, *sys.exc_info()):
+            raise
+    else:
+        await run_blocking_until_complete(manager.__exit__, None, None, None)
+
+
 async def run_blocking_response_turn(
     ctx: ResponseTurnContext,
     adapter: BlockingTurnAdapter,
@@ -769,7 +815,7 @@ async def run_blocking_response_turn(
     """Run one blocking response turn to a final user-visible text."""
     run = TurnRunState()
     try:
-        with adapter.open_scope() as scope_context:
+        async with _open_scope_off_event_loop(adapter.open_scope) as scope_context:
             run.scope_context = scope_context
             if adapter.on_scope_opened is not None:
                 adapter.on_scope_opened(scope_context)
@@ -1023,7 +1069,7 @@ async def stream_response_turn[ChunkT](  # noqa: C901, PLR0912, PLR0915
     """Run one streaming response turn, yielding the attempt chunks as they arrive."""
     run = TurnRunState()
     try:
-        with adapter.open_scope() as scope_context:
+        async with _open_scope_off_event_loop(adapter.open_scope) as scope_context:
             run.scope_context = scope_context
             if adapter.on_scope_opened is not None:
                 adapter.on_scope_opened(scope_context)

--- a/tests/test_response_turn.py
+++ b/tests/test_response_turn.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import threading
 from dataclasses import dataclass, field, fields
 from typing import TYPE_CHECKING, Any, cast
 
@@ -37,7 +38,7 @@ from mindroom.response_turn import (
 from mindroom.tool_system.events import ToolTraceEntry
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Mapping, Sequence
+    from collections.abc import AsyncGenerator, AsyncIterator, Awaitable, Callable, Iterator, Mapping, Sequence
     from contextlib import AbstractContextManager
 
     from mindroom.history.runtime import ScopeSessionContext
@@ -201,6 +202,7 @@ def _blocking_adapter(
     log: _AdapterLog,
     run_attempt: Callable[[TurnRunState, DynamicContinuationRunState], Awaitable[Any]],
     *,
+    open_scope: Callable[[], AbstractContextManager[ScopeSessionContext | None]] | None = None,
     with_standalone_replay: bool = True,
     unexpected_error_text: Callable[[Exception], str] | None = None,
 ) -> BlockingTurnAdapter:
@@ -211,7 +213,7 @@ def _blocking_adapter(
         _bump(log, "finalized")
 
     return BlockingTurnAdapter(
-        open_scope=_open_scope_factory(log),
+        open_scope=open_scope or _open_scope_factory(log),
         run_attempt=run_attempt,
         snapshot_partial=lambda: log.snapshot,
         release_attempt_entity=lambda _scope: _bump(log, "released"),
@@ -446,6 +448,7 @@ def _streaming_adapter(
         AsyncGenerator[str | AttemptResolved, None],
     ],
     *,
+    open_scope: Callable[[], AbstractContextManager[ScopeSessionContext | None]] | None = None,
     with_standalone_replay: bool = True,
     unexpected_error_text: Callable[[Exception], str] | None = None,
 ) -> StreamingTurnAdapter[str]:
@@ -456,7 +459,7 @@ def _streaming_adapter(
         _bump(log, "finalized")
 
     return StreamingTurnAdapter[str](
-        open_scope=_open_scope_factory(log),
+        open_scope=open_scope or _open_scope_factory(log),
         run_attempt=run_attempt,
         snapshot_partial=lambda: log.snapshot,
         release_attempt_entity=lambda _scope: _bump(log, "released"),
@@ -475,6 +478,117 @@ def _bump(log: _AdapterLog, attr: str) -> None:
 
 async def _collect(stream: AsyncIterator[str]) -> list[str]:
     return [chunk async for chunk in stream]
+
+
+@pytest.mark.asyncio
+async def test_blocking_scope_storage_lifecycle_runs_off_event_loop() -> None:
+    """A slow synchronous session open or close must not stall every response."""
+    log = _AdapterLog()
+    event_loop_thread = threading.get_ident()
+    lifecycle_threads: dict[str, int] = {}
+
+    @contextlib.contextmanager
+    def _open_scope() -> Iterator[ScopeSessionContext | None]:
+        lifecycle_threads["enter"] = threading.get_ident()
+        try:
+            yield None
+        finally:
+            lifecycle_threads["exit"] = threading.get_ident()
+
+    async def _attempt(
+        _run: TurnRunState,
+        _continuation_state: DynamicContinuationRunState,
+    ) -> CompletedAttempt:
+        return CompletedAttempt(response_text="done", replayable_text="done", has_visible_content=True)
+
+    assert (
+        await run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _attempt, open_scope=_open_scope),
+            TurnSinks(),
+            continuation=_continuation(),
+        )
+        == "done"
+    )
+    assert lifecycle_threads["enter"] != event_loop_thread
+    assert lifecycle_threads["exit"] != event_loop_thread
+
+
+@pytest.mark.asyncio
+async def test_streaming_scope_storage_lifecycle_runs_off_event_loop() -> None:
+    """Streaming responses use the same non-blocking scope-storage boundary."""
+    log = _AdapterLog()
+    event_loop_thread = threading.get_ident()
+    lifecycle_threads: dict[str, int] = {}
+
+    @contextlib.contextmanager
+    def _open_scope() -> Iterator[ScopeSessionContext | None]:
+        lifecycle_threads["enter"] = threading.get_ident()
+        try:
+            yield None
+        finally:
+            lifecycle_threads["exit"] = threading.get_ident()
+
+    async def _attempt(
+        _run: TurnRunState,
+        _continuation_state: DynamicContinuationRunState,
+    ) -> AsyncGenerator[str | AttemptResolved, None]:
+        yield AttemptResolved(CompletedAttempt(replayable_text="done", has_visible_content=True))
+
+    assert (
+        await _collect(
+            stream_response_turn(
+                _ctx(),
+                _streaming_adapter(log, _attempt, open_scope=_open_scope),
+                TurnSinks(),
+                continuation=_continuation(),
+            ),
+        )
+        == []
+    )
+    assert lifecycle_threads["enter"] != event_loop_thread
+    assert lifecycle_threads["exit"] != event_loop_thread
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_scope_open_closes_entered_context() -> None:
+    """Cancellation waits for an accepted scope open and then closes its storage."""
+    log = _AdapterLog()
+    enter_started = threading.Event()
+    allow_enter = threading.Event()
+    exited = threading.Event()
+
+    @contextlib.contextmanager
+    def _open_scope() -> Iterator[ScopeSessionContext | None]:
+        enter_started.set()
+        if not allow_enter.wait(timeout=5):
+            pytest.fail("scope entry was never released")
+        try:
+            yield None
+        finally:
+            exited.set()
+
+    async def _unexpected_attempt(
+        _run: TurnRunState,
+        _continuation_state: DynamicContinuationRunState,
+    ) -> CompletedAttempt:
+        pytest.fail("a cancelled scope open must not start an attempt")
+
+    turn_task = asyncio.create_task(
+        run_blocking_response_turn(
+            _ctx(),
+            _blocking_adapter(log, _unexpected_attempt, open_scope=_open_scope),
+            TurnSinks(),
+            continuation=_continuation(),
+        ),
+    )
+    assert await asyncio.to_thread(enter_started.wait, 1)
+    turn_task.cancel()
+    allow_enter.set()
+    with pytest.raises(asyncio.CancelledError):
+        await turn_task
+
+    assert exited.is_set()
 
 
 def test_blocking_completion_records_and_updates_collector() -> None:


### PR DESCRIPTION
## Summary
- run synchronous response-scope context entry and exit on worker threads for blocking and streaming turns
- drain an accepted scope entry before propagating cancellation, and close it when cancellation arrives mid-open
- add regression coverage for the thread boundary and cancellation cleanup

## Why
Session storage backends can block while opening, reading, or closing. The shared turn driver previously performed that lifecycle on the event loop, delaying unrelated async work.

## Testing
- `uv run pytest tests/test_response_turn.py tests/test_dynamic_tool_continuation_delivery.py tests/test_ai_user_id.py tests/test_team_response.py -q`
- `uv tool run pre-commit run --files src/mindroom/response_turn.py tests/test_response_turn.py`

## Summary by Sourcery

Keep synchronous response-scope storage lifecycle work off the event loop while preserving cancellation cleanup.

Bug Fixes:
- Prevent synchronous response-scope storage operations from blocking the event loop during blocking and streaming turns.
- Ensure cancellation during scope initialization drains the accepted open operation and closes any context that was entered.

Enhancements:
- Run response-scope context entry and exit on worker threads for both response execution modes.

Tests:
- Add regression coverage confirming scope lifecycle work runs off the event-loop thread and cancellation cleans up a partially opened scope.