### PR TITLE
Validate legacy crypto before retiring transport state

### DIFF
--- a/docs/deployment/nio-upgrade.md
+++ b/docs/deployment/nio-upgrade.md
@@ -17,7 +17,7 @@ The journal migration retires unfinished old requests, deliveries, approvals, an
 An interrupted transaction rolls back; the next startup retries the upgrade.
 After that transaction commits, subsequent startups preserve new pending work normally.
 Recognized older `sync_continuity` records are converted atomically, retaining pending join/decrypt fences while discarding checkpoints now owned by Nio.
-Before Nio first adopts an existing crypto store, MindRoom also retires obsolete transport recovery rows under the store's exclusive lease without changing crypto keys.
+Before Nio first adopts an existing crypto store, MindRoom validates the retained account pickle, then retires obsolete transport recovery rows and legacy sync tokens in one transaction under the store's exclusive lease without changing crypto keys.
 An already durable Nio store is never reset by this migration.
 
 ## What does not continue
@@ -48,3 +48,17 @@ If the device store is missing, restore the deployment's matching storage backup
 Hard logout, a deleted server device, a changed returned identity, corrupt storage, or an unknown storage format still requires operator recovery.
 An existing Nio 1.0 session is bound to its journal consumer; clearing the journal or crypto directory is not a supported repair.
 Preserve the failed deployment's state when recovering it, because retained input and attempted deliveries may still need reconciliation.
+
+## Rolling back
+
+Changing only the image back to an older release is unsafe after the new version has opened persistent storage.
+Older versions can write to upgraded crypto stores and do not reliably reject newer continuity records.
+The journal upgrade and individual crypto upgrades use separate transactions; successful rollback of one database does not roll back the others.
+
+Before the upgrade, stop all primary, worker, script, and background writers and capture a coordinated backup of configuration, credentials, workspaces, memories, the journal and installation binding, every Matrix device store and trust sidecar, continuity files, and session storage.
+Include separately mounted session and state volumes in that recovery point.
+Verify that these backups can be restored before proceeding.
+
+To roll back, stop all writers and hold ingress closed, preserve the failed upgraded state separately, and restore the complete coordinated recovery point before starting the previous release.
+Restore the journal and device stores together; restoring only one can invalidate their consumer binding.
+Keep the preserved upgraded state for reconciliation because post-upgrade user work or external tool actions may not exist in the restored backup.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17730,7 +17730,7 @@ The journal migration retires unfinished old requests, deliveries, approvals, an
 An interrupted transaction rolls back; the next startup retries the upgrade.
 After that transaction commits, subsequent startups preserve new pending work normally.
 Recognized older `sync_continuity` records are converted atomically, retaining pending join/decrypt fences while discarding checkpoints now owned by Nio.
-Before Nio first adopts an existing crypto store, MindRoom also retires obsolete transport recovery rows under the store's exclusive lease without changing crypto keys.
+Before Nio first adopts an existing crypto store, MindRoom validates the retained account pickle, then retires obsolete transport recovery rows and legacy sync tokens in one transaction under the store's exclusive lease without changing crypto keys.
 An already durable Nio store is never reset by this migration.
 
 ## What does not continue
@@ -17761,6 +17761,20 @@ If the device store is missing, restore the deployment's matching storage backup
 Hard logout, a deleted server device, a changed returned identity, corrupt storage, or an unknown storage format still requires operator recovery.
 An existing Nio 1.0 session is bound to its journal consumer; clearing the journal or crypto directory is not a supported repair.
 Preserve the failed deployment's state when recovering it, because retained input and attempted deliveries may still need reconciliation.
+
+## Rolling back
+
+Changing only the image back to an older release is unsafe after the new version has opened persistent storage.
+Older versions can write to upgraded crypto stores and do not reliably reject newer continuity records.
+The journal upgrade and individual crypto upgrades use separate transactions; successful rollback of one database does not roll back the others.
+
+Before the upgrade, stop all primary, worker, script, and background writers and capture a coordinated backup of configuration, credentials, workspaces, memories, the journal and installation binding, every Matrix device store and trust sidecar, continuity files, and session storage.
+Include separately mounted session and state volumes in that recovery point.
+Verify that these backups can be restored before proceeding.
+
+To roll back, stop all writers and hold ingress closed, preserve the failed upgraded state separately, and restore the complete coordinated recovery point before starting the previous release.
+Restore the journal and device stores together; restoring only one can invalidate their consumer binding.
+Keep the preserved upgraded state for reconciliation because post-upgrade user work or external tool actions may not exist in the restored backup.
 
 # Hosted Matrix + Local Backend
 

--- a/skills/mindroom-docs/references/page__deployment__nio-upgrade__index.md
+++ b/skills/mindroom-docs/references/page__deployment__nio-upgrade__index.md
@@ -17,7 +17,7 @@ The journal migration retires unfinished old requests, deliveries, approvals, an
 An interrupted transaction rolls back; the next startup retries the upgrade.
 After that transaction commits, subsequent startups preserve new pending work normally.
 Recognized older `sync_continuity` records are converted atomically, retaining pending join/decrypt fences while discarding checkpoints now owned by Nio.
-Before Nio first adopts an existing crypto store, MindRoom also retires obsolete transport recovery rows under the store's exclusive lease without changing crypto keys.
+Before Nio first adopts an existing crypto store, MindRoom validates the retained account pickle, then retires obsolete transport recovery rows and legacy sync tokens in one transaction under the store's exclusive lease without changing crypto keys.
 An already durable Nio store is never reset by this migration.
 
 ## What does not continue
@@ -48,3 +48,17 @@ If the device store is missing, restore the deployment's matching storage backup
 Hard logout, a deleted server device, a changed returned identity, corrupt storage, or an unknown storage format still requires operator recovery.
 An existing Nio 1.0 session is bound to its journal consumer; clearing the journal or crypto directory is not a supported repair.
 Preserve the failed deployment's state when recovering it, because retained input and attempted deliveries may still need reconciliation.
+
+## Rolling back
+
+Changing only the image back to an older release is unsafe after the new version has opened persistent storage.
+Older versions can write to upgraded crypto stores and do not reliably reject newer continuity records.
+The journal upgrade and individual crypto upgrades use separate transactions; successful rollback of one database does not roll back the others.
+
+Before the upgrade, stop all primary, worker, script, and background writers and capture a coordinated backup of configuration, credentials, workspaces, memories, the journal and installation binding, every Matrix device store and trust sidecar, continuity files, and session storage.
+Include separately mounted session and state volumes in that recovery point.
+Verify that these backups can be restored before proceeding.
+
+To roll back, stop all writers and hold ingress closed, preserve the failed upgraded state separately, and restore the complete coordinated recovery point before starting the previous release.
+Restore the journal and device stores together; restoring only one can invalidate their consumer binding.
+Keep the preserved upgraded state for reconciliation because post-upgrade user work or external tool actions may not exist in the restored backup.

--- a/src/mindroom/matrix/_owned_session.py
+++ b/src/mindroom/matrix/_owned_session.py
@@ -225,6 +225,7 @@ async def open_owned_matrix_session(
                     store_path / database_name,
                     user_id=credentials.user_id,
                     device_id=credentials.device_id,
+                    pickle_key=client.config.pickle_key,
                 ),
             ),
         )

--- a/src/mindroom/matrix/legacy_crypto_upgrade.py
+++ b/src/mindroom/matrix/legacy_crypto_upgrade.py
@@ -45,18 +45,23 @@ def retire_legacy_crypto_recovery(
             }
             if tables & {"niodurablemeta", "nioingestmeta"} or "accounts" not in tables:
                 return
+            transport_tables = tuple(table for table in _LEGACY_TRANSPORT_TABLES if table in tables)
             accounts = connection.execute("SELECT user_id, device_id, account, shared FROM accounts").fetchall()
             if not accounts:
-                msg = "Legacy Matrix store account is missing"
-                raise LocalProtocolError(msg)
+                if any(
+                    connection.execute(f"SELECT 1 FROM {table} LIMIT 1").fetchone() is not None  # noqa: S608
+                    for table in transport_tables
+                ):
+                    msg = "Legacy Matrix store account is missing"
+                    raise LocalProtocolError(msg)
+                return
             if any(account[:2] != (user_id, device_id) for account in accounts):
                 msg = "Legacy Matrix store account/device identity mismatch"
                 raise LocalProtocolError(msg)
             for _, _, pickle, shared in accounts:
                 OlmAccount.from_pickle(pickle, pickle_key, bool(shared))
             retired = 0
-            for table in _LEGACY_TRANSPORT_TABLES:
-                if table in tables:
-                    retired += connection.execute(f"DELETE FROM {table}").rowcount  # noqa: S608 - fixed legacy tables
+            for table in transport_tables:
+                retired += connection.execute(f"DELETE FROM {table}").rowcount  # noqa: S608 - fixed legacy tables
         if retired:
             logger.warning("matrix_legacy_recovery_retired", row_count=retired)

--- a/src/mindroom/matrix/legacy_crypto_upgrade.py
+++ b/src/mindroom/matrix/legacy_crypto_upgrade.py
@@ -7,6 +7,7 @@ from contextlib import closing
 from typing import TYPE_CHECKING
 
 from nio import LocalProtocolError
+from nio.crypto import OlmAccount
 from nio.store._sqlite_lease import FileLease
 
 from mindroom.logging_config import get_logger
@@ -16,16 +17,22 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_LEGACY_RECOVERY_TABLES = ("pendingtimelineevents", "syncrecoverygaps", "syncrecoveryabandonedrooms")
+_LEGACY_TRANSPORT_TABLES = ("pendingtimelineevents", "syncrecoverygaps", "syncrecoveryabandonedrooms", "synctokens")
 
 
-def retire_legacy_crypto_recovery(database_path: Path, *, user_id: str, device_id: str) -> None:
+def retire_legacy_crypto_recovery(
+    database_path: Path,
+    *,
+    user_id: str,
+    device_id: str,
+    pickle_key: str = "DEFAULT_KEY",
+) -> None:
     """Permit first durable adoption after explicitly abandoning old transport work.
 
     Nio 1.0 refuses outstanding 0.40 recovery but no longer exposes its old
-    settlement API. This one-time adapter touches only those retired tables,
-    under the same exclusive file lease Nio uses for durable ownership. It
-    never resets an existing durable stream or edits crypto/trust records.
+    settlement API. Authenticate retained keys before retiring recovery and
+    obsolete sync checkpoints in one transaction under Nio's exclusive file
+    lease. Never reset an existing durable stream or edit crypto/trust records.
     """
     if not database_path.exists():
         return
@@ -38,12 +45,14 @@ def retire_legacy_crypto_recovery(database_path: Path, *, user_id: str, device_i
             }
             if tables & {"niodurablemeta", "nioingestmeta"} or "accounts" not in tables:
                 return
-            identities = connection.execute("SELECT user_id, device_id FROM accounts").fetchall()
-            if any(identity != (user_id, device_id) for identity in identities):
+            accounts = connection.execute("SELECT user_id, device_id, account, shared FROM accounts").fetchall()
+            if any(account[:2] != (user_id, device_id) for account in accounts):
                 msg = "Legacy Matrix store account/device identity mismatch"
                 raise LocalProtocolError(msg)
+            for _, _, pickle, shared in accounts:
+                OlmAccount.from_pickle(pickle, pickle_key, bool(shared))
             retired = 0
-            for table in _LEGACY_RECOVERY_TABLES:
+            for table in _LEGACY_TRANSPORT_TABLES:
                 if table in tables:
                     retired += connection.execute(f"DELETE FROM {table}").rowcount  # noqa: S608 - fixed legacy tables
         if retired:

--- a/src/mindroom/matrix/legacy_crypto_upgrade.py
+++ b/src/mindroom/matrix/legacy_crypto_upgrade.py
@@ -46,6 +46,9 @@ def retire_legacy_crypto_recovery(
             if tables & {"niodurablemeta", "nioingestmeta"} or "accounts" not in tables:
                 return
             accounts = connection.execute("SELECT user_id, device_id, account, shared FROM accounts").fetchall()
+            if not accounts:
+                msg = "Legacy Matrix store account is missing"
+                raise LocalProtocolError(msg)
             if any(account[:2] != (user_id, device_id) for account in accounts):
                 msg = "Legacy Matrix store account/device identity mismatch"
                 raise LocalProtocolError(msg)

--- a/tests/test_legacy_crypto_upgrade.py
+++ b/tests/test_legacy_crypto_upgrade.py
@@ -217,6 +217,19 @@ def test_invalid_crypto_account_keeps_legacy_recovery(tmp_path: Path) -> None:
         assert connection.execute("SELECT account FROM accounts").fetchone() == (b"invalid-pickle",)
 
 
+def test_missing_crypto_account_keeps_legacy_recovery(tmp_path: Path) -> None:
+    """A missing retained identity must block destructive transport cleanup."""
+    _legacy_crypto(tmp_path, "pending")
+    path = tmp_path / f"{ACCOUNT}_{DEVICE}.db"
+    with closing(sqlite3.connect(path)) as connection:
+        connection.execute("DELETE FROM accounts")
+        connection.commit()
+    with pytest.raises(LocalProtocolError, match="account is missing"):
+        retire_legacy_crypto_recovery(path, user_id=ACCOUNT, device_id=DEVICE)
+    with closing(sqlite3.connect(path)) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM pendingtimelineevents").fetchone() == (1,)
+
+
 @pytest.mark.parametrize("correct_key", [False, True])
 def test_crypto_retirement_authenticates_the_configured_pickle_key(tmp_path: Path, correct_key: bool) -> None:
     """Only the actual configured key permits retirement; wrong keys retain recovery."""

--- a/tests/test_legacy_crypto_upgrade.py
+++ b/tests/test_legacy_crypto_upgrade.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 import pytest
 from nio import LocalProtocolError
 from nio.crypto import InboundGroupSession, OlmAccount, OutboundGroupSession
-from nio.durable import DurableSyncConfig
+from nio.durable import DurableSyncConfig, SlidingSyncConfig
 from nio.store import DefaultStore
 from nio.store._sqlite_lease import FileLease
 
@@ -26,10 +26,15 @@ DEVICE = "DEVICE"
 _SCHEMA = Path(__file__).parent / "fixtures" / "pre_nio1_recovery.sql"
 
 
-def _legacy_crypto(path: Path, recovery: str) -> tuple[dict[str, str], InboundGroupSession, str]:
+def _legacy_crypto(
+    path: Path,
+    recovery: str,
+    *,
+    pickle_key: str = "DEFAULT_KEY",
+) -> tuple[dict[str, str], InboundGroupSession, str]:
     """Persist real Olm/Megolm keys beside frozen released recovery tables."""
     path.mkdir(parents=True, exist_ok=True)
-    store = DefaultStore(ACCOUNT, DEVICE, str(path), pickle_key="DEFAULT_KEY")
+    store = DefaultStore(ACCOUNT, DEVICE, str(path), pickle_key=pickle_key)
     account = OlmAccount()
     store.save_account(account)
     outbound = OutboundGroupSession()
@@ -152,9 +157,94 @@ async def test_durable_crypto_store_is_never_migrated_again(tmp_path: Path) -> N
                 INSERT INTO syncrecoverygaps VALUES (
                     1, '!room:example.org', 2, 'target', NULL, 0, (SELECT id FROM accounts LIMIT 1))
             """)
+            connection.execute("UPDATE NioDurableMeta SET cursor = 'retained-durable-checkpoint'")
             connection.commit()
         retire_legacy_crypto_recovery(database_path, user_id=ACCOUNT, device_id=DEVICE)
         with closing(sqlite3.connect(database_path)) as connection:
             assert connection.execute("SELECT COUNT(*) FROM syncrecoverygaps").fetchone() == (1,)
+            assert connection.execute("SELECT cursor FROM NioDurableMeta").fetchone() == (
+                "retained-durable-checkpoint",
+            )
     finally:
         await journal.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("sliding", [False, True])
+async def test_legacy_sync_checkpoint_is_not_adopted(tmp_path: Path, sliding: bool) -> None:
+    """Retired checkpoints cannot select the wrong transport or skip the fresh baseline."""
+    runtime = _runtime_paths(tmp_path)
+    path = olm_store_dir(ACCOUNT, runtime)
+    keys, _, _ = _legacy_crypto(path, "pending")
+    store = DefaultStore(ACCOUNT, DEVICE, str(path), pickle_key="DEFAULT_KEY")
+    store.save_sync_token("obsolete-checkpoint")
+    store.database.close()
+    journal = EventJournalStore.open_sqlite(tmp_path / "journal.db")
+    try:
+        for _ in range(2):
+            opened = await open_owned_matrix_session(
+                "https://example.org",
+                MatrixCredentials(ACCOUNT, DEVICE, "test-token"),
+                runtime,
+                consumer_store=journal.principal(ACCOUNT),
+                new_consumer_generation=uuid4(),
+                config=DurableSyncConfig(sliding=SlidingSyncConfig() if sliding else None),
+            )
+            try:
+                assert opened.client.olm is not None
+                assert opened.client.olm.account.identity_keys == keys
+                with closing(sqlite3.connect(path / f"{ACCOUNT}_{DEVICE}.db")) as connection:
+                    assert connection.execute("SELECT cursor FROM NioDurableMeta").fetchone() == (None,)
+                    assert connection.execute("SELECT COUNT(*) FROM synctokens").fetchone() == (0,)
+            finally:
+                await opened.session.close()
+                await opened.client.close()
+    finally:
+        await journal.close()
+
+
+def test_invalid_crypto_account_keeps_legacy_recovery(tmp_path: Path) -> None:
+    """A failed key preflight must leave all recovery rows available for operator repair."""
+    _legacy_crypto(tmp_path, "pending")
+    path = tmp_path / f"{ACCOUNT}_{DEVICE}.db"
+    with closing(sqlite3.connect(path)) as connection:
+        connection.execute("UPDATE accounts SET account = ?", (b"invalid-pickle",))
+        connection.commit()
+    with pytest.raises(ValueError, match=r"(?i)pickle"):
+        retire_legacy_crypto_recovery(path, user_id=ACCOUNT, device_id=DEVICE)
+    with closing(sqlite3.connect(path)) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM pendingtimelineevents").fetchone() == (1,)
+        assert connection.execute("SELECT account FROM accounts").fetchone() == (b"invalid-pickle",)
+
+
+@pytest.mark.parametrize("correct_key", [False, True])
+def test_crypto_retirement_authenticates_the_configured_pickle_key(tmp_path: Path, correct_key: bool) -> None:
+    """Only the actual configured key permits retirement; wrong keys retain recovery."""
+    _legacy_crypto(tmp_path, "pending", pickle_key="custom-pickle-key")
+    path = tmp_path / f"{ACCOUNT}_{DEVICE}.db"
+    if correct_key:
+        retire_legacy_crypto_recovery(path, user_id=ACCOUNT, device_id=DEVICE, pickle_key="custom-pickle-key")
+    else:
+        with pytest.raises(ValueError, match="pickle couldn't be decrypted"):
+            retire_legacy_crypto_recovery(path, user_id=ACCOUNT, device_id=DEVICE, pickle_key="wrong-key")
+    with closing(sqlite3.connect(path)) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM pendingtimelineevents").fetchone() == (0 if correct_key else 1,)
+
+
+def test_sync_token_retirement_failure_rolls_back_recovery(tmp_path: Path) -> None:
+    """Failure in the last retired table cannot leave earlier recovery partially cleared."""
+    _legacy_crypto(tmp_path, "pending")
+    store = DefaultStore(ACCOUNT, DEVICE, str(tmp_path), pickle_key="DEFAULT_KEY")
+    store.save_sync_token("obsolete-checkpoint")
+    store.database.close()
+    path = tmp_path / f"{ACCOUNT}_{DEVICE}.db"
+    with closing(sqlite3.connect(path)) as connection:
+        connection.executescript("""
+            CREATE TRIGGER fail_token_retirement BEFORE DELETE ON synctokens
+            BEGIN SELECT RAISE(ABORT, 'interrupted token retirement'); END;
+        """)
+    with pytest.raises(sqlite3.IntegrityError, match="interrupted token retirement"):
+        retire_legacy_crypto_recovery(path, user_id=ACCOUNT, device_id=DEVICE)
+    with closing(sqlite3.connect(path)) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM pendingtimelineevents").fetchone() == (1,)
+        assert connection.execute("SELECT COUNT(*) FROM synctokens").fetchone() == (1,)

--- a/tests/test_legacy_crypto_upgrade.py
+++ b/tests/test_legacy_crypto_upgrade.py
@@ -217,6 +217,18 @@ def test_invalid_crypto_account_keeps_legacy_recovery(tmp_path: Path) -> None:
         assert connection.execute("SELECT account FROM accounts").fetchone() == (b"invalid-pickle",)
 
 
+def test_empty_crypto_store_without_transport_state_needs_no_preflight(tmp_path: Path) -> None:
+    """A schema-only store remains adoptable when no legacy transport rows exist."""
+    store = DefaultStore(ACCOUNT, DEVICE, str(tmp_path), pickle_key="DEFAULT_KEY")
+    store.database.close()
+
+    retire_legacy_crypto_recovery(
+        tmp_path / f"{ACCOUNT}_{DEVICE}.db",
+        user_id=ACCOUNT,
+        device_id=DEVICE,
+    )
+
+
 def test_missing_crypto_account_keeps_legacy_recovery(tmp_path: Path) -> None:
     """A missing retained identity must block destructive transport cleanup."""
     _legacy_crypto(tmp_path, "pending")


### PR DESCRIPTION
Legacy sync tokens can make first Nio 1.0 adoption reuse an obsolete checkpoint or permanently reject Sliding Sync.
An invalid account pickle could also fail after obsolete recovery rows had already been deleted.

Validate the retained account with the configured pickle key before retirement, and delete legacy sync tokens in the same transaction as retired recovery state.
Existing durable stores keep their cursor and pending work.
Document coordinated storage restoration for rollback because changing only the image cannot reverse these migrations.

Validation: the complete test suite, 43 focused migration/client-session tests, and all repository pre-commit hooks passed after updating the branch from main.
Independent review of the final commit found no remaining issues.
Regression coverage includes Classic and Sliding adoption, invalid and incorrectly keyed account pickles, token-deletion rollback, repeated startup, and retained durable cursors.

## Summary by Sourcery

Safely retire legacy Matrix transport state during Nio adoption by validating retained crypto first and coordinating recovery cleanup transactionally.

Bug Fixes:
- Prevent obsolete legacy sync checkpoints from being adopted during first Nio 1.0 session startup.
- Prevent destructive legacy recovery cleanup when the retained account pickle is invalid, missing, or encrypted with the wrong configured key.
- Ensure legacy transport recovery rows and sync tokens are retired atomically so failures leave the store unchanged.

Enhancements:
- Preserve existing durable Nio cursors and pending work while retiring only obsolete legacy transport state.
- Pass the configured pickle key through owned-session startup for account validation.

Documentation:
- Document coordinated storage backups and restoration requirements for safely rolling back after persistent Nio migrations.

Tests:
- Add coverage for Classic and Sliding adoption, durable-store preservation, account validation failures, custom pickle keys, repeated startup, and transactional rollback.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified Nio migration validation and transactional cleanup of obsolete recovery data and sync tokens.
  * Added rollback guidance covering coordinated backups, service shutdown, storage restoration, and reconciliation.
  * Documented that image-only rollback is unsafe after persistent storage has been upgraded.

* **Bug Fixes**
  * Improved legacy crypto-store recovery by validating retained account data before retiring obsolete records.
  * Added safeguards for missing or invalid account data and preserved transactional rollback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
