### PR TITLE
fix: migrate legacy sessions after startup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,6 +153,7 @@ Matrix sync callback
 | `ai_runtime.py` | Agent-run input preparation and queued-notice hooks |
 | `provider_media_fallback.py` | Provider-boundary inline-media retry and process-local capability learning per model route |
 | `agent_storage.py` | Agent session and learning SQLite storage helpers |
+| `legacy_session_migration.py` | Background retirement of Agno 2 session run blobs |
 | `agent_descriptions.py` | Shared agent description rendering for delegation and orchestration |
 | `credentials.py` | Unified credential management (CredentialsManager) |
 | `matrix/` | Matrix protocol integration (client, users, rooms, presence, provisioning, message formatting) |

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -58,6 +58,7 @@ MindRoom's architecture consists of several key components working together.
 | `model_loading.py` | Authoritative model instantiation and provider-specific loader selection |
 | `ai_runtime.py` | Agent-run input preparation and queued-notice hooks |
 | `agent_storage.py` | Agent session and learning SQLite storage construction helpers |
+| `legacy_session_migration.py` | Post-readiness retirement of Agno 2 session run blobs |
 | `agent_descriptions.py` | Shared agent description rendering for routing and delegation |
 | `agent_policy.py` | Derives canonical execution policies from authored agent config |
 | `workspaces.py` | Agent workspace scaffolding, template seeding, context file resolution |

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -79,7 +79,7 @@ main() entry
 
 ## Session Storage Upgrades
 
-After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Invalid or conflicting blobs stay intact on the compatibility read path and are reported in the normal logs for a later retry.
+After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Logs report each table's total, progress every 100 sessions, and completion. Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
 
 The now-empty legacy column is retained, matching Agno's v3 migration behavior. Removing it is a separate explicit cleanup because changing a live SQLite table can block writes.
 

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -81,7 +81,7 @@ main() entry
 
 After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Logs report each table's total, progress every 100 sessions, and completion. Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
 
-The now-empty legacy column is retained, matching Agno's v3 migration behavior. Removing it is a separate explicit cleanup because changing a live SQLite table can block writes.
+The legacy column is cleared for successfully migrated sessions and retained for compatibility reads when migration fails. Removing the column is a separate explicit cleanup because changing a live SQLite table can block writes.
 
 ## Runtime Replacement Admission
 

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -77,6 +77,12 @@ main() entry
 - **Sync loops**: Each bot runs `sync_forever_with_restart()` with automatic retry; the default `matrix_sync.mode: classic` uses classic `/v3/sync` and `matrix_sync.mode: sliding` opts into MSC4186 Simplified Sliding Sync
 - **Internal user identity**: `mindroom_user.username` is the account-creation request; runtime authorization uses the persisted actual Matrix ID
 
+## Session Storage Upgrades
+
+After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Invalid or conflicting blobs stay intact on the compatibility read path and are reported in the normal logs for a later retry.
+
+The now-empty legacy column is retained, matching Agno's v3 migration behavior. Removing it is a separate explicit cleanup because changing a live SQLite table can block writes.
+
 ## Runtime Replacement Admission
 
 Config changes are detected via polling (`watch_paths()` checks watched source-file mtimes every second and fires after one quiet scan).

--- a/docs/architecture/orchestration.md
+++ b/docs/architecture/orchestration.md
@@ -79,9 +79,14 @@ main() entry
 
 ## Session Storage Upgrades
 
-After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Logs report each table's total, progress every 100 sessions, and completion. Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
+After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop.
+A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction.
+The runtime remains available throughout.
+Logs report each table's total, progress every 100 sessions, and completion.
+Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
 
-The legacy column is cleared for successfully migrated sessions and retained for compatibility reads when migration fails. Removing the column is a separate explicit cleanup because changing a live SQLite table can block writes.
+The legacy column is cleared for successfully migrated sessions and retained for compatibility reads when migration fails.
+Removing the column is a separate explicit cleanup because changing a live SQLite table can block writes.
 
 ## Runtime Replacement Admission
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16849,6 +16849,7 @@ MindRoom's architecture consists of several key components working together.
 | `model_loading.py` | Authoritative model instantiation and provider-specific loader selection |
 | `ai_runtime.py` | Agent-run input preparation and queued-notice hooks |
 | `agent_storage.py` | Agent session and learning SQLite storage construction helpers |
+| `legacy_session_migration.py` | Post-readiness retirement of Agno 2 session run blobs |
 | `agent_descriptions.py` | Shared agent description rendering for routing and delegation |
 | `agent_policy.py` | Derives canonical execution policies from authored agent config |
 | `workspaces.py` | Agent workspace scaffolding, template seeding, context file resolution |
@@ -17262,6 +17263,12 @@ main() entry
 - **Room setup** (`_setup_rooms_and_memberships`): Router creates rooms, invites agents, teams, and users, then bots join
 - **Sync loops**: Each bot runs `sync_forever_with_restart()` with automatic retry; the default `matrix_sync.mode: classic` uses classic `/v3/sync` and `matrix_sync.mode: sliding` opts into MSC4186 Simplified Sliding Sync
 - **Internal user identity**: `mindroom_user.username` is the account-creation request; runtime authorization uses the persisted actual Matrix ID
+
+## Session Storage Upgrades
+
+After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Invalid or conflicting blobs stay intact on the compatibility read path and are reported in the normal logs for a later retry.
+
+The now-empty legacy column is retained, matching Agno's v3 migration behavior. Removing it is a separate explicit cleanup because changing a live SQLite table can block writes.
 
 ## Runtime Replacement Admission
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17266,9 +17266,14 @@ main() entry
 
 ## Session Storage Upgrades
 
-After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Logs report each table's total, progress every 100 sessions, and completion. Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
+After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop.
+A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction.
+The runtime remains available throughout.
+Logs report each table's total, progress every 100 sessions, and completion.
+Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
 
-The legacy column is cleared for successfully migrated sessions and retained for compatibility reads when migration fails. Removing the column is a separate explicit cleanup because changing a live SQLite table can block writes.
+The legacy column is cleared for successfully migrated sessions and retained for compatibility reads when migration fails.
+Removing the column is a separate explicit cleanup because changing a live SQLite table can block writes.
 
 ## Runtime Replacement Admission
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17268,7 +17268,7 @@ main() entry
 
 After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Logs report each table's total, progress every 100 sessions, and completion. Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
 
-The now-empty legacy column is retained, matching Agno's v3 migration behavior. Removing it is a separate explicit cleanup because changing a live SQLite table can block writes.
+The legacy column is cleared for successfully migrated sessions and retained for compatibility reads when migration fails. Removing the column is a separate explicit cleanup because changing a live SQLite table can block writes.
 
 ## Runtime Replacement Admission
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17266,7 +17266,7 @@ main() entry
 
 ## Session Storage Upgrades
 
-After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Invalid or conflicting blobs stay intact on the compatibility read path and are reported in the normal logs for a later retry.
+After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Logs report each table's total, progress every 100 sessions, and completion. Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
 
 The now-empty legacy column is retained, matching Agno's v3 migration behavior. Removing it is a separate explicit cleanup because changing a live SQLite table can block writes.
 

--- a/skills/mindroom-docs/references/page__architecture__index.md
+++ b/skills/mindroom-docs/references/page__architecture__index.md
@@ -54,6 +54,7 @@ MindRoom's architecture consists of several key components working together.
 | `model_loading.py` | Authoritative model instantiation and provider-specific loader selection |
 | `ai_runtime.py` | Agent-run input preparation and queued-notice hooks |
 | `agent_storage.py` | Agent session and learning SQLite storage construction helpers |
+| `legacy_session_migration.py` | Post-readiness retirement of Agno 2 session run blobs |
 | `agent_descriptions.py` | Shared agent description rendering for routing and delegation |
 | `agent_policy.py` | Derives canonical execution policies from authored agent config |
 | `workspaces.py` | Agent workspace scaffolding, template seeding, context file resolution |

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -75,9 +75,14 @@ main() entry
 
 ## Session Storage Upgrades
 
-After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Logs report each table's total, progress every 100 sessions, and completion. Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
+After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop.
+A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction.
+The runtime remains available throughout.
+Logs report each table's total, progress every 100 sessions, and completion.
+Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
 
-The legacy column is cleared for successfully migrated sessions and retained for compatibility reads when migration fails. Removing the column is a separate explicit cleanup because changing a live SQLite table can block writes.
+The legacy column is cleared for successfully migrated sessions and retained for compatibility reads when migration fails.
+Removing the column is a separate explicit cleanup because changing a live SQLite table can block writes.
 
 ## Runtime Replacement Admission
 

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -73,6 +73,12 @@ main() entry
 - **Sync loops**: Each bot runs `sync_forever_with_restart()` with automatic retry; the default `matrix_sync.mode: classic` uses classic `/v3/sync` and `matrix_sync.mode: sliding` opts into MSC4186 Simplified Sliding Sync
 - **Internal user identity**: `mindroom_user.username` is the account-creation request; runtime authorization uses the persisted actual Matrix ID
 
+## Session Storage Upgrades
+
+After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Invalid or conflicting blobs stay intact on the compatibility read path and are reported in the normal logs for a later retry.
+
+The now-empty legacy column is retained, matching Agno's v3 migration behavior. Removing it is a separate explicit cleanup because changing a live SQLite table can block writes.
+
 ## Runtime Replacement Admission
 
 Config changes are detected via polling (`watch_paths()` checks watched source-file mtimes every second and fires after one quiet scan).

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -75,7 +75,7 @@ main() entry
 
 ## Session Storage Upgrades
 
-After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Invalid or conflicting blobs stay intact on the compatibility read path and are reported in the normal logs for a later retry.
+After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Logs report each table's total, progress every 100 sessions, and completion. Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
 
 The now-empty legacy column is retained, matching Agno's v3 migration behavior. Removing it is a separate explicit cleanup because changing a live SQLite table can block writes.
 

--- a/skills/mindroom-docs/references/page__architecture__orchestration__index.md
+++ b/skills/mindroom-docs/references/page__architecture__orchestration__index.md
@@ -77,7 +77,7 @@ main() entry
 
 After the runtime becomes ready, MindRoom checks session databases for Agno 2 run blobs off the event loop. A child process starts only when legacy data exists, then migrates and verifies each session in its own transaction. The runtime remains available throughout. Logs report each table's total, progress every 100 sessions, and completion. Invalid or conflicting blobs stay intact on the compatibility read path and are reported for a later retry.
 
-The now-empty legacy column is retained, matching Agno's v3 migration behavior. Removing it is a separate explicit cleanup because changing a live SQLite table can block writes.
+The legacy column is cleared for successfully migrated sessions and retained for compatibility reads when migration fails. Removing the column is a separate explicit cleanup because changing a live SQLite table can block writes.
 
 ## Runtime Replacement Admission
 

--- a/src/mindroom/agent_storage.py
+++ b/src/mindroom/agent_storage.py
@@ -40,7 +40,9 @@ logger = get_logger(__name__)
 agno_session_persistence_patch.install_patch()
 
 __all__ = [
+    "configure_state_engine_pragmas",
     "create_session_storage",
+    "create_state_engine",
     "create_state_storage",
     "get_agent_runtime_state_dbs",
     "get_agent_session",
@@ -89,7 +91,7 @@ def create_state_storage(
     )
 
 
-def _state_engine(db_file: str) -> Engine:
+def create_state_engine(db_file: str) -> Engine:
     """Build an engine that waits for state-database locks before failing."""
     return create_engine(
         f"sqlite:///{db_file}",
@@ -116,7 +118,7 @@ def _create_sqlite_state_storage(
         prompt_roles=prompt_roles or frozenset(),
         session_table=session_table,
         db_file=db_file,
-        db_engine=_state_engine(db_file),
+        db_engine=create_state_engine(db_file),
     )
     agno_session_persistence_patch._register_sync_session_storage(
         database,
@@ -129,7 +131,7 @@ def _create_sqlite_state_storage(
 _AGNO_CONNECT_LISTENER_NAME = "_set_sqlite_pragmas"
 
 
-def _replace_agno_connection_pragmas(engine: Engine) -> None:
+def configure_state_engine_pragmas(engine: Engine) -> None:
     """Keep rollback journaling on state databases despite Agno 3 forcing WAL.
 
     Agno's ``SqliteDb`` registers a connect listener that switches every
@@ -210,9 +212,9 @@ class _ConversationSqliteDb(SqliteDb):
     ``upsert_run``, a full read in ``get_session``, an owner guard on bulk
     session writes, and an atomic ``delete_runs``.
 
-    A 2.x database keeps its ``runs`` blob column. Agno merges that blob into
-    every read; ``delete_runs`` scrubs deleted ids out of it in the same
-    transaction as the row delete. Nothing else rewrites the blob.
+    Until background migration retires a 2.x ``runs`` blob, Agno merges it into
+    every read and ``delete_runs`` scrubs deleted ids from both stores in one
+    transaction. A blob that cannot be migrated keeps using this safe fallback.
     """
 
     def __init__(
@@ -225,7 +227,7 @@ class _ConversationSqliteDb(SqliteDb):
     ) -> None:
         super().__init__(session_table=session_table, db_file=db_file, db_engine=db_engine)
         self._prompt_roles = prompt_roles
-        _replace_agno_connection_pragmas(db_engine)
+        configure_state_engine_pragmas(db_engine)
 
     def get_session(
         self,
@@ -306,9 +308,9 @@ class _ConversationSqliteDb(SqliteDb):
                     frontier = [child for child in children if child not in wanted]
                     wanted.update(frontier)
                 sess.execute(runs_table.delete().where(runs_table.c.run_id.in_(wanted)))
-            # --- 2.x legacy only: a sessions table that still has the ``runs`` blob column.
-            # Agno merges that blob into every read, so ids deleted above must leave it too.
-            # Goes away with the refuse-and-migrate gate (#1947).
+            # --- 2.x legacy only: a sessions table whose ``runs`` blob has not
+            # yet migrated (or was refused). Agno merges that blob into every
+            # read, so ids deleted above must leave it too.
             if sessions_table is None or "runs" not in sessions_table.c:
                 return
             rows = sess.execute(
@@ -366,7 +368,7 @@ class _ConversationSqliteDb(SqliteDb):
             )
 
 
-# --- 2.x legacy blob helpers. Only ``delete_runs`` above uses them; delete with #1947.
+# --- 2.x legacy blob helpers used by the safe fallback in ``delete_runs`` above.
 
 
 def _string_field(entry: object, key: str) -> str | None:

--- a/src/mindroom/legacy_session_migration.py
+++ b/src/mindroom/legacy_session_migration.py
@@ -77,7 +77,7 @@ def _decode_legacy_runs(blob: object) -> list[dict[str, Any]]:
 
 
 def _legacy_session_tables(db_file: Path) -> list[str]:
-    """Return session tables in one SQLite file that still carry legacy run data."""
+    """Return session tables in one SQLite file that still have a legacy runs column."""
     connection = sqlite3.connect(f"{db_file.resolve().as_uri()}?mode=ro", uri=True, timeout=30)
     try:
         tables = [
@@ -88,9 +88,9 @@ def _legacy_session_tables(db_file: Path) -> list[str]:
         return [
             table
             for table in tables
-            if "runs" in {row[1] for row in connection.execute(f"PRAGMA table_info({_quote_identifier(table)})")}
-            and connection.execute(
-                f"SELECT 1 FROM {_quote_identifier(table)} WHERE runs IS NOT NULL LIMIT 1",  # noqa: S608
+            if connection.execute(
+                "SELECT 1 FROM pragma_table_info(?) WHERE name = 'runs'",
+                (table,),
             ).fetchone()
             is not None
         ]
@@ -247,6 +247,8 @@ def _migrate_table(db_file: Path, session_table: str) -> _MigrationResult:
                     text(f"SELECT session_id FROM {quoted_table} WHERE runs IS NOT NULL ORDER BY session_id"),  # noqa: S608
                 ).scalars(),
             )
+        if not session_ids:
+            return result
         for session_id in session_ids:
             try:
                 migrated = _migrate_session(database, runs_table, session_id)

--- a/src/mindroom/legacy_session_migration.py
+++ b/src/mindroom/legacy_session_migration.py
@@ -280,7 +280,7 @@ def _migrate_table(db_file: Path, session_table: str) -> _MigrationResult:
                     db_file=str(db_file),
                     session_table=session_table,
                     session_id=session_id,
-                    error=str(exc),
+                    error=str(exc) if isinstance(exc, _MigrationRefusedError) else type(exc).__name__,
                 )
                 result += _MigrationResult(failed_sessions=1)
             else:

--- a/src/mindroom/legacy_session_migration.py
+++ b/src/mindroom/legacy_session_migration.py
@@ -5,21 +5,20 @@ from __future__ import annotations
 import asyncio
 import json
 import multiprocessing
-import sqlite3
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
 from agno.db.sqlite import SqliteDb
 from agno.db.utils import build_single_run_row
-from sqlalchemy import bindparam, select, text, update
+from sqlalchemy import MetaData, Table, bindparam, inspect, null, select, text, update
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from mindroom.agent_storage import configure_state_engine_pragmas, create_state_engine
-from mindroom.logging_config import get_logger
+from mindroom.constants import RuntimePaths
+from mindroom.logging_config import get_logger, setup_logging
 
 if TYPE_CHECKING:
-    from sqlalchemy import Table
     from sqlalchemy.orm import Session as OrmSession
 
 logger = get_logger(__name__)
@@ -53,11 +52,7 @@ def _refuse(reason: str) -> NoReturn:
     raise _MigrationRefusedError(reason)
 
 
-def _quote_identifier(name: str) -> str:
-    return '"' + name.replace('"', '""') + '"'
-
-
-def _decode_legacy_runs(blob: object) -> list[dict[str, Any]]:
+def _validated_legacy_runs(blob: object) -> list[dict[str, Any]]:
     """Decode both JSON layers written by Agno 2 and require stable run identities."""
     decoded = blob
     try:
@@ -76,26 +71,42 @@ def _decode_legacy_runs(blob: object) -> list[dict[str, Any]]:
     return runs
 
 
-def _legacy_session_tables(db_file: Path) -> list[str]:
-    """Return session tables in one SQLite file that still have a legacy runs column."""
-    connection = sqlite3.connect(f"{db_file.resolve().as_uri()}?mode=ro", uri=True, timeout=30)
+def _legacy_session_tables(db_file: Path, *, pending_only: bool = False) -> list[str]:
+    """Return session tables with a legacy column, optionally only when it has data."""
+    engine = create_state_engine(str(db_file))
     try:
-        tables = [
-            row[0]
-            for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
-            if isinstance(row[0], str) and row[0].endswith("sessions")
-        ]
-        return [
-            table
-            for table in tables
-            if connection.execute(
-                "SELECT 1 FROM pragma_table_info(?) WHERE name = 'runs'",
-                (table,),
-            ).fetchone()
-            is not None
-        ]
+        inspector = inspect(engine)
+        tables: list[str] = []
+        for table_name in sorted(inspector.get_table_names()):
+            if not table_name.endswith("sessions"):
+                continue
+            if "runs" not in {column["name"] for column in inspector.get_columns(table_name)}:
+                continue
+            if pending_only:
+                table = Table(table_name, MetaData(), autoload_with=engine)
+                with engine.connect() as connection:
+                    pending = connection.execute(
+                        select(table.c.session_id).where(table.c.runs.isnot(None)).limit(1),
+                    ).first()
+                if pending is None:
+                    continue
+            tables.append(table_name)
+        return tables
     finally:
-        connection.close()
+        engine.dispose()
+
+
+def _pending_migration_targets(storage_root: Path) -> list[tuple[str, str]]:
+    """Find the database/table pairs that have legacy blobs to migrate."""
+    targets: list[tuple[str, str]] = []
+    for db_file in sorted(storage_root.rglob("sessions/*.db")):
+        try:
+            targets.extend(
+                (str(db_file), session_table) for session_table in _legacy_session_tables(db_file, pending_only=True)
+            )
+        except Exception:
+            logger.warning("legacy_session_database_scan_failed", db_file=str(db_file), exc_info=True)
+    return targets
 
 
 def _open_database(db_file: Path, session_table: str) -> SqliteDb:
@@ -107,25 +118,23 @@ def _open_database(db_file: Path, session_table: str) -> SqliteDb:
     return database
 
 
-def _legacy_session_row(sess: OrmSession, session_table: str, session_id: str) -> tuple[str | None, object] | None:
-    quoted_table = _quote_identifier(session_table)
+def _legacy_session_row(sess: OrmSession, sessions_table: Table, session_id: str) -> tuple[str | None, object] | None:
     row = sess.execute(
-        text(f"SELECT user_id, runs FROM {quoted_table} WHERE session_id = :session_id"),  # noqa: S608
-        {"session_id": session_id},
+        select(sessions_table.c.user_id, sessions_table.c.runs).where(sessions_table.c.session_id == session_id),
     ).one_or_none()
     return None if row is None or row[1] is None else (row[0], row[1])
 
 
 def _migrate_session_in_transaction(
     sess: OrmSession,
-    database: SqliteDb,
+    sessions_table: Table,
     runs_table: Table,
     session_id: str,
     expected_blob: object,
     legacy_runs: list[dict[str, Any]],
 ) -> bool:
     """Perform the copy and verification while the caller owns the writer transaction."""
-    session_row = _legacy_session_row(sess, database.session_table_name, session_id)
+    session_row = _legacy_session_row(sess, sessions_table, session_id)
     if session_row is None:
         return False
     user_id, blob = session_row
@@ -160,7 +169,10 @@ def _migrate_session_in_transaction(
     if canonical_ids:
         sess.execute(
             update(runs_table)
-            .where(runs_table.c.run_id == bindparam("target_run_id"))
+            .where(
+                runs_table.c.session_id == session_id,
+                runs_table.c.run_id == bindparam("target_run_id"),
+            )
             .values(run_index=bindparam("target_run_index")),
             [{"target_run_id": run_id, "target_run_index": index} for index, run_id in enumerate(canonical_ids)],
         )
@@ -178,16 +190,15 @@ def _migrate_session_in_transaction(
     if any(stored_by_id.get(run["run_id"]) != run for run in legacy_runs if run["run_id"] not in existing_ids):
         _refuse("stored_run_content_mismatch")
 
-    quoted_table = _quote_identifier(database.session_table_name)
     sess.execute(
-        text(f"UPDATE {quoted_table} SET runs = NULL WHERE session_id = :session_id"),  # noqa: S608
-        {"session_id": session_id},
+        update(sessions_table).where(sessions_table.c.session_id == session_id).values(runs=null()),
     )
     return True
 
 
 def _attempt_migrate_session(
     database: SqliteDb,
+    sessions_table: Table,
     runs_table: Table,
     session_id: str,
     expected_blob: object,
@@ -199,7 +210,7 @@ def _attempt_migrate_session(
             sess.execute(text("BEGIN IMMEDIATE"))
             migrated = _migrate_session_in_transaction(
                 sess,
-                database,
+                sessions_table,
                 runs_table,
                 session_id,
                 expected_blob,
@@ -214,19 +225,20 @@ def _attempt_migrate_session(
 
 def _migrate_session(
     database: SqliteDb,
+    sessions_table: Table,
     runs_table: Table,
     session_id: str,
 ) -> bool:
     """Prepare outside the writer lock, retrying if a current write changes the blob."""
     for _ in range(_MAX_CHANGED_BLOB_RETRIES):
         with database.Session() as sess:
-            session_row = _legacy_session_row(sess, database.session_table_name, session_id)
+            session_row = _legacy_session_row(sess, sessions_table, session_id)
         if session_row is None:
             return False
         _, blob = session_row
-        legacy_runs = _decode_legacy_runs(blob)
+        legacy_runs = _validated_legacy_runs(blob)
         try:
-            return _attempt_migrate_session(database, runs_table, session_id, blob, legacy_runs)
+            return _attempt_migrate_session(database, sessions_table, runs_table, session_id, blob, legacy_runs)
         except _LegacyBlobChangedError:
             continue
     _refuse("legacy_blob_kept_changing")
@@ -237,21 +249,23 @@ def _migrate_table(db_file: Path, session_table: str) -> _MigrationResult:
     database = _open_database(db_file, session_table)
     result = _MigrationResult()
     try:
+        sessions_table = database._get_table(table_type="sessions")
         runs_table = database._get_table(table_type="runs", create_table_if_not_found=True)
-        if runs_table is None:
+        if sessions_table is None or "runs" not in sessions_table.c or runs_table is None:
             return result
-        quoted_table = _quote_identifier(session_table)
         with database.Session() as sess:
             session_ids = list(
                 sess.execute(
-                    text(f"SELECT session_id FROM {quoted_table} WHERE runs IS NOT NULL ORDER BY session_id"),  # noqa: S608
+                    select(sessions_table.c.session_id)
+                    .where(sessions_table.c.runs.isnot(None))
+                    .order_by(sessions_table.c.session_id),
                 ).scalars(),
             )
         if not session_ids:
             return result
         for session_id in session_ids:
             try:
-                migrated = _migrate_session(database, runs_table, session_id)
+                migrated = _migrate_session(database, sessions_table, runs_table, session_id)
             except Exception as exc:
                 logger.warning(
                     "legacy_session_migration_skipped",
@@ -270,24 +284,27 @@ def _migrate_table(db_file: Path, session_table: str) -> _MigrationResult:
     return result
 
 
-def _migrate_database(db_file: Path) -> _MigrationResult:
-    """Migrate every legacy session table in one SQLite database."""
-    result = _MigrationResult()
-    for session_table in _legacy_session_tables(db_file):
-        result += _migrate_table(db_file, session_table)
-    return result
-
-
-def _migrate_storage_root(storage_root: str) -> None:
-    """Child-process entry point: scan and migrate databases one at a time."""
+def _migrate_storage_targets(
+    targets: list[tuple[str, str]],
+    log_level: str,
+    runtime_paths: RuntimePaths,
+) -> None:
+    """Child-process entry point: migrate database tables one at a time."""
+    setup_logging(level=log_level, runtime_paths=runtime_paths)
     result = _MigrationResult()
     failed_databases = 0
-    for db_file in sorted(Path(storage_root).rglob("sessions/*.db")):
+    for db_file_value, session_table in targets:
+        db_file = Path(db_file_value)
         try:
-            result += _migrate_database(db_file)
+            result += _migrate_table(db_file, session_table)
         except Exception:
             failed_databases += 1
-            logger.warning("legacy_session_database_migration_failed", db_file=str(db_file), exc_info=True)
+            logger.warning(
+                "legacy_session_database_migration_failed",
+                db_file=str(db_file),
+                session_table=session_table,
+                exc_info=True,
+            )
     logger.info(
         "legacy_session_migration_finished",
         migrated_sessions=result.migrated_sessions,
@@ -296,12 +313,27 @@ def _migrate_storage_root(storage_root: str) -> None:
     )
 
 
-async def _run_legacy_session_migration(storage_root: Path) -> None:
-    """Run the legacy scan outside this process and stop it with the runtime."""
+async def _run_legacy_session_migration(
+    storage_root: Path,
+    *,
+    log_level: str,
+    runtime_paths: RuntimePaths,
+) -> None:
+    """Preflight off-loop, then migrate pending blobs outside this process."""
+    targets = await asyncio.to_thread(_pending_migration_targets, storage_root)
+    if not targets:
+        return
+    child_runtime_paths = RuntimePaths(
+        config_path=runtime_paths.config_path,
+        config_dir=runtime_paths.config_dir,
+        env_path=runtime_paths.env_path,
+        storage_root=runtime_paths.storage_root,
+        control_state_root=runtime_paths.control_state_root,
+    )
     context = multiprocessing.get_context("spawn")
     process = context.Process(
-        target=_migrate_storage_root,
-        args=(str(storage_root),),
+        target=_migrate_storage_targets,
+        args=(targets, log_level, child_runtime_paths),
         name="legacy-session-migration",
         daemon=True,
     )
@@ -318,11 +350,17 @@ async def _run_legacy_session_migration(storage_root: Path) -> None:
         raise RuntimeError(msg)
 
 
-async def run_legacy_session_migration_after_ready(ready: asyncio.Event, storage_root: Path) -> None:
+async def run_legacy_session_migration_after_ready(
+    ready: asyncio.Event,
+    storage_root: Path,
+    *,
+    log_level: str,
+    runtime_paths: RuntimePaths,
+) -> None:
     """Wait for runtime availability, then run best-effort legacy migration."""
     await ready.wait()
     try:
-        await _run_legacy_session_migration(storage_root)
+        await _run_legacy_session_migration(storage_root, log_level=log_level, runtime_paths=runtime_paths)
     except asyncio.CancelledError:
         raise
     except Exception:

--- a/src/mindroom/legacy_session_migration.py
+++ b/src/mindroom/legacy_session_migration.py
@@ -1,0 +1,327 @@
+"""Retire Agno 2 session run blobs without blocking the runtime process."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import multiprocessing
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn, cast
+
+from agno.db.sqlite import SqliteDb
+from agno.db.utils import build_single_run_row
+from sqlalchemy import bindparam, select, text, update
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+from mindroom.agent_storage import configure_state_engine_pragmas, create_state_engine
+from mindroom.logging_config import get_logger
+
+if TYPE_CHECKING:
+    from sqlalchemy import Table
+    from sqlalchemy.orm import Session as OrmSession
+
+logger = get_logger(__name__)
+_MAX_CHANGED_BLOB_RETRIES = 2
+
+
+@dataclass(frozen=True)
+class _MigrationResult:
+    """Counts from one migration scan."""
+
+    migrated_sessions: int = 0
+    failed_sessions: int = 0
+
+    def __add__(self, other: _MigrationResult) -> _MigrationResult:
+        """Combine counts from independently migrated databases or tables."""
+        return _MigrationResult(
+            migrated_sessions=self.migrated_sessions + other.migrated_sessions,
+            failed_sessions=self.failed_sessions + other.failed_sessions,
+        )
+
+
+class _MigrationRefusedError(ValueError):
+    """A legacy session cannot be represented losslessly as run rows."""
+
+
+class _LegacyBlobChangedError(RuntimeError):
+    """The compatibility blob changed between preparation and the writer transaction."""
+
+
+def _refuse(reason: str) -> NoReturn:
+    raise _MigrationRefusedError(reason)
+
+
+def _quote_identifier(name: str) -> str:
+    return '"' + name.replace('"', '""') + '"'
+
+
+def _decode_legacy_runs(blob: object) -> list[dict[str, Any]]:
+    """Decode both JSON layers written by Agno 2 and require stable run identities."""
+    decoded = blob
+    try:
+        while isinstance(decoded, (str, bytes, bytearray)):
+            decoded = json.loads(decoded)
+    except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+        _refuse("invalid_json")
+    if not isinstance(decoded, list) or not all(isinstance(run, dict) for run in decoded):
+        _refuse("not_a_list_of_objects")
+    runs = cast("list[dict[str, Any]]", decoded)
+    run_ids = [run.get("run_id") for run in runs]
+    if not all(isinstance(run_id, str) and run_id for run_id in run_ids):
+        _refuse("missing_run_id")
+    if len(set(run_ids)) != len(run_ids):
+        _refuse("duplicate_run_ids")
+    return runs
+
+
+def _legacy_session_tables(db_file: Path) -> list[str]:
+    """Return session tables in one SQLite file that still carry legacy run data."""
+    connection = sqlite3.connect(f"{db_file.resolve().as_uri()}?mode=ro", uri=True, timeout=30)
+    try:
+        tables = [
+            row[0]
+            for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name")
+            if isinstance(row[0], str) and row[0].endswith("sessions")
+        ]
+        return [
+            table
+            for table in tables
+            if "runs" in {row[1] for row in connection.execute(f"PRAGMA table_info({_quote_identifier(table)})")}
+            and connection.execute(
+                f"SELECT 1 FROM {_quote_identifier(table)} WHERE runs IS NOT NULL LIMIT 1",  # noqa: S608
+            ).fetchone()
+            is not None
+        ]
+    finally:
+        connection.close()
+
+
+def _open_database(db_file: Path, session_table: str) -> SqliteDb:
+    """Open one Agno database without changing rollback journaling to WAL."""
+    db_path = str(db_file)
+    engine = create_state_engine(db_path)
+    database = SqliteDb(session_table=session_table, db_file=db_path, db_engine=engine)
+    configure_state_engine_pragmas(engine)
+    return database
+
+
+def _legacy_session_row(sess: OrmSession, session_table: str, session_id: str) -> tuple[str | None, object] | None:
+    quoted_table = _quote_identifier(session_table)
+    row = sess.execute(
+        text(f"SELECT user_id, runs FROM {quoted_table} WHERE session_id = :session_id"),  # noqa: S608
+        {"session_id": session_id},
+    ).one_or_none()
+    return None if row is None or row[1] is None else (row[0], row[1])
+
+
+def _migrate_session_in_transaction(
+    sess: OrmSession,
+    database: SqliteDb,
+    runs_table: Table,
+    session_id: str,
+    expected_blob: object,
+    legacy_runs: list[dict[str, Any]],
+) -> bool:
+    """Perform the copy and verification while the caller owns the writer transaction."""
+    session_row = _legacy_session_row(sess, database.session_table_name, session_id)
+    if session_row is None:
+        return False
+    user_id, blob = session_row
+    if blob != expected_blob:
+        raise _LegacyBlobChangedError
+    legacy_ids = [cast("str", run["run_id"]) for run in legacy_runs]
+    legacy_id_set = set(legacy_ids)
+
+    existing_for_session = list(
+        sess.execute(
+            select(runs_table.c.run_id, runs_table.c.run_index, runs_table.c.created_at)
+            .where(runs_table.c.session_id == session_id)
+            .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc()),
+        ).mappings(),
+    )
+    existing_ids = {cast("str", row["run_id"]) for row in existing_for_session}
+    canonical_ids = [
+        *legacy_ids,
+        *[cast("str", row["run_id"]) for row in existing_for_session if row["run_id"] not in legacy_id_set],
+    ]
+    missing_rows = [
+        build_single_run_row(run, session_id=session_id, user_id=user_id, run_index=index)
+        for index, run in enumerate(legacy_runs)
+        if run["run_id"] not in existing_ids
+    ]
+    if missing_rows:
+        sess.execute(
+            sqlite_insert(runs_table).on_conflict_do_nothing(index_elements=["run_id"]),
+            missing_rows,
+        )
+
+    if canonical_ids:
+        sess.execute(
+            update(runs_table)
+            .where(runs_table.c.run_id == bindparam("target_run_id"))
+            .values(run_index=bindparam("target_run_index")),
+            [{"target_run_id": run_id, "target_run_index": index} for index, run_id in enumerate(canonical_ids)],
+        )
+    stored_rows = list(
+        sess.execute(
+            select(runs_table.c.run_id, runs_table.c.run_data)
+            .where(runs_table.c.session_id == session_id)
+            .order_by(runs_table.c.run_index.asc(), runs_table.c.created_at.asc()),
+        ).mappings(),
+    )
+    stored_ids = [row["run_id"] for row in stored_rows]
+    if stored_ids != canonical_ids:
+        _refuse("stored_run_order_mismatch")
+    stored_by_id = {row["run_id"]: row["run_data"] for row in stored_rows}
+    if any(stored_by_id.get(run["run_id"]) != run for run in legacy_runs if run["run_id"] not in existing_ids):
+        _refuse("stored_run_content_mismatch")
+
+    quoted_table = _quote_identifier(database.session_table_name)
+    sess.execute(
+        text(f"UPDATE {quoted_table} SET runs = NULL WHERE session_id = :session_id"),  # noqa: S608
+        {"session_id": session_id},
+    )
+    return True
+
+
+def _attempt_migrate_session(
+    database: SqliteDb,
+    runs_table: Table,
+    session_id: str,
+    expected_blob: object,
+    legacy_runs: list[dict[str, Any]],
+) -> bool:
+    """Commit prepared runs only when the source blob is still current."""
+    with database.Session() as sess:
+        try:
+            sess.execute(text("BEGIN IMMEDIATE"))
+            migrated = _migrate_session_in_transaction(
+                sess,
+                database,
+                runs_table,
+                session_id,
+                expected_blob,
+                legacy_runs,
+            )
+            sess.commit()
+        except BaseException:
+            sess.rollback()
+            raise
+    return migrated
+
+
+def _migrate_session(
+    database: SqliteDb,
+    runs_table: Table,
+    session_id: str,
+) -> bool:
+    """Prepare outside the writer lock, retrying if a current write changes the blob."""
+    for _ in range(_MAX_CHANGED_BLOB_RETRIES):
+        with database.Session() as sess:
+            session_row = _legacy_session_row(sess, database.session_table_name, session_id)
+        if session_row is None:
+            return False
+        _, blob = session_row
+        legacy_runs = _decode_legacy_runs(blob)
+        try:
+            return _attempt_migrate_session(database, runs_table, session_id, blob, legacy_runs)
+        except _LegacyBlobChangedError:
+            continue
+    _refuse("legacy_blob_kept_changing")
+
+
+def _migrate_table(db_file: Path, session_table: str) -> _MigrationResult:
+    """Migrate each legacy session independently so one bad row cannot block the rest."""
+    database = _open_database(db_file, session_table)
+    result = _MigrationResult()
+    try:
+        runs_table = database._get_table(table_type="runs", create_table_if_not_found=True)
+        if runs_table is None:
+            return result
+        quoted_table = _quote_identifier(session_table)
+        with database.Session() as sess:
+            session_ids = list(
+                sess.execute(
+                    text(f"SELECT session_id FROM {quoted_table} WHERE runs IS NOT NULL ORDER BY session_id"),  # noqa: S608
+                ).scalars(),
+            )
+        for session_id in session_ids:
+            try:
+                migrated = _migrate_session(database, runs_table, session_id)
+            except Exception as exc:
+                logger.warning(
+                    "legacy_session_migration_skipped",
+                    db_file=str(db_file),
+                    session_table=session_table,
+                    session_id=session_id,
+                    error=str(exc),
+                )
+                result += _MigrationResult(failed_sessions=1)
+            else:
+                result += _MigrationResult(migrated_sessions=int(migrated))
+        if result.failed_sessions == 0:
+            database.upsert_schema_version(session_table, "3.0.0")
+    finally:
+        database.close()
+    return result
+
+
+def _migrate_database(db_file: Path) -> _MigrationResult:
+    """Migrate every legacy session table in one SQLite database."""
+    result = _MigrationResult()
+    for session_table in _legacy_session_tables(db_file):
+        result += _migrate_table(db_file, session_table)
+    return result
+
+
+def _migrate_storage_root(storage_root: str) -> None:
+    """Child-process entry point: scan and migrate databases one at a time."""
+    result = _MigrationResult()
+    failed_databases = 0
+    for db_file in sorted(Path(storage_root).rglob("sessions/*.db")):
+        try:
+            result += _migrate_database(db_file)
+        except Exception:
+            failed_databases += 1
+            logger.warning("legacy_session_database_migration_failed", db_file=str(db_file), exc_info=True)
+    logger.info(
+        "legacy_session_migration_finished",
+        migrated_sessions=result.migrated_sessions,
+        failed_sessions=result.failed_sessions,
+        failed_databases=failed_databases,
+    )
+
+
+async def _run_legacy_session_migration(storage_root: Path) -> None:
+    """Run the legacy scan outside this process and stop it with the runtime."""
+    context = multiprocessing.get_context("spawn")
+    process = context.Process(
+        target=_migrate_storage_root,
+        args=(str(storage_root),),
+        name="legacy-session-migration",
+        daemon=True,
+    )
+    process.start()
+    try:
+        await asyncio.to_thread(process.join)
+    except asyncio.CancelledError:
+        if process.is_alive():
+            process.terminate()
+        await asyncio.shield(asyncio.to_thread(process.join))
+        raise
+    if process.exitcode != 0:
+        msg = f"Legacy session migration process exited with status {process.exitcode}"
+        raise RuntimeError(msg)
+
+
+async def run_legacy_session_migration_after_ready(ready: asyncio.Event, storage_root: Path) -> None:
+    """Wait for runtime availability, then run best-effort legacy migration."""
+    await ready.wait()
+    try:
+        await _run_legacy_session_migration(storage_root)
+    except asyncio.CancelledError:
+        raise
+    except Exception:
+        logger.warning("legacy_session_migration_process_failed", exc_info=True)

--- a/src/mindroom/legacy_session_migration.py
+++ b/src/mindroom/legacy_session_migration.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import multiprocessing
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, NoReturn, cast
 
@@ -15,14 +15,16 @@ from sqlalchemy import MetaData, Table, bindparam, inspect, null, select, text, 
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
 from mindroom.agent_storage import configure_state_engine_pragmas, create_state_engine
-from mindroom.constants import RuntimePaths
 from mindroom.logging_config import get_logger, setup_logging
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session as OrmSession
 
+    from mindroom.constants import RuntimePaths
+
 logger = get_logger(__name__)
 _MAX_CHANGED_BLOB_RETRIES = 2
+_PROGRESS_INTERVAL = 100
 
 
 @dataclass(frozen=True)
@@ -31,12 +33,14 @@ class _MigrationResult:
 
     migrated_sessions: int = 0
     failed_sessions: int = 0
+    failed_databases: int = 0
 
     def __add__(self, other: _MigrationResult) -> _MigrationResult:
         """Combine counts from independently migrated databases or tables."""
         return _MigrationResult(
             migrated_sessions=self.migrated_sessions + other.migrated_sessions,
             failed_sessions=self.failed_sessions + other.failed_sessions,
+            failed_databases=self.failed_databases + other.failed_databases,
         )
 
 
@@ -71,8 +75,8 @@ def _validated_legacy_runs(blob: object) -> list[dict[str, Any]]:
     return runs
 
 
-def _legacy_session_tables(db_file: Path, *, pending_only: bool = False) -> list[str]:
-    """Return session tables with a legacy column, optionally only when it has data."""
+def _legacy_session_tables(db_file: Path) -> list[str]:
+    """Return session tables that still contain legacy run data."""
     engine = create_state_engine(str(db_file))
     try:
         inspector = inspect(engine)
@@ -82,14 +86,13 @@ def _legacy_session_tables(db_file: Path, *, pending_only: bool = False) -> list
                 continue
             if "runs" not in {column["name"] for column in inspector.get_columns(table_name)}:
                 continue
-            if pending_only:
-                table = Table(table_name, MetaData(), autoload_with=engine)
-                with engine.connect() as connection:
-                    pending = connection.execute(
-                        select(table.c.session_id).where(table.c.runs.isnot(None)).limit(1),
-                    ).first()
-                if pending is None:
-                    continue
+            table = Table(table_name, MetaData(), autoload_with=engine)
+            with engine.connect() as connection:
+                pending = connection.execute(
+                    select(table.c.session_id).where(table.c.runs.isnot(None)).limit(1),
+                ).first()
+            if pending is None:
+                continue
             tables.append(table_name)
         return tables
     finally:
@@ -101,9 +104,7 @@ def _pending_migration_targets(storage_root: Path) -> list[tuple[str, str]]:
     targets: list[tuple[str, str]] = []
     for db_file in sorted(storage_root.rglob("sessions/*.db")):
         try:
-            targets.extend(
-                (str(db_file), session_table) for session_table in _legacy_session_tables(db_file, pending_only=True)
-            )
+            targets.extend((str(db_file), session_table) for session_table in _legacy_session_tables(db_file))
         except Exception:
             logger.warning("legacy_session_database_scan_failed", db_file=str(db_file), exc_info=True)
     return targets
@@ -263,7 +264,14 @@ def _migrate_table(db_file: Path, session_table: str) -> _MigrationResult:
             )
         if not session_ids:
             return result
-        for session_id in session_ids:
+        total_sessions = len(session_ids)
+        logger.info(
+            "legacy_session_migration_started",
+            db_file=str(db_file),
+            session_table=session_table,
+            total_sessions=total_sessions,
+        )
+        for processed_sessions, session_id in enumerate(session_ids, start=1):
             try:
                 migrated = _migrate_session(database, sessions_table, runs_table, session_id)
             except Exception as exc:
@@ -277,6 +285,16 @@ def _migrate_table(db_file: Path, session_table: str) -> _MigrationResult:
                 result += _MigrationResult(failed_sessions=1)
             else:
                 result += _MigrationResult(migrated_sessions=int(migrated))
+            if processed_sessions % _PROGRESS_INTERVAL == 0 or processed_sessions == total_sessions:
+                logger.info(
+                    "legacy_session_migration_progress",
+                    db_file=str(db_file),
+                    session_table=session_table,
+                    processed_sessions=processed_sessions,
+                    total_sessions=total_sessions,
+                    migrated_sessions=result.migrated_sessions,
+                    failed_sessions=result.failed_sessions,
+                )
         if result.failed_sessions == 0:
             database.upsert_schema_version(session_table, "3.0.0")
     finally:
@@ -292,13 +310,12 @@ def _migrate_storage_targets(
     """Child-process entry point: migrate database tables one at a time."""
     setup_logging(level=log_level, runtime_paths=runtime_paths)
     result = _MigrationResult()
-    failed_databases = 0
     for db_file_value, session_table in targets:
         db_file = Path(db_file_value)
         try:
             result += _migrate_table(db_file, session_table)
         except Exception:
-            failed_databases += 1
+            result += _MigrationResult(failed_databases=1)
             logger.warning(
                 "legacy_session_database_migration_failed",
                 db_file=str(db_file),
@@ -309,7 +326,7 @@ def _migrate_storage_targets(
         "legacy_session_migration_finished",
         migrated_sessions=result.migrated_sessions,
         failed_sessions=result.failed_sessions,
-        failed_databases=failed_databases,
+        failed_databases=result.failed_databases,
     )
 
 
@@ -323,13 +340,8 @@ async def _run_legacy_session_migration(
     targets = await asyncio.to_thread(_pending_migration_targets, storage_root)
     if not targets:
         return
-    child_runtime_paths = RuntimePaths(
-        config_path=runtime_paths.config_path,
-        config_dir=runtime_paths.config_dir,
-        env_path=runtime_paths.env_path,
-        storage_root=runtime_paths.storage_root,
-        control_state_root=runtime_paths.control_state_root,
-    )
+    # MappingProxyType environment snapshots cannot cross the spawn boundary.
+    child_runtime_paths = replace(runtime_paths, process_env={}, env_file_values={})
     context = multiprocessing.get_context("spawn")
     process = context.Process(
         target=_migrate_storage_targets,

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -44,6 +44,7 @@ from mindroom.hooks import (
 )
 from mindroom.knowledge import KnowledgeRefreshScheduler, reconcile_knowledge_mode_transition_states
 from mindroom.knowledge.watch import KnowledgeSourceWatcher
+from mindroom.legacy_session_migration import run_legacy_session_migration_after_ready
 from mindroom.matrix.client_room_admin import get_joined_rooms, get_room_members, invite_to_room
 from mindroom.matrix.health import reset_matrix_sync_health
 from mindroom.matrix.identity import managed_account_user_id
@@ -281,6 +282,7 @@ class _MultiAgentOrchestrator:
         repr=False,
     )
     _runtime_shutdown_event: asyncio.Event | None = field(default=None, init=False, repr=False)
+    _runtime_ready_event: asyncio.Event = field(default_factory=asyncio.Event, init=False, repr=False)
     _router_reply_memberships_live_sync_ready: asyncio.Event = field(
         default_factory=asyncio.Event,
         init=False,
@@ -1396,6 +1398,7 @@ class _MultiAgentOrchestrator:
     async def _start_runtime(self) -> None:
         """Run the startup sequence before handing off to the sync loops."""
         runtime_shutdown_event = self._reset_runtime_shutdown_event()
+        self._runtime_ready_event.clear()
         self._router_reply_memberships_live_sync_ready.clear()
         self._approval_transport.reset_startup_cleanup_gate()
         phase_started = log_startup_phase_started("wait_for_matrix_homeserver")
@@ -1467,6 +1470,7 @@ class _MultiAgentOrchestrator:
                 name="embedder_startup_health_check",
             )
             set_runtime_ready()
+            self._runtime_ready_event.set()
         # Stay alive until explicit shutdown. Hot reload replaces sync tasks in
         # self._sync_tasks, so awaiting the initial task generation would let a
         # config-triggered restart look like normal orchestrator completion.
@@ -2657,6 +2661,20 @@ def _sync_credentials_and_prepare_storage(runtime_paths: RuntimePaths, storage_p
     storage_path.mkdir(parents=True, exist_ok=True)
 
 
+def _schedule_legacy_session_migration(
+    orchestrator: _MultiAgentOrchestrator,
+    runtime_paths: RuntimePaths,
+) -> asyncio.Task[None]:
+    """Schedule migration against the resolved session root behind readiness."""
+    runtime_ready_event = asyncio.Event()
+    orchestrator._runtime_ready_event = runtime_ready_event
+    session_storage_path = constants.resolve_session_state_root(runtime_paths.storage_root, runtime_paths)
+    return asyncio.create_task(
+        run_legacy_session_migration_after_ready(runtime_ready_event, session_storage_path),
+        name="legacy_session_migration",
+    )
+
+
 async def main(
     log_level: str,
     runtime_paths: RuntimePaths,
@@ -2713,6 +2731,8 @@ async def main(
                     name=supervisor_name,
                 ),
             )
+
+        auxiliary_tasks.append(_schedule_legacy_session_migration(orchestrator, runtime_paths))
 
         if api:
             api_task = asyncio.create_task(

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2664,11 +2664,17 @@ def _sync_credentials_and_prepare_storage(runtime_paths: RuntimePaths, storage_p
 def _schedule_legacy_session_migration(
     orchestrator: _MultiAgentOrchestrator,
     runtime_paths: RuntimePaths,
+    log_level: str,
 ) -> asyncio.Task[None]:
     """Schedule migration against the resolved session root behind readiness."""
     session_storage_path = constants.resolve_session_state_root(runtime_paths.storage_root, runtime_paths)
     return asyncio.create_task(
-        run_legacy_session_migration_after_ready(orchestrator._runtime_ready_event, session_storage_path),
+        run_legacy_session_migration_after_ready(
+            orchestrator._runtime_ready_event,
+            session_storage_path,
+            log_level=log_level,
+            runtime_paths=runtime_paths,
+        ),
         name="legacy_session_migration",
     )
 
@@ -2730,7 +2736,7 @@ async def main(
                 ),
             )
 
-        auxiliary_tasks.append(_schedule_legacy_session_migration(orchestrator, runtime_paths))
+        auxiliary_tasks.append(_schedule_legacy_session_migration(orchestrator, runtime_paths, log_level))
 
         if api:
             api_task = asyncio.create_task(

--- a/src/mindroom/orchestrator.py
+++ b/src/mindroom/orchestrator.py
@@ -2666,11 +2666,9 @@ def _schedule_legacy_session_migration(
     runtime_paths: RuntimePaths,
 ) -> asyncio.Task[None]:
     """Schedule migration against the resolved session root behind readiness."""
-    runtime_ready_event = asyncio.Event()
-    orchestrator._runtime_ready_event = runtime_ready_event
     session_storage_path = constants.resolve_session_state_root(runtime_paths.storage_root, runtime_paths)
     return asyncio.create_task(
-        run_legacy_session_migration_after_ready(runtime_ready_event, session_storage_path),
+        run_legacy_session_migration_after_ready(orchestrator._runtime_ready_event, session_storage_path),
         name="legacy_session_migration",
     )
 

--- a/src/mindroom/usage_stats_storage.py
+++ b/src/mindroom/usage_stats_storage.py
@@ -54,10 +54,9 @@ TOKEN_FIELDS = (
 _REQUIRED_COLUMNS = frozenset(
     {"session_id", "session_type", "agent_id", "team_id", "user_id", "session_data"},
 )
-# Agno 3 keeps one row per run in ``<session table>_runs``. A database written by
-# agno 2.x still carries the ``runs`` blob on the session row (MindRoom does not
-# migrate it; agno merges blob and rows on read), so this reader merges the same
-# way. The blob branch goes away with the refuse-and-migrate gate (#1947).
+# Agno 3 keeps one row per run in ``<session table>_runs``. Until background
+# migration retires an agno 2.x ``runs`` blob (or when migration refuses a bad
+# blob), this reader merges blob and rows the same way as agno.
 _RUNS_TABLE_REQUIRED_COLUMNS = frozenset({"run_id", "session_id", "run_index", "run_data", "created_at"})
 
 

--- a/tests/test_legacy_session_migration.py
+++ b/tests/test_legacy_session_migration.py
@@ -258,6 +258,8 @@ async def test_orchestrator_starts_migration_after_readiness_against_the_session
         process_env={"MINDROOM_SESSION_STORAGE_PATH": str(session_root)},
     )
     orchestrator = MagicMock()
+    runtime_ready_event = asyncio.Event()
+    orchestrator._runtime_ready_event = runtime_ready_event
 
     async def record_start(storage_root: Path) -> None:
         assert storage_root == session_root
@@ -265,6 +267,7 @@ async def test_orchestrator_starts_migration_after_readiness_against_the_session
 
     monkeypatch.setattr(legacy_session_migration, "_run_legacy_session_migration", record_start)
     task = _schedule_legacy_session_migration(orchestrator, runtime_paths)
+    assert orchestrator._runtime_ready_event is runtime_ready_event
     await asyncio.sleep(0)
     assert not started.is_set()
 

--- a/tests/test_legacy_session_migration.py
+++ b/tests/test_legacy_session_migration.py
@@ -17,7 +17,7 @@ from mindroom import legacy_session_migration
 from mindroom.agent_storage import create_state_storage, get_agent_session, save_runs
 from mindroom.constants import resolve_runtime_paths
 from mindroom.legacy_session_migration import (
-    _migrate_database,
+    _migrate_table,
     _run_legacy_session_migration,
 )
 from mindroom.orchestrator import _schedule_legacy_session_migration
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
 
     from agno.db.base import BaseDb
 
+    from mindroom.constants import RuntimePaths
+
 
 def _storage(tmp_path: Path) -> BaseDb:
     return create_state_storage(
@@ -35,6 +37,14 @@ def _storage(tmp_path: Path) -> BaseDb:
         tmp_path,
         subdir="sessions",
         session_table="code_sessions",
+    )
+
+
+def _runtime_paths(tmp_path: Path) -> RuntimePaths:
+    return resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={},
     )
 
 
@@ -88,7 +98,7 @@ def test_migration_preserves_the_visible_order_of_partially_migrated_sessions(tm
     finally:
         storage.close()
 
-    result = _migrate_database(db_path)
+    result = _migrate_table(db_path, "code_sessions")
 
     assert result.migrated_sessions == 1
     assert result.failed_sessions == 0
@@ -112,7 +122,7 @@ def test_migration_preserves_the_visible_order_of_partially_migrated_sessions(tm
     assert rows == [("run-1", 0), ("run-3", 1), ("run-4", 2)]
     assert journal_mode == ("delete",)
     assert _schema_version(db_path) == "3.0.0"
-    assert _migrate_database(db_path).migrated_sessions == 0
+    assert _migrate_table(db_path, "code_sessions").migrated_sessions == 0
 
 
 def test_malformed_session_is_left_untouched_without_blocking_other_sessions(tmp_path: Path) -> None:
@@ -128,7 +138,7 @@ def test_malformed_session_is_left_untouched_without_blocking_other_sessions(tmp
     finally:
         connection.close()
 
-    result = _migrate_database(db_path)
+    result = _migrate_table(db_path, "code_sessions")
 
     assert result.migrated_sessions == 1
     assert result.failed_sessions == 1
@@ -150,7 +160,7 @@ def test_blob_clear_failure_rolls_back_inserted_rows(tmp_path: Path) -> None:
     finally:
         connection.close()
 
-    result = _migrate_database(db_path)
+    result = _migrate_table(db_path, "code_sessions")
 
     assert result.migrated_sessions == 0
     assert result.failed_sessions == 1
@@ -176,7 +186,7 @@ def test_run_id_owned_by_another_session_keeps_the_legacy_blob(tmp_path: Path) -
     finally:
         storage.close()
 
-    result = _migrate_database(db_path)
+    result = _migrate_table(db_path, "code_sessions")
 
     assert result.migrated_sessions == 0
     assert result.failed_sessions == 1
@@ -184,11 +194,11 @@ def test_run_id_owned_by_another_session_keeps_the_legacy_blob(tmp_path: Path) -
     connection = sqlite3.connect(db_path)
     try:
         owner = connection.execute(
-            "SELECT session_id FROM code_sessions_runs WHERE run_id = 'run-1'",
+            "SELECT session_id, run_index FROM code_sessions_runs WHERE run_id = 'run-1'",
         ).fetchone()
     finally:
         connection.close()
-    assert owner == ("other-session",)
+    assert owner == ("other-session", 0)
 
 
 def test_concurrent_delete_finishes_during_decode_and_is_preserved_by_retry(
@@ -201,15 +211,15 @@ def test_concurrent_delete_finishes_during_decode_and_is_preserved_by_retry(
     allow_decode = threading.Event()
     delete_started = threading.Event()
     delete_finished = threading.Event()
-    original_decode = legacy_session_migration._decode_legacy_runs
+    original_decode = legacy_session_migration._validated_legacy_runs
 
     def blocked_decode(blob: object):  # noqa: ANN202
         decode_started.set()
         assert allow_decode.wait(5)
         return original_decode(blob)
 
-    monkeypatch.setattr(legacy_session_migration, "_decode_legacy_runs", blocked_decode)
-    migration = threading.Thread(target=_migrate_database, args=(db_path,))
+    monkeypatch.setattr(legacy_session_migration, "_validated_legacy_runs", blocked_decode)
+    migration = threading.Thread(target=_migrate_table, args=(db_path, "code_sessions"))
     migration.start()
     assert decode_started.wait(5)
 
@@ -239,9 +249,59 @@ def test_concurrent_delete_finishes_during_decode_and_is_preserved_by_retry(
 async def test_spawned_process_migrates_the_storage_root(tmp_path: Path) -> None:
     """The production process boundary performs the complete storage-root scan."""
     db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
-    await _run_legacy_session_migration(tmp_path)
+    await _run_legacy_session_migration(tmp_path, log_level="INFO", runtime_paths=_runtime_paths(tmp_path))
 
     assert _blob_is_null(db_path, "session-1")
+
+
+@pytest.mark.asyncio
+async def test_current_storage_does_not_spawn_a_migration_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An ordinary restart pays only the read-only preflight scan."""
+    storage = _storage(tmp_path)
+    storage.upsert_session(AgentSession(session_id="current-session", agent_id="code"))
+    storage.close()
+
+    class FakeContext:
+        def Process(self, **_kwargs: object) -> None:  # noqa: N802
+            pytest.fail("a migration process was spawned without legacy data")
+
+    monkeypatch.setattr(
+        legacy_session_migration.multiprocessing,
+        "get_context",
+        lambda _method: FakeContext(),
+    )
+
+    await _run_legacy_session_migration(tmp_path, log_level="INFO", runtime_paths=_runtime_paths(tmp_path))
+
+
+def test_migration_child_configures_normal_logging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Child-process warnings use the same configured handlers as the runtime."""
+    configured: list[tuple[str, object]] = []
+    runtime_paths = _runtime_paths(tmp_path)
+    monkeypatch.setattr(
+        legacy_session_migration,
+        "setup_logging",
+        lambda *, level, runtime_paths: configured.append((level, runtime_paths)),
+    )
+
+    legacy_session_migration._migrate_storage_targets([], "WARNING", runtime_paths)
+
+    assert configured == [("WARNING", runtime_paths)]
+
+
+def test_preflight_skips_an_unreadable_database_without_hiding_valid_work(tmp_path: Path) -> None:
+    """One broken database cannot prevent independent session databases from migrating."""
+    broken = tmp_path / "a" / "sessions" / "broken.db"
+    broken.parent.mkdir(parents=True)
+    broken.write_bytes(b"not sqlite")
+    valid = create_agno_2_sessions_db(tmp_path / "b" / "sessions" / "code.db")
+
+    targets = legacy_session_migration._pending_migration_targets(tmp_path)
+
+    assert targets == [(str(valid), "code_sessions")]
 
 
 @pytest.mark.asyncio
@@ -260,13 +320,16 @@ async def test_orchestrator_starts_migration_after_readiness_against_the_session
     orchestrator = MagicMock()
     runtime_ready_event = asyncio.Event()
     orchestrator._runtime_ready_event = runtime_ready_event
+    expected_runtime_paths = runtime_paths
 
-    async def record_start(storage_root: Path) -> None:
+    async def record_start(storage_root: Path, *, log_level: str, runtime_paths: object) -> None:
         assert storage_root == session_root
+        assert log_level == "INFO"
+        assert runtime_paths is expected_runtime_paths
         started.set()
 
     monkeypatch.setattr(legacy_session_migration, "_run_legacy_session_migration", record_start)
-    task = _schedule_legacy_session_migration(orchestrator, runtime_paths)
+    task = _schedule_legacy_session_migration(orchestrator, runtime_paths, "INFO")
     assert orchestrator._runtime_ready_event is runtime_ready_event
     await asyncio.sleep(0)
     assert not started.is_set()
@@ -282,6 +345,7 @@ async def test_background_process_is_terminated_when_runtime_stops(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Cancellation cannot leave the migration child running after runtime shutdown."""
+    create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
     join_started = threading.Event()
     release_join = threading.Event()
 
@@ -312,7 +376,9 @@ async def test_background_process_is_terminated_when_runtime_stops(
     context = FakeContext()
     monkeypatch.setattr(legacy_session_migration.multiprocessing, "get_context", lambda _method: context)
 
-    task = asyncio.create_task(_run_legacy_session_migration(tmp_path))
+    task = asyncio.create_task(
+        _run_legacy_session_migration(tmp_path, log_level="INFO", runtime_paths=_runtime_paths(tmp_path)),
+    )
     assert await asyncio.to_thread(join_started.wait, 5)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/test_legacy_session_migration.py
+++ b/tests/test_legacy_session_migration.py
@@ -1,0 +1,318 @@
+"""Automatic retirement of Agno 2 session run blobs."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import threading
+from copy import deepcopy
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+from agno.run.agent import RunOutput
+from agno.session.agent import AgentSession
+
+from mindroom import legacy_session_migration
+from mindroom.agent_storage import create_state_storage, get_agent_session, save_runs
+from mindroom.constants import resolve_runtime_paths
+from mindroom.legacy_session_migration import (
+    _migrate_database,
+    _run_legacy_session_migration,
+)
+from mindroom.orchestrator import _schedule_legacy_session_migration
+from tests.conftest import create_agno_2_sessions_db
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from agno.db.base import BaseDb
+
+
+def _storage(tmp_path: Path) -> BaseDb:
+    return create_state_storage(
+        "code",
+        tmp_path,
+        subdir="sessions",
+        session_table="code_sessions",
+    )
+
+
+def _blob_is_null(db_path: Path, session_id: str) -> bool:
+    connection = sqlite3.connect(db_path)
+    try:
+        row = connection.execute(
+            "SELECT runs IS NULL FROM code_sessions WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        assert row is not None
+        return bool(row[0])
+    finally:
+        connection.close()
+
+
+def _loaded_run_ids(tmp_path: Path) -> list[str]:
+    storage = _storage(tmp_path)
+    try:
+        session = get_agent_session(storage, "session-1")
+        assert session is not None
+        return [run.run_id or "" for run in session.runs or []]
+    finally:
+        storage.close()
+
+
+def _schema_version(db_path: Path) -> str:
+    connection = sqlite3.connect(db_path)
+    try:
+        row = connection.execute(
+            "SELECT version FROM agno_schema_versions WHERE table_name = 'code_sessions'",
+        ).fetchone()
+        assert row is not None
+        return row[0]
+    finally:
+        connection.close()
+
+
+def test_migration_preserves_the_visible_order_of_partially_migrated_sessions(tmp_path: Path) -> None:
+    """Legacy runs stay first and newer row-only runs stay last after the blob is cleared."""
+    db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
+    storage = _storage(tmp_path)
+    try:
+        session = get_agent_session(storage, "session-1")
+        assert session is not None
+        storage.delete_runs(["run-2"])
+        edited_run_1 = deepcopy((session.runs or [])[0])
+        edited_run_1.metadata = {"newer_row": True}
+        run_4 = RunOutput(run_id="run-4", session_id="session-1", agent_id="code", messages=[])
+        save_runs(storage, session, [edited_run_1, run_4])
+    finally:
+        storage.close()
+
+    result = _migrate_database(db_path)
+
+    assert result.migrated_sessions == 1
+    assert result.failed_sessions == 0
+    assert _loaded_run_ids(tmp_path) == ["run-1", "run-3", "run-4"]
+    storage = _storage(tmp_path)
+    try:
+        migrated = get_agent_session(storage, "session-1")
+    finally:
+        storage.close()
+    assert migrated is not None
+    assert (migrated.runs or [])[0].metadata == {"newer_row": True}
+    assert _blob_is_null(db_path, "session-1")
+    connection = sqlite3.connect(db_path)
+    try:
+        rows = connection.execute(
+            "SELECT run_id, run_index FROM code_sessions_runs ORDER BY run_index",
+        ).fetchall()
+        journal_mode = connection.execute("PRAGMA journal_mode").fetchone()
+    finally:
+        connection.close()
+    assert rows == [("run-1", 0), ("run-3", 1), ("run-4", 2)]
+    assert journal_mode == ("delete",)
+    assert _schema_version(db_path) == "3.0.0"
+    assert _migrate_database(db_path).migrated_sessions == 0
+
+
+def test_malformed_session_is_left_untouched_without_blocking_other_sessions(tmp_path: Path) -> None:
+    """One bad blob remains readable through compatibility code while valid sessions migrate."""
+    db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            "INSERT INTO code_sessions (session_id, session_type, agent_id, runs, created_at) VALUES (?, ?, ?, ?, ?)",
+            ("broken-session", "agent", "code", "{broken", 1),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = _migrate_database(db_path)
+
+    assert result.migrated_sessions == 1
+    assert result.failed_sessions == 1
+    assert _blob_is_null(db_path, "session-1")
+    assert not _blob_is_null(db_path, "broken-session")
+    assert _schema_version(db_path) == "2.5.6"
+
+
+def test_blob_clear_failure_rolls_back_inserted_rows(tmp_path: Path) -> None:
+    """A crash or write failure cannot leave a blob retired before its run rows commit."""
+    db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            "CREATE TRIGGER refuse_blob_clear BEFORE UPDATE OF runs ON code_sessions "
+            "BEGIN SELECT RAISE(ABORT, 'blob clear refused'); END",
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    result = _migrate_database(db_path)
+
+    assert result.migrated_sessions == 0
+    assert result.failed_sessions == 1
+    assert not _blob_is_null(db_path, "session-1")
+    connection = sqlite3.connect(db_path)
+    try:
+        (stored_runs,) = connection.execute("SELECT COUNT(*) FROM code_sessions_runs").fetchone()
+    finally:
+        connection.close()
+    assert stored_runs == 0
+
+
+def test_run_id_owned_by_another_session_keeps_the_legacy_blob(tmp_path: Path) -> None:
+    """A global run-id collision cannot make verification retire the authoritative blob."""
+    db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
+    storage = _storage(tmp_path)
+    try:
+        storage.upsert_session(AgentSession(session_id="other-session", agent_id="code"))
+        storage.upsert_run(
+            RunOutput(run_id="run-1", session_id="other-session", agent_id="code"),
+            session_id="other-session",
+        )
+    finally:
+        storage.close()
+
+    result = _migrate_database(db_path)
+
+    assert result.migrated_sessions == 0
+    assert result.failed_sessions == 1
+    assert not _blob_is_null(db_path, "session-1")
+    connection = sqlite3.connect(db_path)
+    try:
+        owner = connection.execute(
+            "SELECT session_id FROM code_sessions_runs WHERE run_id = 'run-1'",
+        ).fetchone()
+    finally:
+        connection.close()
+    assert owner == ("other-session",)
+
+
+def test_concurrent_delete_finishes_during_decode_and_is_preserved_by_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Expensive decode holds no writer lock; a changed blob is reread before migration."""
+    db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
+    decode_started = threading.Event()
+    allow_decode = threading.Event()
+    delete_started = threading.Event()
+    delete_finished = threading.Event()
+    original_decode = legacy_session_migration._decode_legacy_runs
+
+    def blocked_decode(blob: object):  # noqa: ANN202
+        decode_started.set()
+        assert allow_decode.wait(5)
+        return original_decode(blob)
+
+    monkeypatch.setattr(legacy_session_migration, "_decode_legacy_runs", blocked_decode)
+    migration = threading.Thread(target=_migrate_database, args=(db_path,))
+    migration.start()
+    assert decode_started.wait(5)
+
+    storage = _storage(tmp_path)
+
+    def delete_run() -> None:
+        delete_started.set()
+        storage.delete_runs(["run-2"])
+        delete_finished.set()
+
+    deletion = threading.Thread(target=delete_run)
+    deletion.start()
+    assert delete_started.wait(5)
+    assert delete_finished.wait(5)
+    allow_decode.set()
+    migration.join(5)
+    deletion.join(5)
+    storage.close()
+
+    assert not migration.is_alive()
+    assert not deletion.is_alive()
+    assert _loaded_run_ids(tmp_path) == ["run-1", "run-3"]
+    assert _blob_is_null(db_path, "session-1")
+
+
+@pytest.mark.asyncio
+async def test_spawned_process_migrates_the_storage_root(tmp_path: Path) -> None:
+    """The production process boundary performs the complete storage-root scan."""
+    db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
+    await _run_legacy_session_migration(tmp_path)
+
+    assert _blob_is_null(db_path, "session-1")
+
+
+@pytest.mark.asyncio
+async def test_orchestrator_starts_migration_after_readiness_against_the_session_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Legacy scanning must never extend the unavailable startup window."""
+    started = asyncio.Event()
+    session_root = tmp_path / "session-state"
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        storage_path=tmp_path / "storage",
+        process_env={"MINDROOM_SESSION_STORAGE_PATH": str(session_root)},
+    )
+    orchestrator = MagicMock()
+
+    async def record_start(storage_root: Path) -> None:
+        assert storage_root == session_root
+        started.set()
+
+    monkeypatch.setattr(legacy_session_migration, "_run_legacy_session_migration", record_start)
+    task = _schedule_legacy_session_migration(orchestrator, runtime_paths)
+    await asyncio.sleep(0)
+    assert not started.is_set()
+
+    orchestrator._runtime_ready_event.set()
+    await task
+    assert started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_background_process_is_terminated_when_runtime_stops(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cancellation cannot leave the migration child running after runtime shutdown."""
+    join_started = threading.Event()
+    release_join = threading.Event()
+
+    class FakeProcess:
+        exitcode = None
+        terminated = False
+
+        def start(self) -> None:
+            return None
+
+        def join(self) -> None:
+            join_started.set()
+            assert release_join.wait(5)
+
+        def is_alive(self) -> bool:
+            return not release_join.is_set()
+
+        def terminate(self) -> None:
+            self.terminated = True
+            release_join.set()
+
+    process = FakeProcess()
+
+    class FakeContext:
+        def Process(self, **_kwargs: object) -> FakeProcess:  # noqa: N802
+            return process
+
+    context = FakeContext()
+    monkeypatch.setattr(legacy_session_migration.multiprocessing, "get_context", lambda _method: context)
+
+    task = asyncio.create_task(_run_legacy_session_migration(tmp_path))
+    assert await asyncio.to_thread(join_started.wait, 5)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert process.terminated

--- a/tests/test_legacy_session_migration.py
+++ b/tests/test_legacy_session_migration.py
@@ -232,6 +232,36 @@ def test_blob_clear_failure_rolls_back_inserted_rows(tmp_path: Path) -> None:
     assert stored_runs == 0
 
 
+def test_failed_migration_does_not_log_conversation_data(tmp_path: Path) -> None:
+    """Database errors report their type without serializing bound run data."""
+    sentinel = "PRIVATE_CONVERSATION_SENTINEL"
+    db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
+    database = legacy_session_migration._open_database(db_path, "code_sessions")
+    database._get_table(table_type="runs", create_table_if_not_found=True)
+    database.close()
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.execute(
+            "UPDATE code_sessions SET runs = replace(runs, 'a1', ?)",
+            (sentinel,),
+        )
+        connection.execute(
+            "CREATE TRIGGER refuse_run_insert BEFORE INSERT ON code_sessions_runs "
+            "BEGIN SELECT RAISE(ABORT, 'run insert refused'); END",
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with capture_logs() as logs:
+        result = _migrate_table(db_path, "code_sessions")
+
+    skipped = next(entry for entry in logs if entry["event"] == "legacy_session_migration_skipped")
+    assert result.failed_sessions == 1
+    assert skipped["error"] == "IntegrityError"
+    assert sentinel not in str(skipped)
+
+
 def test_run_id_owned_by_another_session_keeps_the_legacy_blob(tmp_path: Path) -> None:
     """A global run-id collision cannot make verification retire the authoritative blob."""
     db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")

--- a/tests/test_legacy_session_migration.py
+++ b/tests/test_legacy_session_migration.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock
 import pytest
 from agno.run.agent import RunOutput
 from agno.session.agent import AgentSession
+from structlog.testing import capture_logs
 
 from mindroom import legacy_session_migration
 from mindroom.agent_storage import create_state_storage, get_agent_session, save_runs
@@ -123,6 +124,64 @@ def test_migration_preserves_the_visible_order_of_partially_migrated_sessions(tm
     assert journal_mode == ("delete",)
     assert _schema_version(db_path) == "3.0.0"
     assert _migrate_table(db_path, "code_sessions").migrated_sessions == 0
+
+
+def test_table_migration_logs_start_and_bounded_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Large migrations report totals and periodic progress without logging every session."""
+    monkeypatch.setattr(legacy_session_migration, "_PROGRESS_INTERVAL", 2)
+    db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
+    connection = sqlite3.connect(db_path)
+    try:
+        connection.executemany(
+            "INSERT INTO code_sessions (session_id, session_type, agent_id, runs, created_at) "
+            "VALUES (?, 'agent', 'code', '[]', ?)",
+            [(f"session-{index:03}", index) for index in range(2, 4)],
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+    with capture_logs() as logs:
+        result = _migrate_table(db_path, "code_sessions")
+
+    progress = [
+        entry
+        for entry in logs
+        if entry["event"] in {"legacy_session_migration_started", "legacy_session_migration_progress"}
+    ]
+    assert result.migrated_sessions == 3
+    assert progress == [
+        {
+            "db_file": str(db_path),
+            "session_table": "code_sessions",
+            "total_sessions": 3,
+            "event": "legacy_session_migration_started",
+            "log_level": "info",
+        },
+        {
+            "db_file": str(db_path),
+            "session_table": "code_sessions",
+            "processed_sessions": 2,
+            "total_sessions": 3,
+            "migrated_sessions": 2,
+            "failed_sessions": 0,
+            "event": "legacy_session_migration_progress",
+            "log_level": "info",
+        },
+        {
+            "db_file": str(db_path),
+            "session_table": "code_sessions",
+            "processed_sessions": 3,
+            "total_sessions": 3,
+            "migrated_sessions": 3,
+            "failed_sessions": 0,
+            "event": "legacy_session_migration_progress",
+            "log_level": "info",
+        },
+    ]
 
 
 def test_malformed_session_is_left_untouched_without_blocking_other_sessions(tmp_path: Path) -> None:
@@ -249,9 +308,13 @@ def test_concurrent_delete_finishes_during_decode_and_is_preserved_by_retry(
 async def test_spawned_process_migrates_the_storage_root(tmp_path: Path) -> None:
     """The production process boundary performs the complete storage-root scan."""
     db_path = create_agno_2_sessions_db(tmp_path / "sessions" / "code.db")
-    await _run_legacy_session_migration(tmp_path, log_level="INFO", runtime_paths=_runtime_paths(tmp_path))
+    runtime_paths = _runtime_paths(tmp_path)
+    await _run_legacy_session_migration(tmp_path, log_level="INFO", runtime_paths=runtime_paths)
 
     assert _blob_is_null(db_path, "session-1")
+    log_files = list((runtime_paths.storage_root / "logs").glob("*.log"))
+    assert len(log_files) == 1
+    assert "legacy_session_migration_finished" in log_files[0].read_text()
 
 
 @pytest.mark.asyncio
@@ -275,21 +338,6 @@ async def test_current_storage_does_not_spawn_a_migration_process(
     )
 
     await _run_legacy_session_migration(tmp_path, log_level="INFO", runtime_paths=_runtime_paths(tmp_path))
-
-
-def test_migration_child_configures_normal_logging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Child-process warnings use the same configured handlers as the runtime."""
-    configured: list[tuple[str, object]] = []
-    runtime_paths = _runtime_paths(tmp_path)
-    monkeypatch.setattr(
-        legacy_session_migration,
-        "setup_logging",
-        lambda *, level, runtime_paths: configured.append((level, runtime_paths)),
-    )
-
-    legacy_session_migration._migrate_storage_targets([], "WARNING", runtime_paths)
-
-    assert configured == [("WARNING", runtime_paths)]
 
 
 def test_preflight_skips_an_unreadable_database_without_hiding_valid_work(tmp_path: Path) -> None:

--- a/tests/test_orchestrator_runtime.py
+++ b/tests/test_orchestrator_runtime.py
@@ -253,6 +253,13 @@ def _retry_tasks() -> list[asyncio.Task[Any]]:
     return [task for task in asyncio.all_tasks() if task.get_name() == "approval_startup_cleanup_retry"]
 
 
+def _mock_runtime_orchestrator() -> MagicMock:
+    """Create a lifecycle test double with the runtime readiness contract."""
+    orchestrator = MagicMock()
+    orchestrator._runtime_ready_event = asyncio.Event()
+    return orchestrator
+
+
 @contextmanager
 def _mock_approval_recovery(**kwargs: object) -> Iterator[AsyncMock]:
     recovery = AsyncMock(**kwargs)
@@ -385,7 +392,7 @@ class TestAgentBot(AgentBotTestBase):
         """Permanent startup errors should stop the process and surface the failure."""
         reset_runtime_state()
         blocking_event = asyncio.Event()
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.start = AsyncMock(side_effect=PermanentMatrixStartupError("boom"))
         mock_orchestrator.stop = AsyncMock()
         mock_orchestrator.running = False
@@ -942,7 +949,7 @@ class TestAgentBot(AgentBotTestBase):
         events: list[str] = []
         orchestrator_cancelled = asyncio.Event()
         api_cancelled = asyncio.Event()
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.knowledge_refresh_scheduler = None
         mock_orchestrator.stop = AsyncMock()
 
@@ -1022,7 +1029,7 @@ class TestAgentBot(AgentBotTestBase):
         api_completed = asyncio.Event()
         api_cancelled = asyncio.Event()
         start_blocker = asyncio.Event()
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.knowledge_refresh_scheduler = None
         mock_orchestrator.stop = AsyncMock()
 
@@ -1086,7 +1093,7 @@ class TestAgentBot(AgentBotTestBase):
         """Regression coverage for API server signal shutdown not leaving the process half alive."""
         reset_runtime_state()
         start_released = asyncio.Event()
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.knowledge_refresh_scheduler = None
 
         async def _start() -> None:
@@ -1189,7 +1196,7 @@ class TestAgentBot(AgentBotTestBase):
     async def test_orchestrator_main_fails_when_api_server_exits_unexpectedly(self, tmp_path: Path) -> None:
         """An unexpected API-server task failure should stop the top-level run non-silently."""
         reset_runtime_state()
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.knowledge_refresh_scheduler = None
         mock_orchestrator.stop = AsyncMock()
         start_blocker = asyncio.Event()
@@ -1225,7 +1232,7 @@ class TestAgentBot(AgentBotTestBase):
         watched_paths: list[Path] = []
         config_watcher_ran = asyncio.Event()
         resolved_config_path = (tmp_path / "nested" / "config.yaml").resolve()
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.config_path = resolved_config_path
         mock_orchestrator._require_config_path.return_value = resolved_config_path
         mock_orchestrator.stop = AsyncMock()
@@ -1274,7 +1281,7 @@ class TestAgentBot(AgentBotTestBase):
         runtime_storage = tmp_path / "runtime-storage"
         observed_logging_root: Path | None = None
         observed_credentials_root: Path | None = None
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.start = AsyncMock(side_effect=RuntimeError("stop after storage capture"))
         mock_orchestrator.stop = AsyncMock()
 
@@ -1310,7 +1317,7 @@ class TestAgentBot(AgentBotTestBase):
         event_loop_thread_id = threading.get_ident()
         setup_thread_ids: list[int] = []
         events: list[str] = []
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.start = AsyncMock(side_effect=RuntimeError("stop after setup"))
         mock_orchestrator.stop = AsyncMock()
         stall_detector = MagicMock()
@@ -1398,7 +1405,7 @@ class TestAgentBot(AgentBotTestBase):
     async def test_orchestrator_main_shuts_down_primary_worker_manager(self, tmp_path: Path) -> None:
         """The orchestrator should clear stale workers before startup and shut them down on exit."""
         reset_runtime_state()
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.start = AsyncMock(side_effect=asyncio.CancelledError())
         mock_orchestrator.stop = AsyncMock()
         mock_orchestrator.running = False
@@ -1460,7 +1467,7 @@ class TestAgentBot(AgentBotTestBase):
     async def test_orchestrator_main_shuts_down_primary_worker_manager_when_stop_fails(self, tmp_path: Path) -> None:
         """Shutdown failures should still attempt primary worker manager shutdown."""
         reset_runtime_state()
-        mock_orchestrator = MagicMock()
+        mock_orchestrator = _mock_runtime_orchestrator()
         mock_orchestrator.start = AsyncMock(side_effect=asyncio.CancelledError())
         mock_orchestrator.stop = AsyncMock(side_effect=RuntimeError("stop boom"))
         mock_orchestrator.running = False


### PR DESCRIPTION
## Summary
- migrate legacy SQLite session blobs after runtime readiness
- preflight off-loop and start a child process only when work exists
- preserve concurrent writes with verified per-session transactions and compatibility fallback
- report table totals and progress every 100 sessions through normal logging

## Tests
- `uv run pytest -q`
- `uv run pre-commit run --all-files`

Closes #1947

## Summary by Sourcery

Retire legacy Agno 2 session run blobs after runtime readiness without blocking service availability or compromising concurrent session data.

New Features:
- Add automatic post-readiness migration of legacy Agno 2 session run blobs across session databases.

Bug Fixes:
- Prevent legacy session migration from blocking runtime startup or interfering with concurrent session writes.
- Preserve unreadable, invalid, or conflicting legacy blobs for compatibility reads and later retries.

Enhancements:
- Run migrations only when preflight finds pending legacy data, with per-session transactional verification and progress logging.
- Retain the legacy read fallback while retiring successfully migrated blobs and marking completed tables with the current schema version.

Documentation:
- Document the post-readiness session storage upgrade and legacy compatibility behavior.

Tests:
- Add coverage for migration ordering, rollback safety, conflicts, concurrent writes, process lifecycle, preflight behavior, logging, and runtime readiness integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added background migration for legacy session data after the runtime becomes ready.
  * Migration runs without blocking normal runtime activity and reports progress and completion.
  * Successfully migrated session data is stored in the current format.
  * Invalid or conflicting legacy data remains available through the compatibility path for later retry.
  * Migration starts only when legacy data is detected.

* **Documentation**
  * Added architecture documentation describing session storage upgrades, migration behavior, and compatibility handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->