### PR TITLE
Group external trigger deliveries into one thread with thread_key

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1322,6 +1322,9 @@ Send one signed trigger request to MindRoom.
 │ *  --message                            TEXT   Trigger payload message. [required]     │
 │    --event-id                           TEXT   Optional idempotency event id.          │
 │    --title                              TEXT   Optional trigger title.                 │
+│    --thread-key                         TEXT   Optional key; deliveries sharing it     │
+│                                                land in one Matrix thread on new_thread │
+│                                                triggers.                               │
 │    --data-json                          TEXT   Optional JSON object for trigger data.  │
 │    --timeout                            FLOAT  HTTP request timeout in seconds.        │
 │                                                [default: 10.0]                         │

--- a/docs/external-triggers.md
+++ b/docs/external-triggers.md
@@ -217,6 +217,7 @@ After that, or after `rotate_trigger_key`, the next delivery with the key starts
 Opening a thread is atomic per key.
 While one delivery is posting the first root, a concurrent delivery with the same key receives `409 External trigger thread is being opened by another delivery`; retry it with a fresh signed request and the same `event_id`, and it will join the thread.
 A reservation whose first delivery fails is released immediately; a crashed delivery releases it after 5 minutes.
+Reservations are fenced: a delivery that outlives its reservation can neither bind its root over a newer reservation nor release it, so a slow first delivery cannot orphan the thread that replaced it.
 
 A follow-up that fails to send keeps the key bound to its thread, so a transient error never splits one conversation across two threads.
 

--- a/docs/external-triggers.md
+++ b/docs/external-triggers.md
@@ -131,6 +131,7 @@ For a non-admin caller, the target agent and room are the current agent and curr
 
 `target_thread_id` and `new_thread` are mutually exclusive.
 With `new_thread`, each delivery posts a room-level root and the responding agent answers in a new thread under it with a fresh session.
+A sender can group related deliveries on a `new_thread` trigger by passing the same `thread_key`; see [Grouping Deliveries Into One Thread](#grouping-deliveries-into-one-thread).
 
 For an administrator caller, `target_agent` and `target_room_id` can additionally target a different agent, team, or room.
 
@@ -152,7 +153,7 @@ mindroom trigger send campground \
   --data-json '{"campground":"Yosemite","site":"42","date":"2026-07-04"}'
 ```
 
-The request body contains `kind`, `message`, optional `event_id`, optional `title`, and optional `data`.
+The request body contains `kind`, `message`, optional `event_id`, optional `title`, optional `thread_key`, and optional `data`.
 
 `kind` must match `allowed_kinds` when the trigger record has an allowlist.
 
@@ -189,6 +190,31 @@ Shared target agents must still be configured for the target room.
 Private target agents created from their current live room may use that room even when it is not listed in `rooms`.
 
 The router plus target transport bot must be joined before delivery.
+
+## Grouping Deliveries Into One Thread
+
+A `new_thread` trigger opens a fresh Matrix thread for every delivery.
+That is right for independent events and noisy for a conversation that arrives as many events, such as replies in one upstream chat thread.
+
+Pass `thread_key` to group deliveries.
+The first delivery with a key posts the usual per-fire root and records the key.
+Later deliveries with the same key post into that thread instead of opening another root, so the agent keeps one session and one context for the whole upstream conversation.
+
+```bash
+mindroom trigger send support-inbox \
+  --key-file /etc/mindroom/triggers/support.key \
+  --kind support.message \
+  --event-id ticket-812:msg-3 \
+  --thread-key ticket-812 \
+  --message "Customer replied on ticket 812."
+```
+
+Choose a key that names the upstream conversation, not the message: a ticket ID, an upstream thread timestamp, or a chat channel ID for a direct-message conversation.
+
+Thread key records live in the same replay store as `event_id` records, scoped per trigger, and are retained for 7 days after the most recent delivery that used them.
+After that, the next delivery with the key starts a new thread.
+
+`thread_key` has no effect on triggers with a fixed `target_thread_id`; that thread already collects every delivery.
 
 ## Reusable Trigger Idempotency
 

--- a/docs/external-triggers.md
+++ b/docs/external-triggers.md
@@ -211,8 +211,11 @@ mindroom trigger send support-inbox \
 
 Choose a key that names the upstream conversation, not the message: a ticket ID, an upstream thread timestamp, or a chat channel ID for a direct-message conversation.
 
-Thread key records live in the same replay store as `event_id` records, scoped per trigger, and are retained for 7 days after the most recent delivery that used them.
-After that, the next delivery with the key starts a new thread.
+Thread key records live in the same replay store as `event_id` records, scoped per trigger and signing key epoch, and are retained for 7 days after the most recent delivery that used them.
+After that, or after `rotate_trigger_key`, or when a recorded thread can no longer be delivered to, the next delivery with the key starts a new thread.
+
+Two deliveries that arrive at the same moment with a key nobody has used yet may each open a root; the key then follows the one that finished last.
+Senders that need strict ordering should deliver a conversation's first event before its follow-ups.
 
 `thread_key` has no effect on triggers with a fixed `target_thread_id`; that thread already collects every delivery.
 

--- a/docs/external-triggers.md
+++ b/docs/external-triggers.md
@@ -212,10 +212,13 @@ mindroom trigger send support-inbox \
 Choose a key that names the upstream conversation, not the message: a ticket ID, an upstream thread timestamp, or a chat channel ID for a direct-message conversation.
 
 Thread key records live in the same replay store as `event_id` records, scoped per trigger and signing key epoch, and are retained for 7 days after the most recent delivery that used them.
-After that, or after `rotate_trigger_key`, or when a recorded thread can no longer be delivered to, the next delivery with the key starts a new thread.
+After that, or after `rotate_trigger_key`, the next delivery with the key starts a new thread.
 
-Two deliveries that arrive at the same moment with a key nobody has used yet may each open a root; the key then follows the one that finished last.
-Senders that need strict ordering should deliver a conversation's first event before its follow-ups.
+Opening a thread is atomic per key.
+While one delivery is posting the first root, a concurrent delivery with the same key receives `409 External trigger thread is being opened by another delivery`; retry it with a fresh signed request and the same `event_id`, and it will join the thread.
+A reservation whose first delivery fails is released immediately; a crashed delivery releases it after 5 minutes.
+
+A follow-up that fails to send keeps the key bound to its thread, so a transient error never splits one conversation across two threads.
 
 `thread_key` has no effect on triggers with a fixed `target_thread_id`; that thread already collects every delivery.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16310,10 +16310,13 @@ mindroom trigger send support-inbox \
 Choose a key that names the upstream conversation, not the message: a ticket ID, an upstream thread timestamp, or a chat channel ID for a direct-message conversation.
 
 Thread key records live in the same replay store as `event_id` records, scoped per trigger and signing key epoch, and are retained for 7 days after the most recent delivery that used them.
-After that, or after `rotate_trigger_key`, or when a recorded thread can no longer be delivered to, the next delivery with the key starts a new thread.
+After that, or after `rotate_trigger_key`, the next delivery with the key starts a new thread.
 
-Two deliveries that arrive at the same moment with a key nobody has used yet may each open a root; the key then follows the one that finished last.
-Senders that need strict ordering should deliver a conversation's first event before its follow-ups.
+Opening a thread is atomic per key.
+While one delivery is posting the first root, a concurrent delivery with the same key receives `409 External trigger thread is being opened by another delivery`; retry it with a fresh signed request and the same `event_id`, and it will join the thread.
+A reservation whose first delivery fails is released immediately; a crashed delivery releases it after 5 minutes.
+
+A follow-up that fails to send keeps the key bound to its thread, so a transient error never splits one conversation across two threads.
 
 `thread_key` has no effect on triggers with a fixed `target_thread_id`; that thread already collects every delivery.
 
@@ -20970,6 +20973,9 @@ Send one signed trigger request to MindRoom.
 │ *  --message                            TEXT   Trigger payload message. [required]     │
 │    --event-id                           TEXT   Optional idempotency event id.          │
 │    --title                              TEXT   Optional trigger title.                 │
+│    --thread-key                         TEXT   Optional key; deliveries sharing it     │
+│                                                land in one Matrix thread on new_thread │
+│                                                triggers.                               │
 │    --data-json                          TEXT   Optional JSON object for trigger data.  │
 │    --timeout                            FLOAT  HTTP request timeout in seconds.        │
 │                                                [default: 10.0]                         │

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16309,8 +16309,11 @@ mindroom trigger send support-inbox \
 
 Choose a key that names the upstream conversation, not the message: a ticket ID, an upstream thread timestamp, or a chat channel ID for a direct-message conversation.
 
-Thread key records live in the same replay store as `event_id` records, scoped per trigger, and are retained for 7 days after the most recent delivery that used them.
-After that, the next delivery with the key starts a new thread.
+Thread key records live in the same replay store as `event_id` records, scoped per trigger and signing key epoch, and are retained for 7 days after the most recent delivery that used them.
+After that, or after `rotate_trigger_key`, or when a recorded thread can no longer be delivered to, the next delivery with the key starts a new thread.
+
+Two deliveries that arrive at the same moment with a key nobody has used yet may each open a root; the key then follows the one that finished last.
+Senders that need strict ordering should deliver a conversation's first event before its follow-ups.
 
 `thread_key` has no effect on triggers with a fixed `target_thread_id`; that thread already collects every delivery.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16315,6 +16315,7 @@ After that, or after `rotate_trigger_key`, the next delivery with the key starts
 Opening a thread is atomic per key.
 While one delivery is posting the first root, a concurrent delivery with the same key receives `409 External trigger thread is being opened by another delivery`; retry it with a fresh signed request and the same `event_id`, and it will join the thread.
 A reservation whose first delivery fails is released immediately; a crashed delivery releases it after 5 minutes.
+Reservations are fenced: a delivery that outlives its reservation can neither bind its root over a newer reservation nor release it, so a slow first delivery cannot orphan the thread that replaced it.
 
 A follow-up that fails to send keeps the key bound to its thread, so a transient error never splits one conversation across two threads.
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16229,6 +16229,7 @@ For a non-admin caller, the target agent and room are the current agent and curr
 
 `target_thread_id` and `new_thread` are mutually exclusive.
 With `new_thread`, each delivery posts a room-level root and the responding agent answers in a new thread under it with a fresh session.
+A sender can group related deliveries on a `new_thread` trigger by passing the same `thread_key`; see [Grouping Deliveries Into One Thread](#grouping-deliveries-into-one-thread).
 
 For an administrator caller, `target_agent` and `target_room_id` can additionally target a different agent, team, or room.
 
@@ -16250,7 +16251,7 @@ mindroom trigger send campground \
   --data-json '{"campground":"Yosemite","site":"42","date":"2026-07-04"}'
 ```
 
-The request body contains `kind`, `message`, optional `event_id`, optional `title`, and optional `data`.
+The request body contains `kind`, `message`, optional `event_id`, optional `title`, optional `thread_key`, and optional `data`.
 
 `kind` must match `allowed_kinds` when the trigger record has an allowlist.
 
@@ -16287,6 +16288,31 @@ Shared target agents must still be configured for the target room.
 Private target agents created from their current live room may use that room even when it is not listed in `rooms`.
 
 The router plus target transport bot must be joined before delivery.
+
+## Grouping Deliveries Into One Thread
+
+A `new_thread` trigger opens a fresh Matrix thread for every delivery.
+That is right for independent events and noisy for a conversation that arrives as many events, such as replies in one upstream chat thread.
+
+Pass `thread_key` to group deliveries.
+The first delivery with a key posts the usual per-fire root and records the key.
+Later deliveries with the same key post into that thread instead of opening another root, so the agent keeps one session and one context for the whole upstream conversation.
+
+```bash
+mindroom trigger send support-inbox \
+  --key-file /etc/mindroom/triggers/support.key \
+  --kind support.message \
+  --event-id ticket-812:msg-3 \
+  --thread-key ticket-812 \
+  --message "Customer replied on ticket 812."
+```
+
+Choose a key that names the upstream conversation, not the message: a ticket ID, an upstream thread timestamp, or a chat channel ID for a direct-message conversation.
+
+Thread key records live in the same replay store as `event_id` records, scoped per trigger, and are retained for 7 days after the most recent delivery that used them.
+After that, the next delivery with the key starts a new thread.
+
+`thread_key` has no effect on triggers with a fixed `target_thread_id`; that thread already collects every delivery.
 
 ## Reusable Trigger Idempotency
 

--- a/skills/mindroom-docs/references/page__cli__index.md
+++ b/skills/mindroom-docs/references/page__cli__index.md
@@ -1318,6 +1318,9 @@ Send one signed trigger request to MindRoom.
 │ *  --message                            TEXT   Trigger payload message. [required]     │
 │    --event-id                           TEXT   Optional idempotency event id.          │
 │    --title                              TEXT   Optional trigger title.                 │
+│    --thread-key                         TEXT   Optional key; deliveries sharing it     │
+│                                                land in one Matrix thread on new_thread │
+│                                                triggers.                               │
 │    --data-json                          TEXT   Optional JSON object for trigger data.  │
 │    --timeout                            FLOAT  HTTP request timeout in seconds.        │
 │                                                [default: 10.0]                         │

--- a/skills/mindroom-docs/references/page__external-triggers__index.md
+++ b/skills/mindroom-docs/references/page__external-triggers__index.md
@@ -207,8 +207,11 @@ mindroom trigger send support-inbox \
 
 Choose a key that names the upstream conversation, not the message: a ticket ID, an upstream thread timestamp, or a chat channel ID for a direct-message conversation.
 
-Thread key records live in the same replay store as `event_id` records, scoped per trigger, and are retained for 7 days after the most recent delivery that used them.
-After that, the next delivery with the key starts a new thread.
+Thread key records live in the same replay store as `event_id` records, scoped per trigger and signing key epoch, and are retained for 7 days after the most recent delivery that used them.
+After that, or after `rotate_trigger_key`, or when a recorded thread can no longer be delivered to, the next delivery with the key starts a new thread.
+
+Two deliveries that arrive at the same moment with a key nobody has used yet may each open a root; the key then follows the one that finished last.
+Senders that need strict ordering should deliver a conversation's first event before its follow-ups.
 
 `thread_key` has no effect on triggers with a fixed `target_thread_id`; that thread already collects every delivery.
 

--- a/skills/mindroom-docs/references/page__external-triggers__index.md
+++ b/skills/mindroom-docs/references/page__external-triggers__index.md
@@ -208,10 +208,13 @@ mindroom trigger send support-inbox \
 Choose a key that names the upstream conversation, not the message: a ticket ID, an upstream thread timestamp, or a chat channel ID for a direct-message conversation.
 
 Thread key records live in the same replay store as `event_id` records, scoped per trigger and signing key epoch, and are retained for 7 days after the most recent delivery that used them.
-After that, or after `rotate_trigger_key`, or when a recorded thread can no longer be delivered to, the next delivery with the key starts a new thread.
+After that, or after `rotate_trigger_key`, the next delivery with the key starts a new thread.
 
-Two deliveries that arrive at the same moment with a key nobody has used yet may each open a root; the key then follows the one that finished last.
-Senders that need strict ordering should deliver a conversation's first event before its follow-ups.
+Opening a thread is atomic per key.
+While one delivery is posting the first root, a concurrent delivery with the same key receives `409 External trigger thread is being opened by another delivery`; retry it with a fresh signed request and the same `event_id`, and it will join the thread.
+A reservation whose first delivery fails is released immediately; a crashed delivery releases it after 5 minutes.
+
+A follow-up that fails to send keeps the key bound to its thread, so a transient error never splits one conversation across two threads.
 
 `thread_key` has no effect on triggers with a fixed `target_thread_id`; that thread already collects every delivery.
 

--- a/skills/mindroom-docs/references/page__external-triggers__index.md
+++ b/skills/mindroom-docs/references/page__external-triggers__index.md
@@ -213,6 +213,7 @@ After that, or after `rotate_trigger_key`, the next delivery with the key starts
 Opening a thread is atomic per key.
 While one delivery is posting the first root, a concurrent delivery with the same key receives `409 External trigger thread is being opened by another delivery`; retry it with a fresh signed request and the same `event_id`, and it will join the thread.
 A reservation whose first delivery fails is released immediately; a crashed delivery releases it after 5 minutes.
+Reservations are fenced: a delivery that outlives its reservation can neither bind its root over a newer reservation nor release it, so a slow first delivery cannot orphan the thread that replaced it.
 
 A follow-up that fails to send keeps the key bound to its thread, so a transient error never splits one conversation across two threads.
 

--- a/skills/mindroom-docs/references/page__external-triggers__index.md
+++ b/skills/mindroom-docs/references/page__external-triggers__index.md
@@ -127,6 +127,7 @@ For a non-admin caller, the target agent and room are the current agent and curr
 
 `target_thread_id` and `new_thread` are mutually exclusive.
 With `new_thread`, each delivery posts a room-level root and the responding agent answers in a new thread under it with a fresh session.
+A sender can group related deliveries on a `new_thread` trigger by passing the same `thread_key`; see [Grouping Deliveries Into One Thread](#grouping-deliveries-into-one-thread).
 
 For an administrator caller, `target_agent` and `target_room_id` can additionally target a different agent, team, or room.
 
@@ -148,7 +149,7 @@ mindroom trigger send campground \
   --data-json '{"campground":"Yosemite","site":"42","date":"2026-07-04"}'
 ```
 
-The request body contains `kind`, `message`, optional `event_id`, optional `title`, and optional `data`.
+The request body contains `kind`, `message`, optional `event_id`, optional `title`, optional `thread_key`, and optional `data`.
 
 `kind` must match `allowed_kinds` when the trigger record has an allowlist.
 
@@ -185,6 +186,31 @@ Shared target agents must still be configured for the target room.
 Private target agents created from their current live room may use that room even when it is not listed in `rooms`.
 
 The router plus target transport bot must be joined before delivery.
+
+## Grouping Deliveries Into One Thread
+
+A `new_thread` trigger opens a fresh Matrix thread for every delivery.
+That is right for independent events and noisy for a conversation that arrives as many events, such as replies in one upstream chat thread.
+
+Pass `thread_key` to group deliveries.
+The first delivery with a key posts the usual per-fire root and records the key.
+Later deliveries with the same key post into that thread instead of opening another root, so the agent keeps one session and one context for the whole upstream conversation.
+
+```bash
+mindroom trigger send support-inbox \
+  --key-file /etc/mindroom/triggers/support.key \
+  --kind support.message \
+  --event-id ticket-812:msg-3 \
+  --thread-key ticket-812 \
+  --message "Customer replied on ticket 812."
+```
+
+Choose a key that names the upstream conversation, not the message: a ticket ID, an upstream thread timestamp, or a chat channel ID for a direct-message conversation.
+
+Thread key records live in the same replay store as `event_id` records, scoped per trigger, and are retained for 7 days after the most recent delivery that used them.
+After that, the next delivery with the key starts a new thread.
+
+`thread_key` has no effect on triggers with a fixed `target_thread_id`; that thread already collects every delivery.
 
 ## Reusable Trigger Idempotency
 

--- a/src/mindroom/api/external_triggers.py
+++ b/src/mindroom/api/external_triggers.py
@@ -208,8 +208,9 @@ async def _claim_and_execute_trigger(
     thread_key = payload.thread_key if snapshot.target.new_thread else None
     thread_claim = ExternalTriggerThreadKeyClaim.FRESH
     continue_thread_event_id: str | None = None
+    thread_reservation: str | None = None
     if thread_key is not None:
-        thread_claim, continue_thread_event_id = await _run_replay_store_call(
+        thread_claim, continue_thread_event_id, thread_reservation = await _run_replay_store_call(
             replay_store.claim_thread_key,
             snapshot.replay_scope,
             thread_key,
@@ -231,10 +232,10 @@ async def _claim_and_execute_trigger(
             continue_thread_event_id=continue_thread_event_id,
         )
     except Exception:
-        await _rollback_failed_delivery(replay_store, snapshot, event_id, thread_key, thread_claim)
+        await _rollback_failed_delivery(replay_store, snapshot, event_id, thread_key, thread_reservation)
         raise
     if matrix_event_id is None:
-        await _rollback_failed_delivery(replay_store, snapshot, event_id, thread_key, thread_claim)
+        await _rollback_failed_delivery(replay_store, snapshot, event_id, thread_key, thread_reservation)
         raise HTTPException(status_code=502, detail="External trigger delivery failed")
     if thread_key is not None:
         await _run_replay_store_call(
@@ -243,6 +244,7 @@ async def _claim_and_execute_trigger(
             thread_key,
             continue_thread_event_id or matrix_event_id,
             room_id=snapshot.resolved_room_id,
+            reservation=thread_reservation,
             now=int(time.time()),
             ttl_seconds=_THREAD_KEY_TTL_SECONDS,
         )
@@ -388,20 +390,25 @@ async def _rollback_failed_delivery(
     snapshot: TriggerDeliverySnapshot,
     event_id: str,
     thread_key: str | None,
-    thread_claim: ExternalTriggerThreadKeyClaim,
+    thread_reservation: str | None,
 ) -> None:
     """Undo replay claims after a failed send without masking the failure.
 
-    A failed first delivery releases its thread-key reservation so the next
-    delivery can open the root. A failed continuation keeps the key bound: the
-    root is still the right thread, and a transient send error must not split
-    the conversation.
+    A failed first delivery releases its own thread-key reservation so the next
+    delivery can open the root. A failed continuation holds no reservation and
+    keeps the key bound: the root is still the right thread, and a transient
+    send error must not split the conversation.
     """
     await _release_event_id_best_effort(replay_store, snapshot.replay_scope, event_id)
-    if thread_key is None or thread_claim is not ExternalTriggerThreadKeyClaim.FRESH:
+    if thread_key is None or thread_reservation is None:
         return
     try:
-        await asyncio.to_thread(replay_store.release_thread_key, snapshot.replay_scope, thread_key)
+        await asyncio.to_thread(
+            replay_store.release_thread_key,
+            snapshot.replay_scope,
+            thread_key,
+            reservation=thread_reservation,
+        )
     except Exception:
         logger.warning(
             "Failed to release external trigger thread key after delivery failure",

--- a/src/mindroom/api/external_triggers.py
+++ b/src/mindroom/api/external_triggers.py
@@ -26,6 +26,7 @@ from mindroom.external_triggers.replay_store import (
     ExternalTriggerEventClaim,
     ExternalTriggerReplayStore,
     ExternalTriggerReplayStoreError,
+    ExternalTriggerThreadKeyClaim,
 )
 from mindroom.external_triggers.store import (
     ExternalTriggerRecordNotDeliverableError,
@@ -55,6 +56,9 @@ _IN_PROGRESS_EVENT_ID_TTL_SECONDS = 86400
 _DELIVERED_EVENT_ID_TTL_SECONDS = 86400
 # A thread key keeps routing to the same Matrix thread for a week of activity.
 _THREAD_KEY_TTL_SECONDS = 7 * 86400
+# A reservation for a key whose first root is still being posted; short so a
+# crashed delivery cannot block a conversation for long.
+_PENDING_THREAD_KEY_TTL_SECONDS = 300
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
@@ -202,15 +206,20 @@ async def _claim_and_execute_trigger(
     # Only per-fire targets group by thread key; a fixed target thread already
     # collects every delivery.
     thread_key = payload.thread_key if snapshot.target.new_thread else None
-    continue_thread_event_id = None
+    thread_claim = ExternalTriggerThreadKeyClaim.FRESH
+    continue_thread_event_id: str | None = None
     if thread_key is not None:
-        continue_thread_event_id = await _run_replay_store_call(
-            replay_store.thread_root,
+        thread_claim, continue_thread_event_id = await _run_replay_store_call(
+            replay_store.claim_thread_key,
             snapshot.replay_scope,
             thread_key,
             room_id=snapshot.resolved_room_id,
             now=now,
+            pending_ttl_seconds=_PENDING_THREAD_KEY_TTL_SECONDS,
         )
+        if thread_claim is ExternalTriggerThreadKeyClaim.PENDING:
+            await _release_event_id_best_effort(replay_store, snapshot.replay_scope, event_id)
+            raise HTTPException(status_code=409, detail="External trigger thread is being opened by another delivery")
     try:
         matrix_event_id = await execute_external_trigger(
             client=cast("nio.AsyncClient", runtime.client),
@@ -222,16 +231,14 @@ async def _claim_and_execute_trigger(
             continue_thread_event_id=continue_thread_event_id,
         )
     except Exception:
-        await _release_event_id_best_effort(replay_store, snapshot.replay_scope, event_id)
-        await _forget_stale_thread_root(replay_store, snapshot, thread_key, continue_thread_event_id)
+        await _rollback_failed_delivery(replay_store, snapshot, event_id, thread_key, thread_claim)
         raise
     if matrix_event_id is None:
-        await _release_event_id_best_effort(replay_store, snapshot.replay_scope, event_id)
-        await _forget_stale_thread_root(replay_store, snapshot, thread_key, continue_thread_event_id)
+        await _rollback_failed_delivery(replay_store, snapshot, event_id, thread_key, thread_claim)
         raise HTTPException(status_code=502, detail="External trigger delivery failed")
     if thread_key is not None:
         await _run_replay_store_call(
-            replay_store.remember_thread_root,
+            replay_store.bind_thread_root,
             snapshot.replay_scope,
             thread_key,
             continue_thread_event_id or matrix_event_id,
@@ -376,21 +383,28 @@ async def _run_replay_store_call(call: Callable[_P, _T], *args: _P.args, **kwarg
         raise HTTPException(status_code=503, detail="External trigger replay store is not available") from exc
 
 
-async def _forget_stale_thread_root(
+async def _rollback_failed_delivery(
     replay_store: ExternalTriggerReplayStore,
     snapshot: TriggerDeliverySnapshot,
+    event_id: str,
     thread_key: str | None,
-    continue_thread_event_id: str | None,
+    thread_claim: ExternalTriggerThreadKeyClaim,
 ) -> None:
-    """Drop a recorded root that could not be delivered to, so the next attempt opens a fresh one."""
-    if thread_key is None or continue_thread_event_id is None:
+    """Undo replay claims after a failed send without masking the failure.
+
+    A failed first delivery releases its thread-key reservation so the next
+    delivery can open the root. A failed continuation keeps the key bound: the
+    root is still the right thread, and a transient send error must not split
+    the conversation.
+    """
+    await _release_event_id_best_effort(replay_store, snapshot.replay_scope, event_id)
+    if thread_key is None or thread_claim is not ExternalTriggerThreadKeyClaim.FRESH:
         return
     try:
-        await asyncio.to_thread(replay_store.forget_thread_root, snapshot.replay_scope, thread_key)
+        await asyncio.to_thread(replay_store.release_thread_key, snapshot.replay_scope, thread_key)
     except Exception:
-        # Never let store trouble mask the delivery failure being reported.
         logger.warning(
-            "Could not forget stale external trigger thread root",
+            "Failed to release external trigger thread key after delivery failure",
             trigger_id=snapshot.trigger_id,
             thread_key=thread_key,
             exc_info=True,

--- a/src/mindroom/api/external_triggers.py
+++ b/src/mindroom/api/external_triggers.py
@@ -208,6 +208,7 @@ async def _claim_and_execute_trigger(
             replay_store.thread_root,
             snapshot.replay_scope,
             thread_key,
+            room_id=snapshot.resolved_room_id,
             now=now,
         )
     try:
@@ -222,9 +223,11 @@ async def _claim_and_execute_trigger(
         )
     except Exception:
         await _release_event_id_best_effort(replay_store, snapshot.replay_scope, event_id)
+        await _forget_stale_thread_root(replay_store, snapshot, thread_key, continue_thread_event_id)
         raise
     if matrix_event_id is None:
         await _release_event_id_best_effort(replay_store, snapshot.replay_scope, event_id)
+        await _forget_stale_thread_root(replay_store, snapshot, thread_key, continue_thread_event_id)
         raise HTTPException(status_code=502, detail="External trigger delivery failed")
     if thread_key is not None:
         await _run_replay_store_call(
@@ -232,6 +235,7 @@ async def _claim_and_execute_trigger(
             snapshot.replay_scope,
             thread_key,
             continue_thread_event_id or matrix_event_id,
+            room_id=snapshot.resolved_room_id,
             now=int(time.time()),
             ttl_seconds=_THREAD_KEY_TTL_SECONDS,
         )
@@ -370,6 +374,25 @@ async def _run_replay_store_call(call: Callable[_P, _T], *args: _P.args, **kwarg
         return await asyncio.to_thread(call, *args, **kwargs)
     except ExternalTriggerReplayStoreError as exc:
         raise HTTPException(status_code=503, detail="External trigger replay store is not available") from exc
+
+
+async def _forget_stale_thread_root(
+    replay_store: ExternalTriggerReplayStore,
+    snapshot: TriggerDeliverySnapshot,
+    thread_key: str | None,
+    continue_thread_event_id: str | None,
+) -> None:
+    """Drop a recorded root that could not be delivered to, so the next attempt opens a fresh one."""
+    if thread_key is None or continue_thread_event_id is None:
+        return
+    try:
+        await asyncio.to_thread(replay_store.forget_thread_root, snapshot.replay_scope, thread_key)
+    except ExternalTriggerReplayStoreError:
+        logger.warning(
+            "Could not forget stale external trigger thread root",
+            trigger_id=snapshot.trigger_id,
+            thread_key=thread_key,
+        )
 
 
 async def _release_event_id_best_effort(

--- a/src/mindroom/api/external_triggers.py
+++ b/src/mindroom/api/external_triggers.py
@@ -53,6 +53,8 @@ router = APIRouter(prefix="/api/triggers", tags=["external-triggers"])
 logger = get_logger(__name__)
 _IN_PROGRESS_EVENT_ID_TTL_SECONDS = 86400
 _DELIVERED_EVENT_ID_TTL_SECONDS = 86400
+# A thread key keeps routing to the same Matrix thread for a week of activity.
+_THREAD_KEY_TTL_SECONDS = 7 * 86400
 _P = ParamSpec("_P")
 _T = TypeVar("_T")
 
@@ -197,6 +199,17 @@ async def _claim_and_execute_trigger(
         raise HTTPException(status_code=409, detail="External trigger event is already in progress")
 
     payload = payload.model_copy(update={"event_id": event_id})
+    # Only per-fire targets group by thread key; a fixed target thread already
+    # collects every delivery.
+    thread_key = payload.thread_key if snapshot.target.new_thread else None
+    continue_thread_event_id = None
+    if thread_key is not None:
+        continue_thread_event_id = await _run_replay_store_call(
+            replay_store.thread_root,
+            snapshot.replay_scope,
+            thread_key,
+            now=now,
+        )
     try:
         matrix_event_id = await execute_external_trigger(
             client=cast("nio.AsyncClient", runtime.client),
@@ -205,6 +218,7 @@ async def _claim_and_execute_trigger(
             config=config,
             runtime_paths=runtime_paths,
             conversation_reader=cast("ConversationReader", runtime.conversation_reader),
+            continue_thread_event_id=continue_thread_event_id,
         )
     except Exception:
         await _release_event_id_best_effort(replay_store, snapshot.replay_scope, event_id)
@@ -212,6 +226,15 @@ async def _claim_and_execute_trigger(
     if matrix_event_id is None:
         await _release_event_id_best_effort(replay_store, snapshot.replay_scope, event_id)
         raise HTTPException(status_code=502, detail="External trigger delivery failed")
+    if thread_key is not None:
+        await _run_replay_store_call(
+            replay_store.remember_thread_root,
+            snapshot.replay_scope,
+            thread_key,
+            continue_thread_event_id or matrix_event_id,
+            now=int(time.time()),
+            ttl_seconds=_THREAD_KEY_TTL_SECONDS,
+        )
 
     await _run_replay_store_call(
         replay_store.mark_event_delivered,

--- a/src/mindroom/api/external_triggers.py
+++ b/src/mindroom/api/external_triggers.py
@@ -238,16 +238,27 @@ async def _claim_and_execute_trigger(
         await _rollback_failed_delivery(replay_store, snapshot, event_id, thread_key, thread_reservation)
         raise HTTPException(status_code=502, detail="External trigger delivery failed")
     if thread_key is not None:
-        await _run_replay_store_call(
+        intended_root = continue_thread_event_id or matrix_event_id
+        bound_root = await _run_replay_store_call(
             replay_store.bind_thread_root,
             snapshot.replay_scope,
             thread_key,
-            continue_thread_event_id or matrix_event_id,
+            intended_root,
             room_id=snapshot.resolved_room_id,
             reservation=thread_reservation,
             now=int(time.time()),
             ttl_seconds=_THREAD_KEY_TTL_SECONDS,
         )
+        if bound_root != intended_root:
+            # The delivery outlived its reservation and another one opened the
+            # thread meanwhile. The message is posted; only its root is orphaned.
+            logger.warning(
+                "External trigger delivery lost its thread key to a newer delivery",
+                trigger_id=snapshot.trigger_id,
+                thread_key=thread_key,
+                matrix_event_id=matrix_event_id,
+                bound_root=bound_root,
+            )
 
     await _run_replay_store_call(
         replay_store.mark_event_delivered,

--- a/src/mindroom/api/external_triggers.py
+++ b/src/mindroom/api/external_triggers.py
@@ -387,11 +387,13 @@ async def _forget_stale_thread_root(
         return
     try:
         await asyncio.to_thread(replay_store.forget_thread_root, snapshot.replay_scope, thread_key)
-    except ExternalTriggerReplayStoreError:
+    except Exception:
+        # Never let store trouble mask the delivery failure being reported.
         logger.warning(
             "Could not forget stale external trigger thread root",
             trigger_id=snapshot.trigger_id,
             thread_key=thread_key,
+            exc_info=True,
         )
 
 

--- a/src/mindroom/cli/trigger.py
+++ b/src/mindroom/cli/trigger.py
@@ -105,6 +105,11 @@ def send(
     message: str = typer.Option(..., "--message", help="Trigger payload message."),
     event_id: str | None = typer.Option(None, "--event-id", help="Optional idempotency event id."),
     title: str | None = typer.Option(None, "--title", help="Optional trigger title."),
+    thread_key: str | None = typer.Option(
+        None,
+        "--thread-key",
+        help="Optional key; deliveries sharing it land in one Matrix thread on new_thread triggers.",
+    ),
     data_json: str | None = typer.Option(None, "--data-json", help="Optional JSON object for trigger data."),
     timeout: float = typer.Option(_DEFAULT_TIMEOUT, "--timeout", help="HTTP request timeout in seconds."),
     verify_tls: bool = typer.Option(True, "--verify-tls/--no-verify-tls", help="Verify TLS certificates."),
@@ -128,6 +133,7 @@ def send(
         message=message,
         event_id=event_id or secrets.token_hex(16),
         title=title,
+        thread_key=thread_key,
         data=_decode_data_json(data_json),
     )
     timestamp = str(int(time.time()))
@@ -194,12 +200,14 @@ def _trigger_body_bytes(
     event_id: str,
     title: str | None,
     data: dict[str, object],
+    thread_key: str | None = None,
 ) -> bytes:
     payload: dict[str, object | None] = {
         "kind": kind,
         "message": message,
         "event_id": event_id,
         "title": title,
+        "thread_key": thread_key,
         "data": data,
     }
     return json.dumps(

--- a/src/mindroom/external_triggers/executor.py
+++ b/src/mindroom/external_triggers/executor.py
@@ -51,10 +51,19 @@ async def execute_external_trigger(
     config: Config,
     runtime_paths: RuntimePaths,
     conversation_reader: ConversationReader,
+    continue_thread_event_id: str | None = None,
 ) -> str | None:
-    """Post one authenticated external trigger payload to its configured Matrix target."""
+    """Post one authenticated external trigger payload to its configured Matrix target.
+
+    ``continue_thread_event_id`` names the Matrix thread root an earlier delivery
+    with the same ``thread_key`` created; the new message joins that thread
+    instead of opening another per-fire root.
+    """
     room_id = snapshot.resolved_room_id
-    thread_event_id = None if snapshot.target.new_thread else snapshot.target.thread_id
+    if continue_thread_event_id is not None:
+        thread_event_id: str | None = continue_thread_event_id
+    else:
+        thread_event_id = None if snapshot.target.new_thread else snapshot.target.thread_id
     latest_thread_event_id = None
     if thread_event_id is not None:
         latest_thread_event_id = await conversation_reader.latest_thread_event_id(
@@ -75,7 +84,11 @@ async def execute_external_trigger(
         mentioned_user_ids=mentioned_user_ids,
         thread_event_id=thread_event_id,
         latest_thread_event_id=latest_thread_event_id,
-        extra_content=_external_trigger_content_metadata(snapshot, payload),
+        extra_content=_external_trigger_content_metadata(
+            snapshot,
+            payload,
+            per_fire_root=snapshot.target.new_thread and continue_thread_event_id is None,
+        ),
     )
     delivered = await send_matrix_message(client, room_id, content)
     if delivered is None:
@@ -98,6 +111,8 @@ async def is_external_trigger_owner_joined_target_room(
 def _external_trigger_content_metadata(
     snapshot: TriggerDeliverySnapshot,
     payload: ExternalTriggerPayload,
+    *,
+    per_fire_root: bool,
 ) -> dict[str, Any]:
     """Return Matrix content metadata for one external trigger dispatch."""
     metadata: dict[str, Any] = {
@@ -107,6 +122,6 @@ def _external_trigger_content_metadata(
         _EXTERNAL_TRIGGER_KIND_KEY: payload.kind,
         _EXTERNAL_TRIGGER_EVENT_ID_KEY: payload.event_id,
     }
-    if snapshot.target.new_thread:
+    if per_fire_root:
         metadata[PER_FIRE_THREAD_ROOT_KEY] = True
     return metadata

--- a/src/mindroom/external_triggers/models.py
+++ b/src/mindroom/external_triggers/models.py
@@ -8,6 +8,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from mindroom.config.validation import non_empty_stripped
 
+# Thread keys are retained for days in a shared store, so keep them short.
+MAX_THREAD_KEY_LENGTH = 256
+
 
 class ExternalTriggerPayload(BaseModel):
     """External trigger request body."""
@@ -36,10 +39,14 @@ class ExternalTriggerPayload(BaseModel):
     @field_validator("thread_key")
     @classmethod
     def validate_thread_key(cls, value: str | None) -> str | None:
-        """Reject blank thread keys; ``None`` keeps per-delivery threads."""
+        """Reject blank or oversized thread keys; ``None`` keeps per-delivery threads."""
         if value is None:
             return None
-        return non_empty_stripped(value, field_name="thread_key")
+        stripped = non_empty_stripped(value, field_name="thread_key")
+        if len(stripped) > MAX_THREAD_KEY_LENGTH:
+            msg = f"thread_key must be at most {MAX_THREAD_KEY_LENGTH} characters"
+            raise ValueError(msg)
+        return stripped
 
 
 class ExternalTriggerAcceptedResponse(BaseModel):

--- a/src/mindroom/external_triggers/models.py
+++ b/src/mindroom/external_triggers/models.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from mindroom.config.validation import non_empty_stripped
 
 # Thread keys are retained for days in a shared store, so keep them short.
-MAX_THREAD_KEY_LENGTH = 256
+_MAX_THREAD_KEY_LENGTH = 256
 
 
 class ExternalTriggerPayload(BaseModel):
@@ -43,8 +43,8 @@ class ExternalTriggerPayload(BaseModel):
         if value is None:
             return None
         stripped = non_empty_stripped(value, field_name="thread_key")
-        if len(stripped) > MAX_THREAD_KEY_LENGTH:
-            msg = f"thread_key must be at most {MAX_THREAD_KEY_LENGTH} characters"
+        if len(stripped) > _MAX_THREAD_KEY_LENGTH:
+            msg = f"thread_key must be at most {_MAX_THREAD_KEY_LENGTH} characters"
             raise ValueError(msg)
         return stripped
 

--- a/src/mindroom/external_triggers/models.py
+++ b/src/mindroom/external_triggers/models.py
@@ -18,6 +18,7 @@ class ExternalTriggerPayload(BaseModel):
     message: str
     event_id: str | None = None
     title: str | None = None
+    thread_key: str | None = None
     data: dict[str, Any] = Field(default_factory=dict)
 
     @field_validator("kind")
@@ -31,6 +32,14 @@ class ExternalTriggerPayload(BaseModel):
     def validate_message(cls, value: str) -> str:
         """Reject empty trigger messages."""
         return non_empty_stripped(value, field_name="message")
+
+    @field_validator("thread_key")
+    @classmethod
+    def validate_thread_key(cls, value: str | None) -> str | None:
+        """Reject blank thread keys; ``None`` keeps per-delivery threads."""
+        if value is None:
+            return None
+        return non_empty_stripped(value, field_name="thread_key")
 
 
 class ExternalTriggerAcceptedResponse(BaseModel):

--- a/src/mindroom/external_triggers/replay_store.py
+++ b/src/mindroom/external_triggers/replay_store.py
@@ -161,17 +161,28 @@ class ExternalTriggerReplayStore:
         room_id: str,
         now: int,
         ttl_seconds: int,
-    ) -> None:
-        """Bind one thread key to its Matrix thread root, refreshing retention."""
+    ) -> str:
+        """Bind one thread key to its Matrix thread root, refreshing retention.
+
+        Returns the root the key is bound to afterwards. A root another delivery
+        already bound in the same room wins over the caller's, so a first
+        delivery that outlived its reservation cannot orphan the thread that
+        replaced it.
+        """
         with advisory_file_lock(self._lock_path):
             store = self._read_store()
             _prune_expired(store, now=now)
-            store["threads"].setdefault(replay_scope, {})[thread_key] = {
+            replay_threads = store["threads"].setdefault(replay_scope, {})
+            record = replay_threads.get(thread_key)
+            if record is not None and record["room_id"] == room_id and record["thread_event_id"] is not None:
+                thread_event_id = record["thread_event_id"]
+            replay_threads[thread_key] = {
                 "room_id": room_id,
                 "thread_event_id": thread_event_id,
                 "expires_at": now + ttl_seconds,
             }
             self._write_store(store)
+            return thread_event_id
 
     def release_thread_key(self, replay_scope: str, thread_key: str) -> None:
         """Drop a pending reservation whose first delivery failed; bound keys are kept."""

--- a/src/mindroom/external_triggers/replay_store.py
+++ b/src/mindroom/external_triggers/replay_store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import secrets
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -47,6 +48,7 @@ class _SerializedEvent(TypedDict):
 class _SerializedThread(TypedDict):
     room_id: str
     thread_event_id: str | None
+    reservation: str | None
     expires_at: int
 
 
@@ -126,14 +128,17 @@ class ExternalTriggerReplayStore:
         room_id: str,
         now: int,
         pending_ttl_seconds: int,
-    ) -> tuple[ExternalTriggerThreadKeyClaim, str | None]:
+    ) -> tuple[ExternalTriggerThreadKeyClaim, str | None, str | None]:
         """Atomically resolve or reserve one thread key.
 
-        Returns ``BOUND`` with the recorded Matrix root when an earlier delivery
-        already opened the thread in this room, ``PENDING`` when another
-        delivery is opening it right now, and ``FRESH`` after reserving the key
-        for the caller. A record bound to another room counts as absent: the
-        trigger's configured room may have been re-pointed since it was made.
+        Returns ``(BOUND, root, None)`` when an earlier delivery already opened
+        the thread in this room, ``(PENDING, None, None)`` when another delivery
+        is opening it right now, and ``(FRESH, None, reservation)`` after
+        reserving the key for the caller. The reservation token fences the
+        follow-up ``bind_thread_root`` and ``release_thread_key`` calls so a
+        delivery that outlived its lease cannot disturb a newer owner. A record
+        bound to another room counts as absent: the trigger's configured room
+        may have been re-pointed since it was made.
         """
         with advisory_file_lock(self._lock_path):
             store = self._read_store()
@@ -142,15 +147,17 @@ class ExternalTriggerReplayStore:
             record = replay_threads.get(thread_key)
             if record is not None and record["room_id"] == room_id:
                 if record["thread_event_id"] is not None:
-                    return ExternalTriggerThreadKeyClaim.BOUND, record["thread_event_id"]
-                return ExternalTriggerThreadKeyClaim.PENDING, None
+                    return ExternalTriggerThreadKeyClaim.BOUND, record["thread_event_id"], None
+                return ExternalTriggerThreadKeyClaim.PENDING, None, None
+            reservation = secrets.token_hex(16)
             replay_threads[thread_key] = {
                 "room_id": room_id,
                 "thread_event_id": None,
+                "reservation": reservation,
                 "expires_at": now + pending_ttl_seconds,
             }
             self._write_store(store)
-            return ExternalTriggerThreadKeyClaim.FRESH, None
+            return ExternalTriggerThreadKeyClaim.FRESH, None, reservation
 
     def bind_thread_root(
         self,
@@ -159,40 +166,51 @@ class ExternalTriggerReplayStore:
         thread_event_id: str,
         *,
         room_id: str,
+        reservation: str | None,
         now: int,
         ttl_seconds: int,
-    ) -> str:
+    ) -> str | None:
         """Bind one thread key to its Matrix thread root, refreshing retention.
 
-        Returns the root the key is bound to afterwards. A root another delivery
-        already bound in the same room wins over the caller's, so a first
-        delivery that outlived its reservation cannot orphan the thread that
-        replaced it.
+        Returns the root the key is bound to afterwards, or ``None`` when the
+        caller lost its claim: another delivery reserved the key after the
+        caller's lease expired and has not finished yet. A root already bound in
+        the same room is kept and returned, whoever calls.
         """
         with advisory_file_lock(self._lock_path):
             store = self._read_store()
             _prune_expired(store, now=now)
             replay_threads = store["threads"].setdefault(replay_scope, {})
             record = replay_threads.get(thread_key)
-            if record is not None and record["room_id"] == room_id and record["thread_event_id"] is not None:
-                thread_event_id = record["thread_event_id"]
+            if record is not None and record["room_id"] == room_id:
+                if record["thread_event_id"] is not None:
+                    thread_event_id = record["thread_event_id"]
+                elif record["reservation"] != reservation:
+                    return None
+            elif reservation is not None and record is not None:
+                # The caller's reservation was replaced by a record for another room.
+                return None
             replay_threads[thread_key] = {
                 "room_id": room_id,
                 "thread_event_id": thread_event_id,
+                "reservation": None,
                 "expires_at": now + ttl_seconds,
             }
             self._write_store(store)
             return thread_event_id
 
-    def release_thread_key(self, replay_scope: str, thread_key: str) -> None:
-        """Drop a pending reservation whose first delivery failed; bound keys are kept."""
+    def release_thread_key(self, replay_scope: str, thread_key: str, *, reservation: str) -> None:
+        """Drop the caller's own pending reservation after its first delivery failed.
+
+        Bound keys and reservations owned by another delivery are left alone.
+        """
         with advisory_file_lock(self._lock_path):
             store = self._read_store()
             replay_threads = store["threads"].get(replay_scope)
             if replay_threads is None:
                 return
             record = replay_threads.get(thread_key)
-            if record is None or record["thread_event_id"] is not None:
+            if record is None or record["thread_event_id"] is not None or record["reservation"] != reservation:
                 return
             replay_threads.pop(thread_key)
             if not replay_threads:
@@ -325,19 +343,22 @@ def _normalize_threads(raw_threads: Mapping[object, object]) -> dict[str, dict[s
             if not isinstance(thread_key, str) or not isinstance(record, Mapping):
                 raise _invalid_store_structure()
             record_mapping = cast("Mapping[object, object]", record)
+            if "thread_event_id" not in record_mapping or "reservation" not in record_mapping:
+                raise _invalid_store_structure()
             room_id = record_mapping.get("room_id")
-            thread_event_id = record_mapping.get("thread_event_id")
+            thread_event_id = record_mapping["thread_event_id"]
+            reservation = record_mapping["reservation"]
             expires_at = record_mapping.get("expires_at")
-            if (
-                not isinstance(room_id, str)
-                or not room_id
-                or not (thread_event_id is None or (isinstance(thread_event_id, str) and thread_event_id))
-                or not _is_json_int(expires_at)
-            ):
+            if not isinstance(room_id, str) or not room_id or not _is_json_int(expires_at):
+                raise _invalid_store_structure()
+            is_bound = isinstance(thread_event_id, str) and bool(thread_event_id) and reservation is None
+            is_pending = thread_event_id is None and isinstance(reservation, str) and bool(reservation)
+            if not (is_bound or is_pending):
                 raise _invalid_store_structure()
             normalized_trigger_threads[thread_key] = {
                 "room_id": room_id,
-                "thread_event_id": thread_event_id,
+                "thread_event_id": cast("str | None", thread_event_id),
+                "reservation": cast("str | None", reservation),
                 "expires_at": expires_at,
             }
         if normalized_trigger_threads:

--- a/src/mindroom/external_triggers/replay_store.py
+++ b/src/mindroom/external_triggers/replay_store.py
@@ -37,6 +37,7 @@ class _SerializedEvent(TypedDict):
 
 
 class _SerializedThread(TypedDict):
+    room_id: str
     thread_event_id: str
     expires_at: int
 
@@ -109,13 +110,19 @@ class ExternalTriggerReplayStore:
             }
             self._write_store(store)
 
-    def thread_root(self, replay_scope: str, thread_key: str, *, now: int) -> str | None:
-        """Return the Matrix thread root previously recorded for one thread key."""
+    def thread_root(self, replay_scope: str, thread_key: str, *, room_id: str, now: int) -> str | None:
+        """Return the Matrix thread root recorded for one thread key in one room.
+
+        A record bound to another room is a miss: the trigger's configured room
+        may have been re-pointed since the root was recorded.
+        """
         with advisory_file_lock(self._lock_path):
             store = self._read_store()
             _prune_expired(store, now=now)
             record = store["threads"].get(replay_scope, {}).get(thread_key)
-            return None if record is None else record["thread_event_id"]
+            if record is None or record["room_id"] != room_id:
+                return None
+            return record["thread_event_id"]
 
     def remember_thread_root(
         self,
@@ -123,6 +130,7 @@ class ExternalTriggerReplayStore:
         thread_key: str,
         thread_event_id: str,
         *,
+        room_id: str,
         now: int,
         ttl_seconds: int,
     ) -> None:
@@ -131,9 +139,22 @@ class ExternalTriggerReplayStore:
             store = self._read_store()
             _prune_expired(store, now=now)
             store["threads"].setdefault(replay_scope, {})[thread_key] = {
+                "room_id": room_id,
                 "thread_event_id": thread_event_id,
                 "expires_at": now + ttl_seconds,
             }
+            self._write_store(store)
+
+    def forget_thread_root(self, replay_scope: str, thread_key: str) -> None:
+        """Drop a thread key whose recorded root could not be delivered to."""
+        with advisory_file_lock(self._lock_path):
+            store = self._read_store()
+            replay_threads = store["threads"].get(replay_scope)
+            if replay_threads is None or thread_key not in replay_threads:
+                return
+            replay_threads.pop(thread_key)
+            if not replay_threads:
+                store["threads"].pop(replay_scope, None)
             self._write_store(store)
 
     def release_event_id(self, replay_scope: str, event_id: str) -> None:
@@ -262,11 +283,19 @@ def _normalize_threads(raw_threads: Mapping[object, object]) -> dict[str, dict[s
             if not isinstance(thread_key, str) or not isinstance(record, Mapping):
                 raise _invalid_store_structure()
             record_mapping = cast("Mapping[object, object]", record)
+            room_id = record_mapping.get("room_id")
             thread_event_id = record_mapping.get("thread_event_id")
             expires_at = record_mapping.get("expires_at")
-            if not isinstance(thread_event_id, str) or not thread_event_id or not _is_json_int(expires_at):
+            if (
+                not isinstance(room_id, str)
+                or not room_id
+                or not isinstance(thread_event_id, str)
+                or not thread_event_id
+                or not _is_json_int(expires_at)
+            ):
                 raise _invalid_store_structure()
             normalized_trigger_threads[thread_key] = {
+                "room_id": room_id,
                 "thread_event_id": thread_event_id,
                 "expires_at": expires_at,
             }

--- a/src/mindroom/external_triggers/replay_store.py
+++ b/src/mindroom/external_triggers/replay_store.py
@@ -23,6 +23,14 @@ class ExternalTriggerEventClaim(StrEnum):
     DELIVERED = "delivered"
 
 
+class ExternalTriggerThreadKeyClaim(StrEnum):
+    """State returned when claiming an external trigger thread key."""
+
+    FRESH = "fresh"
+    PENDING = "pending"
+    BOUND = "bound"
+
+
 class ExternalTriggerReplayStoreError(RuntimeError):
     """Raised when durable replay state cannot be trusted."""
 
@@ -38,7 +46,7 @@ class _SerializedEvent(TypedDict):
 
 class _SerializedThread(TypedDict):
     room_id: str
-    thread_event_id: str
+    thread_event_id: str | None
     expires_at: int
 
 
@@ -110,21 +118,41 @@ class ExternalTriggerReplayStore:
             }
             self._write_store(store)
 
-    def thread_root(self, replay_scope: str, thread_key: str, *, room_id: str, now: int) -> str | None:
-        """Return the Matrix thread root recorded for one thread key in one room.
+    def claim_thread_key(
+        self,
+        replay_scope: str,
+        thread_key: str,
+        *,
+        room_id: str,
+        now: int,
+        pending_ttl_seconds: int,
+    ) -> tuple[ExternalTriggerThreadKeyClaim, str | None]:
+        """Atomically resolve or reserve one thread key.
 
-        A record bound to another room is a miss: the trigger's configured room
-        may have been re-pointed since the root was recorded.
+        Returns ``BOUND`` with the recorded Matrix root when an earlier delivery
+        already opened the thread in this room, ``PENDING`` when another
+        delivery is opening it right now, and ``FRESH`` after reserving the key
+        for the caller. A record bound to another room counts as absent: the
+        trigger's configured room may have been re-pointed since it was made.
         """
         with advisory_file_lock(self._lock_path):
             store = self._read_store()
             _prune_expired(store, now=now)
-            record = store["threads"].get(replay_scope, {}).get(thread_key)
-            if record is None or record["room_id"] != room_id:
-                return None
-            return record["thread_event_id"]
+            replay_threads = store["threads"].setdefault(replay_scope, {})
+            record = replay_threads.get(thread_key)
+            if record is not None and record["room_id"] == room_id:
+                if record["thread_event_id"] is not None:
+                    return ExternalTriggerThreadKeyClaim.BOUND, record["thread_event_id"]
+                return ExternalTriggerThreadKeyClaim.PENDING, None
+            replay_threads[thread_key] = {
+                "room_id": room_id,
+                "thread_event_id": None,
+                "expires_at": now + pending_ttl_seconds,
+            }
+            self._write_store(store)
+            return ExternalTriggerThreadKeyClaim.FRESH, None
 
-    def remember_thread_root(
+    def bind_thread_root(
         self,
         replay_scope: str,
         thread_key: str,
@@ -134,7 +162,7 @@ class ExternalTriggerReplayStore:
         now: int,
         ttl_seconds: int,
     ) -> None:
-        """Bind one thread key to a Matrix thread root, refreshing its retention."""
+        """Bind one thread key to its Matrix thread root, refreshing retention."""
         with advisory_file_lock(self._lock_path):
             store = self._read_store()
             _prune_expired(store, now=now)
@@ -145,12 +173,15 @@ class ExternalTriggerReplayStore:
             }
             self._write_store(store)
 
-    def forget_thread_root(self, replay_scope: str, thread_key: str) -> None:
-        """Drop a thread key whose recorded root could not be delivered to."""
+    def release_thread_key(self, replay_scope: str, thread_key: str) -> None:
+        """Drop a pending reservation whose first delivery failed; bound keys are kept."""
         with advisory_file_lock(self._lock_path):
             store = self._read_store()
             replay_threads = store["threads"].get(replay_scope)
-            if replay_threads is None or thread_key not in replay_threads:
+            if replay_threads is None:
+                return
+            record = replay_threads.get(thread_key)
+            if record is None or record["thread_event_id"] is not None:
                 return
             replay_threads.pop(thread_key)
             if not replay_threads:
@@ -289,8 +320,7 @@ def _normalize_threads(raw_threads: Mapping[object, object]) -> dict[str, dict[s
             if (
                 not isinstance(room_id, str)
                 or not room_id
-                or not isinstance(thread_event_id, str)
-                or not thread_event_id
+                or not (thread_event_id is None or (isinstance(thread_event_id, str) and thread_event_id))
                 or not _is_json_int(expires_at)
             ):
                 raise _invalid_store_structure()

--- a/src/mindroom/external_triggers/replay_store.py
+++ b/src/mindroom/external_triggers/replay_store.py
@@ -36,9 +36,15 @@ class _SerializedEvent(TypedDict):
     expires_at: int
 
 
+class _SerializedThread(TypedDict):
+    thread_event_id: str
+    expires_at: int
+
+
 class _SerializedReplayStore(TypedDict):
     nonces: dict[str, dict[str, _SerializedNonce]]
     events: dict[str, dict[str, _SerializedEvent]]
+    threads: dict[str, dict[str, _SerializedThread]]
 
 
 @dataclass
@@ -103,6 +109,33 @@ class ExternalTriggerReplayStore:
             }
             self._write_store(store)
 
+    def thread_root(self, replay_scope: str, thread_key: str, *, now: int) -> str | None:
+        """Return the Matrix thread root previously recorded for one thread key."""
+        with advisory_file_lock(self._lock_path):
+            store = self._read_store()
+            _prune_expired(store, now=now)
+            record = store["threads"].get(replay_scope, {}).get(thread_key)
+            return None if record is None else record["thread_event_id"]
+
+    def remember_thread_root(
+        self,
+        replay_scope: str,
+        thread_key: str,
+        thread_event_id: str,
+        *,
+        now: int,
+        ttl_seconds: int,
+    ) -> None:
+        """Bind one thread key to a Matrix thread root, refreshing its retention."""
+        with advisory_file_lock(self._lock_path):
+            store = self._read_store()
+            _prune_expired(store, now=now)
+            store["threads"].setdefault(replay_scope, {})[thread_key] = {
+                "thread_event_id": thread_event_id,
+                "expires_at": now + ttl_seconds,
+            }
+            self._write_store(store)
+
     def release_event_id(self, replay_scope: str, event_id: str) -> None:
         """Remove an event id claim after delivery failure."""
         with advisory_file_lock(self._lock_path):
@@ -139,7 +172,7 @@ class ExternalTriggerReplayStore:
 
 
 def _empty_store() -> _SerializedReplayStore:
-    return {"nonces": {}, "events": {}}
+    return {"nonces": {}, "events": {}, "threads": {}}
 
 
 def _normalize_store(raw_store: object) -> _SerializedReplayStore:
@@ -150,11 +183,18 @@ def _normalize_store(raw_store: object) -> _SerializedReplayStore:
         raise _invalid_store_structure()
     raw_nonces = store_mapping["nonces"]
     raw_events = store_mapping["events"]
-    if not isinstance(raw_nonces, Mapping) or not isinstance(raw_events, Mapping):
+    # Stores written before thread keys existed have no "threads" section.
+    raw_threads = store_mapping.get("threads", {})
+    if (
+        not isinstance(raw_nonces, Mapping)
+        or not isinstance(raw_events, Mapping)
+        or not isinstance(raw_threads, Mapping)
+    ):
         raise _invalid_store_structure()
     return {
         "nonces": _normalize_nonces(cast("Mapping[object, object]", raw_nonces)),
         "events": _normalize_events(cast("Mapping[object, object]", raw_events)),
+        "threads": _normalize_threads(cast("Mapping[object, object]", raw_threads)),
     }
 
 
@@ -211,6 +251,30 @@ def _normalize_events(raw_events: Mapping[object, object]) -> dict[str, dict[str
     return events
 
 
+def _normalize_threads(raw_threads: Mapping[object, object]) -> dict[str, dict[str, _SerializedThread]]:
+    threads: dict[str, dict[str, _SerializedThread]] = {}
+    for trigger_id, trigger_threads in raw_threads.items():
+        if not isinstance(trigger_id, str) or not isinstance(trigger_threads, Mapping):
+            raise _invalid_store_structure()
+        trigger_thread_mapping = cast("Mapping[object, object]", trigger_threads)
+        normalized_trigger_threads: dict[str, _SerializedThread] = {}
+        for thread_key, record in trigger_thread_mapping.items():
+            if not isinstance(thread_key, str) or not isinstance(record, Mapping):
+                raise _invalid_store_structure()
+            record_mapping = cast("Mapping[object, object]", record)
+            thread_event_id = record_mapping.get("thread_event_id")
+            expires_at = record_mapping.get("expires_at")
+            if not isinstance(thread_event_id, str) or not thread_event_id or not _is_json_int(expires_at):
+                raise _invalid_store_structure()
+            normalized_trigger_threads[thread_key] = {
+                "thread_event_id": thread_event_id,
+                "expires_at": expires_at,
+            }
+        if normalized_trigger_threads:
+            threads[trigger_id] = normalized_trigger_threads
+    return threads
+
+
 def _prune_expired(store: _SerializedReplayStore, *, now: int) -> None:
     for trigger_id, trigger_nonces in list(store["nonces"].items()):
         store["nonces"][trigger_id] = {
@@ -225,3 +289,10 @@ def _prune_expired(store: _SerializedReplayStore, *, now: int) -> None:
         }
         if not store["events"][trigger_id]:
             store["events"].pop(trigger_id)
+
+    for trigger_id, trigger_threads in list(store["threads"].items()):
+        store["threads"][trigger_id] = {
+            thread_key: record for thread_key, record in trigger_threads.items() if record["expires_at"] >= now
+        }
+        if not store["threads"][trigger_id]:
+            store["threads"].pop(trigger_id)

--- a/src/mindroom/external_triggers/replay_store.py
+++ b/src/mindroom/external_triggers/replay_store.py
@@ -187,8 +187,9 @@ class ExternalTriggerReplayStore:
                     thread_event_id = record["thread_event_id"]
                 elif record["reservation"] != reservation:
                     return None
-            elif reservation is not None and record is not None:
-                # The caller's reservation was replaced by a record for another room.
+            elif record is not None:
+                # The key now belongs to a delivery for another room (the trigger
+                # was re-pointed mid-flight); leave that record alone.
                 return None
             replay_threads[thread_key] = {
                 "room_id": room_id,

--- a/tests/api/test_external_triggers_api.py
+++ b/tests/api/test_external_triggers_api.py
@@ -1064,3 +1064,29 @@ def test_thread_key_being_opened_elsewhere_returns_409_for_retry(
         replay_store.claim_event_id(snapshot.replay_scope, "msg-2", now=int(time.time()), ttl_seconds=60)
         is ExternalTriggerEventClaim.FRESH
     )
+
+
+def test_exception_during_first_delivery_releases_thread_key_reservation(
+    trigger_api: TriggerApiContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exception while opening the root releases the key just like a None result does."""
+    continued: list[str | None] = []
+    attempts = iter([RuntimeError("matrix unavailable"), "$root-a"])
+
+    async def execute_external_trigger(*, continue_thread_event_id: str | None = None, **_kwargs: object) -> str:
+        continued.append(continue_thread_event_id)
+        outcome = next(attempts)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr("mindroom.api.external_triggers.execute_external_trigger", execute_external_trigger)
+    trigger_id = _create_new_thread_record(trigger_api)
+
+    with pytest.raises(RuntimeError, match="matrix unavailable"):
+        _post_keyed(trigger_api, trigger_id, "msg-1", "nonce-1")
+    opened = _post_keyed(trigger_api, trigger_id, "msg-1", "nonce-2")
+
+    assert opened.status_code == 202
+    assert continued == [None, None]

--- a/tests/api/test_external_triggers_api.py
+++ b/tests/api/test_external_triggers_api.py
@@ -162,6 +162,25 @@ def _create_record(runtime_paths: constants.RuntimePaths, config: Config, public
     )
 
 
+def _create_new_thread_record(trigger_api: TriggerApiContext, *, trigger_id: str = "campground-threads") -> str:
+    """Create a reusable signed trigger that opens a per-fire thread on every delivery."""
+    ExternalTriggerStore(trigger_api.runtime_paths).create_record(
+        trigger_id=trigger_id,
+        owner_user_id=_OWNER,
+        created_by_agent_name="research",
+        created_in_room_id="campground",
+        created_in_thread_id=None,
+        target=ExternalTriggerTarget(room_id="campground", thread_id=None, agent="research", new_thread=True),
+        public_key=_public_key_b64(trigger_api.private_key),
+        key_id="campground-main",
+        allowed_kinds=["campground.availability"],
+        replay_window_seconds=30,
+        max_body_bytes=65536,
+        config=Config.model_validate(_config_payload()),
+    )
+    return trigger_id
+
+
 def _create_capability_record(
     trigger_api: TriggerApiContext,
     *,
@@ -886,3 +905,59 @@ def test_duplicate_event_id_returns_duplicate_response(
     assert first.status_code == 202
     assert second.status_code == 202
     assert second.json()["duplicate"] is True
+
+
+def test_thread_key_groups_new_thread_deliveries_into_one_matrix_thread(
+    trigger_api: TriggerApiContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Deliveries sharing a thread key continue the first delivery's Matrix thread."""
+    continued: list[str | None] = []
+    delivered_event_ids = iter(["$root-a", "$reply-a", "$root-b"])
+
+    async def execute_external_trigger(*, continue_thread_event_id: str | None = None, **_kwargs: object) -> str:
+        continued.append(continue_thread_event_id)
+        return next(delivered_event_ids)
+
+    monkeypatch.setattr("mindroom.api.external_triggers.execute_external_trigger", execute_external_trigger)
+    trigger_id = _create_new_thread_record(trigger_api)
+
+    def post(event_id: str, thread_key: str, nonce: str) -> Response:
+        return _post_signed(
+            trigger_api,
+            body=_body(event_id=event_id, thread_key=thread_key),
+            nonce=nonce,
+            trigger_id=trigger_id,
+        )
+
+    first = post("msg-1", "chat:C1:100", "nonce-1")
+    second = post("msg-2", "chat:C1:100", "nonce-2")
+    other = post("msg-3", "chat:C1:200", "nonce-3")
+
+    assert [response.status_code for response in (first, second, other)] == [202, 202, 202]
+    assert continued == [None, "$root-a", None]
+    assert [response.json()["matrix_event_id"] for response in (first, second, other)] == [
+        "$root-a",
+        "$reply-a",
+        "$root-b",
+    ]
+
+
+def test_thread_key_is_ignored_for_fixed_thread_targets(
+    trigger_api: TriggerApiContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fixed target thread already collects every delivery, so no key lookup happens."""
+    continued: list[str | None] = []
+
+    async def execute_external_trigger(*, continue_thread_event_id: str | None = None, **_kwargs: object) -> str:
+        continued.append(continue_thread_event_id)
+        return "$matrix-event"
+
+    monkeypatch.setattr("mindroom.api.external_triggers.execute_external_trigger", execute_external_trigger)
+
+    first = _post_signed(trigger_api, body=_body(event_id="msg-1", thread_key="slack:C1:100"), nonce="nonce-1")
+    second = _post_signed(trigger_api, body=_body(event_id="msg-2", thread_key="slack:C1:100"), nonce="nonce-2")
+
+    assert (first.status_code, second.status_code) == (202, 202)
+    assert continued == [None, None]

--- a/tests/api/test_external_triggers_api.py
+++ b/tests/api/test_external_triggers_api.py
@@ -26,6 +26,7 @@ from mindroom.api import external_triggers as external_triggers_api
 from mindroom.api import main as api_main
 from mindroom.config.main import Config
 from mindroom.external_triggers.auth import mint_trigger_capability, sign_trigger_request
+from mindroom.external_triggers.replay_store import ExternalTriggerEventClaim, ExternalTriggerReplayStore
 from mindroom.external_triggers.store import ExternalTriggerStore, ExternalTriggerTarget, TriggerDeliverySnapshot
 from mindroom.matrix.state import MatrixState
 from mindroom.response_admission import ResponseAdmissionGate
@@ -963,13 +964,28 @@ def test_thread_key_is_ignored_for_fixed_thread_targets(
     assert continued == [None, None]
 
 
-def test_failed_continuation_forgets_thread_key_so_next_delivery_opens_fresh_root(
+def _new_thread_replay_store(trigger_api: TriggerApiContext) -> ExternalTriggerReplayStore:
+    control_state_root = trigger_api.runtime_paths.control_state_root
+    assert control_state_root is not None
+    return ExternalTriggerReplayStore(control_state_root)
+
+
+def _post_keyed(trigger_api: TriggerApiContext, trigger_id: str, event_id: str, nonce: str) -> Response:
+    return _post_signed(
+        trigger_api,
+        body=_body(event_id=event_id, thread_key="chat:C1:100"),
+        nonce=nonce,
+        trigger_id=trigger_id,
+    )
+
+
+def test_failed_continuation_keeps_thread_key_bound(
     trigger_api: TriggerApiContext,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A root that can no longer be delivered to is dropped instead of retried for a week."""
+    """A transient send failure on a follow-up must not split the conversation into a new root."""
     continued: list[str | None] = []
-    outcomes = iter(["$root-a", None, "$root-b"])
+    outcomes = iter(["$root-a", None, "$reply-a"])
 
     async def execute_external_trigger(*, continue_thread_event_id: str | None = None, **_kwargs: object) -> str | None:
         continued.append(continue_thread_event_id)
@@ -978,18 +994,73 @@ def test_failed_continuation_forgets_thread_key_so_next_delivery_opens_fresh_roo
     monkeypatch.setattr("mindroom.api.external_triggers.execute_external_trigger", execute_external_trigger)
     trigger_id = _create_new_thread_record(trigger_api)
 
-    def post(event_id: str, nonce: str) -> Response:
-        return _post_signed(
-            trigger_api,
-            body=_body(event_id=event_id, thread_key="chat:C1:100"),
-            nonce=nonce,
-            trigger_id=trigger_id,
-        )
+    first = _post_keyed(trigger_api, trigger_id, "msg-1", "nonce-1")
+    failed = _post_keyed(trigger_api, trigger_id, "msg-2", "nonce-2")
+    retried = _post_keyed(trigger_api, trigger_id, "msg-2", "nonce-3")
 
-    first = post("msg-1", "nonce-1")
-    failed = post("msg-2", "nonce-2")
-    recovered = post("msg-3", "nonce-3")
+    assert (first.status_code, failed.status_code, retried.status_code) == (202, 502, 202)
+    assert continued == [None, "$root-a", "$root-a"]
+    assert retried.json()["matrix_event_id"] == "$reply-a"
 
-    assert (first.status_code, failed.status_code, recovered.status_code) == (202, 502, 202)
-    assert continued == [None, "$root-a", None]
-    assert recovered.json()["matrix_event_id"] == "$root-b"
+
+def test_failed_first_delivery_releases_thread_key_reservation(
+    trigger_api: TriggerApiContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When opening the root fails, the next delivery with the key may open it instead of waiting."""
+    continued: list[str | None] = []
+    outcomes = iter([None, "$root-a", "$reply-a"])
+
+    async def execute_external_trigger(*, continue_thread_event_id: str | None = None, **_kwargs: object) -> str | None:
+        continued.append(continue_thread_event_id)
+        return next(outcomes)
+
+    monkeypatch.setattr("mindroom.api.external_triggers.execute_external_trigger", execute_external_trigger)
+    trigger_id = _create_new_thread_record(trigger_api)
+
+    failed = _post_keyed(trigger_api, trigger_id, "msg-1", "nonce-1")
+    opened = _post_keyed(trigger_api, trigger_id, "msg-1", "nonce-2")
+    followed = _post_keyed(trigger_api, trigger_id, "msg-2", "nonce-3")
+
+    assert (failed.status_code, opened.status_code, followed.status_code) == (502, 202, 202)
+    assert continued == [None, None, "$root-a"]
+
+
+def test_thread_key_being_opened_elsewhere_returns_409_for_retry(
+    trigger_api: TriggerApiContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A concurrent first delivery holds the key; the loser is told to retry, not given a second root."""
+    executed: list[str | None] = []
+
+    async def execute_external_trigger(*, continue_thread_event_id: str | None = None, **_kwargs: object) -> str:
+        executed.append(continue_thread_event_id)
+        return "$never"
+
+    monkeypatch.setattr("mindroom.api.external_triggers.execute_external_trigger", execute_external_trigger)
+    trigger_id = _create_new_thread_record(trigger_api)
+    snapshot = ExternalTriggerStore(trigger_api.runtime_paths).delivery_snapshot(
+        trigger_id,
+        config=Config.model_validate(_config_payload()),
+        config_generation=1,
+    )
+    assert snapshot is not None
+    replay_store = _new_thread_replay_store(trigger_api)
+    replay_store.claim_thread_key(
+        snapshot.replay_scope,
+        "chat:C1:100",
+        room_id=snapshot.resolved_room_id,
+        now=int(time.time()),
+        pending_ttl_seconds=60,
+    )
+
+    response = _post_keyed(trigger_api, trigger_id, "msg-2", "nonce-1")
+
+    assert response.status_code == 409
+    assert response.json()["detail"] == "External trigger thread is being opened by another delivery"
+    assert executed == []
+    # The event id claim was rolled back, so the same event can be retried once the thread exists.
+    assert (
+        replay_store.claim_event_id(snapshot.replay_scope, "msg-2", now=int(time.time()), ttl_seconds=60)
+        is ExternalTriggerEventClaim.FRESH
+    )

--- a/tests/api/test_external_triggers_api.py
+++ b/tests/api/test_external_triggers_api.py
@@ -961,3 +961,35 @@ def test_thread_key_is_ignored_for_fixed_thread_targets(
 
     assert (first.status_code, second.status_code) == (202, 202)
     assert continued == [None, None]
+
+
+def test_failed_continuation_forgets_thread_key_so_next_delivery_opens_fresh_root(
+    trigger_api: TriggerApiContext,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A root that can no longer be delivered to is dropped instead of retried for a week."""
+    continued: list[str | None] = []
+    outcomes = iter(["$root-a", None, "$root-b"])
+
+    async def execute_external_trigger(*, continue_thread_event_id: str | None = None, **_kwargs: object) -> str | None:
+        continued.append(continue_thread_event_id)
+        return next(outcomes)
+
+    monkeypatch.setattr("mindroom.api.external_triggers.execute_external_trigger", execute_external_trigger)
+    trigger_id = _create_new_thread_record(trigger_api)
+
+    def post(event_id: str, nonce: str) -> Response:
+        return _post_signed(
+            trigger_api,
+            body=_body(event_id=event_id, thread_key="chat:C1:100"),
+            nonce=nonce,
+            trigger_id=trigger_id,
+        )
+
+    first = post("msg-1", "nonce-1")
+    failed = post("msg-2", "nonce-2")
+    recovered = post("msg-3", "nonce-3")
+
+    assert (first.status_code, failed.status_code, recovered.status_code) == (202, 502, 202)
+    assert continued == [None, "$root-a", None]
+    assert recovered.json()["matrix_event_id"] == "$root-b"

--- a/tests/test_cli_trigger.py
+++ b/tests/test_cli_trigger.py
@@ -481,3 +481,44 @@ def test_trigger_send_rejects_data_json_that_is_not_object(tmp_path: Path) -> No
 
     assert result.exit_code == 2
     assert "--data-json must decode to a JSON object" in result.output
+
+
+def test_trigger_send_includes_thread_key_when_given(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The optional thread key rides along in the signed body."""
+    key_path = tmp_path / "trigger.key"
+    _write_private_key(key_path)
+    captured: dict[str, object] = {}
+
+    def fake_post(_url: str, *, content: bytes, **_request_options: object) -> _FakeResponse:
+        captured.update(content=content)
+        return _FakeResponse({"accepted": True})
+
+    monkeypatch.setattr(httpx, "post", fake_post)
+
+    result = runner.invoke(
+        app,
+        [
+            "trigger",
+            "send",
+            "campground",
+            "--key-file",
+            str(key_path),
+            "--kind",
+            "campground.availability",
+            "--message",
+            "site open",
+            "--event-id",
+            "event-1",
+            "--thread-key",
+            "site-42",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert json.loads(cast("bytes", captured["content"])) == {
+        "kind": "campground.availability",
+        "message": "site open",
+        "event_id": "event-1",
+        "thread_key": "site-42",
+        "data": {},
+    }

--- a/tests/test_external_trigger_executor.py
+++ b/tests/test_external_trigger_executor.py
@@ -368,3 +368,38 @@ async def test_execute_external_trigger_new_thread_sends_room_message_without_th
     assert "m.relates_to" not in content
     assert content[SOURCE_KIND_KEY] == EXTERNAL_TRIGGER_SOURCE_KIND
     assert content[PER_FIRE_THREAD_ROOT_KEY] is True
+
+
+@pytest.mark.asyncio
+async def test_execute_external_trigger_continues_recorded_thread_instead_of_new_root(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A continued thread key posts into the earlier Matrix thread and is not a per-fire root."""
+    config = _config(tmp_path)
+    conversation_reader = _conversation_reader(latest_thread_event_id="$latest-in-thread")
+    send_and_track_message = AsyncMock(
+        return_value=DeliveredMatrixEvent(event_id="$continued-event", content_sent={}),
+    )
+    monkeypatch.setattr("mindroom.external_triggers.executor.send_matrix_message", send_and_track_message)
+
+    event_id = await execute_external_trigger(
+        client=AsyncMock(),
+        snapshot=_snapshot(new_thread=True, thread_id=None),
+        payload=_payload(),
+        config=config,
+        runtime_paths=runtime_paths_for(config),
+        conversation_reader=conversation_reader,
+        continue_thread_event_id="$first-root",
+    )
+
+    assert event_id == "$continued-event"
+    conversation_reader.latest_thread_event_id.assert_awaited_once_with(
+        room_id="!fixed:localhost",
+        thread_id="$first-root",
+    )
+    content: dict[str, Any] = send_and_track_message.await_args.args[2]
+    assert content["m.relates_to"]["event_id"] == "$first-root"
+    assert content["m.relates_to"]["m.in_reply_to"]["event_id"] == "$latest-in-thread"
+    assert PER_FIRE_THREAD_ROOT_KEY not in content
+    assert content[SOURCE_KIND_KEY] == EXTERNAL_TRIGGER_SOURCE_KIND

--- a/tests/test_external_trigger_replay_store.py
+++ b/tests/test_external_trigger_replay_store.py
@@ -436,3 +436,71 @@ def test_fsync_directory_ignores_unsupported_directory_fsync(
     _fsync_directory(tmp_path)
 
     assert closed_fds == [123]
+
+
+def test_payload_rejects_blank_thread_key() -> None:
+    """A thread key must carry a value when present; ``None`` means per-delivery threads."""
+    with pytest.raises(ValidationError, match="thread_key must not be empty"):
+        ExternalTriggerPayload(kind="campground.availability", message="Site open", thread_key="  ")
+
+    assert ExternalTriggerPayload(kind="campground.availability", message="Site open").thread_key is None
+    assert (
+        ExternalTriggerPayload(kind="campground.availability", message="Site open", thread_key=" site-42 ").thread_key
+        == "site-42"
+    )
+
+
+def test_thread_root_is_remembered_per_scope_until_expiry(tmp_path: Path) -> None:
+    """Thread keys resolve to their recorded Matrix root within one replay scope."""
+    store = ExternalTriggerReplayStore(tmp_path)
+
+    assert store.thread_root("campground", "site-42", now=1_000) is None
+    store.remember_thread_root("campground", "site-42", "$root-1", now=1_000, ttl_seconds=600)
+
+    assert store.thread_root("campground", "site-42", now=1_000) == "$root-1"
+    assert store.thread_root("campground", "site-42", now=1_600) == "$root-1"
+    assert store.thread_root("other-scope", "site-42", now=1_000) is None
+    assert store.thread_root("campground", "site-43", now=1_000) is None
+    assert store.thread_root("campground", "site-42", now=1_601) is None
+
+
+def test_remember_thread_root_refreshes_retention_and_keeps_first_root(tmp_path: Path) -> None:
+    """Re-recording the same key extends retention; callers pass the existing root back."""
+    store = ExternalTriggerReplayStore(tmp_path)
+    store.remember_thread_root("campground", "site-42", "$root-1", now=1_000, ttl_seconds=600)
+    store.remember_thread_root("campground", "site-42", "$root-1", now=1_500, ttl_seconds=600)
+
+    assert store.thread_root("campground", "site-42", now=2_099) == "$root-1"
+    assert store.thread_root("campground", "site-42", now=2_101) is None
+
+
+def test_store_without_threads_section_is_accepted(tmp_path: Path) -> None:
+    """Replay files written before thread keys existed still load."""
+    _store_path(tmp_path).write_text(json.dumps({"nonces": {}, "events": {}}), encoding="utf-8")
+    store = ExternalTriggerReplayStore(tmp_path)
+
+    assert store.thread_root("campground", "site-42", now=1_000) is None
+    store.remember_thread_root("campground", "site-42", "$root-1", now=1_000, ttl_seconds=600)
+    assert json.loads(_store_path(tmp_path).read_text(encoding="utf-8"))["threads"] == {
+        "campground": {"site-42": {"thread_event_id": "$root-1", "expires_at": 1_600}},
+    }
+
+
+@pytest.mark.parametrize(
+    "threads_payload",
+    [
+        {"campground": {"site-42": {"thread_event_id": "", "expires_at": 1}}},
+        {"campground": {"site-42": {"thread_event_id": "$root", "expires_at": "1"}}},
+        {"campground": {"site-42": {"expires_at": 1}}},
+        {"campground": "not-a-mapping"},
+    ],
+)
+def test_invalid_nested_thread_record_fails_closed(tmp_path: Path, threads_payload: object) -> None:
+    """Corrupt thread records are rejected instead of silently dropped."""
+    _store_path(tmp_path).write_text(
+        json.dumps({"nonces": {}, "events": {}, "threads": threads_payload}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ExternalTriggerReplayStoreError, match="invalid external trigger replay store structure"):
+        ExternalTriggerReplayStore(tmp_path).thread_root("campground", "site-42", now=1)

--- a/tests/test_external_trigger_replay_store.py
+++ b/tests/test_external_trigger_replay_store.py
@@ -610,6 +610,8 @@ def test_thread_key_bound_to_another_room_is_reclaimed(tmp_path: Path) -> None:
 
     assert _claim(store, room="!elsewhere:localhost", now=1_002) == (ExternalTriggerThreadKeyClaim.FRESH, None)
     assert _claim(store, room="!elsewhere:localhost", now=1_003) == (ExternalTriggerThreadKeyClaim.PENDING, None)
+    # A continuation still in flight for the old room may not clobber the new room's reservation.
+    assert _bind(store, "$root-1", reservation=None, now=1_004) is None
 
 
 def test_pending_thread_key_expires_and_release_needs_its_reservation(tmp_path: Path) -> None:

--- a/tests/test_external_trigger_replay_store.py
+++ b/tests/test_external_trigger_replay_store.py
@@ -19,6 +19,7 @@ from mindroom.external_triggers.replay_store import (
     ExternalTriggerEventClaim,
     ExternalTriggerReplayStore,
     ExternalTriggerReplayStoreError,
+    ExternalTriggerThreadKeyClaim,
 )
 
 if TYPE_CHECKING:
@@ -450,48 +451,6 @@ def test_payload_rejects_blank_thread_key() -> None:
     )
 
 
-def test_thread_root_is_remembered_per_scope_and_room_until_expiry(tmp_path: Path) -> None:
-    """Thread keys resolve to their recorded Matrix root within one replay scope and room."""
-    store = ExternalTriggerReplayStore(tmp_path)
-    room = "!room:localhost"
-
-    assert store.thread_root("campground", "site-42", room_id=room, now=1_000) is None
-    store.remember_thread_root("campground", "site-42", "$root-1", room_id=room, now=1_000, ttl_seconds=600)
-
-    assert store.thread_root("campground", "site-42", room_id=room, now=1_000) == "$root-1"
-    assert store.thread_root("campground", "site-42", room_id=room, now=1_600) == "$root-1"
-    assert store.thread_root("campground", "site-42", room_id="!other:localhost", now=1_000) is None
-    assert store.thread_root("other-scope", "site-42", room_id=room, now=1_000) is None
-    assert store.thread_root("campground", "site-43", room_id=room, now=1_000) is None
-    assert store.thread_root("campground", "site-42", room_id=room, now=1_601) is None
-
-
-def test_remember_thread_root_refreshes_retention_and_keeps_first_root(tmp_path: Path) -> None:
-    """Re-recording the same key extends retention; callers pass the existing root back."""
-    store = ExternalTriggerReplayStore(tmp_path)
-    room = "!room:localhost"
-    store.remember_thread_root("campground", "site-42", "$root-1", room_id=room, now=1_000, ttl_seconds=600)
-    store.remember_thread_root("campground", "site-42", "$root-1", room_id=room, now=1_500, ttl_seconds=600)
-
-    assert store.thread_root("campground", "site-42", room_id=room, now=2_099) == "$root-1"
-    assert store.thread_root("campground", "site-42", room_id=room, now=2_101) is None
-
-
-def test_forget_thread_root_drops_only_that_key(tmp_path: Path) -> None:
-    """Forgetting a stale root leaves other keys and scopes untouched."""
-    store = ExternalTriggerReplayStore(tmp_path)
-    room = "!room:localhost"
-    store.remember_thread_root("campground", "site-42", "$root-1", room_id=room, now=1_000, ttl_seconds=600)
-    store.remember_thread_root("campground", "site-43", "$root-2", room_id=room, now=1_000, ttl_seconds=600)
-
-    store.forget_thread_root("campground", "site-42")
-    store.forget_thread_root("campground", "missing")
-    store.forget_thread_root("other-scope", "site-42")
-
-    assert store.thread_root("campground", "site-42", room_id=room, now=1_000) is None
-    assert store.thread_root("campground", "site-43", room_id=room, now=1_000) == "$root-2"
-
-
 def test_payload_rejects_oversized_thread_key() -> None:
     """Thread keys live for days in the shared replay store, so their size is bounded."""
     with pytest.raises(ValidationError, match="thread_key must be at most 256 characters"):
@@ -508,15 +467,14 @@ def test_store_without_threads_section_is_accepted(tmp_path: Path) -> None:
     _store_path(tmp_path).write_text(json.dumps({"nonces": {}, "events": {}}), encoding="utf-8")
     store = ExternalTriggerReplayStore(tmp_path)
 
-    assert store.thread_root("campground", "site-42", room_id="!room:localhost", now=1_000) is None
-    store.remember_thread_root(
+    assert store.claim_thread_key(
         "campground",
         "site-42",
-        "$root-1",
         room_id="!room:localhost",
         now=1_000,
-        ttl_seconds=600,
-    )
+        pending_ttl_seconds=60,
+    ) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    store.bind_thread_root("campground", "site-42", "$root-1", room_id="!room:localhost", now=1_000, ttl_seconds=600)
     assert json.loads(_store_path(tmp_path).read_text(encoding="utf-8"))["threads"] == {
         "campground": {
             "site-42": {"room_id": "!room:localhost", "thread_event_id": "$root-1", "expires_at": 1_600},
@@ -543,4 +501,147 @@ def test_invalid_nested_thread_record_fails_closed(tmp_path: Path, threads_paylo
     )
 
     with pytest.raises(ExternalTriggerReplayStoreError, match="invalid external trigger replay store structure"):
-        ExternalTriggerReplayStore(tmp_path).thread_root("campground", "site-42", room_id="!r:x", now=1)
+        ExternalTriggerReplayStore(tmp_path).claim_thread_key(
+            "campground",
+            "site-42",
+            room_id="!r:x",
+            now=1,
+            pending_ttl_seconds=60,
+        )
+
+
+ROOM = "!room:localhost"
+
+
+def _claim(
+    store: ExternalTriggerReplayStore,
+    key: str = "site-42",
+    *,
+    scope: str = "campground",
+    room: str = ROOM,
+    now: int,
+) -> tuple[ExternalTriggerThreadKeyClaim, str | None]:
+    return store.claim_thread_key(scope, key, room_id=room, now=now, pending_ttl_seconds=60)
+
+
+def test_thread_key_claim_reserves_then_binds_then_resolves(tmp_path: Path) -> None:
+    """First claim reserves the key; a bound key resolves to its root within scope and room."""
+    store = ExternalTriggerReplayStore(tmp_path)
+
+    assert _claim(store, now=1_000) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    assert _claim(store, now=1_001) == (ExternalTriggerThreadKeyClaim.PENDING, None)
+    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_002, ttl_seconds=600)
+
+    assert _claim(store, now=1_003) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-1")
+    assert _claim(store, now=1_602) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-1")
+    assert _claim(store, now=1_603) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    assert _claim(store, "site-43", now=1_000) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    assert _claim(store, scope="other-scope", now=1_000) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+
+
+def test_thread_key_bound_to_another_room_is_reclaimed(tmp_path: Path) -> None:
+    """A re-pointed trigger room must not relate deliveries to a foreign root."""
+    store = ExternalTriggerReplayStore(tmp_path)
+    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_000, ttl_seconds=600)
+
+    assert _claim(store, room="!elsewhere:localhost", now=1_001) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    assert _claim(store, room="!elsewhere:localhost", now=1_002) == (ExternalTriggerThreadKeyClaim.PENDING, None)
+
+
+def test_pending_thread_key_expires_and_release_keeps_bound_keys(tmp_path: Path) -> None:
+    """A crashed first delivery frees the key after the pending TTL; release never drops a bound key."""
+    store = ExternalTriggerReplayStore(tmp_path)
+
+    assert _claim(store, now=1_000) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    assert _claim(store, now=1_060) == (ExternalTriggerThreadKeyClaim.PENDING, None)
+    assert _claim(store, now=1_061) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+
+    store.release_thread_key("campground", "site-42")
+    assert _claim(store, now=1_062) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+
+    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_063, ttl_seconds=600)
+    store.release_thread_key("campground", "site-42")
+    store.release_thread_key("campground", "missing")
+    store.release_thread_key("other-scope", "site-42")
+    assert _claim(store, now=1_064) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-1")
+
+
+def test_bind_thread_root_refreshes_retention(tmp_path: Path) -> None:
+    """Every continued delivery extends how long the key keeps routing to its root."""
+    store = ExternalTriggerReplayStore(tmp_path)
+    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_000, ttl_seconds=600)
+    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_500, ttl_seconds=600)
+
+    assert _claim(store, now=2_099) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-1")
+    assert _claim(store, now=2_101) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+
+
+def _claim_thread_key_with_slow_read_worker(
+    control_state_root: str,
+    start_event: Event,
+    result_queue: Queue[tuple[str, str]],
+) -> None:
+    """Claim one new thread key after slowing reads enough to expose missing cross-process locking."""
+    original_read_store = cast(
+        "Callable[[ExternalTriggerReplayStore], object]",
+        ExternalTriggerReplayStore._read_store,
+    )
+
+    def slow_read_store(self: ExternalTriggerReplayStore) -> object:
+        store = original_read_store(self)
+        time.sleep(0.1)
+        return store
+
+    ExternalTriggerReplayStore._read_store = slow_read_store
+    try:
+        if not start_event.wait(timeout=5):
+            result_queue.put(("error", "timed out waiting for start signal"))
+            return
+        claim, _root = ExternalTriggerReplayStore(Path(control_state_root)).claim_thread_key(
+            "campground",
+            "site-42",
+            room_id=ROOM,
+            now=1_000,
+            pending_ttl_seconds=60,
+        )
+        result_queue.put(("ok", claim.value))
+    except Exception as exc:
+        result_queue.put(("error", repr(exc)))
+
+
+def test_concurrent_first_deliveries_reserve_one_thread_key(tmp_path: Path) -> None:
+    """Two processes racing on a new key: exactly one may open the root, the other waits."""
+    context = multiprocessing.get_context("spawn")
+    start_event = context.Event()
+    result_queue = context.Queue()
+    processes = [
+        context.Process(
+            target=_claim_thread_key_with_slow_read_worker,
+            args=(str(tmp_path), start_event, result_queue),
+        )
+        for _ in range(2)
+    ]
+
+    for process in processes:
+        process.start()
+    start_event.set()
+
+    results: list[str] = []
+    try:
+        for _ in processes:
+            try:
+                status, payload = result_queue.get(timeout=10)
+            except Empty as exc:
+                msg = "timed out waiting for replay-store worker result"
+                raise AssertionError(msg) from exc
+            assert status == "ok", payload
+            results.append(payload)
+    finally:
+        for process in processes:
+            process.join(timeout=10)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+
+    assert [process.exitcode for process in processes] == [0, 0]
+    assert sorted(results) == ["fresh", "pending"]

--- a/tests/test_external_trigger_replay_store.py
+++ b/tests/test_external_trigger_replay_store.py
@@ -645,3 +645,21 @@ def test_concurrent_first_deliveries_reserve_one_thread_key(tmp_path: Path) -> N
 
     assert [process.exitcode for process in processes] == [0, 0]
     assert sorted(results) == ["fresh", "pending"]
+
+
+def test_bind_thread_root_keeps_a_root_bound_meanwhile_by_another_delivery(tmp_path: Path) -> None:
+    """A first delivery that outlived its reservation must not orphan the thread that replaced it."""
+    store = ExternalTriggerReplayStore(tmp_path)
+
+    assert _claim(store, now=1_000) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    # Reservation expired; a second delivery opens and binds root B.
+    assert _claim(store, now=1_061) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    assert store.bind_thread_root("campground", "site-42", "$root-b", room_id=ROOM, now=1_062, ttl_seconds=600) == (
+        "$root-b"
+    )
+
+    # The slow first delivery finally finishes with root A.
+    assert store.bind_thread_root("campground", "site-42", "$root-a", room_id=ROOM, now=1_070, ttl_seconds=600) == (
+        "$root-b"
+    )
+    assert _claim(store, now=1_071) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-b")

--- a/tests/test_external_trigger_replay_store.py
+++ b/tests/test_external_trigger_replay_store.py
@@ -450,28 +450,57 @@ def test_payload_rejects_blank_thread_key() -> None:
     )
 
 
-def test_thread_root_is_remembered_per_scope_until_expiry(tmp_path: Path) -> None:
-    """Thread keys resolve to their recorded Matrix root within one replay scope."""
+def test_thread_root_is_remembered_per_scope_and_room_until_expiry(tmp_path: Path) -> None:
+    """Thread keys resolve to their recorded Matrix root within one replay scope and room."""
     store = ExternalTriggerReplayStore(tmp_path)
+    room = "!room:localhost"
 
-    assert store.thread_root("campground", "site-42", now=1_000) is None
-    store.remember_thread_root("campground", "site-42", "$root-1", now=1_000, ttl_seconds=600)
+    assert store.thread_root("campground", "site-42", room_id=room, now=1_000) is None
+    store.remember_thread_root("campground", "site-42", "$root-1", room_id=room, now=1_000, ttl_seconds=600)
 
-    assert store.thread_root("campground", "site-42", now=1_000) == "$root-1"
-    assert store.thread_root("campground", "site-42", now=1_600) == "$root-1"
-    assert store.thread_root("other-scope", "site-42", now=1_000) is None
-    assert store.thread_root("campground", "site-43", now=1_000) is None
-    assert store.thread_root("campground", "site-42", now=1_601) is None
+    assert store.thread_root("campground", "site-42", room_id=room, now=1_000) == "$root-1"
+    assert store.thread_root("campground", "site-42", room_id=room, now=1_600) == "$root-1"
+    assert store.thread_root("campground", "site-42", room_id="!other:localhost", now=1_000) is None
+    assert store.thread_root("other-scope", "site-42", room_id=room, now=1_000) is None
+    assert store.thread_root("campground", "site-43", room_id=room, now=1_000) is None
+    assert store.thread_root("campground", "site-42", room_id=room, now=1_601) is None
 
 
 def test_remember_thread_root_refreshes_retention_and_keeps_first_root(tmp_path: Path) -> None:
     """Re-recording the same key extends retention; callers pass the existing root back."""
     store = ExternalTriggerReplayStore(tmp_path)
-    store.remember_thread_root("campground", "site-42", "$root-1", now=1_000, ttl_seconds=600)
-    store.remember_thread_root("campground", "site-42", "$root-1", now=1_500, ttl_seconds=600)
+    room = "!room:localhost"
+    store.remember_thread_root("campground", "site-42", "$root-1", room_id=room, now=1_000, ttl_seconds=600)
+    store.remember_thread_root("campground", "site-42", "$root-1", room_id=room, now=1_500, ttl_seconds=600)
 
-    assert store.thread_root("campground", "site-42", now=2_099) == "$root-1"
-    assert store.thread_root("campground", "site-42", now=2_101) is None
+    assert store.thread_root("campground", "site-42", room_id=room, now=2_099) == "$root-1"
+    assert store.thread_root("campground", "site-42", room_id=room, now=2_101) is None
+
+
+def test_forget_thread_root_drops_only_that_key(tmp_path: Path) -> None:
+    """Forgetting a stale root leaves other keys and scopes untouched."""
+    store = ExternalTriggerReplayStore(tmp_path)
+    room = "!room:localhost"
+    store.remember_thread_root("campground", "site-42", "$root-1", room_id=room, now=1_000, ttl_seconds=600)
+    store.remember_thread_root("campground", "site-43", "$root-2", room_id=room, now=1_000, ttl_seconds=600)
+
+    store.forget_thread_root("campground", "site-42")
+    store.forget_thread_root("campground", "missing")
+    store.forget_thread_root("other-scope", "site-42")
+
+    assert store.thread_root("campground", "site-42", room_id=room, now=1_000) is None
+    assert store.thread_root("campground", "site-43", room_id=room, now=1_000) == "$root-2"
+
+
+def test_payload_rejects_oversized_thread_key() -> None:
+    """Thread keys live for days in the shared replay store, so their size is bounded."""
+    with pytest.raises(ValidationError, match="thread_key must be at most 256 characters"):
+        ExternalTriggerPayload(kind="campground.availability", message="Site open", thread_key="k" * 257)
+
+    assert (
+        ExternalTriggerPayload(kind="campground.availability", message="Site open", thread_key="k" * 256).thread_key
+        == "k" * 256
+    )
 
 
 def test_store_without_threads_section_is_accepted(tmp_path: Path) -> None:
@@ -479,18 +508,29 @@ def test_store_without_threads_section_is_accepted(tmp_path: Path) -> None:
     _store_path(tmp_path).write_text(json.dumps({"nonces": {}, "events": {}}), encoding="utf-8")
     store = ExternalTriggerReplayStore(tmp_path)
 
-    assert store.thread_root("campground", "site-42", now=1_000) is None
-    store.remember_thread_root("campground", "site-42", "$root-1", now=1_000, ttl_seconds=600)
+    assert store.thread_root("campground", "site-42", room_id="!room:localhost", now=1_000) is None
+    store.remember_thread_root(
+        "campground",
+        "site-42",
+        "$root-1",
+        room_id="!room:localhost",
+        now=1_000,
+        ttl_seconds=600,
+    )
     assert json.loads(_store_path(tmp_path).read_text(encoding="utf-8"))["threads"] == {
-        "campground": {"site-42": {"thread_event_id": "$root-1", "expires_at": 1_600}},
+        "campground": {
+            "site-42": {"room_id": "!room:localhost", "thread_event_id": "$root-1", "expires_at": 1_600},
+        },
     }
 
 
 @pytest.mark.parametrize(
     "threads_payload",
     [
-        {"campground": {"site-42": {"thread_event_id": "", "expires_at": 1}}},
-        {"campground": {"site-42": {"thread_event_id": "$root", "expires_at": "1"}}},
+        {"campground": {"site-42": {"room_id": "!r:x", "thread_event_id": "", "expires_at": 1}}},
+        {"campground": {"site-42": {"room_id": "!r:x", "thread_event_id": "$root", "expires_at": "1"}}},
+        {"campground": {"site-42": {"room_id": "", "thread_event_id": "$root", "expires_at": 1}}},
+        {"campground": {"site-42": {"thread_event_id": "$root", "expires_at": 1}}},
         {"campground": {"site-42": {"expires_at": 1}}},
         {"campground": "not-a-mapping"},
     ],
@@ -503,4 +543,4 @@ def test_invalid_nested_thread_record_fails_closed(tmp_path: Path, threads_paylo
     )
 
     with pytest.raises(ExternalTriggerReplayStoreError, match="invalid external trigger replay store structure"):
-        ExternalTriggerReplayStore(tmp_path).thread_root("campground", "site-42", now=1)
+        ExternalTriggerReplayStore(tmp_path).thread_root("campground", "site-42", room_id="!r:x", now=1)

--- a/tests/test_external_trigger_replay_store.py
+++ b/tests/test_external_trigger_replay_store.py
@@ -467,17 +467,32 @@ def test_store_without_threads_section_is_accepted(tmp_path: Path) -> None:
     _store_path(tmp_path).write_text(json.dumps({"nonces": {}, "events": {}}), encoding="utf-8")
     store = ExternalTriggerReplayStore(tmp_path)
 
-    assert store.claim_thread_key(
+    claim, root, reservation = store.claim_thread_key(
         "campground",
         "site-42",
         room_id="!room:localhost",
         now=1_000,
         pending_ttl_seconds=60,
-    ) == (ExternalTriggerThreadKeyClaim.FRESH, None)
-    store.bind_thread_root("campground", "site-42", "$root-1", room_id="!room:localhost", now=1_000, ttl_seconds=600)
+    )
+    assert (claim, root) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    assert reservation
+    store.bind_thread_root(
+        "campground",
+        "site-42",
+        "$root-1",
+        room_id="!room:localhost",
+        reservation=reservation,
+        now=1_000,
+        ttl_seconds=600,
+    )
     assert json.loads(_store_path(tmp_path).read_text(encoding="utf-8"))["threads"] == {
         "campground": {
-            "site-42": {"room_id": "!room:localhost", "thread_event_id": "$root-1", "expires_at": 1_600},
+            "site-42": {
+                "room_id": "!room:localhost",
+                "thread_event_id": "$root-1",
+                "reservation": None,
+                "expires_at": 1_600,
+            },
         },
     }
 
@@ -485,10 +500,25 @@ def test_store_without_threads_section_is_accepted(tmp_path: Path) -> None:
 @pytest.mark.parametrize(
     "threads_payload",
     [
-        {"campground": {"site-42": {"room_id": "!r:x", "thread_event_id": "", "expires_at": 1}}},
-        {"campground": {"site-42": {"room_id": "!r:x", "thread_event_id": "$root", "expires_at": "1"}}},
-        {"campground": {"site-42": {"room_id": "", "thread_event_id": "$root", "expires_at": 1}}},
-        {"campground": {"site-42": {"thread_event_id": "$root", "expires_at": 1}}},
+        {"campground": {"site-42": {"room_id": "!r:x", "thread_event_id": "", "reservation": None, "expires_at": 1}}},
+        {
+            "campground": {
+                "site-42": {"room_id": "!r:x", "thread_event_id": "$root", "reservation": None, "expires_at": "1"},
+            },
+        },
+        {"campground": {"site-42": {"room_id": "", "thread_event_id": "$root", "reservation": None, "expires_at": 1}}},
+        {"campground": {"site-42": {"thread_event_id": "$root", "reservation": None, "expires_at": 1}}},
+        # Missing thread_event_id must not be read as a pending reservation.
+        {"campground": {"site-42": {"room_id": "!r:x", "reservation": "r1", "expires_at": 1}}},
+        # A pending record must carry its owner's reservation; a bound one must not.
+        {"campground": {"site-42": {"room_id": "!r:x", "thread_event_id": None, "reservation": None, "expires_at": 1}}},
+        {"campground": {"site-42": {"room_id": "!r:x", "thread_event_id": None, "reservation": "", "expires_at": 1}}},
+        {
+            "campground": {
+                "site-42": {"room_id": "!r:x", "thread_event_id": "$root", "reservation": "r1", "expires_at": 1},
+            },
+        },
+        {"campground": {"site-42": {"room_id": "!r:x", "thread_event_id": None, "expires_at": 1}}},
         {"campground": {"site-42": {"expires_at": 1}}},
         {"campground": "not-a-mapping"},
     ],
@@ -521,16 +551,49 @@ def _claim(
     room: str = ROOM,
     now: int,
 ) -> tuple[ExternalTriggerThreadKeyClaim, str | None]:
-    return store.claim_thread_key(scope, key, room_id=room, now=now, pending_ttl_seconds=60)
+    claim, root, _reservation = store.claim_thread_key(scope, key, room_id=room, now=now, pending_ttl_seconds=60)
+    return claim, root
+
+
+def _reserve(store: ExternalTriggerReplayStore, *, now: int, room: str = ROOM) -> str:
+    claim, _root, reservation = store.claim_thread_key(
+        "campground",
+        "site-42",
+        room_id=room,
+        now=now,
+        pending_ttl_seconds=60,
+    )
+    assert claim is ExternalTriggerThreadKeyClaim.FRESH
+    assert reservation
+    return reservation
+
+
+def _bind(
+    store: ExternalTriggerReplayStore,
+    root: str,
+    *,
+    reservation: str | None,
+    now: int,
+    room: str = ROOM,
+) -> str | None:
+    return store.bind_thread_root(
+        "campground",
+        "site-42",
+        root,
+        room_id=room,
+        reservation=reservation,
+        now=now,
+        ttl_seconds=600,
+    )
 
 
 def test_thread_key_claim_reserves_then_binds_then_resolves(tmp_path: Path) -> None:
     """First claim reserves the key; a bound key resolves to its root within scope and room."""
     store = ExternalTriggerReplayStore(tmp_path)
 
-    assert _claim(store, now=1_000) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    reservation = _reserve(store, now=1_000)
     assert _claim(store, now=1_001) == (ExternalTriggerThreadKeyClaim.PENDING, None)
-    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_002, ttl_seconds=600)
+    assert _bind(store, "$root-1", reservation=reservation, now=1_002) == "$root-1"
 
     assert _claim(store, now=1_003) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-1")
     assert _claim(store, now=1_602) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-1")
@@ -542,35 +605,75 @@ def test_thread_key_claim_reserves_then_binds_then_resolves(tmp_path: Path) -> N
 def test_thread_key_bound_to_another_room_is_reclaimed(tmp_path: Path) -> None:
     """A re-pointed trigger room must not relate deliveries to a foreign root."""
     store = ExternalTriggerReplayStore(tmp_path)
-    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_000, ttl_seconds=600)
+    reservation = _reserve(store, now=1_000)
+    assert _bind(store, "$root-1", reservation=reservation, now=1_001) == "$root-1"
 
-    assert _claim(store, room="!elsewhere:localhost", now=1_001) == (ExternalTriggerThreadKeyClaim.FRESH, None)
-    assert _claim(store, room="!elsewhere:localhost", now=1_002) == (ExternalTriggerThreadKeyClaim.PENDING, None)
+    assert _claim(store, room="!elsewhere:localhost", now=1_002) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    assert _claim(store, room="!elsewhere:localhost", now=1_003) == (ExternalTriggerThreadKeyClaim.PENDING, None)
 
 
-def test_pending_thread_key_expires_and_release_keeps_bound_keys(tmp_path: Path) -> None:
-    """A crashed first delivery frees the key after the pending TTL; release never drops a bound key."""
+def test_pending_thread_key_expires_and_release_needs_its_reservation(tmp_path: Path) -> None:
+    """A crashed first delivery frees the key after the pending TTL; only the current owner may release early."""
     store = ExternalTriggerReplayStore(tmp_path)
 
-    assert _claim(store, now=1_000) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    reservation_a = _reserve(store, now=1_000)
     assert _claim(store, now=1_060) == (ExternalTriggerThreadKeyClaim.PENDING, None)
-    assert _claim(store, now=1_061) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    reservation_b = _reserve(store, now=1_061)
 
-    store.release_thread_key("campground", "site-42")
-    assert _claim(store, now=1_062) == (ExternalTriggerThreadKeyClaim.FRESH, None)
+    store.release_thread_key("campground", "site-42", reservation="someone-else")
+    store.release_thread_key("campground", "site-42", reservation=reservation_a)
+    assert _claim(store, now=1_062) == (ExternalTriggerThreadKeyClaim.PENDING, None)
 
-    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_063, ttl_seconds=600)
-    store.release_thread_key("campground", "site-42")
-    store.release_thread_key("campground", "missing")
-    store.release_thread_key("other-scope", "site-42")
-    assert _claim(store, now=1_064) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-1")
+    store.release_thread_key("campground", "site-42", reservation=reservation_b)
+    assert _claim(store, now=1_063) == (ExternalTriggerThreadKeyClaim.FRESH, None)
 
 
-def test_bind_thread_root_refreshes_retention(tmp_path: Path) -> None:
+def test_release_drops_only_the_callers_pending_reservation(tmp_path: Path) -> None:
+    """Release is a no-op for other scopes, missing keys, and bound keys."""
+    store = ExternalTriggerReplayStore(tmp_path)
+    reservation = _reserve(store, now=1_000)
+
+    store.release_thread_key("other-scope", "site-42", reservation=reservation)
+    store.release_thread_key("campground", "missing", reservation=reservation)
+    assert _claim(store, now=1_001) == (ExternalTriggerThreadKeyClaim.PENDING, None)
+
+    assert _bind(store, "$root-1", reservation=reservation, now=1_002) == "$root-1"
+    store.release_thread_key("campground", "site-42", reservation=reservation)
+    assert _claim(store, now=1_003) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-1")
+
+
+def test_late_failure_of_an_expired_reservation_cannot_release_the_new_owner(tmp_path: Path) -> None:
+    """A outlives its lease, B reserves; A's late rollback must not free B's reservation."""
+    store = ExternalTriggerReplayStore(tmp_path)
+    reservation_a = _reserve(store, now=1_000)
+    reservation_b = _reserve(store, now=1_061)
+
+    store.release_thread_key("campground", "site-42", reservation=reservation_a)
+
+    assert _claim(store, now=1_062) == (ExternalTriggerThreadKeyClaim.PENDING, None)
+    assert _bind(store, "$root-b", reservation=reservation_b, now=1_063) == "$root-b"
+
+
+def test_late_success_of_an_expired_reservation_cannot_bind_over_the_new_owner(tmp_path: Path) -> None:
+    """A outlives its lease, B reserves and is still posting; A's late bind is refused."""
+    store = ExternalTriggerReplayStore(tmp_path)
+    reservation_a = _reserve(store, now=1_000)
+    reservation_b = _reserve(store, now=1_061)
+
+    assert _bind(store, "$root-a", reservation=reservation_a, now=1_062) is None
+    assert _claim(store, now=1_063) == (ExternalTriggerThreadKeyClaim.PENDING, None)
+    assert _bind(store, "$root-b", reservation=reservation_b, now=1_064) == "$root-b"
+    # Once bound, a late binder is told the real root and does not overwrite it.
+    assert _bind(store, "$root-a", reservation=reservation_a, now=1_065) == "$root-b"
+    assert _claim(store, now=1_066) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-b")
+
+
+def test_bind_thread_root_refreshes_retention_for_continuations(tmp_path: Path) -> None:
     """Every continued delivery extends how long the key keeps routing to its root."""
     store = ExternalTriggerReplayStore(tmp_path)
-    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_000, ttl_seconds=600)
-    store.bind_thread_root("campground", "site-42", "$root-1", room_id=ROOM, now=1_500, ttl_seconds=600)
+    reservation = _reserve(store, now=1_000)
+    assert _bind(store, "$root-1", reservation=reservation, now=1_000) == "$root-1"
+    assert _bind(store, "$root-1", reservation=None, now=1_500) == "$root-1"
 
     assert _claim(store, now=2_099) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-1")
     assert _claim(store, now=2_101) == (ExternalTriggerThreadKeyClaim.FRESH, None)
@@ -597,7 +700,7 @@ def _claim_thread_key_with_slow_read_worker(
         if not start_event.wait(timeout=5):
             result_queue.put(("error", "timed out waiting for start signal"))
             return
-        claim, _root = ExternalTriggerReplayStore(Path(control_state_root)).claim_thread_key(
+        claim, _root, _reservation = ExternalTriggerReplayStore(Path(control_state_root)).claim_thread_key(
             "campground",
             "site-42",
             room_id=ROOM,
@@ -645,21 +748,3 @@ def test_concurrent_first_deliveries_reserve_one_thread_key(tmp_path: Path) -> N
 
     assert [process.exitcode for process in processes] == [0, 0]
     assert sorted(results) == ["fresh", "pending"]
-
-
-def test_bind_thread_root_keeps_a_root_bound_meanwhile_by_another_delivery(tmp_path: Path) -> None:
-    """A first delivery that outlived its reservation must not orphan the thread that replaced it."""
-    store = ExternalTriggerReplayStore(tmp_path)
-
-    assert _claim(store, now=1_000) == (ExternalTriggerThreadKeyClaim.FRESH, None)
-    # Reservation expired; a second delivery opens and binds root B.
-    assert _claim(store, now=1_061) == (ExternalTriggerThreadKeyClaim.FRESH, None)
-    assert store.bind_thread_root("campground", "site-42", "$root-b", room_id=ROOM, now=1_062, ttl_seconds=600) == (
-        "$root-b"
-    )
-
-    # The slow first delivery finally finishes with root A.
-    assert store.bind_thread_root("campground", "site-42", "$root-a", room_id=ROOM, now=1_070, ttl_seconds=600) == (
-        "$root-b"
-    )
-    assert _claim(store, now=1_071) == (ExternalTriggerThreadKeyClaim.BOUND, "$root-b")

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -132,6 +132,7 @@ _.normalize_allowed_kinds  # unused method (src/mindroom/external_triggers/store
 _.validate_record_keys  # unused method (src/mindroom/external_triggers/store.py)
 _.validate_kind  # unused method (src/mindroom/external_triggers/models.py)
 _.validate_message  # unused method (src/mindroom/external_triggers/models.py)
+_.validate_thread_key  # Pydantic field validator (src/mindroom/external_triggers/models.py)
 _.validate_auth  # unused method (src/mindroom/external_triggers/store.py)
 post_external_trigger  # unused function (src/mindroom/api/external_triggers.py)
 _.validate_team_agents  # unused method (src/mindroom/config/main.py)


### PR DESCRIPTION
## Summary

- add optional `thread_key` to the external trigger payload
- on a `new_thread` trigger, the first delivery with a key posts the usual per-fire root and records the key; later deliveries with the same key continue that Matrix thread instead of opening another root
- thread key records live in the existing replay store, scoped per trigger, retained 7 days after the most recent delivery that used them
- `mindroom trigger send --thread-key ...`
- docs: new "Grouping Deliveries Into One Thread" section

## Why

Some upstream sources deliver one conversation as many events, for example every reply in a chat thread or every message in a direct-message conversation. With `new_thread`, each of those became its own Matrix thread: noisy for the room, and the agent answered each reply with a fresh session and no memory of the earlier ones. Grouping by a sender-chosen key keeps one Matrix thread and one agent session per upstream conversation, while unrelated events still get their own thread.

## Behaviour details

- The key is opaque to MindRoom; senders pick something that names the upstream conversation (ticket ID, upstream thread timestamp, DM channel ID).
- A continued delivery is a normal in-thread message (`m.relates_to` to the recorded root, `m.in_reply_to` the latest thread event) and does **not** carry the per-fire-root marker, so the agent treats it as a follow-up in an existing thread.
- Fixed `target_thread_id` triggers ignore `thread_key`.
- Replay files written before this change have no `threads` section and still load; malformed thread records fail closed like malformed nonce or event records.
- `event_id` idempotency is unchanged and independent of `thread_key`.

## Verification

- `tests/test_external_trigger_replay_store.py`: payload validation, per-scope lookup, expiry, retention refresh, legacy file compatibility, corrupt record rejection
- `tests/test_external_trigger_executor.py`: continued delivery relates to the recorded root and omits the per-fire-root marker
- `tests/api/test_external_triggers_api.py`: two keyed deliveries share one thread, a different key starts a new one, fixed-thread triggers ignore the key
- `tests/test_cli_trigger.py`: `--thread-key` in the signed body
- 100 tests across those suites plus `test_import_graph.py` pass; pre-commit (ruff, ty, vulture, docs skill references) passes on changed files

## Summary by Sourcery

Group external trigger deliveries by an optional sender-defined key so related events share one Matrix thread and agent context.

New Features:
- Add optional `thread_key` support for grouping related external trigger deliveries into a shared Matrix thread and agent session.
- Expose `--thread-key` through the trigger-send CLI and signed request payload.

Bug Fixes:
- Prevent failed or concurrent deliveries from creating duplicate threads, while preserving existing event-id idempotency behavior.

Enhancements:
- Persist per-trigger thread-key routing with scoped retention, atomic reservations, expiry, fencing, room safety, and compatibility with legacy replay stores.
- Continue keyed deliveries as ordinary in-thread messages without marking them as new per-fire roots.

Documentation:
- Document thread-key usage, retention, concurrency behavior, and fixed-thread semantics in the external trigger and CLI references.

Tests:
- Add coverage for payload validation, replay-store lifecycle and corruption handling, keyed delivery routing, failure recovery, fixed-thread behavior, executor metadata, and CLI signing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added optional thread keys to external trigger requests and the `trigger send` CLI command.
  - Deliveries with the same key now share a Matrix thread for `new_thread` triggers.
  - Thread associations are retained for seven days and scoped to the target room; fixed target threads are unaffected.
  - Invalid keys, including blank or overlong values, are rejected.
  - Concurrent first deliveries receive a retryable conflict response.
  - Failed initial deliveries release reservations for retry, while failed continuations retain their thread association.

- **Documentation**
  - Added usage guidance, retention details, scope limitations, concurrency behavior, and CLI examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->