### PR TITLE
Add Gmail send-to-self tool

### DIFF
--- a/docs/tools/messaging-and-social.md
+++ b/docs/tools/messaging-and-social.md
@@ -47,7 +47,9 @@ The wrapper refreshes stored Google tokens when needed and raises `OAuthConnecti
 It does not fall back to Agno's local OAuth flow when MindRoom credentials are missing.
 It only bypasses MindRoom OAuth when configured for Google service-account auth.
 The registered Gmail surface includes archive, trash, star, draft, message and thread retrieval, search, label mutation, attachment download, send, and reply operations.
-Its exact function names are `apply_label()`, `archive_email()`, `create_draft_email()`, `delete_custom_label()`, `download_attachment()`, `get_draft()`, `get_emails_by_context()`, `get_emails_by_date()`, `get_emails_by_thread()`, `get_emails_from_user()`, `get_latest_emails()`, `get_message()`, `get_starred_emails()`, `get_thread()`, `get_unread_emails()`, `list_custom_labels()`, `list_drafts()`, `list_labels()`, `mark_email_as_read()`, `mark_email_as_unread()`, `modify_message_labels()`, `modify_thread_labels()`, `remove_label()`, `search_emails()`, `search_threads()`, `send_draft()`, `send_email()`, `send_email_reply()`, `star_email()`, `trash_message()`, `trash_thread()`, `unstar_email()`, and `update_draft()`.
+Its exact function names are `apply_label()`, `archive_email()`, `create_draft_email()`, `delete_custom_label()`, `download_attachment()`, `get_draft()`, `get_emails_by_context()`, `get_emails_by_date()`, `get_emails_by_thread()`, `get_emails_from_user()`, `get_latest_emails()`, `get_message()`, `get_starred_emails()`, `get_thread()`, `get_unread_emails()`, `list_custom_labels()`, `list_drafts()`, `list_labels()`, `mark_email_as_read()`, `mark_email_as_unread()`, `modify_message_labels()`, `modify_thread_labels()`, `remove_label()`, `search_emails()`, `search_threads()`, `send_draft()`, `send_email()`, `send_email_reply()`, `send_email_to_self()`, `star_email()`, `trash_message()`, `trash_thread()`, `unstar_email()`, and `update_draft()`.
+`send_email_to_self(subject, body)` derives its sole recipient from the connected Gmail profile and accepts no recipient, CC, BCC, or attachment arguments.
+The function follows the configured tool approval policy, so operators can match `send_email_to_self` separately from other send functions.
 Draft and send operations accept local file-system paths for attachments.
 
 ### Configuration
@@ -77,6 +79,7 @@ agents:
 get_latest_emails(10)
 search_emails("label:unread from:billing@example.com", 10)
 send_email("alice@example.com", "Project update", "Here is the latest status.")
+send_email_to_self("Automation finished", "The scheduled report is ready.")
 send_email_reply("thread_id", "message_id", "alice@example.com", "Re: Project update", "Thanks for the update.")
 apply_label("is:unread category:promotions", "Needs Review", count=10)
 ```

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -8127,7 +8127,9 @@ The wrapper refreshes stored Google tokens when needed and raises `OAuthConnecti
 It does not fall back to Agno's local OAuth flow when MindRoom credentials are missing.
 It only bypasses MindRoom OAuth when configured for Google service-account auth.
 The registered Gmail surface includes archive, trash, star, draft, message and thread retrieval, search, label mutation, attachment download, send, and reply operations.
-Its exact function names are `apply_label()`, `archive_email()`, `create_draft_email()`, `delete_custom_label()`, `download_attachment()`, `get_draft()`, `get_emails_by_context()`, `get_emails_by_date()`, `get_emails_by_thread()`, `get_emails_from_user()`, `get_latest_emails()`, `get_message()`, `get_starred_emails()`, `get_thread()`, `get_unread_emails()`, `list_custom_labels()`, `list_drafts()`, `list_labels()`, `mark_email_as_read()`, `mark_email_as_unread()`, `modify_message_labels()`, `modify_thread_labels()`, `remove_label()`, `search_emails()`, `search_threads()`, `send_draft()`, `send_email()`, `send_email_reply()`, `star_email()`, `trash_message()`, `trash_thread()`, `unstar_email()`, and `update_draft()`.
+Its exact function names are `apply_label()`, `archive_email()`, `create_draft_email()`, `delete_custom_label()`, `download_attachment()`, `get_draft()`, `get_emails_by_context()`, `get_emails_by_date()`, `get_emails_by_thread()`, `get_emails_from_user()`, `get_latest_emails()`, `get_message()`, `get_starred_emails()`, `get_thread()`, `get_unread_emails()`, `list_custom_labels()`, `list_drafts()`, `list_labels()`, `mark_email_as_read()`, `mark_email_as_unread()`, `modify_message_labels()`, `modify_thread_labels()`, `remove_label()`, `search_emails()`, `search_threads()`, `send_draft()`, `send_email()`, `send_email_reply()`, `send_email_to_self()`, `star_email()`, `trash_message()`, `trash_thread()`, `unstar_email()`, and `update_draft()`.
+`send_email_to_self(subject, body)` derives its sole recipient from the connected Gmail profile and accepts no recipient, CC, BCC, or attachment arguments.
+The function follows the configured tool approval policy, so operators can match `send_email_to_self` separately from other send functions.
 Draft and send operations accept local file-system paths for attachments.
 
 ### Configuration
@@ -8157,6 +8159,7 @@ agents:
 get_latest_emails(10)
 search_emails("label:unread from:billing@example.com", 10)
 send_email("alice@example.com", "Project update", "Here is the latest status.")
+send_email_to_self("Automation finished", "The scheduled report is ready.")
 send_email_reply("thread_id", "message_id", "alice@example.com", "Re: Project update", "Thanks for the update.")
 apply_label("is:unread category:promotions", "Needs Review", count=10)
 ```

--- a/skills/mindroom-docs/references/page__tools__messaging-and-social__index.md
+++ b/skills/mindroom-docs/references/page__tools__messaging-and-social__index.md
@@ -43,7 +43,9 @@ The wrapper refreshes stored Google tokens when needed and raises `OAuthConnecti
 It does not fall back to Agno's local OAuth flow when MindRoom credentials are missing.
 It only bypasses MindRoom OAuth when configured for Google service-account auth.
 The registered Gmail surface includes archive, trash, star, draft, message and thread retrieval, search, label mutation, attachment download, send, and reply operations.
-Its exact function names are `apply_label()`, `archive_email()`, `create_draft_email()`, `delete_custom_label()`, `download_attachment()`, `get_draft()`, `get_emails_by_context()`, `get_emails_by_date()`, `get_emails_by_thread()`, `get_emails_from_user()`, `get_latest_emails()`, `get_message()`, `get_starred_emails()`, `get_thread()`, `get_unread_emails()`, `list_custom_labels()`, `list_drafts()`, `list_labels()`, `mark_email_as_read()`, `mark_email_as_unread()`, `modify_message_labels()`, `modify_thread_labels()`, `remove_label()`, `search_emails()`, `search_threads()`, `send_draft()`, `send_email()`, `send_email_reply()`, `star_email()`, `trash_message()`, `trash_thread()`, `unstar_email()`, and `update_draft()`.
+Its exact function names are `apply_label()`, `archive_email()`, `create_draft_email()`, `delete_custom_label()`, `download_attachment()`, `get_draft()`, `get_emails_by_context()`, `get_emails_by_date()`, `get_emails_by_thread()`, `get_emails_from_user()`, `get_latest_emails()`, `get_message()`, `get_starred_emails()`, `get_thread()`, `get_unread_emails()`, `list_custom_labels()`, `list_drafts()`, `list_labels()`, `mark_email_as_read()`, `mark_email_as_unread()`, `modify_message_labels()`, `modify_thread_labels()`, `remove_label()`, `search_emails()`, `search_threads()`, `send_draft()`, `send_email()`, `send_email_reply()`, `send_email_to_self()`, `star_email()`, `trash_message()`, `trash_thread()`, `unstar_email()`, and `update_draft()`.
+`send_email_to_self(subject, body)` derives its sole recipient from the connected Gmail profile and accepts no recipient, CC, BCC, or attachment arguments.
+The function follows the configured tool approval policy, so operators can match `send_email_to_self` separately from other send functions.
 Draft and send operations accept local file-system paths for attachments.
 
 ### Configuration
@@ -73,6 +75,7 @@ agents:
 get_latest_emails(10)
 search_emails("label:unread from:billing@example.com", 10)
 send_email("alice@example.com", "Project update", "Here is the latest status.")
+send_email_to_self("Automation finished", "The scheduled report is ready.")
 send_email_reply("thread_id", "message_id", "alice@example.com", "Re: Project update", "Thanks for the update.")
 apply_label("is:unread category:promotions", "Needs Review", count=10)
 ```

--- a/src/mindroom/custom_tools/gmail.py
+++ b/src/mindroom/custom_tools/gmail.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from agno.tools.google.auth import google_authenticate
 from agno.tools.google.gmail import GmailTools as AgnoGmailTools
+from agno.tools.google.gmail import validate_email
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 
@@ -26,6 +28,24 @@ if TYPE_CHECKING:
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
 
 logger = get_logger(__name__)
+_authenticate = google_authenticate("gmail")
+_GMAIL_PROFILE_SCOPES = frozenset(
+    {
+        "https://mail.google.com/",
+        "https://www.googleapis.com/auth/gmail.compose",
+        "https://www.googleapis.com/auth/gmail.metadata",
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.readonly",
+    },
+)
+_GMAIL_SEND_SCOPES = frozenset(
+    {
+        "https://mail.google.com/",
+        "https://www.googleapis.com/auth/gmail.compose",
+        "https://www.googleapis.com/auth/gmail.modify",
+        "https://www.googleapis.com/auth/gmail.send",
+    },
+)
 
 
 class GmailTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, AgnoGmailTools):
@@ -65,10 +85,54 @@ class GmailTools(ScopedOAuthClientMixin, ThreadLocalGoogleServiceMixin, AgnoGmai
 
         # Pass credentials to parent class
         super().__init__(creds=creds, **kwargs)
+        self.register(self.send_email_to_self)
+        if self.functions.get("send_email_to_self") is not None and (
+            not _GMAIL_PROFILE_SCOPES.intersection(self.scopes) or not _GMAIL_SEND_SCOPES.intersection(self.scopes)
+        ):
+            self.functions.pop("send_email_to_self")
+            logger.warning("gmail_send_email_to_self_disabled_missing_scope")
 
         # Store original auth method for fallback
         self._set_original_auth(AgnoGmailTools._resolve_creds)
         self._wrap_oauth_function_entrypoints()
+
+    def _check_tools_filters(
+        self,
+        available_tools: list[str],
+        include_tools: list[str] | None = None,
+        exclude_tools: list[str] | None = None,
+    ) -> None:
+        """Include the local function in Agno's toolkit filter validation."""
+        super()._check_tools_filters(
+            [*available_tools, "send_email_to_self"],
+            include_tools=include_tools,
+            exclude_tools=exclude_tools,
+        )
+
+    @_authenticate
+    def send_email_to_self(self, subject: str, body: str) -> str:
+        """Send an email to the connected Gmail account.
+
+        Args:
+            subject: Email subject.
+            body: Email body content.
+
+        Returns:
+            Stringified dictionary containing the sent email details.
+
+        """
+        service = self.service
+        assert service is not None
+        profile = service.users().getProfile(userId="me").execute()
+        email_address = profile.get("emailAddress") if isinstance(profile, dict) else None
+        if (
+            not isinstance(email_address, str)
+            or email_address != email_address.strip()
+            or not validate_email(email_address)
+        ):
+            msg = "Connected Gmail profile did not return one valid email address"
+            raise RuntimeError(msg)
+        return self.send_email(to=email_address, subject=subject, body=body)
 
     def _build_service(self, creds: Any) -> Any:  # noqa: ANN401
         return build("gmail", "v1", http=self._google_authorized_http(creds))

--- a/src/mindroom/tools/gmail.py
+++ b/src/mindroom/tools/gmail.py
@@ -130,6 +130,7 @@ if TYPE_CHECKING:
         "send_draft",
         "send_email",
         "send_email_reply",
+        "send_email_to_self",
         "star_email",
         "trash_message",
         "trash_thread",

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -7024,6 +7024,7 @@
         "send_draft",
         "send_email",
         "send_email_reply",
+        "send_email_to_self",
         "star_email",
         "trash_message",
         "trash_thread",

--- a/tests/test_gmail_tools.py
+++ b/tests/test_gmail_tools.py
@@ -1,8 +1,12 @@
 """Tests for the custom Gmail tools wrapper."""
 
+import base64
 import json
 from collections.abc import Callable
+from email import policy
+from email.parser import BytesParser
 from functools import partial
+from inspect import signature
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
@@ -11,6 +15,8 @@ import pytest
 from agno.tools.google.gmail import GmailTools as AgnoGmailTools
 from googleapiclient.errors import HttpError
 
+from mindroom.agents import apply_tool_approval_capability
+from mindroom.config.main import Config
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager
 from mindroom.custom_tools.gmail import GmailTools
@@ -76,7 +82,10 @@ class TestGmailTools:
         mock_creds_instance = MagicMock()
         mock_credentials_class.return_value = mock_creds_instance
 
-        with patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init:
+        with (
+            patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init,
+            patch.object(GmailTools, "register"),
+        ):
             mock_parent_init.return_value = None
             GmailTools(runtime_paths=runtime_paths, credentials_manager=mock_credentials_manager)
 
@@ -110,7 +119,10 @@ class TestGmailTools:
         """Test initialization when no credentials are stored."""
         mock_manager = CredentialsManager(runtime_paths.storage_root / "empty_credentials")
 
-        with patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init:
+        with (
+            patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init,
+            patch.object(GmailTools, "register"),
+        ):
             mock_parent_init.return_value = None
             GmailTools(runtime_paths=runtime_paths, credentials_manager=mock_manager)
 
@@ -128,7 +140,10 @@ class TestGmailTools:
             },
         )
 
-        with patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init:
+        with (
+            patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init,
+            patch.object(GmailTools, "register"),
+        ):
             mock_parent_init.return_value = None
             gmail_tools = GmailTools(
                 runtime_paths=runtime_paths,
@@ -156,6 +171,12 @@ class TestGmailTools:
         assert result["provider"] == "google_gmail"
         assert "/api/oauth/google_gmail/authorize" in result["connect_url"]
 
+        result = json.loads(gmail_tools.send_email_to_self("Status", "Finished"))
+
+        assert result["oauth_connection_required"] is True
+        assert result["provider"] == "google_gmail"
+        assert "/api/oauth/google_gmail/authorize" in result["connect_url"]
+
     @patch("mindroom.custom_tools.gmail.logger")
     @patch("google.oauth2.credentials.Credentials")
     def test_initialization_with_invalid_credentials(
@@ -169,7 +190,10 @@ class TestGmailTools:
         mock_credentials_manager.save_credentials("google_gmail_oauth", {"invalid": "data"})
         mock_credentials_class.side_effect = TypeError("Missing required fields")
 
-        with patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init:
+        with (
+            patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init,
+            patch.object(GmailTools, "register"),
+        ):
             mock_parent_init.return_value = None
             GmailTools(runtime_paths=runtime_paths, credentials_manager=mock_credentials_manager)
 
@@ -189,7 +213,10 @@ class TestGmailTools:
         runtime_paths: RuntimePaths,
     ) -> None:
         """Test _auth method with valid credentials."""
-        with patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init:
+        with (
+            patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init,
+            patch.object(GmailTools, "register"),
+        ):
             mock_parent_init.return_value = None
             gmail_tools = GmailTools(runtime_paths=runtime_paths, credentials_manager=mock_credentials_manager)
 
@@ -209,7 +236,10 @@ class TestGmailTools:
         runtime_paths: RuntimePaths,
     ) -> None:
         """Test _auth refreshes expired credentials."""
-        with patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init:
+        with (
+            patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init,
+            patch.object(GmailTools, "register"),
+        ):
             mock_parent_init.return_value = None
             gmail_tools = GmailTools(runtime_paths=runtime_paths, credentials_manager=mock_credentials_manager)
 
@@ -247,7 +277,10 @@ class TestGmailTools:
         """Test _auth falls back to original auth when no credentials stored."""
         mock_manager = CredentialsManager(runtime_paths.storage_root / "empty_credentials")
 
-        with patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init:
+        with (
+            patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init,
+            patch.object(GmailTools, "register"),
+        ):
             mock_parent_init.return_value = None
 
             gmail_tools = GmailTools(runtime_paths=runtime_paths, credentials_manager=mock_manager)
@@ -271,7 +304,10 @@ class TestGmailTools:
         runtime_paths: RuntimePaths,
     ) -> None:
         """Test _auth handles errors properly."""
-        with patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init:
+        with (
+            patch("mindroom.custom_tools.gmail.AgnoGmailTools.__init__") as mock_parent_init,
+            patch.object(GmailTools, "register"),
+        ):
             mock_parent_init.return_value = None
             gmail_tools = GmailTools(runtime_paths=runtime_paths, credentials_manager=mock_credentials_manager)
             gmail_tools.creds = None
@@ -291,6 +327,219 @@ class TestGmailTools:
         # Verify the upstream default scopes are accessible
         assert isinstance(GmailTools.default_scopes, list)
         assert len(GmailTools.default_scopes) > 0
+
+    def test_send_email_to_self_uses_only_connected_account(
+        self,
+        mock_credentials_manager: CredentialsManager,
+        runtime_paths: RuntimePaths,
+    ) -> None:
+        """The self-send tool must derive its sole recipient from Gmail."""
+        gmail_tools = GmailTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=mock_credentials_manager,
+            send_email=False,
+        )
+        service = MagicMock()
+        service.users.return_value.getProfile.return_value.execute.return_value = {
+            "emailAddress": "owner@example.com",
+        }
+        service.users.return_value.messages.return_value.send.return_value.execute.return_value = {"id": "message-1"}
+        gmail_tools.service = service
+
+        function = gmail_tools.functions["send_email_to_self"]
+        result = json.loads(function.entrypoint(subject="Status", body="Finished"))
+
+        assert "send_email" not in gmail_tools.functions
+        assert list(signature(function.entrypoint).parameters) == ["subject", "body"]
+        assert result == {"id": "message-1"}
+        service.users.return_value.getProfile.assert_called_once_with(userId="me")
+        send = service.users.return_value.messages.return_value.send
+        send.assert_called_once()
+        assert send.call_args.kwargs["userId"] == "me"
+        message = BytesParser(policy=policy.default).parsebytes(
+            base64.urlsafe_b64decode(send.call_args.kwargs["body"]["raw"]),
+        )
+        assert message.get_all("To") == ["owner@example.com"]
+        assert message.get_all("Cc") is None
+        assert message.get_all("Bcc") is None
+        assert message["Subject"] == "Status"
+
+    @pytest.mark.parametrize(
+        "scopes",
+        [
+            ["https://mail.google.com/"],
+            ["https://www.googleapis.com/auth/gmail.modify"],
+            ["https://www.googleapis.com/auth/gmail.compose"],
+            [
+                "https://www.googleapis.com/auth/gmail.readonly",
+                "https://www.googleapis.com/auth/gmail.send",
+            ],
+        ],
+    )
+    def test_send_email_to_self_accepts_sufficient_scope(
+        self,
+        mock_credentials_manager: CredentialsManager,
+        runtime_paths: RuntimePaths,
+        scopes: list[str],
+    ) -> None:
+        """Self-send accepts every scope that authorizes both API operations."""
+        gmail_tools = GmailTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=mock_credentials_manager,
+            include_tools=["send_email_to_self"],
+            scopes=scopes,
+        )
+
+        assert set(gmail_tools.functions) == {"send_email_to_self"}
+
+    @pytest.mark.parametrize(
+        "scope",
+        [
+            "https://www.googleapis.com/auth/gmail.readonly",
+            "https://www.googleapis.com/auth/gmail.send",
+        ],
+    )
+    def test_send_email_to_self_is_omitted_with_insufficient_scope(
+        self,
+        mock_credentials_manager: CredentialsManager,
+        runtime_paths: RuntimePaths,
+        scope: str,
+    ) -> None:
+        """Self-send is unavailable when scopes authorize only one required operation."""
+        gmail_tools = GmailTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=mock_credentials_manager,
+            include_tools=["send_email_to_self"],
+            scopes=[scope],
+        )
+
+        assert gmail_tools.functions == {}
+
+    def test_insufficient_self_send_scope_preserves_compatible_gmail_functions(
+        self,
+        mock_credentials_manager: CredentialsManager,
+        runtime_paths: RuntimePaths,
+    ) -> None:
+        """A missing self-send scope must not disable compatible Gmail functions."""
+        gmail_tools = GmailTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=mock_credentials_manager,
+            include_tools=["get_latest_emails", "send_email_to_self"],
+            scopes=["https://www.googleapis.com/auth/gmail.readonly"],
+        )
+
+        assert set(gmail_tools.functions) == {"get_latest_emails"}
+
+    @pytest.mark.parametrize(
+        "tool_filter",
+        [
+            {"include_tools": []},
+            {"include_tools": ["get_latest_emails"]},
+            {"exclude_tools": ["send_email_to_self"]},
+        ],
+        ids=["empty-include", "omitted-from-include", "explicitly-excluded"],
+    )
+    def test_send_email_to_self_respects_tool_filters(
+        self,
+        mock_credentials_manager: CredentialsManager,
+        runtime_paths: RuntimePaths,
+        tool_filter: dict[str, list[str]],
+    ) -> None:
+        """Agno include and exclude filters apply to the local function."""
+        gmail_tools = GmailTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=mock_credentials_manager,
+            **tool_filter,
+        )
+
+        assert "send_email_to_self" not in gmail_tools.functions
+
+    def test_send_email_to_self_rejects_recipient_header_injection(
+        self,
+        mock_credentials_manager: CredentialsManager,
+        runtime_paths: RuntimePaths,
+    ) -> None:
+        """Subject text must not provide another recipient header."""
+        gmail_tools = GmailTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=mock_credentials_manager,
+            send_email=False,
+        )
+        service = MagicMock()
+        service.users.return_value.getProfile.return_value.execute.return_value = {
+            "emailAddress": "owner@example.com",
+        }
+        gmail_tools.service = service
+
+        result = gmail_tools.functions["send_email_to_self"].entrypoint(
+            subject="Status\nBcc: other@example.com",
+            body="Finished",
+        )
+
+        assert result.startswith("Error sending email:")
+        service.users.return_value.messages.return_value.send.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "profile",
+        [
+            None,
+            {},
+            {"emailAddress": None},
+            {"emailAddress": ""},
+            {"emailAddress": "first@example.com,second@example.com"},
+            {"emailAddress": " owner@example.com"},
+            {"emailAddress": "owner@example.com\n"},
+        ],
+    )
+    def test_send_email_to_self_rejects_ambiguous_profile_address(
+        self,
+        mock_credentials_manager: CredentialsManager,
+        runtime_paths: RuntimePaths,
+        profile: object,
+    ) -> None:
+        """Missing, multiple, or padded profile addresses must fail closed."""
+        gmail_tools = GmailTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=mock_credentials_manager,
+            send_email=False,
+        )
+        service = MagicMock()
+        service.users.return_value.getProfile.return_value.execute.return_value = profile
+        gmail_tools.service = service
+
+        with pytest.raises(RuntimeError, match="valid email address"):
+            gmail_tools.functions["send_email_to_self"].entrypoint(subject="Status", body="Finished")
+
+        service.users.return_value.messages.return_value.send.assert_not_called()
+
+    def test_send_email_to_self_follows_configured_approval_policy(
+        self,
+        mock_credentials_manager: CredentialsManager,
+        runtime_paths: RuntimePaths,
+    ) -> None:
+        """Self-send must not override the operator's approval policy."""
+        gmail_tools = GmailTools(
+            runtime_paths=runtime_paths,
+            credentials_manager=mock_credentials_manager,
+        )
+
+        result = apply_tool_approval_capability(
+            gmail_tools,
+            Config.model_validate({"tool_approval": {"default": "require_approval"}}),
+            supports_native_tool_approval=True,
+            registered_tool_name="gmail",
+        )
+
+        assert result is gmail_tools
+        assert gmail_tools.functions["send_email_to_self"].requires_confirmation is True
+        assert gmail_tools.functions["send_email"].requires_confirmation is True
+
+    def test_gmail_metadata_advertises_send_email_to_self(self) -> None:
+        """The built-in Gmail configuration must expose the self-send function."""
+        from mindroom.tool_system.catalog import TOOL_METADATA  # noqa: PLC0415
+        from mindroom.tools import gmail as _gmail_registration  # noqa: F401, PLC0415
+
+        assert "send_email_to_self" in TOOL_METADATA["gmail"].function_names
 
 
 class _GmailBatch:


### PR DESCRIPTION
## Summary

- add `send_email_to_self(subject, body)` to the built-in Gmail toolkit
- derive the sole recipient from the connected Gmail profile
- preserve normal tool approval policy so operators can configure self-send separately
- preserve Gmail scope and function-filter behavior

## Testing

- `uv run pytest -q tests/test_gmail_tools.py`
- `uv run pytest -n 0 --no-cov -q`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Enable Gmail users to send concise, approval-controlled messages to their connected account.

New Features:
- Add a Gmail tool for sending an email to the connected account without accepting recipient, CC, BCC, or attachment inputs.

Enhancements:
- Restrict the self-send tool to Gmail connections with compatible profile and sending scopes while preserving existing tools.
- Apply existing Gmail tool filters and approval policies to the self-send function.

Documentation:
- Document the new self-send function and add a usage example to the Gmail toolkit documentation.

Tests:
- Add coverage for recipient derivation, scope handling, tool filtering, approval behavior, profile validation, and message safety.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to send an email directly to the connected Gmail account using only a subject and message body.
  * The recipient is automatically derived from the connected profile, with validation for account and message safety.
  * The feature is available only when the required Gmail permissions are granted.

* **Improvements**
  * Self-addressed emails now follow configured approval policies and can be managed separately from other email actions.
  * Updated Gmail documentation with usage details and examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->