### PR TITLE
fix: treat approval pauses as expected control flow

### DIFF
--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -4219,7 +4219,7 @@ class ResponseRunner:
                 ),
             )
         except Exception as error:
-            self.deps.logger.exception("Error in non-streaming response", error=str(error))
+            self._log_unexpected_non_streaming_exception(error)
             raise
 
         response_extra_content = _merge_response_extra_content(
@@ -4253,6 +4253,12 @@ class ResponseRunner:
             raise
         self._note_final_delivery_timing(request, delivery)
         return build_outcome(delivery)
+
+    def _log_unexpected_non_streaming_exception(self, error: Exception) -> None:
+        """Log failures while leaving approval suspension to its lifecycle handler."""
+        if isinstance(error, ResponsePausedForApproval):
+            return
+        self.deps.logger.exception("Error in non-streaming response", error=str(error))
 
     async def _process_and_respond_streaming(  # noqa: C901
         self,

--- a/src/mindroom/response_runner.py
+++ b/src/mindroom/response_runner.py
@@ -4130,7 +4130,7 @@ class ResponseRunner:
             )
             raise
 
-    async def _process_and_respond(
+    async def _process_and_respond(  # noqa: C901
         self,
         request: ResponseRequest,
         *,
@@ -4205,6 +4205,8 @@ class ResponseRunner:
                     run_id=run_id,
                     response_event_id=request.existing_event_id,
                 )
+        except ResponsePausedForApproval:
+            raise
         except asyncio.CancelledError as exc:
             return build_outcome(
                 await self._settle_blocking_cancellation(
@@ -4219,7 +4221,7 @@ class ResponseRunner:
                 ),
             )
         except Exception as error:
-            self._log_unexpected_non_streaming_exception(error)
+            self.deps.logger.exception("Error in non-streaming response", error=str(error))
             raise
 
         response_extra_content = _merge_response_extra_content(
@@ -4253,12 +4255,6 @@ class ResponseRunner:
             raise
         self._note_final_delivery_timing(request, delivery)
         return build_outcome(delivery)
-
-    def _log_unexpected_non_streaming_exception(self, error: Exception) -> None:
-        """Log failures while leaving approval suspension to its lifecycle handler."""
-        if isinstance(error, ResponsePausedForApproval):
-            return
-        self.deps.logger.exception("Error in non-streaming response", error=str(error))
 
     async def _process_and_respond_streaming(  # noqa: C901
         self,

--- a/tests/test_response_runner_focused.py
+++ b/tests/test_response_runner_focused.py
@@ -4881,6 +4881,33 @@ async def test_non_streaming_response_delivers_through_deliver_final(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_non_streaming_approval_pause_is_not_logged_as_response_error(tmp_path: Path) -> None:
+    """A native approval pause must reach the lifecycle handler without an error log."""
+    bot = _bot(tmp_path)
+    coordinator = replace_response_runner_deps(bot, logger=MagicMock())
+    pause = ResponsePausedForApproval(
+        PausedAttempt(
+            session_id="session-1",
+            run_id="run-paused",
+            tools=(ToolExecution(tool_call_id="call-1", tool_name="dangerous", requires_confirmation=True),),
+        ),
+    )
+
+    with (
+        patch.object(
+            coordinator,
+            "generate_non_streaming_ai_response",
+            new=AsyncMock(side_effect=pause),
+        ),
+        pytest.raises(ResponsePausedForApproval) as raised,
+    ):
+        await coordinator._process_and_respond(_plain_request(_target()))
+
+    assert raised.value is pause
+    coordinator.deps.logger.exception.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_non_streaming_response_reuses_prepared_room_model_after_override_change(tmp_path: Path) -> None:
     """A blocking agent turn must not re-read a changed room default during execution."""
     bot = _bot(tmp_path)


### PR DESCRIPTION
## Summary
- avoid error logging for expected non-streaming approval pauses
- add a regression test for the logging boundary

## Test
- `uv run pytest tests/test_response_runner_focused.py -n 0 --no-cov -q`

## Summary by Sourcery

Treat approval pauses as expected control flow during non-streaming response processing.

Bug Fixes:
- Prevent expected non-streaming approval pauses from being logged as response errors while allowing them to propagate to lifecycle handling.

Tests:
- Add regression coverage confirming non-streaming approval pauses are propagated without invoking error logging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Approval-paused responses are no longer incorrectly recorded as response errors.
  * Other unexpected errors continue to be logged as before.

* **Tests**
  * Added coverage to verify that approval pauses propagate correctly without triggering error logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->