### PR TITLE
Keep MCP OAuth recovery off the event loop

### DIFF
--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -812,7 +812,7 @@ class MCPServerManager:
                 raise _MCPConfigurationChangedError
             self._require_configured_oauth_target(server_id, worker_target)
             if scope_key in self._retired_scope_keys:
-                raise await asyncio.to_thread(oauth_connection_required, credential_context)
+                raise oauth_connection_required(credential_context)
             state = self._scoped_states.get(key)
             if state is None:
                 state = MCPServerState(
@@ -826,7 +826,7 @@ class MCPServerManager:
 
         try:
             async with state.lock:
-                await self._require_current_request_state(
+                self._require_current_request_state(
                     key,
                     state,
                     credential_context=credential_context,
@@ -835,7 +835,7 @@ class MCPServerManager:
                     base_state,
                     credential_context=credential_context,
                 )
-                await self._require_current_request_state(
+                self._require_current_request_state(
                     key,
                     state,
                     credential_context=credential_context,
@@ -861,7 +861,7 @@ class MCPServerManager:
             session_key=key,
         )
 
-    async def _require_current_request_state(
+    def _require_current_request_state(
         self,
         key: _MCPSessionKey,
         state: MCPServerState,
@@ -870,7 +870,7 @@ class MCPServerManager:
     ) -> None:
         """Distinguish reset retirement from ordinary config-generation replacement."""
         if key.oauth_scope_key in self._retired_scope_keys:
-            raise await asyncio.to_thread(oauth_connection_required, credential_context)
+            raise oauth_connection_required(credential_context)
         if state.retired or self._scoped_states.get(key) is not state:
             raise _MCPConfigurationChangedError
 
@@ -1883,13 +1883,10 @@ class MCPServerManager:
         if not rejected:
             return None
         await self._validate_authoritative_oauth_lease(state, authorization_lease)
-        rejection = await asyncio.to_thread(
-            oauth_connection_required,
+        return oauth_connection_required(
             authorization_lease.credential_context,
             reason=OAUTH_ACCESS_REJECTED_REASON,
         )
-        await self._validate_authoritative_oauth_lease(state, authorization_lease)
-        return rejection
 
     async def _post_dispatch_oauth_rejection(
         self,

--- a/src/mindroom/mcp/manager.py
+++ b/src/mindroom/mcp/manager.py
@@ -720,15 +720,27 @@ class MCPServerManager:
                 provider_id=provider.id,
                 server_id=state.server_id,
             )
-            raise oauth_connection_required(context, reason=OAUTH_RESET_REQUIRED_REASON) from exc
+            raise await asyncio.to_thread(
+                oauth_connection_required,
+                context,
+                reason=OAUTH_RESET_REQUIRED_REASON,
+            ) from exc
         except OAuthProviderError as exc:
             failed_credentials = (await load_oauth_credentials_snapshot(context)).credentials
             self._log_oauth_refresh_failure(state, provider.id, failed_credentials or {}, exc)
             if isinstance(exc, OAuthRefreshRejectedError):
-                raise oauth_connection_required(context, reason=OAUTH_REFRESH_REJECTED_REASON) from exc
-            raise oauth_connection_required(context, reason=OAUTH_REFRESH_FAILED_REASON) from None
+                raise await asyncio.to_thread(
+                    oauth_connection_required,
+                    context,
+                    reason=OAUTH_REFRESH_REJECTED_REASON,
+                ) from exc
+            raise await asyncio.to_thread(
+                oauth_connection_required,
+                context,
+                reason=OAUTH_REFRESH_FAILED_REASON,
+            ) from None
         if not oauth_credentials_usable(provider, self.runtime_paths, credentials):
-            raise oauth_connection_required(context)
+            raise await asyncio.to_thread(oauth_connection_required, context)
         assert credentials is not None
         if refresh_result.refreshed:
             logger.info(
@@ -739,7 +751,7 @@ class MCPServerManager:
             )
         token = credentials.get("token") or credentials.get("access_token")
         if not isinstance(token, str) or not token:
-            raise oauth_connection_required(context)
+            raise await asyncio.to_thread(oauth_connection_required, context)
         return token, refresh_result.generation
 
     async def _request_state_and_headers(
@@ -800,7 +812,7 @@ class MCPServerManager:
                 raise _MCPConfigurationChangedError
             self._require_configured_oauth_target(server_id, worker_target)
             if scope_key in self._retired_scope_keys:
-                raise oauth_connection_required(credential_context)
+                raise await asyncio.to_thread(oauth_connection_required, credential_context)
             state = self._scoped_states.get(key)
             if state is None:
                 state = MCPServerState(
@@ -814,7 +826,7 @@ class MCPServerManager:
 
         try:
             async with state.lock:
-                self._require_current_request_state(
+                await self._require_current_request_state(
                     key,
                     state,
                     credential_context=credential_context,
@@ -823,7 +835,7 @@ class MCPServerManager:
                     base_state,
                     credential_context=credential_context,
                 )
-                self._require_current_request_state(
+                await self._require_current_request_state(
                     key,
                     state,
                     credential_context=credential_context,
@@ -839,7 +851,7 @@ class MCPServerManager:
                         state.last_error = None
                         state.stale = True
                         state.oauth_lease_version = lease_version
-        except OAuthConnectionRequired:
+        except (OAuthConnectionRequired, asyncio.CancelledError):
             await run_coroutine_until_complete(self._disconnect_rejected_oauth_scope_state(key, state))
             raise
         return state, _MCPAuthorizationLease(
@@ -849,7 +861,7 @@ class MCPServerManager:
             session_key=key,
         )
 
-    def _require_current_request_state(
+    async def _require_current_request_state(
         self,
         key: _MCPSessionKey,
         state: MCPServerState,
@@ -858,7 +870,7 @@ class MCPServerManager:
     ) -> None:
         """Distinguish reset retirement from ordinary config-generation replacement."""
         if key.oauth_scope_key in self._retired_scope_keys:
-            raise oauth_connection_required(credential_context)
+            raise await asyncio.to_thread(oauth_connection_required, credential_context)
         if state.retired or self._scoped_states.get(key) is not state:
             raise _MCPConfigurationChangedError
 
@@ -1871,10 +1883,13 @@ class MCPServerManager:
         if not rejected:
             return None
         await self._validate_authoritative_oauth_lease(state, authorization_lease)
-        return oauth_connection_required(
+        rejection = await asyncio.to_thread(
+            oauth_connection_required,
             authorization_lease.credential_context,
             reason=OAUTH_ACCESS_REJECTED_REASON,
         )
+        await self._validate_authoritative_oauth_lease(state, authorization_lease)
+        return rejection
 
     async def _post_dispatch_oauth_rejection(
         self,

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -627,6 +627,60 @@ async def test_mcp_reconnect_link_does_not_block_event_loop(
 
 
 @pytest.mark.asyncio
+async def test_cancelled_reconnect_link_evicts_rejected_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cancellation during link construction still closes the rejected bearer session."""
+    _patch_manager(monkeypatch)
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(runtime_paths, worker_target, "stale-token")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    cached_session = _FakeClientSession.sessions[-1]
+    loop = asyncio.get_running_loop()
+    link_started = asyncio.Event()
+    release_link = threading.Event()
+    build_link = mcp_manager_module.oauth_connection_required
+
+    async def reject_refresh(_context: OAuthCredentialContext) -> object:
+        message = "dead refresh grant"
+        raise OAuthRefreshRejectedError(message, oauth_error=INVALID_GRANT)
+
+    def blocked_link(context: OAuthCredentialContext, *, reason: str) -> OAuthConnectionRequired:
+        loop.call_soon_threadsafe(link_started.set)
+        assert release_link.wait(timeout=5)
+        return build_link(context, reason=reason)
+
+    monkeypatch.setattr(mcp_manager_module, "refresh_oauth_credentials_with_result", reject_refresh)
+    monkeypatch.setattr(mcp_manager_module, "oauth_connection_required", blocked_link)
+    request = asyncio.create_task(
+        manager.get_request_catalog(
+            "demo",
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+        ),
+    )
+    try:
+        await asyncio.wait_for(link_started.wait(), timeout=5)
+        request.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+        assert cached_session.closed
+        assert not manager._scoped_states
+    finally:
+        release_link.set()
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
 async def test_mcp_manager_non_oauth_calls_use_shared_session_without_requester_credentials(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -1318,101 +1372,6 @@ async def test_mcp_discovery_http_401_returns_reconnect_and_evicts_requester_sta
     assert exc_info.value.reason == "access_rejected"
     assert manager._scoped_states == {}
     assert _FakeClientSession.sessions[0].closed is True
-
-
-@pytest.mark.asyncio
-async def test_mcp_rejection_rechecks_credentials_after_building_reconnect_link(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """A slow reconnect link must not retire credentials published while it was built."""
-    _patch_manager(monkeypatch)
-    runtime_paths = _runtime_paths(tmp_path)
-    worker_target = _worker_target("@alice:example.test")
-    _save_mcp_oauth_credentials(runtime_paths, worker_target, "old-token")
-    manager = MCPServerManager(runtime_paths)
-    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
-    state, lease = await manager._request_state_and_headers(
-        "demo",
-        credentials_manager=get_runtime_credentials_manager(runtime_paths),
-        worker_target=worker_target,
-    )
-    state.oauth_transport_authorization_rejected = lambda: True
-    build_link = mcp_manager_module.oauth_connection_required
-    loop = asyncio.get_running_loop()
-
-    def replace_credentials_while_building_link(
-        context: OAuthCredentialContext,
-        *,
-        reason: str,
-    ) -> OAuthConnectionRequired:
-        asyncio.run_coroutine_threadsafe(
-            _publish_oauth_credentials(context, {"token": "new-token"}),
-            loop,
-        ).result(timeout=5)
-        return build_link(context, reason=reason)
-
-    monkeypatch.setattr(mcp_manager_module, "oauth_connection_required", replace_credentials_while_building_link)
-    try:
-        with pytest.raises(_MCPAuthorizationChangedError):
-            await manager._oauth_transport_rejection(state, lease)
-        assert not state.retired
-    finally:
-        await manager.shutdown()
-
-
-@pytest.mark.asyncio
-async def test_cancelled_reconnect_link_evicts_rejected_session(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    """Cancellation during link construction still closes the rejected bearer session."""
-    _patch_manager(monkeypatch)
-    runtime_paths = _runtime_paths(tmp_path)
-    worker_target = _worker_target("@alice:example.test")
-    _save_mcp_oauth_credentials(runtime_paths, worker_target, "stale-token")
-    credentials_manager = get_runtime_credentials_manager(runtime_paths)
-    manager = MCPServerManager(runtime_paths)
-    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
-    await manager.get_request_catalog(
-        "demo",
-        credentials_manager=credentials_manager,
-        worker_target=worker_target,
-    )
-    cached_session = _FakeClientSession.sessions[-1]
-    loop = asyncio.get_running_loop()
-    link_started = asyncio.Event()
-    release_link = threading.Event()
-    build_link = mcp_manager_module.oauth_connection_required
-
-    async def reject_refresh(_context: OAuthCredentialContext) -> object:
-        message = "dead refresh grant"
-        raise OAuthRefreshRejectedError(message, oauth_error=INVALID_GRANT)
-
-    def blocked_link(context: OAuthCredentialContext, *, reason: str) -> OAuthConnectionRequired:
-        loop.call_soon_threadsafe(link_started.set)
-        assert release_link.wait(timeout=5)
-        return build_link(context, reason=reason)
-
-    monkeypatch.setattr(mcp_manager_module, "refresh_oauth_credentials_with_result", reject_refresh)
-    monkeypatch.setattr(mcp_manager_module, "oauth_connection_required", blocked_link)
-    request = asyncio.create_task(
-        manager.get_request_catalog(
-            "demo",
-            credentials_manager=credentials_manager,
-            worker_target=worker_target,
-        ),
-    )
-    try:
-        await asyncio.wait_for(link_started.wait(), timeout=5)
-        request.cancel()
-        with pytest.raises(asyncio.CancelledError):
-            await request
-        assert cached_session.closed
-        assert not manager._scoped_states
-    finally:
-        release_link.set()
-        await manager.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_manager.py
+++ b/tests/test_mcp_manager.py
@@ -23,6 +23,7 @@ from authlib.integrations.base_client.errors import OAuthError
 from mcp.types import CallToolResult, Implementation, ListToolsResult, Tool, ToolListChangedNotification
 
 import mindroom.mcp.manager as mcp_manager_module
+import mindroom.oauth.service as oauth_service_module
 from mindroom.agents import create_agent
 from mindroom.config.auth import AuthorizationConfig
 from mindroom.config.main import Config
@@ -78,6 +79,7 @@ if TYPE_CHECKING:
     from mindroom.constants import RuntimePaths
     from mindroom.mcp.manager import _MCPAuthorizationLease
     from mindroom.mcp.types import MCPServerCatalog
+    from mindroom.oauth.credential_lifecycle import OAuthCredentialsSnapshot
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, WorkerScope
 
 
@@ -589,6 +591,39 @@ async def test_mcp_manager_enforces_call_filters_before_remote_dispatch(
         )
 
     assert _FakeClientSession.call_tool_invocation_count == 0
+
+
+@pytest.mark.asyncio
+async def test_mcp_reconnect_link_does_not_block_event_loop(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A blocked credential snapshot must not stop unrelated loop callbacks."""
+    runtime_paths = _runtime_paths(tmp_path)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    loop = asyncio.get_running_loop()
+    snapshot = oauth_service_module.load_oauth_credentials_snapshot_sync
+
+    def snapshot_waiting_for_loop(context: OAuthCredentialContext) -> OAuthCredentialsSnapshot:
+        loop_progress = threading.Event()
+        loop.call_soon_threadsafe(loop_progress.set)
+        assert loop_progress.wait(timeout=1), "Reconnect link blocked the event loop"
+        return snapshot(context)
+
+    monkeypatch.setattr(oauth_service_module, "load_oauth_credentials_snapshot_sync", snapshot_waiting_for_loop)
+    try:
+        with pytest.raises(OAuthConnectionRequired) as exc_info:
+            await manager.get_request_catalog(
+                "demo",
+                credentials_manager=get_runtime_credentials_manager(runtime_paths),
+                worker_target=_worker_target("@alice:example.test"),
+            )
+        payload = oauth_connection_required_payload(exc_info.value)
+        assert payload["provider"] == "mcp_demo"
+        assert "connect_token=" in str(payload["connect_url"])
+    finally:
+        await manager.shutdown()
 
 
 @pytest.mark.asyncio
@@ -1283,6 +1318,101 @@ async def test_mcp_discovery_http_401_returns_reconnect_and_evicts_requester_sta
     assert exc_info.value.reason == "access_rejected"
     assert manager._scoped_states == {}
     assert _FakeClientSession.sessions[0].closed is True
+
+
+@pytest.mark.asyncio
+async def test_mcp_rejection_rechecks_credentials_after_building_reconnect_link(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """A slow reconnect link must not retire credentials published while it was built."""
+    _patch_manager(monkeypatch)
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(runtime_paths, worker_target, "old-token")
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    state, lease = await manager._request_state_and_headers(
+        "demo",
+        credentials_manager=get_runtime_credentials_manager(runtime_paths),
+        worker_target=worker_target,
+    )
+    state.oauth_transport_authorization_rejected = lambda: True
+    build_link = mcp_manager_module.oauth_connection_required
+    loop = asyncio.get_running_loop()
+
+    def replace_credentials_while_building_link(
+        context: OAuthCredentialContext,
+        *,
+        reason: str,
+    ) -> OAuthConnectionRequired:
+        asyncio.run_coroutine_threadsafe(
+            _publish_oauth_credentials(context, {"token": "new-token"}),
+            loop,
+        ).result(timeout=5)
+        return build_link(context, reason=reason)
+
+    monkeypatch.setattr(mcp_manager_module, "oauth_connection_required", replace_credentials_while_building_link)
+    try:
+        with pytest.raises(_MCPAuthorizationChangedError):
+            await manager._oauth_transport_rejection(state, lease)
+        assert not state.retired
+    finally:
+        await manager.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_reconnect_link_evicts_rejected_session(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Cancellation during link construction still closes the rejected bearer session."""
+    _patch_manager(monkeypatch)
+    runtime_paths = _runtime_paths(tmp_path)
+    worker_target = _worker_target("@alice:example.test")
+    _save_mcp_oauth_credentials(runtime_paths, worker_target, "stale-token")
+    credentials_manager = get_runtime_credentials_manager(runtime_paths)
+    manager = MCPServerManager(runtime_paths)
+    await manager.sync_servers(_ConfigStub({"demo": _oauth_mcp_config()}))
+    await manager.get_request_catalog(
+        "demo",
+        credentials_manager=credentials_manager,
+        worker_target=worker_target,
+    )
+    cached_session = _FakeClientSession.sessions[-1]
+    loop = asyncio.get_running_loop()
+    link_started = asyncio.Event()
+    release_link = threading.Event()
+    build_link = mcp_manager_module.oauth_connection_required
+
+    async def reject_refresh(_context: OAuthCredentialContext) -> object:
+        message = "dead refresh grant"
+        raise OAuthRefreshRejectedError(message, oauth_error=INVALID_GRANT)
+
+    def blocked_link(context: OAuthCredentialContext, *, reason: str) -> OAuthConnectionRequired:
+        loop.call_soon_threadsafe(link_started.set)
+        assert release_link.wait(timeout=5)
+        return build_link(context, reason=reason)
+
+    monkeypatch.setattr(mcp_manager_module, "refresh_oauth_credentials_with_result", reject_refresh)
+    monkeypatch.setattr(mcp_manager_module, "oauth_connection_required", blocked_link)
+    request = asyncio.create_task(
+        manager.get_request_catalog(
+            "demo",
+            credentials_manager=credentials_manager,
+            worker_target=worker_target,
+        ),
+    )
+    try:
+        await asyncio.wait_for(link_started.wait(), timeout=5)
+        request.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await request
+        assert cached_session.closed
+        assert not manager._scoped_states
+    finally:
+        release_link.set()
+        await manager.shutdown()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Reconnect-link construction synchronously waits for a credential snapshot. Offload the five credential-refresh recovery paths so expired or missing grants cannot block unrelated requests. Preserve rejected-session cleanup on cancellation.

Transport-rejection and retired-scope handling stay unchanged; their locking needs a separate change.

Validation: 15,816 tests passed, 22 skipped; all pre-commit checks passed. Regression tests cover event-loop responsiveness and cancellation cleanup. Independently reviewed.