### PR TITLE
fix: let agents inspect context media attachments

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -88,15 +88,21 @@ agents:
 | Operation | Description |
 |-----------|-------------|
 | `list_attachments(target?)` | List metadata for attachments in the current context (ID, kind, local_path, filename, MIME type, size, room_id, thread_id, sender, event_timestamp, created_at) |
-| `get_attachment(attachment_id, mindroom_output_path?, view=False)` | Return metadata, save bytes to a workspace-relative path, or send image pixels to the model with `view=True` |
+| `get_attachment(attachment_id, mindroom_output_path?, view=False)` | Return metadata, save bytes to a workspace-relative path, or send media/document content to the model with `view=True` |
 | `register_attachment(file_path)` | Register a local file path as a context attachment ID (`att_*`) |
 
 By default, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
-Use `get_attachment("att_...", view=True)` to visually inspect an image from earlier in the conversation or a local file registered with `register_attachment(file_path)`.
-Viewing sends image bytes to the configured model; listing or registering an attachment alone does not let the model see its pixels.
-It requires an image-capable model and supports PNG, JPEG, GIF, and WebP images up to 20 MiB, with the format detected from the bytes.
+Use `get_attachment("att_...", view=True)` to inspect media from earlier in the conversation or a local file registered with `register_attachment(file_path)`.
+This sends the attachment bytes to the configured model, using native image, audio, video, or document inputs rather than putting binary data in tool text.
+It supports PNG, JPEG, GIF, and WebP images, audio, video, and Agno-supported document types including PDF and plain text, with a 20 MiB limit per attachment.
+Image format is detected from the bytes; other media uses the attachment's MIME type and filename.
+The selected model and its provider adapter must support the media type and may impose stricter format or size limits.
 The attachment must be available in the current context and have a readable local file.
 `view=True` cannot be combined with `mindroom_output_path`.
+If the provider rejects inline media, MindRoom retries the request without it and explicitly tells the agent that the removed content was not inspected.
+Known adapter omissions use the same guidance, so unsupported media is not silently dropped.
+The agent can then call `get_attachment` without `view` to obtain metadata or save the file, and use other available extraction, transcription, or analysis tools.
+This does not provision another model, grant credentials, or automatically delegate the task.
 For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 `mindroom_output_path` must be a file path relative to the agent workspace.
 It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -88,10 +88,15 @@ agents:
 | Operation | Description |
 |-----------|-------------|
 | `list_attachments(target?)` | List metadata for attachments in the current context (ID, kind, local_path, filename, MIME type, size, room_id, thread_id, sender, event_timestamp, created_at) |
-| `get_attachment(attachment_id, mindroom_output_path?)` | Return one context attachment record, or save its bytes to a workspace-relative path and return a save receipt |
+| `get_attachment(attachment_id, mindroom_output_path?, view=False)` | Return metadata, save bytes to a workspace-relative path, or send image pixels to the model with `view=True` |
 | `register_attachment(file_path)` | Register a local file path as a context attachment ID (`att_*`) |
 
-When `mindroom_output_path` is omitted, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
+By default, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
+Use `get_attachment("att_...", view=True)` to visually inspect an image from earlier in the conversation or a local file registered with `register_attachment(file_path)`.
+Viewing sends image bytes to the configured model; listing or registering an attachment alone does not let the model see its pixels.
+It requires an image-capable model and supports PNG, JPEG, GIF, and WebP images up to 20 MiB, with the format detected from the bytes.
+The attachment must be available in the current context and have a readable local file.
+`view=True` cannot be combined with `mindroom_output_path`.
 For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 `mindroom_output_path` must be a file path relative to the agent workspace.
 It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -421,6 +421,9 @@ matrix_api(
 `list_attachments()` returns the attachment IDs currently available in tool runtime context, the resolved metadata payloads, and any `missing_attachment_ids`.
 Pass a context-available attachment ID as `target` to return only that attachment; an ID outside the current context returns an error.
 `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
+`get_attachment(attachment_id, view=True)` sends the image pixels to the model for visual analysis, including images registered from local files or referenced earlier in the conversation.
+Viewing requires an image-capable model and a readable, context-scoped PNG, JPEG, GIF, or WebP file no larger than 20 MiB.
+It cannot be combined with `mindroom_output_path`.
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 In shell tools, the agent workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.

--- a/docs/tools/matrix-and-attachments.md
+++ b/docs/tools/matrix-and-attachments.md
@@ -421,8 +421,9 @@ matrix_api(
 `list_attachments()` returns the attachment IDs currently available in tool runtime context, the resolved metadata payloads, and any `missing_attachment_ids`.
 Pass a context-available attachment ID as `target` to return only that attachment; an ID outside the current context returns an error.
 `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
-`get_attachment(attachment_id, view=True)` sends the image pixels to the model for visual analysis, including images registered from local files or referenced earlier in the conversation.
-Viewing requires an image-capable model and a readable, context-scoped PNG, JPEG, GIF, or WebP file no larger than 20 MiB.
+`get_attachment(attachment_id, view=True)` sends image, audio, video, or document content (including PDF) to the model, including local files and attachments from earlier in the conversation.
+Viewing requires a model and provider adapter that support the media type, and a readable, context-scoped file no larger than 20 MiB.
+Rejected media requests retry without the media and give the agent explicit guidance to use the attachment ID/path with other available tools; known adapter omissions receive the same guidance.
 It cannot be combined with `mindroom_output_path`.
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7607,6 +7607,9 @@ matrix_api(
 `list_attachments()` returns the attachment IDs currently available in tool runtime context, the resolved metadata payloads, and any `missing_attachment_ids`.
 Pass a context-available attachment ID as `target` to return only that attachment; an ID outside the current context returns an error.
 `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
+`get_attachment(attachment_id, view=True)` sends the image pixels to the model for visual analysis, including images registered from local files or referenced earlier in the conversation.
+Viewing requires an image-capable model and a readable, context-scoped PNG, JPEG, GIF, or WebP file no larger than 20 MiB.
+It cannot be combined with `mindroom_output_path`.
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 In shell tools, the agent workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.
@@ -15295,10 +15298,15 @@ agents:
 | Operation | Description |
 |-----------|-------------|
 | `list_attachments(target?)` | List metadata for attachments in the current context (ID, kind, local_path, filename, MIME type, size, room_id, thread_id, sender, event_timestamp, created_at) |
-| `get_attachment(attachment_id, mindroom_output_path?)` | Return one context attachment record, or save its bytes to a workspace-relative path and return a save receipt |
+| `get_attachment(attachment_id, mindroom_output_path?, view=False)` | Return metadata, save bytes to a workspace-relative path, or send image pixels to the model with `view=True` |
 | `register_attachment(file_path)` | Register a local file path as a context attachment ID (`att_*`) |
 
-When `mindroom_output_path` is omitted, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
+By default, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
+Use `get_attachment("att_...", view=True)` to visually inspect an image from earlier in the conversation or a local file registered with `register_attachment(file_path)`.
+Viewing sends image bytes to the configured model; listing or registering an attachment alone does not let the model see its pixels.
+It requires an image-capable model and supports PNG, JPEG, GIF, and WebP images up to 20 MiB, with the format detected from the bytes.
+The attachment must be available in the current context and have a readable local file.
+`view=True` cannot be combined with `mindroom_output_path`.
 For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 `mindroom_output_path` must be a file path relative to the agent workspace.
 It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -7607,8 +7607,9 @@ matrix_api(
 `list_attachments()` returns the attachment IDs currently available in tool runtime context, the resolved metadata payloads, and any `missing_attachment_ids`.
 Pass a context-available attachment ID as `target` to return only that attachment; an ID outside the current context returns an error.
 `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
-`get_attachment(attachment_id, view=True)` sends the image pixels to the model for visual analysis, including images registered from local files or referenced earlier in the conversation.
-Viewing requires an image-capable model and a readable, context-scoped PNG, JPEG, GIF, or WebP file no larger than 20 MiB.
+`get_attachment(attachment_id, view=True)` sends image, audio, video, or document content (including PDF) to the model, including local files and attachments from earlier in the conversation.
+Viewing requires a model and provider adapter that support the media type, and a readable, context-scoped file no larger than 20 MiB.
+Rejected media requests retry without the media and give the agent explicit guidance to use the attachment ID/path with other available tools; known adapter omissions receive the same guidance.
 It cannot be combined with `mindroom_output_path`.
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
@@ -15298,15 +15299,21 @@ agents:
 | Operation | Description |
 |-----------|-------------|
 | `list_attachments(target?)` | List metadata for attachments in the current context (ID, kind, local_path, filename, MIME type, size, room_id, thread_id, sender, event_timestamp, created_at) |
-| `get_attachment(attachment_id, mindroom_output_path?, view=False)` | Return metadata, save bytes to a workspace-relative path, or send image pixels to the model with `view=True` |
+| `get_attachment(attachment_id, mindroom_output_path?, view=False)` | Return metadata, save bytes to a workspace-relative path, or send media/document content to the model with `view=True` |
 | `register_attachment(file_path)` | Register a local file path as a context attachment ID (`att_*`) |
 
 By default, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
-Use `get_attachment("att_...", view=True)` to visually inspect an image from earlier in the conversation or a local file registered with `register_attachment(file_path)`.
-Viewing sends image bytes to the configured model; listing or registering an attachment alone does not let the model see its pixels.
-It requires an image-capable model and supports PNG, JPEG, GIF, and WebP images up to 20 MiB, with the format detected from the bytes.
+Use `get_attachment("att_...", view=True)` to inspect media from earlier in the conversation or a local file registered with `register_attachment(file_path)`.
+This sends the attachment bytes to the configured model, using native image, audio, video, or document inputs rather than putting binary data in tool text.
+It supports PNG, JPEG, GIF, and WebP images, audio, video, and Agno-supported document types including PDF and plain text, with a 20 MiB limit per attachment.
+Image format is detected from the bytes; other media uses the attachment's MIME type and filename.
+The selected model and its provider adapter must support the media type and may impose stricter format or size limits.
 The attachment must be available in the current context and have a readable local file.
 `view=True` cannot be combined with `mindroom_output_path`.
+If the provider rejects inline media, MindRoom retries the request without it and explicitly tells the agent that the removed content was not inspected.
+Known adapter omissions use the same guidance, so unsupported media is not silently dropped.
+The agent can then call `get_attachment` without `view` to obtain metadata or save the file, and use other available extraction, transcription, or analysis tools.
+This does not provision another model, grant credentials, or automatically delegate the task.
 For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 `mindroom_output_path` must be a file path relative to the agent workspace.
 It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.

--- a/skills/mindroom-docs/references/page__attachments__index.md
+++ b/skills/mindroom-docs/references/page__attachments__index.md
@@ -84,10 +84,15 @@ agents:
 | Operation | Description |
 |-----------|-------------|
 | `list_attachments(target?)` | List metadata for attachments in the current context (ID, kind, local_path, filename, MIME type, size, room_id, thread_id, sender, event_timestamp, created_at) |
-| `get_attachment(attachment_id, mindroom_output_path?)` | Return one context attachment record, or save its bytes to a workspace-relative path and return a save receipt |
+| `get_attachment(attachment_id, mindroom_output_path?, view=False)` | Return metadata, save bytes to a workspace-relative path, or send image pixels to the model with `view=True` |
 | `register_attachment(file_path)` | Register a local file path as a context attachment ID (`att_*`) |
 
-When `mindroom_output_path` is omitted, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
+By default, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
+Use `get_attachment("att_...", view=True)` to visually inspect an image from earlier in the conversation or a local file registered with `register_attachment(file_path)`.
+Viewing sends image bytes to the configured model; listing or registering an attachment alone does not let the model see its pixels.
+It requires an image-capable model and supports PNG, JPEG, GIF, and WebP images up to 20 MiB, with the format detected from the bytes.
+The attachment must be available in the current context and have a readable local file.
+`view=True` cannot be combined with `mindroom_output_path`.
 For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 `mindroom_output_path` must be a file path relative to the agent workspace.
 It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.

--- a/skills/mindroom-docs/references/page__attachments__index.md
+++ b/skills/mindroom-docs/references/page__attachments__index.md
@@ -84,15 +84,21 @@ agents:
 | Operation | Description |
 |-----------|-------------|
 | `list_attachments(target?)` | List metadata for attachments in the current context (ID, kind, local_path, filename, MIME type, size, room_id, thread_id, sender, event_timestamp, created_at) |
-| `get_attachment(attachment_id, mindroom_output_path?, view=False)` | Return metadata, save bytes to a workspace-relative path, or send image pixels to the model with `view=True` |
+| `get_attachment(attachment_id, mindroom_output_path?, view=False)` | Return metadata, save bytes to a workspace-relative path, or send media/document content to the model with `view=True` |
 | `register_attachment(file_path)` | Register a local file path as a context attachment ID (`att_*`) |
 
 By default, `get_attachment()` returns the attachment metadata response, including the runtime-local `local_path`.
-Use `get_attachment("att_...", view=True)` to visually inspect an image from earlier in the conversation or a local file registered with `register_attachment(file_path)`.
-Viewing sends image bytes to the configured model; listing or registering an attachment alone does not let the model see its pixels.
-It requires an image-capable model and supports PNG, JPEG, GIF, and WebP images up to 20 MiB, with the format detected from the bytes.
+Use `get_attachment("att_...", view=True)` to inspect media from earlier in the conversation or a local file registered with `register_attachment(file_path)`.
+This sends the attachment bytes to the configured model, using native image, audio, video, or document inputs rather than putting binary data in tool text.
+It supports PNG, JPEG, GIF, and WebP images, audio, video, and Agno-supported document types including PDF and plain text, with a 20 MiB limit per attachment.
+Image format is detected from the bytes; other media uses the attachment's MIME type and filename.
+The selected model and its provider adapter must support the media type and may impose stricter format or size limits.
 The attachment must be available in the current context and have a readable local file.
 `view=True` cannot be combined with `mindroom_output_path`.
+If the provider rejects inline media, MindRoom retries the request without it and explicitly tells the agent that the removed content was not inspected.
+Known adapter omissions use the same guidance, so unsupported media is not silently dropped.
+The agent can then call `get_attachment` without `view` to obtain metadata or save the file, and use other available extraction, transcription, or analysis tools.
+This does not provision another model, grant credentials, or automatically delegate the task.
 For worker-routed agents, prefer `get_attachment("att_...", mindroom_output_path="incoming/file.ext")` before processing an attachment with `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 `mindroom_output_path` must be a file path relative to the agent workspace.
 It must not be empty, absolute, point at the workspace root, contain `..` or NUL bytes, start with `~`, or contain `$` or `%` characters.

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -417,6 +417,9 @@ matrix_api(
 `list_attachments()` returns the attachment IDs currently available in tool runtime context, the resolved metadata payloads, and any `missing_attachment_ids`.
 Pass a context-available attachment ID as `target` to return only that attachment; an ID outside the current context returns an error.
 `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
+`get_attachment(attachment_id, view=True)` sends the image pixels to the model for visual analysis, including images registered from local files or referenced earlier in the conversation.
+Viewing requires an image-capable model and a readable, context-scoped PNG, JPEG, GIF, or WebP file no larger than 20 MiB.
+It cannot be combined with `mindroom_output_path`.
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.
 In shell tools, the agent workspace is exposed as `$MINDROOM_AGENT_WORKSPACE`; in worker-routed shell and python tools it is also `~` and `$HOME`, so a saved path like `incoming/file.txt` can also be read as `~/incoming/file.txt`.

--- a/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
+++ b/skills/mindroom-docs/references/page__tools__matrix-and-attachments__index.md
@@ -417,8 +417,9 @@ matrix_api(
 `list_attachments()` returns the attachment IDs currently available in tool runtime context, the resolved metadata payloads, and any `missing_attachment_ids`.
 Pass a context-available attachment ID as `target` to return only that attachment; an ID outside the current context returns an error.
 `get_attachment()` returns a single attachment record, including the runtime-local path, when called with only an attachment ID.
-`get_attachment(attachment_id, view=True)` sends the image pixels to the model for visual analysis, including images registered from local files or referenced earlier in the conversation.
-Viewing requires an image-capable model and a readable, context-scoped PNG, JPEG, GIF, or WebP file no larger than 20 MiB.
+`get_attachment(attachment_id, view=True)` sends image, audio, video, or document content (including PDF) to the model, including local files and attachments from earlier in the conversation.
+Viewing requires a model and provider adapter that support the media type, and a readable, context-scoped file no larger than 20 MiB.
+Rejected media requests retry without the media and give the agent explicit guidance to use the attachment ID/path with other available tools; known adapter omissions receive the same guidance.
 It cannot be combined with `mindroom_output_path`.
 `get_attachment(attachment_id, mindroom_output_path="relative/path")` saves the attachment bytes into the agent workspace and returns a `mindroom_tool_output` save receipt with the saved path, byte count, binary format, and SHA256 digest.
 Use `mindroom_output_path` before handing attachments to worker-routed workspace tools such as `file`, `coding`, `python`, or `shell`, because the runtime-local path may not exist inside the worker workspace.

--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -10,7 +10,9 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
+from agno.media import Image
 from agno.tools import Toolkit
+from agno.tools.function import ToolResult
 
 from mindroom.attachments import (
     AttachmentRecord,
@@ -20,6 +22,7 @@ from mindroom.attachments import (
 )
 from mindroom.custom_tools.attachment_helpers import room_access_allowed
 from mindroom.matrix.client_delivery import send_file_message, send_runtime_encrypted_media_message
+from mindroom.matrix.media import resolve_image_mime_type
 from mindroom.matrix.runtime_media import RuntimeEncryptedMediaAttachment
 from mindroom.tool_system.output_files import (
     ToolOutputFilePolicy,
@@ -50,6 +53,7 @@ if TYPE_CHECKING:
 
 _LocalAttachmentKind = Literal["audio", "file", "image", "video"]
 _ResolvedSendAttachment = Path | RuntimeEncryptedMediaAttachment
+_VIEW_IMAGE_MAX_BYTES = 20 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -152,13 +156,13 @@ def _resolve_context_attachment_record(
     return attachment, None
 
 
-def _attachment_bytes_for_save(
+def _read_attachment_bytes(
     attachment: AttachmentRecord,
     *,
     byte_limit: int,
     limit_label: str,
 ) -> tuple[bytes | None, str | None]:
-    """Read attachment bytes after enforcing the selected destination cap."""
+    """Read attachment bytes with a bounded read and the selected destination cap."""
     try:
         size_bytes = attachment.local_path.stat().st_size
     except OSError:
@@ -170,10 +174,35 @@ def _attachment_bytes_for_save(
             f"({size_bytes} bytes > {byte_limit} bytes).",
         )
     try:
-        payload = attachment.local_path.read_bytes()
+        with attachment.local_path.open("rb") as attachment_file:
+            payload = attachment_file.read(byte_limit + 1)
     except OSError:
         return None, f"Attachment file is missing on disk: {attachment.attachment_id}"
+    if len(payload) > byte_limit:
+        return None, f"Attachment {attachment.attachment_id} exceeds {limit_label} size limit ({byte_limit} bytes)."
     return payload, None
+
+
+def _view_attachment(context: ToolRuntimeContext, attachment_id: str, content: str) -> str | ToolResult:
+    """Read a scoped image off-loop and return its bytes as model-facing media."""
+    attachment, error = _resolve_context_attachment_record(context, attachment_id)
+    if error is not None or attachment is None:
+        return _attachment_tool_payload("error", attachment_id=attachment_id, message=error)
+    payload, error = _read_attachment_bytes(
+        attachment,
+        byte_limit=_VIEW_IMAGE_MAX_BYTES,
+        limit_label="image viewing",
+    )
+    if error is not None or payload is None:
+        return _attachment_tool_payload("error", attachment_id=attachment_id, message=error)
+    mime_type = resolve_image_mime_type(payload, attachment.mime_type).detected_mime_type
+    if mime_type not in {"image/png", "image/jpeg", "image/gif", "image/webp"}:
+        return _attachment_tool_payload(
+            "error",
+            attachment_id=attachment_id,
+            message="view requires a PNG, JPEG, GIF, or WebP image.",
+        )
+    return ToolResult(content=content, images=[Image(content=payload, mime_type=mime_type)])
 
 
 def _resolve_attachment_ids(
@@ -509,8 +538,18 @@ class AttachmentTools(Toolkit):
         self,
         attachment_id: str,
         mindroom_output_path: str | None = None,
-    ) -> str:
-        """Return one context attachment record, or save its bytes to a workspace path."""
+        view: bool = False,
+    ) -> str | ToolResult:
+        """Inspect attachment metadata, save a file, or view an image with the model.
+
+        Args:
+            attachment_id: Context-scoped ID from list_attachments or register_attachment.
+            mindroom_output_path: Save bytes to a workspace-relative file instead of returning metadata.
+            view: Send image pixels to the model for visual analysis (PNG, JPEG, GIF, WebP; up to 20 MiB).
+                Use this to inspect local or earlier conversation images. Requires an image-capable model.
+                Cannot be combined with mindroom_output_path.
+
+        """
         context = get_tool_runtime_context()
         if context is None:
             return _attachment_tool_payload(
@@ -519,6 +558,8 @@ class AttachmentTools(Toolkit):
             )
         if not isinstance(attachment_id, str) or not attachment_id.strip():
             return _attachment_tool_payload("error", message="attachment_id must be a non-empty string.")
+        if view and mindroom_output_path is not None:
+            return _attachment_tool_payload("error", message="view cannot be combined with mindroom_output_path.")
 
         requested_attachment_id = attachment_id.strip()
         output_path, output_path_error = self._resolve_output_path_argument(
@@ -551,11 +592,14 @@ class AttachmentTools(Toolkit):
                 output_path=output_path,
             )
 
-        return _attachment_tool_payload(
+        content = _attachment_tool_payload(
             "ok",
             attachment_id=requested_attachment_ids[0],
             attachment=attachments[0],
         )
+        if view:
+            return await asyncio.to_thread(_view_attachment, context, requested_attachment_ids[0], content)
+        return content
 
     def _resolve_output_path_argument(
         self,
@@ -633,7 +677,7 @@ class AttachmentTools(Toolkit):
                 attachment_id=requested_attachment_id,
                 message="mindroom_output_path requires an agent workspace in this runtime path.",
             )
-        payload_bytes, read_error = _attachment_bytes_for_save(
+        payload_bytes, read_error = _read_attachment_bytes(
             attachment,
             byte_limit=byte_limit,
             limit_label=limit_label,

--- a/src/mindroom/custom_tools/attachments.py
+++ b/src/mindroom/custom_tools/attachments.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast
 
-from agno.media import Image
+from agno.media import Audio, File, Image, Video
 from agno.tools import Toolkit
 from agno.tools.function import ToolResult
 
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
 
 _LocalAttachmentKind = Literal["audio", "file", "image", "video"]
 _ResolvedSendAttachment = Path | RuntimeEncryptedMediaAttachment
-_VIEW_IMAGE_MAX_BYTES = 20 * 1024 * 1024
+_VIEW_MEDIA_MAX_BYTES = 20 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -183,26 +183,46 @@ def _read_attachment_bytes(
     return payload, None
 
 
-def _view_attachment(context: ToolRuntimeContext, attachment_id: str, content: str) -> str | ToolResult:
-    """Read a scoped image off-loop and return its bytes as model-facing media."""
+def _view_attachment(context: ToolRuntimeContext, attachment_id: str, content: str) -> str | ToolResult:  # noqa: PLR0911
+    """Read scoped attachment bytes off-loop and return native model media."""
     attachment, error = _resolve_context_attachment_record(context, attachment_id)
     if error is not None or attachment is None:
         return _attachment_tool_payload("error", attachment_id=attachment_id, message=error)
     payload, error = _read_attachment_bytes(
         attachment,
-        byte_limit=_VIEW_IMAGE_MAX_BYTES,
-        limit_label="image viewing",
+        byte_limit=_VIEW_MEDIA_MAX_BYTES,
+        limit_label="media viewing",
     )
     if error is not None or payload is None:
         return _attachment_tool_payload("error", attachment_id=attachment_id, message=error)
+    if not payload:
+        return _attachment_tool_payload("error", attachment_id=attachment_id, message="Attachment file is empty.")
     mime_type = resolve_image_mime_type(payload, attachment.mime_type).detected_mime_type
-    if mime_type not in {"image/png", "image/jpeg", "image/gif", "image/webp"}:
+    if mime_type in {"image/png", "image/jpeg", "image/gif", "image/webp"}:
+        return ToolResult(content=content, images=[Image(content=payload, mime_type=mime_type)])
+    if attachment.kind == "image":
         return _attachment_tool_payload(
             "error",
             attachment_id=attachment_id,
             message="view requires a PNG, JPEG, GIF, or WebP image.",
         )
-    return ToolResult(content=content, images=[Image(content=payload, mime_type=mime_type)])
+    mime_type = attachment.mime_type
+    filename = attachment.filename or attachment.local_path.name
+    media_format = Path(filename).suffix.lstrip(".").lower()
+    if attachment.kind == "audio":
+        return ToolResult(content=content, audios=[Audio(content=payload, mime_type=mime_type, format=media_format)])
+    if attachment.kind == "video":
+        return ToolResult(content=content, videos=[Video(content=payload, mime_type=mime_type, format=media_format)])
+    if mime_type in File.valid_mime_types():
+        return ToolResult(
+            content=content,
+            files=[File(content=payload, mime_type=mime_type, filename=filename, format=media_format)],
+        )
+    return _attachment_tool_payload(
+        "error",
+        attachment_id=attachment_id,
+        message="This file type cannot be sent as model media. Use get_attachment without view to inspect or save it.",
+    )
 
 
 def _resolve_attachment_ids(
@@ -540,13 +560,14 @@ class AttachmentTools(Toolkit):
         mindroom_output_path: str | None = None,
         view: bool = False,
     ) -> str | ToolResult:
-        """Inspect attachment metadata, save a file, or view an image with the model.
+        """Inspect metadata, save a file, or send attachment content to the model.
 
         Args:
             attachment_id: Context-scoped ID from list_attachments or register_attachment.
             mindroom_output_path: Save bytes to a workspace-relative file instead of returning metadata.
-            view: Send image pixels to the model for visual analysis (PNG, JPEG, GIF, WebP; up to 20 MiB).
-                Use this to inspect local or earlier conversation images. Requires an image-capable model.
+            view: Send image, audio, video, or document content (including PDF) to the model; up to 20 MiB.
+                Requires a model that supports the media type. If inline media is unavailable, use
+                get_attachment without view to get metadata or save the file, then use other available tools.
                 Cannot be combined with mindroom_output_path.
 
         """

--- a/src/mindroom/prompts.py
+++ b/src/mindroom/prompts.py
@@ -216,8 +216,12 @@ QUEUED_MESSAGE_NOTICE_TEXT = (
     "intend to resume it on the next turn, subject to the newer message's instructions."
 )
 INLINE_MEDIA_FALLBACK_PROMPT = (
-    "The model rejected inline attachments for this turn. "
-    "Use available attachment IDs and tools to inspect files instead."
+    "The model or provider adapter could not accept some inline attachments for this request. "
+    "Their content was not inspected. Do not claim to have seen, heard, or read the removed media. "
+    "Do not repeat get_attachment(view=True) for it on this model. "
+    "Use get_attachment without view to inspect metadata or save the file with mindroom_output_path. "
+    "Then use other available tools to extract or interpret its content. "
+    "If no suitable tool is available, explain the limitation to the user."
 )
 
 ROUTER_AGENT_SELECTION_PROMPT_TEMPLATE = """Decide which agent or team should respond to this message.

--- a/src/mindroom/provider_media_fallback.py
+++ b/src/mindroom/provider_media_fallback.py
@@ -68,6 +68,18 @@ _REQUEST_STATES: ContextVar[dict[int, _MediaFallbackRequestState] | None] = Cont
 # Learned negative capabilities intentionally live only for this process lifetime.
 _UNSUPPORTED_MEDIA_KINDS_BY_ROUTE: dict[_ModelMediaRoute, set[MediaKind]] = {}
 
+# These Agno adapters omit these inputs instead of rejecting them. Keep their
+# limitations separate from model capabilities learned from provider errors.
+# Module names avoid importing optional provider SDKs here; MRO covers our wrappers.
+_ADAPTER_OMITTED_MEDIA: dict[str, frozenset[MediaKind]] = {
+    "agno.models.openai.responses": frozenset({"audio", "video"}),
+    "agno.models.openai.chat": frozenset({"video"}),
+    "agno.models.anthropic.claude": frozenset({"audio", "video"}),
+    "agno.models.ollama.chat": frozenset({"audio", "file", "video"}),
+    "agno.models.groq.groq": frozenset({"audio", "file", "video"}),
+    "agno.models.cerebras.cerebras": frozenset({"audio", "image", "file", "video"}),
+}
+
 
 @runtime_checkable
 class _AsyncClosableIterator(Protocol):
@@ -158,7 +170,7 @@ async def _ainvoke_with_fallback(
     route = _model_media_route(model)
     present_kinds = _media_kinds(messages)
     request_state = _request_state(model) or _MediaFallbackRequestState()
-    known_unsupported = _known_unsupported_media_kinds(route) & present_kinds
+    known_unsupported = (_known_unsupported_media_kinds(route) | _adapter_omitted_media(model)) & present_kinds
     removed_kinds = known_unsupported | (request_state.removed_kinds & present_kinds)
     initial_args, initial_kwargs = _call_without_media_kinds(
         args,
@@ -226,7 +238,7 @@ async def _stream_with_fallback(
     route = _model_media_route(model)
     present_kinds = _media_kinds(messages)
     request_state = _request_state(model) or _MediaFallbackRequestState()
-    known_unsupported = _known_unsupported_media_kinds(route) & present_kinds
+    known_unsupported = (_known_unsupported_media_kinds(route) | _adapter_omitted_media(model)) & present_kinds
     removed_kinds = known_unsupported | (request_state.removed_kinds & present_kinds)
     initial_args, initial_kwargs = _call_without_media_kinds(
         args,
@@ -341,6 +353,14 @@ def _without_inline_media(message: Message, removed_kinds: frozenset[MediaKind])
 
 def _known_unsupported_media_kinds(route: _ModelMediaRoute) -> frozenset[MediaKind]:
     return frozenset(_UNSUPPORTED_MEDIA_KINDS_BY_ROUTE.get(route, set()))
+
+
+def _adapter_omitted_media(model: Model) -> frozenset[MediaKind]:
+    """Find the nearest known adapter without guessing a model's capabilities."""
+    for adapter in type(model).__mro__:
+        if (omitted := _ADAPTER_OMITTED_MEDIA.get(adapter.__module__)) is not None:
+            return omitted
+    return frozenset()
 
 
 def _record_unsupported_media_kinds(

--- a/tach.toml
+++ b/tach.toml
@@ -1325,6 +1325,7 @@ depends_on = [
 path = "mindroom.custom_tools.attachments"
 depends_on = [
     "mindroom.matrix.client_delivery",
+    "mindroom.matrix.media",
     "mindroom.tool_system.output_files",
     "mindroom.tool_system.runtime_context",
     "mindroom.tool_system.sandbox_proxy",

--- a/tests/test_attachments_tool.py
+++ b/tests/test_attachments_tool.py
@@ -226,6 +226,72 @@ async def test_get_attachment_view_returns_image_media(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("filename", "payload_bytes", "media_field", "mime_type"),
+    [
+        ("recording.mp3", b"ID3 audio bytes", "audios", "audio/mpeg"),
+        ("document.pdf", b"%PDF-1.4 document bytes", "files", "application/pdf"),
+        ("notes.txt", b"Read these notes", "files", "text/plain"),
+        ("clip.mp4", b"video bytes", "videos", "video/mp4"),
+    ],
+)
+async def test_get_attachment_view_returns_other_media(
+    tmp_path: Path,
+    filename: str,
+    payload_bytes: bytes,
+    media_field: str,
+    mime_type: str,
+) -> None:
+    """Audio, documents, and video use their native model media fields."""
+    (tmp_path / filename).write_bytes(payload_bytes)
+    tool = AttachmentTools(tool_output_workspace_root=tmp_path)
+    with tool_runtime_context(_tool_context(tmp_path)):
+        registered = json.loads(await tool.register_attachment(filename))
+        result = await tool.get_attachment(registered["attachment_id"], view=True)
+
+    assert isinstance(result, ToolResult)
+    media = {"audios": result.audios, "files": result.files, "videos": result.videos}[media_field]
+    assert media is not None
+    assert len(media) == 1
+    assert media[0].content == payload_bytes
+    assert media[0].mime_type == mime_type
+    if result.audios:
+        assert result.audios[0].format == "mp3"
+    if result.files:
+        assert result.files[0].filename == filename
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("filename", "data"), [("empty.pdf", b""), ("archive.zip", b"PK archive bytes")])
+async def test_get_attachment_view_rejects_unusable_documents(tmp_path: Path, filename: str, data: bytes) -> None:
+    """Empty and unsupported documents give a recoverable tool error, not an exception."""
+    (tmp_path / filename).write_bytes(data)
+    tool = AttachmentTools(tool_output_workspace_root=tmp_path)
+    with tool_runtime_context(_tool_context(tmp_path)):
+        registered = json.loads(await tool.register_attachment(filename))
+        result = await tool.get_attachment(registered["attachment_id"], view=True)
+
+    assert isinstance(result, str)
+    assert json.loads(result)["status"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_get_attachment_view_uses_local_filename_when_metadata_has_none(tmp_path: Path) -> None:
+    """Older attachment records need not carry an explicit filename."""
+    local_path = tmp_path / "document.pdf"
+    local_path.write_bytes(b"%PDF-1.4 document bytes")
+    attachment = register_local_attachment(tmp_path, local_path, kind="file", mime_type="application/pdf")
+    assert attachment is not None
+    assert attachment.filename is None
+    with tool_runtime_context(_tool_context(tmp_path, attachment_ids=(attachment.attachment_id,))):
+        result = await AttachmentTools().get_attachment(attachment.attachment_id, view=True)
+
+    assert isinstance(result, ToolResult)
+    assert result.files is not None
+    assert result.files[0].filename == "document.pdf"
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("case", ["non_image", "oversized", "missing", "save_and_view"])
 async def test_get_attachment_view_rejects_unusable_images(tmp_path: Path, case: str) -> None:
     """Viewing must fail explicitly rather than forward unusable media or silently save."""

--- a/tests/test_attachments_tool.py
+++ b/tests/test_attachments_tool.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import dataclasses
 import hashlib
 import json
@@ -13,6 +14,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from agno.tools.function import FunctionCall, ToolResult
 
 from mindroom.attachments import load_attachment, register_local_attachment
 from mindroom.config.agent import AgentConfig
@@ -173,7 +175,8 @@ async def test_attachments_tool_get_attachment_returns_local_path(tmp_path: Path
 
 
 @pytest.mark.asyncio
-async def test_attachments_tool_get_attachment_rejects_out_of_context_ids(tmp_path: Path) -> None:
+@pytest.mark.parametrize("view", [False, True])
+async def test_attachments_tool_get_attachment_rejects_out_of_context_ids(tmp_path: Path, view: bool) -> None:
     """Tool should reject attachment IDs not present in runtime context."""
     tool = AttachmentTools()
     sample_file = tmp_path / "sample.txt"
@@ -187,11 +190,72 @@ async def test_attachments_tool_get_attachment_rejects_out_of_context_ids(tmp_pa
     assert attachment is not None
 
     with tool_runtime_context(_tool_context(tmp_path, attachment_ids=())):
-        payload = json.loads(await tool.get_attachment("att_sample"))
+        payload = json.loads(await tool.get_attachment("att_sample", view=view))
 
     assert payload["status"] == "error"
     assert payload["tool"] == "attachments"
     assert "not available in this context" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_get_attachment_view_returns_image_media(tmp_path: Path) -> None:
+    """Registered images reach the model as media, not just a path in JSON."""
+    image_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aX1cAAAAASUVORK5CYII=",
+    )
+    image_path = tmp_path / "plot.jpg"  # Byte detection must win over the extension.
+    image_path.write_bytes(image_bytes)
+    tool = AttachmentTools(tool_output_workspace_root=tmp_path)
+    with tool_runtime_context(_tool_context(tmp_path)):
+        registered = json.loads(await tool.register_attachment("plot.jpg"))
+        attachment_id = registered["attachment_id"]
+        metadata = await tool.get_attachment(attachment_id)
+        execution = await FunctionCall(
+            function=tool.async_functions["get_attachment"],
+            arguments={"attachment_id": attachment_id, "view": True},
+        ).aexecute()
+
+    assert execution.status == "success"
+    result = execution.result
+    assert isinstance(result, ToolResult)
+    assert result.content == metadata
+    assert result.images is not None
+    assert len(result.images) == 1
+    assert result.images[0].content == image_bytes
+    assert result.images[0].mime_type == "image/png"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("case", ["non_image", "oversized", "missing", "save_and_view"])
+async def test_get_attachment_view_rejects_unusable_images(tmp_path: Path, case: str) -> None:
+    """Viewing must fail explicitly rather than forward unusable media or silently save."""
+    image_path = tmp_path / "plot.png"
+    image_path.write_bytes(b"not an image")
+    tool = AttachmentTools(tool_output_workspace_root=tmp_path)
+    with tool_runtime_context(_tool_context(tmp_path)):
+        registered = json.loads(await tool.register_attachment("plot.png"))
+        if case == "oversized":
+            with image_path.open("r+b") as image_file:
+                image_file.truncate(20 * 1024 * 1024 + 1)
+        elif case == "missing":
+            image_path.unlink()
+        result = await tool.get_attachment(
+            registered["attachment_id"],
+            view=True,
+            mindroom_output_path="copy.png" if case == "save_and_view" else None,
+        )
+
+    assert isinstance(result, str)
+    payload = json.loads(result)
+    assert payload["status"] == "error"
+    expected = {
+        "non_image": "PNG, JPEG, GIF, or WebP",
+        "oversized": "size limit",
+        "missing": "missing on disk",
+        "save_and_view": "cannot be combined",
+    }
+    assert expected[case] in payload["message"]
+    assert not (tmp_path / "copy.png").exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_provider_media_fallback.py
+++ b/tests/test_provider_media_fallback.py
@@ -11,7 +11,11 @@ from agno.exceptions import ModelProviderError, ModelRateLimitError, RetryableMo
 from agno.media import Audio, File, Image, Video
 from agno.models.anthropic import Claude
 from agno.models.base import Model
+from agno.models.cerebras import Cerebras
+from agno.models.groq import Groq
 from agno.models.message import Message
+from agno.models.ollama import Ollama
+from agno.models.openai import OpenAIChat, OpenAIResponses
 from agno.models.response import ModelResponse
 
 from mindroom import claude_stream_retry
@@ -19,7 +23,8 @@ from mindroom.config.main import Config
 from mindroom.config.models import ModelConfig
 from mindroom.error_handling import MODEL_SAFEGUARD_REFUSAL_MESSAGE, ModelSafeguardRefusalError
 from mindroom.model_loading import get_model_instance
-from mindroom.provider_media_fallback import reset_model_media_capability_cache
+from mindroom.prompts import INLINE_MEDIA_FALLBACK_PROMPT
+from mindroom.provider_media_fallback import install_provider_media_fallback, reset_model_media_capability_cache
 from tests.conftest import bind_runtime_paths, runtime_paths_for, test_runtime_paths
 
 if TYPE_CHECKING:
@@ -147,6 +152,55 @@ async def test_loaded_model_retries_once_without_inline_media_and_preserves_atta
     assert retry_messages[-1].temporary is True
     assert "Inline media unavailable for this model" in str(retry_messages[-1].content)
     assert original == original_snapshot
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model_class", "removed"),
+    [
+        (OpenAIResponses, {"audio", "video"}),
+        (OpenAIChat, {"video"}),
+        (Claude, {"audio", "video"}),
+        (Ollama, {"audio", "file", "video"}),
+        (Groq, {"audio", "file", "video"}),
+        (Cerebras, {"audio", "image", "file", "video"}),
+    ],
+)
+@pytest.mark.parametrize("streaming", [False, True])
+async def test_adapter_omissions_are_visible_to_the_model(
+    model_class: type[Model],
+    removed: set[str],
+    streaming: bool,
+) -> None:
+    """Adapters that silently omit a media kind must instead send fallback guidance."""
+    model = model_class(id="adapter-test")
+    provider_calls: list[list[Message]] = []
+
+    async def invoke(messages: list[Message]) -> ModelResponse:
+        provider_calls.append(messages)
+        return ModelResponse(content="use another tool")
+
+    async def stream(messages: list[Message]) -> AsyncIterator[ModelResponse]:
+        yield await invoke(messages)
+
+    model.ainvoke = invoke
+    model.ainvoke_stream = stream
+    install_provider_media_fallback(model, fallback_prompt=INLINE_MEDIA_FALLBACK_PROMPT)
+    original = _media_message()
+    if streaming:
+        _ = [chunk async for chunk in model.ainvoke_stream(messages=[original])]
+    else:
+        await model.ainvoke(messages=[original])
+
+    assert len(provider_calls) == 1
+    sent, guidance = provider_calls[0]
+    sent_media = {"audio": sent.audio, "image": sent.images, "file": sent.files, "video": sent.videos}
+    assert {kind for kind, media in sent_media.items() if media is None} == removed
+    assert "Inline media unavailable" in str(guidance.content)
+    assert "att_123" in str(sent.content)
+    assert original.audio
+    assert original.videos
+    assert original.files
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Local and historical attachments could be listed or saved, but their content was not sent to the model. A path in tool output is not enough for media analysis.

Add `get_attachment(attachment_id, view=True)` for images, audio, video, and supported documents including PDFs, using Agno's native `ToolResult` media fields. Metadata remains the default. Reuse context checks and bounded off-loop reads with a 20 MiB cap. Viewing and saving are mutually exclusive.

Reuse the existing provider-media fallback when a model rejects media. Known adapter omissions now get the same explicit guidance instead of silently dropping content. The agent can retrieve the attachment ID/path and use other available tools; no model-name rules, new credentials, or automatic delegation.

Tests cover native media fields, context isolation, invalid/oversized/missing files, optional filenames, metadata/save compatibility, and streaming/non-streaming fallback. Independent no-network model-loop checks cover Chat and Responses media delivery and omission guidance.

Validation: full `pytest tests -n 4 --no-cov` suite, all pre-commit hooks, and Tach checks passed.
