### PR TITLE
Reuse local sentence transformer model clients

### DIFF
--- a/src/mindroom/embeddings.py
+++ b/src/mindroom/embeddings.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 _SENTENCE_TRANSFORMERS_DEPENDENCIES = ["sentence-transformers"]
 _SENTENCE_TRANSFORMERS_EXTRA = "sentence_transformers"
-_SENTENCE_TRANSFORMER_CLIENTS: dict[str, Any] = {}
+_SENTENCE_TRANSFORMER_CLIENT: tuple[str, Any] | None = None
 
 #: One torch model per process is shared by every indexing thread, and torch's
 #: Metal shader-library caches (``libMap``, ``cplMap``, ``kernelCache`` in
@@ -111,16 +111,17 @@ def create_sentence_transformers_embedder(
     dimensions: int | None = None,
 ) -> Embedder:
     """Create a local sentence-transformers embedder after ensuring its optional extra exists."""
-    ensure_sentence_transformers_dependencies(runtime_paths)
-    embedder_class = _serialized_sentence_transformers_class()
-    kwargs: dict[str, Any] = {"id": model}
-    if dimensions is not None:
-        kwargs["dimensions"] = dimensions
-
     with _LOCAL_EMBEDDING_LOCK:
-        client = _SENTENCE_TRANSFORMER_CLIENTS.get(model)
-        if client is None:
+        ensure_sentence_transformers_dependencies(runtime_paths)
+        embedder_class = _serialized_sentence_transformers_class()
+        kwargs: dict[str, Any] = {"id": model}
+        if dimensions is not None:
+            kwargs["dimensions"] = dimensions
+
+        global _SENTENCE_TRANSFORMER_CLIENT
+        if _SENTENCE_TRANSFORMER_CLIENT is None or _SENTENCE_TRANSFORMER_CLIENT[0] != model:
             embedder = cast("Any", embedder_class(**kwargs))
-            _SENTENCE_TRANSFORMER_CLIENTS[model] = embedder.sentence_transformer_client
+            _SENTENCE_TRANSFORMER_CLIENT = (model, embedder.sentence_transformer_client)
             return cast("Embedder", embedder)
+        client = _SENTENCE_TRANSFORMER_CLIENT[1]
         return embedder_class(**kwargs, sentence_transformer_client=client)

--- a/src/mindroom/embeddings.py
+++ b/src/mindroom/embeddings.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 _SENTENCE_TRANSFORMERS_DEPENDENCIES = ["sentence-transformers"]
 _SENTENCE_TRANSFORMERS_EXTRA = "sentence_transformers"
+_SENTENCE_TRANSFORMER_CLIENTS: dict[str, Any] = {}
 
 #: One torch model per process is shared by every indexing thread, and torch's
 #: Metal shader-library caches (``libMap``, ``cplMap``, ``kernelCache`` in
@@ -112,6 +113,14 @@ def create_sentence_transformers_embedder(
     """Create a local sentence-transformers embedder after ensuring its optional extra exists."""
     ensure_sentence_transformers_dependencies(runtime_paths)
     embedder_class = _serialized_sentence_transformers_class()
-    if dimensions is None:
-        return embedder_class(id=model)
-    return embedder_class(id=model, dimensions=dimensions)
+    kwargs: dict[str, Any] = {"id": model}
+    if dimensions is not None:
+        kwargs["dimensions"] = dimensions
+
+    with _LOCAL_EMBEDDING_LOCK:
+        client = _SENTENCE_TRANSFORMER_CLIENTS.get(model)
+        if client is None:
+            embedder = cast("Any", embedder_class(**kwargs))
+            _SENTENCE_TRANSFORMER_CLIENTS[model] = embedder.sentence_transformer_client
+            return cast("Embedder", embedder)
+        return embedder_class(**kwargs, sentence_transformer_client=client)

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -191,6 +191,7 @@ def test_sentence_transformers_embedder_reuses_one_model_client_across_concurren
         ) -> None:
             nonlocal model_constructions
             self.id = kwargs["id"]
+            self.dimensions = kwargs.get("dimensions")
             if sentence_transformer_client is None:
                 with construction_lock:
                     model_constructions += 1
@@ -210,6 +211,7 @@ def test_sentence_transformers_embedder_reuses_one_model_client_across_concurren
                 lambda _index: create_sentence_transformers_embedder(
                     TEST_RUNTIME_PATHS,
                     "sentence-transformers/cache-regression-test",
+                    dimensions=384 if _index % 2 == 0 else 768,
                 ),
                 range(8),
             ),
@@ -219,6 +221,7 @@ def test_sentence_transformers_embedder_reuses_one_model_client_across_concurren
     assert max_dependency_checks_active == 1
     assert len({id(embedder) for embedder in embedders}) == 8
     assert len({id(embedder.sentence_transformer_client) for embedder in embedders}) == 1
+    assert {embedder.dimensions for embedder in embedders} == {384, 768}
 
 
 def test_sentence_transformers_embedder_releases_retired_cached_model(
@@ -254,6 +257,46 @@ def test_sentence_transformers_embedder_releases_retired_cached_model(
     del old_embedder, old_client
     gc.collect()
     assert old_client_ref() is None
+
+
+def test_sentence_transformers_embedder_retries_failed_model_replacement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed replacement should preserve the old client and allow retry."""
+    reject_new_model = True
+
+    class DummyEmbedder:
+        def __init__(
+            self,
+            *,
+            sentence_transformer_client: object | None = None,
+            **kwargs: object,
+        ) -> None:
+            if kwargs["id"] == "sentence-transformers/new" and reject_new_model:
+                error_message = "model load failed"
+                raise RuntimeError(error_message)
+            self.sentence_transformer_client = sentence_transformer_client or object()
+
+    monkeypatch.setattr("mindroom.embeddings.ensure_sentence_transformers_dependencies", lambda _paths: None)
+    monkeypatch.setattr(
+        "mindroom.embeddings.importlib.import_module",
+        lambda _name: SimpleNamespace(SentenceTransformerEmbedder=DummyEmbedder),
+    )
+
+    old_embedder = create_sentence_transformers_embedder(TEST_RUNTIME_PATHS, "sentence-transformers/old")
+
+    with pytest.raises(RuntimeError, match="model load failed"):
+        create_sentence_transformers_embedder(TEST_RUNTIME_PATHS, "sentence-transformers/new")
+
+    old_embedder_after_failure = create_sentence_transformers_embedder(
+        TEST_RUNTIME_PATHS,
+        "sentence-transformers/old",
+    )
+    assert old_embedder_after_failure.sentence_transformer_client is old_embedder.sentence_transformer_client
+
+    reject_new_model = False
+    new_embedder = create_sentence_transformers_embedder(TEST_RUNTIME_PATHS, "sentence-transformers/new")
+    assert new_embedder.sentence_transformer_client is not old_embedder.sentence_transformer_client
 
 
 class _ConcurrencyProbe:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import gc
 import threading
 import time
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
@@ -11,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+import mindroom.embeddings as embedding_helpers
 from mindroom.constants import resolve_primary_runtime_paths
 from mindroom.embeddings import (
     create_sentence_transformers_embedder,
@@ -21,6 +24,11 @@ from mindroom.model_defaults import OPENAI_EMBEDDING_LARGE, SENTENCE_TRANSFORMER
 from mindroom.openai_embedder import MindRoomOpenAIEmbedder
 
 TEST_RUNTIME_PATHS = resolve_primary_runtime_paths(config_path=Path("config.yaml"))
+
+
+@pytest.fixture(autouse=True)
+def _isolate_sentence_transformer_client_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(embedding_helpers, "_SENTENCE_TRANSFORMER_CLIENT", None)
 
 
 def _mock_openai_client() -> MagicMock:
@@ -161,7 +169,18 @@ def test_sentence_transformers_embedder_reuses_one_model_client_across_concurren
 ) -> None:
     """Concurrent index handles should share one expensive local model client."""
     construction_lock = threading.Lock()
+    dependency_checks_active = 0
+    max_dependency_checks_active = 0
     model_constructions = 0
+
+    def _ensure(_runtime_paths: object) -> None:
+        nonlocal dependency_checks_active, max_dependency_checks_active
+        with construction_lock:
+            dependency_checks_active += 1
+            max_dependency_checks_active = max(max_dependency_checks_active, dependency_checks_active)
+        time.sleep(0.02)
+        with construction_lock:
+            dependency_checks_active -= 1
 
     class DummyEmbedder:
         def __init__(
@@ -179,7 +198,7 @@ def test_sentence_transformers_embedder_reuses_one_model_client_across_concurren
                 sentence_transformer_client = object()
             self.sentence_transformer_client = sentence_transformer_client
 
-    monkeypatch.setattr("mindroom.embeddings.ensure_sentence_transformers_dependencies", lambda _paths: None)
+    monkeypatch.setattr("mindroom.embeddings.ensure_sentence_transformers_dependencies", _ensure)
     monkeypatch.setattr(
         "mindroom.embeddings.importlib.import_module",
         lambda _name: SimpleNamespace(SentenceTransformerEmbedder=DummyEmbedder),
@@ -197,8 +216,44 @@ def test_sentence_transformers_embedder_reuses_one_model_client_across_concurren
         )
 
     assert model_constructions == 1
+    assert max_dependency_checks_active == 1
     assert len({id(embedder) for embedder in embedders}) == 8
     assert len({id(embedder.sentence_transformer_client) for embedder in embedders}) == 1
+
+
+def test_sentence_transformers_embedder_releases_retired_cached_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Switching the active model should not permanently retain the old client."""
+
+    class ModelClient:
+        pass
+
+    class DummyEmbedder:
+        def __init__(
+            self,
+            *,
+            sentence_transformer_client: object | None = None,
+            **_kwargs: object,
+        ) -> None:
+            self.sentence_transformer_client = sentence_transformer_client or ModelClient()
+
+    monkeypatch.setattr("mindroom.embeddings.ensure_sentence_transformers_dependencies", lambda _paths: None)
+    monkeypatch.setattr(
+        "mindroom.embeddings.importlib.import_module",
+        lambda _name: SimpleNamespace(SentenceTransformerEmbedder=DummyEmbedder),
+    )
+
+    old_embedder = create_sentence_transformers_embedder(TEST_RUNTIME_PATHS, "sentence-transformers/old")
+    old_client = old_embedder.sentence_transformer_client
+    old_client_ref = weakref.ref(old_client)
+
+    new_embedder = create_sentence_transformers_embedder(TEST_RUNTIME_PATHS, "sentence-transformers/new")
+
+    assert new_embedder.sentence_transformer_client is not old_client
+    del old_embedder, old_client
+    gc.collect()
+    assert old_client_ref() is None
 
 
 class _ConcurrencyProbe:

--- a/tests/test_embeddings.py
+++ b/tests/test_embeddings.py
@@ -131,6 +131,7 @@ def test_create_sentence_transformers_embedder_auto_installs_optional_runtime(
     class DummyEmbedder:
         def __init__(self, **kwargs: object) -> None:
             self.kwargs = kwargs
+            self.sentence_transformer_client = kwargs.get("sentence_transformer_client", object())
 
     def _ensure(runtime_paths: object) -> None:
         captured["installed"] = runtime_paths
@@ -155,6 +156,51 @@ def test_create_sentence_transformers_embedder_auto_installs_optional_runtime(
     }
 
 
+def test_sentence_transformers_embedder_reuses_one_model_client_across_concurrent_construction(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Concurrent index handles should share one expensive local model client."""
+    construction_lock = threading.Lock()
+    model_constructions = 0
+
+    class DummyEmbedder:
+        def __init__(
+            self,
+            *,
+            sentence_transformer_client: object | None = None,
+            **kwargs: object,
+        ) -> None:
+            nonlocal model_constructions
+            self.id = kwargs["id"]
+            if sentence_transformer_client is None:
+                with construction_lock:
+                    model_constructions += 1
+                time.sleep(0.02)
+                sentence_transformer_client = object()
+            self.sentence_transformer_client = sentence_transformer_client
+
+    monkeypatch.setattr("mindroom.embeddings.ensure_sentence_transformers_dependencies", lambda _paths: None)
+    monkeypatch.setattr(
+        "mindroom.embeddings.importlib.import_module",
+        lambda _name: SimpleNamespace(SentenceTransformerEmbedder=DummyEmbedder),
+    )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        embedders = list(
+            pool.map(
+                lambda _index: create_sentence_transformers_embedder(
+                    TEST_RUNTIME_PATHS,
+                    "sentence-transformers/cache-regression-test",
+                ),
+                range(8),
+            ),
+        )
+
+    assert model_constructions == 1
+    assert len({id(embedder) for embedder in embedders}) == 8
+    assert len({id(embedder.sentence_transformer_client) for embedder in embedders}) == 1
+
+
 class _ConcurrencyProbe:
     """Record the highest number of callers inside the embedder at once."""
 
@@ -177,6 +223,7 @@ def _probed_local_embedder(monkeypatch: pytest.MonkeyPatch, probe: _ConcurrencyP
     class DummyEmbedder:
         def __init__(self, **kwargs: object) -> None:
             self.kwargs = kwargs
+            self.sentence_transformer_client = kwargs.get("sentence_transformer_client", object())
 
         def get_embedding(self, text: str) -> list[float]:
             probe.observe()
@@ -201,8 +248,8 @@ def test_sentence_transformers_usage_delegation_does_not_deadlock(
     """Agno's usage method may delegate back through the serialized embedding entry point."""
 
     class DelegatingEmbedder:
-        def __init__(self, **_kwargs: object) -> None:
-            pass
+        def __init__(self, **kwargs: object) -> None:
+            self.sentence_transformer_client = kwargs.get("sentence_transformer_client", object())
 
         def get_embedding(self, text: str) -> list[float]:
             return [float(len(text))]


### PR DESCRIPTION
## Summary

- Reuse an already-loaded local model client across embedder wrappers.
- Serialize cache access and keep the cached model set bounded.
- Cover reuse, concurrency, model switching, dimensions, and failed initialization.

## Testing

- `uv run pytest`
- `uv run pre-commit run --all-files`

## Summary by Sourcery

Reuse local sentence-transformer clients safely across concurrent embedder construction while preserving recovery when model initialization fails.

Bug Fixes:
- Reuse a loaded local sentence-transformer model client across embedder instances while correctly handling model changes and failed replacement attempts.

Enhancements:
- Serialize local sentence-transformer initialization to prevent duplicate concurrent model loading and ensure retired clients can be released.

Tests:
- Add coverage for concurrent client reuse, embedder dimensions, model switching, garbage collection of retired clients, and retrying failed model initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved sentence-transformer embedding initialization by reusing loaded models for repeated requests.
  * Serialized concurrent model setup to avoid duplicate loading.
* **Reliability**
  * Improved recovery after model-loading failures.
  * Ensured previously cached clients are released when switching models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->