### PR TITLE
fix: recover unreadable knowledge candidates

### DIFF
--- a/src/mindroom/knowledge/manager.py
+++ b/src/mindroom/knowledge/manager.py
@@ -1373,7 +1373,11 @@ class KnowledgeManager:
             error_detail = str(inspection_error).lower()
             if not any(
                 marker in error_detail
-                for marker in ("error constructing hnsw segment reader", "error deserializing pickle file")
+                for marker in (
+                    "error constructing hnsw segment reader",
+                    "error deserializing pickle file",
+                    "failed to apply logs to the hnsw segment writer",
+                )
             ):
                 raise
             # A candidate is never live until publication, so an unreadable

--- a/tests/test_knowledge_resumable_refresh.py
+++ b/tests/test_knowledge_resumable_refresh.py
@@ -3732,9 +3732,17 @@ async def test_a_candidate_whose_collection_vanished_is_rebuilt_rather_than_resu
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "unreadable_error",
+    [
+        "Error constructing hnsw segment reader: EOF while parsing",
+        "Error sending backfill request to compactor: Failed to apply logs to the hnsw segment writer",
+    ],
+)
 async def test_an_unreadable_candidate_is_discarded_without_touching_the_published_index(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    unreadable_error: str,
 ) -> None:
     """A corrupt unpublished vector segment must not permanently block refresh."""
     docs_path = tmp_path / "docs"
@@ -3763,8 +3771,7 @@ async def test_an_unreadable_candidate_is_discarded_without_touching_the_publish
 
     def _fail_unreadable_candidate(self: _FakeCollection, **kwargs: object) -> dict[str, object]:
         if self._name == unreadable_candidate:
-            message = "Error constructing hnsw segment reader: EOF while parsing"
-            raise InternalError(message)
+            raise InternalError(unreadable_error)
         return original_get(self, **kwargs)
 
     monkeypatch.setattr(_FakeCollection, "get", _fail_unreadable_candidate)


### PR DESCRIPTION
## Summary
- treat Chroma HNSW backfill failures as unreadable candidate state
- discard only the unpublished candidate and preserve the published index

## Test
- `uv run pytest tests/test_knowledge_resumable_refresh.py -n 0 --no-cov -q`

## Summary by Sourcery

Recover resumable knowledge refreshes by discarding unreadable unpublished candidates while preserving the published index.

Bug Fixes:
- Treat Chroma HNSW backfill failures as unreadable unpublished candidates so refreshes can recover without affecting the published index.

Tests:
- Extend resumable refresh coverage to include HNSW backfill failures alongside existing unreadable-segment errors.