### PR TITLE
fix: make durable Matrix sync byte limits configurable

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -629,6 +629,8 @@ matrix_space:
 matrix_sync:
   mode: classic                    # Default: classic
   sliding_timeline_limit: 100       # Per-room Sliding window, minimum 1
+  max_response_bytes: 16777216      # Per-session HTTP response limit: 16 MiB
+  max_pending_bytes: 67108864       # Per-session encoded pending output limit: 64 MiB
 
 # Timezone for scheduled tasks (optional)
 timezone: America/Los_Angeles      # Default: UTC
@@ -643,6 +645,20 @@ See [Authorization](../authorization.md) for the current access model.
 The root Space invitation roster is the union of managed-room `invite_users`, and those invitees do not automatically receive Space admin power.
 Root Space admin reconciliation is grant-only and preserves existing Matrix admins.
 Demote stale Space admins manually in a Matrix client when needed.
+
+## Matrix Sync Limits
+
+`matrix_sync.max_response_bytes` and `matrix_sync.max_pending_bytes` accept positive integers in bytes and apply to both Classic and Sliding Sync.
+The defaults are 16 MiB per HTTP response and 64 MiB of encoded pending output per sync session.
+If a large initial sync exceeds the durable input bound, increase `max_response_bytes` enough to fit the response.
+If preparing events exceeds the durable pending bound, increase `max_pending_bytes` enough to fit the encoded output.
+These are separate budgets: encoded events can take more space than the HTTP response, so raising the response limit may also require raising the pending limit.
+Each bot owns its own sync session; allow sufficient memory and disk space when increasing these limits.
+Changing either setting through config reload restarts running agents to apply it.
+
+Large initial syncs may also need more startup time.
+`MINDROOM_MATRIX_SYNC_STARTUP_TIMEOUT_SECONDS` controls the first-sync watchdog allowance, and runtime Helm chart values under `probes.startup` control the Kubernetes startup probe allowance.
+Size those time allowances independently of the byte limits.
 
 ## Credential Seeds
 

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -1503,6 +1503,8 @@ matrix_space:
 matrix_sync:
   mode: classic                    # Default: classic
   sliding_timeline_limit: 100       # Per-room Sliding window, minimum 1
+  max_response_bytes: 16777216      # Per-session HTTP response limit: 16 MiB
+  max_pending_bytes: 67108864       # Per-session encoded pending output limit: 64 MiB
 
 # Timezone for scheduled tasks (optional)
 timezone: America/Los_Angeles      # Default: UTC
@@ -1517,6 +1519,20 @@ See [Authorization](https://docs.mindroom.chat/authorization/) for the current a
 The root Space invitation roster is the union of managed-room `invite_users`, and those invitees do not automatically receive Space admin power.
 Root Space admin reconciliation is grant-only and preserves existing Matrix admins.
 Demote stale Space admins manually in a Matrix client when needed.
+
+## Matrix Sync Limits
+
+`matrix_sync.max_response_bytes` and `matrix_sync.max_pending_bytes` accept positive integers in bytes and apply to both Classic and Sliding Sync.
+The defaults are 16 MiB per HTTP response and 64 MiB of encoded pending output per sync session.
+If a large initial sync exceeds the durable input bound, increase `max_response_bytes` enough to fit the response.
+If preparing events exceeds the durable pending bound, increase `max_pending_bytes` enough to fit the encoded output.
+These are separate budgets: encoded events can take more space than the HTTP response, so raising the response limit may also require raising the pending limit.
+Each bot owns its own sync session; allow sufficient memory and disk space when increasing these limits.
+Changing either setting through config reload restarts running agents to apply it.
+
+Large initial syncs may also need more startup time.
+`MINDROOM_MATRIX_SYNC_STARTUP_TIMEOUT_SECONDS` controls the first-sync watchdog allowance, and runtime Helm chart values under `probes.startup` control the Kubernetes startup probe allowance.
+Size those time allowances independently of the byte limits.
 
 ## Credential Seeds
 

--- a/skills/mindroom-docs/references/page__configuration__index.md
+++ b/skills/mindroom-docs/references/page__configuration__index.md
@@ -625,6 +625,8 @@ matrix_space:
 matrix_sync:
   mode: classic                    # Default: classic
   sliding_timeline_limit: 100       # Per-room Sliding window, minimum 1
+  max_response_bytes: 16777216      # Per-session HTTP response limit: 16 MiB
+  max_pending_bytes: 67108864       # Per-session encoded pending output limit: 64 MiB
 
 # Timezone for scheduled tasks (optional)
 timezone: America/Los_Angeles      # Default: UTC
@@ -639,6 +641,20 @@ See [Authorization](https://docs.mindroom.chat/authorization/) for the current a
 The root Space invitation roster is the union of managed-room `invite_users`, and those invitees do not automatically receive Space admin power.
 Root Space admin reconciliation is grant-only and preserves existing Matrix admins.
 Demote stale Space admins manually in a Matrix client when needed.
+
+## Matrix Sync Limits
+
+`matrix_sync.max_response_bytes` and `matrix_sync.max_pending_bytes` accept positive integers in bytes and apply to both Classic and Sliding Sync.
+The defaults are 16 MiB per HTTP response and 64 MiB of encoded pending output per sync session.
+If a large initial sync exceeds the durable input bound, increase `max_response_bytes` enough to fit the response.
+If preparing events exceeds the durable pending bound, increase `max_pending_bytes` enough to fit the encoded output.
+These are separate budgets: encoded events can take more space than the HTTP response, so raising the response limit may also require raising the pending limit.
+Each bot owns its own sync session; allow sufficient memory and disk space when increasing these limits.
+Changing either setting through config reload restarts running agents to apply it.
+
+Large initial syncs may also need more startup time.
+`MINDROOM_MATRIX_SYNC_STARTUP_TIMEOUT_SECONDS` controls the first-sync watchdog allowance, and runtime Helm chart values under `probes.startup` control the Kubernetes startup probe allowance.
+Size those time allowances independently of the byte limits.
 
 ## Credential Seeds
 

--- a/src/mindroom/config/matrix.py
+++ b/src/mindroom/config/matrix.py
@@ -38,6 +38,16 @@ class MatrixSyncConfig(BaseModel):
             " connection-scoped, so this also bounds how many per-room events a restarted connection can replay."
         ),
     )
+    max_response_bytes: int = Field(
+        default=16 * 1024 * 1024,
+        ge=1,
+        description="Maximum HTTP response size in bytes for each durable Matrix sync session.",
+    )
+    max_pending_bytes: int = Field(
+        default=64 * 1024 * 1024,
+        ge=1,
+        description="Maximum encoded pending output size in bytes for each durable Matrix sync session.",
+    )
 
 
 class MindRoomUserConfig(BaseModel):

--- a/src/mindroom/matrix/sync_loop.py
+++ b/src/mindroom/matrix/sync_loop.py
@@ -54,4 +54,10 @@ def bot_ingestion_config(
                 "account_data": {"enabled": True},
             },
         )
-    return DurableSyncConfig(sync_timeout_ms=timeout_ms, sync_filter=sync_filter, sliding=sliding)
+    return DurableSyncConfig(
+        max_response_bytes=config.matrix_sync.max_response_bytes,
+        max_pending_bytes=config.matrix_sync.max_pending_bytes,
+        sync_timeout_ms=timeout_ms,
+        sync_filter=sync_filter,
+        sliding=sliding,
+    )

--- a/tests/test_matrix_sync_limits.py
+++ b/tests/test_matrix_sync_limits.py
@@ -1,0 +1,133 @@
+"""Configured byte budgets govern the real durable Matrix input stream."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import re
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+import nio
+import pytest
+from nio.durable import DurableSyncConfig, open_durable_sync
+from pydantic import ValidationError
+
+from mindroom.config.main import Config
+from mindroom.config.matrix import MatrixSyncConfig
+from mindroom.matrix.sync_loop import bot_ingestion_config
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from aioresponses import aioresponses
+
+
+@pytest.mark.parametrize("field", ["max_response_bytes", "max_pending_bytes"])
+@pytest.mark.parametrize("value", [0, -1])
+def test_sync_byte_limits_require_positive_values(field: str, value: int) -> None:
+    """Reject invalid byte budgets during configuration loading."""
+    with pytest.raises(ValidationError) as error:
+        Config.model_validate({"matrix_sync": {field: value}})
+    assert error.value.errors()[0]["type"] == "greater_than_equal"
+    assert error.value.errors()[0]["loc"] == ("matrix_sync", field)
+
+
+def test_omitted_sync_byte_limits_preserve_durable_defaults() -> None:
+    """Existing configurations retain the library's input and pending budgets."""
+    configured = MatrixSyncConfig()
+    defaults = DurableSyncConfig()
+    assert configured.max_response_bytes == defaults.max_response_bytes
+    assert configured.max_pending_bytes == defaults.max_pending_bytes
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ["classic", "sliding"])
+@pytest.mark.parametrize(
+    ("limits", "large_response", "error_message"),
+    [
+        ({}, True, "HTTP response exceeds the durable input bound"),
+        ({"max_response_bytes": 32 * 1024 * 1024}, True, None),
+        ({"max_pending_bytes": 1024}, False, "prepared output exceeds the durable pending bound"),
+        ({"max_pending_bytes": 32 * 1024}, False, None),
+    ],
+    ids=["default-response-bound", "raised-response-bound", "small-pending-bound", "sufficient-pending-bound"],
+)
+async def test_sync_session_enforces_configured_byte_limits(
+    tmp_path: Path,
+    aioresponse: aioresponses,
+    mode: str,
+    limits: dict[str, int],
+    large_response: bool,
+    error_message: str | None,
+) -> None:
+    """YAML settings control HTTP reads and durable event admission in both modes."""
+    config = Config.model_validate({"matrix_sync": {"mode": mode, **limits}})
+    ingestion = bot_ingestion_config(config, agent_name="general", room_ids=[], timeout_ms=0, sync_filter={})
+    client = nio.AsyncClient("https://example.org", "@bot:example.org", device_id="DEVICE")
+    client.restore_login("@bot:example.org", "DEVICE", "token")
+    session = open_durable_sync(client, consumer_id=uuid4(), store_path=tmp_path / "sync", config=ingestion)
+    event = {
+        "type": "m.room.message",
+        "event_id": "$message",
+        "sender": "@alice:example.org",
+        "origin_server_ts": 1,
+        "content": {"msgtype": "m.text", "body": "x" * 8192},
+    }
+    frame = (
+        {
+            "pos": "next",
+            "rooms": {
+                "!room:example.org": {
+                    "initial": True,
+                    "membership": "join",
+                    "required_state": [],
+                    "timeline": [event],
+                },
+            },
+        }
+        if mode == "sliding"
+        else {
+            "next_batch": "next",
+            "rooms": {
+                "join": {
+                    "!room:example.org": {
+                        "state": {"events": []},
+                        "timeline": {"limited": False, "events": [event]},
+                    },
+                },
+            },
+        }
+    )
+    # Exercise a response larger than the default without an oversized event.
+    if large_response:
+        frame["padding"] = "x" * (16 * 1024 * 1024)
+    aioresponse.add(
+        re.compile(r"https://example\.org/_matrix/client/.*sync.*"),
+        method="POST" if mode == "sliding" else "GET",
+        body=json.dumps(frame),
+    )
+    runner = asyncio.create_task(session.run())
+    try:
+        async with asyncio.timeout(5):
+            if error_message is not None:
+                with pytest.raises(nio.LocalProtocolError, match=error_message):
+                    await runner
+            else:
+                while True:
+                    batch = await session.next_batch()
+                    if batch is not None:
+                        if any(record.source == event for record in batch.records):
+                            break
+                        assert not batch.completes_sync
+                        await session.ack(batch)
+                        continue
+                    if runner.done():
+                        await runner
+                        pytest.fail("Sync runner stopped before publishing the event")
+                    await session.wait_for_work()
+    finally:
+        runner.cancel()
+        await asyncio.gather(runner, return_exceptions=True)
+        await session.close()
+        await client.close()


### PR DESCRIPTION
Large Matrix sync responses can exceed the durable input bound, but the runtime does not expose the library's byte limits in configuration. Add `matrix_sync.max_response_bytes` and `matrix_sync.max_pending_bytes`, validate positive byte counts, and pass them into both Classic and Sliding sync sessions. Existing 16 MiB response and 64 MiB pending-output defaults remain unchanged.

Document sizing, reload behavior, and independent startup time allowances, and regenerate the documentation references. Regression tests use real durable sessions and storage with mocked HTTP responses to verify that a response above the default limit succeeds when configured, and that an insufficient pending-output budget rejects event admission in both modes.

Validation:
- Full backend suite: 16,450 passed, 10 skipped (`uv run pytest -m 'not requires_matrix' -n 8 --no-cov`).
- All repository hooks passed (`uv run pre-commit run --all-files`).
- Verified both fields in the JSON schema, configuration serialization, and reload plans for router, agent, and team entities.
- Independent code review: no findings.

## Summary by Sourcery

Make durable Matrix sync byte budgets configurable across sync modes while retaining current defaults and documenting their operational requirements.

New Features:
- Add configurable per-session Matrix sync HTTP response and pending-output byte limits for Classic and Sliding Sync.

Enhancements:
- Preserve the existing 16 MiB response and 64 MiB pending-output defaults while validating configured limits as positive values.
- Propagate configured limits through durable sync sessions and verify response handling and event admission with real durable-session regression tests.

Documentation:
- Document Matrix sync limit sizing, reload behavior, per-session resource considerations, and independent startup timeout configuration.

Tests:
- Add coverage for default compatibility, invalid values, oversized responses, and insufficient or sufficient pending-output budgets in both sync modes.

Chores:
- Regenerate the configuration reference documentation.