### PR TITLE
Use Responses API for Astra behind compatible proxies

### DIFF
--- a/src/mindroom/model_loading.py
+++ b/src/mindroom/model_loading.py
@@ -295,7 +295,11 @@ def _create_model_for_provider(  # noqa: C901, PLR0911, PLR0912, PLR0915
         from mindroom.openai_tool_search import openai_native_tool_search_supported  # noqa: PLC0415
 
         base_url = extra_kwargs.get("base_url") or runtime_paths.env_value("OPENAI_BASE_URL")
-        if openai_native_tool_search_supported(canonical_provider_key, model_id, base_url=base_url):
+        if model_id == "gpt-6-astra" or openai_native_tool_search_supported(
+            canonical_provider_key,
+            model_id,
+            base_url=base_url,
+        ):
             from mindroom.openai_models import MindRoomOpenAIResponses  # noqa: PLC0415
 
             return MindRoomOpenAIResponses(id=model_id, **extra_kwargs)

--- a/src/mindroom/openai_models.py
+++ b/src/mindroom/openai_models.py
@@ -126,6 +126,10 @@ class MindRoomOpenAIResponses(OpenAIResponses):
 
     approval_receipt_after_response_id: ClassVar[bool] = True
 
+    def _using_reasoning_model(self) -> bool:
+        """Include Astra in Agno's reasoning-aware response continuation."""
+        return self.id == "gpt-6-astra" or super()._using_reasoning_model()
+
     def get_request_params(
         self,
         messages: list[Message] | None = None,

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -70,6 +70,26 @@ def test_first_party_openai_gpt_5_4_and_newer_use_responses(tmp_path: Path) -> N
     assert isinstance(compatible, MindRoomOpenAIChat)
 
 
+def test_openai_gpt_6_astra_uses_responses_through_compatible_proxy(tmp_path: Path) -> None:
+    """Astra must keep function tools on the Responses API when proxied."""
+    config = bind_runtime_paths(
+        Config(
+            models={
+                "astra": ModelConfig(
+                    provider="openai",
+                    id="gpt-6-astra",
+                    extra_kwargs={"api_key": "dummy-key", "base_url": "http://localhost:9292/v1"},
+                ),
+            },
+        ),
+        test_runtime_paths(tmp_path),
+    )
+
+    model = get_model_instance(config, runtime_paths_for(config), "astra")
+
+    assert isinstance(model, MindRoomOpenAIResponses)
+
+
 def test_openai_wire_providers_use_replay_compatible_models(tmp_path: Path) -> None:
     """Every OpenAI-wire chat provider must use the tool-call replay-compatible subclass."""
     expected = {

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -154,6 +154,32 @@ def test_openai_responses_supplies_missing_tool_arguments_without_mutating_histo
     assert "arguments" not in assistant.tool_calls[0]["function"]
 
 
+def test_astra_responses_continue_tool_calls_from_the_previous_response() -> None:
+    """Astra tool results must continue the stored reasoning response."""
+    model = MindRoomOpenAIResponses(id="gpt-6-astra", api_key="test-key")
+    assistant = Message(
+        role="assistant",
+        tool_calls=[
+            {
+                "id": "fc_1",
+                "call_id": "call_1",
+                "type": "function",
+                "function": {"name": "get_status", "arguments": "{}"},
+            },
+        ],
+        provider_data={"response_id": "resp_1"},
+    )
+    tool_result = Message(role="tool", content="ready", tool_call_id="call_1")
+    messages = [assistant, tool_result]
+
+    request_params = model.get_request_params(messages=messages)
+    formatted = model._format_messages(messages)
+
+    assert request_params["store"] is True
+    assert request_params["previous_response_id"] == "resp_1"
+    assert formatted == [{"type": "function_call_output", "call_id": "call_1", "output": "ready"}]
+
+
 @pytest.mark.parametrize(("model_cls", "_agno_cls"), _CHAT_WIRE_PAIRS)
 def test_chat_models_leave_combined_tool_results_for_agno_normalization(
     model_cls: type[OpenAIChat],


### PR DESCRIPTION
## Summary

- route `gpt-6-astra` through the Responses API with compatible proxy base URLs
- preserve reasoning-aware continuation after function calls

## Test

- `uv run pytest -q tests/test_model_loading.py tests/test_openai_models.py tests/test_codex_model.py`
- changed-file pre-commit hooks (all relevant hooks pass; existing unrelated `privata` finding remains)

## Summary by Sourcery

Support gpt-6-astra through compatible proxies while retaining reasoning-aware function-call continuation.

Bug Fixes:
- Route gpt-6-astra through the Responses API when used with compatible proxy base URLs.
- Preserve reasoning-aware response continuation for Astra after function calls.

Tests:
- Add coverage for Astra model selection through compatible proxies and continuation of tool calls from stored Responses API state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `gpt-6-astra` model when using OpenAI-compatible endpoints and proxies.
  * Astra now supports reasoning-aware response continuation and preserves tool-call context across responses.

* **Bug Fixes**
  * Improved handling of function tools and continued tool calls for Astra models routed through compatible proxies.

* **Tests**
  * Added coverage for Astra model routing, proxy usage, and continuation of tool calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->