### PR TITLE
Preserve scoped OAuth credentials across requester-key upgrades

### DIFF
--- a/src/mindroom/oauth/credential_store.py
+++ b/src/mindroom/oauth/credential_store.py
@@ -538,7 +538,11 @@ def _compatible_legacy_worker_key(
     context: _OAuthCredentialStoreContext,
     connection: sqlite3.Connection,
 ) -> str | None:
-    """Accept a lossless old requester spelling only in its canonical primary-runtime store."""
+    """Read legacy requester bindings at stable raw-identity paths without migrating them.
+
+    The requester encoding upgrade changed worker keys but left these stores in place.
+    Accept only lossless legacy spellings and retain the stored binding for rollback.
+    """
     target = context.worker_target
     manager = context.credentials_manager
     if (

--- a/src/mindroom/oauth/credential_store.py
+++ b/src/mindroom/oauth/credential_store.py
@@ -4,24 +4,28 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import secrets
 import sqlite3
 import stat
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 from cryptography.exceptions import InvalidTag
 
+from mindroom.credential_policy import is_oauth_token_service
 from mindroom.credentials import scoped_credentials_path
 from mindroom.durable_write import fsync_directory_durable
 from mindroom.logging_config import get_logger
 from mindroom.oauth.providers import OAuthProviderError
+from mindroom.tool_system.worker_routing import resolve_worker_target
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Mapping
-    from pathlib import Path
 
+    from mindroom.constants import RuntimePaths
     from mindroom.credentials import CredentialsManager
     from mindroom.oauth.providers import OAuthProvider
     from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
@@ -42,6 +46,9 @@ class OAuthCredentialUnreadableError(OAuthProviderError):
 
 class _OAuthCredentialStoreContext(Protocol):
     """Fields the store needs from the lifecycle's canonical scope."""
+
+    @property
+    def runtime_paths(self) -> RuntimePaths: ...
 
     @property
     def provider(self) -> OAuthProvider: ...
@@ -403,7 +410,7 @@ async def _initialize_store(
         if legacy.present:
             legacy_adoption = legacy
     else:
-        _validate_scope_binding(context, row)
+        _validate_scope_binding(context, connection, row)
         legacy_adoption = _adopt_deferred_legacy_payload(context, connection, row)
     legacy_cleanup_deferred = _legacy_cleanup_must_be_deferred(connection)
     await _commit_connection(connection)
@@ -507,15 +514,69 @@ def _validate_initialized_store(
     if stored_row is None:
         msg = "OAuth credential store state is missing"
         raise OAuthProviderError(msg)
-    _validate_scope_binding(context, stored_row)
+    _validate_scope_binding(context, connection, stored_row)
 
 
-def _validate_scope_binding(context: _OAuthCredentialStoreContext, row: sqlite3.Row) -> None:
+def _validate_scope_binding(
+    context: _OAuthCredentialStoreContext,
+    connection: sqlite3.Connection,
+    row: sqlite3.Row,
+) -> None:
     expected_binding = _scope_binding(context)
     actual_binding = {key: str(row[key]) for key in expected_binding}
+    if actual_binding == expected_binding:
+        return
+    legacy_key = _compatible_legacy_worker_key(context, connection)
+    if legacy_key is not None:
+        expected_binding["worker_key"] = legacy_key
     if actual_binding != expected_binding:
         msg = "OAuth credential store belongs to a different credential scope"
         raise OAuthProviderError(msg)
+
+
+def _compatible_legacy_worker_key(
+    context: _OAuthCredentialStoreContext,
+    connection: sqlite3.Connection,
+) -> str | None:
+    """Accept a lossless old requester spelling only in its canonical primary-runtime store."""
+    target = context.worker_target
+    manager = context.credentials_manager
+    if (
+        target is None
+        or target.worker_scope not in {"user", "user_agent"}
+        or not is_oauth_token_service(context.provider.credential_service)
+        or manager.current_worker_key is not None
+        or manager.storage_root != context.runtime_paths.storage_root
+    ):
+        return None
+    identity = target.execution_identity
+    if identity is None or not identity.requester_id:
+        return None
+    requester = identity.requester_id
+    legacy_requester = re.sub(r"[^a-zA-Z0-9._:@+-]+", "_", requester.strip()).strip("_") or "default"
+    if legacy_requester != requester:
+        return None
+    canonical_target = resolve_worker_target(
+        target.worker_scope,
+        target.routing_agent_name,
+        execution_identity=identity,
+        private_agent_names=target.private_agent_names,
+    )
+    if canonical_target != target:
+        return None
+    # Raw requester/agent hashes own legacy stores; never search or adopt worker directories.
+    # Old bindings cannot distinguish a misfiled database from a colliding legacy identity.
+    credential_path = _legacy_credential_path(context)
+    canonical_path = credential_path.with_name(f"{credential_path.stem}.sqlite3")
+    database_path = next(row[2] for row in connection.execute("PRAGMA database_list") if row[1] == "main")
+    if Path(database_path).absolute() != canonical_path.absolute():
+        return None
+    assert canonical_target.worker_key is not None
+    return canonical_target.worker_key.replace(
+        f":{target.worker_scope}:~{requester}",
+        f":{target.worker_scope}:{requester}",
+        1,
+    )
 
 
 async def _commit_connection(connection: sqlite3.Connection) -> None:

--- a/tach.toml
+++ b/tach.toml
@@ -753,6 +753,8 @@ visibility = [
 [[modules]]
 path = "mindroom.oauth.credential_store"
 depends_on = [
+    "mindroom.credential_policy",
+    "mindroom.tool_system.worker_routing",
     "mindroom.credentials",
     "mindroom.logging_config",
     "mindroom.oauth.providers",

--- a/tests/test_oauth_credential_store.py
+++ b/tests/test_oauth_credential_store.py
@@ -9,6 +9,7 @@ import os
 import shutil
 import sqlite3
 import stat
+from dataclasses import replace
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
 from unittest.mock import patch
@@ -31,7 +32,7 @@ from mindroom.tool_system.worker_routing import ToolExecutionIdentity, resolve_w
 if TYPE_CHECKING:
     from multiprocessing.synchronize import Barrier, Event
 
-    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget, WorkerScope
 
 
 class _Provider:
@@ -296,6 +297,232 @@ async def test_copied_database_is_rejected_by_scope_binding(tmp_path: Path) -> N
     with pytest.raises(OAuthProviderError, match="different credential scope"):
         async with oauth_credential_transaction(bob):
             pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("worker_scope", ["user", "user_agent"])
+@pytest.mark.parametrize(
+    ("tenant_id", "account_id", "legacy_tenant"),
+    [(None, None, "default"), ("tenant", "account", "tenant"), (None, "account", "account")],
+)
+async def test_requester_key_upgrade_preserves_primary_runtime_oauth_credentials(
+    tmp_path: Path,
+    worker_scope: WorkerScope,
+    tenant_id: str | None,
+    account_id: str | None,
+    legacy_tenant: str,
+) -> None:
+    """Previously stored credentials remain readable after requester key encoding changes."""
+    context = _context(tmp_path, requester_id="@alice:example.org")
+    assert context.worker_target is not None
+    assert context.worker_target.execution_identity is not None
+    identity = replace(
+        context.worker_target.execution_identity,
+        agent_name="transport",
+        tenant_id=tenant_id,
+        account_id=account_id,
+    )
+    target = resolve_worker_target(worker_scope, "assistant", identity)
+    context = replace(context, worker_target=target)
+    legacy_key = f"v1:{legacy_tenant}:{worker_scope}:@alice:example.org"
+    if worker_scope == "user_agent":
+        legacy_key += ":assistant"
+    legacy_context = replace(context, worker_target=replace(target, worker_key=legacy_key))
+    generations = await _publish(legacy_context, "existing-access")
+    database_path = _oauth_credential_database_path(legacy_context)
+    assert database_path == _oauth_credential_database_path(context)
+    original_bytes = database_path.read_bytes()
+
+    async with oauth_credential_reader(context) as reader:
+        snapshot = reader.snapshot()
+        assert snapshot.credentials == {"token": "existing-access", "refresh_token": "refresh-existing-access"}
+        assert (snapshot.generation, snapshot.connection_generation) == generations
+
+    assert database_path.read_bytes() == original_bytes
+    async with oauth_credential_transaction(context) as transaction:
+        assert transaction.snapshot().credentials == snapshot.credentials
+        await transaction.commit()
+    assert database_path.read_bytes() == original_bytes
+    async with oauth_credential_reader(legacy_context) as reader:
+        assert reader.snapshot().credentials == snapshot.credentials
+    async with oauth_credential_transaction(context) as transaction:
+        refreshed = transaction.publish({"token": "refreshed"}, advance_connection_generation=False)
+        assert refreshed.generation != generations[0]
+        assert refreshed.connection_generation == generations[1]
+        await transaction.commit()
+    async with oauth_credential_reader(legacy_context) as reader:
+        assert reader.snapshot().credentials == {"token": "refreshed"}
+    async with oauth_credential_transaction(context) as transaction:
+        assert transaction.reset("reset-upgraded")
+        await transaction.commit()
+    async with oauth_credential_reader(legacy_context) as reader:
+        assert reader.snapshot().credentials is None
+
+
+async def _assert_scope_rejected(context: OAuthCredentialContext) -> None:
+    for open_store in (oauth_credential_reader, oauth_credential_transaction):
+        with pytest.raises(OAuthProviderError, match="different credential scope"):
+            async with open_store(context):
+                pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("provider_id", "other_provider"),
+        ("credential_service", "other_oauth"),
+        ("routing_agent_name", "other_agent"),
+        ("worker_scope", "user_agent"),
+        ("worker_key", "v1:tenant:user:@bob:example.test"),
+        ("worker_key", "v1:other:user:@alice:example.test"),
+        ("worker_key", "v1:tenant:user_agent:@alice:example.test:code"),
+        ("worker_key", "v2:tenant:user:@alice:example.test"),
+        ("worker_key", "v1:tenant:user:~~@alice:example.test"),
+        ("worker_key", "v1:tenant:user:~%40alice:example.test"),
+        ("worker_key", "v1:tenant:user:~@bob:example.test"),
+    ],
+)
+async def test_legacy_binding_compatibility_rejects_other_scopes(
+    tmp_path: Path,
+    field: str,
+    value: str,
+) -> None:
+    """Legacy spelling never exempts other stored scope fields from validation."""
+    context = _context(tmp_path)
+    assert context.worker_target is not None
+    legacy = replace(
+        context,
+        worker_target=replace(context.worker_target, worker_key="v1:tenant:user:@alice:example.test"),
+    )
+    await _publish(legacy, "existing")
+    with sqlite3.connect(_oauth_credential_database_path(context)) as connection:
+        connection.execute(f"UPDATE oauth_credential_state SET {field} = ? WHERE singleton = 1", (value,))  # noqa: S608
+    await _assert_scope_rejected(context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("requester", "legacy_requester"),
+    [
+        ("alice/foo", "alice_foo"),
+        (" alice ", "alice"),
+        ("_alice", "alice"),
+        ("alice_", "alice"),
+        ("alice%foo", "alice_foo"),
+        ("~alice", "alice"),
+        ("álîce", "l_ce"),
+    ],
+)
+async def test_legacy_binding_compatibility_rejects_lossy_requesters(
+    tmp_path: Path,
+    requester: str,
+    legacy_requester: str,
+) -> None:
+    """A requester that legacy normalization changed must not use compatibility."""
+    context = _context(tmp_path, requester_id=requester)
+    assert context.worker_target is not None
+    legacy = replace(
+        context,
+        worker_target=replace(context.worker_target, worker_key=f"v1:tenant:user:{legacy_requester}"),
+    )
+    await _publish(legacy, "existing")
+    await _assert_scope_rejected(context)
+
+
+@pytest.mark.asyncio
+async def test_legacy_requester_collision_keeps_distinct_raw_identity_paths(tmp_path: Path) -> None:
+    """Lossless upgrade reads its own raw-identity store without importing a colliding store."""
+    lossy = _context(tmp_path, requester_id="alice/foo")
+    lossless = _context(tmp_path, requester_id="alice_foo")
+    for context, token in ((lossy, "lossy"), (lossless, "lossless")):
+        assert context.worker_target is not None
+        legacy = replace(
+            context,
+            worker_target=replace(context.worker_target, worker_key="v1:tenant:user:alice_foo"),
+        )
+        await _publish(legacy, token)
+    assert _oauth_credential_database_path(lossy) != _oauth_credential_database_path(lossless)
+    await _assert_scope_rejected(lossy)
+    async with oauth_credential_reader(lossless) as reader:
+        assert reader.snapshot().credentials == {"token": "lossless", "refresh_token": "refresh-lossless"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_target", ["worker_key", "tenant_id", "account_id"])
+async def test_legacy_binding_compatibility_requires_canonical_current_target(
+    tmp_path: Path,
+    invalid_target: str,
+) -> None:
+    """Forged current keys and inconsistent identity metadata cannot authorize legacy access."""
+    context = _context(tmp_path)
+    assert context.worker_target is not None
+    legacy = replace(
+        context,
+        worker_target=replace(context.worker_target, worker_key="v1:tenant:user:@alice:example.test"),
+    )
+    await _publish(legacy, "existing")
+    target = replace(context.worker_target, **{invalid_target: "other"})
+    await _assert_scope_rejected(replace(context, worker_target=target))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("location", ["worker", "runtime", "database"])
+async def test_legacy_binding_compatibility_requires_primary_runtime_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    location: str,
+) -> None:
+    """Legacy access is limited to the current primary runtime's canonical database path."""
+    context = _context(tmp_path)
+    if location == "worker":
+        context = replace(context, credentials_manager=context.credentials_manager.for_worker("other-worker"))
+    assert context.worker_target is not None
+    legacy = replace(
+        context,
+        worker_target=replace(context.worker_target, worker_key="v1:tenant:user:@alice:example.test"),
+    )
+    await _publish(legacy, "existing")
+    if location == "runtime":
+        context = replace(context, runtime_paths=_runtime_paths(tmp_path / "other-runtime"))
+    elif location == "database":
+        original_path = _oauth_credential_database_path(context)
+        foreign_path = original_path.with_name("foreign.sqlite3")
+        shutil.copyfile(original_path, foreign_path)
+        monkeypatch.setattr(credential_store_module, "_oauth_credential_database_path", lambda _context: foreign_path)
+    await _assert_scope_rejected(context)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("unsupported", ["shared", "unscoped", "service"])
+async def test_legacy_binding_compatibility_rejects_unsupported_storage(
+    tmp_path: Path,
+    unsupported: str,
+) -> None:
+    """Shared, unscoped, and non-OAuth stores retain strict worker-key equality."""
+    context = _context(tmp_path)
+    assert context.worker_target is not None
+    if unsupported in {"shared", "unscoped"}:
+        target = resolve_worker_target(
+            "shared" if unsupported == "shared" else None,
+            "assistant",
+            context.worker_target.execution_identity,
+        )
+        context = replace(context, worker_target=target)
+    else:
+        provider = _Provider()
+        provider.credential_service = "demo_service"
+        context = replace(context, provider=cast("OAuthProvider", provider))
+    assert context.worker_target is not None
+    legacy = replace(
+        context,
+        worker_target=replace(context.worker_target, worker_key="v1:tenant:user:@alice:example.test"),
+    )
+    await _publish(legacy, "existing")
+    if unsupported == "service":
+        current_path = _oauth_credential_database_path(context)
+        shutil.copyfile(_oauth_credential_database_path(legacy), current_path)
+    await _assert_scope_rejected(context)
 
 
 @pytest.mark.asyncio

--- a/tests/test_oauth_credential_store.py
+++ b/tests/test_oauth_credential_store.py
@@ -494,6 +494,54 @@ async def test_legacy_binding_compatibility_requires_primary_runtime_path(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("parent_depth", [0, 1, 2])
+@pytest.mark.parametrize("destination", ["external", "same-runtime"])
+async def test_legacy_binding_rejects_redirected_scoped_directory(
+    tmp_path: Path,
+    parent_depth: int,
+    destination: str,
+) -> None:
+    """Symlinked credential directories cannot authorize a legacy store at another location."""
+    context = _context(tmp_path / "runtime")
+    assert context.worker_target is not None
+    legacy = replace(
+        context,
+        worker_target=replace(context.worker_target, worker_key="v1:tenant:user:@alice:example.test"),
+    )
+    await _publish(legacy, "external")
+    database_path = _oauth_credential_database_path(context)
+    redirected_directory = database_path.parents[parent_depth]
+    destination_root = tmp_path if destination == "external" else context.runtime_paths.storage_root
+    moved_directory = destination_root / "redirected-credentials"
+    redirected_directory.rename(moved_directory)
+    redirected_directory.symlink_to(moved_directory, target_is_directory=True)
+    original_bytes = database_path.read_bytes()
+
+    await _assert_scope_rejected(context)
+
+    assert database_path.read_bytes() == original_bytes
+
+
+@pytest.mark.asyncio
+async def test_legacy_binding_supports_configured_runtime_root_symlink(tmp_path: Path) -> None:
+    """Resolving a configured runtime root preserves its legitimate legacy credentials."""
+    runtime_root = tmp_path / "runtime"
+    runtime_root.mkdir()
+    runtime_alias = tmp_path / "runtime-alias"
+    runtime_alias.symlink_to(runtime_root, target_is_directory=True)
+    context = _context(runtime_alias)
+    assert context.runtime_paths.storage_root == runtime_root
+    assert context.worker_target is not None
+    legacy = replace(
+        context,
+        worker_target=replace(context.worker_target, worker_key="v1:tenant:user:@alice:example.test"),
+    )
+    await _publish(legacy, "existing")
+    async with oauth_credential_reader(context) as reader:
+        assert reader.snapshot().credentials == {"token": "existing", "refresh_token": "refresh-existing"}
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("unsupported", ["shared", "unscoped", "service"])
 async def test_legacy_binding_compatibility_rejects_unsupported_storage(
     tmp_path: Path,


### PR DESCRIPTION
Requester-key encoding changes left existing primary-runtime OAuth databases at their stable raw-identity paths while their stored worker keys retained the previous spelling, causing credential reads to fail with a scope mismatch.
This accepts the exact legacy spelling for lossless requesters in canonical primary-runtime `user` and `user_agent` OAuth stores, preserving the remaining binding checks and stored bytes.

Compatibility requires a canonical current target and database path and rejects lossy requesters, worker directories, other providers or scope metadata, and malformed keys.
Reads preserve generations and rollback compatibility; refreshed credentials and resets remain readable through the legacy binding.
The canonical raw-identity path remains the legacy ownership authority: normalization already erased distinctions between collision-equivalent identities, so misfiled legacy databases cannot retrospectively prove their original requester from the binding alone.

Validation includes real SQLite upgrade regressions for both requester scopes, scope and path rejection cases, OAuth lifecycle and Google Drive tests, import boundaries, full pytest, and all repository pre-commit hooks.
Independent security review found no blocking issues within this ownership model.

## Summary by Sourcery

Preserve scoped OAuth credentials across requester-key upgrades while maintaining strict ownership and scope validation.

Bug Fixes:
- Preserve access to existing primary-runtime OAuth credentials after requester-key encoding changes by accepting the exact lossless legacy worker-key spelling.
- Keep refreshed credentials, resets, generations, and rollback-compatible reads available through legacy bindings.

Enhancements:
- Restrict legacy binding compatibility to canonical primary-runtime OAuth stores and retain all other scope, identity, provider, and path validation.
- Reject lossy requester identities, noncanonical targets, redirected directories, worker stores, unsupported scopes, and non-OAuth providers.

Tests:
- Add SQLite-backed regression coverage for user and user-agent credential upgrades, lifecycle operations, collision handling, path validation, symlink protection, and unsupported scope cases.

Chores:
- Update module dependency declarations for credential policy and worker-routing integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth credential-store compatibility for legacy credential databases, allowing them to remain readable and writable with current key encoding.
  * Added stricter validation for credential scope and worker identity, rejecting mismatched, forged, non-primary, or unsupported storage targets.
  * Preserved compatibility only for narrowly defined legacy worker-key formats when all identity and path checks pass.
  * Prevented redirected credential directories from bypassing legacy-access validation while preserving valid runtime-root configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->