### PR TITLE
docs: link each agno 3 override to its upstream issue and fix

### DIFF
--- a/src/mindroom/agent_storage.py
+++ b/src/mindroom/agent_storage.py
@@ -262,6 +262,10 @@ class _ConversationSqliteDb(SqliteDb):
         redaction), after which that position collides with the indexes stored
         rows keep, so new rows take ``MAX(run_index) + 1`` instead and existing
         rows keep their index either way.
+
+        Upstream: agno-agi/agno#9936, fixed by agno-agi/agno#9938 (or the wider
+        agno-agi/agno#9342). Once the pinned agno includes either, drop this
+        override and pass ``run_index`` through.
         """
         del run_index
         super().upsert_run(
@@ -279,6 +283,10 @@ class _ConversationSqliteDb(SqliteDb):
         table does not exist yet (the state of a 2.x database nothing has
         appended to). A legacy run that survives the scrub comes back on the
         next read, so a redaction must either remove it everywhere or fail.
+
+        Upstream: agno-agi/agno#9934, fixed by agno-agi/agno#9939. Once the
+        pinned agno includes it, the blob scrub below can go; the descendant
+        expansion over the runs table stays (agno deletes only the given ids).
         """
         if not run_ids:
             return
@@ -329,6 +337,9 @@ class _ConversationSqliteDb(SqliteDb):
         ``user_id``, so a batch could hand another user's session to a new
         owner. Nothing in MindRoom or Agno's runtime calls this in bulk, so the
         per-row path costs nothing.
+
+        Upstream: agno-agi/agno#9935, fixed by agno-agi/agno#9937. Once the
+        pinned agno includes it, delete this override and ``_restore_updated_at``.
         """
         accepted: list[Session | dict[str, Any]] = []
         for session in sessions:

--- a/src/mindroom/agno_session_persistence_patch.py
+++ b/src/mindroom/agno_session_persistence_patch.py
@@ -37,6 +37,12 @@ type _PersistenceTarget = tuple[str, str]
 # Agno 3.0 splits one session save into a session-row write (``asave_session``) and
 # per-run writes (``asave_run``); both call the synchronous SQLite adapter directly,
 # so both are offloaded through the same FIFO lane to keep their order.
+# When bumping this pin, check whether these upstream fixes are included and delete
+# the matching MindRoom override (each is linked from its own docstring):
+#   agno-agi/agno#9939  delete_runs scrubs the 2.x blob atomically  -> agent_storage delete_runs blob part
+#   agno-agi/agno#9937  bulk upsert owner check                     -> agent_storage upsert_sessions
+#   agno-agi/agno#9938  run_index never below MAX+1 (or #9342)      -> agent_storage upsert_run
+#   agno-agi/agno#9941  validate_call wrappers drop the caller frame -> agno_tool_wrapper_patch
 _SUPPORTED_AGNO_VERSION = "3.0.5"
 _ORIGINAL_AGENT_ASAVE_SESSION = agent_session.asave_session
 _ORIGINAL_AGENT_SAVE_SESSION = agent_session.save_session

--- a/src/mindroom/agno_tool_wrapper_patch.py
+++ b/src/mindroom/agno_tool_wrapper_patch.py
@@ -10,6 +10,10 @@ was first wrapped, for as long as the cache entry lived.
 
 The validators are built eagerly, so the namespace is dead weight once the
 wrapper exists and is replaced with an empty resolver.
+
+Upstream: agno-agi/agno#9940, fixed by agno-agi/agno#9941. Once the pinned agno
+includes it, delete this module, its test, and the ``apply_patch()`` call in
+``tool_system/tool_hooks.py``.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Comments only. Follow-up to #1944.

Four of the agno 3 seams MindRoom carries are now reported upstream with fixes attached. Each override's docstring names its issue and PR and says exactly what to delete once the pinned agno includes the fix, and `_SUPPORTED_AGNO_VERSION` carries the checklist so a bump cannot miss them.

| MindRoom override | Upstream issue | Upstream fix | Delete when merged |
|---|---|---|---|
| `_ConversationSqliteDb.delete_runs` blob scrub | agno-agi/agno#9934 | agno-agi/agno#9939 | the blob branch and `_dicts_without` / `_string_field` / `_decode_legacy_runs`; descendant expansion over the runs table stays |
| `_ConversationSqliteDb.upsert_sessions` per-row loop | agno-agi/agno#9935 | agno-agi/agno#9937 | the override and `_restore_updated_at` |
| `_ConversationSqliteDb.upsert_run` with `run_index=None` | agno-agi/agno#9936 | agno-agi/agno#9938 (or the wider agno-agi/agno#9342) | pass `run_index` through, keep prompt-role stripping |
| `agno_tool_wrapper_patch` | agno-agi/agno#9940 | agno-agi/agno#9941 | the module, its test, and the `apply_patch()` call in `tool_system/tool_hooks.py` |

Not reported upstream (design choices or already tracked elsewhere): the WAL listener swap, `MigrationManager` class-name dispatch, `agno_team_patch` (older report), agno-agi/agno#8970.

## Summary by Sourcery

Link Agno compatibility workarounds to their upstream fixes and document when they can be removed.

Enhancements:
- Document the upstream issues and fixes associated with Agno compatibility overrides, including explicit removal guidance for each workaround.

Documentation:
- Add an Agno version-bump checklist linking each temporary override to its upstream fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added maintenance notes linking local compatibility workarounds to relevant upstream fixes and identifying when they can be removed.
  * Documented the tool-wrapper memory handling workaround and its upstream resolution path.

* **Bug Fixes**
  * Improved tool-wrapper cleanup to prevent caller-frame namespaces from being retained unnecessarily.
  * Added support for cleaning up wrappers used by asynchronous generator tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->