### PR TITLE
refactor: isolate private-storage and OAuth compatibility

### DIFF
--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -101,6 +101,20 @@ MindRoom's architecture consists of several key components working together.
 | `topic_generator.py` | AI-generated room topics |
 | `background_tasks.py` | Non-blocking async task management with GC protection |
 
+## Storage upgrade boundaries
+
+Historical formats stay with their storage or lifecycle owners, while current callers consume canonical identities and paths.
+`private_storage_compat.py` owns historical requester spellings and verified aliases; only startup migration and `private_storage_paths.py` can import it.
+Worker mount planning and sandbox path validation use `private_storage_paths.py`, while `private_instance_identity_store.py` validates current identities.
+
+`oauth/credential_compat.py` owns legacy JSON adoption, publication-field normalization, lossless historical requester bindings, and obsolete-file cleanup.
+Only `oauth/credential_store.py` can import it; the store retains schema, scope validation, current credential state, transaction locks, retries, and commit ownership.
+Cleanup eligibility is captured inside initialization's transaction, and source files are removed only after successful initialization or a later credential replacement commits.
+Unreadable plaintext remains outside an encrypted database until it can be adopted or explicitly replaced or reset.
+
+Existing lifecycle adapters remain at their focused entry points: `private_storage_migration.py` at startup, `config/access_migration.py` during config loading, Nio journal and crypto adapters when their stores open, and `legacy_session_migration.py` after readiness.
+Tach visibility rules keep compatibility internals behind their owning boundaries.
+
 ## Data Flow
 
 1. **Message arrives** from the Matrix homeserver and is committed by `matrix/journal_ingress.py` before nio is told it was accepted; `journal_dispatch.py` then hands it through `bot.py` to `turn_controller.py`, which owns the turn from ingress to recorded outcome

--- a/skills/mindroom-docs/references/llms-full.txt
+++ b/skills/mindroom-docs/references/llms-full.txt
@@ -17126,6 +17126,20 @@ MindRoom's architecture consists of several key components working together.
 | `topic_generator.py` | AI-generated room topics |
 | `background_tasks.py` | Non-blocking async task management with GC protection |
 
+## Storage upgrade boundaries
+
+Historical formats stay with their storage or lifecycle owners, while current callers consume canonical identities and paths.
+`private_storage_compat.py` owns historical requester spellings and verified aliases; only startup migration and `private_storage_paths.py` can import it.
+Worker mount planning and sandbox path validation use `private_storage_paths.py`, while `private_instance_identity_store.py` validates current identities.
+
+`oauth/credential_compat.py` owns legacy JSON adoption, publication-field normalization, lossless historical requester bindings, and obsolete-file cleanup.
+Only `oauth/credential_store.py` can import it; the store retains schema, scope validation, current credential state, transaction locks, retries, and commit ownership.
+Cleanup eligibility is captured inside initialization's transaction, and source files are removed only after successful initialization or a later credential replacement commits.
+Unreadable plaintext remains outside an encrypted database until it can be adopted or explicitly replaced or reset.
+
+Existing lifecycle adapters remain at their focused entry points: `private_storage_migration.py` at startup, `config/access_migration.py` during config loading, Nio journal and crypto adapters when their stores open, and `legacy_session_migration.py` after readiness.
+Tach visibility rules keep compatibility internals behind their owning boundaries.
+
 ## Data Flow
 
 1. **Message arrives** from the Matrix homeserver and is committed by `matrix/journal_ingress.py` before nio is told it was accepted; `journal_dispatch.py` then hands it through `bot.py` to `turn_controller.py`, which owns the turn from ingress to recorded outcome

--- a/skills/mindroom-docs/references/page__architecture__index.md
+++ b/skills/mindroom-docs/references/page__architecture__index.md
@@ -97,6 +97,20 @@ MindRoom's architecture consists of several key components working together.
 | `topic_generator.py` | AI-generated room topics |
 | `background_tasks.py` | Non-blocking async task management with GC protection |
 
+## Storage upgrade boundaries
+
+Historical formats stay with their storage or lifecycle owners, while current callers consume canonical identities and paths.
+`private_storage_compat.py` owns historical requester spellings and verified aliases; only startup migration and `private_storage_paths.py` can import it.
+Worker mount planning and sandbox path validation use `private_storage_paths.py`, while `private_instance_identity_store.py` validates current identities.
+
+`oauth/credential_compat.py` owns legacy JSON adoption, publication-field normalization, lossless historical requester bindings, and obsolete-file cleanup.
+Only `oauth/credential_store.py` can import it; the store retains schema, scope validation, current credential state, transaction locks, retries, and commit ownership.
+Cleanup eligibility is captured inside initialization's transaction, and source files are removed only after successful initialization or a later credential replacement commits.
+Unreadable plaintext remains outside an encrypted database until it can be adopted or explicitly replaced or reset.
+
+Existing lifecycle adapters remain at their focused entry points: `private_storage_migration.py` at startup, `config/access_migration.py` during config loading, Nio journal and crypto adapters when their stores open, and `legacy_session_migration.py` after readiness.
+Tach visibility rules keep compatibility internals behind their owning boundaries.
+
 ## Data Flow
 
 1. **Message arrives** from the Matrix homeserver and is committed by `matrix/journal_ingress.py` before nio is told it was accepted; `journal_dispatch.py` then hands it through `bot.py` to `turn_controller.py`, which owns the turn from ingress to recorded outcome

--- a/src/mindroom/api/sandbox_worker_prep.py
+++ b/src/mindroom/api/sandbox_worker_prep.py
@@ -13,13 +13,9 @@ from fastapi import HTTPException
 
 from mindroom.api import sandbox_exec
 from mindroom.logging_config import get_logger
-from mindroom.private_instance_identity_store import (
-    historical_private_instance_worker_key,
-    load_private_instance_identity,
-)
+from mindroom.private_storage_paths import resolve_private_scope_path
 from mindroom.tool_system.sandbox_proxy import sandbox_proxy_config
 from mindroom.tool_system.worker_routing import (
-    private_instance_scope_root_path,
     requires_explicit_private_agent_visibility,
     visible_state_roots_for_worker_key,
     worker_dir_name,
@@ -249,21 +245,8 @@ def _resolve_worker_base_dir(
         raise ValueError(msg)
 
     allowed_roots = (paths.root.resolve(), *visible_state_roots)
-    canonical_scope = private_instance_scope_root_path(shared_root, worker_key)
-    if candidate.is_relative_to(canonical_scope.parent) and not any(
-        candidate.is_relative_to(root) for root in allowed_roots
-    ):
-        owner = load_private_instance_identity(shared_root, canonical_scope)
-        if owner is not None and owner.worker_key == worker_key:
-            legacy_scope = private_instance_scope_root_path(
-                shared_root,
-                historical_private_instance_worker_key(worker_key, owner.requester_id),
-            )
-            try:
-                if candidate.is_relative_to(legacy_scope) and legacy_scope.samefile(canonical_scope):
-                    candidate = (canonical_scope / candidate.relative_to(legacy_scope)).resolve()
-            except FileNotFoundError:
-                pass
+    if not any(candidate.is_relative_to(root) for root in allowed_roots):
+        candidate = resolve_private_scope_path(shared_root, worker_key, candidate)
     if not any(candidate.is_relative_to(root) for root in allowed_roots):
         msg = f"base_dir must stay inside the allowed state roots or worker root: {requested_base_dir}"
         raise ValueError(msg)

--- a/src/mindroom/oauth/credential_compat.py
+++ b/src/mindroom/oauth/credential_compat.py
@@ -1,0 +1,254 @@
+"""Historical OAuth credential adoption, normalization, binding and file retirement.
+
+Only the SQLite store invokes this boundary, at its initialization and commit milestones.
+This module never owns a transaction or imports the live store or lifecycle.
+"""
+
+from __future__ import annotations
+
+import re
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from cryptography.exceptions import InvalidTag
+
+from mindroom.credential_policy import is_oauth_token_service
+from mindroom.credentials import scoped_credentials_path
+from mindroom.logging_config import get_logger
+from mindroom.tool_system.worker_routing import resolve_worker_target
+
+if TYPE_CHECKING:
+    import sqlite3
+    from collections.abc import Mapping
+
+    from mindroom.oauth.credential_store_types import OAuthCredentialStoreContext
+
+
+logger = get_logger(__name__)
+_LEGACY_PUBLICATION_KEY = "_mindroom_oauth_publication"
+
+
+@dataclass(frozen=True, slots=True)
+class _LegacyCredentialPayload:
+    """One legacy credential prepared for atomic SQLite adoption."""
+
+    payload: bytes | None
+    present: bool
+    unreadable: bool
+
+
+@dataclass(slots=True)
+class OAuthCredentialCompatibility:
+    """Retain historical adoption and cleanup state across the store's two commits."""
+
+    context: OAuthCredentialStoreContext
+    _adoption: _LegacyCredentialPayload | None = None
+    _cleanup_deferred: bool = False
+    _cleanup_on_commit: bool = False
+
+    def initial_payload(self) -> _LegacyCredentialPayload:
+        """Prepare the first credential state and remember any adoption to report."""
+        payload = _legacy_credential_payload(self.context)
+        if payload.present:
+            self._adoption = payload
+        return payload
+
+    def adopt_deferred_payload(self, connection: sqlite3.Connection, row: sqlite3.Row) -> None:
+        """Retry retained source bytes within the store's initialization transaction."""
+        self._adoption = _adopt_deferred_legacy_payload(self.context, connection, row)
+
+    def prepare_initialization_commit(self, connection: sqlite3.Connection) -> None:
+        """Capture cleanup eligibility while initialization still holds its lock."""
+        self._cleanup_deferred = _legacy_cleanup_must_be_deferred(connection)
+
+    def initialization_committed(self) -> None:
+        """Report committed adoption and retire sources whose bytes are now durable."""
+        if self._adoption is not None:
+            logger.info(
+                "oauth_legacy_credentials_adopted",
+                provider_id=self.context.provider.id,
+                credential_service=self.context.provider.credential_service,
+                credential_present=self._adoption.present,
+                credential_unreadable=self._adoption.unreadable,
+            )
+        if not self._cleanup_deferred:
+            _cleanup_legacy_files(self.context)
+
+    def credentials_replaced(self) -> None:
+        """Schedule retained-source cleanup after publish, reset or normalization."""
+        self._cleanup_on_commit = self._cleanup_deferred
+
+    def transaction_committed(self) -> None:
+        """Retire a retained source only after the replacement has committed."""
+        if self._cleanup_on_commit:
+            _cleanup_legacy_files(self.context)
+
+
+def _adopt_deferred_legacy_payload(
+    context: OAuthCredentialStoreContext,
+    connection: sqlite3.Connection,
+    row: sqlite3.Row,
+) -> _LegacyCredentialPayload | None:
+    """Adopt a retained legacy payload once the active codec can represent it."""
+    legacy = deferred_legacy_payload(context, row)
+    if legacy is None:
+        return None
+    connection.execute(
+        """
+        UPDATE oauth_credential_state
+        SET credential_payload = ?, credential_unreadable = ?,
+            generation = ?, connection_generation = ?
+        WHERE singleton = 1
+        """,
+        (
+            legacy.payload,
+            int(legacy.unreadable),
+            secrets.token_hex(32),
+            secrets.token_hex(32),
+        ),
+    )
+    return legacy
+
+
+def deferred_legacy_payload(
+    context: OAuthCredentialStoreContext,
+    row: sqlite3.Row,
+) -> _LegacyCredentialPayload | None:
+    """Return retained legacy bytes that the active codec can now represent."""
+    if (
+        not bool(row["credential_present"])
+        or not bool(row["credential_unreadable"])
+        or row["credential_payload"] is not None
+    ):
+        return None
+    legacy = _legacy_credential_payload(context)
+    return legacy if legacy.present and legacy.payload is not None else None
+
+
+def compatible_legacy_worker_key(
+    context: OAuthCredentialStoreContext,
+    connection: sqlite3.Connection,
+) -> str | None:
+    """Read legacy requester bindings at stable raw-identity paths without migrating them.
+
+    The requester encoding upgrade changed worker keys but left these stores in place.
+    Accept only lossless legacy spellings and retain the stored binding for rollback.
+    """
+    target = context.worker_target
+    manager = context.credentials_manager
+    if (
+        target is None
+        or target.worker_scope not in {"user", "user_agent"}
+        or not is_oauth_token_service(context.provider.credential_service)
+        or manager.current_worker_key is not None
+        or manager.storage_root != context.runtime_paths.storage_root
+    ):
+        return None
+    identity = target.execution_identity
+    if identity is None or not identity.requester_id:
+        return None
+    requester = identity.requester_id
+    legacy_requester = re.sub(r"[^a-zA-Z0-9._:@+-]+", "_", requester.strip()).strip("_") or "default"
+    if legacy_requester != requester:
+        return None
+    canonical_target = resolve_worker_target(
+        target.worker_scope,
+        target.routing_agent_name,
+        execution_identity=identity,
+        private_agent_names=target.private_agent_names,
+    )
+    if canonical_target != target:
+        return None
+    # Raw requester/agent hashes own legacy stores; never search or adopt worker directories.
+    # Old bindings cannot distinguish a misfiled database from a colliding legacy identity.
+    credential_path = _legacy_credential_path(context)
+    canonical_path = credential_path.with_name(f"{credential_path.stem}.sqlite3")
+    database_path = next(row[2] for row in connection.execute("PRAGMA database_list") if row[1] == "main")
+    if Path(database_path).absolute() != canonical_path.absolute():
+        return None
+    assert canonical_target.worker_key is not None
+    return canonical_target.worker_key.replace(
+        f":{target.worker_scope}:~{requester}",
+        f":{target.worker_scope}:{requester}",
+        1,
+    )
+
+
+def _legacy_cleanup_must_be_deferred(connection: sqlite3.Connection) -> bool:
+    """Keep the legacy source when its bytes were deliberately not adopted."""
+    row = connection.execute(
+        """
+        SELECT credential_payload, credential_present, credential_unreadable
+        FROM oauth_credential_state
+        WHERE singleton = 1
+        """,
+    ).fetchone()
+    return (
+        row is not None
+        and bool(row["credential_present"])
+        and bool(row["credential_unreadable"])
+        and row["credential_payload"] is None
+    )
+
+
+def _legacy_credential_payload(context: OAuthCredentialStoreContext) -> _LegacyCredentialPayload:
+    legacy_path = _legacy_credential_path(context)
+    try:
+        raw = legacy_path.read_bytes()
+    except FileNotFoundError:
+        return _LegacyCredentialPayload(payload=None, present=False, unreadable=False)
+    manager = context.credentials_manager
+    try:
+        credentials = manager.decode_credentials(context.provider.credential_service, raw)
+    except (OSError, TypeError, ValueError, InvalidTag):
+        retain_payload = not manager.credentials_encryption_enabled or manager.payload_is_encrypted(raw)
+        return _LegacyCredentialPayload(
+            payload=raw if retain_payload else None,
+            present=True,
+            unreadable=True,
+        )
+    normalized = without_legacy_publication(credentials)
+    return _LegacyCredentialPayload(
+        payload=manager.encode_credentials(context.provider.credential_service, normalized),
+        present=True,
+        unreadable=False,
+    )
+
+
+def _legacy_credential_path(context: OAuthCredentialStoreContext) -> Path:
+    return scoped_credentials_path(
+        context.provider.credential_service,
+        credentials_manager=context.credentials_manager,
+        worker_target=context.worker_target,
+    )
+
+
+def _cleanup_legacy_files(context: OAuthCredentialStoreContext) -> None:
+    credential_path = _legacy_credential_path(context)
+    paths = (
+        credential_path,
+        credential_path.with_name(f"{credential_path.name}.oauth-generation.json"),
+        credential_path.with_name(f"{credential_path.name}.oauth-operation.lock"),
+        credential_path.with_name(f"{credential_path.name}.oauth-refresh.lock"),
+    )
+    for path in paths:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            logger.warning(
+                "oauth_legacy_credential_cleanup_failed",
+                provider_id=context.provider.id,
+                credential_service=context.provider.credential_service,
+                error_type=type(exc).__name__,
+            )
+
+
+def without_legacy_publication(credentials: Mapping[str, Any]) -> dict[str, Any]:
+    """Remove the retired publication marker from a credential mapping."""
+    result = dict(credentials)
+    result.pop(_LEGACY_PUBLICATION_KEY, None)
+    return result

--- a/src/mindroom/oauth/credential_store.py
+++ b/src/mindroom/oauth/credential_store.py
@@ -4,60 +4,35 @@ from __future__ import annotations
 
 import asyncio
 import os
-import re
 import secrets
 import sqlite3
 import stat
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from cryptography.exceptions import InvalidTag
 
-from mindroom.credential_policy import is_oauth_token_service
 from mindroom.credentials import scoped_credentials_path
 from mindroom.durable_write import fsync_directory_durable
-from mindroom.logging_config import get_logger
+from mindroom.oauth import credential_compat
 from mindroom.oauth.providers import OAuthProviderError
-from mindroom.tool_system.worker_routing import resolve_worker_target
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator, Callable, Mapping
+    from pathlib import Path
 
-    from mindroom.constants import RuntimePaths
-    from mindroom.credentials import CredentialsManager
-    from mindroom.oauth.providers import OAuthProvider
-    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+    from mindroom.oauth.credential_store_types import OAuthCredentialStoreContext
 
-
-logger = get_logger(__name__)
 
 _SCHEMA_VERSION = 1
 _LOCK_RETRY_SECONDS = 0.05
 _LOCK_WAIT_TIMEOUT_SECONDS = 30.0
-_LEGACY_PUBLICATION_KEY = "_mindroom_oauth_publication"
 _T = TypeVar("_T")
 
 
 class OAuthCredentialUnreadableError(OAuthProviderError):
     """Signal that a stored OAuth credential exists but cannot be decoded."""
-
-
-class _OAuthCredentialStoreContext(Protocol):
-    """Fields the store needs from the lifecycle's canonical scope."""
-
-    @property
-    def runtime_paths(self) -> RuntimePaths: ...
-
-    @property
-    def provider(self) -> OAuthProvider: ...
-
-    @property
-    def credentials_manager(self) -> CredentialsManager: ...
-
-    @property
-    def worker_target(self) -> ResolvedWorkerTarget | None: ...
 
 
 @dataclass(frozen=True, slots=True)
@@ -77,19 +52,10 @@ class _OAuthStoredCredentialSnapshot:
     connection_generation: str
 
 
-@dataclass(frozen=True, slots=True)
-class _LegacyCredentialPayload:
-    """One legacy credential prepared for atomic SQLite adoption."""
-
-    payload: bytes | None
-    present: bool
-    unreadable: bool
-
-
 class _OAuthCredentialReader:
     """One read-only view of a committed per-scope credential state."""
 
-    def __init__(self, context: _OAuthCredentialStoreContext, connection: sqlite3.Connection) -> None:
+    def __init__(self, context: OAuthCredentialStoreContext, connection: sqlite3.Connection) -> None:
         self._context = context
         self._connection = connection
 
@@ -116,15 +82,14 @@ class OAuthCredentialTransaction:
 
     def __init__(
         self,
-        context: _OAuthCredentialStoreContext,
+        context: OAuthCredentialStoreContext,
         connection: sqlite3.Connection,
         *,
-        legacy_cleanup_deferred: bool,
+        compatibility: credential_compat.OAuthCredentialCompatibility,
     ) -> None:
         self._context = context
         self._connection = connection
-        self._legacy_cleanup_deferred = legacy_cleanup_deferred
-        self._cleanup_legacy_on_commit = False
+        self._compatibility = compatibility
 
     def generations(self) -> _OAuthStoredGenerations:
         """Read revisions without decoding credential bytes."""
@@ -152,7 +117,7 @@ class OAuthCredentialTransaction:
         connection_generation = (
             secrets.token_hex(32) if advance_connection_generation else generations.connection_generation
         )
-        published = _without_legacy_publication(credentials)
+        published = credential_compat.without_legacy_publication(credentials)
         payload = self._context.credentials_manager.encode_credentials(
             self._context.provider.credential_service,
             published,
@@ -166,7 +131,7 @@ class OAuthCredentialTransaction:
             """,
             (payload, generation, connection_generation),
         )
-        self._cleanup_legacy_on_commit = self._legacy_cleanup_deferred
+        self._compatibility.credentials_replaced()
         return _OAuthStoredCredentialSnapshot(
             credentials=published,
             generation=generation,
@@ -201,7 +166,7 @@ class OAuthCredentialTransaction:
                 """,
                 (operation_id, int(credential_existed)),
             )
-        self._cleanup_legacy_on_commit = self._legacy_cleanup_deferred
+        self._compatibility.credentials_replaced()
         return credential_existed
 
     async def commit(self) -> None:
@@ -210,8 +175,7 @@ class OAuthCredentialTransaction:
             lambda: self._connection.execute("COMMIT"),
             operation="commit",
         )
-        if self._cleanup_legacy_on_commit:
-            _cleanup_legacy_files(self._context)
+        self._compatibility.transaction_committed()
 
     def _decode_credentials(self, row: sqlite3.Row) -> dict[str, Any] | None:
         normalized = _decode_credentials(self._context, row)
@@ -234,7 +198,7 @@ class OAuthCredentialTransaction:
                 """,
                 (encoded,),
             )
-            self._cleanup_legacy_on_commit = self._legacy_cleanup_deferred
+            self._compatibility.credentials_replaced()
         return normalized
 
 
@@ -264,7 +228,7 @@ def _reset_operation_result(connection: sqlite3.Connection, operation_id: str) -
 
 
 def _decode_credentials(
-    context: _OAuthCredentialStoreContext,
+    context: OAuthCredentialStoreContext,
     row: sqlite3.Row,
 ) -> dict[str, Any] | None:
     """Decode and normalize one stored payload without mutating its transaction."""
@@ -282,18 +246,22 @@ def _decode_credentials(
     except (OSError, TypeError, ValueError, InvalidTag) as exc:
         msg = "Stored OAuth credentials could not be loaded"
         raise OAuthCredentialUnreadableError(msg) from exc
-    return _without_legacy_publication(credentials)
+    return credential_compat.without_legacy_publication(credentials)
 
 
-def _oauth_credential_database_path(context: _OAuthCredentialStoreContext) -> Path:
+def _oauth_credential_database_path(context: OAuthCredentialStoreContext) -> Path:
     """Return the private SQLite path for one canonical OAuth credential scope."""
-    legacy_path = _legacy_credential_path(context)
-    return legacy_path.with_name(f"{legacy_path.stem}.sqlite3")
+    credential_path = scoped_credentials_path(
+        context.provider.credential_service,
+        credentials_manager=context.credentials_manager,
+        worker_target=context.worker_target,
+    )
+    return credential_path.with_name(f"{credential_path.stem}.sqlite3")
 
 
 @asynccontextmanager
 async def oauth_credential_transaction(
-    context: _OAuthCredentialStoreContext,
+    context: OAuthCredentialStoreContext,
 ) -> AsyncIterator[OAuthCredentialTransaction]:
     """Acquire one cancellable cross-process transaction for a credential scope."""
     database_path = _oauth_credential_database_path(context)
@@ -304,14 +272,12 @@ async def oauth_credential_transaction(
         await _set_synchronous_extra(connection)
         await _enter_delete_journal(connection)
         await _begin_immediate(connection)
-        legacy_cleanup_deferred = await _initialize_store(context, connection)
-        if not legacy_cleanup_deferred:
-            _cleanup_legacy_files(context)
+        compatibility = await _initialize_store(context, connection)
         await _begin_immediate(connection)
         transaction = OAuthCredentialTransaction(
             context,
             connection,
-            legacy_cleanup_deferred=legacy_cleanup_deferred,
+            compatibility=compatibility,
         )
         yield transaction
     finally:
@@ -322,7 +288,7 @@ async def oauth_credential_transaction(
 
 @asynccontextmanager
 async def oauth_credential_reader(
-    context: _OAuthCredentialStoreContext,
+    context: OAuthCredentialStoreContext,
 ) -> AsyncIterator[_OAuthCredentialReader]:
     """Read the last committed state without contending with an admitted writer."""
     database_path = _oauth_credential_database_path(context)
@@ -343,9 +309,9 @@ async def oauth_credential_reader(
 
 
 async def _initialize_store(
-    context: _OAuthCredentialStoreContext,
+    context: OAuthCredentialStoreContext,
     connection: sqlite3.Connection,
-) -> bool:
+) -> credential_compat.OAuthCredentialCompatibility:
     """Create and bind one database, adopting legacy credentials exactly once."""
     connection.execute(
         """
@@ -383,9 +349,9 @@ async def _initialize_store(
     row = connection.execute(
         "SELECT * FROM oauth_credential_state WHERE singleton = 1",
     ).fetchone()
-    legacy_adoption: _LegacyCredentialPayload | None = None
+    compatibility = credential_compat.OAuthCredentialCompatibility(context)
     if row is None:
-        legacy = _legacy_credential_payload(context)
+        initial = compatibility.initial_payload()
         connection.execute(
             """
             INSERT INTO oauth_credential_state(
@@ -402,72 +368,22 @@ async def _initialize_store(
                 expected_binding["routing_agent_name"],
                 secrets.token_hex(32),
                 secrets.token_hex(32),
-                legacy.payload,
-                int(legacy.present),
-                int(legacy.unreadable),
+                initial.payload,
+                int(initial.present),
+                int(initial.unreadable),
             ),
         )
-        if legacy.present:
-            legacy_adoption = legacy
     else:
         _validate_scope_binding(context, connection, row)
-        legacy_adoption = _adopt_deferred_legacy_payload(context, connection, row)
-    legacy_cleanup_deferred = _legacy_cleanup_must_be_deferred(connection)
+        compatibility.adopt_deferred_payload(connection, row)
+    compatibility.prepare_initialization_commit(connection)
     await _commit_connection(connection)
-    if legacy_adoption is not None:
-        logger.info(
-            "oauth_legacy_credentials_adopted",
-            provider_id=context.provider.id,
-            credential_service=context.provider.credential_service,
-            credential_present=legacy_adoption.present,
-            credential_unreadable=legacy_adoption.unreadable,
-        )
-    return legacy_cleanup_deferred
-
-
-def _adopt_deferred_legacy_payload(
-    context: _OAuthCredentialStoreContext,
-    connection: sqlite3.Connection,
-    row: sqlite3.Row,
-) -> _LegacyCredentialPayload | None:
-    """Adopt a retained legacy payload once the active codec can represent it."""
-    legacy = _deferred_legacy_payload(context, row)
-    if legacy is None:
-        return None
-    connection.execute(
-        """
-        UPDATE oauth_credential_state
-        SET credential_payload = ?, credential_unreadable = ?,
-            generation = ?, connection_generation = ?
-        WHERE singleton = 1
-        """,
-        (
-            legacy.payload,
-            int(legacy.unreadable),
-            secrets.token_hex(32),
-            secrets.token_hex(32),
-        ),
-    )
-    return legacy
-
-
-def _deferred_legacy_payload(
-    context: _OAuthCredentialStoreContext,
-    row: sqlite3.Row,
-) -> _LegacyCredentialPayload | None:
-    """Return retained legacy bytes that the active codec can now represent."""
-    if (
-        not bool(row["credential_present"])
-        or not bool(row["credential_unreadable"])
-        or row["credential_payload"] is not None
-    ):
-        return None
-    legacy = _legacy_credential_payload(context)
-    return legacy if legacy.present and legacy.payload is not None else None
+    compatibility.initialization_committed()
+    return compatibility
 
 
 async def _reader_requires_write_preparation(
-    context: _OAuthCredentialStoreContext,
+    context: OAuthCredentialStoreContext,
     database_path: Path,
 ) -> bool:
     """Return whether a reader needs store creation or deferred legacy adoption."""
@@ -486,7 +402,7 @@ async def _reader_requires_write_preparation(
         if row is None:
             return True
         _validate_initialized_store(context, connection, row=row)
-        return _deferred_legacy_payload(context, row) is not None
+        return credential_compat.deferred_legacy_payload(context, row) is not None
     finally:
         if connection.in_transaction:
             connection.execute("ROLLBACK")
@@ -494,7 +410,7 @@ async def _reader_requires_write_preparation(
 
 
 def _validate_initialized_store(
-    context: _OAuthCredentialStoreContext,
+    context: OAuthCredentialStoreContext,
     connection: sqlite3.Connection,
     *,
     row: sqlite3.Row | None = None,
@@ -518,7 +434,7 @@ def _validate_initialized_store(
 
 
 def _validate_scope_binding(
-    context: _OAuthCredentialStoreContext,
+    context: OAuthCredentialStoreContext,
     connection: sqlite3.Connection,
     row: sqlite3.Row,
 ) -> None:
@@ -526,7 +442,7 @@ def _validate_scope_binding(
     actual_binding = {key: str(row[key]) for key in expected_binding}
     if actual_binding == expected_binding:
         return
-    legacy_key = _compatible_legacy_worker_key(context, connection)
+    legacy_key = credential_compat.compatible_legacy_worker_key(context, connection)
     if legacy_key is not None:
         expected_binding["worker_key"] = legacy_key
     if actual_binding != expected_binding:
@@ -534,74 +450,8 @@ def _validate_scope_binding(
         raise OAuthProviderError(msg)
 
 
-def _compatible_legacy_worker_key(
-    context: _OAuthCredentialStoreContext,
-    connection: sqlite3.Connection,
-) -> str | None:
-    """Read legacy requester bindings at stable raw-identity paths without migrating them.
-
-    The requester encoding upgrade changed worker keys but left these stores in place.
-    Accept only lossless legacy spellings and retain the stored binding for rollback.
-    """
-    target = context.worker_target
-    manager = context.credentials_manager
-    if (
-        target is None
-        or target.worker_scope not in {"user", "user_agent"}
-        or not is_oauth_token_service(context.provider.credential_service)
-        or manager.current_worker_key is not None
-        or manager.storage_root != context.runtime_paths.storage_root
-    ):
-        return None
-    identity = target.execution_identity
-    if identity is None or not identity.requester_id:
-        return None
-    requester = identity.requester_id
-    legacy_requester = re.sub(r"[^a-zA-Z0-9._:@+-]+", "_", requester.strip()).strip("_") or "default"
-    if legacy_requester != requester:
-        return None
-    canonical_target = resolve_worker_target(
-        target.worker_scope,
-        target.routing_agent_name,
-        execution_identity=identity,
-        private_agent_names=target.private_agent_names,
-    )
-    if canonical_target != target:
-        return None
-    # Raw requester/agent hashes own legacy stores; never search or adopt worker directories.
-    # Old bindings cannot distinguish a misfiled database from a colliding legacy identity.
-    credential_path = _legacy_credential_path(context)
-    canonical_path = credential_path.with_name(f"{credential_path.stem}.sqlite3")
-    database_path = next(row[2] for row in connection.execute("PRAGMA database_list") if row[1] == "main")
-    if Path(database_path).absolute() != canonical_path.absolute():
-        return None
-    assert canonical_target.worker_key is not None
-    return canonical_target.worker_key.replace(
-        f":{target.worker_scope}:~{requester}",
-        f":{target.worker_scope}:{requester}",
-        1,
-    )
-
-
 async def _commit_connection(connection: sqlite3.Connection) -> None:
     await _retry_sqlite_lock(lambda: connection.execute("COMMIT"), operation="commit")
-
-
-def _legacy_cleanup_must_be_deferred(connection: sqlite3.Connection) -> bool:
-    """Keep the legacy source when its bytes were deliberately not adopted."""
-    row = connection.execute(
-        """
-        SELECT credential_payload, credential_present, credential_unreadable
-        FROM oauth_credential_state
-        WHERE singleton = 1
-        """,
-    ).fetchone()
-    return (
-        row is not None
-        and bool(row["credential_present"])
-        and bool(row["credential_unreadable"])
-        and row["credential_payload"] is None
-    )
 
 
 async def _begin_immediate(connection: sqlite3.Connection) -> None:
@@ -700,61 +550,7 @@ def _validate_existing_database_path(database_path: Path) -> os.stat_result:
     return database_stat
 
 
-def _legacy_credential_payload(context: _OAuthCredentialStoreContext) -> _LegacyCredentialPayload:
-    legacy_path = _legacy_credential_path(context)
-    try:
-        raw = legacy_path.read_bytes()
-    except FileNotFoundError:
-        return _LegacyCredentialPayload(payload=None, present=False, unreadable=False)
-    manager = context.credentials_manager
-    try:
-        credentials = manager.decode_credentials(context.provider.credential_service, raw)
-    except (OSError, TypeError, ValueError, InvalidTag):
-        retain_payload = not manager.credentials_encryption_enabled or manager.payload_is_encrypted(raw)
-        return _LegacyCredentialPayload(
-            payload=raw if retain_payload else None,
-            present=True,
-            unreadable=True,
-        )
-    normalized = _without_legacy_publication(credentials)
-    return _LegacyCredentialPayload(
-        payload=manager.encode_credentials(context.provider.credential_service, normalized),
-        present=True,
-        unreadable=False,
-    )
-
-
-def _legacy_credential_path(context: _OAuthCredentialStoreContext) -> Path:
-    return scoped_credentials_path(
-        context.provider.credential_service,
-        credentials_manager=context.credentials_manager,
-        worker_target=context.worker_target,
-    )
-
-
-def _cleanup_legacy_files(context: _OAuthCredentialStoreContext) -> None:
-    credential_path = _legacy_credential_path(context)
-    paths = (
-        credential_path,
-        credential_path.with_name(f"{credential_path.name}.oauth-generation.json"),
-        credential_path.with_name(f"{credential_path.name}.oauth-operation.lock"),
-        credential_path.with_name(f"{credential_path.name}.oauth-refresh.lock"),
-    )
-    for path in paths:
-        try:
-            path.unlink()
-        except FileNotFoundError:
-            continue
-        except OSError as exc:
-            logger.warning(
-                "oauth_legacy_credential_cleanup_failed",
-                provider_id=context.provider.id,
-                credential_service=context.provider.credential_service,
-                error_type=type(exc).__name__,
-            )
-
-
-def _scope_binding(context: _OAuthCredentialStoreContext) -> dict[str, str]:
+def _scope_binding(context: OAuthCredentialStoreContext) -> dict[str, str]:
     worker_target = context.worker_target
     worker_scope = (
         worker_target.worker_scope if worker_target is not None and worker_target.worker_scope else "unscoped"
@@ -771,12 +567,6 @@ def _scope_binding(context: _OAuthCredentialStoreContext) -> dict[str, str]:
         "worker_key": worker_target.worker_key if worker_target is not None and worker_target.worker_key else "",
         "routing_agent_name": routing_agent_name,
     }
-
-
-def _without_legacy_publication(credentials: Mapping[str, Any]) -> dict[str, Any]:
-    result = dict(credentials)
-    result.pop(_LEGACY_PUBLICATION_KEY, None)
-    return result
 
 
 def _sqlite_lock_error(exc: sqlite3.OperationalError) -> bool:

--- a/src/mindroom/oauth/credential_store_types.py
+++ b/src/mindroom/oauth/credential_store_types.py
@@ -1,0 +1,35 @@
+"""Shared scope contract for OAuth storage and its compatibility boundary."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from mindroom.constants import RuntimePaths
+    from mindroom.credentials import CredentialsManager
+    from mindroom.oauth.providers import OAuthProvider
+    from mindroom.tool_system.worker_routing import ResolvedWorkerTarget
+
+
+class OAuthCredentialStoreContext(Protocol):
+    """Fields the store needs from the lifecycle's canonical scope."""
+
+    @property
+    def runtime_paths(self) -> RuntimePaths:
+        """Canonical runtime paths owning the credential scope."""
+        ...
+
+    @property
+    def provider(self) -> OAuthProvider:
+        """Provider whose credentials the scope stores."""
+        ...
+
+    @property
+    def credentials_manager(self) -> CredentialsManager:
+        """Credential codec and storage owner for the scope."""
+        ...
+
+    @property
+    def worker_target(self) -> ResolvedWorkerTarget | None:
+        """Canonical worker target, or an unscoped runtime."""
+        ...

--- a/src/mindroom/private_instance_identity_store.py
+++ b/src/mindroom/private_instance_identity_store.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import stat
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Final, NoReturn, cast
@@ -15,7 +14,6 @@ from mindroom.tool_system.worker_routing import (
     ToolExecutionIdentity,
     WorkerScope,
     agent_state_root_path,
-    normalize_worker_key_part,
     private_instance_scope_root_path,
     private_instances_root_path,
     resolve_worker_key,
@@ -303,57 +301,6 @@ def reconstruct_private_instance_worker_key(worker_key: str, requester_id: str) 
     if reconstructed_worker_key is None:
         _raise_invalid_record("has an invalid requester")
     return reconstructed_worker_key
-
-
-def historical_private_instance_worker_key(worker_key: str, requester_id: str) -> str:
-    """Reconstruct the historical key after validating the exact private scope shape."""
-    current = reconstruct_private_instance_worker_key(worker_key, requester_id)
-    parts = current.split(":")
-    requester = re.sub(r"[^a-zA-Z0-9._:@+-]+", "_", requester_id.strip()).strip("_") or "default"
-    historical = f"v1:{normalize_worker_key_part(parts[1])}:{parts[2]}:{requester}"
-    if parts[2] == "user_agent":
-        historical += ":" + normalize_worker_key_part(parts[-1])
-    if worker_key not in {historical, current}:
-        _raise_invalid_record("does not match the historical or current requester encoding")
-    return historical
-
-
-def load_private_instance_legacy_alias(base_storage_path: Path, worker_key: str) -> Path | None:
-    """Return the verified historical alias owned by this current canonical scope.
-
-    The primary's protected namespace retains migration provenance. Owner records
-    alone never authorize aliases, and a historical collision grants no access to
-    the other current owner. Invalid records or namespace entries fail closed.
-    """
-    base = shared_storage_root(base_storage_path)
-    canonical = private_instance_scope_root_path(base, worker_key)
-    owner = load_private_instance_identity(base, canonical)
-    if owner is None:
-        if canonical.exists():
-            _raise_invalid_record("has no canonical owner for its legacy alias")
-        return None
-    if owner.worker_key != worker_key:
-        _raise_invalid_record("does not match the requested current key")
-    historical = historical_private_instance_worker_key(worker_key, owner.requester_id)
-    alias = private_instance_scope_root_path(base, historical)
-    try:
-        info = alias.lstat()
-    except FileNotFoundError:
-        return None
-    if not stat.S_ISLNK(info.st_mode):
-        _raise_invalid_record("legacy alias must be a symlink")
-    # Read the literal target: Path normalization would accept './name' as 'name'.
-    target_name = os.readlink(alias)  # noqa: PTH115 - Preserve the literal target text.
-    if target_name in {"", ".", ".."} or "/" in target_name:
-        _raise_invalid_record("legacy alias must name its canonical sibling")
-    target = alias.parent / target_name
-    target_owner = load_private_instance_identity(base, target)
-    if target_owner is None:
-        _raise_invalid_record("legacy alias has no current target owner")
-    target_historical = historical_private_instance_worker_key(target_owner.worker_key, target_owner.requester_id)
-    if private_instance_scope_root_path(base, target_historical) != alias:
-        _raise_invalid_record("legacy alias does not match its current target owner")
-    return alias if target == canonical else None
 
 
 def _raise_invalid_record(reason: str) -> NoReturn:

--- a/src/mindroom/private_storage_compat.py
+++ b/src/mindroom/private_storage_compat.py
@@ -1,0 +1,78 @@
+"""Historical requester keys and verified private-storage aliases."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+from typing import TYPE_CHECKING, NoReturn
+
+from mindroom.private_instance_identity_store import (
+    PrivateInstanceIdentityError,
+    load_private_instance_identity,
+    reconstruct_private_instance_worker_key,
+)
+from mindroom.tool_system.worker_routing import (
+    normalize_worker_key_part,
+    private_instance_scope_root_path,
+    shared_storage_root,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def historical_private_instance_worker_key(worker_key: str, requester_id: str) -> str:
+    """Reconstruct the historical key after validating the exact private scope shape."""
+    current = reconstruct_private_instance_worker_key(worker_key, requester_id)
+    parts = current.split(":")
+    requester = re.sub(r"[^a-zA-Z0-9._:@+-]+", "_", requester_id.strip()).strip("_") or "default"
+    historical = f"v1:{normalize_worker_key_part(parts[1])}:{parts[2]}:{requester}"
+    if parts[2] == "user_agent":
+        historical += ":" + normalize_worker_key_part(parts[-1])
+    if worker_key not in {historical, current}:
+        _raise_invalid_record("does not match the historical or current requester encoding")
+    return historical
+
+
+def load_private_instance_legacy_alias(base_storage_path: Path, worker_key: str) -> Path | None:
+    """Return the verified historical alias owned by this current canonical scope.
+
+    The primary's protected namespace retains migration provenance. Owner records
+    alone never authorize aliases, and a historical collision grants no access to
+    the other current owner. Invalid records or namespace entries fail closed.
+    """
+    base = shared_storage_root(base_storage_path)
+    canonical = private_instance_scope_root_path(base, worker_key)
+    owner = load_private_instance_identity(base, canonical)
+    if owner is None:
+        if canonical.exists():
+            _raise_invalid_record("has no canonical owner for its legacy alias")
+        return None
+    if owner.worker_key != worker_key:
+        _raise_invalid_record("does not match the requested current key")
+    historical = historical_private_instance_worker_key(worker_key, owner.requester_id)
+    alias = private_instance_scope_root_path(base, historical)
+    try:
+        info = alias.lstat()
+    except FileNotFoundError:
+        return None
+    if not stat.S_ISLNK(info.st_mode):
+        _raise_invalid_record("legacy alias must be a symlink")
+    # Read the literal target: Path normalization would accept './name' as 'name'.
+    target_name = os.readlink(alias)  # noqa: PTH115 - Preserve the literal target text.
+    if target_name in {"", ".", ".."} or "/" in target_name:
+        _raise_invalid_record("legacy alias must name its canonical sibling")
+    target = alias.parent / target_name
+    target_owner = load_private_instance_identity(base, target)
+    if target_owner is None:
+        _raise_invalid_record("legacy alias has no current target owner")
+    target_historical = historical_private_instance_worker_key(target_owner.worker_key, target_owner.requester_id)
+    if private_instance_scope_root_path(base, target_historical) != alias:
+        _raise_invalid_record("legacy alias does not match its current target owner")
+    return alias if target == canonical else None
+
+
+def _raise_invalid_record(reason: str) -> NoReturn:
+    msg = f"Private instance identity record {reason}"
+    raise PrivateInstanceIdentityError(msg)

--- a/src/mindroom/private_storage_migration.py
+++ b/src/mindroom/private_storage_migration.py
@@ -19,12 +19,14 @@ from mindroom.durable_write import fsync_directory_durable, write_json_file_dura
 from mindroom.file_locks import advisory_file_lock
 from mindroom.private_instance_identity_store import (
     PrivateInstanceIdentity,
-    historical_private_instance_worker_key,
     load_private_instance_identity,
-    load_private_instance_legacy_alias,
     load_private_instance_record_payload,
     parse_private_instance_identity_payload,
     reconstruct_private_instance_worker_key,
+)
+from mindroom.private_storage_compat import (
+    historical_private_instance_worker_key,
+    load_private_instance_legacy_alias,
 )
 from mindroom.tool_system.worker_routing import private_instance_scope_root_path
 

--- a/src/mindroom/private_storage_paths.py
+++ b/src/mindroom/private_storage_paths.py
@@ -1,0 +1,44 @@
+"""Resolve private-storage paths and additional mounts at the storage boundary."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from mindroom.private_instance_identity_store import load_private_instance_identity
+from mindroom.private_storage_compat import (
+    historical_private_instance_worker_key,
+    load_private_instance_legacy_alias,
+)
+from mindroom.tool_system.worker_routing import private_instance_scope_root_path
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def private_scope_alias_paths(base_storage_path: Path, worker_key: str) -> tuple[Path, ...]:
+    """Return verified additional mount paths for an owned canonical scope."""
+    canonical = private_instance_scope_root_path(base_storage_path, worker_key)
+    if load_private_instance_identity(base_storage_path, canonical) is None:
+        return ()
+    alias = load_private_instance_legacy_alias(base_storage_path, worker_key)
+    return () if alias is None else (alias,)
+
+
+def resolve_private_scope_path(base_storage_path: Path, worker_key: str, candidate: Path) -> Path:
+    """Resolve a retained scope spelling before the caller checks its allowed roots."""
+    canonical = private_instance_scope_root_path(base_storage_path, worker_key)
+    if not candidate.is_relative_to(canonical.parent):
+        return candidate
+    owner = load_private_instance_identity(base_storage_path, canonical)
+    if owner is None or owner.worker_key != worker_key:
+        return candidate
+    historical = private_instance_scope_root_path(
+        base_storage_path,
+        historical_private_instance_worker_key(worker_key, owner.requester_id),
+    )
+    try:
+        if candidate.is_relative_to(historical) and historical.samefile(canonical):
+            return (canonical / candidate.relative_to(historical)).resolve()
+    except FileNotFoundError:
+        pass
+    return candidate

--- a/src/mindroom/workers/backends/_dedicated_worker_common.py
+++ b/src/mindroom/workers/backends/_dedicated_worker_common.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, cast
 
 from mindroom.agent_policy import build_agent_policy_seeds, resolve_agent_policy_index
 from mindroom.constants import RuntimePaths, deserialize_runtime_paths, serialize_public_runtime_paths
-from mindroom.private_instance_identity_store import load_private_instance_identity, load_private_instance_legacy_alias
+from mindroom.private_storage_paths import private_scope_alias_paths
 from mindroom.runtime_env_policy import CONTROL_STATE_PATH_ENV, SANDBOX_RUNTIME_ENV_BY_KEY, SHARED_CREDENTIALS_PATH_ENV
 from mindroom.tool_system.worker_routing import (
     private_instance_scope_root_path,
@@ -292,16 +292,14 @@ def plan_scoped_visible_state_roots(
         for local_root, worker_visible_root in zip(local_roots, worker_visible_roots, strict=True)
     ]
     canonical_scope = private_instance_scope_root_path(local_shared_storage_root, worker_key)
-    if canonical_scope in local_roots and load_private_instance_identity(local_shared_storage_root, canonical_scope):
-        legacy = load_private_instance_legacy_alias(local_shared_storage_root, worker_key)
-        if legacy is not None:
-            planned_roots.append(
-                ScopedVisibleStateRoot(
-                    local_path=canonical_scope,
-                    worker_visible_path=worker_visible_shared_storage_root
-                    / legacy.relative_to(local_shared_storage_root),
-                ),
+    if canonical_scope in local_roots:
+        planned_roots.extend(
+            ScopedVisibleStateRoot(
+                local_path=canonical_scope,
+                worker_visible_path=worker_visible_shared_storage_root / alias.relative_to(local_shared_storage_root),
             )
+            for alias in private_scope_alias_paths(local_shared_storage_root, worker_key)
+        )
     return tuple(planned_roots)
 
 

--- a/tach.toml
+++ b/tach.toml
@@ -752,13 +752,32 @@ visibility = [
 [[modules]]
 path = "mindroom.oauth.credential_store"
 depends_on = [
-    "mindroom.credential_policy",
-    "mindroom.tool_system.worker_routing",
     "mindroom.credentials",
-    "mindroom.logging_config",
+    "mindroom.oauth.credential_compat",
+    "mindroom.oauth.credential_store_types",
     "mindroom.oauth.providers",
 ]
 visibility = ["mindroom.oauth.credential_lifecycle"]
+
+[[modules]]
+path = "mindroom.oauth.credential_compat"
+depends_on = [
+    "mindroom.credential_policy",
+    "mindroom.credentials",
+    "mindroom.logging_config",
+    "mindroom.oauth.credential_store_types",
+    "mindroom.tool_system.worker_routing",
+]
+visibility = ["mindroom.oauth.credential_store"]
+
+[[modules]]
+path = "mindroom.oauth.credential_store_types"
+depends_on = [
+    "mindroom.credentials",
+    "mindroom.oauth.providers",
+    "mindroom.tool_system.worker_routing",
+]
+visibility = ["mindroom.oauth.credential_store", "mindroom.oauth.credential_compat"]
 
 [[modules]]
 path = "mindroom.oauth.credential_lifecycle"

--- a/tach.toml
+++ b/tach.toml
@@ -754,7 +754,6 @@ path = "mindroom.oauth.credential_store"
 depends_on = [
     "mindroom.credentials",
     "mindroom.oauth.credential_compat",
-    "mindroom.oauth.credential_store_types",
     "mindroom.oauth.providers",
 ]
 visibility = ["mindroom.oauth.credential_lifecycle"]
@@ -765,18 +764,13 @@ depends_on = [
     "mindroom.credential_policy",
     "mindroom.credentials",
     "mindroom.logging_config",
-    "mindroom.oauth.credential_store_types",
     "mindroom.tool_system.worker_routing",
 ]
 visibility = ["mindroom.oauth.credential_store"]
 
 [[modules]]
 path = "mindroom.oauth.credential_store_types"
-depends_on = [
-    "mindroom.credentials",
-    "mindroom.oauth.providers",
-    "mindroom.tool_system.worker_routing",
-]
+depends_on = []
 visibility = ["mindroom.oauth.credential_store", "mindroom.oauth.credential_compat"]
 
 [[modules]]

--- a/tach.toml
+++ b/tach.toml
@@ -108,8 +108,8 @@ depends_on = [
     "mindroom.tool_system.worker_routing",
 ]
 visibility = [
-    "mindroom.api.sandbox_worker_prep",
-    "mindroom.workers.backends._dedicated_worker_common",
+    "mindroom.private_storage_compat",
+    "mindroom.private_storage_paths",
     "mindroom.private_storage_migration",
     "mindroom.private_instance_identity",
     "mindroom.runtime_resolution",
@@ -1266,7 +1266,7 @@ path = "mindroom.api.sandbox_worker_prep"
 depends_on = [
     "mindroom.api.sandbox_exec",
     "mindroom.logging_config",
-    "mindroom.private_instance_identity_store",
+    "mindroom.private_storage_paths",
     "mindroom.tool_system.sandbox_proxy",
     "mindroom.tool_system.worker_routing",
     "mindroom.workers.backend",
@@ -5246,6 +5246,7 @@ depends_on = [
     "mindroom.durable_write",
     "mindroom.file_locks",
     "mindroom.private_instance_identity_store",
+    "mindroom.private_storage_compat",
     "mindroom.tool_system.worker_routing",
     "mindroom.workers.storage_preflight",
 ]
@@ -5260,3 +5261,20 @@ depends_on = [
     "mindroom.workers.backends.kubernetes",
 ]
 visibility = ["mindroom.private_storage_migration"]
+
+[[modules]]
+path = "mindroom.private_storage_compat"
+depends_on = [
+    "mindroom.private_instance_identity_store",
+    "mindroom.tool_system.worker_routing",
+]
+visibility = ["mindroom.private_storage_migration", "mindroom.private_storage_paths"]
+
+[[modules]]
+path = "mindroom.private_storage_paths"
+depends_on = [
+    "mindroom.private_instance_identity_store",
+    "mindroom.private_storage_compat",
+    "mindroom.tool_system.worker_routing",
+]
+visibility = ["mindroom.api.sandbox_worker_prep", "mindroom.workers.backends._dedicated_worker_common"]

--- a/tests/test_oauth_credential_store.py
+++ b/tests/test_oauth_credential_store.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 import pytest
 
 import mindroom.durable_write as durable_write_module
+import mindroom.oauth.credential_compat as credential_compat_module
 import mindroom.oauth.credential_store as credential_store_module
 from mindroom.constants import RuntimePaths, resolve_runtime_paths
 from mindroom.credentials import CredentialsManager, get_runtime_credentials_manager, save_scoped_credentials
@@ -741,7 +742,7 @@ async def test_legacy_adoption_logs_only_safe_metadata(
         worker_target=context.worker_target,
     )
     logger = _CapturingLogger()
-    monkeypatch.setattr(credential_store_module, "logger", logger)
+    monkeypatch.setattr(credential_compat_module, "logger", logger)
 
     async with oauth_credential_transaction(context) as transaction:
         assert transaction.snapshot().credentials == {"token": credential_value}
@@ -791,7 +792,7 @@ async def test_legacy_cleanup_failure_logs_only_safe_metadata(
 
     logger = _CapturingLogger()
     monkeypatch.setattr(Path, "unlink", fail_credential_cleanup)
-    monkeypatch.setattr(credential_store_module, "logger", logger)
+    monkeypatch.setattr(credential_compat_module, "logger", logger)
 
     async with oauth_credential_transaction(context) as transaction:
         assert transaction.snapshot().credentials == {"token": credential_value}
@@ -1050,14 +1051,14 @@ async def test_legacy_cleanup_decision_is_made_inside_initialization_transaction
 ) -> None:
     """Legacy cleanup must not open an unprotected read window after initialization commits."""
     context = _context(tmp_path)
-    original_cleanup_decision = credential_store_module._legacy_cleanup_must_be_deferred
+    original_cleanup_decision = credential_compat_module._legacy_cleanup_must_be_deferred
 
     def require_transaction(connection: sqlite3.Connection) -> bool:
         assert connection.in_transaction
         return original_cleanup_decision(connection)
 
     monkeypatch.setattr(
-        credential_store_module,
+        credential_compat_module,
         "_legacy_cleanup_must_be_deferred",
         require_transaction,
     )

--- a/tests/test_private_instance_identity_store.py
+++ b/tests/test_private_instance_identity_store.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from mindroom import private_instance_identity_store as store
+from mindroom import private_storage_compat as compat
 from mindroom.tool_system.worker_routing import private_instance_scope_root_path
 
 if TYPE_CHECKING:
@@ -39,7 +40,7 @@ def _owner(base: Path, key: str = _NEW, requester: str = _REQUESTER) -> Path:
 )
 def test_reconstruct_historical_key(key: str, requester: str, expected: str) -> None:
     """Exact historical and current private shapes reconstruct the same retained name."""
-    assert store.historical_private_instance_worker_key(key, requester) == expected
+    assert compat.historical_private_instance_worker_key(key, requester) == expected
 
 
 @pytest.mark.parametrize(
@@ -55,17 +56,17 @@ def test_reconstruct_historical_key(key: str, requester: str, expected: str) -> 
 def test_reconstruct_historical_key_rejects_mismatched_shape(key: str) -> None:
     """A scope prefix alone cannot hide a different requester or extra key segments."""
     with pytest.raises(store.PrivateInstanceIdentityError):
-        store.historical_private_instance_worker_key(key, "alice")
+        compat.historical_private_instance_worker_key(key, "alice")
 
 
 def test_load_alias_requires_existing_namespace_provenance(tmp_path: Path) -> None:
     """Current owner records do not imply that an old path was ever owned."""
-    assert store.load_private_instance_legacy_alias(tmp_path, _NEW) is None
+    assert compat.load_private_instance_legacy_alias(tmp_path, _NEW) is None
     new = _owner(tmp_path)
-    assert store.load_private_instance_legacy_alias(tmp_path, _NEW) is None
+    assert compat.load_private_instance_legacy_alias(tmp_path, _NEW) is None
     old = private_instance_scope_root_path(tmp_path, _OLD)
     old.symlink_to(new.name, target_is_directory=True)
-    assert store.load_private_instance_legacy_alias(tmp_path, _NEW) == old
+    assert compat.load_private_instance_legacy_alias(tmp_path, _NEW) == old
     with pytest.raises(store.PrivateInstanceIdentityError):
         store.load_private_instance_identity(tmp_path, old)
 
@@ -106,7 +107,7 @@ def test_load_alias_rejects_invalid_owner_or_link(tmp_path: Path, damage: str) -
                 old.unlink()
                 old.symlink_to(saved.name)
     with pytest.raises(store.PrivateInstanceIdentityError):
-        store.load_private_instance_legacy_alias(tmp_path, _NEW)
+        compat.load_private_instance_legacy_alias(tmp_path, _NEW)
 
 
 def test_historical_collision_never_selects_another_owner(tmp_path: Path) -> None:
@@ -121,7 +122,7 @@ def test_historical_collision_never_selects_another_owner(tmp_path: Path) -> Non
     old.symlink_to(first.name)
     (first / "credentials.bin").write_bytes(b"first owner")
     (second / "credentials.bin").write_bytes(b"second owner")
-    assert store.load_private_instance_legacy_alias(tmp_path, first_key) == old
-    assert store.load_private_instance_legacy_alias(tmp_path, second_key) is None
+    assert compat.load_private_instance_legacy_alias(tmp_path, first_key) == old
+    assert compat.load_private_instance_legacy_alias(tmp_path, second_key) is None
     assert store.load_private_instance_identity(tmp_path, second).requester_id == second_requester
     assert (second / "credentials.bin").read_bytes() == b"second owner"


### PR DESCRIPTION
Migration compatibility currently reaches into worker mount planning, sandbox path validation, identity storage and OAuth transactions. This PR preserves supported upgrades while giving historical formats focused production owners.

- Move historical requester encoding and alias validation into `private_storage_compat.py`. Worker planning and sandbox validation use ordinary path operations from `private_storage_paths.py`, keeping the same ownership and allowed-root checks.
- Move OAuth JSON adoption, old requester bindings, publication metadata and obsolete-file cleanup into `oauth/credential_compat.py`. Its state owner handles deferred cleanup at explicit transaction milestones; the store retains schema, SQLite locks, current credential mutations and commit ownership.
- Enforce the boundaries with Tach and document where compatibility belongs. Existing config, Nio and Agno migration entry points remain in place.

The four ordinary production modules shrink by 282 lines. Total production code grows by 131 lines for the extracted modules and explicit boundaries; supported migrations and recovery behavior are preserved. Existing tests stay in place, with only import and patch-target updates.

This replaces the removal direction discussed in #1984.

Validation: full non-Matrix suite (17,654 passed, 10 skipped; 31 warnings from dependencies/test mocks); repository pre-commit hooks; `tach check --dependencies --interfaces`; independent reviews of both extractions and the complete branch.

## Summary by Sourcery

Refactor private-storage and OAuth migration compatibility into focused, owner-scoped modules without changing supported upgrade or recovery behavior.

Enhancements:
- Isolate private-storage and OAuth historical-format handling behind dedicated compatibility modules while keeping current path, identity, credential, and transaction logic in their owning production modules.
- Preserve supported private-storage and OAuth migrations, deferred credential adoption, verified legacy aliases, and post-commit cleanup behavior.
- Enforce the new ownership boundaries with Tach dependency visibility rules and document the storage upgrade architecture.

Documentation:
- Document storage upgrade boundaries, compatibility ownership, lifecycle entry points, and OAuth cleanup guarantees.

Tests:
- Update tests to target the extracted compatibility modules while retaining coverage of legacy storage and OAuth migration behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved compatibility with historical private-storage paths and aliases, including validation of legacy references.
  - Improved OAuth credential upgrades by adopting older credential formats and safely cleaning up obsolete files after successful saves.
  - Preserved existing lifecycle and worker storage behavior while improving handling of retained legacy paths.

- **Documentation**
  - Added architecture guidance describing storage upgrade boundaries, compatibility handling, migration timing, and cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->