### PR TITLE
Avoid expensive Rich tracebacks for redirected logs

### DIFF
--- a/src/mindroom/logging_config.py
+++ b/src/mindroom/logging_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import logging.config
 import os
+import sys
 from datetime import UTC, datetime
 from io import StringIO
 from typing import TYPE_CHECKING
@@ -174,7 +175,7 @@ def setup_logging(
         _redact_log_event_preserving_exc_info,
     ]
     log_format = os.getenv("MINDROOM_LOG_FORMAT", "text").strip().lower()
-    renderer_name = "json" if log_format == "json" else "text"
+    renderer_name = "json" if log_format == "json" else ("colored" if sys.stderr.isatty() else "text")
     handler_level, loggers = _build_logger_levels(
         global_level=level,
         override_config=os.getenv("MINDROOM_LOGGER_LEVELS"),
@@ -240,7 +241,7 @@ def setup_logging(
                     "level": handler_level,
                     "class": "logging.StreamHandler",
                     "stream": "ext://sys.stderr",
-                    "formatter": "json" if renderer_name == "json" else "colored",
+                    "formatter": renderer_name,
                     "filters": ["nio_validation"],
                 },
                 "file": {

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -310,13 +310,16 @@ def test_setup_logging_text_mode_does_not_emit_json(
         json.loads(line)
 
 
+@pytest.mark.parametrize("is_terminal", [False, True])
 def test_setup_logging_text_mode_redacts_exception_tracebacks_without_pretty_exception_warning(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    is_terminal: bool,
 ) -> None:
-    """Text mode should keep pretty exception formatting without leaking exception secrets."""
+    """Text tracebacks suit their output stream without leaking exception secrets."""
     monkeypatch.delenv("MINDROOM_LOG_FORMAT", raising=False)
+    monkeypatch.setattr(sys.stderr, "isatty", lambda: is_terminal)
     setup_logging(level="INFO", runtime_paths=_runtime_paths(tmp_path))
     capsys.readouterr()
 
@@ -337,6 +340,9 @@ def test_setup_logging_text_mode_redacts_exception_tracebacks_without_pretty_exc
     assert "api-secret" not in output
     assert "auth-secret" not in output
     assert "***redacted***" in output
+    assert ("\x1b[" in output) is is_terminal
+    if not is_terminal:
+        assert "Traceback (most recent call last):" in output
 
 
 def test_setup_logging_json_mode_renders_exception_field_for_exc_info_true(


### PR DESCRIPTION
Redirected text logs still used Rich tracebacks, including expensive source syntax highlighting.
A real 200-thread synthetic Matrix run recorded a 5.6-second event-loop stall inside traceback rendering and then timed out on its health check.
Use the existing plain-text renderer when stderr is not a terminal, while preserving Rich terminal output, JSON mode, and credential redaction.

The focused exception-logging benchmark improved from 17.2 ms to 0.98 ms per exception (94% less time); this is not an end-to-end throughput claim.
The existing traceback test now covers terminal and redirected output, including secret redaction.

Validation:
- 110 logging/redaction tests passed; repository pre-commit hooks passed.
- The 50-thread `sustained-stream-capacity` workload passed with 50 exact replies, 55.4 seconds of full overlap, zero stalls, zero pending journal/outbox rows, and clean shutdown.
- The post-change 200-thread run had zero event-loop stalls and clean shutdown, but still exceeded the workload deadline waiting for recovery/delivery; this PR does not claim to resolve that capacity limit.
- Independent code review found no issues.

## Summary by Sourcery

Avoid expensive Rich traceback rendering when text logs are redirected.

Bug Fixes:
- Use plain-text exception tracebacks for redirected stderr output to avoid expensive Rich rendering and event-loop stalls.

Enhancements:
- Preserve colored Rich tracebacks for terminal text output while retaining JSON rendering and credential redaction.

Tests:
- Extend traceback logging coverage to verify terminal and redirected output formats and secret redaction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Console logs now use plain text in non-terminal environments, avoiding unwanted color and formatting codes.
  * Colored log output remains available when running in an interactive terminal.

* **Tests**
  * Expanded logging coverage to verify terminal-aware formatting and exception tracebacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->