### PR TITLE
feat: support explicit thread targets in lifecycle tools

### DIFF
--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -17,7 +17,7 @@ Use these tools when you need to send or inspect Matrix messages, manage thread 
 - [`matrix_room`] - Inspect Matrix room metadata, members, thread roots, and room state.
 - [`matrix_voice_message`] - Generate speech from text and send it as a Matrix voice note.
 - [`thread_tags`] - Add, remove, and inspect shared tags on a Matrix thread.
-- [`thread_resolution`] - Explicitly resolve or reopen the active Matrix thread.
+- [`thread_resolution`] - Explicitly resolve or reopen Matrix threads in the current room.
 - [`thread_summary`] - Set or update a Matrix thread summary from the current room and thread context.
 - [`thread_model`] - List models or show, switch, and reset the model override for the current Matrix thread.
 - [`matrix_api`] - Use a low-level Matrix event and state API with explicit room and event IDs.
@@ -232,12 +232,14 @@ list_thread_tags(exclude_tag="resolved", include_untagged=True)
 
 ## [`thread_resolution`]
 
-`thread_resolution` gives an agent explicit permission to resolve or reopen its active Matrix thread.
+`thread_resolution` gives an agent explicit permission to resolve or reopen Matrix threads in the current room.
 
 ### What It Does
 
-`thread_resolution` exposes `resolve_thread()` and `reopen_thread()`.
-Both functions require an active thread and always target its canonical thread root.
+`thread_resolution` exposes `resolve_thread(thread_id=None)` and `reopen_thread(thread_id=None)`.
+Without `thread_id`, both functions require an active thread and target its canonical thread root.
+Pass a thread root or reply event ID to target another thread in the current room, including when calling from the room timeline.
+Explicit IDs are normalized to their canonical thread root, and unresolved targets return an error without changing any thread.
 `resolve_thread()` adds the `resolved` lifecycle tag, while `reopen_thread()` removes it.
 
 ### Configuration
@@ -259,7 +261,12 @@ agents:
 ```python
 resolve_thread()
 reopen_thread()
+resolve_thread(thread_id="$completed-thread:example.org")
+reopen_thread(thread_id="$completed-thread:example.org")
 ```
+
+To clear completed project threads, use `list_thread_tags(exclude_tag="resolved", include_untagged=True)` to find candidates, then call `resolve_thread(thread_id=...)` for each selected thread.
+Check the listing's `truncated` flag before treating it as complete.
 
 ### Notes
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7133,7 +7133,7 @@ Use these tools when you need to send or inspect Matrix messages, manage thread 
 - [`matrix_room`] - Inspect Matrix room metadata, members, thread roots, and room state.
 - [`matrix_voice_message`] - Generate speech from text and send it as a Matrix voice note.
 - [`thread_tags`] - Add, remove, and inspect shared tags on a Matrix thread.
-- [`thread_resolution`] - Explicitly resolve or reopen the active Matrix thread.
+- [`thread_resolution`] - Explicitly resolve or reopen Matrix threads in the current room.
 - [`thread_summary`] - Set or update a Matrix thread summary from the current room and thread context.
 - [`thread_model`] - List models or show, switch, and reset the model override for the current Matrix thread.
 - [`matrix_api`] - Use a low-level Matrix event and state API with explicit room and event IDs.
@@ -7348,12 +7348,14 @@ list_thread_tags(exclude_tag="resolved", include_untagged=True)
 
 ## [`thread_resolution`]
 
-`thread_resolution` gives an agent explicit permission to resolve or reopen its active Matrix thread.
+`thread_resolution` gives an agent explicit permission to resolve or reopen Matrix threads in the current room.
 
 ### What It Does
 
-`thread_resolution` exposes `resolve_thread()` and `reopen_thread()`.
-Both functions require an active thread and always target its canonical thread root.
+`thread_resolution` exposes `resolve_thread(thread_id=None)` and `reopen_thread(thread_id=None)`.
+Without `thread_id`, both functions require an active thread and target its canonical thread root.
+Pass a thread root or reply event ID to target another thread in the current room, including when calling from the room timeline.
+Explicit IDs are normalized to their canonical thread root, and unresolved targets return an error without changing any thread.
 `resolve_thread()` adds the `resolved` lifecycle tag, while `reopen_thread()` removes it.
 
 ### Configuration
@@ -7375,7 +7377,12 @@ agents:
 ```python
 resolve_thread()
 reopen_thread()
+resolve_thread(thread_id="$completed-thread:example.org")
+reopen_thread(thread_id="$completed-thread:example.org")
 ```
+
+To clear completed project threads, use `list_thread_tags(exclude_tag="resolved", include_untagged=True)` to find candidates, then call `resolve_thread(thread_id=...)` for each selected thread.
+Check the listing's `truncated` flag before treating it as complete.
 
 ### Notes
 

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -13,7 +13,7 @@ Use these tools when you need to send or inspect Matrix messages, manage thread 
 - [`matrix_room`] - Inspect Matrix room metadata, members, thread roots, and room state.
 - [`matrix_voice_message`] - Generate speech from text and send it as a Matrix voice note.
 - [`thread_tags`] - Add, remove, and inspect shared tags on a Matrix thread.
-- [`thread_resolution`] - Explicitly resolve or reopen the active Matrix thread.
+- [`thread_resolution`] - Explicitly resolve or reopen Matrix threads in the current room.
 - [`thread_summary`] - Set or update a Matrix thread summary from the current room and thread context.
 - [`thread_model`] - List models or show, switch, and reset the model override for the current Matrix thread.
 - [`matrix_api`] - Use a low-level Matrix event and state API with explicit room and event IDs.
@@ -228,12 +228,14 @@ list_thread_tags(exclude_tag="resolved", include_untagged=True)
 
 ## [`thread_resolution`]
 
-`thread_resolution` gives an agent explicit permission to resolve or reopen its active Matrix thread.
+`thread_resolution` gives an agent explicit permission to resolve or reopen Matrix threads in the current room.
 
 ### What It Does
 
-`thread_resolution` exposes `resolve_thread()` and `reopen_thread()`.
-Both functions require an active thread and always target its canonical thread root.
+`thread_resolution` exposes `resolve_thread(thread_id=None)` and `reopen_thread(thread_id=None)`.
+Without `thread_id`, both functions require an active thread and target its canonical thread root.
+Pass a thread root or reply event ID to target another thread in the current room, including when calling from the room timeline.
+Explicit IDs are normalized to their canonical thread root, and unresolved targets return an error without changing any thread.
 `resolve_thread()` adds the `resolved` lifecycle tag, while `reopen_thread()` removes it.
 
 ### Configuration
@@ -255,7 +257,12 @@ agents:
 ```python
 resolve_thread()
 reopen_thread()
+resolve_thread(thread_id="$completed-thread:example.org")
+reopen_thread(thread_id="$completed-thread:example.org")
 ```
+
+To clear completed project threads, use `list_thread_tags(exclude_tag="resolved", include_untagged=True)` to find candidates, then call `resolve_thread(thread_id=...)` for each selected thread.
+Check the listing's `truncated` flag before treating it as complete.
 
 ### Notes
 

--- a/src/mindroom/custom_tools/thread_resolution.py
+++ b/src/mindroom/custom_tools/thread_resolution.py
@@ -4,13 +4,15 @@ from __future__ import annotations
 
 from agno.tools import Toolkit
 
+from mindroom.custom_tools.attachment_helpers import resolve_canonical_tool_thread_target
 from mindroom.custom_tools.tool_payloads import custom_tool_payload
+from mindroom.matrix.thread_room_scan import resolve_thread_root_event_id_for_client
 from mindroom.thread_tags import RESOLVED_THREAD_TAG, ThreadTagsError, remove_thread_tag, set_thread_tag
 from mindroom.tool_system.runtime_context import ToolRuntimeContext, get_tool_runtime_context
 
 
 class ThreadResolutionTools(Toolkit):
-    """Tools for resolving or reopening the active Matrix thread."""
+    """Tools for resolving or reopening Matrix threads in the current room."""
 
     def __init__(self) -> None:
         super().__init__(
@@ -23,17 +25,43 @@ class ThreadResolutionTools(Toolkit):
         return custom_tool_payload("thread_resolution", status, **kwargs)
 
     @classmethod
-    def _thread_context(cls) -> tuple[ToolRuntimeContext, str] | str:
+    async def _thread_context(cls, thread_id: str | None) -> tuple[ToolRuntimeContext, str] | str:
         context = get_tool_runtime_context()
         if context is None:
             return cls._payload("error", message="Thread resolution tool context is unavailable in this runtime path.")
-        if context.resolved_thread_id is None:
-            return cls._payload("error", message="Thread resolution requires an active thread context.")
-        return context, context.resolved_thread_id
+        if thread_id is None:
+            if context.resolved_thread_id is None:
+                return cls._payload(
+                    "error",
+                    message="thread_id is required when no active thread context is available.",
+                )
+            return context, context.resolved_thread_id
 
-    async def resolve_thread(self) -> str:
-        """Mark the active Matrix thread as resolved."""
-        resolved = self._thread_context()
+        target = await resolve_canonical_tool_thread_target(
+            context,
+            room_id=context.room_id,
+            thread_id=thread_id,
+            normalize_thread_id=lambda room_id, event_id: resolve_thread_root_event_id_for_client(
+                context.client,
+                room_id,
+                event_id,
+                relations=context.relations,
+            ),
+        )
+        if target.error is not None:
+            return cls._payload("error", thread_id=target.requested_thread_id, message=target.error)
+        assert target.canonical_thread_id is not None
+        return context, target.canonical_thread_id
+
+    async def resolve_thread(self, thread_id: str | None = None) -> str:
+        """Mark the current or specified Matrix thread in the current room as resolved.
+
+        Args:
+            thread_id: Thread root or reply event ID in the current room.
+                Omit to use the active thread.
+
+        """
+        resolved = await self._thread_context(thread_id)
         if isinstance(resolved, str):
             return resolved
         context, thread_id = resolved
@@ -55,9 +83,15 @@ class ThreadResolutionTools(Toolkit):
             resolved=True,
         )
 
-    async def reopen_thread(self) -> str:
-        """Remove resolved state from the active Matrix thread."""
-        resolved = self._thread_context()
+    async def reopen_thread(self, thread_id: str | None = None) -> str:
+        """Remove resolved state from the current or specified Matrix thread in the current room.
+
+        Args:
+            thread_id: Thread root or reply event ID in the current room.
+                Omit to use the active thread.
+
+        """
+        resolved = await self._thread_context(thread_id)
         if isinstance(resolved, str):
             return resolved
         context, thread_id = resolved

--- a/src/mindroom/custom_tools/thread_resolution.py
+++ b/src/mindroom/custom_tools/thread_resolution.py
@@ -47,6 +47,7 @@ class ThreadResolutionTools(Toolkit):
                 event_id,
                 relations=context.relations,
             ),
+            fail_closed_on_normalization_error=True,
         )
         if target.error is not None:
             return cls._payload("error", thread_id=target.requested_thread_id, message=target.error)

--- a/src/mindroom/tools/thread_resolution.py
+++ b/src/mindroom/tools/thread_resolution.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 @register_tool_with_metadata(
     name="thread_resolution",
     display_name="Thread Resolution",
-    description="Explicitly resolve or reopen the active Matrix thread",
+    description="Explicitly resolve or reopen Matrix threads in the current room",
     category=ToolCategory.COMMUNICATION,
     status=ToolStatus.AVAILABLE,
     setup_type=SetupType.NONE,

--- a/src/mindroom/tools_metadata.json
+++ b/src/mindroom/tools_metadata.json
@@ -644,7 +644,7 @@
       "dependencies": [
         "agno"
       ],
-      "description": "Explicitly resolve or reopen the active Matrix thread",
+      "description": "Explicitly resolve or reopen Matrix threads in the current room",
       "display_name": "Thread Resolution",
       "docs_url": "https://github.com/mindroom-ai/mindroom",
       "function_names": [

--- a/tach.toml
+++ b/tach.toml
@@ -1341,6 +1341,14 @@ depends_on = [
 ]
 
 [[modules]]
+path = "mindroom.custom_tools.thread_resolution"
+depends_on = [
+    "mindroom.matrix.thread_room_scan",
+    "mindroom.thread_tags",
+    "mindroom.tool_system.runtime_context",
+]
+
+[[modules]]
 path = "mindroom.custom_tools.thread_tags"
 depends_on = [
     "mindroom.matrix.room_history_reads",
@@ -4483,6 +4491,7 @@ expose = [
 ]
 from = ["mindroom.matrix.thread_room_scan"]
 visibility = [
+    "mindroom.custom_tools.thread_resolution",
     "mindroom.custom_tools.thread_summary",
     "mindroom.custom_tools.thread_tags",
     "mindroom.matrix.thread_mutation_impact",

--- a/tests/test_thread_resolution_tool.py
+++ b/tests/test_thread_resolution_tool.py
@@ -217,6 +217,32 @@ async def test_thread_resolution_rejects_unresolved_explicit_target(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("reopen", [False, True])
+async def test_thread_resolution_returns_error_when_target_lookup_raises(tmp_path: Path, reopen: bool) -> None:
+    """Lookup failures must return a structured error without changing lifecycle state."""
+    context = _context(tmp_path)
+    tool = ThreadResolutionTools()
+    method = tool.reopen_thread if reopen else tool.resolve_thread
+
+    with (
+        patch(
+            "mindroom.custom_tools.thread_resolution.resolve_thread_root_event_id_for_client",
+            new=AsyncMock(side_effect=RuntimeError("lookup failed")),
+        ),
+        patch("mindroom.custom_tools.thread_resolution.set_thread_tag", new=AsyncMock()) as mock_set,
+        patch("mindroom.custom_tools.thread_resolution.remove_thread_tag", new=AsyncMock()) as mock_remove,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await method(thread_id="$other-root:localhost"))
+
+    assert payload["status"] == "error"
+    assert payload["thread_id"] == "$other-root:localhost"
+    assert "canonical thread root" in payload["message"]
+    mock_set.assert_not_awaited()
+    mock_remove.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("method_name", "dependency", "action"),
     [

--- a/tests/test_thread_resolution_tool.py
+++ b/tests/test_thread_resolution_tool.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from nio import RoomGetEventError
 
 import mindroom.tools  # noqa: F401
 from mindroom.config.agent import AgentConfig
@@ -135,6 +137,83 @@ async def test_reopen_thread_removes_lifecycle_tag(tmp_path: Path) -> None:
         RESOLVED_THREAD_TAG,
         requester_user_id=context.requester_id,
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reopen", [False, True])
+@pytest.mark.parametrize("active_thread_id", [THREAD_ID, None])
+@pytest.mark.parametrize("target_id", ["$other-root:localhost", "$other-reply:localhost"])
+async def test_thread_resolution_targets_explicit_thread(
+    tmp_path: Path,
+    reopen: bool,
+    active_thread_id: str | None,
+    target_id: str,
+) -> None:
+    """An explicit root or reply must mutate its canonical thread, even from the room timeline."""
+    context = _context(tmp_path, thread_id=active_thread_id)
+    context.client.room_get_event = AsyncMock(return_value=RoomGetEventError("missing", status_code="M_NOT_FOUND"))
+    context = replace(
+        context,
+        relations=make_relation_lookup(
+            threads={
+                "$other-root:localhost": "$other-root:localhost",
+                "$other-reply:localhost": "$other-root:localhost",
+            },
+            client=context.client,
+        ),
+    )
+    tool = ThreadResolutionTools()
+    method = tool.reopen_thread if reopen else tool.resolve_thread
+    dependency = "remove_thread_tag" if reopen else "set_thread_tag"
+    requester_kwarg = "requester_user_id" if reopen else "set_by"
+
+    with (
+        patch(f"mindroom.custom_tools.thread_resolution.{dependency}", new=AsyncMock()) as mock_write,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await method(thread_id=target_id))
+
+    assert payload["status"] == "ok"
+    assert payload["thread_id"] == "$other-root:localhost"
+    assert payload["room_id"] == ROOM_ID
+    assert payload["resolved"] is not reopen
+    mock_write.assert_awaited_once_with(
+        context.client,
+        ROOM_ID,
+        "$other-root:localhost",
+        RESOLVED_THREAD_TAG,
+        **{requester_kwarg: context.requester_id},
+    )
+    context.client.room_get_event.assert_awaited_once_with(ROOM_ID, target_id)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("reopen", [False, True])
+@pytest.mark.parametrize("target_id", ["", "   ", "$missing-or-other-room:localhost"])
+async def test_thread_resolution_rejects_unresolved_explicit_target(
+    tmp_path: Path,
+    reopen: bool,
+    target_id: str,
+) -> None:
+    """An invalid explicit target must fail without changing the active thread."""
+    context = _context(tmp_path)
+    context.client.room_get_event = AsyncMock(return_value=RoomGetEventError("missing", status_code="M_NOT_FOUND"))
+    context = replace(context, relations=make_relation_lookup(client=context.client))
+    tool = ThreadResolutionTools()
+    method = tool.reopen_thread if reopen else tool.resolve_thread
+
+    with (
+        patch("mindroom.custom_tools.thread_resolution.set_thread_tag", new=AsyncMock()) as mock_set,
+        patch("mindroom.custom_tools.thread_resolution.remove_thread_tag", new=AsyncMock()) as mock_remove,
+        tool_runtime_context(context),
+    ):
+        payload = json.loads(await method(thread_id=target_id))
+
+    assert payload["status"] == "error"
+    assert payload["thread_id"] == target_id
+    assert "canonical thread root" in payload["message"]
+    mock_set.assert_not_awaited()
+    mock_remove.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Allow `resolve_thread` and `reopen_thread` to accept an optional `thread_id` for selecting another thread in the current Matrix room.
Omitting the argument preserves active-thread behavior; explicit root or reply event IDs are resolved to their canonical thread root, and invalid targets or lookup failures return a structured error without changing thread state.

Update tool descriptions, generated metadata, documentation, and regression coverage for explicit targets, room-timeline calls, invalid IDs, and lookup failures.
Declare the lifecycle tool's runtime dependencies and thread-room-scan interface access in Tach.

Validation:
- Full Python suite: 15,383 passed, 23 skipped.
- Focused thread lifecycle, tagging, and metadata tests: 234 passed.
- Repository-wide pre-commit hooks passed.

## Summary by Sourcery

Support explicit thread targets in lifecycle tools while retaining active-thread behavior by default.

New Features:
- Allow `resolve_thread` and `reopen_thread` to target a specified thread root or reply event in the current Matrix room.

Bug Fixes:
- Reject unresolved or invalid explicit thread targets without changing lifecycle state.

Enhancements:
- Normalize explicit thread targets to their canonical thread roots while preserving active-thread behavior when no target is supplied.

Documentation:
- Update tool descriptions, generated metadata, and Matrix tool documentation for explicit thread targeting and room-timeline usage.

Tests:
- Add regression coverage for explicit root and reply targets, room-timeline calls, invalid IDs, and lookup failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Thread resolution tools can now resolve or reopen any thread in the current room by specifying a thread root or reply event.
  * Thread targets are normalized to their canonical root, with clear errors for unresolved targets.

* **Documentation**
  * Updated tool descriptions, examples, and guidance for targeting threads and reviewing unresolved or completed threads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->