### PR TITLE
Allow credential managers to reset shared OAuth

### DIFF
--- a/docs/dev/oauth-credential-lifecycle-design.md
+++ b/docs/dev/oauth-credential-lifecycle-design.md
@@ -34,8 +34,8 @@ This makes the local state transition atomic instead of reconstructing it after 
 18. Every provider token service ends with `_oauth`, which keeps OAuth tokens out of worker credential mirrors.
 19. Provider adapters classify terminal refresh failures from structured error codes and never expose provider-controlled descriptions.
 20. All consumers build reconnect responses through the shared OAuth service factory.
-21. The reset tool is non-destructive and only issues a requester-bound browser confirmation URL.
-22. The authenticated browser POST is the reset execution boundary.
+21. The reset tool is non-destructive and only issues a requester-issued browser confirmation URL.
+22. The authenticated requester-scoped POST or one-time shared-scope capability POST is the reset execution boundary.
 23. MCP retirement completes before the credential transaction commits a reset.
 24. A same-generation HTTP bearer rejection retires the exact MCP credential-scope session without replaying the remote call.
 
@@ -70,7 +70,8 @@ Credential-scope sessions are fenced during reset so captured stale state cannot
 
 ### Browser reset
 
-`src/mindroom/oauth/reset.py` freezes provider, service, agent, canonical requester, scope, worker key, connection generation, and a random operation ID into a short-lived authenticated browser action.
+`src/mindroom/oauth/reset.py` freezes provider, service, agent, canonical requester, scope, worker key, connection generation, and a random operation ID into a short-lived browser action.
+Requester-scoped actions require the original authenticated browser user, while shared-scope actions are one-time bearer capabilities issued only to configured credential managers.
 `src/mindroom/api/oauth.py` revalidates that target on GET and POST, while GET remains non-mutating.
 `src/mindroom/oauth/reset_execution.py` returns completed operations before transport work, otherwise retires MCP state and asks the lifecycle to atomically reset the credential.
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -456,6 +456,7 @@ It waits up to 600 seconds for active Matrix responses to drain, then force-appl
 - Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
 - OAuth-backed remote MCP credentials and sessions follow the selected agent's effective execution scope.
 - OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the active credential target.
-- Agent-initiated `reset_oauth_connection()` supports `user` and `user_agent` MCP credential scopes; reset shared or installation-level MCP connections from the authenticated dashboard.
+- Agent-initiated `reset_oauth_connection()` supports `shared`, `user`, and `user_agent` MCP credential scopes; shared resets require configured credential-management authority and a one-time browser confirmation link.
+- Reset installation-level unscoped MCP connections from the authenticated dashboard.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.

--- a/docs/oauth-framework.md
+++ b/docs/oauth-framework.md
@@ -7,7 +7,7 @@ icon: lucide/key-round
 MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account.
 Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, optional PKCE requirements, requester-only credential placement, explicitly permitted manual fallback fields and runtime environment names, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
 
-The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/success`, `/api/oauth/{provider}/status`, `/api/oauth/{provider}/disconnect`, and the authenticated `GET`/`POST` `/api/oauth/{provider}/reset` confirmation flow.
+The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/success`, `/api/oauth/{provider}/status`, `/api/oauth/{provider}/disconnect`, and the browser-confirmed `GET`/`POST` `/api/oauth/{provider}/reset` flow.
 When a scoped token exists but cannot be decoded, status returns `reset_required: true`, and the dashboard offers the decode-free scoped disconnect path before reconnecting.
 Agent-facing OAuth tools return the same structured `reset_required` signal and direct the requester to the authenticated dashboard Integrations page, which supports every credential scope and avoids prescribing an unavailable agent tool or unusable connect link.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the browser-openable `authorize` URL before MindRoom redirects to the external provider.
@@ -19,6 +19,8 @@ Unauthorized agent-scoped OAuth connect, authorize, status, disconnect, and call
 Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result.
 That token is a bearer capability for the exact provider, Matrix requester, worker target, and credential connection generation, so its authorize and callback requests do not require a dashboard login.
 MindRoom rechecks the requester's current agent credential-management permission at authorization and callback, and rejects a link if its credential generation changed after issuance.
+Shared-scope reset links use the same capability model for configured credential managers: the GET is non-mutating, the confirmation POST consumes the reset capability before deleting the scoped credential, and reconnection continues through a fresh single-use connect capability.
+Requester-scoped reset links still require the original authenticated browser user.
 Executions without a concrete requester cannot form a conversation capability; their links omit the connect token and use the existing dashboard-authenticated flow.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.
 `MINDROOM_OWNER_USER_ID` is a single-owner shortcut and is not suitable for a hosted multi-user private-agent deployment.

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -156,7 +156,8 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
-With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
+With `defaults.large_message_strategy: split`, a splittable final text response is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
+Payloads that cannot be safely segmented still use the sidecar path.
 See [Matrix Integration — Large Messages](architecture/matrix.md#large-messages) for details.
 
 ## Visibility Toggles

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -156,7 +156,7 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
-With `defaults.large_message_strategy: split`, segmentable oversized final text is delivered as several complete rich-text messages. Unsupported or unsegmentable payloads still use the sidecar path.
+With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
 See [Matrix Integration — Large Messages](architecture/matrix.md#large-messages) for details.
 
 ## Visibility Toggles

--- a/docs/streaming.md
+++ b/docs/streaming.md
@@ -156,7 +156,7 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
-With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
+With `defaults.large_message_strategy: split`, segmentable oversized final text is delivered as several complete rich-text messages. Unsupported or unsegmentable payloads still use the sidecar path.
 See [Matrix Integration — Large Messages](architecture/matrix.md#large-messages) for details.
 
 ## Visibility Toggles

--- a/docs/tools/agent-orchestration.md
+++ b/docs/tools/agent-orchestration.md
@@ -4,16 +4,16 @@ icon: lucide/wrench
 
 # Agent Orchestration
 
-Use these tools and presets to recover requester-scoped OAuth connections, coordinate other agents, save reusable Dynamic Workflows, change runtime configuration, import OpenClaw-style workspaces, and keep long-lived Claude coding sessions alive across turns.
+Use these tools and presets to recover scoped OAuth connections, coordinate other agents, save reusable Dynamic Workflows, change runtime configuration, import OpenClaw-style workspaces, and keep long-lived Claude coding sessions alive across turns.
 
 ## What This Page Covers
 
 This page documents the built-in tools in the `agent-orchestration` group.
-Use these tools when you need requester-scoped OAuth recovery, multi-agent coordination, reusable workflow runs, runtime config changes, config-only presets, persistent Claude Agent SDK sessions, or retained usage statistics.
+Use these tools when you need OAuth recovery, multi-agent coordination, reusable workflow runs, runtime config changes, config-only presets, persistent Claude Agent SDK sessions, or retained usage statistics.
 
 ## Tools On This Page
 
-- [`oauth_connections`] - Issue a browser-confirmed reset for one requester-scoped OAuth connection.
+- [`oauth_connections`] - Issue a browser-confirmed reset for one authorized OAuth connection.
 - [`subagents`] - Spawn Matrix-backed sub-agent sessions and message them later by session key or label.
 - [`delegate`] - Run another configured agent as a one-shot specialist and return its answer inline.
 - [`dynamic_workflow`] - Create, update, run, and inspect saved Dynamic Workflows with persisted report artifacts.
@@ -48,8 +48,8 @@ For [`openclaw_compat`], that means `matrix_message` is added directly and `atta
 
 The toolkit exposes only `reset_oauth_connection(provider_id)`.
 The provider must back one of the current agent's configured tools through that tool's `auth_provider` metadata.
-The call returns a time-limited, retryable, requester-bound browser link and does not change credentials itself.
-The authenticated browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
+The call returns a time-limited, requester-issued browser link and does not change credentials itself.
+The browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
 The reset does not revoke the grant at the external provider.
 Opening the link without confirming is non-destructive.
 Confirming when no local credential exists is safe and still continues to provider authorization.
@@ -70,17 +70,19 @@ agents:
       - google_drive
 ```
 
-### Browser Confirmation And Requester Scope
+### Browser Confirmation And Credential Scope
 
 The tool call itself is non-destructive: it only issues a browser URL and never deletes credentials or retires MCP sessions.
 Normal `tool_approval` policy still applies, so a matching `require_approval` rule can pause the tool call before it issues that URL.
 The browser page is the human approval boundary: its GET only displays the action, and its POST performs the reset.
 The link freezes the provider, credential service, invoking agent, canonical requester, credential scope, worker key, connection generation, and a stable reset operation ID.
-Only the original authenticated human requester can open and confirm the link.
+For `user` and `user_agent` scopes, only the original authenticated human requester can open and confirm the link.
+For `shared` scope, the short-lived link is a one-time bearer capability so a configured credential manager can confirm it without dashboard access.
+Keep a shared-scope link private because anyone with its complete URL can confirm it before it expires.
 Both link issuance and confirmation apply the current agent's credential-management policy, including configured sender aliases.
 Credential management accepts platform `administrators` and `agents.<name>.credential_managers`.
-The resolved credential scope must be `user` or `user_agent`; shared and unscoped credentials are refused.
-Use the authenticated dashboard connection controls to disconnect and reconnect shared or installation-level credentials.
+The resolved credential scope must be `shared`, `user`, or `user_agent`; unscoped credentials are refused.
+A `shared` reset affects every requester using the current agent.
 A `user` reset affects the current requester across agents, while a `user_agent` reset affects only the current requester and current agent.
 Providers that define requester-scoped credentials, such as GitHub, may resolve to `user` scope independently of the agent's `worker_scope`.
 
@@ -89,7 +91,8 @@ Providers that define requester-scoped credentials, such as GitHub, may resolve 
 - `oauth_connections` always runs in the primary MindRoom runtime, even if it appears in `worker_tools`.
 - Invalid, unavailable, unconfigured, unauthorized, expired, or mismatched links fail before credential deletion or MCP session disconnection.
 - Use the returned link, confirm the reset, complete provider authorization, then retry the original provider-backed tool call.
-- If the browser retries after the stable reset completed, MindRoom skips deletion and MCP retirement, so it cannot disturb a later reconnection.
+- If an authenticated requester-scoped reset retries after the stable reset completed, MindRoom skips deletion and MCP retirement, so it cannot disturb a later reconnection.
+- A shared-scope reset link is consumed by its confirmation POST; request a fresh link if that request does not complete.
 - Credential deletion and the stable reset receipt commit atomically, so a restart observes either the intact connection or the completed reset.
 - The browser link expires after 10 minutes; run `reset_oauth_connection()` again to issue a fresh link.
 

--- a/docs/tools/agent-orchestration.md
+++ b/docs/tools/agent-orchestration.md
@@ -47,12 +47,10 @@ For [`openclaw_compat`], that means `matrix_message` is added directly and `atta
 ### What It Does
 
 The toolkit exposes only `reset_oauth_connection(provider_id)`.
-The provider must back one of the current agent's configured tools through that tool's `auth_provider` metadata.
-The call returns a time-limited, requester-issued browser link and does not change credentials itself.
-The browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
-The reset does not revoke the grant at the external provider.
-Opening the link without confirming is non-destructive.
-Confirming when no local credential exists is safe and still continues to provider authorization.
+The provider must back one of the current agent's configured tools.
+The call returns a temporary browser link and does not change the connection by itself.
+After you confirm, MindRoom removes its saved connection and opens the provider's sign-in page so you can reconnect.
+It does not revoke access at the provider itself.
 
 ### Configuration
 
@@ -70,31 +68,39 @@ agents:
       - google_drive
 ```
 
-### Browser Confirmation And Credential Scope
+### Who Can Reset A Connection
 
-The tool call itself is non-destructive: it only issues a browser URL and never deletes credentials or retires MCP sessions.
-Normal `tool_approval` policy still applies, so a matching `require_approval` rule can pause the tool call before it issues that URL.
-The browser page is the human approval boundary: its GET only displays the action, and its POST performs the reset.
-The link freezes the provider, credential service, invoking agent, canonical requester, credential scope, worker key, connection generation, and a stable reset operation ID.
-For `user` and `user_agent` scopes, only the original authenticated human requester can open and confirm the link.
-For `shared` scope, the short-lived link is a one-time bearer capability so a configured credential manager can confirm it without dashboard access.
-Keep a shared-scope link private because anyone with its complete URL can confirm it before it expires.
-Both link issuance and confirmation apply the current agent's credential-management policy, including configured sender aliases.
-Credential management accepts platform `administrators` and `agents.<name>.credential_managers`.
-The resolved credential scope must be `shared`, `user`, or `user_agent`; unscoped credentials are refused.
-A `shared` reset affects every requester using the current agent.
-A `user` reset affects the current requester across agents, while a `user_agent` reset affects only the current requester and current agent.
-Providers that define requester-scoped credentials, such as GitHub, may resolve to `user` scope independently of the agent's `worker_scope`.
+| Connection type | Who confirms the reset | What the reset affects |
+| --- | --- | --- |
+| Shared (`shared`) | An administrator or configured credential manager can request the link. Anyone with the complete link can confirm it before it expires. | Everyone using this agent |
+| Personal (`user`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection across agents |
+| Personal for one agent (`user_agent`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection for this agent only |
+
+A shared connection belongs to the agent or team rather than to one MindRoom user.
+On a private agent, users can manage their own personal connections.
+On other agents, requesting a reset requires platform `administrator` access or an entry in `agents.<name>.credential_managers`.
+Some providers always use personal connections, regardless of the agent's configured scope.
+
+### Reset A Connection
+
+1. Ask the agent to call `reset_oauth_connection()` for the affected provider.
+2. Open the returned link within 10 minutes.
+3. Review which agent and connection type will be affected, then confirm the reset.
+4. Sign in at the provider and retry the original request.
+
+Keep a shared reset link private.
+Anyone with the complete link can confirm it before it expires, and confirming it can disconnect the service for everyone using that agent until reconnection finishes.
 
 ### Notes
 
 - `oauth_connections` always runs in the primary MindRoom runtime, even if it appears in `worker_tools`.
-- Invalid, unavailable, unconfigured, unauthorized, expired, or mismatched links fail before credential deletion or MCP session disconnection.
-- Use the returned link, confirm the reset, complete provider authorization, then retry the original provider-backed tool call.
-- If an authenticated requester-scoped reset retries after the stable reset completed, MindRoom skips deletion and MCP retirement, so it cannot disturb a later reconnection.
-- A shared-scope reset link is consumed by its confirmation POST; request a fresh link if that request does not complete.
-- Credential deletion and the stable reset receipt commit atomically, so a restart observes either the intact connection or the completed reset.
-- The browser link expires after 10 minutes; run `reset_oauth_connection()` again to issue a fresh link.
+- Opening a reset link without confirming it does not change the connection.
+- MindRoom refuses an expired, unauthorized, or outdated link before deleting credentials.
+- A shared reset link works once. Run `reset_oauth_connection()` again if you need a new one.
+- Installation-level connections that are not assigned to an agent scope must be reset from the dashboard.
+- Normal `tool_approval` rules still apply when the agent creates the link.
+
+For implementation details and lifecycle guarantees, see [OAuth Credential Lifecycle Design](../dev/oauth-credential-lifecycle-design.md#browser-reset).
 
 ## [`usage_stats`]
 

--- a/docs/tools/agent-orchestration.md
+++ b/docs/tools/agent-orchestration.md
@@ -76,7 +76,7 @@ agents:
 | Personal (`user`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection across agents |
 | Personal for one agent (`user_agent`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection for this agent only |
 
-A shared connection belongs to the agent or team rather than to one MindRoom user.
+A shared connection belongs to the agent rather than to one MindRoom user.
 On a private agent, users can manage their own personal connections.
 On other agents, requesting a reset requires platform `administrator` access or an entry in `agents.<name>.credential_managers`.
 Some providers always use personal connections, regardless of the agent's configured scope.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15826,7 +15826,7 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
-With `defaults.large_message_strategy: split`, segmentable oversized final text is delivered as several complete rich-text messages. Unsupported or unsegmentable payloads still use the sidecar path.
+With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
 See [Matrix Integration — Large Messages](https://docs.mindroom.chat/architecture/matrix/#large-messages) for details.
 
 ## Visibility Toggles

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -15826,7 +15826,7 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
-With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
+With `defaults.large_message_strategy: split`, segmentable oversized final text is delivered as several complete rich-text messages. Unsupported or unsegmentable payloads still use the sidecar path.
 See [Matrix Integration — Large Messages](https://docs.mindroom.chat/architecture/matrix/#large-messages) for details.
 
 ## Visibility Toggles

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9652,12 +9652,10 @@ For [`openclaw_compat`], that means `matrix_message` is added directly and `atta
 ### What It Does
 
 The toolkit exposes only `reset_oauth_connection(provider_id)`.
-The provider must back one of the current agent's configured tools through that tool's `auth_provider` metadata.
-The call returns a time-limited, requester-issued browser link and does not change credentials itself.
-The browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
-The reset does not revoke the grant at the external provider.
-Opening the link without confirming is non-destructive.
-Confirming when no local credential exists is safe and still continues to provider authorization.
+The provider must back one of the current agent's configured tools.
+The call returns a temporary browser link and does not change the connection by itself.
+After you confirm, MindRoom removes its saved connection and opens the provider's sign-in page so you can reconnect.
+It does not revoke access at the provider itself.
 
 ### Configuration
 
@@ -9675,31 +9673,39 @@ agents:
       - google_drive
 ```
 
-### Browser Confirmation And Credential Scope
+### Who Can Reset A Connection
 
-The tool call itself is non-destructive: it only issues a browser URL and never deletes credentials or retires MCP sessions.
-Normal `tool_approval` policy still applies, so a matching `require_approval` rule can pause the tool call before it issues that URL.
-The browser page is the human approval boundary: its GET only displays the action, and its POST performs the reset.
-The link freezes the provider, credential service, invoking agent, canonical requester, credential scope, worker key, connection generation, and a stable reset operation ID.
-For `user` and `user_agent` scopes, only the original authenticated human requester can open and confirm the link.
-For `shared` scope, the short-lived link is a one-time bearer capability so a configured credential manager can confirm it without dashboard access.
-Keep a shared-scope link private because anyone with its complete URL can confirm it before it expires.
-Both link issuance and confirmation apply the current agent's credential-management policy, including configured sender aliases.
-Credential management accepts platform `administrators` and `agents.<name>.credential_managers`.
-The resolved credential scope must be `shared`, `user`, or `user_agent`; unscoped credentials are refused.
-A `shared` reset affects every requester using the current agent.
-A `user` reset affects the current requester across agents, while a `user_agent` reset affects only the current requester and current agent.
-Providers that define requester-scoped credentials, such as GitHub, may resolve to `user` scope independently of the agent's `worker_scope`.
+| Connection type | Who confirms the reset | What the reset affects |
+| --- | --- | --- |
+| Shared (`shared`) | An administrator or configured credential manager can request the link. Anyone with the complete link can confirm it before it expires. | Everyone using this agent |
+| Personal (`user`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection across agents |
+| Personal for one agent (`user_agent`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection for this agent only |
+
+A shared connection belongs to the agent or team rather than to one MindRoom user.
+On a private agent, users can manage their own personal connections.
+On other agents, requesting a reset requires platform `administrator` access or an entry in `agents.<name>.credential_managers`.
+Some providers always use personal connections, regardless of the agent's configured scope.
+
+### Reset A Connection
+
+1. Ask the agent to call `reset_oauth_connection()` for the affected provider.
+2. Open the returned link within 10 minutes.
+3. Review which agent and connection type will be affected, then confirm the reset.
+4. Sign in at the provider and retry the original request.
+
+Keep a shared reset link private.
+Anyone with the complete link can confirm it before it expires, and confirming it can disconnect the service for everyone using that agent until reconnection finishes.
 
 ### Notes
 
 - `oauth_connections` always runs in the primary MindRoom runtime, even if it appears in `worker_tools`.
-- Invalid, unavailable, unconfigured, unauthorized, expired, or mismatched links fail before credential deletion or MCP session disconnection.
-- Use the returned link, confirm the reset, complete provider authorization, then retry the original provider-backed tool call.
-- If an authenticated requester-scoped reset retries after the stable reset completed, MindRoom skips deletion and MCP retirement, so it cannot disturb a later reconnection.
-- A shared-scope reset link is consumed by its confirmation POST; request a fresh link if that request does not complete.
-- Credential deletion and the stable reset receipt commit atomically, so a restart observes either the intact connection or the completed reset.
-- The browser link expires after 10 minutes; run `reset_oauth_connection()` again to issue a fresh link.
+- Opening a reset link without confirming it does not change the connection.
+- MindRoom refuses an expired, unauthorized, or outdated link before deleting credentials.
+- A shared reset link works once. Run `reset_oauth_connection()` again if you need a new one.
+- Installation-level connections that are not assigned to an agent scope must be reset from the dashboard.
+- Normal `tool_approval` rules still apply when the agent creates the link.
+
+For implementation details and lifecycle guarantees, see [OAuth Credential Lifecycle Design](https://docs.mindroom.chat/dev/oauth-credential-lifecycle-design/#browser-reset).
 
 ## [`usage_stats`]
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9609,16 +9609,16 @@ search_zep_memory(query="release notes", search_scope="edges")
 
 # Agent Orchestration
 
-Use these tools and presets to recover requester-scoped OAuth connections, coordinate other agents, save reusable Dynamic Workflows, change runtime configuration, import OpenClaw-style workspaces, and keep long-lived Claude coding sessions alive across turns.
+Use these tools and presets to recover scoped OAuth connections, coordinate other agents, save reusable Dynamic Workflows, change runtime configuration, import OpenClaw-style workspaces, and keep long-lived Claude coding sessions alive across turns.
 
 ## What This Page Covers
 
 This page documents the built-in tools in the `agent-orchestration` group.
-Use these tools when you need requester-scoped OAuth recovery, multi-agent coordination, reusable workflow runs, runtime config changes, config-only presets, persistent Claude Agent SDK sessions, or retained usage statistics.
+Use these tools when you need OAuth recovery, multi-agent coordination, reusable workflow runs, runtime config changes, config-only presets, persistent Claude Agent SDK sessions, or retained usage statistics.
 
 ## Tools On This Page
 
-- [`oauth_connections`] - Issue a browser-confirmed reset for one requester-scoped OAuth connection.
+- [`oauth_connections`] - Issue a browser-confirmed reset for one authorized OAuth connection.
 - [`subagents`] - Spawn Matrix-backed sub-agent sessions and message them later by session key or label.
 - [`delegate`] - Run another configured agent as a one-shot specialist and return its answer inline.
 - [`dynamic_workflow`] - Create, update, run, and inspect saved Dynamic Workflows with persisted report artifacts.
@@ -9653,8 +9653,8 @@ For [`openclaw_compat`], that means `matrix_message` is added directly and `atta
 
 The toolkit exposes only `reset_oauth_connection(provider_id)`.
 The provider must back one of the current agent's configured tools through that tool's `auth_provider` metadata.
-The call returns a time-limited, retryable, requester-bound browser link and does not change credentials itself.
-The authenticated browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
+The call returns a time-limited, requester-issued browser link and does not change credentials itself.
+The browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
 The reset does not revoke the grant at the external provider.
 Opening the link without confirming is non-destructive.
 Confirming when no local credential exists is safe and still continues to provider authorization.
@@ -9675,17 +9675,19 @@ agents:
       - google_drive
 ```
 
-### Browser Confirmation And Requester Scope
+### Browser Confirmation And Credential Scope
 
 The tool call itself is non-destructive: it only issues a browser URL and never deletes credentials or retires MCP sessions.
 Normal `tool_approval` policy still applies, so a matching `require_approval` rule can pause the tool call before it issues that URL.
 The browser page is the human approval boundary: its GET only displays the action, and its POST performs the reset.
 The link freezes the provider, credential service, invoking agent, canonical requester, credential scope, worker key, connection generation, and a stable reset operation ID.
-Only the original authenticated human requester can open and confirm the link.
+For `user` and `user_agent` scopes, only the original authenticated human requester can open and confirm the link.
+For `shared` scope, the short-lived link is a one-time bearer capability so a configured credential manager can confirm it without dashboard access.
+Keep a shared-scope link private because anyone with its complete URL can confirm it before it expires.
 Both link issuance and confirmation apply the current agent's credential-management policy, including configured sender aliases.
 Credential management accepts platform `administrators` and `agents.<name>.credential_managers`.
-The resolved credential scope must be `user` or `user_agent`; shared and unscoped credentials are refused.
-Use the authenticated dashboard connection controls to disconnect and reconnect shared or installation-level credentials.
+The resolved credential scope must be `shared`, `user`, or `user_agent`; unscoped credentials are refused.
+A `shared` reset affects every requester using the current agent.
 A `user` reset affects the current requester across agents, while a `user_agent` reset affects only the current requester and current agent.
 Providers that define requester-scoped credentials, such as GitHub, may resolve to `user` scope independently of the agent's `worker_scope`.
 
@@ -9694,7 +9696,8 @@ Providers that define requester-scoped credentials, such as GitHub, may resolve 
 - `oauth_connections` always runs in the primary MindRoom runtime, even if it appears in `worker_tools`.
 - Invalid, unavailable, unconfigured, unauthorized, expired, or mismatched links fail before credential deletion or MCP session disconnection.
 - Use the returned link, confirm the reset, complete provider authorization, then retry the original provider-backed tool call.
-- If the browser retries after the stable reset completed, MindRoom skips deletion and MCP retirement, so it cannot disturb a later reconnection.
+- If an authenticated requester-scoped reset retries after the stable reset completed, MindRoom skips deletion and MCP retirement, so it cannot disturb a later reconnection.
+- A shared-scope reset link is consumed by its confirmation POST; request a fresh link if that request does not complete.
 - Credential deletion and the stable reset receipt commit atomically, so a restart observes either the intact connection or the completed reset.
 - The browser link expires after 10 minutes; run `reset_oauth_connection()` again to issue a fresh link.
 
@@ -11734,7 +11737,8 @@ It waits up to 600 seconds for active Matrix responses to drain, then force-appl
 - Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
 - OAuth-backed remote MCP credentials and sessions follow the selected agent's effective execution scope.
 - OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the active credential target.
-- Agent-initiated `reset_oauth_connection()` supports `user` and `user_agent` MCP credential scopes; reset shared or installation-level MCP connections from the authenticated dashboard.
+- Agent-initiated `reset_oauth_connection()` supports `shared`, `user`, and `user_agent` MCP credential scopes; shared resets require configured credential-management authority and a one-time browser confirmation link.
+- Reset installation-level unscoped MCP connections from the authenticated dashboard.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.
 
@@ -13575,7 +13579,7 @@ To adopt hooks:
 MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account.
 Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, optional PKCE requirements, requester-only credential placement, explicitly permitted manual fallback fields and runtime environment names, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
 
-The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/success`, `/api/oauth/{provider}/status`, `/api/oauth/{provider}/disconnect`, and the authenticated `GET`/`POST` `/api/oauth/{provider}/reset` confirmation flow.
+The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/success`, `/api/oauth/{provider}/status`, `/api/oauth/{provider}/disconnect`, and the browser-confirmed `GET`/`POST` `/api/oauth/{provider}/reset` flow.
 When a scoped token exists but cannot be decoded, status returns `reset_required: true`, and the dashboard offers the decode-free scoped disconnect path before reconnecting.
 Agent-facing OAuth tools return the same structured `reset_required` signal and direct the requester to the authenticated dashboard Integrations page, which supports every credential scope and avoids prescribing an unavailable agent tool or unusable connect link.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the browser-openable `authorize` URL before MindRoom redirects to the external provider.
@@ -13587,6 +13591,8 @@ Unauthorized agent-scoped OAuth connect, authorize, status, disconnect, and call
 Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result.
 That token is a bearer capability for the exact provider, Matrix requester, worker target, and credential connection generation, so its authorize and callback requests do not require a dashboard login.
 MindRoom rechecks the requester's current agent credential-management permission at authorization and callback, and rejects a link if its credential generation changed after issuance.
+Shared-scope reset links use the same capability model for configured credential managers: the GET is non-mutating, the confirmation POST consumes the reset capability before deleting the scoped credential, and reconnection continues through a fresh single-use connect capability.
+Requester-scoped reset links still require the original authenticated browser user.
 Executions without a concrete requester cannot form a conversation capability; their links omit the connect token and use the existing dashboard-authenticated flow.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.
 `MINDROOM_OWNER_USER_ID` is a single-owner shortcut and is not suitable for a hosted multi-user private-agent deployment.
@@ -15820,6 +15826,7 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
+With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
 See [Matrix Integration — Large Messages](https://docs.mindroom.chat/architecture/matrix/#large-messages) for details.
 
 ## Visibility Toggles
@@ -17081,6 +17088,13 @@ Messages exceeding the 64KB Matrix event limit are automatically handled by `pre
 - Custom metadata dict `io.mindroom.long_text` contains `version: 2`, `encoding: "matrix_event_content_json"`, original and preview sizes, and a completeness flag
 - Preview event is compact (for example no inline `io.mindroom.tool_trace`), while the sidecar preserves full content fidelity
 - Encrypted rooms: sidecar JSON is encrypted before upload (`message-content.json.enc`)
+
+With `defaults.large_message_strategy: split`, an oversized final text response is instead delivered as several complete rich-text events by `segment_matrix_content()` in `matrix/segmented_messages.py`.
+The body is cut at paragraph or line boundaries, never inside a fenced code block, and concatenating the segment bodies reproduces the original exactly.
+The first segment stays a final `m.replace` of the streaming placeholder when there is one; continuations are plain messages that stay in the thread when there is one.
+Every segment is rendered as standalone Markdown with `m.mentions` attached to the segment whose body carries the mention.
+Continuation payloads are frozen in the local outbox row and sent under deterministic transaction IDs, so a retry or restart resends only the segments the room does not already hold.
+Non-text payloads, metadata that alone exceeds the budget, and a single code fence larger than one event still use the sidecar path.
 
 ## Response Tracking
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -9681,7 +9681,7 @@ agents:
 | Personal (`user`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection across agents |
 | Personal for one agent (`user_agent`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection for this agent only |
 
-A shared connection belongs to the agent or team rather than to one MindRoom user.
+A shared connection belongs to the agent rather than to one MindRoom user.
 On a private agent, users can manage their own personal connections.
 On other agents, requesting a reset requires platform `administrator` access or an entry in `agents.<name>.credential_managers`.
 Some providers always use personal connections, regardless of the agent's configured scope.
@@ -15832,7 +15832,8 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
-With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
+With `defaults.large_message_strategy: split`, a splittable final text response is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
+Payloads that cannot be safely segmented still use the sidecar path.
 See [Matrix Integration — Large Messages](https://docs.mindroom.chat/architecture/matrix/#large-messages) for details.
 
 ## Visibility Toggles

--- a/skills/mindroom-docs/references/page__architecture__matrix__index.md
+++ b/skills/mindroom-docs/references/page__architecture__matrix__index.md
@@ -171,6 +171,13 @@ Messages exceeding the 64KB Matrix event limit are automatically handled by `pre
 - Preview event is compact (for example no inline `io.mindroom.tool_trace`), while the sidecar preserves full content fidelity
 - Encrypted rooms: sidecar JSON is encrypted before upload (`message-content.json.enc`)
 
+With `defaults.large_message_strategy: split`, an oversized final text response is instead delivered as several complete rich-text events by `segment_matrix_content()` in `matrix/segmented_messages.py`.
+The body is cut at paragraph or line boundaries, never inside a fenced code block, and concatenating the segment bodies reproduces the original exactly.
+The first segment stays a final `m.replace` of the streaming placeholder when there is one; continuations are plain messages that stay in the thread when there is one.
+Every segment is rendered as standalone Markdown with `m.mentions` attached to the segment whose body carries the mention.
+Continuation payloads are frozen in the local outbox row and sent under deterministic transaction IDs, so a retry or restart resends only the segments the room does not already hold.
+Non-text payloads, metadata that alone exceeds the budget, and a single code fence larger than one event still use the sidecar path.
+
 ## Response Tracking
 
 Duplicate responses are prevented at two durable layers, both in `tracking/event_journal.db` under `mindroom_data/`.

--- a/skills/mindroom-docs/references/page__mcp__index.md
+++ b/skills/mindroom-docs/references/page__mcp__index.md
@@ -452,6 +452,7 @@ It waits up to 600 seconds for active Matrix responses to drain, then force-appl
 - Non-OAuth MCP integrations always use the shared server session, even on isolating worker scopes; per-requester isolation requires an OAuth-backed server.
 - OAuth-backed remote MCP credentials and sessions follow the selected agent's effective execution scope.
 - OAuth-backed remote MCP typed functions appear only after MindRoom has cached a catalog for the active credential target.
-- Agent-initiated `reset_oauth_connection()` supports `user` and `user_agent` MCP credential scopes; reset shared or installation-level MCP connections from the authenticated dashboard.
+- Agent-initiated `reset_oauth_connection()` supports `shared`, `user`, and `user_agent` MCP credential scopes; shared resets require configured credential-management authority and a one-time browser confirmation link.
+- Reset installation-level unscoped MCP connections from the authenticated dashboard.
 - `server_id` and `tool_prefix` must use letters, numbers, and underscores.
 - The final function name `<prefix>_<remote_tool_name>` must be 64 characters or fewer.

--- a/skills/mindroom-docs/references/page__oauth-framework__index.md
+++ b/skills/mindroom-docs/references/page__oauth-framework__index.md
@@ -3,7 +3,7 @@
 MindRoom owns OAuth state, callback handling, credential scoping, and token persistence because those steps decide which human and agent scope receive access to an external account.
 Providers supply only provider-specific metadata and parsing behavior, such as OAuth endpoints, scopes, client config services, optional PKCE requirements, requester-only credential placement, explicitly permitted manual fallback fields and runtime environment names, token response parsing, claim validation, the token credential service name used by OAuth, and the optional tool config service name used by dashboard settings.
 
-The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/success`, `/api/oauth/{provider}/status`, `/api/oauth/{provider}/disconnect`, and the authenticated `GET`/`POST` `/api/oauth/{provider}/reset` confirmation flow.
+The generic API surface is `/api/oauth/{provider}/connect`, `/api/oauth/{provider}/authorize`, `/api/oauth/{provider}/callback`, `/api/oauth/{provider}/success`, `/api/oauth/{provider}/status`, `/api/oauth/{provider}/disconnect`, and the browser-confirmed `GET`/`POST` `/api/oauth/{provider}/reset` flow.
 When a scoped token exists but cannot be decoded, status returns `reset_required: true`, and the dashboard offers the decode-free scoped disconnect path before reconnecting.
 Agent-facing OAuth tools return the same structured `reset_required` signal and direct the requester to the authenticated dashboard Integrations page, which supports every credential scope and avoids prescribing an unavailable agent tool or unusable connect link.
 Dashboard flows can call `connect` to receive an authorization URL, while conversation flows can show the browser-openable `authorize` URL before MindRoom redirects to the external provider.
@@ -15,6 +15,8 @@ Unauthorized agent-scoped OAuth connect, authorize, status, disconnect, and call
 Conversation OAuth links use an additional opaque, time-limited, single-use connect token that binds the browser flow to the requester that produced the missing-credentials tool result.
 That token is a bearer capability for the exact provider, Matrix requester, worker target, and credential connection generation, so its authorize and callback requests do not require a dashboard login.
 MindRoom rechecks the requester's current agent credential-management permission at authorization and callback, and rejects a link if its credential generation changed after issuance.
+Shared-scope reset links use the same capability model for configured credential managers: the GET is non-mutating, the confirmation POST consumes the reset capability before deleting the scoped credential, and reconnection continues through a fresh single-use connect capability.
+Requester-scoped reset links still require the original authenticated browser user.
 Executions without a concrete requester cannot form a conversation capability; their links omit the connect token and use the existing dashboard-authenticated flow.
 Standalone deployments should set `MINDROOM_OWNER_USER_ID` through pairing so dashboard credential management and agent-issued OAuth links resolve to the owner Matrix user instead of the generic dashboard API-key principal.
 `MINDROOM_OWNER_USER_ID` is a single-owner shortcut and is not suitable for a hosted multi-user private-agent deployment.

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -152,7 +152,7 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
-With `defaults.large_message_strategy: split`, segmentable oversized final text is delivered as several complete rich-text messages. Unsupported or unsegmentable payloads still use the sidecar path.
+With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
 See [Matrix Integration — Large Messages](https://docs.mindroom.chat/architecture/matrix/#large-messages) for details.
 
 ## Visibility Toggles

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -152,7 +152,7 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
-With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
+With `defaults.large_message_strategy: split`, segmentable oversized final text is delivered as several complete rich-text messages. Unsupported or unsegmentable payloads still use the sidecar path.
 See [Matrix Integration — Large Messages](https://docs.mindroom.chat/architecture/matrix/#large-messages) for details.
 
 ## Visibility Toggles

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -152,6 +152,7 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
+With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
 See [Matrix Integration — Large Messages](https://docs.mindroom.chat/architecture/matrix/#large-messages) for details.
 
 ## Visibility Toggles

--- a/skills/mindroom-docs/references/page__streaming__index.md
+++ b/skills/mindroom-docs/references/page__streaming__index.md
@@ -152,7 +152,8 @@ If an error occurs during streaming, the message is finalized with:
 ## Large Streamed Messages
 
 If a streamed response exceeds the Matrix event size limit (55KB for new messages, 27KB for edits), the large message system automatically uploads a JSON sidecar and includes a preview in the event body.
-With `defaults.large_message_strategy: split`, the final edit is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
+With `defaults.large_message_strategy: split`, a splittable final text response is instead delivered as several complete rich-text messages so the whole Markdown answer stays visible without a sidecar.
+Payloads that cannot be safely segmented still use the sidecar path.
 See [Matrix Integration — Large Messages](https://docs.mindroom.chat/architecture/matrix/#large-messages) for details.
 
 ## Visibility Toggles

--- a/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
+++ b/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
@@ -1,15 +1,15 @@
 # Agent Orchestration
 
-Use these tools and presets to recover requester-scoped OAuth connections, coordinate other agents, save reusable Dynamic Workflows, change runtime configuration, import OpenClaw-style workspaces, and keep long-lived Claude coding sessions alive across turns.
+Use these tools and presets to recover scoped OAuth connections, coordinate other agents, save reusable Dynamic Workflows, change runtime configuration, import OpenClaw-style workspaces, and keep long-lived Claude coding sessions alive across turns.
 
 ## What This Page Covers
 
 This page documents the built-in tools in the `agent-orchestration` group.
-Use these tools when you need requester-scoped OAuth recovery, multi-agent coordination, reusable workflow runs, runtime config changes, config-only presets, persistent Claude Agent SDK sessions, or retained usage statistics.
+Use these tools when you need OAuth recovery, multi-agent coordination, reusable workflow runs, runtime config changes, config-only presets, persistent Claude Agent SDK sessions, or retained usage statistics.
 
 ## Tools On This Page
 
-- [`oauth_connections`] - Issue a browser-confirmed reset for one requester-scoped OAuth connection.
+- [`oauth_connections`] - Issue a browser-confirmed reset for one authorized OAuth connection.
 - [`subagents`] - Spawn Matrix-backed sub-agent sessions and message them later by session key or label.
 - [`delegate`] - Run another configured agent as a one-shot specialist and return its answer inline.
 - [`dynamic_workflow`] - Create, update, run, and inspect saved Dynamic Workflows with persisted report artifacts.
@@ -44,8 +44,8 @@ For [`openclaw_compat`], that means `matrix_message` is added directly and `atta
 
 The toolkit exposes only `reset_oauth_connection(provider_id)`.
 The provider must back one of the current agent's configured tools through that tool's `auth_provider` metadata.
-The call returns a time-limited, retryable, requester-bound browser link and does not change credentials itself.
-The authenticated browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
+The call returns a time-limited, requester-issued browser link and does not change credentials itself.
+The browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
 The reset does not revoke the grant at the external provider.
 Opening the link without confirming is non-destructive.
 Confirming when no local credential exists is safe and still continues to provider authorization.
@@ -66,17 +66,19 @@ agents:
       - google_drive
 ```
 
-### Browser Confirmation And Requester Scope
+### Browser Confirmation And Credential Scope
 
 The tool call itself is non-destructive: it only issues a browser URL and never deletes credentials or retires MCP sessions.
 Normal `tool_approval` policy still applies, so a matching `require_approval` rule can pause the tool call before it issues that URL.
 The browser page is the human approval boundary: its GET only displays the action, and its POST performs the reset.
 The link freezes the provider, credential service, invoking agent, canonical requester, credential scope, worker key, connection generation, and a stable reset operation ID.
-Only the original authenticated human requester can open and confirm the link.
+For `user` and `user_agent` scopes, only the original authenticated human requester can open and confirm the link.
+For `shared` scope, the short-lived link is a one-time bearer capability so a configured credential manager can confirm it without dashboard access.
+Keep a shared-scope link private because anyone with its complete URL can confirm it before it expires.
 Both link issuance and confirmation apply the current agent's credential-management policy, including configured sender aliases.
 Credential management accepts platform `administrators` and `agents.<name>.credential_managers`.
-The resolved credential scope must be `user` or `user_agent`; shared and unscoped credentials are refused.
-Use the authenticated dashboard connection controls to disconnect and reconnect shared or installation-level credentials.
+The resolved credential scope must be `shared`, `user`, or `user_agent`; unscoped credentials are refused.
+A `shared` reset affects every requester using the current agent.
 A `user` reset affects the current requester across agents, while a `user_agent` reset affects only the current requester and current agent.
 Providers that define requester-scoped credentials, such as GitHub, may resolve to `user` scope independently of the agent's `worker_scope`.
 
@@ -85,7 +87,8 @@ Providers that define requester-scoped credentials, such as GitHub, may resolve 
 - `oauth_connections` always runs in the primary MindRoom runtime, even if it appears in `worker_tools`.
 - Invalid, unavailable, unconfigured, unauthorized, expired, or mismatched links fail before credential deletion or MCP session disconnection.
 - Use the returned link, confirm the reset, complete provider authorization, then retry the original provider-backed tool call.
-- If the browser retries after the stable reset completed, MindRoom skips deletion and MCP retirement, so it cannot disturb a later reconnection.
+- If an authenticated requester-scoped reset retries after the stable reset completed, MindRoom skips deletion and MCP retirement, so it cannot disturb a later reconnection.
+- A shared-scope reset link is consumed by its confirmation POST; request a fresh link if that request does not complete.
 - Credential deletion and the stable reset receipt commit atomically, so a restart observes either the intact connection or the completed reset.
 - The browser link expires after 10 minutes; run `reset_oauth_connection()` again to issue a fresh link.
 

--- a/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
+++ b/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
@@ -43,12 +43,10 @@ For [`openclaw_compat`], that means `matrix_message` is added directly and `atta
 ### What It Does
 
 The toolkit exposes only `reset_oauth_connection(provider_id)`.
-The provider must back one of the current agent's configured tools through that tool's `auth_provider` metadata.
-The call returns a time-limited, requester-issued browser link and does not change credentials itself.
-The browser confirmation retires the matching MCP OAuth session for that credential scope when applicable, deletes the matching local scoped credential under the same lock used by token refresh, and then opens the provider authorization page.
-The reset does not revoke the grant at the external provider.
-Opening the link without confirming is non-destructive.
-Confirming when no local credential exists is safe and still continues to provider authorization.
+The provider must back one of the current agent's configured tools.
+The call returns a temporary browser link and does not change the connection by itself.
+After you confirm, MindRoom removes its saved connection and opens the provider's sign-in page so you can reconnect.
+It does not revoke access at the provider itself.
 
 ### Configuration
 
@@ -66,31 +64,39 @@ agents:
       - google_drive
 ```
 
-### Browser Confirmation And Credential Scope
+### Who Can Reset A Connection
 
-The tool call itself is non-destructive: it only issues a browser URL and never deletes credentials or retires MCP sessions.
-Normal `tool_approval` policy still applies, so a matching `require_approval` rule can pause the tool call before it issues that URL.
-The browser page is the human approval boundary: its GET only displays the action, and its POST performs the reset.
-The link freezes the provider, credential service, invoking agent, canonical requester, credential scope, worker key, connection generation, and a stable reset operation ID.
-For `user` and `user_agent` scopes, only the original authenticated human requester can open and confirm the link.
-For `shared` scope, the short-lived link is a one-time bearer capability so a configured credential manager can confirm it without dashboard access.
-Keep a shared-scope link private because anyone with its complete URL can confirm it before it expires.
-Both link issuance and confirmation apply the current agent's credential-management policy, including configured sender aliases.
-Credential management accepts platform `administrators` and `agents.<name>.credential_managers`.
-The resolved credential scope must be `shared`, `user`, or `user_agent`; unscoped credentials are refused.
-A `shared` reset affects every requester using the current agent.
-A `user` reset affects the current requester across agents, while a `user_agent` reset affects only the current requester and current agent.
-Providers that define requester-scoped credentials, such as GitHub, may resolve to `user` scope independently of the agent's `worker_scope`.
+| Connection type | Who confirms the reset | What the reset affects |
+| --- | --- | --- |
+| Shared (`shared`) | An administrator or configured credential manager can request the link. Anyone with the complete link can confirm it before it expires. | Everyone using this agent |
+| Personal (`user`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection across agents |
+| Personal for one agent (`user_agent`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection for this agent only |
+
+A shared connection belongs to the agent or team rather than to one MindRoom user.
+On a private agent, users can manage their own personal connections.
+On other agents, requesting a reset requires platform `administrator` access or an entry in `agents.<name>.credential_managers`.
+Some providers always use personal connections, regardless of the agent's configured scope.
+
+### Reset A Connection
+
+1. Ask the agent to call `reset_oauth_connection()` for the affected provider.
+2. Open the returned link within 10 minutes.
+3. Review which agent and connection type will be affected, then confirm the reset.
+4. Sign in at the provider and retry the original request.
+
+Keep a shared reset link private.
+Anyone with the complete link can confirm it before it expires, and confirming it can disconnect the service for everyone using that agent until reconnection finishes.
 
 ### Notes
 
 - `oauth_connections` always runs in the primary MindRoom runtime, even if it appears in `worker_tools`.
-- Invalid, unavailable, unconfigured, unauthorized, expired, or mismatched links fail before credential deletion or MCP session disconnection.
-- Use the returned link, confirm the reset, complete provider authorization, then retry the original provider-backed tool call.
-- If an authenticated requester-scoped reset retries after the stable reset completed, MindRoom skips deletion and MCP retirement, so it cannot disturb a later reconnection.
-- A shared-scope reset link is consumed by its confirmation POST; request a fresh link if that request does not complete.
-- Credential deletion and the stable reset receipt commit atomically, so a restart observes either the intact connection or the completed reset.
-- The browser link expires after 10 minutes; run `reset_oauth_connection()` again to issue a fresh link.
+- Opening a reset link without confirming it does not change the connection.
+- MindRoom refuses an expired, unauthorized, or outdated link before deleting credentials.
+- A shared reset link works once. Run `reset_oauth_connection()` again if you need a new one.
+- Installation-level connections that are not assigned to an agent scope must be reset from the dashboard.
+- Normal `tool_approval` rules still apply when the agent creates the link.
+
+For implementation details and lifecycle guarantees, see [OAuth Credential Lifecycle Design](https://docs.mindroom.chat/dev/oauth-credential-lifecycle-design/#browser-reset).
 
 ## [`usage_stats`]
 

--- a/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
+++ b/skills/mindroom-docs/references/page__tools__agent-orchestration__index.md
@@ -72,7 +72,7 @@ agents:
 | Personal (`user`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection across agents |
 | Personal for one agent (`user_agent`) | The same MindRoom user who requested the link, signed in to the dashboard | That user's connection for this agent only |
 
-A shared connection belongs to the agent or team rather than to one MindRoom user.
+A shared connection belongs to the agent rather than to one MindRoom user.
 On a private agent, users can manage their own personal connections.
 On other agents, requesting a reset requires platform `administrator` access or an entry in `agents.<name>.credential_managers`.
 Some providers always use personal connections, regardless of the agent's configured scope.

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -78,6 +78,7 @@ from mindroom.oauth.service import (
 )
 from mindroom.tool_system.worker_routing import (
     ResolvedWorkerTarget,
+    ToolExecutionIdentity,
     build_agent_toolkit_worker_target,
     build_tool_execution_identity,
 )
@@ -96,6 +97,10 @@ _OAUTH_STALE_CONNECTION_MESSAGE = (
 )
 _OAUTH_STALE_CONVERSATION_MESSAGE = (
     "This OAuth connection changed before the request completed. Request a fresh connection link from the conversation."
+)
+_OAUTH_STALE_SHARED_RESET_MESSAGE = (
+    "This shared OAuth connection changed before the reset completed, so nothing was deleted. "
+    "Retry the original tool call; if it still fails, run reset_oauth_connection() again for a fresh reset link."
 )
 _OAUTH_BROWSER_SECURITY_HEADERS = {
     "Cache-Control": "no-store",
@@ -356,6 +361,24 @@ def _verify_conversation_connect_target_authorized(request: Request, target: OAu
     return config
 
 
+def _conversation_execution_identity(
+    agent_name: str,
+    requester_id: str,
+    runtime_paths: RuntimePaths,
+) -> ToolExecutionIdentity:
+    """Build the execution identity a conversation-issued OAuth link froze for one requester."""
+    return build_tool_execution_identity(
+        channel="matrix",
+        agent_name=agent_name,
+        runtime_paths=runtime_paths,
+        requester_id=requester_id,
+        room_id=None,
+        thread_id=None,
+        resolved_thread_id=None,
+        session_id=None,
+    )
+
+
 def _conversation_connect_context(
     request: Request,
     provider: OAuthProvider,
@@ -368,16 +391,7 @@ def _conversation_connect_context(
     requester_id = target.requester_id
     if not agent_name or not requester_id:
         raise HTTPException(status_code=400, detail="OAuth link target is invalid")
-    identity = build_tool_execution_identity(
-        channel="matrix",
-        agent_name=agent_name,
-        runtime_paths=runtime_paths,
-        requester_id=requester_id,
-        room_id=None,
-        thread_id=None,
-        resolved_thread_id=None,
-        session_id=None,
-    )
+    identity = _conversation_execution_identity(agent_name, requester_id, runtime_paths)
     worker_target = build_agent_toolkit_worker_target(
         config.resolve_entity(agent_name).execution_scope,
         agent_name,
@@ -477,16 +491,7 @@ def _verify_browser_reset_intent(
     if not agent_name:
         raise HTTPException(status_code=403, detail="The current requester cannot manage this agent's credentials")
     if intent.binding.worker_scope == "shared":
-        identity = build_tool_execution_identity(
-            channel="matrix",
-            agent_name=agent_name,
-            runtime_paths=runtime_paths,
-            requester_id=intent.requester_id,
-            room_id=None,
-            thread_id=None,
-            resolved_thread_id=None,
-            session_id=None,
-        )
+        identity = _conversation_execution_identity(agent_name, intent.requester_id, runtime_paths)
     else:
         _verify_connect_target_authorized(request, intent.requester_id, runtime_paths)
         identity = require_agent_oauth_connection_authorized(
@@ -684,17 +689,12 @@ async def reset_and_authorize(
             execution_scope=execution_scope,
         )
         if shared_capability:
-            consume_browser_oauth_reset_intent(
-                provider,
-                runtime_paths,
-                reset_token,
-                expected_intent=intent,
-            )
+            consume_browser_oauth_reset_intent(runtime_paths, reset_token)
     except HTTPException as exc:
         if exc.status_code == 409:
             return _oauth_browser_error_response(str(exc.detail), status_code=409)
         raise
-    except (OAuthProviderError, OAuthResetTargetError) as exc:
+    except OAuthProviderError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     snapshot = config_lifecycle.bind_current_request_snapshot(request)
     config = snapshot.runtime_config
@@ -720,7 +720,7 @@ async def reset_and_authorize(
             ).auth_url
         )
     except OAuthCredentialConflictError:
-        stale_message = _OAUTH_STALE_CONVERSATION_MESSAGE if shared_capability else _OAUTH_STALE_CONNECTION_MESSAGE
+        stale_message = _OAUTH_STALE_SHARED_RESET_MESSAGE if shared_capability else _OAUTH_STALE_CONNECTION_MESSAGE
         return _oauth_browser_error_response(stale_message, status_code=409)
     except OAuthResetPreparationError as exc:
         logger.warning(

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -63,6 +63,7 @@ from mindroom.oauth.registry import load_oauth_providers_for_snapshot
 from mindroom.oauth.reset import (
     BrowserOAuthResetIntent,
     OAuthResetTargetError,
+    consume_browser_oauth_reset_intent,
     lookup_browser_oauth_reset_intent,
     resolve_oauth_reset_target,
 )
@@ -71,6 +72,7 @@ from mindroom.oauth.service import (
     OAuthConnectTarget,
     consume_oauth_connect_token,
     lookup_oauth_connect_token,
+    oauth_connect_url,
     oauth_provider_service_account_configured,
     oauth_success_redirect_url,
 )
@@ -95,6 +97,10 @@ _OAUTH_STALE_CONNECTION_MESSAGE = (
 _OAUTH_STALE_CONVERSATION_MESSAGE = (
     "This OAuth connection changed before the request completed. Request a fresh connection link from the conversation."
 )
+_OAUTH_BROWSER_SECURITY_HEADERS = {
+    "Cache-Control": "no-store",
+    "Referrer-Policy": "no-referrer",
+}
 # Dashboard callbacks verify the browser user inline. Conversation-issued links
 # instead use their short-lived, single-use server-side capability state.
 
@@ -462,7 +468,6 @@ def _verify_browser_reset_intent(
     execution_scope: str | None,
 ) -> OAuthCredentialContext:
     """Reauthorize and resolve the exact browser reset target."""
-    _verify_connect_target_authorized(request, intent.requester_id, runtime_paths)
     _verify_connect_target_query(intent.binding, agent_name, execution_scope)
     snapshot = config_lifecycle.bind_current_request_snapshot(request)
     config = snapshot.runtime_config
@@ -470,12 +475,24 @@ def _verify_browser_reset_intent(
         raise HTTPException(status_code=503, detail="OAuth reset requires an active configuration")
     if not agent_name:
         raise HTTPException(status_code=403, detail="The current requester cannot manage this agent's credentials")
-    identity = require_agent_oauth_connection_authorized(
-        request,
-        config=config,
-        runtime_paths=runtime_paths,
-        agent_name=agent_name,
-    )
+    if intent.binding.worker_scope == "shared":
+        identity = ToolExecutionIdentity(
+            channel="matrix",
+            agent_name=agent_name,
+            requester_id=intent.requester_id,
+            room_id=None,
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+        )
+    else:
+        _verify_connect_target_authorized(request, intent.requester_id, runtime_paths)
+        identity = require_agent_oauth_connection_authorized(
+            request,
+            config=config,
+            runtime_paths=runtime_paths,
+            agent_name=agent_name,
+        )
     try:
         target = resolve_oauth_reset_target(
             provider.id,
@@ -537,6 +554,7 @@ def _oauth_browser_error_response(message: str, *, status_code: int) -> HTMLResp
   </body>
 </html>""",
         status_code=status_code,
+        headers=_OAUTH_BROWSER_SECURITY_HEADERS,
     )
 
 
@@ -596,13 +614,14 @@ async def confirm_reset(
     agent_name: str | None = None,
     execution_scope: str | None = None,
 ) -> Response:
-    """Show the authenticated human confirmation for one scoped reset."""
-    login_redirect = await _require_oauth_browser_user(request)
-    if login_redirect is not None:
-        return login_redirect
+    """Show human confirmation for one authenticated or shared-capability reset."""
     try:
         provider, runtime_paths = _load_provider(request, provider_id)
         intent = _browser_reset_intent(provider, runtime_paths, reset_token)
+        if intent.binding.worker_scope != "shared":
+            login_redirect = await _require_oauth_browser_user(request)
+            if login_redirect is not None:
+                return login_redirect
         _verify_browser_reset_intent(
             request,
             provider,
@@ -616,18 +635,26 @@ async def confirm_reset(
     display_name = escape(provider.display_name)
     target_agent = escape(intent.binding.requested_agent_name or "unknown")
     target_scope = escape(intent.binding.worker_scope)
+    shared_warning = (
+        "<p><strong>This one-time link can reset the shared connection for every requester using this agent. "
+        "Do not share it.</strong></p>"
+        if intent.binding.worker_scope == "shared"
+        else ""
+    )
     return HTMLResponse(
         f"""<!doctype html>
 <html lang="en">
-  <head><meta charset="utf-8"><title>Reset {display_name}</title></head>
+  <head><meta charset="utf-8"><meta name="referrer" content="no-referrer"><title>Reset {display_name}</title></head>
   <body>
     <h1>Reset and reconnect {display_name}</h1>
     <p>This removes the current scoped credential, then opens the provider authorization page.</p>
     <p>Target agent: <strong>{target_agent}</strong>.</p>
     <p>Credential scope: <strong>{target_scope} scope</strong>.</p>
+    {shared_warning}
     <form method="post"><button type="submit">Reset and reconnect</button></form>
   </body>
 </html>""",
+        headers=_OAUTH_BROWSER_SECURITY_HEADERS,
     )
 
 
@@ -640,9 +667,11 @@ async def reset_and_authorize(
     execution_scope: str | None = None,
 ) -> Response:
     """Commit one browser-confirmed reset and continue into provider authorization."""
-    await _require_oauth_api_user(request)
     provider, runtime_paths = _load_provider(request, provider_id)
     intent = _browser_reset_intent(provider, runtime_paths, reset_token)
+    shared_capability = intent.binding.worker_scope == "shared"
+    if not shared_capability:
+        await _require_oauth_api_user(request)
     try:
         context = _verify_browser_reset_intent(
             request,
@@ -652,10 +681,19 @@ async def reset_and_authorize(
             agent_name=agent_name,
             execution_scope=execution_scope,
         )
+        if shared_capability:
+            consume_browser_oauth_reset_intent(
+                provider,
+                runtime_paths,
+                reset_token,
+                expected_intent=intent,
+            )
     except HTTPException as exc:
         if exc.status_code == 409:
             return _oauth_browser_error_response(str(exc.detail), status_code=409)
         raise
+    except (OAuthProviderError, OAuthResetTargetError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     snapshot = config_lifecycle.bind_current_request_snapshot(request)
     config = snapshot.runtime_config
     if config is None:
@@ -667,14 +705,21 @@ async def reset_and_authorize(
             operation_id=intent.operation_id,
             expected_connection_generation=intent.connection_generation,
         )
-        authorization = await _issue_authorization_url(
-            request,
-            provider,
-            runtime_paths,
-            agent_name=agent_name,
+        authorization_url = (
+            oauth_connect_url(provider, runtime_paths, worker_target=context.worker_target)
+            if shared_capability
+            else (
+                await _issue_authorization_url(
+                    request,
+                    provider,
+                    runtime_paths,
+                    agent_name=agent_name,
+                )
+            ).auth_url
         )
     except OAuthCredentialConflictError:
-        return _oauth_browser_error_response(_OAUTH_STALE_CONNECTION_MESSAGE, status_code=409)
+        stale_message = _OAUTH_STALE_CONVERSATION_MESSAGE if shared_capability else _OAUTH_STALE_CONNECTION_MESSAGE
+        return _oauth_browser_error_response(stale_message, status_code=409)
     except OAuthResetPreparationError as exc:
         logger.warning(
             "oauth_connection_reset_preparation_failed",
@@ -688,7 +733,7 @@ async def reset_and_authorize(
         agent_name=agent_name,
         credential_existed=deleted,
     )
-    return RedirectResponse(url=authorization.auth_url, status_code=303)
+    return RedirectResponse(url=authorization_url, status_code=303)
 
 
 @router.get("/{provider_id}/success", response_class=HTMLResponse)

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -490,6 +490,13 @@ def _verify_browser_reset_intent(
         raise HTTPException(status_code=503, detail="OAuth reset requires an active configuration")
     if not agent_name:
         raise HTTPException(status_code=403, detail="The current requester cannot manage this agent's credentials")
+    # Deliberate split. A reset POST deletes a live credential before provider
+    # authorization, so a leaked requester-scoped link must not let another room
+    # member wipe the owner's connection and bind their own provider account into
+    # that scope; only a dashboard login as the token's requester proves the clicker
+    # is that requester. Shared credentials have no single human owner to log in
+    # as, so the one-time bearer link is the delegated authority for a configured
+    # credential manager and is consumed on POST instead.
     if intent.binding.worker_scope == "shared":
         identity = _conversation_execution_identity(agent_name, intent.requester_id, runtime_paths)
     else:

--- a/src/mindroom/api/oauth.py
+++ b/src/mindroom/api/oauth.py
@@ -78,8 +78,8 @@ from mindroom.oauth.service import (
 )
 from mindroom.tool_system.worker_routing import (
     ResolvedWorkerTarget,
-    ToolExecutionIdentity,
     build_agent_toolkit_worker_target,
+    build_tool_execution_identity,
 )
 
 if TYPE_CHECKING:
@@ -368,9 +368,10 @@ def _conversation_connect_context(
     requester_id = target.requester_id
     if not agent_name or not requester_id:
         raise HTTPException(status_code=400, detail="OAuth link target is invalid")
-    identity = ToolExecutionIdentity(
+    identity = build_tool_execution_identity(
         channel="matrix",
         agent_name=agent_name,
+        runtime_paths=runtime_paths,
         requester_id=requester_id,
         room_id=None,
         thread_id=None,
@@ -476,9 +477,10 @@ def _verify_browser_reset_intent(
     if not agent_name:
         raise HTTPException(status_code=403, detail="The current requester cannot manage this agent's credentials")
     if intent.binding.worker_scope == "shared":
-        identity = ToolExecutionIdentity(
+        identity = build_tool_execution_identity(
             channel="matrix",
             agent_name=agent_name,
+            runtime_paths=runtime_paths,
             requester_id=intent.requester_id,
             room_id=None,
             thread_id=None,

--- a/src/mindroom/custom_tools/oauth_connections.py
+++ b/src/mindroom/custom_tools/oauth_connections.py
@@ -29,10 +29,10 @@ class OAuthConnectionTools(Toolkit):
         """Return a browser link to reset and reconnect an OAuth connection this requester may manage.
 
         Use this only when an OAuth connection is stuck or revoked. The operation
-        opens an authenticated browser confirmation before changing credentials;
-        user scope can affect this requester across agents. It does not revoke
-        the grant at the provider. Shared-scope links are short-lived bearer
-        capabilities, so keep them private.
+        opens a browser confirmation before changing credentials. User scope can
+        affect this requester across agents; shared scope affects every requester
+        of this agent. It does not revoke the grant at the provider. Shared-scope
+        links are short-lived bearer capabilities, so keep them private.
 
         Args:
             provider_id: OAuth provider ID backing one of this agent's configured tools.

--- a/src/mindroom/custom_tools/oauth_connections.py
+++ b/src/mindroom/custom_tools/oauth_connections.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 
 class OAuthConnectionTools(Toolkit):
-    """Reset only the current requester's OAuth connections for the current agent."""
+    """Issue browser-confirmed resets for OAuth connections the requester may manage."""
 
     def __init__(self, runtime_paths: RuntimePaths, *, worker_target: ResolvedWorkerTarget | None) -> None:
         self._runtime_paths = runtime_paths
@@ -26,18 +26,19 @@ class OAuthConnectionTools(Toolkit):
         )
 
     async def reset_oauth_connection(self, provider_id: str) -> str:
-        """Return a browser link to reset and reconnect this requester's OAuth connection.
+        """Return a browser link to reset and reconnect an OAuth connection this requester may manage.
 
         Use this only when an OAuth connection is stuck or revoked. The operation
         opens an authenticated browser confirmation before changing credentials;
         user scope can affect this requester across agents. It does not revoke
-        the grant at the provider.
+        the grant at the provider. Shared-scope links are short-lived bearer
+        capabilities, so keep them private.
 
         Args:
             provider_id: OAuth provider ID backing one of this agent's configured tools.
 
         Returns:
-            A requester-bound browser reset link.
+            A requester-issued browser reset link.
 
         """
         runtime_context = get_tool_runtime_context()
@@ -57,8 +58,13 @@ class OAuthConnectionTools(Toolkit):
             reset_url = await issue_browser_oauth_reset_url(target)
         except OAuthResetTargetError as exc:
             return f"Error: {exc}"
+        privacy_guidance = (
+            " Keep this link private because anyone with the complete URL can confirm a shared-scope reset."
+            if target.worker_target.worker_scope == "shared"
+            else ""
+        )
         return (
-            f"Open this requester-bound browser link to confirm resetting provider `{provider_id}`. "
+            f"Open this requester-issued browser link to confirm resetting provider `{provider_id}`. "
             f"No credentials change until you confirm in the browser. `reset_url`: {reset_url}; "
-            "the link is valid for 10 minutes."
+            f"the link is valid for 10 minutes.{privacy_guidance}"
         )

--- a/src/mindroom/oauth/reset.py
+++ b/src/mindroom/oauth/reset.py
@@ -45,7 +45,7 @@ class OAuthResetTargetError(ValueError):
 
 @dataclass(frozen=True, slots=True)
 class BrowserOAuthResetIntent:
-    """One requester-bound browser reset action."""
+    """One browser reset action frozen at issuance."""
 
     binding: OAuthCredentialBinding
     requester_id: str
@@ -138,12 +138,8 @@ def resolve_oauth_reset_target(
         config=config,
     )
     credential_target = credential_context.worker_target
-    if (
-        credential_target is None
-        or credential_target.worker_scope not in {"shared", "user", "user_agent"}
-        or credential_target.worker_key is None
-    ):
-        msg = "Agent-initiated OAuth reset requires a shared, user, or user_agent scope."
+    if credential_target is None or credential_target.worker_scope is None or credential_target.worker_key is None:
+        msg = "Agent-initiated OAuth reset refuses unscoped installation-level credentials; use the dashboard."
         raise OAuthResetTargetError(msg)
     return _ResolvedOAuthResetTarget(
         agent_name=agent_name,
@@ -222,21 +218,10 @@ def lookup_browser_oauth_reset_intent(
     return _browser_oauth_reset_intent_from_payload(provider, payload)
 
 
-def consume_browser_oauth_reset_intent(
-    provider: OAuthProvider,
-    runtime_paths: RuntimePaths,
-    token: str,
-    *,
-    expected_intent: BrowserOAuthResetIntent,
-) -> BrowserOAuthResetIntent:
-    """Consume one browser reset capability and require its target to remain unchanged."""
-    payload = consume_opaque_oauth_state(
+def consume_browser_oauth_reset_intent(runtime_paths: RuntimePaths, token: str) -> None:
+    """Consume one browser reset capability so it cannot be replayed."""
+    consume_opaque_oauth_state(
         runtime_paths,
         kind=_BROWSER_OAUTH_RESET_KIND,
         token=token,
     )
-    intent = _browser_oauth_reset_intent_from_payload(provider, payload)
-    if intent != expected_intent:
-        msg = "OAuth reset link target changed"
-        raise OAuthResetTargetError(msg)
-    return intent

--- a/src/mindroom/oauth/reset.py
+++ b/src/mindroom/oauth/reset.py
@@ -23,7 +23,7 @@ from mindroom.oauth.credential_lifecycle import (
 )
 from mindroom.oauth.registry import load_oauth_providers
 from mindroom.oauth.service import oauth_public_base_url
-from mindroom.oauth.state import issue_opaque_oauth_state, read_opaque_oauth_state
+from mindroom.oauth.state import consume_opaque_oauth_state, issue_opaque_oauth_state, read_opaque_oauth_state
 from mindroom.tool_system.catalog import resolved_tool_metadata_for_runtime
 from mindroom.tool_system.worker_routing import build_agent_toolkit_worker_target
 
@@ -55,7 +55,7 @@ class BrowserOAuthResetIntent:
 
 @dataclass(frozen=True, slots=True)
 class _ResolvedOAuthResetTarget:
-    """Exact provider and requester-isolated credential target for one reset."""
+    """Exact provider and scoped credential target for one reset."""
 
     agent_name: str
     credential_context: OAuthCredentialContext
@@ -67,7 +67,7 @@ class _ResolvedOAuthResetTarget:
 
     @property
     def worker_target(self) -> ResolvedWorkerTarget:
-        """Return the requester-isolated target bound to this reset."""
+        """Return the scoped target bound to this reset."""
         worker_target = self.credential_context.worker_target
         assert worker_target is not None
         return worker_target
@@ -140,10 +140,10 @@ def resolve_oauth_reset_target(
     credential_target = credential_context.worker_target
     if (
         credential_target is None
-        or credential_target.worker_scope not in {"user", "user_agent"}
+        or credential_target.worker_scope not in {"shared", "user", "user_agent"}
         or credential_target.worker_key is None
     ):
-        msg = "Agent-initiated OAuth reset requires a requester-isolated user or user_agent scope."
+        msg = "Agent-initiated OAuth reset requires a shared, user, or user_agent scope."
         raise OAuthResetTargetError(msg)
     return _ResolvedOAuthResetTarget(
         agent_name=agent_name,
@@ -160,7 +160,7 @@ def _browser_oauth_reset_intent_from_payload(
         binding = parse_oauth_credential_binding_payload(
             provider,
             payload,
-            allowed_worker_scopes=frozenset({"user", "user_agent"}),
+            allowed_worker_scopes=frozenset({"shared", "user", "user_agent"}),
             require_agent_name=True,
             require_worker_key=True,
         )
@@ -220,3 +220,23 @@ def lookup_browser_oauth_reset_intent(
         token=token,
     )
     return _browser_oauth_reset_intent_from_payload(provider, payload)
+
+
+def consume_browser_oauth_reset_intent(
+    provider: OAuthProvider,
+    runtime_paths: RuntimePaths,
+    token: str,
+    *,
+    expected_intent: BrowserOAuthResetIntent,
+) -> BrowserOAuthResetIntent:
+    """Consume one browser reset capability and require its target to remain unchanged."""
+    payload = consume_opaque_oauth_state(
+        runtime_paths,
+        kind=_BROWSER_OAUTH_RESET_KIND,
+        token=token,
+    )
+    intent = _browser_oauth_reset_intent_from_payload(provider, payload)
+    if intent != expected_intent:
+        msg = "OAuth reset link target changed"
+        raise OAuthResetTargetError(msg)
+    return intent

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -2326,20 +2326,11 @@ def test_browser_reset_get_is_non_mutating_and_post_resets_then_authorizes(tmp_p
     assert _stored_oauth_credentials(provider, runtime_paths) is None
 
 
-def test_shared_browser_reset_uses_one_time_credential_manager_link_without_dashboard_login(tmp_path: Path) -> None:
-    """A shared credential manager link should confirm and reconnect without dashboard access."""
-    runtime_paths = _runtime_paths(
-        tmp_path,
-        {
-            "TEST_OAUTH_CLIENT_ID": "client-id",
-            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
-            "CUSTOMER_ID": "tenant-a",
-        },
-    )
-    api_app = _make_test_app(
-        runtime_paths,
-        _config_payload(worker_scope="shared", allowed_users=["@alice:example.org"]),
-    )
+def _general_agent_reset_target(
+    api_app: FastAPI,
+    runtime_paths: constants.RuntimePaths,
+) -> tuple[OAuthProvider, oauth_reset._ResolvedOAuthResetTarget]:
+    """Resolve the google_drive reset target alice may issue for `general` at its configured scope."""
     provider = _fake_provider(
         provider_id="google_drive",
         credential_service="google_drive_oauth",
@@ -2364,6 +2355,24 @@ def test_shared_browser_reset_uses_one_time_credential_manager_link_without_dash
             account_id=runtime_paths.env_value("ACCOUNT_ID"),
         ),
     )
+    return provider, target
+
+
+def test_shared_browser_reset_uses_one_time_credential_manager_link_without_dashboard_login(tmp_path: Path) -> None:
+    """A shared credential manager link should confirm and reconnect without dashboard access."""
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+            "CUSTOMER_ID": "tenant-a",
+        },
+    )
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(worker_scope="shared", allowed_users=["@alice:example.org"]),
+    )
+    provider, target = _general_agent_reset_target(api_app, runtime_paths)
     get_runtime_credentials_manager(runtime_paths).for_primary_runtime_agent_scope("general").save_credentials(
         provider.credential_service,
         {
@@ -2438,28 +2447,7 @@ def test_shared_browser_reset_consumes_stale_link_without_deleting_replacement(t
         runtime_paths,
         _config_payload(worker_scope="shared", allowed_users=["@alice:example.org"]),
     )
-    provider = _fake_provider(
-        provider_id="google_drive",
-        credential_service="google_drive_oauth",
-        tool_config_service="google_drive",
-    )
-    config = main._app_context(api_app).runtime_config
-    assert config is not None
-    target = oauth_reset.resolve_oauth_reset_target(
-        provider.id,
-        agent_name="general",
-        config=config,
-        runtime_paths=runtime_paths,
-        execution_identity=ToolExecutionIdentity(
-            channel="matrix",
-            agent_name="general",
-            requester_id="@alice:example.org",
-            room_id="!room:example.org",
-            thread_id=None,
-            resolved_thread_id=None,
-            session_id=None,
-        ),
-    )
+    provider, target = _general_agent_reset_target(api_app, runtime_paths)
     reset_url = asyncio.run(oauth_reset.issue_browser_oauth_reset_url(target))
 
     async def replace_credentials() -> None:
@@ -2508,28 +2496,7 @@ def test_shared_browser_reset_rechecks_credential_manager_authority(tmp_path: Pa
         runtime_paths,
         _config_payload(worker_scope="shared", allowed_users=["@alice:example.org"]),
     )
-    provider = _fake_provider(
-        provider_id="google_drive",
-        credential_service="google_drive_oauth",
-        tool_config_service="google_drive",
-    )
-    config = main._app_context(api_app).runtime_config
-    assert config is not None
-    target = oauth_reset.resolve_oauth_reset_target(
-        provider.id,
-        agent_name="general",
-        config=config,
-        runtime_paths=runtime_paths,
-        execution_identity=ToolExecutionIdentity(
-            channel="matrix",
-            agent_name="general",
-            requester_id="@alice:example.org",
-            room_id="!room:example.org",
-            thread_id=None,
-            resolved_thread_id=None,
-            session_id=None,
-        ),
-    )
+    provider, target = _general_agent_reset_target(api_app, runtime_paths)
     reset_url = asyncio.run(oauth_reset.issue_browser_oauth_reset_url(target))
     _publish_config(api_app, runtime_paths, _config_payload(worker_scope="shared", allowed_users=[]))
 
@@ -2587,28 +2554,7 @@ def test_browser_reset_rejects_stale_connection_generation(tmp_path: Path) -> No
         },
     )
     api_app = _make_test_app(runtime_paths, _config_payload(worker_scope="user_agent"))
-    provider = _fake_provider(
-        provider_id="google_drive",
-        credential_service="google_drive_oauth",
-        tool_config_service="google_drive",
-    )
-    config = main._app_context(api_app).runtime_config
-    assert config is not None
-    target = oauth_reset.resolve_oauth_reset_target(
-        provider.id,
-        agent_name="general",
-        config=config,
-        runtime_paths=runtime_paths,
-        execution_identity=ToolExecutionIdentity(
-            channel="matrix",
-            agent_name="general",
-            requester_id="@alice:example.org",
-            room_id="!room:example.org",
-            thread_id=None,
-            resolved_thread_id=None,
-            session_id=None,
-        ),
-    )
+    provider, target = _general_agent_reset_target(api_app, runtime_paths)
     scoped_manager = get_runtime_credentials_manager(runtime_paths).for_primary_runtime_scope(
         "@alice:example.org",
         "general",
@@ -2738,28 +2684,7 @@ def test_browser_reset_rejects_a_different_authenticated_requester(tmp_path: Pat
         ),
     )
     _use_runtime_auth_settings(api_app)
-    provider = _fake_provider(
-        provider_id="google_drive",
-        credential_service="google_drive_oauth",
-        tool_config_service="google_drive",
-    )
-    config = main._app_context(api_app).runtime_config
-    assert config is not None
-    target = oauth_reset.resolve_oauth_reset_target(
-        provider.id,
-        agent_name="general",
-        config=config,
-        runtime_paths=runtime_paths,
-        execution_identity=ToolExecutionIdentity(
-            channel="matrix",
-            agent_name="general",
-            requester_id="@alice:example.org",
-            room_id="!room:example.org",
-            thread_id=None,
-            resolved_thread_id=None,
-            session_id=None,
-        ),
-    )
+    provider, target = _general_agent_reset_target(api_app, runtime_paths)
     reset_url = asyncio.run(oauth_reset.issue_browser_oauth_reset_url(target))
     bob_headers = trusted_upstream_headers(
         user_id="bob",

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -2487,7 +2487,8 @@ def test_shared_browser_reset_consumes_stale_link_without_deleting_replacement(t
     assert stale.status_code == 409
     assert stale.headers["referrer-policy"] == "no-referrer"
     assert stale.headers["cache-control"] == "no-store"
-    assert "fresh connection link from the conversation" in stale.text
+    assert "nothing was deleted" in stale.text
+    assert "reset_oauth_connection()" in stale.text
     assert replayed.status_code == 400
     stored = _stored_oauth_credentials(provider, runtime_paths, worker_scope="shared")
     assert stored is not None

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -114,6 +114,8 @@ def _stored_oauth_credentials(
         thread_id=None,
         resolved_thread_id=None,
         session_id=None,
+        tenant_id=runtime_paths.env_value("CUSTOMER_ID"),
+        account_id=runtime_paths.env_value("ACCOUNT_ID"),
     )
     worker_target = (
         resolve_worker_target(worker_scope, agent_name, execution_identity=identity)
@@ -2331,6 +2333,7 @@ def test_shared_browser_reset_uses_one_time_credential_manager_link_without_dash
         {
             "TEST_OAUTH_CLIENT_ID": "client-id",
             "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+            "CUSTOMER_ID": "tenant-a",
         },
     )
     api_app = _make_test_app(
@@ -2357,6 +2360,8 @@ def test_shared_browser_reset_uses_one_time_credential_manager_link_without_dash
             thread_id=None,
             resolved_thread_id=None,
             session_id=None,
+            tenant_id=runtime_paths.env_value("CUSTOMER_ID"),
+            account_id=runtime_paths.env_value("ACCOUNT_ID"),
         ),
     )
     get_runtime_credentials_manager(runtime_paths).for_primary_runtime_agent_scope("general").save_credentials(

--- a/tests/api/test_oauth_api.py
+++ b/tests/api/test_oauth_api.py
@@ -2324,6 +2324,220 @@ def test_browser_reset_get_is_non_mutating_and_post_resets_then_authorizes(tmp_p
     assert _stored_oauth_credentials(provider, runtime_paths) is None
 
 
+def test_shared_browser_reset_uses_one_time_credential_manager_link_without_dashboard_login(tmp_path: Path) -> None:
+    """A shared credential manager link should confirm and reconnect without dashboard access."""
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(worker_scope="shared", allowed_users=["@alice:example.org"]),
+    )
+    provider = _fake_provider(
+        provider_id="google_drive",
+        credential_service="google_drive_oauth",
+        tool_config_service="google_drive",
+    )
+    config = main._app_context(api_app).runtime_config
+    assert config is not None
+    target = oauth_reset.resolve_oauth_reset_target(
+        provider.id,
+        agent_name="general",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="general",
+            requester_id="@alice:example.org",
+            room_id="!room:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+        ),
+    )
+    get_runtime_credentials_manager(runtime_paths).for_primary_runtime_agent_scope("general").save_credentials(
+        provider.credential_service,
+        {
+            "token": "old-access-token",
+            "refresh_token": "old-refresh-token",
+            "client_id": "client-id",
+            "scopes": list(provider.scopes),
+            "_source": "oauth",
+            "_oauth_provider": provider.id,
+        },
+    )
+    reset_url = asyncio.run(oauth_reset.issue_browser_oauth_reset_url(target))
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app, base_url="http://localhost:8765") as client:
+            confirmation = client.get(reset_url, follow_redirects=False)
+            before_confirmation = _stored_oauth_credentials(
+                provider,
+                runtime_paths,
+                worker_scope="shared",
+            )
+            confirmed = client.post(reset_url, follow_redirects=False)
+            after_confirmation = _stored_oauth_credentials(
+                provider,
+                runtime_paths,
+                worker_scope="shared",
+            )
+            authorization = client.get(confirmed.headers["location"], follow_redirects=False)
+            state = _state_from_auth_url(authorization.headers["location"])
+            callback = client.get(
+                f"/api/oauth/{provider.id}/callback?code=test-code&state={state}",
+                follow_redirects=False,
+            )
+            replayed = client.post(reset_url, follow_redirects=False)
+            after_replay = _stored_oauth_credentials(provider, runtime_paths, worker_scope="shared")
+
+    assert confirmation.status_code == 200
+    assert "shared scope" in confirmation.text
+    assert "reset the shared connection for every requester" in confirmation.text
+    assert 'name="referrer" content="no-referrer"' in confirmation.text
+    assert confirmation.headers["referrer-policy"] == "no-referrer"
+    assert confirmation.headers["cache-control"] == "no-store"
+    assert before_confirmation is not None
+    assert before_confirmation["refresh_token"] == "old-refresh-token"
+    assert confirmed.status_code == 303
+    confirmed_location = urlparse(confirmed.headers["location"])
+    assert confirmed_location.path == f"/api/oauth/{provider.id}/authorize"
+    assert "connect_token" in parse_qs(confirmed_location.query)
+    assert after_confirmation is None
+    assert replayed.status_code == 400
+    assert authorization.status_code == 307
+    assert urlparse(authorization.headers["location"]).netloc == "auth.example.test"
+    assert callback.status_code == 200
+    assert "Test Drive is connected" in callback.text
+    stored = _stored_oauth_credentials(provider, runtime_paths, worker_scope="shared")
+    assert stored is not None
+    assert stored["token"] == "google_drive-access-token"
+    assert after_replay is not None
+    assert after_replay["token"] == "google_drive-access-token"
+
+
+def test_shared_browser_reset_consumes_stale_link_without_deleting_replacement(tmp_path: Path) -> None:
+    """A stale shared reset capability should be consumed while preserving replacement credentials."""
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(worker_scope="shared", allowed_users=["@alice:example.org"]),
+    )
+    provider = _fake_provider(
+        provider_id="google_drive",
+        credential_service="google_drive_oauth",
+        tool_config_service="google_drive",
+    )
+    config = main._app_context(api_app).runtime_config
+    assert config is not None
+    target = oauth_reset.resolve_oauth_reset_target(
+        provider.id,
+        agent_name="general",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="general",
+            requester_id="@alice:example.org",
+            room_id="!room:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+        ),
+    )
+    reset_url = asyncio.run(oauth_reset.issue_browser_oauth_reset_url(target))
+
+    async def replace_credentials() -> None:
+        async with oauth_credential_store.oauth_credential_transaction(target.credential_context) as transaction:
+            transaction.publish(
+                {
+                    "token": "replacement-access-token",
+                    "refresh_token": "replacement-refresh-token",
+                    "client_id": "client-id",
+                    "scopes": list(provider.scopes),
+                    "_source": "oauth",
+                    "_oauth_provider": provider.id,
+                },
+                advance_connection_generation=True,
+            )
+            await transaction.commit()
+
+    asyncio.run(replace_credentials())
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app, base_url="http://localhost:8765") as client:
+            stale = client.post(reset_url, follow_redirects=False)
+            replayed = client.post(reset_url, follow_redirects=False)
+
+    assert stale.status_code == 409
+    assert stale.headers["referrer-policy"] == "no-referrer"
+    assert stale.headers["cache-control"] == "no-store"
+    assert "fresh connection link from the conversation" in stale.text
+    assert replayed.status_code == 400
+    stored = _stored_oauth_credentials(provider, runtime_paths, worker_scope="shared")
+    assert stored is not None
+    assert stored["refresh_token"] == "replacement-refresh-token"
+
+
+def test_shared_browser_reset_rechecks_credential_manager_authority(tmp_path: Path) -> None:
+    """A shared reset link should fail after its requester's credential authority is removed."""
+    runtime_paths = _runtime_paths(
+        tmp_path,
+        {
+            "TEST_OAUTH_CLIENT_ID": "client-id",
+            "TEST_OAUTH_CLIENT_SECRET": "client-secret",
+        },
+    )
+    api_app = _make_test_app(
+        runtime_paths,
+        _config_payload(worker_scope="shared", allowed_users=["@alice:example.org"]),
+    )
+    provider = _fake_provider(
+        provider_id="google_drive",
+        credential_service="google_drive_oauth",
+        tool_config_service="google_drive",
+    )
+    config = main._app_context(api_app).runtime_config
+    assert config is not None
+    target = oauth_reset.resolve_oauth_reset_target(
+        provider.id,
+        agent_name="general",
+        config=config,
+        runtime_paths=runtime_paths,
+        execution_identity=ToolExecutionIdentity(
+            channel="matrix",
+            agent_name="general",
+            requester_id="@alice:example.org",
+            room_id="!room:example.org",
+            thread_id=None,
+            resolved_thread_id=None,
+            session_id=None,
+        ),
+    )
+    reset_url = asyncio.run(oauth_reset.issue_browser_oauth_reset_url(target))
+    _publish_config(api_app, runtime_paths, _config_payload(worker_scope="shared", allowed_users=[]))
+
+    with patch("mindroom.api.oauth.load_oauth_providers_for_snapshot", return_value={provider.id: provider}):
+        with TestClient(api_app, base_url="http://localhost:8765") as client:
+            confirmation = client.get(reset_url, follow_redirects=False)
+            reset = client.post(reset_url, follow_redirects=False)
+
+    assert confirmation.status_code == 409
+    assert "not authorized" in confirmation.text
+    assert reset.status_code == 409
+    assert "not authorized" in reset.text
+
+
 def test_private_agent_requester_can_resolve_own_oauth_reset_target(tmp_path: Path) -> None:
     """Private-agent requesters need no administrator or credential-manager grant to reset their own OAuth."""
     runtime_paths = _runtime_paths(tmp_path, _trusted_upstream_oauth_env())

--- a/tests/test_oauth_connection_tools.py
+++ b/tests/test_oauth_connection_tools.py
@@ -308,7 +308,7 @@ async def test_reset_oauth_connection_refuses_unscoped_credentials(tmp_path: Pat
     with tool_runtime_context(context):
         result = await tool.reset_oauth_connection("google_drive")
 
-    assert "requires a shared, user, or user_agent scope" in result
+    assert "refuses unscoped installation-level credentials" in result
 
 
 @pytest.mark.asyncio

--- a/tests/test_oauth_connection_tools.py
+++ b/tests/test_oauth_connection_tools.py
@@ -48,7 +48,7 @@ if TYPE_CHECKING:
 def _tool_and_context(
     tmp_path: Path,
     *,
-    worker_scope: WorkerScope,
+    worker_scope: WorkerScope | None,
     context_agent_name: str = "research",
     requester_id: str = "@alice:example.org",
     aliases: dict[str, list[str]] | None = None,
@@ -269,26 +269,46 @@ def test_oauth_target_does_not_canonicalize_configured_bot_alias(tmp_path: Path)
 
 
 @pytest.mark.asyncio
-async def test_reset_oauth_connection_refuses_shared_scope(tmp_path: Path) -> None:
-    """The agent-facing action must not target credentials shared by requesters."""
+async def test_reset_oauth_connection_issues_browser_confirmation_for_shared_scope(tmp_path: Path) -> None:
+    """A credential manager may issue a browser-confirmed reset for the agent's shared credential."""
     tool, context, _worker_target = _tool_and_context(tmp_path, worker_scope="shared")
+    provider = google_drive_oauth_provider()
 
     with tool_runtime_context(context):
-        result = await tool.reset_oauth_connection("google_drive")
+        result = await tool.reset_oauth_connection(provider.id)
 
-    assert "requester-isolated" in result
+    intent = _reset_intent(result, provider=provider, context=context)
+    assert intent.binding.requested_agent_name == "research"
+    assert intent.requester_id == "@alice:example.org"
+    assert intent.binding.worker_scope == "shared"
+    assert "Keep this link private" in result
 
 
 @pytest.mark.asyncio
-async def test_reset_oauth_connection_denies_unauthorized_requester(tmp_path: Path) -> None:
+@pytest.mark.parametrize("worker_scope", ["shared", "user_agent"])
+async def test_reset_oauth_connection_denies_unauthorized_requester(
+    tmp_path: Path,
+    worker_scope: WorkerScope,
+) -> None:
     """Current authorization should be checked before issuing the browser action."""
-    tool, context, _worker_target = _tool_and_context(tmp_path, worker_scope="user_agent")
+    tool, context, _worker_target = _tool_and_context(tmp_path, worker_scope=worker_scope)
     context.config.agents["research"].credential_managers = ["@bob:example.org"]
 
     with tool_runtime_context(context):
         result = await tool.reset_oauth_connection("google_drive")
 
     assert "not authorized" in result
+
+
+@pytest.mark.asyncio
+async def test_reset_oauth_connection_refuses_unscoped_credentials(tmp_path: Path) -> None:
+    """Credential managers must use the dashboard for installation-level credentials."""
+    tool, context, _worker_target = _tool_and_context(tmp_path, worker_scope=None)
+
+    with tool_runtime_context(context):
+        result = await tool.reset_oauth_connection("google_drive")
+
+    assert "requires a shared, user, or user_agent scope" in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- allow configured credential managers to issue browser-confirmed resets for shared OAuth connections
- use a short-lived, one-time capability for shared resets and reconnect through a fresh single-use OAuth capability
- preserve authenticated requester checks for personal resets and reject unscoped installation-level credentials
- document who can reset each connection scope and the effect of doing so
- add security, replay, stale-generation, authorization, and end-to-end reconnection coverage

## Testing
- `uv run pytest -q -n auto --no-cov`
- `uv run pytest -q tests/test_oauth_connection_tools.py tests/api/test_oauth_api.py -n 0 --no-cov`
- focused Ruff, type, dead-code, architecture-boundary, and documentation-generation hooks

## Summary by Sourcery

Allow authorized credential managers to reset shared OAuth connections through secure, one-time browser capabilities while retaining requester-bound personal resets.

New Features:
- Enable configured credential managers to issue browser-confirmed resets for shared OAuth connections, followed by reconnection through a fresh single-use authorization capability.

Bug Fixes:
- Prevent stale, replayed, unauthorized, or unscoped reset links from deleting OAuth credentials, while preserving authenticated requester checks for personal connections.

Enhancements:
- Extend OAuth reset handling across shared, personal, and per-agent personal scopes with scope-specific confirmation and impact rules.

Documentation:
- Document OAuth reset authorization, scope effects, shared-link handling, installation-level restrictions, and segmented streamed-message fallback behavior.

Tests:
- Add coverage for shared reset authorization, one-time use, stale generations, replay protection, end-to-end reconnection, and personal reset security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added browser-confirmed resets for shared OAuth connections using one-time links.
  - Clarified reset permissions for shared, personal, and agent-specific connections.
  - Added a `split` option for delivering large text responses as multiple complete rich-text messages.

- **Documentation**
  - Updated OAuth, MCP, reset, and streaming guidance with the new behavior, security rules, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->