### PR TITLE
Avoid automatic Git maintenance during knowledge polling

### DIFF
--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -793,8 +793,10 @@ class GitKnowledgeSource:
         before_head = await self._rev_parse("HEAD")
 
         remote_ref = f"origin/{git_config.branch}"
+        # Automatic maintenance can detach and outlive the refresh supervisor.
+        # Keep repository repacking out of knowledge polling.
         await self._run_git(
-            ["fetch", "origin", f"+refs/heads/{git_config.branch}:refs/remotes/{remote_ref}"],
+            ["fetch", "--no-auto-maintenance", "origin", f"+refs/heads/{git_config.branch}:refs/remotes/{remote_ref}"],
             env=await _resolved_git_auth_env(
                 git_config.repo_url,
                 git_config.credentials_service,

--- a/src/mindroom/knowledge/git_source.py
+++ b/src/mindroom/knowledge/git_source.py
@@ -796,7 +796,7 @@ class GitKnowledgeSource:
         # Automatic maintenance can detach and outlive the refresh supervisor.
         # Keep repository repacking out of knowledge polling.
         await self._run_git(
-            ["fetch", "--no-auto-maintenance", "origin", f"+refs/heads/{git_config.branch}:refs/remotes/{remote_ref}"],
+            ["fetch", "--no-auto-gc", "origin", f"+refs/heads/{git_config.branch}:refs/remotes/{remote_ref}"],
             env=await _resolved_git_auth_env(
                 git_config.repo_url,
                 git_config.credentials_service,

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -1451,6 +1451,54 @@ async def test_refresh_recovers_orphaned_index_lock_in_linked_worktree(tmp_path:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("advance_remote", [False, True])
+async def test_git_sync_does_not_run_automatic_maintenance(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    advance_remote: bool,
+) -> None:
+    """Real Git polling must not launch automatic maintenance beside knowledge refresh."""
+    remote = tmp_path / "remote"
+    remote.mkdir()
+
+    async def git(cwd: Path, *args: str) -> None:
+        await asyncio.to_thread(subprocess.run, ["git", *args], cwd=cwd, check=True, capture_output=True)
+
+    await git(remote, "init", "-b", "main")
+    await git(remote, "config", "user.email", "tests@example.com")
+    await git(remote, "config", "user.name", "MindRoom Tests")
+    await git(remote, "config", "commit.gpgsign", "false")
+
+    async def commit(content: str) -> None:
+        (remote / "doc.md").write_text(content, encoding="utf-8")
+        await git(remote, "add", "doc.md")
+        await git(remote, "commit", "-m", content)
+
+    await commit("initial")
+    docs = tmp_path / "docs"
+    git_config = KnowledgeGitConfig(repo_url=str(remote), branch="main")
+    config = _config(tmp_path, bases={"docs": docs}, agent_bases=["docs"], git_configs={"docs": git_config})
+    manager = KnowledgeManager("docs", config=config, runtime_paths=runtime_paths_for(config))
+    await manager.git_source.sync()
+    await git(docs, "config", "maintenance.auto", "true")
+    if advance_remote:
+        await commit("updated")
+    trace = tmp_path / "git-trace.jsonl"
+    monkeypatch.setenv("GIT_TRACE2_EVENT", str(trace))
+    result = await manager.git_source.sync()
+
+    events = [json.loads(line) for line in trace.read_text(encoding="utf-8").splitlines()]
+    maintenance = [
+        event
+        for event in events
+        if event.get("event") == "child_start" and event.get("argv", [])[:3] == ["git", "maintenance", "run"]
+    ]
+    assert not maintenance, "Knowledge polling launched automatic maintenance"
+    assert result.updated is advance_remote
+    assert (docs / "doc.md").read_text(encoding="utf-8") == ("updated" if advance_remote else "initial")
+
+
+@pytest.mark.asyncio
 async def test_sync_git_source_once_unchanged_head_skips_worktree_scan(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -1485,7 +1533,7 @@ async def test_sync_git_source_once_unchanged_head_skips_worktree_scan(
     assert updated is False
     assert changed_files == set()
     assert removed_files == set()
-    assert ["fetch", "origin", "+refs/heads/main:refs/remotes/origin/main"] in git_calls
+    assert ["fetch", "--no-auto-maintenance", "origin", "+refs/heads/main:refs/remotes/origin/main"] in git_calls
     assert ["lfs", "pull", "origin", "main"] in git_calls
     assert not any(call[:3] == ["diff", "--name-only", "--no-renames"] for call in git_calls)
 

--- a/tests/test_knowledge_git_source.py
+++ b/tests/test_knowledge_git_source.py
@@ -1533,7 +1533,7 @@ async def test_sync_git_source_once_unchanged_head_skips_worktree_scan(
     assert updated is False
     assert changed_files == set()
     assert removed_files == set()
-    assert ["fetch", "--no-auto-maintenance", "origin", "+refs/heads/main:refs/remotes/origin/main"] in git_calls
+    assert ["fetch", "--no-auto-gc", "origin", "+refs/heads/main:refs/remotes/origin/main"] in git_calls
     assert ["lfs", "pull", "origin", "main"] in git_calls
     assert not any(call[:3] == ["diff", "--name-only", "--no-renames"] for call in git_calls)
 


### PR DESCRIPTION
Knowledge polling now disables fetch-triggered automatic maintenance so detached maintenance processes cannot outlive the refresh supervisor.
Fetch still updates the configured remote branch, preserves unchanged-head behavior, and continues the existing LFS pull path.
Persistent checkouts should receive separately supervised maintenance when needed.
Validation includes real Git regression coverage for unchanged and advancing remotes, all 49 Git-source tests, and repository hooks.

## Summary by Sourcery

Disable Git automatic maintenance during knowledge polling while preserving remote synchronization behavior.

Bug Fixes:
- Prevent knowledge polling from launching Git automatic maintenance processes that could outlive the refresh supervisor.

Enhancements:
- Continue synchronizing configured remote branches while preserving unchanged-head behavior and the existing Git LFS pull path.

Tests:
- Add real Git regression coverage for unchanged and advancing remotes to verify that polling does not run automatic maintenance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Git-based knowledge-base synchronization no longer triggers automatic repository maintenance during polling fetches.
  - Synchronization continues to update content correctly while avoiding unnecessary maintenance operations.

- **Tests**
  - Added coverage confirming automatic maintenance is not launched during synchronization.
  - Updated fetch expectations to reflect the revised behavior.
  - Verified synchronization remains successful when automatic maintenance is enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->