### PR TITLE
fix: authorize OpenAI-compatible delegation with requester-bound API keys

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,7 @@ MATRIX_HOMESERVER=http://localhost:8008  # Your Matrix homeserver URL
 
 # OpenAI-compatible API (see docs/openai-api.md)
 # OPENAI_COMPAT_API_KEYS=sk-key-1,sk-key-2  # Comma-separated API keys for /v1/ endpoints
+# OPENAI_COMPAT_API_KEY_REQUESTERS='{"sk-key-1":"@alice:example.org"}'  # Optional requester binding for authorized delegation
 # OPENAI_COMPAT_ALLOW_UNAUTHENTICATED=false  # Set to "true" to allow access without API keys (dev only)
 
 # Dashboard API authentication (standalone mode only)

--- a/docs/openai-api.md
+++ b/docs/openai-api.md
@@ -202,6 +202,30 @@ Client `system` / `developer` messages are prepended to the prompt. They augment
 
 The OpenAI-compatible API uses its own auth (`OPENAI_COMPAT_API_KEYS`), separate from the dashboard API auth. In standalone mode, the dashboard `/api/*` endpoints can be protected with `MINDROOM_API_KEY`; the browser dashboard uses a same-origin auth cookie, while CLI and curl clients can still send `Authorization: Bearer ...`. These are independent: `MINDROOM_API_KEY` secures the dashboard, while `OPENAI_COMPAT_API_KEYS` secures the `/v1/*` chat completions endpoints.
 
+### Requester identities and delegation
+
+Bind selected API keys to Matrix user IDs with a JSON object in `.env`:
+
+```dotenv
+OPENAI_COMPAT_API_KEYS=sk-astrbot,sk-legacy
+OPENAI_COMPAT_API_KEY_REQUESTERS='{"sk-astrbot":"@alice:example.org"}'
+```
+
+The key must still appear in `OPENAI_COMPAT_API_KEYS`; a mapping alone never authenticates a caller.
+Restart MindRoom after changing these environment settings.
+Mapped identities must be concrete human Matrix user IDs, and `authorization.aliases` resolves bridge identities to their canonical requester.
+The request body's `user` field and requester headers cannot override this identity.
+
+Mapped callers only see and invoke models allowed by the existing responder access policy, including every member of a selected team.
+Auto-routing uses the same permitted agents.
+`delegate_task` checks both the caller agent's `delegate_to` list and the requester's access to each target, and propagates the requester into nested runs and their metadata.
+Grant access with `agents.<name>.access.users`, administrator membership, or a ready managed `members_of_rooms` membership snapshot.
+There is no current Matrix room for `/v1`, so `current_room_members` cannot grant access, and missing or stale room membership fails closed.
+
+Unmapped keys retain their existing model access but cannot delegate.
+Mapped sessions also include the canonical requester in their namespace, preventing a reassigned key from inheriting the previous requester's session.
+Room-context tools and approval-gated tools remain unavailable in delegated API runs.
+
 ## Limitations
 
 - **Token usage is always zeros** — Agno doesn't expose token counts

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -16948,6 +16948,30 @@ Client `system` / `developer` messages are prepended to the prompt. They augment
 
 The OpenAI-compatible API uses its own auth (`OPENAI_COMPAT_API_KEYS`), separate from the dashboard API auth. In standalone mode, the dashboard `/api/*` endpoints can be protected with `MINDROOM_API_KEY`; the browser dashboard uses a same-origin auth cookie, while CLI and curl clients can still send `Authorization: Bearer ...`. These are independent: `MINDROOM_API_KEY` secures the dashboard, while `OPENAI_COMPAT_API_KEYS` secures the `/v1/*` chat completions endpoints.
 
+### Requester identities and delegation
+
+Bind selected API keys to Matrix user IDs with a JSON object in `.env`:
+
+```dotenv
+OPENAI_COMPAT_API_KEYS=sk-astrbot,sk-legacy
+OPENAI_COMPAT_API_KEY_REQUESTERS='{"sk-astrbot":"@alice:example.org"}'
+```
+
+The key must still appear in `OPENAI_COMPAT_API_KEYS`; a mapping alone never authenticates a caller.
+Restart MindRoom after changing these environment settings.
+Mapped identities must be concrete human Matrix user IDs, and `authorization.aliases` resolves bridge identities to their canonical requester.
+The request body's `user` field and requester headers cannot override this identity.
+
+Mapped callers only see and invoke models allowed by the existing responder access policy, including every member of a selected team.
+Auto-routing uses the same permitted agents.
+`delegate_task` checks both the caller agent's `delegate_to` list and the requester's access to each target, and propagates the requester into nested runs and their metadata.
+Grant access with `agents.<name>.access.users`, administrator membership, or a ready managed `members_of_rooms` membership snapshot.
+There is no current Matrix room for `/v1`, so `current_room_members` cannot grant access, and missing or stale room membership fails closed.
+
+Unmapped keys retain their existing model access but cannot delegate.
+Mapped sessions also include the canonical requester in their namespace, preventing a reassigned key from inheriting the previous requester's session.
+Room-context tools and approval-gated tools remain unavailable in delegated API runs.
+
 ## Limitations
 
 - **Token usage is always zeros** — Agno doesn't expose token counts

--- a/skills/mindroom-docs/references/page__openai-api__index.md
+++ b/skills/mindroom-docs/references/page__openai-api__index.md
@@ -198,6 +198,30 @@ Client `system` / `developer` messages are prepended to the prompt. They augment
 
 The OpenAI-compatible API uses its own auth (`OPENAI_COMPAT_API_KEYS`), separate from the dashboard API auth. In standalone mode, the dashboard `/api/*` endpoints can be protected with `MINDROOM_API_KEY`; the browser dashboard uses a same-origin auth cookie, while CLI and curl clients can still send `Authorization: Bearer ...`. These are independent: `MINDROOM_API_KEY` secures the dashboard, while `OPENAI_COMPAT_API_KEYS` secures the `/v1/*` chat completions endpoints.
 
+### Requester identities and delegation
+
+Bind selected API keys to Matrix user IDs with a JSON object in `.env`:
+
+```dotenv
+OPENAI_COMPAT_API_KEYS=sk-astrbot,sk-legacy
+OPENAI_COMPAT_API_KEY_REQUESTERS='{"sk-astrbot":"@alice:example.org"}'
+```
+
+The key must still appear in `OPENAI_COMPAT_API_KEYS`; a mapping alone never authenticates a caller.
+Restart MindRoom after changing these environment settings.
+Mapped identities must be concrete human Matrix user IDs, and `authorization.aliases` resolves bridge identities to their canonical requester.
+The request body's `user` field and requester headers cannot override this identity.
+
+Mapped callers only see and invoke models allowed by the existing responder access policy, including every member of a selected team.
+Auto-routing uses the same permitted agents.
+`delegate_task` checks both the caller agent's `delegate_to` list and the requester's access to each target, and propagates the requester into nested runs and their metadata.
+Grant access with `agents.<name>.access.users`, administrator membership, or a ready managed `members_of_rooms` membership snapshot.
+There is no current Matrix room for `/v1`, so `current_room_members` cannot grant access, and missing or stale room membership fails closed.
+
+Unmapped keys retain their existing model access but cannot delegate.
+Mapped sessions also include the canonical requester in their namespace, preventing a reassigned key from inheriting the previous requester's session.
+Room-context tools and approval-gated tools remain unavailable in delegated API runs.
+
 ## Limitations
 
 - **Token usage is always zeros** — Agno doesn't expose token counts

--- a/src/mindroom/api/openai_compat.py
+++ b/src/mindroom/api/openai_compat.py
@@ -11,6 +11,7 @@ protocol formatting (``openai_streaming_protocol``).
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import time
 import weakref
 from contextlib import ExitStack
@@ -25,9 +26,10 @@ from agno.run.team import RunErrorEvent as TeamRunErrorEvent
 from agno.run.team import TeamRunOutput
 from fastapi import APIRouter, Header, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, StrictStr, TypeAdapter
 from starlette.background import BackgroundTask
 
+from mindroom.agent_reply_membership import AgentReplyMembershipIndex
 from mindroom.agent_run_context import prepend_knowledge_availability_notice
 from mindroom.ai import AIStreamChunk, ResponseTurnContext, ai_response, stream_agent_response
 from mindroom.api import config_lifecycle
@@ -73,6 +75,8 @@ from mindroom.api.openai_streaming_protocol import (
 from mindroom.api.openai_streaming_protocol import (
     is_error_response as _is_error_response,
 )
+from mindroom.authorization import is_sender_allowed_for_responder
+from mindroom.config.access import validate_concrete_matrix_user_ids
 from mindroom.constants import ROUTER_AGENT_NAME, RuntimePaths, runtime_env_flag
 from mindroom.execution_preparation import render_prepared_team_messages_text
 from mindroom.history.runtime import ScopeSessionContext, close_team_runtime_state_dbs, open_bound_scope_session_context
@@ -83,6 +87,7 @@ from mindroom.llm_request_logging import (
     stream_with_llm_request_log_context,
 )
 from mindroom.logging_config import get_logger
+from mindroom.requester_identity import is_human_requester_id, resolve_human_requester_alias
 from mindroom.routing import suggest_responder
 from mindroom.teams import (
     TeamMode,
@@ -93,6 +98,8 @@ from mindroom.teams import (
     materialize_exact_team_members,
     prepare_materialized_team_execution,
 )
+from mindroom.tool_system.context_bound_streams import context_bound_async_stream
+from mindroom.tool_system.runtime_context import DetachedRequesterContext, detached_requester_context
 from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
     build_tool_execution_identity,
@@ -271,7 +278,7 @@ class _ModelListResponse(BaseModel):
 def _authenticate_request(
     authorization: str | None,
     runtime_paths: RuntimePaths,
-) -> JSONResponse | None:
+) -> JSONResponse | str | None:
     """Authenticate one `/v1` request."""
     keys_env = runtime_paths.env_value("OPENAI_COMPAT_API_KEYS", default="") or ""
     allow_unauthenticated = runtime_env_flag(
@@ -301,7 +308,20 @@ def _authenticate_request(
     if token not in valid_keys:
         return _error_response(401, "Invalid API key", code="invalid_api_key")
 
-    return None
+    return _api_key_requester(token, runtime_paths)
+
+
+def _api_key_requester(token: str, runtime_paths: RuntimePaths) -> JSONResponse | str | None:
+    """Resolve a validated key's optional canonical requester binding."""
+    mappings_env = runtime_paths.env_value("OPENAI_COMPAT_API_KEY_REQUESTERS", default="") or ""
+    if not mappings_env.strip():
+        return None
+    try:
+        mappings = TypeAdapter(dict[StrictStr, StrictStr]).validate_json(mappings_env)
+        validate_concrete_matrix_user_ids(list(set(mappings.values())), field_name="API requesters")
+    except (ValueError, TypeError):
+        return _error_response(503, "Invalid API requester configuration", error_type="server_error")
+    return mappings.get(token)
 
 
 def _parse_chat_request(
@@ -330,11 +350,64 @@ def _parse_chat_request(
     return req, config, runtime_paths, prompt, thread_history
 
 
+def _requester_authority(
+    request: Request,
+    requester_id: str | None,
+    config: Config,
+    runtime_paths: RuntimePaths,
+) -> DetachedRequesterContext | JSONResponse | None:
+    """Resolve authenticated API authority without inventing a Matrix conversation."""
+    if requester_id is None:
+        return None
+    requester_id = resolve_human_requester_alias(requester_id, config, runtime_paths)
+    if not is_human_requester_id(requester_id, config, runtime_paths):
+        return _error_response(403, "API requester must be a human identity", code="permission_denied")
+    trigger_runtime = config_lifecycle.app_state(request.app).external_trigger_runtime
+
+    def current_config() -> Config | None:
+        api_state = config_lifecycle.require_api_state(request.app)
+        with api_state.config_lock:
+            snapshot = api_state.snapshot
+            return snapshot.runtime_config if snapshot.runtime_paths == runtime_paths else None
+
+    return DetachedRequesterContext(
+        requester_id=requester_id,
+        config=config,
+        runtime_paths=runtime_paths,
+        agent_reply_memberships=(
+            trigger_runtime.agent_reply_memberships if trigger_runtime is not None else AgentReplyMembershipIndex()
+        ),
+        config_provider=current_config,
+    )
+
+
+def _requester_allows_model(model: str, authority: DetachedRequesterContext | None) -> bool:
+    """Apply responder access to a mapped caller and every configured team member."""
+    if authority is None:
+        return True
+    entities = [model]
+    if model.startswith(TEAM_MODEL_PREFIX):
+        team_name = model.removeprefix(TEAM_MODEL_PREFIX)
+        entities = [team_name, *authority.config.teams[team_name].agents]
+    return all(
+        is_sender_allowed_for_responder(
+            authority.requester_id,
+            entity_name,
+            None,
+            authority.config,
+            authority.runtime_paths,
+            authority.agent_reply_memberships,
+        )
+        for entity_name in entities
+    )
+
+
 async def _resolve_auto_route(
     prompt: str,
     config: Config,
     runtime_paths: RuntimePaths,
     thread_history: Sequence[ResolvedVisibleMessage] | None,
+    authority: DetachedRequesterContext | None = None,
 ) -> str | JSONResponse:
     """Resolve auto-routing to a specific agent name.
 
@@ -342,6 +415,10 @@ async def _resolve_auto_route(
     and no agents are available.
     """
     available = openai_compatible_agent_names(config)
+    if authority is not None:
+        available = [name for name in available if _requester_allows_model(name, authority)]
+        if not available:
+            return _error_response(403, "No agents are authorized for this requester", code="permission_denied")
     if not available:
         return _error_response(
             500,
@@ -376,10 +453,14 @@ async def list_models(
     """List available models (agents) in OpenAI format."""
     runtime_paths = config_lifecycle.bind_current_request_snapshot(request).runtime_paths
     auth_error = _authenticate_request(authorization, runtime_paths)
-    if auth_error is not None:
+    if isinstance(auth_error, JSONResponse):
         return auth_error
 
     config, runtime_paths = _load_config(request, runtime_paths=runtime_paths)
+
+    authority = _requester_authority(request, auth_error, config, runtime_paths)
+    if isinstance(authority, JSONResponse):
+        return authority
 
     # Use config file mtime as creation timestamp
     try:
@@ -388,6 +469,7 @@ async def list_models(
         created = 0
 
     compatible_agents = set(openai_compatible_agent_names(config))
+    compatible_agents = {name for name in compatible_agents if _requester_allows_model(name, authority)}
     models: list[_ModelObject] = []
     if compatible_agents:
         models.append(
@@ -412,6 +494,8 @@ async def list_models(
 
     # Add teams
     for team_name, team_config in (config.teams or {}).items():
+        if not _requester_allows_model(f"{TEAM_MODEL_PREFIX}{team_name}", authority):
+            continue
         if _openai_incompatible_agents(team_config.agents, config):
             continue
         models.append(
@@ -428,22 +512,44 @@ async def list_models(
 
 
 @router.post("/chat/completions", response_model=None)
-async def chat_completions(  # noqa: C901, PLR0912
+async def chat_completions(
     request: Request,
     authorization: Annotated[str | None, Header()] = None,
 ) -> JSONResponse | StreamingResponse:
     """Create a chat completion (non-streaming or streaming)."""
     runtime_paths = config_lifecycle.bind_current_request_snapshot(request).runtime_paths
     auth_error = _authenticate_request(authorization, runtime_paths)
-    if auth_error is not None:
+    if isinstance(auth_error, JSONResponse):
         return auth_error
 
-    # Parse and validate request
     parsed = _parse_chat_request(request, await request.body(), runtime_paths=runtime_paths)
     if isinstance(parsed, JSONResponse):
         return parsed
     req, config, runtime_paths, prompt, thread_history = parsed
+    authority = _requester_authority(request, auth_error, config, runtime_paths)
+    if isinstance(authority, JSONResponse):
+        return authority
+    with detached_requester_context(authority):
+        response = await _chat_completions(request, req, config, runtime_paths, prompt, thread_history, authority)
+    if isinstance(response, StreamingResponse):
+        body_iterator = response.body_iterator
+        response.body_iterator = context_bound_async_stream(
+            context_factory=lambda: detached_requester_context(authority),
+            stream_factory=lambda: aiter(body_iterator),
+        )
+    return response
 
+
+async def _chat_completions(  # noqa: C901, PLR0912
+    request: Request,
+    req: ChatCompletionRequest,
+    config: Config,
+    runtime_paths: RuntimePaths,
+    prompt: str,
+    thread_history: Sequence[ResolvedVisibleMessage] | None,
+    authority: DetachedRequesterContext | None,
+) -> JSONResponse | StreamingResponse:
+    """Execute a completion inside its authenticated requester boundary."""
     # Resolve auto-routing if model is "auto"
     agent_name = req.model
     if agent_name == AUTO_MODEL_NAME:
@@ -452,25 +558,33 @@ async def chat_completions(  # noqa: C901, PLR0912
             config,
             runtime_paths,
             thread_history,
+            authority=authority,
         )
         if isinstance(result, JSONResponse):
             return result
         agent_name = result
 
+    if not _requester_allows_model(agent_name, authority):
+        return _error_response(403, "This requester is not authorized for the model", code="permission_denied")
+
     # Derive a namespaced session ID from request headers or fallback UUID.
     session_id = _derive_session_id(agent_name, request)
+    if authority is not None:
+        requester_digest = hashlib.sha256(authority.requester_id.encode()).hexdigest()
+        session_id = f"requester:{requester_digest}:{session_id}"
     logger.info(
         "Chat completion request",
         model=agent_name,
         stream=req.stream,
         session_id=session_id,
+        requester_id=authority.requester_id if authority is not None else None,
     )
     execution_identity = build_tool_execution_identity(
         channel="openai_compat",
         agent_name=agent_name,
         session_id=session_id,
         runtime_paths=runtime_paths,
-        requester_id=None,
+        requester_id=authority.requester_id if authority is not None else None,
         room_id=None,
         thread_id=None,
         resolved_thread_id=None,
@@ -571,7 +685,12 @@ async def chat_completions(  # noqa: C901, PLR0912
 # ---------------------------------------------------------------------------
 
 
-def _openai_agent_turn_context(agent_name: str, *, session_id: str) -> ResponseTurnContext:
+def _openai_agent_turn_context(
+    agent_name: str,
+    *,
+    session_id: str,
+    execution_identity: ToolExecutionIdentity | None = None,
+) -> ResponseTurnContext:
     """Build the turn context for one OpenAI-compatible agent completion."""
     return ResponseTurnContext(
         entity_label=agent_name,
@@ -581,7 +700,7 @@ def _openai_agent_turn_context(agent_name: str, *, session_id: str) -> ResponseT
         reply_to_event_id=None,
         room_id=None,
         thread_id=None,
-        requester_id=None,
+        requester_id=execution_identity.requester_id if execution_identity is not None else None,
         matrix_run_metadata=None,
     )
 
@@ -600,7 +719,7 @@ async def _non_stream_completion(
 ) -> JSONResponse:
     """Handle non-streaming chat completion."""
     response_text = await ai_response(
-        _openai_agent_turn_context(agent_name, session_id=session_id),
+        _openai_agent_turn_context(agent_name, session_id=session_id, execution_identity=execution_identity),
         prompt=prompt,
         runtime_paths=runtime_paths,
         config=config,
@@ -654,7 +773,7 @@ async def _stream_completion(  # noqa: C901, PLR0915
         stream_with_tool_execution_identity(
             execution_identity,
             stream_factory=lambda: stream_agent_response(
-                _openai_agent_turn_context(agent_name, session_id=session_id),
+                _openai_agent_turn_context(agent_name, session_id=session_id, execution_identity=execution_identity),
                 prompt=prompt,
                 runtime_paths=runtime_paths,
                 config=config,

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -102,15 +102,17 @@ class DelegateTools(Toolkit):
             The delegated agent's response, or an error message if delegation failed.
 
         """
-        if agent_name not in self._delegate_to:
+        if agent_name not in self._delegate_to or not task or not task.strip():
             available = ", ".join(self._delegate_to)
-            return (
+            invalid_target_message = (
                 f"Cannot delegate to '{agent_name}'. Available agents: {available}. "
                 f"Run agents_list to inspect can_delegate flags."
             )
-
-        if not task or not task.strip():
-            return "Cannot delegate an empty task. Please provide a task description."
+            return (
+                "Cannot delegate an empty task. Please provide a task description."
+                if not task or not task.strip()
+                else invalid_target_message
+            )
 
         runtime_context = get_tool_runtime_context()
         detached_context = get_detached_requester_context()
@@ -132,19 +134,24 @@ class DelegateTools(Toolkit):
             membership_index = detached_context.agent_reply_memberships
         else:
             return f"Cannot delegate to '{agent_name}': requester authorization is unavailable."
-        if (
-            active_config is None
-            or agent_name not in active_config.agents
-            or not is_sender_allowed_for_responder(
-                requester_id,
-                agent_name,
-                authorization_room_id,
-                active_config,
-                self._runtime_paths,
-                membership_index,
-            )
-        ):
+        if active_config is None or agent_name not in active_config.agents:
             return f"Cannot delegate to '{agent_name}': that agent is not allowed to reply to you."
+        caller_config = active_config.agents.get(self._agent_name)
+        caller_allows_target = caller_config is not None and agent_name in caller_config.delegate_to
+        if not caller_allows_target or not is_sender_allowed_for_responder(
+            requester_id,
+            agent_name,
+            authorization_room_id,
+            active_config,
+            self._runtime_paths,
+            membership_index,
+        ):
+            reason = (
+                "it is no longer an allowed target"
+                if not caller_allows_target
+                else "that agent is not allowed to reply to you"
+            )
+            return f"Cannot delegate to '{agent_name}': {reason}."
 
         try:
             session_id = f"delegate:{self._agent_name}:{agent_name}:{uuid4()}"

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -22,6 +22,7 @@ from mindroom.logging_config import get_logger
 from mindroom.tool_system.runtime_context import (
     ToolRuntimeContext,
     ToolRuntimeModelBinding,
+    get_detached_requester_context,
     get_tool_runtime_context,
     tool_runtime_context,
 )
@@ -112,16 +113,36 @@ class DelegateTools(Toolkit):
             return "Cannot delegate an empty task. Please provide a task description."
 
         runtime_context = get_tool_runtime_context()
-        active_config = runtime_context.current_config if runtime_context is not None else self._config
-        if runtime_context is None:
+        detached_context = get_detached_requester_context()
+        if runtime_context is not None:
+            active_config = runtime_context.current_config
+            requester_id = runtime_context.requester_id
+            authorization_room_id = runtime_context.room_id
+            membership_index = runtime_context.require_agent_reply_memberships()
+        elif (
+            detached_context is not None
+            and self._execution_identity is not None
+            and self._execution_identity.channel == "openai_compat"
+            and self._execution_identity.requester_id == detached_context.requester_id
+            and self._runtime_paths == detached_context.runtime_paths
+        ):
+            active_config = detached_context.current_config
+            requester_id = detached_context.requester_id
+            authorization_room_id = None
+            membership_index = detached_context.agent_reply_memberships
+        else:
             return f"Cannot delegate to '{agent_name}': requester authorization is unavailable."
-        if not is_sender_allowed_for_responder(
-            runtime_context.requester_id,
-            agent_name,
-            runtime_context.room_id,
-            active_config,
-            self._runtime_paths,
-            runtime_context.require_agent_reply_memberships(),
+        if (
+            active_config is None
+            or agent_name not in active_config.agents
+            or not is_sender_allowed_for_responder(
+                requester_id,
+                agent_name,
+                authorization_room_id,
+                active_config,
+                self._runtime_paths,
+                membership_index,
+            )
         ):
             return f"Cannot delegate to '{agent_name}': that agent is not allowed to reply to you."
 
@@ -148,6 +169,7 @@ class DelegateTools(Toolkit):
                 "Delegating task",
                 from_agent=self._agent_name,
                 to_agent=agent_name,
+                requester_id=requester_id,
                 depth=self._delegation_depth + 1,
                 task_preview=task[:100],
             )
@@ -195,6 +217,9 @@ class DelegateTools(Toolkit):
                     config=active_config,
                     knowledge=knowledge_resolution.knowledge,
                     include_interactive_questions=False,
+                    include_openai_compat_guidance=(
+                        execution_identity is not None and execution_identity.channel == "openai_compat"
+                    ),
                     tool_function_filter=(
                         runtime_context.tool_function_filter if runtime_context is not None else None
                     ),

--- a/src/mindroom/custom_tools/delegate.py
+++ b/src/mindroom/custom_tools/delegate.py
@@ -88,7 +88,7 @@ class DelegateTools(Toolkit):
             "The delegated agent runs independently with no shared conversation history."
         )
 
-    async def delegate_task(self, agent_name: str, task: str) -> str:
+    async def delegate_task(self, agent_name: str, task: str) -> str:  # noqa: PLR0911
         """Delegate a task to one allowed agent and return its response.
 
         The runtime-generated tool description lists caller-specific allowed
@@ -102,16 +102,14 @@ class DelegateTools(Toolkit):
             The delegated agent's response, or an error message if delegation failed.
 
         """
-        if agent_name not in self._delegate_to or not task or not task.strip():
+        if not task or not task.strip():
+            return "Cannot delegate an empty task. Please provide a task description."
+
+        if agent_name not in self._delegate_to:
             available = ", ".join(self._delegate_to)
-            invalid_target_message = (
+            return (
                 f"Cannot delegate to '{agent_name}'. Available agents: {available}. "
                 f"Run agents_list to inspect can_delegate flags."
-            )
-            return (
-                "Cannot delegate an empty task. Please provide a task description."
-                if not task or not task.strip()
-                else invalid_target_message
             )
 
         runtime_context = get_tool_runtime_context()
@@ -128,7 +126,7 @@ class DelegateTools(Toolkit):
             and self._execution_identity.requester_id == detached_context.requester_id
             and self._runtime_paths == detached_context.runtime_paths
         ):
-            active_config = detached_context.current_config
+            active_config = detached_context.config_provider()
             requester_id = detached_context.requester_id
             authorization_room_id = None
             membership_index = detached_context.agent_reply_memberships

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -61,6 +61,43 @@ _ToolContextReturn = TypeVar("_ToolContextReturn")
 _StreamChunk = TypeVar("_StreamChunk")
 
 
+@dataclass(frozen=True)
+class DetachedRequesterContext:
+    """Authenticated requester authority for tools without a Matrix conversation."""
+
+    requester_id: str
+    config: Config
+    runtime_paths: RuntimePaths
+    agent_reply_memberships: AgentReplyMembershipIndex
+    config_provider: Callable[[], Config | None] | None = None
+
+    @property
+    def current_config(self) -> Config | None:
+        """Read current authorization policy, or deny if its runtime was replaced."""
+        return self.config_provider() if self.config_provider is not None else self.config
+
+
+_DETACHED_REQUESTER_CONTEXT: ContextVar[DetachedRequesterContext | None] = ContextVar(
+    "detached_requester_context",
+    default=None,
+)
+
+
+def get_detached_requester_context() -> DetachedRequesterContext | None:
+    """Return authority established by the current detached request boundary."""
+    return _DETACHED_REQUESTER_CONTEXT.get()
+
+
+@contextmanager
+def detached_requester_context(context: DetachedRequesterContext | None) -> Iterator[None]:
+    """Bind detached authority for an operation without leaking between requests."""
+    token = _DETACHED_REQUESTER_CONTEXT.set(context)
+    try:
+        yield
+    finally:
+        _DETACHED_REQUESTER_CONTEXT.reset(token)
+
+
 @contextmanager
 def _tool_runtime_context_scope(tool_context: ToolRuntimeContext | None) -> Iterator[None]:
     """Bind tool runtime state only for the duration of one concrete operation."""

--- a/src/mindroom/tool_system/runtime_context.py
+++ b/src/mindroom/tool_system/runtime_context.py
@@ -69,12 +69,7 @@ class DetachedRequesterContext:
     config: Config
     runtime_paths: RuntimePaths
     agent_reply_memberships: AgentReplyMembershipIndex
-    config_provider: Callable[[], Config | None] | None = None
-
-    @property
-    def current_config(self) -> Config | None:
-        """Read current authorization policy, or deny if its runtime was replaced."""
-        return self.config_provider() if self.config_provider is not None else self.config
+    config_provider: Callable[[], Config | None]
 
 
 _DETACHED_REQUESTER_CONTEXT: ContextVar[DetachedRequesterContext | None] = ContextVar(

--- a/tach.toml
+++ b/tach.toml
@@ -1011,7 +1011,10 @@ depends_on = [
     "mindroom.knowledge",
     "mindroom.logging_config",
     "mindroom.routing",
+    "mindroom.requester_identity",
     "mindroom.teams",
+    "mindroom.tool_system.context_bound_streams",
+    "mindroom.tool_system.runtime_context",
     "mindroom.tool_system.worker_routing",
 ]
 
@@ -3428,6 +3431,7 @@ depends_on = [
 path = "mindroom.tool_system.context_bound_streams"
 depends_on = []
 visibility = [
+    "mindroom.api.openai_compat",
     "mindroom.llm_request_logging",
     "mindroom.tool_system.runtime_context",
     "mindroom.tool_system.worker_routing",
@@ -4745,6 +4749,9 @@ expose = [
     "WorkerProgressEvent",
     "WorkerProgressPump",
     "ToolRuntimeContext",
+    "DetachedRequesterContext",
+    "detached_requester_context",
+    "get_detached_requester_context",
     "ToolRuntimeModelBinding",
     "ToolRuntimeHookBindings",
     "ToolRuntimeSupport",

--- a/tests/test_openai_requester_delegation.py
+++ b/tests/test_openai_requester_delegation.py
@@ -1,0 +1,331 @@
+"""Requester-bound API authentication and real delegation authorization checks."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from mindroom.api import config_lifecycle, openai_compat
+from mindroom.api.main import initialize_api_app
+from mindroom.config.access import ResponderAccessConfig
+from mindroom.config.agent import AgentConfig, TeamConfig
+from mindroom.config.main import Config
+from mindroom.config.models import ModelConfig
+from mindroom.constants import resolve_runtime_paths
+from mindroom.custom_tools.delegate import DelegateTools
+from mindroom.tool_system.runtime_context import get_detached_requester_context, get_tool_runtime_context
+from tests.identity_helpers import persist_entity_accounts
+
+pytestmark = pytest.mark.usefixtures("enforce_turn_authorization")
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+    from pathlib import Path
+
+    from mindroom.ai import ResponseTurnContext
+    from mindroom.constants import RuntimePaths
+    from mindroom.tool_system.worker_routing import ToolExecutionIdentity
+
+
+@dataclass
+class _ApiHarness:
+    client: TestClient
+    config: Config
+    runtime_paths: RuntimePaths
+
+
+@pytest.fixture
+def api(tmp_path: Path) -> Iterator[_ApiHarness]:
+    """Build an authenticated API with one permitted and one forbidden specialist."""
+    config = Config(
+        agents={
+            "leader": AgentConfig(
+                display_name="Leader",
+                delegate_to=["specialist", "forbidden"],
+                access=ResponderAccessConfig(users=["@alice:example.org"]),
+            ),
+            "specialist": AgentConfig(
+                display_name="Specialist",
+                access=ResponderAccessConfig(users=["@alice:example.org"]),
+            ),
+            "forbidden": AgentConfig(
+                display_name="Forbidden",
+                access=ResponderAccessConfig(users=["@bob:example.org"]),
+            ),
+        },
+        models={"default": ModelConfig(provider="ollama", id="test-model")},
+    )
+    config.authorization.aliases = {"@alice:example.org": ["@bridge:example.org"]}
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        process_env={
+            "OPENAI_COMPAT_API_KEYS": "alice-key,bob-key,legacy-key,bridge-key",
+            "OPENAI_COMPAT_API_KEY_REQUESTERS": json.dumps(
+                {
+                    "alice-key": "@alice:example.org",
+                    "bob-key": "@bob:example.org",
+                    "bridge-key": "@bridge:example.org",
+                    "revoked-key": "@alice:example.org",
+                },
+            ),
+        },
+    )
+    persist_entity_accounts(config, runtime_paths)
+    app = FastAPI()
+    app.include_router(openai_compat.router)
+    initialize_api_app(app, runtime_paths)
+    config_lifecycle.require_api_state(app).snapshot.runtime_config = config
+    with patch.object(openai_compat, "_load_config", return_value=(config, runtime_paths)), TestClient(app) as client:
+        yield _ApiHarness(client, config, runtime_paths)
+
+
+@pytest.mark.parametrize("stream", [False, True])
+@pytest.mark.parametrize("key", ["alice-key", "bridge-key"])
+def test_mapped_request_delegates_with_canonical_identity(api: _ApiHarness, stream: bool, key: str) -> None:
+    """Run the real delegate tool from both API drivers, including after an SSE yield."""
+    child_calls: list[ResponseTurnContext] = []
+
+    async def child(ctx: ResponseTurnContext, **kwargs: object) -> str:
+        child_calls.append(ctx)
+        assert ctx.requester_id == "@alice:example.org"
+        assert ctx.room_id is None
+        assert kwargs["include_openai_compat_guidance"] is True
+        assert get_tool_runtime_context() is None
+        assert get_detached_requester_context() is not None
+        return "specialist result"
+
+    async def delegate(
+        ctx: ResponseTurnContext,
+        *,
+        execution_identity: ToolExecutionIdentity,
+        **_kwargs: object,
+    ) -> str:
+        assert ctx.requester_id == "@alice:example.org"
+        assert execution_identity.requester_id == ctx.requester_id
+        tool = DelegateTools("leader", ["specialist"], api.runtime_paths, api.config, execution_identity)
+        return await tool.delegate_task("specialist", "help")
+
+    async def streaming(
+        ctx: ResponseTurnContext,
+        *,
+        execution_identity: ToolExecutionIdentity,
+        **_kwargs: object,
+    ) -> AsyncIterator[str]:
+        yield "Working: "
+        yield await delegate(ctx, execution_identity=execution_identity)
+
+    with (
+        patch.object(openai_compat, "ai_response", side_effect=delegate),
+        patch.object(openai_compat, "stream_agent_response", side_effect=streaming),
+        patch("mindroom.custom_tools.delegate.ai_response", side_effect=child),
+    ):
+        response = api.client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {key}", "X-Requester-ID": "@bob:example.org"},
+            json={
+                "model": "leader",
+                "messages": [{"role": "user", "content": "help"}],
+                "stream": stream,
+                "user": "@bob:example.org",
+            },
+        )
+    assert response.status_code == 200
+    assert "specialist result" in response.text
+    assert len(child_calls) == 1
+    assert get_detached_requester_context() is None
+
+
+@pytest.mark.parametrize(("key", "target"), [("legacy-key", "specialist"), ("alice-key", "forbidden")])
+def test_delegation_fails_closed(api: _ApiHarness, key: str, target: str) -> None:
+    """Unmapped callers and forbidden targets never reach child execution."""
+
+    async def delegate(
+        _ctx: ResponseTurnContext,
+        *,
+        execution_identity: ToolExecutionIdentity,
+        **_kwargs: object,
+    ) -> str:
+        tool = DelegateTools("leader", [target], api.runtime_paths, api.config, execution_identity)
+        return await tool.delegate_task(target, "help")
+
+    with (
+        patch.object(openai_compat, "ai_response", side_effect=delegate),
+        patch("mindroom.custom_tools.delegate.ai_response", new_callable=AsyncMock) as child,
+    ):
+        response = api.client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": f"Bearer {key}"},
+            json={"model": "leader", "messages": [{"role": "user", "content": "help"}]},
+        )
+    assert response.status_code == 200
+    assert "Cannot delegate" in response.text
+    child.assert_not_called()
+
+
+def test_mapped_model_visibility_and_direct_access(api: _ApiHarness) -> None:
+    """The model list and direct selection enforce the same requester permissions."""
+    headers = {"Authorization": "Bearer alice-key"}
+    response = api.client.get("/v1/models", headers=headers)
+    assert {model["id"] for model in response.json()["data"]} == {"auto", "leader", "specialist"}
+    response = api.client.post(
+        "/v1/chat/completions",
+        headers=headers,
+        json={"model": "forbidden", "messages": [{"role": "user", "content": "help"}]},
+    )
+    assert response.status_code == 403
+
+
+def test_team_access_requires_every_member(api: _ApiHarness) -> None:
+    """A permitted team cannot be used to reach a forbidden member."""
+    api.config.teams["mixed"] = TeamConfig(
+        display_name="Mixed",
+        role="Test team",
+        agents=["specialist", "forbidden"],
+        access=ResponderAccessConfig(users=["@alice:example.org"]),
+    )
+    headers = {"Authorization": "Bearer alice-key"}
+    response = api.client.get("/v1/models", headers=headers)
+    assert "team/mixed" not in {model["id"] for model in response.json()["data"]}
+    response = api.client.post(
+        "/v1/chat/completions",
+        headers=headers,
+        json={"model": "team/mixed", "messages": [{"role": "user", "content": "help"}]},
+    )
+    assert response.status_code == 403
+
+
+def test_bot_identity_cannot_be_used_as_requester(api: _ApiHarness) -> None:
+    """Mapped bot identities cannot gain the internal-sender authorization bypass."""
+    api.config.bot_accounts = ["@alice:example.org"]
+    response = api.client.get("/v1/models", headers={"Authorization": "Bearer alice-key"})
+    assert response.status_code == 403
+
+
+def test_mapping_does_not_authenticate_revoked_key(api: _ApiHarness) -> None:
+    """Only the configured active key list grants authentication."""
+    response = api.client.get("/v1/models", headers={"Authorization": "Bearer revoked-key"})
+    assert response.status_code == 401
+
+
+def test_nested_delegation_retains_authority_and_denies_forbidden_target(api: _ApiHarness) -> None:
+    """A specialist can delegate again but cannot acquire another requester's grants."""
+
+    async def parent(_ctx: ResponseTurnContext, *, execution_identity: ToolExecutionIdentity, **_kwargs: object) -> str:
+        tool = DelegateTools("leader", ["specialist"], api.runtime_paths, api.config, execution_identity)
+        return await tool.delegate_task("specialist", "help")
+
+    async def child(ctx: ResponseTurnContext, *, execution_identity: ToolExecutionIdentity, **_kwargs: object) -> str:
+        assert ctx.requester_id == "@alice:example.org"
+        assert execution_identity.agent_name == "specialist"
+        tool = DelegateTools(
+            "specialist",
+            ["forbidden"],
+            api.runtime_paths,
+            api.config,
+            execution_identity,
+            delegation_depth=1,
+        )
+        return await tool.delegate_task("forbidden", "help")
+
+    with (
+        patch.object(openai_compat, "ai_response", side_effect=parent),
+        patch("mindroom.custom_tools.delegate.ai_response", side_effect=child) as child_mock,
+    ):
+        response = api.client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer alice-key"},
+            json={"model": "leader", "messages": [{"role": "user", "content": "help"}]},
+        )
+    assert response.status_code == 200
+    assert "not allowed to reply" in response.text
+    assert child_mock.await_count == 1
+
+
+@pytest.mark.parametrize("policy", ["revoke", "room", "replace_runtime"])
+def test_delegation_rechecks_current_authorization(api: _ApiHarness, policy: str, tmp_path: Path) -> None:
+    """Changed policy and absent room state cannot reuse authority from request admission."""
+
+    async def parent(_ctx: ResponseTurnContext, *, execution_identity: ToolExecutionIdentity, **_kwargs: object) -> str:
+        replacement = api.config.model_copy(deep=True)
+        replacement.agents["specialist"].access = ResponderAccessConfig(
+            current_room_members=True,
+            members_of_rooms=["lobby"] if policy == "room" else [],
+        )
+        snapshot = config_lifecycle.require_api_state(api.client.app).snapshot
+        snapshot.runtime_config = replacement
+        if policy == "replace_runtime":
+            snapshot.runtime_paths = resolve_runtime_paths(config_path=tmp_path / "replaced.yaml", process_env={})
+        tool = DelegateTools("leader", ["specialist"], api.runtime_paths, api.config, execution_identity)
+        return await tool.delegate_task("specialist", "help")
+
+    with (
+        patch.object(openai_compat, "ai_response", side_effect=parent),
+        patch("mindroom.custom_tools.delegate.ai_response", new_callable=AsyncMock) as child,
+    ):
+        response = api.client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer alice-key"},
+            json={"model": "leader", "messages": [{"role": "user", "content": "help"}]},
+        )
+    assert response.status_code == 200
+    assert "Cannot delegate" in response.text
+    child.assert_not_called()
+
+
+def test_auto_route_only_receives_permitted_agents(api: _ApiHarness) -> None:
+    """The routing model cannot select a target outside this caller's access."""
+    with (
+        patch.object(openai_compat, "suggest_responder", new=AsyncMock(return_value="specialist")) as route,
+        patch.object(openai_compat, "ai_response", new=AsyncMock(return_value="done")),
+    ):
+        response = api.client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer alice-key"},
+            json={"model": "auto", "messages": [{"role": "user", "content": "help"}]},
+        )
+    assert response.status_code == 200
+    assert set(route.call_args.args[1]) == {"leader", "specialist"}
+
+
+def test_rebound_key_has_a_separate_session(api: _ApiHarness) -> None:
+    """Reassigning a key's canonical requester cannot open its former conversation."""
+    sessions: list[str] = []
+
+    async def parent(ctx: ResponseTurnContext, **_kwargs: object) -> str:
+        sessions.append(ctx.session_id)
+        return "done"
+
+    api.config.agents["leader"].access = ResponderAccessConfig(users=["@alice:example.org", "@bob:example.org"])
+    with patch.object(openai_compat, "ai_response", side_effect=parent):
+        for requester in ["@alice:example.org", "@bob:example.org"]:
+            with patch.object(openai_compat, "_api_key_requester", return_value=requester):
+                response = api.client.post(
+                    "/v1/chat/completions",
+                    headers={"Authorization": "Bearer alice-key", "X-Session-ID": "same"},
+                    json={"model": "leader", "messages": [{"role": "user", "content": "help"}]},
+                )
+            assert response.status_code == 200
+    assert sessions[0] != sessions[1]
+
+
+@pytest.mark.parametrize(
+    "mapping",
+    ["{", "[]", '{"key": null}', '{"key": 5}', '{"key": "alice"}', '{"key": "@*:example.org"}'],
+)
+def test_invalid_mapping_is_generic_configuration_error(tmp_path: Path, mapping: str) -> None:
+    """Bad identity configuration fails closed without returning secrets."""
+    runtime_paths = resolve_runtime_paths(
+        config_path=tmp_path / "config.yaml",
+        process_env={"OPENAI_COMPAT_API_KEYS": "key", "OPENAI_COMPAT_API_KEY_REQUESTERS": mapping},
+    )
+    response = openai_compat._authenticate_request("Bearer key", runtime_paths)
+    assert isinstance(response, JSONResponse)
+    assert response.status_code == 503
+    assert json.loads(response.body)["error"]["message"] == "Invalid API requester configuration"

--- a/tests/test_openai_requester_delegation.py
+++ b/tests/test_openai_requester_delegation.py
@@ -216,6 +216,7 @@ def test_mapping_does_not_authenticate_revoked_key(api: _ApiHarness) -> None:
 
 def test_nested_delegation_retains_authority_and_denies_forbidden_target(api: _ApiHarness) -> None:
     """A specialist can delegate again but cannot acquire another requester's grants."""
+    api.config.agents["specialist"].delegate_to = ["forbidden"]
 
     async def parent(_ctx: ResponseTurnContext, *, execution_identity: ToolExecutionIdentity, **_kwargs: object) -> str:
         tool = DelegateTools("leader", ["specialist"], api.runtime_paths, api.config, execution_identity)
@@ -276,6 +277,30 @@ def test_delegation_rechecks_current_authorization(api: _ApiHarness, policy: str
         )
     assert response.status_code == 200
     assert "Cannot delegate" in response.text
+    child.assert_not_called()
+
+
+def test_delegation_rechecks_current_caller_allowlist(api: _ApiHarness) -> None:
+    """Hot reload revoking a caller's delegation edge stops an active API run."""
+
+    async def parent(_ctx: ResponseTurnContext, *, execution_identity: ToolExecutionIdentity, **_kwargs: object) -> str:
+        replacement = api.config.model_copy(deep=True)
+        replacement.agents["leader"].delegate_to = []
+        config_lifecycle.require_api_state(api.client.app).snapshot.runtime_config = replacement
+        tool = DelegateTools("leader", ["specialist"], api.runtime_paths, api.config, execution_identity)
+        return await tool.delegate_task("specialist", "help")
+
+    with (
+        patch.object(openai_compat, "ai_response", side_effect=parent),
+        patch("mindroom.custom_tools.delegate.ai_response", new_callable=AsyncMock) as child,
+    ):
+        response = api.client.post(
+            "/v1/chat/completions",
+            headers={"Authorization": "Bearer alice-key"},
+            json={"model": "leader", "messages": [{"role": "user", "content": "help"}]},
+        )
+    assert response.status_code == 200
+    assert "no longer an allowed target" in response.text
     child.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

Fixes #1963.

OpenAI-compatible requests can now bind an API key to a canonical Matrix requester identity.
The identity is propagated through agent and nested delegation runs, and existing responder access checks remain authoritative.

Mapped callers are filtered in `/v1/models`, auto-routing, direct model selection, and `delegate_task`.
Unmapped API keys keep their current behavior and cannot delegate.

## Configuration

```dotenv
OPENAI_COMPAT_API_KEYS=sk-astrbot,sk-legacy
OPENAI_COMPAT_API_KEY_REQUESTERS='{"sk-astrbot":"@alice:example.org"}'
```

## Validation

- 286 focused API, delegation, authorization, membership, runtime-context, and import-graph tests passed.
- Added 22 regression tests covering streaming, nested delegation, aliases, revocation, model visibility, team access, and runtime replacement.
- Full pre-commit suite passed.
- Full repository pytest remains limited by unrelated existing failures on macOS, PostgreSQL worker startup, and Linux-only process-group tests.

## Summary by Sourcery

Authorize OpenAI-compatible delegation with API-key-bound Matrix requester identities while preserving existing responder access controls.

New Features:
- Bind selected OpenAI-compatible API keys to canonical human Matrix requester identities.
- Apply requester-based access filtering to model listing, auto-routing, direct model selection, teams, and delegation.
- Propagate requester identity through streaming, delegated, and nested delegation runs while isolating requester sessions.

Bug Fixes:
- Prevent unmapped API keys from delegating and prevent mapped callers from accessing unauthorized agents or team members.
- Recheck current delegation permissions and fail closed when requester configuration, runtime state, or membership authorization is invalid.

Enhancements:
- Preserve existing responder authorization as the authority for OpenAI-compatible requester access, including alias resolution and membership-based policies.

Documentation:
- Document API-key requester mappings, authorization behavior, delegation rules, configuration validation, and fail-closed membership requirements.

Tests:
- Add regression coverage for requester-bound authentication, streaming and nested delegation, aliases, revocation, model visibility, team access, session isolation, and runtime authorization changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - OpenAI-compatible API keys can be linked to specific Matrix user identities.
  - Requester identity is enforced across model access, delegation, nested runs, and streaming requests.
  - Delegation respects both agent permissions and requester access to target agents or teams.
  - Unmapped API keys retain model access but cannot delegate.
  - Requester-specific session isolation prevents reassigned keys from inheriting prior sessions.

- **Documentation**
  - Added configuration guidance covering requester mapping, delegation rules, access restrictions, session isolation, and unavailable delegated tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->