### PR TITLE
fix: surface dashboard configuration conflicts with recovery guidance

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -171,6 +171,12 @@ The sync status indicator in the header shows:
 - **Sync Error** - Sync failed
 - **Disconnected** - Lost connection to backend
 
+If another dashboard tab or a server-side edit changes the configuration, saving an older draft can return HTTP 409.
+The dashboard keeps your draft and shows persistent recovery guidance, including in the raw configuration recovery editor.
+Copy any changes you want to keep, refresh the page to load the current configuration, then reapply and save your changes.
+Further save attempts are rejected locally while the conflict remains; editing the draft or refreshing agent policies does not resolve it.
+The dashboard does not automatically reload and retry a full replacement, because that could overwrite another writer's changes.
+
 ### Theme and Responsive Design
 
 Toggle between dark and light themes. The dashboard adapts to desktop and mobile devices.

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -12,11 +12,6 @@ vi.mock("@/store/configStore", () => ({
   useConfigStore: vi.fn(),
 }));
 
-vi.mock("@/components/ui/toaster", () => ({
-  toast: vi.fn(),
-  Toaster: () => null,
-}));
-
 describe("resolveCurrentTab", () => {
   it("defaults to dashboard for empty and unknown paths", () => {
     expect(resolveCurrentTab("/")).toBe("dashboard");
@@ -174,13 +169,65 @@ describe("App recovery mode", () => {
       screen.getByRole("button", { name: "Save Replacement Config" }),
     );
 
-    const { toast } = await import("@/components/ui/toaster");
     await waitFor(() => {
-      expect(toast).toHaveBeenCalledWith({
-        title: "Save Failed",
-        description: "Save was superseded by newer recovery edits.",
-        variant: "destructive",
-      });
+      expect(
+        screen.getByText("Save was superseded by newer recovery edits."),
+      ).toBeInTheDocument();
     });
+  });
+
+  it("shows conflict recovery guidance alongside existing validation issues", () => {
+    const state = useConfigStore();
+    state.diagnostics = [
+      {
+        kind: "global",
+        message:
+          "Configuration changed elsewhere. Copy your changes, then refresh this page.",
+        blocking: true,
+      },
+      {
+        kind: "global",
+        message: "Configuration validation failed",
+        blocking: true,
+      },
+      {
+        kind: "validation",
+        issue: {
+          loc: ["agents", "helper", "role"],
+          msg: "role is required",
+          type: "value_error",
+        },
+      },
+    ];
+    render(<App />);
+
+    expect(
+      screen.getByText(/Configuration changed elsewhere/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/role is required/)).toBeInTheDocument();
+    expect(screen.getByRole("textbox")).toHaveValue(state.recoveryConfigSource);
+  });
+
+  it("shows authentication recovery even when an earlier conflict remains", () => {
+    useConfigStore().diagnostics = [
+      {
+        kind: "global",
+        code: "config_conflict",
+        message: "Configuration changed elsewhere.",
+        blocking: true,
+      },
+      {
+        kind: "global",
+        message:
+          "Authentication required. Please log in to access this instance.",
+        blocking: true,
+      },
+    ];
+    render(<App />);
+
+    expect(
+      screen.getByRole("heading", { name: "Access Required" }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -184,7 +184,12 @@ function AppContent() {
   const validationIssues = getConfigValidationIssues(diagnostics);
   const globalDiagnostics = getGlobalConfigDiagnostics(diagnostics);
   const blockingDiagnostic =
-    globalDiagnostics.find((diagnostic) => diagnostic.blocking) ?? null;
+    globalDiagnostics.find(
+      (diagnostic) =>
+        diagnostic.blocking && isAuthDiagnosticMessage(diagnostic.message),
+    ) ??
+    globalDiagnostics.find((diagnostic) => diagnostic.blocking) ??
+    null;
   const showBlockingDiagnosticOverlay = shouldShowBlockingDiagnosticOverlay(
     blockingDiagnostic,
     {
@@ -305,9 +310,12 @@ function AppContent() {
               </p>
             </div>
 
-            {validationIssues.length > 0 ? (
-              <div className="rounded-md border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
-                <p className="font-medium">Current configuration is invalid.</p>
+            <div
+              role="alert"
+              className="rounded-md border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive"
+            >
+              <p className="font-medium">{blockingDiagnostic.message}</p>
+              {validationIssues.length > 0 && (
                 <ul className="mt-3 list-disc space-y-1 pl-5">
                   {validationIssues.map((issue, index) => (
                     <li key={`${issue.loc.join(".")}-${issue.msg}-${index}`}>
@@ -319,12 +327,8 @@ function AppContent() {
                     </li>
                   ))}
                 </ul>
-              </div>
-            ) : (
-              <div className="rounded-md border border-amber-500/20 bg-amber-500/10 px-4 py-3 text-sm text-amber-900 dark:text-amber-100">
-                {blockingDiagnostic?.message}
-              </div>
-            )}
+              )}
+            </div>
 
             <Textarea
               value={recoveryConfigSource}
@@ -806,8 +810,6 @@ function AppContent() {
             </TabsContent>
           </Tabs>
         </div>
-
-        <Toaster />
       </div>
     </div>
   );
@@ -819,6 +821,7 @@ export default function App() {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider>
           <AppContent />
+          <Toaster />
         </ThemeProvider>
       </QueryClientProvider>
     </BrowserRouter>

--- a/frontend/src/lib/configValidation.ts
+++ b/frontend/src/lib/configValidation.ts
@@ -6,6 +6,7 @@ export interface ConfigValidationIssue {
 
 export interface GlobalConfigDiagnostic {
   kind: "global";
+  code?: "config_conflict";
   message: string;
   blocking: boolean;
 }
@@ -17,6 +18,12 @@ export interface ValidationConfigDiagnostic {
 
 export type ConfigDiagnostic =
   GlobalConfigDiagnostic | ValidationConfigDiagnostic;
+
+export function isConfigConflictDiagnostic(
+  diagnostic: ConfigDiagnostic,
+): diagnostic is GlobalConfigDiagnostic & { code: "config_conflict" } {
+  return diagnostic.kind === "global" && diagnostic.code === "config_conflict";
+}
 
 export function getConfigValidationIssues(
   diagnostics: ConfigDiagnostic[],

--- a/frontend/src/store/configStore.test.ts
+++ b/frontend/src/store/configStore.test.ts
@@ -70,6 +70,152 @@ describe("configStore", () => {
     vi.clearAllMocks();
   });
 
+  describe.each(["structured", "raw"] as const)(
+    "%s configuration conflicts",
+    (mode) => {
+      const conflictMessage =
+        "Configuration changed elsewhere. Your draft has not been saved. Copy any changes you want to keep, then refresh this page and reapply them.";
+      const save = () =>
+        mode === "structured"
+          ? useConfigStore.getState().saveConfig()
+          : useConfigStore.getState().saveRecoveryConfigSource();
+      const edit = () =>
+        mode === "structured"
+          ? useConfigStore
+              .getState()
+              .updateModel("default", { provider: "test", id: "newer-edit" })
+          : useConfigStore
+              .getState()
+              .updateRecoveryConfigSource("agents: {}\n# newer edit\n");
+
+      beforeEach(() => {
+        const config: Config = {
+          agents: {},
+          models: { default: { provider: "test", id: "local-edit" } },
+          memory: {
+            embedder: { provider: "test", config: { model: "test-embedder" } },
+          },
+          defaults: { markdown: true },
+          router: { model: "default" },
+        };
+        useConfigStore.setState({
+          committedGeneration: 7,
+          config: mode === "structured" ? config : null,
+          loadedConfig: mode === "structured" ? config : null,
+          recoveryConfigSource:
+            mode === "raw" ? "agents: {}\n# local edit\n" : null,
+          recoveryConfigSourceOriginal: mode === "raw" ? "agents: {}\n" : null,
+          isDirty: true,
+          syncStatus: "error",
+        });
+      });
+
+      it.each([false, true])(
+        "reports a server conflict and preserves the draft (newer edits: %s)",
+        async (newerEdits) => {
+          const response = deferred<Response>();
+          vi.mocked(fetch).mockReturnValueOnce(response.promise);
+          const savePromise = save();
+          if (newerEdits) edit();
+          const draft = useConfigStore.getState();
+          response.resolve(
+            new Response(
+              JSON.stringify({
+                detail:
+                  "Configuration changed while request was in progress. Retry the operation.",
+              }),
+              { status: 409 },
+            ),
+          );
+
+          const result = await savePromise;
+          expect(result).toEqual({
+            status: "error",
+            message: conflictMessage,
+            diagnostics: [
+              {
+                kind: "global",
+                message: conflictMessage,
+                blocking: mode === "raw",
+              },
+            ],
+          });
+          expect(useConfigStore.getState()).toMatchObject({
+            config: draft.config,
+            recoveryConfigSource: draft.recoveryConfigSource,
+            recoveryConfigSourceOriginal: draft.recoveryConfigSourceOriginal,
+            committedGeneration: 7,
+            draftVersion: draft.draftVersion,
+            isDirty: true,
+            isLoading: false,
+            syncStatus: "error",
+            diagnostics: result.status === "error" ? result.diagnostics : [],
+          });
+          // A rejected full replacement must not refresh the generation and retry implicitly.
+          expect(fetch).toHaveBeenCalledTimes(1);
+          expect(fetch).toHaveBeenCalledWith(
+            mode === "structured" ? "/api/config/save" : "/api/config/raw",
+            expect.objectContaining({
+              method: "PUT",
+              headers: expect.objectContaining({
+                "x-mindroom-config-generation": "7",
+              }),
+            }),
+          );
+        },
+      );
+
+      it("keeps draft validation diagnostics without duplicating the conflict on retry", async () => {
+        const validationDiagnostic = {
+          kind: "validation" as const,
+          issue: {
+            loc: ["agents", "helper", "role"],
+            msg: "role is required",
+            type: "value_error",
+          },
+        };
+        useConfigStore.setState({ diagnostics: [validationDiagnostic] });
+        vi.mocked(fetch).mockImplementation(
+          async () =>
+            new Response(JSON.stringify({ detail: "Configuration changed" }), {
+              status: 409,
+            }),
+        );
+
+        await save();
+        await save();
+
+        expect(useConfigStore.getState().diagnostics).toEqual([
+          { kind: "global", message: conflictMessage, blocking: mode === "raw" },
+          validationDiagnostic,
+        ]);
+        expect(useConfigStore.getState().committedGeneration).toBe(7);
+        expect(fetch).toHaveBeenCalledTimes(2);
+      });
+
+      it("ignores a conflict from a save superseded by a newer request", async () => {
+        const response = deferred<Response>();
+        vi.mocked(fetch).mockReturnValueOnce(response.promise);
+        const savePromise = save();
+        useConfigStore.setState({
+          saveConfigRequestId: 2,
+          syncStatus: "syncing",
+        });
+        response.resolve(
+          new Response(JSON.stringify({ detail: "Configuration changed" }), {
+            status: 409,
+          }),
+        );
+
+        expect(await savePromise).toEqual({ status: "stale" });
+        expect(useConfigStore.getState()).toMatchObject({
+          diagnostics: [],
+          syncStatus: "syncing",
+        });
+      });
+    },
+  );
+
   describe("loadConfig", () => {
     it("should load configuration successfully", async () => {
       const mockConfig = {

--- a/frontend/src/store/configStore.test.ts
+++ b/frontend/src/store/configStore.test.ts
@@ -135,6 +135,7 @@ describe("configStore", () => {
             diagnostics: [
               {
                 kind: "global",
+                code: "config_conflict",
                 message: conflictMessage,
                 blocking: mode === "raw",
               },
@@ -165,7 +166,7 @@ describe("configStore", () => {
         },
       );
 
-      it("keeps draft validation diagnostics without duplicating the conflict on retry", async () => {
+      it("rejects retries locally while retaining conflict and validation diagnostics", async () => {
         const validationDiagnostic = {
           kind: "validation" as const,
           issue: {
@@ -183,14 +184,59 @@ describe("configStore", () => {
         );
 
         await save();
-        await save();
+        edit();
+        expect((await save()).status).toBe("error");
 
         expect(useConfigStore.getState().diagnostics).toEqual([
-          { kind: "global", message: conflictMessage, blocking: mode === "raw" },
+          {
+            kind: "global",
+            code: "config_conflict",
+            message: conflictMessage,
+            blocking: mode === "raw",
+          },
           validationDiagnostic,
         ]);
         expect(useConfigStore.getState().committedGeneration).toBe(7);
-        expect(fetch).toHaveBeenCalledTimes(2);
+        expect(fetch).toHaveBeenCalledTimes(1);
+      });
+
+      it("keeps conflict guidance after editing without validation errors", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+          new Response("{}", { status: 409 }),
+        );
+        await save();
+        edit();
+
+        expect(useConfigStore.getState().diagnostics).toEqual([
+          {
+            kind: "global",
+            code: "config_conflict",
+            message: conflictMessage,
+            blocking: mode === "raw",
+          },
+        ]);
+        expect(useConfigStore.getState().committedGeneration).toBe(7);
+      });
+
+      it("keeps conflict guidance when a reload fails", async () => {
+        vi.mocked(fetch).mockResolvedValueOnce(
+          new Response("{}", { status: 409 }),
+        );
+        await save();
+        vi.mocked(fetch).mockRejectedValueOnce(
+          new Error("Network unavailable"),
+        );
+        await useConfigStore.getState().loadConfig();
+
+        expect(useConfigStore.getState().diagnostics).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({
+              code: "config_conflict",
+              message: conflictMessage,
+            }),
+          ]),
+        );
+        expect(useConfigStore.getState().committedGeneration).toBe(7);
       });
 
       it("ignores a conflict from a save superseded by a newer request", async () => {
@@ -215,6 +261,63 @@ describe("configStore", () => {
       });
     },
   );
+
+  it("keeps a raw conflict after undoing edits and failing to reload", async () => {
+    useConfigStore.setState({
+      recoveryConfigSource: "agents: {}\n# draft\n",
+      recoveryConfigSourceOriginal: "agents: {}\n",
+      committedGeneration: 7,
+      isDirty: true,
+    });
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("{}", { status: 409 }));
+    await useConfigStore.getState().saveRecoveryConfigSource();
+    useConfigStore.getState().updateRecoveryConfigSource("agents: {}\n");
+    expect(useConfigStore.getState().isDirty).toBe(false);
+    vi.mocked(fetch).mockRejectedValueOnce(new Error("Network unavailable"));
+    await useConfigStore.getState().loadConfig();
+    expect(useConfigStore.getState().diagnostics).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "config_conflict" }),
+      ]),
+    );
+    useConfigStore
+      .getState()
+      .updateRecoveryConfigSource("agents: {}\n# retry\n");
+    expect(
+      (await useConfigStore.getState().saveRecoveryConfigSource()).status,
+    ).toBe("error");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("retains conflict guidance when an outstanding policy refresh finishes", async () => {
+    const config: Config = {
+      agents: {},
+      models: { default: { provider: "test", id: "draft" } },
+      memory: {
+        embedder: { provider: "test", config: { model: "test-embedder" } },
+      },
+      defaults: { markdown: true },
+      router: { model: "default" },
+    };
+    useConfigStore.setState({
+      config,
+      loadedConfig: config,
+      committedGeneration: 7,
+      isDirty: true,
+    });
+    const policies = deferred<Response>();
+    vi.mocked(fetch).mockReturnValueOnce(policies.promise);
+    const refresh = useConfigStore.getState().refreshAgentPolicies([]);
+    vi.mocked(fetch).mockResolvedValueOnce(new Response("{}", { status: 409 }));
+    await useConfigStore.getState().saveConfig();
+    policies.resolve(new Response(JSON.stringify({ agent_policies: {} })));
+    await refresh;
+
+    expect(useConfigStore.getState().diagnostics).toEqual([
+      expect.objectContaining({ code: "config_conflict" }),
+    ]);
+    expect(useConfigStore.getState().committedGeneration).toBe(7);
+  });
 
   describe("loadConfig", () => {
     it("should load configuration successfully", async () => {

--- a/frontend/src/store/configStore.ts
+++ b/frontend/src/store/configStore.ts
@@ -15,9 +15,10 @@ import {
   RoomDefaultsConfig,
 } from "@/types/config";
 import * as configService from "@/services/configService";
-import type {
-  ConfigDiagnostic,
-  ConfigValidationIssue,
+import {
+  isConfigConflictDiagnostic,
+  type ConfigDiagnostic,
+  type ConfigValidationIssue,
 } from "@/lib/configValidation";
 import {
   cloneToolEntries,
@@ -104,17 +105,15 @@ function retainedDraftDiagnostics(
     );
   });
 
-  if (diagnosticsContainValidationErrors(filteredDiagnostics)) {
-    return filteredDiagnostics.filter(
-      (diagnostic) =>
-        diagnostic.kind === "validation" ||
-        (diagnostic.kind === "global" &&
-          diagnostic.message === CONFIG_VALIDATION_FAILED_MESSAGE),
-    );
-  }
-
+  const hasValidationErrors =
+    diagnosticsContainValidationErrors(filteredDiagnostics);
   return filteredDiagnostics.filter(
-    (diagnostic) => diagnostic.kind === "validation",
+    (diagnostic) =>
+      diagnostic.kind === "validation" ||
+      isConfigConflictDiagnostic(diagnostic) ||
+      (hasValidationErrors &&
+        diagnostic.kind === "global" &&
+        diagnostic.message === CONFIG_VALIDATION_FAILED_MESSAGE),
   );
 }
 
@@ -162,11 +161,14 @@ function configConflictDiagnostics(
   blocking: boolean,
 ): ConfigDiagnostic[] {
   return [
-    ...globalDiagnostics(CONFIG_CONFLICT_MESSAGE, blocking),
+    {
+      kind: "global",
+      code: "config_conflict",
+      message: CONFIG_CONFLICT_MESSAGE,
+      blocking,
+    },
     ...retainedDraftDiagnostics(diagnostics).filter(
-      (diagnostic) =>
-        diagnostic.kind !== "global" ||
-        diagnostic.message !== CONFIG_CONFLICT_MESSAGE,
+      (diagnostic) => !isConfigConflictDiagnostic(diagnostic),
     ),
   ];
 }
@@ -729,7 +731,7 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
       isLoading: true,
       diagnostics: currentState.isDirty
         ? retainedDraftDiagnostics(currentState.diagnostics)
-        : [],
+        : currentState.diagnostics.filter(isConfigConflictDiagnostic),
       loadConfigRequestId,
     });
     try {
@@ -839,12 +841,15 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
           return;
         }
         if (recoveryConfigSourceError != null) {
-          const recoveryDiagnostics = globalDiagnostics(
-            recoveryConfigSourceError instanceof Error
-              ? recoveryConfigSourceError.message
-              : "Failed to load raw configuration",
-            true,
-          );
+          const recoveryDiagnostics = [
+            ...latestState.diagnostics.filter(isConfigConflictDiagnostic),
+            ...globalDiagnostics(
+              recoveryConfigSourceError instanceof Error
+                ? recoveryConfigSourceError.message
+                : "Failed to load raw configuration",
+              true,
+            ),
+          ];
           if (
             latestState.isDirty ||
             latestState.draftVersion != draftVersionAtStart
@@ -873,11 +878,14 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
           set({
             isLoading: false,
             syncStatus: "error",
-            diagnostics: validationDiagnostics(error.issues, {
-              blocking:
-                latestState.recoveryConfigSource != null &&
-                latestState.config == null,
-            }),
+            diagnostics: [
+              ...latestState.diagnostics.filter(isConfigConflictDiagnostic),
+              ...validationDiagnostics(error.issues, {
+                blocking:
+                  latestState.recoveryConfigSource != null &&
+                  latestState.config == null,
+              }),
+            ],
           });
           return;
         }
@@ -895,6 +903,7 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
       }
       set({
         diagnostics: [
+          ...get().diagnostics.filter(isConfigConflictDiagnostic),
           {
             kind: "global",
             message:
@@ -961,6 +970,10 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
       diagnostics,
       dirtyRoots,
     } = get();
+    const conflict = diagnostics.find(isConfigConflictDiagnostic);
+    if (conflict) {
+      return { status: "error", message: conflict.message, diagnostics };
+    }
     if (!config) {
       return {
         status: "error",
@@ -1263,6 +1276,10 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
       draftVersion,
       committedGeneration,
     } = get();
+    const conflict = diagnostics.find(isConfigConflictDiagnostic);
+    if (conflict) {
+      return { status: "error", message: conflict.message, diagnostics };
+    }
     if (recoveryConfigSource == null) {
       return {
         status: "error",

--- a/frontend/src/store/configStore.ts
+++ b/frontend/src/store/configStore.ts
@@ -31,6 +31,8 @@ import {
 
 const AGENT_POLICIES_ERROR_MESSAGE = "Failed to derive agent policies";
 const CONFIG_VALIDATION_FAILED_MESSAGE = "Configuration validation failed";
+const CONFIG_CONFLICT_MESSAGE =
+  "Configuration changed elsewhere. Your draft has not been saved. Copy any changes you want to keep, then refresh this page and reapply them.";
 
 export type SaveConfigResult =
   | { status: "saved" }
@@ -153,6 +155,20 @@ function firstGlobalDiagnosticMessage(
     diagnostics.find((diagnostic) => diagnostic.kind === "global")?.message ??
     fallbackMessage
   );
+}
+
+function configConflictDiagnostics(
+  diagnostics: ConfigDiagnostic[],
+  blocking: boolean,
+): ConfigDiagnostic[] {
+  return [
+    ...globalDiagnostics(CONFIG_CONFLICT_MESSAGE, blocking),
+    ...retainedDraftDiagnostics(diagnostics).filter(
+      (diagnostic) =>
+        diagnostic.kind !== "global" ||
+        diagnostic.message !== CONFIG_CONFLICT_MESSAGE,
+    ),
+  ];
 }
 
 function nextDraftVersion(draftVersion: number): number {
@@ -1144,16 +1160,25 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
         return { status: "stale" };
       }
       const currentState = get();
+      if (error instanceof configService.ConfigStaleError) {
+        const errorDiagnostics = configConflictDiagnostics(
+          currentState.diagnostics,
+          false,
+        );
+        set({
+          diagnostics: errorDiagnostics,
+          isLoading: false,
+          syncStatus: "error",
+        });
+        return {
+          status: "error",
+          message: CONFIG_CONFLICT_MESSAGE,
+          diagnostics: errorDiagnostics,
+        };
+      }
       const draftChangedSinceSaveStarted =
         currentState.draftVersion !== savedDraftVersion;
       if (draftChangedSinceSaveStarted) {
-        set({
-          isLoading: false,
-          syncStatus: draftSyncStatus(currentState),
-        });
-        return { status: "stale" };
-      }
-      if (error instanceof configService.ConfigStaleError) {
         set({
           isLoading: false,
           syncStatus: draftSyncStatus(currentState),
@@ -1317,16 +1342,25 @@ export const useConfigStore = create<ConfigState>((set, get) => ({
         return { status: "stale" };
       }
       const currentState = get();
+      if (error instanceof configService.ConfigStaleError) {
+        const errorDiagnostics = configConflictDiagnostics(
+          currentState.diagnostics,
+          true,
+        );
+        set({
+          diagnostics: errorDiagnostics,
+          isLoading: false,
+          syncStatus: "error",
+        });
+        return {
+          status: "error",
+          message: CONFIG_CONFLICT_MESSAGE,
+          diagnostics: errorDiagnostics,
+        };
+      }
       const draftChangedSinceSaveStarted =
         currentState.draftVersion !== savedDraftVersion;
       if (draftChangedSinceSaveStarted) {
-        set({
-          isLoading: false,
-          syncStatus: draftSyncStatus(currentState),
-        });
-        return { status: "stale" };
-      }
-      if (error instanceof configService.ConfigStaleError) {
         set({
           isLoading: false,
           syncStatus: draftSyncStatus(currentState),

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -742,6 +742,12 @@ The sync status indicator in the header shows:
 - **Sync Error** - Sync failed
 - **Disconnected** - Lost connection to backend
 
+If another dashboard tab or a server-side edit changes the configuration, saving an older draft can return HTTP 409.
+The dashboard keeps your draft and shows persistent recovery guidance, including in the raw configuration recovery editor.
+Copy any changes you want to keep, refresh the page to load the current configuration, then reapply and save your changes.
+Further save attempts are rejected locally while the conflict remains; editing the draft or refreshing agent policies does not resolve it.
+The dashboard does not automatically reload and retry a full replacement, because that could overwrite another writer's changes.
+
 ### Theme and Responsive Design
 
 Toggle between dark and light themes. The dashboard adapts to desktop and mobile devices.

--- a/skills/mindroom-docs/references/page__dashboard__index.md
+++ b/skills/mindroom-docs/references/page__dashboard__index.md
@@ -167,6 +167,12 @@ The sync status indicator in the header shows:
 - **Sync Error** - Sync failed
 - **Disconnected** - Lost connection to backend
 
+If another dashboard tab or a server-side edit changes the configuration, saving an older draft can return HTTP 409.
+The dashboard keeps your draft and shows persistent recovery guidance, including in the raw configuration recovery editor.
+Copy any changes you want to keep, refresh the page to load the current configuration, then reapply and save your changes.
+Further save attempts are rejected locally while the conflict remains; editing the draft or refreshing agent policies does not resolve it.
+The dashboard does not automatically reload and retry a full replacement, because that could overwrite another writer's changes.
+
 ### Theme and Responsive Design
 
 Toggle between dark and light themes. The dashboard adapts to desktop and mobile devices.


### PR DESCRIPTION
## Summary

When another dashboard tab or a server-side edit advances the configuration generation, an older tab's save is rejected with HTTP 409.
The dashboard now preserves the draft and shows persistent instructions to copy desired changes, refresh the page, and reapply them.

- Identify configuration conflicts with a stable diagnostic code and preserve them across edits, policy refreshes, and failed reloads, including when raw edits are undone.
- Reject further saves locally while a known conflict remains; never refresh the generation and retry a full replacement implicitly.
- Display raw-recovery conflict guidance alongside validation issues and keep failure toasts available on recovery screens.
- Give authentication failures priority over retained conflict warnings.
- Preserve superseded-request handling and document manual conflict recovery.

Fixes #1962.

## Validation

- Frontend suite: 526 passed, 1 skipped across 32 test files.
- Full Python suite: 15,686 passed, 22 skipped.
- Frontend lint, TypeScript checking, and production build passed.
- All repository pre-commit hooks passed except the pre-existing module-privacy finding for `LargeMessageStrategy` in `src/mindroom/config/models.py`.
- Chromium checks against a controlled generation-aware HTTP mock covered two-tab structured saves and raw recovery: HTTP 409 preserves the draft, guidance survives later edits, repeat saves send no HTTP request, the other writer's data remains intact, and refresh/reapply saves successfully.
- Independent source review approved the final changes.

Browser checks exercise the real frontend against mocked HTTP responses; no Matrix or LLM deployment was used for those checks.

