### PR TITLE
Preserve response attribution across typing events

### DIFF
--- a/src/mindroom/approval_execution.py
+++ b/src/mindroom/approval_execution.py
@@ -35,7 +35,7 @@ from mindroom.tool_system.runtime_context import runtime_context_from_dispatch_c
 from mindroom.tool_system.worker_routing import run_with_tool_execution_identity
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator, Callable
+    from collections.abc import AsyncIterator, Callable, Mapping
 
     import nio
     from agno.agent import Agent
@@ -145,6 +145,7 @@ class AgentApprovalExecution:
         decisions: dict[str, bool],
         denial_reasons: dict[str, str | None],
         tool_trace_collector: list[ToolTraceEntry],
+        typing_log_context: Mapping[str, object],
     ) -> CompletedApprovalRun | PausedAttempt:
         """Apply exact decisions and continue the matching persisted Agno run."""
         config = self.config()
@@ -203,7 +204,11 @@ class AgentApprovalExecution:
                 denial_reasons=denial_reasons,
             )
 
-            async with typing_indicator(self.client(), continuation.room_id):
+            async with typing_indicator(
+                self.client(),
+                continuation.room_id,
+                log_context=typing_log_context,
+            ):
                 response, presentation = await self.tool_runtime.run_in_context(
                     tool_context=runtime_context_from_dispatch_context(tool_dispatch),
                     operation=lambda: run_with_tool_execution_identity(

--- a/src/mindroom/matrix/typing.py
+++ b/src/mindroom/matrix/typing.py
@@ -51,9 +51,9 @@ def _typing_log_fields(
 async def _set_typing(
     client: nio.AsyncClient,
     room_id: str,
-    typing: bool = True,
-    timeout_seconds: int = 30,
     *,
+    typing: bool,
+    timeout_seconds: int,
     log_context: Mapping[str, object],
 ) -> None:
     """Set typing status for a user in a room.
@@ -102,8 +102,8 @@ async def _refresh_typing(
             await _set_typing(
                 client,
                 room_id,
-                True,
-                sent_timeout_seconds,
+                typing=True,
+                timeout_seconds=sent_timeout_seconds,
                 log_context=state.log_context,
             )
         except asyncio.CancelledError:
@@ -149,7 +149,7 @@ async def _acquire_typing_state(
         references=1,
         timeout_seconds=timeout_seconds,
         started=started,
-        log_context={**log_context, "room_id": room_id},
+        log_context=dict(log_context),
     )
     state.refresh_task = asyncio.create_task(
         _refresh_typing(
@@ -185,8 +185,8 @@ async def _release_typing_state(
         await _set_typing(
             client,
             room_id,
-            False,
-            state.timeout_seconds,
+            typing=False,
+            timeout_seconds=state.timeout_seconds,
             log_context=state.log_context,
         )
     except Exception:
@@ -207,12 +207,12 @@ async def typing_indicator(
     room_id: str,
     timeout_seconds: int = 30,
     *,
-    log_context: Mapping[str, object] | None = None,
+    log_context: Mapping[str, object],
 ) -> AsyncGenerator[None, None]:
     """Context manager for showing typing indicator while processing.
 
     Usage:
-        async with typing_indicator(client, room_id):
+        async with typing_indicator(client, room_id, log_context={}):
             # Do work here - typing indicator shown
             response = await generate_response()
         # Typing indicator automatically stopped
@@ -228,7 +228,7 @@ async def typing_indicator(
         client,
         room_id,
         timeout_seconds=timeout_seconds,
-        log_context={} if log_context is None else log_context,
+        log_context=log_context,
     )
     try:
         await asyncio.shield(state.started)

--- a/src/mindroom/matrix/typing.py
+++ b/src/mindroom/matrix/typing.py
@@ -12,7 +12,7 @@ import nio
 from mindroom.logging_config import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncGenerator
+    from collections.abc import AsyncGenerator, Mapping
 
 logger = get_logger(__name__)
 
@@ -26,6 +26,7 @@ class _TypingState:
     references: int
     timeout_seconds: int
     started: asyncio.Future[None]
+    log_context: dict[str, object]
     refresh_task: asyncio.Task[None] | None = None
     stopping: asyncio.Future[None] | None = None
     # Set when a joiner raises ``timeout_seconds``. The refresh loop waits on it
@@ -37,11 +38,23 @@ class _TypingState:
 _ACTIVE_TYPING: dict[tuple[nio.AsyncClient, str], _TypingState] = {}
 
 
+def _typing_log_fields(
+    log_context: Mapping[str, object],
+    *,
+    room_id: str,
+    typing: bool,
+) -> dict[str, object]:
+    """Return stable response attribution for one typing event."""
+    return {**log_context, "room_id": room_id, "typing": typing}
+
+
 async def _set_typing(
     client: nio.AsyncClient,
     room_id: str,
     typing: bool = True,
     timeout_seconds: int = 30,
+    *,
+    log_context: Mapping[str, object],
 ) -> None:
     """Set typing status for a user in a room.
 
@@ -50,19 +63,20 @@ async def _set_typing(
         room_id: Room to show typing indicator in
         typing: Whether to show or hide typing indicator
         timeout_seconds: How long the typing indicator should last (in seconds)
+        log_context: Stable attribution for this typing lease
 
     """
     timeout_ms = timeout_seconds * 1000
     response = await client.room_typing(room_id, typing, timeout_ms)
+    log_fields = _typing_log_fields(log_context, room_id=room_id, typing=typing)
     if isinstance(response, nio.RoomTypingError):
         logger.warning(
             "Failed to set typing status",
-            room_id=room_id,
-            typing=typing,
             error=response.message,
+            **log_fields,
         )
     else:
-        logger.debug("Set typing status", room_id=room_id, typing=typing)
+        logger.debug("Set typing status", **log_fields)
 
 
 async def _refresh_typing(
@@ -85,13 +99,23 @@ async def _refresh_typing(
         state.timeout_raised.clear()
         sent_timeout_seconds = state.timeout_seconds
         try:
-            await _set_typing(client, room_id, True, sent_timeout_seconds)
+            await _set_typing(
+                client,
+                room_id,
+                True,
+                sent_timeout_seconds,
+                log_context=state.log_context,
+            )
         except asyncio.CancelledError:
             if not state.started.done():
                 state.started.cancel()
             raise
         except Exception:
-            logger.warning("Failed to set typing indicator", room_id=room_id, exc_info=True)
+            logger.warning(
+                "Failed to set typing indicator",
+                **_typing_log_fields(state.log_context, room_id=room_id, typing=True),
+                exc_info=True,
+            )
         if not state.started.done():
             state.started.set_result(None)
         with suppress(TimeoutError):
@@ -106,6 +130,7 @@ async def _acquire_typing_state(
     room_id: str,
     *,
     timeout_seconds: int,
+    log_context: Mapping[str, object],
 ) -> tuple[tuple[nio.AsyncClient, str], _TypingState]:
     """Acquire one process-local typing lease after any prior stop completes."""
     key = (client, room_id)
@@ -124,6 +149,7 @@ async def _acquire_typing_state(
         references=1,
         timeout_seconds=timeout_seconds,
         started=started,
+        log_context={**log_context, "room_id": room_id},
     )
     state.refresh_task = asyncio.create_task(
         _refresh_typing(
@@ -156,9 +182,19 @@ async def _release_typing_state(
         await refresh_task
     client, room_id = key
     try:
-        await _set_typing(client, room_id, False, state.timeout_seconds)
+        await _set_typing(
+            client,
+            room_id,
+            False,
+            state.timeout_seconds,
+            log_context=state.log_context,
+        )
     except Exception:
-        logger.warning("Failed to stop typing indicator", room_id=room_id, exc_info=True)
+        logger.warning(
+            "Failed to stop typing indicator",
+            **_typing_log_fields(state.log_context, room_id=room_id, typing=False),
+            exc_info=True,
+        )
     finally:
         if _ACTIVE_TYPING.get(key) is state:
             del _ACTIVE_TYPING[key]
@@ -170,6 +206,8 @@ async def typing_indicator(
     client: nio.AsyncClient,
     room_id: str,
     timeout_seconds: int = 30,
+    *,
+    log_context: Mapping[str, object] | None = None,
 ) -> AsyncGenerator[None, None]:
     """Context manager for showing typing indicator while processing.
 
@@ -183,9 +221,15 @@ async def typing_indicator(
         client: Matrix client instance
         room_id: Room to show typing indicator in
         timeout_seconds: How long each typing notification lasts
+        log_context: Stable response attribution for typing log events
 
     """
-    key, state = await _acquire_typing_state(client, room_id, timeout_seconds=timeout_seconds)
+    key, state = await _acquire_typing_state(
+        client,
+        room_id,
+        timeout_seconds=timeout_seconds,
+        log_context={} if log_context is None else log_context,
+    )
     try:
         await asyncio.shield(state.started)
         yield

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -475,6 +475,11 @@ def _is_silent_schedule_response(request: ResponseRequest) -> bool:
     return request.response_envelope.source_kind == SILENT_SCHEDULE_SOURCE_KIND
 
 
+def _correlation_id_for_request(request: ResponseRequest) -> str:
+    """Resolve the correlation id for one request."""
+    return request.correlation_id or request.reply_to_event_id or request.response_envelope.source_event_id
+
+
 def _response_typing_log_context(
     request: ResponseRequest,
     *,
@@ -486,9 +491,7 @@ def _response_typing_log_context(
         "requester_id": request.response_envelope.requester_id,
         "room_id": request.room_id,
         "thread_id": request.thread_id,
-        "correlation_id": request.correlation_id
-        or request.reply_to_event_id
-        or request.response_envelope.source_event_id,
+        "correlation_id": _correlation_id_for_request(request),
         "response_run_id": response_run_id,
     }
 
@@ -1630,7 +1633,7 @@ class ResponseRunner:
             agent_name=continuation.entity_name,
             active_model_name=continuation.runtime_model_name,
             attachment_ids=continuation.attachment_ids,
-            correlation_id=self._correlation_id_for_request(request),
+            correlation_id=_correlation_id_for_request(request),
             source_envelope=request.response_envelope,
         )
         if tool_dispatch.execution_identity != execution_identity:
@@ -2603,16 +2606,12 @@ class ResponseRunner:
             used_streaming=used_streaming,
         )
 
-    def _correlation_id_for_request(self, request: ResponseRequest) -> str:
-        """Resolve the correlation id for one request."""
-        return request.correlation_id or request.reply_to_event_id or request.response_envelope.source_event_id
-
     def _response_identity(self, request: ResponseRequest, *, response_kind: str) -> ResponseIdentity:
         """Build the per-turn identity carried by delivery requests and response hooks."""
         return ResponseIdentity(
             response_kind=response_kind,
             response_envelope=request.response_envelope,
-            correlation_id=self._correlation_id_for_request(request),
+            correlation_id=_correlation_id_for_request(request),
             participating_agent_names=request.participating_agent_names or (self.deps.agent_name,),
         )
 
@@ -2640,7 +2639,7 @@ class ResponseRunner:
             entity_label=self.deps.agent_name,
             session_id=runtime.session_id,
             run_id=run_id,
-            correlation_id=self._correlation_id_for_request(request),
+            correlation_id=_correlation_id_for_request(request),
             reply_to_event_id=request.reply_to_event_id,
             room_id=request.room_id,
             thread_id=runtime.resolved_target.resolved_thread_id,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -486,11 +486,13 @@ def _response_typing_log_context(
     response_run_id: str | None,
 ) -> dict[str, object]:
     """Return the stable response attribution shared by one typing lease."""
+    target = request.response_envelope.target
     return {
+        **target.log_context,
         "agent_id": request.response_envelope.agent_name,
         "requester_id": request.response_envelope.requester_id,
-        "room_id": request.room_id,
-        "thread_id": request.thread_id,
+        "session_id": target.session_id,
+        "reply_to_event_id": target.reply_to_event_id,
         "correlation_id": _correlation_id_for_request(request),
         "response_run_id": response_run_id,
     }

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -475,16 +475,43 @@ def _is_silent_schedule_response(request: ResponseRequest) -> bool:
     return request.response_envelope.source_kind == SILENT_SCHEDULE_SOURCE_KIND
 
 
+def _response_typing_log_context(
+    request: ResponseRequest,
+    *,
+    response_run_id: str | None,
+) -> dict[str, object]:
+    """Return the stable response attribution shared by one typing lease."""
+    return {
+        "agent_id": request.response_envelope.agent_name,
+        "requester_id": request.response_envelope.requester_id,
+        "room_id": request.room_id,
+        "thread_id": request.thread_id,
+        "correlation_id": request.correlation_id
+        or request.reply_to_event_id
+        or request.response_envelope.source_event_id,
+        "response_run_id": response_run_id,
+    }
+
+
 @asynccontextmanager
 async def _response_typing_indicator(
     client: nio.AsyncClient,
     request: ResponseRequest,
+    *,
+    response_run_id: str | None,
 ) -> AsyncIterator[None]:
     """Expose typing only for response kinds whose progress may be visible."""
     if _is_silent_schedule_response(request):
         yield
         return
-    async with typing_indicator(client, request.room_id):
+    async with typing_indicator(
+        client,
+        request.room_id,
+        log_context=_response_typing_log_context(
+            request,
+            response_run_id=response_run_id,
+        ),
+    ):
         yield
 
 
@@ -1646,7 +1673,11 @@ class ResponseRunner:
                         tool_trace_collector=tool_trace_collector,
                     )
 
-                async with typing_indicator(self._client(), continuation.room_id):
+                async with _response_typing_indicator(
+                    self._client(),
+                    request,
+                    response_run_id=continuation.run_id,
+                ):
                     response_text = await self._run_in_tool_context(
                         tool_dispatch=tool_dispatch,
                         operation=continue_team,
@@ -1659,6 +1690,10 @@ class ResponseRunner:
                     decisions=decisions,
                     denial_reasons=denial_reasons,
                     tool_trace_collector=tool_trace_collector,
+                    typing_log_context=_response_typing_log_context(
+                        request,
+                        response_run_id=continuation.run_id,
+                    ),
                 )
         return response_text
 
@@ -3503,7 +3538,11 @@ class ResponseRunner:
             if use_streaming and (
                 delivery_request.existing_event_id is None or delivery_request.existing_event_is_placeholder
             ):
-                async with _response_typing_indicator(self._client(), request):
+                async with _response_typing_indicator(
+                    self._client(),
+                    delivery_request,
+                    response_run_id=response_run_id,
+                ):
                     event_id: str | None = None
 
                     def build_response_stream() -> AsyncIterator[StreamInputChunk]:
@@ -3601,7 +3640,11 @@ class ResponseRunner:
             else:
                 try:
                     try:
-                        async with _response_typing_indicator(self._client(), request):
+                        async with _response_typing_indicator(
+                            self._client(),
+                            delivery_request,
+                            response_run_id=response_run_id,
+                        ):
 
                             async def build_response_text() -> str:
                                 return await team_response(
@@ -3935,7 +3978,11 @@ class ResponseRunner:
             )
 
         try:
-            async with _response_typing_indicator(self._client(), request):
+            async with _response_typing_indicator(
+                self._client(),
+                request,
+                response_run_id=run_id,
+            ):
                 response_text = await self._run_in_tool_context(
                     tool_dispatch=runtime.tool_dispatch,
                     operation=build_response_text,
@@ -4028,7 +4075,11 @@ class ResponseRunner:
                 attempt_model_runtime=self.deps.tool_runtime,
             )
 
-            async with _response_typing_indicator(self._client(), request):
+            async with _response_typing_indicator(
+                self._client(),
+                request,
+                response_run_id=run_id,
+            ):
                 wrapped_response_stream = self._stream_in_tool_context(
                     tool_dispatch=runtime.tool_dispatch,
                     stream_factory=lambda: response_stream,

--- a/tests/test_matrix_typing.py
+++ b/tests/test_matrix_typing.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
@@ -13,8 +12,6 @@ import pytest_asyncio
 
 from mindroom.matrix import typing as typing_module
 from mindroom.matrix.typing import typing_indicator
-from mindroom.response_runner import _response_typing_indicator
-from tests.response_runner_helpers import _plain_request, _target
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -46,7 +43,7 @@ async def test_concurrent_typing_indicators_share_one_matrix_lease(turn_count: i
 
     async def turn() -> None:
         nonlocal entered_count
-        async with typing_indicator(client, room_id):
+        async with typing_indicator(client, room_id, log_context={}):
             entered_count += 1
             if entered_count == turn_count:
                 all_entered.set()
@@ -81,7 +78,7 @@ async def test_cancelled_initial_typing_request_releases_shared_lease() -> None:
     client.room_typing.side_effect = block_initial_request
 
     async def run_turn() -> None:
-        async with typing_indicator(client, room_id):
+        async with typing_indicator(client, room_id, log_context={}):
             pass
 
     task = asyncio.create_task(run_turn())
@@ -115,12 +112,12 @@ async def test_new_typing_lease_waits_for_prior_stop_request() -> None:
     client.room_typing.side_effect = room_typing
 
     async def first_turn() -> None:
-        async with typing_indicator(client, room_id):
+        async with typing_indicator(client, room_id, log_context={}):
             first_entered.set()
             await release_first.wait()
 
     async def second_turn() -> None:
-        async with typing_indicator(client, room_id):
+        async with typing_indicator(client, room_id, log_context={}):
             second_entered.set()
             await release_second.wait()
 
@@ -162,7 +159,12 @@ async def test_shared_typing_lease_uses_longest_requested_timeout() -> None:
     client.room_typing.side_effect = room_typing
 
     async def turn(timeout_seconds: int, entered: asyncio.Event) -> None:
-        async with typing_indicator(client, room_id, timeout_seconds=timeout_seconds):
+        async with typing_indicator(
+            client,
+            room_id,
+            timeout_seconds=timeout_seconds,
+            log_context={},
+        ):
             entered.set()
             await release_turns.wait()
 
@@ -195,7 +197,7 @@ async def test_typing_start_failure_does_not_fail_response_turn() -> None:
     client.room_typing.side_effect = RuntimeError("Matrix unavailable")
     body_entered = False
 
-    async with typing_indicator(client, "!room:example.org"):
+    async with typing_indicator(client, "!room:example.org", log_context={}):
         body_entered = True
 
     assert body_entered is True
@@ -227,7 +229,12 @@ async def test_typing_refresh_failure_is_logged_and_retried() -> None:
 
     client.room_typing.side_effect = room_typing
 
-    async with typing_indicator(client, "!room:example.org", timeout_seconds=0):
+    async with typing_indicator(
+        client,
+        "!room:example.org",
+        timeout_seconds=0,
+        log_context={},
+    ):
         await asyncio.wait_for(refresh_failed.wait(), timeout=1)
         await asyncio.wait_for(recovered.wait(), timeout=1)
 
@@ -259,7 +266,12 @@ async def test_typing_recovers_for_joiner_after_failed_start() -> None:
     first_entered = asyncio.Event()
 
     async def holder(entered: asyncio.Event) -> None:
-        async with typing_indicator(client, room_id, timeout_seconds=0):
+        async with typing_indicator(
+            client,
+            room_id,
+            timeout_seconds=0,
+            log_context={},
+        ):
             entered.set()
             await let_holders_exit.wait()
 
@@ -308,6 +320,8 @@ async def test_typing_heartbeat_and_stop_keep_initial_response_attribution(
         "requester_id": "@user:example.org",
         "room_id": room_id,
         "thread_id": "$thread:example.org",
+        "session_id": "!room:example.org:$thread:example.org",
+        "reply_to_event_id": "$request:example.org",
         "correlation_id": "$request:example.org",
         "response_run_id": "response-run-1",
     }
@@ -332,7 +346,13 @@ async def test_typing_heartbeat_and_stop_keep_initial_response_attribution(
     await asyncio.wait_for(first_entered.wait(), timeout=1)
     await asyncio.wait_for(heartbeat_sent.wait(), timeout=1)
 
-    joiner_context = {**log_context, "agent_id": "secondary", "response_run_id": "response-run-2"}
+    joiner_context = {
+        **log_context,
+        "agent_id": "secondary",
+        "session_id": "!room:example.org:$other-thread:example.org",
+        "reply_to_event_id": "$other-request:example.org",
+        "response_run_id": "response-run-2",
+    }
     second_task = asyncio.create_task(hold_typing(joiner_context, second_entered, release_second))
     await asyncio.wait_for(second_entered.wait(), timeout=1)
     release_first.set()
@@ -347,35 +367,3 @@ async def test_typing_heartbeat_and_stop_keep_initial_response_attribution(
     assert typing_logs[-1]["typing"] is False
     for entry in typing_logs:
         assert {key: entry[key] for key in log_context} == log_context
-
-
-@pytest.mark.asyncio
-async def test_response_typing_supplies_complete_attribution(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Response typing should supply every stable attribution field it owns."""
-    client = AsyncMock()
-    request = replace(
-        _plain_request(_target(thread_id="$thread:example.org")),
-        correlation_id="$correlation:example.org",
-    )
-    logger = MagicMock()
-    monkeypatch.setattr(typing_module, "logger", logger)
-
-    async with _response_typing_indicator(
-        client,
-        request,
-        response_run_id="response-run-1",
-    ):
-        pass
-
-    typing_logs = [call.kwargs for call in logger.debug.call_args_list if call.args == ("Set typing status",)]
-    expected_attribution = {
-        "agent_id": "general",
-        "requester_id": "@user:localhost",
-        "room_id": "!room:localhost",
-        "thread_id": "$thread:example.org",
-        "correlation_id": "$correlation:example.org",
-        "response_run_id": "response-run-1",
-    }
-    assert [entry["typing"] for entry in typing_logs] == [True, False]
-    for entry in typing_logs:
-        assert {key: entry[key] for key in expected_attribution} == expected_attribution

--- a/tests/test_matrix_typing.py
+++ b/tests/test_matrix_typing.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
+from dataclasses import replace
 from typing import TYPE_CHECKING
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 import pytest_asyncio
 
 from mindroom.matrix import typing as typing_module
 from mindroom.matrix.typing import typing_indicator
+from mindroom.response_runner import _response_typing_indicator
+from tests.response_runner_helpers import _plain_request, _target
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -276,3 +279,103 @@ async def test_typing_recovers_for_joiner_after_failed_start() -> None:
 
     assert start_attempts > 1
     assert not typing_module._ACTIVE_TYPING
+
+
+@pytest.mark.asyncio
+async def test_typing_heartbeat_and_stop_keep_initial_response_attribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every log from one typing lease should retain its response attribution."""
+    client = AsyncMock()
+    room_id = "!room:example.org"
+    heartbeat_sent = asyncio.Event()
+    first_entered = asyncio.Event()
+    second_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    release_second = asyncio.Event()
+    typing_calls = 0
+
+    async def room_typing(_room_id: str, typing: bool, _timeout_ms: int) -> None:
+        nonlocal typing_calls
+        if typing:
+            typing_calls += 1
+            if typing_calls == 2:
+                heartbeat_sent.set()
+
+    client.room_typing.side_effect = room_typing
+    log_context = {
+        "agent_id": "general",
+        "requester_id": "@user:example.org",
+        "room_id": room_id,
+        "thread_id": "$thread:example.org",
+        "correlation_id": "$request:example.org",
+        "response_run_id": "response-run-1",
+    }
+    logger = MagicMock()
+    monkeypatch.setattr(typing_module, "logger", logger)
+
+    async def hold_typing(
+        context: dict[str, str],
+        entered: asyncio.Event,
+        release: asyncio.Event,
+    ) -> None:
+        async with typing_indicator(
+            client,
+            room_id,
+            timeout_seconds=0,
+            log_context=context,
+        ):
+            entered.set()
+            await release.wait()
+
+    first_task = asyncio.create_task(hold_typing(log_context, first_entered, release_first))
+    await asyncio.wait_for(first_entered.wait(), timeout=1)
+    await asyncio.wait_for(heartbeat_sent.wait(), timeout=1)
+
+    joiner_context = {**log_context, "agent_id": "secondary", "response_run_id": "response-run-2"}
+    second_task = asyncio.create_task(hold_typing(joiner_context, second_entered, release_second))
+    await asyncio.wait_for(second_entered.wait(), timeout=1)
+    release_first.set()
+    await first_task
+    release_second.set()
+    await second_task
+
+    typing_logs = [call.kwargs for call in logger.debug.call_args_list if call.args == ("Set typing status",)]
+    assert len(typing_logs) >= 3
+    assert typing_logs[0]["typing"] is True
+    assert typing_logs[1]["typing"] is True
+    assert typing_logs[-1]["typing"] is False
+    for entry in typing_logs:
+        assert {key: entry[key] for key in log_context} == log_context
+
+
+@pytest.mark.asyncio
+async def test_response_typing_supplies_complete_attribution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Response typing should supply every stable attribution field it owns."""
+    client = AsyncMock()
+    request = replace(
+        _plain_request(_target(thread_id="$thread:example.org")),
+        correlation_id="$correlation:example.org",
+    )
+    logger = MagicMock()
+    monkeypatch.setattr(typing_module, "logger", logger)
+
+    async with _response_typing_indicator(
+        client,
+        request,
+        response_run_id="response-run-1",
+    ):
+        pass
+
+    typing_logs = [call.kwargs for call in logger.debug.call_args_list if call.args == ("Set typing status",)]
+    expected_attribution = {
+        "agent_id": "general",
+        "requester_id": "@user:localhost",
+        "room_id": "!room:localhost",
+        "thread_id": "$thread:example.org",
+        "correlation_id": "$correlation:example.org",
+        "response_run_id": "response-run-1",
+    }
+    assert [entry["typing"] for entry in typing_logs] == [True, False]
+    for entry in typing_logs:
+        assert {key: entry[key] for key in expected_attribution} == expected_attribution

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -2513,6 +2513,7 @@ async def test_agent_continuation_executes_real_agno_confirmation(
             decisions={tool_call_id: approved},
             denial_reasons={tool_call_id: reason},
             tool_trace_collector=tool_trace,
+            typing_log_context={},
         )
 
     assert isinstance(result, CompletedApprovalRun)
@@ -2632,6 +2633,7 @@ async def test_agent_continuation_rejects_non_exact_persisted_call_ids(
             decisions=decisions,
             denial_reasons=denial_reasons,
             tool_trace_collector=[],
+            typing_log_context={},
         )
 
     agent.acontinue_run.assert_not_awaited()
@@ -2692,6 +2694,7 @@ async def test_agent_continuation_closes_runtime_when_notice_hook_setup_fails(tm
             decisions={},
             denial_reasons={},
             tool_trace_collector=[],
+            typing_log_context={},
         )
 
     close_runtime.assert_called_once_with(agent, shared_scope_storage=storage)
@@ -2764,6 +2767,7 @@ async def test_approval_collaborators_read_live_config_after_hot_reload(tmp_path
             decisions={},
             denial_reasons={},
             tool_trace_collector=[],
+            typing_log_context={},
         )
 
 

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -71,6 +71,7 @@ from mindroom.final_delivery import FinalDeliveryOutcome, StreamTransportOutcome
 from mindroom.handled_turns import TurnRecord
 from mindroom.history.turn_recorder import TurnRecorder
 from mindroom.logging_config import get_logger
+from mindroom.matrix import typing as typing_module
 from mindroom.matrix.client import DeliveredMatrixEvent
 from mindroom.matrix.client_visible_messages import fetch_latest_visible_body
 from mindroom.matrix.state import MatrixState
@@ -88,6 +89,7 @@ from mindroom.response_runner import (
     PostLockRequestPreparationError,
     ResponseRequest,
     ResponseRunner,
+    _response_typing_indicator,
     _ResponseGenerationOutcome,
     prepare_memory_and_model_context,
 )
@@ -178,6 +180,40 @@ def _completed_outcome(event_id: str = "$response", body: str = "ok") -> FinalDe
         final_visible_body=body,
         delivery_kind="sent",
     )
+
+
+@pytest.mark.asyncio
+async def test_response_typing_supplies_complete_attribution(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Response typing should supply every stable attribution field it owns."""
+    client = AsyncMock()
+    request = replace(
+        _plain_request(_target(thread_id="$thread:example.org")),
+        correlation_id="$correlation:example.org",
+    )
+    logger = MagicMock()
+    monkeypatch.setattr(typing_module, "logger", logger)
+
+    async with _response_typing_indicator(
+        client,
+        request,
+        response_run_id="response-run-1",
+    ):
+        pass
+
+    typing_logs = [call.kwargs for call in logger.debug.call_args_list if call.args == ("Set typing status",)]
+    expected_attribution = {
+        "agent_id": "general",
+        "requester_id": "@user:localhost",
+        "room_id": "!room:localhost",
+        "thread_id": "$thread:example.org",
+        "session_id": "!room:localhost:$thread:example.org",
+        "reply_to_event_id": "$event",
+        "correlation_id": "$correlation:example.org",
+        "response_run_id": "response-run-1",
+    }
+    assert [entry["typing"] for entry in typing_logs] == [True, False]
+    for entry in typing_logs:
+        assert {key: entry[key] for key in expected_attribution} == expected_attribution
 
 
 async def _admit_approval_source(store: PrincipalStore, *, event_id: str = "$source") -> None:


### PR DESCRIPTION
## Summary

Keep one response attribution snapshot across typing start, heartbeats, and stop, including approval continuations.

## Testing

- Focused response and typing tests: 230 passed.
- Full pytest suite passed.
- Pre-commit passed except the existing module-privacy finding reproduced on clean main.

## Summary by Sourcery

Preserve response attribution throughout the full typing lifecycle, including streaming responses and approval continuations.

Bug Fixes:
- Preserve a single response attribution snapshot across typing start, heartbeat, stop, and approval-continuation events.

Enhancements:
- Centralize response correlation and typing attribution context for consistent logging across response execution paths.
- Carry stable attribution data through shared Matrix typing leases, including concurrent joiners.

Tests:
- Add focused coverage verifying complete and stable attribution across typing lifecycle events and response runs.